### PR TITLE
Fix emoji picker icon location for RTL

### DIFF
--- a/packages/rocketchat-theme/assets/stylesheets/rtl.less
+++ b/packages/rocketchat-theme/assets/stylesheets/rtl.less
@@ -222,6 +222,11 @@
 		}
 		.message-form {
 			> div {
+				.input-message-container {
+					.inner-right-toolbar {
+						.left(10px);
+					}
+				}
 				> .file {
 					border-right-width: 1px;
 					border-radius: 0 5px 5px 0;


### PR DESCRIPTION
This fix moves the emoji icon to the left side in RTL interfaces
@sampaiodiego