### PR TITLE
Prevent error when parsing oembed meta

### DIFF
--- a/packages/rocketchat-oembed/server/providers.coffee
+++ b/packages/rocketchat-oembed/server/providers.coffee
@@ -71,10 +71,11 @@ RocketChat.callbacks.add 'oembed:afterParseContent', (data) ->
 			provider = providers.getProviderForUrl url
 			if provider?
 				if data.content?.body?
-					metas = JSON.parse data.content.body;
-					_.each metas, (value, key) ->
-						if _.isString value
-							data.meta[changeCase.camelCase('oembed_' + key)] = value
-					data.meta['oembedUrl'] = url
+					try
+						metas = JSON.parse data.content.body;
+						_.each metas, (value, key) ->
+							if _.isString value
+								data.meta[changeCase.camelCase('oembed_' + key)] = value
+						data.meta['oembedUrl'] = url
 
 	return data


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Fix exception:
```
SyntaxError: Unexpected end of input
  at Object.parse (native)
  at /var/www/rocket.chat/bundle/programs/server/packages/rocketchat_oembed.js:421:24
  at /var/www/rocket.chat/bundle/programs/server/packages/rocketchat_lib.js:290:24
  at Array.reduce (native)
  at Object.RocketChat.callbacks.run (/var/www/rocket.chat/bundle/programs/server/packages/rocketchat_lib.js:285:8)
  at Object.OEmbed.getUrlMeta (/var/www/rocket.chat/bundle/programs/server/packages/rocketchat_oembed.js:191:31)
  at Object.OEmbed.getUrlMetaWithCache (/var/www/rocket.chat/bundle/programs/server/packages/rocketchat_oembed.js:206:17)
  at /var/www/rocket.chat/bundle/programs/server/packages/rocketchat_oembed.js:268:21
  at Array.forEach (native)
  at OEmbed.RocketUrlParser (/var/www/rocket.chat/bundle/programs/server/packages/rocketchat_oembed.js:251:18)
  at /var/www/rocket.chat/bundle/programs/server/packages/rocketchat_lib.js:290:24
  at Array.reduce (native)
  at Object.RocketChat.callbacks.run (/var/www/rocket.chat/bundle/programs/server/packages/rocketchat_lib.js:285:8)
  at /var/www/rocket.chat/bundle/programs/server/packages/rocketchat_lib.js:2506:33
  at [object Object]._.extend.withValue (/var/www/rocket.chat/bundle/programs/server/packages/meteor.js:1107:17)
  at /var/www/rocket.chat/bundle/programs/server/packages/meteor.js:445:45
  at runWithEnvironment (/var/www/rocket.chat/bundle/programs/server/packages/meteor.js:1161:24)
```
