### PR TITLE
Stop using cache to find a livechat room by code

### DIFF
--- a/packages/rocketchat-livechat/server/models/Rooms.js
+++ b/packages/rocketchat-livechat/server/models/Rooms.js
@@ -48,16 +48,16 @@ RocketChat.models.Rooms.findLivechatByCode = function(code, fields) {
 		options.fields = fields;
 	}
 
-	if (this.useCache) {
-		return this.cache.findByIndex('t,code', ['l', code], options);
-	}
+	// if (this.useCache) {
+	// 	return this.cache.findByIndex('t,code', ['l', code], options).fetch();
+	// }
 
 	const query = {
 		t: 'l',
 		code: code
 	};
 
-	return this.find(query, options);
+	return this.findOne(query, options);
 };
 
 /**

--- a/packages/rocketchat-livechat/server/startup.js
+++ b/packages/rocketchat-livechat/server/startup.js
@@ -1,6 +1,6 @@
 Meteor.startup(() => {
 	RocketChat.roomTypes.setRoomFind('l', (code) => {
-		return RocketChat.models.Rooms.findLivechatByCode(code).fetch();
+		return RocketChat.models.Rooms.findLivechatByCode(code);
 	});
 
 	RocketChat.authz.addRoomAccessValidator(function(room, user) {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #5547

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
@rodrigok how can we enable the find by index on cache for `t,code` fields?