### PR TITLE
Fix setting username from REST API

### DIFF
--- a/packages/rocketchat-lib/server/functions/setUsername.coffee
+++ b/packages/rocketchat-lib/server/functions/setUsername.coffee
@@ -62,4 +62,4 @@ RocketChat._setUsername = (userId, username) ->
 	return user
 
 RocketChat.setUsername = RocketChat.RateLimiter.limitFunction RocketChat._setUsername, 1, 60000,
-	0: () -> return not Meteor.userId() or not RocketChat.authz.hasPermission(Meteor.userId(), 'edit-other-user-info') # Administrators have permission to change others usernames, so don't limit those
+	0: (userId) -> return not userId or not RocketChat.authz.hasPermission(userId, 'edit-other-user-info') # Administrators have permission to change others usernames, so don't limit those


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

It was giving an error because the use of `Meteor.userId()` outside a Meteor method.

I'm slightly changing rate limiter's behaviour. It was checking previously the user that is calling the `setUsername` function, now it checks for whom the username is being set. 

So, previously: the same user could not set more than one username per minute.
Now the same user can't change the *same* user's username more than once per minute.