### PR TITLE
Split LDAP_CA_Cert into array of strings.

### DIFF
--- a/packages/rocketchat-ldap/server/ldap.js
+++ b/packages/rocketchat-ldap/server/ldap.js
@@ -63,7 +63,18 @@ LDAP = class LDAP {
 		};
 
 		if (self.options.ca_cert && self.options.ca_cert !== '') {
-			tlsOptions.ca = [self.options.ca_cert];
+			// Split CA cert into array of strings
+			var chainLines = RocketChat.settings.get('LDAP_CA_Cert').split("\n");
+			var cert = [];
+			var ca = [];
+			chainLines.forEach(function(line) {
+				cert.push(line);
+				if (line.match(/-END CERTIFICATE-/)) {
+					ca.push(cert.join("\n"));
+					cert = [];
+				}
+			});
+			tlsOptions.ca = ca;
 		}
 
 		if (self.options.encryption === 'ssl') {


### PR DESCRIPTION
This is needed when LDAP server is using certificate which is issued by a CA.


As per NodeJS documentation:
https://nodejs.org/api/tls.html#tls_tls_connect_options_callback
ca: A string, Buffer or array of strings or Buffers of trusted certificates in PEM format. If this is omitted several well known "root" CAs will be used, like VeriSign. These are used to authorize connections.

Tested and working. Refactor code if necessary.

It would not resolve following issues:
https://github.com/RocketChat/Rocket.Chat/issues/2188
https://github.com/RocketChat/Rocket.Chat/issues/2035