### PR TITLE
[sandstorm] Add spk generation to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,16 @@ before_install:
 - export JASMINE_DEBUG=1
 - export VELOCITY_DEBUG=1
 - export VELOCITY_DEBUG_MIRROR=1
+- export SANDSTORM_VERSION=$(curl -f "https://install.sandstorm.io/dev?from=0&type=install")
+- cd /tmp
+- curl https://dl.sandstorm.io/sandstorm-$SANDSTORM_VERSION.tar.xz | tar -xJf -
+- export PATH=$PATH:${PWD}/sandstorm-$SANDSTORM_VERSION/bin
+- sudo mkdir -p /home/vagrant
+- sudo chown -R travis /home/vagrant
+- sudo mkdir -p /opt
+- sudo chown -R travis /opt
+- cd $TRAVIS_BUILD_DIR
+- cp -r . /opt/app
 script:
 - if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then echo "Building PR $TRAVIS_PULL_REQUEST"; meteor build ../build; exit $?; fi
 - cd .travis
@@ -33,11 +43,18 @@ script:
 - cd .travis
 - sh ./namefiles.sh
 - cd ..
-- meteor add  rocketchat:livechat rocketchat:hubot 
+- meteor add  rocketchat:livechat rocketchat:hubot
 - meteor build --server demo.rocket.chat  ../build
 - cd .travis
 - sh ./namedemo.sh
-- cd ..
+- cd /tmp
+- spk init -p3000 -- nothing
+- export SANDSTORM_ID=$(grep '\sid =' sandstorm-pkgdef.capnp)
+- cd $TRAVIS_BUILD_DIR/.sandstorm
+- sed -i "s/\sid = .*/$SANDSTORM_ID/" sandstorm-pkgdef.capnp
+- ./build.sh
+- spk pack $TRAVIS_BUILD_DIR/rocket.chat.spk
+- cd $TRAVIS_BUILD_DIR
 after_deploy:
 - "curl -H \"Content-Type: application/json\" --data \"{'build': true}\" -X POST https://registry.hub.docker.com/u/rocketchat/rocket.chat/trigger/$PUSHTOKEN/"
 deploy:


### PR DESCRIPTION
@Sing-Li 

This adds spk generation to the travis-ci build. I didn't add a deploy step, since I'm not sure what you guys want to do there. Also, the commands to setup/build the spk got more complicated than I expected, and it may be better to move them to scripts in the `.travis` directory.

One thing worth noting. This uses a randomized app key instead of the private Rocket.chat key (see the `spk init/grep/sed` steps). This is useful for testing purposes, but means that you can't deploy the spk as-is. You could tweak this to use your Sandstorm private key by passing it in as a travis environment variable (obtainable by running `spk getkey vfnwptfn02ty21w715snyyczw0nqxkv3jvawcah10c6z7hj1hnu0
`). Just be *very* careful to not leak it.

If there's interest, we could instead add a `spk repack` command or something similar to repackage the spk with a different id and key, allowing you to use randomized keys for testing, and then manually repack with your private key before publishing.