### PR TITLE
Add support for skype-like thumbsup emoji (y)

### DIFF
--- a/packages/rocketchat-emoji/emojiParser.js
+++ b/packages/rocketchat-emoji/emojiParser.js
@@ -11,6 +11,9 @@ RocketChat.callbacks.add('renderMessage', (message) => {
 	if (_.trim(message.html)) {
 		//&#39; to apostrophe (') for emojis such as :')
 		message.html = message.html.replace(/&#39;/g, '\'');
+		//support for skype-like thumbsup emoji (y)
+		message.html = message.html.replace(/(^|\s)\(Y\)(\s|$)/ig, ' :thumbsup: ');
+		message.html = message.html.replace(/(^|\s)\(Y\)(\s|$)/ig, ':thumbsup:');
 
 		Object.keys(RocketChat.emoji.packages).forEach((emojiPackage) => {
 			message.html = RocketChat.emoji.packages[emojiPackage].render(message.html);


### PR DESCRIPTION
There is two steps of replace for correct replacing strings like "(y) (y)"

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #5453

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
