### PR TITLE
Rocket.Cat Shouldn't be Admin

### DIFF
--- a/server/lib/accounts.coffee
+++ b/server/lib/accounts.coffee
@@ -77,7 +77,6 @@ Accounts.insertUserDoc = _.wrap Accounts.insertUserDoc, (insertUserDoc) ->
 	# when inserting first user give them admin privileges otherwise make a regular user
 	firstUser = RocketChat.models.Users.findOne({ _id: { $ne: 'rocket.cat' }}, { sort: { createdAt: 1 }})
 	roleName = if firstUser?._id is _id then 'admin' else 'user'
-	console.log "The role for #{_id} is #{roleName}."
 
 	RocketChat.authz.addUsersToRoles(_id, roleName)
 	RocketChat.callbacks.run 'afterCreateUser', options, user

--- a/server/lib/accounts.coffee
+++ b/server/lib/accounts.coffee
@@ -75,8 +75,9 @@ Accounts.insertUserDoc = _.wrap Accounts.insertUserDoc, (insertUserDoc) ->
 	_id = insertUserDoc.call(Accounts, options, user)
 
 	# when inserting first user give them admin privileges otherwise make a regular user
-	firstUser = RocketChat.models.Users.findOne({},{sort:{createdAt:1}})
+	firstUser = RocketChat.models.Users.findOne({ _id: { $ne: 'rocket.cat' }}, { sort: { createdAt: 1 }})
 	roleName = if firstUser?._id is _id then 'admin' else 'user'
+	console.log "The role for #{_id} is #{roleName}."
 
 	RocketChat.authz.addUsersToRoles(_id, roleName)
 	RocketChat.callbacks.run 'afterCreateUser', options, user

--- a/server/startup/initialData.coffee
+++ b/server/startup/initialData.coffee
@@ -53,7 +53,7 @@ Meteor.startup ->
 		# Set oldest user as admin, if none exists yet
 		if _.isEmpty( RocketChat.authz.getUsersInRole( 'admin' ).fetch())
 			# get oldest user
-			oldestUser = RocketChat.models.Users.findOne({}, { fields: { username: 1 }, sort: {createdAt: 1}})
+			oldestUser = RocketChat.models.Users.findOne({ _id: { $ne: 'rocket.cat' }}, { fields: { username: 1 }, sort: {createdAt: 1}})
 			if oldestUser
 				RocketChat.authz.addUsersToRoles( oldestUser._id, 'admin')
 				console.log "No admins are found. Set #{oldestUser.username} as admin for being the oldest user"


### PR DESCRIPTION
The recent addition of the user `Rocket.Cat` for integration and it being created as a first user has caused the "real" first users to no longer be made admin. This fixes #1632 and #1646 