### PR TITLE
Minor Grammar Fixup

### DIFF
--- a/i18n/de.i18n.json
+++ b/i18n/de.i18n.json
@@ -485,7 +485,7 @@
   "The_image_resize_will_not_work_because_we_can_not_detect_ImageMagick_or_GraphicsMagick_installed_in_your_server" : "Die automatische Skalierung der Bilder funktioniert nicht, da ImageMagick oder GraphicsMagick nicht auf dem Server installiert sind.",
   "The_server_will_restart_in_s_seconds" : "Der Server wird in %s Sekunden neu gestartet",
   "The_setting_s_is_configured_to_s_and_you_are_accessing_from_s" : "Die Einstellung <strong>%s</strong> wurde zu <strong>%s</strong> konfiguriert und Sie greifen von <strong>%s</strong> zu!",
-  "There_is_no_integrations" : "Keine Integrationen vorhanden.",
+  "There_are_no_integrations" : "Keine Integrationen vorhanden.",
   "This_is_a_push_test_messsage" : "Dies ist eine Test-Push-Nachricht.",
   "True" : "Ja",
   "Type_your_new_password" : "Geben Sie Ihr neues Passwort ein",

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -486,7 +486,7 @@
   "The_image_resize_will_not_work_because_we_can_not_detect_ImageMagick_or_GraphicsMagick_installed_in_your_server" : "The image resize will not work because we can not detect ImageMagick or GraphicsMagick installed on your server.",
   "The_server_will_restart_in_s_seconds" : "The server will restart in %s seconds",
   "The_setting_s_is_configured_to_s_and_you_are_accessing_from_s" : "The setting <strong>%s</strong> is configured to <strong>%s</strong> and you are accessing from <strong>%s</strong>!",
-  "There_is_no_integrations" : "There is no integrations",
+  "There_are_no_integrations" : "There are no integrations",
   "This_is_a_push_test_messsage" : "This is a push test messsage",
   "True" : "True",
   "Type_your_new_password" : "Type your new password",

--- a/i18n/fi.i18n.json
+++ b/i18n/fi.i18n.json
@@ -458,7 +458,7 @@
   "Success" : "Onnistui",
   "The_field_is_required" : "Kenttä %s vaaditaan.",
   "The_server_will_restart_in_s_seconds" : "Palvelin käynnistyy %s sekunnin kuluttua",
-  "There_is_no_integrations" : "Integraatioita ei ole",
+  "There_are_no_integrations" : "Integraatioita ei ole",
   "This_is_a_push_test_messsage" : "Tämä on testi-pushviesti",
   "True" : "Kyllä",
   "Unnamed" : "Nimetön",

--- a/i18n/ro.i18n.json
+++ b/i18n/ro.i18n.json
@@ -486,7 +486,7 @@
   "The_image_resize_will_not_work_because_we_can_not_detect_ImageMagick_or_GraphicsMagick_installed_in_your_server" : "Redimensionarea imaginii nu va funcționa, deoarece nu putem detecta ImageMagick sau GraphicsMagick instalat pe server.",
   "The_server_will_restart_in_s_seconds" : "Serverul va reporni în %s secunde",
   "The_setting_s_is_configured_to_s_and_you_are_accessing_from_s" : "Setarea <strong>%s</strong> e configurată să <strong>%s</strong> iar dumneavoastră accesați din <strong>%s</strong>!",
-  "There_is_no_integrations" : "Nu sunt integrări",
+  "There_are_no_integrations" : "Nu sunt integrări",
   "This_is_a_push_test_messsage" : "Acesta este un test de notificare Push",
   "True" : "Adevărat",
   "Type_your_new_password" : "Introduceți noua parolă",

--- a/packages/rocketchat-integrations/client/views/integrations.html
+++ b/packages/rocketchat-integrations/client/views/integrations.html
@@ -27,7 +27,7 @@
 								</a>
 							{{/if}}
 						{{else}}
-							<h1>{{_ "There_is_no_integrations"}}</h1>
+							<h1>{{_ "There_are_no_integrations"}}</h1>
 						{{/each}}
 						{{#each integrations}}
 							{{#if $eq type 'webhook-outgoing'}}


### PR DESCRIPTION
`There_are_no_integrations` should be `There_are_no_integrations` in both the source and interface. 

This is a redo of #1803, but I butchered the Pull Request, so this is fresh and clean.