### PR TITLE
When uploading an avatar keep "Select file" button

### DIFF
--- a/packages/rocketchat-ui-account/account/avatar/prompt.html
+++ b/packages/rocketchat-ui-account/account/avatar/prompt.html
@@ -48,14 +48,12 @@
 							<div style="background-image: url({{upload.blob}});" class="avatar {{#unless upload}}question-mark icon-upload{{/unless}}">
 							</div>
 							<div class="action">
+								<div class="button primary">{{_ "Select_file"}}
+									<input type="file" class="avatar-file-input" accept="image/*">
+								</div>
 								{{#with upload}}
 									<button type="button" class="button primary select-service">{{_ "Use_uploaded_avatar"}}</button>
 								{{/with}}
-								{{#unless upload}}
-									<div class="button primary">{{_ "Select_file"}}
-										<input type="file" class="avatar-file-input" accept="image/*">
-									</div>
-								{{/unless}}
 							</div>
 						</div>
 						<div class="avatar-suggestion-item">


### PR DESCRIPTION
Currently when you upload an image as an avatar, the "SELECT FILE" button disappears and you get another button to use the uploaded file. However, if you didn't like how the uploaded image looks you cannot upload another one. The work around is to reopen the avatar settings page, instead the upload button should stay there to allow the user to upload a different image.

![rocket_bug2](https://cloud.githubusercontent.com/assets/432460/11694352/abf280ac-9e77-11e5-8b4b-99b247862397.png)
