### PR TITLE
Import fixes

### DIFF
--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -576,6 +576,7 @@
   "Importer_Prepare_Uncheck_Deleted_Users": "Uncheck Deleted Users",
   "Importer_progress_error": "Failed to get the progress for the import.",
   "Importer_setup_error": "An error occurred while setting up the importer.",
+  "Importer_Source_File": "Source File Selection",
   "Incoming_Livechats": "Incoming Livechats",
   "inline_code": "inline_code",
   "Install_Extension": "Install Extension",

--- a/packages/rocketchat-importer-slack/server.coffee
+++ b/packages/rocketchat-importer-slack/server.coffee
@@ -296,6 +296,14 @@ Importer.Slack = class Importer.Slack extends Importer.Base
 													msgObj.ets = new Date(parseInt(message.edited.ts.split('.')[0]) * 1000)
 
 												RocketChat.sendMessage @getRocketUser(message.user), msgObj, room, true
+
+									# Process the reactions
+									if RocketChat.models.Messages.findOneById(msgDataDefaults._id)? and message.reactions?.length > 0
+										for reaction in message.reactions
+											for u in reaction.users
+												if @getRocketUser(u)?
+													Meteor.call 'setReaction', ":#{reaction.name}:", createdMsg._id
+
 									@addCountCompleted 1
 			console.log missedTypes
 			@updateProgress Importer.ProgressStep.FINISHING
@@ -322,6 +330,7 @@ Importer.Slack = class Importer.Slack extends Importer.Base
 		if message?
 			message = message.replace /<!everyone>/g, '@all'
 			message = message.replace /<!channel>/g, '@all'
+			message = message.replace /<!here>/g, '@here'
 			message = message.replace /&gt;/g, '<'
 			message = message.replace /&lt;/g, '>'
 			message = message.replace /&amp;/g, '&'

--- a/packages/rocketchat-importer/client/admin/adminImportPrepare.html
+++ b/packages/rocketchat-importer/client/admin/adminImportPrepare.html
@@ -4,7 +4,7 @@
 			<header class="fixed-title">
 				{{> burger}}
 				<h2>
-					<span class="room-title">{{name}} - {{_ description }}</span>
+					<span class="room-title">{{name}}</span>
 				</h2>
 			</header>
 			<div class="content">
@@ -57,7 +57,12 @@
 								{{#if isPreparing}}
 									{{> loading}}
 								{{else}}
-									<input type="file" class="import-file-input" accept="{{ fileType }}">
+									<div class="section">
+										<h1>{{_ "Importer_Source_File"}}</h1>
+										<div class="section-content">
+											<input type="file" class="import-file-input" accept="{{ fileType }}">
+										</div>
+									</div>
 								{{/if}}
 							{{/if}}
 						</fieldset>

--- a/packages/rocketchat-importer/client/admin/adminImportProgress.coffee
+++ b/packages/rocketchat-importer/client/admin/adminImportProgress.coffee
@@ -12,28 +12,29 @@ Template.adminImportProgress.onCreated ->
 	@completed = new ReactiveVar 0
 	@total = new ReactiveVar 0
 	@updateProgress = ->
-		Meteor.call 'getImportProgress', FlowRouter.getParam('importer'), (error, progress) ->
-			if error
-				console.warn 'Error on getting the import progress:', error
-				handleError error
-				return
+		if FlowRouter.getParam('importer') isnt ''
+			Meteor.call 'getImportProgress', FlowRouter.getParam('importer'), (error, progress) ->
+				if error
+					console.warn 'Error on getting the import progress:', error
+					handleError error
+					return
 
-			if progress
-				if progress.step is 'importer_done'
-					toastr.success t(progress.step)
-					FlowRouter.go '/admin/import'
-				else if progress.step is 'importer_import_failed'
-					toastr.error t(progress.step)
-					FlowRouter.go '/admin/import/prepare/' + FlowRouter.getParam('importer')
+				if progress
+					if progress.step is 'importer_done'
+						toastr.success t(progress.step[0].toUpperCase() + progress.step.slice(1))
+						FlowRouter.go '/admin/import'
+					else if progress.step is 'importer_import_failed'
+						toastr.error t(progress.step[0].toUpperCase() + progress.step.slice(1))
+						FlowRouter.go '/admin/import/prepare/' + FlowRouter.getParam('importer')
+					else
+						instance.step.set t(progress.step[0].toUpperCase() + progress.step.slice(1))
+						instance.completed.set progress.count.completed
+						instance.total.set progress.count.total
+						setTimeout(() ->
+							instance.updateProgress()
+						, 100)
 				else
-					instance.step.set t(progress.step)
-					instance.completed.set progress.count.completed
-					instance.total.set progress.count.total
-					setTimeout(() ->
-						instance.updateProgress()
-					, 100)
-			else
-				toastr.warning t('importer_not_in_progress')
-				FlowRouter.go '/admin/import/prepare/' + FlowRouter.getParam('importer')
+					toastr.warning t('Importer_not_in_progress')
+					FlowRouter.go '/admin/import/prepare/' + FlowRouter.getParam('importer')
 
 	instance.updateProgress()


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #4934 
Closes #4899
Closes #3911

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
A few other fixes:
* Fixed the file selection screen not looking like the rest of the import page
* Fixed Slack's `@here` not being converted to Rocket.Chat's
* Added reaction importing, Slack's naming of emojis doesn't always match Emoji One's so not all of them get imported.
* Fixed the edit timestamps being lost due to an internal change in Rocket.Chat
* A channel's purpose in Slack is a channel's description in Rocket.Chat
* Added import support for renaming channels