### PR TITLE
Fix "Show_only_online" link bug in french

### DIFF
--- a/packages/rocketchat-lib/i18n/fr.i18n.json
+++ b/packages/rocketchat-lib/i18n/fr.i18n.json
@@ -963,7 +963,7 @@
   "Should_exists_a_user_with_this_username" : "L'utilisateur doit déjà exister",
   "Show_all" : "Afficher tout",
   "Show_more" : "Afficher plus",
-  "Show_only_online" : "Ne montrer que les utilisateurs connectés",
+  "Show_only_online" : "Seulement les connectés",
   "Show_preregistration_form" : "Afficher le formulaire de pré-inscription",
   "Showing_archived_results" : "<p>Affichage de <b>%s</b> résultats archivés</p>",
   "Showing_online_users" : "<b>__total_showing__</b> utilisateur(s) affichés sur un total de __total__",


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

Broken link due to long useless text.

![capture d ecran 2016-07-09 a 00 43 32](https://cloud.githubusercontent.com/assets/1545450/16703749/7af9f58e-4570-11e6-8c56-405d05ab837e.png)

Now fixed : 
![capture d ecran 2016-07-09 a 01 02 17](https://cloud.githubusercontent.com/assets/1545450/16703792/d5e22890-4570-11e6-85f9-f3b660e24d35.png)
