### PR TITLE
[FIX] Settings not getting applied from Meteor.settings and process.env 

### DIFF
--- a/packages/rocketchat-lib/server/functions/settings.js
+++ b/packages/rocketchat-lib/server/functions/settings.js
@@ -42,8 +42,8 @@ RocketChat.settings.add = function(_id, value, options = {}) {
 	if (options.i18nDefaultQuery != null) {
 		options.i18nDefaultQuery = JSON.stringify(options.i18nDefaultQuery);
 	}
-	if (typeof process !== 'undefined' && process.env && process.env._id) {
-		let value = process.env[_id];
+	if (typeof process !== 'undefined' && process.env && process.env[_id]) {
+		value = process.env[_id];
 		if (value.toLowerCase() === 'true') {
 			value = true;
 		} else if (value.toLowerCase() === 'false') {
@@ -51,8 +51,12 @@ RocketChat.settings.add = function(_id, value, options = {}) {
 		}
 		options.processEnvValue = value;
 		options.valueSource = 'processEnvValue';
-	} else if (Meteor.settings && Meteor.settings) {
-		const value = Meteor.settings[_id];
+	} else if (Meteor.settings && typeof Meteor.settings[_id] !== 'undefined') {
+		if (Meteor.settings[_id] == null) {
+			return false;
+		}
+
+		value = Meteor.settings[_id];
 		options.meteorSettingsValue = value;
 		options.valueSource = 'meteorSettingsValue';
 	}


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
This fixes settings not getting applied when launching a fresh install of RC.

The issues are the variable `value` had an incorrect scope and Meteor.settings and process.env were accessed incorrectly. These crept up after the conversion from coffeescript to ES6.

