### PR TITLE
HTML-escape user data when storing in Meteor Error

### DIFF
--- a/packages/rocketchat-lib/server/methods/insertOrUpdateUser.coffee
+++ b/packages/rocketchat-lib/server/methods/insertOrUpdateUser.coffee
@@ -32,17 +32,17 @@ Meteor.methods
 			nameValidation = new RegExp '^[0-9a-zA-Z-_.]+$'
 
 		if userData.username? and not nameValidation.test userData.username
-			throw new Meteor.Error 'error-input-is-not-a-valid-field', "#{userData.username} is not a valid username", { method: 'insertOrUpdateUser', input: userData.username, field: 'Username' }
+			throw new Meteor.Error 'error-input-is-not-a-valid-field', "#{_.escape(userData.username)} is not a valid username", { method: 'insertOrUpdateUser', input: userData.username, field: 'Username' }
 
 		if not userData._id and not userData.password
 			throw new Meteor.Error 'error-the-field-is-required', 'The field Password is required', { method: 'insertOrUpdateUser', field: 'Password' }
 
 		if not userData._id
 			if not RocketChat.checkUsernameAvailability userData.username
-				throw new Meteor.Error 'error-field-unavailable', "#{userData.username} is already in use :(", { method: 'insertOrUpdateUser', field: userData.username }
+				throw new Meteor.Error 'error-field-unavailable', "#{_.escape(userData.username)} is already in use :(", { method: 'insertOrUpdateUser', field: userData.username }
 
 			if userData.email and not RocketChat.checkEmailAvailability userData.email
-				throw new Meteor.Error 'error-field-unavailable', "#{userData.email} is already in use :(", { method: 'insertOrUpdateUser', field: userData.email }
+				throw new Meteor.Error 'error-field-unavailable', "#{_.escape(userData.email)} is already in use :(", { method: 'insertOrUpdateUser', field: userData.email }
 
 			RocketChat.validateEmailDomain(userData.email);
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->

@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
The purpose of this PR is to address a problem (seemingly a self-XSS issue, so not exploitable to attack other users as far as I know) where Rocket.Chat's username prompt can be abused to show HTML. This HTML can contain Javascript, per the following screenshots:

![screenshot from 2016-09-07 11 25 31](https://cloud.githubusercontent.com/assets/25457/18323740/d24c8318-74ed-11e6-96b0-58cf0e8bb44f.png)

![screenshot from 2016-09-07 11 25 28](https://cloud.githubusercontent.com/assets/25457/18323741/d255d7a6-74ed-11e6-8d5b-e3ef86c5316e.png)

Note that I haven't tested this yet -- it might be missing a `require()` somewhere -- but it should be an adequate fix. I'm submitting it for feedback and to have Travis-CI run its tests. :)
