### PR TITLE
Terminal output should be displayed in LTR always

### DIFF
--- a/packages/rocketchat-theme/assets/stylesheets/rtl.less
+++ b/packages/rocketchat-theme/assets/stylesheets/rtl.less
@@ -184,6 +184,10 @@
 		}
 	}
 
+	.terminal {
+		direction: ltr;
+	}
+
 	.container-bars {
 		.upload-progress {
 			.upload-progress-progress {


### PR DESCRIPTION
Terminal output messages are in English and need to be displayed in a fixed direction