### PR TITLE
Force file names to always be in LTR

### DIFF
--- a/packages/rocketchat-theme/assets/stylesheets/rtl.less
+++ b/packages/rocketchat-theme/assets/stylesheets/rtl.less
@@ -576,6 +576,9 @@
 			}
 		}
 		&.uploaded-files-list {
+			a {
+				direction: ltr;
+			}
 			i {
 				float: right;
 				.margin-left(10px);


### PR DESCRIPTION
In RTL interface if the file name  has only number, or included RTL characters the file extension will be shown in the wrong side. This fix makes file extensions show correctly for all files