### PR TITLE
RocketChat hijacking Firefox shortcut

### DIFF
--- a/packages/rocketchat-ui-master/master/main.coffee
+++ b/packages/rocketchat-ui-master/master/main.coffee
@@ -2,7 +2,7 @@ Template.body.onRendered ->
 	new Clipboard('.clipboard')
 
 	$(document.body).on 'keydown', (e) ->
-		if e.keyCode is 80 and (e.ctrlKey is true or e.metaKey is true)
+		if e.keyCode is 80 and (e.ctrlKey is true or e.metaKey is true) and e.shiftKey is false
 			e.preventDefault()
 			e.stopPropagation()
 			spotlight.show()


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #2696

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Do not show the spotlight search when pressing `cmd/ctrl+shit+p`, only when pressing `cmd/ctrl+p`
