### PR TITLE
fix keydown when photoswipe is open

### DIFF
--- a/packages/rocketchat-ui-master/master/main.coffee
+++ b/packages/rocketchat-ui-master/master/main.coffee
@@ -34,10 +34,13 @@ Template.body.onRendered ->
 			return
 		if /input|textarea|select/i.test(target.tagName)
 			return
-		$inputMessage = $('textarea.input-message')
-		if 0 == $inputMessage.length
+		if target.id is 'pswp'
 			return
-		$inputMessage.focus()
+
+		inputMessage = $('textarea.input-message')
+		if inputMessage.length is 0
+			return
+		inputMessage.focus()
 
 	$(document.body).on 'click', 'a', (e) ->
 		link = e.currentTarget


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #6037 

When you press any key with photoswipe open, these keys will appear on message-box. This PR fix this behavior.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
