### PR TITLE
disable rendering media links/syntaxes inside literals

### DIFF
--- a/packages/rocketchat-autolinker/autolinker.coffee
+++ b/packages/rocketchat-autolinker/autolinker.coffee
@@ -7,19 +7,20 @@ class AutoLinker
 	constructor: (message) ->
 		if _.trim message.html
 			# Separate text in code blocks and non code blocks
-			msgParts = message.html.split(/(```\w*[\n\ ]?[\s\S]*?```+?)/)
+			msgParts = message.html.split /(```\w*[\n ]?[\s\S]*?```+?)|(`(?:[^`]+)`)/
 
 			for part, index in msgParts
-				# Verify if this part is code
-				codeMatch = part.match(/```(\w*)[\n\ ]?([\s\S]*?)```+?/)
-				if not codeMatch?
-					msgParts[index] = Autolinker.link part,
-						stripPrefix: false
-						twitter: false
-						replaceFn: (autolinker, match) ->
-							if match.getType() is 'url'
-								return /(:\/\/|www\.).+/.test match.matchedText
-							return true
+				if part?.length? > 0
+					# Verify if this part is code
+					codeMatch = part.match /(?:```(\w*)[\n ]?([\s\S]*?)```+?)|(?:`(?:[^`]+)`)/
+					if not codeMatch?
+						msgParts[index] = Autolinker.link part,
+							stripPrefix: false
+							twitter: false
+							replaceFn: (autolinker, match) ->
+								if match.getType() is 'url'
+									return /(:\/\/|www\.).+/.test match.matchedText
+								return true
 
 			# Re-mount message
 			message.html = msgParts.join('')

--- a/packages/rocketchat-spotify/spotify.coffee
+++ b/packages/rocketchat-spotify/spotify.coffee
@@ -7,13 +7,14 @@ class Spotify
 	process = (message, source, callback) ->
 		if _.trim source
 			# Separate text in code blocks and non code blocks
-			msgParts = source.split(/(```\w*[\n\ ]?[\s\S]*?```+?)/)
+			msgParts = source.split /(```\w*[\n ]?[\s\S]*?```+?)|(`(?:[^`]+)`)/
 
 			for part, index in msgParts
 				# Verify if this part is code
-				codeMatch = part.match(/```(\w*)[\n\ ]?([\s\S]*?)```+?/)
-				if not codeMatch?
-					callback message, msgParts, index, part
+				if part?.length? > 0
+					codeMatch = part.match /(?:```(\w*)[\n ]?([\s\S]*?)```+?)|(?:`(?:[^`]+)`)/
+					if not codeMatch?
+						callback message, msgParts, index, part
 
 	@transform: (message) ->
 		urls = []
@@ -46,8 +47,7 @@ class Spotify
 					if item.source
 						quotedSource = item.source.replace /[\\^$.*+?()[\]{}|]/g, '\\$&'
 						re = new RegExp '(^|\\s)' + quotedSource + '(\\s|$)', 'g'
-						part = part.replace re, '$1<a href="' + item.url + '" target="_blank">' + item.source + '</a>$2'
-				msgParts[index] = part
+						msgParts[index] = part.replace re, '$1<a href="' + item.url + '" target="_blank">' + item.source + '</a>$2'
 				message.html = msgParts.join ''
 
 		return message


### PR DESCRIPTION
Actual behavior

![screen shot 2015-09-29 at 18 54 02](https://cloud.githubusercontent.com/assets/275609/10171665/7fbdf954-66db-11e5-98d3-c0a3aa864b75.png)

(Spotify is not installed on current demo)

As you can see links for media are rendered even inside `` `literal` `` markdown syntax.

Result

![screen shot 2015-09-29 at 18 51 39](https://cloud.githubusercontent.com/assets/275609/10171723/cafb00a6-66db-11e5-8557-c33ffd66ef30.png)

![screen shot 2015-09-29 at 18 52 56](https://cloud.githubusercontent.com/assets/275609/10171726/cfcd22f8-66db-11e5-9db5-8e8b86c5a801.png)
