### PR TITLE
fix invalid role error msg when removing user from room

### DIFF
--- a/packages/rocketchat-authorization/server/functions/removeUserFromRoles.coffee
+++ b/packages/rocketchat-authorization/server/functions/removeUserFromRoles.coffee
@@ -8,7 +8,7 @@ RocketChat.authz.removeUserFromRoles = (userId, roleNames, scope) ->
 
 	roleNames = [].concat roleNames
 
-	existingRoleNames = _.pluck(RocketChat.authz.getRoles(), 'name')
+	existingRoleNames = _.pluck(RocketChat.authz.getRoles(), '_id')
 	invalidRoleNames = _.difference(roleNames, existingRoleNames)
 	unless _.isEmpty(invalidRoleNames)
 		throw new Meteor.Error 'error-invalid-role', 'Invalid role', { function: 'RocketChat.authz.removeUserFromRoles' }


### PR DESCRIPTION
@RocketChat/core 

Closes #3603 

it seems that the "invalid role" error message was introduced with this commit here:
https://github.com/RocketChat/Rocket.Chat/commit/eaf025ec372ea52121d702aeba4432d5901cc7c2#diff-f3c90a3a07547aae97a0932a692ed32cR11

and then fixed here:
https://github.com/RocketChat/Rocket.Chat/commit/d156abdc295094b8377ce616485a198dabde8291#diff-53bebdff2367150c99d8735019545906R11

but it seems that it was only fixed for the method ```addUserRoles``` and not also in ```removeUserFromRoles```

The attached pullreq should fix the problem.
