### PR TITLE
Hide user admin controls except for in admin panel

### DIFF
--- a/packages/rocketchat-ui-flextab/flex-tab/tabs/membersList.coffee
+++ b/packages/rocketchat-ui-flextab/flex-tab/tabs/membersList.coffee
@@ -92,6 +92,7 @@ Template.membersList.helpers
 			username: Template.instance().userDetail.get()
 			clear: Template.instance().clearUserDetail
 			showAll: room?.t in ['c', 'p']
+			hideAdminControls: room?.t in ['c', 'p', 'd']
 			video: room?.t in ['d']
 		}
 

--- a/packages/rocketchat-ui-flextab/flex-tab/tabs/userInfo.html
+++ b/packages/rocketchat-ui-flextab/flex-tab/tabs/userInfo.html
@@ -73,26 +73,28 @@
 					{{/if}}
 				{{/if}}
 
-				{{#if hasPermission 'edit-other-user-info'}}
-				<button class='button lightblue edit-user button-block'><span><i class='icon-edit'></i> {{_ "Edit"}}</span></button>
-				{{/if}}
-				{{#if hasPermission 'assign-admin-role'}}
-					{{#if hasAdminRole}}
-					<button class='button lightblue remove-admin button-block'><span><i class='icon-shield'></i> {{_ "Remove_Admin"}}</span></button>
-					{{else}}
-					<button class='button lightblue make-admin button-block'><span><i class='icon-shield'></i> {{_ "Make_Admin"}}</span></button>
+				{{#unless hideAdminControls}}
+					{{#if hasPermission 'edit-other-user-info'}}
+					<button class='button lightblue edit-user button-block'><span><i class='icon-edit'></i> {{_ "Edit"}}</span></button>
 					{{/if}}
-				{{/if}}
-				{{#if hasPermission 'edit-other-user-active-status'}}
-					{{#if active}}
-					<button class='button deactivate button-block'><span><i class='icon-block'></i> {{_ "Deactivate"}}</span></button>
-					{{else}}
-					<button class='button activate button-block'><span><i class='icon-ok-circled'></i> {{_ "Activate"}}</span></button>
+					{{#if hasPermission 'assign-admin-role'}}
+						{{#if hasAdminRole}}
+						<button class='button lightblue remove-admin button-block'><span><i class='icon-shield'></i> {{_ "Remove_Admin"}}</span></button>
+						{{else}}
+						<button class='button lightblue make-admin button-block'><span><i class='icon-shield'></i> {{_ "Make_Admin"}}</span></button>
+						{{/if}}
 					{{/if}}
-				{{/if}}
-				{{#if hasPermission 'delete-user'}}
-				<button class='button delete red button-block'><span><i class='icon-trash'></i> {{_ "Delete"}}</span></button>
-				{{/if}}
+					{{#if hasPermission 'edit-other-user-active-status'}}
+						{{#if active}}
+						<button class='button deactivate button-block'><span><i class='icon-block'></i> {{_ "Deactivate"}}</span></button>
+						{{else}}
+						<button class='button activate button-block'><span><i class='icon-ok-circled'></i> {{_ "Activate"}}</span></button>
+						{{/if}}
+					{{/if}}
+					{{#if hasPermission 'delete-user'}}
+					<button class='button delete red button-block'><span><i class='icon-trash'></i> {{_ "Delete"}}</span></button>
+					{{/if}}
+				{{/unless}}
 
 				{{#if showAll}}
 					<button class='button secondary back'><span>{{_ "View_All"}} <i class='icon-angle-right'></i></span></button>


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #3847 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Remove the admin controls from the user display in channels, private groups and private messages. Make it so that it is only possible to edit, remove, make admin, and deactivate a user from the administration panel.

Before:
![image](https://cloud.githubusercontent.com/assets/5689874/17077645/d9c5b7b0-50ce-11e6-9920-bf66dd2f183e.png)

After:
![image](https://cloud.githubusercontent.com/assets/5689874/17077650/1c2762e8-50cf-11e6-8cbc-de61266658e1.png)
