### PR TITLE
rocketchat:markdown - Settings file should only be present on server.

### DIFF
--- a/packages/rocketchat-markdown/package.js
+++ b/packages/rocketchat-markdown/package.js
@@ -13,8 +13,8 @@ Package.onUse(function(api) {
 		'rocketchat:lib@0.0.1'
 	]);
 
-	api.addFiles('settings.coffee', ['server','client']);
-	api.addFiles('markdown.coffee', ['server','client']);
+	api.addFiles('settings.coffee', 'server');
+	api.addFiles('markdown.coffee');
 });
 
 Package.onTest(function(api) {


### PR DESCRIPTION
This will prevent rocketchat:markdown tests to fail when PR #1045 is merged.

![screen shot 2015-10-09 at 16 06 53](https://cloud.githubusercontent.com/assets/190883/10403107/d1bc06ee-6e9f-11e5-9b38-98efc6130993.png)
