### PR TITLE
Allow invalid ssl certs.  IE self signed on oembed fetch

### DIFF
--- a/packages/rocketchat-oembed/server/server.coffee
+++ b/packages/rocketchat-oembed/server/server.coffee
@@ -15,6 +15,7 @@ getUrlContent = (urlObj, redirectCount = 5, callback) ->
 		port: urlObj.port
 		hostname: urlObj.hostname
 		path: urlObj.path
+		rejectUnauthorized: false
 
 	httpOrHttps = if urlObj.protocol is 'https:' then https else http
 


### PR DESCRIPTION
Reference issue: #727

I think also an issue being had where uploads aren't showing previews when behind nginx with ssl.