### PR TITLE
Set user's name to alias in message

### DIFF
--- a/packages/rocketchat-lib/i18n/en.i18n.json
+++ b/packages/rocketchat-lib/i18n/en.i18n.json
@@ -653,6 +653,8 @@
   "Message_MaxAllowedSize" : "Maximum Allowed Message Size",
   "Message_pinning" : "Message pinning",
   "Message_removed" : "Message removed",
+  "Message_SetNameToAliasEnabled" : "Set a user name to alias in message",
+  "Message_SetNameToAliasEnabled_Description" : "Only if not already set alias. The old messages alias not changed if user has changed the name.",
   "Message_ShowDeletedStatus" : "Show Deleted Status",
   "Message_ShowEditedStatus" : "Show Edited Status",
   "Message_ShowFormattingTips" : "Show Formatting Tips",

--- a/packages/rocketchat-lib/i18n/ja.i18n.json
+++ b/packages/rocketchat-lib/i18n/ja.i18n.json
@@ -650,6 +650,8 @@
   "Message_MaxAllowedSize" : "メッセージの最大文字数",
   "Message_pinning" : "ピニングメッセージ",
   "Message_removed" : "メッセージを削除しました",
+  "Message_SetNameToAliasEnabled" : "ユーザの名前をメッセージのエイリアスにセット",
+  "Message_SetNameToAliasEnabled_Description" : "エイリアスが既にセットされていない場合のみ。古いメッセージのエイリアスは、ユーザが名前を変えたとしても変更されません。",
   "Message_ShowDeletedStatus" : "削除した状態を表示する",
   "Message_ShowEditedStatus" : "編集した状態を表示する",
   "Message_ShowFormattingTips" : "書式のヒントを表示する",

--- a/packages/rocketchat-lib/server/methods/sendMessage.coffee
+++ b/packages/rocketchat-lib/server/methods/sendMessage.coffee
@@ -6,7 +6,7 @@ Meteor.methods
 		if not Meteor.userId()
 			throw new Meteor.Error('error-invalid-user', "Invalid user", { method: 'sendMessage' })
 
-		user = RocketChat.models.Users.findOneById Meteor.userId(), fields: username: 1
+		user = RocketChat.models.Users.findOneById Meteor.userId(), fields: username: 1, name: 1
 
 		room = Meteor.call 'canAccessRoom', message.rid, user._id
 
@@ -21,6 +21,8 @@ Meteor.methods
 				msg: TAPi18n.__('You_have_been_muted', {}, user.language);
 			}
 			return false
+
+		message.alias = message.alias or user.name
 
 		RocketChat.sendMessage user, message, room
 

--- a/packages/rocketchat-lib/server/methods/sendMessage.coffee
+++ b/packages/rocketchat-lib/server/methods/sendMessage.coffee
@@ -22,7 +22,7 @@ Meteor.methods
 			}
 			return false
 
-		message.alias = message.alias or user.name
+		message.alias = user.name if not message.alias? and RocketChat.settings.get 'Message_SetNameToAliasEnabled'
 
 		RocketChat.sendMessage user, message, room
 

--- a/packages/rocketchat-lib/server/startup/settings.coffee
+++ b/packages/rocketchat-lib/server/startup/settings.coffee
@@ -157,6 +157,7 @@ RocketChat.settings.addGroup 'Message', ->
 	@add 'Message_MaxAll', 0, { type: 'int', public: true }
 	@add 'Message_MaxAllowedSize', 5000, { type: 'int', public: true }
 	@add 'Message_ShowFormattingTips', true, { type: 'boolean', public: true }
+	@add 'Message_SetNameToAliasEnabled', false, { type: 'boolean', public: false, i18nDescription: 'Message_SetNameToAliasEnabled_Description' }
 	@add 'Message_AudioRecorderEnabled', true, { type: 'boolean', public: true, i18nDescription: 'Message_AudioRecorderEnabledDescription' }
 	@add 'Message_GroupingPeriod', 300, { type: 'int', public: true, i18nDescription: 'Message_GroupingPeriodDescription' }
 	@add 'API_Embed', true, { type: 'boolean', public: true }


### PR DESCRIPTION
@RocketChat/core 

Related #1209

I think this solution is not perfect. However, this is easy and low cost.
I focused only to now and future messages. A message's alias not changed if a user has changed the name. But I thought that was okay anyway.

![set-realname-to-alias](https://cloud.githubusercontent.com/assets/9736483/15504808/b4c3091a-21fb-11e6-8b17-dae807c6d3e9.png)

EDIT:
Add settings for this feature.

![ss2](https://cloud.githubusercontent.com/assets/9736483/15543347/786e7646-22cf-11e6-9d6f-ff94a0b5ed07.png)
