### PR TITLE
Fix the nameFilter being required on groupsList, since it isn't

### DIFF
--- a/server/methods/groupsList.js
+++ b/server/methods/groupsList.js
@@ -1,7 +1,7 @@
 Meteor.methods({
 	groupsList: function(nameFilter, limit, sort) {
 
-		check(nameFilter, Math.Optional(String));
+		check(nameFilter, Match.Optional(String));
 		check(limit, Match.Optional(Number));
 		check(sort, Match.Optional(String));
 

--- a/server/methods/groupsList.js
+++ b/server/methods/groupsList.js
@@ -1,7 +1,7 @@
 Meteor.methods({
 	groupsList: function(nameFilter, limit, sort) {
 
-		check(nameFilter, String);
+		check(nameFilter, Math.Optional(String));
 		check(limit, Match.Optional(Number));
 		check(sort, Match.Optional(String));
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Right now the `groupsList` method is bugged due to the imposed requirement of the parameter `nameFilter`. I noticed this was broke when I was working on my Minecraft implementation which calls this method.

Note, this method can be done away with once the `experimental` branch gets merged as a result of the addition of the `rooms/get` method.