### PR TITLE
update ldapjs for support node 0.12.x tls

### DIFF
--- a/packages/rocketchat-ldap/package.js
+++ b/packages/rocketchat-ldap/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  ldapjs: "0.7.1",
+  ldapjs: "1.0.0",
 });
 
 // Loads all i18n.json files into tapi18nFiles


### PR DESCRIPTION
use nodejs 0.12.x on ldaps:// throw error #1363, update ldapjs fix this issuse