### PR TITLE
Improve oembed description

### DIFF
--- a/packages/rocketchat-oembed/client/oembedUrlWidget.coffee
+++ b/packages/rocketchat-oembed/client/oembedUrlWidget.coffee
@@ -12,7 +12,7 @@ getDescription = (self) ->
 	if not description?
 		return
 
-	return description.replace /(^“)|(”$)/g, ''
+	return _.unescape description.replace /(^[“\s]*)|([”\s]*$)/g, ''
 
 
 Template.oembedUrlWidget.helpers

--- a/packages/rocketchat-oembed/client/oembedUrlWidget.html
+++ b/packages/rocketchat-oembed/client/oembedUrlWidget.html
@@ -21,7 +21,7 @@
 						<a href="{{url}}" target="_blank"><strong>{{{title}}}</strong></a>
 					</div>
 				{{/if}}
-				{{{description}}}
+				<div style="overflow:hidden;white-space:nowrap;text-overflow:ellipsis">{{{description}}}</div>
 			</div>
 		</blockquote>
 	{{/if}}


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Fixed following issues.

- Twice escaped
- Unnecessary begin/end of the blank
- Very long long description

##### Unescape ([Test sample](http://stackoverflow.com/questions/5987908/how-to-resolve-can-not-find-the-tag-library-descriptor-for-http-java-sun-co))
Before:
![before](https://cloud.githubusercontent.com/assets/9736483/14495167/51b3e9e0-01c9-11e6-8231-a45471017464.png)

Expect (Twitter):
![twitter-result](https://cloud.githubusercontent.com/assets/9736483/14495194/616ec558-01c9-11e6-9f9c-d157563abffe.png)

After:
![after](https://cloud.githubusercontent.com/assets/9736483/14495197/6806c1b8-01c9-11e6-80a5-160c7c661d2e.png)

##### Ellipsis
Before:
![before](https://cloud.githubusercontent.com/assets/9736483/14495354/1298f59c-01ca-11e6-92ee-e5d0d307c1fb.png)

After:
![after](https://cloud.githubusercontent.com/assets/9736483/14495362/17e47116-01ca-11e6-8471-dd732b49bea8.png)