### PR TITLE
Fix CAS in Android Cordova

### DIFF
--- a/packages/rocketchat-cas/cas_client.js
+++ b/packages/rocketchat-cas/cas_client.js
@@ -40,29 +40,46 @@ Meteor.loginWithCas = function(options, callback) {
 		popup_height || 600
 	);
 
-	var checkPopupOpen = setInterval(function() {
-		var popupClosed;
-		try {
-			// Fix for #328 - added a second test criteria (popup.closed === undefined)
-			// to humour this Android quirk:
-			// http://code.google.com/p/android/issues/detail?id=21061
-			popupClosed = popup.closed || popup.closed === undefined;
-		} catch (e) {
-			// For some unknown reason, IE9 (and others?) sometimes (when
-			// the popup closes too quickly?) throws "SCRIPT16386: No such
-			// interface supported" when trying to read 'popup.closed'. Try
-			// again in 100ms.
-			return;
-		}
-
-		if (popupClosed) {
-			clearInterval(checkPopupOpen);
-
+	// Fix for #3200: monitor the popup differently if it's Cordova
+	if (Meteor.isCordova) {
+		// Check the URL when each page finishes loading, and if the URL contains "ticket", then close the popup because CAS has finished
+		popup.addEventListener('loadstop', function(e) {
+			if (e.url.indexOf('?ticket=') !== -1) {
+				popup.close();
+			}
+		});
+		popup.addEventListener('exit', function() {
 			// check auth on server.
 			Accounts.callLoginMethod({
 				methodArguments: [{ cas: { credentialToken: credentialToken } }],
 				userCallback: callback
 			});
-		}
-	}, 100);
+		});
+	} else {
+		var checkPopupOpen = setInterval(function() {
+			var popupClosed;
+			try {
+				// Fix for #328 - added a second test criteria (popup.closed === undefined)
+				// to humour this Android quirk:
+				// http://code.google.com/p/android/issues/detail?id=21061
+				popupClosed = popup.closed || popup.closed === undefined;
+			} catch (e) {
+				// For some unknown reason, IE9 (and others?) sometimes (when
+				// the popup closes too quickly?) throws "SCRIPT16386: No such
+				// interface supported" when trying to read 'popup.closed'. Try
+				// again in 100ms.
+				return;
+			}
+
+			if (popupClosed) {
+				clearInterval(checkPopupOpen);
+
+				// check auth on server.
+				Accounts.callLoginMethod({
+					methodArguments: [{ cas: { credentialToken: credentialToken } }],
+					userCallback: callback
+				});
+			}
+		}, 100);
+	}
 };


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #3200

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Cordova InAppBrowser doesn't have the "closed" property that is checked in the "checkPopupOpen" interval, so that interval immediately fires and fails to authenticate (since the user hasn't finished logging in inside the popup). This checks if we're in Cordova, then uses InAppBrowser events to check the status of the popup and act accordingly.

Needs testing in iOS before merging.
