### PR TITLE
[FIX] Fix not being able to add more than 2 default rooms

### DIFF
--- a/packages/rocketchat-channel-settings/client/lib/ChannelSettings.js
+++ b/packages/rocketchat-channel-settings/client/lib/ChannelSettings.js
@@ -21,12 +21,13 @@ RocketChat.ChannelSettings = new class {
 		});
 	}
 
-	getOptions(currentData, group) {
+	getOptions(currentData = {}, group) {
 		const allOptions = _.toArray(this.options.get());
 		const allowedOptions = _.compact(_.map(allOptions, function(option) {
+			const ret = {...option};
 			if (option.validation == null || option.validation()) {
-				option.data = Object.assign({}, typeof option.data === 'function' ? option.data() : option.data, currentData);
-				return option;
+				ret.data = Object.assign({}, typeof option.data === 'function' ? option.data() : option.data, currentData);
+				return ret;
 			}
 		})).filter(function(option) {
 			return !group || !option.group || option.group.includes(group);

--- a/packages/rocketchat-ui-admin/client/rooms/adminRoomInfo.js
+++ b/packages/rocketchat-ui-admin/client/rooms/adminRoomInfo.js
@@ -19,7 +19,7 @@ Template.adminRoomInfo.helpers({
 		return room && room.t;
 	},
 	channelSettings() {
-		return RocketChat.ChannelSettings.getOptions(Session.get('adminRoomsSelected'), 'admin-room');
+		return RocketChat.ChannelSettings.getOptions(undefined, 'admin-room');
 	},
 	roomTypeDescription() {
 		const room = AdminChatRoom.findOne(this.rid, { fields: { t: 1 } });

--- a/packages/rocketchat-ui-admin/client/rooms/adminRoomInfo.js
+++ b/packages/rocketchat-ui-admin/client/rooms/adminRoomInfo.js
@@ -19,7 +19,7 @@ Template.adminRoomInfo.helpers({
 		return room && room.t;
 	},
 	channelSettings() {
-		return RocketChat.ChannelSettings.getOptions(null, 'admin-room');
+		return RocketChat.ChannelSettings.getOptions(Session.get('adminRoomsSelected'), 'admin-room');
 	},
 	roomTypeDescription() {
 		const room = AdminChatRoom.findOne(this.rid, { fields: { t: 1 } });


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
related #5975 and #7004 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Under administration -> Rooms if you selected a channel from the list, the `default channel` option would refer to that channel, even if you selected another channel in the list

