### PR TITLE
[FIX] Fix new room sound being played too much

### DIFF
--- a/client/notifications/notification.js
+++ b/client/notifications/notification.js
@@ -11,7 +11,7 @@ function notifyNewRoom(sub) {
 		return;
 	}
 
-	if (!(FlowRouter.getParam('name') && FlowRouter.getParam('name') === sub.name) && !sub.ls && sub.alert === true) {
+	if ((!FlowRouter.getParam('name') || FlowRouter.getParam('name') !== sub.name) && !sub.ls && sub.alert === true) {
 		return KonchatNotification.newRoom(sub.rid);
 	}
 }
@@ -69,7 +69,7 @@ Meteor.startup(function() {
 			});
 
 			CachedChatSubscription.onSyncData = function(action, sub) {
-				if (action === 'changed') {
+				if (action !== 'removed') {
 					notifyNewRoom(sub);
 				}
 			};

--- a/client/notifications/notification.js
+++ b/client/notifications/notification.js
@@ -55,6 +55,17 @@ Meteor.startup(function() {
 					KonchatNotification.newMessage(notification.payload.rid);
 				}
 			});
+
+			RocketChat.Notifications.onUser('subscriptions-changed', function(action, sub) {
+				// Do not play new room sound if user is busy
+				if (Session.equals(`user_${ Meteor.userId() }_status`, 'busy')) {
+					return;
+				}
+
+				if (!(FlowRouter.getParam('name') && FlowRouter.getParam('name') === sub.name) && !sub.ls && sub.alert === true) {
+					return KonchatNotification.newRoom(sub.rid);
+				}
+			});
 		}
 	});
 });

--- a/client/notifications/notification.js
+++ b/client/notifications/notification.js
@@ -1,8 +1,20 @@
-/* globals KonchatNotification, fireGlobalEvent, readMessage */
+/* globals KonchatNotification, fireGlobalEvent, readMessage, CachedChatSubscription */
 
 // Show notifications and play a sound for new messages.
 // We trust the server to only send notifications for interesting messages, e.g. direct messages or
 // group messages in which the user is mentioned.
+
+function notifyNewRoom(sub) {
+
+	// Do not play new room sound if user is busy
+	if (Session.equals(`user_${ Meteor.userId() }_status`, 'busy')) {
+		return;
+	}
+
+	if (!(FlowRouter.getParam('name') && FlowRouter.getParam('name') === sub.name) && !sub.ls && sub.alert === true) {
+		return KonchatNotification.newRoom(sub.rid);
+	}
+}
 
 Meteor.startup(function() {
 	Tracker.autorun(function() {
@@ -56,15 +68,14 @@ Meteor.startup(function() {
 				}
 			});
 
-			RocketChat.Notifications.onUser('subscriptions-changed', function(action, sub) {
-				// Do not play new room sound if user is busy
-				if (Session.equals(`user_${ Meteor.userId() }_status`, 'busy')) {
-					return;
+			CachedChatSubscription.onSyncData = function(action, sub) {
+				if (action === 'changed') {
+					notifyNewRoom(sub);
 				}
+			};
 
-				if (!(FlowRouter.getParam('name') && FlowRouter.getParam('name') === sub.name) && !sub.ls && sub.alert === true) {
-					return KonchatNotification.newRoom(sub.rid);
-				}
+			RocketChat.Notifications.onUser('subscriptions-changed', (action, sub) => {
+				notifyNewRoom(sub);
 			});
 		}
 	});

--- a/packages/rocketchat-lib/client/lib/cachedCollection.js
+++ b/packages/rocketchat-lib/client/lib/cachedCollection.js
@@ -99,7 +99,8 @@ class CachedCollection {
 		useCache = true,
 		debug = false,
 		version = 6,
-		maxCacheTime = 60*60*24*30
+		maxCacheTime = 60*60*24*30,
+		onSyncData = (/* action, record */) => {}
 	}) {
 		this.collection = collection || new Mongo.Collection(null);
 
@@ -116,6 +117,7 @@ class CachedCollection {
 		this.userRelated = userRelated;
 		this.updatedAt = new Date(0);
 		this.maxCacheTime = maxCacheTime;
+		this.onSyncData = onSyncData;
 
 		RocketChat.CachedCollectionManager.register(this);
 
@@ -268,11 +270,15 @@ class CachedCollection {
 				if (record._deletedAt) {
 					this.collection.remove({ _id: record._id });
 
+					this.onSyncData('removed', record);
+
 					if (record._deletedAt && record._deletedAt > this.updatedAt) {
 						this.updatedAt = record._deletedAt;
 					}
 				} else {
 					this.collection.upsert({ _id: record._id }, _.omit(record, '_id'));
+
+					this.onSyncData('changed', record);
 
 					if (record._updatedAt && record._updatedAt > this.updatedAt) {
 						this.updatedAt = record._updatedAt;

--- a/packages/rocketchat-lib/client/lib/cachedCollection.js
+++ b/packages/rocketchat-lib/client/lib/cachedCollection.js
@@ -208,6 +208,8 @@ class CachedCollection {
 				delete record.$loki;
 				this.collection.upsert({ _id: record._id }, _.omit(record, '_id'));
 
+				this.onSyncData('changed', record);
+
 				if (record._updatedAt && record._updatedAt > this.updatedAt) {
 					this.updatedAt = record._updatedAt;
 				}

--- a/packages/rocketchat-ui-sidenav/client/accountBox.js
+++ b/packages/rocketchat-ui-sidenav/client/accountBox.js
@@ -29,7 +29,7 @@ Template.accountBox.helpers({
 	},
 
 	isAnonymous() {
-		if (Meteor.user() == null && RocketChat.settings.get('Accounts_AllowAnonymousRead')) {
+		if (Meteor.userId() == null && RocketChat.settings.get('Accounts_AllowAnonymousRead')) {
 			return 'disabled';
 		}
 	}

--- a/packages/rocketchat-ui-sidenav/client/chatRoomItem.js
+++ b/packages/rocketchat-ui-sidenav/client/chatRoomItem.js
@@ -1,5 +1,3 @@
-/* globals KonchatNotification */
-
 Template.chatRoomItem.helpers({
 	roomData() {
 		let name = this.name;
@@ -25,10 +23,6 @@ Template.chatRoomItem.helpers({
 		if (!this.hideUnreadStatus && (FlowRouter.getParam('_id') !== this.rid || !document.hasFocus()) && this.alert) {
 			alertClass = 'sidebar-item__link--active';
 		}
-		// Sound notification
-		if (!(FlowRouter.getParam('name') === this.name) && !this.ls && this.alert === true) {
-			KonchatNotification.newRoom(this.rid);
-		}
 
 		const icon = RocketChat.roomTypes.getIcon(this.t);
 		const avatar = !icon;
@@ -47,9 +41,3 @@ Template.chatRoomItem.helpers({
 		};
 	}
 });
-
-Template.chatRoomItem.onRendered = function() {
-	if (!(FlowRouter.getParam('name') && (FlowRouter.getParam('name') === this.name)) && !this.ls && (this.alert === true)) {
-		return KonchatNotification.newRoom(this.rid);
-	}
-};

--- a/packages/rocketchat-ui-sidenav/client/sideNav.html
+++ b/packages/rocketchat-ui-sidenav/client/sideNav.html
@@ -5,7 +5,7 @@
 				{{> toolbar}}
 			</header>
 
-			{{#if currentUser}}
+			{{#if loggedInUser}}
 				<div class="unread-rooms background-primary-action-color color-primary-action-contrast top-unread-rooms hidden">
 					{{_ "More_unreads"}} <i class="icon-up-big"></i>
 				</div>

--- a/packages/rocketchat-ui-sidenav/client/sideNav.js
+++ b/packages/rocketchat-ui-sidenav/client/sideNav.js
@@ -1,14 +1,6 @@
 /* globals menu*/
 
 Template.sideNav.helpers({
-	hasUnread() {
-		const user = Meteor.user();
-		return user && user.settings && user.settings.preferences && user.settings.preferences.roomsListExhibitionMode === 'unread';
-	},
-	sortByActivity() {
-		const user = Meteor.user();
-		return user && user.settings && user.settings.preferences && user.settings.preferences.roomsListExhibitionMode === 'activity';
-	},
 	flexTemplate() {
 		return SideNav.getFlex().template;
 	},
@@ -23,6 +15,10 @@ Template.sideNav.helpers({
 
 	roomType() {
 		return RocketChat.roomTypes.getTypes();
+	},
+
+	loggedInUser() {
+		return !!Meteor.userId();
 	}
 });
 
@@ -69,7 +65,12 @@ Template.sideNav.onCreated(function() {
 	this.mergedChannels = new ReactiveVar(false);
 
 	this.autorun(() => {
-		const user = Meteor.user();
+		const user = RocketChat.models.Users.findOne(Meteor.userId(), {
+			fields: {
+				'settings.preferences.roomsListExhibitionMode': 1,
+				'settings.preferences.mergeChannels': 1
+			}
+		});
 		let userPref = null;
 		if (user && user.settings && user.settings.preferences) {
 			userPref = user.settings.preferences.roomsListExhibitionMode === 'category' && user.settings.preferences.mergeChannels;

--- a/packages/rocketchat-ui/client/lib/notification.js
+++ b/packages/rocketchat-ui/client/lib/notification.js
@@ -124,36 +124,38 @@ const KonchatNotification = {
 	}
 };
 
-Tracker.autorun(function() {
-	const user = RocketChat.models.Users.findOne(Meteor.userId(), {
-		fields: {
-			'settings.preferences.newRoomNotification': 1,
-			'settings.preferences.notificationsSoundVolume': 1
-		}
-	});
-	const newRoomNotification = user && user.settings && user.settings.preferences && user.settings.preferences.newRoomNotification || 'door';
-	const audioVolume = user && user.settings && user.settings.preferences && user.settings.preferences.notificationsSoundVolume || 100;
-
-	if ((Session.get('newRoomSound') || []).length > 0) {
-		Tracker.nonreactive(function() {
-			if (newRoomNotification !== 'none') {
-				const [audio] = $(`audio#${ newRoomNotification }`);
-				if (audio && audio.play) {
-					audio.volume = Number((audioVolume/100).toPrecision(2));
-					return audio.play();
-				}
+Meteor.startup(() => {
+	Tracker.autorun(function() {
+		const user = RocketChat.models.Users.findOne(Meteor.userId(), {
+			fields: {
+				'settings.preferences.newRoomNotification': 1,
+				'settings.preferences.notificationsSoundVolume': 1
 			}
 		});
-	} else {
-		const [room] = $(`audio#${ newRoomNotification }`);
-		if (!room) {
-			return;
+		const newRoomNotification = user && user.settings && user.settings.preferences && user.settings.preferences.newRoomNotification || 'door';
+		const audioVolume = user && user.settings && user.settings.preferences && user.settings.preferences.notificationsSoundVolume || 100;
+
+		if ((Session.get('newRoomSound') || []).length > 0) {
+			Meteor.defer(function() {
+				if (newRoomNotification !== 'none') {
+					const [audio] = $(`audio#${ newRoomNotification }`);
+					if (audio && audio.play) {
+						audio.volume = Number((audioVolume/100).toPrecision(2));
+						return audio.play();
+					}
+				}
+			});
+		} else {
+			const [room] = $(`audio#${ newRoomNotification }`);
+			if (!room) {
+				return;
+			}
+			if (room.pause) {
+				room.pause();
+				return room.currentTime = 0;
+			}
 		}
-		if (room.pause) {
-			room.pause();
-			return room.currentTime = 0;
-		}
-	}
+	});
 });
 export { KonchatNotification };
 this.KonchatNotification = KonchatNotification;

--- a/packages/rocketchat-ui/client/lib/notification.js
+++ b/packages/rocketchat-ui/client/lib/notification.js
@@ -125,13 +125,18 @@ const KonchatNotification = {
 };
 
 Tracker.autorun(function() {
-	const user = Meteor.user();
+	const user = RocketChat.models.Users.findOne(Meteor.userId(), {
+		fields: {
+			'settings.preferences.newRoomNotification': 1,
+			'settings.preferences.notificationsSoundVolume': 1
+		}
+	});
 	const newRoomNotification = user && user.settings && user.settings.preferences && user.settings.preferences.newRoomNotification || 'door';
 	const audioVolume = user && user.settings && user.settings.preferences && user.settings.preferences.notificationsSoundVolume || 100;
 
 	if ((Session.get('newRoomSound') || []).length > 0) {
 		Tracker.nonreactive(function() {
-			if (!Session.equals(`user_${ Meteor.userId() }_status`, 'busy') && newRoomNotification !== 'none') {
+			if (newRoomNotification !== 'none') {
 				const [audio] = $(`audio#${ newRoomNotification }`);
 				if (audio && audio.play) {
 					audio.volume = Number((audioVolume/100).toPrecision(2));


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

I removed logic from the template to a listener on the `subscription-changed` stream, so the sound will play only when new data comes from server and not due to any random reactivity.

I've also removed some calls to `Meteor.user()` which adds reactivity to changes to any field of the current user, which was not desired, and replaced by `Meteor.userId()` (when the test was to see the user is logged in) and by a query on specific fields (this way if I care about `settings` field my code will not reactivity ran if the `status` field changes).

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
