### PR TITLE
Fixes to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 mongo:
   image: mongo
 # volumes:
-#    - ./data/runtime/mongo:/data/mongo
+#    - ./data/runtime/db:/data/db
 #    - ./data/dump:/dump
-  command: mongod --smallfiles --replSet rs0 --oplogSize 128
+  command: mongod --smallfiles --oplogSize 128
 
 rocketchat:
   image: rocketchat/rocket.chat:develop
@@ -19,4 +19,3 @@ rocketchat:
     - mongo:mongo
   ports:
     - 3000:3000
-


### PR DESCRIPTION
* Removing --replSet rs0 which causes issue as [described here](https://github.com/RocketChat/Rocket.Chat/issues/1472)

* Updating the mongo database datadir location so that if somebody decides to use volumes in order to maintain state, it works. I'm guessing mongodb changed it's default location from "mongo" to "db" and nobody noticed.