### PR TITLE
Fixes #3571: sort slash commands before filtering

### DIFF
--- a/packages/rocketchat-ui-message/message/popup/messagePopupConfig.coffee
+++ b/packages/rocketchat-ui-message/message/popup/messagePopupConfig.coffee
@@ -148,11 +148,10 @@ Template.messagePopupConfig.helpers
 							params: item.params
 							description: TAPi18n.__ item.description
 
-					if commands.length > 10
-						break
-
 				commands = commands.sort (a, b) ->
 					return a._id > b._id
+
+				commands = commands[0..10]
 
 				template.resultsLength.set commands.length
 				return commands


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #3571

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

rather than breaking out of the loop after processing the 11th slash command, we will process all of the slash commands, sort them alphabetically, then return the top 11