### PR TITLE
Set code blocks to always be LTR globally

### DIFF
--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -53,6 +53,8 @@ code {
 	word-wrap: break-word;
 	text-align: left;
 	white-space: pre-wrap;
+	unicode-bidi: embed;
+	direction: ltr;
 	&.inline {
 		display: inline;
 		padding: 0 0.5em;

--- a/packages/rocketchat-theme/assets/stylesheets/rtl.less
+++ b/packages/rocketchat-theme/assets/stylesheets/rtl.less
@@ -32,11 +32,6 @@
 		padding-right: 0px;
 	}
 
-	code {
-		unicode-bidi: embed;
-		direction: ltr;
-	}
-
 	.side-nav {
 		.right(0px);
 		.header {


### PR DESCRIPTION
Update to the previous pull https://github.com/RocketChat/Rocket.Chat/pull/1626

>Code blocks and inline code that are preceded by RTL text will get displayed in RTL, and that breaks the formatting. This fix forces it to always display in LTR

Moved the changes to the `base.less` since it is not specific to RTL interface it also applies even if the user interface is LTR.