### PR TITLE
Replace $all with $contains in Rooms model

### DIFF
--- a/packages/rocketchat-lib/server/models/Rooms.coffee
+++ b/packages/rocketchat-lib/server/models/Rooms.coffee
@@ -230,7 +230,7 @@ class ModelRooms extends RocketChat.models._Base
 	findByTypeContainingUsernames: (type, username, options) ->
 		query =
 			t: type
-			usernames: { $all: [].concat(username) }
+			usernames: { $contains: [].concat(username) }
 
 		return @find query, options
 


### PR DESCRIPTION
@RocketChat/core 

Closes #5871 

'$contains' operator in Loki also seems to be able to meet the requirements of the function 'findByTypeContainingUsernames'