### PR TITLE
Fixed Rocket.Chat crashes at startup if Slack bridge enabled and slac…

### DIFF
--- a/packages/rocketchat-slackbridge/slackbridge.js
+++ b/packages/rocketchat-slackbridge/slackbridge.js
@@ -56,7 +56,12 @@ class SlackBridge {
 				}
 			});
 			Meteor.startup(() => {
-				this.populateSlackChannelMap(); // If run outside of Meteor.startup, HTTP is not defined
+				try {
+					this.populateSlackChannelMap(); // If run outside of Meteor.startup, HTTP is not defined
+				} catch (err) {
+					logger.class.error('Error attempting to connect to Slack', err);
+					this.disconnect();
+				}
 			});
 		}
 	}


### PR DESCRIPTION
@RocketChat/core 

Closes #5426 

Placed a try/catch around communication's to Slack during start up.  If Slack isn't available the bridge will disconnect and not listen for Rocket events.

Additionally tested that after a normal startup if Slack was to go offline, communications to Slack will fail, but it doesn't affect the Rocket server.  Once Slack comes back on-line then things continue to flow as normal.

Future refactoring should be done to try/catch all calls out to Slack.
