### PR TITLE
Custom OAuth fixes

### DIFF
--- a/packages/rocketchat-custom-oauth/custom_oauth_server.coffee
+++ b/packages/rocketchat-custom-oauth/custom_oauth_server.coffee
@@ -55,6 +55,7 @@ class CustomOAuth
 		response = undefined
 		try
 			response = HTTP.post @tokenPath,
+				auth: config.clientId + ':' + OAuth.openSecret(config.secret)
 				headers:
 					Accept: 'application/json'
 					'User-Agent': @userAgent
@@ -106,6 +107,10 @@ class CustomOAuth
 			console.log 'at:', accessToken
 
 			identity = self.getIdentity accessToken
+
+			# Fix for Reddit
+			if identity?.result
+				identity = identity.result
 
 			# Fix WordPress-like identities having 'ID' instead of 'id'
 			if identity?.ID and not identity.id

--- a/packages/rocketchat-custom-oauth/custom_oauth_server.coffee
+++ b/packages/rocketchat-custom-oauth/custom_oauth_server.coffee
@@ -80,7 +80,7 @@ class CustomOAuth
 		headers =
 			'User-Agent': @userAgent # http://doc.gitlab.com/ce/api/users.html#Current-user
 
-		if @accessTokenSentVia is 'header'
+		if @tokenSentVia is 'header'
 			headers['Authorization'] = 'Bearer ' + accessToken
 		else
 			params['access_token'] = accessToken


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #2920

This pull request does three things in custom OAuth server module:
* it fixes a typo that prevented "Token Sent Via" switch from working
* it adds HTTP Basic Auth to token retrieval request (so it works with Reddit as per [their docs](https://github.com/reddit/reddit/wiki/OAuth2))
* it adds a fix for parsing response in `registerService` method for Reddit
