### PR TITLE
Fix min-height on link oembed.

### DIFF
--- a/packages/rocketchat-oembed/client/oembedUrlWidget.html
+++ b/packages/rocketchat-oembed/client/oembedUrlWidget.html
@@ -1,7 +1,7 @@
 <template name="oembedUrlWidget">
 	{{#if show}}
 		<blockquote>
-			<div style="{{#if image}}min-height: 60px;{{/if}} padding: 10px 3px;">
+			<div style="{{#if image}}min-height: 80px;{{/if}} padding: 10px 3px;">
 				{{#if image}}
 					{{#if meta.ogImageUserGenerated}}
 						<div>


### PR DESCRIPTION
Because of the 10px top and 10px bottom padding the min-height for the content really is only 40.  So this causes the image to bleed over when there is no description.

Link used for testing: http://codenamecrud.ru

@sampaiodiego