### PR TITLE
Switch logic of artifact name

### DIFF
--- a/.travis/setartname.sh
+++ b/.travis/setartname.sh
@@ -1,6 +1,6 @@
-if [[ $TRAVIS_BRANCH ]]
+if [[ $TRAVIS_TAG ]]
  then
-  export ARTIFACT_NAME="$(meteor npm run version --silent).$TRAVIS_BUILD_NUMBER"
-else
   export ARTIFACT_NAME="$(meteor npm run version --silent)"
+else
+  export ARTIFACT_NAME="$(meteor npm run version --silent).$TRAVIS_BUILD_NUMBER"
 fi


### PR DESCRIPTION
TRAVIS_BRANCH is always set.  In the case of a tag its set to the tag name.  TRAVIS_TAG however is only set when its a tag.

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

