### PR TITLE
Changed internal bot to only listen on public rooms

### DIFF
--- a/packages/rocketchat-hubot/hubot.coffee
+++ b/packages/rocketchat-hubot/hubot.coffee
@@ -135,11 +135,15 @@ class RocketChatAdapter extends Hubot.Adapter
 
 class RocketBotReceiver
 	constructor: (message) ->
-		console.log message
+		#console.log message
 		if message.u.username isnt RocketBot.name
-			RocketBotUser = new Hubot.User(message.u.username, room: message.rid)
-			RocketBotTextMessage = new Hubot.TextMessage(RocketBotUser, message.msg, message._id)
-			RocketBot.adapter.receive RocketBotTextMessage
+			room = RocketChat.models.Rooms.findOneById message.rid
+
+			if room.t is 'c'
+				console.log message
+				RocketBotUser = new Hubot.User(message.u.username, room: message.rid)
+				RocketBotTextMessage = new Hubot.TextMessage(RocketBotUser, message.msg, message._id)
+				RocketBot.adapter.receive RocketBotTextMessage
 		return message
 
 class HubotScripts


### PR DESCRIPTION
this will close #895

Currently the bot listens in every room.  When having a private conversation its really annoying to have the bot pop in.  Could probably be limited further.  But this to me is a great start.