### PR TITLE
Handle shared locations better when new shares are disabled

### DIFF
--- a/packages/rocketchat-lib/i18n/en.i18n.json
+++ b/packages/rocketchat-lib/i18n/en.i18n.json
@@ -1029,6 +1029,7 @@
   "Settings" : "Settings",
   "Settings_updated" : "Settings updated",
   "Share_Location_Title" : "Share Location?",
+  "Shared_Location" : "Shared Location",
   "Should_be_a_URL_of_an_image" : "Should be a URL of an image.",
   "Should_exists_a_user_with_this_username" : "The user must already exist.",
   "Show_all" : "Show all",

--- a/packages/rocketchat-mapview/client/mapview.coffee
+++ b/packages/rocketchat-mapview/client/mapview.coffee
@@ -7,7 +7,6 @@ class MapView
 	constructor: (message) ->
 
 		# get MapView settings
-		mv_enabled = RocketChat.settings.get 'MapView_Enabled'
 		mv_googlekey = RocketChat.settings.get 'MapView_GMapsAPIKey'
 
 		if message.location
@@ -17,10 +16,10 @@ class MapView
 			latitude = message.location.coordinates[1]
 
 			# confirm we have an api key set, and generate the html required for the mapview
-			if mv_enabled and mv_googlekey?.length
+			if mv_googlekey?.length
 				message.html  = '<a href="https://maps.google.com/maps?daddr='+latitude+','+longitude+'" target="_blank"><img src="https://maps.googleapis.com/maps/api/staticmap?zoom=14&size=250x250&markers=color:gray%7Clabel:%7C'+latitude+','+longitude+'&key='+mv_googlekey+'" /></a>'
 			else
-				message.html  = '<a href="https://maps.google.com/maps?daddr='+latitude+','+longitude+'" target="_blank">Shared Location</a>'
+				message.html  = '<a href="https://maps.google.com/maps?daddr='+latitude+','+longitude+'" target="_blank">'+TAPi18n.__('Shared_Location')+'</a>'
 
 		return message
 

--- a/packages/rocketchat-mapview/client/mapview.coffee
+++ b/packages/rocketchat-mapview/client/mapview.coffee
@@ -10,15 +10,17 @@ class MapView
 		mv_enabled = RocketChat.settings.get 'MapView_Enabled'
 		mv_googlekey = RocketChat.settings.get 'MapView_GMapsAPIKey'
 
-		if message.location and mv_enabled
+		if message.location
 
 			# GeoJSON is reversed - ie. [lng, lat]
 			longitude = message.location.coordinates[0]
 			latitude = message.location.coordinates[1]
 
 			# confirm we have an api key set, and generate the html required for the mapview
-			if mv_googlekey?.length
+			if mv_enabled and mv_googlekey?.length
 				message.html  = '<a href="https://maps.google.com/maps?daddr='+latitude+','+longitude+'" target="_blank"><img src="https://maps.googleapis.com/maps/api/staticmap?zoom=14&size=250x250&markers=color:gray%7Clabel:%7C'+latitude+','+longitude+'&key='+mv_googlekey+'" /></a>'
+			else
+				message.html  = '<a href="https://maps.google.com/maps?daddr='+latitude+','+longitude+'" target="_blank">Shared Location</a>'
 
 		return message
 


### PR DESCRIPTION
@RocketChat/core 

This is a small bugfix for when an administrator disables the mapview sharing, but there are still messages in a channel that require location rendering.

Previously, it would display a blank, empty message, post-pull these messages will show a link to google maps with the coordinates stored in msg.location.

Enabled, before/after
![image](https://cloud.githubusercontent.com/assets/293107/17758671/fbc93602-6523-11e6-856f-9107355d757f.png)

Disabled, Before
![image](https://cloud.githubusercontent.com/assets/293107/17758709/5179ed44-6524-11e6-8d09-7a23bf37dbf9.png)

After
![image](https://cloud.githubusercontent.com/assets/293107/17758666/df2f84c4-6523-11e6-981a-8216201d5ddd.png)


