### PR TITLE
Set gitlabs scope to 'api', the only support scope.

### DIFF
--- a/packages/rocketchat-gitlab/common.coffee
+++ b/packages/rocketchat-gitlab/common.coffee
@@ -1,6 +1,7 @@
 config =
 	serverURL: 'https://gitlab.com'
 	identityPath: '/api/v3/user'
+	scope: 'api'
 	addAutopublishFields:
 		forLoggedInUser: ['services.gitlab']
 		forOtherUsers: ['services.gitlab.username']


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #3987 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

This pull request adds the default scope for gitlab. With the merge request for #3837 it broke gitlab oauth authentication.

I have not been able to test this, as we only have one production instance. I am hoping over the next few days I can standup a development rocket chat instance to verify.

Gitlab currently only supports a single oauth scope, api. There is work being done to allow for custom scopes but it has not been merged yet.