### PR TITLE
Set max width on author icon

### DIFF
--- a/packages/rocketchat-message-attachments/client/stylesheets/messageAttachments.less
+++ b/packages/rocketchat-message-attachments/client/stylesheets/messageAttachments.less
@@ -76,7 +76,7 @@
 
 		.attachment-field {
 			&.attachment-field-short {
-				width: 48%;
+				margin-left: 12px;
 				display: inline-block;
 			}
 

--- a/packages/rocketchat-message-attachments/client/stylesheets/messageAttachments.less
+++ b/packages/rocketchat-message-attachments/client/stylesheets/messageAttachments.less
@@ -76,7 +76,7 @@
 
 		.attachment-field {
 			&.attachment-field-short {
-				margin-left: 12px;
+				margin-right: 12px;
 				display: inline-block;
 			}
 

--- a/packages/rocketchat-message-attachments/client/stylesheets/messageAttachments.less
+++ b/packages/rocketchat-message-attachments/client/stylesheets/messageAttachments.less
@@ -35,6 +35,7 @@
 
 		img {
 			max-height: 16px;
+			max-width: 16px;
 			margin-right: 2px;
 			margin-bottom: -2px;
 		}


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->


<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

On JIRA the default icons are svgs. When using custom messages with attachments the `author-image` appears in the middle of the chat window with a size of 16x16 because of the `max-height` restriction. By setting `max-width` as well it appears on the left, where it should.

Also changed attachment fields width so they are just the size of the item put in the field, with a margin to add some space between. It also allows the items to wrap onto a new line if they don't fit on the screen.

Before: (small `author_icon` in middle of the screen & second field `User` in middle)
![image](https://cloud.githubusercontent.com/assets/5689874/17307888/35bbfe46-582f-11e6-8702-a8f348f6b02a.png)


After: (icon on left & `User` field closer (allows for more fields to be put next to each other)
![image](https://cloud.githubusercontent.com/assets/5689874/17307876/24179d4e-582f-11e6-9e2d-088c2dbade8e.png)

You can then choose to have a field go on a new line by specifying `short: false` as you could before.
