### PR TITLE
fix flex-tab-bar position on swipe

### DIFF
--- a/packages/rocketchat-ui-master/master/main.coffee
+++ b/packages/rocketchat-ui-master/master/main.coffee
@@ -143,7 +143,7 @@ Template.main.events
 		if $(e.currentTarget).closest('.main-content').length > 0
 			t.touchstartX = e.originalEvent.touches[0].clientX
 			t.touchstartY = e.originalEvent.touches[0].clientY
-			t.mainContent = $('.main-content, .flex-tab-bar')
+			t.mainContent = $('.main-content')
 			t.wrapper = $('.messages-box > .wrapper')
 
 	'touchmove': (e, t) ->

--- a/packages/rocketchat-ui/lib/menu.coffee
+++ b/packages/rocketchat-ui/lib/menu.coffee
@@ -1,6 +1,6 @@
 @menu = new class
 	init: ->
-		@mainContent = $('.main-content, .flex-tab-bar')
+		@mainContent = $('.main-content')
 		@list = $('.rooms-list')
 
 		Session.set("isMenuOpen", false)


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
When you swipe to open sidenav the flex-tab-bar change its position like this:
![2017-01-17 17 19 36](https://cloud.githubusercontent.com/assets/9200155/22036137/a1735a56-dcd9-11e6-95b2-cf4ca5a760b4.gif)

Now its fixed :)
![2017-01-17 17 20 15](https://cloud.githubusercontent.com/assets/9200155/22036154/af6b6310-dcd9-11e6-866f-87400e3e86b8.gif)


<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
