### PR TITLE
properly stop AV tracks when closing video recording dialog

### DIFF
--- a/packages/rocketchat-ui/lib/recorderjs/videoRecorder.coffee
+++ b/packages/rocketchat-ui/lib/recorderjs/videoRecorder.coffee
@@ -47,9 +47,13 @@
 			@stopRecording()
 
 			if @stream?
-				vtracks = @stream.getVideoTracks()[0]
-				if vtracks
-					vtracks.stop()
+				vtracks = @stream.getVideoTracks()
+				for vtrack in vtracks
+					vtrack.stop()
+
+				atracks = @stream.getAudioTracks()
+				for atrack in atracks
+					atrack.stop()
 
 			if @videoel?
 				@videoel.pause


### PR DESCRIPTION
@RocketChat/core 

after using and closing the record video message button in the message box, the camera remains still in use, as indicated by the red icon in the chrome tab.

This happens because in the `stop()` function only the videotracks are stopped, but non the audio tracks.

This fix should solve the issue.
