### PR TITLE
Make the server information of the api consistant with others

### DIFF
--- a/packages/rocketchat-api/server/v1/misc.js
+++ b/packages/rocketchat-api/server/v1/misc.js
@@ -1,6 +1,8 @@
 RocketChat.API.v1.addRoute('info', { authRequired: false }, {
 	get: function() {
-		return RocketChat.Info;
+		return RocketChat.API.v1.success({
+			info: RocketChat.Info
+		});
 	}
 });
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

I was working on a rest api client and noticed the server information wasn't consistent with the other v1 api results.

