### PR TITLE
Require 'view-c-room' permission for accessing channels

### DIFF
--- a/server/methods/canAccessRoom.coffee
+++ b/server/methods/canAccessRoom.coffee
@@ -11,10 +11,10 @@ Meteor.methods
 		room = RocketChat.models.Rooms.findOneById rid, { fields: { usernames: 1, t: 1, name: 1, muted: 1 } }
 
 		if room
-			if room.t is 'c'
+			if room.usernames.indexOf(user.username) isnt -1
 				canAccess = true
-			else if room.usernames.indexOf(user.username) isnt -1
-				canAccess = true
+			else if room.t is 'c'
+				canAccess = RocketChat.authz.hasPermission(userId, 'view-c-room')
 
 			if canAccess isnt true
 				return false

--- a/server/methods/joinRoom.coffee
+++ b/server/methods/joinRoom.coffee
@@ -6,7 +6,7 @@ Meteor.methods
 		if not room?
 			throw new Meteor.Error 500, 'No channel with this id'
 
-		if room.t isnt 'c'
+		if room.t isnt 'c' or RocketChat.authz.hasPermission(Meteor.userId(), 'view-c-room') isnt true
 			throw new Meteor.Error 403, '[methods] joinRoom -> Not allowed'
 
 		now = new Date()

--- a/server/startup/migrations/v28.coffee
+++ b/server/startup/migrations/v28.coffee
@@ -1,0 +1,5 @@
+Meteor.startup ->
+  Migrations.add
+    version: 28
+    up: ->
+      RocketChat.models.Permissions.addRole 'view-c-room', 'bot'


### PR DESCRIPTION
A user without 'view-c-room' permission is not allowed to see the
channel list. However, it was still possible to read and write
to a channel by guessing the name and modifying the URL accordingly.

Reading channel contents now requires either the 'view-c-room' permission
or being a member of the channel.