### PR TITLE
Add ability to hide embedded media

### DIFF
--- a/packages/rocketchat-lib/i18n/de.i18n.json
+++ b/packages/rocketchat-lib/i18n/de.i18n.json
@@ -183,6 +183,7 @@
   "Client_Secret" : "Client-Secret",
   "close" : "Schließen",
   "Closed" : "Geschlossen",
+  "Collapse_Embedded_Media_By_Default": "Eingebettete Medien standardmäßig ausblenden",
   "coming_soon" : "kommt bald",
   "Commands" : "Befehle",
   "Compact_View" : "Kompaktansicht",

--- a/packages/rocketchat-lib/i18n/en.i18n.json
+++ b/packages/rocketchat-lib/i18n/en.i18n.json
@@ -189,6 +189,7 @@
   "Clients_will_refresh_in_a_few_seconds" : "Clients will refresh in a few seconds",
   "close" : "close",
   "Closed" : "Closed",
+  "Collapse_Embedded_Media_By_Default": "Collapse embedded media by default",
   "coming_soon" : "coming soon",
   "Commands" : "Commands",
   "Compact_View" : "Compact View",

--- a/packages/rocketchat-message-attachments/client/messageAttachment.coffee
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.coffee
@@ -13,7 +13,7 @@ Template.messageAttachment.helpers
 	parsedText: ->
 		renderMessageBody { msg: this.text }
 
-	showImage: ->
+	loadImage: ->
 		if Meteor.user()?.settings?.preferences?.autoImageLoad is false and this.downloadImages? is not true
 			return false
 
@@ -31,3 +31,9 @@ Template.messageAttachment.helpers
 			when 'warning' then return '#FCB316'
 			when 'danger' then return '#D30230'
 			else return @color
+				
+	collapsed: ->
+		if this.collapsed?
+			return this.collapsed
+		else
+			return Meteor.user()?.settings?.preferences?.collapseMediaByDefault is true

--- a/packages/rocketchat-message-attachments/client/messageAttachment.html
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.html
@@ -22,20 +22,23 @@
 					</div>
 				{{/if}}
 			{{/if}}
-
 			{{#if title}}
-				{{#if title_link}}
-					<div class="attachment-title">
+				<div class="attachment-title">	
+					{{#if title_link}}
 						<a href="{{fixCordova title_link}}" target="_blank">{{title}}</a>
 						{{#if title_link_download}}
 							<a class="icon-download attachment-download-icon" href="{{fixCordova title_link}}" target="_blank" download=""></a>
 						{{/if}}
-					</div>
 				{{else}}
-					<div class="attachment-title">{{title}}</div>
+					{{title}}
 				{{/if}}
+				{{#if collapsed}}
+					<span class="collapse-switch icon-right-dir" data-url="{{image_url}}" data-collapsed="{{collapsed}}"></span>
+				{{else}}
+					<span class="collapse-switch icon-down-dir" data-url="{{image_url}}" data-collapsed="{{collapsed}}"></span>
+				{{/if}}
+				</div>			
 			{{/if}}
-
 			<div class="attachment-flex">
 				{{#if thumb_url}}
 					<div class="attachment-thumb">
@@ -51,8 +54,9 @@
 			</div>
 
 			{{#if image_url}}
-				<div class="attachment-image">
-					{{#if showImage}}
+				{{#unless collapsed}}
+					<div class="attachment-image">
+					{{#if loadImage}}
 						<a href="{{fixCordova image_url}}" class="swipebox" target="_blank">
 							<div class="inline-image" style="background-image: url('{{fixCordova image_url}}');">
 								<img src="{{fixCordova image_url}}" height="{{getImageHeight image_dimensions.height}}">
@@ -64,25 +68,30 @@
 							<div>click to load</div>
 						</div>
 					{{/if}}
-				</div>
+					</div>
+				{{/unless}}
 			{{/if}}
 
 			{{#if audio_url}}
-				<div class="attachment-audio">
-					<audio controls>
-						<source src="{{fixCordova audio_url}}" type="{{audio_type}}">
-						Your browser does not support the audio element.
-					</audio>
-				</div>
+				{{#unless collapsed}}
+					<div class="attachment-audio">
+						<audio controls>
+							<source src="{{fixCordova audio_url}}" type="{{audio_type}}">
+							Your browser does not support the audio element.
+						</audio>
+					</div>
+				{{/unless}}
 			{{/if}}
 
 			{{#if video_url}}
-				<div class="attachment-video">
-					<video controls class="inline-video">
-						<source src="{{fixCordova video_url}}" type="{{video_type}}">
-						Your browser does not support the video element.
-					</video>
-				</div>
+				{{#unless collapsed}}
+					<div class="attachment-video">
+						<video controls class="inline-video">
+							<source src="{{fixCordova video_url}}" type="{{video_type}}">
+							Your browser does not support the video element.
+						</video>
+					</div>
+				{{/unless}}
 			{{/if}}
 
 			{{#if fields}}

--- a/packages/rocketchat-oembed/client/oembedAudioWidget.coffee
+++ b/packages/rocketchat-oembed/client/oembedAudioWidget.coffee
@@ -1,0 +1,7 @@
+Template.oembedAudioWidget.helpers
+
+	collapsed: ->
+		if this.collapsed?
+			return this.collapsed
+		else
+			return Meteor.user()?.settings?.preferences?.collapseMediaByDefault is true

--- a/packages/rocketchat-oembed/client/oembedAudioWidget.html
+++ b/packages/rocketchat-oembed/client/oembedAudioWidget.html
@@ -1,12 +1,17 @@
 <template name="oembedAudioWidget">
 	<a href="{{url}}" target="_blank">
 		{{#if parsedUrl}}
-			<blockquote>
-				<audio controls>
-					<source src="{{url}}" type="{{headers.contentType}}">
-					Your browser does not support the audio element.
-				</audio>
-			</blockquote>
+			{{#if collapsed}}
+				<span class="collapse-switch icon-right-dir" data-url="{{url}}" data-collapsed="{{collapsed}}"></span>
+			{{else}}
+				<span class="collapse-switch icon-down-dir" data-url="{{url}}" data-collapsed="{{collapsed}}"></span>
+				<blockquote>
+					<audio controls>
+						<source src="{{url}}" type="{{headers.contentType}}">
+						Your browser does not support the audio element.
+					</audio>
+				</blockquote>
+			{{/if}}
 		{{/if}}
 	</a>
 </template>

--- a/packages/rocketchat-oembed/client/oembedFrameWidget.coffee
+++ b/packages/rocketchat-oembed/client/oembedFrameWidget.coffee
@@ -1,0 +1,7 @@
+Template.oembedFrameWidget.helpers
+
+	collapsed: ->
+		if this.collapsed?
+			return this.collapsed
+		else
+			return Meteor.user()?.settings?.preferences?.collapseMediaByDefault is true

--- a/packages/rocketchat-oembed/client/oembedFrameWidget.html
+++ b/packages/rocketchat-oembed/client/oembedFrameWidget.html
@@ -1,25 +1,32 @@
 <template name="oembedFrameWidget">
-	{{#if parsedUrl}}
-		<blockquote>
-			{{#if meta.oembedProviderName}}
-				{{#if meta.oembedProviderUrl}}
-					<a href="{{meta.oembedProviderUrl}}" style="color: #9e9ea6">{{meta.oembedProviderName}}</a><br/>
-				{{/if}}
+{{#if parsedUrl}}
+	<blockquote>
+		{{#if meta.oembedProviderName}}
+			{{#if meta.oembedProviderUrl}}
+				<a href="{{meta.oembedProviderUrl}}" style="color: #9e9ea6">{{meta.oembedProviderName}}</a>
 			{{/if}}
-			{{#if meta.oembedAuthorName}}
-				{{#if meta.oembedAuthorUrl}}
-					<a href="{{meta.oembedAuthorUrl}}">{{meta.oembedAuthorName}}</a><br/>
-				{{/if}}
+		{{/if}}
+		{{#if meta.oembedAuthorName}}
+			{{#if meta.oembedAuthorUrl}}
+				<br class="only-after-a"/>
+				<a href="{{meta.oembedAuthorUrl}}">{{meta.oembedAuthorName}}</a>
 			{{/if}}
-			{{#if meta.oembedTitle}}
-				{{#if meta.oembedUrl}}
-					<a href="{{meta.oembedUrl}}">{{meta.oembedTitle}}</a><br/>
-				{{/if}}
+		{{/if}}
+		{{#if meta.oembedTitle}}
+			{{#if meta.oembedUrl}}
+				<br class="only-after-a"/>
+				<a href="{{meta.oembedUrl}}">{{meta.oembedTitle}}</a>
 			{{/if}}
+		{{/if}}
+		{{#if collapsed}}
+			<span class="collapse-switch icon-right-dir" data-url="{{url}}" data-collapsed="{{collapsed}}"></span><br/>
+		{{else}}
+			<span class="collapse-switch icon-down-dir" data-url="{{url}}" data-collapsed="{{collapsed}}"></span><br/>
 			{{#if meta.oembedDescription}}
 				<p>{{meta.oembedDescription}}</p>
 			{{/if}}
 			{{{meta.oembedHtml}}}
-		</blockquote>
-	{{/if}}
+		{{/if}}
+	</blockquote>
+{{/if}}
 </template>

--- a/packages/rocketchat-oembed/client/oembedImageWidget.coffee
+++ b/packages/rocketchat-oembed/client/oembedImageWidget.coffee
@@ -1,5 +1,5 @@
 Template.oembedImageWidget.helpers
-	showImage: ->
+	loadImage: ->
 
 		if Meteor.user()?.settings?.preferences?.autoImageLoad is false and this.downloadImages? is not true
 			return false
@@ -8,3 +8,10 @@ Template.oembedImageWidget.helpers
 			return false
 
 		return true
+
+
+	collapsed: ->
+		if this.collapsed?
+			return this.collapsed
+		else
+			return Meteor.user()?.settings?.preferences?.collapseMediaByDefault is true

--- a/packages/rocketchat-oembed/client/oembedImageWidget.html
+++ b/packages/rocketchat-oembed/client/oembedImageWidget.html
@@ -1,20 +1,23 @@
 <template name="oembedImageWidget">
-	{{#if showImage}}
-		{{#if parsedUrl}}
-			<div>
-				<a href="{{url}}" class="swipebox" target="_blank">
-					<div class="inline-image" style="background-image: url('{{url}}');">
-						<img src="{{url}}" height="200">
-					</div>
-				</a>
-			</div>
-		{{/if}}
-	{{else}}
-		{{#if parsedUrl}}
-			<div class="image-to-download" data-url="{{url}}">
-				<i class="icon-picture"></i>
-				<div>click to load</div>
-			</div>
+	{{#if parsedUrl}}
+		{{#if collapsed}}
+			<span class="collapse-switch icon-right-dir" data-url="{{url}}" data-collapsed="{{collapsed}}"></span>
+		{{else}}
+			<span class="collapse-switch icon-down-dir" data-url="{{url}}" data-collapsed="{{collapsed}}"></span>
+			{{#if loadImage}}
+				<div>
+					<a href="{{url}}" class="swipebox" target="_blank">
+						<div class="inline-image" style="background-image: url('{{url}}');">
+							<img src="{{url}}" height="200">
+						</div>
+					</a>
+				</div>
+			{{else}}
+				<div class="image-to-download" data-url="{{url}}">
+					<i class="icon-picture"></i>
+					<div>click to load</div>
+				</div>
+			{{/if}}
 		{{/if}}
 	{{/if}}
 </template>

--- a/packages/rocketchat-oembed/client/oembedUrlWidget.coffee
+++ b/packages/rocketchat-oembed/client/oembedUrlWidget.coffee
@@ -34,3 +34,9 @@ Template.oembedUrlWidget.helpers
 
 	show: ->
 		return getDescription(this)? or getTitle(this)?
+
+	collapsed: ->
+		if this.collapsed?
+			return this.collapsed
+		else
+			return Meteor.user()?.settings?.preferences?.collapseMediaByDefault is true

--- a/packages/rocketchat-oembed/client/oembedVideoWidget.coffee
+++ b/packages/rocketchat-oembed/client/oembedVideoWidget.coffee
@@ -14,3 +14,9 @@ Template.oembedVideoWidget.helpers
 
 	title: ->
 		return getTitle @
+
+	collapsed: ->
+		if this.collapsed?
+			return this.collapsed
+		else
+			return Meteor.user()?.settings?.preferences?.collapseMediaByDefault is true

--- a/packages/rocketchat-oembed/client/oembedVideoWidget.html
+++ b/packages/rocketchat-oembed/client/oembedVideoWidget.html
@@ -2,11 +2,16 @@
 {{#if parsedUrl}}
 	<blockquote>
 		<div><a href="{{url}}">{{parsedUrl.host}}</a></div>
-		<div>{{title}}</div>
-		<video controls class="inline-video">
-			<source src="{{url}}" type="{{contentType}}">
-			Your browser does not support the video element.
-		</video>
+		<span>{{title}}</span>
+		{{#if collapsed}}
+			<span class="collapse-switch icon-right-dir" data-url="{{url}}" data-collapsed="{{collapsed}}"></span>
+		{{else}}
+			<span class="collapse-switch icon-down-dir" data-url="{{url}}" data-collapsed="{{collapsed}}"></span><br/>
+			<video controls class="inline-video">
+				<source src="{{url}}" type="{{contentType}}">
+				Your browser does not support the video element.
+			</video>
+		{{/if}}
 	</blockquote>
 {{/if}}
 </template>

--- a/packages/rocketchat-oembed/client/oembedYoutubeWidget.coffee
+++ b/packages/rocketchat-oembed/client/oembedYoutubeWidget.coffee
@@ -1,0 +1,7 @@
+Template.oembedYoutubeWidget.helpers
+
+	collapsed: ->
+		if this.collapsed?
+			return this.collapsed
+		else
+			return Meteor.user()?.settings?.preferences?.collapseMediaByDefault is true

--- a/packages/rocketchat-oembed/client/oembedYoutubeWidget.html
+++ b/packages/rocketchat-oembed/client/oembedYoutubeWidget.html
@@ -1,9 +1,14 @@
 <template name="oembedYoutubeWidget">
 	{{#if parsedUrl}}
 		<blockquote>
-			<a href="{{url}}">{{parsedUrl.host}}</a><br>
-			<iframe width="355" height="200" src="{{meta.twitterPlayer}}" frameborder="0" allowfullscreen></iframe><br>
-			{{{meta.description}}}
+			<a href="{{url}}">{{parsedUrl.host}}</a>
+			{{#if collapsed}}
+				<span class="collapse-switch icon-right-dir" data-url="{{url}}" data-collapsed="{{collapsed}}"></span><br>
+			{{else}}
+				<span class="collapse-switch icon-down-dir" data-url="{{url}}" data-collapsed="{{collapsed}}"></span><br>
+				<iframe width="355" height="200" src="{{meta.twitterPlayer}}" frameborder="0" allowfullscreen></iframe><br>
+				{{{meta.description}}}
+			{{/if}}
 		</blockquote>
 	{{/if}}
 </template>

--- a/packages/rocketchat-oembed/package.js
+++ b/packages/rocketchat-oembed/package.js
@@ -28,16 +28,19 @@ Package.onUse(function(api) {
 	api.addFiles('client/oembedImageWidget.coffee', 'client');
 
 	api.addFiles('client/oembedAudioWidget.html', 'client');
+	api.addFiles('client/oembedAudioWidget.coffee', 'client');
 
 	api.addFiles('client/oembedVideoWidget.html', 'client');
 	api.addFiles('client/oembedVideoWidget.coffee', 'client');
 
 	api.addFiles('client/oembedYoutubeWidget.html', 'client');
+	api.addFiles('client/oembedYoutubeWidget.coffee', 'client');
 
 	api.addFiles('client/oembedUrlWidget.html', 'client');
 	api.addFiles('client/oembedUrlWidget.coffee', 'client');
 
 	api.addFiles('client/oembedFrameWidget.html', 'client');
+	api.addFiles('client/oembedFrameWidget.coffee', 'client');
 
 	api.addFiles('server/server.coffee', 'server');
 	api.addFiles('server/providers.coffee', 'server');

--- a/packages/rocketchat-spotify/lib/client/oembedSpotifyWidget.html
+++ b/packages/rocketchat-spotify/lib/client/oembedSpotifyWidget.html
@@ -3,11 +3,16 @@
 		<blockquote>
 			<a href="https://www.spotify.com" style="color: #9e9ea6">Spotify</a><br/>
 			{{#if match meta.ogAudio "spotify:artist:\\S+"}}
-				<a href="{{url}}">{{{meta.ogTitle}}}</a><br/>
+				<a href="{{url}}">{{{meta.ogTitle}}}</a>
 			{{else}}
-				<a href="{{url}}">{{{replace meta.ogDescription ", an? (?:song|album) by (.+?) on Spotify" " - $1" regex=true}}}</a><br/>
+				<a href="{{url}}">{{{replace meta.ogDescription ", an? (?:song|album) by (.+?) on Spotify" " - $1" regex=true}}}</a>
 			{{/if}}
-			<iframe width="300" height="380" src="https://embed.spotify.com/?uri={{meta.ogAudio}}" frameborder="0"></iframe><br/>
+			{{#if collapsed}}
+				<span class="collapse-switch icon-right-dir" data-url="{{url}}" data-collapsed="{{collapsed}}"></span>
+			{{else}}
+				<span class="collapse-switch icon-down-dir" data-url="{{url}}" data-collapsed="{{collapsed}}"></span>
+				<iframe width="300" height="380" src="https://embed.spotify.com/?uri={{meta.ogAudio}}" frameborder="0"></iframe><br/>
+			{{/if}}
 		</blockquote>
 	{{/if}}
 </template>

--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -2817,8 +2817,8 @@ a.github-fork {
 		}
 
 		// .message-dropdown {
-		// 	top: 100%;
-		// 	left: 0;
+		//	top: 100%;
+		//	left: 0;
 		// }
 
 		&:hover {
@@ -4764,4 +4764,17 @@ body:not(.is-cordova) {
 	right: -8px;
 	top: -5px;
 	opacity: .6;
+}
+
+.collapse-switch {
+	cursor: pointer;
+}
+
+// kinda hacky, needed in oembedFrageWidget.html
+br.only-after-a {
+	display: none;
+}
+
+a + br.only-after-a {
+	display: block;
 }

--- a/packages/rocketchat-ui-account/account/accountPreferences.coffee
+++ b/packages/rocketchat-ui-account/account/accountPreferences.coffee
@@ -67,6 +67,7 @@ Template.accountPreferences.onCreated ->
 		data.useEmojis = $('input[name=useEmojis]:checked').val()
 		data.convertAsciiEmoji = $('input[name=convertAsciiEmoji]:checked').val()
 		data.saveMobileBandwidth = $('input[name=saveMobileBandwidth]:checked').val()
+		data.collapseMediaByDefault = $('input[name=collapseMediaByDefault]:checked').val()
 		data.compactView = $('input[name=compactView]:checked').val()
 		data.unreadRoomsMode = $('input[name=unreadRoomsMode]:checked').val()
 		data.autoImageLoad = $('input[name=autoImageLoad]:checked').val()

--- a/packages/rocketchat-ui-account/account/accountPreferences.html
+++ b/packages/rocketchat-ui-account/account/accountPreferences.html
@@ -70,6 +70,13 @@
 									<label><input type="radio" name="saveMobileBandwidth" value="0" checked="{{checked 'saveMobileBandwidth' false}}" /> {{_ "False"}}</label>
 								</div>
 							</div>
+							<div class="input-line double-col" id="collapseMediaByDefault">
+								<label>{{_ "Collapse_Embedded_Media_By_Default"}}</label>
+								<div>
+									<label><input type="radio" name="collapseMediaByDefault" value="1" checked="{{checked 'collapseMediaByDefault' true}}" /> {{_ "True"}}</label>
+									<label><input type="radio" name="collapseMediaByDefault" value="0" checked="{{checked 'collapseMediaByDefault' false true}}" /> {{_ "False"}}</label>
+								</div>
+							</div>
 							<div class="input-line double-col" id="compactView">
 								<label>{{_ "Compact_View"}}</label>
 								<div>

--- a/packages/rocketchat-ui/views/app/room.coffee
+++ b/packages/rocketchat-ui/views/app/room.coffee
@@ -418,6 +418,14 @@ Template.room.events
 		ChatMessage.update {_id: this._arguments[1]._id, 'urls.url': $(event.currentTarget).data('url')}, {$set: {'urls.$.downloadImages': true}}
 		ChatMessage.update {_id: this._arguments[1]._id, 'attachments.image_url': $(event.currentTarget).data('url')}, {$set: {'attachments.$.downloadImages': true}}
 
+	'click .collapse-switch': (e) ->
+		url = $(e.currentTarget).data('url')
+		collapsed = $(e.currentTarget).data('collapsed')
+		id = @_arguments[1]._id
+		ChatMessage.update {_id: id, 'urls.url': url}, {$set: {'urls.$.collapsed': !collapsed}}
+		for type in ['image_url', 'audio_url', 'video_url']
+			ChatMessage.update {_id: id, "attachments.#{type}": url}, {$set: {'attachments.$.collapsed': !collapsed}}
+
 	'dragenter .dropzone': (e) ->
 		e.currentTarget.classList.add 'over'
 

--- a/server/methods/saveUserPreferences.coffee
+++ b/server/methods/saveUserPreferences.coffee
@@ -21,6 +21,9 @@ Meteor.methods
 			if settings.saveMobileBandwidth?
 				preferences.saveMobileBandwidth = if settings.saveMobileBandwidth is "1" then true else false
 
+			if settings.collapseMediaByDefault?
+				preferences.collapseMediaByDefault = if settings.collapseMediaByDefault is "1" then true else false
+
 			if settings.compactView?
 				preferences.compactView = if settings.compactView is "1" then true else false
 


### PR DESCRIPTION
@RocketChat/core 
Embedded media like images and video can now individually be collapsed

A new preference "Collapse media by default" is also added, the default
is to not collapse media.

Since images are not always shown, "showImage" is also renamed to
"loadImage"

Known limitation: if the same url is used multiple times in the same message, collapse only works for the first one. This is a deficiency in mongodb that already affects the "save bandwidth" feature, so I think it's not a big deal (who posts the same url twice in the same message anyway?)

Closes #1187