### PR TITLE
[FIX] make channels.create API check for create-c

### DIFF
--- a/packages/rocketchat-api/server/v1/channels.js
+++ b/packages/rocketchat-api/server/v1/channels.js
@@ -128,7 +128,7 @@ RocketChat.API.v1.addRoute('channels.close', { authRequired: true }, {
 
 RocketChat.API.v1.addRoute('channels.create', { authRequired: true }, {
 	post() {
-		if (!RocketChat.authz.hasPermission(this.userId, 'create-p')) {
+		if (!RocketChat.authz.hasPermission(this.userId, 'create-c')) {
 			return RocketChat.API.v1.unauthorized();
 		}
 


### PR DESCRIPTION
Seems to be an old mistake while rewriting code caused it to check for create-p.