### PR TITLE
Allow outgoing integrations to post as the triggering user

### DIFF
--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -584,6 +584,8 @@
   "Installation": "Installation",
   "Installed_at": "Installed at",
   "Instructions_to_your_visitor_fill_the_form_to_send_a_message": "Instructions to your visitor fill the form to send a message",
+  "Impersonate_user": "Impersonate User",
+  "Impersonate_user_description": "When enabled, integration posts as the user that triggered integration",
   "Integration_added": "Integration has been added",
   "Integration_Incoming_WebHook": "Incoming WebHook Integration",
   "Integration_New": "New Integration",

--- a/packages/rocketchat-integrations/client/views/integrationsOutgoing.coffee
+++ b/packages/rocketchat-integrations/client/views/integrationsOutgoing.coffee
@@ -145,6 +145,7 @@ Template.integrationsOutgoing.events
 	"click .submit > .save": ->
 		enabled = $('[name=enabled]:checked').val().trim()
 		name = $('[name=name]').val().trim()
+		impersonateUser = $('[name=impersonateUser]:checked').val().trim()
 		alias = $('[name=alias]').val().trim()
 		emoji = $('[name=emoji]').val().trim()
 		avatar = $('[name=avatar]').val().trim()
@@ -156,7 +157,7 @@ Template.integrationsOutgoing.events
 		scriptEnabled = $('[name=scriptEnabled]:checked').val().trim()
 		script = $('[name=script]').val().trim()
 
-		if username is ''
+		if username is '' and impersonateUser is '0'
 			return toastr.error TAPi18n.__("The_username_is_required")
 
 		triggerWords = triggerWords.split(',')
@@ -189,6 +190,7 @@ Template.integrationsOutgoing.events
 			token: token if token isnt ''
 			script: script if script isnt ''
 			scriptEnabled: scriptEnabled is '1'
+			impersonateUser: impersonateUser is '1'
 
 		params = Template.instance().data.params?()
 		if params?.id?

--- a/packages/rocketchat-integrations/client/views/integrationsOutgoing.html
+++ b/packages/rocketchat-integrations/client/views/integrationsOutgoing.html
@@ -44,6 +44,14 @@
 							</div>
 						</div>
 						<div class="input-line double-col">
+							<label>{{_ "Impersonate_user"}}</label>
+							<div>
+								<label><input type="radio" name="impersonateUser" value="1" checked="{{$eq data.impersonateUser true}}" /> {{_ "True"}}</label>
+								<label><input type="radio" name="impersonateUser" value="0" checked="{{$neq data.impersonateUser true}}" /> {{_ "False"}}</label>
+								<div class="settings-description">{{_ "Impersonate_user_description"}}</div>
+							</div>
+						</div>
+						<div class="input-line double-col">
 							<label>{{_ "Post_as"}}</label>
 							<div>
 								<input type="text" name="username" value="{{data.username}}" />

--- a/packages/rocketchat-integrations/server/methods/outgoing/updateOutgoingIntegration.coffee
+++ b/packages/rocketchat-integrations/server/methods/outgoing/updateOutgoingIntegration.coffee
@@ -103,6 +103,7 @@ Meteor.methods
 				emoji: integration.emoji
 				alias: integration.alias
 				channel: channels
+				impersonateUser: integration.impersonateUser
 				username: integration.username
 				userId: user._id
 				urls: integration.urls

--- a/packages/rocketchat-integrations/server/triggers.coffee
+++ b/packages/rocketchat-integrations/server/triggers.coffee
@@ -155,7 +155,10 @@ ExecuteTriggerUrl = (url, trigger, message, room, tries=0) ->
 	logger.outgoing.debug data
 
 	sendMessage = (message) ->
-		user = RocketChat.models.Users.findOneByUsername(trigger.username)
+		if trigger.impersonateUser ? false
+			user = RocketChat.models.Users.findOneByUsername(data.user_name)
+		else
+			user = RocketChat.models.Users.findOneByUsername(trigger.username)
 
 		message.bot =
 			i: trigger._id


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

The feature allows an outgoing integration to be configured to post as the user that triggered the integration instead of as a separate bot account, similar to how links and other embedded media are handled. The main benefit is that it allows the triggering user to edit/delete the returned data. For example, giphy can always (even with the rating system) return an inappropriate gif. Right now an admin/moderator must be around the delete the image, it cannot be done by the user that triggered it.

Combined with a groupable integration, this also reduces the amount of noise in the chat window.

![inpersonateuser](https://cloud.githubusercontent.com/assets/852230/19216619/7b59cfe0-8d91-11e6-918d-c0d2cb88c96d.png)

Setting:

![impersonatesetting](https://cloud.githubusercontent.com/assets/852230/19216630/cd852814-8d91-11e6-90c4-72ef09a00533.png)

When the setting is disabled, integrations behave exactly the same as they currently do. This is an opt-in behavior.