### PR TITLE
[FIX] Adds default search text padding for emoji search

### DIFF
--- a/packages/rocketchat-emoji/client/emojiPicker.css
+++ b/packages/rocketchat-emoji/client/emojiPicker.css
@@ -112,7 +112,7 @@
 
 			width: 100%;
 			height: 35px;
-			padding: 2px 8px;
+			padding: 0.5rem 1rem 0.5rem 2.25rem;
 
 			border-width: 1px;
 			border-style: solid;

--- a/packages/rocketchat-emoji/client/lib/EmojiPicker.js
+++ b/packages/rocketchat-emoji/client/lib/EmojiPicker.js
@@ -78,7 +78,6 @@ RocketChat.EmojiPicker = {
 		return $('.emoji-picker').css(cssProperties);
 	},
 	open(source, callback) {
-		console.log('open', source);
 		if (!this.initiated) {
 			this.init();
 		}


### PR DESCRIPTION
@RocketChat/core 

Closes #7875

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Adds default search padding for the emoji search input so we don't add text below the search icon.
Also removes a console.log triggered when opening the emoji window.

![image](https://user-images.githubusercontent.com/6303966/29699325-4c83ae1e-8932-11e7-9512-10814cb3659f.png)
