### PR TITLE
[FIX] User avatar in DM list.

### DIFF
--- a/packages/rocketchat-ui-sidenav/client/chatRoomItem.js
+++ b/packages/rocketchat-ui-sidenav/client/chatRoomItem.js
@@ -1,6 +1,6 @@
 Template.chatRoomItem.helpers({
 	roomData() {
-		let name = this.name;
+		let {name} = this;
 		const realNameForDirectMessages = RocketChat.settings.get('UI_Use_Real_Name') && this.t === 'd';
 		const realNameForChannel = RocketChat.settings.get('UI_Allow_room_names_with_special_chars') && this.t !== 'd';
 		if ((realNameForDirectMessages || realNameForChannel) && this.fname) {
@@ -31,6 +31,7 @@ Template.chatRoomItem.helpers({
 			...this,
 			icon,
 			avatar,
+			username : this.name,
 			route: RocketChat.roomTypes.getRouteLink(this.t, this),
 			name,
 			unread,

--- a/packages/rocketchat-ui-sidenav/client/sidebarItem.html
+++ b/packages/rocketchat-ui-sidenav/client/sidebarItem.html
@@ -10,7 +10,7 @@
 				{{else}}
 					{{#if avatar}}
 						<div class="sidebar-item__user-thumb">
-							{{> avatar username=name}}
+							{{> avatar username=username}}
 						</div>
 					{{/if}}
 				{{/if}}


### PR DESCRIPTION
@RocketChat/core
thanks @nishimaki10
Closes #7907

Fix to use original name for avatar URL.
Avatar URL is not correct when Use Real Name is True.