### PR TITLE
[FIX] Prevent new room status from playing when user status changes

### DIFF
--- a/packages/rocketchat-ui/client/lib/notification.js
+++ b/packages/rocketchat-ui/client/lib/notification.js
@@ -116,23 +116,24 @@ const KonchatNotification = {
 };
 
 Tracker.autorun(function() {
-	const user = Meteor.user();
-	const newRoomNotification = user && user.settings && user.settings.preferences && user.settings.preferences.newRoomNotification || 'door';
+	let audio;
 	if ((Session.get('newRoomSound') || []).length > 0) {
 		Tracker.nonreactive(function() {
+			const user = RocketChat.models.Users.findOne({ _id: Meteor.userId() }, { fields: { 'settings.preferences.newRoomNotification': 1 } });
+			const newRoomNotification = user && user.settings && user.settings.preferences && user.settings.preferences.newRoomNotification || 'door';
 			if (!Session.equals(`user_${ Meteor.userId() }_status`, 'busy') && newRoomNotification !== 'none') {
-				const [audio] = $(`audio#${ newRoomNotification }`);
+				[audio] = $(`audio#${ newRoomNotification }`);
 				return audio && audio.play && audio.play();
 			}
 		});
 	} else {
-		const [room] = $(`audio#${ newRoomNotification }`);
-		if (!room) {
+		if (!audio) {
 			return;
 		}
-		if (room.pause) {
-			room.pause();
-			return room.currentTime = 0;
+		if (audio.pause) {
+			audio.pause();
+			audio.currentTime = 0;
+			audio = null;
 		}
 	}
 });


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Fix new room sound notification playing when any user data changes (the status is the most common)

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

![sound webm](https://user-images.githubusercontent.com/8591547/28180331-2e048fa8-67db-11e7-8e7f-5130d80d36ec.gif)
