### PR TITLE
Update messageBox.html - replace video record logo 

### DIFF
--- a/packages/rocketchat-ui-message/client/messageBox.html
+++ b/packages/rocketchat-ui-message/client/messageBox.html
@@ -40,7 +40,7 @@
 
 								{{#if showVRec}}
 									<div class="message-buttons video-button">
-										<i class="icon-videocam" aria-label="{{_ "Record"}}"></i>
+										<i class="icon-file-video" aria-label="{{_ "Record"}}"></i>
 									</div>
 								{{/if}}
 


### PR DESCRIPTION
Replace videocam icon with file-video icon at message box right (to record a video), because same video chat logo for jitsi-meet in the right side bar confuses users, live video and record video are two different functions

<!-- [FIX] For bug fixes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
![videologoseparation](https://cloud.githubusercontent.com/assets/485723/25802787/32367980-33f4-11e7-9d4c-c5d6beb29629.png)

