### PR TITLE
Include alias and bot values in outgoing webhook.

### DIFF
--- a/packages/rocketchat-integrations/server/triggers.coffee
+++ b/packages/rocketchat-integrations/server/triggers.coffee
@@ -144,6 +144,14 @@ ExecuteTriggerUrl = (url, trigger, message, room, tries=0) ->
 		user_name: message.u.username
 		text: message.msg
 
+	if message.alias?
+		data.alias = message.alias
+
+	if message.bot?
+		data.bot = message.bot
+	else
+		data.bot = false
+
 	if word?
 		data.trigger_word = word
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

This pull request includes the fields 'alias' and 'bot' for outgoing webhooks. We needed this in our environment to make sure we did not echo messages from Rocket.Chat to Slack and back again (incoming messages from Slack are alias-tagged; refer to #3804).
