### PR TITLE
Message box resizes properly if sent via click event

### DIFF
--- a/packages/rocketchat-lib/client/MessageAction.coffee
+++ b/packages/rocketchat-lib/client/MessageAction.coffee
@@ -82,6 +82,7 @@ Meteor.startup ->
 			input = instance.find('.input-message')
 			Meteor.setTimeout ->
 				input.focus()
+				input.updateAutogrow()
 			, 200
 		validation: (message) ->
 			hasPermission = RocketChat.authz.hasAtLeastOnePermission('edit-message', message.rid)

--- a/packages/rocketchat-ui-message/message/messageBox.coffee
+++ b/packages/rocketchat-ui-message/message/messageBox.coffee
@@ -75,10 +75,13 @@ Template.messageBox.events
 
 	'click .send-button': (event, instance) ->
 		input = instance.find('.input-message')
-		chatMessages[@_id].send(@_id, input)
+		chatMessages[@_id].send(@_id, input, =>
+			# fixes https://github.com/RocketChat/Rocket.Chat/issues/3037
+			# at this point, the input is cleared and ready for autogrow
+			input.updateAutogrow()
+			instance.isMessageFieldEmpty.set(chatMessages[@_id].isEmpty())
+		)
 		input.focus()
-		input.updateAutogrow()
-		instance.isMessageFieldEmpty.set(chatMessages[@_id].isEmpty())
 
 	'keyup .input-message': (event, instance) ->
 		chatMessages[@_id].keyup(@_id, event, instance)

--- a/packages/rocketchat-ui/lib/chatMessages.coffee
+++ b/packages/rocketchat-ui/lib/chatMessages.coffee
@@ -141,7 +141,12 @@ class @ChatMessages
 			this.editing.saved = this.input.value
 			this.editing.savedCursor = this.input.selectionEnd
 
-	send: (rid, input) ->
+	###*
+	# * @param {string} rim room ID
+	# * @param {Element} input DOM element
+	# * @param {function?} done callback
+	###
+	send: (rid, input, done = ->) ->
 		if _.trim(input.value) isnt ''
 			readMessage.enable()
 			readMessage.readNow()
@@ -177,7 +182,8 @@ class @ChatMessages
 						return
 
 				Meteor.call 'sendMessage', msgObject
-				
+				done()
+
 		# If edited message was emptied we ask for deletion
 		else if this.editing.element
 			message = this.getMessageById this.editing.id
@@ -185,9 +191,9 @@ class @ChatMessages
 			# Restore original message in textbox in case delete is canceled
 			this.resetToDraft this.editing.id
 
-			this.confirmDeleteMsg message
+			this.confirmDeleteMsg message, done
 
-	confirmDeleteMsg: (message) ->
+	confirmDeleteMsg: (message, done = ->) ->
 		return if RocketChat.MessageTypes.isSystemMessage(message)
 		swal {
 			title: t('Are_you_sure')
@@ -212,6 +218,7 @@ class @ChatMessages
 			this.deleteMsg message
 
 			this.$input.focus()
+			done()
 
 		# In order to avoid issue "[Callback not called when still animating](https://github.com/t4t5/sweetalert/issues/528)"
 		$('.sweet-alert').addClass 'visible'


### PR DESCRIPTION
@RocketChat/core 

Closes https://github.com/RocketChat/Rocket.Chat/issues/3037

The issue was that box attempted to resize before it was cleared. I added a callback that is called after `input.val = ''` which fixes it.

The other issue was missing `input.updateAutogrow()` call