### PR TITLE
Fix for #1411 and #1407. Corrected ill-referenced variables

### DIFF
--- a/packages/rocketchat-lib/server/models/Messages.coffee
+++ b/packages/rocketchat-lib/server/models/Messages.coffee
@@ -110,9 +110,9 @@ RocketChat.models.Messages = new class extends RocketChat.models._Base
 		record.editedBy =
 			_id: Meteor.userId()
 			username: me.username
-		message.pinned = record.pinned
-		message.pinnedAt = record.pinnedAt
-		message.pinnedBy =
+		record.pinned = record.pinned
+		record.pinnedAt = record.pinnedAt
+		record.pinnedBy =
 			_id: record.pinnedBy?._id
 			username: record.pinnedBy?.username
 		delete record._id

--- a/packages/rocketchat-message-pin/client/actionButton.coffee
+++ b/packages/rocketchat-message-pin/client/actionButton.coffee
@@ -16,7 +16,7 @@ Meteor.startup ->
 			if RocketChat.settings.get('Message_AllowPinningByAnyone') or RocketChat.authz.hasRole Meteor.userId(), 'admin'
 				return true
 
-			return room.u?._id is Meteor.userId()
+			return ChatRoom.findOne(message.rid).u?._id is Meteor.userId()
 		order: 20
 
 	RocketChat.MessageAction.addButton
@@ -36,5 +36,5 @@ Meteor.startup ->
 			if RocketChat.settings.get('Message_AllowPinningByAnyone') or RocketChat.authz.hasRole Meteor.userId(), 'admin'
 				return true
 
-			return room.u?._id is Meteor.userId()
+			return ChatRoom.findOne(message.rid).u?._id is Meteor.userId()
 		order: 21


### PR DESCRIPTION
I was was not able to verify #1407 as being fixed since there wasn't step by step instructions on how to replicate it, but I was able to edit messages as a regular user and admin user.

Think this is a good point to say that when doing "code reviews" on pull requests we should be more detail focused. My reason for this is because a quick look at the code should have showed that the variables being referenced weren't actually there. I am to blame for not doing as thorough as I should have, but would have been helpful to have a someone else point it out before it got merged....just my two cents on the subject.