### PR TITLE
Bugfix: Sort channels list

### DIFF
--- a/packages/rocketchat-ui-sidenav/side-nav/listChannelsFlex.coffee
+++ b/packages/rocketchat-ui-sidenav/side-nav/listChannelsFlex.coffee
@@ -87,7 +87,7 @@ Template.listChannelsFlex.onCreated ->
 			if @channelsList.get().length < @limit.get()
 				@hasMore.set false
 		else
-			Meteor.call 'channelsList', @nameFilter.get(), @limit.get(), @sortChannels.get(), (err, result) =>
+			Meteor.call 'channelsList', @nameFilter.get(), 'public', @limit.get(), @sortChannels.get(), (err, result) =>
 				if result
 					@hasMore.set true
 					@channelsList.set result.channels


### PR DESCRIPTION
@RocketChat/core

1. Set `Merge private groups with channels` to `false`
2. Click `More channels...`
3. Set sort mode to `Name`, but not working

See also: [listCombinedFlex.coffee](https://github.com/RocketChat/Rocket.Chat/blob/develop/packages/rocketchat-ui-sidenav/side-nav/listCombinedFlex.coffee#L110)

`@channelType.get()` to `'public'`