### PR TITLE
Added room check on leaveRoom to make sure it isn't a direct message

### DIFF
--- a/packages/rocketchat-lib/server/methods/leaveRoom.coffee
+++ b/packages/rocketchat-lib/server/methods/leaveRoom.coffee
@@ -11,6 +11,9 @@ Meteor.methods
 		fromId = Meteor.userId()
 		room = RocketChat.models.Rooms.findOneById rid
 		user = Meteor.user()
+		
+		if room.t is 'd'
+			throw new Meteor.Error 'error-not-allowed', 'Not allowed', { method: 'joinRoom' } 
 
 		# If user is room owner, check if there are other owners. If there isn't anyone else, warn user to set a new owner.
 		if RocketChat.authz.hasRole(user._id, 'owner', room._id)

--- a/packages/rocketchat-lib/server/methods/leaveRoom.coffee
+++ b/packages/rocketchat-lib/server/methods/leaveRoom.coffee
@@ -13,7 +13,7 @@ Meteor.methods
 		user = Meteor.user()
 		
 		if room.t is 'd'
-			throw new Meteor.Error 'error-not-allowed', 'Not allowed', { method: 'joinRoom' } 
+			throw new Meteor.Error 'error-not-allowed', 'Not allowed', { method: 'leaveRoom' } 
 
 		# If user is room owner, check if there are other owners. If there isn't anyone else, warn user to set a new owner.
 		if RocketChat.authz.hasRole(user._id, 'owner', room._id)


### PR DESCRIPTION
@RocketChat/core 
Closes #4663

I removed the ability to leave a direct message room by using the /leave command by checking if room type is equal to d in the method leaveRoom to resolve and close issue #4663.