### PR TITLE
Fix for word highlighting of none Latin characters

### DIFF
--- a/packages/rocketchat-highlight-words/client.coffee
+++ b/packages/rocketchat-highlight-words/client.coffee
@@ -17,7 +17,7 @@ class HighlightWordsClient
 
     _.forEach to_highlight, (highlight) ->
       if not _.isBlank(highlight)
-        msg = msg.replace(new RegExp("(\\b)(#{s.escapeRegExp(highlight)})(\\b)(?![^<]*>|[^<>]*<\\/)", 'gmi'), '$1<span class="highlight-text">$2</span>$3')
+        msg = msg.replace(new RegExp("(^|\\b|[\\s\\n\\r\\t.,،'\\\"\\+!?:-])(#{s.escapeRegExp(highlight)})($|\\b|[\\s\\n\\r\\t.,،'\\\"\\+!?:-])(?![^<]*>|[^<>]*<\\/)", 'gmi'), '$1<span class="highlight-text">$2</span>$3')
 
     message.html = msg
     return message


### PR DESCRIPTION
Closes #2610 

Updated regex that supports words using other than ASCII characters