### PR TITLE
Add Sandstorm activity/notification events

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -78,6 +78,7 @@ rocketchat:otr
 rocketchat:piwik
 rocketchat:push-notifications
 rocketchat:reactions
+rocketchat:sandstorm
 rocketchat:slackbridge
 rocketchat:slashcommands-archive
 rocketchat:slashcommands-asciiarts

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -61,7 +61,7 @@ jparker:gravatar@0.4.1
 jquery@1.11.4
 kadira:blaze-layout@2.3.0
 kadira:flow-router@2.10.1
-kenton:accounts-sandstorm@0.4.1
+kenton:accounts-sandstorm@0.5.1
 konecty:change-case@2.3.0
 konecty:delayed-task@1.0.0
 konecty:mongo-counter@0.0.3
@@ -173,6 +173,7 @@ rocketchat:otr@0.0.1
 rocketchat:piwik@0.0.1
 rocketchat:push-notifications@0.0.1
 rocketchat:reactions@0.0.1
+rocketchat:sandstorm@0.0.1
 rocketchat:slackbridge@0.0.1
 rocketchat:slashcommands-archive@0.0.1
 rocketchat:slashcommands-asciiarts@0.0.1

--- a/.sandstorm/sandstorm-pkgdef.capnp
+++ b/.sandstorm/sandstorm-pkgdef.capnp
@@ -82,11 +82,22 @@ const pkgdef :Spk.PackageDefinition = (
 		]
 	),
 
-	alwaysInclude = [ "." ]
+	alwaysInclude = [ "." ],
 	# This says that we always want to include all files from the source map.
 	# (An alternative is to automatically detect dependencies by watching what
 	# the app opens while running in dev mode. To see what that looks like,
 	# run `spk init` without the -A option.)
+
+  bridgeConfig = (
+    viewInfo = (
+      eventTypes = [
+				(name = "message", verbPhrase = (defaultText = "message received")),
+				(name = "privateMessage", verbPhrase = (defaultText = "private message received"), requiredPermission = (explicitList = void)),
+			]
+    ),
+
+    saveIdentityCaps = true,
+  ),
 );
 
 const myCommand :Spk.Manifest.Command = (

--- a/.sandstorm/setup.sh
+++ b/.sandstorm/setup.sh
@@ -4,7 +4,7 @@ set -euvo pipefail
 
 cd /opt/
 
-PACKAGE=meteor-spk-0.2.0
+PACKAGE=meteor-spk-0.2.1
 PACKAGE_FILENAME="$PACKAGE.tar.xz"
 CACHE_TARGET="/host-dot-sandstorm/caches/${PACKAGE_FILENAME}"
 

--- a/.sandstorm/setup.sh
+++ b/.sandstorm/setup.sh
@@ -4,7 +4,7 @@ set -euvo pipefail
 
 cd /opt/
 
-PACKAGE=meteor-spk-0.1.8
+PACKAGE=meteor-spk-0.2.0
 PACKAGE_FILENAME="$PACKAGE.tar.xz"
 CACHE_TARGET="/host-dot-sandstorm/caches/${PACKAGE_FILENAME}"
 

--- a/packages/rocketchat-lib/server/functions/sendMessage.coffee
+++ b/packages/rocketchat-lib/server/functions/sendMessage.coffee
@@ -18,6 +18,12 @@ RocketChat.sendMessage = (user, message, room, upsert = false) ->
 
 	message = RocketChat.callbacks.run 'beforeSaveMessage', message
 
+	sandstormSessionId = null
+	if message.sandstormSessionId
+		# Persisting sessionId to the database is a bad idea.
+		sandstormSessionId = message.sandstormSessionId
+		delete message.sandstormSessionId
+
 	if message._id? and upsert
 		_id = message._id
 		delete message._id
@@ -31,6 +37,7 @@ RocketChat.sendMessage = (user, message, room, upsert = false) ->
 	###
 	Meteor.defer ->
 		# Execute all callbacks
+		message.sandstormSessionId = sandstormSessionId
 		RocketChat.callbacks.run 'afterSaveMessage', message, room
 
 	return message

--- a/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
@@ -159,6 +159,8 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 				});
 				return message;
 			}
+			RocketChat.Sandstorm.notify(message, [userOfMention._id],
+				'@' + user.username + ': ' + message.msg, 'privateMessage');
 		}
 	} else {
 		mentionIds = [];
@@ -314,6 +316,15 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 					}
 				});
 			}
+		}
+
+		const allUserIdsToNotify = _.unique(userIdsToNotify.concat(userIdsToPushNotify));
+		if (room.t === 'p') {
+			RocketChat.Sandstorm.notify(message, allUserIdsToNotify,
+				'@' + user.username + ': ' + message.msg, 'privateMessage');
+		} else {
+			RocketChat.Sandstorm.notify(message, allUserIdsToNotify,
+				'@' + user.username + ': ' + message.msg, 'message');
 		}
 	}
 

--- a/packages/rocketchat-lib/server/methods/sendMessage.coffee
+++ b/packages/rocketchat-lib/server/methods/sendMessage.coffee
@@ -23,6 +23,8 @@ Meteor.methods
 			return false
 
 		message.alias = user.name if not message.alias? and RocketChat.settings.get 'Message_SetNameToAliasEnabled'
+		if Meteor.settings.public.sandstorm
+			message.sandstormSessionId = this.connection.sandstormSessionId()
 
 		RocketChat.sendMessage user, message, room
 

--- a/packages/rocketchat-sandstorm/package.js
+++ b/packages/rocketchat-sandstorm/package.js
@@ -1,0 +1,14 @@
+Package.describe({
+	name: 'rocketchat:sandstorm',
+	version: '0.0.1',
+	summary: 'Sandstorm integeration for Rocket.Chat',
+	git: ''
+});
+
+Package.onUse(function(api) {
+	api.versionsFrom('1.0');
+
+	api.use([ 'ecmascript', 'rocketchat:lib' ]);
+
+	api.addFiles([ 'server/events.js' ], 'server');
+});

--- a/packages/rocketchat-sandstorm/server/events.js
+++ b/packages/rocketchat-sandstorm/server/events.js
@@ -1,0 +1,64 @@
+RocketChat.Sandstorm = {};
+
+RocketChat.Sandstorm.notify = function() {};
+
+if (process.env.SANDSTORM === '1') {
+	var Future = Npm.require('fibers/future');
+	var Capnp = Npm.require('capnp');
+	var SandstormHttpBridge = Npm.require('sandstorm/sandstorm-http-bridge.capnp').SandstormHttpBridge;
+
+	var capnpConnection = null;
+	var httpBridge = null;
+
+	var getHttpBridge = function() {
+		if (!httpBridge) {
+			capnpConnection = Capnp.connect('unix:/tmp/sandstorm-api');
+			httpBridge = capnpConnection.restore(null, SandstormHttpBridge);
+		}
+		return httpBridge;
+	};
+
+	var ACTIVITY_TYPES = {
+		'message': 0,
+		'privateMessage': 1
+	};
+
+	var promiseToFuture = function(promise) {
+		const result = new Future();
+		promise.then(result.return.bind(result), result.throw.bind(result));
+		return result;
+	};
+
+	var waitPromise = function(promise) {
+		return promiseToFuture(promise).wait();
+	};
+
+	RocketChat.Sandstorm.notify = function(message, userIds, caption, type) {
+		var sessionId = message.sandstormSessionId;
+		if (!sessionId) {
+			return;
+		}
+		var httpBridge = getHttpBridge();
+		var activity = {};
+
+		if (type) {
+			activity.type = ACTIVITY_TYPES[type];
+		}
+
+		if (caption) {
+			activity.notification = {caption: {defaultText: caption}};
+		}
+
+		if (userIds) {
+			activity.users = _.map(userIds, function(userId) {
+				var user = Meteor.users.findOne({_id: userId}, {fields: {'services.sandstorm.id': 1}});
+				return {
+					identity: httpBridge.getSavedIdentity(user.services.sandstorm.id).identity,
+					mentioned: true
+				};
+			});
+		}
+
+		return waitPromise(httpBridge.getSessionContext(sessionId).context.activity(activity));
+	};
+}

--- a/packages/rocketchat-ui/lib/notification.coffee
+++ b/packages/rocketchat-ui/lib/notification.coffee
@@ -4,7 +4,7 @@
 
 	# notificacoes HTML5
 	getDesktopPermission: ->
-		if window.Notification && Notification.permission != "granted"
+		if window.Notification && Notification.permission != "granted" && !Meteor.settings.public.sandstorm
 			Notification.requestPermission (status) ->
 				KonchatNotification.notificationStatus.set status
 				if Notification.permission != status
@@ -35,13 +35,10 @@
 								FlowRouter.go 'group', {name: notification.payload.name}
 
 	showDesktop: (notification) ->
-		if not window.document.hasFocus?() and Meteor.user().status isnt 'busy'
-			if Meteor.settings.public.sandstorm
+		if not window.document.hasFocus?() and Meteor.user().status isnt 'busy' and !Meteor.settings.public.sandstorm
+			getAvatarAsPng notification.payload.sender.username, (avatarAsPng) ->
+				notification.icon = avatarAsPng
 				KonchatNotification.notify(notification)
-			else
-				getAvatarAsPng notification.payload.sender.username, (avatarAsPng) ->
-					notification.icon = avatarAsPng
-					KonchatNotification.notify(notification)
 
 	newMessage: ->
 		if not Session.equals('user_' + Meteor.userId() + '_status', 'busy') and Meteor.user()?.settings?.preferences?.newMessageNotification isnt false


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Sandstorm recently grew new mechanisms for notifications (see https://github.com/sandstorm-io/sandstorm/pull/2174). This PR disables normal desktop notifications under Sandstorm and replaces them with the new Sandstorm notification system. I tried to be as non-invasive as possible, with the bulk of the custom code going in a new package named `rocketchat-sandstorm`.

I did end up editing rocketchat-lib/sendMessage to include the sandstorm session id. The only other invasive change was in rocketchat-lib/sendNotificationsOnMessage, where I thought it made the most sense to re-use the current notification logic. The new method `RocketChat.Sandstorm.notify` is a no-op under non-Sandstorm environments.
