### PR TITLE
Add nitrous.io quickstart config and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The Ultimate Open Source WebChat Platform
    * [DPlatform](#dplatform) 
    * [IndieHosters](#indiehosters)
    * [Cloudron.io](#cloudronio) 
+   * [Nitrous.io](#nitrousio)
    * [Heroku](#heroku)
   * [Scalingo](#scalingo)
   * [Sloppy.io](#sloppyio)
@@ -83,6 +84,14 @@ Get your Rocket.Chat instance hosted in a "as a Service" style. You register and
 Install Rocket.Chat on [Cloudron](https://cloudron.io) Smartserver:
 
 [![Install](https://cloudron.io/img/button.svg)](https://cloudron.io/button.html?app=chat.rocket.cloudronapp)
+
+## Nitrous.io
+**Free** development environment for Rocket.Chat in the cloud on [Nitrous.io](https://www.nitrous.io):
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
 ## Heroku
 Host your own Rocket.Chat server for **FREE** with [One-Click Deploy](https://heroku.com/deploy)
 

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,16 @@
+# Setup
+
+Welcome to your Rocket.Chat project on Nitrous.
+
+## Running the development server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), enter the following commands in the terminal window:
+
+1. `cd ~/code/Rocket.Chat`
+2. `meteor --port 0.0.0.0:3000`
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3000".

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,6 @@
+{
+  "template": "meteor",
+  "ports": [3000],
+  "name": "Rocket.Chat",
+  "description": "Have your own Slack like online chat, built with Meteor."
+}


### PR DESCRIPTION
Nitrous.io provides a lightning fast way to set up development environments and code in the cloud. [Nitrous Quickstart](https://community.nitrous.io/posts/nitrous-quickstarts) button provides an easy way to run apps without requiring developers to install anything locally. This PR let users deploy their own version of 'Rocket.Chat' in their own container in an instant.

I'm also featuring [Rocket.Chat](https://www.nitrous.io/quickstarts/) on this page because I think it's a great use case for Nitrous Quickstarts. 