### PR TITLE
update stylelint

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -78,11 +78,8 @@
 		"number-no-trailing-zeros": true,
 		"property-case": "lower",
 		"property-no-unknown": true,
-		"rule-nested-empty-line-before": [ "always", {
+		"rule-empty-line-before": [ "always", {
 			except: ["first-nested"],
-			ignore: ["after-comment"],
-		} ],
-		"rule-non-nested-empty-line-before": [ "always", {
 			ignore: ["after-comment"],
 		} ],
 		"selector-attribute-brackets-space-inside": "never",


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
`rule-nested-empty-line-before` and `rule-non-nested-empty-line-before` are deprecated

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
