### PR TITLE
Fix outgoing integrations erroring out when a channel isn't provided

### DIFF
--- a/packages/rocketchat-integrations/server/methods/outgoing/addOutgoingIntegration.coffee
+++ b/packages/rocketchat-integrations/server/methods/outgoing/addOutgoingIntegration.coffee
@@ -23,7 +23,7 @@ Meteor.methods
 		if integration.urls.length is 0
 			throw new Meteor.Error 'error-invalid-urls', 'Invalid URLs', { method: 'addOutgoingIntegration' }
 
-		channels = _.map(integration.channel.split(','), (channel) -> s.trim(channel))
+		channels = if integration.channel then _.map(integration.channel.split(','), (channel) -> s.trim(channel)) else []
 
 		for channel in channels
 			if channel[0] not in ['@', '#']

--- a/packages/rocketchat-integrations/server/methods/outgoing/updateOutgoingIntegration.coffee
+++ b/packages/rocketchat-integrations/server/methods/outgoing/updateOutgoingIntegration.coffee
@@ -20,7 +20,7 @@ Meteor.methods
 		else
 			integration.channel = undefined
 
-		channels = _.map(integration.channel.split(','), (channel) -> s.trim(channel))
+		channels = if integration.channel then _.map(integration.channel.split(','), (channel) -> s.trim(channel)) else []
 
 		for channel in channels
 			if channel[0] not in ['@', '#']


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Fixes an issue when adding an outgoing integration without providing a channel.