### PR TITLE
Fix slackbridge calling setUserActiveStatus as normal user

### DIFF
--- a/packages/rocketchat-slackbridge/slackbridge.js
+++ b/packages/rocketchat-slackbridge/slackbridge.js
@@ -183,12 +183,13 @@ class SlackBridge {
 					}
 					if (userData.profile.real_name) {
 						RocketChat.models.Users.setName(userData.rocketId, userData.profile.real_name);
-						// Deleted users are 'inactive' users in Rocket.Chat
-						if (userData.deleted) {
-							Meteor.call('setUserActiveStatus', userData.rocketId, false);
-						}
 					}
 				});
+				// Deleted users are 'inactive' users in Rocket.Chat
+				if (userData.deleted) {
+					RocketChat.models.Users.setUserActive(userData.rocketId, false);
+					RocketChat.models.Users.unsetLoginTokens(userData.rocketId);
+				}
 			}
 			RocketChat.models.Users.update({ _id: userData.rocketId }, { $addToSet: { importIds: userData.id } });
 			if (!this.userTags[userId]) {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

The method `setUserActiveStatus` requires admin permission (`edit-other-user-active-status`) but slackbridge was calling it as a normal user.

So I'm doing the same stuff `setUserActiveStatus` does without calling it.

I'm also changing the logic to inactive the user even if he hasn't a real name.

