### PR TITLE
updated buffer to string conversion using utf8.

### DIFF
--- a/packages/meteor-accounts-saml/saml_utils.js
+++ b/packages/meteor-accounts-saml/saml_utils.js
@@ -309,7 +309,7 @@ SAML.prototype.validateLogoutResponse = function(samlResponse, callback) {
 
 SAML.prototype.validateResponse = function(samlResponse, relayState, callback) {
 	var self = this;
-	var xml = new Buffer(samlResponse, 'base64').toString('ascii');
+	var xml = new Buffer(samlResponse, 'base64').toString('utf8');
 	// We currently use RelayState to save SAML provider
 	if (Meteor.settings.debug) {
 		console.log('Validating response with relay state: ' + xml);


### PR DESCRIPTION
@RocketChat/core 
I had issues dealing with Japanese characters which used to get converted to unsafe xml characters. Instead of ascii, utf8 is a much better option.