### PR TITLE
[FIX] New screen sharing Chrome extension checking method

### DIFF
--- a/packages/rocketchat-webrtc/client/WebRTCClass.js
+++ b/packages/rocketchat-webrtc/client/WebRTCClass.js
@@ -426,13 +426,17 @@ class WebRTCClass {
 			return;
 		}
 		const getScreen = (audioStream) => {
-			if (document.cookie.indexOf('rocketchatscreenshare=chrome') === -1 && (window.rocketchatscreenshare == null) && this.navigator !== 'electron') {
-				const refresh = function() {
-					swal({
-						type: 'warning',
-						title: TAPi18n.__('Refresh_your_page_after_install_to_enable_screen_sharing')
-					});
-				};
+			const refresh = function() {
+				swal({
+					type: 'warning',
+					title: TAPi18n.__('Refresh_your_page_after_install_to_enable_screen_sharing')
+				});
+			};
+
+			const isChromeExtensionInstalled = this.navigator === 'chrome' && ChromeScreenShare.installed;
+			const isFirefoxExtensionInstalled = this.navigator === 'firefox' && window.rocketchatscreenshare != null;
+
+			if (!isChromeExtensionInstalled || !isFirefoxExtensionInstalled) {
 				swal({
 					type: 'warning',
 					title: TAPi18n.__('Screen_Share'),
@@ -461,6 +465,7 @@ class WebRTCClass {
 				});
 				return onError(false);
 			}
+
 			const getScreenSuccess = (stream) => {
 				if (audioStream != null) {
 					stream.addTrack(audioStream.getAudioTracks()[0]);


### PR DESCRIPTION
Try to communicate with Chrome extension to see it is installed instead of checking for a cookie (the Chrome extension will not set a cookie anymore).

Chrome extension version 0.3+ accepts this method.

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
