### PR TITLE
[FIX] UTC offset missing UTC text when positive

### DIFF
--- a/packages/rocketchat-ui-flextab/client/tabs/membersList.js
+++ b/packages/rocketchat-ui-flextab/client/tabs/membersList.js
@@ -38,7 +38,7 @@ Template.membersList.helpers({
 					if (utcOffset === userUtcOffset) {
 						utcOffset = '';
 					} else if (utcOffset > 0) {
-						utcOffset = `+${ utcOffset }`;
+						utcOffset = `(UTC +${ utcOffset })`;
 					} else {
 						utcOffset = `(UTC ${ utcOffset })`;
 					}


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

UTC offset in members list displays `+1` for UTC offset instead of displaying `(UTC +1)`
