### PR TITLE
meteor update

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -25,7 +25,7 @@ check@1.1.0
 chrismbeckett:toastr@2.1.2_1
 chuangbo:cookie@1.1.0
 coffeescript@1.0.11
-cosmos:browserify@0.9.4
+cosmos:browserify@0.10.0
 dandv:caret-position@2.1.1
 ddp@1.2.2
 ddp-client@1.2.1
@@ -39,7 +39,7 @@ ecmascript@0.1.6
 ecmascript-runtime@0.2.6
 ejson@1.0.7
 email@1.0.8
-emojione:emojione@2.1.0
+emojione:emojione@2.1.1
 facebook@1.2.2
 fastclick@1.0.7
 francocatena:status@1.5.1
@@ -60,7 +60,7 @@ jparker:gravatar@0.4.1
 jquery@1.11.4
 kadira:blaze-layout@2.3.0
 kadira:flow-router@2.10.1
-kenton:accounts-sandstorm@0.1.8
+kenton:accounts-sandstorm@0.2.1
 konecty:autolinker@1.0.3
 konecty:change-case@2.3.0
 konecty:delayed-task@1.0.0
@@ -74,13 +74,14 @@ livedata@1.0.15
 localstorage@1.0.5
 logging@1.0.8
 matb33:collection-hooks@0.8.1
-mdg:validation-error@0.4.0
+mdg:validation-error@0.5.1
 meteor@1.1.10
 meteor-base@1.0.1
 meteor-developer@1.1.5
-meteorhacks:fast-render@2.10.0
-meteorhacks:inject-data@1.4.1
+meteorhacks:fast-render@2.13.0
+meteorhacks:inject-data@2.0.0
 meteorhacks:inject-initial@1.0.3
+meteorhacks:meteorx@1.4.1
 meteorhacks:picker@1.0.3
 meteorspark:util@0.2.0
 minifiers@1.1.7
@@ -89,7 +90,7 @@ mizzao:autocomplete@0.5.1
 mizzao:timesync@0.3.4
 mobile-experience@1.0.1
 mobile-status-bar@1.0.6
-momentjs:moment@2.11.2
+momentjs:moment@2.12.0
 monbro:mongodb-mapreduce-aggregation@1.0.1
 mongo@1.1.3
 mongo-id@1.0.1
@@ -98,8 +99,8 @@ mrt:moment@2.8.1
 mrt:moment-timezone@0.2.1
 mrt:reactive-store@0.0.1
 mystor:device-detection@0.2.0
-nimble:restivus@0.8.4
-nooitaf:colors@0.0.2
+nimble:restivus@0.8.7
+nooitaf:colors@0.0.3
 npm-bcrypt@0.7.8_2
 npm-mongo@1.4.39_1
 oauth@1.1.6
@@ -207,7 +208,7 @@ tracker@1.0.9
 twitter@1.1.5
 ui@1.0.8
 underscore@1.0.4
-underscorestring:underscore.string@3.2.3
+underscorestring:underscore.string@3.3.4
 url@1.0.5
 webapp@1.2.3
 webapp-hashing@1.0.5


### PR DESCRIPTION
emojione:emojione upgraded from 2.1.0 to 2.1.1
kenton:accounts-sandstorm upgraded from 0.1.8 to 0.2.1
mdg:validation-error upgraded from 0.4.0 to 0.5.1
meteorhacks:fast-render upgraded from 2.10.0 to 2.13.0
meteorhacks:meteorx added, version 1.4.1
momentjs:moment upgraded from 2.11.2 to 2.12.0
nimble:restivus upgraded from 0.8.4 to 0.8.7
nooitaf:colors upgraded from 0.0.2 to 0.0.3
underscorestring:underscore.string upgraded from 3.2.3 to 3.3.4
meteorhacks:inject-data upgraded from 1.4.1 to 2.0.0