### PR TITLE
added support for apostrophe emojis

### DIFF
--- a/packages/rocketchat-emoji/emojiParser.js
+++ b/packages/rocketchat-emoji/emojiParser.js
@@ -9,6 +9,9 @@ RocketChat.callbacks.add('renderMessage', (message) => {
 	}
 
 	if (_.trim(message.html)) {
+		//&#39; to apostrophe (') for emojis such as :')
+		message.html = message.html.replace(/&#39;/g, "'");
+
 		Object.keys(RocketChat.emoji.packages).forEach((emojiPackage) => {
 			message.html = RocketChat.emoji.packages[emojiPackage].render(message.html);
 		});
@@ -36,6 +39,9 @@ RocketChat.callbacks.add('renderMessage', (message) => {
 		if (emojiOnly) {
 			message.html = checkEmojiOnly.unwrap().html();
 		}
+
+		//apostrophe (') back to &#39;
+		message.html = message.html.replace(/\'/g, "&#39;");
 	}
 
 	return message;

--- a/packages/rocketchat-emoji/emojiParser.js
+++ b/packages/rocketchat-emoji/emojiParser.js
@@ -10,7 +10,7 @@ RocketChat.callbacks.add('renderMessage', (message) => {
 
 	if (_.trim(message.html)) {
 		//&#39; to apostrophe (') for emojis such as :')
-		message.html = message.html.replace(/&#39;/g, "'");
+		message.html = message.html.replace(/&#39;/g, '\'');
 
 		Object.keys(RocketChat.emoji.packages).forEach((emojiPackage) => {
 			message.html = RocketChat.emoji.packages[emojiPackage].render(message.html);
@@ -41,7 +41,7 @@ RocketChat.callbacks.add('renderMessage', (message) => {
 		}
 
 		//apostrophe (') back to &#39;
-		message.html = message.html.replace(/\'/g, "&#39;");
+		message.html = message.html.replace(/\'/g, '&#39;');
 	}
 
 	return message;


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #2013

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
A simple line of regex in emojiParser.js to change `&#39;` to ' and then a second line after to change ' back to `&#39;`
The second line might not be needed, as everything seemed to work fine in my demo, but just in case the apostrophe needs to be put back to `&#39;` it is there.

Emjois which use the apostrophe  such as :') now work as expected.

