### PR TITLE
Added special room name

### DIFF
--- a/client/startup/defaultRoomTypes.coffee
+++ b/client/startup/defaultRoomTypes.coffee
@@ -41,7 +41,11 @@ RocketChat.roomTypes.add 'd', 20,
 				$all: [identifier, user.username]
 		return ChatRoom.findOne(query)
 	roomName: (roomData) ->
-		return ChatSubscription.findOne({ rid: roomData._id }, { fields: { name: 1 } })?.name
+		subscription = ChatSubscription.findOne({ rid: roomData._id }, { fields: { name: 1, roomName: 1 } })
+		if subscription.roomName
+			return subscription.roomName
+
+		return subscription?.name
 	condition: ->
 		return RocketChat.authz.hasAllPermission 'view-d-room'
 

--- a/packages/rocketchat-lib/server/models/Subscriptions.coffee
+++ b/packages/rocketchat-lib/server/models/Subscriptions.coffee
@@ -10,6 +10,7 @@ RocketChat.models.Subscriptions = new class extends RocketChat.models._Base
 		@tryEnsureIndex { 'open': 1 }
 		@tryEnsureIndex { 'alert': 1 }
 		@tryEnsureIndex { 'unread': 1 }
+		@tryEnsureIndex { 'roomName': 1 }
 		@tryEnsureIndex { 'ts': 1 }
 		@tryEnsureIndex { 'ls': 1 }
 		@tryEnsureIndex { 'desktopNotifications': 1 }, { sparse: 1 }

--- a/packages/rocketchat-ui-sidenav/side-nav/chatRoomItem.coffee
+++ b/packages/rocketchat-ui-sidenav/side-nav/chatRoomItem.coffee
@@ -14,6 +14,12 @@ Template.chatRoomItem.helpers
 	name: ->
 		return this.name
 
+	roomName: ->
+		if this.roomName
+			return this.roomName
+
+		return this.name
+
 	roomIcon: ->
 		return RocketChat.roomTypes.getIcon this.t
 

--- a/packages/rocketchat-ui-sidenav/side-nav/chatRoomItem.html
+++ b/packages/rocketchat-ui-sidenav/side-nav/chatRoomItem.html
@@ -5,7 +5,7 @@
 				<span class="unread">{{unread}}</span>
 			{{/if}}
 			<i class="{{roomIcon}} {{userStatus}}" aria-label=""></i>
-			<span class='name'>{{name}}</span>
+			<span class='name'>{{roomName}}</span>
 			{{#if $not unread}}
 				<span class='opt'>
 					<i class="icon-eye-off hide-room" title="{{_ "Hide_room"}}" aria-label="{{_ "Hide_room"}}"></i>

--- a/server/methods/createDirectMessage.coffee
+++ b/server/methods/createDirectMessage.coffee
@@ -23,12 +23,12 @@ Meteor.methods
 
 		now = new Date()
 
-		if to.name
+		if to.name and to.name != to.username
 			toRoomName = to.username + ' (' + to.name + ')'
 		else
 			toRoomName = to.username
 
-		if me.name
+		if me.name and me.name != me.username
 			meRoomName = me.username + ' (' + me.name + ')'
 		else
 			meRoomName = me.username

--- a/server/methods/createDirectMessage.coffee
+++ b/server/methods/createDirectMessage.coffee
@@ -23,6 +23,16 @@ Meteor.methods
 
 		now = new Date()
 
+		if to.name
+			toRoomName = to.username + ' (' + to.name + ')'
+		else
+			toRoomName = to.username
+
+		if me.name
+			meRoomName = me.username + ' (' + me.name + ')'
+		else
+			meRoomName = me.username
+
 		# Make sure we have a room
 		RocketChat.models.Rooms.upsert
 			_id: rid
@@ -45,6 +55,7 @@ Meteor.methods
 				open: true
 			$setOnInsert:
 				name: to.username
+				roomName: toRoomName
 				t: 'd'
 				alert: false
 				unread: 0
@@ -59,6 +70,7 @@ Meteor.methods
 		,
 			$setOnInsert:
 				name: me.username
+				roomName: meRoomName
 				t: 'd'
 				open: false
 				alert: false

--- a/server/publications/subscription.coffee
+++ b/server/publications/subscription.coffee
@@ -3,6 +3,7 @@ fields =
 	ts: 1
 	ls: 1
 	name: 1
+	roomName: 1
 	rid: 1
 	code: 1
 	f: 1


### PR DESCRIPTION
@RocketChat/core 

I've changed the naming from direct chat rooms. If the chat partner has a real name and a username, the room subscription will be called "{username} ({name})". If the user has no name, the room subscription will be called like before "{username}". 

The reason for the change is the same like in #3323, our staff members doesn't know the username of each employee. The real names are much more helpful to find the room again.

I've added to the Subscription model a new optional field called "roomName" because I don't want to set a different "name" cause the name field is used to fetch the user information if a room will be opened.

Old rooms before the update will be called like before, no database migration script added.

Sorry, I am currently not very familiar with the Rocket.Chat code and the Meteor framework. If you see anything what I need to change, please let me know. 

Regards,
Alexander
