### PR TITLE
Fix 'username-already-in-use' on Slack Imports

### DIFF
--- a/packages/rocketchat-importer-slack/server.coffee
+++ b/packages/rocketchat-importer-slack/server.coffee
@@ -112,6 +112,9 @@ Importer.Slack = class Importer.Slack extends Importer.Base
 				do (user) =>
 					Meteor.runAsUser startedByUserId, () =>
 						existantUser = RocketChat.models.Users.findOneByEmailAddress user.profile.email
+						if not existantUser
+							existantUser = RocketChat.models.Users.findOneByUsername user.name
+
 						if existantUser
 							user.rocketId = existantUser._id
 							@userTags.push


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

This fixes an issue where someone already has a user account on the Rocket.Chat server that is not the same as in the import.