### PR TITLE
CAS settings cleanup and user creation bugfix

### DIFF
--- a/packages/rocketchat-cas/cas_client.js
+++ b/packages/rocketchat-cas/cas_client.js
@@ -2,24 +2,20 @@
 Meteor.loginWithCas = function(callback) {
 
     var credentialToken = Random.id();
+    var login_url = RocketChat.settings.get("CAS_login_url");
+    var popup_width = RocketChat.settings.get("CAS_popup_width");
+    var popup_height = RocketChat.settings.get("CAS_popup_height");
 
-    if (!Meteor.settings.public &&
-        !Meteor.settings.public.cas &&
-        !Meteor.settings.public.cas.loginUrl) {
+    if (!login_url) { 
         return;
     }
 
-    var settings = Meteor.settings.public.cas;
-
-    var loginUrl = settings.loginUrl +
-        "?" + (settings.service || "service") + "=" +
-        Meteor.absoluteUrl('_cas/') +
-        credentialToken;
+    var loginUrl = login_url + "?service=" + Meteor.absoluteUrl('_cas/') + credentialToken;
 
     var popup = openCenteredPopup(
         loginUrl,
-        settings.width || 800,
-        settings.height || 600
+        popup_width || 800,
+        popup_height || 600
     );
 
     var checkPopupOpen = setInterval(function() {

--- a/packages/rocketchat-cas/cas_rocketchat.js
+++ b/packages/rocketchat-cas/cas_rocketchat.js
@@ -1,12 +1,12 @@
 Meteor.startup(function(){
     RocketChat.settings.addGroup('CAS', function() {
-        this.add("CAS_enabled", false, { type: 'boolean', group: 'CAS'});
-        this.add("CAS_base_url" , '' , { type: 'string' , group: 'CAS' });
-        this.add("CAS_login_url" , '' , { type: 'string' , group: 'CAS' });
+        this.add("CAS_enabled", false, { type: 'boolean', group: 'CAS', public: true });
+        this.add("CAS_base_url" , '' , { type: 'string' , group: 'CAS', public: true });
+        this.add("CAS_login_url" , '' , { type: 'string' , group: 'CAS', public: true });
 
         this.section('CAS Login Layout', function() {
-            this.add("CAS_popup_width" , '810' , { type: 'string' , group: 'CAS'});
-            this.add("CAS_popup_height" , '610' , { type: 'string' , group: 'CAS'});
+            this.add("CAS_popup_width" , '810' , { type: 'string' , group: 'CAS', public: true });
+            this.add("CAS_popup_height" , '610' , { type: 'string' , group: 'CAS', public: true });
             this.add("CAS_button_label_text" , 'CAS' , { type: 'string' , group: 'CAS'});
             this.add("CAS_button_label_color", '#FFFFFF' , { type: 'color' , group: 'CAS'});
             this.add("CAS_button_color" , '#13679A' , { type: 'color' , group: 'CAS'});
@@ -41,13 +41,8 @@ function updateServices(record) {
         // Either register or deregister the CAS login service based upon its configuration
         if( data.enabled ) {
             ServiceConfiguration.configurations.upsert({service: 'cas'}, { $set: data });
-            // Export needed settings for meteor-accounts-cas here
-            Meteor.settings.public.cas = { loginUrl: data.login_url };
-            Meteor.settings.cas = { baseUrl: data.base_url };
         } else {
             ServiceConfiguration.configurations.remove({service: 'cas'});
-            Meteor.settings.public.cas = {};
-            Meteor.settings.cas = {};
         }
     }, 2000);
 };

--- a/packages/rocketchat-cas/cas_server.js
+++ b/packages/rocketchat-cas/cas_server.js
@@ -111,7 +111,7 @@ var casTicket = function (req, token, callback) {
 		globalRoles: ['user'],
 	};
 
-	var userId = Accounts.insertUserDoc({}, newUser);
+	var userId = Meteor.users.insert(newUser);
 	user = Meteor.users.findOne(userId);
   }
 

--- a/packages/rocketchat-cas/cas_server.js
+++ b/packages/rocketchat-cas/cas_server.js
@@ -49,18 +49,18 @@ middleware = function (req, res, next) {
 
 var casTicket = function (req, token, callback) {
   // get configuration
-  if (!Meteor.settings.cas && !Meteor.settings.cas.validate) {
-    console.log("accounts-cas: unable to get configuration");
+  if (!RocketChat.settings.get("CAS_enabled")) {
+    console.log("accounts-cas: cas ist not enabled");
     callback();
   }
 
   // get ticket and validate.
   var parsedUrl = url.parse(req.url, true);
   var ticketId = parsedUrl.query.ticket;
-  var baseUrl = Meteor.settings.cas.baseUrl;
+  var baseUrl = RocketChat.settings.get("CAS_base_url");
 
   var cas = new CAS({
-    base_url: Meteor.settings.cas.baseUrl,
+    base_url: baseUrl,
     service: Meteor.absoluteUrl() + "_cas/" + token
   });
 

--- a/packages/rocketchat-cas/package.js
+++ b/packages/rocketchat-cas/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "rocketchat:cas",
   summary: "CAS support for accounts",
-  version: "1.0.0",
+  version: "1.0.1",
   git: "https://github.com/rocketchat/rocketchat-cas"
 });
 


### PR DESCRIPTION
- Switched from Meteor.settings to RocketChat.settings to get CAS needed settings without having to restart the instance
- BugFix for user creation, use Meteor.users.insert instead of the silent-dieing Accounts.insertUserDoc 