### PR TITLE
Make deactivated users look different in admin user list

### DIFF
--- a/packages/rocketchat-theme/client/imports/base.less
+++ b/packages/rocketchat-theme/client/imports/base.less
@@ -4922,7 +4922,7 @@ a + br.only-after-a {
 
 .user-info.deactivated {
 	text-decoration: line-through;
-	color: gray;
+	opacity: 0.8;
 }
 
 // MEDIA QUERIES

--- a/packages/rocketchat-theme/client/imports/base.less
+++ b/packages/rocketchat-theme/client/imports/base.less
@@ -4920,6 +4920,11 @@ a + br.only-after-a {
 	}
 }
 
+.user-info.deactivated {
+	text-decoration: line-through;
+	color: gray;
+}
+
 // MEDIA QUERIES
 
 @media all and(max-width: 1100px) {

--- a/packages/rocketchat-ui-admin/client/users/adminUsers.html
+++ b/packages/rocketchat-ui-admin/client/users/adminUsers.html
@@ -33,7 +33,7 @@
 							</thead>
 							<tbody>
 								{{#each users}}
-								<tr class="user-info row-link">
+								<tr class="user-info row-link {{#if not active}}deactivated{{/if}}">
 									<td class="border-component-color">
 										<div class="user-image status-{{status}}">
 											{{> avatar username=username}}


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

Administrators can't tell which users are deactivated without going through each user. This PR made a small change to make the deactivated users look different (see screenshot below)

![image](https://cloud.githubusercontent.com/assets/7694895/23963542/9126abfe-09ec-11e7-8776-88050a4710de.png)
