### PR TITLE
Fixes #942. Use relative url for avatars.

### DIFF
--- a/client/lib/avatar.coffee
+++ b/client/lib/avatar.coffee
@@ -4,7 +4,7 @@
 	if not username?
 		return
 
-	return "#{Meteor.absoluteUrl()}avatar/#{username}.jpg?_dc=#{random}"
+	return Meteor._relativeToSiteRootUrl "/avatar/#{username}.jpg?_dc=#{random}"
 
 Blaze.registerHelper 'avatarUrlFromUsername', getAvatarUrlFromUsername
 


### PR DESCRIPTION
Avatars using absolute url can generate erros on `toDataURL` when accessing via HTTPS and roo url was configured to HTTP