### PR TITLE
[FIX] Fixed function closure syntax allowing validation emails to be sent.

### DIFF
--- a/packages/rocketchat-ui-account/client/accountProfile.js
+++ b/packages/rocketchat-ui-account/client/accountProfile.js
@@ -424,7 +424,7 @@ Template.accountProfile.events({
 		e.preventDefault();
 		e.currentTarget.innerHTML = `${ e.currentTarget.innerHTML } ...`;
 		e.currentTarget.disabled = true;
-		Meteor.call('sendConfirmationEmail', user.emails && user.emails[0] && user.emails[0].address((error, results) => {
+		Meteor.call('sendConfirmationEmail', user.emails && user.emails[0] && user.emails[0].address, (error, results) => {
 			if (results) {
 				toastr.success(t('Verification_email_sent'));
 			} else if (error) {
@@ -432,7 +432,7 @@ Template.accountProfile.events({
 			}
 			e.currentTarget.innerHTML = e.currentTarget.innerHTML.replace(' ...', '');
 			return e.currentTarget.disabled = false;
-		}));
+		});
 	},
 	'change .js-select-avatar-upload [type=file]'(event, template) {
 		const e = event.originalEvent || event;


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

When attempting to send verification emails from the Account panel, a console error surfaced:
![screen shot 2017-08-16 at 3 10 09 pm](https://user-images.githubusercontent.com/3599795/29383921-397cc334-82a0-11e7-9a23-18bfd7a61ce5.png)

This was due to incorrect syntax on a function call to Meteor, where a function was being created from an Email object. This is a small change that fixes this bug and users can now resend themselves verification emails.

