### PR TITLE
Add support to inbox style push notifications for Android

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -152,7 +152,7 @@ ostrio:cookies
 pauli:accounts-linkedin
 percolate:synced-cron
 raix:handlebar-helpers
-raix:push
+raix:push@3.0.3-rc.7
 raix:ui-dropped-event
 smoral:sweetalert
 steffo:meteor-accounts-saml

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -111,7 +111,7 @@ promise@0.8.8
 raix:eventemitter@0.1.3
 raix:eventstate@0.0.4
 raix:handlebar-helpers@0.2.5
-raix:push@3.0.2
+raix:push@3.0.3-rc.7
 raix:ui-dropped-event@0.0.7
 random@1.0.10
 rate-limit@1.0.6

--- a/packages/rocketchat-lib/lib/getURL.js
+++ b/packages/rocketchat-lib/lib/getURL.js
@@ -1,0 +1,18 @@
+RocketChat.getURL = (path, { cdn = true, full = false } = {}) => {
+	const cdnPrefix = _.rtrim(_.trim(RocketChat.settings.get('CDN_PREFIX') || ''), '/');
+	const pathPrefix = _.rtrim(_.trim(__meteor_runtime_config__.ROOT_URL_PATH_PREFIX || ''), '/');
+
+	let basePath;
+
+	let finalPath = _.ltrim(_.trim(path), '/');
+
+	if (cdn && cdnPrefix !== '') {
+		basePath = cdnPrefix + pathPrefix;
+	} else if (full || Meteor.isCordova) {
+		return Meteor.absoluteUrl(finalPath);
+	} else {
+		basePath = pathPrefix;
+	}
+
+	return basePath + '/' + finalPath;
+};

--- a/packages/rocketchat-lib/package.js
+++ b/packages/rocketchat-lib/package.js
@@ -49,6 +49,7 @@ Package.onUse(function(api) {
 	api.addFiles('server/lib/debug.js', 'server');
 
 	// COMMON LIB
+	api.addFiles('lib/getURL.js');
 	api.addFiles('lib/settings.coffee');
 	api.addFiles('lib/configLogger.coffee');
 	api.addFiles('lib/callbacks.coffee');
@@ -88,6 +89,7 @@ Package.onUse(function(api) {
 	api.addFiles('server/functions/Notifications.coffee', 'server');
 
 	// SERVER LIB
+	api.addFiles('server/lib/PushNotification.js', 'server');
 	api.addFiles('server/lib/defaultBlockedDomainsList.js', 'server');
 	api.addFiles('server/lib/notifyUsersOnMessage.js', 'server');
 	api.addFiles('server/lib/roomTypes.coffee', 'server');

--- a/packages/rocketchat-lib/server/lib/PushNotification.js
+++ b/packages/rocketchat-lib/server/lib/PushNotification.js
@@ -1,0 +1,51 @@
+/* globals Push */
+class PushNotification {
+	getNotificationId(roomId) {
+		let serverId = RocketChat.settings.get('uniqueID');
+		return this.hash(`${serverId}|${roomId}`); // hash
+	}
+
+	hash(str) {
+		let hash = 0,
+			i = str.length;
+
+		while (i) {
+			hash = ((hash << 5) - hash) + str.charCodeAt(--i);
+			hash = hash & hash; // Convert to 32bit integer
+		}
+		return hash;
+	}
+
+	send({ roomName, roomId, username, message, usersTo, payload }) {
+		let title;
+		if (roomName && roomName !== '') {
+			title = `${roomName}`;
+			message = `${username}: ${message}`;
+		} else {
+			title = `${username}`;
+		}
+		let icon = RocketChat.settings.get('Assets_favicon_512').url || RocketChat.settings.get('Assets_favicon_512').defaultUrl;
+		const config = {
+			from: 'push',
+			badge: 1,
+			sound: 'chime',
+			title: title,
+			text: message,
+			payload,
+			query: usersTo,
+			notId: this.getNotificationId(roomId),
+			gcm: {
+				style: 'inbox',
+				summaryText: '%n% new messages',
+				image: RocketChat.getURL(icon, { full: true })
+			},
+			apn: {
+				text: title + ((title !== '' && message !== '') ? '\n' : '') + message
+			}
+		};
+
+		return Push.send(config);
+	}
+}
+
+RocketChat.PushNotification = new PushNotification();

--- a/packages/rocketchat-lib/server/lib/PushNotification.js
+++ b/packages/rocketchat-lib/server/lib/PushNotification.js
@@ -24,7 +24,7 @@ class PushNotification {
 		} else {
 			title = `${username}`;
 		}
-		let icon = RocketChat.settings.get('Assets_favicon_512').url || RocketChat.settings.get('Assets_favicon_512').defaultUrl;
+		let icon = RocketChat.settings.get('Assets_favicon_192').url || RocketChat.settings.get('Assets_favicon_192').defaultUrl;
 		const config = {
 			from: 'push',
 			badge: 1,

--- a/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
@@ -113,11 +113,11 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 	let push_username;
 	let push_room;
 	if (RocketChat.settings.get('Push_show_username_room')) {
-		push_username = '@' + user.username;
-		push_room = '#' + room.name + ' ';
+		push_username = user.username;
+		push_room = '#' + room.name;
 	} else {
-		push_username = ' ';
-		push_room = ' ';
+		push_username = '';
+		push_room = '';
 	}
 
 	if ((room.t == null) || room.t === 'd') {
@@ -154,16 +154,10 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 
 		if ((userOfMention != null) && canBeNotified(userOfMentionId, 'desktop')) {
 			if (Push.enabled === true && userOfMention.statusConnection !== 'online') {
-				Push.send({
-					from: 'push',
-					title: push_username,
-					text: push_message,
-					apn: {
-						// ternary operator
-						text: push_username + ((push_username !== ' ' && push_message !== ' ') ? ':\n' : '') + push_message
-					},
-					badge: 1,
-					sound: 'chime',
+				RocketChat.PushNotification.send({
+					roomId: message.rid,
+					username: push_username,
+					message: push_message,
 					payload: {
 						host: Meteor.absoluteUrl(),
 						rid: message.rid,
@@ -171,7 +165,7 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 						type: room.t,
 						name: room.name
 					},
-					query: {
+					usersTo: {
 						userId: userOfMention._id
 					}
 				});
@@ -314,16 +308,11 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 
 		if (userIdsToPushNotify.length > 0) {
 			if (Push.enabled === true) {
-				Push.send({
-					from: 'push',
-					title: push_room + push_username,
-					text: push_message,
-					apn: {
-						// ternary operator
-						text: push_room + push_username + ((push_username !== ' ' && push_room !== ' ' && push_message !== ' ') ? ':\n' : '') + push_message
-					},
-					badge: 1,
-					sound: 'chime',
+				RocketChat.PushNotification.send({
+					roomId: message.rid,
+					roomName: push_room,
+					username: push_username,
+					message: push_message,
 					payload: {
 						host: Meteor.absoluteUrl(),
 						rid: message.rid,
@@ -331,7 +320,7 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 						type: room.t,
 						name: room.name
 					},
-					query: {
+					usersTo: {
 						userId: {
 							$in: userIdsToPushNotify
 						}


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #2812

I had to update the raix:push package to `3.0.3-rc.7` because it [was not included on 3.0.2](https://github.com/RocketChat/Rocket.Chat/issues/2812#issuecomment-232382040)

I'm using the `android-chrome 192x192 (png)` asset as the server icon on the push notification. if someone has an suggest/objection on that, please adivise.
_edit: I've changed to use the 192x192 icon instead of 512x512 after a few tests._

This is how the new notifications should look like:

- Single push notification on a channel:
![image](https://cloud.githubusercontent.com/assets/8591547/21859369/76b1d326-d813-11e6-970c-b62607e24588.png)

- Multiple notifications for same channel:
![image](https://cloud.githubusercontent.com/assets/8591547/21859039/4b2f44aa-d812-11e6-8ef4-1ab91c819c07.png)

- Single direct message notification:
![image](https://cloud.githubusercontent.com/assets/8591547/21859068/690ceb4e-d812-11e6-8caa-3805fb5a7674.png)

- Multiple notifications for the direct message:
![image](https://cloud.githubusercontent.com/assets/8591547/21859217/f97a2142-d812-11e6-9ce1-798fe6ff3ae2.png)

- Mixed notifications:
![image](https://cloud.githubusercontent.com/assets/8591547/21859142/ae001c80-d812-11e6-826f-4ad7ee28c95d.png)

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
