### PR TITLE
Added user preference to enable/disable "User Joined" and "User Left" messages

### DIFF
--- a/packages/rocketchat-lib/i18n/en.i18n.json
+++ b/packages/rocketchat-lib/i18n/en.i18n.json
@@ -1111,6 +1111,7 @@
   "User_joined_channel" : "Has joined the channel.",
   "User_joined_channel_female" : "Has joined the channel.",
   "User_joined_channel_male" : "Has joined the channel.",
+  "User_joined_or_left_notification" : "Show user joined/left notifications",
   "User_left" : "Has left the channel.",
   "User_left_female" : "Has left the channel.",
   "User_left_male" : "Has left the channel.",

--- a/packages/rocketchat-ui-account/account/accountPreferences.coffee
+++ b/packages/rocketchat-ui-account/account/accountPreferences.coffee
@@ -72,6 +72,7 @@ Template.accountPreferences.onCreated ->
 		data.hideUsernames = $('#hideUsernames').find('input:checked').val()
 		data.unreadRoomsMode = $('input[name=unreadRoomsMode]:checked').val()
 		data.autoImageLoad = $('input[name=autoImageLoad]:checked').val()
+		data.userJoinedOrLeftNotification = $('input[name=userJoinedOrLeftNotification]:checked').val()
 		data.emailNotificationMode = $('select[name=emailNotificationMode]').val()
 		data.highlights = _.compact(_.map($('[name=highlights]').val().split(','), (e) -> return _.trim(e)))
 

--- a/packages/rocketchat-ui-account/account/accountPreferences.html
+++ b/packages/rocketchat-ui-account/account/accountPreferences.html
@@ -91,6 +91,13 @@
 									<label><input type="radio" name="hideUsernames" value="0" checked="{{checked 'hideUsernames' false true}}" /> {{_ "False"}}</label>
 								</div>
 							</div>
+                                                        <div class="input-line double-col" id="userJoinedOrLeftNotification">
+                                                                <label>{{_ "User_joined_or_left_notification"}}</label>
+                                                                <div>
+                                                                        <label><input type="radio" name="userJoinedOrLeftNotification" value="1" checked="{{checked 'userJoinedOrLeftNotification' true true}}" /> {{_ "True"}}</label>
+                                                                        <label><input type="radio" name="userJoinedOrLeftNotification" value="0" checked="{{checked 'userJoinedOrLeftNotification' false}}" /> {{_ "False"}}</label>
+                                                                </div>
+                                                        </div>
 							<div class="input-line double-col" id="viewMode">
 								<label>{{_ "View_mode"}}</label>
 								<div>

--- a/packages/rocketchat-ui/views/app/room.coffee
+++ b/packages/rocketchat-ui/views/app/room.coffee
@@ -22,7 +22,8 @@ Template.room.helpers
 		return isSubscribed(this._id)
 
 	messagesHistory: ->
-		return ChatMessage.find { rid: this._id, t: { '$ne': 't' }  }, { sort: { ts: 1 } }
+		return ChatMessage.find { rid: this._id, t: { '$ne': 't' }  }, { sort: { ts: 1 } } if Meteor.user()?.settings?.preferences?.userJoinedOrLeftNotification is true
+		return ChatMessage.find { rid: this._id, t: { '$nin': ['t', 'uj', 'ul'] }  }, { sort: { ts: 1 } }
 
 	hasMore: ->
 		return RoomHistoryManager.hasMore this._id

--- a/server/methods/saveUserPreferences.coffee
+++ b/server/methods/saveUserPreferences.coffee
@@ -30,6 +30,9 @@ Meteor.methods
 			if settings.autoImageLoad?
 				preferences.autoImageLoad = if settings.autoImageLoad is "1" then true else false
 
+			if settings.userJoinedOrLeftNotification?
+				preferences.userJoinedOrLeftNotification = if settings.userJoinedOrLeftNotification is "1" then true else false
+
 			if settings.emailNotificationMode?
 				preferences.emailNotificationMode = settings.emailNotificationMode
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #2959

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Added a user preference to filter out "User Joined" and "User Left" messages. These tend to clutter up large channels.
