### PR TITLE
feat(message-ui/edit-info): add information about message editor

### DIFF
--- a/client/lib/avatar.coffee
+++ b/client/lib/avatar.coffee
@@ -8,7 +8,7 @@
 		path = Meteor.absoluteUrl()
 	else
 		path = '/'
-	return "#{path}avatar/#{username}.jpg?_dc=#{random}"
+	"#{path}avatar/#{encodeURIComponent(username)}.jpg?_dc=#{random}"
 
 Blaze.registerHelper 'avatarUrlFromUsername', getAvatarUrlFromUsername
 

--- a/client/methods/updateMessage.coffee
+++ b/client/methods/updateMessage.coffee
@@ -23,8 +23,9 @@ Meteor.methods
 
 		Tracker.nonreactive ->
 
-			message.editBy = Meteor.userId()
-			message.ets = new Date(Date.now() + TimeSync.serverOffset())
+			message.edit =
+				by: Meteor.userId()
+				at: new Date(Date.now() + TimeSync.serverOffset())
 			message = RocketChat.callbacks.run 'beforeSaveMessage', message
 
 			ChatMessage.update
@@ -32,5 +33,6 @@ Meteor.methods
 				'u._id': Meteor.userId()
 			,
 				$set:
-					ets: message.ets
+					"edit.by": message.edit.by
+					"edit.at": message.edit.at
 					msg: message.msg

--- a/client/methods/updateMessage.coffee
+++ b/client/methods/updateMessage.coffee
@@ -23,6 +23,7 @@ Meteor.methods
 
 		Tracker.nonreactive ->
 
+			message.editBy = Meteor.userId()
 			message.ets = new Date(Date.now() + TimeSync.serverOffset())
 			message = RocketChat.callbacks.run 'beforeSaveMessage', message
 

--- a/client/views/app/message.coffee
+++ b/client/views/app/message.coffee
@@ -1,5 +1,5 @@
 wasEdited = (msg) ->
-	msg.ets and msg.t not in ['s', 'p', 'f', 'r', 'au', 'ru', 'ul', 'nu', 'wm', 'uj', 'rm']
+	msg.edit?.at? and msg.t not in ['s', 'p', 'f', 'r', 'au', 'ru', 'ul', 'nu', 'wm', 'uj', 'rm']
 Template.message.helpers
 	actions: ->
 		return RocketChat.MessageAction.getButtons(this)
@@ -51,14 +51,14 @@ Template.message.helpers
 	edited: -> wasEdited(@)
 	editTime: ->
 		return "" unless wasEdited(@)
-		moment(@ets).format('LL hh:mma') #TODO profile pref for 12hr/24hr clock?
+		moment(@edit.at).format('LL hh:mma') #TODO profile pref for 12hr/24hr clock?
 	editedBy: ->
 		return "" unless wasEdited(@)
 		# try to return the username of the editor,
 		# otherwise a special "?" character that will be
 		# rendered as a special avatar
-		if @editBy
-			user = Meteor.users.findOne(@editBy)
+		if @edit.by
+			user = Meteor.users.findOne(@edit.by)
 			if user?
 				user.username
 			else

--- a/client/views/app/message.coffee
+++ b/client/views/app/message.coffee
@@ -1,3 +1,5 @@
+wasEdited = (msg) ->
+	msg.ets and msg.t not in ['s', 'p', 'f', 'r', 'au', 'ru', 'ul', 'nu', 'wm', 'uj', 'rm']
 Template.message.helpers
 	actions: ->
 		return RocketChat.MessageAction.getButtons(this)
@@ -46,8 +48,13 @@ Template.message.helpers
 
 	system: ->
 		return 'system' if this.t in ['s', 'p', 'f', 'r', 'au', 'ru', 'ul', 'nu', 'wm', 'uj', 'rm']
-	edited: ->
-		return @ets and @t not in ['s', 'p', 'f', 'r', 'au', 'ru', 'ul', 'nu', 'wm', 'uj', 'rm']
+	edited: -> wasEdited(@)
+	editTime: ->
+		return "" unless wasEdited(@)
+		moment(@ets).format('LL hh:mma') #TODO profile pref for 12hr/24hr clock?
+	editedBy: ->
+		return "" unless wasEdited(@)
+		Meteor.users.findOne(@editBy ? Meteor.userId())?.username
 	pinned: ->
 		return this.pinned
 	canEdit: ->

--- a/client/views/app/message.coffee
+++ b/client/views/app/message.coffee
@@ -54,7 +54,17 @@ Template.message.helpers
 		moment(@ets).format('LL hh:mma') #TODO profile pref for 12hr/24hr clock?
 	editedBy: ->
 		return "" unless wasEdited(@)
-		Meteor.users.findOne(@editBy ? Meteor.userId())?.username
+		# try to return the username of the editor,
+		# otherwise a special "?" character that will be
+		# rendered as a special avatar
+		if @editBy
+			user = Meteor.users.findOne(@editBy)
+			if user?
+				user.username
+			else
+				"?"
+		else
+			"?"
 	pinned: ->
 		return this.pinned
 	canEdit: ->

--- a/client/views/app/message.html
+++ b/client/views/app/message.html
@@ -3,19 +3,27 @@
 		<a class="thumb user-card-message" href="#" data-username="{{u.username}}" tabindex="1">{{> avatar username=u.username}}</a>
 		<a class="user user-card-message" href="#" data-username="{{u.username}}" tabindex="1">{{u.username}}</a>
 		<span class="info">
-			<span class="time">{{time}}</span>
 		{{#if edited}}
-			<span class="edited">
-				(<a
-					title='{{_ "edited"}} at {{editTime}} {{_ "by"}} {{editedBy}}'
+			<span
+				title='{{_ "edited"}} at {{editTime}} {{_ "by"}} {{editedBy}}'
+				class="time">
+				{{time}}
+			</span>
+			<span
+				class="edited"
+				title='{{_ "edited"}} at {{editTime}} {{_ "by"}} {{editedBy}}'>
+				<i class="icon-edit"></i>
+				{{_ "by"}}
+				<a
 					class="thumb thumb-small user-card-message"
 					href="#"
 					data-username="{{editedBy}}"
 					tabindex="1">
-						{{> avatar username=editedBy}}
+					{{> avatar username=editedBy}}
 				</a>
-				{{_ "edited"}})
 			</span>
+		{{else}}
+			<span class="time">{{time}}</span>
 		{{/if}}
 		{{#if private}}
 			<span class="private">{{_ "Only_you_can_see_this_message"}}</span>

--- a/client/views/app/message.html
+++ b/client/views/app/message.html
@@ -5,7 +5,17 @@
 		<span class="info">
 			<span class="time">{{time}}</span>
 		{{#if edited}}
-			<span class="edited">({{_ "edited"}})</span>
+			<span class="edited">
+				(<a
+					title='{{_ "edited"}} at {{editTime}} {{_ "by"}} {{editedBy}}'
+					class="thumb thumb-small user-card-message"
+					href="#"
+					data-username="{{editedBy}}"
+					tabindex="1">
+						{{> avatar username=editedBy}}
+				</a>
+				{{_ "edited"}})
+			</span>
 		{{/if}}
 		{{#if private}}
 			<span class="private">{{_ "Only_you_can_see_this_message"}}</span>

--- a/packages/rocketchat-lib/server/models/Messages.coffee
+++ b/packages/rocketchat-lib/server/models/Messages.coffee
@@ -3,7 +3,8 @@ RocketChat.models.Messages = new class extends RocketChat.models._Base
 		@_initModel 'message'
 
 		@tryEnsureIndex { 'rid': 1, 'ts': 1 }
-		@tryEnsureIndex { 'ets': 1 }, { sparse: 1 }
+		@tryEnsureIndex { 'edit.at': 1 }, { sparse: 1 }
+		@tryEnsureIndex { 'edit.by': 1 }, { sparse: 1 }
 		@tryEnsureIndex { 'rid': 1, 't': 1, 'u._id': 1 }
 		@tryEnsureIndex { 'expireAt': 1 }, { expireAfterSeconds: 0 }
 		@tryEnsureIndex { 'msg': 'text' }
@@ -76,7 +77,7 @@ RocketChat.models.Messages = new class extends RocketChat.models._Base
 				ts:
 					$gt: timestamp
 			,
-				ets:
+				'edit.at':
 					$gt: timestamp
 			]
 
@@ -96,7 +97,9 @@ RocketChat.models.Messages = new class extends RocketChat.models._Base
 		record = @findOneById _id
 		record._hidden = true
 		record.parent = record._id
-		record.ets = new Date()
+		record.edit =
+			at: new Date()
+			by: Meteor.userId()
 		delete record._id
 
 		return @insert record
@@ -121,7 +124,8 @@ RocketChat.models.Messages = new class extends RocketChat.models._Base
 			$set:
 				msg: ''
 				t: 'rm'
-				ets: new Date()
+				'edit.at': new Date()
+				'edit.by': Meteor.userId()
 
 		return @update query, update
 

--- a/packages/rocketchat-livechat/app/client/views/message.html
+++ b/packages/rocketchat-livechat/app/client/views/message.html
@@ -1,10 +1,10 @@
 <template name="message">
 	<li id="{{_id}}" class="message sequential {{system}} {{t}} {{own}} {{isTemp}} {{error}}" data-username="{{u.username}}" data-date="{{date}}">
-		<span class="thumb" href="#" data-username="{{u.username}}" tabindex="1">{{> avatar username=u.username}}</span>
+		<span class="thumb thumb-small" href="#" data-username="{{u.username}}" tabindex="1">{{> avatar username=u.username}}</span>
 		<span class="user" href="#" data-username="{{u.username}}" tabindex="1">{{u.username}}</span>
 		<span class="info">
 			<span class="time">{{time}}</span>
-			{{#if ets}}
+			{{#if edit}}
 				<span class="edited">({{_ "edited"}})</span>
 			{{/if}}
 		</span>

--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -2454,10 +2454,18 @@ a.github-fork {
 			height: 20px;
 			display: inline-block;
 			vertical-align: bottom;
+			.avatar {
+				border-radius: 50%;
+			}
 		}
 	}
 	.info {
 		font-size: 12px;
+		.edited {
+			border-left: 1px dotted #BAB8B8;
+			padding-left: 3px;
+			margin-left: 3px;
+		}
 	}
 	.private {
 		margin-left: 10px;
@@ -2469,7 +2477,7 @@ a.github-fork {
 		.user {
 			display: none;
 		}
-		.thumb {
+		.thumb:not(.thumb-small) {
 			display: none;
 		}
 		.info {
@@ -2482,6 +2490,9 @@ a.github-fork {
 			}
 			.edited {
 				display: block;
+				border-left: 0;
+				margin-left: 0;
+				padding-left: 0;
 			}
 			.private {
 				display: none;

--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -2553,7 +2553,7 @@ a.github-fork {
 .compact {
 	.message {
 		padding: 5px 20px 5px 70px;
-		.thumb .avatar {
+		.thumb:not(.thumb-small) .avatar {
 			margin-top: -15px;
 		}
 	}

--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -2448,6 +2448,13 @@ a.github-fork {
 		display: block;
 		width: 40px;
 		height: 40px;
+		&.thumb-small {
+			position: initial;
+			width: 20px;
+			height: 20px;
+			display: inline-block;
+			vertical-align: bottom;
+		}
 	}
 	.info {
 		font-size: 12px;

--- a/server/methods/loadHistory.coffee
+++ b/server/methods/loadHistory.coffee
@@ -12,7 +12,7 @@ Meteor.methods
 			limit: limit
 
 		if not RocketChat.settings.get 'Message_ShowEditedStatus'
-			options.fields = { ets: 0 }
+			options.fields = { 'edit.at': 0 }
 
 		if end?
 			records = RocketChat.models.Messages.findVisibleByRoomIdBeforeTimestamp(rid, end, options).fetch()

--- a/server/methods/loadMissedMessages.coffee
+++ b/server/methods/loadMissedMessages.coffee
@@ -11,6 +11,6 @@ Meteor.methods
 				ts: -1
 
 		if not RocketChat.settings.get 'Message_ShowEditedStatus'
-			options.fields = { ets: 0 }
+			options.fields = { 'edit.at': 0 }
 
 		return RocketChat.models.Messages.findVisibleByRoomIdAfterTimestamp(rid, start, options).fetch()

--- a/server/methods/updateMessage.coffee
+++ b/server/methods/updateMessage.coffee
@@ -28,9 +28,9 @@ Meteor.methods
 		if RocketChat.settings.get 'Message_KeepHistory'
 			RocketChat.models.Messages.cloneAndSaveAsHistoryById originalMessage._id
 
-		message.ets = new Date()
-		# save who message was edited by
-		message.editBy = Meteor.userId()
+		message.edit =
+			at: new Date()
+			by: Meteor.userId()
 
 		if urls = message.msg.match /([A-Za-z]{3,9}):\/\/([-;:&=\+\$,\w]+@{1})?([-A-Za-z0-9\.]+)+:?(\d+)?((\/[-\+=!:~%\/\.@\,\w]+)?\??([-\+=&!:;%@\/\.\,\w]+)?#?([\w]+)?)?/g
 			message.urls = urls.map (url) -> url: url

--- a/server/methods/updateMessage.coffee
+++ b/server/methods/updateMessage.coffee
@@ -29,6 +29,8 @@ Meteor.methods
 			RocketChat.models.Messages.cloneAndSaveAsHistoryById originalMessage._id
 
 		message.ets = new Date()
+		# save who message was edited by
+		message.editBy = Meteor.userId()
 
 		if urls = message.msg.match /([A-Za-z]{3,9}):\/\/([-;:&=\+\$,\w]+@{1})?([-A-Za-z0-9\.]+)+:?(\d+)?((\/[-\+=!:~%\/\.@\,\w]+)?\??([-\+=&!:;%@\/\.\,\w]+)?#?([\w]+)?)?/g
 			message.urls = urls.map (url) -> url: url

--- a/server/startup/avatar.coffee
+++ b/server/startup/avatar.coffee
@@ -30,13 +30,14 @@ Meteor.startup ->
 
 	WebApp.connectHandlers.use '/avatar/', (req, res, next) ->
 		this.params =
-			username: req.url.replace(/^\//, '').replace(/\?.*$/, '')
+			username: decodeURIComponent(req.url.replace(/^\//, '').replace(/\?.*$/, ''))
 
 		if this.params.username[0] isnt '@'
 			file = RocketChatFileAvatarInstance.getFileWithReadStream this.params.username
 		else
 			this.params.username = this.params.username.replace '@', ''
 
+		#console.log "[avatar] checking username #{@params.username} (derrived from path #{req.url})"
 		res.setHeader 'Content-Disposition', 'inline'
 
 		if not file?
@@ -45,19 +46,22 @@ Meteor.startup ->
 
 			colors = ['#F44336','#E91E63','#9C27B0','#673AB7','#3F51B5','#2196F3','#03A9F4','#00BCD4','#009688','#4CAF50','#8BC34A','#CDDC39','#FFC107','#FF9800','#FF5722','#795548','#9E9E9E','#607D8B']
 
-			username = this.params.username.replace('.jpg', '')
-			position = username.length % colors.length
-			color = colors[position]
-
-			username = username.replace(/[^A-Za-z0-9]/g, '.').replace(/\.+/g, '.').replace(/(^\.)|(\.$)/g, '')
-			usernameParts = username.split('.')
+			username = @params.username.replace('.jpg', '')
+			color = ''
 			initials = ''
-			if usernameParts.length > 1
-				initials = _.first(usernameParts)[0] + _.last(usernameParts)[0]
+			if username is "?"
+				color = "#000"
+				initials = username
 			else
-				initials = username.replace(/[^A-Za-z0-9]/g, '').substr(0, 2)
-
-			initials = initials.toUpperCase()
+				position = username.length % colors.length
+				color = colors[position]
+				username = username.replace(/[^A-Za-z0-9]/g, '.').replace(/\.+/g, '.').replace(/(^\.)|(\.$)/g, '')
+				usernameParts = username.split('.')
+				initials = if usernameParts.length > 1
+					_.first(usernameParts)[0] + _.last(usernameParts)[0]
+				else
+					username.replace(/[^A-Za-z0-9]/g, '').substr(0, 2)
+				initials = initials.toUpperCase()
 
 			svg = """
 			<?xml version="1.0" encoding="UTF-8" standalone="no"?>

--- a/server/stream/messages.coffee
+++ b/server/stream/messages.coffee
@@ -23,7 +23,7 @@ Meteor.startup ->
 	options = {}
 
 	if not RocketChat.settings.get 'Message_ShowEditedStatus'
-		options.fields = { ets: 0 }
+		options.fields = { 'edit.at': 0 }
 
 	RocketChat.models.Messages.findVisibleCreatedOrEditedAfterTimestamp(new Date(), options).observe
 		added: (record) ->


### PR DESCRIPTION
This comes in the form of the user's avatar, along with a hover
title that shows username and edit time. As a side note, this
requires us to start saving 'editBy' id as part of message updates.

This has been tested with all 4 of the current avatar methods.

fixes #824