### PR TITLE
Fixes oembed error with ogImage URLs that start with double slash

### DIFF
--- a/packages/rocketchat-oembed/client/oembedUrlWidget.coffee
+++ b/packages/rocketchat-oembed/client/oembedUrlWidget.coffee
@@ -36,7 +36,10 @@ Template.oembedUrlWidget.helpers
 
 		url = decodedOgImage or this.meta.twitterImage
 
-		if url?[0] is '/' and this.parsedUrl?.host?
+		if url.indexOf('//') is 0
+			url = "#{this.parsedUrl.protocol}#{url}"
+
+		else if url.indexOf('/') is 0 and this.parsedUrl?.host?
 			url = "#{this.parsedUrl.protocol}//#{this.parsedUrl.host}#{url}"
 
 		return url


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Before:
![image](https://cloud.githubusercontent.com/assets/1986378/21453259/88607510-c8f4-11e6-853f-847b15d2e2d1.png)

After:
![image](https://cloud.githubusercontent.com/assets/1986378/21453263/8ea84f10-c8f4-11e6-972d-cb33662ac81e.png)


<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
