### PR TITLE
Remove colon from users autocomplete

### DIFF
--- a/packages/rocketchat-ui-message/message/popup/messagePopupConfig.coffee
+++ b/packages/rocketchat-ui-message/message/popup/messagePopupConfig.coffee
@@ -103,7 +103,7 @@ Template.messagePopupConfig.helpers
 					getUsersFromServerDelayed filter, items, cb
 
 				all =
-					_id: '@all'
+					_id: 'all'
 					username: 'all'
 					system: true
 					name: t 'Notify_all_in_this_room'
@@ -116,17 +116,8 @@ Template.messagePopupConfig.helpers
 
 				return items
 
-			getValue: (_id, collection, firstPartValue) ->
-				if _id is '@all'
-					if firstPartValue.indexOf(' ') > -1
-						return 'all'
-
-					return 'all:'
-
-				if firstPartValue.indexOf(' ') > -1
-					return _id
-
-				return _id + ':'
+			getValue: (_id) ->
+				return _id
 
 		return config
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

per @engelgabriel 's request

@rodrigok is there any reason to use `_id: '@all'` instead of just `_id: 'all'` ? I removed the `@` in advance.