### PR TITLE
add requiring of authentication for /avatar/* route

### DIFF
--- a/server/startup/avatar.coffee
+++ b/server/startup/avatar.coffee
@@ -31,6 +31,12 @@ Meteor.startup ->
 		transformWrite: transformWrite
 
 	WebApp.connectHandlers.use '/avatar/', Meteor.bindEnvironment (req, res, next) ->
+		if not Meteor.user()?
+			res.setHeader 'Location', '/login'
+			res.writeHead 302
+			res.end()
+			return
+			
 		params =
 			username: decodeURIComponent(req.url.replace(/^\//, '').replace(/\?.*$/, ''))
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->

@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->


<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

Edit: Actually it closes the issue completely because enumeration of usernames via the avatar filename is only possible to authenticated users. The list of users is not considered sensitive to authenticated users as far as i know.
