### PR TITLE
Improving rocketchat-theme styles

### DIFF
--- a/client/views/admin/rooms/adminRooms.html
+++ b/client/views/admin/rooms/adminRooms.html
@@ -48,7 +48,7 @@
 		<div class="control">
 			<button class="more"><span class="arrow {{arrowPosition}}"></span></button>
 			<div class="info-tabs">
-				<a href="#adminRoomInfo" class="active"><i class="icon-hash"></i></a>
+				<a href="#adminRoomInfo" class="active"><i class="icon-cancel"></i></a>
 			</div>
 		</div>
 		{{#if flexOpened}}

--- a/client/views/admin/users/adminUsers.html
+++ b/client/views/admin/users/adminUsers.html
@@ -24,10 +24,10 @@
 					<table>
 						<thead>
 							<tr>
-								<td>&nbsp;</td>
-								<td width="34%">{{_ "Name"}}</td>
-								<td width="33%">{{_ "Username"}}</td>
-								<td width="33%">{{_ "E-mail"}}</td>
+								<th>&nbsp;</th>
+								<th width="34%">{{_ "Name"}}</th>
+								<th width="33%">{{_ "Username"}}</th>
+								<th width="33%">{{_ "E-mail"}}</th>
 							</tr>
 						</thead>
 						<tbody>

--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -2469,7 +2469,7 @@ a.github-fork {
 				display: none;
 			}
 			.edited {
-				display: inline-block;
+				display: block;
 			}
 			.private {
 				display: none;

--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -2703,6 +2703,7 @@ a.github-fork {
 		&:extend(.fill-all);
 		overflow-x: hidden;
 		overflow-y: auto;
+		top: auto;
 		-webkit-overflow-scrolling: touch;
 		> div {
 			.transition(transform .45s cubic-bezier(.5,

--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -1874,6 +1874,11 @@ a.github-fork {
 		}
 		table {
 			width: 100%;
+			thead {
+				th {
+					text-align: left;
+				}
+			}
 			tbody {
 				td {
 					vertical-align: middle;

--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -1847,6 +1847,19 @@ a.github-fork {
 	}
 
 	.list {
+		a {
+			display: block;
+			padding: 3px;
+			margin-bottom: 5px;
+			.info {
+				h3 {
+					margin-bottom: 5px;
+				}
+				ul {
+					margin-left: 3px;
+				}
+			}
+		}
 		.user-image {
 			float: right;
 			margin-left: 12px;

--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -2993,6 +2993,9 @@ a.github-fork {
 			margin-top: 20px;
 		}
 	}
+	.room-info-content > div {
+		margin: 0 0 20px 0;
+	}
 }
 
 .user-image-status(@color) {

--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -1860,6 +1860,14 @@ a.github-fork {
 				}
 			}
 		}
+		.room-info {
+			padding: 3px;
+			margin-bottom: 5px;
+			cursor: pointer;
+			h3 {
+				margin-bottom: 5px;
+			}
+		}
 		.user-image {
 			float: right;
 			margin-left: 12px;

--- a/packages/rocketchat-theme/assets/stylesheets/utils/_colors.import.less
+++ b/packages/rocketchat-theme/assets/stylesheets/utils/_colors.import.less
@@ -627,6 +627,11 @@ a.github-fork {
 				color: @primary-font-color;
 			}
 		}
+		.room-info {
+			&:hover {
+				background-color: @secondary-background-color;
+			}
+		}
 		.status {
 			color: @secondary-font-color;
 		}


### PR DESCRIPTION
Various small improvements to the rocketchat-theme, affecting:

**Alignment of (Edited) status in messages**

![edited-alignment](https://cloud.githubusercontent.com/assets/8068/10668127/aafa0cc6-78d2-11e5-8492-1a176d8f5fcc.png)

**History**

Adding margin, padding, fixed on hover background colouring.

![history](https://cloud.githubusercontent.com/assets/8068/10667968/ea04b7b4-78d1-11e5-965d-3e92035faee1.png)

**Rooms**

Adding margin, padding, fixed on hover background colouring and mouse pointer.

![rooms](https://cloud.githubusercontent.com/assets/8068/10667977/f0fe483c-78d1-11e5-84c9-6d090e5d1015.png)

**Deleting a Room**

Adding margin, padding and fixed top margin of .room-info-content. Replaced hash with a cancel icon.

![delete-room](https://cloud.githubusercontent.com/assets/8068/10667981/f5f8ea2c-78d1-11e5-8cb3-1d3c8fc5bcfb.png)

**Users**

Converted table headings from _td_ to _th_, making them bold by default.

![users](https://cloud.githubusercontent.com/assets/8068/10667985/fa6dbb3c-78d1-11e5-9d45-ee2137582380.png)