### PR TITLE
Don't allow changing the room type no other permission

### DIFF
--- a/packages/rocketchat-channel-settings/client/views/channelSettings.coffee
+++ b/packages/rocketchat-channel-settings/client/views/channelSettings.coffee
@@ -143,7 +143,14 @@ Template.channelSettings.onCreated ->
 			options:
 				c: 'Channel'
 				p: 'Private_Group'
-			canView: (room) => room.t in ['c', 'p']
+			canView: (room) ->
+				if not room.t in ['c', 'p']
+					return false
+				else if room.t is 'p' and not RocketChat.authz.hasAllPermission('create-c')
+					return false
+				else if room.t is 'c' and not RocketChat.authz.hasAllPermission('create-p')
+					return false
+				return true
 			canEdit: (room) => RocketChat.authz.hasAllPermission('edit-room', room._id)
 			save: (value, room) ->
 				if value not in ['c', 'p']

--- a/packages/rocketchat-channel-settings/server/methods/saveRoomSettings.coffee
+++ b/packages/rocketchat-channel-settings/server/methods/saveRoomSettings.coffee
@@ -17,6 +17,12 @@ Meteor.methods
 
 		room = RocketChat.models.Rooms.findOneById rid
 		if room?
+			if setting is 'roomType' and value isnt room.t and value is 'c' and not RocketChat.authz.hasPermission(@userId, 'create-c')
+				throw new Meteor.Error 'error-action-not-allowed', 'Changing a private group to a public channel is not allowed', { method: 'saveRoomSettings', action: 'Change_Room_Type' }
+
+			if setting is 'roomType' and value isnt room.t and value is 'p' and not RocketChat.authz.hasPermission(@userId, 'create-p')
+				throw new Meteor.Error 'error-action-not-allowed', 'Changing a public channel to a private room is not allowed', { method: 'saveRoomSettings', action: 'Change_Room_Type' }
+
 			switch setting
 				when 'roomName'
 					name = RocketChat.saveRoomName rid, value, Meteor.user()

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -252,6 +252,7 @@
   "CDN_PREFIX": "CDN Prefix",
   "Certificates_and_Keys": "Certificates and Keys",
   "Changing_email": "Changing email",
+  "Change_Room_Type": "Changing the Room Type",
   "channel": "channel",
   "Channel": "Channel",
   "Channel_already_exist": "The channel '#%s' already exists.",


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #5141 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

This prevents users from changing the type of room if they don't have permission to create the other type of room. See #5141 for how to replicate this issue.