### PR TITLE
Fix probem with 720p video full screen display on chrome browser

### DIFF
--- a/client/stylesheets/base.less
+++ b/client/stylesheets/base.less
@@ -3082,6 +3082,14 @@ a.github-fork {
 	}
 }
 
+#fullscreendiv:-webkit-full-screen {
+	position: fixed;
+	width: 100%;
+	height: 100%;
+	top: 0;
+	background: none;
+}
+
 @media all and(max-width: 1100px) {
 	#rocket-chat {
 		.flex-opened {

--- a/client/views/app/room.html
+++ b/client/views/app/room.html
@@ -164,7 +164,7 @@
 
 									{{#if selfVideoUrl}}
 										{{#if rtcLayout3}}
-											<div id='fullscreendiv' style="width: 800px; height: 350px">
+											<div id='fullscreendiv' style="width: 100%">
 											<video id='videoremote' class="video-remote" src="{{remoteVideoUrl}}" style="width: 100%; align-items: center; margin-bottom: 10px; background-color: #000; transition: width 2s, height 2s, top 2s, left 2s, transform 2s;" autoplay></video>
 											<video id='videoself' class="video-self" src="{{selfVideoUrl}}" style="width: 250px; position: absolute; top: 21px; right: 31px; border: 1px solid #FFF; background-color: #000; transition: width 2s, height 2s, top 2s, left 2s, transform 2s;" autoplay muted></video>
 											</div>

--- a/packages/rocketchat-webrtc/webrtc.js
+++ b/packages/rocketchat-webrtc/webrtc.js
@@ -85,7 +85,7 @@ webrtc.start = function (isCaller, fromUsername) {
 
 	var getUserMedia = function() {
 		// get the local stream, show it in the local video element and send it
-		navigator.getUserMedia({ "audio": true, "video": true }, function (stream) {
+		navigator.getUserMedia({ "audio": true, "video": {mandatory: {minWidth:1280, minHeight:720}} }, function (stream) {
 			webrtc.onSelfUrl(URL.createObjectURL(stream));
 
 			webrtc.pc.addStream(stream);


### PR DESCRIPTION
720p video will now display full screen (while in full screen video conferencing mode) on Chrome browsers.  Previously it was centered and had a big black border.

Tested, on in-band stack, with calls from Chrome to Chrome, Firefox to Chrome, and Chrome to Firefox.

