### PR TITLE
new behavior to ESC on toolbar search

### DIFF
--- a/packages/rocketchat-ui-master/master/main.coffee
+++ b/packages/rocketchat-ui-master/master/main.coffee
@@ -7,7 +7,7 @@ Template.body.onRendered ->
 		if e.keyCode is 80 and (e.ctrlKey is true or e.metaKey is true) and e.shiftKey is false
 			e.preventDefault()
 			e.stopPropagation()
-			toolbarSearch.focus()
+			toolbarSearch.focus(true)
 
 		unread = Session.get('unread')
 		if e.keyCode is 27 and e.shiftKey is true and unread? and unread isnt ''

--- a/packages/rocketchat-ui-sidenav/client/toolbar.js
+++ b/packages/rocketchat-ui-sidenav/client/toolbar.js
@@ -9,13 +9,25 @@ Meteor.startup(() => {
 });
 
 const toolbarSearch = {
+	shortcut: false,
 	clear() {
-		$('.toolbar-search__input').val('');
-	},
+		const $inputMessage = $('textarea.input-message');
 
-	focus() {
+		if (0 === $inputMessage.length) {
+			return;
+		}
+
+		$inputMessage.focus();
+		$('.toolbar-search__input').val('');
+
+		if (this.shortcut) {
+			menu.close();
+		}
+	},
+	focus(fromShortcut) {
 		menu.open();
 		$('.toolbar-search__input').focus();
+		this.shortcut = fromShortcut;
 	}
 };
 
@@ -161,14 +173,12 @@ Template.toolbar.events({
 			e.preventDefault();
 			e.stopPropagation();
 
-			const $inputMessage = $('textarea.input-message');
-
-			if (0 === $inputMessage.length) {
-				return;
-			}
-
-			$inputMessage.focus();
+			toolbarSearch.clear();
 		}
+	},
+
+	'click .toolbar-search__input'() {
+		toolbarSearch.shortcut = false;
 	},
 
 	'click .toolbar-search__create-channel, touchend .toolbar-search__create-channel'(e) {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #6031 

When you open toolbar search from Ctrl/CMD + P the sidenav will close on esc, but if you open sidenav and click on toolbar search input ESC will only clear the input.

![2017-02-15 14 36 55](https://cloud.githubusercontent.com/assets/9200155/22984614/17a413a4-f38d-11e6-8e88-4cd03d65a0e3.gif)


<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
