### PR TITLE
More consistent HTML notifications and sounds

### DIFF
--- a/client/notifications/notification.coffee
+++ b/client/notifications/notification.coffee
@@ -1,3 +1,21 @@
+# Show notifications and play a sound for new messages.
+# We trust the server to only send notifications for interesting messages, e.g. direct messages or
+# group messages in which the user is mentioned.
+
 Meteor.startup ->
-	RocketChat.Notifications.onUser 'notification', (data) ->
-		KonchatNotification.showDesktop data
+	RocketChat.Notifications.onUser 'notification', (notification) ->
+
+		openedRoomId = undefined
+		if FlowRouter.getRouteName() in ['channel', 'group', 'direct']
+			openedRoomId = Session.get 'openedRoom'
+
+		# This logic is duplicated in /client/startup/unread.coffee.
+		hasFocus = readMessage.isEnable()
+		messageIsInOpenedRoom = openedRoomId is notification.payload.rid
+
+		if !(hasFocus and messageIsInOpenedRoom)
+			# Play a sound.
+			KonchatNotification.newMessage()
+
+			# Show a notification.
+			KonchatNotification.showDesktop notification

--- a/packages/rocketchat-lib/server/sendMessage.coffee
+++ b/packages/rocketchat-lib/server/sendMessage.coffee
@@ -105,20 +105,6 @@ RocketChat.sendMessage = (user, message, room, options) ->
 					# the mentioned user if mention isn't for all
 					RocketChat.models.Subscriptions.incUnreadForRoomIdAndUserIds message.rid, mentionIds, 1
 
-				query =
-					statusConnection: {$ne: 'online'}
-
-				if toAll
-					if room.usernames?.length > 0
-						query.username =
-							$in: room.usernames
-					else
-						query.username =
-							$in: []
-				else
-					query._id =
-						$in: mentionIds
-
 				userIdsToNotify = _.pluck(usersOfMention, '_id')
 
 				# If the message is @all, send a notification to all online room users except for the sender.

--- a/packages/rocketchat-lib/server/sendMessage.coffee
+++ b/packages/rocketchat-lib/server/sendMessage.coffee
@@ -49,7 +49,7 @@ RocketChat.sendMessage = (user, message, room, options) ->
 			###
 			RocketChat.models.Subscriptions.incUnreadOfDirectForRoomIdExcludingUserId message.rid, message.u._id, 1
 
-			userOfMention = Meteor.users.findOne({_id: message.rid.replace(message.u._id, '')}, {fields: {username: 1, statusConnection: 1}})
+			userOfMention = RocketChat.models.Users.findOne({_id: message.rid.replace(message.u._id, '')}, {fields: {username: 1, statusConnection: 1}})
 			if userOfMention?
 				RocketChat.Notifications.notifyUser userOfMention._id, 'notification',
 					title: "@#{user.username}"
@@ -86,7 +86,7 @@ RocketChat.sendMessage = (user, message, room, options) ->
 			toAll = mentionIds.indexOf('all') > -1
 
 			if mentionIds.length > 0
-				usersOfMention = Meteor.users.find({_id: {$in: mentionIds}}, {fields: {_id: 1, username: 1}}).fetch()
+				usersOfMention = RocketChat.models.Users.find({_id: {$in: mentionIds}}, {fields: {_id: 1, username: 1}}).fetch()
 
 				if room.t is 'c' and !toAll
 					for usersOfMentionItem in usersOfMention
@@ -123,7 +123,7 @@ RocketChat.sendMessage = (user, message, room, options) ->
 
 				# If the message is @all, send a notification to all online room users except for the sender.
 				if toAll and room.usernames?.length > 0
-					onlineUsersOfRoom = Meteor.users.find({
+					onlineUsersOfRoom = RocketChat.models.Users.find({
 							username: {$in: room.usernames},
 							_id: {$ne: user._id}
 							status: {$in: ['online', 'away', 'busy']}},


### PR DESCRIPTION
First steps for #1068.

- HTML notifications are shown when the user has selected the room of the message but the chat window does not have the focus.
- HTML notification and new message sound use the same conditions.
- The unread count is updated (and a dock icon badge shown) if the chat window does not have the focus.
- For room messages with "@all", notifications are sent to all online users of the room except for the sender.

There is some duplicate code in /client/startup/unread.coffee (unread count) and /client/notifications/notification.coffee (notifications) for finding out whether the user has immediately read the new message. This could possibly be unified, but I need to get a better feel of the code first, I think.