### PR TITLE
[FIX] make flex-tab visible again when reduced width

### DIFF
--- a/packages/rocketchat-theme/client/imports/base.css
+++ b/packages/rocketchat-theme/client/imports/base.css
@@ -4827,6 +4827,7 @@ a + br.only-after-a {
 		right: 40px;
 		border-width: 0 0 0 1px;
 		z-index: 100;
+		height: 100%;
 	}
 }
 


### PR DESCRIPTION
@RocketChat/core 

Currently:
![image](https://user-images.githubusercontent.com/51996/29288129-4b07c76a-80fd-11e7-87af-26922e721c6c.png)


Should be:
![image](https://user-images.githubusercontent.com/51996/29288112-368587aa-80fd-11e7-859e-2d2231e8eb77.png)
