### PR TITLE
[FIX] Fix login with Meteor saving an object as email address

### DIFF
--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -18,7 +18,8 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 
 	if (serviceName === 'meteor-developer') {
 		if (Array.isArray(serviceData.emails)) {
-			serviceData.email = serviceData.emails.sort(a => a.primary !== true).filter(item => item.verified === true)[0];
+			const primaryEmail = serviceData.emails.sort(a => a.primary !== true).filter(item => item.verified === true)[0];
+			serviceData.email = primaryEmail && primaryEmail.address;
 		}
 	}
 

--- a/server/startup/migrations/v094.js
+++ b/server/startup/migrations/v094.js
@@ -1,0 +1,26 @@
+RocketChat.Migrations.add({
+	version: 94,
+	up() {
+		const query = {
+			'emails.address.address': { $exists: true }
+		};
+
+		RocketChat.models.Users.find(query, {'emails.address.address': 1}).forEach((user) => {
+			let emailAddress;
+			user.emails.some(email => {
+				if (email.address && email.address.address) {
+					emailAddress = email.address.address;
+					return true;
+				}
+			});
+			RocketChat.models.Users.update({
+				_id: user._id,
+				'emails.address.address': emailAddress
+			}, {
+				$set: {
+					'emails.$.address': emailAddress
+				}
+			});
+		});
+	}
+});


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
We were saving an object for `emails.address` user's property for Meteor's OAuth as shown bellow:

```json
{
    "_id" : "fAkeId",
    "type" : "user",
    "name" : "fakename",
    "emails" : [ 
        {
            "address" : {
                "address" : "fakename@meteoroauth.com",
                "verified" : true,
                "primary" : true
            },
            "verified" : true
        }
    ],
    "roles" : [ 
        "user"
    ]
}
```

This PR is to get only the primary email address from Meteor's OAuth and also fixes problems related to `getUsernameSuggestion` because `address` property was not a string.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
