### PR TITLE
Avoid turning hashtags clickable if not related to channels

### DIFF
--- a/packages/rocketchat-mentions/client.coffee
+++ b/packages/rocketchat-mentions/client.coffee
@@ -39,6 +39,9 @@ class MentionsClient
 				channels = _.unique channels
 				channels = channels.join('|')
 				msg = msg.replace new RegExp("(?:^|\\s|\\n)(#(#{channels}))\\b", 'g'), (match, mention, channel) ->
+					if not message.temp?
+						if not _.findWhere(message.channels, {name: channel})?
+							return match
 					return match.replace mention, "<a href=\"\" class=\"mention-link\" data-channel=\"#{channel}\">#{mention}</a>"
 
 

--- a/packages/rocketchat-mentions/server.coffee
+++ b/packages/rocketchat-mentions/server.coffee
@@ -23,6 +23,20 @@ class MentionsServer
 				verifiedMentions.push verifiedMention if verifiedMention?
 			if verifiedMentions.length isnt 0
 				message.mentions = verifiedMentions
+
+		channels = []
+		message.msg.replace /(?:^|\s|\n)(?:#)([A-Za-z0-9-_.]+)/g, (match, mention) ->
+			channels.push mention
+
+		if channels.length isnt 0
+			channels = _.unique channels
+			verifiedChannels = []
+			channels.forEach (mention) ->
+				verifiedChannel = ChatRoom.findOne({ name: mention, t: 'c' }, { fields: {_id: 1, name: 1 } })
+				verifiedChannels.push verifiedChannel if verifiedChannel?
+
+			if verifiedChannels.length isnt 0
+				message.channels = verifiedChannels
 		return message
 
 RocketChat.callbacks.add 'beforeSaveMessage', MentionsServer


### PR DESCRIPTION
Prevents turning hashtags into channel links if there are no such channel (should close #807)
![git_hashes](https://cloud.githubusercontent.com/assets/190883/9890568/10238442-5bd7-11e5-9268-9872a9cababe.gif)
