### PR TITLE
AudioContext can be closed only if it exists.

### DIFF
--- a/packages/rocketchat-webrtc/WebRTCClass.coffee
+++ b/packages/rocketchat-webrtc/WebRTCClass.coffee
@@ -464,7 +464,7 @@ class WebRTCClass
 	stopAllPeerConnections: ->
 		for id, peerConnection of @peerConnections
 			@stopPeerConnection id
-		window.audioContext.close()
+		window.audioContext?.close()
 
 	setAudioEnabled: (enabled=true) ->
 		if @localStream?


### PR DESCRIPTION
@RocketChat/core 

There is a bug at the [pull request](https://github.com/RocketChat/Rocket.Chat/pull/5223) which i made 6 days ago.
When a user makes a call and opponent refuse it, `close() function undefined` error occurs. If a call is not created, there will be no `window.audioContext`. Sorry about my mistake.
