### PR TITLE
Fix issue where the first inserted user is not assigned the 'admin' role

### DIFF
--- a/server/lib/accounts.coffee
+++ b/server/lib/accounts.coffee
@@ -51,7 +51,8 @@ Accounts.insertUserDoc = _.wrap Accounts.insertUserDoc, (insertUserDoc) ->
 	_id = insertUserDoc(options, user)
 
 	# when inserting first user give them admin privileges otherwise make a regular user
-	roleName = if Meteor.users.findOne() then 'user' else 'admin'
+	firstUser = Meteor.users.findOne({},{sort:{createdAt:1}})
+	roleName = if firstUser?._id is _id then 'admin' else 'user'
 	
 	RocketChat.authz.addUsersToRoles(_id, roleName)
 	RocketChat.callbacks.run 'afterCreateUser', options, user


### PR DESCRIPTION
Modifies admin role assignment to check if the inserted user is the
first user based on sorted query using "createdAt".

Originally, the admin role assignment was done onCreateUser before
the user record was inserted into the db.  It assigned the 'admin' role
to a user if no other user existed in the db.  However, with the change
to insertUserDoc, the 'admin' assignment is done AFTER the first user
is inserted and the original query logic (check if any user exists) no
longer applies