### PR TITLE
[NEW] Room type and recipient data for global event

### DIFF
--- a/packages/rocketchat-ui/client/lib/RoomManager.js
+++ b/packages/rocketchat-ui/client/lib/RoomManager.js
@@ -49,6 +49,8 @@ const RoomManager = new function() {
 											].map(e => e.roles);
 											msg.roles = _.union.apply(_.union, roles);
 											ChatMessage.upsert({ _id: msg._id }, msg);
+											msg.t = typeName[0];
+											msg.recipient = typeName.substr(1, typeName.length);
 										}
 
 										Meteor.defer(() => RoomManager.updateMentionsMarksOfRoom(typeName));


### PR DESCRIPTION
[NEW] Room type (direct or group or channel) and recipient username (room or person) data is missing from the global even fired when a new message is sent.