### PR TITLE
[FIX] avoid double escaping of ampersand in markdown.js

### DIFF
--- a/packages/rocketchat-markdown/markdown.js
+++ b/packages/rocketchat-markdown/markdown.js
@@ -3,9 +3,29 @@
  * @param {Object} message - The message object
  */
 
+const escapeHTML = (html) => (html || '').replace(/[&<>]/g, (c, offset, str) => {
+	if (c === '&') {
+		if (str.startsWith("amp;", offset+1) ||
+			str.startsWith("lt;" , offset+1) ||
+			str.startsWith("gt;" , offset+1)) {
+			// already escaped!
+			return c;
+		}
+
+		return "&amp;";
+	}
+
+	if (c === '<') {
+		return "&lt;";
+	}
+
+	return "&gt;";
+});
+
+
 class MarkdownClass {
 	parse(text) {
-		return this.parseNotEscaped(_.escapeHTML(text));
+		return this.parseNotEscaped(escapeHTML(text));
 	}
 
 	parseNotEscaped(msg) {
@@ -53,19 +73,19 @@ class MarkdownClass {
 		// Support ![alt text](http://image url)
 		msg = msg.replace(new RegExp(`!\\[([^\\]]+)\\]\\(((?:${ schemes }):\\/\\/[^\\)]+)\\)`, 'gm'), function(match, title, url) {
 			const target = url.indexOf(Meteor.absoluteUrl()) === 0 ? '' : '_blank';
-			return `<a href="${ _.escapeHTML(url) }" title="${ _.escapeHTML(title) }" target="${ _.escapeHTML(target) }"><div class="inline-image" style="background-image: url(${ _.escapeHTML(url) });"></div></a>`;
+			return `<a href="${ escapeHTML(url) }" title="${ escapeHTML(title) }" target="${ escapeHTML(target) }"><div class="inline-image" style="background-image: url(${ escapeHTML(url) });"></div></a>`;
 		});
 
 		// Support [Text](http://link)
 		msg = msg.replace(new RegExp(`\\[([^\\]]+)\\]\\(((?:${ schemes }):\\/\\/[^\\)]+)\\)`, 'gm'), function(match, title, url) {
 			const target = url.indexOf(Meteor.absoluteUrl()) === 0 ? '' : '_blank';
-			return `<a href="${ _.escapeHTML(url) }" target="${ _.escapeHTML(target) }">${ _.escapeHTML(title) }</a>`;
+			return `<a href="${ escapeHTML(url) }" target="${ escapeHTML(target) }">${ escapeHTML(title) }</a>`;
 		});
 
 		// Support <http://link|Text>
 		msg = msg.replace(new RegExp(`(?:<|&lt;)((?:${ schemes }):\\/\\/[^\\|]+)\\|(.+?)(?=>|&gt;)(?:>|&gt;)`, 'gm'), (match, url, title) => {
 			const target = url.indexOf(Meteor.absoluteUrl()) === 0 ? '' : '_blank';
-			return `<a href="${ _.escapeHTML(url) }" target="${ _.escapeHTML(target) }">${ _.escapeHTML(title) }</a>`;
+			return `<a href="${ escapeHTML(url) }" target="${ escapeHTML(target) }">${ escapeHTML(title) }</a>`;
 		});
 
 		if (typeof window !== 'undefined' && window !== null ? window.rocketDebug : undefined) { console.log('Markdown', msg); }

--- a/packages/rocketchat-markdown/markdown.js
+++ b/packages/rocketchat-markdown/markdown.js
@@ -5,21 +5,21 @@
 
 const escapeHTML = (html) => (html || '').replace(/[&<>]/g, (c, offset, str) => {
 	if (c === '&') {
-		if (str.startsWith("amp;", offset+1) ||
-			str.startsWith("lt;" , offset+1) ||
-			str.startsWith("gt;" , offset+1)) {
+		if (str.startsWith('amp;', offset+1) ||
+			str.startsWith('lt;', offset+1) ||
+			str.startsWith('gt;', offset+1)) {
 			// already escaped!
 			return c;
 		}
 
-		return "&amp;";
+		return '&amp;';
 	}
 
 	if (c === '<') {
-		return "&lt;";
+		return '&lt;';
 	}
 
-	return "&gt;";
+	return '&gt;';
 });
 
 


### PR DESCRIPTION
@RocketChat/core 

Closes #6719, #6586

I've added a separate "escapeHTML" function, which can be called multiple times on the same input without double escaping of ampersand. A more general fix would be to adjust the original escapeHTML function, but I'm not aware of where this function is pulled from.

