### PR TITLE
Add missing required sessionId to api.ai call on externalMessage

### DIFF
--- a/packages/rocketchat-livechat/server/hooks/externalMessage.js
+++ b/packages/rocketchat-livechat/server/hooks/externalMessage.js
@@ -37,7 +37,8 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 			const response = HTTP.post('https://api.api.ai/api/query?v=20150910', {
 				data: {
 					query: message.msg,
-					lang: apiaiLanguage
+					lang: apiaiLanguage,
+					sessionId: room._id
 				},
 				headers: {
 					'Content-Type': 'application/json; charset=utf-8',


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Hi, the API call to api.ai wasn't working as they have now a [required field `sessionId`](https://docs.api.ai/docs/query#query-parameters-and-json-fields)  that the codebase was not sending, I just made it send `room._id`. I used `room._id` because the intent there in api.ai needs to follow the whole conversation in order to fill all parameters and produce more accurate responses.
