### PR TITLE
Fix sandstorm WebRTC

### DIFF
--- a/packages/rocketchat-otr/client/rocketchat.otr.js
+++ b/packages/rocketchat-otr/client/rocketchat.otr.js
@@ -34,11 +34,15 @@ class OTR {
 RocketChat.OTR = new OTR();
 
 Meteor.startup(function() {
-	RocketChat.Notifications.onUser('otr', (type, data) => {
-		if (!data.roomId || !data.userId || data.userId === Meteor.userId()) {
-			return;
-		} else {
-			RocketChat.OTR.getInstanceByRoomId(data.roomId).onUserStream(type, data);
+	Tracker.autorun(function() {
+		if (Meteor.userId()) {
+			RocketChat.Notifications.onUser('otr', (type, data) => {
+				if (!data.roomId || !data.userId || data.userId === Meteor.userId()) {
+					return;
+				} else {
+					RocketChat.OTR.getInstanceByRoomId(data.roomId).onUserStream(type, data);
+				}
+			});
 		}
 	});
 

--- a/packages/rocketchat-webrtc/WebRTCClass.coffee
+++ b/packages/rocketchat-webrtc/WebRTCClass.coffee
@@ -803,9 +803,11 @@ WebRTC = new class
 
 
 Meteor.startup ->
-	RocketChat.Notifications.onUser 'webrtc', (type, data) =>
-		if not data.room? then return
+	Tracker.autorun ->
+		if Meteor.userId()
+			RocketChat.Notifications.onUser 'webrtc', (type, data) =>
+				if not data.room? then return
 
-		webrtc = WebRTC.getInstanceByRoomId(data.room)
+				webrtc = WebRTC.getInstanceByRoomId(data.room)
 
-		webrtc.transport.onUserStream type, data
+				webrtc.transport.onUserStream type, data


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

This change wraps the `Notifications.onUser` subscription for WebRTC messages in an autorun, similar to how it is done elsewhere in the Rocket.chat codebase. It seems that Meteor.userId() takes a while to be populated on Sandstorm, so this subscription would never get setup correctly.

Also grep'ed the codebase and found another case of `Notifications.onUser` being called on startup without an autorun.
