### PR TITLE
add owner when changing from channel to private group - closes #1252

### DIFF
--- a/packages/rocketchat-channel-settings/server/functions/saveRoomType.coffee
+++ b/packages/rocketchat-channel-settings/server/functions/saveRoomType.coffee
@@ -5,4 +5,7 @@ RocketChat.saveRoomType = (rid, roomType) ->
 	if roomType not in ['c', 'p']
 		throw new Meteor.Error 'invalid-room-type', 'Invalid_room_type', { roomType: roomType }
 
+	if roomType is 'p'
+		RocketChat.models.Rooms.setUserById(rid, Meteor.user())
+
 	return RocketChat.models.Rooms.setTypeById(rid, roomType) and RocketChat.models.Subscriptions.updateTypeByRoomId(rid, roomType)


### PR DESCRIPTION
applies to GENERAL which does not have an owner;  also replaces the existing public channel's owner with the administrator who changes a group from public to private (allowing him/her to add members immediately)