### PR TITLE
serve theme.css through WebApp.rawConnectHandlers

### DIFF
--- a/packages/rocketchat-theme/server/server.coffee
+++ b/packages/rocketchat-theme/server/server.coffee
@@ -8,17 +8,23 @@ logger = new Logger 'rocketchat:theme',
 			type: 'info'
 
 
+WebApp.rawConnectHandlers.use (req, res, next) ->
+	path = req.url.split("?")[0];
+	if (path == '/__cordova/theme.css' || path == '/theme.css')
+		css = RocketChat.theme.getCss()
+		hash = crypto.createHash('sha1').update(css).digest('hex')
+		res.setHeader('Content-Type', 'text/css; charset=UTF-8')
+		res.setHeader('ETag', '"' + hash + '"')
+		res.write(css)
+		res.end();
+	else
+		next()
+
 calculateClientHash = WebAppHashing.calculateClientHash
 WebAppHashing.calculateClientHash = (manifest, includeFilter, runtimeConfigOverride) ->
 	css = RocketChat.theme.getCss()
 
 	if css.trim() isnt ''
-		WebAppInternals.staticFiles['/__cordova/theme.css'] = WebAppInternals.staticFiles['/theme.css'] =
-			cacheable: true
-			sourceMapUrl: undefined
-			type: 'css'
-			content: css
-
 		hash = crypto.createHash('sha1').update(css).digest('hex')
 
 		themeManifestItem = _.find manifest, (item) -> return item.path is 'app/theme.css'

--- a/packages/rocketchat-theme/server/server.coffee
+++ b/packages/rocketchat-theme/server/server.coffee
@@ -9,14 +9,14 @@ logger = new Logger 'rocketchat:theme',
 
 
 WebApp.rawConnectHandlers.use (req, res, next) ->
-	path = req.url.split("?")[0];
+	path = req.url.split("?")[0]
 	if (path == '/__cordova/theme.css' || path == '/theme.css')
 		css = RocketChat.theme.getCss()
 		hash = crypto.createHash('sha1').update(css).digest('hex')
 		res.setHeader('Content-Type', 'text/css; charset=UTF-8')
 		res.setHeader('ETag', '"' + hash + '"')
 		res.write(css)
-		res.end();
+		res.end()
 	else
 		next()
 


### PR DESCRIPTION
@RocketChat/core 
@rodrigok

Closes #4818


`WebAppInternals.staticFiles` is [only exposed for testing purposes](https://github.com/meteor/meteor/blob/45b01ba8093ca207fe546a5db26f942cc3c5c188/packages/webapp/webapp_server.js#L528-L529) and does not seem to be suitable for reliably serving content. In particular, the [internal private variable](https://github.com/meteor/meteor/blob/45b01ba8093ca207fe546a5db26f942cc3c5c188/packages/webapp/webapp_server.js#L332) that it aliases can frequently get [cleared](https://github.com/meteor/meteor/blob/45b01ba8093ca207fe546a5db26f942cc3c5c188/packages/webapp/webapp_server.js#L461) in a way that can cause requests to a manually-injected file like "/theme.css" to fail to get served, causing the behavior described in #4818.

This pull request fixes the problem by setting up a proper server-side route for "/theme.css" using `WebApp.rawConnectHandlers`.

The `WebAppHashing.calculateClientHash()` monkeypatch is still needed so that the client knows about "theme.css" in the first place.
