### PR TITLE
Improved user search (name and username)

### DIFF
--- a/packages/rocketchat-authorization/client/views/permissionsRole.coffee
+++ b/packages/rocketchat-authorization/client/views/permissionsRole.coffee
@@ -60,7 +60,7 @@ Template.permissionsRole.helpers
 					filter:
 						exceptions: Template.instance().usersInRole.get()?.fetch()
 					selector: (match) ->
-						return { username: match }
+						return { term: match }
 					sort: 'username'
 				}
 			]

--- a/packages/rocketchat-channel-settings-mail-messages/client/views/mailMessagesInstructions.coffee
+++ b/packages/rocketchat-channel-settings-mail-messages/client/views/mailMessagesInstructions.coffee
@@ -23,7 +23,7 @@ Template.mailMessagesInstructions.helpers
 					filter:
 						exceptions: Template.instance().selectedUsers.get()
 					selector: (match) ->
-						return { username: match }
+						return { term: match }
 					sort: 'username'
 				}
 			]

--- a/packages/rocketchat-lib/server/models/Users.coffee
+++ b/packages/rocketchat-lib/server/models/Users.coffee
@@ -84,16 +84,24 @@ RocketChat.models.Users = new class extends RocketChat.models._Base
 
 		return @find query, options
 
-	findActiveByUsernameRegexWithExceptions: (username, exceptions = [], options = {}) ->
+	findActiveByUsernameOrNameRegexWithExceptions: (searchTerm, exceptions = [], options = {}) ->
 		if not _.isArray exceptions
 			exceptions = [ exceptions ]
 
-		usernameRegex = new RegExp username, "i"
+		termRegex = new RegExp searchTerm, "i"
 		query =
 			$and: [
 				{ active: true }
-				{ username: { $nin: exceptions } }
-				{ username: usernameRegex }
+				{'$or': [
+					{'$and': [
+						{ username: { $nin: exceptions } }
+						{ username: termRegex }
+					]}
+					{'$and': [
+						{ name: { $nin: exceptions } }
+						{ name: termRegex }
+					]}
+				]}
 			]
 			type:
 				$in: ['user', 'bot']
@@ -149,6 +157,9 @@ RocketChat.models.Users = new class extends RocketChat.models._Base
 		options.limit = 1
 
 		return @find(query, options)?.fetch?()?[0]?.lastLogin
+
+	getDisplayName: (_id) ->
+		return "display name"
 
 	findUsersByUsernames: (usernames, options) ->
 		query =

--- a/packages/rocketchat-livechat/app/client/views/message.html
+++ b/packages/rocketchat-livechat/app/client/views/message.html
@@ -9,7 +9,7 @@
 			{{/if}}
 		</span>
 		<div class="body" dir="auto">
-			{{{body}}}
+			{{{body}}} dasds
 		</div>
 	</li>
 </template>

--- a/packages/rocketchat-ui-flextab/flex-tab/tabs/membersList.coffee
+++ b/packages/rocketchat-ui-flextab/flex-tab/tabs/membersList.coffee
@@ -72,9 +72,9 @@ Template.membersList.helpers
 					noMatchTemplate: Template.userSearchEmpty
 					matchAll: true
 					filter:
-						exceptions: [Meteor.user().username]
+						exceptions: [Meteor.user().username, Meteor.user().name]
 					selector: (match) ->
-						return { username: match }
+						return { term: match }
 					sort: 'username'
 				}
 			]

--- a/packages/rocketchat-ui-message/message/message.html
+++ b/packages/rocketchat-ui-message/message/message.html
@@ -4,7 +4,7 @@
 			{{#if avatarFromUsername}}
 				<button class="thumb user-card-message" data-username="{{u.username}}" tabindex="1">{{> avatar username=avatarFromUsername}}</button>
 			{{else}}
-				<button class="thumb user-card-message" data-username="{{u.username}}" tabindex="1">
+				<button class="thumb user-card-message" data-username="{{u.username}} {{u.name}}" tabindex="1">
 					<div class="avatar">
 						<div class="avatar-image" style="background-image:url({{avatar}});"></div>
 					</div>

--- a/packages/rocketchat-ui-sidenav/side-nav/createChannelFlex.coffee
+++ b/packages/rocketchat-ui-sidenav/side-nav/createChannelFlex.coffee
@@ -27,7 +27,7 @@ Template.createChannelFlex.helpers
 					filter:
 						exceptions: [Meteor.user().username].concat(Template.instance().selectedUsers.get())
 					selector: (match) ->
-						return { username: match }
+						return { term: match }
 					sort: 'username'
 				}
 			]

--- a/packages/rocketchat-ui-sidenav/side-nav/directMessagesFlex.coffee
+++ b/packages/rocketchat-ui-sidenav/side-nav/directMessagesFlex.coffee
@@ -16,11 +16,11 @@ Template.directMessagesFlex.helpers
 					noMatchTemplate: Template.userSearchEmpty
 					matchAll: true
 					filter:
-						exceptions: [Meteor.user().username]
+						exceptions: [Meteor.user().username, Meteor.user().name]
 					selector: (match) ->
-						return { username: match }
+						return { term: match }
 					sort: 'username'
-				}
+				},
 			]
 		}
 

--- a/packages/rocketchat-ui-sidenav/side-nav/privateGroupsFlex.coffee
+++ b/packages/rocketchat-ui-sidenav/side-nav/privateGroupsFlex.coffee
@@ -27,7 +27,7 @@ Template.privateGroupsFlex.helpers
 					filter:
 						exceptions: [Meteor.user().username].concat(Template.instance().selectedUsers.get())
 					selector: (match) ->
-						return { username: match }
+						return { term: match }
 					sort: 'username'
 				}
 			]

--- a/server/publications/userAutocomplete.coffee
+++ b/server/publications/userAutocomplete.coffee
@@ -15,7 +15,7 @@ Meteor.publish 'userAutocomplete', (selector) ->
 
 	exceptions = selector.exceptions or []
 
-	cursorHandle = RocketChat.models.Users.findActiveByUsernameRegexWithExceptions(selector.username, exceptions, options).observeChanges
+	cursorHandle = RocketChat.models.Users.findActiveByUsernameOrNameRegexWithExceptions(selector.term, exceptions, options).observeChanges
 		added: (_id, record) ->
 			pub.added("autocompleteRecords", _id, record)
 		changed: (_id, record) ->


### PR DESCRIPTION
Hello guys,

we are using Rocket.Chat as company and our LDAP usernames are very difficult. So most employees knowing only the real names of the employees and not their LDAP username.

That's the reason why we needed to change the user search to username or name (real name) instead of only username.

I hope you like this change and it will be merged to upstream.

Have a nice weekend! 

Regards,
Alexander Birkner