### PR TITLE
Snap print to journal

### DIFF
--- a/.snapcraft/edge/snapcraft.yaml
+++ b/.snapcraft/edge/snapcraft.yaml
@@ -13,7 +13,7 @@ description: Have your own Slack like online chat, built with Meteor. https://ro
 confinement: strict
 apps:
     rocketchat-server:
-        command: env BABEL_CACHE_DIR=/tmp ROOT_URL=http://localhost PORT=3000 MONGO_URL=mongodb://localhost:27017/parties Accounts_AvatarStorePath=$SNAP_COMMON/uploads node $SNAP/main.js >$SNAP_DATA/server.log 2>&1
+        command: env BABEL_CACHE_DIR=/tmp ROOT_URL=http://localhost PORT=3000 MONGO_URL=mongodb://localhost:27017/parties Accounts_AvatarStorePath=$SNAP_COMMON/uploads node $SNAP/main.js
         daemon: simple
         plugs: [network, network-bind]
     rocketchat-mongo:

--- a/.snapcraft/stable/snapcraft.yaml
+++ b/.snapcraft/stable/snapcraft.yaml
@@ -13,7 +13,7 @@ description: Have your own Slack like online chat, built with Meteor. https://ro
 confinement: strict
 apps:
     rocketchat-server:
-        command: env BABEL_CACHE_DIR=/tmp ROOT_URL=http://localhost PORT=3000 MONGO_URL=mongodb://localhost:27017/parties Accounts_AvatarStorePath=$SNAP_COMMON/uploads node $SNAP/main.js >$SNAP_DATA/server.log 2>&1
+        command: env BABEL_CACHE_DIR=/tmp ROOT_URL=http://localhost PORT=3000 MONGO_URL=mongodb://localhost:27017/parties Accounts_AvatarStorePath=$SNAP_COMMON/uploads node $SNAP/main.js
         daemon: simple
         plugs: [network, network-bind]
     rocketchat-mongo:


### PR DESCRIPTION
@RocketChat/core 

We were spitting all output in the file, but we've been telling people to check the journal.  Going to use this way, as in the future logs will also be accessible via `snap logs rocketchat-server` and pulls from journal.
