### PR TITLE
Fix text clipping in spotlight input

### DIFF
--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -1670,8 +1670,7 @@ a.github-fork {
 			border-width: 0px;
 			line-height: 46px;
 			height: 46px;
-			padding: 18px;
-			padding-left: 46px;
+			padding: 0 10px 0 46px;
 		}
 		> i {
 			position: absolute;


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #1533

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

No need to have top and bottom padding when you have defined a height and line-heigt to vertically center the text.

**FireFox before**

![ff-before](https://cloud.githubusercontent.com/assets/441011/15264343/7ccd9228-1972-11e6-9adc-fcb60d072b88.png)

**FireFox after**

![ff-after](https://cloud.githubusercontent.com/assets/441011/15264342/7cccb0e2-1972-11e6-9006-46f0de8aa508.png)

**Chrome after** (no impact)

![chrome-after](https://cloud.githubusercontent.com/assets/441011/15264341/7ccc0250-1972-11e6-9bd6-a9a694d25867.png)

