### PR TITLE
added emoji category header in emoji picker

### DIFF
--- a/packages/rocketchat-emojione/emojiPicker.html
+++ b/packages/rocketchat-emojione/emojiPicker.html
@@ -2,31 +2,31 @@
 	<div class="emoji-picker">
 		<div class="filter">
 			<ul>
-				<li class="{{activeCategory 'recent'}}" title="{{_ "Frequently_Used" }}">
+				<li class="{{activeCategory 'recent'}}" title="{{categoryName 'recent' }}">
 					<a href="#recent" class="category-link"><i class="icon-recent"></i></a>
 				</li>
-				<li class="{{activeCategory 'people'}}" title="{{_ "Smileys_and_People" }}">
+				<li class="{{activeCategory 'people'}}" title="{{categoryName 'people' }}">
 					<a href="#people" class="category-link"><i class="icon-people"></i></a>
 				</li>
-				<li class="{{activeCategory 'nature'}}" title="{{_ "Animals_and_Nature" }}">
+				<li class="{{activeCategory 'nature'}}" title="{{categoryName 'nature' }}">
 					<a href="#nature" class="category-link"><i class="icon-nature"></i></a>
 				</li>
-				<li class="{{activeCategory 'food'}}" title="{{_ "Food_and_Drink" }}">
+				<li class="{{activeCategory 'food'}}" title="{{categoryName 'food' }}">
 					<a href="#food" class="category-link"><i class="icon-foods"></i></a>
 				</li>
-				<li class="{{activeCategory 'activity'}}" title="{{_ "Activity" }}">
+				<li class="{{activeCategory 'activity'}}" title="{{categoryName 'activity' }}">
 					<a href="#activity" class="category-link"><i class="icon-activity"></i></a>
 				</li>
-				<li class="{{activeCategory 'travel'}}" title="{{_ "Travel_and_Places" }}">
+				<li class="{{activeCategory 'travel'}}" title="{{categoryName 'travel' }}">
 					<a href="#travel" class="category-link"><i class="icon-travel"></i></a>
 				</li>
-				<li class="{{activeCategory 'objects'}}" title="{{_ "Objects" }}">
+				<li class="{{activeCategory 'objects'}}" title="{{categoryName 'objects' }}">
 					<a href="#objects" class="category-link"><i class="icon-objects"></i></a>
 				</li>
-				<li class="{{activeCategory 'symbols'}}" title="{{_ "Symbols" }}">
+				<li class="{{activeCategory 'symbols'}}" title="{{categoryName 'symbols' }}">
 					<a href="#symbols" class="category-link"><i class="icon-symbols"></i></a>
 				</li>
-				<li class="{{activeCategory 'flags'}}" title="{{_ "Flags" }}">
+				<li class="{{activeCategory 'flags'}}" title="{{categoryName 'flags' }}">
 					<a href="#flags" class="category-link"><i class="icon-flags"></i></a>
 				</li>
 				<li class="change-tone">

--- a/packages/rocketchat-emojione/emojiPicker.html
+++ b/packages/rocketchat-emojione/emojiPicker.html
@@ -42,6 +42,9 @@
 				</li>
 			</ul>
 		</div>
+		<h2 class="current-category-header">
+			{{ currentCategory }}
+		</h2>
 		<div class="emojis">
 			{{#each category}}
 				<ul class="{{.}} emoji-list {{isVisible .}}">

--- a/packages/rocketchat-emojione/emojiPicker.js
+++ b/packages/rocketchat-emojione/emojiPicker.js
@@ -3,6 +3,14 @@
 var emojisByCategory;
 var toneList;
 
+/**
+ * @param {string} string
+ * @return {string} Firstletterisnowcapital
+ */
+function capitalizeFirstLetter(string) {
+	return string.charAt(0).toUpperCase() + string.substring(1);
+}
+
 Template.emojiPicker.helpers({
 	category() {
 		return Object.keys(emojisByCategory);
@@ -35,8 +43,22 @@ Template.emojiPicker.helpers({
 	currentTone() {
 		return 'tone-' + Template.instance().tone;
 	},
+	/**
+	 * Returns true if a given emoji category is active
+	 *
+	 * @param {string} category
+	 * @return {boolean} true if active, false otherwise
+	 */
 	activeCategory(category) {
 		return Template.instance().currentCategory.get() === category ? 'active' : '';
+	},
+	/**
+	 * Returns currently active emoji category
+	 *
+	 * @return {string}
+	 */
+	currentCategory() {
+		return capitalizeFirstLetter(Template.instance().currentCategory.get());
 	}
 });
 

--- a/packages/rocketchat-emojione/emojiPicker.js
+++ b/packages/rocketchat-emojione/emojiPicker.js
@@ -3,12 +3,32 @@
 var emojisByCategory;
 var toneList;
 
-/**
- * @param {string} string
- * @return {string} Firstletterisnowcapital
+/*
+ * Mapping category hashes into human readable and translated names
  */
-function capitalizeFirstLetter(string) {
-	return string.charAt(0).toUpperCase() + string.substring(1);
+var emojiCategories = {
+	recent: TAPi18n.__('Frequently_Used'),
+	people: TAPi18n.__('Smileys_and_People'),
+	nature: TAPi18n.__('Animals_and_Nature'),
+	food: TAPi18n.__('Food_and_Drink'),
+	activity: TAPi18n.__('Activity'),
+	travel: TAPi18n.__('Travel_and_Places'),
+	objects: TAPi18n.__('Objects'),
+	symbols: TAPi18n.__('Symbols'),
+	flags: TAPi18n.__('Flags')
+};
+
+/**
+ * Turns category hash to a nice readable translated name
+ * @param {string} category hash
+ * @return {string} readable and translated
+ */
+function categoryName(category) {
+	if (emojiCategories[category]) {
+		return emojiCategories[category];
+	}
+	// unknown category; better hash than nothing
+	return category;
 }
 
 Template.emojiPicker.helpers({
@@ -46,19 +66,21 @@ Template.emojiPicker.helpers({
 	/**
 	 * Returns true if a given emoji category is active
 	 *
-	 * @param {string} category
+	 * @param {string} category hash
 	 * @return {boolean} true if active, false otherwise
 	 */
 	activeCategory(category) {
 		return Template.instance().currentCategory.get() === category ? 'active' : '';
 	},
+	categoryName: categoryName,
 	/**
-	 * Returns currently active emoji category
+	 * Returns currently active emoji category hash
 	 *
-	 * @return {string}
+	 * @return {string} category hash
 	 */
 	currentCategory() {
-		return capitalizeFirstLetter(Template.instance().currentCategory.get());
+		var hash = Template.instance().currentCategory.get();
+		return categoryName(hash);
 	}
 });
 

--- a/packages/rocketchat-emojione/emojiPicker.less
+++ b/packages/rocketchat-emojione/emojiPicker.less
@@ -147,6 +147,10 @@
 		}
 	}
 
+	.current-category-header {
+		padding: 3px 6px 2px 6px;
+	}
+
 	.emojis {
 		height: 160px;
 		overflow-y: auto;


### PR DESCRIPTION
@RocketChat/core 

The header was still there in a title, visible on mouse hover. However some people are very impatient and this change helps them understand which category are they currently viewing.

![image](https://cloud.githubusercontent.com/assets/1100170/14797820/e01703ce-0b34-11e6-8e47-f091f708ce08.png)

If you have suggestions about the size or appearance of the header, let them sound here.