### PR TITLE
[FIX] File upload on multi-instances using a path prefix

### DIFF
--- a/packages/rocketchat-file-upload/server/lib/proxy.js
+++ b/packages/rocketchat-file-upload/server/lib/proxy.js
@@ -74,7 +74,7 @@ WebApp.connectHandlers.stack.unshift({
 		const options = {
 			hostname: instance.extraInformation.host,
 			port: instance.extraInformation.port,
-			path: req.url,
+			path: req.originalUrl,
 			method: 'POST'
 		};
 


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
When running RC with multi-instances and a path prefix like http://domain.com/rocket-chat, file uploads return an error when 2 requests are handled by different instances. The reason is req.url does not contain url prefix (it's stripped by Meteor https://github.com/meteor/meteor/blob/59aca741ccc22fbacc72786b94c97d74fb66e3a9/packages/webapp/webapp_server.js#L618) so when the request is rerouted to the correct instance it goes MIA.

I tested this change with 1 and many instances running, with a prefix and no prefix and using S3 and FileSystem. 