### PR TITLE
Add session as a dependency of rocketchat:lib

### DIFF
--- a/packages/rocketchat-lib/package.js
+++ b/packages/rocketchat-lib/package.js
@@ -13,6 +13,7 @@ Npm.depends({
 
 Package.onUse(function(api) {
 	api.use('rate-limit');
+	api.use('session');
 	api.use('reactive-var');
 	api.use('reactive-dict');
 	api.use('accounts-base');


### PR DESCRIPTION
@RocketChat/core 

The package `rocketchat:lib` is using `session` in `/packages/rocketchat-lib/client/CustomTranslations.js` but it's not declared as a direct dependency.

<pre>
Meteor.autorun(function() {
	// Re apply translations if tap language was changed
	Session.get(TAPi18n._loaded_lang_session_key);
	RocketChat.applyCustomTranslations();
});
</pre>

This commit will add it as a dependency to let apps include `rocketchat:lib` with errors.



