### PR TITLE
Add reject unauthorized option to crowd login

### DIFF
--- a/packages/rocketchat-crowd/server/crowd.js
+++ b/packages/rocketchat-crowd/server/crowd.js
@@ -42,7 +42,8 @@ const CROWD = class CROWD {
 			application: {
 				name: RocketChat.settings.get('CROWD_APP_USERNAME'),
 				password: RocketChat.settings.get('CROWD_APP_PASSWORD')
-			}
+			},
+			rejectUnauthorized: RocketChat.settings.get('CROWD_Reject_Unauthorized')
 		};
 
 		this.crowdClient = new AtlassianCrowd(this.options);

--- a/packages/rocketchat-crowd/server/settings.js
+++ b/packages/rocketchat-crowd/server/settings.js
@@ -3,6 +3,7 @@ Meteor.startup(function() {
 		const enableQuery = {_id: 'CROWD_Enable', value: true};
 		this.add('CROWD_Enable', false, { type: 'boolean', public: true, i18nLabel: 'Enabled' });
 		this.add('CROWD_URL', '', { type: 'string', enableQuery: enableQuery, i18nLabel: 'URL' });
+		this.add('CROWD_Reject_Unauthorized', true, { type: 'boolean', enableQuery: enableQuery });
 		this.add('CROWD_APP_USERNAME', '', { type: 'string', enableQuery: enableQuery, i18nLabel: 'Username' });
 		this.add('CROWD_APP_PASSWORD', '', { type: 'string', enableQuery: enableQuery, i18nLabel: 'Password' });
 		this.add('CROWD_Sync_User_Data', false, { type: 'boolean', enableQuery: enableQuery, i18nLabel: 'Sync_Users' });

--- a/packages/rocketchat-crowd/server/settings.js
+++ b/packages/rocketchat-crowd/server/settings.js
@@ -5,7 +5,7 @@ Meteor.startup(function() {
 		this.add('CROWD_URL', '', { type: 'string', enableQuery: enableQuery, i18nLabel: 'URL' });
 		this.add('CROWD_Reject_Unauthorized', true, { type: 'boolean', enableQuery: enableQuery });
 		this.add('CROWD_APP_USERNAME', '', { type: 'string', enableQuery: enableQuery, i18nLabel: 'Username' });
-		this.add('CROWD_APP_PASSWORD', '', { type: 'string', enableQuery: enableQuery, i18nLabel: 'Password' });
+		this.add('CROWD_APP_PASSWORD', '', { type: 'password', enableQuery: enableQuery, i18nLabel: 'Password' });
 		this.add('CROWD_Sync_User_Data', false, { type: 'boolean', enableQuery: enableQuery, i18nLabel: 'Sync_Users' });
 		this.add('CROWD_Test_Connection', 'crowd_test_connection', { type: 'action', actionText: 'Test_Connection', i18nLabel: 'Test_Connection' });
 	});

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -278,6 +278,7 @@
   "Create_new" : "Create new",
   "Created_at" : "Created at",
   "Created_at_s_by_s" : "Created at <strong>%s</strong> by <strong>%s</strong>",
+  "CROWD_Reject_Unauthorized" : "Reject Unauthorized",
   "Current_Chats" : "Current Chats",
   "Custom" : "Custom",
   "Custom_Emoji" : "Custom Emoji",


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
- Add reject unauthorized setting for crowd login to allow all ssl certificates (same as LDAP)
- Set password field as a password input to hide entered password

![image](https://cloud.githubusercontent.com/assets/5689874/18599431/5c3f8cd2-7c50-11e6-8393-949e82da8b89.png)
