### PR TITLE
Allow livechat managers to transfer chats

### DIFF
--- a/packages/rocketchat-livechat/server/methods/transfer.js
+++ b/packages/rocketchat-livechat/server/methods/transfer.js
@@ -17,7 +17,7 @@ Meteor.methods({
 
 		const user = Meteor.user();
 
-		if (room.usernames.indexOf(user.username) === -1) {
+		if (room.usernames.indexOf(user.username) === -1 && !RocketChat.authz.hasRole(Meteor.userId(), 'livechat-manager')) {
 			throw new Meteor.Error('error-not-authorized', 'Not authorized', { method: 'livechat:transfer' });
 		}
 


### PR DESCRIPTION
@RocketChat/core

This PR allows livechat managers to transfer chats. Right now, only the active agent is allowed to do that. 
Sometimes, those people forget to forward it and just leave it open and it's easier for the manager to simply forward it to someone else than having to ask the active agent to do it.

