### PR TITLE
Fix #911.  Set MAIL_URL variable after Meteor.startup

### DIFF
--- a/packages/rocketchat-lib/settings/server/startup.coffee
+++ b/packages/rocketchat-lib/settings/server/startup.coffee
@@ -94,7 +94,8 @@ RocketChat.settings.add 'Layout_Login_Terms', 'By proceeding to create your acco
 
 RocketChat.settings.add 'Statistics_opt_out', false, { type: 'boolean', group: false }
 
-if process?.env? and not process.env['MAIL_URL']? and RocketChat.settings.get('SMTP_Host') and RocketChat.settings.get('SMTP_Username') and RocketChat.settings.get('SMTP_Password')
-	process.env['MAIL_URL'] = "smtp://" + encodeURIComponent(RocketChat.settings.get('SMTP_Username')) + ':' + encodeURIComponent(RocketChat.settings.get('SMTP_Password')) + '@' + encodeURIComponent(RocketChat.settings.get('SMTP_Host'))
-	if RocketChat.settings.get('SMTP_Port')
-		process.env['MAIL_URL'] += ':' + parseInt(RocketChat.settings.get('SMTP_Port'))
+Meteor.startup ->
+	if process?.env? and not process.env['MAIL_URL']? and RocketChat.settings.get('SMTP_Host') and RocketChat.settings.get('SMTP_Username') and RocketChat.settings.get('SMTP_Password')
+		process.env['MAIL_URL'] = "smtp://" + encodeURIComponent(RocketChat.settings.get('SMTP_Username')) + ':' + encodeURIComponent(RocketChat.settings.get('SMTP_Password')) + '@' + encodeURIComponent(RocketChat.settings.get('SMTP_Host'))
+		if RocketChat.settings.get('SMTP_Port')
+			process.env['MAIL_URL'] += ':' + parseInt(RocketChat.settings.get('SMTP_Port'))


### PR DESCRIPTION
Set environment value after RocketChat.settings have been initialized.

RocketChat settings are loaded ASAP as of 39fe1365b58638e0fa9e66ade8c1705b05ea3692
RocketChat.settings depends on Meteor.settings under the covers, but Meteor.settings
 doesn't seem to return values until Meteor is fully started.  Thus, we
can only call RocketChat.settings.get after Meteor.startup