### PR TITLE
Allow REST API viewing the messages of others direct messages

### DIFF
--- a/packages/rocketchat-api/server/api.js
+++ b/packages/rocketchat-api/server/api.js
@@ -58,45 +58,52 @@ class API extends Restivus {
 		};
 	}
 
-	addRoute(route, options, endpoints) {
+	addRoute(routes, options, endpoints) {
 		//Note: required if the developer didn't provide options
 		if (typeof endpoints === 'undefined') {
 			endpoints = options;
 			options = {};
 		}
 
-		//Note: This is required due to Restivus calling `addRoute` in the constructor of itself
-		if (this.helperMethods) {
-			Object.keys(endpoints).forEach((method) => {
-				if (typeof endpoints[method] === 'function') {
-					endpoints[method] = { action: endpoints[method] };
-				}
-
-				//Add a try/catch for each much
-				const originalAction = endpoints[method].action;
-				endpoints[method].action = function() {
-					this.logger.debug(`${this.request.method.toUpperCase()}: ${this.request.url}`);
-					let result;
-					try {
-						result = originalAction.apply(this);
-					} catch (e) {
-						this.logger.debug(`${method} ${route} threw an error:`, e);
-						return RocketChat.API.v1.failure(e.message, e.error);
-					}
-
-					return result ? result : RocketChat.API.v1.success();
-				};
-
-				for (const [name, helperMethod] of this.helperMethods) {
-					endpoints[method][name] = helperMethod;
-				}
-
-				//Allow the endpoints to make usage of the logger which respects the user's settings
-				endpoints[method].logger = this.logger;
-			});
+		//Allow for more than one route using the same option and endpoints
+		if (!_.isArray(routes)) {
+			routes = [routes];
 		}
 
-		super.addRoute(route, options, endpoints);
+		routes.forEach((route) => {
+			//Note: This is required due to Restivus calling `addRoute` in the constructor of itself
+			if (this.helperMethods) {
+				Object.keys(endpoints).forEach((method) => {
+					if (typeof endpoints[method] === 'function') {
+						endpoints[method] = { action: endpoints[method] };
+					}
+
+					//Add a try/catch for each much
+					const originalAction = endpoints[method].action;
+					endpoints[method].action = function() {
+						this.logger.debug(`${this.request.method.toUpperCase()}: ${this.request.url}`);
+						let result;
+						try {
+							result = originalAction.apply(this);
+						} catch (e) {
+							this.logger.debug(`${method} ${route} threw an error:`, e);
+							return RocketChat.API.v1.failure(e.message, e.error);
+						}
+
+						return result ? result : RocketChat.API.v1.success();
+					};
+
+					for (const [name, helperMethod] of this.helperMethods) {
+						endpoints[method][name] = helperMethod;
+					}
+
+					//Allow the endpoints to make usage of the logger which respects the user's settings
+					endpoints[method].logger = this.logger;
+				});
+			}
+
+			super.addRoute(route, options, endpoints);
+		});
 	}
 }
 

--- a/packages/rocketchat-api/server/settings.js
+++ b/packages/rocketchat-api/server/settings.js
@@ -3,5 +3,6 @@ RocketChat.settings.addGroup('General', function() {
 		this.add('API_Upper_Count_Limit', 100, { type: 'int', public: false });
 		this.add('API_Default_Count', 50, { type: 'int', public: false });
 		this.add('API_Allow_Infinite_Count', true, { type: 'boolean', public: false });
+		this.add('API_Enable_Direct_Message_History_EndPoint', false, { type: 'boolean', public: false });
 	});
 });

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -170,6 +170,8 @@
   "API_EmbedIgnoredHosts_Description": "Comma-separated list of hosts or CIDR addresses, eg. localhost, 127.0.0.1, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16",
   "API_EmbedSafePorts": "Safe Ports",
   "API_EmbedSafePorts_Description": "Comma-separated list of ports allowed for previewing.",
+	"API_Enable_Direct_Message_History_EndPoint": "Enable Direct Message History Endpoint",
+	"API_Enable_Direct_Message_History_EndPoint_Description": "This enables the `/api/v1/im.history.others` which allows the viewing of direct messages sent by other users that the caller is not part of.",
   "API_GitHub_Enterprise_URL": "Server URL",
   "API_GitHub_Enterprise_URL_Description": "Example: http://domain.com (excluding trailing slash)",
   "API_Gitlab_URL": "GitLab URL",


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Adds a setting `API_Enable_Direct_Message_History_EndPoint` which is disabled by default.
The endpoint requires the permission `view-room-administration` to use.

Also, adds the ability for rest api endpoints to have several routes for the same logic. This adds `dm` to all of the current `im` items.

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #5492

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
