### PR TITLE
[NEW] Search users by fields defined by admin

### DIFF
--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -118,6 +118,7 @@
   "Accounts_RegistrationForm_SecretURL_Description": "You must provide a random string that will be added to your registration URL. Example: https://demo.rocket.chat/register/[secret_hash]",
   "Accounts_RequireNameForSignUp": "Require Name For Signup",
   "Accounts_RequirePasswordConfirmation": "Require Password Confirmation",
+  "Accounts_SearchFields": "Fields to consider in search",
   "Accounts_SetDefaultAvatar": "Set Default Avatar",
   "Accounts_SetDefaultAvatar_Description": "Tries to determine default avatar based on OAuth Account or Gravatar",
   "Accounts_ShowFormLogin": "Show form-based Login",

--- a/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
@@ -104,6 +104,7 @@
   "Accounts_RegistrationForm_SecretURL_Description": "Você deve fornecer uma seqüência aleatória que será adicionada à sua URL de registro. Exemplo: https://demo.rocket.chat/register/[secret_hash]",
   "Accounts_RequireNameForSignUp": "Nome é obrigatório para cadastro",
   "Accounts_RequirePasswordConfirmation": "Requer Confirmação de Senha",
+  "Accounts_SearchFields": "Campos a considerar na busca",
   "Accounts_ShowFormLogin": "Mostrar formulário de login",
   "Accounts_UseDefaultBlockedDomainsList": "Use Lista Padrão de Domínios Bloqueados",
   "Accounts_UseDNSDomainCheck": "Use verificação de Domínio DNS",

--- a/packages/rocketchat-i18n/i18n/pt.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pt.i18n.json
@@ -112,6 +112,7 @@
   "Accounts_RegistrationForm_SecretURL_Description": "Você deve fornecer uma seqüência aleatória que será adicionada à sua URL de registro. Exemplo: https://demo.rocket.chat/register/[secret_hash]",
   "Accounts_RequireNameForSignUp": "Nome é obrigatório para cadastro",
   "Accounts_RequirePasswordConfirmation": "Requer Confirmação de Senha",
+  "Accounts_SearchFields": "Campos a considerar na busca",
   "Accounts_ShowFormLogin": "Mostrar formulário de login",
   "Accounts_UseDefaultBlockedDomainsList": "Use Lista Padrão de Domínios Bloqueados",
   "Accounts_UseDNSDomainCheck": "Use verificação de Domínio DNS",

--- a/packages/rocketchat-lib/server/models/Users.js
+++ b/packages/rocketchat-lib/server/models/Users.js
@@ -138,21 +138,14 @@ class ModelUsers extends RocketChat.models._Base {
 		}
 
 		const termRegex = new RegExp(s.escapeRegExp(searchTerm), 'i');
+		const orStmt = _.reduce(_.keys(options.fields), function(acc, el) {
+			acc.push({ [el]: termRegex }); return acc;
+		}, []);
 		const query = {
 			$and: [
 				{
 					active: true,
-					$or: [
-						{
-							username: termRegex
-						},
-						{
-							name: termRegex
-						},
-						{
-							'emails.address': termRegex
-						}
-					]
+					$or: orStmt
 				},
 				{
 					username: { $exists: true, $nin: exceptions }

--- a/packages/rocketchat-lib/server/models/Users.js
+++ b/packages/rocketchat-lib/server/models/Users.js
@@ -138,8 +138,10 @@ class ModelUsers extends RocketChat.models._Base {
 		}
 
 		const termRegex = new RegExp(s.escapeRegExp(searchTerm), 'i');
-		const orStmt = _.reduce(_.keys(options.fields), function(acc, el) {
-			acc.push({ [el]: termRegex }); return acc;
+
+		const orStmt = _.reduce(RocketChat.settings.get('Accounts_SearchFields').trim().split(','), function(acc, el) {
+			acc.push({ [el.trim()]: termRegex });
+			return acc;
 		}, []);
 		const query = {
 			$and: [

--- a/packages/rocketchat-lib/server/startup/settings.js
+++ b/packages/rocketchat-lib/server/startup/settings.js
@@ -70,6 +70,10 @@ RocketChat.settings.addGroup('Accounts', function() {
 		type: 'boolean',
 		'public': true
 	});
+	this.add('Accounts_SearchFields', 'username, name, status', {
+		type: 'string',
+		public: true
+	});
 
 	this.section('Registration', function() {
 		this.add('Accounts_DefaultUsernamePrefixSuggestion', 'user', {

--- a/packages/rocketchat-lib/server/startup/settings.js
+++ b/packages/rocketchat-lib/server/startup/settings.js
@@ -70,7 +70,7 @@ RocketChat.settings.addGroup('Accounts', function() {
 		type: 'boolean',
 		'public': true
 	});
-	this.add('Accounts_SearchFields', 'username, name, status', {
+	this.add('Accounts_SearchFields', 'username, name, emails.address', {
 		type: 'string',
 		public: true
 	});

--- a/server/publications/spotlight.js
+++ b/server/publications/spotlight.js
@@ -28,13 +28,13 @@ Meteor.methods({
 		if (type.users === true && RocketChat.authz.hasPermission(this.userId, 'view-d-room')) {
 			const userOptions = {
 				limit: 5,
-				fields: {
-					username: 1,
-					name: 1,
-					status: 1
-				},
+				fields: {},
 				sort: {}
 			};
+
+			_.map(RocketChat.settings.get('Accounts_SearchFields').trim().split(','), function(field) {
+				userOptions.fields[field.trim()] = 1;
+			});
 
 			if (RocketChat.settings.get('UI_Use_Real_Name')) {
 				userOptions.sort.name = 1;

--- a/server/publications/spotlight.js
+++ b/server/publications/spotlight.js
@@ -28,13 +28,13 @@ Meteor.methods({
 		if (type.users === true && RocketChat.authz.hasPermission(this.userId, 'view-d-room')) {
 			const userOptions = {
 				limit: 5,
-				fields: {},
+				fields: {
+					username: 1,
+					name: 1,
+					status: 1
+				},
 				sort: {}
 			};
-
-			_.map(RocketChat.settings.get('Accounts_SearchFields').trim().split(','), function(field) {
-				userOptions.fields[field.trim()] = 1;
-			});
 
 			if (RocketChat.settings.get('UI_Use_Real_Name')) {
 				userOptions.sort.name = 1;


### PR DESCRIPTION
These changes introduce the possibility of searching users by any field the Rocket.Chat's administrator defines in the new "Accounts -> Fields to consider in search" field.

@RocketChat/core 

Related to #7334 and #7210.

## Example:
![searchbycustomfields](https://user-images.githubusercontent.com/1634735/28787020-64e70f7c-75f1-11e7-8d4c-d19279721d5b.png)