### PR TITLE
fixes language_version on catalan and spanish translation

### DIFF
--- a/packages/rocketchat-lib/i18n/ca.i18n.json
+++ b/packages/rocketchat-lib/i18n/ca.i18n.json
@@ -541,7 +541,7 @@
   "Knowledge_Base" : "Centre de suport",
   "Label" : "Etiqueta",
   "Language" : "Idioma",
-  "Language_Version" : "Versió en anglès",
+  "Language_Version" : "Versió en Català",
   "Last_login" : "Darrer inici de sessió",
   "Last_Message_At" : "Últim missatge a",
   "Last_seen" : "Vist per darrer cop",

--- a/packages/rocketchat-lib/i18n/es.i18n.json
+++ b/packages/rocketchat-lib/i18n/es.i18n.json
@@ -534,7 +534,7 @@
   "Knowledge_Base" : "Base de conocimiento",
   "Label" : "Etiqueta",
   "Language" : "Idioma",
-  "Language_Version" : "Versión en Inglés",
+  "Language_Version" : "Versión en Español",
   "Last_login" : "Ultimo inicio de sesion",
   "Last_Message_At" : "Último Mensaje Por",
   "Last_seen" : "Ultima vez visto",


### PR DESCRIPTION
@RocketChat/core 

I think the pull request is clear

this is an example of other translation that did it correctly:
https://github.com/RocketChat/Rocket.Chat/blob/develop/packages/rocketchat-lib/i18n/de.i18n.json#L539