### PR TITLE
 added new rest method to retrive room info

### DIFF
--- a/packages/rocketchat-api/server/routes.coffee
+++ b/packages/rocketchat-api/server/routes.coffee
@@ -256,4 +256,26 @@ RocketChat.API.v1.addRoute 'groups.create', authRequired: true,
 
 		return RocketChat.API.v1.success
 			group: RocketChat.models.Rooms.findOne({_id: id.rid})
+			
+RocketChat.API.v1.addRoute 'room.info', authRequired: true,
+	post: ->
+	
+		if RocketChat.authz.hasRole(@userId, 'admin') is false
+			return RocketChat.API.v1.unauthorized()
+		try
+			this.response.setTimeout (1000)	
+			room = RocketChat.models.Rooms.findOneById @bodyParams.rid
+			if !room
+				room = RocketChat.models.Rooms.findOneByName @bodyParams.name
+				if !room
+					return RocketChat.API.v1.failure 'room identifier is invalid'
+					
+			return RocketChat.API.v1.success
+				room: room
+		
+		catch e
+			console.log '[routes.coffee] api/v1/admin.listRoomInfo Error: ', e.message, e.stack
+			return RocketChat.API.v1.failure e.name + ': ' + e.message
+			
+			
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
allows rest-api method to get a specific channel/group/directMessage with either the "name" or _id.

rlist= requests.post ('http://devbox:3000/api/v1/room.info', headers=jg,data='{"rid":"GENERAL"}')

>>> rlist.json()
{u'room': {u'usernames': [u'jgreen', u'jgreen-1'], u'name': u'general', u'msgs': 2, u'default': True, u'lm': u'2016-09-10T17:15:13.316Z', u'ts': u'2016-09-10T15:56:57.212Z', u't': u'c', u'_id': u'GENERAL', u'_updatedAt': u'2016-09-12T23:57:40.140Z'}, u'success': True}
  
