### PR TITLE
[FIX] Add CSS support for Safari versions > 7

### DIFF
--- a/.postcssrc
+++ b/.postcssrc
@@ -14,7 +14,7 @@
 				"last 1 FirefoxAndroid versions",
 				"last 2 Chrome versions",
 				"last 1 ChromeAndroid versions",
-				"last 2 Safari versions",
+				"Safari > 7",
 				"last 2 Opera versions",
 				"last 2 iOS versions",
 				"last 1 Android version"


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #7699

This will fix issues with flexbox on older Safari versions, although we still not officially support old Safari versions.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
