### PR TITLE
Fixed crash if a webhook payload had a field named "payload"

### DIFF
--- a/packages/rocketchat-integrations/server/api/api.coffee
+++ b/packages/rocketchat-integrations/server/api/api.coffee
@@ -50,6 +50,12 @@ Api = new Restivus
 	apiPath: 'hooks/'
 	auth:
 		user: ->
+			payloadKeys = Object.keys @bodyParams
+			payloadIsWrapped = @bodyParams?.payload? and payloadKeys.length == 1
+
+			if payloadIsWrapped and @request.headers['content-type'] is 'application/x-www-form-urlencoded'
+				@bodyParams = @bodyParams.payload
+
 			@integration = RocketChat.models.Integrations.findOne
 				_id: @request.params.integrationId
 				token: decodeURIComponent @request.params.token

--- a/packages/rocketchat-integrations/server/api/api.coffee
+++ b/packages/rocketchat-integrations/server/api/api.coffee
@@ -50,9 +50,6 @@ Api = new Restivus
 	apiPath: 'hooks/'
 	auth:
 		user: ->
-			if @bodyParams?.payload?
-				@bodyParams = JSON.parse @bodyParams.payload
-
 			@integration = RocketChat.models.Integrations.findOne
 				_id: @request.params.integrationId
 				token: decodeURIComponent @request.params.token


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes [#5113](https://github.com/RocketChat/Rocket.Chat/issues/5113)

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
It appears that the Incoming Webhooks script accounted the fact that some JSONs might be packed inside a "payload" field, like the following:

```
{
  "payload": { actual JSON here }
}
```
and started parsing from inside that field, if it was the case.

However, this solution conflicts with the possibility that this field is not a container for the whole thing, but simply another field, like Crashlytics's payloads:

```
{
  "event": "issue_impact_change",
  "payload_type": "issue",
  "payload": {
    "display_id": 123 ,
    "title": "Issue Title" ,
    "method": "methodName of issue",
    "impact_level": 2,
    "crashes_count": 54,
    "impacted_devices_count": 16,
    "url": "http://crashlytics.com/full/url/to/issue"
  }
}
```

This resulted in crashes, so I removed this special treatment.