### PR TITLE
[NEW] Allow channel property in the integrations returned content

### DIFF
--- a/packages/rocketchat-integrations/server/lib/triggerHandler.js
+++ b/packages/rocketchat-integrations/server/lib/triggerHandler.js
@@ -165,8 +165,8 @@ RocketChat.integrations.triggerHandler = new class RocketChatIntegrationHandler 
 		}
 
 		let tmpRoom;
-		if (nameOrId || trigger.targetRoom) {
-			tmpRoom = RocketChat.getRoomByNameOrIdWithOptionToJoin({ currentUserId: user._id, nameOrId: nameOrId || trigger.targetRoom, errorOnEmpty: false }) || room;
+		if (nameOrId || trigger.targetRoom || message.channel) {
+			tmpRoom = RocketChat.getRoomByNameOrIdWithOptionToJoin({ currentUserId: user._id, nameOrId: nameOrId || message.channel || trigger.targetRoom, errorOnEmpty: false }) || room;
 		} else {
 			tmpRoom = room;
 		}


### PR DESCRIPTION
<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #7008 - Allows returning a channel where the messages should be sent when inside of the integration script.

```
return {
    content: {
        text: 'Hiya ;)',
        channel: data.channel || '@username'
    }
};
```

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
