### PR TITLE
Allow to send a temp message to one user to one room

### DIFF
--- a/client/lib/RoomManager.coffee
+++ b/client/lib/RoomManager.coffee
@@ -34,6 +34,13 @@ onDeleteMessageStream = (msg) ->
 	ChatMessage.remove _id: msg._id
 
 
+RocketChat.Notifications.onUser 'message', (msg) ->
+	msg.u =
+		username: 'rocketbot'
+
+	ChatMessage.upsert { _id: msg._id }, msg
+
+
 @RoomManager = new class
 	defaultTime = 600000 # 10 minutes
 	openedRooms = {}


### PR DESCRIPTION
Allow send a message to one user via the notification system, this message is temporary and go away when user lost the data on minimongo.

From **server** to **client**
```javascript
RocketChat.Notifications.notifyUser('UserID', 'message', messageObject);
```

Example:
```javascript
RocketChat.Notifications.notifyUser('MZiFvWAfF4RF4AD5u', 'message', {
	_id: Random.id(),
	rid: 'GENERAL',
	ts: new Date,
	msg: 'user/client only message'
});
```