### PR TITLE
Videomsg fixes

### DIFF
--- a/packages/rocketchat-ui-message/message/messageBox.coffee
+++ b/packages/rocketchat-ui-message/message/messageBox.coffee
@@ -173,7 +173,7 @@ Template.messageBox.onCreated ->
 
 	@autorun =>
 		videoRegex = /video\/webm/i
-		videoEnabled = !RocketChat.settings.get("FileUpload_MediaTypeWhiteList") || RocketChat.settings.get("FileUpload_MediaTypeWhiteList").match(wavRegex)
+		videoEnabled = !RocketChat.settings.get("FileUpload_MediaTypeWhiteList") || RocketChat.settings.get("FileUpload_MediaTypeWhiteList").match(videoRegex)
 		if RocketChat.settings.get('Message_VideoRecorderEnabled') and (navigator.getUserMedia? or navigator.webkitGetUserMedia?) and videoEnabled and RocketChat.settings.get('FileUpload_Enabled')
 			@showVideoRec.set true
 		else

--- a/packages/rocketchat-ui-message/message/messageBox.coffee
+++ b/packages/rocketchat-ui-message/message/messageBox.coffee
@@ -71,7 +71,7 @@ Template.messageBox.helpers
 
 	showVRec: ->
 		if not Template.instance().isMessageFieldEmpty.get()
-			return
+			return 'hide-vrec'
 
 		if Template.instance().showVideoRec.get()
 			return ''

--- a/packages/rocketchat-ui/lib/recorderjs/videoRecorder.coffee
+++ b/packages/rocketchat-ui/lib/recorderjs/videoRecorder.coffee
@@ -47,7 +47,9 @@
 			@stopRecording()
 
 			if @stream?
-				@stream.getVideoTracks()[0].stop()
+				vtracks = @stream.getVideoTracks()[0]
+				if vtracks
+					vtracks.stop()
 
 			if @videoel?
 				@videoel.pause


### PR DESCRIPTION
@RocketChat/core 

I found some little problems with the new feature added with pullreq #3550:
- if the video button is disabled, it is shown anyway when typing a text message
- if no camera is found the cancel button in the video preview dialog raises an exception and the window is not closed
- a small typo to disable the video button if the relevant mime type is not found in the upload file preference

this small patch should fix them
