### PR TITLE
[FIX] REST API user.update throwing error due to rate limiting

### DIFF
--- a/packages/rocketchat-api/server/v1/users.js
+++ b/packages/rocketchat-api/server/v1/users.js
@@ -248,7 +248,7 @@ RocketChat.API.v1.addRoute('users.update', { authRequired: true }, {
 
 		const userData = _.extend({ _id: this.bodyParams.userId }, this.bodyParams.data);
 
-		RocketChat.saveUser(this.userId, userData);
+		Meteor.runAsUser(this.userId, () => RocketChat.saveUser(this.userId, userData));
 
 		if (this.bodyParams.data.customFields) {
 			RocketChat.saveCustomFields(this.bodyParams.userId, this.bodyParams.data.customFields);


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core the rest api `users.update` was throwing an error due to the update of the rate limit functions due to the call to the `RocketChat.setUsername` function not being ran as the calling user.

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #6787

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
