### PR TITLE
Fix logo markdown for docker hub compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="http://rocket.chat/images/logo/logo-dark.svg?v2" />
+![Rocket.Chat logo](http://rocket.chat/images/logo/logo-dark.svg?v2)
 
 The Complete Open Source Chat Solution
 


### PR DESCRIPTION
HTML embed does not work on docker hub and the SVG is broken.   Change to more universal markdown supported by both.