### PR TITLE
Prevent edited messaged breaking line

### DIFF
--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -2591,6 +2591,7 @@ label.required:after {
 				border-left: 0;
 				margin-left: 0;
 				padding-left: 0;
+				white-space: nowrap;
 			}
 			.private {
 				display: none;


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

It happens depending on translation.. It's happening for portuguese:

Before:
![image](https://cloud.githubusercontent.com/assets/8591547/18877073/61afc1e6-84a2-11e6-9bde-046de1983e50.png)

After
![image](https://cloud.githubusercontent.com/assets/8591547/18877077/658e5430-84a2-11e6-91e1-3d6c2831c9a8.png)


