### PR TITLE
Only a User should become Admin

### DIFF
--- a/server/lib/accounts.js
+++ b/server/lib/accounts.js
@@ -113,7 +113,8 @@ Accounts.insertUserDoc = _.wrap(Accounts.insertUserDoc, function(insertUserDoc, 
 
 	if (roles.length === 0) {
 		const hasAdmin = RocketChat.models.Users.findOne({
-			roles: 'admin'
+			roles: 'admin',
+			type: 'user'
 		}, {
 			fields: {
 				_id: 1


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 


<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
**The bug:**
The first "user" should be made admin. Instead `rocket.cat` becomes the admin in new installs.

**History:**
* This Bug was fixed once in  #1647
* It regressed in https://github.com/RocketChat/Rocket.Chat/commit/6157e7763cb7fb3c0b068c9f67d1144383abda49#diff-80879a72bba8e1d0cb43a26400c2041f
* In a recent commit, the files were moved from coffee to js and the bug got carried over.

**The Fix**
Check `type: user` before making a user admin.