### PR TITLE
[FIX] Make link inside YouTube preview open in new tab

### DIFF
--- a/packages/rocketchat-oembed/client/oembedFrameWidget.html
+++ b/packages/rocketchat-oembed/client/oembedFrameWidget.html
@@ -3,19 +3,19 @@
 	<blockquote class="background-transparent-darker-before">
 		{{#if meta.oembedProviderName}}
 			{{#if meta.oembedProviderUrl}}
-				<a href="{{meta.oembedProviderUrl}}" style="color: #9e9ea6">{{meta.oembedProviderName}}</a>
+				<a href="{{meta.oembedProviderUrl}}" target="_blank" style="color: #9e9ea6">{{meta.oembedProviderName}}</a>
 			{{/if}}
 		{{/if}}
 		{{#if meta.oembedAuthorName}}
 			{{#if meta.oembedAuthorUrl}}
 				<br class="only-after-a"/>
-				<a href="{{meta.oembedAuthorUrl}}">{{meta.oembedAuthorName}}</a>
+				<a href="{{meta.oembedAuthorUrl}}" target="_blank">{{meta.oembedAuthorName}}</a>
 			{{/if}}
 		{{/if}}
 		{{#if meta.oembedTitle}}
 			{{#if meta.oembedUrl}}
 				<br class="only-after-a"/>
-				<a href="{{meta.oembedUrl}}">{{meta.oembedTitle}}</a>
+				<a href="{{meta.oembedUrl}}" target="_blank">{{meta.oembedTitle}}</a>
 			{{/if}}
 		{{/if}}
 		{{#if collapsed}}

--- a/packages/rocketchat-oembed/client/oembedVideoWidget.html
+++ b/packages/rocketchat-oembed/client/oembedVideoWidget.html
@@ -1,7 +1,7 @@
 <template name="oembedVideoWidget">
 {{#if parsedUrl}}
 	<blockquote class="background-transparent-darker-before">
-		<div><a href="{{url}}">{{parsedUrl.host}}</a></div>
+		<div><a href="{{url}}" target="_blank">{{parsedUrl.host}}</a></div>
 		<span>{{title}}</span>
 		{{#if collapsed}}
 			<span class="collapse-switch icon-right-dir" data-index="{{index}}" data-collapsed="{{collapsed}}"></span>

--- a/packages/rocketchat-oembed/client/oembedYoutubeWidget.html
+++ b/packages/rocketchat-oembed/client/oembedYoutubeWidget.html
@@ -1,7 +1,7 @@
 <template name="oembedYoutubeWidget">
 	{{#if parsedUrl}}
 		<blockquote class="background-transparent-darker-before">
-			<a href="{{url}}">{{parsedUrl.host}}</a>
+			<a href="{{url}}" target="_blank">{{parsedUrl.host}}</a>
 			{{#if collapsed}}
 				<span class="collapse-switch icon-right-dir" data-index="{{index}}" data-collapsed="{{collapsed}}"></span><br>
 			{{else}}


### PR DESCRIPTION
Currently, the YouTube link in an preview opens the link in the current Rocket.Chat tab. This pull request changes this behaviour to open the YouTube link in a new tab.