### PR TITLE
Add sandstorm powerbox sharing

### DIFF
--- a/packages/rocketchat-lib/i18n/en.i18n.json
+++ b/packages/rocketchat-lib/i18n/en.i18n.json
@@ -962,6 +962,7 @@
   "SAML_Custom_Generate_Username" : "Generate Username",
   "SAML_Custom_Issuer" : "Custom Issuer",
   "SAML_Custom_Provider" : "Custom Provider",
+  "Sandstorm_Powerbox_Share" : "Share a Sandstorm grain",
   "Save" : "Save",
   "Save_changes" : "Save changes",
   "Save_Mobile_Bandwidth" : "Save Mobile Bandwidth",

--- a/packages/rocketchat-oembed/client/baseWidget.coffee
+++ b/packages/rocketchat-oembed/client/baseWidget.coffee
@@ -15,4 +15,7 @@ Template.oembedBaseWidget.helpers
 		if this.meta?.oembedHtml?
 			return 'oembedFrameWidget'
 
+		if this.meta?.sandstorm?.grain?
+			return 'oembedSandstormGrain'
+
 		return 'oembedUrlWidget'

--- a/packages/rocketchat-oembed/client/oembedSandstormGrain.coffee
+++ b/packages/rocketchat-oembed/client/oembedSandstormGrain.coffee
@@ -1,0 +1,14 @@
+Template.oembedSandstormGrain.helpers
+	token: ->
+		return @meta.sandstorm.grain.token
+	appTitle: ->
+		return @meta.sandstorm.grain.appTitle.defaultText
+	grainTitle: ->
+		return @meta.sandstorm.grain.grainTitle
+	appIconUrl: ->
+		return @meta.sandstorm.grain.appIconUrl
+window.sandstormOembed = (e) ->
+	e = e or window.event
+	src = e.target or e.srcElement
+	token = src.getAttribute "data-token"
+	Meteor.call "sandstormOffer", token

--- a/packages/rocketchat-oembed/client/oembedSandstormGrain.html
+++ b/packages/rocketchat-oembed/client/oembedSandstormGrain.html
@@ -1,0 +1,11 @@
+<template name="oembedSandstormGrain">
+	<blockquote class="sandstorm-grain">
+		<label>
+			<h3>{{grainTitle}}</h3>
+			<img src="{{appIconUrl}}" />
+			<button onclick="sandstormOembed(event)" data-token="{{token}}">
+				Click to open the grain
+			</button>
+		</label>
+	</blockquote>
+</template>

--- a/packages/rocketchat-oembed/package.js
+++ b/packages/rocketchat-oembed/package.js
@@ -44,6 +44,9 @@ Package.onUse(function(api) {
 	api.addFiles('client/oembedFrameWidget.html', 'client');
 	api.addFiles('client/oembedFrameWidget.coffee', 'client');
 
+	api.addFiles('client/oembedSandstormGrain.html', 'client');
+	api.addFiles('client/oembedSandstormGrain.coffee', 'client');
+
 	api.addFiles('server/server.coffee', 'server');
 	api.addFiles('server/providers.coffee', 'server');
 	api.addFiles('server/jumpToMessage.js', 'server');

--- a/packages/rocketchat-oembed/server/server.coffee
+++ b/packages/rocketchat-oembed/server/server.coffee
@@ -182,6 +182,13 @@ OEmbed.RocketUrlParser = (message) ->
 		changed = false
 		message.urls.forEach (item) ->
 			if item.ignoreParse is true then return
+			if item.url.startsWith "grain://"
+				changed = true
+				item.meta =
+					sandstorm:
+						grain: item.sandstormViewInfo
+				return
+
 			if not /^https?:\/\//i.test item.url then return
 
 			data = OEmbed.getUrlMetaWithCache item.url

--- a/packages/rocketchat-sandstorm/client/powerboxListener.js
+++ b/packages/rocketchat-sandstorm/client/powerboxListener.js
@@ -1,0 +1,28 @@
+RocketChat.Sandstorm = RocketChat.Sandstorm || {};
+
+RocketChat.Sandstorm.request = function() {};
+if (Meteor.settings.public.sandstorm) {
+  var callbackMap = {};
+
+  var messageListener = function(event) {
+    if (event.data.rpcId) {
+      var cb = callbackMap[event.data.rpcId];
+
+      cb(event.data.error, event.data);
+    }
+  };
+  window.addEventListener('message', messageListener);
+
+  var interfaces = {
+    uiView: "EAZQAQEAABEBF1EEAQH_5-Jn6pjXtNsAAAA",
+  };
+
+  RocketChat.Sandstorm.request = function(interfaceName, cb) {
+    var rpcId = Math.random().toString();
+    callbackMap[rpcId] = cb;
+    window.parent.postMessage({ powerboxRequest: {
+      rpcId: rpcId,
+      query: [interfaces[interfaceName]],
+    }}, "*")
+  };
+}

--- a/packages/rocketchat-sandstorm/client/powerboxListener.js
+++ b/packages/rocketchat-sandstorm/client/powerboxListener.js
@@ -2,27 +2,27 @@ RocketChat.Sandstorm = RocketChat.Sandstorm || {};
 
 RocketChat.Sandstorm.request = function() {};
 if (Meteor.settings.public.sandstorm) {
-  var callbackMap = {};
+	var callbackMap = {};
 
-  var messageListener = function(event) {
-    if (event.data.rpcId) {
-      var cb = callbackMap[event.data.rpcId];
+	var messageListener = function(event) {
+		if (event.data.rpcId) {
+			var cb = callbackMap[event.data.rpcId];
 
-      cb(event.data.error, event.data);
-    }
-  };
-  window.addEventListener('message', messageListener);
+			cb(event.data.error, event.data);
+		}
+	};
+	window.addEventListener('message', messageListener);
 
-  var interfaces = {
-    uiView: "EAZQAQEAABEBF1EEAQH_5-Jn6pjXtNsAAAA",
-  };
+	var interfaces = {
+		uiView: 'EAZQAQEAABEBF1EEAQH_5-Jn6pjXtNsAAAA'
+	};
 
-  RocketChat.Sandstorm.request = function(interfaceName, cb) {
-    var rpcId = Math.random().toString();
-    callbackMap[rpcId] = cb;
-    window.parent.postMessage({ powerboxRequest: {
-      rpcId: rpcId,
-      query: [interfaces[interfaceName]],
-    }}, "*")
-  };
+	RocketChat.Sandstorm.request = function(interfaceName, cb) {
+		var rpcId = Math.random().toString();
+		callbackMap[rpcId] = cb;
+		window.parent.postMessage({ powerboxRequest: {
+			rpcId: rpcId,
+			query: [interfaces[interfaceName]]
+		}}, '*');
+	};
 }

--- a/packages/rocketchat-sandstorm/package.js
+++ b/packages/rocketchat-sandstorm/package.js
@@ -10,6 +10,6 @@ Package.onUse(function(api) {
 
 	api.use([ 'ecmascript', 'rocketchat:lib' ]);
 
-	api.addFiles([ 'server/lib.js', 'server/events.js' ], 'server');
+	api.addFiles([ 'server/lib.js', 'server/events.js', 'server/powerbox.js' ], 'server');
 	api.addFiles([ 'client/powerboxListener.js' ], 'client');
 });

--- a/packages/rocketchat-sandstorm/package.js
+++ b/packages/rocketchat-sandstorm/package.js
@@ -10,5 +10,6 @@ Package.onUse(function(api) {
 
 	api.use([ 'ecmascript', 'rocketchat:lib' ]);
 
-	api.addFiles([ 'server/events.js' ], 'server');
+	api.addFiles([ 'server/lib.js', 'server/events.js' ], 'server');
+	api.addFiles([ 'client/powerboxListener.js' ], 'client');
 });

--- a/packages/rocketchat-sandstorm/server/events.js
+++ b/packages/rocketchat-sandstorm/server/events.js
@@ -1,36 +1,9 @@
-RocketChat.Sandstorm = {};
-
 RocketChat.Sandstorm.notify = function() {};
 
 if (process.env.SANDSTORM === '1') {
-	var Future = Npm.require('fibers/future');
-	var Capnp = Npm.require('capnp');
-	var SandstormHttpBridge = Npm.require('sandstorm/sandstorm-http-bridge.capnp').SandstormHttpBridge;
-
-	var capnpConnection = null;
-	var httpBridge = null;
-
-	var getHttpBridge = function() {
-		if (!httpBridge) {
-			capnpConnection = Capnp.connect('unix:/tmp/sandstorm-api');
-			httpBridge = capnpConnection.restore(null, SandstormHttpBridge);
-		}
-		return httpBridge;
-	};
-
 	var ACTIVITY_TYPES = {
 		'message': 0,
 		'privateMessage': 1
-	};
-
-	var promiseToFuture = function(promise) {
-		const result = new Future();
-		promise.then(result.return.bind(result), result.throw.bind(result));
-		return result;
-	};
-
-	var waitPromise = function(promise) {
-		return promiseToFuture(promise).wait();
 	};
 
 	RocketChat.Sandstorm.notify = function(message, userIds, caption, type) {

--- a/packages/rocketchat-sandstorm/server/events.js
+++ b/packages/rocketchat-sandstorm/server/events.js
@@ -1,3 +1,5 @@
+/* globals getHttpBridge, waitPromise */
+
 RocketChat.Sandstorm.notify = function() {};
 
 if (process.env.SANDSTORM === '1') {

--- a/packages/rocketchat-sandstorm/server/lib.js
+++ b/packages/rocketchat-sandstorm/server/lib.js
@@ -1,0 +1,28 @@
+RocketChat.Sandstorm = {};
+
+if (process.env.SANDSTORM === '1') {
+	var Future = Npm.require('fibers/future');
+	var Capnp = Npm.require('capnp');
+	var SandstormHttpBridge = Npm.require('sandstorm/sandstorm-http-bridge.capnp').SandstormHttpBridge;
+
+	var capnpConnection = null;
+	var httpBridge = null;
+
+	getHttpBridge = function() {
+		if (!httpBridge) {
+			capnpConnection = Capnp.connect('unix:/tmp/sandstorm-api');
+			httpBridge = capnpConnection.restore(null, SandstormHttpBridge);
+		}
+		return httpBridge;
+	};
+
+	promiseToFuture = function(promise) {
+		const result = new Future();
+		promise.then(result.return.bind(result), result.throw.bind(result));
+		return result;
+	};
+
+	waitPromise = function(promise) {
+		return promiseToFuture(promise).wait();
+	};
+}

--- a/packages/rocketchat-sandstorm/server/lib.js
+++ b/packages/rocketchat-sandstorm/server/lib.js
@@ -1,3 +1,6 @@
+/* globals getHttpBridge, waitPromise */
+/* exported getHttpBridge, waitPromise */
+
 RocketChat.Sandstorm = {};
 
 if (process.env.SANDSTORM === '1') {
@@ -16,7 +19,7 @@ if (process.env.SANDSTORM === '1') {
 		return httpBridge;
 	};
 
-	promiseToFuture = function(promise) {
+	const promiseToFuture = function(promise) {
 		const result = new Future();
 		promise.then(result.return.bind(result), result.throw.bind(result));
 		return result;

--- a/packages/rocketchat-sandstorm/server/powerbox.js
+++ b/packages/rocketchat-sandstorm/server/powerbox.js
@@ -1,0 +1,41 @@
+RocketChat.Sandstorm.offerUiView = function() {};
+
+if (process.env.SANDSTORM === '1') {
+	var Capnp = Npm.require('capnp');
+	var Powerbox = Npm.require('sandstorm/powerbox.capnp');
+	var Grain = Npm.require('sandstorm/grain.capnp');
+
+	RocketChat.Sandstorm.offerUiView = function(token, sessionId) {
+		var httpBridge = getHttpBridge();
+		var session = httpBridge.getSessionContext(sessionId).context;
+		var api = httpBridge.getSandstormApi(sessionId).api;
+		var cap = waitPromise(api.restore(new Buffer(token, 'base64'))).cap;
+		return waitPromise(session.offer(cap, undefined, {tags: [{id: "15831515641881813735"}]}));
+	};
+
+	Meteor.methods({
+		sandstormClaimRequest: function(token, seriliazedDescriptor) {
+			var descriptor = Capnp.parsePacked(Powerbox.PowerboxDescriptor, new Buffer(seriliazedDescriptor, "base64"));
+			var grainTitle = Capnp.parse(Grain.UiView.PowerboxTag, descriptor.tags[0].value).title;
+			var sessionId = this.connection.sandstormSessionId();
+			var httpBridge = getHttpBridge();
+			var session = httpBridge.getSessionContext(sessionId).context;
+			var cap = waitPromise(session.claimRequest(token)).cap.castAs(Grain.UiView);
+			var api = httpBridge.getSandstormApi(sessionId).api;
+			var newToken = waitPromise(api.save(cap)).token.toString('base64');
+			var viewInfo = waitPromise(cap.getViewInfo());
+			var appTitle = viewInfo.appTitle;
+			var asset = waitPromise(viewInfo.grainIcon.getUrl());
+			var appIconUrl = asset.protocol + '://' + asset.hostPath;
+			return {
+				token: newToken,
+				appTitle: appTitle,
+				appIconUrl: appIconUrl,
+				grainTitle: grainTitle,
+			};
+		},
+		sandstormOffer: function(token) {
+			RocketChat.Sandstorm.offerUiView(token, this.connection.sandstormSessionId());
+		}
+	});
+}

--- a/packages/rocketchat-sandstorm/server/powerbox.js
+++ b/packages/rocketchat-sandstorm/server/powerbox.js
@@ -1,3 +1,5 @@
+/* globals getHttpBridge, waitPromise */
+
 RocketChat.Sandstorm.offerUiView = function() {};
 
 if (process.env.SANDSTORM === '1') {
@@ -10,12 +12,12 @@ if (process.env.SANDSTORM === '1') {
 		var session = httpBridge.getSessionContext(sessionId).context;
 		var api = httpBridge.getSandstormApi(sessionId).api;
 		var cap = waitPromise(api.restore(new Buffer(token, 'base64'))).cap;
-		return waitPromise(session.offer(cap, undefined, {tags: [{id: "15831515641881813735"}]}));
+		return waitPromise(session.offer(cap, undefined, {tags: [{id: '15831515641881813735'}]}));
 	};
 
 	Meteor.methods({
 		sandstormClaimRequest: function(token, seriliazedDescriptor) {
-			var descriptor = Capnp.parsePacked(Powerbox.PowerboxDescriptor, new Buffer(seriliazedDescriptor, "base64"));
+			var descriptor = Capnp.parsePacked(Powerbox.PowerboxDescriptor, new Buffer(seriliazedDescriptor, 'base64'));
 			var grainTitle = Capnp.parse(Grain.UiView.PowerboxTag, descriptor.tags[0].value).title;
 			var sessionId = this.connection.sandstormSessionId();
 			var httpBridge = getHttpBridge();
@@ -31,7 +33,7 @@ if (process.env.SANDSTORM === '1') {
 				token: newToken,
 				appTitle: appTitle,
 				appIconUrl: appIconUrl,
-				grainTitle: grainTitle,
+				grainTitle: grainTitle
 			};
 		},
 		sandstormOffer: function(token) {

--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -2703,6 +2703,17 @@ label.required:after {
 			font-size: 1.5em;
 			line-height: 1em;
 		}
+		blockquote.sandstorm-grain {
+			img {
+				width: 50px;
+			}
+			label {
+				cursor: pointer;
+			}
+			button {
+				display: block;
+			}
+		}
 	}
 	&.temp .body {
 		opacity: .5;

--- a/packages/rocketchat-ui-message/message/messageBox.coffee
+++ b/packages/rocketchat-ui-message/message/messageBox.coffee
@@ -82,6 +82,9 @@ Template.messageBox.helpers
 	notSubscribedTpl: ->
 		return RocketChat.roomTypes.getNotSubscribedTpl @_id
 
+	showSandstorm: ->
+		return Meteor.settings.public.sandstorm
+
 Template.messageBox.events
 	'click .join': (event) ->
 		event.stopPropagation()
@@ -172,6 +175,24 @@ Template.messageBox.events
 
 		t.$('.stop-mic').addClass('hidden')
 		t.$('.mic').removeClass('hidden')
+
+	'click .sandstorm-offer': (e, t) ->
+		roomId = @_id
+		RocketChat.Sandstorm.request "uiView", (err, data) =>
+			if err or !data.token
+				console.error err
+				return
+			Meteor.call "sandstormClaimRequest", data.token, data.descriptor, (err, viewInfo) =>
+				if err
+					console.error err
+					return
+
+				Meteor.call "sendMessage", {
+					_id: Random.id()
+					rid: roomId
+					msg: ""
+					urls: [{ url: "grain://sandstorm", sandstormViewInfo: viewInfo }]
+				}
 
 Template.messageBox.onCreated ->
 	@isMessageFieldEmpty = new ReactiveVar true

--- a/packages/rocketchat-ui-message/message/messageBox.html
+++ b/packages/rocketchat-ui-message/message/messageBox.html
@@ -7,6 +7,11 @@
 					<i class="icon-attach file"></i>
 					<input type="file" accept="{{fileUploadAllowedMediaTypes}}">
 				</div>
+				{{#if showSandstorm}}
+					<div class="message-buttons sandstorm-offer">
+						<i class="icon-plus" title="{{_ "Sandstorm_Powerbox_Share"}}"></i>
+					</div>
+				{{/if}}
 				<div class="input-message-container">
 					<textarea dir="auto" name="msg" maxlength="{{maxMessageLength}}" class="input-message autogrow-short" placeholder="{{_ 'Message'}}"></textarea>
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
This adds support for Sandstorm powerbox sharing. What this means is you can share other grains quickly and easily with everyone else in your Rocket.chat by clicking the "plus" icon next to the attachment icon. See:

![image](https://cloud.githubusercontent.com/assets/1595880/17450443/f9312fa8-5b14-11e6-9946-c73967acb4a1.png)

Or go to https://oasis.sandstorm.io/shared/8WwgH63Tie4VzBLp0eP2KsRX7d7obE1A-AUWL3yCD2E to see it in action.