### PR TITLE
[FIX] Translation of word Away to Ausente instead of ausente in (PT,PT-BR)

### DIFF
--- a/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
@@ -202,7 +202,7 @@
   "away_female": "ausente",
   "Away_female": "Ausente",
   "away_male": "ausente",
-  "Away_male": "ausente",
+  "Away_male": "Ausente",
   "Back": "Voltar",
   "Back_to_applications": "Voltar para aplicações",
   "Back_to_integrations": "Voltar para integrações",

--- a/packages/rocketchat-i18n/i18n/pt.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pt.i18n.json
@@ -221,7 +221,7 @@
   "away_female": "ausente",
   "Away_female": "Ausente",
   "away_male": "ausente",
-  "Away_male": "ausente",
+  "Away_male": "Ausente",
   "Back": "Voltar",
   "Back_to_applications": "Voltar para aplicações",
   "Back_to_integrations": "Voltar para integrações",


### PR DESCRIPTION
There is no Issue for this fix.

Example:
![image](https://user-images.githubusercontent.com/401307/27482127-8449ae10-57f6-11e7-99bf-1d5b19d31dfe.png)

