### PR TITLE
Don't show leader if unread count is more than 0

### DIFF
--- a/packages/rocketchat-ui/client/views/app/room.js
+++ b/packages/rocketchat-ui/client/views/app/room.js
@@ -383,7 +383,8 @@ Template.room.helpers({
 		return { buttons };
 	},
 	hideLeaderHeader() {
-		return Template.instance().hideLeaderHeader.get() ? 'animated-hidden' : '';
+		return (Template.instance().hideLeaderHeader.get() || (Template.instance().unreadCount.curValue > 0)) ?
+			'animated-hidden' : '';
 	},
 	hasLeader() {
 		if (RoomRoles.findOne({ rid: this._id, roles: 'leader', 'u._id': { $ne: Meteor.userId() } }, { fields: { _id: 1 } })) {


### PR DESCRIPTION
[FIX] Leader bar was hiding the unread bar. Don't show it if there are unread messages