### PR TITLE
[FIX] Do not add default roles for users without services field

### DIFF
--- a/server/lib/accounts.js
+++ b/server/lib/accounts.js
@@ -103,7 +103,7 @@ Accounts.insertUserDoc = _.wrap(Accounts.insertUserDoc, function(insertUserDoc, 
 
 	delete user.globalRoles;
 
-	if (!user.services || !user.services.password) {
+	if (user.services && !user.services.password) {
 		const defaultAuthServiceRoles = String(RocketChat.settings.get('Accounts_Registration_AuthenticationServices_Default_Roles')).split(',');
 		if (defaultAuthServiceRoles.length > 0) {
 			roles = roles.concat(defaultAuthServiceRoles.map(s => s.trim()));


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #1848

The addition of default roles by #6028 also added default roles to livechat guests. Since the idea of default roles was to add them only for OAuth created users, I'm now checking if the `services` field exists and the `services.password` does not. This seems to be a better way to know if a user was created by an OAuth or not.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
