### PR TITLE
Change artifact path

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -5,8 +5,8 @@ ENV RC_VERSION 0.59.0-develop
 MAINTAINER buildmaster@rocket.chat
 
 RUN set -x \
- && curl -SLf "https://rocket.chat/releases/${RC_VERSION}/download" -o rocket.chat.tgz \
- && curl -SLf "https://rocket.chat/releases/${RC_VERSION}/asc" -o rocket.chat.tgz.asc \
+ && curl -SLf "https://download.rocket.chat/build/${RC_VERSION}.tgz" -o rocket.chat.tgz \
+ && curl -SLf "https://download.rocket.chat/build/${RC_VERSION}.tgz.asc" -o rocket.chat.tgz.asc \
  && mkdir /app \
  && gpg --verify rocket.chat.tgz.asc \
  && mkdir -p /app \

--- a/.snapcraft/snapcraft.yaml
+++ b/.snapcraft/snapcraft.yaml
@@ -49,7 +49,7 @@ parts:
         plugin: dump
         prepare: cd programs/server; npm install
         after: [node]
-        source: https://rocket.chat/releases/#{RC_VERSION}/download
+        source: https://download.rocket.chat/build/#{RC_VERSION}.tgz
         source-type: tar
         stage-packages:
             - graphicsmagick


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

New website, the paths that once existed don't any more.

- [ ] The update release script also doesn't need hit any more.
- [ ] Develop docker image and snap image needs to have version set to the artifact being uploaded... or a redirect setup on s3.