### PR TITLE
UserPresence.start() is called twice

### DIFF
--- a/client/startup/startup.coffee
+++ b/client/startup/startup.coffee
@@ -1,6 +1,5 @@
 Meteor.startup ->
 	UserPresence.awayTime = 300000
-	UserPresence.start()
 	Meteor.subscribe("activeUsers")
 
 	Session.setDefault('flexOpened', false)
@@ -47,4 +46,3 @@ Meteor.startup ->
 			document.title = '(' + unreadCount + ') Rocket.Chat'
 		else
 			document.title = 'Rocket.Chat'
-


### PR DESCRIPTION
The method UserPresence.start() is called twice within Meteor.startup once in presence.coffee and once in startup.coffee nothing big but I guess we need just one call right?