### PR TITLE
fix broken ldap when custom filter specifies no userId

### DIFF
--- a/packages/rocketchat-ldap/server/ldap.js
+++ b/packages/rocketchat-ldap/server/ldap.js
@@ -142,8 +142,8 @@ LDAP = class LDAP {
 
 			return {
 				filter: custom_domain_search.filter,
-				domain_search_user: custom_domain_search.userDN,
-				domain_search_password: custom_domain_search.password
+				domain_search_user: custom_domain_search.userDN || '',
+				domain_search_password: custom_domain_search.password || ''
 			};
 		}
 


### PR DESCRIPTION
the ldap refactoring broke older configurations that use a custom filter but use anonymous
access. Login per LDAP was not possible anymore.

The migration didnt add "userDN" and "password" to the Custom_Domain_Search JSON.

Since people might forget it in the future, just generally handle the case where these values are missing.

PR against master because it broke the 0.18.0 release