### PR TITLE
Fix firefox font smoothing to be consistent with chrome

### DIFF
--- a/packages/rocketchat-theme/client/imports/base.less
+++ b/packages/rocketchat-theme/client/imports/base.less
@@ -528,6 +528,7 @@ body {
 	height: 100%;
 	width: 100%;
 	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 	line-height: 1rem;
 	padding: 0;
 	overflow: visible;


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Firefox on macbook air 2015

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
## Chrome
![screen shot 2017-03-04 at 12 42 12 pm](https://cloud.githubusercontent.com/assets/920422/23580877/44c9b70a-00d8-11e7-956b-c2d5ca608e50.png)

## Firefox before
![screen shot 2017-03-04 at 12 45 33 pm](https://cloud.githubusercontent.com/assets/920422/23580895/7f27e62e-00d8-11e7-8e51-76dd31c8ca33.png)


## Firefox after
![screen shot 2017-03-04 at 12 43 21 pm](https://cloud.githubusercontent.com/assets/920422/23580880/4aab36bc-00d8-11e7-9047-1e6607febffc.png)

