### PR TITLE
ADD transition to main-content

### DIFF
--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -1609,6 +1609,7 @@ label.required:after {
 	right: 40px;
 	width: auto;
 	height: auto;
+	.transition(right .25s cubic-bezier(.5, 0, .1, 1));
 	&.flex-opened {
 		right: @flex-tab-width + 40px;
 		.flex-tab {


### PR DESCRIPTION
@RocketChat/core 

Added transition in ``.main-content`` when open the flexbar.

Before:
![2016-10-07 23 06 05](https://cloud.githubusercontent.com/assets/9200155/19209563/1136ae98-8ce3-11e6-978c-234de006aad1.gif)

After:
![2016-10-07 23 07 01](https://cloud.githubusercontent.com/assets/9200155/19209566/1bf831f8-8ce3-11e6-9030-d929c2f233b2.gif)
