### PR TITLE
[FIX] emoji picker exception

### DIFF
--- a/packages/rocketchat-emoji-custom/client/lib/emojiCustom.js
+++ b/packages/rocketchat-emoji-custom/client/lib/emojiCustom.js
@@ -49,15 +49,6 @@ getEmojiUrlFromName = function(name, extension) {
 
 Blaze.registerHelper('emojiUrlFromName', getEmojiUrlFromName);
 
-function updateEmojiPickerList() {
-	let html = '';
-	for (const entry of RocketChat.emoji.packages.emojiCustom.emojisByCategory.rocket) {
-		const renderedEmoji = RocketChat.emoji.packages.emojiCustom.render(`:${ entry }:`);
-		html += `<li class="emoji-${ entry }" data-emoji="${ entry }">${ renderedEmoji }</li>`;
-	}
-	$('.rocket.emoji-list').empty().append(html);
-}
-
 deleteEmojiCustom = function(emojiData) {
 	delete RocketChat.emoji.list[`:${ emojiData.name }:`];
 	const arrayIndex = RocketChat.emoji.packages.emojiCustom.emojisByCategory.rocket.indexOf(emojiData.name);
@@ -77,7 +68,7 @@ deleteEmojiCustom = function(emojiData) {
 			}
 		}
 	}
-	updateEmojiPickerList();
+	RocketChat.EmojiPicker.updateRecent();
 };
 
 updateEmojiCustom = function(emojiData) {
@@ -153,7 +144,7 @@ updateEmojiCustom = function(emojiData) {
 		}
 	}
 
-	updateEmojiPickerList();
+	RocketChat.EmojiPicker.updateRecent();
 };
 
 Meteor.startup(() =>

--- a/packages/rocketchat-emoji-custom/client/lib/emojiCustom.js
+++ b/packages/rocketchat-emoji-custom/client/lib/emojiCustom.js
@@ -56,7 +56,6 @@ function updateEmojiPickerList() {
 		html += `<li class="emoji-${ entry }" data-emoji="${ entry }">${ renderedEmoji }</li>`;
 	}
 	$('.rocket.emoji-list').empty().append(html);
-	RocketChat.EmojiPicker.updateRecent();
 }
 
 deleteEmojiCustom = function(emojiData) {

--- a/packages/rocketchat-emoji/emojiPicker.js
+++ b/packages/rocketchat-emoji/emojiPicker.js
@@ -24,7 +24,7 @@ function getEmojisByCategory(category) {
 	const t = Template.instance();
 	const actualTone = t.tone;
 	let html = '';
-	for (const emojiPackage in RocketChat.emoji.packages) {
+	for (let emojiPackage in RocketChat.emoji.packages) {
 		if (RocketChat.emoji.packages.hasOwnProperty(emojiPackage)) {
 			if (RocketChat.emoji.packages[emojiPackage].emojisByCategory.hasOwnProperty(category)) {
 				const total = RocketChat.emoji.packages[emojiPackage].emojisByCategory[category].length;
@@ -133,7 +133,9 @@ Template.emojiPicker.helpers({
 		}
 
 		if (searchTerm.length > 0) {
-			return getEmojisBySearchTerm(searchTerm);
+			if (t.currentCategory.get() === category) {
+				return getEmojisBySearchTerm(searchTerm);
+			}
 		} else {
 			return getEmojisByCategory(category);
 		}
@@ -266,6 +268,7 @@ Template.emojiPicker.onCreated(function() {
 
 	this.currentCategory = new ReactiveVar(recent.length > 0 ? 'recent' : 'people');
 	this.currentSearchTerm = new ReactiveVar('');
+	this.currentResults = new ReactiveVar('');
 
 	recent.forEach((emoji) => {
 		RocketChat.emoji.packages.base.emojisByCategory.recent.push(emoji);

--- a/packages/rocketchat-emoji/emojiPicker.js
+++ b/packages/rocketchat-emoji/emojiPicker.js
@@ -127,7 +127,7 @@ Template.emojiPicker.helpers({
 		const searchTerm = t.currentSearchTerm.get();
 		const activeCategory = t.currentCategory.get();
 		//this will cause the reflow when recent list gets updated
-		const recentNeedsUpdate = t.recentNeedsUpdate.get();
+		t.recentNeedsUpdate.get();
 
 		//we only need to replace the active category, since switching tabs resets the filter
 		if (activeCategory !== category) {

--- a/packages/rocketchat-emoji/emojiPicker.js
+++ b/packages/rocketchat-emoji/emojiPicker.js
@@ -6,7 +6,7 @@ const emojiCategories = {};
  * @return {string} readable and translated
  */
 function categoryName(category) {
-	for (const emojiPackage in RocketChat.emoji.packages) {
+	for (let emojiPackage in RocketChat.emoji.packages) {
 		if (RocketChat.emoji.packages.hasOwnProperty(emojiPackage)) {
 			if (RocketChat.emoji.packages[emojiPackage].emojiCategories.hasOwnProperty(category)) {
 				return RocketChat.emoji.packages[emojiPackage].emojiCategories[category];
@@ -39,7 +39,6 @@ function getEmojisByCategory(category) {
 					//set correctPackage here to allow for recent emojis to work properly
 					if (isSetNotNull(() => RocketChat.emoji.list[`:${ emoji }:`].emojiPackage)) {
 						const correctPackage = RocketChat.emoji.list[`:${ emoji }:`].emojiPackage;
-
 						const image = RocketChat.emoji.packages[correctPackage].render(`:${ emoji }${ tone }:`);
 
 						html += `<li class="emoji-${ emoji }" data-emoji="${ emoji }" title="${ emoji }">${ image }</li>`;
@@ -75,7 +74,7 @@ function getEmojisBySearchTerm(searchTerm) {
 
 			let emojiFound = false;
 
-			for (const key in RocketChat.emoji.packages[emojiPackage].emojisByCategory) {
+			for (let key in RocketChat.emoji.packages[emojiPackage].emojisByCategory) {
 				if (RocketChat.emoji.packages[emojiPackage].emojisByCategory.hasOwnProperty(key)) {
 					const contents = RocketChat.emoji.packages[emojiPackage].emojisByCategory[key];
 					if (contents.indexOf(emoji) !== -1) {
@@ -98,9 +97,9 @@ function getEmojisBySearchTerm(searchTerm) {
 Template.emojiPicker.helpers({
 	category() {
 		const categories = [];
-		for (const emojiPackage in RocketChat.emoji.packages) {
+		for (let emojiPackage in RocketChat.emoji.packages) {
 			if (RocketChat.emoji.packages.hasOwnProperty(emojiPackage)) {
-				for (const key in RocketChat.emoji.packages[emojiPackage].emojisByCategory) {
+				for (let key in RocketChat.emoji.packages[emojiPackage].emojisByCategory) {
 					if (RocketChat.emoji.packages[emojiPackage].emojisByCategory.hasOwnProperty(key)) {
 						categories.push(key);
 					}
@@ -111,7 +110,7 @@ Template.emojiPicker.helpers({
 	},
 	emojiByCategory(category) {
 		let emojisByCategory = [];
-		for (const emojiPackage in RocketChat.emoji.packages) {
+		for (let emojiPackage in RocketChat.emoji.packages) {
 			if (RocketChat.emoji.packages.hasOwnProperty(emojiPackage)) {
 				if (RocketChat.emoji.packages[emojiPackage].emojisByCategory.hasOwnProperty(category)) {
 					emojisByCategory = emojisByCategory.concat(RocketChat.emoji.packages[emojiPackage].emojisByCategory[category]);
@@ -126,16 +125,15 @@ Template.emojiPicker.helpers({
 	emojiList(category) {
 		const t = Template.instance();
 		const searchTerm = t.currentSearchTerm.get();
+		const activeCategory = t.currentCategory.get();
 
-		//clear dynamic categories to prevent duplication issues
-		if (category === 'recent' || category === 'rocket') {
-			$(`.${ category }.emoji-list`).empty();
+		//we only need to replace the active category, since switching tabs resets the filter
+		if (activeCategory !== category) {
+			return;
 		}
 
 		if (searchTerm.length > 0) {
-			if (t.currentCategory.get() === category) {
-				return getEmojisBySearchTerm(searchTerm);
-			}
+			return getEmojisBySearchTerm(searchTerm);
 		} else {
 			return getEmojisByCategory(category);
 		}
@@ -206,10 +204,10 @@ Template.emojiPicker.events({
 			newTone = '';
 		}
 
-		for (const emojiPackage in RocketChat.emoji.packages) {
+		for (let emojiPackage in RocketChat.emoji.packages) {
 			if (RocketChat.emoji.packages.hasOwnProperty(emojiPackage)) {
 				if (RocketChat.emoji.packages[emojiPackage].hasOwnProperty('toneList')) {
-					for (const emoji in RocketChat.emoji.packages[emojiPackage].toneList) {
+					for (let emoji in RocketChat.emoji.packages[emojiPackage].toneList) {
 						if (RocketChat.emoji.packages[emojiPackage].toneList.hasOwnProperty(emoji)) {
 							$(`.emoji-${ emoji }`).html(RocketChat.emoji.packages[emojiPackage].render(`:${ emoji }${ newTone }:`));
 						}
@@ -231,7 +229,7 @@ Template.emojiPicker.events({
 		const actualTone = instance.tone;
 		let tone = '';
 
-		for (const emojiPackage in RocketChat.emoji.packages) {
+		for (let emojiPackage in RocketChat.emoji.packages) {
 			if (RocketChat.emoji.packages.hasOwnProperty(emojiPackage)) {
 				if (actualTone > 0 && RocketChat.emoji.packages[emojiPackage].toneList.hasOwnProperty(emoji)) {
 					tone = `_tone${ actualTone }`;
@@ -268,7 +266,6 @@ Template.emojiPicker.onCreated(function() {
 
 	this.currentCategory = new ReactiveVar(recent.length > 0 ? 'recent' : 'people');
 	this.currentSearchTerm = new ReactiveVar('');
-	this.currentResults = new ReactiveVar('');
 
 	recent.forEach((emoji) => {
 		RocketChat.emoji.packages.base.emojisByCategory.recent.push(emoji);

--- a/packages/rocketchat-emoji/emojiPicker.js
+++ b/packages/rocketchat-emoji/emojiPicker.js
@@ -6,7 +6,7 @@ const emojiCategories = {};
  * @return {string} readable and translated
  */
 function categoryName(category) {
-	for (let emojiPackage in RocketChat.emoji.packages) {
+	for (const emojiPackage in RocketChat.emoji.packages) {
 		if (RocketChat.emoji.packages.hasOwnProperty(emojiPackage)) {
 			if (RocketChat.emoji.packages[emojiPackage].emojiCategories.hasOwnProperty(category)) {
 				return RocketChat.emoji.packages[emojiPackage].emojiCategories[category];
@@ -24,7 +24,7 @@ function getEmojisByCategory(category) {
 	const t = Template.instance();
 	const actualTone = t.tone;
 	let html = '';
-	for (let emojiPackage in RocketChat.emoji.packages) {
+	for (const emojiPackage in RocketChat.emoji.packages) {
 		if (RocketChat.emoji.packages.hasOwnProperty(emojiPackage)) {
 			if (RocketChat.emoji.packages[emojiPackage].emojisByCategory.hasOwnProperty(category)) {
 				const total = RocketChat.emoji.packages[emojiPackage].emojisByCategory[category].length;
@@ -74,7 +74,7 @@ function getEmojisBySearchTerm(searchTerm) {
 
 			let emojiFound = false;
 
-			for (let key in RocketChat.emoji.packages[emojiPackage].emojisByCategory) {
+			for (const key in RocketChat.emoji.packages[emojiPackage].emojisByCategory) {
 				if (RocketChat.emoji.packages[emojiPackage].emojisByCategory.hasOwnProperty(key)) {
 					const contents = RocketChat.emoji.packages[emojiPackage].emojisByCategory[key];
 					if (contents.indexOf(emoji) !== -1) {
@@ -97,9 +97,9 @@ function getEmojisBySearchTerm(searchTerm) {
 Template.emojiPicker.helpers({
 	category() {
 		const categories = [];
-		for (let emojiPackage in RocketChat.emoji.packages) {
+		for (const emojiPackage in RocketChat.emoji.packages) {
 			if (RocketChat.emoji.packages.hasOwnProperty(emojiPackage)) {
-				for (let key in RocketChat.emoji.packages[emojiPackage].emojisByCategory) {
+				for (const key in RocketChat.emoji.packages[emojiPackage].emojisByCategory) {
 					if (RocketChat.emoji.packages[emojiPackage].emojisByCategory.hasOwnProperty(key)) {
 						categories.push(key);
 					}
@@ -110,7 +110,7 @@ Template.emojiPicker.helpers({
 	},
 	emojiByCategory(category) {
 		let emojisByCategory = [];
-		for (let emojiPackage in RocketChat.emoji.packages) {
+		for (const emojiPackage in RocketChat.emoji.packages) {
 			if (RocketChat.emoji.packages.hasOwnProperty(emojiPackage)) {
 				if (RocketChat.emoji.packages[emojiPackage].emojisByCategory.hasOwnProperty(category)) {
 					emojisByCategory = emojisByCategory.concat(RocketChat.emoji.packages[emojiPackage].emojisByCategory[category]);
@@ -206,7 +206,7 @@ Template.emojiPicker.events({
 			newTone = '';
 		}
 
-		for (let emojiPackage in RocketChat.emoji.packages) {
+		for (const emojiPackage in RocketChat.emoji.packages) {
 			if (RocketChat.emoji.packages.hasOwnProperty(emojiPackage)) {
 				if (RocketChat.emoji.packages[emojiPackage].hasOwnProperty('toneList')) {
 					for (let emoji in RocketChat.emoji.packages[emojiPackage].toneList) {
@@ -231,7 +231,7 @@ Template.emojiPicker.events({
 		const actualTone = instance.tone;
 		let tone = '';
 
-		for (let emojiPackage in RocketChat.emoji.packages) {
+		for (const emojiPackage in RocketChat.emoji.packages) {
 			if (RocketChat.emoji.packages.hasOwnProperty(emojiPackage)) {
 				if (actualTone > 0 && RocketChat.emoji.packages[emojiPackage].toneList.hasOwnProperty(emoji)) {
 					tone = `_tone${ actualTone }`;

--- a/packages/rocketchat-emoji/emojiPicker.js
+++ b/packages/rocketchat-emoji/emojiPicker.js
@@ -209,7 +209,7 @@ Template.emojiPicker.events({
 		for (const emojiPackage in RocketChat.emoji.packages) {
 			if (RocketChat.emoji.packages.hasOwnProperty(emojiPackage)) {
 				if (RocketChat.emoji.packages[emojiPackage].hasOwnProperty('toneList')) {
-					for (let emoji in RocketChat.emoji.packages[emojiPackage].toneList) {
+					for (const emoji in RocketChat.emoji.packages[emojiPackage].toneList) {
 						if (RocketChat.emoji.packages[emojiPackage].toneList.hasOwnProperty(emoji)) {
 							$(`.emoji-${ emoji }`).html(RocketChat.emoji.packages[emojiPackage].render(`:${ emoji }${ newTone }:`));
 						}

--- a/packages/rocketchat-emoji/emojiPicker.js
+++ b/packages/rocketchat-emoji/emojiPicker.js
@@ -126,6 +126,8 @@ Template.emojiPicker.helpers({
 		const t = Template.instance();
 		const searchTerm = t.currentSearchTerm.get();
 		const activeCategory = t.currentCategory.get();
+		//this will cause the reflow when recent list gets updated
+		const recentNeedsUpdate = t.recentNeedsUpdate.get();
 
 		//we only need to replace the active category, since switching tabs resets the filter
 		if (activeCategory !== category) {
@@ -263,7 +265,7 @@ Template.emojiPicker.events({
 Template.emojiPicker.onCreated(function() {
 	this.tone = RocketChat.EmojiPicker.getTone();
 	const recent = RocketChat.EmojiPicker.getRecent();
-
+	this.recentNeedsUpdate = new ReactiveVar(false);
 	this.currentCategory = new ReactiveVar(recent.length > 0 ? 'recent' : 'people');
 	this.currentSearchTerm = new ReactiveVar('');
 
@@ -276,4 +278,10 @@ Template.emojiPicker.onCreated(function() {
 		$('.current-tone').addClass(`tone-${ newTone }`);
 		this.tone = newTone;
 	};
+
+	this.autorun(() => {
+		if (this.recentNeedsUpdate.get()) {
+			this.recentNeedsUpdate.set(false);
+		}
+	});
 });

--- a/packages/rocketchat-emoji/lib/EmojiPicker.js
+++ b/packages/rocketchat-emoji/lib/EmojiPicker.js
@@ -115,8 +115,6 @@ RocketChat.EmojiPicker = {
 
 		window.localStorage.setItem('emoji.recent', this.recent);
 		RocketChat.emoji.packages.base.emojisByCategory.recent = this.recent;
-
-		this.updateRecent();
 	},
 	updateRecent() {
 		const total = RocketChat.emoji.packages.base.emojisByCategory.recent.length;

--- a/packages/rocketchat-emoji/lib/EmojiPicker.js
+++ b/packages/rocketchat-emoji/lib/EmojiPicker.js
@@ -119,7 +119,7 @@ RocketChat.EmojiPicker = {
 	},
 	updateRecent() {
 		const instance = Template.instance();
-		if(instance) {
+		if (instance) {
 			instance.recentNeedsUpdate.set(true);
 		} else {
 			this.refreshDynamicEmojiLists();
@@ -127,18 +127,16 @@ RocketChat.EmojiPicker = {
 	},
 	refreshDynamicEmojiLists() {
 		const dynamicEmojiLists = [
-			{ name: 'recent',
-				source: RocketChat.emoji.packages.base.emojisByCategory.recent
-			},
-			{ name: 'rocket',
-				source: RocketChat.emoji.packages.emojiCustom.emojisByCategory.rocket
-		}];
-		dynamicEmojiLists.forEach(({name, source}) => {
-			if(source) {
-				for (let i = 0; i < source.length; i++) {
-					const emoji = source[i];
+			RocketChat.emoji.packages.base.emojisByCategory.recent,
+			RocketChat.emoji.packages.emojiCustom.emojisByCategory.rocket
+		];
+
+		dynamicEmojiLists.forEach((category) => {
+			if (category) {
+				for (let i = 0; i < category.length; i++) {
+					const emoji = category[i];
 					if (!RocketChat.emoji.list[`:${ emoji }:`]) {
-						source = _.without(source, emoji);
+						category = _.without(category, emoji);
 					}
 				}
 			}

--- a/packages/rocketchat-emoji/lib/EmojiPicker.js
+++ b/packages/rocketchat-emoji/lib/EmojiPicker.js
@@ -1,4 +1,4 @@
-/* globals Blaze, isSetNotNull, Template */
+/* globals Blaze, Template */
 RocketChat.EmojiPicker = {
 	width: 390,
 	height: 238,

--- a/packages/rocketchat-emoji/lib/EmojiPicker.js
+++ b/packages/rocketchat-emoji/lib/EmojiPicker.js
@@ -115,21 +115,33 @@ RocketChat.EmojiPicker = {
 
 		window.localStorage.setItem('emoji.recent', this.recent);
 		RocketChat.emoji.packages.base.emojisByCategory.recent = this.recent;
+		this.updateRecent();
 	},
 	updateRecent() {
-		const total = RocketChat.emoji.packages.base.emojisByCategory.recent.length;
-		let html = '';
-		for (let i = 0; i < total; i++) {
-			const emoji = RocketChat.emoji.packages.base.emojisByCategory.recent[i];
-
-			if (isSetNotNull(() => RocketChat.emoji.list[`:${ emoji }:`])) {
-				const emojiPackage = RocketChat.emoji.list[`:${ emoji }:`].emojiPackage;
-				const renderedEmoji = RocketChat.emoji.packages[emojiPackage].render(`:${ emoji }:`);
-				html += `<li class="emoji-${ emoji }" data-emoji="${ emoji }">${ renderedEmoji }</li>`;
-			} else {
-				this.recent = _.without(this.recent, emoji);
-			}
+		const instance = Template.instance();
+		if(instance) {
+			instance.recentNeedsUpdate.set(true);
+		} else {
+			this.refreshDynamicEmojiLists();
 		}
-		$('.recent.emoji-list').empty().append(html);
+	},
+	refreshDynamicEmojiLists() {
+		const dynamicEmojiLists = [
+			{ name: 'recent',
+				source: RocketChat.emoji.packages.base.emojisByCategory.recent
+			},
+			{ name: 'rocket',
+				source: RocketChat.emoji.packages.emojiCustom.emojisByCategory.rocket
+		}];
+		dynamicEmojiLists.forEach(({name, source}) => {
+			if(source) {
+				for (let i = 0; i < source.length; i++) {
+					const emoji = source[i];
+					if (!RocketChat.emoji.list[`:${ emoji }:`]) {
+						source = _.without(source, emoji);
+					}
+				}
+			}
+		});
 	}
 };


### PR DESCRIPTION
@RocketChat/core 

Closes #6636

This changes are intended to fix the exception that was happening when changing the Emoji Picker filter text, which was caused by some race conditions with Blaze computations and the jquery used to clear the emoji picker window for the dynamic categories (recent and rocket).

I aimed at removing the jquery code that was a fix for the duplication bug for these categories, which was being caused by some bad structure on the UI. The fix I found was to add a new reactive variable as a flag, so whenever we need to update the dynamic categories, the flag would be set as true and the UI would react properly (see emojiPicker.js:268 and emojiPicker.js:282).

I noticed a small change that could improve the performance of the Emoji Picker rendering, because we were adding all the emojis to the categories, even when we didn't show those categories, and this would happen again every time we changed categories. Now the emojiList only renders the emojis for the selected category (see emojiList.js:132), let me know if this is not something we want (since the html would be incomplete).

The major change is on the emojiList.js updateRecent function, where we no longer return an html, but only trigger structural changes and let the UI update reactively. Although we have to check if there is an active instance, since this changes can be triggered when removing custom emojis from the admin panel.

This is my first time touching some of this stuff, so feedback here is *much* appreciated. 