### PR TITLE
API Groups rename fix

### DIFF
--- a/packages/rocketchat-api/server/v1/groups.js
+++ b/packages/rocketchat-api/server/v1/groups.js
@@ -325,7 +325,7 @@ RocketChat.API.v1.addRoute('groups.rename', { authRequired: true }, {
 		});
 
 		return RocketChat.API.v1.success({
-			channel: RocketChat.models.Rooms.findOneById(findResult.rid, { fields: RocketChat.API.v1.defaultFieldsToExclude })
+			group: RocketChat.models.Rooms.findOneById(findResult.rid, { fields: RocketChat.API.v1.defaultFieldsToExclude })
 		});
 	}
 });


### PR DESCRIPTION
The Rest API Groups rename method was returning a channel object, when it was supposed to return a group object.

@RocketChat/core 

