### PR TITLE
Added docker-compose file for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ temp_*
 Thumbs.db
 thumbs.db
 tramp
+data/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+mongo:
+  image: mongo
+  ports:
+    - "27017"
+  volumes:
+    - ./data:/data
+web:
+  build: .
+  ports:
+    - "3000:80"
+  volumes:
+    - .:/app
+  environment:
+    - MONGO_URL=mongodb://mongo:27017
+    - ROOT_URL=http://localhost:3000
+  links:
+    - mongo


### PR DESCRIPTION
I was just getting a Rocket.Chat environment setup for development (hope to be contributing soon!).

I noticed a Dockerfile, so I added a docker compose file, and now all it takes to get started with development is `docker-compose up`, which I find super convenient.