### PR TITLE
Improved performance of sidebar rendering. Fixed RTL sidebar opening.

### DIFF
--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -1585,23 +1585,17 @@ label.required:after {
 	.transition(right .25s cubic-bezier(.5, 0, .1, 1));
 	&.flex-opened {
 		right: @flex-tab-width + 40px;
-		.flex-tab {
-			right: 40px;
-			.transform(translateX(0));
-		}
 	}
 	&.layout1 {
 		right: @flex-tab-webrtc-width;
 		.flex-tab {
 			max-width: @flex-tab-webrtc-width;
-			.transform(translateX(0));
 		}
 	}
 	&.layout2 {
 		right: @flex-tab-webrtc-2-width;
 		.flex-tab {
 			max-width: @flex-tab-webrtc-2-width;
-			.transform(translateX(0));
 		}
 	}
 	&.main-modal {
@@ -2816,15 +2810,14 @@ body:not(.is-cordova) {
 
 // FLEX-TAB and FLEX-TAB views
 .flex-tab {
-	overflow-x: visible;
 	position: fixed;
-	z-index: 110;
-	max-width: @flex-tab-width;
-	width: 90%;
-	bottom: 0;
-	right: 0;
 	top: 0;
-	.transform(translateX(100%));
+	bottom: 0;
+	left: 100%;
+	width: 90%;
+	max-width: @flex-tab-width;
+	z-index: 110;
+	overflow-x: visible;
 	.transition(transform .25s cubic-bezier(.5, 0, .1, 1));
 	.control {
 		.header {
@@ -3908,6 +3901,9 @@ body:not(.is-cordova) {
 	#rocket-chat {
 		.flex-opened {
 			right: 40px;
+			.flex-tab {
+				.transform(translateX(-100%));
+			}
 		}
 	}
 }
@@ -3931,9 +3927,6 @@ body:not(.is-cordova) {
 		}
 		.fixed-title h2 {
 			margin-left: 45px;
-		}
-		.flex-tab {
-			top: 0;
 		}
 		.messages-box {
 			padding: 0 10px;

--- a/packages/rocketchat-theme/assets/stylesheets/base.less
+++ b/packages/rocketchat-theme/assets/stylesheets/base.less
@@ -656,6 +656,7 @@ label.required:after {
 	position: absolute;
 	top: 5px;
 	left: 0px;
+	will-change: transform;
 	.transition(transform .2s ease-out .1s);
 	i {
 		display: block;
@@ -663,10 +664,7 @@ label.required:after {
 		width: 20px;
 		margin: 5px 0;
 		opacity: .8;
-		.transition(transform .2s ease-out, width .2s ease-out);
-		&:nth-child(1) {
-			//	.transition-delay(.06s);
-		}
+		.transition(transform .2s ease-out);
 		&:nth-child(3) {
 			.transition-delay(.1s);
 		}
@@ -684,6 +682,21 @@ label.required:after {
 		right: 4px;
 		z-index: 3;
 		padding: 0px 4px;
+	}
+	&.menu-opened {
+		i {
+			&:nth-child(1),
+			&:nth-child(3) {
+				opacity: 1;
+				.transform-origin(50%, 50%, 0);
+			}
+			&:nth-child(1) {
+				.transform(translate(-25%, 3px) rotate(-45deg) scale(0.5, 1));
+			}
+			&:nth-child(3) {
+				.transform(translate(-25%, -3px) rotate(45deg) scale(0.5, 1));
+			}
+		}
 	}
 }
 
@@ -1096,7 +1109,6 @@ label.required:after {
 
 .side-nav {
 	position: fixed;
-	display: block;
 	top: 0;
 	bottom: 0;
 	left: 0;
@@ -1105,7 +1117,7 @@ label.required:after {
 	overflow: visible;
 	z-index: 100;
 	padding: 12px 0 0 0;
-	.transition(transform .3s ease-out);
+	will-change: transform;
 	&:before {
 		content: " ";
 		height: 1px;
@@ -1569,6 +1581,7 @@ label.required:after {
 	right: 40px;
 	width: auto;
 	height: auto;
+	will-change: transform;
 	.transition(right .25s cubic-bezier(.5, 0, .1, 1));
 	&.flex-opened {
 		right: @flex-tab-width + 40px;
@@ -2710,6 +2723,7 @@ body:not(.is-cordova) {
 	top: 0;
 	right: 0;
 	z-index: 130;
+	will-change: transform;
 	.tab-button {
 		position: relative;
 		cursor: pointer;
@@ -3904,21 +3918,16 @@ body:not(.is-cordova) {
 			visibility: visible;
 			display: inline-block;
 		}
-		.side-nav {
-			top: 0;
-			// .transform(translateX(-100%));
-			.transition(transform .3s ease-out);
-		}
 		.main-content {
 			left: 0;
 			z-index: 120;
-			&.notransition {
-				.transition(transform .0s);
-			}
 		}
 		.main-content,
 		.flex-tab-bar {
 			.transition(transform .2s linear);
+			&.notransition {
+				.transition(transform .0s);
+			}
 		}
 		.fixed-title h2 {
 			margin-left: 45px;
@@ -3928,34 +3937,6 @@ body:not(.is-cordova) {
 		}
 		.messages-box {
 			padding: 0 10px;
-		}
-		&.menu-opened {
-			.side-nav {
-				.transform(translateX(0));
-			}
-			.burger {
-				i {
-					&:nth-child(1) {
-						opacity: 1;
-						width: 10px;
-						.transform-origin(50%, 50%, 0);
-						.transform(translateY(3px) rotate(-45deg));
-					}
-					&:nth-child(2) {
-						//.transform(rotate(180deg));
-					}
-					&:nth-child(3) {
-						opacity: 1;
-						width: 10px;
-						.transform-origin(50%, 50%, 0);
-						.transform(translateY(-3px) rotate(45deg));
-					}
-				}
-			}
-			.main-content,
-			.flex-tab-bar {
-				.transform(translateX(@rooms-box-width));
-			}
 		}
 	}
 	.sweet-alert {

--- a/packages/rocketchat-theme/assets/stylesheets/rtl.less
+++ b/packages/rocketchat-theme/assets/stylesheets/rtl.less
@@ -170,12 +170,9 @@
 	.main-content {
 		left: 0;
 		right: @rooms-box-width;
-		.margin-left(40px);
+		.transition(left .25s cubic-bezier(.5, 0, .1, 1));
 		&.flex-opened {
-			left: @flex-tab-width;
-			.flex-tab {
-				.left(40px);
-			}
+			left: @flex-tab-width + 40px;
 		}
 	}
 	.page-settings {
@@ -279,7 +276,6 @@
 		.left(0);
 		border-right: 1px solid #eaeaea;
 		border-left: none;
-		z-index: 13;
 		.tab-button {
 			&.active {
 				.margin-right(-1px);
@@ -289,11 +285,10 @@
 		}
 	}
 	.flex-tab {
+		.right(100%);
 		border-left: unset;
 		border-width: 0 1px 0 0;
 		border-right-color: @tertiary-background-color;
-		.left(0);
-		.transform(translateX(-100%));
 		.control {
 			text-align: right;
 			padding: 12px 30px 12px;
@@ -405,6 +400,9 @@
 			.flex-opened {
 				left: 0;
 				right: @rooms-box-width;
+				.flex-tab {
+					.transform(translateX(calc(~'100% + 40px')));
+				}
 			}
 		}
 	}

--- a/packages/rocketchat-theme/assets/stylesheets/rtl.less
+++ b/packages/rocketchat-theme/assets/stylesheets/rtl.less
@@ -416,21 +416,6 @@
 			.fixed-title h2 {
 				margin-right: 45px;
 			}
-			&.menu-opened {
-				.burger {
-					i {
-						&:nth-child(1) {
-							.transform(translateY(3px) rotate(45deg));
-						}
-						&:nth-child(3) {
-							.transform(translateY(-3px) rotate(-45deg));
-						}
-					}
-				}
-				.main-content {
-					.transform(translateX(-@rooms-box-width));
-				}
-			}
 		}
 	}
 	.burger {
@@ -438,6 +423,16 @@
 		.right(0px);
 		.unread-burger-alert {
 			.left(4px);
+		}
+		&.menu-opened {
+			i {
+				&:nth-child(1) {
+					.transform(translate(25%, 3px) rotate(45deg) scale(0.5, 1));
+				}
+				&:nth-child(3) {
+					.transform(translate(25%, -3px) rotate(-45deg) scale(0.5, 1));
+				}
+			}
 		}
 	}
 	.arrow {

--- a/packages/rocketchat-ui-master/master/main.html
+++ b/packages/rocketchat-ui-master/master/main.html
@@ -63,7 +63,7 @@
 					{{> spotlight}}
 					{{> videoCall overlay=true}}
 					<div id="user-card-popover"></div>
-					<div id="rocket-chat" class="{{embeddedVersion}} menu-nav menu-closed">
+					<div id="rocket-chat" class="{{embeddedVersion}} menu-nav">
 						<div class="connection-status">
 							{{> status}}
 						</div>

--- a/packages/rocketchat-ui/lib/menu.coffee
+++ b/packages/rocketchat-ui/lib/menu.coffee
@@ -1,18 +1,23 @@
 @menu = new class
 	init: ->
-		@container = $("#rocket-chat")
+		@mainContent = $('.main-content, .flex-tab-bar')
 		@list = $('.rooms-list')
 
+		Session.set("isMenuOpen", false)
+
 	isOpen: ->
-		return @container?.hasClass("menu-opened") is true
+		return Session.get("isMenuOpen")
 
 	open: ->
-		if not @isOpen()
-			@container?.removeClass("menu-closed").addClass("menu-opened")
+		Session.set("isMenuOpen", true)
+		if isRtl localStorage.getItem "userLanguage"
+			@mainContent?.css('transform', 'translateX(-260px)')
+		else
+			@mainContent?.css('transform', 'translateX(260px)')
 
 	close: ->
-		if @isOpen()
-			@container?.removeClass("menu-opened").addClass("menu-closed")
+		Session.set("isMenuOpen", false)
+		@mainContent?.css('transform', 'translateX(0)')
 
 	toggle: ->
 		if @isOpen()

--- a/packages/rocketchat-ui/views/app/burger.coffee
+++ b/packages/rocketchat-ui/views/app/burger.coffee
@@ -1,3 +1,5 @@
 Template.burger.helpers
 	unread: ->
 		return Session.get 'unread'
+	isMenuOpen: ->
+		if Session.equals('isMenuOpen', true) then 'menu-opened'

--- a/packages/rocketchat-ui/views/app/burger.html
+++ b/packages/rocketchat-ui/views/app/burger.html
@@ -1,5 +1,5 @@
 <template name="burger">
-	<div class="burger">
+	<div class="burger {{isMenuOpen}}">
 		<i></i>
 		<i></i>
 		<i></i>


### PR DESCRIPTION
@RocketChat/core 

I moved rendering of sidebar, main content and "burger" blocks to new composite layers using `will-change`, which improve performance of open/close animations and overall rendering performance.

I removed some global classes, b/c applying them forces browser to unnecessary layout calculations on child elements. Now it use same method as in swiping (just operate on the numbers directly on selected elements) to open sidebar. Previously go get state of menu, we have to check if some element has an class, right now it's reactive, based on `Session` object and it's used also to set `menu-opened` class to 🍔 element (synchronizing DOM Ready events of few async modules it's kinda tricky, I'm not sure how to handle it).

I changed also a way of animating 🍔  icon, replacing not so fast `width` based translations, with pure transforms solution.


I fixed also sidebar opening for RLT lang users, b/c was totally broken.

Tested on Chrome with 5x CPU slowdown, previously min fps was like 10-15, now it's almost stable 60fps - there are still some minor (AFAIK) Meteor related performance issues related to event listeners, but currently I have no idea how to fix it 😞 