### PR TITLE
[FIX] Incorrect URL for login terms when using prefix

### DIFF
--- a/packages/rocketchat-lib/server/startup/settings.js
+++ b/packages/rocketchat-lib/server/startup/settings.js
@@ -1255,7 +1255,7 @@ RocketChat.settings.addGroup('Layout', function() {
 			multiline: true,
 			'public': true
 		});
-		this.add('Layout_Login_Terms', 'By proceeding you are agreeing to our <a href="/terms-of-service">Terms of Service</a> and <a href="/privacy-policy">Privacy Policy</a>.', {
+		this.add('Layout_Login_Terms', 'By proceeding you are agreeing to our <a href="terms-of-service">Terms of Service</a> and <a href="privacy-policy">Privacy Policy</a>.', {
 			type: 'string',
 			multiline: true,
 			'public': true

--- a/packages/rocketchat-ui/client/views/cmsPage.html
+++ b/packages/rocketchat-ui/client/views/cmsPage.html
@@ -1,7 +1,7 @@
 <template name="cmsPage">
 	<div class="cms-page content-background-color">
 		<div class="cms-page-close">
-			<a href="/login" class="button primary"><i class="icon-cancel"></i></a>
+			<a href="login" class="button primary"><i class="icon-cancel"></i></a>
 		</div>
 		{{{page}}}
 	</div>


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
When RC was behind a prefix, navigating to and from the login terms would lead to an incorrect URL.