### PR TITLE
Add the channel id to the _id property of the messages

### DIFF
--- a/packages/rocketchat-importer-slack/server.coffee
+++ b/packages/rocketchat-importer-slack/server.coffee
@@ -204,7 +204,7 @@ Importer.Slack = class Importer.Slack extends Importer.Base
 								@updateRecord { 'messagesstatus': "#{channel}/#{date}.#{msgs.messages.length}" }
 								for message in msgs.messages
 									msgDataDefaults =
-										_id: "S#{message.ts}"
+										_id: "#{slackChannel.id}.S#{message.ts}"
 										ts: new Date(parseInt(message.ts.split('.')[0]) * 1000)
 
 									if message.type is 'message'


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Fixes an issue reported in the slack-import channel on the demo server. If someone imported a slack export with 0.30 and try again with this change, they will get duplicate messages.

