### PR TITLE
Fix picking fields from cache

### DIFF
--- a/packages/rocketchat-lib/server/models/_BaseCache.js
+++ b/packages/rocketchat-lib/server/models/_BaseCache.js
@@ -552,6 +552,18 @@ class ModelsBaseCache extends EventEmitter {
 			fieldsToGet.push('_id');
 		}
 
+		let pickFields = (obj, fields) => {
+			let picked = {};
+			fields.forEach((field) => {
+				if (field.indexOf('.') !== -1) {
+					objectPath.set(picked, field, objectPath.get(obj, field));
+				} else {
+					picked[field] = obj[field];
+				}
+			});
+			return picked;
+		};
+
 		if (fieldsToRemove.length > 0 || fieldsToGet.length > 0) {
 			if (Array.isArray(result)) {
 				result = result.map((record) => {
@@ -560,7 +572,7 @@ class ModelsBaseCache extends EventEmitter {
 					}
 
 					if (fieldsToGet.length > 0) {
-						return _.pick(record, ...fieldsToGet);
+						return pickFields(record, fieldsToGet);
 					}
 				});
 			} else {
@@ -569,7 +581,7 @@ class ModelsBaseCache extends EventEmitter {
 				}
 
 				if (fieldsToGet.length > 0) {
-					return _.pick(result, ...fieldsToGet);
+					return pickFields(result, fieldsToGet);
 				}
 			}
 		}


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

This fixes queries that were specifying nested fields like these: `model.find(query, { fields: { name: 1, username: 1, emails: 1, 'settings.preferences.emailNotificationMode': 1 } })`

In the query above the field `settings.preferences.emailNotificationMode` would not be returned.

@rodrigok is this fix ok or should we treat this somewhat different?