### PR TITLE
fix channel merge option of user preferences

### DIFF
--- a/packages/rocketchat-ui-sidenav/client/sideNav.js
+++ b/packages/rocketchat-ui-sidenav/client/sideNav.js
@@ -26,7 +26,7 @@ Template.sideNav.helpers({
 
 	canShowRoomType() {
 		let userPref = undefined;
-		if (Meteor.user() && Meteor.user().settings && Meteor.user().settings.preferences && Meteor.user().settings.preferences.mergeChannels) {
+		if (Meteor.user() && Meteor.user().settings && Meteor.user().settings.preferences) {
 			userPref = Meteor.user().settings.preferences.mergeChannels;
 		}
 		const globalPref = RocketChat.settings.get('UI_Merge_Channels_Groups');
@@ -40,7 +40,7 @@ Template.sideNav.helpers({
 
 	templateName() {
 		let userPref = undefined;
-		if (Meteor.user() && Meteor.user().settings && Meteor.user().settings.preferences && Meteor.user().settings.preferences.mergeChannels) {
+		if (Meteor.user() && Meteor.user().settings && Meteor.user().settings.preferences) {
 			userPref = Meteor.user().settings.preferences.mergeChannels;
 		}
 		const globalPref = RocketChat.settings.get('UI_Merge_Channels_Groups');


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
This fixes the problem where user's option of choosing not combining room list doesn't work. I believe it is caused by the conversion from CoffeeScript to JavaScript.