### PR TITLE
Changed Github Enterprise endpoints to be relative to the domain.

### DIFF
--- a/packages/rocketchat-github-enterprise/common.coffee
+++ b/packages/rocketchat-github-enterprise/common.coffee
@@ -2,9 +2,9 @@
 # In RocketChat -> Administration the URL needs to be http(s)://{github.enterprise.server}/
 config =
 	serverURL: ''
-	identityPath: 'api/v3/user'
-	authorizePath: 'login/oauth/authorize'
-	tokenPath: 'login/oauth/access_token'
+	identityPath: '/api/v3/user'
+	authorizePath: '/login/oauth/authorize'
+	tokenPath: '/login/oauth/access_token'
 	addAutopublishFields:
 		forLoggedInUser: ['services.github-enterprise']
 		forOtherUsers: ['services.github-enterprise.username']

--- a/packages/rocketchat-github-enterprise/i18n/en.i18n.json
+++ b/packages/rocketchat-github-enterprise/i18n/en.i18n.json
@@ -1,6 +1,7 @@
 {
-  "Accounts_OAuth_GitHub_Enterprise" : "GitHub Enterprise OAuth",
-  "API_GitHub_Enterprise_URL" : "GitHub Enterprise Server URL",
-  "Accounts_OAuth_GitHub_Enterprise_id" : "GitHub OAuth Client Id",
-  "Accounts_OAuth_GitHub_Enterprise_secret" : "GitHub OAuth Client Secret"
+  "Accounts_OAuth_GitHub_Enterprise" : "OAuth Enabled",
+  "API_GitHub_Enterprise_URL" : "Server URL",
+  "Accounts_OAuth_GitHub_Enterprise_id" : "Client ID",
+  "Accounts_OAuth_GitHub_Enterprise_secret" : "Client Secret",
+  "Github_Enterprise_Url_No_Trail" : "Note: Please exclude trailing slash"
 }

--- a/packages/rocketchat-github-enterprise/package.js
+++ b/packages/rocketchat-github-enterprise/package.js
@@ -4,33 +4,30 @@ Package.describe({
     summary: 'RocketChat settings for GitHub Enterprise Oauth Flow'
 });
 
-// Loads all i18n.json files into tapi18nFiles
-var _ = Npm.require('underscore');
-var fs = Npm.require('fs');
-tapi18nFiles = fs.readdirSync('packages/rocketchat-github-enterprise/i18n').forEach(function(filename) {
-    if (fs.statSync('packages/rocketchat-github-enterprise/i18n/' + filename).size > 16) {
-        return 'i18n/' + filename;
-    }
-});
-
 Package.onUse(function(api) {
     api.versionsFrom('1.0');
 
-    api.use("tap:i18n@1.5.1");
     api.use('coffeescript');
     api.use('rocketchat:lib@0.0.1');
     api.use('rocketchat:custom-oauth');
 
-    api.use('templating', 'client');
-
-
-    api.addFiles("package-tap.i18n");
-    api.addFiles("common.coffee");
-    api.addFiles(tapi18nFiles);
-
+	api.addFiles("common.coffee");
     api.addFiles('github-enterprise-login-button.css', 'client');
-
     api.addFiles('startup.coffee', 'server');
+
+	// TAPi18n
+    api.use('templating', 'client');
+    var _ = Npm.require('underscore');
+    var fs = Npm.require('fs');
+    tapi18nFiles = _.compact(_.map(fs.readdirSync('packages/rocketchat-github-enterprise/i18n'), function(filename) {
+        if (fs.statSync('packages/rocketchat-github-enterprise/i18n/' + filename).size > 16) {
+            return 'i18n/' + filename;
+        }
+    }));
+    api.use('tap:i18n@1.6.1', ['client', 'server']);
+    api.imply('tap:i18n');
+    api.addFiles(tapi18nFiles, ['client', 'server']);
+
 });
 
 Package.onTest(function(api) {

--- a/packages/rocketchat-github-enterprise/startup.coffee
+++ b/packages/rocketchat-github-enterprise/startup.coffee
@@ -1,6 +1,6 @@
 
 Meteor.startup ->
-  RocketChat.settings.add 'Accounts_OAuth_GitHub_Enterprise', false, {type: 'boolean', group: 'Accounts', section: 'GitHub Enterprise', i18nLabel: 'OAuth Enabled'}
-  RocketChat.settings.add 'API_GitHub_Enterprise_URL', '', { type: 'string', group: 'Accounts', public: true, section: 'GitHub Enterprise', i18nLabel: 'Server URL' }
-  RocketChat.settings.add	'Accounts_OAuth_GitHub_Enterprise_id', '', { type: 'string', group: 'Accounts', section: 'GitHub Enterprise', i18nLabel: 'Client ID' }
-  RocketChat.settings.add	'Accounts_OAuth_GitHub_Enterprise_secret', '', { type: 'string', group: 'Accounts', section: 'GitHub Enterprise', i18nLabel: 'Client Secret' }
+  RocketChat.settings.add 'Accounts_OAuth_GitHub_Enterprise', false, {type: 'boolean', group: 'Accounts', section: 'GitHub Enterprise', i18nLabel: 'Accounts_OAuth_GitHub_Enterprise'}
+  RocketChat.settings.add 'API_GitHub_Enterprise_URL', '', { type: 'string', group: 'Accounts', public: true, section: 'GitHub Enterprise', i18nLabel: 'API_GitHub_Enterprise_URL', i18nDescription: 'Github_Enterprise_Url_No_Trail' }
+  RocketChat.settings.add	'Accounts_OAuth_GitHub_Enterprise_id', '', { type: 'string', group: 'Accounts', section: 'GitHub Enterprise', i18nLabel: 'Accounts_OAuth_GitHub_Enterprise_id' }
+  RocketChat.settings.add	'Accounts_OAuth_GitHub_Enterprise_secret', '', { type: 'string', group: 'Accounts', section: 'GitHub Enterprise', i18nLabel: 'Accounts_OAuth_GitHub_Enterprise_secret' }


### PR DESCRIPTION
Before when you put server URL in you'd have to put domain.com/ if you forgot the slash all urls would end up like this: `domain.comapi/v3/user`

Added i18n incase needed in future and added note to exclude trailing slash

![image](https://cloud.githubusercontent.com/assets/51996/10400013/f04ec462-6e7b-11e5-98e3-8b42819942d2.png)

@leefaus if you could take a look at your convenience.  