### PR TITLE
The right way to verify the date

### DIFF
--- a/packages/rocketchat-ui-message/message/message.coffee
+++ b/packages/rocketchat-ui-message/message/message.coffee
@@ -196,8 +196,10 @@ Template.message.onViewRendered = (context) ->
 
 		else if previousNode?.dataset?
 			previousDataset = previousNode.dataset
+			previousMessageDate = new Date(parseInt(previousDataset.timestamp))
+			currentMessageDate = new Date(parseInt(currentDataset.timestamp))
 
-			if previousDataset.date isnt currentDataset.date
+			if previousMessageDate.toDateString() isnt currentMessageDate.toDateString()
 				$currentNode.addClass('new-day').removeClass('sequential')
 			else
 				$currentNode.removeClass('new-day')


### PR DESCRIPTION
Closes #5859 
Improves the way that rocket chat verify the date to group messages under the `new day` line
so that the test don’t rely on the current language 
![screenshot from 2017-02-13 15-52-05](https://cloud.githubusercontent.com/assets/20868078/22895662/758d8be2-f204-11e6-876c-8d0c20970a19.png)

