### PR TITLE
Prevent browsers from trying to validate the input fields

### DIFF
--- a/packages/rocketchat-ui-login/login/form.html
+++ b/packages/rocketchat-ui-login/login/form.html
@@ -4,7 +4,7 @@
 			You must login to Sandstorm (on the top right) in order to access this chat.
 		</div>
 	{{else}}
-	<form id="login-card" method='/'>
+	<form id="login-card" method='/' novalidate>
 		{{#if waitActivation}}
 			<header>
 				<h2>{{{_ "Registration_Succeeded"}}}</h2>


### PR DESCRIPTION
This will stop the browsers such as Firefox from trying to validate the input field since they are handled by the javascript.