### PR TITLE
[FIX] Sidebar items letters g j p q y were cut

### DIFF
--- a/packages/rocketchat-theme/client/imports/components/sidebar/sidebar-item.css
+++ b/packages/rocketchat-theme/client/imports/components/sidebar/sidebar-item.css
@@ -115,6 +115,7 @@
 		flex: 1;
 
 		margin: 0 4px;
+		padding: 5px 0;
 
 		white-space: nowrap;
 		text-overflow: ellipsis;


### PR DESCRIPTION
Here's how it was

![image](https://user-images.githubusercontent.com/3885848/30543459-50c07a0a-9c94-11e7-9fdf-461ba6939356.png)

I added a padding `5px 0` on `sidebar-item__name`

![image](https://user-images.githubusercontent.com/3885848/30543491-6f6f378e-9c94-11e7-881e-7e54f40d22b1.png)
