### PR TITLE
Fix importer relying on os file type, use file signature instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
     "bcrypt": "^1.0.2",
     "moment": "^2.17.1",
     "moment-timezone": "^0.5.11",
-    "toastr": "^2.1.2"
+    "toastr": "^2.1.2",
+    "mime-types": "2.1.13",
+    "file-type": "4.0.0"
   }
 }

--- a/packages/rocketchat-assets/package.js
+++ b/packages/rocketchat-assets/package.js
@@ -20,6 +20,5 @@ Package.onUse(function(api) {
 });
 
 Npm.depends({
-	'image-size': '0.4.0',
-	'mime-types': '2.1.9'
+	'image-size': '0.4.0'
 });

--- a/packages/rocketchat-file-upload/package.js
+++ b/packages/rocketchat-file-upload/package.js
@@ -47,6 +47,5 @@ Package.onUse(function(api) {
 });
 
 Npm.depends({
-	'mime-types': '2.1.11',
 	'filesize': '3.3.0'
 });

--- a/packages/rocketchat-importer-csv/main.js
+++ b/packages/rocketchat-importer-csv/main.js
@@ -6,5 +6,5 @@ Importer.addImporter('csv', Importer.CSV, {
 		text: 'Importer_CSV_Information',
 		href: 'https://rocket.chat/docs/administrator-guides/import/csv/'
 	}],
-	fileTypeRegex: new RegExp('application\/.*?zip')
+	mimeType: 'application/zip'
 });

--- a/packages/rocketchat-importer-csv/server.js
+++ b/packages/rocketchat-importer-csv/server.js
@@ -1,8 +1,8 @@
 /* globals Importer */
 
 Importer.CSV = class ImporterCSV extends Importer.Base {
-	constructor(name, descriptionI18N, fileTypeRegex) {
-		super(name, descriptionI18N, fileTypeRegex);
+	constructor(name, descriptionI18N, mimeType) {
+		super(name, descriptionI18N, mimeType);
 		this.logger.debug('Constructed a new CSV Importer.');
 
 		this.csvParser = Npm.require('csv-parse/lib/sync');

--- a/packages/rocketchat-importer-hipchat-enterprise/main.js
+++ b/packages/rocketchat-importer-hipchat-enterprise/main.js
@@ -11,5 +11,5 @@ Importer.addImporter('hipchatenterprise', Importer.HipChatEnterprise, {
 			href: 'https://github.com/RocketChat/Rocket.Chat/issues/new'
 		}
 	],
-	fileTypeRegex: new RegExp('application\/.*?gzip')
+	mimeType: 'application/gzip'
 });

--- a/packages/rocketchat-importer-hipchat-enterprise/server.js
+++ b/packages/rocketchat-importer-hipchat-enterprise/server.js
@@ -1,8 +1,8 @@
 /* globals Importer */
 
 Importer.HipChatEnterprise = class ImporterHipChatEnterprise extends Importer.Base {
-	constructor(name, descriptionI18N, fileTypeRegex) {
-		super(name, descriptionI18N, fileTypeRegex);
+	constructor(name, descriptionI18N, mimeType) {
+		super(name, descriptionI18N, mimeType);
 		this.logger.debug('Constructed a new HipChat Enterprise Importer.');
 
 		this.Readable = require('stream').Readable;

--- a/packages/rocketchat-importer-hipchat/main.coffee
+++ b/packages/rocketchat-importer-hipchat/main.coffee
@@ -1,3 +1,3 @@
 Importer.addImporter 'hipchat', Importer.HipChat,
 	name: 'HipChat'
-	fileTypeRegex: new RegExp 'application\/.*?zip'
+	mimeType: 'application/zip'

--- a/packages/rocketchat-importer-hipchat/server.coffee
+++ b/packages/rocketchat-importer-hipchat/server.coffee
@@ -5,8 +5,8 @@ Importer.HipChat = class Importer.HipChat extends Importer.Base
 	@RoomPrefix = 'hipchat_export/rooms/'
 	@UsersPrefix = 'hipchat_export/users/'
 
-	constructor: (name, descriptionI18N, fileTypeRegex) ->
-		super(name, descriptionI18N, fileTypeRegex)
+	constructor: (name, descriptionI18N, mimeType) ->
+		super(name, descriptionI18N, mimeType)
 		@logger.debug('Constructed a new Slack Importer.')
 		@userTags = []
 

--- a/packages/rocketchat-importer-slack/main.coffee
+++ b/packages/rocketchat-importer-slack/main.coffee
@@ -1,3 +1,3 @@
 Importer.addImporter 'slack', Importer.Slack,
 	name: 'Slack'
-	fileTypeRegex: new RegExp 'application\/.*?zip'
+	mimeType: 'application/zip'

--- a/packages/rocketchat-importer-slack/server.coffee
+++ b/packages/rocketchat-importer-slack/server.coffee
@@ -1,6 +1,6 @@
 Importer.Slack = class Importer.Slack extends Importer.Base
-	constructor: (name, descriptionI18N, fileTypeRegex) ->
-		super(name, descriptionI18N, fileTypeRegex)
+	constructor: (name, descriptionI18N, mimeType) ->
+		super(name, descriptionI18N, mimeType)
 		@userTags = []
 		@bots = {}
 		@logger.debug('Constructed a new Slack Importer.')

--- a/packages/rocketchat-importer/.npm/package/npm-shrinkwrap.json
+++ b/packages/rocketchat-importer/.npm/package/npm-shrinkwrap.json
@@ -9,6 +9,11 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/bson/-/bson-0.5.5.tgz",
       "from": "bson@0.5.5"
+    },
+    "file-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.0.0.tgz",
+      "from": "file-type@4.0.0"
     }
   }
 }

--- a/packages/rocketchat-importer/client/admin/adminImportPrepare.coffee
+++ b/packages/rocketchat-importer/client/admin/adminImportPrepare.coffee
@@ -38,8 +38,8 @@ Template.adminImportPrepare.events
 			reader.onloadend = ->
 				Meteor.call 'prepareImport', importer.key, reader.result, blob.type, blob.name, (error, data) ->
 					if error
-						console.warn 'Errored out preparing the import:', error
-						handleError(error)
+						toastr.error t('Invalid_Import_File_Type')
+						template.preparing.set false
 						return
 
 					if !data

--- a/packages/rocketchat-importer/client/admin/adminImportPrepare.coffee
+++ b/packages/rocketchat-importer/client/admin/adminImportPrepare.coffee
@@ -32,10 +32,6 @@ Template.adminImportPrepare.events
 
 		for blob in files
 			template.preparing.set true
-			if not importer.fileTypeRegex.test blob.type
-				toastr.error t('Invalid_Import_File_Type')
-				template.preparing.set false
-				return
 
 			reader = new FileReader()
 			reader.readAsDataURL(blob)

--- a/packages/rocketchat-importer/client/admin/adminImportPrepare.html
+++ b/packages/rocketchat-importer/client/admin/adminImportPrepare.html
@@ -70,7 +70,7 @@
 									<div class="section">
 										<h1>{{_ "Importer_Source_File"}}</h1>
 										<div class="section-content">
-											<input type="file" class="import-file-input" accept="{{ fileType }}">
+											<input type="file" class="import-file-input">
 										</div>
 									</div>
 								{{/if}}

--- a/packages/rocketchat-importer/lib/importTool.coffee
+++ b/packages/rocketchat-importer/lib/importTool.coffee
@@ -5,5 +5,5 @@ Importer.addImporter = (name, importer, options) ->
 		Importer.Importers[name] =
 			name: options.name
 			importer: importer
-			fileTypeRegex: options.fileTypeRegex
+			mimeType: options.mimeType
 			warnings: options.warnings

--- a/packages/rocketchat-importer/package.js
+++ b/packages/rocketchat-importer/package.js
@@ -55,5 +55,6 @@ Package.onUse(function(api) {
 
 Npm.depends({
 	'adm-zip': '0.4.7',
-	'bson': '0.5.5'
+	'bson': '0.5.5',
+	'file-type': '4.0.0'
 });

--- a/packages/rocketchat-importer/package.js
+++ b/packages/rocketchat-importer/package.js
@@ -55,6 +55,5 @@ Package.onUse(function(api) {
 
 Npm.depends({
 	'adm-zip': '0.4.7',
-	'bson': '0.5.5',
-	'file-type': '4.0.0'
+	'bson': '0.5.5'
 });

--- a/packages/rocketchat-importer/server/classes/ImporterBase.coffee
+++ b/packages/rocketchat-importer/server/classes/ImporterBase.coffee
@@ -38,13 +38,14 @@ Importer.Base = class Importer.Base
 	#
 	# @param [String] name the name of the Importer
 	# @param [String] description the i18n string which describes the importer
-	# @param [RegExp] fileTypeRegex the regexp to validate the uploaded file type against
+	# @param [String] mimeType the of the expected file type
 	#
-	constructor: (@name, @description, @fileTypeRegex) ->
+	constructor: (@name, @description, @mimeType) ->
 		@logger = new Logger("#{@name} Importer", {});
 		@progress = new Importer.Progress @name
 		@collection = Importer.RawImports
 		@AdmZip = Npm.require 'adm-zip'
+		@getFileType = Npm.require 'file-type'
 		importId = Importer.Imports.insert { 'type': @name, 'ts': Date.now(), 'status': @progress.step, 'valid': true, 'user': Meteor.user()._id }
 		@importRecord = Importer.Imports.findOne importId
 		@users = {}
@@ -60,7 +61,8 @@ Importer.Base = class Importer.Base
 	# @return [Importer.Selection] Contains two properties which are arrays of objects, `channels` and `users`.
 	#
 	prepare: (dataURI, sentContentType, fileName) =>
-		if not @fileTypeRegex.test sentContentType
+		fileType = @getFileType(new Buffer(dataURI.split(',')[1], 'base64'))
+		if fileType.mime isnt @mimeType
 			throw new Error "Invalid file uploaded to import #{@name} data from." #TODO: Make translatable
 
 		@updateProgress Importer.ProgressStep.PREPARING_STARTED

--- a/packages/rocketchat-importer/server/classes/ImporterBase.coffee
+++ b/packages/rocketchat-importer/server/classes/ImporterBase.coffee
@@ -62,8 +62,12 @@ Importer.Base = class Importer.Base
 	#
 	prepare: (dataURI, sentContentType, fileName) =>
 		fileType = @getFileType(new Buffer(dataURI.split(',')[1], 'base64'))
-		if fileType.mime isnt @mimeType
-			throw new Error "Invalid file uploaded to import #{@name} data from." #TODO: Make translatable
+		@logger.debug 'Uploaded file information is:', fileType
+		@logger.debug 'Expected file type is:', @mimeType
+
+		if not fileType or fileType.mime isnt @mimeType
+			@logger.warn "Invalid file uploaded for the #{@name} importer."
+			throw new Meteor.Error('error-invalid-file-uploaded', "Invalid file uploaded to import #{@name} data from.", { step: 'prepare' })
 
 		@updateProgress Importer.ProgressStep.PREPARING_STARTED
 		@updateRecord { 'file': fileName }

--- a/packages/rocketchat-importer/server/methods/restartImport.coffee
+++ b/packages/rocketchat-importer/server/methods/restartImport.coffee
@@ -8,7 +8,7 @@ Meteor.methods
 			importer.importerInstance.updateProgress Importer.ProgressStep.CANCELLED
 			importer.importerInstance.updateRecord { valid: false }
 			importer.importerInstance = undefined
-			importer.importerInstance = new importer.importer importer.name, importer.description, importer.fileTypeRegex
+			importer.importerInstance = new importer.importer importer.name, importer.description, importer.mimeType
 			return importer.importerInstance.getProgress()
 		else
 			throw new Meteor.Error 'error-importer-not-defined', 'The importer was not defined correctly, it is missing the Import class.', { method: 'restartImport' }

--- a/packages/rocketchat-importer/server/methods/setupImporter.coffee
+++ b/packages/rocketchat-importer/server/methods/setupImporter.coffee
@@ -9,7 +9,7 @@ Meteor.methods
 			if importer.importerInstance
 				return importer.importerInstance.getProgress()
 			else
-				importer.importerInstance = new importer.importer importer.name, importer.description, importer.fileTypeRegex
+				importer.importerInstance = new importer.importer importer.name, importer.description, importer.mimeType
 				return importer.importerInstance.getProgress()
 		else
 			console.warn "Tried to setup #{name} as an importer."


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core Before now we relied on the operating system/browser to tell us which type of file the user is providing us, now we instead rely on [file signature](https://en.wikipedia.org/wiki/List_of_file_signatures) via the [file-type npm package](https://github.com/sindresorhus/file-type) which was suggested by @whren.

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #3050

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
