### PR TITLE
[FIX] Usage of subtagged languages

### DIFF
--- a/client/startup/startup.js
+++ b/client/startup/startup.js
@@ -44,6 +44,7 @@ Meteor.startup(function() {
 		return RocketChat.settings.get('Language') || defaultAppLanguage();
 	};
 
+	const availableLanguages = TAPi18n.getLanguages();
 	const loadedLanguages = [];
 
 	window.setLanguage = function(language) {
@@ -63,7 +64,10 @@ Meteor.startup(function() {
 			$('html').removeClass('rtl');
 		}
 
-		language = language.split('-').shift();
+		if (!availableLanguages[language]) {
+			language = language.split('-').shift();
+		}
+
 		TAPi18n.setLanguage(language);
 
 		language = language.toLowerCase();

--- a/packages/rocketchat-livechat/app/client/views/livechatWindow.js
+++ b/packages/rocketchat-livechat/app/client/views/livechatWindow.js
@@ -70,6 +70,8 @@ Template.livechatWindow.events({
 Template.livechatWindow.onCreated(function() {
 	Session.set({sound: true});
 
+	const availableLanguages = TAPi18n.getLanguages();
+
 	const defaultAppLanguage = () => {
 		let lng = window.navigator.userLanguage || window.navigator.language || 'en';
 		const regexp = /([a-z]{2}-)([a-z]{2})/;
@@ -118,7 +120,13 @@ Template.livechatWindow.onCreated(function() {
 				Livechat.agent = result.agentData;
 			}
 
-			TAPi18n.setLanguage((result.language || defaultAppLanguage()).split('-').shift());
+			let language = result.language || defaultAppLanguage();
+
+			if (!availableLanguages[language]) {
+				language = language.split('-').shift();
+			}
+
+			TAPi18n.setLanguage(language);
 
 			Triggers.setTriggers(result.triggers);
 			Triggers.init();


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #4277

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
This PR allow the usage of languages subtags (like `pt-BR`, `zh-TW` and so on) instead of just using the region definition (like `pt` or `zh`).

I'm now checking if the subtag exists before discarding it's usage.