### PR TITLE
Markdown url links that point to server url should not open in blank

### DIFF
--- a/packages/rocketchat-markdown/markdown.coffee
+++ b/packages/rocketchat-markdown/markdown.coffee
@@ -16,13 +16,19 @@ class Markdown
 		schemes = RocketChat.settings.get('Markdown_SupportSchemesForLink').split(',').join('|')
 
 		# Support ![alt text](http://image url)
-		msg = msg.replace(new RegExp("!\\[([^\\]]+)\\]\\(((?:#{schemes}):\\/\\/[^\\)]+)\\)", 'gm'), '<a href="$2" title="$1" class="swipebox" target="_blank"><div class="inline-image" style="background-image: url($2);"></div></a>')
+		msg = msg.replace new RegExp("!\\[([^\\]]+)\\]\\(((?:#{schemes}):\\/\\/[^\\)]+)\\)", 'gm'), (match, title, url) ->
+			target = if url.indexOf(Meteor.absoluteUrl()) is 0 then '' else '_blank'
+			return '<a href="' + url + '" title="' + title + '" class="swipebox" target="' + target + '"><div class="inline-image" style="background-image: url(' + url + ');"></div></a>'
 
 		# Support [Text](http://link)
-		msg = msg.replace(new RegExp("\\[([^\\]]+)\\]\\(((?:#{schemes}):\\/\\/[^\\)]+)\\)", 'gm'), '<a href="$2" target="_blank">$1</a>')
+		msg = msg.replace new RegExp("\\[([^\\]]+)\\]\\(((?:#{schemes}):\\/\\/[^\\)]+)\\)", 'gm'), (match, title, url) ->
+			target = if url.indexOf(Meteor.absoluteUrl()) is 0 then '' else '_blank'
+			return '<a href="' + url + '" target="' + target + '">' + title + '</a>'
 
 		# Support <http://link|Text>
-		msg = msg.replace(new RegExp("(?:<|&lt;)((?:#{schemes}):\\/\\/[^\\|]+)\\|(.+?)(?=>|&gt;)(?:>|&gt;)", 'gm'), '<a href="$1" target="_blank">$2</a>')
+		msg = msg.replace new RegExp("(?:<|&lt;)((?:#{schemes}):\\/\\/[^\\|]+)\\|(.+?)(?=>|&gt;)(?:>|&gt;)", 'gm'), (match, url, title) ->
+			target = if url.indexOf(Meteor.absoluteUrl()) is 0 then '' else '_blank'
+			return '<a href="' + url + '" target="' + target + '">' + title + '</a>'
 
 		if RocketChat.settings.get('Markdown_Headers')
 			# Support # Text for h1


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #3432

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Markdown links such as `[Rocket.Chat](https://demo.rocket.chat/channel/meteor)` that point to the server URL should not open in  a new tab (_blank).