### PR TITLE
Add the join command

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -38,6 +38,7 @@ rocketchat:me
 rocketchat:mentions
 rocketchat:oembed
 rocketchat:slashcommands-invite
+rocketchat:slashcommands-join
 rocketchat:slashcommands-leave
 rocketchat:statistics
 rocketchat:webrtc

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -116,6 +116,7 @@ rocketchat:me@0.0.1
 rocketchat:mentions@0.0.1
 rocketchat:oembed@0.0.1
 rocketchat:slashcommands-invite@0.0.1
+rocketchat:slashcommands-join@0.0.1
 rocketchat:slashcommands-leave@0.0.1
 rocketchat:statistics@0.0.1
 rocketchat:webrtc@0.0.1

--- a/packages/rocketchat-slashcommands-join/join.coffee
+++ b/packages/rocketchat-slashcommands-join/join.coffee
@@ -1,0 +1,30 @@
+###
+# Join is a named function that will replace /join commands
+# @param {Object} message - The message object
+###
+
+if Meteor.isClient
+	RocketChat.slashCommands.add 'join', undefined,
+		description: 'Join the given channel'
+		params: '#channel'
+else
+	class Join
+		constructor: (command, params) ->
+			if command isnt 'join' or not Match.test params, String
+				return
+
+			channel = params.trim()
+			if channel is ''
+				return
+
+			channel = channel.replace('#', '')
+
+			user = Meteor.users.findOne Meteor.userId()
+			room = ChatRoom.findOne({ name: channel, t: 'c', usernames: { $nin: [ user.username ]} })
+
+			if not room?
+				return
+
+			Meteor.call 'joinRoom', room._id
+
+	RocketChat.slashCommands.add 'join', Join

--- a/packages/rocketchat-slashcommands-join/package.js
+++ b/packages/rocketchat-slashcommands-join/package.js
@@ -1,0 +1,22 @@
+Package.describe({
+	name: 'rocketchat:slashcommands-join',
+	version: '0.0.1',
+	summary: 'Command handler for the /join command',
+	git: ''
+});
+
+Package.onUse(function(api) {
+	api.versionsFrom('1.0');
+
+	api.use([
+		'coffeescript',
+		'check',
+		'rocketchat:lib@0.0.1'
+	]);
+
+	api.addFiles('join.coffee');
+});
+
+Package.onTest(function(api) {
+
+});


### PR DESCRIPTION
This adds the `/join` command, allowing a user to type `/join #test` to join the test channel if they haven't already joined it.

Couple of notes:
* The channels listed when you start typing `#` are ones you've joined, so it feels pointless at the moment
* There is no error message if you type a channel you're already part of

Those two things should probably be discussed on another issue to determine how they should be handled.