### PR TITLE
Remove dot from message _id on imported messages

### DIFF
--- a/packages/rocketchat-importer-slack/server.coffee
+++ b/packages/rocketchat-importer-slack/server.coffee
@@ -211,7 +211,7 @@ Importer.Slack = class Importer.Slack extends Importer.Base
 								@updateRecord { 'messagesstatus': "#{channel}/#{date}.#{msgs.messages.length}" }
 								for message in msgs.messages
 									msgDataDefaults =
-										_id: "#{slackChannel.id}.S#{message.ts}"
+										_id: "slack-#{slackChannel.id}-#{message.ts}"
 										ts: new Date(parseInt(message.ts.split('.')[0]) * 1000)
 
 									if message.type is 'message'

--- a/packages/rocketchat-slackbridge/slackbridge.js
+++ b/packages/rocketchat-slackbridge/slackbridge.js
@@ -543,7 +543,7 @@ class SlackBridge {
 				}
 				if (channel && user) {
 					let msgDataDefaults = {
-						_id: `${message.channel}S${message.ts}`,
+						_id: `slack-${message.channel}-${message.ts}`,
 						ts: new Date(parseInt(message.ts.split('.')[0]) * 1000)
 					};
 					this.saveMessage(channel, user, message, msgDataDefaults);

--- a/server/startup/migrations/v056.js
+++ b/server/startup/migrations/v056.js
@@ -1,0 +1,11 @@
+RocketChat.Migrations.add({
+	version: 56,
+	up: function() {
+		RocketChat.models.Messages.find({ _id: /\./ }).forEach(function(message) {
+			var oldId = message._id;
+			message._id = message._id.replace(/(.*)\.S?(.*)/, 'slack-$1-$2');
+			RocketChat.models.Messages.insert(message);
+			RocketChat.models.Messages.remove({ _id: oldId });
+		});
+	}
+});


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Slack importer adds a `.` (dot) on the message _id which is causing problems because an HTML element cannot have a dot on the `id` property.

