### PR TITLE
Allow owner to delete the room

### DIFF
--- a/packages/rocketchat-channel-settings/client/views/channelSettings.coffee
+++ b/packages/rocketchat-channel-settings/client/views/channelSettings.coffee
@@ -33,8 +33,37 @@ Template.channelSettings.helpers
 			return t('Room_archivation_state_true')
 		else
 			return t('Room_archivation_state_false')
+	canDeleteRoom: ->
+		roomType = ChatRoom.findOne(@rid, { fields: { t: 1 }})?.t
+		return roomType? and RocketChat.authz.hasAtLeastOnePermission("delete-#{roomType}", @rid)
 
 Template.channelSettings.events
+	'click .delete': ->
+		swal {
+			title: t('Are_you_sure')
+			text: t('Delete_Room_Warning')
+			type: 'warning'
+			showCancelButton: true
+			confirmButtonColor: '#DD6B55'
+			confirmButtonText: t('Yes_delete_it')
+			cancelButtonText: t('Cancel')
+			closeOnConfirm: false
+			html: false
+		}, =>
+			swal.disableButtons()
+
+			Meteor.call 'eraseRoom', @rid, (error, result) ->
+				if error
+					handleError(error)
+					swal.enableButtons()
+				else
+					swal
+						title: t('Deleted')
+						text: t('Room_has_been_deleted')
+						type: 'success'
+						timer: 2000
+						showConfirmButton: false
+
 	'keydown input[type=text]': (e, t) ->
 		if e.keyCode is 13
 			e.preventDefault()

--- a/packages/rocketchat-channel-settings/client/views/channelSettings.html
+++ b/packages/rocketchat-channel-settings/client/views/channelSettings.html
@@ -75,6 +75,11 @@
 					{{/each}}
 				</ul>
 			</form>
+			{{#if canDeleteRoom}}
+			<nav>
+				<button class='button delete red'><span><i class='icon-trash'></i> {{_ "Delete"}}</span></button>
+			</nav>
+			{{/if}}
 		</div>
 	</div>
 </template>


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #1578 
(already closed...)

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
I copied implementations from admin's' room info tab to general room's right tab can access non admin users.

This implementation allows deleting room to user who have `delete-*` permission.

![can-delete](https://cloud.githubusercontent.com/assets/147102/16828985/ea88f45a-49cf-11e6-99c1-ffe66073ef1f.png)
![cant-delete](https://cloud.githubusercontent.com/assets/147102/16828986/eae63afc-49cf-11e6-9d5c-e5f06678ec35.png)

If you want to enable this user, you need to add these permissions to owner or user.

I think there are no owners in direct channel. We have to add `delete-d` to **user**.

![permissions](https://cloud.githubusercontent.com/assets/147102/16828999/021c5544-49d0-11e6-8c23-8e42b37deac9.png)
