### PR TITLE
fix broken image-link when og:image contains "&amp;" (e.g. Google Maps)

### DIFF
--- a/packages/rocketchat-oembed/client/oembedUrlWidget.coffee
+++ b/packages/rocketchat-oembed/client/oembedUrlWidget.coffee
@@ -26,7 +26,9 @@ Template.oembedUrlWidget.helpers
 		if not this.meta?
 			return
 
-		return this.meta.ogImage or this.meta.twitterImage
+		decodedOgImage = @meta.ogImage.replace(/&amp;/g, '&')
+
+		return decodedOgImage or this.meta.twitterImage
 
 	show: ->
 		return getDescription(this)? or getTitle(this)?


### PR DESCRIPTION
When sending a link to Google Maps the preview image is broken. Background: The link to the image is grabbed from the target page from the meta.og:image element - which contains several "&amp" instead of "&" in case of GM.