### PR TITLE
SoundCloud embed widget integration

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -41,6 +41,7 @@ rocketchat:oembed
 rocketchat:slashcommands-invite
 rocketchat:slashcommands-join
 rocketchat:slashcommands-leave
+#rocketchat:soundcloud
 rocketchat:spotify
 rocketchat:statistics
 rocketchat:webrtc

--- a/packages/rocketchat-oembed/server/server.coffee
+++ b/packages/rocketchat-oembed/server/server.coffee
@@ -15,6 +15,9 @@ getUrlContent = (urlObj, redirectCount = 5, callback) ->
 		hostname: urlObj.hostname
 		path: urlObj.path
 		rejectUnauthorized: !RocketChat.settings.get 'Allow_Invalid_SelfSigned_Certs'
+		headers: {
+			'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.0 Safari/537.36'
+		}
 
 	httpOrHttps = if urlObj.protocol is 'https:' then https else http
 

--- a/packages/rocketchat-soundcloud/lib/client/oembedSoundcloudWidget.html
+++ b/packages/rocketchat-soundcloud/lib/client/oembedSoundcloudWidget.html
@@ -1,0 +1,13 @@
+<template name="oembedSoundcloudWidget">
+	{{#if parsedUrl}}
+		<blockquote>
+			<a href="https://www.soundcloud.com" style="color: #9e9ea6">SoundCloud</a><br/>
+			{{#if meta.twitterAudioArtistName}}
+				<a href="https://www.soundcloud.com/{{meta.twitterAudioArtistName}}">{{meta.twitterAudioArtistName}}</a><br/>
+			{{/if}}
+			<a href="{{meta.ogUrl}}">{{meta.ogTitle}}</a><br/>
+			<p>{{meta.ogDescription}}</p>
+			<iframe width="100%" height="150" src="{{meta.twitterPlayer}}" frameborder="0"></iframe><br/>
+		</blockquote>
+	{{/if}}
+</template>

--- a/packages/rocketchat-soundcloud/lib/client/widget.coffee
+++ b/packages/rocketchat-soundcloud/lib/client/widget.coffee
@@ -1,0 +1,3 @@
+Template.oembedBaseWidget.onCreated () ->
+	if this.data?.parsedUrl?.host is 'soundcloud.com' and this.data?.meta?.twitterPlayer?
+		this.data._overrideTemplate = 'oembedSoundcloudWidget'

--- a/packages/rocketchat-soundcloud/package.js
+++ b/packages/rocketchat-soundcloud/package.js
@@ -1,0 +1,23 @@
+Package.describe({
+	name: 'rocketchat:soundcloud',
+	version: '0.0.1',
+	summary: 'Soundcloud integration',
+	git: ''
+});
+
+Package.onUse(function(api) {
+	api.versionsFrom('1.0');
+
+	api.use([
+		'coffeescript',
+		'templating',
+		'rocketchat:oembed@0.0.1'
+	]);
+
+	api.addFiles('lib/client/widget.coffee', 'client');
+	api.addFiles('lib/client/oembedSoundcloudWidget.html', 'client');
+});
+
+Package.onTest(function(api) {
+
+});


### PR DESCRIPTION
**Attention** package is disabled (comment on https://github.com/kakawait/Rocket.Chat/blob/soundcloud-integration/.meteor/packages#L44) by default

related issue #1090

![screen shot 2015-10-18 at 18 58 22](https://github-cloud.s3.amazonaws.com/assets/275609/10565161/41398524-75ca-11e5-9da9-fe0bd47f0c14.png)

**Do not merge PR before reading below**

Indeed current implementation does not support *group* embed widget (like https://soundcloud.com/groups/made-with-ableton-live) unlike Slack

![screen shot 2015-10-18 at 18 53 02](https://github-cloud.s3.amazonaws.com/assets/275609/10565135/83bf05c8-75c9-11e5-8a7f-22783e945b68.png)

Problem is due to `meta` does not provide any direct link to `player`. I need to rebuild url but url should look like

https://w.soundcloud.com/player/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Fgroups%2F3&show_artwork=true&maxheight=150

As you can see we need to use url like `api.soundcloud.com/groups/{id}` but meta does not provide `{id}` for group `made-with-ableton-live`.

We can use https://developers.soundcloud.com/docs/api/reference#resolve API but we need a `client_id` or parse source view-source:https://soundcloud.com/groups/made-with-ableton-live on `webpackJsonp` json there is a reference to `"uri":"https://api.soundcloud.com/groups/3"`

Any advices?