### PR TITLE
[FIX] video message recording dialog is shown in an incorrect position

### DIFF
--- a/packages/rocketchat-ui-vrecord/client/VRecDialog.js
+++ b/packages/rocketchat-ui-vrecord/client/VRecDialog.js
@@ -1,9 +1,9 @@
 export const VRecDialog = new class {
-	static initClass() {
-		this.prototype.opened = false;
-		this.prototype.initiated = false;
-		this.prototype.width = 400;
-		this.prototype.height = 280;
+	constructor() {
+		this.opened = false;
+		this.initiated = false;
+		this.width = 400;
+		this.height = 280;
 	}
 
 	init() {


### PR DESCRIPTION
[FIX] video message recording dialog is shown in an incorrect position

@RocketChat/core 

This [change](https://github.com/RocketChat/Rocket.Chat/commit/ae125556471b8a00a878c09699127e3d057a05d9#diff-f90978acbc3ad72cce9a3175f0ff8a71) caused the class variables to not being correctly defined, thus breaking the `setPosition()` method and causing the video recording dialog to be rendered in an incorrect position.

EDIT: image that shows the problem. The dialog is malpositioned because of this.width and this.height not being defined.
![vrecord_dialog](https://cloud.githubusercontent.com/assets/879129/26203455/a89da334-3bdb-11e7-9f0c-7d8c64a189bb.png)
