### PR TITLE
[Fix] Users and Channels list not respecting permissions

### DIFF
--- a/packages/rocketchat-api/server/v1/channels.js
+++ b/packages/rocketchat-api/server/v1/channels.js
@@ -332,7 +332,7 @@ RocketChat.API.v1.addRoute('channels.leave', { authRequired: true }, {
 
 RocketChat.API.v1.addRoute('channels.list', { authRequired: true }, {
 	get: {
-		//This is defined as much  only to provide an example of how the routes can be defined :X
+		//This is defined as such only to provide an example of how the routes can be defined :X
 		action() {
 			const { offset, count } = this.getPaginationItems();
 			const { sort, fields, query } = this.parseJsonQuery();

--- a/packages/rocketchat-api/server/v1/channels.js
+++ b/packages/rocketchat-api/server/v1/channels.js
@@ -332,12 +332,21 @@ RocketChat.API.v1.addRoute('channels.leave', { authRequired: true }, {
 
 RocketChat.API.v1.addRoute('channels.list', { authRequired: true }, {
 	get: {
-		//This is like this only to provide an example of how we routes can be defined :X
+		//This is defined as much  only to provide an example of how the routes can be defined :X
 		action() {
 			const { offset, count } = this.getPaginationItems();
 			const { sort, fields, query } = this.parseJsonQuery();
 
 			const ourQuery = Object.assign({}, query, { t: 'c' });
+
+			//Special check for the permissions
+			if (RocketChat.authz.hasPermission(this.userId, 'view-joined-room')) {
+				ourQuery.usernames = {
+					$in: [ this.user.username ]
+				};
+			} else if (!RocketChat.authz.hasPermission(this.userId, 'view-c-room')) {
+				return RocketChat.API.v1.unauthorized();
+			}
 
 			const rooms = RocketChat.models.Rooms.find(ourQuery, {
 				sort: sort ? sort : { name: 1 },

--- a/packages/rocketchat-api/server/v1/users.js
+++ b/packages/rocketchat-api/server/v1/users.js
@@ -105,6 +105,10 @@ RocketChat.API.v1.addRoute('users.info', { authRequired: true }, {
 
 RocketChat.API.v1.addRoute('users.list', { authRequired: true }, {
 	get() {
+		if (!RocketChat.authz.hasPermission(this.userId, 'view-d-room')) {
+			return RocketChat.API.v1.unauthorized();
+		}
+
 		const { offset, count } = this.getPaginationItems();
 		const { sort, fields, query } = this.parseJsonQuery();
 


### PR DESCRIPTION
<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #7144 - to be able to use `/api/v1/users.list` you must have `view-d-room` permission and then to view other channels that you aren't joined you must have `view-c-room` and can not have `view-joined-room`.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
