### PR TITLE
Fixing misaligned boxes + Fix for dropdown menu appearing in front of username box

### DIFF
--- a/client/stylesheets/base.less
+++ b/client/stylesheets/base.less
@@ -2366,7 +2366,6 @@ a.github-fork {
 			position: absolute;
 			top: -20px;
 			left: 0;
-			width: 100%;
 			border-top: 1px solid;
 			width: 96%;
 			margin-left: 2%;

--- a/client/stylesheets/base.less
+++ b/client/stylesheets/base.less
@@ -938,6 +938,7 @@ a.github-fork {
 		position: relative;
 		height: 100%;
 		padding: 10px 0px 10px 18px;
+		z-index:100;
 		.thumb {
 			float: left;
 			height: 100%;
@@ -1012,6 +1013,8 @@ a.github-fork {
 		direction: rtl;
 		.calc(height, ~'100% - ' @header-min-height + @footer-min-height);
 		.transition(transform .3s cubic-bezier(.5, 0, .1, 1));
+		z-index:99;
+		
 		&._hidden {
 			.transform(translateY(-100%) translateY(-50px));
 		}
@@ -1583,7 +1586,7 @@ a.github-fork {
 	top: 0;
 	left: 0;
 	width: 100%;
-	height: @header-min-height;
+	height: @header-min-height+1px;
 	&.visible {
 		h2 {
 			overflow: visible;
@@ -2037,7 +2040,7 @@ a.github-fork {
 	}
 	.footer {
 		position: absolute;
-		padding: 10px 20px 0px 20px;
+		padding: 8px 20px 0px 20px;
 		border-top: 1px solid;
 		z-index: 100;
 		bottom: 0;
@@ -2110,6 +2113,8 @@ a.github-fork {
 			}
 			> .file {
 				width: 44px;
+				height: 38px;
+				margin: 1px 0 0 0;
 				font-size: 22px;
 				padding: 6px 0;
 				text-align: center;
@@ -2118,6 +2123,7 @@ a.github-fork {
 				border-right: none;
 				cursor: pointer;
 				.transition(background-color 0.1s linear, color 0.1s linear);
+				
 				&:hover {
 				}
 
@@ -2349,8 +2355,7 @@ a.github-fork {
 			font-size: 12px;
 			font-weight: 600;
 			text-align: center;
-			.calc(left,
-			~"50% - 70px");
+			.calc(left,~"50% - 70px");
 			z-index: 10;
 			padding: 0 10px;
 			min-width: 140px;
@@ -2363,6 +2368,8 @@ a.github-fork {
 			left: 0;
 			width: 100%;
 			border-top: 1px solid;
+			width: 96%;
+			margin-left: 2%;
 		}
 	}
 	.edit-message {

--- a/client/stylesheets/utils/_colors.import.less
+++ b/client/stylesheets/utils/_colors.import.less
@@ -328,6 +328,7 @@ a.github-fork {
 
 .account-box {
 	.info {
+		background-color:@primary-background-color;
 		h4 {
 			color: rgba(255, 255, 255, 0.65);
 		}


### PR DESCRIPTION
Except dropdown menu, all others are small fixes.
Images show more than words now.

#### Misaligned Boxes

Date before
![date-before](https://cloud.githubusercontent.com/assets/37474/9836486/9649bd20-59f2-11e5-92b1-399dd11e3c5e.PNG)

Date after
![date-after](https://cloud.githubusercontent.com/assets/37474/9836488/9e2238c4-59f2-11e5-8dd2-725f2b6bd3d6.PNG)

--

Top Line before
![fixed_top-before](https://cloud.githubusercontent.com/assets/37474/9836507/0dc94d48-59f3-11e5-804d-99346b21aeb1.PNG)

Top Line after
![fixed_top-after](https://cloud.githubusercontent.com/assets/37474/9836508/15a57488-59f3-11e5-85e8-b7cb3169fa90.PNG)

--

Bottom box and attachment box before
![misaligned_bottom-before](https://cloud.githubusercontent.com/assets/37474/9836517/65a1ba1e-59f3-11e5-9a13-5893a843a21e.png)

Bottom box and attachment box after
![misaligned_bottom-after](https://cloud.githubusercontent.com/assets/37474/9836520/74337eb4-59f3-11e5-83ab-d1492ad4892c.png)

--

#### Dropdown Menu 
I remeber something talkling about this, but i don't find the issue.

Before:
![menu-before](https://cloud.githubusercontent.com/assets/37474/9836525/a22e79c2-59f3-11e5-840c-70f8f3e457c9.gif)

After:
![menu-after](https://cloud.githubusercontent.com/assets/37474/9836527/a8fd25a0-59f3-11e5-9a15-99ddc58ea387.gif)


