### PR TITLE
[FIX] Fix emoji picker translations

### DIFF
--- a/packages/rocketchat-2fa/client/accountSecurity.html
+++ b/packages/rocketchat-2fa/client/accountSecurity.html
@@ -14,7 +14,7 @@
 						<div class="section-content border-component-color">
 							<div class="alert pending-background pending-color pending-border">
 								<strong>
-									WARNING: Once you enable this, you will not be able to login on the native mobile apps (Rocket.Chat+) using your password until they implement the 2FA.
+									{{_ "Two-factor_authentication_native_mobile_app_warning"}}
 								</strong>
 							</div>
 							{{#if isEnabled}}

--- a/packages/rocketchat-emoji-custom/client/lib/emojiCustom.js
+++ b/packages/rocketchat-emoji-custom/client/lib/emojiCustom.js
@@ -1,6 +1,6 @@
 /* globals getEmojiUrlFromName:true, updateEmojiCustom:true, deleteEmojiCustom:true, isSetNotNull */
 RocketChat.emoji.packages.emojiCustom = {
-	emojiCategories: { rocket: TAPi18n.__('Custom') },
+	emojiCategories: { rocket: 'Custom' },
 	toneList: {},
 	list: [],
 

--- a/packages/rocketchat-emoji-emojione/emojiPicker.js
+++ b/packages/rocketchat-emoji-emojione/emojiPicker.js
@@ -4,14 +4,14 @@
  * Mapping category hashes into human readable and translated names
  */
 emojiCategories = {
-	people: TAPi18n.__('Smileys_and_People'),
-	nature: TAPi18n.__('Animals_and_Nature'),
-	food: TAPi18n.__('Food_and_Drink'),
-	activity: TAPi18n.__('Activity'),
-	travel: TAPi18n.__('Travel_and_Places'),
-	objects: TAPi18n.__('Objects'),
-	symbols: TAPi18n.__('Symbols'),
-	flags: TAPi18n.__('Flags')
+	people: 'Smileys_and_People',
+	nature: 'Animals_and_Nature',
+	food: 'Food_and_Drink',
+	activity: 'Activity',
+	travel: 'Travel_and_Places',
+	objects: 'Objects',
+	symbols: 'Symbols',
+	flags: 'Flags'
 };
 
 toneList = {

--- a/packages/rocketchat-emoji/emojiPicker.js
+++ b/packages/rocketchat-emoji/emojiPicker.js
@@ -9,7 +9,8 @@ function categoryName(category) {
 	for (const emojiPackage in RocketChat.emoji.packages) {
 		if (RocketChat.emoji.packages.hasOwnProperty(emojiPackage)) {
 			if (RocketChat.emoji.packages[emojiPackage].emojiCategories.hasOwnProperty(category)) {
-				return RocketChat.emoji.packages[emojiPackage].emojiCategories[category];
+				const categoryTag = RocketChat.emoji.packages[emojiPackage].emojiCategories[category];
+				return TAPi18n.__(categoryTag);
 			}
 		}
 	}

--- a/packages/rocketchat-emoji/rocketchat.js
+++ b/packages/rocketchat-emoji/rocketchat.js
@@ -1,7 +1,7 @@
 RocketChat.emoji = {
 	packages: {
 		base: {
-			emojiCategories: { recent: TAPi18n.__('Frequently_Used') },
+			emojiCategories: { recent: 'Frequently_Used' },
 			emojisByCategory: {
 				recent: []
 			},

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -1523,6 +1523,7 @@
   "Two-factor_authentication_disabled": "Two-factor authentication disabled",
   "Two-factor_authentication_enabled": "Two-factor authentication enabled",
   "Two-factor_authentication_is_currently_disabled": "Two-factor authentication is currently disabled",
+  "Two-factor_authentication_native_mobile_app_warning" : "WARNING: Once you enable this, you will not be able to login on the native mobile apps (Rocket.Chat+) using your password until they implement the 2FA.",
   "Thursday": "Thursday",
   "Time_in_seconds": "Time in seconds",
   "Title": "Title",


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #6969 and #5559

The emoji titles were being translated directly in their package, and this was causing to keep the first translation it got

also fixed a hardcoded string on the security page


