### PR TITLE
Auto generated admin account should be active upon creation

### DIFF
--- a/server/startup/initialData.coffee
+++ b/server/startup/initialData.coffee
@@ -34,6 +34,7 @@ Meteor.startup ->
 						console.log "email: #{process.env.ADMIN_EMAIL} | password: #{process.env.ADMIN_PASS}".red
 
 						id = RocketChat.models.Users.create
+							active: true
 							emails: [
 								address: process.env.ADMIN_EMAIL
 								verified: true


### PR DESCRIPTION
When using the environment variables to create the admin account, you're unable to login or reset your password until the account is [flagged as active in the db](https://github.com/RocketChat/Rocket.Chat/blob/0e95760e9173cebde107cac3a7b56588126b6c4a/server/lib/accounts.coffee#L103).

Adding the `{active: true}` flag here seems to make senses unless this was intentionally left out for some security reason.

![login](https://cloud.githubusercontent.com/assets/35968/13115021/fbc0c1f2-d54a-11e5-920f-d099fdebdd2a.png)
![password](https://cloud.githubusercontent.com/assets/35968/13115022/fbc54696-d54a-11e5-8c8e-32529aff3077.png)
