### PR TITLE
[FIX] Long filename covers 'CANCEL' button in upload progress bar

### DIFF
--- a/packages/rocketchat-file-upload/lib/FileUploadBase.js
+++ b/packages/rocketchat-file-upload/lib/FileUploadBase.js
@@ -27,7 +27,7 @@ FileUploadBase = class FileUploadBase {
 	}
 
 	getFileName() {
-		return this.meta.name;
+		return (this.meta.name.length > 50) ? this.meta.name.substring(0, 50) : this.meta.name;
 	}
 
 	start(callback) {


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #6868

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
If a file with a very long name is uploaded, the cancel button is hidden in the upload bar. Simple solution is to truncate the filename at X chars.

![2017-10-18-121227_1920x1080_scrot](https://user-images.githubusercontent.com/5003990/31729912-68efc1a4-b3fe-11e7-9507-1a1e2c24a5ad.png)

![2017-10-18-121658_1920x1080_scrot](https://user-images.githubusercontent.com/5003990/31729918-6aa2931e-b3fe-11e7-9a2f-993cded05f35.png)