### PR TITLE
Fix #1117 - Display Meteor package version information

### DIFF
--- a/.travis/setbuildinfo.js
+++ b/.travis/setbuildinfo.js
@@ -1,5 +1,5 @@
 var BUILD_INFO_PATH = '../public/buildinfo/buildinfo.txt';
-var PACKAGES_PATH = '../.meteor/packages';
+var PACKAGES_PATH = '../.meteor/versions';
 var BUILD_PATH = '../../build';
 var LineByLineReader = require('line-by-line');
 var mkdirp = require('mkdirp');


### PR DESCRIPTION
Related to #1117 

Every new build now includes a version + build number.