### PR TITLE
Fixes the rendering of user info when accessed by @mention.

### DIFF
--- a/client/views/app/room.coffee
+++ b/client/views/app/room.coffee
@@ -387,8 +387,9 @@ Template.room.events
 			FlowRouter.go 'channel', {name: channel}
 			return
 
-		RocketChat.TabBar.openFlex()
+		RocketChat.TabBar.setTemplate 'membersList'
 		Session.set('showUserInfo', $(e.currentTarget).data('username'))
+		RocketChat.TabBar.openFlex()
 
 	'click .image-to-download': (event) ->
 		ChatMessage.update {_id: this._arguments[1]._id, 'urls.url': $(event.currentTarget).data('url')}, {$set: {'urls.$.downloadImages': true}}


### PR DESCRIPTION
Closes #973 

![memberslist](https://cloud.githubusercontent.com/assets/190883/10407564/68e2424a-6ec3-11e5-89f5-d829694439cc.gif)
