### PR TITLE
Improvements to pinned items

### DIFF
--- a/packages/rocketchat-lib/server/models/Messages.coffee
+++ b/packages/rocketchat-lib/server/models/Messages.coffee
@@ -171,14 +171,14 @@ RocketChat.models.Messages = new class extends RocketChat.models._Base
 
 		return @update query, update
 
-	setPinnedByIdAndUserId: (_id, pinnedBy, pinned=true) ->
+	setPinnedByIdAndUserId: (_id, pinnedBy, pinned=true, pinnedAt=0) ->
 		query =
 			_id: _id
 
 		update =
 			$set:
 				pinned: pinned
-				pinnedAt: new Date
+				pinnedAt: pinnedAt || new Date
 				pinnedBy: pinnedBy
 
 		return @update query, update

--- a/packages/rocketchat-message-pin/server/pinMessage.coffee
+++ b/packages/rocketchat-message-pin/server/pinMessage.coffee
@@ -1,5 +1,5 @@
 Meteor.methods
-	pinMessage: (message, createMessagePinnedMessage = true) ->
+	pinMessage: (message, pinnedAt) ->
 		if not Meteor.userId()
 			throw new Meteor.Error('error-invalid-user', "Invalid user", { method: 'pinMessage' })
 
@@ -18,7 +18,7 @@ Meteor.methods
 		me = RocketChat.models.Users.findOneById Meteor.userId()
 
 		message.pinned = true
-		message.pinnedAt = Date.now
+		message.pinnedAt = pinnedAt || Date.now
 		message.pinnedBy =
 			_id: Meteor.userId()
 			username: me.username
@@ -27,14 +27,13 @@ Meteor.methods
 
 		RocketChat.models.Messages.setPinnedByIdAndUserId message._id, message.pinnedBy, message.pinned
 
-		if createMessagePinnedMessage
-			RocketChat.models.Messages.createWithTypeRoomIdMessageAndUser 'message_pinned', message.rid, '', me,
-				attachments: [
-					"text" : message.msg
-					"author_name" : message.u.username,
-					"author_icon" : getAvatarUrlFromUsername(message.u.username),
-					"ts" : message.ts
-				]
+		RocketChat.models.Messages.createWithTypeRoomIdMessageAndUser 'message_pinned', message.rid, '', me,
+			attachments: [
+				"text" : message.msg
+				"author_name" : message.u.username,
+				"author_icon" : getAvatarUrlFromUsername(message.u.username),
+				"ts" : message.ts
+			]
 
 	unpinMessage: (message) ->
 		if not Meteor.userId()


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #4032

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
With this PR, messages are pinned by checking their pin status, instead of looking for a "someone has pinned a message" message type. 

Also, the "someone has pinned a message" is now sent over to rocket.chat with the correct timestamp.