### PR TITLE
Fix the over creation of AudioContexts when record audio message.

### DIFF
--- a/packages/rocketchat-ui/lib/recorderjs/audioRecorder.coffee
+++ b/packages/rocketchat-ui/lib/recorderjs/audioRecorder.coffee
@@ -4,7 +4,7 @@
 		navigator.getUserMedia = navigator.getUserMedia or navigator.webkitGetUserMedia
 		window.URL = window.URL or window.webkitURL
 
-		@audio_context = new AudioContext
+		window.audioContext = new AudioContext
 
 		ok = (stream) =>
 			@startUserMedia(stream)
@@ -18,7 +18,7 @@
 
 	startUserMedia: (stream) ->
 		@stream = stream
-		input = @audio_context.createMediaStreamSource(stream)
+		input = window.audioContext.createMediaStreamSource(stream)
 		@recorder = new Recorder(input, {workerPath: '/recorderWorker.js'})
 		@recorder.record()
 
@@ -32,7 +32,8 @@
 
 		@recorder.clear()
 
-		delete @audio_context
+		window.audioContext.close()
+		delete window.audioContext
 		delete @recorder
 		delete @stream
 


### PR DESCRIPTION
@RocketChat/core 

Same thing with this [pull request](https://github.com/RocketChat/Rocket.Chat/pull/5223). When a user records 6 consecutive audio message, DOMException happens. I added AudioContext's close function.