### PR TITLE
Case insensitive username

### DIFF
--- a/server/methods/getUsernameSuggestion.coffee
+++ b/server/methods/getUsernameSuggestion.coffee
@@ -5,8 +5,7 @@ slug = (text) ->
 usernameIsAvaliable = (username) ->
 	if username.length < 1
 		return false
-
-	return not Meteor.users.findOne({username: username})?
+	return not Meteor.users.findOne({username: {$regex : new RegExp(username, "i") }})
 
 @generateSuggestion = (user) ->
 	usernames = []

--- a/server/methods/setUsername.coffee
+++ b/server/methods/setUsername.coffee
@@ -13,7 +13,7 @@ Meteor.methods
 		if not usernameIsAvaliable username
 			throw new Meteor.Error 'username-unavaliable'
 
-		if not /^[0-9a-z-_.]+$/.test username
+		if not /^[0-9a-zA-Z-_.]+$/.test username
 			throw new Meteor.Error 'username-invalid'
 
 		if not user.username?
@@ -58,5 +58,4 @@ slug = (text) ->
 usernameIsAvaliable = (username) ->
 	if username.length < 1
 		return false
-
-	return not Meteor.users.findOne({username: username})?
+	return not Meteor.users.findOne({username: {$regex : new RegExp(username, "i") }})


### PR DESCRIPTION
I was looking into open source slack alternatives for a little startup and came across rocket.chat. I deployed it locally and when I tried to signup with username IshwerDAS (that's how we would like to spell it as DAS is actually an acronym). Anyway, it gave me an error. It took me a while to figure out what was wrong as all that error said was `use only letters, numbers, dots and dashes` and that was all I was using. A little look into code made me realize that regex used was only for lower case letters. So now either the error given should have been better or it should accept mixed case usernames. I preferred later and edited code to accept mixed case usernames. But I also didn't want 2 people signing up with same username in different case, so changed the function `usernameIsAvaliable` to be case insensitive when searching. 

Other solutions could be 
* Change the error message for better
* Convert whatever user types in username box to lowercase before submitting. 