### PR TITLE
Autohide audio recorder

### DIFF
--- a/client/views/admin/admin.html
+++ b/client/views/admin/admin.html
@@ -65,10 +65,11 @@
 												<div>
 													<label><input type="radio" name="{{_id}}" value="1" checked="{{$eq value true}}" /> {{_ "True"}}</label>
 													<label><input type="radio" name="{{_id}}" value="0" checked="{{$eq value false}}" /> {{_ "False"}}</label>
-												</div>
 												{{#if description}}
-													<small>{{description}}</small>
+												<br /><small>{{description}}</small>
 												{{/if}}
+												</div>
+												
 											</div>
 										{{/if}}
 										{{#if $eq type 'color'}}

--- a/client/views/app/room.coffee
+++ b/client/views/app/room.coffee
@@ -188,7 +188,9 @@ Template.room.helpers
 		return !! ChatRoom.findOne { _id: @_id, t: 'c' }
 
 	canRecordAudio: ->
-		return RocketChat.settings.get('Message_AudioRecorderEnabled') and (navigator.getUserMedia? or navigator.webkitGetUserMedia?)
+		wavRegex = /audio\/wav|audio\/\*/i
+		wavEnabled = RocketChat.settings.get("FileUpload_MediaTypeWhiteList").match(wavRegex)
+		return RocketChat.settings.get('Message_AudioRecorderEnabled') and (navigator.getUserMedia? or navigator.webkitGetUserMedia?) and wavEnabled
 
 	unreadSince: ->
 		room = ChatRoom.findOne(this._id, { reactive: false })

--- a/client/views/app/room.coffee
+++ b/client/views/app/room.coffee
@@ -190,7 +190,7 @@ Template.room.helpers
 	canRecordAudio: ->
 		wavRegex = /audio\/wav|audio\/\*/i
 		wavEnabled = RocketChat.settings.get("FileUpload_MediaTypeWhiteList").match(wavRegex)
-		return RocketChat.settings.get('Message_AudioRecorderEnabled') and (navigator.getUserMedia? or navigator.webkitGetUserMedia?) and wavEnabled
+		return RocketChat.settings.get('Message_AudioRecorderEnabled') and (navigator.getUserMedia? or navigator.webkitGetUserMedia?) and wavEnabled and RocketChat.settings.get('FileUpload_Enabled')
 
 	unreadSince: ->
 		room = ChatRoom.findOne(this._id, { reactive: false })

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -216,6 +216,7 @@
   "Message_AllowEditing_BlockEditInMinutes" : "Block Message Editing After (n) Minutes",
   "Message_AllowEditing_BlockEditInMinutesDescription" : "Enter 0 to disable blocking",
   "Message_AudioRecorderEnabled" : "Audio Recorder Enabled",
+  "Message_AudioRecorderEnabledDescription" : "For this to work upload of Wav files must be enabled in the 'File Upload' section",
   "Message_deleting_not_allowed" : "Message deleting not allowed",
   "Message_editing_not_allowed" : "Message editing not allowed",
   "Message_editing_blocked" : "This message cannot be edited anymore",

--- a/packages/rocketchat-lib/settings/server/startup.coffee
+++ b/packages/rocketchat-lib/settings/server/startup.coffee
@@ -78,7 +78,7 @@ RocketChat.settings.add 'Message_ShowDeletedStatus', false, { type: 'boolean', g
 RocketChat.settings.add 'Message_KeepHistory', false, { type: 'boolean', group: 'Message', public: true }
 RocketChat.settings.add 'Message_MaxAllowedSize', 5000, { type: 'int', group: 'Message', public: true }
 RocketChat.settings.add 'Message_ShowFormattingTips', true, { type: 'boolean', group: 'Message', public: true }
-RocketChat.settings.add 'Message_AudioRecorderEnabled', true, { type: 'boolean', group: 'Message', public: true }
+RocketChat.settings.add 'Message_AudioRecorderEnabled', true, { type: 'boolean', group: 'Message', public: true, i18nDescription: 'Message_AudioRecorderEnabledDescription' }
 
 RocketChat.settings.addGroup 'Meta'
 RocketChat.settings.add 'Meta_language', '', { type: 'string', group: 'Meta' }


### PR DESCRIPTION
Hides the microphone for audio recordings (right hand side of chat box) unless wav files are in the file upload whitelist. Currently when wav's are disabled the record button silently fails to upload with no warning on finishing the recording (can test this on the demo server).

There is one slight problem I foresee with this is the default for the upload whitelist is images only, this means when merged everyone ones mic will disappear unless the have manually allowed wav's. If you are an existing user you might notice it disappear but a new user might not know they are missing a feature. Perhaps a compromise is to allow wav's on the demo server? Hopefully most people start there so they at least see the button to go looking into why it is not on their version. One other option is to add `audio/wav` to the default whitelist. Not a deal breaker just something to be aware of. At least this way the pressure is on the admin to work out why it's gone rather than the user wondering why the recorder button is there but not working which is less obvious.
