### PR TITLE
canAddUser update to use owner and moderator roles instead of creator…

### DIFF
--- a/packages/rocketchat-ui-flextab/flex-tab/tabs/membersList.coffee
+++ b/packages/rocketchat-ui-flextab/flex-tab/tabs/membersList.coffee
@@ -57,7 +57,7 @@ Template.membersList.helpers
 	canAddUser: ->
 		roomData = Session.get('roomData' + this._id)
 		return '' unless roomData
-		return roomData.t in ['p', 'c'] and roomData.u?._id is Meteor.userId()
+		return roomData.t in ['p', 'c'] and RoomModeratorsAndOwners.findOne({ rid: this._id, 'u._id': Meteor.userId(), roles: { $in: ['moderator','owner'] }})
 
 	autocompleteSettingsAddUser: ->
 		return {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->


<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

… for

canAddUser update to use owner and moderator roles instead of creator for adding users to a channel or private group