### PR TITLE
Change to user's language once user login if user's language is different from app language

### DIFF
--- a/client/startup/startup.coffee
+++ b/client/startup/startup.coffee
@@ -23,12 +23,14 @@ Meteor.startup ->
 
 	loadedLaguages = []
 
-	setLanguage = (language) ->
+	@setLanguage = (language) ->
 		if loadedLaguages.indexOf(language) > -1
 			return
 
 		loadedLaguages.push language
 
+		if isRtl language
+			$('html').addClass "rtl"
 		language = language.split('-').shift()
 		TAPi18n.setLanguage(language)
 
@@ -44,8 +46,6 @@ Meteor.startup ->
 
 		if localStorage.getItem('userLanguage') isnt userLanguage
 			localStorage.setItem('userLanguage', userLanguage)
-			if isRtl localStorage.getItem 'userLanguage'
-				$('html').addClass "rtl"
 
 		setLanguage userLanguage
 	)

--- a/packages/rocketchat-ui-account/account/accountProfile.coffee
+++ b/packages/rocketchat-ui-account/account/accountProfile.coffee
@@ -7,7 +7,7 @@ Template.accountProfile.helpers
 		return _.sortBy(result, 'key')
 
 	userLanguage: (key) ->
-		return (localStorage.getItem('userLanguage') or Meteor.user().language or defaultUserLanguage())?.split('-').shift().toLowerCase() is key
+		return (Meteor.user().language or defaultUserLanguage())?.split('-').shift().toLowerCase() is key
 
 	realname: ->
 		return Meteor.user().name

--- a/packages/rocketchat-ui-login/login/form.coffee
+++ b/packages/rocketchat-ui-login/login/form.coffee
@@ -115,6 +115,8 @@ Template.loginForm.events
 						else
 							toastr.error t 'User_not_found_or_incorrect_password'
 						return
+					localStorage.setItem('userLanguage', Meteor.user()?.language)
+					setLanguage(Meteor.user()?.language)
 
 	'click .register': ->
 		Template.instance().state.set 'register'

--- a/packages/rocketchat-ui-sidenav/side-nav/accountBox.coffee
+++ b/packages/rocketchat-ui-sidenav/side-nav/accountBox.coffee
@@ -36,9 +36,6 @@ Template.accountBox.events
 		user = Meteor.user()
 		Meteor.logout ->
 			FlowRouter.go 'home'
-			# remove userLanguage in localStorage
-			# in case of another account with different language login
-			localStorage.removeItem('userLanguage')
 			Meteor.call('logoutCleanUp', user)
 
 	'click #avatar': (event) ->


### PR DESCRIPTION
1. Set current app language to user's language after user login;
    If users language setting is different from default app language setting, front end app language should change to user's language once user login
2. Fix the wrong language display in the view of  accountProfile.