### PR TITLE
[NEW] Closes tab bar on mobile when leaving room

### DIFF
--- a/packages/rocketchat-lib/client/lib/roomExit.js
+++ b/packages/rocketchat-lib/client/lib/roomExit.js
@@ -1,5 +1,10 @@
 /*globals currentTracker */
 this.roomExit = function() {
+	// 7370 - Close flex-tab when opening a room on mobile UI
+	if (window.matchMedia('(max-width: 500px)').matches) {
+		const templateData = Blaze.getData(document.querySelector('.flex-tab'));
+		templateData && templateData.tabBar && templateData.tabBar.close();
+	}
 	RocketChat.callbacks.run('roomExit');
 	BlazeLayout.render('main', {
 		center: 'none'

--- a/packages/rocketchat-mentions-flextab/client/actionButton.js
+++ b/packages/rocketchat-mentions-flextab/client/actionButton.js
@@ -7,6 +7,9 @@ Meteor.startup(function() {
 		action() {
 			const message = this._arguments[1];
 			RocketChat.MessageAction.hideDropDown();
+			if (window.matchMedia('(max-width: 500px)').matches) {
+				Template.instance().tabBar.close();
+			}
 			return RoomHistoryManager.getSurroundingMessages(message, 50);
 		},
 		validation(message) {

--- a/packages/rocketchat-message-pin/client/actionButton.js
+++ b/packages/rocketchat-message-pin/client/actionButton.js
@@ -62,6 +62,9 @@ Meteor.startup(function() {
 		action() {
 			const message = this._arguments[1];
 			RocketChat.MessageAction.hideDropDown();
+			if (window.matchMedia('(max-width: 500px)').matches) {
+				Template.instance().tabBar.close();
+			}
 			return RoomHistoryManager.getSurroundingMessages(message, 50);
 		},
 		validation(message) {

--- a/packages/rocketchat-message-star/client/actionButton.js
+++ b/packages/rocketchat-message-star/client/actionButton.js
@@ -54,6 +54,9 @@ Meteor.startup(function() {
 		action() {
 			const message = this._arguments[1];
 			RocketChat.MessageAction.hideDropDown();
+			if (window.matchMedia('(max-width: 500px)').matches) {
+				Template.instance().tabBar.close();
+			}
 			return RoomHistoryManager.getSurroundingMessages(message, 50);
 		},
 		validation(message) {

--- a/packages/rocketchat-ui-flextab/client/tabs/messageSearch.js
+++ b/packages/rocketchat-ui-flextab/client/tabs/messageSearch.js
@@ -9,6 +9,9 @@ Meteor.startup(function() {
 		action() {
 			const message = this._arguments[1];
 			RocketChat.MessageAction.hideDropDown();
+			if (window.matchMedia('(max-width: 500px)').matches) {
+				Template.instance().tabBar.close();
+			}
 			return RoomHistoryManager.getSurroundingMessages(message, 50);
 		},
 		order: 100


### PR DESCRIPTION
@RocketChat/core 

Closes #7370

When leaving a room on mobile UI (screen less than 500px) it automatically closes the tab bar so when the user goes back to the room it's not open by default.