### PR TITLE
Check timestamp before notifying users

### DIFF
--- a/packages/rocketchat-lib/server/functions/sendMessage.coffee
+++ b/packages/rocketchat-lib/server/functions/sendMessage.coffee
@@ -18,9 +18,9 @@ RocketChat.sendMessage = (user, message, room, upsert = false) ->
 
 	message = RocketChat.callbacks.run 'beforeSaveMessage', message
 
+	# Avoid saving sandstormSessionId to the database
 	sandstormSessionId = null
 	if message.sandstormSessionId
-		# Persisting sessionId to the database is a bad idea.
 		sandstormSessionId = message.sandstormSessionId
 		delete message.sandstormSessionId
 

--- a/packages/rocketchat-lib/server/lib/notifyUsersOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/notifyUsersOnMessage.js
@@ -4,6 +4,10 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 		return message;
 	}
 
+	if (message.ts && (moment(message.ts).subtract(5, 'seconds').isBefore(new Date) || moment(message.ts).isAfter(moment().add(5, 'seconds')))) {
+		return message;
+	}
+
 	/**
 	 * Chechs if a messages contains a user highlight
 	 *

--- a/packages/rocketchat-lib/server/lib/notifyUsersOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/notifyUsersOnMessage.js
@@ -4,7 +4,7 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 		return message;
 	}
 
-	if (message.ts && (moment(message.ts).subtract(5, 'seconds').isBefore(new Date) || moment(message.ts).isAfter(moment().add(5, 'seconds')))) {
+	if (message.ts && Math.abs(moment(message.ts).diff()) > 60000) {
 		return message;
 	}
 

--- a/packages/rocketchat-lib/server/lib/sendEmailOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendEmailOnMessage.js
@@ -4,6 +4,10 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 		return message;
 	}
 
+	if (message.ts && (moment(message.ts).subtract(5, 'seconds').isBefore(new Date) || moment(message.ts).isAfter(moment().add(5, 'seconds')))) {
+		return message;
+	}
+
 	var emailSubject, usersToSendEmail = {};
 	var directMessage = room.t === 'd';
 

--- a/packages/rocketchat-lib/server/lib/sendEmailOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendEmailOnMessage.js
@@ -4,7 +4,7 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 		return message;
 	}
 
-	if (message.ts && (moment(message.ts).subtract(5, 'seconds').isBefore(new Date) || moment(message.ts).isAfter(moment().add(5, 'seconds')))) {
+	if (message.ts && Math.abs(moment(message.ts).diff()) > 60000) {
 		return message;
 	}
 

--- a/packages/rocketchat-lib/server/methods/sendMessage.coffee
+++ b/packages/rocketchat-lib/server/methods/sendMessage.coffee
@@ -1,5 +1,8 @@
 Meteor.methods
 	sendMessage: (message) ->
+		if message.ts and (moment(message.ts).subtract(5, 'seconds').isBefore(new Date) or moment(message.ts).isAfter(moment().add(5, 'seconds')))
+			throw new Meteor.Error('error-message-ts-out-of-sync', 'Message timestamp is out of sync', { method: 'sendMessage', message_ts: message.ts, server_ts: new Date().getTime() })
+
 		if message.msg?.length > RocketChat.settings.get('Message_MaxAllowedSize')
 			throw new Meteor.Error('error-message-size-exceeded', 'Message size exceeds Message_MaxAllowedSize', { method: 'sendMessage' })
 

--- a/packages/rocketchat-lib/server/methods/sendMessage.coffee
+++ b/packages/rocketchat-lib/server/methods/sendMessage.coffee
@@ -7,6 +7,8 @@ Meteor.methods
 				throw new Meteor.Error('error-message-ts-out-of-sync', 'Message timestamp is out of sync', { method: 'sendMessage', message_ts: message.ts, server_ts: new Date().getTime() })
 			else if tsDiff > 10000
 				message.ts = new Date()
+		else
+			message.ts = new Date()
 
 		if message.msg?.length > RocketChat.settings.get('Message_MaxAllowedSize')
 			throw new Meteor.Error('error-message-size-exceeded', 'Message size exceeds Message_MaxAllowedSize', { method: 'sendMessage' })

--- a/packages/rocketchat-lib/server/methods/sendMessage.coffee
+++ b/packages/rocketchat-lib/server/methods/sendMessage.coffee
@@ -1,7 +1,12 @@
 Meteor.methods
 	sendMessage: (message) ->
-		if message.ts and (moment(message.ts).subtract(5, 'seconds').isBefore(new Date) or moment(message.ts).isAfter(moment().add(5, 'seconds')))
-			throw new Meteor.Error('error-message-ts-out-of-sync', 'Message timestamp is out of sync', { method: 'sendMessage', message_ts: message.ts, server_ts: new Date().getTime() })
+
+		if message.ts
+			tsDiff = Math.abs(moment(message.ts).diff())
+			if tsDiff > 60000
+				throw new Meteor.Error('error-message-ts-out-of-sync', 'Message timestamp is out of sync', { method: 'sendMessage', message_ts: message.ts, server_ts: new Date().getTime() })
+			else if tsDiff > 10000
+				message.ts = new Date()
 
 		if message.msg?.length > RocketChat.settings.get('Message_MaxAllowedSize')
 			throw new Meteor.Error('error-message-size-exceeded', 'Message size exceeds Message_MaxAllowedSize', { method: 'sendMessage' })


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
@engelgabriel suggested ts is checked before sending notification; also thinks ts should not be sent by the client
