### PR TITLE
Update Sandstorm Vagrantfile.

### DIFF
--- a/.sandstorm/Vagrantfile
+++ b/.sandstorm/Vagrantfile
@@ -10,8 +10,8 @@ VM_NAME = File.basename(File.dirname(File.dirname(__FILE__))) + "_sandstorm_#{Ti
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # We base ourselves off Debian Jessie
-  config.vm.box = "debian/jessie64"
+  # Base on the Sandstorm snapshots of the official Debian 8 (jessie) box.
+  config.vm.box = "sandstorm/debian-jessie64"
 
   if Vagrant.has_plugin?("vagrant-vbguest") then
     # vagrant-vbguest is a Vagrant plugin that upgrades
@@ -29,9 +29,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Use a shell script to "provision" the box. This installs Sandstorm using
   # the bundled installer.
-  config.vm.provision "shell", inline: "sudo bash /opt/app/.sandstorm/global-setup.sh"
+  config.vm.provision "shell", inline: "sudo bash /opt/app/.sandstorm/global-setup.sh", keep_color: true
   # Then, do stack-specific and app-specific setup.
-  config.vm.provision "shell", inline: "sudo bash /opt/app/.sandstorm/setup.sh"
+  config.vm.provision "shell", inline: "sudo bash /opt/app/.sandstorm/setup.sh", keep_color: true
 
   # Shared folders are configured per-provider since vboxsf can't handle >4096 open files,
   # NFS requires privilege escalation every time you bring a VM up,
@@ -82,7 +82,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     override.vm.synced_folder "..", "/opt/app"
     override.vm.synced_folder ENV["HOME"] + "/.sandstorm", "/host-dot-sandstorm"
-    override.vm.synced_folder "..", "/vagrant"
+    override.vm.synced_folder "..", "/vagrant", disabled: true
   end
   config.vm.provider :libvirt do |libvirt, override|
     libvirt.cpus = cpus
@@ -91,6 +91,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     override.vm.synced_folder "..", "/opt/app", type: "9p", accessmode: "passthrough"
     override.vm.synced_folder ENV["HOME"] + "/.sandstorm", "/host-dot-sandstorm", type: "9p", accessmode: "passthrough"
-    override.vm.synced_folder "..", "/vagrant", type: "9p", accessmode: "passthrough"
+    override.vm.synced_folder "..", "/vagrant", type: "9p", accessmode: "passthrough", disabled: true
   end
 end


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

This pulls in some recent vagrant-spk changes: https://github.com/sandstorm-io/vagrant-spk/commit/ffd9cebd6f4e01323e6967fdc6da9debeabd82d7, https://github.com/sandstorm-io/vagrant-spk/commit/2e8a484af5f7f391b3d3c8d812ecaa7bf6480407, https://github.com/sandstorm-io/vagrant-spk/commit/f9d75eb6a7eca12cbc7f6af97d26f7aea548ffa0.

In particular, these make it possible to run the app with `vagrant-spk dev` using a [libvirt](https://github.com/sandstorm-io/vagrant-spk/blob/master/HOWTO-libvirt.md) provider on a Linux host.

cc @paulproteus, @zarvox
