### PR TITLE
fix for DnD files upload in Firefox

### DIFF
--- a/packages/rocketchat-ui/views/app/room.coffee
+++ b/packages/rocketchat-ui/views/app/room.coffee
@@ -397,9 +397,15 @@ Template.room.events
 			ChatMessage.update {_id: id}, {$set: {"urls.#{index}.collapsed": !collapsed}}
 
 	'dragenter .dropzone': (e) ->
-		items = e.originalEvent?.dataTransfer?.items
-		if items?.length > 0 and items?[0]?.kind isnt 'string' and userCanDrop this._id
-			e.currentTarget.classList.add 'over'
+		isChrome = navigator.userAgent.toLocaleLowerCase().indexOf('chrome') > -1
+
+		if isChrome
+			items = e.originalEvent?.dataTransfer?.items
+			if items?.length > 0 and items?[0]?.kind isnt 'string' and userCanDrop this._id
+				e.currentTarget.classList.add 'over'
+		else
+			if userCanDrop this._id
+				e.currentTarget.classList.add 'over'
 
 	'dragleave .dropzone-overlay': (e) ->
 		e.currentTarget.parentNode.classList.remove 'over'
@@ -415,9 +421,7 @@ Template.room.events
 		event.currentTarget.parentNode.classList.remove 'over'
 
 		e = event.originalEvent or event
-		files = e.target.files
-		if not files or files.length is 0
-			files = e.dataTransfer?.files or []
+		files = e.dataTransfer?.files or []
 
 		filesToUpload = []
 		for file in files

--- a/packages/rocketchat-ui/views/app/room.coffee
+++ b/packages/rocketchat-ui/views/app/room.coffee
@@ -397,10 +397,10 @@ Template.room.events
 			ChatMessage.update {_id: id}, {$set: {"urls.#{index}.collapsed": !collapsed}}
 
 	'dragenter .dropzone': (e) ->
-		isChrome = navigator.userAgent.toLocaleLowerCase().indexOf('chrome') > -1
+		# Check for dataTransfer.items browser support
+		items = e.originalEvent?.dataTransfer?.items
 
-		if isChrome
-			items = e.originalEvent?.dataTransfer?.items
+		if items
 			if items?.length > 0 and items?[0]?.kind isnt 'string' and userCanDrop this._id
 				e.currentTarget.classList.add 'over'
 		else


### PR DESCRIPTION
@RocketChat/core 

Closes #4420 

I changed the verification step because only Chrome has the ``items`` array in ``dataTransfer``. Other browsers such Firefox, Safari and IE still doesn't has this ``items`` implementation ([Firefox will in v50](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/items)). I found in [W3C docs](http://w3c.github.io/html/editing.html#events-summary) that only ``drop`` event is readable. Others events like ``dragenter`` are protected.

Chrome is the only browser that populate ``dataTransfer`` with files info, so I removed the count and string verification steps for others browsers. If the user drag and drop a string the ``over`` will appear but will not upload.

I think is just not fare to remove DnD from others browsers just for this verification step.

I also changed the ``files`` declaration. ``e.target.files`` doesn't exists, ``.target`` is only a DOM element.
