### PR TITLE
Fix attachments under Sandstorm

### DIFF
--- a/packages/rocketchat-message-attachments/client/messageAttachment.coffee
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.coffee
@@ -8,7 +8,7 @@ Template.messageAttachment.helpers
 			else
 				url = url + '&' + query
 
-		if url.match /^(https?:)?\/\//i
+		if Meteor.settings.public.sandstorm or url.match /^(https?:)?\/\//i
 			return url
 		else
 			return Meteor.absoluteUrl().replace(/\/$/, '') + __meteor_runtime_config__.ROOT_URL_PATH_PREFIX + url


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Attachments were broken under Sandstorm. This commit fixes it, and makes it more clear in the future that attachments need to be handled slightly differently under Sandstorm.
