### PR TITLE
[FIX] Add support for carriage return in markdown code blocks

### DIFF
--- a/packages/rocketchat-markdown/markdowncode.js
+++ b/packages/rocketchat-markdown/markdowncode.js
@@ -51,12 +51,12 @@ class MarkdownCode {
 			}
 
 			// Separate text in code blocks and non code blocks
-			const msgParts = message.html.split(/(^.*)(```(?:[a-zA-Z]+)?(?:(?:.|\n)*?)```)(.*\n?)$/gm);
+			const msgParts = message.html.split(/(^.*)(```(?:[a-zA-Z]+)?(?:(?:.|\r|\n)*?)```)(.*\n?)$/gm);
 
 			for (let index = 0; index < msgParts.length; index++) {
 				// Verify if this part is code
 				const part = msgParts[index];
-				const codeMatch = part.match(/^```(.*[\n\ ]?)([\s\S]*?)```+?$/);
+				const codeMatch = part.match(/^```(.*[\r\n\ ]?)([\s\S]*?)```+?$/);
 
 				if (codeMatch != null) {
 					// Process highlight if this part is code


### PR DESCRIPTION
@RocketChat/core

When I created an integration with Github (to notify PR comments), I noticed that the markdown is not working for code blocks if its a message attachment. Its because Github webhook payload has carriage return and new line `\r\n`. That's why javascript regex cannot split the text correctly

refs: <https://demo.rocket.chat/channel/support?msg=hkHxtB3vtnCq7X9JY>