### PR TITLE
[FIX] Archiving Direct Messages

### DIFF
--- a/packages/rocketchat-lib/server/methods/archiveRoom.js
+++ b/packages/rocketchat-lib/server/methods/archiveRoom.js
@@ -17,6 +17,10 @@ Meteor.methods({
 			throw new Meteor.Error('error-not-authorized', 'Not authorized', { method: 'archiveRoom' });
 		}
 
+		if (room.t === 'd') {
+			throw new Meteor.Error('error-direct-message-room', 'Direct Messages can not be archived', { method: 'archiveRoom' });
+		}
+
 		return RocketChat.archiveRoom(rid);
 	}
 });

--- a/packages/rocketchat-slashcommands-archiveroom/server.js
+++ b/packages/rocketchat-slashcommands-archiveroom/server.js
@@ -14,6 +14,11 @@ function Archive(command, params, item) {
 		room = RocketChat.models.Rooms.findOneByName(channel);
 	}
 
+	// You can not archive direct messages.
+	if (room.t === 'd') {
+		return;
+	}
+
 	const user = Meteor.users.findOne(Meteor.userId());
 
 	if (room.archived) {

--- a/packages/rocketchat-slashcommands-unarchiveroom/server.js
+++ b/packages/rocketchat-slashcommands-unarchiveroom/server.js
@@ -13,6 +13,12 @@ function Unarchive(command, params, item) {
 		channel = channel.replace('#', '');
 		room = RocketChat.models.Rooms.findOneByName(channel);
 	}
+
+	// You can not archive direct messages.
+	if (room.t === 'd') {
+		return;
+	}
+
 	const user = Meteor.users.findOne(Meteor.userId());
 
 	if (!room.archived) {
@@ -27,7 +33,9 @@ function Unarchive(command, params, item) {
 		});
 		return;
 	}
+
 	Meteor.call('unarchiveRoom', room._id);
+
 	RocketChat.models.Messages.createRoomUnarchivedByRoomIdAndUser(room._id, Meteor.user());
 	RocketChat.Notifications.notifyUser(Meteor.userId(), 'message', {
 		_id: Random.id(),
@@ -38,6 +46,7 @@ function Unarchive(command, params, item) {
 			sprintf: [channel]
 		}, user.language)
 	});
+
 	return Unarchive;
 }
 


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core the reason I did not check the `unarchiveRoom` meteor method is because if a room is already archived, keeping the ability to unarchive a direct message room is the only way to unarchive one without editing the database.

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #6728

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
