### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ mongo:
 
 rocketchat:
   image: rocketchat/rocket.chat:latest
-# volumes:
-#    - ./uploads:/app/uploads
   environment:
     - PORT=3000
     - ROOT_URL=http://yourhost:3000


### PR DESCRIPTION
removed the volume mount option from rocketchat since the files are stored inside mongodb