### PR TITLE
fix delete msg with oembed problem -  closes #1429

### DIFF
--- a/packages/rocketchat-lib/server/models/Messages.coffee
+++ b/packages/rocketchat-lib/server/models/Messages.coffee
@@ -140,6 +140,7 @@ RocketChat.models.Messages = new class extends RocketChat.models._Base
 			$set:
 				msg: ''
 				t: 'rm'
+				urls: []
 				editedAt: new Date()
 				editedBy:
 					_id: Meteor.userId()


### PR DESCRIPTION
view will render oembed in (marked as deleted) msg - even if msg type is 'rm'