### PR TITLE
Added option to disable "Forgot Password" link on login page.

### DIFF
--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -57,6 +57,7 @@
   "Accounts_RegistrationForm_SecretURL_Description" : "You must provide a random string that will be added to your registration URL. Example: https://demo.rocket.chat/register/[secret_hash]",
   "Accounts_RegistrationRequired" : "Registration Required",
   "Accounts_RequireNameForSignUp" : "Require Name For Signup",
+  "Accounts_PasswordReset" : "Password Reset",
   "Accounts_Enrollment_Email" : "Enrollment E-mail",
   "Accounts_Enrollment_Email_Description" : "You may use [name], [fname], [lname] for the user's full name, first name or last name, respectively.<br />You may use [email] for the user's e-mail.",
   "Activate" : "Activate",

--- a/packages/rocketchat-lib/server/startup/settings.coffee
+++ b/packages/rocketchat-lib/server/startup/settings.coffee
@@ -12,6 +12,8 @@ RocketChat.settings.add 'Accounts_RegistrationForm_SecretURL', Random.id(), { ty
 RocketChat.settings.add 'Accounts_RegistrationForm_LinkReplacementText', 'New user registration is currently disabled', { type: 'string', group: 'Accounts', section: 'Registration', public: true }
 RocketChat.settings.add 'Accounts_Registration_AuthenticationServices_Enabled', true, { type: 'boolean', group: 'Accounts', section: 'Registration', public: true }
 
+RocketChat.settings.add 'Accounts_PasswordReset', true, { type: 'boolean', group: 'Accounts', public: true, section: 'Registration' }
+
 RocketChat.settings.add 'Accounts_AvatarStoreType', 'GridFS', { type: 'string', group: 'Accounts', section: 'Avatar' }
 RocketChat.settings.add 'Accounts_AvatarStorePath', '', { type: 'string', group: 'Accounts', section: 'Avatar' }
 RocketChat.settings.add 'Accounts_AvatarResize', false, { type: 'boolean', group: 'Accounts', section: 'Avatar' }

--- a/packages/rocketchat-ui-login/login/form.coffee
+++ b/packages/rocketchat-ui-login/login/form.coffee
@@ -57,6 +57,9 @@ Template.loginForm.helpers
 	linkReplacementText: ->
 		return RocketChat.settings.get('Accounts_RegistrationForm_LinkReplacementText')
 
+	passwordresetAllowed: ->
+		return RocketChat.settings.get 'Accounts_PasswordReset'
+
 Template.loginForm.events
 	'submit #login-card': (event, instance) ->
 		event.preventDefault()

--- a/packages/rocketchat-ui-login/login/form.html
+++ b/packages/rocketchat-ui-login/login/form.html
@@ -45,9 +45,11 @@
 			{{else}}{{#if linkReplacementText}}
 				{{{linkReplacementText}}}
 			{{/if}}{{/if}}
+			{{#if passwordresetAllowed}}
 			<div class="forgot-password {{showForgotPasswordLink}}">
 				<a href="">{{_ 'Forgot_password'}}</a>
 			</div>
+			{{/if}}
 		{{/if}}
 		<div class="back-to-login {{showBackToLoginLink}}">
 			<a href="">{{_ 'Back_to_login'}}</a>


### PR DESCRIPTION
Added a option to Accounts -> Registration to disable Forgot Password link on login page.
Link isn't necessary in our case as we use LDAP for authentication. This link will probably just confuse our users.
Perhaps anyone else needs this also :)

I'm not a developer so feel free to refactor as needed or toss it into junk :)