### PR TITLE
[WIP] Send all messages directly through msgStream

### DIFF
--- a/packages/rocketchat-channel-settings/server/methods/saveRoomSettings.coffee
+++ b/packages/rocketchat-channel-settings/server/methods/saveRoomSettings.coffee
@@ -18,10 +18,12 @@ Meteor.methods
 				when 'roomName'
 					name = RocketChat.saveRoomName rid, value
 					RocketChat.models.Messages.createRoomRenamedWithRoomIdRoomNameAndUser rid, name, Meteor.user()
+					# @TODO sent through stream
 				when 'roomTopic'
 					if value isnt room.topic
 						RocketChat.saveRoomTopic(rid, value)
 						RocketChat.models.Messages.createRoomSettingsChangedWithTypeRoomIdMessageAndUser 'room_changed_topic', rid, value, Meteor.user()
+						# @TODO sent through stream
 				when 'roomType'
 					if value isnt room.t
 						RocketChat.saveRoomType(rid, value)
@@ -30,6 +32,7 @@ Meteor.methods
 						else
 							message = TAPi18n.__('Private_Group')
 						RocketChat.models.Messages.createRoomSettingsChangedWithTypeRoomIdMessageAndUser 'room_changed_privacy', rid, message, Meteor.user()
+						# @TODO sent through stream
 				when 'default'
 					RocketChat.models.Rooms.saveDefaultById rid, value
 

--- a/packages/rocketchat-lib/server/functions/sendMessage.coffee
+++ b/packages/rocketchat-lib/server/functions/sendMessage.coffee
@@ -33,4 +33,7 @@ RocketChat.sendMessage = (user, message, room) ->
 		# Execute all callbacks
 		RocketChat.callbacks.run 'afterSaveMessage', message, room
 
+	oldMsgStream.emit message.rid, message
+	msgStream.emit message.rid, message
+
 	return message

--- a/packages/rocketchat-lib/server/functions/setUsername.coffee
+++ b/packages/rocketchat-lib/server/functions/setUsername.coffee
@@ -32,6 +32,7 @@ RocketChat._setUsername = (userId, username) ->
 
 	# Username is available; if coming from old username, update all references
 	if previousUsername
+		# @TODO sent through stream
 		RocketChat.models.Messages.updateAllUsernamesByUserId user._id, username
 		RocketChat.models.Messages.updateUsernameOfEditByUserId user._id, username
 

--- a/packages/rocketchat-message-pin/server/pinMessage.coffee
+++ b/packages/rocketchat-message-pin/server/pinMessage.coffee
@@ -27,6 +27,7 @@ Meteor.methods
 
 		RocketChat.models.Messages.setPinnedByIdAndUserId message._id, message.pinnedBy, message.pinned
 
+		# @TODO sent through stream
 		RocketChat.models.Messages.createWithTypeRoomIdMessageAndUser 'message_pinned', message.rid, '', me,
 			attachments: [
 				"text" : message.msg
@@ -60,6 +61,7 @@ Meteor.methods
 
 		message = RocketChat.callbacks.run 'beforeSaveMessage', message
 
+		# @TODO sent through stream
 		RocketChat.models.Messages.setPinnedByIdAndUserId message._id, message.pinnedBy, message.pinned
 
 

--- a/packages/rocketchat-message-star/server/starMessage.coffee
+++ b/packages/rocketchat-message-star/server/starMessage.coffee
@@ -11,4 +11,5 @@ Meteor.methods
 		if Array.isArray(room.usernames) && room.usernames.indexOf(Meteor.user().username) is -1
 			return false
 
+		# @TODO sent through stream
 		RocketChat.models.Messages.updateUserStarById(message._id, Meteor.userId(), message.starred)

--- a/packages/rocketchat-oembed/server/server.coffee
+++ b/packages/rocketchat-oembed/server/server.coffee
@@ -197,9 +197,11 @@ OEmbed.RocketUrlParser = (message) ->
 
 		if attachments.length
 			RocketChat.models.Messages.setMessageAttachments message._id, attachments
+			# @TODO sent through stream
 
 		if changed is true
 			RocketChat.models.Messages.setUrlsById message._id, message.urls
+			# @TODO sent through stream
 
 	return message
 

--- a/packages/rocketchat-reactions/setReaction.js
+++ b/packages/rocketchat-reactions/setReaction.js
@@ -37,8 +37,10 @@ Meteor.methods({
 			if (_.isEmpty(message.reactions)) {
 				delete message.reactions;
 				RocketChat.models.Messages.unsetReactions(messageId);
+				// # @TODO sent through stream
 			} else {
 				RocketChat.models.Messages.setReactions(messageId, message.reactions);
+				// # @TODO sent through stream
 			}
 		} else {
 			if (!message.reactions) {
@@ -52,6 +54,7 @@ Meteor.methods({
 			message.reactions[reaction].usernames.push(user.username);
 
 			RocketChat.models.Messages.setReactions(messageId, message.reactions);
+			// # @TODO sent through stream
 		}
 
 		msgStream.emit(message.rid, message);

--- a/server/methods/addRoomModerator.coffee
+++ b/server/methods/addRoomModerator.coffee
@@ -22,6 +22,7 @@ Meteor.methods
 				_id: fromUser._id
 				username: fromUser.username
 			role: 'moderator'
+		# @TODO sent through stream
 
 		if RocketChat.settings.get('UI_DisplayRoles')
 			RocketChat.Notifications.notifyAll('roles-change', { type: 'added', _id: 'moderator', u: { _id: user._id, username: user.username }, scope: rid });

--- a/server/methods/addRoomOwner.coffee
+++ b/server/methods/addRoomOwner.coffee
@@ -22,6 +22,7 @@ Meteor.methods
 				_id: fromUser._id
 				username: fromUser.username
 			role: 'owner'
+		# @TODO sent through stream
 
 		if RocketChat.settings.get('UI_DisplayRoles')
 			RocketChat.Notifications.notifyAll('roles-change', { type: 'added', _id: 'owner', u: { _id: user._id, username: user.username }, scope: rid });

--- a/server/methods/addUserToRoom.coffee
+++ b/server/methods/addUserToRoom.coffee
@@ -44,5 +44,6 @@ Meteor.methods
 			u:
 				_id: fromUser._id
 				username: fromUser.username
+		# @TODO sent through stream
 
 		return true

--- a/server/methods/deleteMessage.coffee
+++ b/server/methods/deleteMessage.coffee
@@ -46,3 +46,5 @@ Meteor.methods
 			RocketChat.models.Messages.setAsDeletedById originalMessage._id
 		else
 			RocketChat.Notifications.notifyRoom originalMessage.rid, 'deleteMessage', {_id: originalMessage._id}
+
+		# @TODO sent through stream

--- a/server/methods/joinRoom.coffee
+++ b/server/methods/joinRoom.coffee
@@ -32,6 +32,7 @@ Meteor.methods
 
 		RocketChat.models.Messages.createUserJoinWithRoomIdAndUser rid, user,
 			ts: now
+		# @TODO sent through stream
 
 		Meteor.defer ->
 			RocketChat.callbacks.run 'afterJoinRoom', user, room

--- a/server/methods/leaveRoom.coffee
+++ b/server/methods/leaveRoom.coffee
@@ -22,9 +22,11 @@ Meteor.methods
 		if room.usernames.indexOf(user.username) isnt -1
 			removedUser = user
 			RocketChat.models.Messages.createUserLeaveWithRoomIdAndUser rid, removedUser
+			# @TODO sent through stream
 
 		if room.t is 'l'
 			RocketChat.models.Messages.createCommandWithRoomIdAndUser 'survey', rid, user
+			# @TODO sent through stream
 
 		RocketChat.models.Subscriptions.removeByRoomIdAndUserId rid, Meteor.userId()
 

--- a/server/methods/muteUserInRoom.coffee
+++ b/server/methods/muteUserInRoom.coffee
@@ -28,5 +28,6 @@ Meteor.methods
 			u:
 				_id: fromUser._id
 				username: fromUser.username
+		# @TODO sent through stream
 
 		return true

--- a/server/methods/removeRoomModerator.coffee
+++ b/server/methods/removeRoomModerator.coffee
@@ -22,6 +22,7 @@ Meteor.methods
 				_id: fromUser._id
 				username: fromUser.username
 			role: 'moderator'
+		# @TODO sent through stream
 
 		if RocketChat.settings.get('UI_DisplayRoles')
 			RocketChat.Notifications.notifyAll('roles-change', { type: 'removed', _id: 'moderator', u: { _id: user._id, username: user.username }, scope: rid });

--- a/server/methods/removeRoomOwner.coffee
+++ b/server/methods/removeRoomOwner.coffee
@@ -26,6 +26,7 @@ Meteor.methods
 				_id: fromUser._id
 				username: fromUser.username
 			role: 'owner'
+		# @TODO sent through stream
 
 		if RocketChat.settings.get('UI_DisplayRoles')
 			RocketChat.Notifications.notifyAll('roles-change', { type: 'removed', _id: 'owner', u: { _id: user._id, username: user.username }, scope: rid });

--- a/server/methods/removeUserFromRoom.coffee
+++ b/server/methods/removeUserFromRoom.coffee
@@ -28,5 +28,6 @@ Meteor.methods
 			u:
 				_id: fromUser._id
 				username: fromUser.username
+		# @TODO sent through stream
 
 		return true

--- a/server/methods/unmuteUserInRoom.coffee
+++ b/server/methods/unmuteUserInRoom.coffee
@@ -25,5 +25,6 @@ Meteor.methods
 			u:
 				_id: fromUser._id
 				username: fromUser.username
+		# @TODO sent through stream
 
 		return true

--- a/server/methods/updateMessage.coffee
+++ b/server/methods/updateMessage.coffee
@@ -48,5 +48,18 @@ Meteor.methods
 
 		room = RocketChat.models.Rooms.findOneById message.rid
 
+		sentMessage = RocketChat.models.Messages.findOneById tempid
+
 		Meteor.defer ->
-			RocketChat.callbacks.run 'afterSaveMessage', RocketChat.models.Messages.findOneById(tempid), room
+			RocketChat.callbacks.run 'afterSaveMessage', sentMessage, room
+
+		if not showEditedStatus
+			delete sentMessage.editedAt
+
+		oldMsgStream.emit sentMessage.rid, sentMessage
+		msgStream.emit sentMessage.rid, sentMessage
+
+showEditedStatus = true
+RocketChat.settings.get 'Message_ShowEditedStatus', (key, value) ->
+	showEditedStatus = value
+

--- a/server/stream/messages.coffee
+++ b/server/stream/messages.coffee
@@ -1,5 +1,5 @@
 # COMPATIBILITY
-oldMsgStream = new Meteor.Stream 'messages'
+@oldMsgStream = new Meteor.Stream 'messages'
 
 oldMsgStream.permissions.write (eventName) ->
 	return false
@@ -32,19 +32,3 @@ msgStream.allowRead (eventName) ->
 		return true
 	catch e
 		return false
-
-
-Meteor.startup ->
-	options = {}
-
-	if not RocketChat.settings.get 'Message_ShowEditedStatus'
-		options.fields = { 'editedAt': 0 }
-
-	RocketChat.models.Messages.findVisibleCreatedOrEditedAfterTimestamp(new Date(), options).observe
-		added: (record) ->
-			oldMsgStream.emit record.rid, record
-			msgStream.emitWithoutBroadcast record.rid, record
-
-		changed: (record) ->
-			oldMsgStream.emit record.rid, record
-			msgStream.emitWithoutBroadcast record.rid, record


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Today, sending a message has this flow:

1. [client] call `sendMessage` method
2. [server] runs method `sendMessage` - insert message on DB
3. [server] receive the message from DB on an `observe` issued on server startup
4. [server] send the message received thourgh `msgStream`
5. [client] receives the new message (with extra details)

This idea is sending the message to clients without waiting for DB (removing step 3).

I'm expecting a faster startup process, lower memory usage (both because I'll remove the forever-`observe` on startup), faster data sync on all connected clients.