### PR TITLE
Fix passing creatRoom parameteras

### DIFF
--- a/packages/rocketchat-lib/server/methods/createPrivateGroup.coffee
+++ b/packages/rocketchat-lib/server/methods/createPrivateGroup.coffee
@@ -10,4 +10,7 @@ Meteor.methods
 		unless RocketChat.authz.hasPermission(Meteor.userId(), 'create-p')
 			throw new Meteor.Error 'error-not-allowed', "Not allowed", { method: 'createPrivateGroup' }
 
-		return RocketChat.createRoom('p', name, Meteor.user()?.username, members, {customFields: customFields});
+		if customFields
+			return RocketChat.createRoom('p', name, Meteor.user()?.username, members, undefined, {customFields: customFields});
+
+		return RocketChat.createRoom('p', name, Meteor.user()?.username, members);


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Fix passing creatRoom parameteras it's take readOnly parameter before customFields I passed readOnly as undefined value so now it's work and it was adding customFields to group object even if the body don't have customFields value so I fixed that also
