### PR TITLE
[FIX] do only store password if LDAP_Login_Fallback is on

### DIFF
--- a/packages/rocketchat-ldap/server/loginHandler.js
+++ b/packages/rocketchat-ldap/server/loginHandler.js
@@ -123,9 +123,12 @@ Accounts.registerLoginHandler('ldap', function(loginRequest) {
 				'services.resume.loginTokens': Accounts._hashStampedToken(stampedToken)
 			}
 		});
-
 		syncUserData(user, ldapUser);
-		Accounts.setPassword(user._id, loginRequest.ldapPass, {logout: false});
+
+		if (RocketChat.settings.get('LDAP_Login_Fallback') !== true) {
+			Accounts.setPassword(user._id, loginRequest.ldapPass, {logout: false});
+		}
+
 		return {
 			userId: user._id,
 			token: stampedToken.token

--- a/packages/rocketchat-ldap/server/loginHandler.js
+++ b/packages/rocketchat-ldap/server/loginHandler.js
@@ -123,6 +123,7 @@ Accounts.registerLoginHandler('ldap', function(loginRequest) {
 				'services.resume.loginTokens': Accounts._hashStampedToken(stampedToken)
 			}
 		});
+
 		syncUserData(user, ldapUser);
 
 		if (RocketChat.settings.get('LDAP_Login_Fallback') !== true) {

--- a/packages/rocketchat-ldap/server/loginHandler.js
+++ b/packages/rocketchat-ldap/server/loginHandler.js
@@ -126,7 +126,7 @@ Accounts.registerLoginHandler('ldap', function(loginRequest) {
 
 		syncUserData(user, ldapUser);
 
-		if (RocketChat.settings.get('LDAP_Login_Fallback') !== true) {
+		if (RocketChat.settings.get('LDAP_Login_Fallback') === true) {
 			Accounts.setPassword(user._id, loginRequest.ldapPass, {logout: false});
 		}
 


### PR DESCRIPTION
@RocketChat/core 
@TwizzyDizzy

See #6144

[Comment](https://github.com/RocketChat/Rocket.Chat/issues/6144#issuecomment-284715888) by [TwizzyDizzy](https://github.com/TwizzyDizzy)


> We do NOT want passwords to be saved in MongoDB when LDAP is enabled (this might be made into an option in the backend, if not, they should not be saved by default)
unless fallback-login is activated
> this means the passwords need to be erased (for LDAP-flagged accounts) on disabling fallback login and stored on next login, when this feature is enabled

This PR changes the password storage behaviour if `LDAP_Login_Fallback` is enabled. The password will not be saved in MongoDB.

