### PR TITLE
Added setting to allow the sending of unrecognized slash commands

### DIFF
--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -749,6 +749,7 @@
   "Message_AllowDeleting" : "Allow Message Deleting",
   "Message_AllowDeleting_BlockDeleteInMinutes" : "Block Message Deleting After (n) Minutes",
   "Message_AllowDeleting_BlockDeleteInMinutes_Description" : "Enter 0 to disable blocking.",
+  "Message_AllowUnrecognizedSlashCommand" : "Allow Unrecognized Slash Commands",
   "Message_AllowEditing" : "Allow Message Editing",
   "Message_AllowEditing_BlockEditInMinutes" : "Block Message Editing After (n) Minutes",
   "Message_AllowEditing_BlockEditInMinutesDescription" : "Enter 0 to disable blocking.",

--- a/packages/rocketchat-lib/server/startup/settings.coffee
+++ b/packages/rocketchat-lib/server/startup/settings.coffee
@@ -167,6 +167,7 @@ RocketChat.settings.addGroup 'Message', ->
 	@add 'Message_AllowEditing_BlockEditInMinutes', 0, { type: 'int', public: true, i18nDescription: 'Message_AllowEditing_BlockEditInMinutesDescription' }
 	@add 'Message_AllowDeleting', true, { type: 'boolean', public: true }
 	@add 'Message_AllowDeleting_BlockDeleteInMinutes', 0, { type: 'int', public: true, i18nDescription: 'Message_AllowDeleting_BlockDeleteInMinutes' }
+	@add 'Message_AllowUnrecognizedSlashCommand', false, { type: 'boolean', public: true}
 	@add 'Message_AlwaysSearchRegExp', false, { type: 'boolean' }
 	@add 'Message_ShowEditedStatus', true, { type: 'boolean', public: true }
 	@add 'Message_ShowDeletedStatus', false, { type: 'boolean', public: true }

--- a/packages/rocketchat-ui/lib/chatMessages.coffee
+++ b/packages/rocketchat-ui/lib/chatMessages.coffee
@@ -186,6 +186,8 @@ class @ChatMessages
 							else
 								Meteor.call 'slashCommand', {cmd: command, params: param, msg: msgObject }
 							return
+
+					if !RocketChat.settings.get('Message_AllowUnrecognizedSlashCommand')
 						invalidCommandMsg =
 							_id: Random.id()
 							rid: rid

--- a/packages/rocketchat-ui/lib/chatMessages.coffee
+++ b/packages/rocketchat-ui/lib/chatMessages.coffee
@@ -187,17 +187,17 @@ class @ChatMessages
 								Meteor.call 'slashCommand', {cmd: command, params: param, msg: msgObject }
 							return
 
-					if !RocketChat.settings.get('Message_AllowUnrecognizedSlashCommand')
-						invalidCommandMsg =
-							_id: Random.id()
-							rid: rid
-							ts: new Date
-							msg: TAPi18n.__('No_such_command', { command: match[1] })
-							u:
-								username: "rocketbot"
-							private: true
-						ChatMessage.upsert { _id: invalidCommandMsg._id }, invalidCommandMsg
-						return
+						if !RocketChat.settings.get('Message_AllowUnrecognizedSlashCommand')
+							invalidCommandMsg =
+								_id: Random.id()
+								rid: rid
+								ts: new Date
+								msg: TAPi18n.__('No_such_command', { command: match[1] })
+								u:
+									username: "rocketbot"
+								private: true
+							ChatMessage.upsert { _id: invalidCommandMsg._id }, invalidCommandMsg
+							return
 
 				Meteor.call 'sendMessage', msgObject
 				done()


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #3906

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

This adds a setting that allows unrecognized slash commands to be sent.  So they can be handled by bots if users wish