### PR TITLE
Sandstorm build: use node and npm from Meteor dev bundle, and don't u…

### DIFF
--- a/.sandstorm/build.sh
+++ b/.sandstorm/build.sh
@@ -8,8 +8,14 @@ sudo chown vagrant:vagrant /home/vagrant -R
 cd /opt/app
 meteor npm install --production
 meteor build --directory /home/vagrant/
+
+# Use npm and node from the Meteor dev bundle to install the bundle's dependencies.
+TOOL_VERSION=$(meteor show --ejson $(<.meteor/release) | grep '^ *"tool":' |
+    sed -re 's/^.*"(meteor-tool@[^"]*)".*$/\1/g')
+TOOLDIR=$(echo $TOOL_VERSION | tr @ /)
+PATH=$HOME/.meteor/packages/$TOOLDIR/mt-os.linux.x86_64/dev_bundle/bin:$PATH
 cd /home/vagrant/bundle/programs/server
-sudo meteor npm install --production
+npm install --production
 
 # Copy our launcher script into the bundle so the grain can start up.
 mkdir -p /home/vagrant/bundle/opt/app/.sandstorm/

--- a/.sandstorm/setup.sh
+++ b/.sandstorm/setup.sh
@@ -8,7 +8,7 @@ apt-get install build-essential git -y
 cd /opt/
 
 NODE_ENV=production
-PACKAGE=meteor-spk-0.3.0
+PACKAGE=meteor-spk-0.3.1
 PACKAGE_FILENAME="$PACKAGE.tar.xz"
 CACHE_TARGET="/host-dot-sandstorm/caches/${PACKAGE_FILENAME}"
 


### PR DESCRIPTION
@RocketChat/core

Currently when I try to run the Sandstorm package with `vagrant-spk vm up; vagrant-spk dev` I get the following error:

```
Error: Can't get default release version for track undefined
    at [object Object]._.extend.getDefaultReleaseVersion (/tools/packaging/catalog/catalog-remote.js:852:13)
    at Object.release.latestKnown (/tools/packaging/release.js:189:41)
    at /tools/cli/main.js:853:29
```

The problem seems to be the `sudo` that was added to the final `npm install` step in this commit: https://github.com/RocketChat/Rocket.Chat/commit/a2b6d28656a6ad8b64a42e2f27771e3e106e5bc8. Removing that `sudo` makes the problem go away.

Another problem with that `sudo meteor npm install` line is that it does not constrain the version of Meteor used. Meteor decides to use the latest released version, which is problematic for a couple reasons. First, it adds several unnecessary minutes to the build time. Second, if a new version of Meteor is released, its bundled `node` and `npm` may be incompatible with the Rocket.Chat build, which is currently pinned at Meteor 1.4.2. To solve these problems, this PR uses `node` and `npm` from the Meteor distribution that was used to build Rocket.Chat in the previous step. We've been using this approach to build Sandstorm itself: https://github.com/sandstorm-io/sandstorm/blob/v0.195/find-meteor-dev-bundle.sh#L34-L61
