### PR TITLE
don't consider invalid commands to be messages

### DIFF
--- a/packages/rocketchat-lib/i18n/en.i18n.json
+++ b/packages/rocketchat-lib/i18n/en.i18n.json
@@ -747,6 +747,7 @@
   "No_pinned_messages" : "No pinned messages",
   "No_results_found" : "No results found",
   "No_starred_messages" : "No starred messages",
+  "No_such_command" : "No such command: `/__command__`",
   "No_user_with_username_%s_was_found" : "No user with username <strong>\"%s\"</strong> was found!",
   "Node_version" : "Node version",
   "Not_authorized" : "Not authorized",

--- a/packages/rocketchat-ui/lib/chatMessages.coffee
+++ b/packages/rocketchat-ui/lib/chatMessages.coffee
@@ -175,10 +175,21 @@ class @ChatMessages
 				#Check if message starts with /command
 				if msg[0] is '/'
 					match = msg.match(/^\/([^\s]+)(?:\s+(.*))?$/m)
-					if match? and RocketChat.slashCommands.commands[match[1]]
-						command = match[1]
-						param = match[2]
-						Meteor.call 'slashCommand', {cmd: command, params: param, msg: msgObject }
+					if match?
+						if RocketChat.slashCommands.commands[match[1]]
+							command = match[1]
+							param = match[2]
+							Meteor.call 'slashCommand', {cmd: command, params: param, msg: msgObject }
+							return
+						invalidCommandMsg =
+							_id: Random.id()
+							rid: rid
+							ts: new Date
+							msg: TAPi18n.__('No_such_command', { command: match[1] })
+							u:
+								username: "rocketbot"
+							private: true
+						ChatMessage.upsert { _id: invalidCommandMsg._id }, invalidCommandMsg
 						return
 
 				Meteor.call 'sendMessage', msgObject


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #3697

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

If a user types an invalid slash command, we'll respond from `rocketbot` letting the user know that the command was invalid (rather than just calling `sendMessage` for the invalid slash command).