### PR TITLE
update ip-range-check to version 0.0.2 to get rid of debugger call

### DIFF
--- a/packages/rocketchat-oembed/package.js
+++ b/packages/rocketchat-oembed/package.js
@@ -8,7 +8,7 @@ Package.describe({
 Npm.depends({
 	'he': '1.1.0',
 	'iconv-lite': '0.4.13',
-	'ip-range-check': '0.0.1'
+	'ip-range-check': '0.0.2'
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
@RocketChat/core 

When running the app in debug mode, at startup it hung at ip-range-check module cause there is a debugger call. This was removed in version 0.0.2, check [here ](https://github.com/Day8/ip-range-check/pull/1)