### PR TITLE
list rocketchat:authorization as a dependency of rocketchat:lib

### DIFF
--- a/packages/rocketchat-lib/package.js
+++ b/packages/rocketchat-lib/package.js
@@ -36,6 +36,7 @@ Package.onUse(function(api) {
 	api.use('rocketchat:version');
 	api.use('rocketchat:logger');
 	api.use('rocketchat:custom-oauth');
+	api.use('rocketchat:authorization', {unordered: true});
 
 	api.use('templating', 'client');
 	api.use('kadira:flow-router');


### PR DESCRIPTION
@RocketChat/core 

`rocketchat:lib` is using `rocketchat:authorization` but it's not listed as a dependency in `package.js`.
The problem here is that `rocketchat:authorization` is also using `rocketchat:lib`. The is a cyclic dependency between those two packages, there for the use of `{unordered: true}`.

All packages needs the namespace RocketChat which is defined in `rocketchat:lib`. I think it's best to define a new package `rocketchat:core` to broke many cyclic dependencies between packages. What do you guys think?
