### PR TITLE
[FIX] Fix Caddy by forcing go 1.7 as needed by one of caddy's dependencies

### DIFF
--- a/.snapcraft/candidate/snapcraft.yaml
+++ b/.snapcraft/candidate/snapcraft.yaml
@@ -98,3 +98,8 @@ parts:
         source-commit: 53e117802fedd5915eeb32907873d8786a4b2936
         snap:
             - bin/caddy
+        after: [go]
+    go:
+        source-tag: go1.8
+        stage:
+        - bin

--- a/.snapcraft/edge/snapcraft.yaml
+++ b/.snapcraft/edge/snapcraft.yaml
@@ -98,3 +98,8 @@ parts:
         source-commit: 53e117802fedd5915eeb32907873d8786a4b2936
         snap:
             - bin/caddy
+        after: [go]
+    go:
+        source-tag: go1.8
+        stage:
+        - bin

--- a/.snapcraft/stable/snapcraft.yaml
+++ b/.snapcraft/stable/snapcraft.yaml
@@ -98,3 +98,8 @@ parts:
         source-commit: 53e117802fedd5915eeb32907873d8786a4b2936
         snap:
             - bin/caddy
+        after: [go]
+    go:
+        source-tag: go1.8
+        stage:
+        - bin


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->


Something changed in a dependency of caddy.  Causing the snap builds to fail. This fixes that.