### PR TITLE
Add minified version of livechat widget script

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,7 @@ packages/rocketchat-emoji-emojione/generateEmojiIndex.js
 packages/rocketchat-favico/favico.js
 packages/rocketchat-katex/client/katex/katex.min.js
 packages/rocketchat-livechat/app/node_modules
+packages/rocketchat-livechat/assets/rocketchat-livechat.min.js
 packages/rocketchat-migrations/
 packages/rocketchat-theme/client/minicolors/jquery.minicolors.js
 packages/rocketchat-ui/lib/customEventPolyfill.js

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@
 .meteor/meteorite
 .meteor/dev_bundle
 packages/rocketchat-livechat/app/.meteor/dev_bundle
+packages/rocketchat-livechat/assets/rocketchat-livechat.min.js
 .mule
 .pmd
 .project

--- a/packages/rocketchat-livechat/assets/demo.html
+++ b/packages/rocketchat-livechat/assets/demo.html
@@ -10,7 +10,7 @@
 		var h = d.getElementsByTagName(s)[0],
 			j = d.createElement(s);
 		j.async = true;
-		j.src = '/packages/rocketchat_livechat/assets/rocket-livechat.js';
+		j.src = '/packages/rocketchat_livechat/assets/rocketchat-livechat.min.js?_=201702160944';
 		h.parentNode.insertBefore(j, h);
 	})(window, document, 'script', '/livechat');
 	</script>

--- a/packages/rocketchat-livechat/client/views/app/livechatInstallation.js
+++ b/packages/rocketchat-livechat/client/views/app/livechatInstallation.js
@@ -7,7 +7,7 @@ Template.livechatInstallation.helpers({
 (function(w, d, s, u) {
 	w.RocketChat = function(c) { w.RocketChat._.push(c) }; w.RocketChat._ = []; w.RocketChat.url = u;
 	var h = d.getElementsByTagName(s)[0], j = d.createElement(s);
-	j.async = true; j.src = '${siteUrl}/packages/rocketchat_livechat/assets/rocket-livechat.js';
+	j.async = true; j.src = '${siteUrl}/packages/rocketchat_livechat/assets/rocketchat-livechat.min.js?_=201702160944';
 	h.parentNode.insertBefore(j, h);
 })(window, document, 'script', '${siteUrl}/livechat');
 </script>

--- a/packages/rocketchat-livechat/package.js
+++ b/packages/rocketchat-livechat/package.js
@@ -11,12 +11,14 @@ Package.registerBuildPlugin({
 		'plugin/build-livechat.js'
 	],
 	npmDependencies: {
-		'shelljs': '0.5.1'
+		'shelljs': '0.5.1',
+		'uglify-js': '2.7.5'
 	}
 });
 
 Npm.depends({
-	'ua-parser-js': '0.7.10'
+	'ua-parser-js': '0.7.10',
+	'uglify-js': '2.7.5'
 });
 
 Package.onUse(function(api) {
@@ -205,6 +207,10 @@ Package.onUse(function(api) {
 
 	// livechat app
 	api.addAssets('assets/demo.html', 'client');
-	api.addAssets('assets/rocket-livechat.js', 'client');
+
+	// DEPRECATED
+	api.addAssets('assets/rocket-livechat.js', 'client'); // this file is still added to not break currently installed livechat widgets
+
+	api.addAssets('assets/rocketchat-livechat.min.js', 'client');
 	api.addAssets('public/head.html', 'server');
 });

--- a/packages/rocketchat-livechat/plugin/build-livechat.js
+++ b/packages/rocketchat-livechat/plugin/build-livechat.js
@@ -1,5 +1,11 @@
 var path = Npm.require('path');
 var shell = Npm.require('shelljs');
+var fs = Npm.require('fs');
+var UglifyJS = Npm.require('uglify-js');
+
+var result = UglifyJS.minify(path.resolve('packages', 'rocketchat-livechat', 'assets', 'rocket-livechat.js'));
+
+fs.writeFileSync(path.resolve('packages', 'rocketchat-livechat', 'assets', 'rocketchat-livechat.min.js'), result.code);
 
 var packagePath = path.join(path.resolve('.'), 'packages', 'rocketchat-livechat');
 var pluginPath = path.join(packagePath, 'plugin');


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
The minified version is 41% lighter (not gzipped - 4.9KB vs 2.9KB) as you can see on the image below:
![image](https://cloud.githubusercontent.com/assets/8591547/23021433/1f63e69a-f433-11e6-942e-0a555c7025a3.png)

But with the additions of https://github.com/RocketChat/Rocket.Chat/pull/6070 it is 71% lighter (not gzipped - 22.3KB vs 6.5KB) as you can see on the image below:
![image](https://cloud.githubusercontent.com/assets/8591547/23021409/f4d409a0-f432-11e6-9611-08e7e0c5d0e0.png)

@RocketChat/core how can we deprecate the old (non-minified) file and tell users to use the new minified version? I've added a [comment on the code](https://github.com/RocketChat/Rocket.Chat/pull/6071/files#diff-801b93110abea405d3309407f6e16db0R211) but I know it's not enough =\