### PR TITLE
[FIX] Allow unknown file types if no allowed whitelist has been set (#7074)

### DIFF
--- a/packages/rocketchat-lib/lib/fileUploadRestrictions.js
+++ b/packages/rocketchat-lib/lib/fileUploadRestrictions.js
@@ -11,7 +11,15 @@ RocketChat.fileUploadMediaWhiteList = function() {
 
 RocketChat.fileUploadIsValidContentType = function(type) {
 	const list = RocketChat.fileUploadMediaWhiteList();
-	if (!list || _.contains(list, type)) {
+	if (!list) {
+		return true;
+	}
+
+	if (!type) {
+		return false;
+	}
+
+	if (_.contains(list, type)) {
 		return true;
 	} else {
 		const wildCardGlob = '/*';

--- a/packages/rocketchat-ui/client/lib/fileUpload.js
+++ b/packages/rocketchat-ui/client/lib/fileUpload.js
@@ -56,7 +56,7 @@ fileUpload = function(filesToUpload) {
 			return;
 		}
 
-		if (!file.file.type || !RocketChat.fileUploadIsValidContentType(file.file.type)) {
+		if (!RocketChat.fileUploadIsValidContentType(file.file.type)) {
 			swal({
 				title: t('FileUpload_MediaType_NotAccepted'),
 				text: file.file.type || `*.${ s.strRightBack(file.file.name, '.') }`,


### PR DESCRIPTION
@RocketChat/core 

Closes #7074 

This moves the type validity check down to fileUploadIsValidContentType(). This way the whitelist can be checked first, before denying uploads of unknown file types. This way unknown/undetected file types are allowed, if and only if the whitelist is completely empty.