### PR TITLE
RTL: Give `padding-right` to `.input-message`

### DIFF
--- a/packages/rocketchat-theme/assets/stylesheets/rtl.less
+++ b/packages/rocketchat-theme/assets/stylesheets/rtl.less
@@ -641,4 +641,8 @@
 	.toast-top-right {
 		.left(12px);
 	}
+	
+	.input-message {
+		padding-right: 3em;
+	}
 }


### PR DESCRIPTION
Closes #2566 

So the the emoji button won't overlap the message