### PR TITLE
Fix the Zapier oAuth return url to the new one

### DIFF
--- a/packages/rocketchat-oauth2-server-config/oauth/server/default-services.js
+++ b/packages/rocketchat-oauth2-server-config/oauth/server/default-services.js
@@ -5,7 +5,7 @@ if (!RocketChat.models.OAuthApps.findOne('zapier')) {
 		active: true,
 		clientId: 'zapier',
 		clientSecret: 'RTK6TlndaCIolhQhZ7_KHIGOKj41RnlaOq_o-7JKwLr',
-		redirectUri: 'https://zapier.com/dashboard/auth/oauth/return/App32270API/',
+		redirectUri: 'https://zapier.com/dashboard/auth/oauth/return/RocketChatDevAPI/',
 		_createdAt: new Date,
 		_createdBy: {
 			_id: 'system',

--- a/server/startup/migrations/v098.js
+++ b/server/startup/migrations/v098.js
@@ -1,0 +1,10 @@
+RocketChat.Migrations.add({
+	version: 98,
+	up() {
+		RocketChat.models.OAuthApps.update({ _id: 'zapier' }, {
+			$set: {
+				redirectUri: 'https://zapier.com/dashboard/auth/oauth/return/RocketChatDevAPI/'
+			}
+		});
+	}
+});


### PR DESCRIPTION
This is a permanent oAuth return url which needs to be in everyone's system. Will be updated again when we go to a public beta instead of invite only.