### PR TITLE
Fix set user's email from REST API

### DIFF
--- a/packages/rocketchat-lib/server/functions/setEmail.js
+++ b/packages/rocketchat-lib/server/functions/setEmail.js
@@ -29,5 +29,5 @@ RocketChat._setEmail = function(userId, email) {
 };
 
 RocketChat.setEmail = RocketChat.RateLimiter.limitFunction(RocketChat._setEmail, 1, 60000, {
-	0: function() { return !Meteor.userId() || !RocketChat.authz.hasPermission(Meteor.userId(), 'edit-other-user-info'); } // Administrators have permission to change others emails, so don't limit those
+	0: function(userId) { return !userId || !RocketChat.authz.hasPermission(userId, 'edit-other-user-info'); } // Administrators have permission to change others emails, so don't limit those
 });


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

It was giving an error because the use of `Meteor.userId()` outside a Meteor method.

This PR slightly change rate limiter's behaviour. It was checking previously the user that is calling the `setEmail` function, now it checks for whom the email is being set.

The same as previously done on `setUsername` function on #4520 
