### PR TITLE
Lower highlight timeout.

### DIFF
--- a/packages/rocketchat-ui/lib/RoomHistoryManager.coffee
+++ b/packages/rocketchat-ui/lib/RoomHistoryManager.coffee
@@ -127,7 +127,7 @@
 
 			setTimeout ->
 				msgElement.removeClass('highlight')
-			, 3000
+			, 500
 		else
 			room = getRoom message.rid
 			room.isLoading.set true


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
When lots of unread messages appear and you click "Jump to first unread"...

<img width="599" alt="_ __rocket_chat" src="https://cloud.githubusercontent.com/assets/322665/15256640/6f9e4258-1910-11e6-8c11-ac30a20eccef.png">

The channel is highlighted and clicking the jump take you up to the first unread and unhighlights the channel. 

However it takes 3 seconds to unhighlight the channel. I thought this was a slow server issue but it turned out to be deliberate timer. I lowered the timer to 0.5 seconds so there is still time for your eye to travel, but it doesn't come across as a clunky application. 