### PR TITLE
Simplify travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 branches:
   only:


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

`sudo: false` is not longer required to make use of the container-based infrastructure.

See [Travis CI docs](https://docs.travis-ci.com/user/workers/container-based-infrastructure/#Routing-your-build-to-container-based-infrastructure):

> The default behavior, when no `sudo` usage is detected in any customizable build phases, depends on the date when the repository is first recognized by Travis CI:
>
>+ For repos we recognize before 2015-01-01, linux builds are sent to our standard infrastructure.
>+ For repos we recognize on or after 2015-01-01, linux builds are sent to our container-based infrastructure.

According to the `git log` the projects  `travis.yml` was created on 2015-06-28

:octocat: 