### PR TITLE
Set code blocks to always be LTR

### DIFF
--- a/packages/rocketchat-theme/assets/stylesheets/rtl.less
+++ b/packages/rocketchat-theme/assets/stylesheets/rtl.less
@@ -32,6 +32,11 @@
 		padding-right: 0px;
 	}
 
+	code {
+		unicode-bidi: embed;
+		direction: ltr;
+	}
+
 	.side-nav {
 		.right(0px);
 		.header {


### PR DESCRIPTION
Code blocks and inline code that are preceded by RTL text will get displayed in RTL, and that breaks the formatting. This fix forces it to always display in LTR