### PR TITLE
Allow login via OAuth access token. Only for Google now

### DIFF
--- a/packages/rocketchat-lib/package.js
+++ b/packages/rocketchat-lib/package.js
@@ -110,6 +110,9 @@ Package.onUse(function(api) {
 	api.addFiles('server/models/Uploads.coffee', 'server');
 	api.addFiles('server/models/Users.coffee', 'server');
 
+	api.addFiles('server/oauth/oauth.js', 'server');
+	api.addFiles('server/oauth/google.js', 'server');
+
 	api.addFiles('server/startup/statsTracker.js', 'server');
 
 	// CACHE

--- a/packages/rocketchat-lib/server/oauth/google.js
+++ b/packages/rocketchat-lib/server/oauth/google.js
@@ -1,0 +1,53 @@
+/* globals Google */
+
+function getIdentity(accessToken) {
+	console.log('accessToken', accessToken);
+	try {
+		return HTTP.get(
+			'https://www.googleapis.com/oauth2/v1/userinfo',
+			{params: {access_token: accessToken}}).data;
+	} catch (err) {
+		throw _.extend(new Error('Failed to fetch identity from Google. ' + err.message), {response: err.response});
+	}
+}
+
+function getScopes(accessToken) {
+	try {
+		return HTTP.get(
+			'https://www.googleapis.com/oauth2/v1/tokeninfo',
+			{params: {access_token: accessToken}}).data.scope.split(' ');
+	} catch (err) {
+		throw _.extend(new Error('Failed to fetch tokeninfo from Google. ' + err.message), {response: err.response});
+	}
+}
+
+
+RocketChat.registerAccessTokenService('google', function(options) {
+	const identity = options.identity || getIdentity(options.accessToken);
+
+	const serviceData = {
+		accessToken: options.accessToken,
+		idToken: options.idToken,
+		expiresAt: (+new Date) + (1000 * parseInt(options.expiresIn, 10)),
+		scope: options.scopes || getScopes(options.accessToken)
+	};
+
+	const fields = _.pick(identity, Google.whitelistedFields);
+	_.extend(serviceData, fields);
+
+	// only set the token in serviceData if it's there. this ensures
+	// that we don't lose old ones (since we only get this on the first
+	// log in attempt)
+	if (options.refreshToken) {
+		serviceData.refreshToken = options.refreshToken;
+	}
+
+	return {
+		serviceData: serviceData,
+		options: {
+			profile: {
+				name: identity.name
+			}
+		}
+	};
+});

--- a/packages/rocketchat-lib/server/oauth/google.js
+++ b/packages/rocketchat-lib/server/oauth/google.js
@@ -1,7 +1,6 @@
 /* globals Google */
 
 function getIdentity(accessToken) {
-	console.log('accessToken', accessToken);
 	try {
 		return HTTP.get(
 			'https://www.googleapis.com/oauth2/v1/userinfo',
@@ -23,6 +22,14 @@ function getScopes(accessToken) {
 
 
 RocketChat.registerAccessTokenService('google', function(options) {
+	check(options, {
+		accessToken: String,
+		idToken: String,
+		expiresAt: Match.Integer,
+		scope: Match.Maybe(String),
+		identity: Match.Maybe(Object)
+	});
+
 	const identity = options.identity || getIdentity(options.accessToken);
 
 	const serviceData = {

--- a/packages/rocketchat-lib/server/oauth/oauth.js
+++ b/packages/rocketchat-lib/server/oauth/oauth.js
@@ -1,0 +1,52 @@
+const AccessTokenServices = {};
+
+RocketChat.registerAccessTokenService = function(serviceName, handleAccessTokenRequest) {
+	AccessTokenServices[serviceName] = {
+		serviceName: serviceName,
+		handleAccessTokenRequest: handleAccessTokenRequest
+	};
+};
+
+// Listen to calls to `login` with an oauth option set. This is where
+// users actually get logged in to meteor via oauth.
+Accounts.registerLoginHandler(function(options) {
+	if (!options.accessToken) {
+		return undefined; // don't handle
+	}
+
+	check(options.oauth, {
+		serviceName: String
+	});
+
+	const service = AccessTokenServices[options.serviceName];
+
+	// Skip everything if there's no service set by the oauth middleware
+	if (!service) {
+		throw new Error(`Unexpected AccessToken service ${options.serviceName}`);
+	}
+
+	// Make sure we're configured
+	if (!ServiceConfiguration.configurations.findOne({service: service.serviceName})) {
+		throw new ServiceConfiguration.ConfigError();
+	}
+
+	if (!_.contains(Accounts.oauth.serviceNames(), service.serviceName)) {
+		// serviceName was not found in the registered services list.
+		// This could happen because the service never registered itself or
+		// unregisterService was called on it.
+		return {
+			type: 'oauth',
+			error: new Meteor.Error(
+				Accounts.LoginCancelledError.numericError,
+				`No registered oauth service found for: ${service.serviceName}`
+			)
+		};
+	}
+
+	const oauthResult = service.handleAccessTokenRequest(options);
+
+	return Accounts.updateOrCreateUserFromExternalService(service.serviceName, oauthResult.serviceData, oauthResult.options);
+});
+
+
+


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
### Javascript
```javascript
Accounts.callLoginMethod({
	methodArguments: [{
		serviceName: 'google',
		accessToken: 'xxx',
		refreshToken: 'xxx',
		idToken: 'xxx',
		expiresIn: 3557,
		scope: 'profile'
	}],
	userCallback: function() {
		console.log(arguments);
	}
});
```

### DDP
```JSON
{
	"msg": "method",
	"method": "login",
	"params": [{
		"serviceName": "google",
		"accessToken": "xxx",
		"refreshToken": "xxx",
		"idToken": "xxx",
		"expiresIn": 3557,
		"scope": "profile"
	}],
	"id": "25"
}
`