### PR TITLE
[FIX] Modernize rate limiting of sendMessage

### DIFF
--- a/packages/rocketchat-authorization/server/startup.js
+++ b/packages/rocketchat-authorization/server/startup.js
@@ -46,6 +46,7 @@ Meteor.startup(function() {
 		{ _id: 'run-migration',                 roles : ['admin'] },
 		{ _id: 'set-moderator',                 roles : ['admin', 'owner'] },
 		{ _id: 'set-owner',                     roles : ['admin', 'owner'] },
+		{ _id: 'send-many-messages',            roles : ['admin', 'bot'] },
 		{ _id: 'unarchive-room',                roles : ['admin'] },
 		{ _id: 'view-c-room',                   roles : ['admin', 'user', 'bot', 'anonymous'] },
 		{ _id: 'user-generate-access-token',    roles : ['admin'] },

--- a/packages/rocketchat-lib/server/methods/sendMessage.js
+++ b/packages/rocketchat-lib/server/methods/sendMessage.js
@@ -68,14 +68,8 @@ Meteor.methods({
 	}
 });
 // Limit a user, who does not have the "bot" role, to sending 5 msgs/second
-DDPRateLimiter.addRule({
-	type: 'method',
-	name: 'sendMessage',
+RocketChat.RateLimiter.limitMethod('sendMessage', 5, 1000, {
 	userId(userId) {
-		const user = RocketChat.models.Users.findOneById(userId);
-		if (user == null || !user.roles) {
-			return true;
-		}
-		return user.roles.includes('bot');
+		return !RocketChat.authz.hasPermission(userId, 'send-many-messages');
 	}
-}, 5, 1000);
+});


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
In the old coffee script code line 97 was `return 'bot' not in user.roles`, but it was converted to JavaScript to `user.roles.includes('bot')`.
