### PR TITLE
Added /leave and alternate /part

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -38,6 +38,7 @@ rocketchat:me
 rocketchat:mentions
 rocketchat:oembed
 rocketchat:slashcommands-invite
+rocketchat:slashcommands-leave
 rocketchat:statistics
 rocketchat:webrtc
 #rocketchat:external

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -116,6 +116,7 @@ rocketchat:me@0.0.1
 rocketchat:mentions@0.0.1
 rocketchat:oembed@0.0.1
 rocketchat:slashcommands-invite@0.0.1
+rocketchat:slashcommands-leave@0.0.1
 rocketchat:statistics@0.0.1
 rocketchat:webrtc@0.0.1
 routepolicy@1.0.5

--- a/packages/meteor-accounts-saml/.npm/package/npm-shrinkwrap.json
+++ b/packages/meteor-accounts-saml/.npm/package/npm-shrinkwrap.json
@@ -54,9 +54,6 @@
     "xml-crypto": {
       "version": "0.6.0",
       "dependencies": {
-        "xmldom": {
-          "version": "0.1.19"
-        },
         "xpath.js": {
           "version": "1.0.6"
         }

--- a/packages/rocketchat-slashcommands-leave/leave.coffee
+++ b/packages/rocketchat-slashcommands-leave/leave.coffee
@@ -1,0 +1,21 @@
+###
+# Leave is a named function that will replace /leave commands
+# @param {Object} message - The message object
+###
+
+if Meteor.isClient
+	RocketChat.slashCommands.add 'leave', undefined,
+		description: 'Leave the current channel'
+		params: ''
+
+	RocketChat.slashCommands.add 'part', undefined,
+		description: 'Leave the current channel'
+		params: ''
+else
+	class Leave
+		constructor: (command, params, item) ->
+			if(command == "leave" || command == "part")
+				Meteor.call 'leaveRoom', item.rid
+
+	RocketChat.slashCommands.add 'leave', Leave
+	RocketChat.slashCommands.add 'part', Leave

--- a/packages/rocketchat-slashcommands-leave/package.js
+++ b/packages/rocketchat-slashcommands-leave/package.js
@@ -1,0 +1,20 @@
+Package.describe({
+	name: 'rocketchat:slashcommands-leave',
+	version: '0.0.1',
+	summary: 'Message pre-processor that will translate /leave commands',
+	git: ''
+});
+
+Package.onUse(function(api) {
+	api.versionsFrom('1.0');
+
+	api.use([
+		'coffeescript',
+		'rocketchat:lib@0.0.1'
+	]);
+	api.addFiles('leave.coffee');
+});
+
+Package.onTest(function(api) {
+
+});


### PR DESCRIPTION
Lets try this again.  Now this includes just the slashcommand-leave package.  Kick will be done seperately. 

Looks like two copies of xmldom were in npm-shrinkwrap.json and meteor decided one didn't belong.