### PR TITLE
[FIX] Hides nav buttons when selecting own profile

### DIFF
--- a/packages/rocketchat-ui-flextab/client/tabs/userInfo.html
+++ b/packages/rocketchat-ui-flextab/client/tabs/userInfo.html
@@ -41,67 +41,69 @@
 			</div>
 			{{/with}}
 			<nav>
-				{{#if user.active}}
-					{{> videoButtons}}
-				{{/if}}
-				{{#if isDirect}}
-					{{#if isBlocker}}
-						<button class='button button-block tertiary unblock-user'><span><i class='icon-block'></i> {{_ "Unblock_User"}}</span></button>
-					{{else}}
-						<button class='button button-block danger block-user'><span><i class='icon-block'></i> {{_ "Block_User"}}</span></button>
+				{{#unless isSelf user.username}}
+					{{#if user.active}}
+						{{> videoButtons}}
 					{{/if}}
-				{{/if}}
+					{{#if isDirect}}
+						{{#if isBlocker}}
+							<button class='button button-block tertiary unblock-user'><span><i class='icon-block'></i> {{_ "Unblock_User"}}</span></button>
+						{{else}}
+							<button class='button button-block danger block-user'><span><i class='icon-block'></i> {{_ "Block_User"}}</span></button>
+						{{/if}}
+					{{/if}}
 
-				{{#if showAll}}
-					{{#if canDirectMessage user.username}}
-						<button class='button button-block primary pvt-msg'><span><i class='icon-chat'></i> {{_ "Conversation"}}</span></button> {{/if}}
-					{{#if canSetOwner}}
-						{{#if isOwner}}
-							<button class="button button-block danger unset-owner"><span>{{_ "Remove_as_owner"}}</span></button>
-						{{else}}
-							<button class="button button-block tertiary set-owner"><span>{{_ "Set_as_owner"}}</span></button>
+					{{#if showAll}}
+						{{#if canDirectMessage user.username}}
+							<button class='button button-block primary pvt-msg'><span><i class='icon-chat'></i> {{_ "Conversation"}}</span></button> {{/if}}
+						{{#if canSetOwner}}
+							{{#if isOwner}}
+								<button class="button button-block danger unset-owner"><span>{{_ "Remove_as_owner"}}</span></button>
+							{{else}}
+								<button class="button button-block tertiary set-owner"><span>{{_ "Set_as_owner"}}</span></button>
+							{{/if}}
+						{{/if}}
+						{{#if canSetModerator}}
+							{{#if isModerator}}
+								<button class="button button-block danger unset-moderator"><span>{{_ "Remove_as_moderator"}}</span></button>
+							{{else}}
+								<button class="button button-block tertiary set-moderator"><span>{{_ "Set_as_moderator"}}</span></button>
+							{{/if}}
+						{{/if}}
+						{{#if canMuteUser}}
+							{{#if userMuted}}
+								<button class="button button-block secondary unmute-user primary"><span>{{_ "Unmute_user"}}</span></button>
+							{{else}}
+								<button class="button button-block danger mute-user"><span>{{_ "Mute_user"}}</span></button>
+							{{/if}}
+						{{/if}}
+						{{#if canRemoveUser}}
+							<button class="button button-block danger remove-user"><span>{{_ "Remove_from_room"}}</span></button>
 						{{/if}}
 					{{/if}}
-					{{#if canSetModerator}}
-						{{#if isModerator}}
-							<button class="button button-block danger unset-moderator"><span>{{_ "Remove_as_moderator"}}</span></button>
-						{{else}}
-							<button class="button button-block tertiary set-moderator"><span>{{_ "Set_as_moderator"}}</span></button>
-						{{/if}}
-					{{/if}}
-					{{#if canMuteUser}}
-						{{#if userMuted}}
-							<button class="button button-block secondary unmute-user primary"><span>{{_ "Unmute_user"}}</span></button>
-						{{else}}
-							<button class="button button-block danger mute-user"><span>{{_ "Mute_user"}}</span></button>
-						{{/if}}
-					{{/if}}
-					{{#if canRemoveUser}}
-						<button class="button button-block danger remove-user"><span>{{_ "Remove_from_room"}}</span></button>
-					{{/if}}
-				{{/if}}
 
-				{{#unless hideAdminControls}}
-					{{#if hasPermission 'edit-other-user-info'}}
-					<button class='button button-block primary edit-user'><span><i class='icon-edit'></i> {{_ "Edit"}}</span></button>
-					{{/if}}
-					{{#if hasPermission 'assign-admin-role'}}
-						{{#if hasAdminRole}}
-						<button class='button button-block danger remove-admin'><span><i class='icon-shield'></i> {{_ "Remove_Admin"}}</span></button>
-						{{else}}
-						<button class='button button-block secondary make-admin'><span><i class='icon-shield'></i> {{_ "Make_Admin"}}</span></button>
+					{{#unless hideAdminControls}}
+						{{#if hasPermission 'edit-other-user-info'}}
+						<button class='button button-block primary edit-user'><span><i class='icon-edit'></i> {{_ "Edit"}}</span></button>
 						{{/if}}
-					{{/if}}
-					{{#if hasPermission 'edit-other-user-active-status'}}
-						{{#if active}}
-						<button class='button button-block danger deactivate'><span><i class='icon-block'></i> {{_ "Deactivate"}}</span></button>
-						{{else}}
-						<button class='button button-block secondary activate'><span><i class='icon-ok-circled'></i> {{_ "Activate"}}</span></button>
+						{{#if hasPermission 'assign-admin-role'}}
+							{{#if hasAdminRole}}
+							<button class='button button-block danger remove-admin'><span><i class='icon-shield'></i> {{_ "Remove_Admin"}}</span></button>
+							{{else}}
+							<button class='button button-block secondary make-admin'><span><i class='icon-shield'></i> {{_ "Make_Admin"}}</span></button>
+							{{/if}}
 						{{/if}}
-					{{/if}}
-					{{#if hasPermission 'delete-user'}}
-					<button class='button button-block danger delete'><span><i class='icon-trash'></i> {{_ "Delete"}}</span></button>
-					{{/if}}
+						{{#if hasPermission 'edit-other-user-active-status'}}
+							{{#if active}}
+							<button class='button button-block danger deactivate'><span><i class='icon-block'></i> {{_ "Deactivate"}}</span></button>
+							{{else}}
+							<button class='button button-block secondary activate'><span><i class='icon-ok-circled'></i> {{_ "Activate"}}</span></button>
+							{{/if}}
+						{{/if}}
+						{{#if hasPermission 'delete-user'}}
+						<button class='button button-block danger delete'><span><i class='icon-trash'></i> {{_ "Delete"}}</span></button>
+						{{/if}}
+					{{/unless}}
 				{{/unless}}
 
 				{{#if showAll}}

--- a/packages/rocketchat-ui-flextab/client/tabs/userInfo.js
+++ b/packages/rocketchat-ui-flextab/client/tabs/userInfo.js
@@ -46,6 +46,11 @@ Template.userInfo.helpers({
 		const user = Meteor.user();
 		return RocketChat.authz.hasAllPermission('create-d') && user && user.username !== username;
 	},
+	
+	isSelf(username) {
+		const user = Meteor.user();
+		return user && user.username === username;
+	},
 
 	linkedinUsername() {
 		const user = Template.instance().user.get();

--- a/packages/rocketchat-ui-flextab/client/tabs/userInfo.js
+++ b/packages/rocketchat-ui-flextab/client/tabs/userInfo.js
@@ -46,7 +46,7 @@ Template.userInfo.helpers({
 		const user = Meteor.user();
 		return RocketChat.authz.hasAllPermission('create-d') && user && user.username !== username;
 	},
-	
+
 	isSelf(username) {
 		const user = Meteor.user();
 		return user && user.username === username;


### PR DESCRIPTION
@RocketChat/core 

Closes #6726

This hides most of the interaction buttons when opening your own profile from a chat room or direct message. The changes are basically adding a helper function to check if the open userInfo is your own and adding a check on the layout to show or hide based on that.

Adding screenshots for the different cases:

When viewing profile from another person in a public/private room as a normal user:
<img width="433" alt="other profile in public room as user" src="https://cloud.githubusercontent.com/assets/6303966/25301397/90748cf8-26fc-11e7-8ca1-8aa709630148.png">
When viewing your own profile in public room:
<img width="440" alt="self profile in public room" src="https://cloud.githubusercontent.com/assets/6303966/25301398/9075e4c2-26fc-11e7-9b0f-08f6f5868aed.png">
When viewing profile from another person in public/private chat as admin:
<img width="439" alt="other profile in public room as admin" src="https://cloud.githubusercontent.com/assets/6303966/25301399/9079819a-26fc-11e7-9b24-fb8c075efa3d.png">
When viewing profile from another in direct chat:
<img width="443" alt="other profile in direct" src="https://cloud.githubusercontent.com/assets/6303966/25301400/907b9106-26fc-11e7-8d81-ba927a85199d.png">
When viewing your own profile in direct chat:
<img width="435" alt="self profile in direct" src="https://cloud.githubusercontent.com/assets/6303966/25301401/9080bd02-26fc-11e7-97fb-445bb20d8f96.png">

