### PR TITLE
Tabbar rework

### DIFF
--- a/client/routes/adminRouter.coffee
+++ b/client/routes/adminRouter.coffee
@@ -1,33 +1,27 @@
-tabReset = ->
-	RocketChat.TabBar.reset()
-
 FlowRouter.route '/admin/users',
 	name: 'admin-users'
-	triggersEnter: [tabReset]
-	triggersExit: [tabReset]
+	triggersExit: [ ->
+		Session.set 'adminSelectedUser'
+	]
 	action: ->
+		Session.set 'adminSelectedUser'
+		RocketChat.TabBar.showGroup 'adminusers'
 		BlazeLayout.render 'main', {center: 'adminUsers'}
-
 
 FlowRouter.route '/admin/rooms',
 	name: 'admin-rooms'
-	triggersEnter: [tabReset]
-	triggersExit: [tabReset]
 	action: ->
+		RocketChat.TabBar.showGroup 'rooms'
 		BlazeLayout.render 'main', {center: 'adminRooms'}
-
 
 FlowRouter.route '/admin/statistics',
 	name: 'admin-statistics'
-	triggersEnter: [tabReset]
-	triggersExit: [tabReset]
 	action: ->
+		RocketChat.TabBar.showGroup 'adminstatistics'
 		BlazeLayout.render 'main', {center: 'adminStatistics'}
-
 
 FlowRouter.route '/admin/:group?',
 	name: 'admin'
-	triggersEnter: [tabReset]
-	triggersExit: [tabReset]
 	action: ->
+		RocketChat.TabBar.showGroup 'admin'
 		BlazeLayout.render 'main', {center: 'admin'}

--- a/client/routes/adminRouter.coffee
+++ b/client/routes/adminRouter.coffee
@@ -11,7 +11,7 @@ FlowRouter.route '/admin/users',
 FlowRouter.route '/admin/rooms',
 	name: 'admin-rooms'
 	action: ->
-		RocketChat.TabBar.showGroup 'rooms'
+		RocketChat.TabBar.showGroup 'adminrooms'
 		BlazeLayout.render 'main', {center: 'adminRooms'}
 
 FlowRouter.route '/admin/statistics',

--- a/client/routes/router.coffee
+++ b/client/routes/router.coffee
@@ -3,7 +3,6 @@ Blaze.registerHelper 'pathFor', (path, kw) ->
 
 BlazeLayout.setRoot 'body'
 
-
 FlowRouter.subscriptions = ->
 	Tracker.autorun =>
 		RoomManager.init()
@@ -42,7 +41,7 @@ FlowRouter.route '/home',
 	name: 'home'
 
 	action: ->
-		RocketChat.TabBar.reset()
+		RocketChat.TabBar.showGroup 'home'
 		BlazeLayout.render 'main', {center: 'home'}
 		KonchatNotification.getDesktopPermission()
 
@@ -51,18 +50,17 @@ FlowRouter.route '/changeavatar',
 	name: 'changeAvatar'
 
 	action: ->
+		RocketChat.TabBar.showGroup 'changeavatar'
 		BlazeLayout.render 'main', {center: 'avatarPrompt'}
 
 FlowRouter.route '/account/:group?',
 	name: 'account'
 
 	action: (params) ->
-		RocketChat.TabBar.closeFlex()
-		RocketChat.TabBar.resetButtons()
-
 		unless params.group
 			params.group = 'Preferences'
 		params.group = _.capitalize params.group, true
+		RocketChat.TabBar.showGroup 'account'
 		BlazeLayout.render 'main', { center: "account#{params.group}" }
 
 
@@ -74,6 +72,7 @@ FlowRouter.route '/history/private',
 
 	action: ->
 		Session.setDefault('historyFilter', '')
+		RocketChat.TabBar.showGroup 'private-history'
 		BlazeLayout.render 'main', {center: 'privateHistory'}
 
 

--- a/client/startup/defaultRoomTypes.coffee
+++ b/client/startup/defaultRoomTypes.coffee
@@ -11,6 +11,7 @@ RocketChat.roomTypes.add 'c', 10,
 		action: (params, queryParams) ->
 			Session.set 'showUserInfo'
 			openRoom 'c', params.name
+			RocketChat.TabBar.showGroup 'channel'
 		link: (sub) ->
 			return { name: sub.name }
 	permissions: [ 'view-c-room' ]
@@ -24,6 +25,7 @@ RocketChat.roomTypes.add 'd', 20,
 		action: (params, queryParams) ->
 			Session.set 'showUserInfo', params.username
 			openRoom 'd', params.username
+			RocketChat.TabBar.showGroup 'directmessage'
 		link: (sub) ->
 			return { username: sub.name }
 	permissions: [ 'view-d-room' ]
@@ -37,6 +39,7 @@ RocketChat.roomTypes.add 'p', 30,
 		action: (params, queryParams) ->
 			Session.set 'showUserInfo'
 			openRoom 'p', params.name
+			RocketChat.TabBar.showGroup 'privategroup'
 		link: (sub) ->
 			return { name: sub.name }
 	permissions: [ 'view-p-room' ]

--- a/packages/rocketchat-authorization/client/route.coffee
+++ b/packages/rocketchat-authorization/client/route.coffee
@@ -1,6 +1,7 @@
 FlowRouter.route '/admin/permissions',
 	name: 'admin-permissions'
 	action: (params) ->
+		RocketChat.TabBar.showGroup 'admin-permissions'
 		BlazeLayout.render 'main',
 			center: 'pageContainer'
 			pageTitle: t('Permissions')
@@ -9,6 +10,7 @@ FlowRouter.route '/admin/permissions',
 FlowRouter.route '/admin/permissions/:name?/edit',
 	name: 'admin-permissions-edit'
 	action: (params) ->
+		RocketChat.TabBar.showGroup 'admin-permissions'
 		BlazeLayout.render 'main',
 			center: 'pageContainer'
 			pageTitle: t('Role_Editing')
@@ -17,6 +19,7 @@ FlowRouter.route '/admin/permissions/:name?/edit',
 FlowRouter.route '/admin/permissions/new',
 	name: 'admin-permissions-new'
 	action: (params) ->
+		RocketChat.TabBar.showGroup 'admin-permissions'
 		BlazeLayout.render 'main',
 			center: 'pageContainer'
 			pageTitle: t('Role_Editing')

--- a/packages/rocketchat-channel-settings/client/startup/tabBar.coffee
+++ b/packages/rocketchat-channel-settings/client/startup/tabBar.coffee
@@ -1,12 +1,8 @@
 Meteor.startup ->
-
-	RocketChat.callbacks.add 'enter-room', (subscription) ->
-
-		RocketChat.TabBar.addButton
-			id: 'channel-settings'
-			i18nTitle: 'Room_Info'
-			icon: 'octicon octicon-info'
-			template: 'channelSettings'
-			order: 0
-
-	, RocketChat.callbacks.priority.MEDIUM, 'enter-room-tabbar-channel-settings'
+	RocketChat.TabBar.addButton
+		groups: ['channel', 'privategroup', 'directmessage']
+		id: 'channel-settings'
+		i18nTitle: 'Room_Info'
+		icon: 'octicon octicon-info'
+		template: 'channelSettings'
+		order: 0

--- a/packages/rocketchat-chatops/client/tabBar.coffee
+++ b/packages/rocketchat-chatops/client/tabBar.coffee
@@ -1,18 +1,9 @@
 Meteor.startup ->
-
-	RocketChat.callbacks.add 'enter-room', ->
-		#if Meteor.user()?.services?.github?.id or Meteor.user()?.services?.gitlab?.id
-		# console.log 'Adding chatops to tabbar'
-		# RocketChat.TabBar.addButton
-		# 	id: 'chatops-button'
-		# 	i18nTitle: 'rocketchat-chatops:Chatops_Title'
-		# 	icon: 'icon-code'
-		# 	template: 'chatops'
-		# 	order: 4
-
+	Tracker.autorun ->
 		if RocketChat.settings.get('Chatops_Enabled')
 			console.log 'Adding chatops to tabbar'
 			RocketChat.TabBar.addButton
+				groups: ['channel', 'privategroup', 'directmessage']
 				id: 'chatops-button2'
 				i18nTitle: 'rocketchat-chatops:Chatops_Title'
 				icon: 'octicon octicon-hubot'
@@ -21,10 +12,13 @@ Meteor.startup ->
 
 			console.log 'Adding chatops to tabbar'
 			RocketChat.TabBar.addButton
+				groups: ['channel', 'privategroup', 'directmessage']
 				id: 'chatops-button3'
 				i18nTitle: 'rocketchat-chatops:Chatops_Title'
 				icon: 'octicon octicon-inbox'
 				template: 'chatops_droneflight'
 				width: 675
 				order: 5
-	, RocketChat.callbacks.priority.MEDIUM, 'enter-room-tabbar-chatops'
+		else
+			RocketChat.TabBar.removeButton 'chatops-button2'
+			RocketChat.TabBar.removeButton 'chatops-button3'

--- a/packages/rocketchat-integrations/client/route.coffee
+++ b/packages/rocketchat-integrations/client/route.coffee
@@ -1,34 +1,35 @@
 FlowRouter.route '/admin/integrations',
 	name: 'admin-integrations'
 	action: (params) ->
+		RocketChat.TabBar.showGroup 'admin-integrations'
 		BlazeLayout.render 'main',
 			center: 'pageSettingsContainer'
 			pageTitle: t('Integrations')
 			pageTemplate: 'integrations'
 
-
 FlowRouter.route '/admin/integrations/new',
 	name: 'admin-integrations-new'
 	action: (params) ->
+		RocketChat.TabBar.showGroup 'admin-integrations'
 		BlazeLayout.render 'main',
 			center: 'pageSettingsContainer'
 			pageTitle: t('Integration_New')
 			pageTemplate: 'integrationsNew'
 
-
 FlowRouter.route '/admin/integrations/incoming/:id?',
 	name: 'admin-integrations-incoming'
 	action: (params) ->
+		RocketChat.TabBar.showGroup 'admin-integrations'
 		BlazeLayout.render 'main',
 			center: 'pageSettingsContainer'
 			pageTitle: t('Integration_Incoming_WebHook')
 			pageTemplate: 'integrationsIncoming'
 			params: params
 
-
 FlowRouter.route '/admin/integrations/outgoing/:id?',
 	name: 'admin-integrations-outgoing'
 	action: (params) ->
+		RocketChat.TabBar.showGroup 'admin-integrations'
 		BlazeLayout.render 'main',
 			center: 'pageSettingsContainer'
 			pageTitle: t('Integration_Outgoing_WebHook')

--- a/packages/rocketchat-lib/client/TabBar.coffee
+++ b/packages/rocketchat-lib/client/TabBar.coffee
@@ -9,6 +9,8 @@ RocketChat.TabBar = new class
 	template = new ReactiveVar ''
 	data = new ReactiveVar {}
 
+	visibleGroup = new ReactiveVar ''
+
 	setTemplate = (t, callback) ->
 		return if animating is true
 		template.set t
@@ -93,6 +95,12 @@ RocketChat.TabBar = new class
 	resetButtons = ->
 		buttons.set {}
 
+	showGroup = (group) ->
+		visibleGroup.set group
+
+	getVisibleGroup = ->
+		visibleGroup.get()
+
 	setTemplate: setTemplate
 	setData: setData
 	getTemplate: getTemplate
@@ -108,3 +116,6 @@ RocketChat.TabBar = new class
 	getButtons: getButtons
 	reset: reset
 	resetButtons: resetButtons
+
+	showGroup: showGroup
+	getVisibleGroup: getVisibleGroup

--- a/packages/rocketchat-lib/client/TabBar.coffee
+++ b/packages/rocketchat-lib/client/TabBar.coffee
@@ -4,6 +4,8 @@ RocketChat.TabBar = new class
 
 	buttons = new ReactiveVar {}
 
+	extraGroups = {}
+
 	animating = false
 	open = new ReactiveVar false
 	template = new ReactiveVar ''
@@ -67,6 +69,12 @@ RocketChat.TabBar = new class
 		Tracker.nonreactive ->
 			btns = buttons.get()
 			btns[config.id] = config
+
+			if extraGroups[config.id]?
+				btns[config.id].groups ?= []
+				btns[config.id].groups = _.union btns[config.id].groups, extraGroups[config.id]
+				delete extraGroups[config.id]
+
 			buttons.set btns
 
 	removeButton = (id) ->
@@ -101,6 +109,17 @@ RocketChat.TabBar = new class
 	getVisibleGroup = ->
 		visibleGroup.get()
 
+	addGroup = (id, groups) ->
+		Tracker.nonreactive ->
+			btns = buttons.get()
+			if btns[id]
+				btns[id].groups ?= []
+				btns[id].groups = _.union btns[id].groups, groups
+				buttons.set btns
+			else
+				extraGroups[id] ?= []
+				extraGroups[id] = _.union extraGroups[id], groups
+
 	setTemplate: setTemplate
 	setData: setData
 	getTemplate: getTemplate
@@ -119,3 +138,4 @@ RocketChat.TabBar = new class
 
 	showGroup: showGroup
 	getVisibleGroup: getVisibleGroup
+	addGroup: addGroup

--- a/packages/rocketchat-lib/client/defaultTabBars.js
+++ b/packages/rocketchat-lib/client/defaultTabBars.js
@@ -1,0 +1,35 @@
+RocketChat.TabBar.addButton({
+	groups: ['channel', 'privategroup', 'directmessage'],
+	id: 'message-search',
+	i18nTitle: TAPi18n.__('Search'),
+	icon: 'octicon octicon-search',
+	template: 'messageSearch',
+	order: 1
+});
+
+RocketChat.TabBar.addButton({
+	groups: ['directmessage'],
+	id: 'members-list',
+	i18nTitle: TAPi18n.__('User_Info'),
+	icon: 'octicon octicon-person',
+	template: 'membersList',
+	order: 2
+});
+
+RocketChat.TabBar.addButton({
+	groups: ['channel', 'privategroup'],
+	id: 'members-list',
+	i18nTitle: TAPi18n.__('Members_List'),
+	icon: 'octicon octicon-organization',
+	template: 'membersList',
+	order: 2
+});
+
+RocketChat.TabBar.addButton({
+	groups: ['channel', 'privategroup', 'directmessage'],
+	id: 'uploaded-files-list',
+	i18nTitle: TAPi18n.__('Room_uploaded_file_list'),
+	icon: 'octicon octicon-file-symlink-directory',
+	template: 'uploadedFilesList',
+	order: 3
+});

--- a/packages/rocketchat-lib/client/defaultTabBars.js
+++ b/packages/rocketchat-lib/client/defaultTabBars.js
@@ -1,7 +1,7 @@
 RocketChat.TabBar.addButton({
 	groups: ['channel', 'privategroup', 'directmessage'],
 	id: 'message-search',
-	i18nTitle: TAPi18n.__('Search'),
+	i18nTitle: 'Search',
 	icon: 'octicon octicon-search',
 	template: 'messageSearch',
 	order: 1
@@ -10,7 +10,7 @@ RocketChat.TabBar.addButton({
 RocketChat.TabBar.addButton({
 	groups: ['directmessage'],
 	id: 'user-info',
-	i18nTitle: TAPi18n.__('User_Info'),
+	i18nTitle: 'User_Info',
 	icon: 'octicon octicon-person',
 	template: 'membersList',
 	order: 2
@@ -19,7 +19,7 @@ RocketChat.TabBar.addButton({
 RocketChat.TabBar.addButton({
 	groups: ['channel', 'privategroup'],
 	id: 'members-list',
-	i18nTitle: TAPi18n.__('Members_List'),
+	i18nTitle: 'Members_List',
 	icon: 'octicon octicon-organization',
 	template: 'membersList',
 	order: 2
@@ -28,7 +28,7 @@ RocketChat.TabBar.addButton({
 RocketChat.TabBar.addButton({
 	groups: ['channel', 'privategroup', 'directmessage'],
 	id: 'uploaded-files-list',
-	i18nTitle: TAPi18n.__('Room_uploaded_file_list'),
+	i18nTitle: 'Room_uploaded_file_list',
 	icon: 'octicon octicon-file-symlink-directory',
 	template: 'uploadedFilesList',
 	order: 3

--- a/packages/rocketchat-lib/client/defaultTabBars.js
+++ b/packages/rocketchat-lib/client/defaultTabBars.js
@@ -9,7 +9,7 @@ RocketChat.TabBar.addButton({
 
 RocketChat.TabBar.addButton({
 	groups: ['directmessage'],
-	id: 'members-list',
+	id: 'user-info',
 	i18nTitle: TAPi18n.__('User_Info'),
 	icon: 'octicon octicon-person',
 	template: 'membersList',

--- a/packages/rocketchat-lib/client/lib/openRoom.coffee
+++ b/packages/rocketchat-lib/client/lib/openRoom.coffee
@@ -50,16 +50,9 @@ currentTracker = undefined
 					$('.message-form .input-message').focus()
 				, 100
 
-			RocketChat.TabBar.resetButtons()
-			RocketChat.TabBar.addButton({ id: 'message-search', i18nTitle: t('Search'), icon: 'octicon octicon-search', template: 'messageSearch', order: 1 })
-			if type is 'd'
-				RocketChat.TabBar.addButton({ id: 'members-list', i18nTitle: t('User_Info'), icon: 'octicon octicon-person', template: 'membersList', order: 2 })
-			else
-				RocketChat.TabBar.addButton({ id: 'members-list', i18nTitle: t('Members_List'), icon: 'octicon octicon-organization', template: 'membersList', order: 2 })
-			RocketChat.TabBar.addButton({ id: 'uploaded-files-list', i18nTitle: t('Room_uploaded_file_list'), icon: 'octicon octicon-file-symlink-directory', template: 'uploadedFilesList', order: 3 })
-
 			# update user's room subscription
-			if ChatSubscription.findOne({rid: room._id})?.open is false
+			sub = ChatSubscription.findOne({rid: room._id})
+			if sub?.open is false
 				Meteor.call 'openRoom', room._id
 
-			RocketChat.callbacks.run 'enter-room', ChatSubscription.findOne({rid: room._id})
+			RocketChat.callbacks.run 'enter-room', sub

--- a/packages/rocketchat-lib/package.js
+++ b/packages/rocketchat-lib/package.js
@@ -96,6 +96,8 @@ Package.onUse(function(api) {
 	api.addFiles('client/TabBar.coffee', 'client');
 	api.addFiles('client/MessageAction.coffee', 'client');
 
+	api.addFiles('client/defaultTabBars.js', 'client');
+
 	// VERSION
 	api.addFiles('rocketchat.info');
 

--- a/packages/rocketchat-livechat/app/client/lib/triggers.js
+++ b/packages/rocketchat-livechat/app/client/lib/triggers.js
@@ -54,7 +54,7 @@ this.Triggers = (function() {
 			trigger.conditions.forEach(function(condition) {
 				switch (condition.name) {
 					case 'page-url':
-						if (request.href.match(new RegExp(urlRegex))) {
+						if (request.href.match(new RegExp(condition.value))) {
 							fire(trigger.actions);
 						}
 						break;

--- a/packages/rocketchat-mailer/client/router.coffee
+++ b/packages/rocketchat-mailer/client/router.coffee
@@ -1,11 +1,7 @@
-tabReset = ->
-	RocketChat.TabBar.reset()
-
 FlowRouter.route '/mailer',
 	name: 'mailer'
-	triggersEnter: [tabReset]
-	triggersExit: [tabReset]
 	action: ->
+		RocketChat.TabBar.showGroup 'mailer'
 		BlazeLayout.render 'main', {center: 'mailer'}
 
 FlowRouter.route '/mailer/unsubscribe/:_id/:createdAt',

--- a/packages/rocketchat-mentions-flextab/client/tabBar.coffee
+++ b/packages/rocketchat-mentions-flextab/client/tabBar.coffee
@@ -1,4 +1,9 @@
 Meteor.startup ->
-	RocketChat.callbacks.add 'enter-room', ->
-		RocketChat.TabBar.addButton({ id: 'mentions', i18nTitle: 'Mentions', icon: 'icon-at', template: 'mentionsFlexTab', order: 3 })
-	, RocketChat.callbacks.priority.MEDIUM, 'enter-room-tabbar-mentions'
+	RocketChat.TabBar.addButton({
+		groups: ['channel', 'privategroup'],
+		id: 'mentions',
+		i18nTitle: 'Mentions',
+		icon: 'icon-at',
+		template: 'mentionsFlexTab',
+		order: 3
+	})

--- a/packages/rocketchat-message-pin/client/tabBar.coffee
+++ b/packages/rocketchat-message-pin/client/tabBar.coffee
@@ -1,5 +1,10 @@
 Meteor.startup ->
-	RocketChat.callbacks.add 'enter-room', ->
-		if RocketChat.settings.get 'Message_AllowPinning'
-			RocketChat.TabBar.addButton({ id: 'pinned-messages', i18nTitle: 'Pinned_Messages', icon: 'icon-pin', template: 'pinnedMessages', order: 10 })
-	, RocketChat.callbacks.priority.MEDIUM, 'enter-room-tabbar-pin'
+	if RocketChat.settings.get 'Message_AllowPinning'
+		RocketChat.TabBar.addButton({
+			groups: ['channel', 'privategroup', 'directmessage'],
+			id: 'pinned-messages',
+			i18nTitle: 'Pinned_Messages',
+			icon: 'icon-pin',
+			template: 'pinnedMessages',
+			order: 10
+		})

--- a/packages/rocketchat-message-star/client/tabBar.coffee
+++ b/packages/rocketchat-message-star/client/tabBar.coffee
@@ -1,4 +1,9 @@
 Meteor.startup ->
-	RocketChat.callbacks.add 'enter-room', ->
-		RocketChat.TabBar.addButton({ id: 'starred-messages', i18nTitle: 'Starred_Messages', icon: 'icon-star', template: 'starredMessages', order: 3 })
-	, RocketChat.callbacks.priority.MEDIUM, 'enter-room-tabbar-star'
+	RocketChat.TabBar.addButton({
+		groups: ['channel', 'privategroup', 'directmessage'],
+		id: 'starred-messages',
+		i18nTitle: 'Starred_Messages',
+		icon: 'icon-star',
+		template: 'starredMessages',
+		order: 3
+	})

--- a/packages/rocketchat-ui-admin/admin/users/adminUsers.coffee
+++ b/packages/rocketchat-ui-admin/admin/users/adminUsers.coffee
@@ -40,7 +40,7 @@ Template.adminUsers.onCreated ->
 	RocketChat.TabBar.addButton({
 		groups: ['adminusers', 'adminusers-selected'],
 		id: 'invite-user',
-		i18nTitle: t('Invite_Users'),
+		i18nTitle: 'Invite_Users',
 		icon: 'icon-plus',
 		template: 'adminInviteUser',
 		order: 1
@@ -48,8 +48,8 @@ Template.adminUsers.onCreated ->
 
 	RocketChat.TabBar.addButton({
 		groups: ['adminusers-selected']
-		id: 'user-info',
-		i18nTitle: t('User_Info'),
+		id: 'admin-user-info',
+		i18nTitle: 'User_Info',
 		icon: 'icon-user',
 		template: 'adminUserInfo',
 		order: 2

--- a/packages/rocketchat-ui-admin/admin/users/adminUsers.coffee
+++ b/packages/rocketchat-ui-admin/admin/users/adminUsers.coffee
@@ -37,7 +37,23 @@ Template.adminUsers.onCreated ->
 	@filter = new ReactiveVar ''
 	@ready = new ReactiveVar true
 
-	RocketChat.TabBar.addButton({ id: 'invite-user', i18nTitle: t('Invite_Users'), icon: 'icon-plus', template: 'adminInviteUser', order: 1 })
+	RocketChat.TabBar.addButton({
+		groups: ['adminusers', 'adminusers-selected'],
+		id: 'invite-user',
+		i18nTitle: t('Invite_Users'),
+		icon: 'icon-plus',
+		template: 'adminInviteUser',
+		order: 1
+	})
+
+	RocketChat.TabBar.addButton({
+		groups: ['adminusers-selected']
+		id: 'user-info',
+		i18nTitle: t('User_Info'),
+		icon: 'icon-user',
+		template: 'adminUserInfo',
+		order: 2
+	})
 
 	@autorun ->
 		filter = instance.filter.get()
@@ -49,11 +65,10 @@ Template.adminUsers.onCreated ->
 		if Session.get 'adminSelectedUser'
 			channelSubscription = instance.subscribe 'userChannels', Session.get 'adminSelectedUser'
 			RocketChat.TabBar.setData Meteor.users.findOne Session.get 'adminSelectedUser'
-			RocketChat.TabBar.addButton({ id: 'user-info', i18nTitle: t('User_Info'), icon: 'icon-user', template: 'adminUserInfo', order: 2 })
-			# RocketChat.TabBar.addButton({ id: 'user-channel', i18nTitle: t('User_Channels'), icon: 'icon-hash', template: 'adminUserChannels', order: 3 })
+
+			RocketChat.TabBar.showGroup 'adminusers-selected'
 		else
-			RocketChat.TabBar.reset()
-			RocketChat.TabBar.addButton({ id: 'invite-user', i18nTitle: t('Invite_Users'), icon: 'icon-plus', template: 'adminInviteUser', order: 1 })
+			RocketChat.TabBar.showGroup 'adminusers'
 
 	@users = ->
 		filter = _.trim instance.filter?.get()
@@ -89,8 +104,8 @@ Template.adminUsers.events
 
 	'click .user-info': (e) ->
 		e.preventDefault()
-		Session.set 'adminSelectedUser', $(e.currentTarget).data('id')
-		Session.set 'showUserInfo', Meteor.users.findOne($(e.currentTarget).data('id'))?.username or true
+		Session.set 'adminSelectedUser', @_id
+		Session.set 'showUserInfo', Meteor.users.findOne(@_id)?.username or true
 		RocketChat.TabBar.setTemplate 'adminUserInfo'
 		RocketChat.TabBar.openFlex()
 

--- a/packages/rocketchat-ui-admin/admin/users/adminUsers.html
+++ b/packages/rocketchat-ui-admin/admin/users/adminUsers.html
@@ -32,7 +32,7 @@
 						</thead>
 						<tbody>
 							{{#each users}}
-							<tr class="user-info" data-id="{{_id}}">
+							<tr class="user-info">
 								<td>
 									<div class="user-image status-{{status}}">
 										{{> avatar username=username}}

--- a/packages/rocketchat-ui-flextab/flex-tab/flexTabBar.coffee
+++ b/packages/rocketchat-ui-flextab/flex-tab/flexTabBar.coffee
@@ -2,15 +2,11 @@ Template.flexTabBar.helpers
 	active: ->
 		return 'active' if @template is RocketChat.TabBar.getTemplate() and RocketChat.TabBar.isFlexOpen()
 	buttons: ->
-		RocketChat.TabBar.getButtons()
 		return RocketChat.TabBar.getButtons()
 	title: ->
 		return t(@i18nTitle) or @title
 	visible: ->
 		if @groups.indexOf(RocketChat.TabBar.getVisibleGroup()) is -1
-			# if it was active, close it
-			if @template is RocketChat.TabBar.getTemplate() and RocketChat.TabBar.isFlexOpen()
-				RocketChat.TabBar.closeFlex()
 			return 'hidden'
 
 Template.flexTabBar.events
@@ -29,3 +25,18 @@ Template.flexTabBar.events
 			RocketChat.TabBar.setTemplate @template, ->
 				$('.flex-tab')?.find("input[type='text']:first")?.focus()
 				$('.flex-tab .content')?.scrollTop(0)
+
+Template.flexTabBar.onCreated ->
+	# close flex if the visible group changed and the opened template is not in the new visible group
+	@autorun =>
+		visibleGroup = RocketChat.TabBar.getVisibleGroup()
+
+		Tracker.nonreactive =>
+			openedTemplate = RocketChat.TabBar.getTemplate()
+			exists = false
+			RocketChat.TabBar.getButtons().forEach (button) ->
+				if button.groups.indexOf(visibleGroup) isnt -1 and openedTemplate is button.template
+					exists = true
+
+			unless exists
+				RocketChat.TabBar.closeFlex()

--- a/packages/rocketchat-ui-flextab/flex-tab/flexTabBar.coffee
+++ b/packages/rocketchat-ui-flextab/flex-tab/flexTabBar.coffee
@@ -6,22 +6,26 @@ Template.flexTabBar.helpers
 		return RocketChat.TabBar.getButtons()
 	title: ->
 		return t(@i18nTitle) or @title
+	visible: ->
+		if @groups.indexOf(RocketChat.TabBar.getVisibleGroup()) is -1
+			# if it was active, close it
+			if @template is RocketChat.TabBar.getTemplate() and RocketChat.TabBar.isFlexOpen()
+				RocketChat.TabBar.closeFlex()
+			return 'hidden'
 
 Template.flexTabBar.events
 	'click .tab-button': (e, t) ->
 		e.preventDefault()
 
-		if RocketChat.TabBar.isFlexOpen() and RocketChat.TabBar.getTemplate() is $(e.currentTarget).data('template')
+		if RocketChat.TabBar.isFlexOpen() and RocketChat.TabBar.getTemplate() is @template
 			RocketChat.TabBar.closeFlex()
 			$('.flex-tab').css('max-width', '')
 		else
-			width = $(e.currentTarget).data('width')
-
-			if width?
-				$('.flex-tab').css('max-width', "#{width}px")
+			if @width?
+				$('.flex-tab').css('max-width', "#{@width}px")
 			else
 				$('.flex-tab').css('max-width', '')
 
-			RocketChat.TabBar.setTemplate $(e.currentTarget).data('template'), ->
+			RocketChat.TabBar.setTemplate @template, ->
 				$('.flex-tab')?.find("input[type='text']:first")?.focus()
 				$('.flex-tab .content')?.scrollTop(0)

--- a/packages/rocketchat-ui-flextab/flex-tab/flexTabBar.html
+++ b/packages/rocketchat-ui-flextab/flex-tab/flexTabBar.html
@@ -1,6 +1,6 @@
 <template name="flexTabBar">
 	{{#each buttons}}
-		<div class="tab-button {{active}}" data-template="{{template}}" data-width="{{width}}" title="{{title}}">
+		<div class="tab-button {{active}} {{visible}}" title="{{title}}">
 			<i class="{{icon}}" aria-label="{{title}}" role="button" tabindex="0"></i>
 		</div>
 	{{/each}}

--- a/packages/rocketchat-ui/lib/accountBox.coffee
+++ b/packages/rocketchat-ui/lib/accountBox.coffee
@@ -63,13 +63,13 @@
 			name: newRoute.name
 			action: ->
 				Session.set 'openedRoom'
+				RocketChat.TabBar.showGroup newRoute.name
 				BlazeLayout.render 'main', routeConfig
 			triggersEnter: [ ->
 				if newRoute.sideNav?
 					SideNav.setFlex newRoute.sideNav
 					SideNav.openFlex()
 			]
-
 
 	setStatus: setStatus
 	toggle: toggle

--- a/packages/rocketchat-ui/views/app/privateHistory.coffee
+++ b/packages/rocketchat-ui/views/app/privateHistory.coffee
@@ -37,9 +37,6 @@ Template.privateHistory.helpers
 			when 'd'
 				return FlowRouter.path 'direct', { username: this.name }
 
-Template.privateHistory.onRendered ->
-	RocketChat.TabBar.reset()
-
 Template.privateHistory.events
 	'keydown #history-filter': (event) ->
 		if event.which is 13

--- a/packages/rocketchat-ui/views/app/room.coffee
+++ b/packages/rocketchat-ui/views/app/room.coffee
@@ -484,12 +484,8 @@ Template.room.onCreated ->
 	@autorun =>
 		@subscribe 'fullUserData', Session.get('showUserInfo'), 1
 
-
 Template.room.onDestroyed ->
-	RocketChat.TabBar.resetButtons()
-
 	window.removeEventListener 'resize', this.onWindowResize
-
 
 Template.room.onRendered ->
 	unless window.chatMessages

--- a/server/startup/roomPublishes.coffee
+++ b/server/startup/roomPublishes.coffee
@@ -36,5 +36,6 @@ Meteor.startup ->
 				cl: 1
 				u: 1
 				usernames: 1
+				topic: 1
 		user = RocketChat.models.Users.findOneById this.userId, fields: username: 1
 		return RocketChat.models.Rooms.findByTypeContainigUsernames 'd', [user.username, identifier], options


### PR DESCRIPTION
Previously every time you access a room, all tab bar buttons were removed and re-added. This were done on `enter-room` callbacks.
Because of this a package was not able to display only one tab bar button, because everytime `enter-room` callbacks were called, all buttons are added again.

Now, every tab bar button is added once with a group option. Every time the tab bar buttons should be displayed, it's called to display a group of buttons, then each button from another group are simply hidden.
