### PR TITLE
Add setting to change jitsi URL prefix

### DIFF
--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -1377,6 +1377,7 @@
   "Uploading_file": "Uploading file...",
   "Uptime": "Uptime",
   "URL": "URL",
+  "URL_room_prefix": "URL room prefix",
   "Use_account_preference": "Use account preference",
   "Use_Emojis": "Use Emojis",
   "Use_Global_Settings": "Use Global Settings",

--- a/packages/rocketchat-i18n/i18n/pt.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pt.i18n.json
@@ -1177,6 +1177,7 @@
   "Uploading_file": "Subindo arquivo...",
   "Uptime": "Tempo online",
   "URL": "URL",
+  "URL_room_prefix": "Prefixo da URL da sala",
   "Use_account_preference": "Use preferências da conta",
   "Use_Emojis": "Usar Emojis",
   "Use_initials_avatar": "Usar as iniciais do seu nome de usuário",

--- a/packages/rocketchat-livechat/server/methods/startVideoCall.js
+++ b/packages/rocketchat-livechat/server/methods/startVideoCall.js
@@ -27,7 +27,7 @@ Meteor.methods({
 		return {
 			roomId: room._id,
 			domain: RocketChat.settings.get('Jitsi_Domain'),
-			jitsiRoom: 'RocketChat' + CryptoJS.MD5(RocketChat.settings.get('uniqueID') + roomId).toString()
+			jitsiRoom: RocketChat.settings.get('Jitsi_URL_Room_Prefix') + CryptoJS.MD5(RocketChat.settings.get('uniqueID') + roomId).toString()
 		};
 	}
 });

--- a/packages/rocketchat-videobridge/client/views/videoFlexTab.js
+++ b/packages/rocketchat-videobridge/client/views/videoFlexTab.js
@@ -39,7 +39,7 @@ Template.videoFlexTab.onCreated(function() {
 				let roomId = Session.get('openedRoom');
 
 				let domain = RocketChat.settings.get('Jitsi_Domain');
-				let jitsiRoom = 'RocketChat' + CryptoJS.MD5(RocketChat.settings.get('uniqueID') + roomId).toString();
+				let jitsiRoom = RocketChat.settings.get('Jitsi_URL_Room_Prefix') + CryptoJS.MD5(RocketChat.settings.get('uniqueID') + roomId).toString();
 				let noSsl = RocketChat.settings.get('Jitsi_SSL') ? false : true;
 
 				if (jitsiRoomActive !== null && jitsiRoomActive !== jitsiRoom) {

--- a/packages/rocketchat-videobridge/server/settings.js
+++ b/packages/rocketchat-videobridge/server/settings.js
@@ -17,6 +17,16 @@ Meteor.startup(function() {
 			public: true
 		});
 
+		this.add('Jitsi_URL_Room_Prefix', 'RocketChat', {
+			type: 'string',
+			enableQuery: {
+				_id: 'Jitsi_Enabled',
+				value: true
+			},
+			i18nLabel: 'URL_room_prefix',
+			public: true
+		});
+
 		this.add('Jitsi_SSL', true, {
 			type: 'boolean',
 			enableQuery: {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Now, Jitsi URL is composed by: `[jitsi_domain] / RocketChat[room-unique-identifier]`

This PR adds the ability to change the only hard coded part of the URL: `RocketChat`