### PR TITLE
Fix for keeping a room hidden after activity

### DIFF
--- a/packages/rocketchat-lib/server/lib/notifyUsersOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/notifyUsersOnMessage.js
@@ -81,6 +81,7 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 
 	// Update all other subscriptions to alert their owners but witout incrementing
 	// the unread counter, as it is only for mentions and direct messages
+	// If a room is hidden, it will remain hidden
 	RocketChat.models.Subscriptions.setAlertForRoomIdExcludingUserId(message.rid, message.u._id);
 
 	return message;

--- a/packages/rocketchat-lib/server/models/Subscriptions.coffee
+++ b/packages/rocketchat-lib/server/models/Subscriptions.coffee
@@ -312,7 +312,6 @@ class ModelSubscriptions extends RocketChat.models._Base
 		update =
 			$set:
 				alert: true
-				open: true
 
 		return @update query, update, { multi: true }
 


### PR DESCRIPTION
@RocketChat/core 

Currently you can mark a room as hidden and it will be removed from your channel list, even after a browser refresh.  BUT, if any activity occurs in this hidden channel, it no longer remains hidden.

This fix keeps the channel hidden w/ normal channel activity.  Other things (notification settings) will make the room visible (mentions, etc.) but that is a different concern.
