### PR TITLE
Decrease the callback priority of highlight words

### DIFF
--- a/packages/rocketchat-highlight-words/client.coffee
+++ b/packages/rocketchat-highlight-words/client.coffee
@@ -22,4 +22,4 @@ class HighlightWordsClient
     message.html = msg
     return message
 
-RocketChat.callbacks.add 'renderMessage', HighlightWordsClient
+RocketChat.callbacks.add 'renderMessage', HighlightWordsClient, RocketChat.callbacks.priority.MEDIUM + 1


### PR DESCRIPTION
Highlight words and mentions have the same priority.
Highlight words seem to be processed before mentions, and this breaks mentions in certain cases.
If I have my name as a highlight word, mentioning me using `@my name` is incorrectly displayed. Clicking the mention in the message doesn't bring up my profile info.