### PR TITLE
[FIX] Fixes scope error preventing file upload errors from being dismissed

### DIFF
--- a/packages/rocketchat-ui/client/lib/fileUpload.js
+++ b/packages/rocketchat-ui/client/lib/fileUpload.js
@@ -45,6 +45,10 @@ function formatBytes(bytes, decimals) {
 	return `${ parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) } ${ sizes[i] }`;
 }
 
+function clearUploadError(id) {
+	const uploading = Session.get('uploading') || [];
+}
+
 fileUpload = function(filesToUpload) {
 	const roomId = Session.get('openedRoom');
 	const files = [].concat(filesToUpload);
@@ -135,7 +139,7 @@ fileUpload = function(filesToUpload) {
 				html: true
 			}, function(isConfirm) {
 				consume();
-				if (isConfirm !== true) {
+				if (!isConfirm) {
 					return;
 				}
 
@@ -175,10 +179,10 @@ fileUpload = function(filesToUpload) {
 							uploading = [];
 						}
 
-						const item = _.findWhere(uploading, { id: this.id });
+						const item = _.findWhere(uploading, { id: upload.id });
 
 						if (_.isObject(item)) {
-							item.error = error.error;
+							item.error = error.message;
 							item.percentage = 0;
 						} else {
 							uploading.push({

--- a/packages/rocketchat-ui/client/lib/fileUpload.js
+++ b/packages/rocketchat-ui/client/lib/fileUpload.js
@@ -45,10 +45,6 @@ function formatBytes(bytes, decimals) {
 	return `${ parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) } ${ sizes[i] }`;
 }
 
-function clearUploadError(id) {
-	const uploading = Session.get('uploading') || [];
-}
-
 fileUpload = function(filesToUpload) {
 	const roomId = Session.get('openedRoom');
 	const files = [].concat(filesToUpload);


### PR DESCRIPTION
@RocketChat/core 
Closes #7220 

There was a scope error that caused the file uploaded ID to be undefined, causing the error to append instead of replace the file on the uploading list:
![Current behavior](https://user-images.githubusercontent.com/6303966/27049866-010477a0-4f87-11e7-90ff-333afd4989c0.png)

With the fix, the file upload indicator is replaced with the error and the close buttons works when trying to dismiss the error.
![Fixed](https://user-images.githubusercontent.com/6303966/27049865-01026dde-4f87-11e7-9314-d885355bf3b1.png)

Not sure if the 'error.message' is the best choice there, but I think it's better than doing just the error code that was there previously.