### PR TITLE
Fix livechat appearance page by not saving settings directly from client

### DIFF
--- a/packages/rocketchat-livechat/package.js
+++ b/packages/rocketchat-livechat/package.js
@@ -144,6 +144,7 @@ Package.onUse(function(api) {
 	api.addFiles('server/methods/removeDepartment.js', 'server');
 	api.addFiles('server/methods/removeManager.js', 'server');
 	api.addFiles('server/methods/removeTrigger.js', 'server');
+	api.addFiles('server/methods/saveAppearance.js', 'server');
 	api.addFiles('server/methods/saveCustomField.js', 'server');
 	api.addFiles('server/methods/saveDepartment.js', 'server');
 	api.addFiles('server/methods/saveInfo.js', 'server');
@@ -188,6 +189,7 @@ Package.onUse(function(api) {
 	api.addFiles('server/publications/departmentAgents.js', 'server');
 	api.addFiles('server/publications/externalMessages.js', 'server');
 	api.addFiles('server/publications/livechatAgents.js', 'server');
+	api.addFiles('server/publications/livechatAppearance.js', 'server');
 	api.addFiles('server/publications/livechatDepartments.js', 'server');
 	api.addFiles('server/publications/livechatIntegration.js', 'server');
 	api.addFiles('server/publications/livechatManagers.js', 'server');

--- a/packages/rocketchat-livechat/server/methods/saveAppearance.js
+++ b/packages/rocketchat-livechat/server/methods/saveAppearance.js
@@ -1,0 +1,33 @@
+Meteor.methods({
+	'livechat:saveAppearance'(settings) {
+		if (!Meteor.userId() || !RocketChat.authz.hasPermission(Meteor.userId(), 'view-livechat-manager')) {
+			throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'livechat:saveAppearance' });
+		}
+
+		const validSettings = [
+			'Livechat_title',
+			'Livechat_title_color',
+			'Livechat_display_offline_form',
+			'Livechat_offline_form_unavailable',
+			'Livechat_offline_message',
+			'Livechat_offline_success_message',
+			'Livechat_offline_title',
+			'Livechat_offline_title_color',
+			'Livechat_offline_email'
+		];
+
+		const valid = settings.every((setting) => {
+			return validSettings.indexOf(setting._id) !== -1;
+		});
+
+		if (!valid) {
+			throw new Meteor.Error('invalid-setting');
+		}
+
+		settings.forEach((setting) => {
+			RocketChat.settings.updateById(setting._id, setting.value);
+		});
+
+		return;
+	}
+});

--- a/packages/rocketchat-livechat/server/publications/livechatAppearance.js
+++ b/packages/rocketchat-livechat/server/publications/livechatAppearance.js
@@ -1,0 +1,45 @@
+Meteor.publish('livechat:appearance', function() {
+	if (!this.userId) {
+		return this.error(new Meteor.Error('error-not-authorized', 'Not authorized', { publish: 'livechat:appearance' }));
+	}
+
+	if (!RocketChat.authz.hasPermission(this.userId, 'view-livechat-manager')) {
+		return this.error(new Meteor.Error('error-not-authorized', 'Not authorized', { publish: 'livechat:appearance' }));
+	}
+
+	const query = {
+		_id: {
+			$in: [
+				'Livechat_title',
+				'Livechat_title_color',
+				'Livechat_display_offline_form',
+				'Livechat_offline_form_unavailable',
+				'Livechat_offline_message',
+				'Livechat_offline_success_message',
+				'Livechat_offline_title',
+				'Livechat_offline_title_color',
+				'Livechat_offline_email'
+			]
+		}
+	};
+
+	const self = this;
+
+	const handle = RocketChat.models.Settings.find(query).observeChanges({
+		added(id, fields) {
+			self.added('livechatAppearance', id, fields);
+		},
+		changed(id, fields) {
+			self.changed('livechatAppearance', id, fields);
+		},
+		removed(id) {
+			self.removed('livechatAppearance', id);
+		}
+	});
+
+	this.ready();
+
+	this.onStop(() => {
+		handle.stop();
+	});
+});


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Closes #5717

Doing this was necessary because a livechat manager could not be an admin, so it would not be able to save some settings and barely see some others.

So I had to everything related to settings management to server side. So I can properly check if the user has the proper access rights and manipulate settings directly on DB.