### PR TITLE
Use user-select: text; to re-enable selections

### DIFF
--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -2291,15 +2291,15 @@ a.github-fork {
 	min-height: 40px;
 
 	.body, .user.user-card-message, .time {
-		-webkit-user-select: all;
-		-moz-user-select: all;
-		-ms-user-select: all;
-		user-select: all;
+		-webkit-user-select: text;
+		-moz-user-select: text;
+		-ms-user-select: text;
+		user-select: text;
 		* {
-			-webkit-user-select: all;
-			-moz-user-select: all;
-			-ms-user-select: all;
-			user-select: all;
+			-webkit-user-select: text;
+			-moz-user-select: text;
+			-ms-user-select: text;
+			user-select: text;
 		}
 	}
 


### PR DESCRIPTION
Firefox interprets user-select: all; to mean that any clicks should result in
the entire element's container being selected, regardless of the user's gesture.
This results in the inability to select only a subset of characters in a chat
message.

Fixes #1242