### PR TITLE
[FIX] Add option to ignore TLS in SMTP server settings

### DIFF
--- a/packages/rocketchat-lib/server/startup/settings.js
+++ b/packages/rocketchat-lib/server/startup/settings.js
@@ -467,7 +467,7 @@ RocketChat.settings.addGroup('General', function() {
 
 RocketChat.settings.addGroup('Email', function() {
 	this.section('Header_and_Footer', function() {
-		this.add('Email_Header', '<table border="0" cellspacing="0" cellpadding="0" width="100%" bgcolor="#f3f3f3" style="color:#4a4a4a;font-family: Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;border-collapse:callapse;border-spacing:0;margin:0 auto"><tr><td style="padding:1em"><table border="0" cellspacing="0" cellpadding="0" align="center" width="100%" style="width:100%;margin:0 auto;max-width:800px"><tr><td bgcolor="#ffffff" style="background-color:#ffffff; border: 1px solid #DDD; font-size: 10pt; font-family: Helvetica,Arial,sans-serif;"><table width="100%" border="0" cellspacing="0" cellpadding="0"><tr><td style="background-color: #04436a;"><h1 style="font-family: Helvetica,Arial,sans-serif; padding: 0 1em; margin: 0; line-height: 70px; color: #FFF;">[Site_Name]</h1></td></tr><tr><td style="padding: 1em; font-size: 10pt; font-family: Helvetica,Arial,sans-serif;">', {
+		this.add('Email_Header', '<table border="0" cellspacing="0" cellpadding="0" width="100%" bgcolor="#f3f3f3" style="color:#4a4a4a;font-family: Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;border-collapse:collapse;border-spacing:0;margin:0 auto"><tr><td style="padding:1em"><table border="0" cellspacing="0" cellpadding="0" align="center" width="100%" style="width:100%;margin:0 auto;max-width:800px"><tr><td bgcolor="#ffffff" style="background-color:#ffffff; border: 1px solid #DDD; font-size: 10pt; font-family: Helvetica,Arial,sans-serif;"><table width="100%" border="0" cellspacing="0" cellpadding="0"><tr><td style="background-color: #04436a;"><h1 style="font-family: Helvetica,Arial,sans-serif; padding: 0 1em; margin: 0; line-height: 70px; color: #FFF;">[Site_Name]</h1></td></tr><tr><td style="padding: 1em; font-size: 10pt; font-family: Helvetica,Arial,sans-serif;">', {
 			type: 'code',
 			code: 'text/html',
 			multiline: true,
@@ -504,6 +504,15 @@ RocketChat.settings.addGroup('Email', function() {
 			type: 'string',
 			env: true,
 			i18nLabel: 'Port'
+		});
+		this.add('SMTP_IgnoreTLS', false, {
+			type: 'boolean',
+			env: true,
+			i18nLabel: 'IgnoreTLS',
+			enableQuery: {
+				_id: 'SMTP_Protocol',
+				value: 'smtp'
+            }
 		});
 		this.add('SMTP_Pool', true, {
 			type: 'boolean',

--- a/packages/rocketchat-lib/server/startup/settings.js
+++ b/packages/rocketchat-lib/server/startup/settings.js
@@ -512,7 +512,7 @@ RocketChat.settings.addGroup('Email', function() {
 			enableQuery: {
 				_id: 'SMTP_Protocol',
 				value: 'smtp'
-            }
+			}
 		});
 		this.add('SMTP_Pool', true, {
 			type: 'boolean',

--- a/packages/rocketchat-lib/server/startup/settingsOnLoadSMTP.js
+++ b/packages/rocketchat-lib/server/startup/settingsOnLoadSMTP.js
@@ -16,6 +16,10 @@ const buildMailURL = _.debounce(function() {
 
 		process.env.MAIL_URL += `?pool=${ RocketChat.settings.get('SMTP_Pool') }`;
 
+		if (RocketChat.settings.get('SMTP_Protocol') === 'smtp' && RocketChat.settings.get('SMTP_IgnoreTLS')) {
+			process.env.MAIL_URL += '&secure=false&ignoreTLS=true';
+		}
+
 		return process.env.MAIL_URL;
 	}
 }, 500);
@@ -47,6 +51,10 @@ RocketChat.settings.onload('SMTP_Protocol', function() {
 });
 
 RocketChat.settings.onload('SMTP_Pool', function() {
+	return buildMailURL();
+});
+
+RocketChat.settings.onload('SMTP_IgnoreTLS', function() {
 	return buildMailURL();
 });
 


### PR DESCRIPTION
@RocketChat/core 

email after email@1.1.18/node4mailer will STARTTLS automatically even if that is unwanted behaviour: 
Updates #6996

Adds an option to set "IgnoreTLS" when 'smtp' is selected in settings, allowing unencrypted SMTP if required.
