### PR TITLE
Include _id of added user for 'au' messages

### DIFF
--- a/packages/rocketchat-lib/server/models/Messages.coffee
+++ b/packages/rocketchat-lib/server/models/Messages.coffee
@@ -402,7 +402,7 @@ RocketChat.models.Messages = new class extends RocketChat.models._Base
 
 	createUserAddedWithRoomIdAndUser: (roomId, user, extraData) ->
 		message = user.username
-		return @createWithTypeRoomIdMessageAndUser 'au', roomId, message, user, extraData
+		return @createWithTypeRoomIdMessageAndUser 'au', roomId, message, user, _.extend extraData || {}, added : _id : user._id
 
 	createCommandWithRoomIdAndUser: (command, roomId, user, extraData) ->
 		return @createWithTypeRoomIdMessageAndUser 'command', roomId, command, user, extraData


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
At present hubot-rocketchat will only create an `enterMessage` for a user who actively joined a room (messagetype == 'uj'). We need hubot to also welcome a user if they get added to the room by another user (messagetype == 'au'). This extra functionality will allow hubot-rocketchat to identify that added user and create an `enterMessage` for them.