### PR TITLE
Fix issue caused by new and unique loading

### DIFF
--- a/packages/rocketchat-ui-message/message/popup/messagePopup.html
+++ b/packages/rocketchat-ui-message/message/popup/messagePopup.html
@@ -6,7 +6,6 @@
 					{{title}}
 				</div>
 				<div class="message-popup-items">
-					{{> loading}}
 					{{#each data}}
 						<div class="popup-item" data-id="{{_id}}">
 							{{> Template.dynamic template=../template}}


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

Do not add the loading template to the template messagePopup. Fixes an issue introduced by commit 7e42466d538d22359c876b844bd306591ee0ee28 that causes the UI to become unresponsive to mouse input when the autocomplete window for slash commands or emoji is open.