### PR TITLE
Add permission checks to bulk rest api methods

### DIFF
--- a/packages/rocketchat-authorization/server/startup.coffee
+++ b/packages/rocketchat-authorization/server/startup.coffee
@@ -72,6 +72,11 @@ Meteor.startup ->
 		{ _id: 'delete-d',
 		roles : ['admin', 'site-moderator']}
 
+		{ _id: 'bulk-register-user',
+		roles : ['admin']}
+
+		{ _id: 'bulk-create-c',
+		roles : ['admin']}
 	]
 
 	#alanning:roles

--- a/server/methods/createChannel.coffee
+++ b/server/methods/createChannel.coffee
@@ -14,7 +14,7 @@ Meteor.methods
 		now = new Date()
 		user = Meteor.user()
 
-		members.push user.username
+		members.push user.username if user.username not in members
 
 		# avoid duplicate names
 		if RocketChat.models.Rooms.findOneByName name

--- a/server/methods/registerUser.coffee
+++ b/server/methods/registerUser.coffee
@@ -10,3 +10,5 @@ Meteor.methods
 
 		if userData.email
 			Accounts.sendVerificationEmail(userId, userData.email);
+
+		return userId

--- a/server/restapi/restapi.coffee
+++ b/server/restapi/restapi.coffee
@@ -99,7 +99,7 @@ NOTE:   remove room is NOT recommended; use Meteor.reset() to clear db and re-se
 ###
 Api.addRoute 'bulk/register', authRequired: true,
 	post:
-		roleRequired: ['testagent', 'adminautomation']
+		#roleRequired: ['testagent', 'adminautomation']
 		action: ->
 			try
 				Api.testapiValidateUsers  @bodyParams.users
@@ -107,10 +107,10 @@ Api.addRoute 'bulk/register', authRequired: true,
 				ids = []
 				endCount = @bodyParams.users.length - 1
 				for incoming, i in @bodyParams.users
-					ids[i] = Meteor.call 'registerUser', incoming
-					Meteor.runAsUser ids[i].uid, () =>
-						Meteor.call 'setUsername', incoming.name
-						Meteor.call 'joinDefaultChannels'
+				 	ids[i] = {uid: Meteor.call 'registerUser', incoming}
+				 	Meteor.runAsUser ids[i].uid, () =>
+				 		Meteor.call 'setUsername', incoming.name
+				 		Meteor.call 'joinDefaultChannels'
 
 				status: 'success', ids: ids
 			catch e
@@ -136,7 +136,7 @@ Api.testapiValidateRooms =  (rooms) ->
 @apiName createRoom
 @apiGroup TestAndAdminAutomation
 @apiVersion 0.0.1
-@apiParam {json} rooms An array of rooms in the body of the POST.
+@apiParam {json} rooms An array of rooms in the body of the POST. 'name' is room name, 'members' is array of usernames 
 @apiParamExample {json} POST Request Body example:
   {
     'rooms':[ {'name': 'room1',
@@ -163,7 +163,7 @@ NOTE:   remove room is NOT recommended; use Meteor.reset() to clear db and re-se
 ###
 Api.addRoute 'bulk/createRoom', authRequired: true,
 	post:
-		roleRequired: ['testagent', 'adminautomation']
+		#roleRequired: ['testagent', 'adminautomation']
 		action: ->
 			try
 				this.response.setTimeout (1000 * @bodyParams.rooms.length)


### PR DESCRIPTION
Fixes #1332 

Replaced bulk REST api methods rolesRequired option with RocketChat.authz.hasPermission checks because Restivus (provides our REST framework) does not support alanning:roles WITH groups (e.g. global, channel specific).  

Added 2 new permissions for bulk user registration and channel creation.  

@Sing-Li can you please take a look since you implemented the original rest api. Thanks!