### PR TITLE
Time Range filter from and to in livechat current chat page

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -162,3 +162,4 @@ todda00:friendly-slugs
 underscorestring:underscore.string
 yasaricli:slugify
 yasinuslu:blaze-meta
+deepwell:bootstrap-datepicker2

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -30,6 +30,7 @@ ddp-client@1.3.1_1
 ddp-common@1.2.6
 ddp-rate-limiter@1.0.5
 ddp-server@1.3.10_1
+deepwell:bootstrap-datepicker2@1.3.0
 deps@1.0.12
 diff-sequence@1.0.6
 dispatch:run-as-user@1.1.1

--- a/packages/rocketchat-livechat/client/views/app/livechatCurrentChats.html
+++ b/packages/rocketchat-livechat/client/views/app/livechatCurrentChats.html
@@ -24,7 +24,7 @@
 				</select>
 			</div>
 			<!--Added by Deepankar-->
-				<div class="input-group input-daterange" data-date-autoclose="true" data-provide="datepicker" >
+				<div class="input-group input-daterange" data-date-autoclose="true" data-date-todayHighlight="true" data-provide="datepicker" >
 					<span class="input-group-addon">From</span>
 					<input type="text" class="form-control" id="from" name="from" >
 						<span class="input-group-addon">to</span>

--- a/packages/rocketchat-livechat/client/views/app/livechatCurrentChats.html
+++ b/packages/rocketchat-livechat/client/views/app/livechatCurrentChats.html
@@ -26,9 +26,9 @@
 			<!--Added by Deepankar-->
 				<div class="input-group input-daterange" data-date-autoclose="true" data-provide="datepicker" >
 					<span class="input-group-addon">From</span>
-					<input type="text" class="form-control" id="From" name="From" >
+					<input type="text" class="form-control" id="from" name="from" >
 						<span class="input-group-addon">to</span>
-					<input type="text" class="form-control" id="To" name="To">
+					<input type="text" class="form-control" id="to" name="to">
 
 					<button class="button">{{_ "Filter"}}</button>
 				</div>		

--- a/packages/rocketchat-livechat/client/views/app/livechatCurrentChats.html
+++ b/packages/rocketchat-livechat/client/views/app/livechatCurrentChats.html
@@ -23,7 +23,16 @@
 					<option value="closed">{{_ "Closed"}}</option>
 				</select>
 			</div>
-			<button class="button">{{_ "Filter"}}</button>
+			<!--Added by Deepankar-->
+				<div class="input-group input-daterange" data-date-autoclose="true" data-provide="datepicker" >
+					<span class="input-group-addon">From</span>
+					<input type="text" class="form-control" id="From" name="From" >
+						<span class="input-group-addon">to</span>
+					<input type="text" class="form-control" id="To" name="To">
+
+					<button class="button">{{_ "Filter"}}</button>
+				</div>		
+			<!--Added by Deepankar-->
 		</form>
 	</fieldset>
 	<div class="list">

--- a/packages/rocketchat-livechat/server/publications/livechatRooms.js
+++ b/packages/rocketchat-livechat/server/publications/livechatRooms.js
@@ -11,8 +11,8 @@ Meteor.publish('livechat:rooms', function(filter = {}, offset = 0, limit = 20) {
 		name: Match.Maybe(String), // room name to filter
 		agent: Match.Maybe(String), // agent _id who is serving
 		status: Match.Maybe(String), // either 'opened' or 'closed'
-		from: Match.Maybe(String), 
-		to: Match.Maybe(String) 
+		from: Match.Maybe(String),
+		to: Match.Maybe(String)
 	});
 
 	let query = {};
@@ -29,7 +29,7 @@ Meteor.publish('livechat:rooms', function(filter = {}, offset = 0, limit = 20) {
 			query.open = { $exists: false };
 		}
 	}
-	if (filter.from && filter.to){
+	if (filter.from && filter.to) {
 		var StartDate = new Date(filter.from);
 		var ToDate = new Date(filter.to);
 		ToDate.setDate(ToDate.getDate() + 1);

--- a/packages/rocketchat-livechat/server/publications/livechatRooms.js
+++ b/packages/rocketchat-livechat/server/publications/livechatRooms.js
@@ -10,7 +10,9 @@ Meteor.publish('livechat:rooms', function(filter = {}, offset = 0, limit = 20) {
 	check(filter, {
 		name: Match.Maybe(String), // room name to filter
 		agent: Match.Maybe(String), // agent _id who is serving
-		status: Match.Maybe(String) // either 'opened' or 'closed'
+		status: Match.Maybe(String), // either 'opened' or 'closed'
+		From: Match.Maybe(String), 
+		To: Match.Maybe(String) 
 	});
 
 	let query = {};
@@ -26,6 +28,11 @@ Meteor.publish('livechat:rooms', function(filter = {}, offset = 0, limit = 20) {
 		} else {
 			query.open = { $exists: false };
 		}
+	}
+	if(filter.From && filter.To){
+		var StartDate = new Date(filter.From);
+		var ToDate = new Date(filter.To);
+		query["ts"] = {$gt: StartDate,$lt: ToDate};
 	}
 
 	return RocketChat.models.Rooms.findLivechat(query, offset, limit);

--- a/packages/rocketchat-livechat/server/publications/livechatRooms.js
+++ b/packages/rocketchat-livechat/server/publications/livechatRooms.js
@@ -11,8 +11,8 @@ Meteor.publish('livechat:rooms', function(filter = {}, offset = 0, limit = 20) {
 		name: Match.Maybe(String), // room name to filter
 		agent: Match.Maybe(String), // agent _id who is serving
 		status: Match.Maybe(String), // either 'opened' or 'closed'
-		From: Match.Maybe(String), 
-		To: Match.Maybe(String) 
+		from: Match.Maybe(String), 
+		to: Match.Maybe(String) 
 	});
 
 	let query = {};
@@ -29,10 +29,11 @@ Meteor.publish('livechat:rooms', function(filter = {}, offset = 0, limit = 20) {
 			query.open = { $exists: false };
 		}
 	}
-	if(filter.From && filter.To){
-		var StartDate = new Date(filter.From);
-		var ToDate = new Date(filter.To);
-		query["ts"] = {$gt: StartDate,$lt: ToDate};
+	if (filter.from && filter.to){
+		var StartDate = new Date(filter.from);
+		var ToDate = new Date(filter.to);
+		ToDate.setDate(ToDate.getDate() + 1);
+		query['ts'] = { $gt: StartDate, $lt: ToDate };
 	}
 
 	return RocketChat.models.Rooms.findLivechat(query, offset, limit);


### PR DESCRIPTION
Added Filter based on From date and To date from Room "ts".
Need a bit of design improvement and the To date currently takes the date as the 00:00 AM
Like if you select 10/14/2016 To 10/15/2016, it searches between 10/14/2016 00:00:00:000 AM To 10/15/2016  00:00:00.000am rather than 10/14/2016 00:00:00:000 AM To 10/15/2016  11:59:59.998pm as that seems more logical thing to do.

 
![screen shot 2016-10-20 at 1 38 51 am](https://cloud.githubusercontent.com/assets/14363289/19535709/77dbb198-9666-11e6-8755-c15e1c2e73d7.png)
![screen shot 2016-10-20 at 1 42 54 am](https://cloud.githubusercontent.com/assets/14363289/19535740/97d40efa-9666-11e6-8422-5edf27041f2e.png)

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

