### PR TITLE
Moved oembed code to a template helper

### DIFF
--- a/client/views/app/message.html
+++ b/client/views/app/message.html
@@ -45,6 +45,11 @@
 
 		<div class="body" dir="auto">
 			{{{body}}}
+			{{#if hasOembed}}
+				{{#each urls}}
+					{{> oembed}}
+				{{/each}}
+			{{/if}}
 		</div>
 	</li>
 </template>


### PR DESCRIPTION
This makes message rendering much more self-contained and Meteor-like.

I also simplified `wasEdited`. Also I moved body to be rendered in `onCreated` so that it can be reused and accessed elsewhere. Ideally, I would make it so that it is simply a DOM fragment, as I described here: https://github.com/Konecty/meteor-nrr/issues/1. But I think it is a good first step.