### PR TITLE
[NEW] Add generic tag field to user

### DIFF
--- a/packages/rocketchat-lib/server/models/Users.js
+++ b/packages/rocketchat-lib/server/models/Users.js
@@ -148,6 +148,9 @@ class ModelUsers extends RocketChat.models._Base {
 						},
 						{
 							name: termRegex
+						},
+						{
+							tag: termRegex
 						}
 					]
 				},

--- a/packages/rocketchat-ui/client/lib/chatMessages.js
+++ b/packages/rocketchat-ui/client/lib/chatMessages.js
@@ -104,7 +104,7 @@ this.ChatMessages = class ChatMessages {
 		const editAllowed = RocketChat.settings.get('Message_AllowEditing');
 		const editOwn = message && message.u && message.u._id === Meteor.userId();
 
-		if (!hasPermission && !editAllowed || !editOwn) { return; }
+		if (!hasPermission && (!editAllowed || !editOwn)) { return; }
 		if (element.classList.contains('system')) { return; }
 
 		const blockEditInMinutes = RocketChat.settings.get('Message_AllowEditing_BlockEditInMinutes');

--- a/server/publications/spotlight.js
+++ b/server/publications/spotlight.js
@@ -31,6 +31,7 @@ Meteor.methods({
 				fields: {
 					username: 1,
 					name: 1,
+					tag: 1,
 					status: 1
 				},
 				sort: {}


### PR DESCRIPTION
@RocketChat/core 

Beside the current username and real user name, this change introduces a generic field that can be mapped to any LDAP attribute. This new field, named tag, is invisible to the final user but is used in the users search functionality. For instance, suppose the LDAP attribute 'color' is mapped to 'tag'. After that, one could find all users whose 'color' LDAP attribute is blue by typing 'blue' in the searh field.

TODO: Update documentation (if accepted)