### PR TITLE
Just admins can change a Default Channel to Private (the channel will be a non default channel)

### DIFF
--- a/packages/rocketchat-channel-settings-mail-messages/client/lib/startup.coffee
+++ b/packages/rocketchat-channel-settings-mail-messages/client/lib/startup.coffee
@@ -1,5 +1,6 @@
 Meteor.startup ->
 	RocketChat.ChannelSettings.addOption
+		group: ['room']
 		id: 'mail-messages'
 		template: 'channelSettingsMailMessages'
 		validation: ->

--- a/packages/rocketchat-channel-settings/client/lib/ChannelSettings.coffee
+++ b/packages/rocketchat-channel-settings/client/lib/ChannelSettings.coffee
@@ -17,13 +17,14 @@ RocketChat.ChannelSettings = new class
 			opts[config.id] = config
 			options.set opts
 
-	getOptions = (currentData) ->
+	getOptions = (currentData, group) ->
 		allOptions = _.toArray options.get()
 		allowedOptions = _.compact _.map allOptions, (option) ->
 			if not option.validation? or option.validation()
 				option.data = Object.assign (option.data or {}), currentData
 				return option
-
+		allowedOptions = allowedOptions.filter (option) ->
+			!group or !option.group or option.group?.indexOf(group) > -1
 		return _.sortBy allowedOptions, 'order'
 
 	addOption: addOption

--- a/packages/rocketchat-channel-settings/client/views/channelSettings.html
+++ b/packages/rocketchat-channel-settings/client/views/channelSettings.html
@@ -75,6 +75,17 @@
 											{{/unless}}
 										</div>
 									</li>
+									{{# if has $value 'message' }}
+										{{#let message=($value.message room)}}
+											{{#if message}}
+												<li>
+													<div class="alert alert-warning pending-background pending-border">
+														{{_ message}}
+													</div>
+												</li>
+											{{/if}}
+										{{/let}}
+									{{/if}}
 								{{/let}}
 							{{/if}}
 						{{/each}}

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -1235,6 +1235,8 @@
   "Room_has_been_deleted": "Room has been deleted",
   "Room_has_been_archived": "Room has been archived",
   "Room_has_been_unarchived": "Room has been unarchived",
+  "Room_type_of_default_rooms_cant_be_changed": "This is a default room and the type can not be changed, please consult with your administrator.",
+  "Room_default_change_to_private_will_be_default_no_more": "This is a default channel and changing it to a private group will cause it to no longer be a default channel. Do you want to proceed?",
   "Room_Info": "Room Info",
   "room_is_blocked": "This room is blocked",
   "room_is_read_only": "This room is read only",

--- a/packages/rocketchat-lib/server/models/Rooms.coffee
+++ b/packages/rocketchat-lib/server/models/Rooms.coffee
@@ -482,10 +482,11 @@ class ModelRooms extends RocketChat.models._Base
 	setTypeById: (_id, type) ->
 		query =
 			_id: _id
-
 		update =
 			$set:
 				t: type
+		if type == 'p'
+			update.$unset = {default: ''}
 
 		return @update query, update
 

--- a/packages/rocketchat-ui-admin/client/rooms/adminRoomInfo.coffee
+++ b/packages/rocketchat-ui-admin/client/rooms/adminRoomInfo.coffee
@@ -11,7 +11,7 @@ Template.adminRoomInfo.helpers
 	roomType: ->
 		return AdminChatRoom.findOne(@rid, { fields: { t: 1 }})?.t
 	channelSettings: ->
-		return RocketChat.ChannelSettings.getOptions()
+		return RocketChat.ChannelSettings.getOptions(null, 'admin-room')
 	roomTypeDescription: ->
 		roomType = AdminChatRoom.findOne(@rid, { fields: { t: 1 }})?.t
 		if roomType is 'c'
@@ -138,12 +138,27 @@ Template.adminRoomInfo.onCreated ->
 						toastr.success TAPi18n.__ 'Room_topic_changed_successfully'
 						RocketChat.callbacks.run 'roomTopicChanged', AdminChatRoom.findOne(rid)
 			when 'roomType'
+				val = @$('input[name=roomType]:checked').val()
 				if @validateRoomType(rid)
 					RocketChat.callbacks.run 'roomTypeChanged', AdminChatRoom.findOne(rid)
-					Meteor.call 'saveRoomSettings', rid, 'roomType', @$('input[name=roomType]:checked').val(), (err, result) ->
-						if err
-							return handleError(err)
-						toastr.success TAPi18n.__ 'Room_type_changed_successfully'
+					saveRoomSettings = =>
+						Meteor.call 'saveRoomSettings', rid, 'roomType', val, (err, result) ->
+							if err
+								return handleError(err)
+								toastr.success TAPi18n.__ 'Room_type_changed_successfully'
+					unless AdminChatRoom.findOne(rid, { fields: { default: 1 }}).default
+						return saveRoomSettings()
+					swal
+						title: t('Room_default_change_to_private_will_be_default_no_more')
+						type: 'warning'
+						showCancelButton: true
+						confirmButtonColor: '#DD6B55'
+						confirmButtonText: t('Yes')
+						cancelButtonText: t('Cancel')
+						closeOnConfirm: true
+						html: false
+						(confirmed) =>
+							return !confirmed || saveRoomSettings()
 			when 'archivationState'
 				if @$('input[name=archivationState]:checked').val() is 'true'
 					if AdminChatRoom.findOne(rid)?.archived isnt true

--- a/packages/rocketchat-ui-admin/client/rooms/adminRooms.coffee
+++ b/packages/rocketchat-ui-admin/client/rooms/adminRooms.coffee
@@ -53,6 +53,7 @@ Template.adminRooms.onCreated ->
 	});
 
 	RocketChat.ChannelSettings.addOption
+		group: ['admin-room']
 		id: 'make-default'
 		template: 'channelSettingsDefault'
 		data: ->

--- a/packages/rocketchat-ui-admin/client/rooms/channelSettingsDefault.js
+++ b/packages/rocketchat-ui-admin/client/rooms/channelSettingsDefault.js
@@ -1,23 +1,23 @@
 import toastr from 'toastr';
-/* globals ChatRoom */
+/* globals AdminChatRoom */
 
 Template.channelSettingsDefault.helpers({
 	canMakeDefault() {
-		var room = ChatRoom.findOne(this.rid, { fields: { t: 1 }});
+		var room = AdminChatRoom.findOne(this.rid, { fields: { t: 1 }});
 		return room && room.t === 'c';
 	},
 	editing(field) {
 		return Template.instance().editing.get() === field;
 	},
 	roomDefault() {
-		var room = ChatRoom.findOne(this.rid, { fields: { default: 1 }});
+		var room = AdminChatRoom.findOne(this.rid, { fields: { default: 1 }});
 
 		if (room) {
 			return room.default;
 		}
 	},
 	defaultDescription() {
-		var room = ChatRoom.findOne(this.rid, { fields: { default: 1 }});
+		var room = AdminChatRoom.findOne(this.rid, { fields: { default: 1 }});
 		if (room && room.default) {
 			return t('True');
 		} else {


### PR DESCRIPTION
@RocketChat/core 

closes #6403 

For default channels,

- If you are an admin you can change the type, but you need confirm that you will lost the "default"
- If you are the owner a message appears asking you to talk if your admin


I changed this methods to
```RocketChat.ChannelSettings.addOption```
```RocketChat.ChannelSettings.getOptions ```
now you can pass a filter, if you dont will return all options.