### PR TITLE
Fix 'create new' in private group list opening 'create channel' flex

### DIFF
--- a/packages/rocketchat-ui-sidenav/side-nav/listPrivateGroupsFlex.coffee
+++ b/packages/rocketchat-ui-sidenav/side-nav/listPrivateGroupsFlex.coffee
@@ -10,7 +10,7 @@ Template.listPrivateGroupsFlex.events
 		SideNav.closeFlex()
 
 	'click footer .create': ->
-		SideNav.setFlex "createChannelFlex"
+		SideNav.setFlex "privateGroupsFlex"
 
 	'mouseenter header': ->
 		SideNav.overArrow()


### PR DESCRIPTION
Currently, if one opens the list of their private groups ("More private groups ..") and then clicks on 'CREATE NEW'  the 'Create a new public channel' dialog is opened. I believe that this is not intended behaviour, so this PR makes it open the 'Create a new private group' dialog instead.