### PR TITLE
Do not close request window by mistake

### DIFF
--- a/packages/rocketchat-otr/client/rocketchat.otr.room.js
+++ b/packages/rocketchat-otr/client/rocketchat.otr.room.js
@@ -203,6 +203,7 @@ RocketChat.OTR.Room = class {
 						text: TAPi18n.__('Username_wants_to_start_otr_Do_you_want_to_accept', { username: user.username }),
 						html: true,
 						showCancelButton: true,
+						allowOutsideClick: false,
 						confirmButtonText: TAPi18n.__('Yes'),
 						cancelButtonText: TAPi18n.__('No')
 					}, (isConfirm) => {


### PR DESCRIPTION
If you receive a OTR request from another user while you are currently writing or clicking in Rocket.Chat, the window gets closed accidentally. 

This change keeps the window open until you click on accept or deny. 