### PR TITLE
Fix 3651, update to /api.../info endpoints to be secure and backwards compatible for mobile clients.

### DIFF
--- a/packages/rocketchat-api/package.js
+++ b/packages/rocketchat-api/package.js
@@ -20,7 +20,12 @@ Package.onUse(function(api) {
 	api.addFiles('server/v1/helpers/getPaginationItems.js', 'server');
 	api.addFiles('server/v1/helpers/getUserFromParams.js', 'server');
 	api.addFiles('server/v1/helpers/parseJsonQuery.js', 'server');
+	api.addFiles('server/v1/helpers/getLoggedInUser.js', 'server');
 
+	//Register default helpers
+	api.addFiles('server/default/helpers/getLoggedInUser.js', 'server');
+
+	//Add default routes
 	api.addFiles('server/default/info.js', 'server');
 	api.addFiles('server/default/metrics.js', 'server');
 

--- a/packages/rocketchat-api/server/default/helpers/getLoggedInUser.js
+++ b/packages/rocketchat-api/server/default/helpers/getLoggedInUser.js
@@ -1,10 +1,11 @@
 RocketChat.API.default.helperMethods.set('getLoggedInUser', function _getLoggedInUser() {
-	let token;
 	let user;
 
-	if (this.request.headers['x-auth-token']) {
-		token = Accounts._hashLoginToken(this.request.headers['x-auth-token']);
-		user = RocketChat.models.Users.findOne({'services.resume.loginTokens.hashedToken': token});
+	if (this.request.headers['x-auth-token'] && this.request.headers['x-user-id']) {
+		user = RocketChat.models.Users.findOne({
+			'_id': this.request.headers['x-user-id'],
+			'services.resume.loginTokens.hashedToken': Accounts._hashLoginToken(this.request.headers['x-auth-token'])
+		});
 	}
 
 	return user;

--- a/packages/rocketchat-api/server/default/helpers/getLoggedInUser.js
+++ b/packages/rocketchat-api/server/default/helpers/getLoggedInUser.js
@@ -1,0 +1,9 @@
+RocketChat.API.default.helperMethods.set('getLoggedInUser', function _getLoggedInUser() {
+	let user;
+
+	if (this.request.headers['x-user-id'] && this.request.headers['x-auth-token']) {
+		user = RocketChat.models.Users.findOneById(this.request.headers['x-user-id']);
+	}
+
+	return user;
+});

--- a/packages/rocketchat-api/server/default/helpers/getLoggedInUser.js
+++ b/packages/rocketchat-api/server/default/helpers/getLoggedInUser.js
@@ -1,8 +1,10 @@
 RocketChat.API.default.helperMethods.set('getLoggedInUser', function _getLoggedInUser() {
+	let token;
 	let user;
 
-	if (this.request.headers['x-user-id'] && this.request.headers['x-auth-token']) {
-		user = RocketChat.models.Users.findOneById(this.request.headers['x-user-id']);
+	if (this.request.headers['x-auth-token']) {
+		token = Accounts._hashLoginToken(this.request.headers['x-auth-token']);
+		user = RocketChat.models.Users.findOne({'services.resume.loginTokens.hashedToken': token});
 	}
 
 	return user;

--- a/packages/rocketchat-api/server/default/info.js
+++ b/packages/rocketchat-api/server/default/info.js
@@ -6,7 +6,7 @@ RocketChat.API.default.addRoute('info', { authRequired: false }, {
 
 		return RocketChat.API.v1.success({
 			info: {
-				"version": RocketChat.Info.version
+				'version': RocketChat.Info.version
 			}
 		});
 	}

--- a/packages/rocketchat-api/server/default/info.js
+++ b/packages/rocketchat-api/server/default/info.js
@@ -1,6 +1,6 @@
 RocketChat.API.default.addRoute('info', { authRequired: false }, {
 	get: function() {
-		let user = this.getLoggedInUser();
+		const user = this.getLoggedInUser();
 
 		if (user && RocketChat.authz.hasRole(user._id, 'admin')) {
 			return {

--- a/packages/rocketchat-api/server/default/info.js
+++ b/packages/rocketchat-api/server/default/info.js
@@ -9,8 +9,7 @@ RocketChat.API.default.addRoute('info', { authRequired: false }, {
 		}
 
 		return RocketChat.API.v1.success({
-			version: RocketChat.Info.version,
-			build: RocketChat.Info.build
+			version: RocketChat.Info.version
 		});
 	}
 });

--- a/packages/rocketchat-api/server/default/info.js
+++ b/packages/rocketchat-api/server/default/info.js
@@ -1,7 +1,11 @@
 RocketChat.API.default.addRoute('info', { authRequired: false }, {
 	get: function() {
-		if (this.request.headers['x-user-id'] != null && RocketChat.authz.hasRole(this.request.headers['x-user-id'], 'admin')) {
-			return RocketChat.Info;
+		let user = this.getLoggedInUser();
+
+		if (user && RocketChat.authz.hasRole(user._id, 'admin')) {
+			return {
+				info: RocketChat.Info
+			};
 		}
 
 		return RocketChat.API.v1.success({

--- a/packages/rocketchat-api/server/default/info.js
+++ b/packages/rocketchat-api/server/default/info.js
@@ -3,15 +3,14 @@ RocketChat.API.default.addRoute('info', { authRequired: false }, {
 		const user = this.getLoggedInUser();
 
 		if (user && RocketChat.authz.hasRole(user._id, 'admin')) {
-			return {
+			return RocketChat.API.v1.success({
 				info: RocketChat.Info
-			};
+			});
 		}
 
 		return RocketChat.API.v1.success({
-			info: {
-				'version': RocketChat.Info.version
-			}
+			version: RocketChat.Info.version,
+			build: RocketChat.Info.build
 		});
 	}
 });

--- a/packages/rocketchat-api/server/default/info.js
+++ b/packages/rocketchat-api/server/default/info.js
@@ -1,5 +1,13 @@
 RocketChat.API.default.addRoute('info', { authRequired: false }, {
 	get: function() {
-		return RocketChat.Info;
+		if (this.request.headers['x-user-id'] != null && RocketChat.authz.hasRole(this.request.headers['x-user-id'], 'admin')) {
+			return RocketChat.Info;
+		}
+
+		return RocketChat.API.v1.success({
+			info: {
+				"version": RocketChat.Info.version
+			}
+		});
 	}
 });

--- a/packages/rocketchat-api/server/v1/helpers/getLoggedInUser.js
+++ b/packages/rocketchat-api/server/v1/helpers/getLoggedInUser.js
@@ -1,9 +1,31 @@
 RocketChat.API.v1.helperMethods.set('getLoggedInUser', function _getLoggedInUser() {
+	let token;
 	let user;
 
-	if (this.request.headers['x-user-id'] && this.request.headers['x-auth-token']) {
-		user = RocketChat.models.Users.findOneById(this.request.headers['x-user-id']);
+	if (this.request.headers['x-auth-token']) {
+		token = Accounts._hashLoginToken(this.request.headers['x-auth-token']);
+		user = RocketChat.models.Users.findOne({'services.resume.loginTokens.hashedToken': token});
 	}
 
 	return user;
 });
+
+// const auth = function _auth () {
+// 	const invalidResults = [undefined, null, false];
+// 	return {
+// 		token: 'services.resume.loginTokens.hashedToken',
+// 		user: function(headerId, headerToken) {
+
+
+// 			let token;
+// 			if (headerToken) {
+// 				token = Accounts._hashLoginToken(headerToken);
+// 			}
+
+// 			return {
+// 				userId: headerId,
+// 				token
+// 			};
+// 		}
+// 	};
+// }

--- a/packages/rocketchat-api/server/v1/helpers/getLoggedInUser.js
+++ b/packages/rocketchat-api/server/v1/helpers/getLoggedInUser.js
@@ -9,23 +9,3 @@ RocketChat.API.v1.helperMethods.set('getLoggedInUser', function _getLoggedInUser
 
 	return user;
 });
-
-// const auth = function _auth () {
-// 	const invalidResults = [undefined, null, false];
-// 	return {
-// 		token: 'services.resume.loginTokens.hashedToken',
-// 		user: function(headerId, headerToken) {
-
-
-// 			let token;
-// 			if (headerToken) {
-// 				token = Accounts._hashLoginToken(headerToken);
-// 			}
-
-// 			return {
-// 				userId: headerId,
-// 				token
-// 			};
-// 		}
-// 	};
-// }

--- a/packages/rocketchat-api/server/v1/helpers/getLoggedInUser.js
+++ b/packages/rocketchat-api/server/v1/helpers/getLoggedInUser.js
@@ -1,0 +1,9 @@
+RocketChat.API.v1.helperMethods.set('getLoggedInUser', function _getLoggedInUser() {
+	let user;
+
+	if (this.request.headers['x-user-id'] && this.request.headers['x-auth-token']) {
+		user = RocketChat.models.Users.findOneById(this.request.headers['x-user-id']);
+	}
+
+	return user;
+});

--- a/packages/rocketchat-api/server/v1/helpers/getLoggedInUser.js
+++ b/packages/rocketchat-api/server/v1/helpers/getLoggedInUser.js
@@ -1,10 +1,11 @@
 RocketChat.API.v1.helperMethods.set('getLoggedInUser', function _getLoggedInUser() {
-	let token;
 	let user;
 
-	if (this.request.headers['x-auth-token']) {
-		token = Accounts._hashLoginToken(this.request.headers['x-auth-token']);
-		user = RocketChat.models.Users.findOne({'services.resume.loginTokens.hashedToken': token});
+	if (this.request.headers['x-auth-token'] && this.request.headers['x-user-id']) {
+		user = RocketChat.models.Users.findOne({
+			'_id': this.request.headers['x-user-id'],
+			'services.resume.loginTokens.hashedToken': Accounts._hashLoginToken(this.request.headers['x-auth-token'])
+		});
 	}
 
 	return user;

--- a/packages/rocketchat-api/server/v1/misc.js
+++ b/packages/rocketchat-api/server/v1/misc.js
@@ -3,9 +3,9 @@ RocketChat.API.v1.addRoute('info', { authRequired: false }, {
 		const user = this.getLoggedInUser();
 
 		if (user && RocketChat.authz.hasRole(user._id, 'admin')) {
-			return {
+			return RocketChat.API.v1.success({
 				info: RocketChat.Info
-			};
+			});
 		}
 
 		return RocketChat.API.v1.success({

--- a/packages/rocketchat-api/server/v1/misc.js
+++ b/packages/rocketchat-api/server/v1/misc.js
@@ -1,7 +1,15 @@
 RocketChat.API.v1.addRoute('info', { authRequired: false }, {
 	get: function() {
+		if (this.request.headers['x-user-id'] != null && RocketChat.authz.hasRole(this.request.headers['x-user-id'], 'admin')) {
+			return {
+				info: RocketChat.Info
+			}
+		}
+
 		return RocketChat.API.v1.success({
-			info: RocketChat.Info
+			info: {
+				"version": RocketChat.Info.version
+			}
 		});
 	}
 });

--- a/packages/rocketchat-api/server/v1/misc.js
+++ b/packages/rocketchat-api/server/v1/misc.js
@@ -1,6 +1,6 @@
 RocketChat.API.v1.addRoute('info', { authRequired: false }, {
 	get: function() {
-		let user = this.getLoggedInUser();
+		const user = this.getLoggedInUser();
 
 		if (user && RocketChat.authz.hasRole(user._id, 'admin')) {
 			return {

--- a/packages/rocketchat-api/server/v1/misc.js
+++ b/packages/rocketchat-api/server/v1/misc.js
@@ -3,12 +3,12 @@ RocketChat.API.v1.addRoute('info', { authRequired: false }, {
 		if (this.request.headers['x-user-id'] != null && RocketChat.authz.hasRole(this.request.headers['x-user-id'], 'admin')) {
 			return {
 				info: RocketChat.Info
-			}
+			};
 		}
 
 		return RocketChat.API.v1.success({
 			info: {
-				"version": RocketChat.Info.version
+				'version': RocketChat.Info.version
 			}
 		});
 	}

--- a/packages/rocketchat-api/server/v1/misc.js
+++ b/packages/rocketchat-api/server/v1/misc.js
@@ -1,6 +1,8 @@
 RocketChat.API.v1.addRoute('info', { authRequired: false }, {
 	get: function() {
-		if (this.request.headers['x-user-id'] != null && RocketChat.authz.hasRole(this.request.headers['x-user-id'], 'admin')) {
+		let user = this.getLoggedInUser();
+
+		if (user && RocketChat.authz.hasRole(user._id, 'admin')) {
 			return {
 				info: RocketChat.Info
 			};

--- a/tests/end-to-end/api/00-miscellaneous.js
+++ b/tests/end-to-end/api/00-miscellaneous.js
@@ -29,14 +29,6 @@ describe('miscellaneous', function() {
 				.expect(200)
 				.expect((res) => {
 					expect(res.body).to.have.property('version');
-					expect(res.body).to.have.deep.property('build.date');
-					expect(res.body).to.have.deep.property('build.nodeVersion');
-					expect(res.body).to.have.deep.property('build.arch');
-					expect(res.body).to.have.deep.property('build.platform');
-					expect(res.body).to.have.deep.property('build.osRelease');
-					expect(res.body).to.have.deep.property('build.totalMemory');
-					expect(res.body).to.have.deep.property('build.freeMemory');
-					expect(res.body).to.have.deep.property('build.cpus');
 				})
 				.end(done);
 		});


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #3651 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
When hitting /api/info or /api/v1/info, default response to be just version number of the info object. If user has admin role, show entire object.