### PR TITLE
fix publish user_data  under "spotlight"

### DIFF
--- a/server/publications/spotlight.coffee
+++ b/server/publications/spotlight.coffee
@@ -8,7 +8,7 @@ Meteor.publish 'spotlight', (selector, options, collName) ->
 
 	subHandleUsers = RocketChat.models.Users.findUsersByNameOrUsername(new RegExp(selector.name.$regex, 'i'), { limit: 10, fields: { name: 1, username: 1, status: 1 }, sort: { name: 1 } }).observeChanges
 		added: (id, fields) ->
-			data = { type: 'u', uid: id, name: fields.username + ' - ' + fields.name, status: fields.status }
+			data = { type: 'u', uid: id, username: fields.username, name: fields.username + ' - ' + fields.name, status: fields.status }
 			self.added("autocompleteRecords", id, data)
 		removed: (id) ->
 			self.removed("autocompleteRecords", id)


### PR DESCRIPTION
this is try to fix the small bug :  I typed "Ctrl+P" to global search, but nothing changed when i selected a user in rocket.chat. There may be some fields (actually,name) lost.
