### PR TITLE
Feature to add permission for user to manage their own integrations only

### DIFF
--- a/packages/rocketchat-authorization/server/startup.coffee
+++ b/packages/rocketchat-authorization/server/startup.coffee
@@ -28,7 +28,8 @@ Meteor.startup ->
 		{ _id: 'edit-privileged-setting', roles : ['admin'] }
 		{ _id: 'edit-room', roles : ['admin', 'moderator', 'owner'] }
 		{ _id: 'manage-assets', roles : ['admin'] }
-		{ _id: 'manage-integrations', roles : ['admin', 'bot'] }
+		{ _id: 'manage-integrations', roles : ['admin'] }
+		{ _id: 'manage-own-integrations', roles : ['bot'] }
 		{ _id: 'manage-oauth-apps', roles : ['admin'] }
 		{ _id: 'mute-user', roles : ['admin', 'moderator', 'owner'] }
 		{ _id: 'remove-user', roles : ['admin', 'moderator', 'owner'] }

--- a/packages/rocketchat-integrations/client/startup.coffee
+++ b/packages/rocketchat-integrations/client/startup.coffee
@@ -4,4 +4,4 @@ RocketChat.AdminBox.addOption
 	href: 'admin-integrations'
 	i18nLabel: 'Integrations'
 	permissionGranted: ->
-		return RocketChat.authz.hasAllPermission('manage-integrations')
+		return RocketChat.authz.hasAtLeastOnePermission(['manage-integrations', 'manage-own-integrations'])

--- a/packages/rocketchat-integrations/client/views/integrations.coffee
+++ b/packages/rocketchat-integrations/client/views/integrations.coffee
@@ -1,6 +1,6 @@
 Template.integrations.helpers
 	hasPermission: ->
-		return RocketChat.authz.hasAllPermission 'manage-integrations'
+		return RocketChat.authz.hasAtLeastOnePermission(['manage-integrations', 'manage-own-integrations'])
 
 	integrations: ->
 		return ChatIntegrations.find()

--- a/packages/rocketchat-integrations/client/views/integrationsNew.coffee
+++ b/packages/rocketchat-integrations/client/views/integrationsNew.coffee
@@ -1,3 +1,3 @@
 Template.integrationsNew.helpers
 	hasPermission: ->
-		return RocketChat.authz.hasAllPermission 'manage-integrations'
+		return RocketChat.authz.hasAtLeastOnePermission(['manage-integrations', 'manage-own-integrations'])

--- a/packages/rocketchat-integrations/client/views/integrationsOutgoing.coffee
+++ b/packages/rocketchat-integrations/client/views/integrationsOutgoing.coffee
@@ -13,13 +13,17 @@ Template.integrationsOutgoing.helpers
 		return arr.join sep
 
 	hasPermission: ->
-		return RocketChat.authz.hasAllPermission 'manage-integrations'
+		return RocketChat.authz.hasAtLeastOnePermission(['manage-integrations', 'manage-own-integrations'])
 
 	data: ->
 		params = Template.instance().data.params?()
 
 		if params?.id?
-			data = ChatIntegrations.findOne({_id: params.id})
+			data = null
+			if RocketChat.authz.hasAllPermission 'manage-integrations'
+				data = ChatIntegrations.findOne({_id: params.id})
+			else if RocketChat.authz.hasAllPermission 'manage-own-integrations'
+				data = ChatIntegrations.findOne({_id: params.id, "_createdBy._id": Meteor.userId()})
 			if data?
 				if not data.token?
 					data.token = Random.id(24)

--- a/packages/rocketchat-integrations/server/methods/incoming/addIncomingIntegration.coffee
+++ b/packages/rocketchat-integrations/server/methods/incoming/addIncomingIntegration.coffee
@@ -1,7 +1,7 @@
 Meteor.methods
 	addIncomingIntegration: (integration) ->
-		if not RocketChat.authz.hasPermission @userId, 'manage-integrations'
-			throw new Meteor.Error 'error-action-not-allowed', 'Managing integrations is not allowed', { method: 'addIncomingIntegration', action: 'Managing_integrations' }
+		if (not RocketChat.authz.hasPermission @userId, 'manage-integrations') and (not RocketChat.authz.hasPermission @userId, 'manage-own-integrations')
+			throw new Meteor.Error 'not_authorized'
 
 		if not _.isString(integration.channel)
 			throw new Meteor.Error 'error-invalid-channel', 'Invalid channel', { method: 'addIncomingIntegration' }
@@ -49,6 +49,12 @@ Meteor.methods
 
 		if record is undefined
 			throw new Meteor.Error 'error-invalid-room', 'Invalid room', { method: 'addIncomingIntegration' }
+
+		if record.usernames? and
+		(not RocketChat.authz.hasPermission @userId, 'manage-integrations') and
+		(RocketChat.authz.hasPermission @userId, 'manage-own-integrations') and
+		Meteor.user()?.username not in record.usernames
+			throw new Meteor.Error 'error-invalid-channel', 'Invalid Channel', { method: 'addIncomingIntegration' }
 
 		user = RocketChat.models.Users.findOne({username: integration.username})
 

--- a/packages/rocketchat-integrations/server/methods/incoming/deleteIncomingIntegration.coffee
+++ b/packages/rocketchat-integrations/server/methods/incoming/deleteIncomingIntegration.coffee
@@ -1,9 +1,13 @@
 Meteor.methods
 	deleteIncomingIntegration: (integrationId) ->
-		if not RocketChat.authz.hasPermission @userId, 'manage-integrations'
-			throw new Meteor.Error 'error-action-not-allowed', 'Managing integrations is not allowed', { method: 'deleteIncomingIntegration', action: 'Managing_integrations' }
+		integration = null
 
-		integration = RocketChat.models.Integrations.findOne(integrationId)
+		if RocketChat.authz.hasPermission @userId, 'manage-integrations'
+			integration = RocketChat.models.Integrations.findOne(integrationId)
+		else if RocketChat.authz.hasPermission @userId, 'manage-own-integrations'
+			integration = RocketChat.models.Integrations.findOne(integrationId, { fields : {"_createdBy._id": @userId} })
+		else
+			throw new Meteor.Error 'not_authorized'
 
 		if not integration?
 			throw new Meteor.Error 'error-invalid-integration', 'Invalid integration', { method: 'deleteIncomingIntegration' }

--- a/packages/rocketchat-integrations/server/methods/outgoing/deleteOutgoingIntegration.coffee
+++ b/packages/rocketchat-integrations/server/methods/outgoing/deleteOutgoingIntegration.coffee
@@ -1,9 +1,13 @@
 Meteor.methods
 	deleteOutgoingIntegration: (integrationId) ->
-		if not RocketChat.authz.hasPermission(@userId, 'manage-integrations') and not RocketChat.authz.hasPermission(@userId, 'manage-integrations', 'bot')
-			throw new Meteor.Error 'error-action-not-allowed', 'Managing integrations is not allowed', { method: 'deleteOutgoingIntegration', action: 'Managing_integrations' }
+		integration = null
 
-		integration = RocketChat.models.Integrations.findOne(integrationId)
+		if RocketChat.authz.hasPermission(@userId, 'manage-integrations') or RocketChat.authz.hasPermission(@userId, 'manage-integrations', 'bot')
+			integration = RocketChat.models.Integrations.findOne(integrationId)
+		else if RocketChat.authz.hasPermission(@userId, 'manage-own-integrations') or RocketChat.authz.hasPermission(@userId, 'manage-own-integrations', 'bot')
+			integration = RocketChat.models.Integrations.findOne(integrationId, { fields : {"_createdBy._id": @userId} })
+		else
+			throw new Meteor.Error 'not_authorized'
 
 		if not integration?
 			throw new Meteor.Error 'error-invalid-integration', 'Invalid integration', { method: 'deleteOutgoingIntegration' }

--- a/packages/rocketchat-integrations/server/publications/integrations.coffee
+++ b/packages/rocketchat-integrations/server/publications/integrations.coffee
@@ -2,8 +2,9 @@ Meteor.publish 'integrations', ->
 	unless @userId
 		return @ready()
 
-	if not RocketChat.authz.hasPermission @userId, 'manage-integrations'
-		return @error new Meteor.Error "error-not-allowed", "Not allowed", { publish: 'integrations' }
-		return @ready()
-
-	return RocketChat.models.Integrations.find()
+	if RocketChat.authz.hasPermission @userId, 'manage-integrations'
+		return RocketChat.models.Integrations.find()
+	else if RocketChat.authz.hasPermission @userId, 'manage-own-integrations'
+		return RocketChat.models.Integrations.find({"_createdBy._id": @userId})
+	else
+		throw new Meteor.Error "not-authorized"


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #2900 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

A new permission is added 'manage-own-integrations'.

The new permission, if present without 'manage-integrations', grants
the user access to add integrations, but only to view, modify or delete their own.

This permission is given to the 'bot' role , which has 'manage-integrations'
removed from it.
