### PR TITLE
Add an option to SlackBridge to exclude some bots messages from propagating

### DIFF
--- a/packages/rocketchat-lib/i18n/en.i18n.json
+++ b/packages/rocketchat-lib/i18n/en.i18n.json
@@ -336,6 +336,8 @@
   "Enter_name_here" : "Enter name here",
   "Enter_to" : "Enter to",
   "Error" : "Error",
+  "Exclude_Botnames": "Exclude bots",
+  "Exclude_Botnames_Description": "Do not propagate messages from bots whose name matches the regular expression above. If left empty, all messages from bots will be propagated.",
   "error-action-not-allowed" : "__action__ is not allowed",
   "error-application-not-found" : "Application not found",
   "error-archived-duplicate-name" : "There's an archived channel with name '__room_name__'",

--- a/packages/rocketchat-slackbridge/settings.js
+++ b/packages/rocketchat-slackbridge/settings.js
@@ -13,5 +13,11 @@ Meteor.startup(function() {
 			},
 			i18nLabel: 'API_Token'
 		});
+
+		this.add('SlackBridge_ExcludeBotnames', '', {
+			type: 'string',
+			i18nLabel: 'Exclude_Botnames',
+			i18nDescription: 'Exclude_Botnames_Description'
+		});
 	});
 });

--- a/packages/rocketchat-slackbridge/slackbridge.js
+++ b/packages/rocketchat-slackbridge/slackbridge.js
@@ -4,6 +4,7 @@ class SlackBridge {
 	constructor() {
 		this.slackClient = Npm.require('slack-client');
 		this.apiToken = RocketChat.settings.get('SlackBridge_APIToken');
+		this.excludeBotnames = RocketChat.settings.get('SlackBridge_Botnames');
 		this.rtm = {};
 		this.connected = false;
 		this.userTags = {};
@@ -24,6 +25,10 @@ class SlackBridge {
 			} else {
 				this.disconnect();
 			}
+		});
+
+		RocketChat.settings.onload('SlackBridge_ExcludeBotnames', (key, value) => {
+			this.excludeBotnames = value;
 		});
 	}
 
@@ -233,6 +238,10 @@ class SlackBridge {
 		let msgObj = null;
 		switch (message.subtype) {
 			case 'bot_message':
+				if (message.username !== undefined && this.excludeBotnames && message.username.match(this.excludeBotnames)) {
+					return;
+				}
+
 				msgObj = {
 					msg: this.convertSlackMessageToRocketChat(message.text),
 					rid: room._id,


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
In our setup, we use an outgoing webhook to copy messages from Rocket.Chat to Slack. Unfortunately, in combination with SlackBridge, messages copied to Slack this way are copied back again to Rocket.Chat. This change adds a configuration option to prevent some bots' messages from propagating to Rocket.Chat; we use this option to pick out messages from Slack that originated from Rocket.Chat and ignore them.