### PR TITLE
don't crash if RocketChat.Info is not defined

### DIFF
--- a/packages/rocketchat-cors/cors.coffee
+++ b/packages/rocketchat-cors/cors.coffee
@@ -29,7 +29,7 @@ WebApp.rawConnectHandlers.use (req, res, next) ->
 
 WebApp.rawConnectHandlers.use (req, res, next) ->
 	res.setHeader("Access-Control-Allow-Origin", "*")
-	res.setHeader("X-Rocket-Chat-Version", RocketChat.Info.version)
+	res.setHeader("X-Rocket-Chat-Version", RocketChat.Info?.version)
 	res.setHeader("Access-Control-Expose-Headers",  "X-Rocket-Chat-Version")
 
 	# Block next handlers to override CORS with value http://meteor.local


### PR DESCRIPTION
Sometimes during development, RocketChat.Info does not seem to be
defined in time before cors.coffee is executed, resulting in an
exception.

So just return "undefined" as version in that case.