### PR TITLE
Show guest name as message alias

### DIFF
--- a/packages/rocketchat-livechat/app/client/stylesheets/main.less
+++ b/packages/rocketchat-livechat/app/client/stylesheets/main.less
@@ -615,7 +615,6 @@ input:focus {
 }
 
 .powered-by {
-	position: absolute;
 	margin-top: -20px;
 	line-height: 20px;
 	right: 0;

--- a/packages/rocketchat-livechat/app/client/views/message.html
+++ b/packages/rocketchat-livechat/app/client/views/message.html
@@ -1,7 +1,13 @@
 <template name="message">
 	<li id="{{_id}}" class="message sequential {{system}} {{t}} {{own}} {{isTemp}} {{error}}" data-username="{{u.username}}" data-date="{{date}}">
 		<span class="thumb thumb-small" data-username="{{u.username}}" tabindex="1">{{> avatar username=u.username}}</span>
-		<span class="user" data-username="{{u.username}}" tabindex="1">{{u.username}}</span>
+		<span class="user" data-username="{{u.username}}" tabindex="1">
+			{{#if own}}
+				{{_ "You"}}
+			{{else}}
+				{{u.username}}
+			{{/if}}
+		</span>
 		<span class="info">
 			<span class="time">{{time}}</span>
 			{{#if edit}}

--- a/packages/rocketchat-livechat/app/i18n/en.i18n.json
+++ b/packages/rocketchat-livechat/app/i18n/en.i18n.json
@@ -33,5 +33,6 @@
   "User_left" : "User left",
   "We_are_offline_Sorry_for_the_inconvenience" : "We are offline. Sorry for the inconvenience.",
   "Yes" : "Yes",
+  "You" : "You",
   "You_must_complete_all_fields" : "You must complete all fields"
 }

--- a/packages/rocketchat-livechat/app/i18n/pt.i18n.json
+++ b/packages/rocketchat-livechat/app/i18n/pt.i18n.json
@@ -33,5 +33,6 @@
   "User_left" : "Usuário saiu",
   "We_are_offline_Sorry_for_the_inconvenience" : "Nós estamos offline. Desculpe pelo inconveniente.",
   "Yes" : "Sim",
+  "You" : "Você",
   "You_must_complete_all_fields" : "Você deve preencher todos os campos"
 }

--- a/packages/rocketchat-livechat/server/lib/Livechat.js
+++ b/packages/rocketchat-livechat/server/lib/Livechat.js
@@ -58,6 +58,9 @@ RocketChat.Livechat = {
 		if (!room) {
 			throw new Meteor.Error('cannot-acess-room');
 		}
+		if (guest.name) {
+			message.alias = guest.name;
+		}
 		return _.extend(RocketChat.sendMessage(guest, message, room), { newRoom: newRoom });
 	},
 	registerGuest({ token, name, email, department, phone, loginToken, username } = {}) {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

It's not the ideal solution, but it looks better than we have now.

## Before

Agent view | Guest view
---------------|------------
![image](https://cloud.githubusercontent.com/assets/8591547/17671665/93b6ed48-62ee-11e6-913f-c28d78d1888e.png) | ![image](https://cloud.githubusercontent.com/assets/8591547/17671667/97974af2-62ee-11e6-8bf3-c3df75c54896.png)


## After

Agent view | Guest view
---------------|------------
![image](https://cloud.githubusercontent.com/assets/8591547/17671571/191449aa-62ee-11e6-8896-1b185027cbbe.png) | ![image](https://cloud.githubusercontent.com/assets/8591547/17671575/1d3b0b36-62ee-11e6-8822-a865ea75e792.png)

