### PR TITLE
Fix i18n in subfolder environment

### DIFF
--- a/client/startup/startup.coffee
+++ b/client/startup/startup.coffee
@@ -10,6 +10,8 @@ Meteor.startup ->
 	window.lastMessageWindow = {}
 	window.lastMessageWindowHistory = {}
 
+	TAPi18n.conf.i18n_files_route = Meteor._relativeToSiteRootUrl('/tap-i18n')
+
 	@defaultAppLanguage = ->
 		lng = window.navigator.userLanguage || window.navigator.language || 'en'
 		# Fix browsers having all-lowercase language settings eg. pt-br, en-us


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
If Rocket.Chat is running in subfolder environment(ex: `ROOT_URL` is set to `https://domain/chat`), i18n is not working.

In spite of `ROOT_URL` is set to `https://domain/chat`, TAPi18n fetches `/tap-i18n/*.json`.
It should fetch `/chat/tap-i18n/*.json`.
Then, 404 error has occurred.
(this screenshot is produced with `ROOT_URL=http://localhost:3000/test meteor`)

![tap-i18n-not-found](https://cloud.githubusercontent.com/assets/147102/16826946/bf367876-49bc-11e6-8974-a9bf3d4c6ebf.png)

If `TAPi18n.conf.cdn_path` or `TAPi18n.conf.i18n_files_route` is not set, TAPi18n fetches `/tap-i18n` (maps to packages/rocketchat-lib/i18n directory).

Please review. Is this correct implementation?