### PR TITLE
Inline image improvements: border & click area

### DIFF
--- a/packages/rocketchat-oembed/client/oembedImageWidget.html
+++ b/packages/rocketchat-oembed/client/oembedImageWidget.html
@@ -1,10 +1,12 @@
 <template name="oembedImageWidget">
 	{{#if showImage}}
-		<a href="{{url}}" class="swipebox" target="_blank">
-			{{#if parsedUrl}}
-				<div class="inline-image" style="background-image: url({{url}});"></div>
-			{{/if}}
-		</a>
+	  <div class="inline-image-container">
+			<a href="{{url}}" class="swipebox" target="_blank">
+				{{#if parsedUrl}}
+					<img src="{{url}}" class="inline-image"/>
+				{{/if}}
+			</a>
+		</div>
 	{{else}}
 		{{#if parsedUrl}}
 			<div class="image-to-download" data-url="{{url}}">

--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -2517,10 +2517,14 @@ a.github-fork {
 		.transition(opacity 1s linear);
 
 		.inline-image {
-			background-size: contain;
-			background-repeat: no-repeat;
-			background-position: center left;
-			height: 200px;
+			max-height: 200px;
+			max-width: 100%;
+			border: 1px solid rgba(0, 0, 0, 0.1);
+		}
+
+		.inline-image-container {
+			max-height: 200px;
+			max-width: 100%;
 		}
 	}
 	&.temp .body {


### PR DESCRIPTION
- Switched to using an image tag instead of a div with background-image
- Clicking to view the larger image now fits to the actual size of the
smaller image rather than the full width of the message
- A semi-transparent border was added to improve visibility of lighter
images