### PR TITLE
[NEW] Search users also by email in toolbar

### DIFF
--- a/packages/rocketchat-lib/server/models/Users.js
+++ b/packages/rocketchat-lib/server/models/Users.js
@@ -148,6 +148,9 @@ class ModelUsers extends RocketChat.models._Base {
 						},
 						{
 							name: termRegex
+						},
+						{
+							'emails.address': termRegex
 						}
 					]
 				},


### PR DESCRIPTION
@RocketChat/core 

Closes #7333

## Changes
* Changed `findByActiveUsersExcept` query to allow to search users also by email (`emails.address`) in toolbar

