### PR TITLE
Fix #911 where emails not sent.

### DIFF
--- a/packages/rocketchat-lib/server/models/Users.coffee
+++ b/packages/rocketchat-lib/server/models/Users.coffee
@@ -15,7 +15,7 @@ RocketChat.models.Users = new class extends RocketChat.models._Base
 
 	findOneByEmailAddress: (emailAddress, options) ->
 		query =
-			'email.address': emailAddress
+			'emails.address': emailAddress
 
 		return @findOne query, options
 


### PR DESCRIPTION
RocketChat.models.Users findOneByEmailAddress had a typo in the query field.  The
following use cases are fixed:
1. sendConfirmationEmail
2. sendForgotPasswordEmail
3. lookup existing admin by email when initializing RocketChat at
startup