### PR TITLE
Make the location button use the full button and not just the icon

### DIFF
--- a/packages/rocketchat-ui-message/message/messageBox.coffee
+++ b/packages/rocketchat-ui-message/message/messageBox.coffee
@@ -179,7 +179,7 @@ Template.messageBox.events
 
 		fileUpload filesToUpload
 
-	'click .message-form .icon-location.location': (event, instance) ->
+	'click .message-form .geo-location': (event, instance) ->
 		roomId = @_id
 
 		position = RocketChat.Geolocation.get()


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->

@RocketChat/core this is a very simple pull request to fix something that was bothering me, the location button only listens for the icon being clicked and this changes it so the entire button area is used to be like the other buttons are.
