### PR TITLE
[FIX] Bugs in `isUserFromParams` helper

### DIFF
--- a/packages/rocketchat-api/server/v1/helpers/getUserFromParams.js
+++ b/packages/rocketchat-api/server/v1/helpers/getUserFromParams.js
@@ -2,32 +2,29 @@
 RocketChat.API.v1.helperMethods.set('getUserFromParams', function _getUserFromParams() {
 	const doesntExist = { _doesntExist: true };
 	let user;
+	let params;
 
 	switch (this.request.method) {
 		case 'POST':
 		case 'PUT':
-			if (this.bodyParams.userId && this.bodyParams.userId.trim()) {
-				user = RocketChat.models.Users.findOneById(this.bodyParams.userId) || doesntExist;
-			} else if (this.bodyParams.username && this.bodyParams.username.trim()) {
-				user = RocketChat.models.Users.findOneByUsername(this.bodyParams.username) || doesntExist;
-			} else if (this.bodyParams.user && this.bodyParams.user.trim()) {
-				user = RocketChat.models.Users.findOneByUsername(this.bodyParams.user) || doesntExist;
-			}
+			params = this.bodyParams;
 			break;
 		default:
-			if (this.queryParams.userId && this.queryParams.userId.trim()) {
-				user = RocketChat.models.Users.findOneById(this.queryParams.userId) || doesntExist;
-			} else if (this.queryParams.username && this.queryParams.username.trim()) {
-				user = RocketChat.models.Users.findOneByUsername(this.queryParams.username) || doesntExist;
-			} else if (this.queryParams.user && this.queryParams.user.trim()) {
-				user = RocketChat.models.Users.findOneByUsername(this.queryParams.user) || doesntExist;
-			}
+			params = this.queryParams;
 			break;
 	}
 
-	if (!user) {
+	if (params.userId && params.userId.trim()) {
+		user = RocketChat.models.Users.findOneById(params.userId) || doesntExist;
+	} else if (params.username && params.username.trim()) {
+		user = RocketChat.models.Users.findOneByUsername(params.username) || doesntExist;
+	} else if (params.user && params.user.trim()) {
+		user = RocketChat.models.Users.findOneByUsername(params.user) || doesntExist;
+	} else {
 		throw new Meteor.Error('error-user-param-not-provided', 'The required "userId" or "username" param was not provided');
-	} else if (user._doesntExist) {
+	}
+
+	if (user._doesntExist) {
 		throw new Meteor.Error('error-invalid-user', 'The required "userId" or "username" param provided does not match any users');
 	}
 

--- a/packages/rocketchat-api/server/v1/helpers/isUserFromParams.js
+++ b/packages/rocketchat-api/server/v1/helpers/isUserFromParams.js
@@ -1,5 +1,18 @@
 RocketChat.API.v1.helperMethods.set('isUserFromParams', function _isUserFromParams() {
-	return (this.queryParams.userId && this.userId === this.queryParams.userId) ||
-		(this.queryParams.username && this.user.username === this.queryParams.username) ||
-		(this.queryParams.user && this.user.username === this.queryParams.user);
+	let params;
+
+	switch (this.request.method) {
+		case 'POST':
+		case 'PUT':
+			params = this.bodyParams;
+			break;
+		default:
+			params = this.queryParams;
+			break;
+	}
+
+	return (!params.userId && !params.username && !params.user) ||
+		(params.userId && this.userId === params.userId) ||
+		(params.username && this.user.username === params.username) ||
+		(params.user && this.user.username === params.user);
 });


### PR DESCRIPTION
@RocketChat/core 

Fixed up definition of `isUserFromParams` to handle case where no params are passed
 => assumption is no user type params to mean 'current user'
Fixed bug where POST/PUT request method didn't use `bodyParams` in place of `queryParams`

Refactored `getUserFromParams` to remove duplication of calls to find user
