### PR TITLE
fix the problem where user can't see messages (old or new) after joining a channel with preview disabled

### DIFF
--- a/packages/rocketchat-ui-message/client/messageBox.coffee
+++ b/packages/rocketchat-ui-message/client/messageBox.coffee
@@ -121,7 +121,7 @@ Template.messageBox.events
 	'click .join': (event) ->
 		event.stopPropagation()
 		event.preventDefault()
-		Meteor.call 'joinRoom', @_id, Template.instance().$('[name=joinCode]').val(), (err) ->
+		Meteor.call 'joinRoom', @_id, Template.instance().$('[name=joinCode]').val(), (err) =>
 			if err?
 				toastr.error t(err.reason)
 


### PR DESCRIPTION
If the administrator turns off preview permission for users, when a user joins a channel, he can't see message history or new messages, until a reload of the page / application.
This is caused by a bug which prevents the handling of such situation from being executed.

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 