### PR TITLE
Add scroll listener to rooms and admin log viewer

### DIFF
--- a/packages/rocketchat-logger/client/views/viewLogs.coffee
+++ b/packages/rocketchat-logger/client/views/viewLogs.coffee
@@ -96,3 +96,8 @@ Template.viewLogs.onRendered ->
 		Meteor.setTimeout ->
 			template.checkIfScrollIsAtBottom()
 		, 2000
+
+	wrapper.addEventListener 'scroll', ->
+		template.atBottom = false
+		Meteor.defer ->
+			template.checkIfScrollIsAtBottom()

--- a/packages/rocketchat-logger/client/views/viewLogs.coffee
+++ b/packages/rocketchat-logger/client/views/viewLogs.coffee
@@ -32,8 +32,9 @@ Template.viewLogs.onRendered ->
 
 	template = this
 
-	template.isAtBottom = ->
-		if wrapper.scrollTop >= wrapper.scrollHeight - wrapper.clientHeight
+	template.isAtBottom = (scrollThreshold) ->
+		if not scrollThreshold? then scrollThreshold = 0
+		if wrapper.scrollTop + scrollThreshold >= wrapper.scrollHeight - wrapper.clientHeight
 			newLogs.className = "new-logs not"
 			return true
 		return false
@@ -43,7 +44,7 @@ Template.viewLogs.onRendered ->
 		newLogs.className = "new-logs not"
 
 	template.checkIfScrollIsAtBottom = ->
-		template.atBottom = template.isAtBottom()
+		template.atBottom = template.isAtBottom(100)
 		readMessage.enable()
 		readMessage.read()
 

--- a/packages/rocketchat-ui/views/app/room.coffee
+++ b/packages/rocketchat-ui/views/app/room.coffee
@@ -547,8 +547,9 @@ Template.room.onRendered ->
 
 	messageBox = $('.messages-box')
 
-	template.isAtBottom = ->
-		if wrapper.scrollTop >= wrapper.scrollHeight - wrapper.clientHeight
+	template.isAtBottom = (scrollThreshold) ->
+		if not scrollThreshold? then scrollThreshold = 0
+		if wrapper.scrollTop + scrollThreshold >= wrapper.scrollHeight - wrapper.clientHeight
 			newMessage.className = "new-message not"
 			return true
 		return false
@@ -558,7 +559,7 @@ Template.room.onRendered ->
 		newMessage.className = "new-message not"
 
 	template.checkIfScrollIsAtBottom = ->
-		template.atBottom = template.isAtBottom()
+		template.atBottom = template.isAtBottom(100)
 		readMessage.enable()
 		readMessage.read()
 

--- a/packages/rocketchat-ui/views/app/room.coffee
+++ b/packages/rocketchat-ui/views/app/room.coffee
@@ -611,6 +611,11 @@ Template.room.onRendered ->
 			template.checkIfScrollIsAtBottom()
 		, 2000
 
+	wrapper.addEventListener 'scroll', ->
+		template.atBottom = false
+		Meteor.defer ->
+			template.checkIfScrollIsAtBottom()
+
 	$('.flex-tab-bar').on 'click', (e, t) ->
 		Meteor.setTimeout ->
 			template.sendToBottomIfNecessaryDebounced()


### PR DESCRIPTION
Closes #4673

This also adds a threshold when calling `checkIfScrollIsAtBottom`.
Without any threshold, being scrolled up by even a few pixels prevents autoscrolling on new messages.

I'm using 100 pixels as the threshold for the following reason:
I have my Windows 10 mouse scroll settings set to their default values.
If I scroll up one notch in Chrome, the text area is scrolled up 100 pixels.
While scrolled up 100 pixels, the view is still considered to be scrolled all the way down before this pull request.
If I scroll up another notch, then the view is not considered to be scrolled all the way down before this pull request.