### PR TITLE
[FIX] Fix Custom Fields Crashing on Register

### DIFF
--- a/packages/rocketchat-lib/server/functions/saveCustomFieldsWithoutValidation.js
+++ b/packages/rocketchat-lib/server/functions/saveCustomFieldsWithoutValidation.js
@@ -1,33 +1,35 @@
 RocketChat.saveCustomFieldsWithoutValidation = function(userId, formData) {
-	if (s.trim(RocketChat.settings.get('Accounts_CustomFields')) !== '') {
-		let customFieldsMeta;
-		try {
-			customFieldsMeta = JSON.parse(RocketChat.settings.get('Accounts_CustomFields'));
-		} catch (e) {
-			throw new Meteor.Error('error-invalid-customfield-json', 'Invalid JSON for Custom Fields');
-		}
-
-		const customFields = formData;
-
-		// for fieldName, field of customFieldsMeta
-		RocketChat.models.Users.setCustomFields(userId, customFields);
-
-		Object.keys(customFields).forEach((fieldName) => {
-			if (!customFieldsMeta[fieldName].modifyRecordField) {
-				return;
-			}
-
-			const modifyRecordField = customFieldsMeta[fieldName].modifyRecordField;
-			const update = {};
-			if (modifyRecordField.array) {
-				update.$addToSet = {};
-				update.$addToSet[modifyRecordField.field] = customFields[fieldName];
-			} else {
-				update.$set = {};
-				update.$set[modifyRecordField.field] = customFields[fieldName];
-			}
-
-			RocketChat.models.Users.update(userId, update);
-		});
+	if (s.trim(RocketChat.settings.get('Accounts_CustomFields')) === '') {
+		return;
 	}
+
+	let customFieldsMeta;
+	try {
+		customFieldsMeta = JSON.parse(RocketChat.settings.get('Accounts_CustomFields'));
+	} catch (e) {
+		throw new Meteor.Error('error-invalid-customfield-json', 'Invalid JSON for Custom Fields');
+	}
+
+	const customFields = Object.keys(customFieldsMeta).filter(fieldName => !customFieldsMeta[fieldName].modifyRecordField).
+			reduce((update, key) => {
+				update[key] = formData[key];
+				return update;
+			}, {});
+
+	RocketChat.models.Users.setCustomFields(userId, customFields);
+	const update = Object.keys(customFieldsMeta).
+			filter(fieldName => customFieldsMeta[fieldName].modifyRecordField).
+			reduce((update, fieldName) => {
+				const modifyRecordField = customFieldsMeta[fieldName].modifyRecordField;
+				if (modifyRecordField.array) {
+					update.$addToSet[modifyRecordField.field] = formData[fieldName];
+				} else {
+					update.$set[modifyRecordField.field] = formData[fieldName];
+				}
+				return update;
+			}, {
+				$addToSet: {},
+				$set: {}
+			});
+	RocketChat.models.Users.update(userId, update);
 };

--- a/packages/rocketchat-lib/server/functions/saveCustomFieldsWithoutValidation.js
+++ b/packages/rocketchat-lib/server/functions/saveCustomFieldsWithoutValidation.js
@@ -1,36 +1,32 @@
 RocketChat.saveCustomFieldsWithoutValidation = function(userId, formData) {
-	if (s.trim(RocketChat.settings.get('Accounts_CustomFields')) === '') {
-		return;
-	}
+	if (s.trim(RocketChat.settings.get('Accounts_CustomFields')) !== '') {
+		let customFieldsMeta;
+		try {
+			customFieldsMeta = JSON.parse(RocketChat.settings.get('Accounts_CustomFields'));
+		} catch (e) {
+			throw new Meteor.Error('error-invalid-customfield-json', 'Invalid JSON for Custom Fields');
+		}
 
-	let customFieldsMeta;
-	try {
-		customFieldsMeta = JSON.parse(RocketChat.settings.get('Accounts_CustomFields'));
-	} catch (e) {
-		throw new Meteor.Error('error-invalid-customfield-json', 'Invalid JSON for Custom Fields');
-	}
+		const customFields = {};
+		Object.keys(customFieldsMeta).forEach(key => customFields[key] = formData[key]);
+		RocketChat.models.Users.setCustomFields(userId, customFields);
 
-	const customFields = Object.keys(customFieldsMeta).filter(fieldName => !customFieldsMeta[fieldName].modifyRecordField).
-		reduce((update, key) => {
-			update[key] = formData[key];
-			return update;
-		}, {});
-
-
-	RocketChat.models.Users.setCustomFields(userId, customFields);
-	const update = Object.keys(customFieldsMeta).
-		filter(fieldName => customFieldsMeta[fieldName].modifyRecordField).
-		reduce((update, fieldName) => {
-			const modifyRecordField = customFieldsMeta[fieldName].modifyRecordField;
-			if (modifyRecordField.array) {
-				update.$addToSet[modifyRecordField.field] = formData[fieldName];
-			} else {
-				update.$set[modifyRecordField.field] = formData[fieldName];
+		Object.keys(customFields).forEach((fieldName) => {
+			if (!customFieldsMeta[fieldName].modifyRecordField) {
+				return;
 			}
-			return update;
-		}, {
-			$addToSet: {},
-			$set: {}
+
+			const modifyRecordField = customFieldsMeta[fieldName].modifyRecordField;
+			const update = {};
+			if (modifyRecordField.array) {
+				update.$addToSet = {};
+				update.$addToSet[modifyRecordField.field] = customFields[fieldName];
+			} else {
+				update.$set = {};
+				update.$set[modifyRecordField.field] = customFields[fieldName];
+			}
+
+			RocketChat.models.Users.update(userId, update);
 		});
-	RocketChat.models.Users.update(userId, update);
+	}
 };

--- a/packages/rocketchat-lib/server/functions/saveCustomFieldsWithoutValidation.js
+++ b/packages/rocketchat-lib/server/functions/saveCustomFieldsWithoutValidation.js
@@ -11,25 +11,26 @@ RocketChat.saveCustomFieldsWithoutValidation = function(userId, formData) {
 	}
 
 	const customFields = Object.keys(customFieldsMeta).filter(fieldName => !customFieldsMeta[fieldName].modifyRecordField).
-			reduce((update, key) => {
-				update[key] = formData[key];
-				return update;
-			}, {});
+		reduce((update, key) => {
+			update[key] = formData[key];
+			return update;
+		}, {});
+
 
 	RocketChat.models.Users.setCustomFields(userId, customFields);
 	const update = Object.keys(customFieldsMeta).
-			filter(fieldName => customFieldsMeta[fieldName].modifyRecordField).
-			reduce((update, fieldName) => {
-				const modifyRecordField = customFieldsMeta[fieldName].modifyRecordField;
-				if (modifyRecordField.array) {
-					update.$addToSet[modifyRecordField.field] = formData[fieldName];
-				} else {
-					update.$set[modifyRecordField.field] = formData[fieldName];
-				}
-				return update;
-			}, {
-				$addToSet: {},
-				$set: {}
-			});
+		filter(fieldName => customFieldsMeta[fieldName].modifyRecordField).
+		reduce((update, fieldName) => {
+			const modifyRecordField = customFieldsMeta[fieldName].modifyRecordField;
+			if (modifyRecordField.array) {
+				update.$addToSet[modifyRecordField.field] = formData[fieldName];
+			} else {
+				update.$set[modifyRecordField.field] = formData[fieldName];
+			}
+			return update;
+		}, {
+			$addToSet: {},
+			$set: {}
+		});
 	RocketChat.models.Users.update(userId, update);
 };


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 
@ggazzo 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

This fixes the issue when registering with custom fields giving ` Exception while invoking method 'registerUser' TypeError: Cannot read property 'modifyRecordField' of undefined`

But this reveals more problems with custom fields, as roles being duplicate and problems to see the current roles #7618
