### PR TITLE
Migrate livechat visitors' emails field to visitorEmails

### DIFF
--- a/packages/rocketchat-livechat/app/client/lib/commands.js
+++ b/packages/rocketchat-livechat/app/client/lib/commands.js
@@ -14,7 +14,7 @@ this.Commands = {
 	promptTranscript: function() {
 		if (Livechat.transcript) {
 			const user = Meteor.user();
-			let email = user.emails && user.emails.length > 0 ? user.emails[0].address : '';
+			let email = user.visitorEmails && user.visitorEmails.length > 0 ? user.visitorEmails[0].address : '';
 
 			swal({
 				title: t('Chat_ended'),

--- a/packages/rocketchat-livechat/client/views/app/tabbar/visitorEdit.js
+++ b/packages/rocketchat-livechat/client/views/app/tabbar/visitorEdit.js
@@ -10,8 +10,8 @@ Template.visitorEdit.helpers({
 
 	email() {
 		const visitor = Template.instance().visitor.get();
-		if (visitor.emails && visitor.emails.length > 0) {
-			return visitor.emails[0].address;
+		if (visitor.visitorEmails && visitor.visitorEmails.length > 0) {
+			return visitor.visitorEmails[0].address;
 		}
 	},
 

--- a/packages/rocketchat-livechat/client/views/app/tabbar/visitorInfo.html
+++ b/packages/rocketchat-livechat/client/views/app/tabbar/visitorInfo.html
@@ -15,7 +15,7 @@
 
 						<ul>
 							{{#if utc}}<li><i class="icon-clock"></i>{{userTime}} (UTC {{utc}})</li>{{/if}}
-							{{#each emails}} <li><i class="icon-mail"></i> {{address}}{{#if verified}}&nbsp;<i class="icon-ok"></i>{{/if}}</li> {{/each}}
+							{{#each visitorEmails}} <li><i class="icon-mail"></i> {{address}}{{#if verified}}&nbsp;<i class="icon-ok"></i>{{/if}}</li> {{/each}}
 							{{#each phone}} <li><i class="icon-phone"></i> {{phoneNumber}}</li> {{/each}}
 							{{#if lastLogin}} <li><i class="icon-calendar"></i> {{_ "Created_at"}}: {{createdAt}}</li> {{/if}}
 							{{#if lastLogin}} <li><i class="icon-calendar"></i> {{_ "Last_login"}}: {{lastLogin}}</li> {{/if}}

--- a/packages/rocketchat-livechat/server/lib/Livechat.js
+++ b/packages/rocketchat-livechat/server/lib/Livechat.js
@@ -106,15 +106,7 @@ RocketChat.Livechat = {
 
 			var existingUser = null;
 
-			if (s.trim(email) !== '' && (existingUser = RocketChat.models.Users.findOneByEmailAddress(email))) {
-				if (existingUser.type !== 'visitor') {
-					throw new Meteor.Error('error-invalid-user', 'This email belongs to a registered user.');
-				}
-
-				updateUser.$addToSet = {
-					globalRoles: 'livechat-guest'
-				};
-
+			if (s.trim(email) !== '' && (existingUser = RocketChat.models.Users.findOneGuestByEmailAddress(email))) {
 				if (loginToken) {
 					updateUser.$addToSet['services.resume.loginTokens'] = loginToken;
 				}
@@ -156,7 +148,7 @@ RocketChat.Livechat = {
 		}
 
 		if (email && email.trim() !== '') {
-			updateUser.$set.emails = [
+			updateUser.$set.visitorEmails = [
 				{ address: email }
 			];
 		}
@@ -178,7 +170,7 @@ RocketChat.Livechat = {
 		if (phone) {
 			updateData.phone = phone;
 		}
-		const ret = RocketChat.models.Users.saveUserById(_id, updateData);
+		const ret = RocketChat.models.Users.saveGuestById(_id, updateData);
 
 		Meteor.defer(() => {
 			RocketChat.callbacks.run('livechat.saveGuest', updateData);
@@ -387,8 +379,8 @@ RocketChat.Livechat = {
 			postData.crmData = room.crmData;
 		}
 
-		if (visitor.emails && visitor.emails.length > 0) {
-			postData.visitor.email = visitor.emails[0].address;
+		if (visitor.visitorEmails && visitor.visitorEmails.length > 0) {
+			postData.visitor.email = visitor.visitorEmails[0].address;
 		}
 		if (visitor.phone && visitor.phone.length > 0) {
 			postData.visitor.phone = visitor.phone[0].phoneNumber;

--- a/packages/rocketchat-livechat/server/models/Users.js
+++ b/packages/rocketchat-livechat/server/models/Users.js
@@ -214,3 +214,60 @@ RocketChat.models.Users.getNextVisitorUsername = function() {
 
 	return 'guest-' + (livechatCount.value.value + 1);
 };
+
+RocketChat.models.Users.saveGuestById = function(_id, data) {
+	const setData = {};
+	const unsetData = {};
+
+	if (data.name) {
+		if (!_.isEmpty(s.trim(data.name))) {
+			setData.name = s.trim(data.name);
+		} else {
+			unsetData.name = 1;
+		}
+	}
+
+	if (data.email) {
+		if (!_.isEmpty(s.trim(data.email))) {
+			setData.visitorEmails = [
+				{ address: s.trim(data.email) }
+			];
+		} else {
+			unsetData.visitorEmails = 1;
+		}
+	}
+
+	if (data.phone) {
+		if (!_.isEmpty(s.trim(data.phone))) {
+			setData.phone = [
+				{ phoneNumber: s.trim(data.phone) }
+			];
+		} else {
+			unsetData.phone = 1;
+		}
+	}
+
+	const update = {};
+
+	if (!_.isEmpty(setData)) {
+		update.$set = setData;
+	}
+
+	if (!_.isEmpty(unsetData)) {
+		update.$unset = unsetData;
+	}
+
+	if (_.isEmpty(update)) {
+		return true;
+	}
+
+	return this.update({ _id }, update);
+};
+
+RocketChat.models.Users.findOneGuestByEmailAddress = function(emailAddress) {
+	const query = {
+		'visitorEmails.address': new RegExp('^' + s.escapeRegExp(emailAddress) + '$', 'i')
+	};
+
+	return this.findOne(query);
+};

--- a/packages/rocketchat-livechat/server/models/indexes.js
+++ b/packages/rocketchat-livechat/server/models/indexes.js
@@ -1,4 +1,5 @@
 Meteor.startup(function() {
 	RocketChat.models.Rooms.tryEnsureIndex({ code: 1 });
 	RocketChat.models.Rooms.tryEnsureIndex({ open: 1 }, { sparse: 1 });
+	RocketChat.models.Users.tryEnsureIndex({ 'visitorEmails.address': 1 });
 });

--- a/server/startup/migrations/v072.js
+++ b/server/startup/migrations/v072.js
@@ -1,0 +1,15 @@
+RocketChat.Migrations.add({
+	version: 72,
+	up: function() {
+		RocketChat.models.Users.find({ type: 'visitor', 'emails.address': { $exists: true } }, { emails: 1 }).forEach(function(visitor) {
+			RocketChat.models.Users.update({ _id: visitor._id }, {
+				$set: {
+					visitorEmails: visitor.emails
+				},
+				$unset: {
+					emails: 1
+				}
+			});
+		});
+	}
+});


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Using `emails` field to store livechat visitor's emails is leading to problems because `emails` field has an unique index created by [Meteor Accounts package](https://github.com/meteor/meteor/blob/devel/packages/accounts-base/accounts_server.js#L1492).

So I'm moving to another field without the unique index but keeping all functionality.
