### PR TITLE
Only Suggest Active Users in the Popup

### DIFF
--- a/packages/rocketchat-lib/server/models/Users.coffee
+++ b/packages/rocketchat-lib/server/models/Users.coffee
@@ -52,6 +52,19 @@ RocketChat.models.Users = new class extends RocketChat.models._Base
 
 		return @find query, options
 
+	findByActiveUsersNameOrUsername: (nameOrUsername, options) ->
+		query =
+			username:
+				$exists: 1
+			active: true
+
+			$or: [
+				{name: nameOrUsername}
+				{username: nameOrUsername}
+			]
+
+		return @find query, options
+
 	findUsersByNameOrUsername: (nameOrUsername, options) ->
 		query =
 			username:

--- a/server/publications/filteredUsers.coffee
+++ b/server/publications/filteredUsers.coffee
@@ -18,7 +18,7 @@ Meteor.publish 'filteredUsers', (name) ->
 
 	pub = this
 
-	cursorHandle = RocketChat.models.Users.findUsersByNameOrUsername(exp, options).observeChanges
+	cursorHandle = RocketChat.models.Users.findByActiveUsersNameOrUsername(exp, options).observeChanges
 		added: (_id, record) ->
 			pub.added('filtered-users', _id, record)
 


### PR DESCRIPTION
Since deactivated users are treated as banned users and they can't login anymore, don't suggest them to be mentioned. This might not be the best route to go as I'm not 100% sure what else uses the filteredUsers publication, but from my small amount of testing it seemed to do the trick just fine.