### PR TITLE
Fix search not coming up

### DIFF
--- a/client/views/main.coffee
+++ b/client/views/main.coffee
@@ -1,6 +1,6 @@
 Template.body.onRendered ->
 	$(document.body).on 'keydown', (e) ->
-		if e.keyCode is 80 and e.ctrlKey is true
+		if e.keyCode is 80 and (e.ctrlKey is true or e.metaKey is true)
 			e.preventDefault()
 			e.stopPropagation()
 			spotlight.show()

--- a/client/views/main.coffee
+++ b/client/views/main.coffee
@@ -1,6 +1,6 @@
 Template.body.onRendered ->
 	$(document.body).on 'keydown', (e) ->
-		if e.keyCode is 80 and e.metaKey is true
+		if e.keyCode is 80 and e.ctrlKey is true
 			e.preventDefault()
 			e.stopPropagation()
 			spotlight.show()


### PR DESCRIPTION
This fixes #531

Tested this on mac / windows / linux.  Super + p on windows and linux is a no go.  

On the gnome display environment in linux it actually is bound to changing between mirrored and extended for your monitors.