### PR TITLE
[FIX] Wrong message when reseting password and 2FA is enabled

### DIFF
--- a/packages/rocketchat-ui-login/client/reset-password/resetPassword.js
+++ b/packages/rocketchat-ui-login/client/reset-password/resetPassword.js
@@ -44,10 +44,16 @@ Template.resetPassword.events({
 				RocketChat.Button.reset(button);
 				if (error) {
 					console.log(error);
-					swal({
-						title: t('Error_changing_password'),
-						type: 'error'
-					});
+					if (error.error === 'totp-required') {
+						toastr.success(t('Password_changed_successfully'));
+						RocketChat.callbacks.run('userPasswordReset');
+						FlowRouter.go('login');
+					} else {
+						swal({
+							title: t('Error_changing_password'),
+							type: 'error'
+						});
+					}
 				} else {
 					FlowRouter.go('home');
 					toastr.success(t('Password_changed_successfully'));


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #8472

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

When password is reset the user is logged in automatically, but one error is received when the user has 2FA enabled requiring to pass the token, that is why we have the password reset but one error is displayed.

This PR just check the error message and redirect the user to the login page when 2FA is required and show a success alert about the message reset.

The 2 possible results are:
- 2FA Disabled: After a successful password reset the user will be logged in automatically
- 2FA Enabled: After a successful password reset the user will receive a successful message and will be redirect to the login page