### PR TITLE
fix problem of saving int typed setting #701

### DIFF
--- a/client/views/admin/admin.coffee
+++ b/client/views/admin/admin.coffee
@@ -48,6 +48,8 @@ Template.admin.events
 			value = null
 			if setting.type is 'string'
 				value = _.trim(t.$("[name=#{setting._id}]").val())
+			else if setting.type is 'int'
+				value = parseInt(_.trim(t.$("[name=#{setting._id}]").val()))
 			else if setting.type is 'boolean' and t.$("[name=#{setting._id}]:checked").length
 				value = if t.$("[name=#{setting._id}]:checked").val() is "1" then true else false
 


### PR DESCRIPTION
should fix it.  spin button on UI ensures only int data is incoming - no need to validate again.

closes #701 

pls merge and push 2 demo, need for ongoing bot testing