### PR TITLE
Escape KaTeX error messages

### DIFF
--- a/packages/rocketchat-katex/katex.coffee
+++ b/packages/rocketchat-katex/katex.coffee
@@ -92,7 +92,7 @@ class Katex
 		catch e
 			display_mode = if displayMode then "block" else "inline"
 			rendered =  "<div class=\"katex-error katex-#{display_mode}-error\">"
-			rendered += 	"#{e.message}"
+			rendered += 	"#{s.escapeHTML e.message}"
 			rendered += "</div>"
 
 		return rendered


### PR DESCRIPTION
@RocketChat/core

KaTeX error messages are currently not being escaped. Sending a message containing the string `\( \/<s>test</s> \)` for instance gets us the following error message:
![screen shot 2016-06-02 at 19 18 28](https://cloud.githubusercontent.com/assets/10801000/15754444/76ee00e6-28f8-11e6-868e-bd59b9165195.png)
I simply added an `s.escapeHTML` instruction so the error message is properly displayed:
![screen shot 2016-06-02 at 19 20 06](https://cloud.githubusercontent.com/assets/10801000/15754445/76f158ea-28f8-11e6-9647-3cae0e0daef8.png)
