### PR TITLE
Remove whitespace around blockquote in message

### DIFF
--- a/packages/rocketchat-markdown/markdown.coffee
+++ b/packages/rocketchat-markdown/markdown.coffee
@@ -70,6 +70,9 @@ class Markdown
 		msg = msg.replace(/^&gt;(.*)$/gm, '<blockquote><span class="copyonly">&gt;</span>$1</blockquote>')
 		msg = msg.replace(/<\/blockquote>\n<blockquote>/gm, '</blockquote><blockquote>')
 
+		# Remove white-space around blockquote (prevent <br>). Because blockquote is block element.
+		msg = msg.replace(/(?:\s*)(<blockquote>.*<\/blockquote>)(?:\s*)/gm, '$1')
+
 		if not _.isString message
 			message.html = msg
 		else


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Send:
```
bar
>fooooo
http://www.engadg..............
```

Before:
![before](https://cloud.githubusercontent.com/assets/9736483/14523516/17b170cc-026f-11e6-9cf8-7883bd22c881.png)
Unexpected blank-line have cut in between `>foooo` and `http://www.engad.....`.

After:
![after](https://cloud.githubusercontent.com/assets/9736483/14523526/25709b7a-026f-11e6-8c11-35dd6277e47a.png)
