### PR TITLE
[FIX] Don't strip trailing slash on autolinker urls

### DIFF
--- a/packages/rocketchat-autolinker/client/client.js
+++ b/packages/rocketchat-autolinker/client/client.js
@@ -25,6 +25,7 @@ function AutoLinker(message) {
 			email: RocketChat.settings.get('AutoLinker_Email'),
 			phone: RocketChat.settings.get('AutoLinker_Phone'),
 			twitter: false,
+			stripTrailingSlash: false,
 			replaceFn(match) {
 				if (match.getType() === 'url') {
 					if (regUrls.test(match.matchedText)) {


### PR DESCRIPTION
Library default is to strip slashes, this is not helpful most of the time

@RocketChat/core 