### PR TITLE
fix a bug in webrtc stream signaling stack to improve stability

### DIFF
--- a/packages/rocketchat-webrtc/webrtc.js
+++ b/packages/rocketchat-webrtc/webrtc.js
@@ -2,6 +2,7 @@ webrtc = {
 	// cid: Random.id(),
 	pc: undefined,
 	to: undefined,
+	room: undefined,
 	debug: false,
 	config: {
 		iceServers: [
@@ -12,6 +13,7 @@ webrtc = {
 	stream: stream,
 	send: function(data) {
 		data.to = webrtc.to;
+		data.room = webrtc.room;
 		data.from = Meteor.user().username;
 		stream.emit('send', data);
 	},
@@ -21,7 +23,7 @@ webrtc = {
 				webrtc.pc.close();
 			}
 			if (sendEvent != false) {
-				stream.emit('send', {to: webrtc.to, close: true});
+				stream.emit('send', {to: webrtc.to, room: webrtc.room, from: Meteor.userId(), close: true});
 			}
 		}
 	},
@@ -126,6 +128,14 @@ webrtc.start = function (isCaller, fromUsername) {
 
 stream.on(Meteor.userId(), function(data) {
 	webrtc.log('stream.on', Meteor.userId(), data)
+	if (!webrtc.to) {
+		webrtc.to = data.room.replace(Meteor.userId(), '');
+	}
+
+	if (!webrtc.room) {
+		webrtc.room = data.room;
+	}
+
 	if (data.close == true) {
 		webrtc.stop(false);
 		return


### PR DESCRIPTION
Description of bug condition:

* caller clicks `Video` button:  `webrtc.to` is set in `Video onclick`,  stack starts and `stream.emit()` issued to callee
* callee receives message and displays dialog:  for convenience, callee uses the `from` field of message as the caller's **name** to be displayed in dialog;  callee needs to respond immediately; since `Video` button was not clicked on callee - `webrtc.to` is not set, callee ends up calling `stream.emit()` with destination **undefined** (most of the time, unless callee's video button was clicked in a previous test, and the browser has not been reloaded - and there were no intervening code hot-deploys)

This bug was discovered while experimenting with the in-band stack. The fix should greatly improve usability of the default stream stack.