### PR TITLE
Use the login layout for the reset password screen.

### DIFF
--- a/packages/rocketchat-ui-master/master/main.html
+++ b/packages/rocketchat-ui-master/master/main.html
@@ -59,7 +59,7 @@
 				{{> username}}
 			{{else}}
 				{{#if requirePasswordChange}}
-					{{> logoLayout render="resetPassword"}}
+					{{> loginLayout center="resetPassword"}}
 				{{else}}
 					{{> spotlight}}
 					{{> mobileMessageMenu}}


### PR DESCRIPTION
This uses the login layout setting for the reset password, pretty simple change that will make people happy who are currently relying on the settings to customize the Rocket.Chat experience.

