### PR TITLE
Custom STUN and TURN servers

### DIFF
--- a/packages/rocketchat-webrtc/WebRTCClass.coffee
+++ b/packages/rocketchat-webrtc/WebRTCClass.coffee
@@ -104,9 +104,17 @@ class WebRTCTransportClass
 class WebRTCClass
 	config:
 		iceServers: [
-			{urls: "stun:stun.l.google.com:19302"}
-			{urls: "stun:23.21.150.121"}
-			{urls: "turn:numb.viagenie.ca:3478", username: "team@rocket.chat", credential: "demo"}
+			{
+				urls: RocketChat.settings.get("WebRTC_STUN_Server")
+			},
+			{
+				urls: RocketChat.settings.get("WebRTC_STUN_Server")
+			},
+			{
+				urls: RocketChat.settings.get("WebRTC_TURN_Server"),
+				username: RocketChat.settings.get("WebRTC_TURN_Username"),
+				credential: RocketChat.settings.get("WebRTC_TURN_Password")
+			}
 		]
 
 	debug: false

--- a/packages/rocketchat-webrtc/i18n/en.i18n.json
+++ b/packages/rocketchat-webrtc/i18n/en.i18n.json
@@ -1,5 +1,9 @@
 {
   "WebRTC_Enable_Channel" : "Enable for Public Channels",
   "WebRTC_Enable_Direct" : "Enable for Direct Messages",
-  "WebRTC_Enable_Private" : "Enable for Private Channels"
+  "WebRTC_Enable_Private" : "Enable for Private Channels",
+  "WebRTC_STUN_Server" : "STUN Server",
+  "WebRTC_TURN_Server" : "TURN Server",
+  "WebRTC_TURN_Username" : "TURN Server Username",
+  "WebRTC_TURN_Password" : "TURN Server Password"
 }

--- a/packages/rocketchat-webrtc/server/settings.coffee
+++ b/packages/rocketchat-webrtc/server/settings.coffee
@@ -2,3 +2,7 @@ RocketChat.settings.addGroup 'WebRTC'
 RocketChat.settings.add 'WebRTC_Enable_Channel', false, { type: 'boolean', group: 'WebRTC', public: true, i18nLabel: 'WebRTC_Enable_Channel'}
 RocketChat.settings.add 'WebRTC_Enable_Private', true , { type: 'boolean', group: 'WebRTC', public: true, i18nLabel: 'WebRTC_Enable_Private'}
 RocketChat.settings.add 'WebRTC_Enable_Direct' , true , { type: 'boolean', group: 'WebRTC', public: true, i18nLabel: 'WebRTC_Enable_Direct'}
+RocketChat.settings.add 'WebRTC_STUN_Server', 'stun:stun.l.google.com:19302', { type: 'string', group: 'WebRTC', public: true, i18nLabel: 'WebRTC_STUN_Server'}
+RocketChat.settings.add 'WebRTC_TURN_Server', 'turn:numb.viagenie.ca:3478', { type: 'string', group: 'WebRTC', public: true, i18nLabel: 'WebRTC_TURN_Server'}
+RocketChat.settings.add 'WebRTC_TURN_Username', 'team@rocket.chat', { type: 'string', group: 'WebRTC', public: true, i18nLabel: 'WebRTC_TURN_Username'}
+RocketChat.settings.add 'WebRTC_TURN_Password', 'demo', { type: 'string', group: 'WebRTC', public: true, i18nLabel: 'WebRTC_TURN_Password'}


### PR DESCRIPTION
I've added a few extra options to the settings panel where admins can configure custom STUN and TURN servers. We're trying to use RC in my organisation and the external calls made by the client whenever WebRTC sessions are started is troubling for the operations guys :)

This hopes to address this issue #1392 - I'll need someone from the RC dev team to verify that these changes actually work as intended.