### PR TITLE
Make keyup event in livechat office-hour form only relevant to radio …

### DIFF
--- a/packages/rocketchat-livechat/client/views/app/livechatOfficeHours.js
+++ b/packages/rocketchat-livechat/client/views/app/livechatOfficeHours.js
@@ -69,9 +69,8 @@ Template.livechatOfficeHours.events({
 		let value = e.currentTarget.value;
 		if (e.currentTarget.type === 'radio') {
 			value = value === 'true';
+			instance[e.currentTarget.name].set(value);
 		}
-
-		instance[e.currentTarget.name].set(value);
 	},
 	'submit .rocket-form'(e, instance) {
 		e.preventDefault();


### PR DESCRIPTION
…buttons

Causes error when adjusting start/finish time

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
