### PR TITLE
force browser to re-render css in situations where transitions break the layout

### DIFF
--- a/packages/rocketchat-ui-flextab/flex-tab/flexTabBar.coffee
+++ b/packages/rocketchat-ui-flextab/flex-tab/flexTabBar.coffee
@@ -26,6 +26,7 @@ Template.flexTabBar.events
 				RocketChat.TabBar.setTemplate @template, ->
 					$('.flex-tab')?.find("input[type='text']:first")?.focus()
 					$('.flex-tab .content')?.scrollTop(0)
+		$('<style></style>').appendTo($(document.body)).remove()
 
 Template.flexTabBar.onCreated ->
 	# close flex if the visible group changed and the opened template is not in the new visible group

--- a/packages/rocketchat-ui-master/master/main.coffee
+++ b/packages/rocketchat-ui-master/master/main.coffee
@@ -213,6 +213,10 @@ Template.main.events
 				else
 					menu.close()
 
+	'transitionend .main-content': ->
+		$('<style></style>').appendTo($(document.body)).remove()
+		console.log('hello')
+
 
 Template.main.onRendered ->
 

--- a/packages/rocketchat-ui-master/master/main.coffee
+++ b/packages/rocketchat-ui-master/master/main.coffee
@@ -215,7 +215,6 @@ Template.main.events
 
 	'transitionend .main-content': ->
 		$('<style></style>').appendTo($(document.body)).remove()
-		console.log('hello')
 
 
 Template.main.onRendered ->


### PR DESCRIPTION
Closes RocketChat/Rocket.Chat.Cordova#57, RocketChat/Rocket.Chat.Cordova#15 and RocketChat/Rocket.Chat#782