### PR TITLE
Tweak SandstormOembed styling/format

### DIFF
--- a/packages/rocketchat-oembed/client/oembedSandstormGrain.html
+++ b/packages/rocketchat-oembed/client/oembedSandstormGrain.html
@@ -1,12 +1,11 @@
 <template name="oembedSandstormGrain">
 	<blockquote class="sandstorm-grain">
 		<label>
-			<h3>{{grainTitle}}</h3>
-			<img src="{{appIconUrl}}" />
 			<button onclick="sandstormOembed(event)" data-token="{{token}}"
 							data-descriptor="{{descriptor}}">
-				Click to open the grain
+				{{grainTitle}}
 			</button>
+			<img src="{{appIconUrl}}" />
 		</label>
 	</blockquote>
 </template>

--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -2690,6 +2690,14 @@ label.required:after {
 			}
 			button {
 				display: block;
+				color: #008ce3;
+				border: 0px;
+				min-height: 26px;
+				text-decoration: none;
+
+				&:hover {
+					color: #006db0;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Remove the "Click to open grain" text and make the title look like a link.

