### PR TITLE
Various fixes to Sandstorm notifications

### DIFF
--- a/.sandstorm/sandstorm-pkgdef.capnp
+++ b/.sandstorm/sandstorm-pkgdef.capnp
@@ -91,8 +91,8 @@ const pkgdef :Spk.PackageDefinition = (
   bridgeConfig = (
     viewInfo = (
       eventTypes = [
-				(name = "message", verbPhrase = (defaultText = "message sent")),
-				(name = "privateMessage", verbPhrase = (defaultText = "private message sent"), requiredPermission = (explicitList = void)),
+				(name = "message", verbPhrase = (defaultText = "sent message")),
+				(name = "privateMessage", verbPhrase = (defaultText = "sent private message"), requiredPermission = (explicitList = void)),
 			]
     ),
 

--- a/.sandstorm/sandstorm-pkgdef.capnp
+++ b/.sandstorm/sandstorm-pkgdef.capnp
@@ -91,8 +91,8 @@ const pkgdef :Spk.PackageDefinition = (
   bridgeConfig = (
     viewInfo = (
       eventTypes = [
-				(name = "message", verbPhrase = (defaultText = "message received")),
-				(name = "privateMessage", verbPhrase = (defaultText = "private message received"), requiredPermission = (explicitList = void)),
+				(name = "message", verbPhrase = (defaultText = "message sent")),
+				(name = "privateMessage", verbPhrase = (defaultText = "private message sent"), requiredPermission = (explicitList = void)),
 			]
     ),
 

--- a/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
@@ -121,6 +121,13 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 				statusConnection: 1
 			}
 		});
+
+		// Always notify Sandstorm
+		if (userOfMention != null) {
+			RocketChat.Sandstorm.notify(message, [userOfMention._id],
+				'@' + user.username + ': ' + message.msg, 'privateMessage');
+
+		}
 		if ((userOfMention != null) && canBeNotified(userOfMentionId, 'mobile')) {
 			RocketChat.Notifications.notifyUser(userOfMention._id, 'notification', {
 				title: '@' + user.username,
@@ -160,8 +167,6 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 				});
 				return message;
 			}
-			RocketChat.Sandstorm.notify(message, [userOfMention._id],
-				'@' + user.username + ': ' + message.msg, 'privateMessage');
 		}
 	} else {
 		mentionIds = [];

--- a/packages/rocketchat-oembed/client/oembedSandstormGrain.coffee
+++ b/packages/rocketchat-oembed/client/oembedSandstormGrain.coffee
@@ -7,8 +7,11 @@ Template.oembedSandstormGrain.helpers
 		return @meta.sandstorm.grain.grainTitle
 	appIconUrl: ->
 		return @meta.sandstorm.grain.appIconUrl
+	descriptor: ->
+		return @meta.sandstorm.grain.descriptor
 window.sandstormOembed = (e) ->
 	e = e or window.event
 	src = e.target or e.srcElement
 	token = src.getAttribute "data-token"
-	Meteor.call "sandstormOffer", token
+	descriptor = src.getAttribute "data-descriptor"
+	Meteor.call "sandstormOffer", token, descriptor

--- a/packages/rocketchat-oembed/client/oembedSandstormGrain.html
+++ b/packages/rocketchat-oembed/client/oembedSandstormGrain.html
@@ -3,7 +3,8 @@
 		<label>
 			<h3>{{grainTitle}}</h3>
 			<img src="{{appIconUrl}}" />
-			<button onclick="sandstormOembed(event)" data-token="{{token}}">
+			<button onclick="sandstormOembed(event)" data-token="{{token}}"
+							data-descriptor="{{descriptor}}">
 				Click to open the grain
 			</button>
 		</label>

--- a/packages/rocketchat-sandstorm/server/events.js
+++ b/packages/rocketchat-sandstorm/server/events.js
@@ -28,7 +28,7 @@ if (process.env.SANDSTORM === '1') {
 			activity.users = _.map(userIds, function(userId) {
 				var user = Meteor.users.findOne({_id: userId}, {fields: {'services.sandstorm.id': 1}});
 				return {
-					identity: httpBridge.getSavedIdentity(user.services.sandstorm.id).identity,
+					identity: waitPromise(httpBridge.getSavedIdentity(user.services.sandstorm.id)).identity,
 					mentioned: true
 				};
 			});

--- a/packages/rocketchat-sandstorm/server/powerbox.js
+++ b/packages/rocketchat-sandstorm/server/powerbox.js
@@ -14,7 +14,7 @@ if (process.env.SANDSTORM === '1') {
 		var cap = waitPromise(api.restore(new Buffer(token, 'base64'))).cap;
 		return waitPromise(session.offer(cap, undefined, {tags: [{
 			id: '15831515641881813735',
-			value: new Buffer(seriliazedDescriptor, 'base64'),
+			value: new Buffer(seriliazedDescriptor, 'base64')
 		}]}));
 	};
 
@@ -37,7 +37,7 @@ if (process.env.SANDSTORM === '1') {
 				appTitle: appTitle,
 				appIconUrl: appIconUrl,
 				grainTitle: grainTitle,
-				descriptor: descriptor.tags[0].value.toString('base64'),
+				descriptor: descriptor.tags[0].value.toString('base64')
 			};
 		},
 		sandstormOffer: function(token, seriliazedDescriptor) {

--- a/packages/rocketchat-sandstorm/server/powerbox.js
+++ b/packages/rocketchat-sandstorm/server/powerbox.js
@@ -7,12 +7,15 @@ if (process.env.SANDSTORM === '1') {
 	var Powerbox = Npm.require('sandstorm/powerbox.capnp');
 	var Grain = Npm.require('sandstorm/grain.capnp');
 
-	RocketChat.Sandstorm.offerUiView = function(token, sessionId) {
+	RocketChat.Sandstorm.offerUiView = function(token, seriliazedDescriptor, sessionId) {
 		var httpBridge = getHttpBridge();
 		var session = httpBridge.getSessionContext(sessionId).context;
 		var api = httpBridge.getSandstormApi(sessionId).api;
 		var cap = waitPromise(api.restore(new Buffer(token, 'base64'))).cap;
-		return waitPromise(session.offer(cap, undefined, {tags: [{id: '15831515641881813735'}]}));
+		return waitPromise(session.offer(cap, undefined, {tags: [{
+			id: '15831515641881813735',
+			value: new Buffer(seriliazedDescriptor, 'base64'),
+		}]}));
 	};
 
 	Meteor.methods({
@@ -33,11 +36,13 @@ if (process.env.SANDSTORM === '1') {
 				token: newToken,
 				appTitle: appTitle,
 				appIconUrl: appIconUrl,
-				grainTitle: grainTitle
+				grainTitle: grainTitle,
+				descriptor: descriptor.tags[0].value.toString('base64'),
 			};
 		},
-		sandstormOffer: function(token) {
-			RocketChat.Sandstorm.offerUiView(token, this.connection.sandstormSessionId());
+		sandstormOffer: function(token, seriliazedDescriptor) {
+			RocketChat.Sandstorm.offerUiView(token, seriliazedDescriptor,
+				this.connection.sandstormSessionId());
 		}
 	});
 }

--- a/packages/rocketchat-sandstorm/server/powerbox.js
+++ b/packages/rocketchat-sandstorm/server/powerbox.js
@@ -7,20 +7,20 @@ if (process.env.SANDSTORM === '1') {
 	var Powerbox = Npm.require('sandstorm/powerbox.capnp');
 	var Grain = Npm.require('sandstorm/grain.capnp');
 
-	RocketChat.Sandstorm.offerUiView = function(token, seriliazedDescriptor, sessionId) {
+	RocketChat.Sandstorm.offerUiView = function(token, serializedDescriptor, sessionId) {
 		var httpBridge = getHttpBridge();
 		var session = httpBridge.getSessionContext(sessionId).context;
 		var api = httpBridge.getSandstormApi(sessionId).api;
 		var cap = waitPromise(api.restore(new Buffer(token, 'base64'))).cap;
 		return waitPromise(session.offer(cap, undefined, {tags: [{
 			id: '15831515641881813735',
-			value: new Buffer(seriliazedDescriptor, 'base64')
+			value: new Buffer(serializedDescriptor, 'base64')
 		}]}));
 	};
 
 	Meteor.methods({
-		sandstormClaimRequest: function(token, seriliazedDescriptor) {
-			var descriptor = Capnp.parsePacked(Powerbox.PowerboxDescriptor, new Buffer(seriliazedDescriptor, 'base64'));
+		sandstormClaimRequest: function(token, serializedDescriptor) {
+			var descriptor = Capnp.parsePacked(Powerbox.PowerboxDescriptor, new Buffer(serializedDescriptor, 'base64'));
 			var grainTitle = Capnp.parse(Grain.UiView.PowerboxTag, descriptor.tags[0].value).title;
 			var sessionId = this.connection.sandstormSessionId();
 			var httpBridge = getHttpBridge();
@@ -40,8 +40,8 @@ if (process.env.SANDSTORM === '1') {
 				descriptor: descriptor.tags[0].value.toString('base64')
 			};
 		},
-		sandstormOffer: function(token, seriliazedDescriptor) {
-			RocketChat.Sandstorm.offerUiView(token, seriliazedDescriptor,
+		sandstormOffer: function(token, serializedDescriptor) {
+			RocketChat.Sandstorm.offerUiView(token, serializedDescriptor,
 				this.connection.sandstormSessionId());
 		}
 	});


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Fixes some minor issues with Sandstorm notifications:
* Sometimes DMs wouldn't trigger a notification
* Workaround an occasional bug in Sandstorm's supervisor when restoring identity capabilities
* Fix some wording for event types
* Offer grains with a title now