### PR TITLE
Keycloak OpenID Custom Provider (#4757)

### DIFF
--- a/packages/rocketchat-custom-oauth/custom_oauth_server.coffee
+++ b/packages/rocketchat-custom-oauth/custom_oauth_server.coffee
@@ -132,6 +132,10 @@ class CustomOAuth
 			if identity?.phid and not identity.id
 				identity.id = identity.phid
 
+			# Fix Keycloak-like identities having 'sub' instead of 'id'
+			if identity?.sub and not identity.id
+				identity.id = identity.sub
+
 			# Fix general 'userid' instead of 'id' from provider
 			if identity?.userid and not identity.id
 				identity.id = identity.userid
@@ -148,7 +152,7 @@ class CustomOAuth
 				serviceData: serviceData
 				options:
 					profile:
-						name: identity.name or identity.username or identity.nickname or identity.CharacterName or identity.userName or identity.user?.name
+						name: identity.name or identity.username or identity.nickname or identity.CharacterName or identity.userName or identity.preferred_username or identity.user?.name
 
 			# console.log data
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #4757

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Hello ! 

I've made an update for the keycloak identity provider (openid) 

The userId is the property `sub` and the username is the property `preferred_username`

I've only add the missing properties 

Thanks ! 
