### PR TITLE
Fix Openshift Templates

### DIFF
--- a/.openshift/rocket-chat-ephemeral.json
+++ b/.openshift/rocket-chat-ephemeral.json
@@ -142,8 +142,33 @@
                         "securityContext": {}
                     }
                 }
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "rocketchat"
             },
-            "status": {}
+            "spec": {
+                "dockerImageRepository": "docker.io/rocket.chat",
+                "tags": [
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "description": "Provides a Rocket.Chat application",
+                            "iconClass": "icon-nodejs",
+                            "tags": "rocketchat"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "latest"
+                        },
+                        "generation": 1,
+                        "importPolicy": {}
+                    }
+                ]
+            }
         },
         {
             "kind": "DeploymentConfig",
@@ -264,7 +289,6 @@
                 }
             },
             "spec": {
-                "host": "rocketchat-rocket-chat.rhel-cdk.10.1.2.2.xip.io",
                 "to": {
                     "kind": "Service",
                     "name": "rocketchat"

--- a/.openshift/rocket-chat-persistent.json
+++ b/.openshift/rocket-chat-persistent.json
@@ -165,6 +165,32 @@
             "status": {}
         },
         {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "rocketchat"
+            },
+            "spec": {
+                "dockerImageRepository": "docker.io/rocket.chat",
+                "tags": [
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "description": "Provides a Rocket.Chat application",
+                            "iconClass": "icon-nodejs",
+                            "tags": "rocketchat"
+                        },
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "name": "latest"
+                        },
+                        "generation": 1,
+                        "importPolicy": {}
+                    }
+                ]
+            }
+        },
+        {
             "kind": "DeploymentConfig",
             "apiVersion": "v1",
             "metadata": {
@@ -283,7 +309,6 @@
                 }
             },
             "spec": {
-                "host": "rocketchat-rocket-chat.rhel-cdk.10.1.2.2.xip.io",
                 "to": {
                     "kind": "Service",
                     "name": "rocketchat"


### PR DESCRIPTION
* There was a problem with DeploymentConfig that was missing the correct ImageStream (which should be merged in this file)
* Removing the host attribute from route object to let Openshift create a dynamic hostname for Rocket.Chat

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
