### PR TITLE
Fix updating a message with @all by copying "u" property

### DIFF
--- a/packages/rocketchat-lib/server/methods/updateMessage.js
+++ b/packages/rocketchat-lib/server/methods/updateMessage.js
@@ -33,6 +33,8 @@ Meteor.methods({
 			}
 		}
 
+		message.u = originalMessage.u;
+
 		return RocketChat.updateMessage(message, Meteor.user());
 	}
 });


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

This fixes a weird bug that was preventing a message mentioning `@all` from being updated.