### PR TITLE
webrtc: fix deprecation warning 'MediaStream.stop() is deprecated'

### DIFF
--- a/packages/rocketchat-webrtc/WebRTCClass.coffee
+++ b/packages/rocketchat-webrtc/WebRTCClass.coffee
@@ -447,7 +447,9 @@ class WebRTCClass
 		@active = false
 		@monitor = false
 		@remoteMonitoring = false
-		@localStream?.stop()
+		if @localStream? and typeof @localStream isnt 'undefined'
+			@localStream.getTracks().forEach (track) ->
+				track.stop()
 		@localUrl.set undefined
 		delete @localStream
 


### PR DESCRIPTION
Calling ```stop()``` on the localstream is deprecated.

Instead, this iterates through the localstream's tracks and calls ```stop()``` on each one.

Got it from here: 

https://developers.google.com/web/updates/2015/07/mediastream-deprecations?hl=en

> Use MediaStreamTrack.stop() to stop streaming, not MediaStream.stop()