### PR TITLE
Added Chrome Extension setting for jitsi integration

### DIFF
--- a/packages/rocketchat-lib/i18n/en.i18n.json
+++ b/packages/rocketchat-lib/i18n/en.i18n.json
@@ -531,6 +531,8 @@
   "is_typing_male" : "is typing",
   "italics" : "italics",
   "It_works" : "It works",
+  "Jitsi_Enable_Channels": "Enable in Channels",
+  "Jitsi_Chrome_Extension": "Chrome Extension Id",
   "join" : "Join",
   "Join_audio_call" : "Join audio call",
   "Join_default_channels" : "Join default channels",

--- a/packages/rocketchat-videobridge/client/views/videoFlexTab.js
+++ b/packages/rocketchat-videobridge/client/views/videoFlexTab.js
@@ -13,7 +13,9 @@ Template.videoFlexTab.onCreated(function() {
 	let width = 500;
 	let height = 500;
 
-	let configOverwrite = {};
+	let configOverwrite = {
+		desktopSharingChromeExtId: RocketChat.settings.get('Jitsi_Chrome_Extension')
+	};
 	let interfaceConfigOverwrite = {};
 
 	let jitsiRoomActive = null;

--- a/packages/rocketchat-videobridge/server/settings.js
+++ b/packages/rocketchat-videobridge/server/settings.js
@@ -36,5 +36,15 @@ Meteor.startup(function() {
 			i18nLabel: 'Jitsi_Enable_Channels',
 			public: true
 		});
+
+		this.add('Jitsi_Chrome_Extension', 'nocfbnnmjnndkbipkabodnheejiegccf', {
+			type: 'string',
+			enableQuery: {
+				_id: 'Jitsi_Enabled',
+				value: true
+			},
+			i18nLabel: 'Jitsi_Chrome_Extension',
+			public: true
+		});
 	});
 });


### PR DESCRIPTION
@RocketChat/core 

adds new setting to be able to set the screenshare extension for jitsi:

![image](https://cloud.githubusercontent.com/assets/51996/16398082/e03db0de-3c8d-11e6-81a5-be7c09e39edf.png)

