### PR TITLE
Rename Video Chat settings group

### DIFF
--- a/packages/rocketchat-videobridge/server/settings.js
+++ b/packages/rocketchat-videobridge/server/settings.js
@@ -1,5 +1,5 @@
 Meteor.startup(function() {
-	RocketChat.settings.addGroup('Group VideoChat', function() {
+	RocketChat.settings.addGroup('Video Conference', function() {
 		this.add('Jitsi_Enabled', false, {
 			type: 'boolean',
 			i18nLabel: 'Enabled',

--- a/packages/rocketchat-videobridge/server/settings.js
+++ b/packages/rocketchat-videobridge/server/settings.js
@@ -1,5 +1,5 @@
 Meteor.startup(function() {
-	RocketChat.settings.addGroup('Jitsi', function() {
+	RocketChat.settings.addGroup('Group VideoChat', function() {
 		this.add('Jitsi_Enabled', false, {
 			type: 'boolean',
 			i18nLabel: 'Enabled',


### PR DESCRIPTION
Time and again , the direct mention of "Jitsi" , either in watermark or settings or release notes, causes our user base to freak out and enter long drawn discussions of how video over the web should be accomplished.    

With no disrespect to our FOSS partner, we need to start calling this a Rocket.Chat Group VideoChat feature - powered by Jitsi to ease the fear factor.