### PR TITLE
fix message action menu on cordova

### DIFF
--- a/packages/rocketchat-ui/package.js
+++ b/packages/rocketchat-ui/package.js
@@ -98,6 +98,7 @@ Package.onUse(function(api) {
 	api.addFiles('views/404/roomNotFound.coffee', 'client');
 	api.addFiles('views/app/burger.coffee', 'client');
 	api.addFiles('views/app/home.coffee', 'client');
+	api.addFiles('views/app/mobileMessageMenu.js', 'client');
 	api.addFiles('views/app/privateHistory.coffee', 'client');
 	api.addFiles('views/app/room.coffee', 'client');
 	api.addFiles('views/app/roomSearch.coffee', 'client');

--- a/packages/rocketchat-ui/views/app/mobileMessageMenu.js
+++ b/packages/rocketchat-ui/views/app/mobileMessageMenu.js
@@ -1,0 +1,76 @@
+const mobileMessageMenu = {
+	show(message, template, e, scope) {
+		if (!window.plugins.actionsheet) {
+			return false;
+		}
+
+		const options = {
+			'androidTheme': window.plugins.actionsheet.ANDROID_THEMES.THEME_HOLO_LIGHT,
+			'buttonLabels': [
+				TAPi18n.__('Report Abuse')
+			],
+			androidEnableCancelButton: true,
+			addCancelButtonWithLabel: TAPi18n.__('Cancel')
+		};
+
+		const buttonActions = [
+			mobileMessageMenu.reportAbuse
+		];
+
+		const buttons = RocketChat.MessageAction.getButtons(message, message.customClass || 'message-mobile');
+
+		for (let i = 0, len = buttons.length; i < len; i++) {
+			if (buttons[i].id === 'delete-message') {
+				options.addDestructiveButtonWithLabel = TAPi18n.__(buttons[i].i18nLabel);
+				buttonActions.unshift(buttons[i].action);
+			} else {
+				buttonActions.push(buttons[i].action);
+				options.buttonLabels.push(TAPi18n.__(buttons[i].i18nLabel));
+			}
+		}
+
+		window.plugins.actionsheet.show(options, (buttonIndex) => {
+			if (buttonActions[buttonIndex - 1] != null) {
+				return buttonActions[buttonIndex - 1].call(scope, e, template, message);
+			}
+		});
+
+	},
+	reportAbuse: (e, t, message) => {
+		swal({
+			title: TAPi18n.__('Report_this_message_question_mark'),
+			text: message.msg,
+			inputPlaceholder: TAPi18n.__('Why_do_you_want_to_report_question_mark'),
+			type: 'input',
+			showCancelButton: true,
+			confirmButtonColor: '#DD6B55',
+			confirmButtonText: TAPi18n.__('Report_exclamation_mark'),
+			cancelButtonText: TAPi18n.__('Cancel'),
+			closeOnConfirm: false,
+			html: false
+		}, (inputValue) => {
+			if (inputValue === false) {
+				return false;
+			}
+
+			if (inputValue === '') {
+				swal.showInputError(TAPi18n.__('You_need_to_write_something'));
+				return false;
+			}
+
+			Meteor.call('reportMessage', message, inputValue);
+
+			swal({
+				title: TAPi18n.__('Report_sent'),
+				text: TAPi18n.__('Thank_you_exclamation_mark '),
+				type: 'success',
+				timer: 1000,
+				showConfirmButton: false
+			});
+		});
+	}
+};
+
+this.mobileMessageMenu = mobileMessageMenu;
+
+console.log('mobileMessageMenu');


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #5963

`mobileMessageMenu` was deleted with the old spotlight.

![image](https://cloud.githubusercontent.com/assets/9200155/22796149/6be0b58c-eee0-11e6-917b-df4ad11f1f0d.png)


<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
