### PR TITLE
Fix #5739

### DIFF
--- a/.snapcraft/edge/snapcraft.yaml
+++ b/.snapcraft/edge/snapcraft.yaml
@@ -56,11 +56,13 @@ parts:
         stage:
             - programs
             - main.js
+            - .node_version.txt
             - usr
             - lib
         snap:
             - programs
             - main.js
+            - .node_version.txt
             - usr
             - lib
     mongodb:

--- a/.snapcraft/stable/snapcraft.yaml
+++ b/.snapcraft/stable/snapcraft.yaml
@@ -56,11 +56,13 @@ parts:
         stage:
             - programs
             - main.js
+            - .node_version.txt
             - usr
             - lib
         snap:
             - programs
             - main.js
+            - .node_version.txt
             - usr
             - lib
     mongodb:


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #5739

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
We started depending on .node_version.txt as a result of this commit: https://github.com/RocketChat/Rocket.Chat/commit/aae98863be03cd5eb581b716c537263069587d86

But snap did not include that file.  This adds that file to the snap.

I've pushed an emergency fix for this to the snap release channel to keep from taking any more servers down via auto update.