### PR TITLE
[FIX] Check that username is not in the room when being muted / unmuted

### DIFF
--- a/packages/rocketchat-slashcommands-mute/server/mute.js
+++ b/packages/rocketchat-slashcommands-mute/server/mute.js
@@ -26,7 +26,7 @@ RocketChat.slashCommands.add('mute', function Mute(command, params, item) {
 		});
 		return;
 	}
-	if ((room.usernames || []).includes(username)) {
+	if ((room.usernames || []).includes(username) === false) {
 		RocketChat.Notifications.notifyUser(Meteor.userId(), 'message', {
 			_id: Random.id(),
 			rid: item.rid,

--- a/packages/rocketchat-slashcommands-mute/server/unmute.js
+++ b/packages/rocketchat-slashcommands-mute/server/unmute.js
@@ -26,7 +26,7 @@ RocketChat.slashCommands.add('unmute', function Unmute(command, params, item) {
 			}, user.language)
 		});
 	}
-	if ((room.usernames || []).includes(username)) {
+	if ((room.usernames || []).includes(username) === false) {
 		return RocketChat.Notifications.notifyUser(Meteor.userId(), 'message', {
 			_id: Random.id(),
 			rid: item.rid,


### PR DESCRIPTION
@RocketChat/core 
Closes #6835

When a user is muted or unmuted, the server checks if that user is in the room and if not, throw an error. Previously, the server would throw an error if the user was in the room.