### PR TITLE
Add status support to room types

### DIFF
--- a/packages/rocketchat-lib/client/lib/roomTypes.coffee
+++ b/packages/rocketchat-lib/client/lib/roomTypes.coffee
@@ -21,6 +21,9 @@ RocketChat.roomTypes = new class roomTypesClient extends roomTypesCommon
 		list = _.reject @roomTypesOrder, (t) -> return except.indexOf(t.identifier) isnt -1
 		return _.map list, (t) -> return t.identifier
 
+	getUserStatus: (roomType, roomId) ->
+		return @roomTypes[roomType]?.getUserStatus?(roomId)
+
 	findRoom: (roomType, identifier, user) ->
 		return @roomTypes[roomType]?.findRoom identifier, user
 

--- a/packages/rocketchat-lib/startup/defaultRoomTypes.coffee
+++ b/packages/rocketchat-lib/startup/defaultRoomTypes.coffee
@@ -48,6 +48,11 @@ RocketChat.roomTypes.add 'd', 20,
 		return ChatSubscription.findOne({ rid: roomData._id }, { fields: { name: 1 } })?.name
 	condition: ->
 		return RocketChat.authz.hasAtLeastOnePermission ['view-d-room', 'view-joined-room']
+	getUserStatus: (roomId) ->
+		subscription = RocketChat.models.Subscriptions.findOne({rid: roomId});
+		return if not subscription?
+
+		return Session.get('user_' + subscription.name + '_status');
 
 RocketChat.roomTypes.add 'p', 30,
 	template: 'privateGroups'

--- a/packages/rocketchat-livechat/roomType.js
+++ b/packages/rocketchat-livechat/roomType.js
@@ -38,6 +38,21 @@ RocketChat.roomTypes.add('l', 5, {
 		return room && room.open === true;
 	},
 
+	getUserStatus(roomId) {
+		const room = Session.get('roomData' + roomId);
+		if (!room) {
+			return;
+		}
+		const subscription = RocketChat.models.Subscriptions.findOne({rid: roomId});
+		if (!subscription) {
+			return;
+		}
+		let guestName = _.without(room.usernames, subscription.u.username);
+		if (guestName) {
+			return Session.get('user_' + guestName + '_status');
+		}
+	},
+
 	notSubscribedTpl: {
 		template: 'livechatNotSubscribed'
 	}

--- a/packages/rocketchat-ui-sidenav/side-nav/chatRoomItem.coffee
+++ b/packages/rocketchat-ui-sidenav/side-nav/chatRoomItem.coffee
@@ -9,7 +9,8 @@ Template.chatRoomItem.helpers
 			return this.unread
 
 	userStatus: ->
-		return 'status-' + (Session.get('user_' + this.name + '_status') or 'offline') if this.t is 'd'
+		userStatus = RocketChat.roomTypes.getUserStatus(this.t, this.rid);
+		return 'status-' + (userStatus or 'offline')
 
 	name: ->
 		return this.name

--- a/packages/rocketchat-ui/views/app/room.coffee
+++ b/packages/rocketchat-ui/views/app/room.coffee
@@ -93,14 +93,7 @@ Template.room.helpers
 
 	userStatus: ->
 		roomData = Session.get('roomData' + this._id)
-
-		return {} unless roomData
-
-		if roomData.t in ['d', 'l']
-			subscription = RocketChat.models.Subscriptions.findOne({rid: this._id});
-			return Session.get('user_' + subscription.name + '_status') || 'offline'
-		else
-			return 'offline'
+		return RocketChat.roomTypes.getUserStatus(roomData.t, this._id) or 'offline'
 
 	flexOpened: ->
 		return 'opened' if RocketChat.TabBar.isFlexOpen()

--- a/packages/rocketchat-ui/views/app/spotlight/spotlight.coffee
+++ b/packages/rocketchat-ui/views/app/spotlight/spotlight.coffee
@@ -26,7 +26,7 @@ getFromServer = (filter, records, cb) =>
 			for room in results.rooms
 				server.push({
 					_id: room._id
-					t: 'c',
+					t: room.t,
 					name: room.name
 				})
 

--- a/packages/rocketchat-ui/views/app/spotlight/spotlightTemplate.js
+++ b/packages/rocketchat-ui/views/app/spotlight/spotlightTemplate.js
@@ -4,9 +4,10 @@ Template.spotlightTemplate.helpers({
 	},
 
 	userStatus() {
-		if (this.t === 'd' || this.t === 'l') {
+		if (this.t === 'd') {
 			return 'status-' + (Session.get(`user_${this.name}_status`) || 'offline');
+		} else {
+			return 'status-' + (RocketChat.roomTypes.getUserStatus(this.t, this.rid || this._id) || 'offline');
 		}
-		return 'status-offline';
 	}
 });


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

This adds the ability for custom room types to be able to control their own "status".

So it fixes livechat room status not showing properly.