### PR TITLE
Fix spelling on /api/info

### DIFF
--- a/packages/rocketchat-version/plugin/compile-version.coffee
+++ b/packages/rocketchat-version/plugin/compile-version.coffee
@@ -16,8 +16,8 @@ class VersionCompiler
 				arch: process.arch
 				platform: process.platform
 				osRelease: os.release()
-				totalMemmory: os.totalmem()
-				freeMemmory: os.freemem()
+				totalMemory: os.totalmem()
+				freeMemory: os.freemem()
 				cpus: os.cpus().length
 
 			if process.env.TRAVIS_BUILD_NUMBER


### PR DESCRIPTION
Fixed the spelling from memmory to memory
