### PR TITLE
Add support for attachment recursion

### DIFF
--- a/packages/rocketchat-message-attachments/client/messageAttachment.coffee
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.coffee
@@ -43,3 +43,7 @@ Template.messageAttachment.helpers
 
 	time: ->
 		return moment(@ts).format(RocketChat.settings.get('Message_TimeFormat'))
+
+	injectIndex: (data, index) ->
+		data.index = index
+		return

--- a/packages/rocketchat-message-attachments/client/messageAttachment.coffee
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.coffee
@@ -44,6 +44,6 @@ Template.messageAttachment.helpers
 	time: ->
 		return moment(@ts).format(RocketChat.settings.get('Message_TimeFormat'))
 
-	injectIndex: (data, index) ->
-		data.index = index
+	injectIndex: (data, previousIndex, index) ->
+		data.index = previousIndex + '.attachments.' + index
 		return

--- a/packages/rocketchat-message-attachments/client/messageAttachment.html
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.html
@@ -121,6 +121,9 @@
 					</div>
 				{{/unless}}
 			{{/if}}
+			{{#each attachments}}
+				{{injectIndex . @index}} {{> messageAttachment}}
+			{{/each}}
 		</div>
 	</div>
 </template>

--- a/packages/rocketchat-message-attachments/client/messageAttachment.html
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.html
@@ -122,7 +122,7 @@
 				{{/unless}}
 			{{/if}}
 			{{#each attachments}}
-				{{injectIndex . @index}} {{> messageAttachment}}
+				{{injectIndex . ../index @index}} {{> messageAttachment}}
 			{{/each}}
 		</div>
 	</div>

--- a/packages/rocketchat-oembed/server/jumpToMessage.js
+++ b/packages/rocketchat-oembed/server/jumpToMessage.js
@@ -19,6 +19,7 @@ RocketChat.callbacks.add('beforeSaveMessage', (msg) => {
 								'author_name' : jumpToMessage.u.username,
 								'author_icon' : getAvatarUrlFromUsername(jumpToMessage.u.username),
 								'message_link' : item.url,
+								'attachments' : jumpToMessage.attachments || [],
 								'ts': jumpToMessage.ts
 							});
 							item.ignoreParse = true;


### PR DESCRIPTION
Closes #3855

This adds support for showing attachments in quoted messages or other attachments.

![image](https://cloud.githubusercontent.com/assets/828413/19719079/f047155c-9b2d-11e6-9626-15e7b24f7bc2.png)

~~The only problem I am aware of is that the collapse button does not work in recursive attachments.~~
~~If I manually do something like `ChatMessage.update({_id: 'Huwgrfjya4NFsQwzE'}, {$set: {"attachments.0.attachments.0.collapsed": true}})` in Chrome's developer console, I can (un)collapse images.~~
~~`injectIndex` needs to set `data.index` to something like `#.attachments.#` (or `#.attachments.#.attachments.#` if there is a third level of attachments)~~

~~The development environment I have access to right now is extremely slow and broken, taking over 20 minutes for even a single change to be compiled, and I don't have that kind of patience to figure out what variables I have access to.~~
~~It would probably be a lot faster for someone else to fix the index issue.~~

~~If I am able to access the development environment I had access to previously, I will try taking care of this myself.~~