### PR TITLE
Improves styling for code.inline runs

### DIFF
--- a/client/stylesheets/base.less
+++ b/client/stylesheets/base.less
@@ -50,10 +50,10 @@ code {
 	text-align: left;
 	white-space: pre-wrap;
 	&.inline {
-		display: inline-block;
-		padding: 0 5px;
-		margin: 0;
-		line-height: 16px;
+		display: inline;
+		padding: 0 0.5em;
+		margin: 0 0.1em;
+		font-family: monospace;
 	}
 }
 


### PR DESCRIPTION
I'm guessing there was some sort of regression which went uncaught, because it's hard to see how/why this was the intended behavior:

![before](https://cloud.githubusercontent.com/assets/542223/9664793/f7705e58-5220-11e5-93d7-c66b19bf66af.png)

But with this change, we now have:

![after](http://i.imgur.com/ucjD1i1.png)

---

Screenshots come from Chrome 45.0.2454.85 on Linux