### PR TITLE
[FIX] Fix hiding flex-tab on embedded view

### DIFF
--- a/packages/rocketchat-theme/client/imports/base.css
+++ b/packages/rocketchat-theme/client/imports/base.css
@@ -4745,12 +4745,12 @@ a + br.only-after-a {
 }
 
 .embedded-view {
-	& .flex-tab-bar {
-		display: none;
-	}
-
 	& .messages-container {
 		border-width: 0;
+
+		& .flex-tab-container {
+			display: none;
+		}
 
 		& .messages-box {
 			margin-top: 0;


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Using the embedded view mode (appending `?layout=embedded` to the URL) the flex-tab should be hidden. This behavior was changed by #7448 

Before:
![image](https://user-images.githubusercontent.com/8591547/28172066-d1647124-67c0-11e7-8204-0f227b8f2d68.png)

After:
![image](https://user-images.githubusercontent.com/8591547/28172064-ce7eef66-67c0-11e7-94de-80dc8f704cab.png)

