### PR TITLE
Revert "RTL: Give `padding-right` to `.input-message`"

### DIFF
--- a/packages/rocketchat-theme/assets/stylesheets/rtl.less
+++ b/packages/rocketchat-theme/assets/stylesheets/rtl.less
@@ -641,8 +641,4 @@
 	.toast-top-right {
 		.left(12px);
 	}
-	
-	.input-message {
-		padding-right: 3em;
-	}
 }


### PR DESCRIPTION
Reverts RocketChat/Rocket.Chat#2567

As per https://github.com/RocketChat/Rocket.Chat/pull/2572