### PR TITLE
Fix bot users being rate limited

### DIFF
--- a/packages/rocketchat-lib/server/methods/sendMessage.coffee
+++ b/packages/rocketchat-lib/server/methods/sendMessage.coffee
@@ -5,6 +5,9 @@ Meteor.methods
 
 		check message, Object
 
+		if not Meteor.userId()
+			throw new Meteor.Error('error-invalid-user', "Invalid user", { method: 'sendMessage' })
+
 		if message.ts
 			tsDiff = Math.abs(moment(message.ts).diff())
 			if tsDiff > 60000
@@ -16,9 +19,6 @@ Meteor.methods
 
 		if message.msg?.length > RocketChat.settings.get('Message_MaxAllowedSize')
 			throw new Meteor.Error('error-message-size-exceeded', 'Message size exceeds Message_MaxAllowedSize', { method: 'sendMessage' })
-
-		if not Meteor.userId()
-			throw new Meteor.Error('error-invalid-user', "Invalid user", { method: 'sendMessage' })
 
 		user = RocketChat.models.Users.findOneById Meteor.userId(), fields: username: 1, name: 1
 
@@ -47,5 +47,7 @@ DDPRateLimiter.addRule
 	type: 'method'
 	name: 'sendMessage'
 	userId: (userId) ->
-		return 'bot' not in RocketChat.models.Users.findOneById(userId)?.roles
+		user = RocketChat.models.Users.findOneById(userId)
+		return true if not user?.roles
+		return 'bot' not in user.roles
 , 5, 1000

--- a/packages/rocketchat-lib/server/methods/sendMessage.coffee
+++ b/packages/rocketchat-lib/server/methods/sendMessage.coffee
@@ -42,10 +42,10 @@ Meteor.methods
 
 		RocketChat.sendMessage user, message, room
 
-# Limit a user to sending 5 msgs/second
+# Limit a user, who does not have the "bot" role, to sending 5 msgs/second
 DDPRateLimiter.addRule
 	type: 'method'
 	name: 'sendMessage'
 	userId: (userId) ->
-		return RocketChat.models.Users.findOneById(userId)?.username isnt RocketChat.settings.get('InternalHubot_Username')
+		return 'bot' not in RocketChat.models.Users.findOneById(userId)?.roles
 , 5, 1000


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #5119 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Right now we rate limit everyone except for the internal "hubot" bot. With this pull request all of the bot users are now *not* rate limited.
