### PR TITLE
Fix error with CustomOAuth on startup

### DIFF
--- a/packages/rocketchat-lib/package.js
+++ b/packages/rocketchat-lib/package.js
@@ -32,6 +32,7 @@ Package.onUse(function(api) {
 	api.use('rocketchat:streamer');
 	api.use('rocketchat:version');
 	api.use('rocketchat:logger');
+	api.use('rocketchat:custom-oauth');
 
 	api.use('templating', 'client');
 	api.use('kadira:flow-router');


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Fix this error:
```
Exception in setTimeout callback: ReferenceError: CustomOAuth is not defined
    at packages/rocketchat_lib/server/startup/oAuthServicesUpdate.coffee:40:10
    at [object Object]._.extend.withValue (packages/meteor/dynamics_nodejs.js:56:1)
    at packages/meteor/timers.js:6:1
    at runWithEnvironment (packages/meteor/dynamics_nodejs.js:110:1)
```
