### PR TITLE
Make unread messages badges only show mentions

### DIFF
--- a/client/startup/startup.coffee
+++ b/client/startup/startup.coffee
@@ -81,15 +81,15 @@ Meteor.startup ->
 				KonchatNotification.newMessage()
 
 	Tracker.autorun ->
-		unreadCount = 0
-		subscriptions = ChatSubscription.find({}, { fields: { unread: 1 } })
-		(unreadCount += r.unread) for r in subscriptions.fetch()
+		mentionsCount = 0
+		subscriptions = ChatSubscription.find({}, { fields: { mentions: 1 } })
+		(mentionsCount += r.mentions) for r in subscriptions.fetch()
 
 		rxFavico.set 'type', 'warn'
-		rxFavico.set 'count', unreadCount
+		rxFavico.set 'count', mentionsCount
 
-		if unreadCount > 0
-			document.title = '(' + unreadCount + ') Rocket.Chat'
+		if mentionsCount > 0
+			document.title = '(' + mentionsCount + ') Rocket.Chat'
 		else
 			document.title = 'Rocket.Chat'
 

--- a/client/stylesheets/base.less
+++ b/client/stylesheets/base.less
@@ -1159,7 +1159,7 @@ a.github-fork {
 			}
 		}
 	}
-	.unread {
+	.mentions {
 		background-color: #1dce73;
 		min-width: 15px;
 		padding: 0 2px;
@@ -1208,7 +1208,11 @@ a.github-fork {
 					background-color: transparent;
 				}
 			}
-			&.has-unread {
+			&.has-unread a, &.has-mentions a {
+				font-weight: bold;
+				color: #fff;
+			}
+			&.has-mentions {
 				.opt {
 					opacity: 0;
 				}

--- a/client/views/app/sideNav/chatRoomItem.coffee
+++ b/client/views/app/sideNav/chatRoomItem.coffee
@@ -5,6 +5,12 @@ Template.chatRoomItem.helpers
 		else if Router.current().params._id is this.rid and this.unread > 0
 			Meteor.call 'readMessages', this.rid
 
+	mentions: ->
+		if (not Router.current().params._id) or Router.current().params._id isnt this.rid
+			return this.mentions
+		else if Router.current().params._id is this.rid and this.mentions > 0
+			Meteor.call 'readMessages', this.rid
+
 	isDirectRoom: ->
 		return this.t is 'd'
 

--- a/client/views/app/sideNav/chatRoomItem.html
+++ b/client/views/app/sideNav/chatRoomItem.html
@@ -1,8 +1,8 @@
 <template name="chatRoomItem">
-	<li class="link-room-{{rid}} {{active}} {{#if unread}}has-unread{{/if}}">
+	<li class="link-room-{{rid}} {{active}} {{#if unread}}has-unread{{/if}} {{#if mentions}}has-mentions{{/if}}">
 		<a href="{{ pathFor 'room' _id=rid}}" title="{{name}}">
-			{{#if unread}}
-				<span class="unread">{{unread}}</span>
+			{{#if mentions}}
+				<span class="mentions">{{mentions}}</span>
 			{{/if}}
 			<i class="{{roomIcon}} {{userStatus}}"></i>
 			<span>{{name}}</span>

--- a/server/methods/addUserToRoom.coffee
+++ b/server/methods/addUserToRoom.coffee
@@ -31,6 +31,7 @@ Meteor.methods
 			rn: room.name
 			t: room.t
 			unread: 0
+			mentions: 0
 
 		ChatMessage.insert
 			rid: data.rid

--- a/server/methods/canAccessRoom.coffee
+++ b/server/methods/canAccessRoom.coffee
@@ -29,6 +29,7 @@ Meteor.methods
 				rn: room.name
 				t: room.t
 				unread: 0
+				mentions: 0
 			$set:
 				ls: (new Date())
 				ts: (new Date())

--- a/server/methods/createChannel.coffee
+++ b/server/methods/createChannel.coffee
@@ -37,6 +37,7 @@ Meteor.methods
 				rn: name
 				t: 'c'
 				unread: 0
+				mentions: 0
 
 			if username is Meteor.user().username
 				sub.ls = now

--- a/server/methods/createDirectRoom.coffee
+++ b/server/methods/createDirectRoom.coffee
@@ -32,6 +32,7 @@ Meteor.methods
 			$setOnInsert:
 				t: 'd'
 				unread: 0
+				mentions: 0
 				'u._id': userTo._id
 
 		ChatSubscription.upsert { $and: [{'u._id': userTo._id}], rid: roomId },
@@ -40,6 +41,7 @@ Meteor.methods
 			$setOnInsert:
 				t: 'd'
 				unread: 0
+				mentions: 0
 				'u._id': userTo._id
 
 		return {

--- a/server/methods/createPrivateGroup.coffee
+++ b/server/methods/createPrivateGroup.coffee
@@ -34,6 +34,7 @@ Meteor.methods
 				rn: name
 				t: 'p'
 				unread: 0
+				mentions: 0
 
 			if username is Meteor.user().username
 				sub.ls = now

--- a/server/methods/readMessages.coffee
+++ b/server/methods/readMessages.coffee
@@ -8,4 +8,4 @@ Meteor.methods
 		else
 			throw new Meteor.Error 203, '[methods] readMessages -> Invalid user'
 
-		ChatSubscription.update filter, { $set: { unread: 0, ls: (new Date()) } }
+		ChatSubscription.update filter, { $set: { unread: 0, mentions: 0, ls: (new Date()) } }

--- a/server/methods/sendMessage.coffee
+++ b/server/methods/sendMessage.coffee
@@ -62,6 +62,18 @@ Meteor.methods
 		# increment unread counter on which user in room
 		Meteor.defer -> ChatSubscription.update activityFilter, { $inc: { unread: 1 }, $set: { ts: now } }, { multi: true }
 
+		updateMentions = (username, rid) ->
+			user = Meteor.users.findOne({username: username}, {fields: {_id: 1}})
+			if !user
+				return
+			filter = { rid: rid, 'u._id': user._id }
+			Meteor.defer -> ChatSubscription.update filter, { $inc: { mentions: 1 }, $set: { ts: now } }, { multi: true }
+
+		if mentions
+			updateMentions m.username, rid for m in mentions
+
+		Meteor.defer -> ChatSubscription.update activityFilter, { $inc: { unread: 1 }, $set: { ts: now } }, { multi: true }
+
 		return retObj
 
 	updateMessage: (msg) ->

--- a/server/methods/setUsername.coffee
+++ b/server/methods/setUsername.coffee
@@ -44,6 +44,7 @@ Meteor.methods
 					f: true
 					ts: new Date()
 					unread: 0
+					mentions: 0
 
 				ChatMessage.insert
 					u:


### PR DESCRIPTION
It used to show count of all unread messages.  Instead, now channel names go bold and white if there are unread messages, but the count next to them only shows the number of mentions.

The favicon and page title only show the total number of mentions.

This is an enhancement described in #122.