### PR TITLE
Fix oauth payload method

### DIFF
--- a/packages/rocketchat-custom-oauth/custom_oauth_server.coffee
+++ b/packages/rocketchat-custom-oauth/custom_oauth_server.coffee
@@ -80,7 +80,7 @@ class CustomOAuth
 		headers =
 			'User-Agent': @userAgent # http://doc.gitlab.com/ce/api/users.html#Current-user
 
-		if @accessTokenSentVia is 'header'
+		if @tokenSentVia is 'header'
 			headers['Authorization'] = 'Bearer ' + accessToken
 		else
 			params['access_token'] = accessToken


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

The new patch had a bug in it, where the variable name was mistyped.
This time, i have tested it with:

Oauth via header to my own django server (works!)
Oauth via payload to gitlab (works!)
Oauth via header to gitlab (works!)

We *should* also add some sort of note in the gui about what the setting means, since the authorization-bearer header is the RFC specified method, but the setting probably should default to payload for legacy reasons :). Does any other oauth provider use the access_token method? Then again, we probably won't know if its safe, unless you collect target oauth server statistics ;).