### PR TITLE
[FIX] Missing eventName in unUser

### DIFF
--- a/packages/rocketchat-lib/client/Notifications.js
+++ b/packages/rocketchat-lib/client/Notifications.js
@@ -79,8 +79,8 @@ RocketChat.Notifications = new class {
 	unRoom(room, eventName, callback) {
 		return this.streamRoom.removeListener(`${ room }/${ eventName }`, callback);
 	}
-	unUser(callback) {
-		return this.streamUser.removeListener(Meteor.userId(), callback);
+	unUser(eventName, callback) {
+		return this.streamUser.removeListener(`${ Meteor.userId() }/${ eventName }`, callback);
 	}
 
 };

--- a/packages/rocketchat-livechat/app/client/lib/fromApp/Notifications.js
+++ b/packages/rocketchat-livechat/app/client/lib/fromApp/Notifications.js
@@ -72,8 +72,8 @@ this.Notifications = new class {
 	unRoom(room, eventName, callback) {
 		return this.streamRoom.removeListener(`${ room }/${ eventName }`, callback);
 	}
-	unUser(callback) {
-		return this.streamUser.removeListener(Meteor.userId(), callback);
+	unUser(eventName, callback) {
+		return this.streamUser.removeListener(`${ Meteor.userId() }/${ eventName }`, callback);
 	}
 
 };


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
`return this.streamUser.removeListener(Meteor.userId(), callback)` was missing eventName so listeners were leaking