### PR TITLE
[FIX] Show leader on first load

### DIFF
--- a/packages/rocketchat-ui/client/views/app/room.js
+++ b/packages/rocketchat-ui/client/views/app/room.js
@@ -831,7 +831,7 @@ Template.room.onRendered(function() {
 
 	template.sendToBottomIfNecessaryDebounced = _.debounce(template.sendToBottomIfNecessary, 10);
 
-	template.sendToBottomIfNecessary();
+	//template.sendToBottomIfNecessary(); //Only need one of these
 
 	if ((window.MutationObserver == null)) {
 		wrapperUl.addEventListener('DOMSubtreeModified', () => template.sendToBottomIfNecessaryDebounced());

--- a/packages/rocketchat-ui/client/views/app/room.js
+++ b/packages/rocketchat-ui/client/views/app/room.js
@@ -310,7 +310,6 @@ let touchMoved = false;
 let lastTouchX = null;
 let lastTouchY = null;
 let lastScrollTop;
-let leaderLoaded;
 
 Template.room.events({
 	'click .iframe-toolbar button'() {
@@ -504,12 +503,11 @@ Template.room.events({
 	'scroll .wrapper': _.throttle(function(e, t) {
 		const $roomLeader = $('.room-leader');
 		if ($roomLeader.length) {
-			if (e.target.scrollTop < lastScrollTop || !leaderLoaded) {
+			if (e.target.scrollTop < lastScrollTop) {
 				t.hideLeaderHeader.set(false);
-			} else if (e.target.scrollTop > $('.room-leader').height()) {
+			} else if (t.isAtBottom(100) === false && e.target.scrollTop > $('.room-leader').height()) {
 				t.hideLeaderHeader.set(true);
 			}
-			leaderLoaded = true;
 		}
 		lastScrollTop = e.target.scrollTop;
 
@@ -678,7 +676,6 @@ Template.room.events({
 Template.room.onCreated(function() {
 	// this.scrollOnBottom = true
 	// this.typing = new msgTyping this.data._id
-	leaderLoaded = false;
 	this.showUsersOffline = new ReactiveVar(false);
 	this.atBottom = FlowRouter.getQueryParam('msg') ? false : true;
 	this.unreadCount = new ReactiveVar(0);
@@ -831,7 +828,7 @@ Template.room.onRendered(function() {
 
 	template.sendToBottomIfNecessaryDebounced = _.debounce(template.sendToBottomIfNecessary, 10);
 
-	//template.sendToBottomIfNecessary(); //Only need one of these
+	template.sendToBottomIfNecessary();
 
 	if ((window.MutationObserver == null)) {
 		wrapperUl.addEventListener('DOMSubtreeModified', () => template.sendToBottomIfNecessaryDebounced());

--- a/packages/rocketchat-ui/client/views/app/room.js
+++ b/packages/rocketchat-ui/client/views/app/room.js
@@ -310,7 +310,7 @@ let touchMoved = false;
 let lastTouchX = null;
 let lastTouchY = null;
 let lastScrollTop;
-let leaderLoaded = false;
+let leaderLoaded;
 
 Template.room.events({
 	'click .iframe-toolbar button'() {
@@ -678,6 +678,7 @@ Template.room.events({
 Template.room.onCreated(function() {
 	// this.scrollOnBottom = true
 	// this.typing = new msgTyping this.data._id
+	leaderLoaded = false;
 	this.showUsersOffline = new ReactiveVar(false);
 	this.atBottom = FlowRouter.getQueryParam('msg') ? false : true;
 	this.unreadCount = new ReactiveVar(0);

--- a/packages/rocketchat-ui/client/views/app/room.js
+++ b/packages/rocketchat-ui/client/views/app/room.js
@@ -310,6 +310,7 @@ let touchMoved = false;
 let lastTouchX = null;
 let lastTouchY = null;
 let lastScrollTop;
+let leaderLoaded = false;
 
 Template.room.events({
 	'click .iframe-toolbar button'() {
@@ -501,10 +502,14 @@ Template.room.events({
 	},
 
 	'scroll .wrapper': _.throttle(function(e, t) {
-		if (e.target.scrollTop < lastScrollTop) {
-			t.hideLeaderHeader.set(false);
-		} else if (e.target.scrollTop > $('.room-leader').height()) {
-			t.hideLeaderHeader.set(true);
+		const $roomLeader = $('.room-leader');
+		if ($roomLeader.length) {
+			if (e.target.scrollTop < lastScrollTop || !leaderLoaded) {
+				t.hideLeaderHeader.set(false);
+			} else if (e.target.scrollTop > $('.room-leader').height()) {
+				t.hideLeaderHeader.set(true);
+			}
+			leaderLoaded = true;
 		}
 		lastScrollTop = e.target.scrollTop;
 


### PR DESCRIPTION
Display the leader at the top of the chat when you first enter a room. The room scrolls to the bottom, which will hide the leader, so manually unhide the leader.