### PR TITLE
[FIX] file upload broken when running in subdirectory https://github.com…

### DIFF
--- a/packages/rocketchat-cors/cors.js
+++ b/packages/rocketchat-cors/cors.js
@@ -12,7 +12,7 @@ WebApp.rawConnectHandlers.use(function(req, res, next) {
 	if (req.headers['content-type'] !== '' && req.headers['content-type'] !== undefined) {
 		return next();
 	}
-	if (req.url.indexOf('/ufs/') === 0) {
+	if (req.url.indexOf(`${ __meteor_runtime_config__.ROOT_URL_PATH_PREFIX }/${UploadFS.config.storesPath}/`) === 0) {
 		return next();
 	}
 

--- a/packages/rocketchat-cors/cors.js
+++ b/packages/rocketchat-cors/cors.js
@@ -2,7 +2,7 @@
 
 import url from 'url';
 
-WebApp.rawConnectHandlers.use(function(req, res, next) {
+WebApp.rawConnectHandlers.use(Meteor.bindEnvironment(function(req, res, next) {
 	if (req._body) {
 		return next();
 	}
@@ -12,7 +12,7 @@ WebApp.rawConnectHandlers.use(function(req, res, next) {
 	if (req.headers['content-type'] !== '' && req.headers['content-type'] !== undefined) {
 		return next();
 	}
-	if (req.url.indexOf(`${ __meteor_runtime_config__.ROOT_URL_PATH_PREFIX }/${UploadFS.config.storesPath}/`) === 0) {
+	if (req.url.indexOf(`${ __meteor_runtime_config__.ROOT_URL_PATH_PREFIX }/ufs/`) === 0) {
 		return next();
 	}
 
@@ -36,7 +36,7 @@ WebApp.rawConnectHandlers.use(function(req, res, next) {
 
 		return next();
 	});
-});
+}));
 
 WebApp.rawConnectHandlers.use(function(req, res, next) {
 	if (/^\/(api|_timesync|sockjs|tap-i18n|__cordova)(\/|$)/.test(req.url)) {

--- a/packages/rocketchat-file-upload/server/lib/requests.js
+++ b/packages/rocketchat-file-upload/server/lib/requests.js
@@ -7,7 +7,8 @@ RocketChat.settings.get('FileUpload_ProtectFiles', function(key, value) {
 	protectedFiles = value;
 });
 
-WebApp.connectHandlers.use('/file-upload/', function(req, res, next) {
+WebApp.connectHandlers.use(`${ __meteor_runtime_config__.ROOT_URL_PATH_PREFIX }/file-upload/`,	function(req, res, next) {
+
 	const match = /^\/([^\/]+)\/(.*)/.exec(req.url);
 
 	if (match[1]) {

--- a/packages/rocketchat-lib/client/lib/settings.js
+++ b/packages/rocketchat-lib/client/lib/settings.js
@@ -59,8 +59,8 @@ Meteor.startup(function() {
 			return c.stop();
 		}
 		Meteor.setTimeout(function() {
-			if (__meteor_runtime_config__.ROOT_URL !== location.origin) {
-				const currentUrl = location.origin + __meteor_runtime_config__.ROOT_URL_PATH_PREFIX;
+			const currentUrl = location.origin + __meteor_runtime_config__.ROOT_URL_PATH_PREFIX;
+			if (__meteor_runtime_config__.ROOT_URL !== currentUrl) {
 				swal({
 					type: 'warning',
 					title: t('Warning'),

--- a/packages/rocketchat-lib/lib/startup/settingsOnLoadSiteUrl.js
+++ b/packages/rocketchat-lib/lib/startup/settingsOnLoadSiteUrl.js
@@ -10,10 +10,13 @@ RocketChat.settings.get('Site_Url', function(key, value) {
 		host = match[1];
 		// prefix = match[2].replace(/\/$/, '');
 	}
-	__meteor_runtime_config__.ROOT_URL = host;
+	__meteor_runtime_config__.ROOT_URL = value;
+
+	console.log('__meteor_runtime_config__.ROOT_URL_PATH_PREFIX =' + __meteor_runtime_config__.ROOT_URL_PATH_PREFIX)
+	console.log('__meteor_runtime_config__.ROOT_URL=' + __meteor_runtime_config__.ROOT_URL)
 
 	if (Meteor.absoluteUrl.defaultOptions && Meteor.absoluteUrl.defaultOptions.rootUrl) {
-		Meteor.absoluteUrl.defaultOptions.rootUrl = host;
+		Meteor.absoluteUrl.defaultOptions.rootUrl = value;
 	}
 	if (Meteor.isServer) {
 		RocketChat.hostname = host.replace(/^https?:\/\//, '');

--- a/packages/rocketchat-lib/lib/startup/settingsOnLoadSiteUrl.js
+++ b/packages/rocketchat-lib/lib/startup/settingsOnLoadSiteUrl.js
@@ -12,9 +12,6 @@ RocketChat.settings.get('Site_Url', function(key, value) {
 	}
 	__meteor_runtime_config__.ROOT_URL = value;
 
-	console.log('__meteor_runtime_config__.ROOT_URL_PATH_PREFIX =' + __meteor_runtime_config__.ROOT_URL_PATH_PREFIX)
-	console.log('__meteor_runtime_config__.ROOT_URL=' + __meteor_runtime_config__.ROOT_URL)
-
 	if (Meteor.absoluteUrl.defaultOptions && Meteor.absoluteUrl.defaultOptions.rootUrl) {
 		Meteor.absoluteUrl.defaultOptions.rootUrl = value;
 	}


### PR DESCRIPTION
…/RocketChat/Rocket.Chat/issues/6679

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #6679

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
File upload using jalik:ufs was broken due to the following reasons:

1. rocketchat-cors/cors.js handler ignoring ROOT_URL_PATH_PREFIX when skipping UFS stores path
2. rocketchat-file-upload/server/lib/requests.js igoring ROOT_URL_PATH_PREFIX when getting file-upload path
3. packages/rocketchat-lib/client/lib/settings.js should check for the location.origin + url path prefix for the case when rocketchat is run off a subdir
4. packages/rocketchat-lib/lib/startup/settingsOnLoadSiteUrl.js dropping the url path prefix when Site_Url is set
