### PR TITLE
Changed callback not needed

### DIFF
--- a/server/publications/messages.coffee
+++ b/server/publications/messages.coffee
@@ -31,8 +31,6 @@ Meteor.publish 'messages', (rid, start) ->
 	cursorDeleteHandle = cursorDelete.observeChanges
 		added: (_id, record) ->
 			publication.added('rocketchat_message', _id, {_hidden: true})
-		changed: (_id, record) ->
-			publication.added('rocketchat_message', _id, {_hidden: true})
 
 	@ready()
 	@onStop ->


### PR DESCRIPTION
The query is limited to `_id` only.

I must say that I do not understand this publish function. Maybe some comments should be there?

Doesn't this publish function publish ALL deleted messages ever (with only `{_hidden: true}` fields, though) for a given channel, every time user subscribes it? Because query `findInvisibleByRoomId` is not limited in any way?