### PR TITLE
Remove error-color class when creating new channel. closes #5454

### DIFF
--- a/packages/rocketchat-ui-sidenav/client/createCombinedFlex.html
+++ b/packages/rocketchat-ui-sidenav/client/createCombinedFlex.html
@@ -35,7 +35,7 @@
 				</ul>
 			</div>
 			{{#if error.fields}}
-				<div class="input-error error-color">
+				<div class="input-error">
 					<strong>{{_ "Oops!"}}</strong>
 					{{#each error.fields}}
 						<p>{{_ "The_field_is_required" .}}</p>
@@ -43,19 +43,19 @@
 				</div>
 			{{/if}}
 			{{#if error.invalid}}
-				<div class="input-error error-color">
+				<div class="input-error">
 					<strong>{{_ "Oops!"}}</strong>
 					{{{_ "Invalid_room_name" roomName}}}
 				</div>
 			{{/if}}
 			{{#if error.duplicate}}
-				<div class="input-error error-color">
+				<div class="input-error">
 					<strong>{{_ "Oops!"}}</strong>
 					{{{_ "Duplicate_channel_name" roomName}}}
 				</div>
 			{{/if}}
 			{{#if error.archivedduplicate}}
-				<div class="input-error error-color">
+				<div class="input-error">
 					<strong>{{_ "Oops!"}}</strong>
 					{{{_ "Duplicate_archived_channel_name" roomName}}}
 				</div>


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

In order to fix the issue #5454, I removed the `.error-color` class from the markup. By doing this, I achieved the folowing result:

![captura de tela de 2017-02-21 17-33-30](https://cloud.githubusercontent.com/assets/2279686/23183755/e59dfda6-f85b-11e6-9fa9-1a25ffc2f58c.png)
