### PR TITLE
Bi-directional message deletes between Rocket and Slack

### DIFF
--- a/packages/rocketchat-lib/server/functions/deleteMessage.js
+++ b/packages/rocketchat-lib/server/functions/deleteMessage.js
@@ -2,6 +2,7 @@
 RocketChat.deleteMessage = function(message, user) {
 	let keepHistory = RocketChat.settings.get('Message_KeepHistory');
 	let showDeletedStatus = RocketChat.settings.get('Message_ShowDeletedStatus');
+	let deletedMsg;
 
 	if (keepHistory) {
 		if (showDeletedStatus) {
@@ -15,12 +16,17 @@ RocketChat.deleteMessage = function(message, user) {
 		}
 	} else {
 		if (!showDeletedStatus) {
+			deletedMsg = RocketChat.models.Messages.findOneById(message._id);
 			RocketChat.models.Messages.removeById(message._id);
 		}
 
 		if (message.file && message.file._id) {
 			FileUpload.delete(message.file._id);
 		}
+
+		Meteor.defer(function() {
+			RocketChat.callbacks.run('afterDeleteMessage', deletedMsg);
+		});
 	}
 
 	if (showDeletedStatus) {

--- a/packages/rocketchat-slackbridge/README.md
+++ b/packages/rocketchat-slackbridge/README.md
@@ -1,0 +1,36 @@
+## Rocket.Chat Slack Bridge
+
+This package creates a bi-directional bridge between a single Slack installation and your Rocket.Chat installation.
+
+* Configure Rocket.Chat with your Slack API token
+* Invite 'rocketbot' to your Slack channel
+
+### Settings
+
+The following can be configured in your Rocket.Chat Administration SlackBridge panel.
+
+#### Enabled
+
+#### API Token
+
+#### Alias format
+
+#### Exclude bots
+
+#### SlackBridge Out Enabled
+
+#### SlackBridge Out All
+
+#### SlackBridge Out Channels
+
+### Features
+
+#### Group Chat Messages
+* Send and receive basic messages
+* Delete messages
+#### Files
+#### Imports
+
+### TODO
+* Support multiple slack installations
+* Private IM's


### PR DESCRIPTION
Delete Slack msgs from Slack
Delete Slack msgs from Rocket
Delete Rocket message from Rocket
Delete Rocket msg from Slack

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Added the start to a README.md
Added a new Rocket event 'afterDeleteMessage'
Refactoring existing handling of Slack events into smaller single concern methods