### PR TITLE
Adjust layout direction based on user's language

### DIFF
--- a/client/startup/startup.coffee
+++ b/client/startup/startup.coffee
@@ -39,8 +39,11 @@ Meteor.startup ->
 		if Meteor.user()?.language?
 			c.stop()
 
-			localStorage.setItem("userLanguage", Meteor.user().language)
-			setLanguage Meteor.user().language
+			if localStorage.getItem('userLanguage') isnt Meteor.user().language
+				localStorage.setItem("userLanguage", Meteor.user().language)
+				setLanguage Meteor.user().language
+				if isRtl localStorage.getItem "userLanguage"
+					$('html').addClass "rtl"
 
 	userLanguage = localStorage.getItem("userLanguage")
 	userLanguage ?= defaultUserLanguage()


### PR DESCRIPTION
This fixes the issue https://github.com/RocketChat/Rocket.Chat/issues/1623

So basically if a user login from a new machine and the language loaded from their profile is different from the local one then set the correct language and if it is an RTL language set the RTL class immediately.