### PR TITLE
fixes cordova build after meteor 1.2 update - closes #985

### DIFF
--- a/.meteor/cordova-plugins
+++ b/.meteor/cordova-plugins
@@ -1,2 +1,2 @@
-com.ionic.keyboard@https://github.com/driftyco/ionic-plugin-keyboard.git#66926f5e25fcd71b65799adaf12fa0b2df65ce78
-com.phonegap.plugins.facebookconnect@0.11.0
+ionic-plugin-keyboard@1.0.7
+phonegap-facebook-plugin@https://github.com/Sing-Li/phonegap-facebook-plugin.git#667dda292cf70d8fb725f512cedef3fe0dd55ac3

--- a/mobile-config.js
+++ b/mobile-config.js
@@ -52,12 +52,12 @@ App.setPreference('StatusBarOverlaysWebView', false);
 App.setPreference('StatusBarStyle', 'lightcontent');
 App.setPreference('StatusBarBackgroundColor', '#000000');
 App.setPreference('ShowSplashScreenSpinner', false);
-App.setPreference('android-targetSdkVersion', '19');
+App.setPreference('android-targetSdkVersion', '22');
 App.setPreference('android-minSdkVersion', '19');
 App.accessRule('*');
 
 // Pass preferences for a particular PhoneGap/Cordova plugin
-App.configurePlugin('com.phonegap.plugins.facebookconnect', {
+App.configurePlugin('phonegap-facebook-plugin', {
 	APP_NAME: 'Rocket.Chat',
 	APP_ID: '835103589938459'
 });


### PR DESCRIPTION
Crazy complicated fix:

* cordova 5.x will now needs npm modules for plug-ins  - causing  plug-in name change
* facebook connect plugin has library conflict and is not actively tested/maintained
* formerly maintained Telerik fork of facebook connect plugin never migrated to npm modules
* pull request to fix facebook connect plugin library version conflict was never merged
* need for fork and cherry pick from another fork to create our own (for now) working branch
