### PR TITLE
[FIX] Check attachments is defined before accessing first element

### DIFF
--- a/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
@@ -31,7 +31,7 @@ function parseMessageText(message, userId) {
 	const user = RocketChat.models.Users.findOneById(userId);
 	const lng = user && user.language || RocketChat.settings.get('language') || 'en';
 
-	if (!message.msg && message.attachments[0]) {
+	if (!message.msg && message.attachments && message.attachments[0]) {
 		message.msg = message.attachments[0].image_type ? TAPi18n.__('User_uploaded_image', {lng}) : TAPi18n.__('User_uploaded_file', {lng});
 	}
 	message.msg = RocketChat.callbacks.run('beforeNotifyUser', message.msg);


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Prevents an error if `attachments` is undefined. It's not possible to create an empty message with no attachments in Rocket.Chat at the moment so this is mainly for those that are building on top of Rocket.Chat and are extending the message model.