### PR TITLE
Textarea theme fix for RTL

### DIFF
--- a/packages/rocketchat-theme/assets/stylesheets/rtl.less
+++ b/packages/rocketchat-theme/assets/stylesheets/rtl.less
@@ -222,9 +222,19 @@
 
   .messages-container {
     .message-form {
+    	> div {
+    		> .file {
+    			border: 1px;
+    			border-radius: 0 5px 5px 0;
+    			border-left: none;
+    			border-right: solid;
+    		}
+    	}
       textarea {
           padding-left: 38px;
           padding-right: 8px;
+          border-radius: 5px 0 0 5px;
+          text-align: right;
         }
        >.users-typing {
          float: right;


### PR DESCRIPTION
These changes alters the theme of the text-area and the upload button to look correct with RTL interface.

![rocketchat-bug11](https://cloud.githubusercontent.com/assets/432460/11514136/f434e230-9844-11e5-8579-451560466add.png)

Related issue: #1521