### PR TITLE
Feature/sharesecret #268

### DIFF
--- a/packages/rocketchat-sharedsecret/package.js
+++ b/packages/rocketchat-sharedsecret/package.js
@@ -1,0 +1,21 @@
+Package.describe({
+	name: 'rocketchat:sharedsecret',
+	version: '0.0.1',
+	summary: 'RocketChat libraries',
+	git: ''
+});
+
+Package.onUse(function(api) {
+	api.versionsFrom('1.0');
+
+	api.use([
+		'coffeescript',
+		'rocketchat:lib@0.0.1'
+	]);
+
+	api.use(['jparker:crypto-aes'], ['server','client']);
+
+	api.addFiles('sharedsecret.coffee', ['server','client']);
+});
+
+Package.onTest(function(api) {});

--- a/packages/rocketchat-sharedsecret/sharedsecret.coffee
+++ b/packages/rocketchat-sharedsecret/sharedsecret.coffee
@@ -1,0 +1,82 @@
+SharedSecret = []
+
+if (Meteor.isServer)
+	class EncryptMessage
+		constructor: (message) ->
+			currentUser = Meteor.user()._id
+			currentRoomId = message.rid
+
+			if(SharedSecret? && SharedSecret[currentUser]? && SharedSecret[currentUser][currentRoomId]?)
+				currentSecret = SharedSecret[currentUser][currentRoomId]
+				encrypted = CryptoJS.AES.encrypt(message.msg, currentSecret)
+				message.msg = encrypted.toString()
+
+				#urls
+				if(message.urls)
+					for urls in message.urls
+						urls.url = CryptoJS.AES.encrypt(urls.url, currentSecret).toString()
+
+				message.encrypted = true
+
+			return message
+
+	class HandleSlashCommand
+		constructor: (command, params, item) ->
+			if(command == "setsecretkey")
+				currentUser = Meteor.user()._id
+				currentRoomId = item.rid
+				secret = params
+
+				if(secret == "off")
+					secret = null
+
+				if(SharedSecret[currentUser]?)
+					SharedSecret[currentUser][currentRoomId] = secret
+				else
+					SharedSecret[currentUser] = []
+					SharedSecret[currentUser][currentRoomId] = secret
+
+	RocketChat.callbacks.add 'beforeSaveMessage', EncryptMessage, 9999 #LAST
+	RocketChat.slashCommands.add 'setsecretkey', HandleSlashCommand
+
+if (Meteor.isClient)
+	class DecryptMessage
+		constructor: (message) ->
+			if(message.encrypted)
+				currentRoomId = message.rid
+				currentSecret = localStorage.getItem("rocket.chat.sharedSecretKey.#{currentRoomId}")
+
+				if(currentSecret?)
+					decrypted = CryptoJS.AES.decrypt(message.msg, currentSecret).toString(CryptoJS.enc.Utf8)
+
+					if(decrypted == "")
+						message.msg = "~ encrypted message ~"
+						message.html = "~ encrypted message ~"
+					else
+						lockImage = "/images/lock8.png"
+						message.msg = "<img src=#{lockImage} style='width:8px;height:9px;'></img> " + decrypted
+						message.html = "<img src=#{lockImage} style='width:8px;height:9px;'></img> " + decrypted
+
+					#urls
+					if(message.urls)
+						for urls in message.urls
+							urls.url = CryptoJS.AES.decrypt(urls.url, currentSecret).toString(CryptoJS.enc.Utf8)
+				else
+					message.msg = "~ encrypted message ~"
+					message.html = "~ encrypted message ~"
+
+			return message
+
+	class HandleSlashCommand
+		constructor: (command, params, item) ->
+			if(command == "setsecretkey")
+				secret = params
+				if(secret == "off")
+					secret = null
+				currentRoomId = item.rid
+				localStorage.setItem("rocket.chat.sharedSecretKey.#{currentRoomId}", secret)
+
+
+
+	RocketChat.callbacks.add 'renderMessage', DecryptMessage, -9999 #FIRST
+	RocketChat.slashCommands.add 'setsecretkey', HandleSlashCommand


### PR DESCRIPTION
See issue #268

Note that this plugin was always intended to do both encryption and decryption on the client.

The current implementation does encryption on the server, and uses a temporary server-side key storage which means a user has to set the shared secret every time they open the client and enter a room. If the server restarts all keys are lost and have to be entered again.

This means the data is encrypted at rest, but can be intercepted by anyone who has access to the server. To offer proper confidentiality of message contents you would have to move the encryption to the client.