### PR TITLE
Show a desktop notification only for the opened room if on embedded mode

### DIFF
--- a/client/notifications/notification.coffee
+++ b/client/notifications/notification.coffee
@@ -3,11 +3,8 @@
 # group messages in which the user is mentioned.
 
 Meteor.startup ->
-
 	Tracker.autorun ->
-
 		if Meteor.userId()
-
 			RocketChat.Notifications.onUser 'notification', (notification) ->
 
 				openedRoomId = undefined
@@ -23,9 +20,12 @@ Meteor.startup ->
 					fromOpenedRoom: messageIsInOpenedRoom
 					hasFocus: hasFocus
 
-				if !(hasFocus and messageIsInOpenedRoom)
-					# Play a sound.
+				if RocketChat.Layout.isEmbedded()
+					if !hasFocus and messageIsInOpenedRoom
+						# Play a sound and show a notification.
+						KonchatNotification.newMessage()
+						KonchatNotification.showDesktop notification
+				else if !(hasFocus and messageIsInOpenedRoom)
+					# Play a sound and show a notification.
 					KonchatNotification.newMessage()
-
-					# Show a notification.
 					KonchatNotification.showDesktop notification


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

When using the embedded mode (`?layout=embedded`) the expected behavior should only notify the user for messages on the current opened room since it has no way to see the list of joined rooms.

With this, Rocket.Chat will only show a desktop notification and play a sound if the message was sent to the opened room and the window has no focus.