### PR TITLE
[sandstorm] call setPath on navigation

### DIFF
--- a/packages/rocketchat-sandstorm/client/setPath.js
+++ b/packages/rocketchat-sandstorm/client/setPath.js
@@ -1,0 +1,10 @@
+// Set the path of the parent frame when the grain's path changes.
+// See https://docs.sandstorm.io/en/latest/developing/path/
+
+function updateSandstormMetaData(msg) {
+  return window.parent.postMessage(msg, '*');
+}
+
+FlowRouter.triggers.enter([({ path }) => {
+  updateSandstormMetaData({ setPath: path });
+}]);

--- a/packages/rocketchat-sandstorm/client/setPath.js
+++ b/packages/rocketchat-sandstorm/client/setPath.js
@@ -1,10 +1,10 @@
+function updateSandstormMetaData(msg) {
+	return window.parent.postMessage(msg, '*');
+}
+
 if (Meteor.settings.public.sandstorm) {
 	// Set the path of the parent frame when the grain's path changes.
 	// See https://docs.sandstorm.io/en/latest/developing/path/
-
-	function updateSandstormMetaData(msg) {
-		return window.parent.postMessage(msg, '*');
-	}
 
 	FlowRouter.triggers.enter([({ path }) => {
 		updateSandstormMetaData({ setPath: path });

--- a/packages/rocketchat-sandstorm/client/setPath.js
+++ b/packages/rocketchat-sandstorm/client/setPath.js
@@ -1,10 +1,12 @@
-// Set the path of the parent frame when the grain's path changes.
-// See https://docs.sandstorm.io/en/latest/developing/path/
+if (Meteor.settings.public.sandstorm) {
+	// Set the path of the parent frame when the grain's path changes.
+	// See https://docs.sandstorm.io/en/latest/developing/path/
 
-function updateSandstormMetaData(msg) {
-  return window.parent.postMessage(msg, '*');
+	function updateSandstormMetaData(msg) {
+		return window.parent.postMessage(msg, '*');
+	}
+
+	FlowRouter.triggers.enter([({ path }) => {
+		updateSandstormMetaData({ setPath: path });
+	}]);
 }
-
-FlowRouter.triggers.enter([({ path }) => {
-  updateSandstormMetaData({ setPath: path });
-}]);

--- a/packages/rocketchat-sandstorm/package.js
+++ b/packages/rocketchat-sandstorm/package.js
@@ -6,8 +6,8 @@ Package.describe({
 });
 
 Package.onUse(function(api) {
-	api.use([ 'ecmascript', 'rocketchat:lib', 'jalik:ufs' ]);
+	api.use([ 'ecmascript', 'rocketchat:lib', 'jalik:ufs', 'kadira:flow-router']);
 
 	api.addFiles([ 'server/lib.js', 'server/events.js', 'server/powerbox.js' ], 'server');
-	api.addFiles([ 'client/powerboxListener.js' ], 'client');
+	api.addFiles([ 'client/powerboxListener.js', 'client/setPath.js' ], 'client');
 });


### PR DESCRIPTION
@RocketChat/core 

Currently if you have a Rocket.Chat grain open in Sandstorm and you refresh the page, you get navigated back to the grain's home screen, because the path of the URL gets lost. This pull request fixes that problem by calling Sandstorm's `setPath()` function to update the parent frame's path. 

Note that the strategy used here, where we hook into `FlowRouter,` has been [successfully used by Wekan](https://github.com/wefork/wekan/blob/cacaa0ee8c8811145df9a888ca5bce3c9178397d/sandstorm.js#L396-L402) for a while now. And note that Rocket.Chat [already depends on flow-router](https://github.com/RocketChat/Rocket.Chat/blob/a68c2dedc6ce10923dfe6ef85c8b2d20fca3df4e/.meteor/packages#L142).