### PR TITLE
Fix livechat routing to agents that have never logged in

### DIFF
--- a/packages/rocketchat-livechat/server/models/Users.js
+++ b/packages/rocketchat-livechat/server/models/Users.js
@@ -19,7 +19,10 @@ RocketChat.models.Users.setOperator = function(_id, operator) {
  */
 RocketChat.models.Users.findOnlineAgents = function() {
 	var query = {
-		statusConnection: { $ne: 'offline' },
+		statusConnection: {
+			$exists: true,
+			$ne: 'offline'
+		},
 		statusLivechat: 'available',
 		roles: 'livechat-agent'
 	};
@@ -46,7 +49,10 @@ RocketChat.models.Users.findAgents = function() {
  */
 RocketChat.models.Users.findOnlineUserFromList = function(userList) {
 	var query = {
-		statusConnection: { $ne: 'offline' },
+		statusConnection: {
+			$exists: true,
+			$ne: 'offline'
+		},
 		statusLivechat: 'available',
 		roles: 'livechat-agent',
 		username: {
@@ -63,7 +69,10 @@ RocketChat.models.Users.findOnlineUserFromList = function(userList) {
  */
 RocketChat.models.Users.getNextAgent = function() {
 	var query = {
-		statusConnection: { $ne: 'offline' },
+		statusConnection: {
+			$exists: true,
+			$ne: 'offline'
+		},
 		statusLivechat: 'available',
 		roles: 'livechat-agent'
 	};


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

If an user is created using the admin area, and put on some department, it will receive a livechat even if not logged in.
