### PR TITLE
focus first textbox element

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -143,6 +143,8 @@
 		"Triggers"                    : false,
 		"UAParser"                    : false,
 		"visitor"                     : false,
-		"WebApp"                      : false
+		"WebApp"                      : false,
+		"VideoRecorder"               : false,
+		"VRecDialog"                  : false
 	}
 }

--- a/packages/rocketchat-ui/client/lib/esc.js
+++ b/packages/rocketchat-ui/client/lib/esc.js
@@ -1,0 +1,58 @@
+const escapify = {
+	init() {
+		const that = this;
+		document.addEventListener('keyup', (event) => {
+			const keyName = event.key;
+			if (keyName === 'Escape') {
+				that.sideNavIcon();
+				that.flextTabButton();
+				that.videoDialog();
+				that.sweetAlerts();
+			}
+		}, false);
+	},
+
+	getClickEvent() {
+		return new MouseEvent('click', {
+			bubbles: true,
+			cancelable: true,
+			view: window
+		});
+	},
+
+	flextTabButton() {
+		const flextTabButton = document.querySelector('.flex-tab-bar .tab-button.active');
+		if (flextTabButton) {
+			flextTabButton.dispatchEvent(this.getClickEvent());
+			return;
+		}
+	},
+
+	sideNavIcon() {
+		const sideNavArrow = document.querySelector('.side-nav .arrow');
+		if (sideNavArrow && (sideNavArrow.classList.contains('top') || sideNavArrow.classList.contains('close'))) {
+			SideNav.toggleCurrent();
+			return;
+		}
+	},
+
+	videoDialog() {
+		const vrecDialog = document.querySelector('.vrec-dialog');
+		if (vrecDialog && Number(window.getComputedStyle(vrecDialog).opacity) === 1) {
+			VideoRecorder.stop();
+			VRecDialog.close();
+			return;
+		}
+	},
+
+	sweetAlerts() {
+		const sweetAlert = document.querySelector('.sweet-alert');
+		if (sweetAlert) {
+			document.querySelector('.sweet-alert .sa-button-container .cancel').dispatchEvent(this.getClickEvent());
+			return;
+		}
+	}
+};
+
+this.escapify = escapify;
+this.escapify.init();

--- a/packages/rocketchat-ui/client/lib/sideNav.coffee
+++ b/packages/rocketchat-ui/client/lib/sideNav.coffee
@@ -41,8 +41,8 @@
 		highestZidx = 0
 		highestZidxElem = undefined
 		_.each sideNavDivs, (ele) ->
-			zIndex = window.getComputedStyle(ele).zIndex
-			if Number(zIndex).toString() != 'NaN' and Number(zIndex) > highestZidx
+			zIndex = Number(window.getComputedStyle(ele).zIndex)
+			if Number(zIndex) > highestZidx
 				highestZidx = Number(zIndex)
 				highestZidxElem = ele
 			return

--- a/packages/rocketchat-ui/client/lib/sideNav.coffee
+++ b/packages/rocketchat-ui/client/lib/sideNav.coffee
@@ -36,8 +36,18 @@
 			sideNav.find("header").removeClass "hover"
 
 	focusInput = ->
+		sideNavDivs = _.filter document.querySelectorAll('aside.side-nav')[0].children, (ele) ->
+			ele.tagName == 'DIV' and !ele.classList.contains('hidden')
+		highestZidx = 0
+		highestZidxElem = undefined
+		_.each sideNavDivs, (ele) ->
+			zIndex = window.getComputedStyle(ele).zIndex
+			if Number(zIndex).toString() != 'NaN' and Number(zIndex) > highestZidx
+				highestZidx = Number(zIndex)
+				highestZidxElem = ele
+			return
 		setTimeout ->
-			sideNav.find("input[type='text']:first")?.focus()
+			highestZidxElem.querySelector('input')?.focus()
 		, 200
 		return
 

--- a/packages/rocketchat-ui/package.js
+++ b/packages/rocketchat-ui/package.js
@@ -71,6 +71,7 @@ Package.onUse(function(api) {
 
 	// TEXTAREA CURSOR MANAGEMENT
 	api.addFiles('client/lib/textarea-cursor/set-cursor-position.js', 'client');
+	api.addFiles('client/lib/esc.js', 'client');
 
 	// TEMPLATE FILES
 	api.addFiles('client/views/cmsPage.html', 'client');


### PR DESCRIPTION
@RocketChat/core 

While creating new channels by clicking + icon, first textbox input element of a rendered form gets focus.

Closes #6247
Closes #6248 

![focustextbox](https://cloud.githubusercontent.com/assets/330362/23590357/5c577f36-0206-11e7-84ed-92c8dda067f6.gif)

![escape](https://cloud.githubusercontent.com/assets/330362/23629348/9779810c-02df-11e7-8200-251c31bac2b4.gif)
