### PR TITLE
[FIX] Parse HTML on admin setting's descriptions

### DIFF
--- a/packages/rocketchat-markdown/markdown.js
+++ b/packages/rocketchat-markdown/markdown.js
@@ -90,4 +90,5 @@ RocketChat.callbacks.add('renderMessage', MarkdownMessage, RocketChat.callbacks.
 
 if (Meteor.isClient) {
 	Blaze.registerHelper('RocketChatMarkdown', text => Markdown.parse(text));
+	Blaze.registerHelper('RocketChatMarkdownUnescape', text => Markdown.parseNotEscaped(text));
 }

--- a/packages/rocketchat-ui-admin/client/admin.html
+++ b/packages/rocketchat-ui-admin/client/admin.html
@@ -186,7 +186,7 @@
 												{{/if}}
 
 												{{#if description}}
-													<div class="settings-description">{{{RocketChatMarkdown description}}}</div>
+													<div class="settings-description">{{{RocketChatMarkdownUnescape description}}}</div>
 												{{/if}}
 												{{#if alert}}
 													<div class="settings-alert pending-color pending-background pending-border"><i class="icon-attention secondary-font-color"></i>{{{_ alert}}}</div>


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #6992

Markdown changed to always escape HTML before parsing markdown. I'm creating a new helper so admin descriptions can still have HTML and display them correctly.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Before:
![image](https://cloud.githubusercontent.com/assets/8591547/26206151/6292ba30-3bba-11e7-98cc-6416fcce288d.png)

After:
![image](https://cloud.githubusercontent.com/assets/8591547/26206155/6594366e-3bba-11e7-9b8f-d120a9c2f57a.png)
