### PR TITLE
add error message for duplicate channel creation

### DIFF
--- a/packages/rocketchat-lib/i18n/en.i18n.json
+++ b/packages/rocketchat-lib/i18n/en.i18n.json
@@ -288,6 +288,7 @@
   "Drop_to_upload_file" : "Drop to upload file",
   "Dry_run" : "Dry run",
   "Dry_run_description" : "Will only send one email, to the same address as in From. The email must belong to a valid user.",
+  "Duplicate_channel_name" : "A Channel with name '%s' exists",
   "Duplicate_archived_channel_name" : "An archived Channel with name '%s' exists",
   "Duplicate_archived_private_group_name" : "An archived Private Group with name '%s' exists",
   "Duplicate_private_group_name" : "A Private Group with name '%s' exists",


### PR DESCRIPTION
@RocketChat/core 

this patch adds the error message to be displayed when trying to create an already existing channel. It is referenced [here](https://github.com/RocketChat/Rocket.Chat/blob/ffef53e5235a9f932f48d611eb7498799fce485f/packages/rocketchat-ui-sidenav/side-nav/createChannelFlex.html#L40), but never defined in en.i18n.json.

