### PR TITLE
Fix livechat take inquiry after removing username fields from rooms

### DIFF
--- a/packages/rocketchat-livechat/server/methods/takeInquiry.js
+++ b/packages/rocketchat-livechat/server/methods/takeInquiry.js
@@ -38,11 +38,9 @@ Meteor.methods({
 
 		// update room
 		const room = RocketChat.models.Rooms.findOneById(inquiry.rid);
-		const usernames = room.usernames.concat(agent.username);
 
-		RocketChat.models.Rooms.changeAgentByRoomId(inquiry.rid, usernames, agent);
+		RocketChat.models.Rooms.changeAgentByRoomId(inquiry.rid, agent);
 
-		room.usernames = usernames;
 		room.servedBy = {
 			_id: agent.agentId,
 			username: agent.username

--- a/packages/rocketchat-livechat/server/models/Rooms.js
+++ b/packages/rocketchat-livechat/server/models/Rooms.js
@@ -166,13 +166,12 @@ RocketChat.models.Rooms.findOpenByAgent = function(userId) {
 	return this.find(query);
 };
 
-RocketChat.models.Rooms.changeAgentByRoomId = function(roomId, newUsernames, newAgent) {
+RocketChat.models.Rooms.changeAgentByRoomId = function(roomId, newAgent) {
 	const query = {
 		_id: roomId
 	};
 	const update = {
 		$set: {
-			usernames: newUsernames,
 			servedBy: {
 				_id: newAgent.agentId,
 				username: newAgent.username


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Livechat guest pool is currently broken on `develop` since we don't have the `username` fields on rooms anymore.

