### PR TITLE
User left message token replacement not working

### DIFF
--- a/client/views/app/message.coffee
+++ b/client/views/app/message.coffee
@@ -19,9 +19,9 @@ Template.message.helpers
 			when 'r'  then t('Room_name_changed', { room_name: this.msg, user_by: this.u.username })
 			when 'au' then t('User_added_by', { user_added: this.msg, user_by: this.u.username })
 			when 'ru' then t('User_removed_by', { user_removed: this.msg, user_by: this.u.username })
-			when 'ul' then tr('User_left', { context: this.u.gender }, { user_left: this.u.username })
+			when 'ul' then t('User_left', { user_left: this.u.username })
 			when 'nu' then t('User_added', { user_added: this.u.username })
-			when 'uj' then tr('User_joined_channel', { context: this.u.gender }, { user: this.u.username })
+			when 'uj' then t('User_joined_channel', { user: this.u.username })
 			when 'wm' then t('Welcome', { user: this.u.username })
 			when 'rtc' then RocketChat.callbacks.run 'renderRtcMessage', this
 			else


### PR DESCRIPTION
Fix for #466 

Replaces gender specific translation with non-gender translation.

Grammatical gender change from 6329d071180bccf86586c5627cb8bc06bf231c39
references 'gender' message field.  If field doesn't exist, then
username is not replaced.

Gender specific messages don't seem to be implemented.  The
6329d071180bccf86586c5627cb8bc06bf231c39 commit hardcoded "male" value
in other places that used gender specific translation.

Replaced gender specific translation with non-gender specific translation, and
removed gender option.

