### PR TITLE
Simple ignores the custom audio from being added

### DIFF
--- a/packages/rocketchat-custom-sounds/client/lib/CustomSounds.js
+++ b/packages/rocketchat-custom-sounds/client/lib/CustomSounds.js
@@ -10,6 +10,10 @@ class CustomSounds {
 	}
 
 	add(sound) {
+		if (Meteor.isCordova) {
+			return;
+		}
+
 		if (!sound.src) {
 			sound.src = this.getURL(sound);
 		}


### PR DESCRIPTION
@RocketChat/core 

Closes #6112 

On Wi-Fi, the chromium browser tries to load the metadata from the mp3 files present on `audio` tags (even without preload).

This `fix` is just a temporary fix until someone with more Cordova experience may do a real fix.
