### PR TITLE
reset video chat mode when user close flex tab directly + minor webrtc edge cond fix #115

### DIFF
--- a/client/views/app/room.coffee
+++ b/client/views/app/room.coffee
@@ -289,11 +289,10 @@ Template.room.events
 	"click .flex-tab .more": (event) ->
 		console.log 'room click .flex-tab .more' if window.rocketDebug
 		if (Session.get('flexOpened'))
-			Session.set('flexOpenedRTC2', false);
-			Session.set('flexOpenedRTC1', false);
-			Session.set('flexOpened',false);
+			Session.set('rtcLayoutmode', 0)
+			Session.set('flexOpened',false)
 		else
-			Session.set('flexOpened', !Session.get('flexOpened'))
+			Session.set('flexOpened', true)
 
 
 	'click .chat-new-messages': (event) ->

--- a/packages/rocketchat-webrtc/webrtc.js
+++ b/packages/rocketchat-webrtc/webrtc.js
@@ -17,7 +17,9 @@ webrtc = {
 	},
 	stop: function(sendEvent) {
 		if (webrtc.pc) {
-			webrtc.pc.close();
+			if (webrtc.pc.signalingState != 'closed') {
+				webrtc.pc.close();
+			}
 			if (sendEvent != false) {
 				stream.emit('send', {to: webrtc.to, close: true});
 			}


### PR DESCRIPTION
Mode is now reset to zero if user closes flex tab directly.

Also fixes a web-rtc edge condition that usually does not occur in production, but frequently during testing.

@rodrigok  - thanks for the deferred mute BTW ... unfortunately I blew my tube amp on feedback before then :(