### PR TITLE
Fix livechat knowledge base by properly initiating it's model

### DIFF
--- a/packages/rocketchat-livechat/server/models/LivechatExternalMessage.js
+++ b/packages/rocketchat-livechat/server/models/LivechatExternalMessage.js
@@ -1,6 +1,10 @@
 class LivechatExternalMessage extends RocketChat.models._Base {
 	constructor() {
 		super('livechat_external_message');
+
+		if (Meteor.isClient) {
+			this._initModel('livechat_external_message');
+		}
 	}
 
 	// FIND


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #6101

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Looks like it's currently needed to call `this._initModel` on client side.
