### PR TITLE
Fix OEmbed exception on request error

### DIFF
--- a/packages/rocketchat-oembed/server/server.coffee
+++ b/packages/rocketchat-oembed/server/server.coffee
@@ -50,6 +50,7 @@ getUrlContent = (urlObj, redirectCount = 5, callback) ->
 
 	headers = null
 	statusCode = null
+	error = null
 	chunks = []
 	chunksTotalLength = 0
 
@@ -67,6 +68,12 @@ getUrlContent = (urlObj, redirectCount = 5, callback) ->
 			stream.abort()
 
 	stream.on 'end', Meteor.bindEnvironment ->
+		if error?
+			return callback null, {
+				error: error
+				parsedUrl: parsedUrl
+			}
+
 		buffer = Buffer.concat(chunks)
 
 		callback null, {
@@ -76,11 +83,8 @@ getUrlContent = (urlObj, redirectCount = 5, callback) ->
 			statusCode: statusCode
 		}
 
-	stream.on 'error', (error) ->
-		callback null, {
-			error: error
-			parsedUrl: parsedUrl
-		}
+	stream.on 'error', (err) ->
+		error = err
 
 OEmbed.getUrlMeta = (url, withFragment) ->
 	getUrlContentSync = Meteor.wrapAsync getUrlContent


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

Fix exception:
```
Error: Future resolved more than once
  at Object.Future.return (/var/www/rocket.chat/bundle/programs/server/node_modules/fibers/future.js:261:10)
  at Object.<anonymous> (/var/www/rocket.chat/bundle/programs/server/node_modules/fibers/future.js:349:16)
  at runWithEnvironment (/var/www/rocket.chat/bundle/programs/server/packages/meteor.js:1161:24)
  at /var/www/rocket.chat/bundle/programs/server/packages/meteor.js:1174:14
  at /var/www/rocket.chat/bundle/programs/server/packages/rocketchat_oembed.js:123:12
  at runWithEnvironment (/var/www/rocket.chat/bundle/programs/server/packages/meteor.js:1161:24)
```