### PR TITLE
Notify users of all direct messages by default

### DIFF
--- a/server/methods/createDirectMessage.coffee
+++ b/server/methods/createDirectMessage.coffee
@@ -48,6 +48,8 @@ Meteor.methods
 				t: 'd'
 				alert: false
 				unread: 0
+                                desktopNotifications: 'all'
+                                mobilePushNotifications: 'all'
 				u:
 					_id: me._id
 					username: me.username
@@ -63,6 +65,8 @@ Meteor.methods
 				open: false
 				alert: false
 				unread: 0
+                                desktopNotifications: 'all'
+                                mobilePushNotifications: 'all'
 				u:
 					_id: to._id
 					username: to.username


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
I admit this is a bit of a hack, but I think it's an absolutely critical feature to have all direct messages cause notifications by default. This PR simply sets the notification fields to "all" in the database when creating new direct messages to quickly provide a better default.

The ideal solution here (IMHO) would be to allow administrators to set the global default per room type, rather than having it hard-coded to 'mentions' when not set. But that's a more involved change, which I hope to do at some point, but unfortunately don't have time to do just now.