### PR TITLE
[FIX] Recent emojis not updated when adding via text

### DIFF
--- a/packages/rocketchat-ui-message/client/popup/messagePopupConfig.js
+++ b/packages/rocketchat-ui-message/client/popup/messagePopupConfig.js
@@ -88,6 +88,42 @@ const getUsersFromServerDelayed = _.throttle(getUsersFromServer, 500);
 
 const getRoomsFromServerDelayed = _.throttle(getRoomsFromServer, 500);
 
+const addEmojiToRecents = (emoji) => {
+	const pickerEl = $('.emoji-picker')[0];
+	if (pickerEl) {
+		const view = Blaze.getView(pickerEl);
+		if (view) {
+			Template._withTemplateInstanceFunc(view.templateInstance, () => {
+				RocketChat.EmojiPicker.addRecent(emoji.replace(/:/g, ''));
+			});
+		}
+	}
+};
+
+const emojiSort = (recents) => {
+	return (a, b) => {
+		let idA = a._id;
+		let idB = a._id;
+
+		if (recents.includes(a._id)) {
+			idA = recents.indexOf(a._id) + idA;
+		}
+		if (recents.includes(b._id)) {
+			idB = recents.indexOf(b._id) + idB;
+		}
+
+		if (idA < idB) {
+			return -1;
+		}
+
+		if (idA > idB) {
+			return 1;
+		}
+
+		return 0;
+	};
+};
+
 Template.messagePopupConfig.helpers({
 	popupUserConfig() {
 		const self = this;
@@ -273,11 +309,12 @@ Template.messagePopupConfig.helpers({
 				getFilter(collection, filter) {
 					const key = `:${ filter }`;
 
-					if (!RocketChat.emoji.packages.emojione || RocketChat.emoji.packages.emojione.asciiList[key] || filter.length < 2) {
+					if (!RocketChat.emoji.packages.emojione || RocketChat.emoji.packages.emojione.asciiList[key]) {
 						return [];
 					}
 
 					const regExp = new RegExp(`^${ RegExp.escape(key) }`, 'i');
+					const recents = RocketChat.EmojiPicker.getRecent().map(item => `:${ item }:`);
 					return Object.keys(collection).map(key => {
 						const value = collection[key];
 						return {
@@ -286,16 +323,12 @@ Template.messagePopupConfig.helpers({
 						};
 					})
 						.filter(obj => regExp.test(obj._id))
-						.slice(0, 10)
-						.sort(function(a, b) {
-							if (a._id < b._id) {
-								return -1;
-							}
-							if (a._id > b._id) {
-								return 1;
-							}
-							return 0;
-						});
+						.sort(emojiSort(recents))
+						.slice(0, 10);
+				},
+				getValue(_id) {
+					addEmojiToRecents(_id);
+					return _id;
 				}
 			};
 		}
@@ -314,11 +347,12 @@ Template.messagePopupConfig.helpers({
 				getFilter(collection, filter) {
 					const key = `${ filter }`;
 
-					if (!RocketChat.emoji.packages.emojione || RocketChat.emoji.packages.emojione.asciiList[key] || filter.length < 2) {
+					if (!RocketChat.emoji.packages.emojione || RocketChat.emoji.packages.emojione.asciiList[key]) {
 						return [];
 					}
 
 					const regExp = new RegExp(`^${ RegExp.escape(key) }`, 'i');
+					const recents = RocketChat.EmojiPicker.getRecent().map(item => `:${ item }:`);
 					return Object.keys(collection).map(key => {
 						const value = collection[key];
 						return {
@@ -327,16 +361,12 @@ Template.messagePopupConfig.helpers({
 						};
 					})
 						.filter(obj => regExp.test(obj._id))
-						.slice(0, 10)
-						.sort(function(a, b) {
-							if (a._id < b._id) {
-								return -1;
-							}
-							if (a._id > b._id) {
-								return 1;
-							}
-							return 0;
-						});
+						.sort(emojiSort(recents))
+						.slice(0, 10);
+				},
+				getValue(_id) {
+					addEmojiToRecents(_id);
+					return _id;
 				}
 			};
 		}


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

- Update the recent's list when adding via text `Ex: :smile:`
- Show recent emojis first on emoji popup
- Show emoji popup when type `:` directly, was expecting 2 chars to show it