### PR TITLE
Added File Uploaded text on attachments to i18n

### DIFF
--- a/packages/rocketchat-file-upload/server/methods/sendFileMessage.js
+++ b/packages/rocketchat-file-upload/server/methods/sendFileMessage.js
@@ -15,7 +15,7 @@ Meteor.methods({
 		var fileUrl = '/file-upload/' + file._id + '/' + file.name;
 
 		var attachment = {
-			title: `File Uploaded: ${file.name}`,
+			title: `${TAPi18n.__('Attachment_File_Uploaded')}: ${file.name}`,
 			title_link: fileUrl,
 			title_link_download: true
 		};

--- a/packages/rocketchat-lib/i18n/en.i18n.json
+++ b/packages/rocketchat-lib/i18n/en.i18n.json
@@ -170,6 +170,7 @@
   "Are_you_sure_you_want_to_delete_your_account" : "Are you sure you want to delete your account?",
   "Assign_admin" : "Assigning admin",
   "at" : "at",
+  "Attachment_File_Uploaded" : "File Uploaded",
   "Auth_Token" : "Auth Token",
   "Author" : "Author",
   "Authorization_URL" : "Authorization URL",


### PR DESCRIPTION
@RocketChat/core 

Closes #3944

Moves "File Uploaded" text into i18n so that it can be translated into other languages.

@Molle500 :wink:

