### PR TITLE
[FIX] #6719 Not to escape markdown links which url has & 

### DIFF
--- a/packages/rocketchat-markdown/markdown.js
+++ b/packages/rocketchat-markdown/markdown.js
@@ -14,19 +14,19 @@ class MarkdownClass {
 		// Support ![alt text](http://image url)
 		msg = msg.replace(new RegExp(`!\\[([^\\]]+)\\]\\(((?:${ schemes }):\\/\\/[^\\)]+)\\)`, 'gm'), function(match, title, url) {
 			const target = url.indexOf(Meteor.absoluteUrl()) === 0 ? '' : '_blank';
-			return `<a href="${ _.escapeHTML(url) }" title="${ _.escapeHTML(title) }" target="${ _.escapeHTML(target) }"><div class="inline-image" style="background-image: url(${ _.escapeHTML(url) });"></div></a>`;
+			return `<a href="${ url }" title="${ _.escapeHTML(title) }" target="${ _.escapeHTML(target) }"><div class="inline-image" style="background-image: url(${ _.escapeHTML(url) });"></div></a>`;
 		});
 
 		// Support [Text](http://link)
 		msg = msg.replace(new RegExp(`\\[([^\\]]+)\\]\\(((?:${ schemes }):\\/\\/[^\\)]+)\\)`, 'gm'), function(match, title, url) {
 			const target = url.indexOf(Meteor.absoluteUrl()) === 0 ? '' : '_blank';
-			return `<a href="${ _.escapeHTML(url) }" target="${ _.escapeHTML(target) }">${ _.escapeHTML(title) }</a>`;
+			return `<a href="${ url }" target="${ _.escapeHTML(target) }">${ _.escapeHTML(title) }</a>`;
 		});
 
 		// Support <http://link|Text>
 		msg = msg.replace(new RegExp(`(?:<|&lt;)((?:${ schemes }):\\/\\/[^\\|]+)\\|(.+?)(?=>|&gt;)(?:>|&gt;)`, 'gm'), (match, url, title) => {
 			const target = url.indexOf(Meteor.absoluteUrl()) === 0 ? '' : '_blank';
-			return `<a href="${ _.escapeHTML(url) }" target="${ _.escapeHTML(target) }">${ _.escapeHTML(title) }</a>`;
+			return `<a href="${ url }" target="${ _.escapeHTML(target) }">${ _.escapeHTML(title) }</a>`;
 		});
 
 		if (RocketChat.settings.get('Markdown_Headers')) {


### PR DESCRIPTION

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #6719

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Now links which has `&` could accessable.