### PR TITLE
Use SoundCloud Oembed API for SoundCloud integration

### DIFF
--- a/packages/rocketchat-oembed/server/server.coffee
+++ b/packages/rocketchat-oembed/server/server.coffee
@@ -168,7 +168,7 @@ getRelevantHeaders = (headersObj) ->
 getRelevantMetaTags = (metaObj) ->
 	tags = {}
 	for key, value of metaObj
-		if /^(og|fb|twitter).+|description|title|pageTitle$/.test(key.toLowerCase()) and value?.trim() isnt ''
+		if /^(og|fb|twitter|oembed).+|description|title|pageTitle$/.test(key.toLowerCase()) and value?.trim() isnt ''
 			tags[key] = value
 
 	if Object.keys(tags).length > 0

--- a/packages/rocketchat-soundcloud/lib/client/oembedSoundcloudWidget.html
+++ b/packages/rocketchat-soundcloud/lib/client/oembedSoundcloudWidget.html
@@ -2,12 +2,20 @@
 	{{#if parsedUrl}}
 		<blockquote>
 			<a href="https://www.soundcloud.com" style="color: #9e9ea6">SoundCloud</a><br/>
-			{{#if meta.twitterAudioArtistName}}
-				<a href="https://www.soundcloud.com/{{meta.twitterAudioArtistName}}">{{meta.twitterAudioArtistName}}</a><br/>
+			{{#if meta.oembedAuthorName}}
+				{{#if meta.oembedAuthorUrl}}
+					<a href="meta.oembedAuthorUrl">{{meta.oembedAuthorName}}</a><br/>
+				{{/if}}
 			{{/if}}
-			<a href="{{meta.ogUrl}}">{{meta.ogTitle}}</a><br/>
-			<p>{{meta.ogDescription}}</p>
-			<iframe width="100%" height="150" src="{{meta.twitterPlayer}}" frameborder="0"></iframe><br/>
+			{{#if meta.oembedTitle}}
+				{{#if meta.oembedUrl}}
+					<a href="{{meta.oembedUrl}}">{{meta.oembedTitle}}</a><br/>
+				{{/if}}
+			{{/if}}
+			{{#if meta.oembedDescription}}
+				<p>{{meta.oembedDescription}}</p>
+			{{/if}}
+			{{{meta.oembedHtml}}}
 		</blockquote>
 	{{/if}}
 </template>

--- a/packages/rocketchat-soundcloud/lib/client/widget.coffee
+++ b/packages/rocketchat-soundcloud/lib/client/widget.coffee
@@ -1,3 +1,3 @@
 Template.oembedBaseWidget.onCreated () ->
-	if this.data?.parsedUrl?.host is 'soundcloud.com' and this.data?.meta?.twitterPlayer?
+	if this.data?.parsedUrl?.host is 'soundcloud.com' and this.data?.meta?.oembedHtml?
 		this.data._overrideTemplate = 'oembedSoundcloudWidget'

--- a/packages/rocketchat-soundcloud/lib/server/server.coffee
+++ b/packages/rocketchat-soundcloud/lib/server/server.coffee
@@ -1,10 +1,19 @@
-RocketChat.callbacks.add 'oembed:beforeGetUrlContent', (data) ->
-	# if data.parsedUrl is 'soundcloud.com'
-		# Do whatever you whant in sync way
-		# You can modify the object data.requestOptions to change how the request will be executed
+URL = Npm.require('url')
 
+RocketChat.callbacks.add 'oembed:beforeGetUrlContent', (data) ->
+	if data.parsedUrl.host is 'soundcloud.com'
+		newUrlObj = URL.format data.parsedUrl
+		newUrlObj = URL.parse "https://soundcloud.com/oembed?url=" + encodeURIComponent newUrlObj + "&format=json&maxheight=150"
+		data.requestOptions.port = newUrlObj.port
+		data.requestOptions.hostname = newUrlObj.hostname
+		data.requestOptions.path = newUrlObj.path
 
 RocketChat.callbacks.add 'oembed:afterParseContent', (data) ->
-	# if data.parsedUrl is 'soundcloud.com'
-		# Do whatever you whant in sync way
-		# You can modify the object data to change the parsed object
+	if data.parsedUrl.host is 'soundcloud.com'
+		if data.content?.body?
+			metas = JSON.parse data.content.body;
+			_.each metas, (value, key) ->
+				if _.isString value
+					data.meta[changeCase.camelCase('oembed_' + key)] = value
+		if data.parsedUrl?
+			data.meta['oembedUrl'] = URL.format data.parsedUrl

--- a/packages/rocketchat-soundcloud/package.js
+++ b/packages/rocketchat-soundcloud/package.js
@@ -9,9 +9,11 @@ Package.onUse(function(api) {
 	api.versionsFrom('1.0');
 
 	api.use([
-		'rocketchat:lib',
 		'coffeescript',
 		'templating',
+		'underscore',
+		'konecty:change-case',
+		'rocketchat:lib',
 		'rocketchat:oembed@0.0.1'
 	]);
 


### PR DESCRIPTION
Use SoundCloud Oembed API https://developers.soundcloud.com/docs/api/reference#oembed in order to support more links than previous implementation

- for track

![screen shot 2015-10-23 at 09 34 31](https://cloud.githubusercontent.com/assets/275609/10686962/bc06b18a-7969-11e5-80fe-46cc875e4ecc.png)

- for user

![screen shot 2015-10-23 at 09 34 41](https://cloud.githubusercontent.com/assets/275609/10686966/c6b7b1ba-7969-11e5-9f9b-9d46af1bb165.png)

- for group

![screen shot 2015-10-23 at 09 35 08](https://cloud.githubusercontent.com/assets/275609/10686974/ceb4d672-7969-11e5-953f-18abb82ea871.png)

- for set

![screen shot 2015-10-23 at 09 36 33](https://cloud.githubusercontent.com/assets/275609/10686978/d4b0921e-7969-11e5-8310-06be72901e1c.png)
