### PR TITLE
Katex formatting tip

### DIFF
--- a/packages/rocketchat-ui-message/message/messageBox.coffee
+++ b/packages/rocketchat-ui-message/message/messageBox.coffee
@@ -13,7 +13,7 @@ Template.messageBox.helpers
 	showMarkdown: ->
 		return RocketChat.Markdown
 	showKatex: ->
-		return RocketChat.Katex
+		return RocketChat.katex
 	showFormattingTips: ->
 		return RocketChat.settings.get('Message_ShowFormattingTips') and (RocketChat.Markdown or RocketChat.Highlight or RocketChat.Katex)
 	canJoin: ->

--- a/packages/rocketchat-ui-message/message/messageBox.coffee
+++ b/packages/rocketchat-ui-message/message/messageBox.coffee
@@ -12,8 +12,10 @@ Template.messageBox.helpers
 			return roomData.name
 	showMarkdown: ->
 		return RocketChat.Markdown
+	showKatex: ->
+		return RocketChat.Katex
 	showFormattingTips: ->
-		return RocketChat.settings.get('Message_ShowFormattingTips') and (RocketChat.Markdown or RocketChat.Highlight)
+		return RocketChat.settings.get('Message_ShowFormattingTips') and (RocketChat.Markdown or RocketChat.Highlight or RocketChat.Katex)
 	canJoin: ->
 		return !! ChatRoom.findOne { _id: @_id, t: 'c' }
 	subscribed: ->

--- a/packages/rocketchat-ui-message/message/messageBox.html
+++ b/packages/rocketchat-ui-message/message/messageBox.html
@@ -48,9 +48,6 @@
 
 			{{#if showFormattingTips}}
 			<div class="formatting-tips" aria-hidden="true" dir="auto">
-				{{#if showKatex}}
-				<span>\[katex\]</span>
-				{{/if}}
 				{{#if showMarkdown}}
 				<b>*{{_ "bold"}}*</b>
 				<i>_{{_ "italics"}}_</i>
@@ -60,10 +57,12 @@
 				{{#if showHighlight}}
 				<code class="inline"><span class="hidden-br"><br></span>```<span class="hidden-br"><br></span><i class="icon-level-down"></i>{{_ "multi"}}<span class="hidden-br"><br></span><i class="icon-level-down"></i>{{_ "line"}}<span class="hidden-br"><br></span><i class="icon-level-down"></i>```</code>
 				{{/if}}
+				{{#if showKatex}}
+				<span><a href="https://github.com/Khan/KaTeX/wiki/Function-Support-in-KaTeX" target="_blank">\[KaTeX\]</a></span>
+				{{/if}}
 				{{#if showMarkdown}}
 				<q><span class="hidden-br"><br></span>&gt;{{_ "quote"}}</q>
 				{{/if}}
-
 			</div>
 			{{/if}}
 			<div class="editing-commands" aria-hidden="true" dir="auto">

--- a/packages/rocketchat-ui-message/message/messageBox.html
+++ b/packages/rocketchat-ui-message/message/messageBox.html
@@ -48,6 +48,9 @@
 
 			{{#if showFormattingTips}}
 			<div class="formatting-tips" aria-hidden="true" dir="auto">
+				{{#if showKatex}}
+				<span>\[katex\]</span>
+				{{/if}}
 				{{#if showMarkdown}}
 				<b>*{{_ "bold"}}*</b>
 				<i>_{{_ "italics"}}_</i>


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
refs #2755 <-- addresses last comment in that issue, does not address the initial request

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Adds KaTeX formatting tip under message entry field. Clicking on \[KaTeX\] in the formatting tip opens KaTeX docs in new tab.