### PR TITLE
Fix the over creation of AudioContexts.

### DIFF
--- a/packages/rocketchat-webrtc/WebRTCClass.coffee
+++ b/packages/rocketchat-webrtc/WebRTCClass.coffee
@@ -228,10 +228,10 @@ class WebRTCClass
 		if @active isnt true or @monitor is true or @remoteMonitoring is true then return
 
 		remoteConnections = []
-		for id, peerConnections of @peerConnections
+		for id, peerConnection of @peerConnections
 			remoteConnections.push
 				id: id
-				media: peerConnections.remoteMedia
+				media: peerConnection.remoteMedia
 
 		@transport.sendStatus
 			media: @media
@@ -339,6 +339,8 @@ class WebRTCClass
 				stream.removeTrack(stream.getAudioTracks()[0])
 				stream.addTrack(peer.stream.getAudioTracks()[0])
 				stream.volume = volume
+
+				this.audioContext = audioContext
 
 			onSuccess(stream)
 
@@ -461,7 +463,8 @@ class WebRTCClass
 
 	stopAllPeerConnections: ->
 		for id, peerConnection of @peerConnections
-				@stopPeerConnection id
+			@stopPeerConnection id
+		window.audioContext.close()
 
 	setAudioEnabled: (enabled=true) ->
 		if @localStream?


### PR DESCRIPTION
@RocketChat/core 

After a user makes 6 consecutive calls, 7th call can't be established. Since the number of hardware contexts provided is only 6, we have to "close AudioContext" after user click the stop-call button.

related error message:

> WebRTCClass.coffee:330
> 
> Uncaught DOMException: Failed to construct 'AudioContext': The number of hardware contexts provided (6) is greater than or equal to the maximum bound (6).
>     at onSuccessLocal (http://localhost:3000/packages/rocketchat_webrtc.js?hash=d0189ef653b43578dca35032cacb8073032dc160:523:24)
> onSuccessLocal @ WebRTCClass.coffee:330