### PR TITLE
[FIX] Uploading an unknown file type erroring out

### DIFF
--- a/packages/rocketchat-ui/client/lib/fileUpload.js
+++ b/packages/rocketchat-ui/client/lib/fileUpload.js
@@ -56,7 +56,7 @@ fileUpload = function(filesToUpload) {
 			return;
 		}
 
-		if (!RocketChat.fileUploadIsValidContentType(file.file.type)) {
+		if (!file.file.type || !RocketChat.fileUploadIsValidContentType(file.file.type)) {
 			swal({
 				title: t('FileUpload_MediaType_NotAccepted'),
 				text: file.file.type || `*.${ s.strRightBack(file.file.name, '.') }`,


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core When uploading an unknown file type, such as a `.sketch`, and the browser doesn't have any mimetype about that file type it will currently error out. This handles that case.

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #7462

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
