### PR TITLE
Show File Description For All Files

### DIFF
--- a/packages/rocketchat-message-attachments/client/messageAttachment.html
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.html
@@ -69,6 +69,9 @@
 							<div class="inline-image" style="background-image: url('{{fixCordova image_url}}');">
 								<img src="{{fixCordova image_url}}" height="{{getImageHeight image_dimensions.height}}" class="gallery-item" data-title="{{title}}" data-description="{{description}}">
 							</div>
+							{{#if description}}
+								<figcaption class="attachment-description">{{description}}</figcaption>
+							{{/if}}
 						</figure>
 					{{else}}
 						<div class="image-to-download" data-url="{{image_url}}">
@@ -125,9 +128,11 @@
 				{{/unless}}
 			{{/if}}
 
-			{{#if description}}
-				<div class="attachment-description">{{description}}</div>
-			{{/if}}
+			{{#unless image_url}}
+				{{#if description}}
+					<div class="attachment-description">{{description}}</div>
+				{{/if}}
+			{{/unless}}
 
 			{{#each attachments}}
 				{{injectIndex . ../index @index}} {{> messageAttachment}}

--- a/packages/rocketchat-message-attachments/client/messageAttachment.html
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.html
@@ -69,9 +69,6 @@
 							<div class="inline-image" style="background-image: url('{{fixCordova image_url}}');">
 								<img src="{{fixCordova image_url}}" height="{{getImageHeight image_dimensions.height}}" class="gallery-item" data-title="{{title}}" data-description="{{description}}">
 							</div>
-							{{#if description}}
-								<figcaption class="attachment-description">{{description}}</figcaption>
-							{{/if}}
 						</figure>
 					{{else}}
 						<div class="image-to-download" data-url="{{image_url}}">
@@ -87,7 +84,7 @@
 				{{#unless collapsed}}
 					<div class="attachment-audio">
 						<audio controls>
-							<source src="{{fixCordova audio_url}}" type="{{audio_type}}">
+							<source src="{{fixCordova audio_url}}" type="{{audio_type}}" data-description="{{description}}">
 							Your browser does not support the audio element.
 						</audio>
 					</div>
@@ -98,7 +95,7 @@
 				{{#unless collapsed}}
 					<div class="attachment-video">
 						<video controls class="inline-video">
-							<source src="{{fixCordova video_url}}" type="{{video_type}}">
+							<source src="{{fixCordova video_url}}" type="{{video_type}}" data-description="{{description}}">
 							Your browser does not support the video element.
 						</video>
 					</div>
@@ -126,6 +123,10 @@
 						{{/each}}
 					</div>
 				{{/unless}}
+			{{/if}}
+
+			{{#if description}}
+				<div class="attachment-description">{{description}}</div>
 			{{/if}}
 
 			{{#each attachments}}


### PR DESCRIPTION
Closes #6205
Currently rocket chat prompts you to set a description for a file but doesn’t show this description on the actual message. This makes so that if a attachment has a description, it will show on the message.
![screenshot from 2017-03-02 10-32-11](https://cloud.githubusercontent.com/assets/20868078/23509150/8e89f16c-ff33-11e6-9197-582ca75bc691.png)
@karlprieb what do you think?


