### PR TITLE
CAS Plugin: Use Meteor.users.services.cas.external_id to identify use…

### DIFF
--- a/packages/rocketchat-cas/cas_server.js
+++ b/packages/rocketchat-cas/cas_server.js
@@ -103,7 +103,7 @@ var casTicket = function (req, token, callback) {
   var options = { profile: { name: result.id } };
 
   logger.debug("Looking up user with username: " + result.id );
-  var user = Meteor.users.findOne({ 'username': result.id });
+  var user = Meteor.users.findOne({ 'services.cas.external_id': result.id });
 
   if (user) {
     logger.debug("Using existing user for '" + result.id + "' with id: " + user._id);
@@ -112,6 +112,11 @@ var casTicket = function (req, token, callback) {
 		username: result.id,
 		active: true,
 		globalRoles: ['user'],
+        services: {
+            cas: {
+                external_id: result.id
+            }
+        }
 	};
 
     logger.debug("User '" + result.id + "'does not exist yet, creating it");


### PR DESCRIPTION
CAS Plugin: Use Meteor.users.services.cas.external_id to identify users instead of Meteor.users.username. This should fix #2414 partially as it allows users to change their username in their profile without losing the ability to identify themselves through CAS sso.