### PR TITLE
add some missing dependencies

### DIFF
--- a/packages/rocketchat-i18n/package.js
+++ b/packages/rocketchat-i18n/package.js
@@ -9,8 +9,8 @@ Package.onUse(function(api) {
 	api.use('templating', 'client');
 
 	var fs = Npm.require('fs');
-	fs.readdirSync('packages/rocketchat-i18n/i18n').forEach(function(filename) {
-		if (filename.indexOf('.json') > -1 && fs.statSync('packages/rocketchat-i18n/i18n/' + filename).size > 16) {
+	fs.readdirSync(process.env.PWD + '/packages/rocketchat-i18n/i18n').forEach(function(filename) {
+		if (filename.indexOf('.json') > -1 && fs.statSync(process.env.PWD + '/packages/rocketchat-i18n/i18n/' + filename).size > 16) {
 			api.addFiles('i18n/' + filename);
 		}
 	});

--- a/packages/rocketchat-lib/package.js
+++ b/packages/rocketchat-lib/package.js
@@ -26,7 +26,7 @@ Package.onUse(function(api) {
 	api.use('ddp-rate-limiter');
 	api.use('underscore');
 	api.use('mongo');
-	api.use('underscorestring:underscore.string');
+	api.use('underscorestring:underscore.string@3.3.4');
 	api.use('matb33:collection-hooks');
 	api.use('service-configuration');
 	api.use('check');
@@ -36,6 +36,8 @@ Package.onUse(function(api) {
 	api.use('rocketchat:version');
 	api.use('rocketchat:logger');
 	api.use('rocketchat:custom-oauth');
+	api.use('rocketchat:authorization', {unordered: true});
+	api.use('rocketchat:push-notifications', {unordered: true});
 
 	api.use('templating', 'client');
 	api.use('kadira:flow-router');


### PR DESCRIPTION
@RocketChat/core 

When you integrate the `rocketchat-i18n` package by creating a symbolic link to the rocket chat project folder (e.g `rocketchat-i18n -> /Users/User/Documents/meteor/Rocket.Chat/packages/rocketchat-i18n`), the `fs.readdirSync` will fail with unfound directory error.
