### PR TITLE
Fix RocketChat/Rocket.Chat#12 Standardize collection names

### DIFF
--- a/client/lib/collections.coffee
+++ b/client/lib/collections.coffee
@@ -1,9 +1,9 @@
 @UserAndRoom = new Meteor.Collection null
 @ChatMessageHistory = new Meteor.Collection null
 
-@ChatRoom = new Meteor.Collection 'data.ChatRoom'
-@ChatSubscription = new Meteor.Collection 'data.ChatSubscription'
-# @ChatMessage = new Meteor.Collection 'data.ChatMessage'
+@ChatRoom = new Meteor.Collection 'rocketchat_room'
+@ChatSubscription = new Meteor.Collection 'rocketchat_subscription'
+#@ChatMessage = new Meteor.Collection 'rocketchat_message'
 
 # Meteor.startup ->
 # 	ChatMessage.find().observe

--- a/server/lib/collections.coffee
+++ b/server/lib/collections.coffee
@@ -1,3 +1,3 @@
-@ChatMessage = new Meteor.Collection 'data.ChatMessage'
-@ChatRoom = new Meteor.Collection 'data.ChatRoom'
-@ChatSubscription = new Meteor.Collection 'data.ChatSubscription'
+@ChatMessage = new Meteor.Collection 'rocketchat_message'
+@ChatRoom = new Meteor.Collection 'rocketchat_room'
+@ChatSubscription = new Meteor.Collection 'rocketchat_subscription'

--- a/server/publications/messages.coffee
+++ b/server/publications/messages.coffee
@@ -23,10 +23,10 @@ Meteor.publish 'messages', (rid, start) ->
 
 	cursorHandle = cursor.observeChanges
 		added: (_id, record) ->
-			publication.added('data.ChatMessage', _id, record)
+			publication.added('rocketchat_message', _id, record)
 
 		changed: (_id, record) ->
-			publication.changed('data.ChatMessage', _id, record)
+			publication.changed('rocketchat_message', _id, record)
 
 	cursorDelete = ChatMessage.find
 		rid: rid
@@ -37,9 +37,9 @@ Meteor.publish 'messages', (rid, start) ->
 
 	cursorDeleteHandle = cursorDelete.observeChanges
 		added: (_id, record) ->
-			publication.added('data.ChatMessage', _id, {_deleted: true})
+			publication.added('rocketchat_message', _id, {_deleted: true})
 		changed: (_id, record) ->
-			publication.added('data.ChatMessage', _id, {_deleted: true})
+			publication.added('rocketchat_message', _id, {_deleted: true})
 
 	@ready()
 	@onStop ->

--- a/server/startup/migrations/v9.coffee
+++ b/server/startup/migrations/v9.coffee
@@ -1,0 +1,37 @@
+Meteor.startup ->
+	Migrations.add
+		version: 9
+		up: ->
+			# Migrate existing source collection data to target collection
+			# target collection is defined in collections.coffee using the new collection name
+			toMigrate = [ 
+				{
+					source: new Meteor.Collection 'data.ChatRoom'
+					target: ChatRoom 
+				}
+				{
+					source: new Meteor.Collection 'data.ChatSubscription'
+					target: ChatSubscription 
+				}
+				{
+					source: new Meteor.Collection 'data.ChatMessage'
+					target: ChatMessage 
+				}
+			]
+
+			toMigrate.forEach ( collection ) ->
+				source = collection.source
+				target = collection.target
+				# rawCollection available as of Meteor 1.0.4
+				console.log 'Migrating data from: ' + source.rawCollection().collectionName + ' to: ' + target.rawCollection().collectionName
+				source.find().forEach ( doc ) ->
+					target.upsert({_id: doc._id}, doc )
+
+				rawSource = source.rawCollection();
+				Meteor.wrapAsync(rawSource.drop, rawSource )()
+
+				# Note: the following would have been much easier, but didn't work.  The serverside
+				# data was not published to the client for some reason.  
+				# newName = target.rawCollection().collectionName
+				# Meteor.wrapAsync(rawSource.rename, rawSource )(newName, {dropTarget:true}) 
+


### PR DESCRIPTION
Standardize collection names to rocketchat_XXX (from data.ChatXXX).

Update Collection variables to use new rocketchat_XXX collections and
migrate data (v9.coffee) from old collection to new collections.  After
migration, drop old collection (data.ChatXXX) via rawCollection access.
Note: rawCollection access added with Meteor version 1.0.4.