### PR TITLE
Fix RocketChat/Rocket.Chat#329. Check for duplicate name before creating Channel and Private Group.  Also, check Private Group for illegal name. 

### DIFF
--- a/client/views/app/sideNav/createChannelFlex.coffee
+++ b/client/views/app/sideNav/createChannelFlex.coffee
@@ -84,6 +84,9 @@ Template.createChannelFlex.events
 					if err.error is 'name-invalid'
 						instance.error.set({ invalid: true })
 						return
+					if err.error is 'duplicate-name'
+						instance.error.set({ duplicate: true })
+						return
 					else
 						return toastr.error err.reason
 

--- a/client/views/app/sideNav/createChannelFlex.html
+++ b/client/views/app/sideNav/createChannelFlex.html
@@ -34,6 +34,12 @@
 					{{{_ "Invalid_room_name" roomName}}}
 				</div>
 			{{/if}}
+			{{#if error.duplicate}}
+				<div class="input-error">
+					<strong>{{_ "Oops!"}}</strong>
+					{{{_ "Duplicate_channel_name" roomName}}}
+				</div>
+			{{/if}}
 			<div class="input-submit">
 				<button class="button clean primary save-channel">{{_ "Save" }}</button>
 				<button class="button clean cancel-channel">{{_ "Cancel" }}</button>

--- a/client/views/app/sideNav/privateGroupsFlex.coffee
+++ b/client/views/app/sideNav/privateGroupsFlex.coffee
@@ -5,6 +5,9 @@ Template.privateGroupsFlex.helpers
 	name: ->
 		return Template.instance().selectedUserNames[this.valueOf()]
 
+	groupName: ->
+		return Template.instance().groupName.get()
+
 	error: ->
 		return Template.instance().error.get()
 
@@ -68,24 +71,35 @@ Template.privateGroupsFlex.events
 
 	'click .save-pvt-group': (e, instance) ->
 		err = SideNav.validate()
+		instance.groupName.set instance.find('#pvt-group-name').value
+		console.log err
 		if not err
 			Meteor.call 'createPrivateGroup', instance.find('#pvt-group-name').value, instance.selectedUsers.get(), (err, result) ->
 				if err
+					console.log err
+					if err.error is 'name-invalid'
+						instance.error.set({ invalid: true })
+						return
+					if err.error is 'duplicate-name'
+						instance.error.set({ duplicate: true })
+						return
 					return toastr.error err.reason
 				SideNav.closeFlex()
 				instance.clearForm()
 				FlowRouter.go 'room', { _id: result.rid }
 		else
-			Template.instance().error.set(err)
+			Template.instance().error.set({fields: err})
 
 Template.privateGroupsFlex.onCreated ->
 	instance = this
 	instance.selectedUsers = new ReactiveVar []
 	instance.selectedUserNames = {}
 	instance.error = new ReactiveVar []
+	instance.groupName = new ReactiveVar ''
 
 	instance.clearForm = ->
 		instance.error.set([])
+		instance.groupName.set('')
 		instance.selectedUsers.set([])
 		instance.find('#pvt-group-name').value = ''
 		instance.find('#pvt-group-members').value = ''

--- a/client/views/app/sideNav/privateGroupsFlex.html
+++ b/client/views/app/sideNav/privateGroupsFlex.html
@@ -20,14 +20,26 @@
 					{{/each}}
 				</ul>
 			</div>
-			{{#if error}}
+			{{#if error.fields}}
 				<div class="input-error">
-					<strong>Ops!</strong>
-					{{#each error}}
-						<p>{{_ "The_field_is_required" error}}</p>
+					<strong>{{_ "Oops!"}}</strong>
+					{{#each error.fields}}
+						<p>{{_ "The_field_is_required" .}}</p>
 					{{/each}}
 				</div>
 			{{/if}}
+			{{#if error.invalid}}
+				<div class="input-error">
+					<strong>{{_ "Oops!"}}</strong>
+					{{{_ "Invalid_room_name" groupName}}}
+				</div>
+			{{/if}}
+			{{#if error.duplicate}}
+				<div class="input-error">
+					<strong>{{_ "Oops!"}}</strong>
+					{{{_ "Duplicate_private_group_name" groupName}}}
+				</div>
+			{{/if}}	
 			<div class="input-submit">
 				<button class="button clean primary save-pvt-group">{{_ "Save" }}</button>
 				<button class="button clean cancel-pvt-group">{{_ "Cancel" }}</button>

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -40,6 +40,8 @@
   "Created_at" : "Created at",
   "Direct_Messages" : "Direct Messages",
   "Deleted" : "Deleted!",
+  "Duplicate_private_group_name" : "A Private Group with the name, '%s', exists",
+  "Duplicate_channel_name" : "A Channel with the name, '%s', exists",
   "edited" : "edited",
   "Email_or_username" : "Email or username",
   "Email_verified" : "Email verified",

--- a/server/methods/createChannel.coffee
+++ b/server/methods/createChannel.coffee
@@ -15,7 +15,7 @@ Meteor.methods
 
 		# avoid duplicate names
 		if ChatRoom.findOne({name:name})
-			throw new Meteor.Error 'duplicate-name', "A Channel with the same name exists"
+			throw new Meteor.Error 'duplicate-name'
 
 		# name = s.slugify name
 

--- a/server/methods/createChannel.coffee
+++ b/server/methods/createChannel.coffee
@@ -13,6 +13,10 @@ Meteor.methods
 
 		members.push user.username
 
+		# avoid duplicate names
+		if ChatRoom.findOne({name:name})
+			throw new Meteor.Error 'duplicate-name', "A Channel with the same name exists"
+
 		# name = s.slugify name
 
 		room =

--- a/server/methods/createPrivateGroup.coffee
+++ b/server/methods/createPrivateGroup.coffee
@@ -5,6 +5,9 @@ Meteor.methods
 
 		console.log '[methods] createPrivateGroup -> '.green, 'userId:', Meteor.userId(), 'arguments:', arguments
 
+		if not /^[0-9a-z-_]+$/i.test name
+			throw new Meteor.Error 'name-invalid'
+
 		now = new Date()
 
 		me = Meteor.user()
@@ -15,7 +18,7 @@ Meteor.methods
 
 		# avoid duplicate names
 		if ChatRoom.findOne({name:name})
-			throw new Meteor.Error 'duplicate-name', "A private group with the same name exists"
+			throw new Meteor.Error 'duplicate-name'
 
 		# create new room
 		rid = ChatRoom.insert

--- a/server/methods/createPrivateGroup.coffee
+++ b/server/methods/createPrivateGroup.coffee
@@ -13,6 +13,10 @@ Meteor.methods
 
 		name = s.slugify name
 
+		# avoid duplicate names
+		if ChatRoom.findOne({name:name})
+			throw new Meteor.Error 'duplicate-name', "A private group with the same name exists"
+
 		# create new room
 		rid = ChatRoom.insert
 			usernames: members


### PR DESCRIPTION
channel or private group

Queried ChatRoom for Room with same name and returned a descriptive
error if one was found when creating a Channel or Private Group.