### PR TITLE
Move room display name logic to roomType definition

### DIFF
--- a/packages/rocketchat-lib/client/lib/roomTypes.coffee
+++ b/packages/rocketchat-lib/client/lib/roomTypes.coffee
@@ -16,6 +16,9 @@ RocketChat.roomTypes = new class roomTypesClient extends roomTypesCommon
 	getRoomName: (roomType, roomData) ->
 		return @roomTypes[roomType]?.roomName roomData
 
+	getSecondaryRoomName: (roomType, roomData) ->
+		return @roomTypes[roomType]?.secondaryRoomName?(roomData)
+
 	getIdentifiers: (except) ->
 		except = [].concat except
 		list = _.reject @roomTypesOrder, (t) -> return except.indexOf(t.identifier) isnt -1

--- a/packages/rocketchat-lib/startup/defaultRoomTypes.js
+++ b/packages/rocketchat-lib/startup/defaultRoomTypes.js
@@ -1,5 +1,13 @@
 /* globals openRoom */
 
+function getRoomName(room) {
+	if (RocketChat.settings.get('UI_Use_Real_Name') && room.fname) {
+		return room.fname;
+	}
+
+	return room.name;
+}
+
 RocketChat.roomTypes.add(null, 0, {
 	template: 'starredRooms',
 	icon: 'icon-star'
@@ -24,9 +32,7 @@ RocketChat.roomTypes.add('c', 10, {
 		return ChatRoom.findOne(query);
 	},
 
-	roomName(roomData) {
-		return { name: roomData.name };
-	},
+	roomName: getRoomName,
 
 	condition() {
 		return RocketChat.authz.hasAtLeastOnePermission(['view-c-room', 'view-joined-room']);
@@ -64,7 +70,7 @@ RocketChat.roomTypes.add('d', 20, {
 	},
 
 	roomName(roomData) {
-		return ChatSubscription.findOne({ rid: roomData._id }, { fields: { name: 1, fname: 1 } });
+		return getRoomName(ChatSubscription.findOne({ rid: roomData._id }, { fields: { name: 1, fname: 1 } }));
 	},
 
 	condition() {
@@ -98,9 +104,7 @@ RocketChat.roomTypes.add('p', 30, {
 		return ChatRoom.findOne(query);
 	},
 
-	roomName(roomData) {
-		return { name: roomData.name };
-	},
+	roomName: getRoomName,
 
 	condition() {
 		return RocketChat.authz.hasAllPermission('view-p-room');

--- a/packages/rocketchat-lib/startup/defaultRoomTypes.js
+++ b/packages/rocketchat-lib/startup/defaultRoomTypes.js
@@ -1,13 +1,4 @@
 /* globals openRoom */
-
-function getRoomName(room) {
-	if (RocketChat.settings.get('UI_Use_Real_Name') && room.fname) {
-		return room.fname;
-	}
-
-	return room.name;
-}
-
 RocketChat.roomTypes.add(null, 0, {
 	template: 'starredRooms',
 	icon: 'icon-star'
@@ -32,7 +23,9 @@ RocketChat.roomTypes.add('c', 10, {
 		return ChatRoom.findOne(query);
 	},
 
-	roomName: getRoomName,
+	roomName(roomData) {
+		return roomData.name;
+	},
 
 	condition() {
 		return RocketChat.authz.hasAtLeastOnePermission(['view-c-room', 'view-joined-room']);
@@ -70,7 +63,22 @@ RocketChat.roomTypes.add('d', 20, {
 	},
 
 	roomName(roomData) {
-		return getRoomName(ChatSubscription.findOne({ rid: roomData._id }, { fields: { name: 1, fname: 1 } }));
+		const subscription = ChatSubscription.findOne({ rid: roomData._id }, { fields: { name: 1, fname: 1 } });
+		if (!subscription) {
+			return '';
+		}
+		if (RocketChat.settings.get('UI_Use_Real_Name') && subscription.fname) {
+			return subscription.fname;
+		}
+
+		return subscription.name;
+	},
+
+	secondaryRoomName(roomData) {
+		if (RocketChat.settings.get('UI_Use_Real_Name')) {
+			const subscription = ChatSubscription.findOne({ rid: roomData._id }, { fields: { name: 1 } });
+			return subscription && subscription.name;
+		}
 	},
 
 	condition() {
@@ -104,7 +112,9 @@ RocketChat.roomTypes.add('p', 30, {
 		return ChatRoom.findOne(query);
 	},
 
-	roomName: getRoomName,
+	roomName(roomData) {
+		return roomData.name;
+	},
 
 	condition() {
 		return RocketChat.authz.hasAllPermission('view-p-room');

--- a/packages/rocketchat-ui/client/views/app/room.coffee
+++ b/packages/rocketchat-ui/client/views/app/room.coffee
@@ -83,13 +83,13 @@ Template.room.helpers
 		roomData = Session.get('roomData' + this._id)
 		return '' unless roomData
 
-		return RocketChat.roomTypes.getRoomName roomData?.t, roomData
+		return RocketChat.roomTypes.getRoomName roomData.t, roomData
 
 	secondaryName: ->
 		roomData = Session.get('roomData' + this._id)
-		return '' unless roomData and RocketChat.settings.get('UI_Use_Real_Name') and roomData.t is 'd'
+		return '' unless roomData
 
-		return RocketChat.roomTypes.getRoomName(roomData.t, roomData).name
+		return RocketChat.roomTypes.getSecondaryRoomName roomData.t, roomData
 
 	roomTopic: ->
 		roomData = Session.get('roomData' + this._id)

--- a/packages/rocketchat-ui/client/views/app/room.coffee
+++ b/packages/rocketchat-ui/client/views/app/room.coffee
@@ -83,9 +83,7 @@ Template.room.helpers
 		roomData = Session.get('roomData' + this._id)
 		return '' unless roomData
 
-		room = RocketChat.roomTypes.getRoomName roomData?.t, roomData
-		return room.fname if RocketChat.settings.get('UI_Use_Real_Name') and room.fname
-		return room.name
+		return RocketChat.roomTypes.getRoomName roomData?.t, roomData
 
 	secondaryName: ->
 		roomData = Session.get('roomData' + this._id)


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

The new logic introduced by #3851 broke livechat room titles, so I moved the logic to the specific roomType definition.
