### PR TITLE
Update the flex-nav hidden element for RTL

### DIFF
--- a/packages/rocketchat-theme/assets/stylesheets/rtl.less
+++ b/packages/rocketchat-theme/assets/stylesheets/rtl.less
@@ -94,7 +94,7 @@
       .right(0px);
     }
 
-    .flex-nav.hidden {
+    .flex-nav.animated-hidden {
       transform: translateX(100%);
     }
 


### PR DESCRIPTION
Updated the name of the flex-nav element for RTL from `hidden` to the correct name `animated-hidden`

Related issue: https://github.com/RocketChat/Rocket.Chat/issues/1521