### PR TITLE
Changed icon for hiding direct messages in sideNav

### DIFF
--- a/client/views/app/sideNav/chatRoomItem.html
+++ b/client/views/app/sideNav/chatRoomItem.html
@@ -7,7 +7,7 @@
 			<i class="{{roomIcon}} {{userStatus}}"></i>
 			<span class='name'>{{name}}</span>
 			<span class='opt'>
-				<i class="octicon octicon-eye hide-room" title="{{_ "Hide_room"}}"></i>
+				<i class="icon-eye-off hide-room" title="{{_ "Hide_room"}}"></i>
 				{{#if canLeave}}
 					<i class="octicon octicon-sign-out" title="{{_ "Leave_room"}}"></i>
 				{{/if}}


### PR DESCRIPTION
This fixes #1101.

<img width="321" alt="screen shot 2015-10-22 at 9 39 06 am" src="https://cloud.githubusercontent.com/assets/284902/10666626/c6d43b60-78a0-11e5-950e-336493e2893f.png">
