### PR TITLE
add or fix input tips when create a channel

### DIFF
--- a/packages/rocketchat-ui-sidenav/side-nav/createChannelFlex.coffee
+++ b/packages/rocketchat-ui-sidenav/side-nav/createChannelFlex.coffee
@@ -1,4 +1,7 @@
 Template.createChannelFlex.helpers
+	tRoomMembers: ->
+		return t('Members_placeholder')
+	
 	selectedUsers: ->
 		return Template.instance().selectedUsers.get()
 

--- a/packages/rocketchat-ui-sidenav/side-nav/privateGroupsFlex.coffee
+++ b/packages/rocketchat-ui-sidenav/side-nav/privateGroupsFlex.coffee
@@ -1,4 +1,7 @@
 Template.privateGroupsFlex.helpers
+	tRoomMembers: ->
+		return t('Members_placeholder')
+	
 	selectedUsers: ->
 		return Template.instance().selectedUsers.get()
 


### PR DESCRIPTION
the input add members tips ( auto-complete --"placeholder") should be replaced by some strings when create a new channel (or private group)
