### PR TITLE
Fixes the create new btn bug

### DIFF
--- a/packages/rocketchat-ui-sidenav/side-nav/listCombinedFlex.coffee
+++ b/packages/rocketchat-ui-sidenav/side-nav/listCombinedFlex.coffee
@@ -30,7 +30,7 @@ Template.listCombinedFlex.events
 		SideNav.closeFlex()
 
 	'click footer .create': ->
-		if RocketChat.authz.hasAtLeastOnePermission( 'create-c')
+		if RocketChat.authz.hasAtLeastOnePermission ['create-c', 'create-p']
 			SideNav.setFlex "createCombinedFlex"
 
 	'mouseenter header': ->


### PR DESCRIPTION
@RocketChat/core 
Closes: #4777
Users with only the create-p permission were not able to click the "create new" button in "all channels" tab 