### PR TITLE
Fix bug with Disable Embed for Users

### DIFF
--- a/packages/rocketchat-ui-message/message/message.coffee
+++ b/packages/rocketchat-ui-message/message/message.coffee
@@ -88,7 +88,7 @@ Template.message.helpers
 	hasOembed: ->
 		return false unless this.urls?.length > 0 and Template.oembedBaseWidget? and RocketChat.settings.get 'API_Embed'
 
-		return false unless this.u?.username not in RocketChat.settings.get('API_EmbedDisabledFor')?.split(',')
+		return false unless this.u?.username not in RocketChat.settings.get('API_EmbedDisabledFor')?.split(',').map (username) -> username.trim()
 
 		return true
 


### PR DESCRIPTION
@RocketChat/core 

CSV usernames were broken when using spaces in list (it tried to match the name including the space).