### PR TITLE
Fix ctrl/alt/cmd+enter line break

### DIFF
--- a/packages/rocketchat-ui/lib/chatMessages.coffee
+++ b/packages/rocketchat-ui/lib/chatMessages.coffee
@@ -334,11 +334,18 @@ class @ChatMessages
 		$input = $(input)
 		k = event.which
 		this.resize(input)
-		if k is 13 and not event.shiftKey and not event.ctrlKey and not event.altKey # Enter without shift/ctrl/alt
-			event.preventDefault()
-			event.stopPropagation()
-			this.send(rid, input)
-			return
+		if k is 13
+			if not event.shiftKey and not event.ctrlKey and not event.altKey and not event.metaKey # Enter without shift/ctrl/alt
+				event.preventDefault()
+				event.stopPropagation()
+				if this.editing.id
+					this.update(this.editing.id, rid, input)
+				else
+					this.send(rid, input)
+				return
+			else if not event.shiftKey
+				return input.value +='\n'
+
 
 		if k is 9 # Tab
 			event.preventDefault()


### PR DESCRIPTION
Closes #5673 
It adds a line break when ctrl, alt or cmd is pressed with enter