### PR TITLE
removed stop from autorun

### DIFF
--- a/packages/rocketchat-livechat/app/client/lib/_livechat.js
+++ b/packages/rocketchat-livechat/app/client/lib/_livechat.js
@@ -26,7 +26,6 @@ this.Livechat = new (class Livechat {
 				RoomHistoryManager.getMoreIfIsEmpty(this._room.get());
 				visitor.subscribeToRoom(this._room.get());
 				visitor.setRoom(this._room.get());
-				c.stop();
 			}
 		});
 	}

--- a/packages/rocketchat-livechat/app/client/lib/_livechat.js
+++ b/packages/rocketchat-livechat/app/client/lib/_livechat.js
@@ -21,7 +21,7 @@ this.Livechat = new (class Livechat {
 
 		this._room = new ReactiveVar(null);
 
-		Tracker.autorun((c) => {
+		Tracker.autorun(() => {
 			if (this._room.get() && Meteor.userId()) {
 				RoomHistoryManager.getMoreIfIsEmpty(this._room.get());
 				visitor.subscribeToRoom(this._room.get());


### PR DESCRIPTION
@RocketChat/core 
If a livechat room is closed, and then within the widget the guest sends a new message the guest creates a new room, but does not properly subscribe to it. A guest could try multiple times creating many dead livechat rooms.  

The Tracker.autorun stops after one call because of `c.stop` at the end of the function (https://docs.meteor.com/api/tracker.html), so I just removed it 
