### PR TITLE
Added server-side reactivity

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -100,3 +100,4 @@ random
 ejson
 spacebars
 check
+peerlibrary:reactive-publish

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -103,6 +103,11 @@ observe-sequence@1.0.7
 ordered-dict@1.0.4
 pauli:accounts-linkedin@1.1.2
 pauli:linkedin@1.1.2
+peerlibrary:assert@0.2.5
+peerlibrary:fiber-utils@0.5.1
+peerlibrary:reactive-mongo@0.1.0
+peerlibrary:reactive-publish@0.1.0
+peerlibrary:server-autorun@0.4.0
 percolate:migrations@0.9.6
 percolate:synced-cron@1.3.0
 promise@0.5.0

--- a/packages/rocketchat-authorization/server/functions/getPermissionsForRole.coffee
+++ b/packages/rocketchat-authorization/server/functions/getPermissionsForRole.coffee
@@ -6,4 +6,4 @@ RocketChat.authz.getPermissionsForRole = (roleName) ->
 	unless roleName in roleNames
 		throw new Meteor.Error 'invalid-role'
 
-	return _.pluck(RocketChat.models.Permissions.findByRole( roleName ).fetch(), '_id')
+	return _.pluck(RocketChat.models.Permissions.findByRole( roleName, fields: _id: 1 ).fetch(), '_id')

--- a/packages/rocketchat-lib/package.js
+++ b/packages/rocketchat-lib/package.js
@@ -17,6 +17,7 @@ Package.onUse(function(api) {
 	api.use('underscore');
 	api.use('underscorestring:underscore.string');
 	api.use('monbro:mongodb-mapreduce-aggregation@1.0.1');
+	api.use('peerlibrary:reactive-publish@0.1.0');
 
 	// TAPi18n
 	api.use('templating', 'client');

--- a/packages/rocketchat-lib/settings/server/publication.coffee
+++ b/packages/rocketchat-lib/settings/server/publication.coffee
@@ -17,8 +17,10 @@ Meteor.publish 'admin-settings', ->
 	unless @userId
 		return @ready()
 
-	if RocketChat.authz.hasPermission( @userId, 'view-privileged-setting')
-		return RocketChat.models.Settings.find()
-	else
-		return @ready()
+	@autorun (computation) =>
+		if RocketChat.authz.hasPermission( @userId, 'view-privileged-setting')
+			return RocketChat.models.Settings.find()
+		else
+			return @ready()
 
+	return

--- a/server/publications/adminRooms.coffee
+++ b/server/publications/adminRooms.coffee
@@ -2,32 +2,35 @@ Meteor.publish 'adminRooms', (filter, types, limit) ->
 	unless this.userId
 		return this.ready()
 
-	if RocketChat.authz.hasPermission(@userId, 'view-room-administration') isnt true
-		return this.ready()
+	@autorun (computation) =>
+		if RocketChat.authz.hasPermission(@userId, 'view-room-administration') isnt true
+			return this.ready()
 
-	unless _.isArray types
-		types = []
+		unless _.isArray types
+			types = []
 
-	options =
-		fields:
-			name: 1
-			t: 1
-			cl: 1
-			u: 1
-			usernames: 1
-		limit: limit
-		sort:
-			name: 1
+		options =
+			fields:
+				name: 1
+				t: 1
+				cl: 1
+				u: 1
+				usernames: 1
+			limit: limit
+			sort:
+				name: 1
 
-	filter = _.trim filter
+		filter = _.trim filter
 
-	console.log '[publish] adminRooms'.green, filter, types, limit
+		console.log '[publish] adminRooms'.green, filter, types, limit
 
-	if filter and types.length
-		return RocketChat.models.Rooms.findByNameContainingAndTypes filter, types, options
+		if filter and types.length
+			return RocketChat.models.Rooms.findByNameContainingAndTypes filter, types, options
 
-	if filter
-		return RocketChat.models.Rooms.findByNameContaining filter, options
+		if filter
+			return RocketChat.models.Rooms.findByNameContaining filter, options
 
-	if types.length
-		return RocketChat.models.Rooms.findByTypes types, options
+		if types.length
+			return RocketChat.models.Rooms.findByTypes types, options
+
+	return

--- a/server/publications/fullUserData.coffee
+++ b/server/publications/fullUserData.coffee
@@ -10,36 +10,39 @@ Meteor.publish 'fullUserData', (filter, limit) ->
 		status: 1
 		utcOffset: 1
 
-	if RocketChat.authz.hasPermission( @userId, 'view-full-other-user-info') is true
-		fields = _.extend fields,
-			emails: 1
-			phone: 1
-			statusConnection: 1
-			createdAt: 1
-			lastLogin: 1
-			active: 1
-			services: 1
-			roles : 1
-	else
-		limit = 1
-
-	filter = s.trim filter
-
-	if not filter and limit is 1
-		return @ready()
-
-	options =
-		fields: fields
-		limit: limit
-		sort: { username: 1 }
-
-	console.log '[publish] fullUserData'.green, filter, limit
-
-	if filter
-		if limit is 1
-			return RocketChat.models.Users.findByUsername filter, options
+	@autorun (computation) =>
+		if RocketChat.authz.hasPermission( @userId, 'view-full-other-user-info') is true
+			fields = _.extend fields,
+				emails: 1
+				phone: 1
+				statusConnection: 1
+				createdAt: 1
+				lastLogin: 1
+				active: 1
+				services: 1
+				roles : 1
 		else
-			filterReg = new RegExp filter, "i"
-			return RocketChat.models.Users.findByUsernameNameOrEmailAddress filterReg, options
+			limit = 1
 
-	return RocketChat.models.Users.find {}, options
+		filter = s.trim filter
+
+		if not filter and limit is 1
+			return @ready()
+
+		options =
+			fields: fields
+			limit: limit
+			sort: { username: 1 }
+
+		console.log '[publish] fullUserData'.green, filter, limit
+
+		if filter
+			if limit is 1
+				return RocketChat.models.Users.findByUsername filter, options
+			else
+				filterReg = new RegExp filter, "i"
+				return RocketChat.models.Users.findByUsernameNameOrEmailAddress filterReg, options
+
+		return RocketChat.models.Users.find {}, options
+
+	return

--- a/server/publications/messages.coffee
+++ b/server/publications/messages.coffee
@@ -9,32 +9,32 @@ Meteor.publish 'messages', (rid, start) ->
 	if typeof rid isnt 'string'
 		return this.ready()
 
-	if not Meteor.call 'canAccessRoom', rid, this.userId
-		return this.ready()
+	this.autorun (computation) ->
+		if not Meteor.call 'canAccessRoom', rid, publication.userId
+			return publication.ready()
 
-	cursor = RocketChat.models.Messages.findVisibleByRoomId rid,
-		sort:
-			ts: -1
-		limit: 50
+		cursor = RocketChat.models.Messages.findVisibleByRoomId rid,
+			sort:
+				ts: -1
+			limit: 50
 
-	cursorHandle = cursor.observeChanges
-		added: (_id, record) ->
-			publication.added('rocketchat_message', _id, record)
+		cursor.observeChanges
+			added: (_id, record) ->
+				publication.added('rocketchat_message', _id, record)
 
-		changed: (_id, record) ->
-			publication.changed('rocketchat_message', _id, record)
+			changed: (_id, record) ->
+				publication.changed('rocketchat_message', _id, record)
 
-	cursorDelete = RocketChat.models.Messages.findInvisibleByRoomId rid,
-		fields:
-			_id: 1
+		cursorDelete = RocketChat.models.Messages.findInvisibleByRoomId rid,
+			fields:
+				_id: 1
 
-	cursorDeleteHandle = cursorDelete.observeChanges
-		added: (_id, record) ->
-			publication.added('rocketchat_message', _id, {_hidden: true})
-		changed: (_id, record) ->
-			publication.added('rocketchat_message', _id, {_hidden: true})
+		cursorDelete.observeChanges
+			added: (_id, record) ->
+				publication.added('rocketchat_message', _id, {_hidden: true})
+			changed: (_id, record) ->
+				publication.added('rocketchat_message', _id, {_hidden: true})
 
-	@ready()
-	@onStop ->
-		cursorHandle.stop()
-		cursorDeleteHandle.stop()
+		@ready()
+
+	return

--- a/server/publications/privateHistory.coffee
+++ b/server/publications/privateHistory.coffee
@@ -4,12 +4,14 @@ Meteor.publish 'privateHistory', ->
 
 	console.log '[publish] privateHistory'.green
 
-	RocketChat.models.Rooms.findByContainigUsername RocketChat.models.Users.findOneById(this.userId).username,
-		fields:
-			t: 1
-			name: 1
-			msgs: 1
-			ts: 1
-			lm: 1
-			cl: 1
+	this.autorun (computation) =>
+		RocketChat.models.Rooms.findByContainigUsername RocketChat.models.Users.findOneById(this.userId, fields: username: 1).username,
+			fields:
+				t: 1
+				name: 1
+				msgs: 1
+				ts: 1
+				lm: 1
+				cl: 1
 
+	return

--- a/server/publications/userChannels.coffee
+++ b/server/publications/userChannels.coffee
@@ -2,15 +2,18 @@ Meteor.publish 'userChannels', (userId) ->
 	unless this.userId
 		return this.ready()
 
-	if RocketChat.authz.hasPermission( @userId, 'view-other-user-channels') isnt true
-		return this.ready()
+	this.autorun (computation) =>
+		if RocketChat.authz.hasPermission( @userId, 'view-other-user-channels') isnt true
+			return this.ready()
 
-	console.log '[publish] userChannels'.green, userId
+		console.log '[publish] userChannels'.green, userId
 
-	RocketChat.models.Subscriptions.findByUserId userId,
-		fields:
-			rid: 1,
-			name: 1,
-			t: 1,
-			u: 1
-		sort: { t: 1, name: 1 }
+		RocketChat.models.Subscriptions.findByUserId userId,
+			fields:
+				rid: 1,
+				name: 1,
+				t: 1,
+				u: 1
+			sort: { t: 1, name: 1 }
+
+	return


### PR DESCRIPTION
Fixes #983.

This allows reactive changes when permissions are changed. So user does not have to reload anything on the client for permissions to get into the effect. Because permissions are changed rarely this does not introduce much overhead. But when permissions change, user sees results immediately which is a nice "oho" effect.

Merging this in makes `Tracker.autorun` full reactive on the server side.