### PR TITLE
hide Sandstorm offer button on Cordova

### DIFF
--- a/packages/rocketchat-ui-message/message/messageBox.coffee
+++ b/packages/rocketchat-ui-message/message/messageBox.coffee
@@ -105,7 +105,7 @@ Template.messageBox.helpers
 		return RocketChat.roomTypes.getNotSubscribedTpl @_id
 
 	showSandstorm: ->
-		return Meteor.settings.public.sandstorm
+		return Meteor.settings.public.sandstorm && !Meteor.isCordova
 
 
 Template.messageBox.events


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

The Sandstorm offer "+" button (added in #3932) does not work in the Cordova app. So let's hide it there.

