### PR TITLE
Fix screen sharing bug when receiving audio call. issue #5286

### DIFF
--- a/packages/rocketchat-webrtc/WebRTCClass.coffee
+++ b/packages/rocketchat-webrtc/WebRTCClass.coffee
@@ -160,7 +160,7 @@ class WebRTCClass
 		@screenShareAvailable = @navigator in ['chrome', 'firefox']
 
 		@media =
-			video: true
+			video: false
 			audio: true
 
 		@transport = new @transportClass @


### PR DESCRIPTION
@RocketChat/core 

Closes #5286

How about set "video: false" as a default? I test a few cases and it works.
