### PR TITLE
Add room setting which allows reacting when read only

### DIFF
--- a/packages/rocketchat-channel-settings/client/views/channelSettings.coffee
+++ b/packages/rocketchat-channel-settings/client/views/channelSettings.coffee
@@ -171,6 +171,16 @@ Template.channelSettings.onCreated ->
 					return handleError err if err
 					toastr.success TAPi18n.__ 'Read_only_changed_successfully'
 
+		reactWhenReadOnly:
+			type: 'boolean'
+			label: 'React_when_read_only'
+			canView: (room) => room.t isnt 'd' and room.ro
+			canEdit: (room) => RocketChat.authz.hasAllPermission('set-react-when-readonly', room._id)
+			save: (value, room) ->
+				Meteor.call 'saveRoomSettings', room._id, 'reactWhenReadOnly', value, (err, result) ->
+					return handleError err if err
+					toastr.success TAPi18n.__ 'React_when_read_only_changed_successfully'
+
 		archived:
 			type: 'boolean'
 			label: 'Room_archivation_state_true'

--- a/packages/rocketchat-channel-settings/package.js
+++ b/packages/rocketchat-channel-settings/package.js
@@ -27,6 +27,7 @@ Package.onUse(function(api) {
 	], 'client');
 
 	api.addFiles([
+		'server/functions/saveReactWhenReadOnly.js',
 		'server/functions/saveRoomType.coffee',
 		'server/functions/saveRoomTopic.coffee',
 		'server/functions/saveRoomName.coffee',

--- a/packages/rocketchat-channel-settings/server/functions/saveReactWhenReadOnly.js
+++ b/packages/rocketchat-channel-settings/server/functions/saveReactWhenReadOnly.js
@@ -1,0 +1,7 @@
+RocketChat.saveReactWhenReadOnly = function(rid, allowReact) {
+	if (!Match.test(rid, String)) {
+		throw new Meteor.Error('invalid-room', 'Invalid room', { function: 'RocketChat.saveReactWhenReadOnly' });
+	}
+
+	return RocketChat.models.Rooms.setAllowReactingWhenReadOnlyById(rid, allowReact);
+};

--- a/packages/rocketchat-channel-settings/server/methods/saveRoomSettings.coffee
+++ b/packages/rocketchat-channel-settings/server/methods/saveRoomSettings.coffee
@@ -6,7 +6,7 @@ Meteor.methods
 		unless Match.test rid, String
 			throw new Meteor.Error 'error-invalid-room', 'Invalid room', { method: 'saveRoomSettings' }
 
-		if setting not in ['roomName', 'roomTopic', 'roomDescription', 'roomType', 'readOnly', 'systemMessages', 'default', 'joinCode']
+		if setting not in ['roomName', 'roomTopic', 'roomDescription', 'roomType', 'readOnly', 'reactWhenReadOnly', 'systemMessages', 'default', 'joinCode']
 			throw new Meteor.Error 'error-invalid-settings', 'Invalid settings provided', { method: 'saveRoomSettings' }
 
 		unless RocketChat.authz.hasPermission(Meteor.userId(), 'edit-room', rid)
@@ -38,6 +38,9 @@ Meteor.methods
 				when 'readOnly'
 					if value isnt room.ro
 						RocketChat.saveRoomReadOnly rid, value, Meteor.user()
+				when 'reactWhenReadOnly'
+					if value isnt room.reactWhenReadOnly
+						RocketChat.saveReactWhenReadOnly rid, value, Meteor.user()
 				when 'systemMessages'
 					if value isnt room.sysMes
 						RocketChat.saveRoomSystemMessages rid, value, Meteor.user()

--- a/packages/rocketchat-channel-settings/server/models/Rooms.coffee
+++ b/packages/rocketchat-channel-settings/server/models/Rooms.coffee
@@ -32,6 +32,16 @@ RocketChat.models.Rooms.setReadOnlyById = (_id, readOnly) ->
 
 	return @update query, update
 
+RocketChat.models.Rooms.setAllowReactingWhenReadOnlyById = (_id, allowReacting) ->
+	query =
+		_id: _id
+
+	update =
+		$set:
+			reactWhenReadOnly: allowReacting
+
+	return @update query, update
+
 RocketChat.models.Rooms.setSystemMessagesById = (_id, systemMessages) ->
 	query =
 		_id: _id

--- a/packages/rocketchat-channel-settings/server/startup.js
+++ b/packages/rocketchat-channel-settings/server/startup.js
@@ -1,4 +1,5 @@
 Meteor.startup(function() {
 	RocketChat.models.Permissions.upsert('post-readonly', {$set: { roles: ['admin', 'owner', 'moderator'] } });
 	RocketChat.models.Permissions.upsert('set-readonly', {$set: { roles: ['admin', 'owner'] } });
+	RocketChat.models.Permissions.upsert('set-react-when-readonly', {$set: { roles: ['admin', 'owner'] }});
 });

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -1050,6 +1050,8 @@
   "quote": "quote",
   "Quote": "Quote",
   "Random": "Random",
+  "React_when_read_only": "Allow Reacting",
+  "React_when_read_only_changed_successfully": "Allow reacting when read only changed successfully",
   "Reacted_with": "Reacted with",
   "Reactions": "Reactions",
   "Read_only": "Read Only",

--- a/packages/rocketchat-reactions/client/init.js
+++ b/packages/rocketchat-reactions/client/init.js
@@ -57,9 +57,11 @@ Meteor.startup(function() {
 			let room = RocketChat.models.Rooms.findOne({ _id: message.rid });
 			let user = Meteor.user();
 
-			if (Array.isArray(room.muted) && room.muted.indexOf(user.username) !== -1) {
+			if (Array.isArray(room.muted) && room.muted.indexOf(user.username) !== -1 && !room.reactWhenReadOnly) {
 				return false;
 			} else if (!RocketChat.models.Subscriptions.findOne({ rid: message.rid })) {
+				return false;
+			} else if (message.private) {
 				return false;
 			}
 

--- a/packages/rocketchat-reactions/client/init.js
+++ b/packages/rocketchat-reactions/client/init.js
@@ -7,7 +7,7 @@ Template.room.events({
 		let user = Meteor.user();
 		let room = RocketChat.models.Rooms.findOne({ _id: data._arguments[1].rid });
 
-		if (Array.isArray(room.muted) && room.muted.indexOf(user.username) !== -1) {
+		if (Array.isArray(room.muted) && room.muted.indexOf(user.username) !== -1 && !room.reactWhenReadOnly) {
 			return false;
 		}
 

--- a/packages/rocketchat-reactions/client/methods/setReaction.js
+++ b/packages/rocketchat-reactions/client/methods/setReaction.js
@@ -13,6 +13,8 @@ Meteor.methods({
 			return false;
 		} else if (!RocketChat.models.Subscriptions.findOne({ rid: message.rid })) {
 			return false;
+		} else if (message.private) {
+			return false;
 		}
 
 		if (message.reactions && message.reactions[reaction] && message.reactions[reaction].usernames.indexOf(user.username) !== -1) {

--- a/packages/rocketchat-reactions/client/methods/setReaction.js
+++ b/packages/rocketchat-reactions/client/methods/setReaction.js
@@ -9,7 +9,7 @@ Meteor.methods({
 		let message = RocketChat.models.Messages.findOne({ _id: messageId });
 		let room = RocketChat.models.Rooms.findOne({ _id: message.rid });
 
-		if (Array.isArray(room.muted) && room.muted.indexOf(user.username) !== -1) {
+		if (Array.isArray(room.muted) && room.muted.indexOf(user.username) !== -1 && !room.reactWhenReadOnly) {
 			return false;
 		} else if (!RocketChat.models.Subscriptions.findOne({ rid: message.rid })) {
 			return false;

--- a/packages/rocketchat-reactions/setReaction.js
+++ b/packages/rocketchat-reactions/setReaction.js
@@ -7,6 +7,10 @@ Meteor.methods({
 
 		let message = RocketChat.models.Messages.findOneById(messageId);
 
+		if (!message) {
+			throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'setReaction' });
+		}
+
 		let room = Meteor.call('canAccessRoom', message.rid, Meteor.userId());
 
 		if (!room) {

--- a/packages/rocketchat-reactions/setReaction.js
+++ b/packages/rocketchat-reactions/setReaction.js
@@ -15,7 +15,7 @@ Meteor.methods({
 
 		const user = Meteor.user();
 
-		if (Array.isArray(room.muted) && room.muted.indexOf(user.username) !== -1) {
+		if (Array.isArray(room.muted) && room.muted.indexOf(user.username) !== -1 && !room.reactWhenReadOnly) {
 			RocketChat.Notifications.notifyUser(Meteor.userId(), 'message', {
 				_id: Random.id(),
 				rid: room._id,

--- a/packages/rocketchat-ui-message/message/message.coffee
+++ b/packages/rocketchat-ui-message/message/message.coffee
@@ -128,7 +128,6 @@ Template.message.helpers
 	hideReactions: ->
 		return 'hidden' if _.isEmpty(@reactions)
 
-
 	actionLinks: ->
 		# remove 'method_id' and 'params' properties
 		return _.map(@actionLinks, (actionLink, key) -> _.extend({ id: key }, _.omit(actionLink, 'method_id', 'params')))

--- a/server/startup/roomPublishes.coffee
+++ b/server/startup/roomPublishes.coffee
@@ -11,6 +11,7 @@ Meteor.startup ->
 				muted: 1
 				archived: 1
 				ro: 1
+				reactWhenReadOnly: 1
 				jitsiTimeout: 1
 				description: 1
 				sysMes: 1
@@ -40,6 +41,7 @@ Meteor.startup ->
 				muted: 1
 				archived: 1
 				ro: 1
+				reactWhenReadOnly: 1
 				jitsiTimeout: 1
 				description: 1
 				sysMes: 1


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #5147 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
This adds the ability to configure a room that is read only to allow people to react to messages. The usefulness of this is for servers that have "announcement/news" channels yet they would like to get their communities reactions to the news without spamming the channel with messages.