### PR TITLE
Don't Check for Last Admin on Update

### DIFF
--- a/packages/rocketchat-lib/server/methods/insertOrUpdateUser.coffee
+++ b/packages/rocketchat-lib/server/methods/insertOrUpdateUser.coffee
@@ -97,11 +97,6 @@ Meteor.methods
 
 			return _id
 		else
-			# prevent removing admin role of last admin
-			adminCount = Meteor.users.find({ roles: { $in: ['admin'] } }).count()
-			if adminCount is 1 and userData.role isnt 'admin'
-				throw new Meteor.Error 'error-action-not-allowed', 'Leaving the app without admins is not allowed', { method: 'insertOrUpdateUser', action: 'Remove_last_admin' }
-
 			#update user
 			updateUser = $set: {}
 

--- a/packages/rocketchat-lib/server/methods/insertOrUpdateUser.coffee
+++ b/packages/rocketchat-lib/server/methods/insertOrUpdateUser.coffee
@@ -97,6 +97,11 @@ Meteor.methods
 
 			return _id
 		else
+			# prevent removing admin role of last admin
+			adminCount = Meteor.users.find({ _id: { $ne: userData._id }, roles: { $in: ['admin'] } }).count()
+			if adminCount is 0 and userData.role isnt 'admin'
+				throw new Meteor.Error 'error-action-not-allowed', 'Leaving the app without admins is not allowed', { method: 'insertOrUpdateUser', action: 'Remove_last_admin' }
+
 			#update user
 			updateUser = $set: {}
 

--- a/packages/rocketchat-lib/server/methods/insertOrUpdateUser.coffee
+++ b/packages/rocketchat-lib/server/methods/insertOrUpdateUser.coffee
@@ -97,11 +97,6 @@ Meteor.methods
 
 			return _id
 		else
-			# prevent removing admin role of last admin
-			adminCount = Meteor.users.find({ _id: { $ne: userData._id }, roles: { $in: ['admin'] } }).count()
-			if adminCount is 0 and userData.role isnt 'admin'
-				throw new Meteor.Error 'error-action-not-allowed', 'Leaving the app without admins is not allowed', { method: 'insertOrUpdateUser', action: 'Remove_last_admin' }
-
 			#update user
 			updateUser = $set: {}
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #4131

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
There was a check on the `update` part of `insertOrUpdateUser` which was checking, incorrectly, if the user being updated wasn't admin and if they weren't then the update wasn't allowed. Since the `update` part of that method doesn't actually handle roles I removed that check.