### PR TITLE
Don’t report gravitar 404 as server error

### DIFF
--- a/packages/rocketchat-lib/server/functions/setUserAvatar.js
+++ b/packages/rocketchat-lib/server/functions/setUserAvatar.js
@@ -9,8 +9,10 @@ RocketChat.setUserAvatar = function(user, dataURI, contentType, service) {
 		try {
 			result = HTTP.get(dataURI, { npmRequestOptions: {encoding: 'binary'} });
 		} catch (error) {
-			console.log(`Error while handling the setting of the avatar from a url (${dataURI}) for ${user.username}:`, error);
-			throw new Meteor.Error('error-avatar-url-handling', `Error while handling avatar setting from a URL (${dataURI}) for ${user.username}`, { function: 'RocketChat.setUserAvatar', url: dataURI, username: user.username });
+			if (error.response.statusCode !== 404) {
+				console.log(`Error while handling the setting of the avatar from a url (${dataURI}) for ${user.username}:`, error);
+				throw new Meteor.Error('error-avatar-url-handling', `Error while handling avatar setting from a URL (${dataURI}) for ${user.username}`, { function: 'RocketChat.setUserAvatar', url: dataURI, username: user.username });
+			}
 		}
 
 		if (result.statusCode !== 200) {


### PR DESCRIPTION
My server logs were being spammed with gravatar fetch errors. I don't think it's worth reporting as an error when gravatar service returns a 404, it just means that email doesn't have a gravatar associated, which is pretty common.

@RocketChat/core 