### PR TITLE
Use status code 403 forbidden instead of 401 unauthorized

### DIFF
--- a/packages/rocketchat-api/server/api.coffee
+++ b/packages/rocketchat-api/server/api.coffee
@@ -28,7 +28,7 @@ class API extends Restivus
 
 	unauthorized: (msg) ->
 		return {} =
-			statusCode: 401
+			statusCode: 403
 			body:
 				success: false
 				error: msg or 'unauthorized'
@@ -40,7 +40,7 @@ RocketChat.API = {}
 RocketChat.API.v1 = new API
 	version: 'v1'
 	useDefaultAuth: true
-	prettyJson: false
+	prettyJson: true
 	enableCors: false
 	auth:
 		token: 'services.resume.loginTokens.hashedToken'


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Since we use `RocketChat.API.v1.unauthorized()` if a permission is not granted (see [here](https://github.com/RocketChat/Rocket.Chat/blob/25ffa1919ddc26939cbd6be5f0985f133d0d0404/packages/rocketchat-api/server/routes.coffee#L80), [here](https://github.com/RocketChat/Rocket.Chat/blob/25ffa1919ddc26939cbd6be5f0985f133d0d0404/packages/rocketchat-api/server/routes.coffee#L96), [here](https://github.com/RocketChat/Rocket.Chat/blob/25ffa1919ddc26939cbd6be5f0985f133d0d0404/packages/rocketchat-api/server/routes.coffee#L132) ), we should use `403 Forbidden` instead of `401 Unauthorized` ( [reference](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_Client_Error) )

Also returns a pretty JSON =)