### PR TITLE
Do not reset pin-message permission roles on server restart

### DIFF
--- a/packages/rocketchat-message-pin/server/settings.coffee
+++ b/packages/rocketchat-message-pin/server/settings.coffee
@@ -1,4 +1,4 @@
 Meteor.startup ->
 	RocketChat.settings.add 'Message_AllowPinning', true, { type: 'boolean', group: 'Message', public: true }
 
-	RocketChat.models.Permissions.upsert( 'pin-message', {$set: { roles: [ 'owner', 'moderator', 'admin' ] } })
+	RocketChat.models.Permissions.upsert('pin-message', {$addToSet: {roles: {$each: ['owner', 'moderator', 'admin']}}})


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
When you assign the pin-message role to for example normal users, they lose that permission when the server restarts. This change prevents the permissions from resetting to default so that doesn't happen anymore.
