### PR TITLE
FIX: Error when starting local development environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4062,7 +4062,7 @@
 			"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
 		},
 		"phantomjs-prebuilt": {
-			"version": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.13.tgz",
+			"version": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.14.tgz",
 			"integrity": "sha1-ZlVq2ell2JPKWn3J52PffoaX920=",
 			"dev": true,
 			"dependencies": {


### PR DESCRIPTION
When I ran `meteor npm start ` to run a local environment, I got a "permission denied" error when trying to run PhantomJS. Upgrading to PhantomJS 2.1.14 fixes the problem for me. The issue may be related to [PhantomJS bug 107](https://github.com/Medium/phantomjs/issues/707).

[Here's my error log](https://hastebin.com/isibifejep.txt). I'm running Node 6.11.1, npm 3.10.10, and Fedora 26.

If I can provide any additional details, just let me know. Thanks!

@RocketChat/core 