### PR TITLE
Fix for image swipebox to show in RTL interface

### DIFF
--- a/packages/rocketchat-theme/assets/stylesheets/rtl.less
+++ b/packages/rocketchat-theme/assets/stylesheets/rtl.less
@@ -620,6 +620,9 @@
 			.left(10px);
 		}
 	}
+	#swipebox-overlay{
+		direction: ltr;
+	}
 
 	/* Overridding the icons Unicode to suit RTL languages
 	 * from _octicons.less */


### PR DESCRIPTION
swipebox has not built in support for RTL, and without this fix the images will display outside of the window range since it does the calculation for the window location assuming every thing is aligned left, and that is hard-coded in its javascript and cannot be overridden with css.

The easiest fix which is proposed here is to override the global RTL just for swipebox, and make it display in LTR to match its calculations. The problem however, is that the Next and Prev buttons are still in LTR direction which is the opposite of what users of RTL expect.

The other solution is to either replace swipebox with something that is RTL aware, or modify swipebox code to add RTL support.