### PR TITLE
Fix RocketChat/Rocket.Chat#239 room's message count and last message

### DIFF
--- a/packages/rocketchat-lib/server/sendMessage.coffee
+++ b/packages/rocketchat-lib/server/sendMessage.coffee
@@ -45,12 +45,12 @@ RocketChat.sendMessage = (user, message, room) ->
 
 		ChatRoom.update
 			# only subscriptions to the same room
-			rid: message.rid
+			_id: message.rid
 		,
 			# update the last message timestamp
 			$set:
 				lm: message.ts
-			# increate the messages counter
+			# increment the messages counter
 			$inc:
 				msgs: 1
 


### PR DESCRIPTION
The message count when viewing History is incorrect because the ChatRoom message count and last message timestamp is not updated when a message is sent.

The ChatRoom update selector referenced the wrong (non-existant) field.
Thus, the room's message count was never incremented.  Also fixes issue
where the room's last message timestamp is not set on the room document.