### PR TITLE
Allow to merge users with LDAP on bulk sync

### DIFF
--- a/packages/rocketchat-ldap/server/sync.js
+++ b/packages/rocketchat-ldap/server/sync.js
@@ -221,8 +221,7 @@ sync = function sync() {
 
 				if (!user) {
 					addLdapUser(ldapUser, username);
-				}
-				else if (user.ldap !== true && RocketChat.settings.get('LDAP_Merge_Existing_Users') === true) {
+				} else if (user.ldap !== true && RocketChat.settings.get('LDAP_Merge_Existing_Users') === true) {
 					syncUserData(user, ldapUser);
 				}
 			});

--- a/packages/rocketchat-ldap/server/sync.js
+++ b/packages/rocketchat-ldap/server/sync.js
@@ -222,6 +222,9 @@ sync = function sync() {
 				if (!user) {
 					addLdapUser(ldapUser, username);
 				}
+				else if (user.ldap !== true && RocketChat.settings.get('LDAP_Merge_Existing_Users') === true) {
+					syncUserData(user, ldapUser);
+				}
 			});
 		}
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #5227

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Present implementation of bulk ldap sync doesn't merge existing users with ldap users if they exist. We have a lot of user signing by Google Auth but then we need to standardize them based on LDAP information. This modification makes this work. 
