### PR TITLE
Avatars for Unicode usernames

### DIFF
--- a/server/methods/setAvatarFromService.coffee
+++ b/server/methods/setAvatarFromService.coffee
@@ -32,8 +32,8 @@ Meteor.methods
 				throw new Meteor.Error('invalid-avatar-url', '[methods] setAvatarFromService -> url service -> invalid content-type')
 
 			ars = RocketChatFile.bufferToStream new Buffer(result.content, 'binary')
-			RocketChatFileAvatarInstance.deleteFile "#{user.username}.jpg"
-			aws = RocketChatFileAvatarInstance.createWriteStream "#{user.username}.jpg", result.headers['content-type']
+			RocketChatFileAvatarInstance.deleteFile encodeURIComponent("#{user.username}.jpg")
+			aws = RocketChatFileAvatarInstance.createWriteStream encodeURIComponent("#{user.username}.jpg"), result.headers['content-type']
 			aws.on 'end', Meteor.bindEnvironment ->
 				Meteor.setTimeout ->
 					console.log "Set #{user.username}'s avatar from the url: #{dataURI}"

--- a/server/startup/avatar.coffee
+++ b/server/startup/avatar.coffee
@@ -33,7 +33,7 @@ Meteor.startup ->
 			username: decodeURIComponent(req.url.replace(/^\//, '').replace(/\?.*$/, ''))
 
 		if params.username[0] isnt '@'
-			file = RocketChatFileAvatarInstance.getFileWithReadStream params.username
+			file = RocketChatFileAvatarInstance.getFileWithReadStream encodeURIComponent(params.username)
 		else
 			params.username = params.username.replace '@', ''
 


### PR DESCRIPTION
When a new avatar is saved the user name gets encoded using `encodeURIComponent`, this does not affect names in latin characters, however it does change non-latin/unicode names to an encoded string.

However, when reading the avatar image file, the function uses the username directly without enocinding it, so latin names work since the encoding doesn't change anything, however, Unicode names don't since the usernames don't match the encoded names.

This fix adds the encoding function when reading the avatars.
Also adds the encoding to the function that writes avatars from URL.