### PR TITLE
Fix cross-origin issue that happens on chrome on windows

### DIFF
--- a/client/lib/avatar.coffee
+++ b/client/lib/avatar.coffee
@@ -11,7 +11,7 @@ Blaze.registerHelper 'avatarUrlFromUsername', getAvatarUrlFromUsername
 @getAvatarAsPng = (username, cb) ->
 	image = new Image
 	image.src = getAvatarUrlFromUsername(username)
-
+	image.setAttribute('crossOrigin', 'anonymous')
 	image.onload = ->
 		canvas = document.createElement('canvas')
 		canvas.width = image.width


### PR DESCRIPTION
Uncaught SecurityError: Failed to execute 'toDataURL' on 'HTMLCanvasElement': Tainted canvases may not be exported.image.onload @ avatar.coffee:21
avatar.coffee:12 Uncaught SecurityError: Failed to execute 'toDataURL' on 'HTMLCanvasElement': Tainted canvases may not be exported.image.onload @ avatar.coffee:12