### PR TITLE
[FIX] URL parse error fix for issue #7169

### DIFF
--- a/packages/rocketchat-lib/server/functions/sendMessage.js
+++ b/packages/rocketchat-lib/server/functions/sendMessage.js
@@ -20,6 +20,7 @@ RocketChat.sendMessage = function(user, message, room, upsert = false) {
 	}
 	if (message.parseUrls !== false) {
 		const urls = message.msg.match(/([A-Za-z]{3,9}):\/\/([-;:&=\+\$,\w]+@{1})?([-A-Za-z0-9\.]+)+:?(\d+)?((\/[-\+=!:~%\/\.@\,\(\)\w]*)?\??([-\+=&!:;%@\/\.\,\w]+)?(?:#([^\s\)]+))?)?/g);
+
 		if (urls) {
 			message.urls = urls.map(function(url) {
 				return {

--- a/packages/rocketchat-lib/server/functions/sendMessage.js
+++ b/packages/rocketchat-lib/server/functions/sendMessage.js
@@ -19,7 +19,7 @@ RocketChat.sendMessage = function(user, message, room, upsert = false) {
 		}
 	}
 	if (message.parseUrls !== false) {
-		const urls = message.msg.match(/([A-Za-z]{3,9}):\/\/([-;:&=\+\$,\w]+@{1})?([-A-Za-z0-9\.]+)+:?(\d+)?((\/[-\+=!:~%\/\.@\,\w]*)?\??([-\+=&!:;%@\/\.\,\w]+)?(?:#([^\s\)]+))?)?/g);
+		const urls = message.msg.match(/([A-Za-z]{3,9}):\/\/([-;:&=\+\$,\w]+@{1})?([-A-Za-z0-9\.]+)+:?(\d+)?((\/[-\+=!:~%\/\.@\,\(\)\w]*)?\??([-\+=&!:;%@\/\.\,\w]+)?(?:#([^\s\)]+))?)?/g);
 		if (urls) {
 			message.urls = urls.map(function(url) {
 				return {


### PR DESCRIPTION
@RocketChat/core 

Closes #7169 #7482 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
The url parse issue happens in `sendMessage` while the regex match looks for a url pattern. This pattern ignore the `(` and `)` characters. This has been added in this PR.

To test the regex you can use [Regex101.com](https://regex101.com/) with the new regex
<code>([A-Za-z]{3,9}):\/\/([-;:&=\+\$,\w]+@{1})?([-A-Za-z0-9\.]+)+:?(\d+)?((\/[-\+=!:~%\/\.@\,\(\)\w]*)?\??([-\+=&!:;%@\/\.\,\w]+)?(?:#([^\s\)]+))?)?</code>

Examples:
`https://en.wikipedia.org/wiki/Bear_(disambiguation)`
`https://cs.wikipedia.org/wiki/Bylina_(pov%C4%9Bst)`

Hope this helps!