### PR TITLE
Add Scalingo Deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The Ultimate Open Source WebChat Platform
 * [Desktop apps](#desktop-apps)
 * [Deployment](#deployment)
   * [Heroku](#heroku)
+  * [Scalingo](#scalingo)
   * [Sandstorm.io](#sandstormio)
   * [Sloppy.io](#sloppyio)
   * [Docker](#docker)
@@ -67,6 +68,17 @@ Branch **master** (Latest stable version):
 Branch **develop** (Newer but unstable):
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/RocketChat/Rocket.Chat/tree/develop)
+
+## Scalingo
+Deploy your own Rocket.Chat server instantly on [Scalingo](https://scalingo.com)
+
+Branch **master** (Latest stable version):
+
+[![Deploy on Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/RocketChat/Rocket.Chat#master)
+
+Branch **develop** (Newer but unstable):
+
+[![Deploy on Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/RocketChat/Rocket.Chat#develop)
 
 ## Sandstorm.io
 [![Rocket.Chat on Sandstorm.io](https://raw.githubusercontent.com/Sing-Li/bbug/master/images/sandstorm.jpg)](https://apps.sandstorm.io/app/vfnwptfn02ty21w715snyyczw0nqxkv3jvawcah10c6z7hj1hnu0)

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,8 @@
+{
+  "name": "Rocket.Chat",
+  "repository": "https://github.com/RocketChat/Rocket.Chat",
+  "description": "Have your own open-source Slack-like online chat, built with Meteor.",
+  "logo": "https://raw.githubusercontent.com/RocketChat/Rocket.Chat/master/public/images/logo/512x512.png?v=3",
+  "website": "https://rocket.chat",
+  "addons": ["scalingo-mongodb"]
+}


### PR DESCRIPTION
Scalingo is a PaaS that supports Meteor pretty well, we've done a lot of work to make things work out of the box. Oplog and horizontal scaling are available for further needs. Meteor is a really promising technology and we'd be glad helping this project to grow. So this PR is in the continuity of the heroku deploy button and works the same way to let users deploy their own version of 'Rocket.Chat' in an instant.

You can test the button (link to fork) here : https://github.com/Zyko0/Rocket.Chat/tree/one_click