### PR TITLE
Fix multiple notifications (closes #3517)

### DIFF
--- a/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
@@ -40,7 +40,7 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 	}
 
 	/**
-	 * Chechs if a messages contains a user highlight
+	 * Checks if a message contains a user highlight
 	 *
 	 * @param {string} message
 	 * @param {array|undefined} highlights
@@ -127,6 +127,7 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 				text: message.msg,
 				duration: settings.desktopNotificationDurations[userOfMention._id],
 				payload: {
+					_id: message._id,
 					rid: message.rid,
 					sender: message.u,
 					type: room.t,
@@ -281,6 +282,7 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 					text: message.msg,
 					duration: settings.desktopNotificationDurations[usersOfMentionId],
 					payload: {
+						_id: message._id,
 						rid: message.rid,
 						sender: message.u,
 						type: room.t,

--- a/packages/rocketchat-ui/lib/notification.coffee
+++ b/packages/rocketchat-ui/lib/notification.coffee
@@ -17,6 +17,7 @@
 				n = new Notification notification.title,
 					icon: notification.icon or getAvatarUrlFromUsername notification.payload.sender.username
 					body: _.stripTags(message.msg)
+					tag: message.rid
 					silent: true
 
 				notificationDuration = (notification.duration - 0) or (Meteor.user()?.settings?.preferences?.desktopNotificationDuration - 0) or RocketChat.settings.get('Desktop_Notifications_Duration')
@@ -25,6 +26,7 @@
 
 				if notification.payload?.rid?
 					n.onclick = ->
+						this.close()
 						window.focus()
 						switch notification.payload.type
 							when 'd'

--- a/packages/rocketchat-ui/lib/notification.coffee
+++ b/packages/rocketchat-ui/lib/notification.coffee
@@ -17,7 +17,7 @@
 				n = new Notification notification.title,
 					icon: notification.icon or getAvatarUrlFromUsername notification.payload.sender.username
 					body: _.stripTags(message.msg)
-					tag: message.rid
+					tag: notification.payload._id,
 					silent: true
 
 				notificationDuration = (notification.duration - 0) or (Meteor.user()?.settings?.preferences?.desktopNotificationDuration - 0) or RocketChat.settings.get('Desktop_Notifications_Duration')


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #3517

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
If multiple tabs of RocketChat are open, the user's screen was spammed with multiple notifications of the same message. This PR fixes this issue.

Also, now the notification is closed immediately after the user clicks on it.