### PR TITLE
Remove $ and $$ as Katex delimiters

### DIFF
--- a/packages/rocketchat-katex/katex.coffee
+++ b/packages/rocketchat-katex/katex.coffee
@@ -7,8 +7,6 @@ class Katex
 	delimiters_map: [
 		{ opener: '\\[', closer: '\\]', displayMode: true  },
 		{ opener: '\\(', closer: '\\)', displayMode: false },
-		{ opener: '$$' , closer: '$$' , displayMode: true  },
-		{ opener: '$'  , closer: '$'  , displayMode: false },
 	]
 
 	# Searches for the first opening delimiter in the string from a given position


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #3327

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
$ and $$ were being used as Katex delimiters, but this seems unnecessary since \\[ \\] and \\( \\) already do the same thing, and are much less likely to be used accidentally.
