### PR TITLE
[BREAK] Remove Sandstorm login method

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -150,7 +150,7 @@ jalik:ufs-gridfs
 jparker:gravatar
 kadira:blaze-layout
 kadira:flow-router
-kenton:accounts-sandstorm
+#kenton:accounts-sandstorm
 mizzao:autocomplete
 mizzao:timesync
 mrt:reactive-store

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -62,7 +62,6 @@ jparker:gravatar@0.5.1
 jquery@1.11.10
 kadira:blaze-layout@2.3.0
 kadira:flow-router@2.12.1
-kenton:accounts-sandstorm@0.2.0
 konecty:change-case@2.3.0
 konecty:delayed-task@1.0.0
 konecty:mongo-counter@0.0.5_3


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Looks like the Sandstorm package does not work with Meteor 1.5. It's logging me out on every page refresh and given the error below:
![image](https://user-images.githubusercontent.com/8591547/28523730-134ae636-7054-11e7-97c8-4b22e9a95551.png)

Also looks like our latest version available on Sandstorm grain is outdated, so I'm removing the Sandstorm login package until it can get it fixed.



<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
