### PR TITLE
Add missing i18n properties

### DIFF
--- a/packages/rocketchat-lib/i18n/de.i18n.json
+++ b/packages/rocketchat-lib/i18n/de.i18n.json
@@ -1163,6 +1163,7 @@
   "You_need_to_type_in_your_username_in_order_to_do_this" : "Sie müssen Ihren Benutzernamen angeben, um diese Aktion durchzuführen!",
   "You_need_to_verifiy_your_email_address_to_get_notications" : "Sie müssen Ihre E-Mail-Adresse bestätigen, um Benachrichtigungen zu erhalten",
   "You_need_to_write_something" : "Sie müssen etwas dazu schreiben!",
+  "You_should_inform_one_url_at_least": "Sie müssen mindestens eine URL definieren.",
   "You_should_name_it_to_easily_manage_your_integrations" : "Zur einfachen Verwaltung der Integrationen empfehlen wir, der Integration einen Namen zuzuordnen.",
   "You_will_not_be_able_to_recover" : "Die Nachricht kann anschließend nicht wiederhergestellt werden.",
   "You_will_not_be_able_to_recover_file" : "Das Wiederherstellen dieser Datei wird nicht möglich sein.",

--- a/packages/rocketchat-lib/i18n/en.i18n.json
+++ b/packages/rocketchat-lib/i18n/en.i18n.json
@@ -1165,6 +1165,7 @@
   "You_need_to_type_in_your_username_in_order_to_do_this" : "You need to type in your username in order to do this!",
   "You_need_to_verifiy_your_email_address_to_get_notications" : "You need to verifiy your email address to get notifications",
   "You_need_to_write_something" : "You need to write something!",
+  "You_should_inform_one_url_at_least": "You should define at least one URL.",
   "You_should_name_it_to_easily_manage_your_integrations" : "You should name it to easily manage your integrations.",
   "You_will_not_be_able_to_recover" : "You will not be able to recover this message!",
   "You_will_not_be_able_to_recover_file" : "You will not be able to recover this file!",


### PR DESCRIPTION
… At least for `de` and `en` language files.

I don’t know how you handle translations. Feel free to close the PR if it doesn’t fit your workflow.

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

**Before:**
![i18n](https://cloud.githubusercontent.com/assets/441011/15371120/5b72e8a0-1d3a-11e6-813a-f5fa9876de32.png)

**After:**
![i18n-after](https://cloud.githubusercontent.com/assets/441011/15371193/aa5c015e-1d3a-11e6-901d-6f67be86772a.png)
