### PR TITLE
Fix variable name issue from #4437

### DIFF
--- a/packages/rocketchat-integrations/server/processWebhookMessage.js
+++ b/packages/rocketchat-integrations/server/processWebhookMessage.js
@@ -82,7 +82,7 @@ this.processWebhookMessage = function(messageObj, user, defaultValues) {
 			attachments: messageObj.attachments,
 			parseUrls: messageObj.parseUrls !== undefined ? messageObj.parseUrls : !messageObj.attachments,
 			bot: messageObj.bot,
-			groupable: (message.groupable !== undefined) ? messageObj.groupable : false
+			groupable: (messageObj.groupable !== undefined) ? messageObj.groupable : false
 		};
 
 		if (!_.isEmpty(messageObj.icon_url) || !_.isEmpty(messageObj.avatar)) {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Had a typo in variable name that causes no webhooks to work.
