### PR TITLE
color change on online status to improve accessibility - issue  #3625

### DIFF
--- a/packages/rocketchat-livechat/app/client/stylesheets/_variables.less
+++ b/packages/rocketchat-livechat/app/client/stylesheets/_variables.less
@@ -24,7 +24,7 @@
 @quaternary-font-color: rgba(255, 255, 255, 0.85);
 @info-font-color: #AAAAAA;
 
-@status-online: #35AC19;
+@status-online: #4dff4d;
 @status-offline: rgba(150, 150, 150, 0.50);
 @status-busy: #D30230;
 @status-away: #fcb316;

--- a/packages/rocketchat-theme/assets/stylesheets/utils/_colors.import.less
+++ b/packages/rocketchat-theme/assets/stylesheets/utils/_colors.import.less
@@ -371,8 +371,8 @@ a.github-fork {
 			}
 			&.online {
 				&:after {
-					border-color: #2c9210;
-					background-color: #35AC19;
+					border-color: #40f240;
+					background-color: #4dff4d;
 				}
 			}
 			&.away {

--- a/packages/rocketchat-theme/server/variables.coffee
+++ b/packages/rocketchat-theme/server/variables.coffee
@@ -26,7 +26,7 @@ RocketChat.theme.addPublicColor "smallprint-hover-color", "#ffffff"
 RocketChat.theme.addPublicColor "status-away", "#fcb316"
 RocketChat.theme.addPublicColor "status-busy", "#d30230"
 RocketChat.theme.addPublicColor "status-offline", "rgba(150, 150, 150, 0.50)"
-RocketChat.theme.addPublicColor "status-online", "#35ac19"
+RocketChat.theme.addPublicColor "status-online", "#4dff4d"
 RocketChat.theme.addPublicColor "unread-notification-color", "#1dce73"
 
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->

@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

Improves on  #3625 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

I just change the color from the original #35AC19 (dark green) to a clear one #4dff4d (adding a 5% darker as border too), as requested in the issue.
