### PR TITLE
[NEW] Add toolbar buttons for iframe API

### DIFF
--- a/packages/rocketchat-theme/client/imports/base.css
+++ b/packages/rocketchat-theme/client/imports/base.css
@@ -1586,6 +1586,7 @@ label.required::after {
 		font-size: 22px;
 		font-weight: 500;
 		line-height: 29px;
+		flex: 1;
 
 		& .icon-at,
 		& .icon-hash,
@@ -1596,6 +1597,11 @@ label.required::after {
 		& .icon-star,
 		& .icon-star-empty {
 			margin-right: -4px;
+		}
+
+		& .iframe-toolbar {
+			flex-grow: 0;
+			white-space: nowrap;
 		}
 	}
 

--- a/packages/rocketchat-ui/client/lib/iframeCommands.js
+++ b/packages/rocketchat-ui/client/lib/iframeCommands.js
@@ -50,6 +50,18 @@ const commands = {
 			Meteor.call('logoutCleanUp', user);
 			return FlowRouter.go('home');
 		});
+	},
+
+	'set-toolbar-button'({ id, icon, label }) {
+		const toolbar = Session.get('toolbarButtons') || { buttons: {} };
+		toolbar.buttons[id] = { icon, label };
+		Session.set('toolbarButtons', toolbar);
+	},
+
+	'remove-toolbar-button'({ id }) {
+		const toolbar = Session.get('toolbarButtons') || { buttons: {} };
+		delete toolbar.buttons[id];
+		Session.set('toolbarButtons', toolbar);
 	}
 };
 

--- a/packages/rocketchat-ui/client/views/app/room.html
+++ b/packages/rocketchat-ui/client/views/app/room.html
@@ -27,8 +27,19 @@
 							{{/if}}
 							<span class="room-topic">{{{RocketChatMarkdown roomTopic}}}</span>
 						</h2>
+
+						{{#with toolbarButtons}}
+							<div class="iframe-toolbar">
+								{{#each buttons}}
+									<button class="{{id}}">
+										{{#if icon}}<i class="{{icon}}"></i>{{/if}}
+										{{label}}
+									</button>
+								{{/each}}
+							</div>
+						{{/with}}
 					</header>
-					
+
 				{{/unless}}
 				<div class="messages-container-wrapper">
 					<div class="messages-container-main">

--- a/packages/rocketchat-ui/client/views/app/room.js
+++ b/packages/rocketchat-ui/client/views/app/room.js
@@ -234,6 +234,16 @@ Template.room.helpers({
 
 		return (RocketChat.models.Subscriptions.findOne({rid: this._id}) != null);
 
+	},
+	toolbarButtons() {
+		const toolbar = Session.get('toolbarButtons') || { buttons: {} };
+		const buttons = Object.keys(toolbar.buttons).map(key => {
+			return {
+				id: key,
+				...toolbar.buttons[key]
+			};
+		});
+		return { buttons };
 	}
 });
 
@@ -243,6 +253,10 @@ let lastTouchX = null;
 let lastTouchY = null;
 
 Template.room.events({
+	'click .iframe-toolbar button'() {
+		fireGlobalEvent('click-toolbar-button', { id: this.id });
+	},
+
 	'click, touchend'(e, t) {
 		return Meteor.setTimeout(() => t.sendToBottomIfNecessaryDebounced(), 100);
 	},


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #7433

This PR adds two new external commands: `set-toolbar-button` and `remove-toolbar-button`.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
To add/set a button at the top toolbar:
```
document.querySelector('iframe').contentWindow.postMessage({
  externalCommand: 'set-toolbar-button',
  id: 'resize',
  icon: 'icon-resize-small'
}, '*')
```

![image](https://user-images.githubusercontent.com/8591547/28338695-1ce4f394-6be0-11e7-95f7-063516527224.png)

A button can be updated using the same `id`:
```
document.querySelector('iframe').contentWindow.postMessage({
  externalCommand: 'set-toolbar-button',
  id: 'resize',
  icon: 'icon-resize-full'
}, '*')
```

To remove a toolbar button:
```
document.querySelector('iframe').contentWindow.postMessage({
  externalCommand: 'remove-toolbar-button',
  id: 'resize'
}, '*')
```

When a button is clicked, the parent window will receive a `postMessage` called `click-toolbar-button` and an object with button's `id`