### PR TITLE
Ensure slash command parameters are defined

### DIFF
--- a/packages/rocketchat-ui/lib/chatMessages.coffee
+++ b/packages/rocketchat-ui/lib/chatMessages.coffee
@@ -180,7 +180,7 @@ class @ChatMessages
 						if RocketChat.slashCommands.commands[match[1]]
 							commandOptions = RocketChat.slashCommands.commands[match[1]]
 							command = match[1]
-							param = match[2]
+							param = if match[2]? then match[2] else ''
 							if commandOptions.clientOnly
 								commandOptions.callback(command, param, msgObject)
 							else


### PR DESCRIPTION
This fixes issues with certain slash commands. (`/lennyface`, `/shrug`, `/gimme`, `/tableflip`, `/unflip`, and possibly others)

Before, if you sent a message such as `/gimme` (with no space after the command), your final message would be `༼ つ ◕_◕ ༽つ undefined`