### PR TITLE
Allow pass @username in avatar

### DIFF
--- a/packages/rocketchat-ui-message/message/message.coffee
+++ b/packages/rocketchat-ui-message/message/message.coffee
@@ -5,6 +5,9 @@ Template.message.helpers
 		return 'false' if this.groupable is false
 	isSequential: ->
 		return 'sequential' if this.groupable isnt false
+	avatarFromUsername: ->
+		if this.avatar? and this.avatar[0] is '@'
+			return this.avatar.replace(/^@/, '')
 	getEmoji: (emoji) ->
 		return emojione.toImage emoji
 	own: ->

--- a/packages/rocketchat-ui-message/message/message.html
+++ b/packages/rocketchat-ui-message/message/message.html
@@ -1,11 +1,15 @@
 <template name="message">
 	<li id="{{_id}}" class="message {{isSequential}} {{system}} {{t}} {{own}} {{isTemp}} {{chatops}}" data-username="{{u.username}}" data-groupable="{{isGroupable}}" data-date="{{date}}" data-timestamp="{{timestamp}}">
 		{{#if avatar}}
-			<a class="thumb user-card-message" href="#" data-username="{{u.username}}" tabindex="1">
-				<div class="avatar">
-					<div class="avatar-image" style="background-image:url({{avatar}});"></div>
-				</div>
-			</a>
+			{{#if avatarFromUsername}}
+				<a class="thumb user-card-message" href="#" data-username="{{u.username}}" tabindex="1">{{> avatar username=avatarFromUsername}}</a>
+			{{else}}
+				<a class="thumb user-card-message" href="#" data-username="{{u.username}}" tabindex="1">
+					<div class="avatar">
+						<div class="avatar-image" style="background-image:url({{avatar}});"></div>
+					</div>
+				</a>
+			{{/if}}
 		{{else}}
 			{{#if emoji}}
 				<a class="thumb user-card-message" href="#" data-username="{{u.username}}" tabindex="1">


### PR DESCRIPTION
Closes #2495

Pass "@username" in field "avatar" when posting new messages via integrations, like @rocket.cat, will use avatar from that username

Example: 
```javascript
{
  "text": "Example message",
  "alias": "Rodrigo Nascimento",
  "avatar": "@rodrigo.nascimento",
  "attachments": [
    {
      "title": "Rocket.Chat",
      "title_link": "https://rocket.chat",
      "text": "Rocket.Chat, the best open source chat",
      "image_url": "https://rocket.chat/images/mockup.png",
      "color": "#764FA5"
    }
  ]
}
```