### PR TITLE
Rename atlassian crowd url to remove space

### DIFF
--- a/packages/rocketchat-crowd/server/settings.js
+++ b/packages/rocketchat-crowd/server/settings.js
@@ -1,5 +1,5 @@
 Meteor.startup(function() {
-	RocketChat.settings.addGroup('Atlassian Crowd', function() {
+	RocketChat.settings.addGroup('AtlassianCrowd', function() {
 		const enableQuery = {_id: 'CROWD_Enable', value: true};
 		this.add('CROWD_Enable', false, { type: 'boolean', public: true, i18nLabel: 'Enabled' });
 		this.add('CROWD_URL', '', { type: 'string', enableQuery: enableQuery, i18nLabel: 'URL' });

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -177,6 +177,7 @@
   "Are_you_sure_you_want_to_delete_your_account" : "Are you sure you want to delete your account?",
   "Assign_admin" : "Assigning admin",
   "at" : "at",
+  "AtlassianCrowd" : "Atlassian Crowd",
   "Attachment_File_Uploaded" : "File Uploaded",
   "Auth_Token" : "Auth Token",
   "Author" : "Author",

--- a/server/startup/migrations/v062.js
+++ b/server/startup/migrations/v062.js
@@ -1,0 +1,6 @@
+RocketChat.Migrations.add({
+	version: 62,
+	up: function() {
+		RocketChat.models.Settings.remove({ _id: 'Atlassian Crowd', type: 'group' });
+	}
+});


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->


<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Rename crowd setting to remove space (changing url from `admin/Atlassian%2520Crowd` to `admin/AtlassianCrowd`

I did this in a separate PR as I'm not sure if it requires a db migration or anything?
