### PR TITLE
Support Integration webhook calls originating from client browsers

### DIFF
--- a/packages/rocketchat-integrations/server/api/api.coffee
+++ b/packages/rocketchat-integrations/server/api/api.coffee
@@ -1,5 +1,5 @@
 Api = new Restivus
-	enableCors: false
+	enableCors: true
 	apiPath: 'hooks/'
 	auth:
 		user: ->


### PR DESCRIPTION
Most modern browser will issue a pre-flight request with HTTP OPTION method before the actual asynchronous POST; and will not continue of it the OPTION fails.    This adds a CORS supporting option endpoint.