### PR TITLE
[FIX] Fix placeholders in account profile

### DIFF
--- a/packages/rocketchat-ui-account/client/accountProfile.html
+++ b/packages/rocketchat-ui-account/client/accountProfile.html
@@ -99,7 +99,7 @@
 									<label class="rc-input__label">
 										<div class="rc-input__title">{{_ "Email"}}</div>
 										<div class="rc-input__wrapper">
-											<input name="email" type="text" class="rc-input__element" placeholder="Type channel name" value="{{email}}" autocomplete="false" {{ifThenElse canChange '' 'disabled'}}>
+											<input name="email" type="text" class="rc-input__element" placeholder="Type email" value="{{email}}" autocomplete="false" {{ifThenElse canChange '' 'disabled'}}>
 										</div>
 									</label>
 									{{# unless canChange}}
@@ -112,7 +112,7 @@
 									<label class="rc-input__label">
 										<div class="rc-input__title">{{_ "New_password"}}</div>
 										<div class="rc-input__wrapper">
-											<input name="password" type="password" class="rc-input__element" placeholder="Type channel name"  autocomplete="new-password" {{ifThenElse canChange '' 'disabled'}}>
+											<input name="password" type="password" class="rc-input__element" placeholder="Type new password"  autocomplete="new-password" {{ifThenElse canChange '' 'disabled'}}>
 										</div>
 									</label>
 									{{# unless canChange}}


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Fixes wrong placeholders on account profile. Not sure if the placeholders are needed here though, since there's a label above each input field.

Before:
<img width="715" alt="screen shot 2017-08-28 at 21 13 15" src="https://user-images.githubusercontent.com/882253/29799091-b70d183a-8c37-11e7-9281-433cbf0039db.png">

After:
<img width="710" alt="screen shot 2017-08-28 at 21 12 51" src="https://user-images.githubusercontent.com/882253/29799099-ba841d10-8c37-11e7-9469-5cf5a64e80ee.png">

