### PR TITLE
Fixes #547 where editing channel/group name crashed RoomManager

### DIFF
--- a/client/lib/RoomHistoryManager.coffee
+++ b/client/lib/RoomHistoryManager.coffee
@@ -30,10 +30,14 @@
 			ts = new Date
 
 		Meteor.call 'loadHistory', rid, ts, limit, 0, (err, result) ->
+			if err 
+				console.log err
+				return
+
 			ChatMessage.insert item for item in result
 			room.isLoading.set false
 			room.loaded += result.length
-			if result.length < limit
+			if result?.length < limit
 				room.hasMore.set false
 
 	hasMore = (rid) ->

--- a/client/routes/roomRoute.coffee
+++ b/client/routes/roomRoute.coffee
@@ -24,6 +24,8 @@ openRoom = (type, name) ->
 				FlowRouter.go 'home'
 				return
 
+			RoomManager.refreshDomOfRoom(type + name, room._id)
+			###
 			mainNode = document.querySelector('.main-content')
 			if mainNode?
 				for child in mainNode.children
@@ -33,6 +35,7 @@ openRoom = (type, name) ->
 				if roomDom.classList.contains('room-container')
 					roomDom.querySelector('.messages-box > .wrapper').scrollTop = roomDom.oldScrollTop
 
+			###
 			Session.set 'openedRoom', room._id
 
 			Session.set 'editRoomTitle', false
@@ -44,8 +47,9 @@ openRoom = (type, name) ->
 					$('.message-form .input-message').focus()
 				, 100
 
-
 roomExit = ->
+	RoomManager.removeDomOfRoom()
+	###
 	mainNode = document.querySelector('.main-content')
 	if mainNode?
 		for child in mainNode.children
@@ -53,6 +57,7 @@ roomExit = ->
 				if child.classList.contains('room-container')
 					child.oldScrollTop = child.querySelector('.messages-box > .wrapper').scrollTop
 				mainNode.removeChild child
+	###
 
 
 FlowRouter.route '/channel/:name',

--- a/client/startup/roomObserve.coffee
+++ b/client/startup/roomObserve.coffee
@@ -2,7 +2,33 @@ Meteor.startup ->
 	ChatRoom.find().observe
 		added: (data) ->
 			Session.set('roomData' + data._id, data)
-		changed: (data) ->
-			Session.set('roomData' + data._id, data)
+		changed: (newData, oldData) ->
+			handleRoomNameChanged( newData, oldData)
+			Session.set('roomData' + newData._id, null)
+			Session.set('roomData' + newData._id, newData)
 		removed: (data) ->
 			Session.set('roomData' + data._id, undefined)
+
+handleRoomNameChanged = (newData, oldData) ->
+	if newData.t in ['p','c'] and newData.name isnt oldData.name
+		oldTypeName = oldData.t + oldData.name
+		RoomManager.remove oldTypeName
+		openedRoom = Session.get('openedRoom')
+		if openedRoom is newData._id
+			newTypeName = newData.t + newData.name
+			Tracker.autorun (c) ->
+				if RoomManager.open(newTypeName).ready() isnt true
+					return
+				c.stop()
+				RoomManager.removeDomOfRoom()
+				RoomManager.refreshDomOfRoom( newTypeName, newData._id )
+				Session.set 'openedRoom', newData._id
+				Session.set 'editRoomTitle', false
+				Meteor.call 'readMessages', newData._id if Meteor.userId()?
+				# KonchatNotification.removeRoomNotification(params._id)
+
+				if Meteor.Device.isDesktop()
+					setTimeout ->
+						$('.message-form .input-message').focus()
+					, 100	
+


### PR DESCRIPTION
Adds code that observes room name changes, closes the old room, and
opens the new room via the RoomManager.  There is still a small bug
where the room name changed message is not displayed to the user who changed
the name probably due to the message stream subscribing after the message was sent.