### PR TITLE
Modified find for autocomplete to show usernames that begin your input

### DIFF
--- a/client/views/app/messagePopupConfig.coffee
+++ b/client/views/app/messagePopupConfig.coffee
@@ -11,7 +11,7 @@ Template.messagePopupConfig.helpers
 			getInput: self.getInput
 			textFilterDelay: 200
 			getFilter: (collection, filter) ->
-				exp = new RegExp(filter, 'i')
+				exp = new RegExp("^#{filter}", 'i')
 				Meteor.subscribe 'onlineUsers', filter
 				items = onlineUsers.find({$or: [{name: exp}, {username: exp}]}, {limit: 5}).fetch()
 
@@ -25,7 +25,6 @@ Template.messagePopupConfig.helpers
 				exp = new RegExp("(^|\\s)#{filter}", 'i')
 				if exp.test(all.username) or exp.test(all.compatibility)
 					items.unshift all
-
 				return items
 
 			getValue: (_id, collection, firstPartValue) ->

--- a/client/views/app/messagePopupConfig.coffee
+++ b/client/views/app/messagePopupConfig.coffee
@@ -13,7 +13,7 @@ Template.messagePopupConfig.helpers
 			getFilter: (collection, filter) ->
 				exp = new RegExp("^#{filter}", 'i')
 				Meteor.subscribe 'onlineUsers', filter
-				items = onlineUsers.find({$or: [{name: exp}, {username: exp}]}, {limit: 5}).fetch()
+				items = onlineUsers.find({$or: [{username: exp}, {name: exp}]}, {limit: 5}).fetch()
 
 				all =
 					_id: '@all'


### PR DESCRIPTION
Currently the situation is something like this:

![image](https://cloud.githubusercontent.com/assets/51996/10000522/49e2d7a2-6062-11e5-899a-ee4e194adb64.png)

That first user should not be even displayed. If i'm typing @ something.  I would expect it to only match beginning with what i've typed.  Otherwise its more of a search then a completion.