### PR TITLE
[FIX] Fix setting user avatar on LDAP login

### DIFF
--- a/packages/rocketchat-ldap/server/sync.js
+++ b/packages/rocketchat-ldap/server/sync.js
@@ -163,11 +163,13 @@ syncUserData = function syncUserData(user, ldapUser) {
 				type: 'image/jpeg'
 			};
 
-			fileStore.insert(file, rs, () => {
-				Meteor.setTimeout(function() {
-					RocketChat.models.Users.setAvatarOrigin(user._id, 'ldap');
-					RocketChat.Notifications.notifyLogged('updateAvatar', {username: user.username});
-				}, 500);
+			Meteor.runAsUser(user._id, () => {
+				fileStore.insert(file, rs, () => {
+					Meteor.setTimeout(function() {
+						RocketChat.models.Users.setAvatarOrigin(user._id, 'ldap');
+						RocketChat.Notifications.notifyLogged('updateAvatar', {username: user.username});
+					}, 500);
+				});
 			});
 		}
 	}


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #7405

Fixes an issue that makes the whole LDAP login process to fail when trying to set the user's avatar from AD.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
