### PR TITLE
[FIX] Fix avatar upload fail on Cordova app

### DIFF
--- a/packages/rocketchat-ui-account/client/avatar/prompt.js
+++ b/packages/rocketchat-ui-account/client/avatar/prompt.js
@@ -85,7 +85,8 @@ Template.avatarPrompt.events({
 				files = event.dataTransfer && event.dataTransfer.files || [];
 			}
 
-			for (const file of files) {
+			for (let i = 0; i < files.length; i++) {
+				const file = files[i];
 				Object.defineProperty(file, 'type', { value: mime.lookup(file.name) });
 			}
 


### PR DESCRIPTION
@RocketChat/core 

When uploading avatar on Cordova app, Android or iOS, it can't work and appear js error below:
![screenshot - 2017_8_4 02_03_30](https://user-images.githubusercontent.com/1438603/28956446-90c0e6e6-791f-11e7-8ab1-5cc21f580877.png)

Clicking the error code, found the error near the "for...of" loop:
![screenshot - 2017_8_4 02_06_43](https://user-images.githubusercontent.com/1438603/28956489-d52c32ae-791f-11e7-84bf-6667e790401d.png)

So i changed the for...of loop to the normal for loop, and it work fine.
