### PR TITLE
[NEW] Add customFields in rooms/get method

### DIFF
--- a/server/publications/room.js
+++ b/server/publications/room.js
@@ -13,6 +13,7 @@ const options = {
 		jitsiTimeout: 1,
 		description: 1,
 		default: 1,
+		customFields: 1,
 
 		// @TODO create an API to register this fields based on room type
 		livechatData: 1,


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 
In 'userData' it is available now to see customFields, if this value exists, but in 'rooms/get' is not. I think, that it will be helpful.