### PR TITLE
Fix running afterCreateChannel callbacks

### DIFF
--- a/packages/rocketchat-lib/server/functions/createRoom.js
+++ b/packages/rocketchat-lib/server/functions/createRoom.js
@@ -86,7 +86,7 @@ RocketChat.createRoom = function(type, name, owner, members, readOnly, extraData
 
 	if (type === 'c') {
 		Meteor.defer(() => {
-			RocketChat.callbacks.run('afterCreateChannel', owner, room);
+			RocketChat.callbacks.run('afterCreateChannel', room);
 		});
 	}
 


### PR DESCRIPTION
The only place where afterCreateChannel callback is added is 
https://github.com/RocketChat/Rocket.Chat/blob/develop/packages/rocketchat-piwik/client/trackEvents.js#L29
where the callback has the created room as the only argument.

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
