### PR TITLE
Auto hide scrollbars on windows

### DIFF
--- a/packages/rocketchat-theme/assets/stylesheets/utils/_colors.import.less
+++ b/packages/rocketchat-theme/assets/stylesheets/utils/_colors.import.less
@@ -1,4 +1,6 @@
 .custom-scroll(@background, @thumb, @width: 8px, @height: 8px) {
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+
 	&::-webkit-scrollbar {
 		height: @height;
 		width: @width;

--- a/packages/rocketchat-theme/assets/stylesheets/utils/_colors.import.less
+++ b/packages/rocketchat-theme/assets/stylesheets/utils/_colors.import.less
@@ -1,6 +1,5 @@
 .custom-scroll(@background, @thumb, @width: 8px, @height: 8px) {
-    -ms-overflow-style: -ms-autohiding-scrollbar;
-
+	-ms-overflow-style: -ms-autohiding-scrollbar;
 	&::-webkit-scrollbar {
 		height: @height;
 		width: @width;


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

@rodrigok the change we discussed in relation to #4317

Haven't hovered over message window for a few seconds, bar is gone.
![image](https://cloud.githubusercontent.com/assets/51996/18571224/626f717e-7b76-11e6-9725-254a8f56c94d.png)

Mouse had just been in the message area:
![image](https://cloud.githubusercontent.com/assets/51996/18571235/7c2ae4ae-7b76-11e6-8ccd-be350efeff25.png)



