### PR TITLE
Reset avatar before uploading to prevent caching issues

### DIFF
--- a/server/methods/setAvatarFromService.coffee
+++ b/server/methods/setAvatarFromService.coffee
@@ -32,6 +32,7 @@ Meteor.methods
 				throw new Meteor.Error('invalid-avatar-url', '[methods] setAvatarFromService -> url service -> invalid content-type')
 
 			ars = RocketChatFile.bufferToStream new Buffer(result.content, 'binary')
+			RocketChatFileAvatarInstance.deleteFile "#{user.username}.jpg"
 			aws = RocketChatFileAvatarInstance.createWriteStream "#{user.username}.jpg", result.headers['content-type']
 			aws.on 'end', Meteor.bindEnvironment ->
 				Meteor.setTimeout ->
@@ -46,6 +47,7 @@ Meteor.methods
 		{image, contentType} = RocketChatFile.dataURIParse dataURI
 
 		rs = RocketChatFile.bufferToStream new Buffer(image, 'base64')
+		RocketChatFileAvatarInstance.deleteFile encodeURIComponent("#{user.username}.jpg")
 		ws = RocketChatFileAvatarInstance.createWriteStream encodeURIComponent("#{user.username}.jpg"), contentType
 		ws.on 'end', Meteor.bindEnvironment ->
 			Meteor.setTimeout ->


### PR DESCRIPTION
Adds a call to `RocketChatFileAvatarInstance.deleteFile` before uploading avatars, which removes the file from store before uploading new one. This prevents caching issues when avatar is later changed by the same user. Fixes issue #1546.