### PR TITLE
embed from youtu.be fixed

### DIFF
--- a/packages/rocketchat-oembed/server/providers.coffee
+++ b/packages/rocketchat-oembed/server/providers.coffee
@@ -58,6 +58,7 @@ RocketChat.callbacks.add 'oembed:beforeGetUrlContent', (data) ->
 			data.urlObj.pathname = consumerUrl.pathname
 			data.urlObj.query = consumerUrl.query
 			delete data.urlObj.search
+			delete data.urlObj.host
 
 	return data
 , RocketChat.callbacks.priority.MEDIUM, 'oembed-providers-before'


### PR DESCRIPTION
@RocketChat/core 

Closes #5861

The attribute ```host``` excludes another params (hostname, port, etc....)

Should shorter links like "https://goo.gl/UOAt0Q" be resolved? I think that would be nice.
