### PR TITLE
[FIX] meteor-accounts-saml issue with ns0,ns1 namespaces, makes it compatible with pysaml2 lib

### DIFF
--- a/packages/meteor-accounts-saml/saml_client.js
+++ b/packages/meteor-accounts-saml/saml_client.js
@@ -101,7 +101,7 @@ Accounts.saml.initiateLogin = function(options, callback, dimensions) {
 
 Meteor.loginWithSaml = function(options, callback) {
 	options = options || {};
-	const credentialToken = Random.id();
+	const credentialToken = 'id-'+Random.id();
 	options.credentialToken = credentialToken;
 
 	Accounts.saml.initiateLogin(options, function(/*error, result*/) {

--- a/packages/meteor-accounts-saml/saml_client.js
+++ b/packages/meteor-accounts-saml/saml_client.js
@@ -101,7 +101,7 @@ Accounts.saml.initiateLogin = function(options, callback, dimensions) {
 
 Meteor.loginWithSaml = function(options, callback) {
 	options = options || {};
-	const credentialToken = 'id-'+Random.id();
+	const credentialToken = `id-${ Random.id() }`;
 	options.credentialToken = credentialToken;
 
 	Accounts.saml.initiateLogin(options, function(/*error, result*/) {

--- a/packages/meteor-accounts-saml/saml_utils.js
+++ b/packages/meteor-accounts-saml/saml_utils.js
@@ -49,7 +49,7 @@ SAML.prototype.initialize = function(options) {
 
 SAML.prototype.generateUniqueID = function() {
 	const chars = 'abcdef0123456789';
-	let uniqueID = '';
+	let uniqueID = 'id-';
 	for (let i = 0; i < 20; i++) {
 		uniqueID += chars.substr(Math.floor((Math.random() * 15)), 1);
 	}
@@ -258,6 +258,10 @@ SAML.prototype.getElement = function(parentElement, elementName) {
 		return parentElement[`saml2p:${ elementName }`];
 	} else if (parentElement[`saml2:${ elementName }`]) {
 		return parentElement[`saml2:${ elementName }`];
+	} else if (parentElement[`ns0:${ elementName }`]) {
+		return parentElement[`ns0:${ elementName }`];
+	} else if (parentElement[`ns1:${ elementName }`]) {
+		return parentElement[`ns1:${ elementName }`];
 	}
 	return parentElement[elementName];
 };
@@ -314,7 +318,8 @@ SAML.prototype.validateResponse = function(samlResponse, relayState, callback) {
 		console.log(`Validating response with relay state: ${ xml }`);
 	}
 	const parser = new xml2js.Parser({
-		explicitRoot: true
+		explicitRoot: true,
+		xmlns:true
 	});
 
 	parser.parseString(xml, function(err, doc) {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #7723

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
this fix adds support for ns0 and ns1 namespaces, to be able to process saml responses which are generated with pysaml2

this fix also adds the "id-" prefix to the unique id , to prevent issues with ids starting with a number