### PR TITLE
Fix chat.postMessage not behaving like the web client

### DIFF
--- a/packages/rocketchat-integrations/server/processWebhookMessage.js
+++ b/packages/rocketchat-integrations/server/processWebhookMessage.js
@@ -4,7 +4,15 @@ function retrieveRoomInfo({ currentUserId, channel, ignoreEmpty=false }) {
 		throw new Meteor.Error('invalid-channel');
 	}
 
-	if (room && room.t === 'c') {
+	//Since the room object can be empty, return out now since we depend on it to be an object below
+	if (!room) {
+		return room;
+	}
+
+	//Check if the user already has a Subscription or not, this avoids this issue: https://github.com/RocketChat/Rocket.Chat/issues/5477
+	const sub = RocketChat.models.Subscriptions.findOneByRoomIdAndUserId(room._id, currentUserId);
+
+	if (!sub && room.t === 'c') {
 		Meteor.runAsUser(currentUserId, function() {
 			return Meteor.call('joinRoom', room._id);
 		});


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core Right now the web client lets you send messages to any channels you have joined (aka have a subscription to) whether or not you have permission to view that channel type. This fixes the issue where the rest api `chat.postMessage` wasn't behaving that way as well by checking for a Subscription before we try to join the user to a room.

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #5477

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
