### PR TITLE
[New] LDAP: Use variables in User_Data_FieldMap for name mapping

### DIFF
--- a/packages/rocketchat-ldap/server/sync.js
+++ b/packages/rocketchat-ldap/server/sync.js
@@ -70,7 +70,7 @@ getDataToSyncUserData = function getDataToSyncUserData(ldapUser, user) {
 			switch (userField) {
 				case 'email':
 					if (!ldapUser.object.hasOwnProperty(ldapField)) {
-						logger.debug(`user does not have attribute: ${ldapField}`);
+						logger.debug(`user does not have attribute: ${ ldapField }`);
 						return;
 					}
 
@@ -90,7 +90,7 @@ getDataToSyncUserData = function getDataToSyncUserData(ldapUser, user) {
 
 					if (match == null) {
 						if (!ldapUser.object.hasOwnProperty(ldapField)) {
-							logger.debug(`user does not have attribute: ${ldapField}`);
+							logger.debug(`user does not have attribute: ${ ldapField }`);
 							return;
 						}
 						tmpLdapField = ldapUser.object[ldapField];
@@ -101,12 +101,12 @@ getDataToSyncUserData = function getDataToSyncUserData(ldapUser, user) {
 							const tmplAttrName = match[1];
 
 							if (!ldapUser.object.hasOwnProperty(tmplAttrName)) {
-								logger.debug(`user does not have attribute: ${tmplAttrName}`);
+								logger.debug(`user does not have attribute: ${ tmplAttrName }`);
 								return;
 							}
 
 							const attrVal = ldapUser.object[tmplAttrName];
-							logger.debug(`replacing template var: ${tmplVar} with value from ldap: ${attrVal}`);
+							logger.debug(`replacing template var: ${ tmplVar } with value from ldap: ${ attrVal }`);
 							tmpLdapField = tmpLdapField.replace(tmplVar, attrVal);
 							match = templateRegex.exec(ldapField);
 						}
@@ -114,7 +114,7 @@ getDataToSyncUserData = function getDataToSyncUserData(ldapUser, user) {
 
 					if (user.name !== tmpLdapField) {
 						userData.name = tmpLdapField;
-						logger.debug(`user.name changed to: ${tmpLdapField}`);
+						logger.debug(`user.name changed to: ${ tmpLdapField }`);
 					}
 					break;
 			}

--- a/packages/rocketchat-ldap/server/sync.js
+++ b/packages/rocketchat-ldap/server/sync.js
@@ -66,16 +66,18 @@ getDataToSyncUserData = function getDataToSyncUserData(ldapUser, user) {
 		const fieldMap = JSON.parse(syncUserDataFieldMap);
 		const userData = {};
 
-		const emailList = [];
-		_.map(fieldMap, function(userField, ldapField) {
-			if (!ldapUser.object.hasOwnProperty(ldapField)) {
-				return;
-			}
 
+		const emailList = [];
+		_.map(fieldMap, function (userField, ldapField) {
 			switch (userField) {
 				case 'email':
+					if (!ldapUser.object.hasOwnProperty(ldapField)) {
+						logger.debug('user does not have attribute: ' + ldapField)
+						return;
+					}
+
 					if (_.isObject(ldapUser.object[ldapField])) {
-						_.map(ldapUser.object[ldapField], function(item) {
+						_.map(ldapUser.object[ldapField], function (item) {
 							emailList.push({ address: item, verified: true });
 						});
 					} else {
@@ -84,8 +86,38 @@ getDataToSyncUserData = function getDataToSyncUserData(ldapUser, user) {
 					break;
 
 				case 'name':
-					if (user.name !== ldapUser.object[ldapField]) {
-						userData.name = ldapUser.object[ldapField];
+					var templateRegex = /#{(\w+)}/gi;
+					var match = templateRegex.exec(ldapField)
+					var tmpLdapField = ldapField;
+
+					if (match == null) {
+						if (!ldapUser.object.hasOwnProperty(ldapField)) {
+							logger.debug('user does not have attribute: ' + ldapField)
+							return;
+						}
+						tmpLdapField = ldapUser.object[ldapField];
+					}
+					else {
+						logger.debug('template found. replacing values')
+						while (match != null) {
+							var tmplVar = match[0];
+							var tmplAttrName = match[1];
+
+							if (!ldapUser.object.hasOwnProperty(tmplAttrName)) {
+								logger.debug('user does not have attribute: ' + tmplAttrName)
+								return;
+							}
+
+							var attrVal = ldapUser.object[tmplAttrName];
+							logger.debug('replacing template var: ' + tmplVar + ' with value from ldap: ' + attrVal);
+							tmpLdapField = tmpLdapField.replace(tmplVar, attrVal);
+							match = templateRegex.exec(ldapField)
+						}
+					}
+
+					if (user.name !== tmpLdapField) {
+						userData.name = tmpLdapField;
+						logger.debug('user.name changed to: ' + tmpLdapField);
 					}
 					break;
 			}

--- a/packages/rocketchat-ldap/server/sync.js
+++ b/packages/rocketchat-ldap/server/sync.js
@@ -68,16 +68,16 @@ getDataToSyncUserData = function getDataToSyncUserData(ldapUser, user) {
 
 
 		const emailList = [];
-		_.map(fieldMap, function (userField, ldapField) {
+		_.map(fieldMap, function(userField, ldapField) {
 			switch (userField) {
 				case 'email':
 					if (!ldapUser.object.hasOwnProperty(ldapField)) {
-						logger.debug('user does not have attribute: ' + ldapField)
+						logger.debug(`user does not have attribute: ${ldapField}`);
 						return;
 					}
 
 					if (_.isObject(ldapUser.object[ldapField])) {
-						_.map(ldapUser.object[ldapField], function (item) {
+						_.map(ldapUser.object[ldapField], function(item) {
 							emailList.push({ address: item, verified: true });
 						});
 					} else {
@@ -86,38 +86,37 @@ getDataToSyncUserData = function getDataToSyncUserData(ldapUser, user) {
 					break;
 
 				case 'name':
-					var templateRegex = /#{(\w+)}/gi;
-					var match = templateRegex.exec(ldapField)
-					var tmpLdapField = ldapField;
+					const templateRegex = /#{(\w+)}/gi;
+					let match = templateRegex.exec(ldapField)
+					let tmpLdapField = ldapField;
 
 					if (match == null) {
 						if (!ldapUser.object.hasOwnProperty(ldapField)) {
-							logger.debug('user does not have attribute: ' + ldapField)
+							logger.debug(`user does not have attribute: ${ldapField}`)
 							return;
 						}
 						tmpLdapField = ldapUser.object[ldapField];
-					}
-					else {
-						logger.debug('template found. replacing values')
+					} else {
+						logger.debug('template found. replacing values');
 						while (match != null) {
-							var tmplVar = match[0];
-							var tmplAttrName = match[1];
+							const tmplVar = match[0];
+							const tmplAttrName = match[1];
 
 							if (!ldapUser.object.hasOwnProperty(tmplAttrName)) {
-								logger.debug('user does not have attribute: ' + tmplAttrName)
+								logger.debug(`user does not have attribute: ${tmplAttrName}`);
 								return;
 							}
 
-							var attrVal = ldapUser.object[tmplAttrName];
-							logger.debug('replacing template var: ' + tmplVar + ' with value from ldap: ' + attrVal);
+							const attrVal = ldapUser.object[tmplAttrName];
+							logger.debug(`replacing template var: ${tmplVar} with value from ldap: ${attrVal}`);
 							tmpLdapField = tmpLdapField.replace(tmplVar, attrVal);
-							match = templateRegex.exec(ldapField)
+							match = templateRegex.exec(ldapField);
 						}
 					}
 
 					if (user.name !== tmpLdapField) {
 						userData.name = tmpLdapField;
-						logger.debug('user.name changed to: ' + tmpLdapField);
+						logger.debug(`user.name changed to: ${tmpLdapField}`);
 					}
 					break;
 			}

--- a/packages/rocketchat-ldap/server/sync.js
+++ b/packages/rocketchat-ldap/server/sync.js
@@ -65,8 +65,6 @@ getDataToSyncUserData = function getDataToSyncUserData(ldapUser, user) {
 	if (syncUserData && syncUserDataFieldMap) {
 		const fieldMap = JSON.parse(syncUserDataFieldMap);
 		const userData = {};
-
-
 		const emailList = [];
 		_.map(fieldMap, function(userField, ldapField) {
 			switch (userField) {
@@ -87,12 +85,12 @@ getDataToSyncUserData = function getDataToSyncUserData(ldapUser, user) {
 
 				case 'name':
 					const templateRegex = /#{(\w+)}/gi;
-					let match = templateRegex.exec(ldapField)
+					let match = templateRegex.exec(ldapField);
 					let tmpLdapField = ldapField;
 
 					if (match == null) {
 						if (!ldapUser.object.hasOwnProperty(ldapField)) {
-							logger.debug(`user does not have attribute: ${ldapField}`)
+							logger.debug(`user does not have attribute: ${ldapField}`);
 							return;
 						}
 						tmpLdapField = ldapUser.object[ldapField];


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

This refers to #6172. A lot of ldap backends do not have a single attribut with the users name, but rather a combination of multiple. This PR makes it possible to use variables in the ldap userdata mapping as seen in the screenshot below. The variables will be replaced with the actual ldap values on ldap user sync.

![fieldmap](https://cloud.githubusercontent.com/assets/6813310/25855247/f130ebde-34d2-11e7-8508-7324d3f46204.PNG)

