### PR TITLE
Fix multiline code when there is text after closing ```

### DIFF
--- a/packages/rocketchat-highlight/highlight.coffee
+++ b/packages/rocketchat-highlight/highlight.coffee
@@ -21,11 +21,11 @@ class Highlight
 					message.msg = message.msg + "\n```"
 
 				# Separate text in code blocks and non code blocks
-				msgParts = message.html.split(/(```\w*[\n\ ]?[\s\S]*?```+?)$/)
+				msgParts = message.html.split(/^\s*(```(?:[a-zA-Z]+)?(?:(?:.|\n)*?)```)(?:\n)?$/gm)
 
 				for part, index in msgParts
 					# Verify if this part is code
-					codeMatch = part.match(/```(\w*[\n\ ]?)([\s\S]*?)```+?$/)
+					codeMatch = part.match(/^```(\w*[\n\ ]?)([\s\S]*?)```+?$/)
 					if codeMatch?
 						# Process highlight if this part is code
 						singleLine = codeMatch[0].indexOf('\n') is -1


### PR DESCRIPTION
The new behavior only accepts starting a multiline code block at the beggining of the line (but still accepts spaces before starting \`\`\`)

I've sent the following messages:

![image](https://cloud.githubusercontent.com/assets/8591547/15189865/63d5c272-1783-11e6-80f2-cfc94ff43fdd.png)

And get this results (added a `hover` style between message to see clearly they are different messages):

![image](https://cloud.githubusercontent.com/assets/8591547/15189613/194d8f60-1782-11e6-99c0-940c3bc7f795.png)
