### PR TITLE
Add basic support for rfc 7233

### DIFF
--- a/packages/rocketchat-file-upload/server/config/configFileUploadGridFS.js
+++ b/packages/rocketchat-file-upload/server/config/configFileUploadGridFS.js
@@ -22,22 +22,18 @@ ExtractRange.prototype._transform = function(chunk, enc, cb) {
 	if (this.bytes_read > this.stop) {
 		// done reading
 		this.end();
-	}
-	else if (this.bytes_read + chunk.length < this.start) {
+	} else if (this.bytes_read + chunk.length < this.start) {
 		// this chunk is still before the start byte
-	}
-	else {
+	} else {
 		var start, stop;
 		if (this.start <= this.bytes_read) {
 			start = 0;
-		}
-		else {
+		} else {
 			start = this.start - this.bytes_read;
 		}
 		if ((this.stop - this.bytes_read + 1) < chunk.length) {
 			stop = this.stop - this.bytes_read + 1;
-		}
-		else {
+		} else {
 			stop = chunk.length;
 		}
 		var newchunk = chunk.slice(start, stop);

--- a/packages/rocketchat-file-upload/server/config/configFileUploadGridFS.js
+++ b/packages/rocketchat-file-upload/server/config/configFileUploadGridFS.js
@@ -104,20 +104,20 @@ var readFromGridFS = function(storeName, fileId, file, headers, req, res) {
 		res.writeHead(200, headers);
 		ws.pipe(zlib.createDeflate()).pipe(res);
 	} else if (range && out_of_range) {
-			// out of range request, return 416
-			delete headers['Content-Length'];
-			delete headers['Content-Type'];
-			delete headers['Content-Disposition'];
-			delete headers['Last-Modified'];
-			headers['Content-Range'] = 'bytes */' + file.size;
-			res.writeHead(416, headers);
-			res.end();
+		// out of range request, return 416
+		delete headers['Content-Length'];
+		delete headers['Content-Type'];
+		delete headers['Content-Disposition'];
+		delete headers['Last-Modified'];
+		headers['Content-Range'] = 'bytes */' + file.size;
+		res.writeHead(416, headers);
+		res.end();
 	} else if (range) {
-			headers['Content-Range'] = 'bytes ' + range.start + '-' + range.stop + '/' + file.size;
-			delete headers['Content-Length'];
-			headers['Content-Length'] = range.stop - range.start + 1;
-			res.writeHead(206, headers);
-			ws.pipe(new ExtractRange({start: range.start, stop: range.stop})).pipe(res);
+		headers['Content-Range'] = 'bytes ' + range.start + '-' + range.stop + '/' + file.size;
+		delete headers['Content-Length'];
+		headers['Content-Length'] = range.stop - range.start + 1;
+		res.writeHead(206, headers);
+		ws.pipe(new ExtractRange({start: range.start, stop: range.stop})).pipe(res);
 	} else {
 		res.writeHead(200, headers);
 		ws.pipe(res);


### PR DESCRIPTION
@RocketChat/core 

currently it is not possible to play multimedia files using the html5 player in rocket.chat using Safari because the web server used to serve the files is currently missing support for byte range requests, as documented [here](https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariWebContent/CreatingVideoforSafarioniPhone/CreatingVideoforSafarioniPhone.html#//apple_ref/doc/uid/TP40006514-SW6) for iOS.

This patch adds basic support for rfc 7233 making it possible to play multimedia files on that browser too.

I tested this very quickly and it seems to work fine on iOS 9.3.5 and Mac Os X 10.11.5, but please have a thorough look before merging.
