### PR TITLE
[NEW] feat: bot first queue method for livechat

### DIFF
--- a/packages/rocketchat-livechat/permissions.js
+++ b/packages/rocketchat-livechat/permissions.js
@@ -10,10 +10,10 @@ Meteor.startup(() => {
 		RocketChat.models.Roles.createOrUpdate('livechat-guest');
 	}
 	if (RocketChat.models && RocketChat.models.Permissions) {
-		RocketChat.models.Permissions.createOrUpdate('view-l-room', ['livechat-agent', 'livechat-manager', 'admin']);
+		RocketChat.models.Permissions.createOrUpdate('view-l-room', ['bot', 'livechat-agent', 'livechat-manager', 'admin']);
 		RocketChat.models.Permissions.createOrUpdate('view-livechat-manager', ['livechat-manager', 'admin']);
 		RocketChat.models.Permissions.createOrUpdate('view-livechat-rooms', ['livechat-manager', 'admin']);
-		RocketChat.models.Permissions.createOrUpdate('close-livechat-room', ['livechat-agent', 'livechat-manager', 'admin']);
+		RocketChat.models.Permissions.createOrUpdate('close-livechat-room', ['bot', 'livechat-agent', 'livechat-manager', 'admin']);
 		RocketChat.models.Permissions.createOrUpdate('close-others-livechat-room', ['livechat-manager', 'admin']);
 		RocketChat.models.Permissions.createOrUpdate('save-others-livechat-room-info', ['livechat-manager']);
 	}

--- a/packages/rocketchat-livechat/server/lib/Livechat.js
+++ b/packages/rocketchat-livechat/server/lib/Livechat.js
@@ -10,6 +10,9 @@ RocketChat.Livechat = {
 		}
 	}),
 
+	getBotAgent() {
+		return RocketChat.models.Users.getBotAgent();
+	},
 	getNextAgent(department) {
 		if (department) {
 			return RocketChat.models.LivechatDepartmentAgents.getNextAgentForDepartment(department);

--- a/packages/rocketchat-livechat/server/models/Users.js
+++ b/packages/rocketchat-livechat/server/models/Users.js
@@ -67,6 +67,45 @@ RocketChat.models.Users.findOnlineUserFromList = function(userList) {
  * Get next user agent in order
  * @return {object} User from db
  */
+RocketChat.models.Users.getBotAgent = function() {
+	const query = {
+        status: {
+			$exists: true,
+			$ne: 'offline'
+		},
+		statusLivechat: 'available',
+        roles: ['bot', 'livechat-agent']
+	};
+
+	const collectionObj = this.model.rawCollection();
+	const findAndModify = Meteor.wrapAsync(collectionObj.findAndModify, collectionObj);
+
+	const sort = {
+		livechatCount: 1,
+		username: 1
+	};
+
+	const update = {
+		$inc: {
+			livechatCount: 1
+		}
+	};
+
+	const user = findAndModify(query, sort, update);
+	if (user && user.value) {
+		return {
+			agentId: user.value._id,
+			username: user.value.username
+		};
+	} else {
+		return null;
+	}
+};
+
+/**
+ * Get next user agent in order
+ * @return {object} User from db
+ */
 RocketChat.models.Users.getNextAgent = function() {
 	const query = {
 		status: {


### PR DESCRIPTION
@RocketChat/core 

This PR gives bots the ability to view and close livechat rooms, as long as they're also livechat agents.
It also adds a new queue method, which is Bot First. It's a copy of least amount, but tries to find bot before agent.

This, together with (https://github.com/RocketChat/hubot-rocketchat/pull/211) brings to Rocket.Chat Livechat the possibility of conversational bots on Livechat

Any feedback is more than welcome :^)