### PR TITLE
fix URL for cordova when quoting a message

### DIFF
--- a/packages/rocketchat-lib/client/MessageAction.coffee
+++ b/packages/rocketchat-lib/client/MessageAction.coffee
@@ -175,7 +175,7 @@ Meteor.startup ->
 		action: (event, instance) ->
 			message = @_arguments[1]
 			input = instance.find('.input-message')
-			url = document.location.origin + document.location.pathname + '?msg=' + message._id
+			url = Meteor.absoluteUrl().replace(/\/$/, '') + document.location.pathname + '?msg=' + message._id
 			text = '[ ](' + url + ') '
 			input.value = text
 			input.focus()


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

When quoting a message, the URL that was being posted looked something like `http://httpsyourdomain.meteor.local/channel/general?msg=xxx` so it would not show the quoted message
