### PR TITLE
@here support for only notifying users that are active

### DIFF
--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -878,6 +878,7 @@
   "Notification_Duration": "Notification Duration",
   "Notifications": "Notifications",
   "Notify_all_in_this_room": "Notify all in this room",
+  "Notify_active_in_this_room": "Notify active users in this room",
   "Num_Agents": "# Agents",
   "Number_of_messages": "Number of messages",
   "OAuth_Application": "OAuth Application",

--- a/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
@@ -24,7 +24,7 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 		return -1;
 	};
 
-	var settings, desktopMentionIds, i, j, len, len1, highlights, mentionIds, highlightsIds, usersWithHighlights, mobileMentionIds, ref, ref1, toAll, userIdsToNotify, userIdsToPushNotify, userOfMention, userOfMentionId, usersOfDesktopMentions, usersOfMentionId, usersOfMentionItem, usersOfMobileMentions;
+	var settings, desktopMentionIds, i, j, len, len1, highlights, mentionIds, highlightsIds, usersWithHighlights, mobileMentionIds, ref, ref1, toAll, toHere, userIdsToNotify, userIdsToPushNotify, userOfMention, userOfMentionId, usersOfDesktopMentions, usersOfMentionId, usersOfMentionItem, usersOfMobileMentions;
 
 	/**
 	 * Checks if a given user can be notified
@@ -181,6 +181,7 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 			});
 		}
 		toAll = mentionIds.indexOf('all') > -1;
+		toHere = mentionIds.indexOf('here') > -1;
 		if (mentionIds.length > 0 || settings.alwaysNotifyDesktopUsers.length > 0) {
 			desktopMentionIds = _.union(mentionIds, settings.alwaysNotifyDesktopUsers);
 			desktopMentionIds = _.difference(desktopMentionIds, settings.dontNotifyDesktopUsers);
@@ -248,7 +249,7 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 			}), '_id');
 		}
 
-		if (toAll && ((ref1 = room.usernames) != null ? ref1.length : void 0) > 0) {
+		if ((toAll || toHere) && ((ref1 = room.usernames) != null ? ref1.length : void 0) > 0) {
 			RocketChat.models.Users.find({
 				username: {
 					$in: room.usernames
@@ -268,7 +269,7 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 				if (((ref2 = user.status) === 'online' || ref2 === 'away' || ref2 === 'busy') && (ref3 = user._id, indexOf.call(settings.dontNotifyDesktopUsers, ref3) < 0)) {
 					userIdsToNotify.push(user._id);
 				}
-				if (user.statusConnection !== 'online' && (ref4 = user._id, indexOf.call(settings.dontNotifyMobileUsers, ref4) < 0)) {
+				if (toAll && user.statusConnection !== 'online' && (ref4 = user._id, indexOf.call(settings.dontNotifyMobileUsers, ref4) < 0)) {
 					return userIdsToPushNotify.push(user._id);
 				}
 			});

--- a/packages/rocketchat-mentions/client.coffee
+++ b/packages/rocketchat-mentions/client.coffee
@@ -20,7 +20,7 @@ class MentionsClient
 				mentions = _.unique mentions
 				mentions = mentions.join('|')
 				msg = msg.replace new RegExp("(?:^|\\s|\\n)(@(#{mentions}):?)[:.,\s]?", 'g'), (match, mention, username) ->
-					if username is 'all'
+					if username is 'all' or username is 'here'
 						return match.replace mention, "<a class=\"mention-link mention-link-me mention-link-all\">#{mention}</a>"
 
 					if not message.temp?

--- a/packages/rocketchat-mentions/server.coffee
+++ b/packages/rocketchat-mentions/server.coffee
@@ -26,6 +26,10 @@ class MentionsServer
 						verifiedMention =
 							_id: mention
 							username: mention
+				else if mention is 'here'
+					verifiedMention =
+						_id: mention
+						username: mention
 				else
 					verifiedMention = Meteor.users.findOne({username: mention}, {fields: {_id: 1, username: 1}})
 

--- a/packages/rocketchat-ui-message/message/popup/messagePopupConfig.coffee
+++ b/packages/rocketchat-ui-message/message/popup/messagePopupConfig.coffee
@@ -114,6 +114,17 @@ Template.messagePopupConfig.helpers
 				if exp.test(all.username) or exp.test(all.compatibility)
 					items.push all
 
+				here =
+					_id: 'here'
+					username: 'here'
+					system: true
+					name: t 'Notify_active_in_this_room'
+					compatibility: 'channel group'
+					sort: 4
+
+				if exp.test(here.username) or exp.test(here.compatibility)
+					items.push here
+
 				return items
 
 			getValue: (_id) ->


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #3283 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
This pull request adds a new notification target, `@here`, which only notifies users that are either "online", "away", or "busy", and never sends push notifications.

This is essential for large deployments, especially where users are around the world. When a user uses `@all` it ends up sending notifications to people that are sleeping/not working/etc, making people really unhappy. `@here` is meant for when you need to ping anyone who is available but do not want people going out of their way to login and read/reply.

![at-here](https://cloud.githubusercontent.com/assets/852230/19140337/37b3709a-8b5a-11e6-8a74-f329c995e77b.png)


