### PR TITLE
Message box changes direction explicitly upon input change

### DIFF
--- a/packages/rocketchat-ui-message/message/messageBox.coffee
+++ b/packages/rocketchat-ui-message/message/messageBox.coffee
@@ -124,6 +124,13 @@ Template.messageBox.events
 	'keydown .input-message': (event) ->
 		chatMessages[@_id].keydown(@_id, event, Template.instance())
 
+	'input .input-message': (event) ->
+		chatMessages[@_id].valueChanged(@_id, event, Template.instance())
+
+	'propertychange .input-message': (event) ->
+		if event.originalEvent.propertyName is 'value'
+			chatMessages[@_id].valueChanged(@_id, event, Template.instance())
+
 	"click .editing-commands-cancel > button": (e) ->
 		chatMessages[@_id].clearEditing()
 

--- a/packages/rocketchat-ui/lib/chatMessages.coffee
+++ b/packages/rocketchat-ui/lib/chatMessages.coffee
@@ -378,6 +378,20 @@ class @ChatMessages
 		else if k is 75 and ((navigator?.platform?.indexOf('Mac') isnt -1 and event.metaKey and event.shiftKey) or (navigator?.platform?.indexOf('Mac') is -1 and event.ctrlKey and event.shiftKey))
 			RoomHistoryManager.clear rid
 
+	valueChanged: (rid, event) ->
+		this.determineInputDirection()
+
+	determineInputDirection: () ->
+		this.input.dir = if this.isMessageRtl(this.input.value) then 'rtl' else 'ltr'
+
+	# http://stackoverflow.com/a/14824756
+	isMessageRtl: (message) ->
+		ltrChars    = 'A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02B8\u0300-\u0590\u0800-\u1FFF'+'\u2C00-\uFB1C\uFDFE-\uFE6F\uFEFD-\uFFFF'
+		rtlChars    = '\u0591-\u07FF\uFB1D-\uFDFD\uFE70-\uFEFC'
+		rtlDirCheck = new RegExp "^[^#{ltrChars}]*[#{rtlChars}]"
+
+		return rtlDirCheck.test message
+
 	isMessageTooLong: (message) ->
 		message?.length > this.messageMaxSize
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Message box does not handle well text consisting of both left-to-right and right-to-left parts. (Arch linux, Chrome version 51.0.2704.84 (Official Build) (64-bit))
Here is the behavior I experience when clicking only the left arrow:
![before](https://cloud.githubusercontent.com/assets/4238626/16716211/f730e7ae-46fe-11e6-9b66-72f15823c941.gif)
Notice the skip over the space in the middle and the jump to the start right before the end.
After:
![after](https://cloud.githubusercontent.com/assets/4238626/16716220/0cc6de0c-46ff-11e6-972b-be1610600cc1.gif)

It seems to be a bug with how chrome handles `dir="auto"` in textareas (Firefox seems better, but not perfect. Other browsers might have problems too, I did not test).
This fix explicitly sets `dir="ltr"` or `dir="rtl"` depending on the input.
The problem I see with this fix is that now the entire message has the same direction. Ideally each line could have its own direction, but I couldn't a better solution.