### PR TITLE
Limit maximum message size

### DIFF
--- a/client/lib/chatMessages.coffee
+++ b/client/lib/chatMessages.coffee
@@ -2,6 +2,7 @@ class @ChatMessages
 	init: (node) ->
 		this.editing = {}
 
+		this.messageMaxSize = RocketChat.settings.get('Message_MaxAllowedSize')
 		this.wrapper = $(node).find(".wrapper")
 		this.input = $(node).find(".input-message").get(0)
 		this.bindEvents()
@@ -65,7 +66,8 @@ class @ChatMessages
 			this.editing.saved = this.input.value
 
 	send: (rid, input) ->
-		if _.trim(input.value) isnt ''
+		if _.trim(input.value) isnt '' and not this.isMessageTooLong(input)
+			console.error 'sending', input.value
 			KonchatNotification.removeRoomNotification(rid)
 			msg = input.value
 			input.value = ''
@@ -185,3 +187,6 @@ class @ChatMessages
 		# ctrl (command) + shift + k -> clear room messages
 		else if k is 75 and ((navigator?.platform?.indexOf('Mac') isnt -1 and event.metaKey and event.shiftKey) or (navigator?.platform?.indexOf('Mac') is -1 and event.ctrlKey and event.shiftKey))
 			RoomHistoryManager.clear rid
+	
+	isMessageTooLong: (input) ->
+		input?.value.length > this.messageMaxSize

--- a/client/views/app/room.coffee
+++ b/client/views/app/room.coffee
@@ -266,6 +266,8 @@ Template.room.helpers
 	noRtcLayout: ->
 		return (!Session.get('rtcLayoutmode') || (Session.get('rtcLayoutmode') == 0) ? true: false);
 
+	maxMessageLength: ->
+		return RocketChat.settings.get('Message_MaxAllowedSize')
 
 
 Template.room.events

--- a/client/views/app/room.html
+++ b/client/views/app/room.html
@@ -47,7 +47,7 @@
 					<form class="message-form" method="post" action="/">
 						<div>
 							{{> messagePopupConfig getPupupConfig}}
-							<textarea dir="auto" name="msg" class="input-message"></textarea>
+							<textarea dir="auto" name="msg" maxlength="{{maxMessageLength}}" class="input-message"></textarea>
 							<i class="icon-paper-plane" title="{{_ "Send_Message"}}"></i>
 						</div>
 						<div class="users-typing">

--- a/packages/rocketchat-lib/settings/server/startup.coffee
+++ b/packages/rocketchat-lib/settings/server/startup.coffee
@@ -22,6 +22,7 @@ Meteor.startup ->
 	RocketChat.settings.add 'Message_ShowEditedStatus', '', { type: 'string', group: 'Message' }
 	RocketChat.settings.add 'Message_ShowDeletedStatus', '', { type: 'string', group: 'Message' }
 	RocketChat.settings.add 'Message_KeepStatusHistory', '', { type: 'string', group: 'Message' }
+	RocketChat.settings.add 'Message_MaxAllowedSize', 500, { type: 'int', group: 'Message', public: true }
 
 	RocketChat.settings.addGroup 'Meta'
 	RocketChat.settings.add 'Meta:language', '', { type: 'string', group: 'Meta' }


### PR DESCRIPTION
This fixes #38

- introduce Message_MaxAllowedSize setting that defaults to 500
- set max-length attribute on the message textarea equal to Message_MaxAllowedSize
- do not send messages with size >  Message_MaxAllowedSize