### PR TITLE
Fix for mentioning RTL names

### DIFF
--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -499,6 +499,7 @@
   "Users" : "Users",
   "UTF8_Names_Slugify" : "UTF8 Names Slugify",
   "UTF8_Names_Validation" : "UTF8 Names Validation",
+  "UTF8_Names_Validation_Description" : "Do not allow special characters and spaces. You can use - _ and . but not at the end of the name",
   "View_All" : "View All",
   "Wait_activation_warning" : "Before you can login, your account must be manually activated by an administrator.",
   "We_have_sent_password_email" : "We have sent you an e-mail with password reset instructions. If you do not receive an e-mail shortly, please come back and try again.",

--- a/packages/rocketchat-lib/server/startup/settings.coffee
+++ b/packages/rocketchat-lib/server/startup/settings.coffee
@@ -61,7 +61,7 @@ RocketChat.settings.add 'Disable_Favorite_Rooms', false, { type: 'boolean', grou
 RocketChat.settings.add 'CDN_PREFIX', '', { type: 'string', group: 'General' }
 RocketChat.settings.add 'Restart', 'restart_server', { type: 'action', group: 'General', actionText: 'Restart_the_server' }
 
-RocketChat.settings.add 'UTF8_Names_Validation', '[0-9a-zA-Z-_.]+', { type: 'string', group: 'General', section: 'UTF8', public: true }
+RocketChat.settings.add 'UTF8_Names_Validation', '[0-9a-zA-Z-_.]+', { type: 'string', group: 'General', section: 'UTF8', public: true  ,i18nDescription: 'UTF8_Names_Validation_Description'}
 RocketChat.settings.add 'UTF8_Names_Slugify', true, { type: 'boolean', group: 'General', section: 'UTF8', public: true }
 
 RocketChat.settings.addGroup 'API'

--- a/packages/rocketchat-mentions/client.coffee
+++ b/packages/rocketchat-mentions/client.coffee
@@ -19,7 +19,7 @@ class MentionsClient
 			if mentions.length isnt 0
 				mentions = _.unique mentions
 				mentions = mentions.join('|')
-				msg = msg.replace new RegExp("(?:^|\\s|\\n)(@(#{mentions}):?)\\b", 'g'), (match, mention, username) ->
+				msg = msg.replace new RegExp("(?:^|\\s|\\n)(@(#{mentions}):?)[:.,\s]?", 'g'), (match, mention, username) ->
 					if username is 'all'
 						return match.replace mention, "<a href=\"\" class=\"mention-link mention-link-me\">#{mention}</a>"
 
@@ -41,7 +41,7 @@ class MentionsClient
 			if channels.length isnt 0
 				channels = _.unique channels
 				channels = channels.join('|')
-				msg = msg.replace new RegExp("(?:^|\\s|\\n)(#(#{channels}))\\b", 'g'), (match, mention, channel) ->
+				msg = msg.replace new RegExp("(?:^|\\s|\\n)(#(#{channels}))[:.,\s]?", 'g'), (match, mention, channel) ->
 					if not message.temp?
 						if not _.findWhere(message.channels, {name: channel})?
 							return match


### PR DESCRIPTION
The current @mention (for user names and channel names) uses the regex `\b` to detect the name boundaries, however that token doesn't support Unicode characters. This solution replaces the word boundary with a regex that matches end of the word with any of the following white space, colon, comma and dot.

_However, ending a name with a dot still has a problem as it doesn't get a mention link and this fix does not fix it. Part of the problem is that dots are allowed in the name validation regex. So this problem need to be solved later._

Another thing that this fix adds is a description to the UTF8 Name Validation settings, to inform chat admins about the characters that they need to avoid using in their regexes to not break other chat functionalities that depends on special characters to denote special meanings.