### PR TITLE
Added setting Accounts_LoginExpiration

### DIFF
--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -17,6 +17,7 @@
   "Accounts_EmailVerification" : "E-mail Verification",
   "Accounts_Enrollment_Email" : "Enrollment E-mail",
   "Accounts_Enrollment_Email_Description" : "You may use [name], [fname], [lname] for the user's full name, first name or last name, respectively.<br />You may use [email] for the user's e-mail.",
+  "Accounts_LoginExpiration" : "Login Expiration in Days",
   "Accounts_ManuallyApproveNewUsers" : "Manually Approve New Users",
   "Accounts_OAuth_Custom_Authorize_Path" : "Authorize Path",
   "Accounts_OAuth_Custom_Button_Color" : "Button Color",

--- a/packages/rocketchat-lib/server/startup/settings.coffee
+++ b/packages/rocketchat-lib/server/startup/settings.coffee
@@ -47,6 +47,8 @@ RocketChat.settings.add 'Accounts_AllowUsernameChange', true, { type: 'boolean',
 RocketChat.settings.add 'Accounts_AllowPasswordChange', true, { type: 'boolean', group: 'Accounts', section: 'General', public: true }
 RocketChat.settings.add 'Accounts_RequireNameForSignUp', true, { type: 'boolean', group: 'Accounts', section: 'General', public: true }
 
+RocketChat.settings.add 'Accounts_LoginExpiration', 90, { type: 'int', group: 'Accounts', section: 'General', public: true }
+
 RocketChat.settings.addGroup 'FileUpload'
 RocketChat.settings.add 'FileUpload_Enabled', true, { type: 'boolean', group: 'FileUpload', public: true }
 RocketChat.settings.add 'FileUpload_MaxFileSize', 2097152, { type: 'int', group: 'FileUpload', public: true }

--- a/server/lib/accounts.coffee
+++ b/server/lib/accounts.coffee
@@ -1,5 +1,5 @@
-# Deny Account.createUser in client
-accountsConfig = { forbidClientAccountCreation: true }
+# Deny Account.createUser in client and set Meteor.loginTokenExpires
+accountsConfig = { forbidClientAccountCreation: true, loginExpirationInDays: RocketChat.settings.get 'Accounts_LoginExpiration' }
 
 if RocketChat.settings.get('Account_AllowedDomainsList')
 	domainWhiteList = _.map RocketChat.settings.get('Account_AllowedDomainsList').split(','), (domain) -> domain.trim()


### PR DESCRIPTION
Setting allows admin to modify Meteor.loginTokenExpires from default 90 days to something else.
Server restart is required for this setting to take effect.
Default value is still 90 days if not modified by admin.