### PR TITLE
[FIX] Always set LDAP properties on login

### DIFF
--- a/packages/rocketchat-ldap/server/sync.js
+++ b/packages/rocketchat-ldap/server/sync.js
@@ -62,9 +62,10 @@ getDataToSyncUserData = function getDataToSyncUserData(ldapUser, user) {
 	const syncUserData = RocketChat.settings.get('LDAP_Sync_User_Data');
 	const syncUserDataFieldMap = RocketChat.settings.get('LDAP_Sync_User_Data_FieldMap').trim();
 
+	const userData = {};
+
 	if (syncUserData && syncUserDataFieldMap) {
 		const fieldMap = JSON.parse(syncUserDataFieldMap);
-		const userData = {};
 		const emailList = [];
 		_.map(fieldMap, function(userField, ldapField) {
 			switch (userField) {
@@ -125,21 +126,21 @@ getDataToSyncUserData = function getDataToSyncUserData(ldapUser, user) {
 				userData.emails = emailList;
 			}
 		}
+	}
 
-		const uniqueId = getLdapUserUniqueID(ldapUser);
+	const uniqueId = getLdapUserUniqueID(ldapUser);
 
-		if (uniqueId && (!user.services || !user.services.ldap || user.services.ldap.id !== uniqueId.value || user.services.ldap.idAttribute !== uniqueId.attribute)) {
-			userData['services.ldap.id'] = uniqueId.value;
-			userData['services.ldap.idAttribute'] = uniqueId.attribute;
-		}
+	if (uniqueId && (!user.services || !user.services.ldap || user.services.ldap.id !== uniqueId.value || user.services.ldap.idAttribute !== uniqueId.attribute)) {
+		userData['services.ldap.id'] = uniqueId.value;
+		userData['services.ldap.idAttribute'] = uniqueId.attribute;
+	}
 
-		if (user.ldap !== true) {
-			userData.ldap = true;
-		}
+	if (user.ldap !== true) {
+		userData.ldap = true;
+	}
 
-		if (_.size(userData)) {
-			return userData;
-		}
+	if (_.size(userData)) {
+		return userData;
 	}
 };
 


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
This PR will prevent new LDAP logins from being stuck even if `Merge existing users` is disabled.

For users that currently cannot log in (see #7429 and #7405) you'll need to enable `Merge existing users`.