### PR TITLE
Fix bug when changing room name and leaving value unchanged

### DIFF
--- a/packages/rocketchat-channel-settings/client/views/channelSettings.coffee
+++ b/packages/rocketchat-channel-settings/client/views/channelSettings.coffee
@@ -83,13 +83,17 @@ Template.channelSettings.onCreated ->
 	@saveSetting = =>
 		switch @editing.get()
 			when 'roomName'
-				if @validateRoomName()
-					Meteor.call 'saveRoomSettings', @data?.rid, 'roomName', @$('input[name=roomName]').val(), (err, result) ->
-						if err
-							if err.error in [ 'duplicate-name', 'name-invalid' ]
-								return toastr.error TAPi18n.__(err.reason, err.details.channelName)
-							return toastr.error TAPi18n.__(err.reason)
-						toastr.success TAPi18n.__ 'Room_name_changed_successfully'
+				room = ChatRoom.findOne @data?.rid
+				if $('input[name=roomName]').val() is room.name
+					toastr.success TAPi18n.__ 'Room_name_changed_successfully'
+				else
+					if @validateRoomName()
+						Meteor.call 'saveRoomSettings', @data?.rid, 'roomName', @$('input[name=roomName]').val(), (err, result) ->
+							if err
+								if err.error in [ 'duplicate-name', 'name-invalid' ]
+									return toastr.error TAPi18n.__(err.reason, err.details.channelName)
+								return toastr.error TAPi18n.__(err.reason)
+							toastr.success TAPi18n.__ 'Room_name_changed_successfully'
 			when 'roomTopic'
 				if @validateRoomTopic()
 					Meteor.call 'saveRoomSettings', @data?.rid, 'roomTopic', @$('input[name=roomTopic]').val(), (err, result) ->


### PR DESCRIPTION
Just stumbled over a bug where editing the room name in the 'Room Info' tab and then clicking on save without actually making any changes to the room name results in the following message being displayed in the room:
![screen shot 2016-03-09 at 16 58 15](https://cloud.githubusercontent.com/assets/10801000/13643631/1c5b7b90-e622-11e5-8f8b-a179ff8a4807.png)

I added in a check to prevent this from happening. Now it will instead simply show the green success message, the same way as is done when editing one of the other values and leaving them unchanged.

Also, this problem only seems to affect the 'Room Info' tab but not the one in the admin area.