### PR TITLE
Update accounts-sandstorm to 0.4.1

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -61,7 +61,7 @@ jparker:gravatar@0.4.1
 jquery@1.11.4
 kadira:blaze-layout@2.3.0
 kadira:flow-router@2.10.1
-kenton:accounts-sandstorm@0.4.0
+kenton:accounts-sandstorm@0.4.1
 konecty:change-case@2.3.0
 konecty:delayed-task@1.0.0
 konecty:mongo-counter@0.0.3


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #3055

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

This update to accounts-sandstorm fixes a bug on old versions of IceWeasel.

Or, at least, it should. I haven't personally attempted to build Rocket.Chat with this change.