### PR TITLE
Sandstorm: Update meteor-spk for Meteor 1.4

### DIFF
--- a/.sandstorm/build.sh
+++ b/.sandstorm/build.sh
@@ -3,13 +3,9 @@ set -x
 set -euvo pipefail
 
 # Make meteor bundle
-
-METEOR_WAREHOUSE_DIR="${METEOR_WAREHOUSE_DIR:-$HOME/.meteor}"
-METEOR_DEV_BUNDLE=$(dirname $(readlink -f "$METEOR_WAREHOUSE_DIR/meteor"))/dev_bundle
-
 cd /opt/app
 meteor build --directory /home/vagrant/
-(cd /home/vagrant/bundle/programs/server && "$METEOR_DEV_BUNDLE/bin/npm" install)
+(cd /home/vagrant/bundle/programs/server && meteor npm install)
 
 # Copy our launcher script into the bundle so the grain can start up.
 mkdir -p /home/vagrant/bundle/opt/app/.sandstorm/

--- a/.sandstorm/setup.sh
+++ b/.sandstorm/setup.sh
@@ -4,7 +4,7 @@ set -euvo pipefail
 
 cd /opt/
 
-PACKAGE=meteor-spk-0.2.1
+PACKAGE=meteor-spk-0.3.0
 PACKAGE_FILENAME="$PACKAGE.tar.xz"
 CACHE_TARGET="/host-dot-sandstorm/caches/${PACKAGE_FILENAME}"
 
@@ -28,7 +28,7 @@ cp -a /lib/x86_64-linux-gnu/libtinfo.so.* /opt/meteor-spk/meteor-spk.deps/lib/x8
 # Unfortunately, Meteor does not explicitly make it easy to cache packages, but
 # we know experimentally that the package is mostly directly extractable to a
 # user's $HOME/.meteor directory.
-METEOR_RELEASE=1.2.1
+METEOR_RELEASE=1.4.1.1
 METEOR_PLATFORM=os.linux.x86_64
 METEOR_TARBALL_FILENAME="meteor-bootstrap-${METEOR_PLATFORM}.tar.gz"
 METEOR_TARBALL_URL="https://d3sqy0vbqsdhku.cloudfront.net/packages-bootstrap/${METEOR_RELEASE}/${METEOR_TARBALL_FILENAME}"


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Rocket.Chat should now build properly for Sandstorm with this change. Tested working locally. Make sure to destroy your old box (`vagrant-spk destroy` then `vagrant-spk up`), since I changed setup.sh