### PR TITLE
Fix wrong PGP signature for Sandstorm spk builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,9 @@ script:
 - cd $TRAVIS_BUILD_DIR/.sandstorm
 - sed -i "s/\sid = .*/$SANDSTORM_ID/" sandstorm-pkgdef.capnp
 - ./build.sh
-- spk pack $TRAVIS_BUILD_DIR/rocket.chat.spk
+- sed -i "s/\spgp/#pgp/g" sandstorm-pkgdef.capnp
+- spk pack $TRAVIS_BUILD_DIR/../build/rocket.chat.latest.spk
 - cd $TRAVIS_BUILD_DIR
-- mv rocket.chat.spk ../build/rocket.chat.latest.spk
 after_deploy:
 - cd .travis
 - sh ./builddocker.sh


### PR DESCRIPTION
There's a bug (feature?) in Sandstorm that prevents spks with an
improper PGP signature from being installed. This change produces an
spk without PGP signatures, and the future `spk repack` command will
allow you to add/change the PGP signatures in addition to changing app id.