### PR TITLE
Fixing broken editing when keep message history is enabled

### DIFF
--- a/packages/rocketchat-lib/server/models/Messages.coffee
+++ b/packages/rocketchat-lib/server/models/Messages.coffee
@@ -110,9 +110,9 @@ RocketChat.models.Messages = new class extends RocketChat.models._Base
 		record.editedBy =
 			_id: Meteor.userId()
 			username: me.username
-		message.pinned = record.pinned
-		message.pinnedAt = record.pinnedAt
-		message.pinnedBy =
+		record.pinned = record.pinned
+		record.pinnedAt = record.pinnedAt
+		record.pinnedBy =
 			_id: record.pinnedBy?._id
 			username: record.pinnedBy?.username
 		delete record._id


### PR DESCRIPTION
I was getting the same error as described in #1407.

```
debug.js:41 Error invoking Method 'updateMessage': Internal server error [500]
debug.js:41 Error invoking Method 'updateMessage': Internal server error [500]
```

Only occurred when Keep Message History was enabled. This small fix sorted it for me.