### PR TITLE
Only require a password if change email or password in user profile

### DIFF
--- a/packages/rocketchat-ui-account/account/accountProfile.coffee
+++ b/packages/rocketchat-ui-account/account/accountProfile.coffee
@@ -98,7 +98,9 @@ Template.accountProfile.onRendered ->
 
 Template.accountProfile.events
 	'click .submit button': (e, instance) ->
-		unless s.trim Meteor.user()?.services?.password?.bcrypt
+		user = Meteor.user()
+		reqPass = ((_.trim($('#email').val()) isnt user?.emails?[0]?.address) or _.trim($('#password').val())) and s.trim(user?.services?.password?.bcrypt)
+		unless reqPass
 			return instance.save()
 
 		swal


### PR DESCRIPTION
@RocketChat/core

In my use case, allow only changing name.
I think unnecessary that re-enter password in this case.