### PR TITLE
Fix RocketChat/Rocket.Chat#412.  Hide button when user views their profile in a private group or channel's member section.

### DIFF
--- a/client/views/app/room.coffee
+++ b/client/views/app/room.coffee
@@ -148,6 +148,9 @@ Template.room.helpers
 		return '' unless roomData
 		return roomData.u?._id is Meteor.userId() and roomData.t in ['c', 'p']
 
+	canDirectMessage: ->
+		return Meteor.user().username isnt this.username
+
 	roomNameEdit: ->
 		return Session.get('roomData' + this._id)?.name
 

--- a/client/views/app/room.html
+++ b/client/views/app/room.html
@@ -153,7 +153,9 @@
 								</div>
 								<nav>
 									<button class='button secondary back'><span>{{_ "View_All"}} <i class='icon-angle-right'></i></span></button>
+									{{#if canDirectMessage}}
 									<button class='button pvt-msg'><span><i class='icon-chat'></i> {{_ "Conversation"}}</span></button>
+									{{/if}}
 								</nav>
 							{{/with}}
 						</div>


### PR DESCRIPTION
The conversation button is currently visible, but doesn't work because
the user can't start a direct message with themself.  This change hides
the button only when viewing their own profile.