### PR TITLE
Fix code highlight on code that contains delimiter

### DIFF
--- a/packages/rocketchat-highlight/highlight.coffee
+++ b/packages/rocketchat-highlight/highlight.coffee
@@ -21,11 +21,11 @@ class Highlight
 					message.msg = message.msg + "\n```"
 
 				# Separate text in code blocks and non code blocks
-				msgParts = message.html.split(/(```\w*[\n\ ]?[\s\S]*?```+?)/)
+				msgParts = message.html.split(/(```\w*[\n\ ]?[\s\S]*?```+?)$/)
 
 				for part, index in msgParts
 					# Verify if this part is code
-					codeMatch = part.match(/```(\w*)[\n\ ]?([\s\S]*?)```+?/)
+					codeMatch = part.match(/```(\w*)[\n\ ]?([\s\S]*?)```+?$/)
 					if codeMatch?
 						# Process highlight if this part is code
 						singleLine = codeMatch[0].indexOf('\n') is -1


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #3086 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Using the same example:

![screen shot 2016-05-01 at 1 41 47 am](https://cloud.githubusercontent.com/assets/1100843/14937038/887c77f8-0f3e-11e6-9bad-b8afdd3f7b6a.png)

The message posted will now show as such:

![screen shot 2016-05-01 at 1 46 00 am](https://cloud.githubusercontent.com/assets/1100843/14937040/9312071e-0f3e-11e6-8906-d0135b8e81af.png)
