### PR TITLE
fix nav-bar footer covered by flex-nav

### DIFF
--- a/client/stylesheets/base.less
+++ b/client/stylesheets/base.less
@@ -1339,7 +1339,7 @@ a.github-fork {
 		left: 0;
 		width: 100%;
 		padding: 10px 15px 0px 15px;
-		z-index: 120;
+		z-index: 1000;
 		text-align: right;
 		min-height: @footer-min-height;
 		height: @footer-min-height;


### PR DESCRIPTION
when opening `My Account` or `Administration`, link in nav-bar footer no longer clickable