### PR TITLE
[FIX] Sync of non existent field throws exception

### DIFF
--- a/packages/rocketchat-ldap/server/sync.js
+++ b/packages/rocketchat-ldap/server/sync.js
@@ -121,7 +121,7 @@ export function getDataToSyncUserData(ldapUser, user) {
 					}
 
 					const tmpUserField = getPropertyValue(user, userField);
-					const tmpLdapField = RocketChat.templateVarHandler(ldapField, ldapUser.object);
+					const tmpLdapField = RocketChat.templateVarHandler(ldapField, ldapUser);
 
 					if (tmpLdapField && tmpUserField !== tmpLdapField) {
 						// creates the object structure instead of just assigning 'tmpLdapField' to

--- a/packages/rocketchat-ldap/server/sync.js
+++ b/packages/rocketchat-ldap/server/sync.js
@@ -20,7 +20,7 @@ export function getPropertyValue(obj, key) {
 	} catch (err) {
 		return undefined;
 	}
-};
+}
 
 
 export function getLdapUsername(ldapUser) {

--- a/packages/rocketchat-ldap/server/sync.js
+++ b/packages/rocketchat-ldap/server/sync.js
@@ -14,6 +14,15 @@ export function slug(text) {
 }
 
 
+export function getPropertyValue(obj, key) {
+	try {
+		return _.reduce(key.split('.'), (acc, el) => acc[el], obj);
+	} catch (err) {
+		return undefined;
+	}
+};
+
+
 export function getLdapUsername(ldapUser) {
 	const usernameField = RocketChat.settings.get('LDAP_Username_Field');
 
@@ -88,16 +97,45 @@ export function getDataToSyncUserData(ldapUser, user) {
 					break;
 
 				default:
-					if (!_.find(whitelistedUserFields, (el) => el === userField.split('.')[0])) {
+					const [outerKey, innerKeys] = userField.split(/\.(.+)/);
+
+					if (!_.find(whitelistedUserFields, (el) => el === outerKey)) {
 						logger.debug(`user attribute not whitelisted: ${ userField }`);
 						return;
 					}
 
-					const tmpLdapField = RocketChat.templateVarHandler(ldapField, ldapUser);
-					const userFieldValue = _.reduce(userField.split('.'), (acc, el) => acc[el], user);
+					if (outerKey === 'customFields') {
+						let customFieldsMeta;
 
-					if (tmpLdapField && userFieldValue !== tmpLdapField) {
-						userData[userField] = tmpLdapField;
+						try {
+							customFieldsMeta = JSON.parse(RocketChat.settings.get('Accounts_CustomFields'));
+						} catch (e) {
+							logger.debug('Invalid JSON for Custom Fields');
+							return;
+						}
+
+						if (!getPropertyValue(customFieldsMeta, innerKeys)) {
+							logger.debug(`user attribute does not exist: ${ userField }`);
+							return;
+						}
+					}
+
+					const tmpUserField = getPropertyValue(user, userField);
+					const tmpLdapField = RocketChat.templateVarHandler(ldapField, ldapUser.object);
+
+					if (tmpLdapField && tmpUserField !== tmpLdapField) {
+						// creates the object structure instead of just assigning 'tmpLdapField' to
+						// 'userData[userField]' in order to avoid the "cannot use the part (...)
+						// to traverse the element" (MongoDB) error that can happen. Do not handle
+						// arrays.
+						// TODO: Find a better solution.
+						const dKeys = userField.split('.');
+						const lastKey = _.last(dKeys);
+						_.reduce(dKeys, (obj, currKey) =>
+							(currKey === lastKey)
+								? obj[currKey] = tmpLdapField
+								: obj[currKey] = obj[currKey] || {}
+							, userData);
 						logger.debug(`user.${ userField } changed to: ${ tmpLdapField }`);
 					}
 			}


### PR DESCRIPTION
- checks if the field is whitelisted for sync
- if a customField, checks its validity before syncing (through Accounts_CustomFields)
- fixes the case when the field is still absent in the user document
* This implementation does not allow dots in the customField name, because the dots would be treated as nested fields

@RocketChat/core