### PR TITLE
[FIX] overlapping text for users-typing-message

### DIFF
--- a/packages/rocketchat-theme/client/imports/base.less
+++ b/packages/rocketchat-theme/client/imports/base.less
@@ -2467,6 +2467,8 @@ label.required::after {
 			text-overflow: ellipsis;
 			max-width: 100%;
 			z-index: 10;
+			position: relative;
+			background-color: #ffffff;
 		}
 
 		.formatting-tips {


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Beneath the message input field there is a line with formatting tips. If a user in a chat room starts to type a message a user-typing-hint is shown. If the width of the browser window is too narrow that hint will overlay the formatting tips making it hard to read. This patch just sets the background color of the hint element to white to preserve readability.

![screenshot](https://cloud.githubusercontent.com/assets/582546/26157025/5b8f10b4-3b18-11e7-814c-153c73798506.png)
