### PR TITLE
Add bad word filter to settings UI

### DIFF
--- a/packages/rocketchat-lib/server/startup/settings.coffee
+++ b/packages/rocketchat-lib/server/startup/settings.coffee
@@ -155,6 +155,8 @@ RocketChat.settings.addGroup 'Message', ->
 	@add 'Message_AlwaysSearchRegExp', false, { type: 'boolean' }
 	@add 'Message_ShowEditedStatus', true, { type: 'boolean', public: true }
 	@add 'Message_ShowDeletedStatus', false, { type: 'boolean', public: true }
+	@add 'Message_AllowBadWordsFilter', false, { type: 'boolean', public: true}
+	@add 'Message_BadWordsFilterList', '', {type: 'string', public: true}
 	@add 'Message_KeepHistory', false, { type: 'boolean', public: true }
 	@add 'Message_MaxAll', 0, { type: 'int', public: true }
 	@add 'Message_MaxAllowedSize', 5000, { type: 'int', public: true }


### PR DESCRIPTION
Adds settings UI for bad word filter added via #2991 / #2940 

![image](https://cloud.githubusercontent.com/assets/51996/15657891/04b30de8-267b-11e6-9bb6-93102a89dfbe.png)

![image](https://cloud.githubusercontent.com/assets/51996/15657895/189e33a0-267b-11e6-8b67-fa6ebde0783a.png)


