### PR TITLE
#324 Add Option to Show Full Names in Channel User List

### DIFF
--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -618,6 +618,7 @@
   "Hide_Room_Warning": "Are you sure you want to hide the room \"%s\"?",
   "Hide_roles": "Hide roles",
   "Hide_usernames": "Hide usernames",
+  "Show_names": "Show names",
   "Highlights": "Highlights",
   "Highlights_How_To": "To be notified when someone mentions a word or phrase, add it here. You can separate words or phrases with commas. Highlight Words are not case sensitive.",
   "Highlights_List": "Highlight words",

--- a/packages/rocketchat-ui-account/account/accountPreferences.coffee
+++ b/packages/rocketchat-ui-account/account/accountPreferences.coffee
@@ -86,6 +86,7 @@ Template.accountPreferences.onCreated ->
 		data.collapseMediaByDefault = $('input[name=collapseMediaByDefault]:checked').val()
 		data.viewMode = parseInt($('#viewMode').find('select').val())
 		data.hideUsernames = $('#hideUsernames').find('input:checked').val()
+		data.showNames = $('#showNames').find('input:checked').val()
 		data.hideRoles = $('#hideRoles').find('input:checked').val()
 		data.hideFlexTab = $('#hideFlexTab').find('input:checked').val()
 		data.hideAvatars = $('#hideAvatars').find('input:checked').val()

--- a/packages/rocketchat-ui-account/account/accountPreferences.html
+++ b/packages/rocketchat-ui-account/account/accountPreferences.html
@@ -108,6 +108,13 @@
 									<label><input type="radio" name="hideUsernames" value="0" checked="{{checked 'hideUsernames' false true}}" /> {{_ "False"}}</label>
 								</div>
 							</div>
+							<div class="input-line double-col" id="showNames">
+								<label>{{_ "Show_names"}}</label>
+								<div>
+									<label><input type="radio" name="showNames" value="1" checked="{{checked 'showNames' true}}" /> {{_ "True"}}</label>
+									<label><input type="radio" name="showNames" value="0" checked="{{checked 'showNames' false true}}" /> {{_ "False"}}</label>
+								</div>
+							</div>
 							{{#if showRoles}}
 								<div class="input-line double-col" id="hideRoles">
 									<label>{{_ "Hide_roles"}}</label>

--- a/packages/rocketchat-ui-flextab/flex-tab/tabs/membersList.coffee
+++ b/packages/rocketchat-ui-flextab/flex-tab/tabs/membersList.coffee
@@ -17,11 +17,19 @@ Template.membersList.helpers
 	roomUsers: ->
 		onlineUsers = RoomManager.onlineUsers.get()
 		roomUsernames = Template.instance().users.get()
+		namesOfUsers = Template.instance().names.get()
 		room = ChatRoom.findOne(this.rid)
 		roomMuted = room?.muted or []
 		userUtcOffset = Meteor.user().utcOffset
 		totalOnline = 0
+		prefs = Meteor.user()?.settings?.preferences
+
 		users = roomUsernames.map (username) ->
+			name = ''
+
+			if prefs?.showNames
+				name = namesOfUsers[username]
+
 			if onlineUsers[username]?
 				totalOnline++
 				utcOffset = onlineUsers[username].utcOffset
@@ -36,6 +44,7 @@ Template.membersList.helpers
 
 			return {
 				username: username
+				name: name
 				status: onlineUsers[username]?.status
 				muted: username in roomMuted
 				utcOffset: utcOffset
@@ -137,6 +146,7 @@ Template.membersList.onCreated ->
 	@showDetail = new ReactiveVar false
 
 	@users = new ReactiveVar []
+	@names = new ReactiveVar []
 	@total = new ReactiveVar
 	@loading = new ReactiveVar true
 
@@ -149,6 +159,7 @@ Template.membersList.onCreated ->
 		Meteor.call 'getUsersOfRoom', this.data.rid, this.showAllUsers.get(), (error, users) =>
 			@users.set users.records
 			@total.set users.total
+			@names.set users.names
 			@loading.set false
 
 	@clearUserDetail = =>

--- a/packages/rocketchat-ui-flextab/flex-tab/tabs/membersList.html
+++ b/packages/rocketchat-ui-flextab/flex-tab/tabs/membersList.html
@@ -32,7 +32,7 @@
 								<li class='user-image user-card-room status-{{status}}'>
 									<button data-username="{{username}}" tabindex="0" title="{{username}}">
 										{{> avatar username=username}}
-										<p>{{username}} {{utcOffset}}</p>
+										<p>{{name}} @{{username}} {{utcOffset}}</p>
 										{{#if muted}}
 											<i class="icon-mute" title="{{_ "User_muted"}}"></i>
 										{{/if}}

--- a/packages/rocketchat-videobridge/client/views/videoFlexTab.js
+++ b/packages/rocketchat-videobridge/client/views/videoFlexTab.js
@@ -66,7 +66,7 @@ Template.videoFlexTab.onRendered(function() {
 
 						timeOut = Meteor.setInterval(() => Meteor.call('jitsi:updateTimeout', roomId), 10*1000);
 
-						const newWindow = window.open((noSsl ? 'http://' : 'https://') + domain + '/' + jitsiRoom, jitsiRoom);
+						const newWindow = window.open((noSsl ? 'http://' : 'https://') + domain + '/' + jitsiRoom, '_external_app_window');
 						newWindow.focus();
 
 						const closeInterval = setInterval(() => {

--- a/server/methods/getUsersOfRoom.js
+++ b/server/methods/getUsersOfRoom.js
@@ -26,11 +26,18 @@ Meteor.methods({
 			return record._user.username;
 		};
 
+		var names = {};
+
 		const records = RocketChat.models.Subscriptions.findByRoomId(roomId).fetch();
+
+		records.filter(filter).forEach(function(record) {
+			names[record._user.username] = record._user.name;
+		});
 
 		return {
 			total: records.length,
-			records: records.filter(filter).map(map)
+			records: records.filter(filter).map(map),
+			names: names
 		};
 	}
 });

--- a/server/methods/saveUserPreferences.js
+++ b/server/methods/saveUserPreferences.js
@@ -58,6 +58,7 @@ Meteor.methods({
 			preferences.desktopNotificationDuration = settings.desktopNotificationDuration - 0;
 			preferences.viewMode = settings.viewMode || 0;
 			preferences.hideUsernames = settings.hideUsernames === '1';
+			preferences.showNames = settings.showNames === '1';
 			preferences.hideRoles = settings.hideRoles === '1';
 			preferences.hideAvatars = settings.hideAvatars === '1';
 			preferences.hideFlexTab = settings.hideFlexTab === '1';


### PR DESCRIPTION
 - Add Option
 - Transmit user names to client
 - Show them

The user's full names can be always transmitted, as they were already
visibile before in the user info.

@RocketChat/core 

Closes #324

![selection_265](https://cloud.githubusercontent.com/assets/1087128/23335439/dc3fbddc-fbb5-11e6-82df-11fe5a900eaa.png)
