### PR TITLE
Fix #4173

### DIFF
--- a/packages/rocketchat-channel-settings/client/views/channelSettings.coffee
+++ b/packages/rocketchat-channel-settings/client/views/channelSettings.coffee
@@ -41,8 +41,8 @@ Template.channelSettings.helpers
 			return t('True')
 		else
 			return t('False')
-		
-		
+
+
 
 Template.channelSettings.events
 	'click .delete': ->
@@ -110,11 +110,10 @@ Template.channelSettings.onCreated ->
 				if not nameValidation.test value
 					return toastr.error t('error-invalid-room-name', { room_name: name: value })
 
-				if @validateRoomName()
-					RocketChat.callbacks.run 'roomNameChanged', { _id: room._id, name: value }
-					Meteor.call 'saveRoomSettings', room._id, 'roomName', value, (err, result) ->
-						return handleError err if err
-						toastr.success TAPi18n.__ 'Room_name_changed_successfully'
+				RocketChat.callbacks.run 'roomNameChanged', { _id: room._id, name: value }
+				Meteor.call 'saveRoomSettings', room._id, 'roomName', value, (err, result) ->
+					return handleError err if err
+					toastr.success TAPi18n.__ 'Room_name_changed_successfully'
 
 		topic:
 			type: 'markdown'
@@ -163,7 +162,7 @@ Template.channelSettings.onCreated ->
 			save: (value, room) ->
 				Meteor.call 'saveRoomSettings', room._id, 'readOnly', value, (err, result) ->
 					return handleError err if err
-					toastr.success TAPi18n.__ 'Read_only_changed_successfully'					
+					toastr.success TAPi18n.__ 'Read_only_changed_successfully'
 
 		archived:
 			type: 'boolean'


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #4173

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
`validateRoomName()` is not necessary. Because, [`save()`](https://github.com/nishimaki10/Rocket.Chat/blob/develop/packages/rocketchat-channel-settings/client/views/channelSettings.coffee#L101) has the same process as [this](https://github.com/RocketChat/Rocket.Chat/blob/develop/packages/rocketchat-ui-admin/admin/rooms/adminRoomInfo.coffee#L100).