### PR TITLE
[NEW] #661 Combining user joins on the front-end.

### DIFF
--- a/packages/rocketchat-ui-message/client/message.html
+++ b/packages/rocketchat-ui-message/client/message.html
@@ -60,6 +60,9 @@
 			{{#each attachments}}
 				{{injectIndex . @index}} {{> messageAttachment}}
 			{{/each}}
+			{{#if hasOtherJoins}}
+				{{{otherJoinMessage}}} also joined.
+			{{/if}}
 		</div>
 		{{#unless system}}
 			<div class="message-actions">

--- a/packages/rocketchat-ui-message/client/message.js
+++ b/packages/rocketchat-ui-message/client/message.js
@@ -281,6 +281,15 @@ Template.message.helpers({
 		}
 
 		return RocketChat.MessageAction.getButtons(Template.currentData(), context, messageGroup);
+	},
+	hasOtherJoins() {
+		return Template.instance().data.otherJoins && Template.instance().data.otherJoins.length > 0;
+	},
+	otherJoinMessage() {
+		const otherJoins = Template.instance().data.otherJoins;
+		return otherJoins.map(join => {
+			return join.u.username;
+		}).join(', ');
 	}
 });
 

--- a/packages/rocketchat-ui/client/views/app/room.js
+++ b/packages/rocketchat-ui/client/views/app/room.js
@@ -183,7 +183,23 @@ Template.room.helpers({
 			}
 		};
 
-		return ChatMessage.find(query, options);
+		let previousMessageType = '';
+		const messages = ChatMessage.find(query, options).fetch().reduce((messages, message) => {
+			if (previousMessageType === message.t &&
+					message.t === 'uj') {
+				if (messages[messages.length - 1].otherJoins) {
+					messages[messages.length - 1].otherJoins.push(message);
+				} else {
+					messages[messages.length - 1].otherJoins = [message];
+				}
+
+			} else {
+				messages.push(message);
+			}
+			previousMessageType = message.t;
+			return messages;
+		}, []);
+		return messages;
 	},
 
 	hasMore() {


### PR DESCRIPTION
@RocketChat/core 

About #661 and #906.

This is a first attempt at collapsing multiple user join messages into one message. I'm mainly putting this in so early in the process to get feedback on whether I'm going about this correctly. If this is right I'll add things styling the display for this differently, and expanding to show timestamps for when users actually joined.

![screenshot 2017-11-05 13 06 52](https://user-images.githubusercontent.com/485583/32419284-53d53722-c22c-11e7-953c-0eff4833421e.png)

Thoughts?

_Edit:_ just removed the shrinkwrap update from the commit. 