### PR TITLE
Include a fallback click event for loading more messages

### DIFF
--- a/packages/rocketchat-ui-flextab/flex-tab/tabs/messageSearch.coffee
+++ b/packages/rocketchat-ui-flextab/flex-tab/tabs/messageSearch.coffee
@@ -59,6 +59,10 @@ Template.messageSearch.events
 		$(".search-messages-list \##{message_id} .message-cog-container").append el
 		dropDown = $(".search-messages-list \##{message_id} .message-dropdown")
 		dropDown.show()
+		
+	'click .load-more a': (e, t) ->
+		t.limit.set(t.limit.get() + 20)
+		t.search()
 
 	'scroll .content': _.throttle (e, t) ->
 		if e.target.scrollTop >= e.target.scrollHeight - e.target.clientHeight


### PR DESCRIPTION
If the scroll event does not get triggered, the "has more..." link does nothing. This adds the capability to click the "has more..." link and load more message search results