### PR TITLE
[FIX] Vague error message when creating integration and rocket.cat is deleted

### DIFF
--- a/packages/rocketchat-integrations/server/lib/validation.js
+++ b/packages/rocketchat-integrations/server/lib/validation.js
@@ -149,7 +149,7 @@ RocketChat.integrations.validateOutgoing = function _validateOutgoing(integratio
 	const user = RocketChat.models.Users.findOne({ username: integration.username });
 
 	if (!user) {
-		throw new Meteor.Error('error-invalid-user', 'Invalid user', { function: 'validateOutgoing' });
+		throw new Meteor.Error('error-invalid-user', 'Invalid user (did you delete the `rocket.cat` user?)', { function: 'validateOutgoing' });
 	}
 
 	integration.type = 'webhook-outgoing';


### PR DESCRIPTION
Currently when creating Zaps the `rocket.cat` user is required. This improves the error message which comes up inside of Zapier when someone has deleted this user in their instance but tries to get a Zap going.