### PR TITLE
[FIX] Markdown noopener/noreferrer: use correct HTML attribute

### DIFF
--- a/packages/rocketchat-markdown/markdown.js
+++ b/packages/rocketchat-markdown/markdown.js
@@ -57,7 +57,7 @@ class MarkdownClass {
 		// Support ![alt text](http://image url)
 		msg = msg.replace(new RegExp(`!\\[([^\\]]+)\\]\\(((?:${ schemes }):\\/\\/[^\\)]+)\\)`, 'gm'), function(match, title, url) {
 			const target = url.indexOf(Meteor.absoluteUrl()) === 0 ? '' : '_blank';
-			const html = `<a href="${ _.escapeHTML(url) }" title="${ _.escapeHTML(title) }" target="${ _.escapeHTML(target) }" ref="noopener noreferrer"><div class="inline-image" style="background-image: url(${ _.escapeHTML(url) });"></div></a>`;
+			const html = `<a href="${ _.escapeHTML(url) }" title="${ _.escapeHTML(title) }" target="${ _.escapeHTML(target) }" rel="noopener noreferrer"><div class="inline-image" style="background-image: url(${ _.escapeHTML(url) });"></div></a>`;
 
 			if (message && message.tokens) {
 				const token = `=!=${ Random.id() }=!=`;
@@ -76,13 +76,13 @@ class MarkdownClass {
 		// Support [Text](http://link)
 		msg = msg.replace(new RegExp(`\\[([^\\]]+)\\]\\(((?:${ schemes }):\\/\\/[^\\)]+)\\)`, 'gm'), function(match, title, url) {
 			const target = url.indexOf(Meteor.absoluteUrl()) === 0 ? '' : '_blank';
-			return `<a href="${ _.escapeHTML(url) }" target="${ _.escapeHTML(target) }" ref="noopener noreferrer">${ _.escapeHTML(title) }</a>`;
+			return `<a href="${ _.escapeHTML(url) }" target="${ _.escapeHTML(target) }" rel="noopener noreferrer">${ _.escapeHTML(title) }</a>`;
 		});
 
 		// Support <http://link|Text>
 		msg = msg.replace(new RegExp(`(?:<|&lt;)((?:${ schemes }):\\/\\/[^\\|]+)\\|(.+?)(?=>|&gt;)(?:>|&gt;)`, 'gm'), (match, url, title) => {
 			const target = url.indexOf(Meteor.absoluteUrl()) === 0 ? '' : '_blank';
-			return `<a href="${ _.escapeHTML(url) }" target="${ _.escapeHTML(target) }" ref="noopener noreferrer">${ _.escapeHTML(title) }</a>`;
+			return `<a href="${ _.escapeHTML(url) }" target="${ _.escapeHTML(target) }" rel="noopener noreferrer">${ _.escapeHTML(title) }</a>`;
 		});
 
 		if (typeof window !== 'undefined' && window !== null ? window.rocketDebug : undefined) { console.log('Markdown', msg); }


### PR DESCRIPTION
Follow-up to #7327 fixing the usage of `ref` to `rel` as pointed out by @pitamar.