### PR TITLE
Allow deleting of files whose corresponding message is not currently loaded in the client

### DIFF
--- a/server/methods/deleteMessage.coffee
+++ b/server/methods/deleteMessage.coffee
@@ -38,4 +38,8 @@ Meteor.methods
 		if showDeletedStatus
 			RocketChat.models.Messages.setAsDeletedById originalMessage._id
 		else
-			RocketChat.Notifications.notifyRoom originalMessage.rid, 'deleteMessage', { _id: originalMessage._id }
+			RocketChat.Notifications.notifyRoom originalMessage.rid, 'deleteMessage', {_id: originalMessage._id}
+
+	,
+	deleteFileMessage: (fileID) ->
+		Meteor.call 'deleteMessage', RocketChat.models.Messages.findOne { file: { _id: fileID } }

--- a/server/publications/roomFiles.coffee
+++ b/server/publications/roomFiles.coffee
@@ -17,6 +17,7 @@ Meteor.publish 'roomFiles', (rid, limit = 50) ->
 			uploadedAt: -1
 		fields:
 			_id: 1
+			userId: 1
 			rid: 1
 			name: 1
 			type: 1


### PR DESCRIPTION
Turns out file deletion had a minor issue; this resolves it.