### PR TITLE
Pass restricted domain as string when only one

### DIFF
--- a/server/lib/accounts.coffee
+++ b/server/lib/accounts.coffee
@@ -4,7 +4,7 @@ Accounts.config accountsConfig
 
 RocketChat.settings.get 'Accounts_AllowedDomainsList', (_id, value) ->
 	domainWhiteList = _.map value.split(','), (domain) -> domain.trim()
-	restrictCreationByEmailDomain = (email) ->
+	restrictCreationByEmailDomain = if domainWhiteList.length == 1 then domainWhiteList[0] else (email) ->
 		ret = false
 		for domain in domainWhiteList
 			if email.match(domain + '$')


### PR DESCRIPTION
restrictCreationByEmailDomain accepts either a function or a string. When it is a string, it will be used by some of the OAuth integrations (like google) to proactively restrict logins.

For my use case this means that employees are automatically asked by google to login with their work credentials instead of first having to select between their personal and work accounts.