### PR TITLE
[FIX] AmazonS3: Quote file.name for ContentDisposition for files with commas

### DIFF
--- a/packages/rocketchat-file-upload/ufs/AmazonS3/server.js
+++ b/packages/rocketchat-file-upload/ufs/AmazonS3/server.js
@@ -138,7 +138,7 @@ export class AmazonS3Store extends UploadFS.Store {
 				Key: this.getPath(file),
 				Body: writeStream,
 				ContentType: file.type,
-				ContentDisposition: `inline; filename=${ file.name }`
+				ContentDisposition: `inline; filename="${ file.name }"`
 
 			}, (error) => {
 				if (error) {


### PR DESCRIPTION
Adds quotes around the filename attribute.

See:
 - https://github.com/RocketChat/Rocket.Chat/issues/8584
 - https://stackoverflow.com/questions/38320996/s3-downloading-images-with-comma-in-filename-results-in-neterr-response-heade

Fixes #8584

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core
