### PR TITLE
[NEW] Show different shape for alert numbers when have mentions

### DIFF
--- a/packages/rocketchat-theme/server/colors.less
+++ b/packages/rocketchat-theme/server/colors.less
@@ -666,6 +666,10 @@ a:hover {
 	}
 
 	.unread {
+		color: @success-color;
+	}
+
+	.unread.unread-mention {
 		background-color: @success-color;
 		color: contrast(@success-color, #000000, #ffffff, 50%);
 	}

--- a/packages/rocketchat-ui-sidenav/client/chatRoomItem.html
+++ b/packages/rocketchat-ui-sidenav/client/chatRoomItem.html
@@ -2,7 +2,7 @@
 	<li class="link-room-{{rid}} background-transparent-darker-hover {{active}} {{#if unread}}has-unread{{/if}} {{#if alert}}has-alert{{/if}}">
 		<a class="open-room" href="{{route}}" title="{{name}}">
 			{{#if unread}}
-				<span class="unread">{{unread}}</span>
+				<span class="{{unreadClass}}">{{unread}}</span>
 			{{/if}}
 			<i class="{{roomIcon}} {{userStatus}}" aria-label=""></i>
 			<span class='name {{archived}}'>{{name}}</span>

--- a/packages/rocketchat-ui-sidenav/client/chatRoomItem.js
+++ b/packages/rocketchat-ui-sidenav/client/chatRoomItem.js
@@ -14,6 +14,14 @@ Template.chatRoomItem.helpers({
 		}
 	},
 
+	unreadClass() {
+		if (Match.test(this.userMentions, Number) && this.userMentions > 0) {
+			return 'unread unread-mention';
+		} else {
+			return 'unread';
+		}
+	},
+
 	userStatus() {
 		const userStatus = RocketChat.roomTypes.getUserStatus(this.t, this.rid);
 		return `status-${ userStatus || 'offline' }`;


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
The default format for alert numbers by the room's name is the number only `@all and @here`
The rounded square will show only when there are mentions to the user.

![image](https://user-images.githubusercontent.com/234261/28649505-bd7ffbf2-724b-11e7-8e41-51c96ed027a0.png)
