### PR TITLE
[FIX] Fix iframe wise issues

### DIFF
--- a/packages/rocketchat-theme/client/imports/base.less
+++ b/packages/rocketchat-theme/client/imports/base.less
@@ -4996,7 +4996,7 @@ a + br.only-after-a {
 				border-width: 0;
 			}
 
-			.stream-info {
+			.users-typing {
 				display: none;
 			}
 

--- a/packages/rocketchat-ui/client/lib/fireEvent.js
+++ b/packages/rocketchat-ui/client/lib/fireEvent.js
@@ -1,10 +1,16 @@
-window.fireGlobalEvent = (eventName, params) => {
-	window.dispatchEvent(new CustomEvent(eventName, {detail: params}));
-
-	if (RocketChat.settings.get('Iframe_Integration_send_enable') === true) {
-		parent.postMessage({
-			eventName,
-			data: params
-		}, RocketChat.settings.get('Iframe_Integration_send_target_origin'));
-	}
+window.fireGlobalEvent = function _fireGlobalEvent(eventName, params) {
+	Tracker.autorun((computation) => {
+		const enabled = RocketChat.settings.get('Iframe_Integration_send_enable');
+		if (enabled === undefined) {
+			return;
+		}
+		computation.stop();
+		if (enabled) {
+			window.dispatchEvent(new CustomEvent(eventName, {detail: params}));
+			parent.postMessage({
+				eventName,
+				data: params
+			}, RocketChat.settings.get('Iframe_Integration_send_target_origin'));
+		}
+	});
 };

--- a/packages/rocketchat-webrtc/WebRTCClass.coffee
+++ b/packages/rocketchat-webrtc/WebRTCClass.coffee
@@ -377,8 +377,13 @@ class WebRTCClass
 				, (isConfirm) =>
 					if isConfirm
 						if @navigator is 'chrome'
-							chrome.webstore.install undefined, refresh, ->
-								window.open('https://chrome.google.com/webstore/detail/rocketchat-screen-share/nocfbnnmjnndkbipkabodnheejiegccf')
+							url = 'https://chrome.google.com/webstore/detail/rocketchat-screen-share/nocfbnnmjnndkbipkabodnheejiegccf'
+							try
+								chrome.webstore.install url, refresh, ->
+									window.open(url)
+									refresh()
+							catch e
+								window.open(url)
 								refresh()
 						else if @navigator is 'firefox'
 							window.open('https://addons.mozilla.org/en-GB/firefox/addon/rocketchat-screen-share/')


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

- https://github.com/RocketChat/Rocket.Chat/commit/7b636a7bc36d8b656d96d907d515e1eb065c8666 Try to directly install screen share extension or open a new windows if it's not allowed 
- https://github.com/RocketChat/Rocket.Chat/commit/e6004426bee9e7f14e9a994ccd7c536c5d162436 Wait for iframe setting to start sending `postMessage`s (previously some `postMessage` could being lost because the `Iframe_Integration_send_enable` was not loaded on the client yet)
- https://github.com/RocketChat/Rocket.Chat/commit/070a0089db1da25a06ba4da72b03a9f3f3851415 Hide users typing if on loaded on an iframe (to prevent the white space after the message input):

before:
![image](https://cloud.githubusercontent.com/assets/8591547/25406781/493748d2-29de-11e7-914e-787a3406d4da.png)
after:
![image](https://cloud.githubusercontent.com/assets/8591547/25406785/4d28065c-29de-11e7-837f-8e4fb8ade05b.png)



