### PR TITLE
Automatic language detect on code blocks

### DIFF
--- a/packages/rocketchat-highlight/highlight.coffee
+++ b/packages/rocketchat-highlight/highlight.coffee
@@ -38,7 +38,7 @@ class Highlight
 							code = _.unescapeHTML codeMatch[2]
 
 						if lang not in hljs.listLanguages()
-							result = hljs.highlightAuto code
+							result = hljs.highlightAuto (lang + ' ' + code)
 						else
 							result = hljs.highlight lang, code
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #3035 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

When posting the following text:

![screen shot 2016-05-01 at 12 41 59 am](https://cloud.githubusercontent.com/assets/1100843/14936668/dfca694c-0f35-11e6-8f2e-42ee30d5f4fa.png)

it will now yield:

![screen shot 2016-05-01 at 12 45 12 am](https://cloud.githubusercontent.com/assets/1100843/14936673/121242a8-0f36-11e6-8ed5-d76582768702.png)

The code will check what languages are supported, and if it's not in the list of supported language, it will get HighlightJS to attempt to guess the language.