### PR TITLE
[NEW] Template to show Custom Fields in user info view

### DIFF
--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -34,6 +34,7 @@
   "Accounts_BlockedUsernameList": "Blocked Username List",
   "Accounts_BlockedUsernameList_Description": "Comma-separated list of blocked usernames (case-insensitive)",
   "Accounts_CustomFields_Description": "Should be a valid JSON where keys are the field names containing a dictionary of field settings. Example:<br/><code>{\n \"role\": {\n  \"type\": \"select\",\n  \"defaultValue\": \"student\",\n  \"options\": [\"teacher\", \"student\"],\n  \"required\": true,\n  \"modifyRecordField\": {\n   \"array\": true,\n   \"field\": \"roles\"\n  }\n },\n \"twitter\": {\n  \"type\": \"text\",\n  \"required\": true,\n  \"minLength\": 2,\n  \"maxLength\": 10\n }\n}</code> ",
+  "Accounts_CustomFieldsToShowInUserInfo": "Custom Fields to Show in User Info",
   "Accounts_DefaultUsernamePrefixSuggestion": "Default username prefix suggestion",
   "Accounts_denyUnverifiedEmail": "Deny unverified email",
   "Accounts_EmailVerification": "Email Verification",

--- a/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
@@ -32,6 +32,7 @@
   "Accounts_BlockedUsernameList": "Lista de nomes de usuário bloqueados",
   "Accounts_BlockedUsernameList_Description": "Lista de nomes de usuários bloqueados, separada por vírgulas (não diferencia maiúsculas)",
   "Accounts_CustomFields_Description": "Deve ser um JSON válido onde as chaves são os nomes de campos contendo um dicionário de configuração de campos. Exemplo:<br/><code>{\n \"role\": {\n  \"type\": \"select\",\n  \"defaultValue\": \"estudante\",\n  \"options\": [\"professor\", \"estudante\"],\n  \"required\": true,\n  \"modifyRecordField\": {\n   \"array\": true,\n   \"field\": \"roles\"\n  }\n },\n \"twitter\": {\n  \"type\": \"text\",\n  \"required\": true,\n  \"minLength\": 2,\n  \"maxLength\": 10\n }\n}</code> ",
+  "Accounts_CustomFieldsToShowInUserInfo": "Campos personalizados a exibir",
   "Accounts_denyUnverifiedEmail": "Proibir e-mail não verificado",
   "Accounts_EmailVerification": "Verificação de E-mail",
   "Accounts_EmailVerification_Description": "Certifique-se de que as configurações de SMTP estão corretas para usar este recurso",

--- a/packages/rocketchat-i18n/i18n/pt.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pt.i18n.json
@@ -34,6 +34,7 @@
   "Accounts_BlockedUsernameList": "Lista de nomes de usuário bloqueados",
   "Accounts_BlockedUsernameList_Description": "Lista de nomes de usuários bloqueados, separada por vírgulas (não diferencia maiúsculas)",
   "Accounts_CustomFields_Description": "Deve ser um JSON válido onde as chaves são os nomes de campos contendo um dicionário de configuração de campos. Exemplo:<br/><code>{\n \"role\": {\n  \"type\": \"select\",\n  \"defaultValue\": \"estudante\",\n  \"options\": [\"professor\", \"estudante\"],\n  \"required\": true,\n  \"modifyRecordField\": {\n   \"array\": true,\n   \"field\": \"roles\"\n  }\n },\n \"twitter\": {\n  \"type\": \"text\",\n  \"required\": true,\n  \"minLength\": 2,\n  \"maxLength\": 10\n }\n}</code> ",
+  "Accounts_CustomFieldsToShowInUserInfo": "Campos personalizados a exibir",
   "Accounts_DefaultUsernamePrefixSuggestion": "Sugestão de prefixo de utilizador por defeito",
   "Accounts_denyUnverifiedEmail": "Proibir e-mail não verificado",
   "Accounts_EmailVerification": "Verificação de E-mail",

--- a/packages/rocketchat-ldap/server/sync.js
+++ b/packages/rocketchat-ldap/server/sync.js
@@ -85,35 +85,9 @@ getDataToSyncUserData = function getDataToSyncUserData(ldapUser, user) {
 					break;
 
 				case 'name':
-					const templateRegex = /#{(\w+)}/gi;
-					let match = templateRegex.exec(ldapField);
-					let tmpLdapField = ldapField;
+					const tmpLdapField = RocketChat.templateVarHandler(ldapField, ldapUser.object);
 
-					if (match == null) {
-						if (!ldapUser.object.hasOwnProperty(ldapField)) {
-							logger.debug(`user does not have attribute: ${ ldapField }`);
-							return;
-						}
-						tmpLdapField = ldapUser.object[ldapField];
-					} else {
-						logger.debug('template found. replacing values');
-						while (match != null) {
-							const tmplVar = match[0];
-							const tmplAttrName = match[1];
-
-							if (!ldapUser.object.hasOwnProperty(tmplAttrName)) {
-								logger.debug(`user does not have attribute: ${ tmplAttrName }`);
-								return;
-							}
-
-							const attrVal = ldapUser.object[tmplAttrName];
-							logger.debug(`replacing template var: ${ tmplVar } with value from ldap: ${ attrVal }`);
-							tmpLdapField = tmpLdapField.replace(tmplVar, attrVal);
-							match = templateRegex.exec(ldapField);
-						}
-					}
-
-					if (user.name !== tmpLdapField) {
+					if (tmpLdapField && user.name !== tmpLdapField) {
 						userData.name = tmpLdapField;
 						logger.debug(`user.name changed to: ${ tmpLdapField }`);
 					}

--- a/packages/rocketchat-lib/lib/templateVarHandler.js
+++ b/packages/rocketchat-lib/lib/templateVarHandler.js
@@ -1,0 +1,37 @@
+let logger;
+
+if (Meteor.isServer) {
+  logger = new Logger('TemplateVarHandler', {});
+}
+
+RocketChat.templateVarHandler = function(variable, object) {
+
+  const templateRegex = /#{([\w\-]+)}/gi;
+  let match = templateRegex.exec(variable);
+  let tmpVariable = variable;
+
+  if (match == null) {
+    if (!object.hasOwnProperty(variable)) {
+      logger && logger.debug(`user does not have attribute: ${ variable }`);
+      return;
+    }
+    return object[variable];
+  } else {
+    logger && logger.debug('template found. replacing values');
+    while (match != null) {
+      const tmplVar = match[0];
+      const tmplAttrName = match[1];
+
+      if (!object.hasOwnProperty(tmplAttrName)) {
+        logger && logger.debug(`user does not have attribute: ${ tmplAttrName }`);
+        return;
+      }
+
+      const attrVal = object[tmplAttrName];
+      logger && logger.debug(`replacing template var: ${ tmplVar } with value: ${ attrVal }`);
+      tmpVariable = tmpVariable.replace(tmplVar, attrVal);
+      match = templateRegex.exec(variable);
+    }
+    return tmpVariable;
+  }
+}

--- a/packages/rocketchat-lib/lib/templateVarHandler.js
+++ b/packages/rocketchat-lib/lib/templateVarHandler.js
@@ -1,37 +1,37 @@
 let logger;
 
 if (Meteor.isServer) {
-  logger = new Logger('TemplateVarHandler', {});
+	logger = new Logger('TemplateVarHandler', {});
 }
 
 RocketChat.templateVarHandler = function(variable, object) {
 
-  const templateRegex = /#{([\w\-]+)}/gi;
-  let match = templateRegex.exec(variable);
-  let tmpVariable = variable;
+	const templateRegex = /#{([\w\-]+)}/gi;
+	let match = templateRegex.exec(variable);
+	let tmpVariable = variable;
 
-  if (match == null) {
-    if (!object.hasOwnProperty(variable)) {
-      logger && logger.debug(`user does not have attribute: ${ variable }`);
-      return;
-    }
-    return object[variable];
-  } else {
-    logger && logger.debug('template found. replacing values');
-    while (match != null) {
-      const tmplVar = match[0];
-      const tmplAttrName = match[1];
+	if (match == null) {
+		if (!object.hasOwnProperty(variable)) {
+			logger && logger.debug(`user does not have attribute: ${ variable }`);
+			return;
+		}
+		return object[variable];
+	} else {
+		logger && logger.debug('template found. replacing values');
+		while (match != null) {
+			const tmplVar = match[0];
+			const tmplAttrName = match[1];
 
-      if (!object.hasOwnProperty(tmplAttrName)) {
-        logger && logger.debug(`user does not have attribute: ${ tmplAttrName }`);
-        return;
-      }
+			if (!object.hasOwnProperty(tmplAttrName)) {
+				logger && logger.debug(`user does not have attribute: ${ tmplAttrName }`);
+				return;
+			}
 
-      const attrVal = object[tmplAttrName];
-      logger && logger.debug(`replacing template var: ${ tmplVar } with value: ${ attrVal }`);
-      tmpVariable = tmpVariable.replace(tmplVar, attrVal);
-      match = templateRegex.exec(variable);
-    }
-    return tmpVariable;
-  }
-}
+			const attrVal = object[tmplAttrName];
+			logger && logger.debug(`replacing template var: ${ tmplVar } with value: ${ attrVal }`);
+			tmpVariable = tmpVariable.replace(tmplVar, attrVal);
+			match = templateRegex.exec(variable);
+		}
+		return tmpVariable;
+	}
+};

--- a/packages/rocketchat-lib/package.js
+++ b/packages/rocketchat-lib/package.js
@@ -62,6 +62,7 @@ Package.onUse(function(api) {
 	api.addFiles('lib/slashCommand.js');
 	api.addFiles('lib/Message.js');
 	api.addFiles('lib/MessageTypes.js');
+	api.addFiles('lib/templateVarHandler.js');
 
 	api.addFiles('server/lib/bugsnag.js', 'server');
 	api.addFiles('server/lib/metrics.js', 'server');

--- a/packages/rocketchat-lib/server/startup/settings.js
+++ b/packages/rocketchat-lib/server/startup/settings.js
@@ -48,6 +48,10 @@ RocketChat.settings.addGroup('Accounts', function() {
 		type: 'boolean',
 		'public': true
 	});
+	this.add('Accounts_CustomFieldsToShowInUserInfo', '', {
+		type: 'string',
+		public: true
+	});
 	this.add('Accounts_LoginExpiration', 90, {
 		type: 'int',
 		'public': true

--- a/packages/rocketchat-ui-flextab/client/tabs/userInfo.html
+++ b/packages/rocketchat-ui-flextab/client/tabs/userInfo.html
@@ -28,6 +28,7 @@
 						{{/if}}
 						{{#if lastLogin}} <p class="secondary-font-color"><i class="icon-calendar"></i> {{_ "Created_at"}}: {{createdAt}}</p> {{/if}}
 						{{#if lastLogin}} <p class="secondary-font-color"><i class="icon-calendar"></i> {{_ "Last_login"}}: {{lastLogin}}</p> {{/if}}
+						{{#each customField}} <p class="secondary-font-color">{{.}}</p> {{/each}}
 						{{#if services.facebook.id}} <p class="secondary-font-color"><i class="icon-facebook"></i><a href="{{services.facebook.link}}" target="_blank">{{services.facebook.name}}</a></p> {{/if}}
 						{{#if services.github.id}} <p class="secondary-font-color"><i class="icon-github-circled"></i><a href="https://www.github.com/{{services.github.username}}" target="_blank">{{services.github.username}}</a></p> {{/if}}
 						{{#if services.gitlab.id}} <p class="secondary-font-color"><i class="icon-gitlab"></i>{{services.gitlab.username}}</p> {{/if}}

--- a/packages/rocketchat-ui-flextab/client/tabs/userInfo.js
+++ b/packages/rocketchat-ui-flextab/client/tabs/userInfo.js
@@ -3,6 +3,39 @@ import moment from 'moment';
 import toastr from 'toastr';
 
 Template.userInfo.helpers({
+	customField() {
+		if (!RocketChat.authz.hasAllPermission('view-full-other-user-info')) {
+			return;
+		}
+
+		const sCustomFieldsToShow = RocketChat.settings.get('Accounts_CustomFieldsToShowInUserInfo').trim();
+		const customFields = [];
+
+		if (sCustomFieldsToShow) {
+			const user = Template.instance().user.get();
+			const userCustomFields = user && user.customFields || {};
+			const listOfCustomFieldsToShow = JSON.parse(sCustomFieldsToShow);
+
+			_.map(listOfCustomFieldsToShow, (el) => {
+				let content = '';
+				if (_.isObject(el)) {
+					_.map(el, (key, label) => {
+						const value = RocketChat.templateVarHandler(key, userCustomFields);
+						if (value) {
+							content = `${ label }: ${ value }`;
+						}
+					});
+				} else {
+					content = RocketChat.templateVarHandler(el, userCustomFields);
+				}
+				if (content) {
+					customFields.push(content);
+				}
+			});
+		}
+		return customFields;
+	},
+
 	name() {
 		const user = Template.instance().user.get();
 		return user && user.name ? user.name : TAPi18n.__('Unnamed');


### PR DESCRIPTION
@RocketChat/core 

Closes #7610

This change allows admin user to choose extra fields to be shown in the user's info tab. A new field was introduced (Accounts):

![screenshot from 2017-08-08 12-58-15](https://user-images.githubusercontent.com/1634735/29081666-8a81e9ac-7c39-11e7-85de-18cf648fd81a.png)

Below is a screenshot of the UserInfo tab:

![screenshot from 2017-08-08 12-57-49](https://user-images.githubusercontent.com/1634735/29081718-a85ddff8-7c39-11e7-8342-549b5ebbdbdf.png)

Besides that, as the template var handling logic was extracted to a method, I changed the ```getDataToSyncUserData``` method to use it.