### PR TITLE
[New] Add instance id to response headers

### DIFF
--- a/packages/rocketchat-lib/package.js
+++ b/packages/rocketchat-lib/package.js
@@ -17,6 +17,7 @@ Npm.depends({
 
 Package.onUse(function(api) {
 	api.use('rate-limit');
+	api.use('webapp')
 	api.use('session');
 	api.use('reactive-var');
 	api.use('reactive-dict');

--- a/packages/rocketchat-lib/package.js
+++ b/packages/rocketchat-lib/package.js
@@ -17,7 +17,7 @@ Npm.depends({
 
 Package.onUse(function(api) {
 	api.use('rate-limit');
-	api.use('webapp')
+	api.use('webapp');
 	api.use('session');
 	api.use('reactive-var');
 	api.use('reactive-dict');

--- a/packages/rocketchat-lib/server/lib/debug.js
+++ b/packages/rocketchat-lib/server/lib/debug.js
@@ -1,3 +1,4 @@
+/* global InstanceStatus */
 const logger = new Logger('Meteor', {
 	methods: {
 		method: {

--- a/packages/rocketchat-lib/server/lib/debug.js
+++ b/packages/rocketchat-lib/server/lib/debug.js
@@ -38,7 +38,6 @@ Meteor.publish = function(name, func) {
 };
 
 WebApp.rawConnectHandlers.use(function(req, res, next) {
-	const setHeader = res.setHeader;
 	res.setHeader('X-Instance-ID', InstanceStatus.id());
 	return next();
 });

--- a/packages/rocketchat-lib/server/lib/debug.js
+++ b/packages/rocketchat-lib/server/lib/debug.js
@@ -36,3 +36,9 @@ Meteor.publish = function(name, func) {
 		return func.apply(this, arguments);
 	});
 };
+
+WebApp.rawConnectHandlers.use(function(req, res, next) {
+	const setHeader = res.setHeader;
+	res.setHeader('X-Instance-ID', InstanceStatus.id());
+	return next();
+});


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

This will help a lot with debugging multi-instance issues.

Debating putting behind a setting.  I don't think we use instance id for anything special, so I don't know that exposing it would be harmful in any way.