### PR TITLE
Add startup event for iframe integrations

### DIFF
--- a/packages/rocketchat-ui-master/client/main.coffee
+++ b/packages/rocketchat-ui-master/client/main.coffee
@@ -229,7 +229,6 @@ Template.main.onRendered ->
 				$('.input-message').focus()
 		, 100
 
-
 	Tracker.autorun ->
 		swal.setDefaults({cancelButtonText: t('Cancel')})
 
@@ -249,3 +248,6 @@ Template.main.onRendered ->
 		else
 			$(document.body).off('mouseenter', 'button.thumb')
 			$(document.body).off('mouseleave', 'button.thumb')
+
+Meteor.startup ->
+	fireGlobalEvent 'startup', true


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

With this event, people who are using Rocket.Chat as an iframe will be able to know when starting sending commands.
