### PR TITLE
Fix agents not being able to see queue list page

### DIFF
--- a/packages/rocketchat-livechat/client/views/app/livechatQueue.html
+++ b/packages/rocketchat-livechat/client/views/app/livechatQueue.html
@@ -1,5 +1,5 @@
 <template name="livechatQueue">
-	{{#requiresPermission 'view-livechat-manager'}}
+	{{#if hasPermission}}
 		{{#each departments}}
 			<p class="queue-department">
 				{{_ "Department"}}: <strong>{{name}}</strong>
@@ -34,5 +34,7 @@
 				</div>
 			</div>
 		{{/each}}
-	{{/requiresPermission}}
+	{{else}}
+		<p>{{_ "You_are_not_authorized_to_view_this_page"}}</p>
+	{{/if}}
 </template>


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

The page permissions were mistakenly changed, this reverts it to the old permissions.

Maybe a hotfix should be released with this included.