### PR TITLE
Fix exception in template helper, iframe login

### DIFF
--- a/packages/rocketchat-ui-master/master/main.coffee
+++ b/packages/rocketchat-ui-master/master/main.coffee
@@ -97,10 +97,12 @@ Template.main.helpers
 			return false
 
 	useIframe: ->
-		return RocketChat.iframeLogin.reactiveEnabled.get()
+		iframeEnabled = (typeof RocketChat.iframeLogin isnt "undefined")
+		return (iframeEnabled and RocketChat.iframeLogin.reactiveEnabled.get())
 
 	iframeUrl: ->
-		return RocketChat.iframeLogin.reactiveIframeUrl.get()
+		iframeEnabled = (typeof RocketChat.iframeLogin isnt "undefined")
+		return (iframeEnabled and RocketChat.iframeLogin.reactiveIframeUrl.get())
 
 	subsReady: ->
 		routerReady = FlowRouter.subsReady('userData', 'activeUsers')


### PR DESCRIPTION
`useIframe` makes method call to `rocketchat-iframe-login` package, which throws if that package is disabled. Resolved with package enabled conditional.