### PR TITLE
Improves message quoting

### DIFF
--- a/packages/rocketchat-lib/client/MessageAction.coffee
+++ b/packages/rocketchat-lib/client/MessageAction.coffee
@@ -172,29 +172,10 @@ Meteor.startup ->
 			'message-mobile'
 		]
 		action: (event, instance) ->
-			m = @_arguments[1]
-			message = m.msg
-			msg = $(event.currentTarget).closest('.message')[0]
-			$("\##{msg.id} .message-dropdown").hide()
-			zpad = (n) ->
-				result = n.toString()
-				if result.length > 1
-					return result
-				else
-					return '0' + result
-			ts = zpad(m.ts.getUTCHours()) + ':' + zpad(m.ts.getUTCMinutes()) + ' UTC'
-			now = new Date
-			if (now.getUTCFullYear() isnt m.ts.getUTCFullYear() or
-			    now.getUTCMonth() isnt m.ts.getUTCMonth() or
-			    now.getUTCDate() isnt m.ts.getUTCDate())
-				ts = m.ts.getUTCFullYear() + '-' + zpad(m.ts.getUTCMonth()) + '-' + zpad(m.ts.getUTCDate()) + ' ' + ts
+			message = @_arguments[1]
 			input = instance.find('.input-message')
-			text = input.value
-			if text
-				text += '\n'
-			text += '@' + m.u.username + ' said (' + ts + '):\n'
-			for line in message.split(/\r\n|\r|\n/)
-				text += '> ' + line + '\n'
+			url = document.location.origin + document.location.pathname + '?msg=' + message._id
+			text = '[ ](' + url + ') '
 			input.value = text
 			input.focus()
 			$(input).keyup()

--- a/packages/rocketchat-message-attachments/client/messageAttachment.coffee
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.coffee
@@ -37,3 +37,6 @@ Template.messageAttachment.helpers
 			return this.collapsed
 		else
 			return Meteor.user()?.settings?.preferences?.collapseMediaByDefault is true
+
+	time: ->
+		return moment(@ts).format(RocketChat.settings.get('Message_TimeFormat'))

--- a/packages/rocketchat-message-attachments/client/messageAttachment.html
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.html
@@ -12,6 +12,9 @@
 							<img src="{{fixCordova author_icon}}">
 						{{/if}}
 						<a href="{{fixCordova author_link}}" target="_blank">{{author_name}}</a>
+						{{#if ts}}
+							<span class="time">{{time}}</span>
+						{{/if}}
 					</div>
 				{{else}}
 					<div class="attachment-author">
@@ -19,6 +22,9 @@
 							<img src="{{fixCordova author_icon}}">
 						{{/if}}
 						{{author_name}}
+					{{#if ts}}
+						<span class="time">{{time}}</span>
+					{{/if}}
 					</div>
 				{{/if}}
 			{{/if}}

--- a/packages/rocketchat-message-attachments/client/stylesheets/messageAttachments.less
+++ b/packages/rocketchat-message-attachments/client/stylesheets/messageAttachments.less
@@ -30,6 +30,11 @@
 			margin-right: 2px;
 			margin-bottom: -2px;
 		}
+		.time {
+			font-weight: normal;
+			font-size: .8em;
+			color: #aaa;
+		}
 	}
 
 	.attachment-title {

--- a/packages/rocketchat-message-pin/server/pinMessage.coffee
+++ b/packages/rocketchat-message-pin/server/pinMessage.coffee
@@ -26,7 +26,8 @@ Meteor.methods
 			attachments: [
 				"text" : message.msg
 				"author_name" : message.u.username,
-				"author_icon" : getAvatarUrlFromUsername(message.u.username)
+				"author_icon" : getAvatarUrlFromUsername(message.u.username),
+				"ts" : new Date()
 			]
 
 	unpinMessage: (message) ->

--- a/packages/rocketchat-oembed/server/jumpToMessage.js
+++ b/packages/rocketchat-oembed/server/jumpToMessage.js
@@ -17,7 +17,8 @@ RocketChat.callbacks.add('beforeSaveMessage', (msg) => {
 							msg.attachments.push({
 								'text' : jumpToMessage.msg,
 								'author_name' : jumpToMessage.u.username,
-								'author_icon' : getAvatarUrlFromUsername(jumpToMessage.u.username)
+								'author_icon' : getAvatarUrlFromUsername(jumpToMessage.u.username),
+								'ts': new Date()
 							});
 							item.ignoreParse = true;
 						}


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

before/after:
![ ](http://puu.sh/oFcbF/946331eea6.png)

Pressing the 'quote' button now inserts a permalink into the text box , which in turn shows the original message when posted.
So it basically just inserts `[ ](https://your.chat.site/channel/general?msg=msg_id)` instead of copying the message entirely.