### PR TITLE
Added option to populate Rocket Chat with LDAP users (import them)

### DIFF
--- a/packages/rocketchat-ldap/server/ldap.js
+++ b/packages/rocketchat-ldap/server/ldap.js
@@ -50,7 +50,7 @@ LDAP = class LDAP {
 
 		const connectionOptions = {
 			url: `${self.options.host}:${self.options.port}`,
-			timeout: 1000 * 5,
+			timeout: 1000 * 60 * 10,
 			connectTimeout: 1000 * 10,
 			idleTimeout: 1000 * 10,
 			reconnect: false

--- a/packages/rocketchat-ldap/server/settings.js
+++ b/packages/rocketchat-ldap/server/settings.js
@@ -40,6 +40,7 @@ Meteor.startup(function() {
 		this.add('LDAP_Sync_User_Data_FieldMap', '{"cn":"name", "mail":"email"}', { type: 'string', enableQuery: syncDataQuery });
 		this.add('LDAP_Default_Domain', '', { type: 'string', enableQuery: enableQuery });
 		this.add('LDAP_Merge_Existing_Users', false, { type: 'boolean', enableQuery: enableQuery });
+		this.add('LDAP_Import_Users', false, { type: 'boolean', enableQuery: syncDataQuery });
 		this.add('LDAP_Test_Connection', 'ldap_test_connection', { type: 'action', actionText: 'Test_Connection' });
 		this.add('LDAP_Sync_Users', 'ldap_sync_users', { type: 'action', actionText: 'Sync_Users' });
 	});

--- a/packages/rocketchat-ldap/server/sync.js
+++ b/packages/rocketchat-ldap/server/sync.js
@@ -1,4 +1,4 @@
-/* globals slug:true, slugify, LDAP, getLdapUsername:true, getLdapUserUniqueID:true, getDataToSyncUserData:true, syncUserData:true, sync:true  */
+/* globals slug:true, slugify, LDAP, getLdapUsername:true, getLdapUserUniqueID:true, getDataToSyncUserData:true, syncUserData:true, sync:true, addLdapUser:true  */
 
 const logger = new Logger('LDAPSync', {});
 
@@ -151,6 +151,46 @@ syncUserData = function syncUserData(user, ldapUser) {
 	}
 };
 
+addLdapUser = function addLdapUser(ldapUser) {
+		const username = slug(getLdapUsername(ldapUser));
+		var userObject = {
+			username: username
+		};
+
+		let userData = getDataToSyncUserData(ldapUser, {});
+
+		if (userData && userData.emails) {
+			userObject.email = userData.emails[0].address;
+		} else if (ldapUser.object.mail && ldapUser.object.mail.indexOf('@') > -1) {
+			userObject.email = ldapUser.object.mail;
+		} else if (RocketChat.settings.get('LDAP_Default_Domain') !== '') {
+			userObject.email = username + '@' + RocketChat.settings.get('LDAP_Default_Domain');
+		} else {
+			const error = new Meteor.Error('LDAP-login-error', 'LDAP Authentication succeded, there is no email to create an account. Have you tried setting your Default Domain in LDAP Settings?');
+			logger.error(error);
+			throw error;
+		}
+
+		logger.debug('New user data', userObject);
+
+		try {
+			userObject._id = Accounts.createUser(userObject);
+		} catch (error) {
+			logger.error('Error creating user', error);
+			throw error;
+		}
+
+		syncUserData(userObject, ldapUser);
+
+		logger.info('Joining user to default channels');
+		Meteor.runAsUser(userObject._id, function() {
+			Meteor.call('joinDefaultChannels');
+		});
+
+		return {
+			userId: userObject._id
+		};
+};
 
 sync = function sync() {
 	if (RocketChat.settings.get('LDAP_Enable') !== true) {
@@ -163,6 +203,27 @@ sync = function sync() {
 		ldap.connectSync();
 
 		const users = RocketChat.models.Users.findLDAPUsers();
+
+		if (RocketChat.settings.get('LDAP_Import_Users') === true) {
+			const ldapUsers = ldap.searchUsersSync('*');
+			ldapUsers.forEach(function(ldapUser) {
+				const username = slug(getLdapUsername(ldapUser));
+				// Look to see if user already exists
+				let userQuery;
+				let user;
+				userQuery = {
+					username: username
+				};
+
+				logger.debug('userQuery', userQuery);
+
+				user = Meteor.users.findOne(userQuery);
+
+				if (!user) {
+					addLdapUser(ldapUser);
+				}
+			});
+		}
 
 		users.forEach(function(user) {
 			let ldapUser;
@@ -200,7 +261,7 @@ RocketChat.settings.get('LDAP_Sync_User_Data', function(key, value) {
 		interval = Meteor.setInterval(sync, 1000 * 60 * 60);
 		timeout = Meteor.setTimeout(function() {
 			sync();
-		}, 1000 * 30);
+		}, 1000 * 60 * 10);
 	} else {
 		logger.info('Disabling LDAP user sync');
 	}

--- a/packages/rocketchat-ldap/server/sync.js
+++ b/packages/rocketchat-ldap/server/sync.js
@@ -152,44 +152,44 @@ syncUserData = function syncUserData(user, ldapUser) {
 };
 
 addLdapUser = function addLdapUser(ldapUser) {
-		const username = slug(getLdapUsername(ldapUser));
-		var userObject = {
-			username: username
-		};
+	const username = slug(getLdapUsername(ldapUser));
+	var userObject = {
+		username: username
+	};
 
-		let userData = getDataToSyncUserData(ldapUser, {});
+	let userData = getDataToSyncUserData(ldapUser, {});
 
-		if (userData && userData.emails) {
-			userObject.email = userData.emails[0].address;
-		} else if (ldapUser.object.mail && ldapUser.object.mail.indexOf('@') > -1) {
-			userObject.email = ldapUser.object.mail;
-		} else if (RocketChat.settings.get('LDAP_Default_Domain') !== '') {
-			userObject.email = username + '@' + RocketChat.settings.get('LDAP_Default_Domain');
-		} else {
-			const error = new Meteor.Error('LDAP-login-error', 'LDAP Authentication succeded, there is no email to create an account. Have you tried setting your Default Domain in LDAP Settings?');
-			logger.error(error);
-			throw error;
-		}
+	if (userData && userData.emails) {
+		userObject.email = userData.emails[0].address;
+	} else if (ldapUser.object.mail && ldapUser.object.mail.indexOf('@') > -1) {
+		userObject.email = ldapUser.object.mail;
+	} else if (RocketChat.settings.get('LDAP_Default_Domain') !== '') {
+		userObject.email = username + '@' + RocketChat.settings.get('LDAP_Default_Domain');
+	} else {
+		const error = new Meteor.Error('LDAP-login-error', 'LDAP Authentication succeded, there is no email to create an account. Have you tried setting your Default Domain in LDAP Settings?');
+		logger.error(error);
+		throw error;
+	}
 
-		logger.debug('New user data', userObject);
+	logger.debug('New user data', userObject);
 
-		try {
-			userObject._id = Accounts.createUser(userObject);
-		} catch (error) {
-			logger.error('Error creating user', error);
-			throw error;
-		}
+	try {
+		userObject._id = Accounts.createUser(userObject);
+	} catch (error) {
+		logger.error('Error creating user', error);
+		throw error;
+	}
 
-		syncUserData(userObject, ldapUser);
+	syncUserData(userObject, ldapUser);
 
-		logger.info('Joining user to default channels');
-		Meteor.runAsUser(userObject._id, function() {
-			Meteor.call('joinDefaultChannels');
-		});
+	logger.info('Joining user to default channels');
+	Meteor.runAsUser(userObject._id, function() {
+		Meteor.call('joinDefaultChannels');
+	});
 
-		return {
-			userId: userObject._id
-		};
+	return {
+		userId: userObject._id
+	};
 };
 
 sync = function sync() {

--- a/packages/rocketchat-lib/i18n/en.i18n.json
+++ b/packages/rocketchat-lib/i18n/en.i18n.json
@@ -627,6 +627,8 @@
   "LDAP_Host_Description" : "The LDAP host, e.g. `ldap.example.com` or `10.0.0.30`.",
   "LDAP_Merge_Existing_Users" : "Merge existing users",
   "LDAP_Merge_Existing_Users_Description" : "*Caution!* When importing an user from LDAP and an user with same username already exists the LDAP info and password will be set into the existing user.",
+  "LDAP_Import_Users" : "Import LDAP users",
+  "LDAP_Import_Users_Description" : "It True sync process will be import all LDAP users <br/> *Caution!* Specify search filter to not import excess users.",
   "LDAP_Port" : "Port",
   "LDAP_Port_Description" : "Port to access LDAP. eg: `389` or `636` for LDAPS",
   "LDAP_Reject_Unauthorized" : "Reject Unauthorized",


### PR DESCRIPTION
@RocketChat/core I would like to add LDAP import option (create users during sync) so users can mentioned and invite other users to channels if their have not logged yet.

I think it's important feature because it boosts service introduction. Users does not need to invite each other via email or other way and wait until they make a first login to invite them to channel or make a mention.

Please note I had to increase LDAP timeout because LDAP ldap search thought group of 300 users can take about 2 minutes.
