### PR TITLE
Right sidebar animation cancelled on tab button clicked

### DIFF
--- a/packages/rocketchat-lib/client/TabBar.coffee
+++ b/packages/rocketchat-lib/client/TabBar.coffee
@@ -6,7 +6,6 @@ RocketChat.TabBar = new class
 
 	extraGroups = {}
 
-	animating = false
 	open = new ReactiveVar false
 	template = new ReactiveVar ''
 	data = new ReactiveVar {}
@@ -14,7 +13,6 @@ RocketChat.TabBar = new class
 	visibleGroup = new ReactiveVar ''
 
 	setTemplate = (t, callback) ->
-		return if animating is true
 		template.set t
 		openFlex(callback)
 
@@ -28,17 +26,12 @@ RocketChat.TabBar = new class
 		return data.get()
 
 	openFlex = (callback) ->
-		return if animating is true
 		toggleFlex 1, callback
 
 	closeFlex = (callback) ->
-		return if animating is true
 		toggleFlex -1, callback
 
 	toggleFlex = (status, callback) ->
-		return if animating is true
-		animating = true
-
 		if status is -1 or (status isnt 1 and open.get())
 			open.set false
 		else
@@ -48,9 +41,8 @@ RocketChat.TabBar = new class
 				open.set true
 			, 50
 		setTimeout ->
-			animating = false
 			callback?()
-		, 500
+		, if open.get() then 0 else 500
 
 	show = ->
 		$('.flex-tab-bar').show()
@@ -94,7 +86,6 @@ RocketChat.TabBar = new class
 		return _.sortBy (_.toArray buttons.get()), 'order'
 
 	reset = ->
-		animating = false
 		resetButtons()
 		closeFlex()
 		template.set ''

--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -1718,7 +1718,7 @@ a.github-fork {
 	right: 40px;
 	width: auto;
 	height: auto;
-	.transition(width .25s cubic-bezier(.5, 0, .1, 1));
+	.transition(right .25s cubic-bezier(.5, 0, .1, 1));
 	&.flex-opened {
 		right: @flex-tab-width + 40px;
 		.flex-tab {


### PR DESCRIPTION
@RocketChat/core 

Closes #1297

When clicking a tab bar button, it will cancel the animation if it is still animating. This is instead of waiting for the animation to finish before being able to close the sidebar.

![animation](https://cloud.githubusercontent.com/assets/741068/15255397/b7e10d0c-1933-11e6-90d9-a646aa20b11a.gif)
