### PR TITLE
Fix issue #4387, crash when using StartTLS and LDAP

### DIFF
--- a/packages/rocketchat-ldap/server/ldap.js
+++ b/packages/rocketchat-ldap/server/ldap.js
@@ -110,7 +110,7 @@ LDAP = class LDAP {
 			// Set host parameter for tls.connect which is used by ldapjs starttls. This shouldn't be needed in newer nodejs versions (e.g v5.6.0).
 			// https://github.com/RocketChat/Rocket.Chat/issues/2035
 			// https://github.com/mcavage/node-ldapjs/issues/349
-			tlsOptions.host = [self.options.host];
+			tlsOptions.host = self.options.host;
 
 			logger.connection.info('Starting TLS');
 			logger.connection.debug('tlsOptions', tlsOptions);


### PR DESCRIPTION
@RocketChat/core 

Closes #4387

This is the fix I originally attached as a patch to the issue. We've been running this patch for months without problems.
