### PR TITLE
Support aliases in the direct messages list

### DIFF
--- a/packages/rocketchat-cas/cas_server.js
+++ b/packages/rocketchat-cas/cas_server.js
@@ -188,7 +188,7 @@ Accounts.registerLoginHandler(function(options) {
 			logger.debug('Syncing user attributes');
 			// Update name
 			if (int_attrs.name) {
-				Meteor.users.update(user, { $set: { name: int_attrs.name }});
+				RocketChat._setRealName(user._id, int_attrs.name);
 			}
 
 			// Update email

--- a/packages/rocketchat-crowd/server/crowd.js
+++ b/packages/rocketchat-crowd/server/crowd.js
@@ -85,7 +85,6 @@ const CROWD = class CROWD {
 
 	syncDataToUser(crowdUser, id) {
 		const user = {
-			name: crowdUser.displayname,
 			username: crowdUser.username,
 			emails: [{
 				address : crowdUser.email,
@@ -94,6 +93,10 @@ const CROWD = class CROWD {
 			password: crowdUser.password,
 			active: crowdUser.active
 		};
+
+		if (crowdUser.displayname) {
+			RocketChat._setRealName(user._id, crowdUser.displayname);
+		}
 
 		Meteor.users.update(id, {
 			$set: user

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -858,6 +858,7 @@
   "Message_removed": "Message removed",
   "Message_SetNameToAliasEnabled": "Set a user name to alias in message",
   "Message_SetNameToAliasEnabled_Description": "Only if not already set alias. The old messages alias not changed if user has changed the name.",
+  "Message_SetNameAsAliasInDirectMessagesEnabled": "Set the user name as alias in the direct messages",
   "Message_ShowDeletedStatus": "Show Deleted Status",
   "Message_ShowEditedStatus": "Show Edited Status",
   "Message_ShowFormattingTips": "Show Formatting Tips",

--- a/packages/rocketchat-ldap/server/sync.js
+++ b/packages/rocketchat-ldap/server/sync.js
@@ -122,9 +122,13 @@ syncUserData = function syncUserData(user, ldapUser) {
 
 	const userData = getDataToSyncUserData(ldapUser, user);
 	if (user && user._id && userData) {
+		logger.debug('setting', JSON.stringify(userData, null, 2));
+		if (userData.name) {
+			RocketChat._setRealName(user._id, userData.name);
+			delete userData.name;
+		}
 		Meteor.users.update(user._id, { $set: userData });
 		user = Meteor.users.findOne({_id: user._id});
-		logger.debug('setting', JSON.stringify(userData, null, 2));
 	}
 
 	if (RocketChat.settings.get('LDAP_Username_Field') !== '') {

--- a/packages/rocketchat-lib/package.js
+++ b/packages/rocketchat-lib/package.js
@@ -82,6 +82,7 @@ Package.onUse(function(api) {
 	api.addFiles('server/functions/settings.coffee', 'server');
 	api.addFiles('server/functions/setUserAvatar.js', 'server');
 	api.addFiles('server/functions/setUsername.coffee', 'server');
+	api.addFiles('server/functions/setRealName.coffee', 'server');
 	api.addFiles('server/functions/setEmail.js', 'server');
 	api.addFiles('server/functions/unarchiveRoom.js', 'server');
 	api.addFiles('server/functions/updateMessage.js', 'server');

--- a/packages/rocketchat-lib/server/functions/saveUser.js
+++ b/packages/rocketchat-lib/server/functions/saveUser.js
@@ -126,6 +126,10 @@ RocketChat.saveUser = function(userId, userData) {
 			RocketChat.setUsername(userData._id, userData.username);
 		}
 
+		if (userData.name) {
+			RocketChat.setRealName(userData._id, userData.name);
+		}
+
 		if (userData.email) {
 			RocketChat.setEmail(userData._id, userData.email);
 		}
@@ -137,10 +141,6 @@ RocketChat.saveUser = function(userId, userData) {
 		const updateUser = {
 			$set: {}
 		};
-
-		if (userData.name) {
-			updateUser.$set.name = userData.name;
-		}
 
 		if (userData.roles) {
 			updateUser.$set.roles = userData.roles;

--- a/packages/rocketchat-lib/server/functions/setRealName.coffee
+++ b/packages/rocketchat-lib/server/functions/setRealName.coffee
@@ -1,0 +1,20 @@
+RocketChat._setRealName = (userId, name) ->
+	if not userId or not name
+		return false
+
+	user = RocketChat.models.Users.findOneById userId
+
+	# User already has desired name, return
+	if user.name is name
+		return user
+
+	# Set new name
+	RocketChat.models.Users.setName user._id, name
+	user.name = name
+
+	RocketChat.models.Subscriptions.setAliasForDirectRoomsWithName user.username, name
+
+	return user
+
+RocketChat.setRealName = RocketChat.RateLimiter.limitFunction RocketChat._setRealName, 1, 60000,
+	0: (userId) -> return not userId or not RocketChat.authz.hasPermission(userId, 'edit-other-user-info') # Administrators have permission to change others names, so don't limit those

--- a/packages/rocketchat-lib/server/methods/setRealName.coffee
+++ b/packages/rocketchat-lib/server/methods/setRealName.coffee
@@ -14,7 +14,10 @@ Meteor.methods
 		if _.trim name
 			name = _.trim name
 
-		unless RocketChat.models.Users.setName Meteor.userId(), name
+		unless RocketChat.setRealName user._id, name
 			throw new Meteor.Error 'error-could-not-change-name', "Could not change name", { method: 'setRealName' }
 
 		return name
+
+RocketChat.RateLimiter.limitMethod 'setRealName', 1, 1000,
+	userId: (userId) -> return true

--- a/packages/rocketchat-lib/server/models/Subscriptions.coffee
+++ b/packages/rocketchat-lib/server/models/Subscriptions.coffee
@@ -12,6 +12,7 @@ class ModelSubscriptions extends RocketChat.models._Base
 		@tryEnsureIndex { 'unread': 1 }
 		@tryEnsureIndex { 'ts': 1 }
 		@tryEnsureIndex { 'ls': 1 }
+		@tryEnsureIndex { 'alias': 1 }
 		@tryEnsureIndex { 'desktopNotifications': 1 }, { sparse: 1 }
 		@tryEnsureIndex { 'mobilePushNotifications': 1 }, { sparse: 1 }
 		@tryEnsureIndex { 'emailNotifications': 1 }, { sparse: 1 }
@@ -238,6 +239,17 @@ class ModelSubscriptions extends RocketChat.models._Base
 		update =
 			$set:
 				name: name
+
+		return @update query, update, { multi: true }
+
+	setAliasForDirectRoomsWithName: (name, alias) ->
+		query =
+			name: name
+			t: "d"
+
+		update =
+			$set:
+				alias: alias
 
 		return @update query, update, { multi: true }
 

--- a/packages/rocketchat-lib/server/startup/settings.coffee
+++ b/packages/rocketchat-lib/server/startup/settings.coffee
@@ -181,6 +181,7 @@ RocketChat.settings.addGroup 'Message', ->
 	@add 'Message_MaxAllowedSize', 5000, { type: 'int', public: true }
 	@add 'Message_ShowFormattingTips', true, { type: 'boolean', public: true }
 	@add 'Message_SetNameToAliasEnabled', false, { type: 'boolean', public: false, i18nDescription: 'Message_SetNameToAliasEnabled_Description' }
+	@add 'Message_SetNameAsAliasInDirectMessagesEnabled', false, { type: 'boolean', public: true }
 	@add 'Message_AudioRecorderEnabled', true, { type: 'boolean', public: true, i18nDescription: 'Message_AudioRecorderEnabledDescription' }
 	@add 'Message_GroupingPeriod', 300, { type: 'int', public: true, i18nDescription: 'Message_GroupingPeriodDescription' }
 	@add 'API_Embed', true, { type: 'boolean', public: true }

--- a/packages/rocketchat-livechat/server/lib/Livechat.js
+++ b/packages/rocketchat-livechat/server/lib/Livechat.js
@@ -116,8 +116,6 @@ RocketChat.Livechat = {
 
 				userId = existingUser._id;
 			} else {
-				updateUser.$set.name = name;
-
 				var userData = {
 					username: username,
 					globalRoles: ['livechat-guest'],
@@ -154,6 +152,10 @@ RocketChat.Livechat = {
 			updateUser.$set.visitorEmails = [
 				{ address: email }
 			];
+		}
+
+		if (name) {
+			RocketChat._setRealName(userId, name);
 		}
 
 		Meteor.users.update(userId, updateUser);

--- a/packages/rocketchat-ui-sidenav/side-nav/chatRoomItem.coffee
+++ b/packages/rocketchat-ui-sidenav/side-nav/chatRoomItem.coffee
@@ -15,6 +15,12 @@ Template.chatRoomItem.helpers
 	name: ->
 		return this.name
 
+	alias: ->
+		return this.alias
+
+	showAlias: ->
+		return this.t == 'd' && RocketChat.settings.get('Message_SetNameAsAliasInDirectMessagesEnabled')
+
 	roomIcon: ->
 		return RocketChat.roomTypes.getIcon this.t
 

--- a/packages/rocketchat-ui-sidenav/side-nav/chatRoomItem.html
+++ b/packages/rocketchat-ui-sidenav/side-nav/chatRoomItem.html
@@ -1,11 +1,11 @@
 <template name="chatRoomItem">
 	<li class="link-room-{{rid}} {{active}} {{#if unread}}has-unread{{/if}} {{#if alert}}has-alert{{/if}}">
-		<a class="open-room" href="{{route}}" title="{{name}}">
+		<a class="open-room" href="{{route}}" title="{{#if showAlias}}{{alias}}{{/if}} @{{name}}">
 			{{#if unread}}
 				<span class="unread">{{unread}}</span>
 			{{/if}}
 			<i class="{{roomIcon}} {{userStatus}}" aria-label=""></i>
-			<span class='name {{archived}}'>{{name}}</span>
+			<span class='name {{archived}}'>{{#if showAlias}}{{alias}}{{else}}{{name}}{{/if}}</span>
 			{{#if $not unread}}
 				<span class='opt'>
 					<i class="icon-eye-off hide-room" title="{{_ "Hide_room"}}" aria-label="{{_ "Hide_room"}}"></i>

--- a/server/methods/createDirectMessage.coffee
+++ b/server/methods/createDirectMessage.coffee
@@ -45,6 +45,7 @@ Meteor.methods
 				open: true
 			$setOnInsert:
 				name: to.username
+				alias: to.name
 				t: 'd'
 				alert: false
 				unread: 0

--- a/server/publications/subscription.coffee
+++ b/server/publications/subscription.coffee
@@ -3,6 +3,7 @@ fields =
 	ts: 1
 	ls: 1
 	name: 1
+	alias: 1
 	rid: 1
 	code: 1
 	f: 1

--- a/server/startup/migrations/v076.js
+++ b/server/startup/migrations/v076.js
@@ -1,0 +1,13 @@
+RocketChat.Migrations.add({
+	version: 76,
+	up: () => {
+		RocketChat.models.Subscriptions.find({ t: 'd' }).forEach((subscription) => {
+			if (subscription && subscription.u && subscription.u._id) {
+				const user = RocketChat.models.Users.findOneById(subscription.u._id);
+				if (user && user.username && user.name) {
+					RocketChat.models.Subscriptions.setAliasForDirectRoomsWithName(user.username, user.name);
+				}
+			}
+		});
+	}
+});


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Related to #4210

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

<img width="253" alt="screen shot 2016-12-23 at 21 28 23" src="https://cloud.githubusercontent.com/assets/6920421/21461933/cc699b8a-c956-11e6-98b7-4b495229c41e.png">

This PR enables admins to change the direct messages list appearance so that the user names (real name) are displayed instead of the username ( ... confusing :p). When hovering a user in the direct messages list then the real name and username will be shown.

For the sake of performance I've added an alias field to the subscription model which holds in case of direct messages the real name of an user so that the client can render it right way. For other subscription types this alias field won't be added but it could be also used in future for e.g. channel types if you wish to introduce there aliases as well. Also I've added a migration script that populates all direct message subscriptions with this alias field.

Default behaviour is the current behaviour (i.e. the usernames are shown in the direct messages list instead of the real names) and the admin can toggle to show the alias within the "messages" settings. Not sure if this is the best place but I couldn't find a better one.

When the real name of a user gets updated then the alias within the subscriptions will be updated as well. I've tried to spot all user real name updates but as so many files are updating it directly via the user model this was rather of tricky.

Sending you the best season greetings 🎄 🎁 !