### PR TITLE
[FIX] url click events in the cordova app open in external browser or not at all

### DIFF
--- a/packages/rocketchat-ui-master/client/main.js
+++ b/packages/rocketchat-ui-master/client/main.js
@@ -184,7 +184,7 @@ Template.main.events({
 	},
 	'touchmove'(e, t) {
 		if (t.touchstartX != null) {
-			const [touch] = e.originalEvent.touches;
+			const touch = e.originalEvent.touches[0];
 			const diffX = touch.clientX - t.touchstartX;
 			const diffY = touch.clientY - t.touchstartY;
 			const absX = Math.abs(diffX);

--- a/packages/rocketchat-ui/client/lib/cordova/urls.js
+++ b/packages/rocketchat-ui/client/lib/cordova/urls.js
@@ -8,7 +8,7 @@ Meteor.startup(() => {
 			if (!($link.length > 0)) { return; }
 			const url = $link.attr('href');
 
-			if (/^https?:\/\/.+/.test(url) === true) {
+			if (/^https?:\/\/.+/i.test(url) === true) {
 				window.open(url, '_system');
 				return e.preventDefault();
 			}

--- a/packages/rocketchat-ui/client/lib/cordova/urls.js
+++ b/packages/rocketchat-ui/client/lib/cordova/urls.js
@@ -1,7 +1,7 @@
 Meteor.startup(() => {
 	if (!Meteor.isCordova) { return; }
 	// Handle click events for all external URLs
-	$(document).on('deviceready', () => {
+	document.addEventListener('deviceready', () => {
 		// const platform = device.platform.toLowerCase();
 		$(document).on('click', function(e) {
 			const $link = $(e.target).closest('a[href]');

--- a/packages/rocketchat-ui/client/views/app/room.js
+++ b/packages/rocketchat-ui/client/views/app/room.js
@@ -234,6 +234,8 @@ Template.room.helpers({
 
 let isSocialSharingOpen = false;
 let touchMoved = false;
+let lastTouchX = null;
+let lastTouchY = null;
 
 Template.room.events({
 	'click, touchend'(e, t) {
@@ -250,6 +252,11 @@ Template.room.events({
 	},
 
 	'touchstart .message'(e, t) {
+		const touches = e.originalEvent.touches;
+		if (touches && touches.length) {
+			lastTouchX = touches[0].pageX;
+			lastTouchY = touches[0].pagey;
+		}
 		touchMoved = false;
 		isSocialSharingOpen = false;
 		if (e.originalEvent.touches.length !== 1) {
@@ -344,7 +351,14 @@ Template.room.events({
 	},
 
 	'touchmove .message'(e, t) {
-		touchMoved = true;
+		const touches = e.originalEvent.touches;
+		if (touches && touches.length) {
+			const deltaX = Math.abs(lastTouchX - touches[0].pageX);
+			const deltaY = Math.abs(lastTouchY - touches[0].pageY);
+			if (deltaX > 5 || deltaY > 5) {
+				touchMoved = true;
+			}
+		}
 		return Meteor.clearTimeout(t.touchtime);
 	},
 


### PR DESCRIPTION
@RocketChat/core 
this should fix the following problems:
- exception on touchmove events in the cordova app
- http links are not opened in an external browser in the cordova app
- sometimes url clicks are not handled because the touchMoved variable is set

Please let me know if this also works for you.

Closes RocketChat/Rocket.Chat.Cordova#142 and #7075
