### PR TITLE
remove "Private" button for direct messages

### DIFF
--- a/packages/rocketchat-channel-settings/client/views/channelSettings.coffee
+++ b/packages/rocketchat-channel-settings/client/views/channelSettings.coffee
@@ -9,6 +9,11 @@ Template.channelSettings.helpers
 		return arr
 
 	valueOf: (obj, key) ->
+		if key is 't'
+			if obj[key] is 'c'
+				return false
+
+			return true
 		return obj?[key]
 
 	showSetting: (setting, room) ->
@@ -156,7 +161,7 @@ Template.channelSettings.onCreated ->
 			isToggle: true
 			processing: new ReactiveVar(false)
 			canView: (room) ->
-				if not room.t in ['c', 'p']
+				if room.t not in ['c', 'p']
 					return false
 				else if room.t is 'p' and not RocketChat.authz.hasAllPermission('create-c')
 					return false


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Related to #5808

I removed the "Private" button when `room.t` is not `c` or `p` and fixed the representation of this button when the room is private or not.

![image](https://cloud.githubusercontent.com/assets/9200155/22440841/25ed8594-e71c-11e6-8c31-98bae743dbcd.png)


<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
