### PR TITLE
Ignore keypress if swipebox is open

### DIFF
--- a/packages/rocketchat-ui-master/master/main.coffee
+++ b/packages/rocketchat-ui-master/master/main.coffee
@@ -33,6 +33,8 @@ Template.body.onRendered ->
 		target = e.target
 		if /input|textarea|select/i.test(target.tagName)
 			return
+		if $.swipebox.isOpen
+			return
 		$inputMessage = $('textarea.input-message')
 		if 0 == $inputMessage.length
 			return


### PR DESCRIPTION
If you hit any character-producing key while the swipebox is open, the message input area gains focus when it shouldn't.
