### PR TITLE
Let bot messages propagate through SlackBridge again.

### DIFF
--- a/packages/rocketchat-slackbridge/slackbridge.js
+++ b/packages/rocketchat-slackbridge/slackbridge.js
@@ -243,7 +243,7 @@ class SlackBridge {
 				if (message.icons) {
 					msgObj.emoji = message.icons.emoji;
 				}
-				break;
+				return msgObj;
 			case 'me_message':
 				return {
 					msg: `_${this.convertSlackMessageToRocketChat(message.text)}_`


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

I noticed that bot messages were not propagated through SlackBridge. This is due to the fact that the processSubtypedMessage function did not return the crafted mgsObj when the subtype was a bot_message. As a result, saveMessage ignored messages that originated from bots.