### PR TITLE
#6273 Fix http missing from links when starting blockquotes

### DIFF
--- a/packages/rocketchat-markdown/markdowncode.coffee
+++ b/packages/rocketchat-markdown/markdowncode.coffee
@@ -46,7 +46,7 @@ class MarkdownCode
 
 			for part, index in msgParts
 				# Verify if this part is code
-				codeMatch = part.match(/^```(\w*[\n\ ]?)([\s\S]*?)```+?$/)
+				codeMatch = part.match(/^```(.*[\n\ ]?)([\s\S]*?)```+?$/)
 
 				if codeMatch?
 					# Process highlight if this part is code


### PR DESCRIPTION
@RocketChat/core 

Closes #6273
Bug: 
![image](https://cloud.githubusercontent.com/assets/6303966/23775300/c76262ca-0506-11e7-8fca-8f6279c7d16b.png)

Problem found: The start of URLs was getting removed from the start of blockquotes. This was caused by the regex parsing `http://url.com` in the same way the single word `http` was, which is unintended as far as I understood.
The feature of highlighting code snippets in blockquotes is still available, and if the user enters the single word http in the first line, it still identifies as a http code block.

The fix changed the `\w` which would parse words (and stop when reaching `:`) to `.` which parses every character (with the following rule for spaces and end of line to determine spaces), this will cause the regex to understand `http` and `perl` as languages but not `http://url.com` nor `perl?`.

Trying to reproduce the bug after the fix:
![image](https://cloud.githubusercontent.com/assets/6303966/23775228/66c28526-0506-11e7-85ea-58e8ecc656dd.png)
![image](https://cloud.githubusercontent.com/assets/6303966/23775233/6c2f0b06-0506-11e7-8844-bb9d58e4d966.png)
