### PR TITLE
install grpc package manually to fix snap armhf build

### DIFF
--- a/.snapcraft/snapcraft.yaml
+++ b/.snapcraft/snapcraft.yaml
@@ -47,7 +47,7 @@ parts:
             - nodejs
     rocketchat-server:
         plugin: dump
-        prepare: cd programs/server; npm install
+        prepare: cd programs/server; npm install; cd npm/node_modules/meteor/rocketchat_google-vision; npm install grpc
         after: [node]
         source: https://download.rocket.chat/build/#{RC_VERSION}.tgz
         source-type: tar


### PR DESCRIPTION
@RocketChat/core 

With out this snap builds for armhf (raspberry pi) fails.