### PR TITLE
[FIX] DM email notifications always being sent regardless of account setting

### DIFF
--- a/packages/rocketchat-lib/server/lib/sendEmailOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendEmailOnMessage.js
@@ -128,7 +128,7 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 						return;
 					}
 
-					if (directMessageEmailPreference === 'default' && userEmailPreferenceIsDisable) {
+					if ((directMessageEmailPreference === 'default' || directMessageEmailPreference == null) && userEmailPreferenceIsDisable) {
 						return;
 					}
 				}

--- a/packages/rocketchat-lib/server/lib/sendEmailOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendEmailOnMessage.js
@@ -121,14 +121,14 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room) {
 				}
 
 				if (usersToSendEmail[user._id] === 'direct') {
-					const userEmailPreferenceIsDisable = !user.settings || !user.settings.preferences || !user.settings.preferences.emailNotificationMode || user.settings.preferences.emailNotificationMode === 'disabled';
+					const userEmailPreferenceIsDisabled = user.settings && user.settings.preferences && user.settings.preferences.emailNotificationMode && (user.settings.preferences.emailNotificationMode === 'disabled');
 					const directMessageEmailPreference = RocketChat.models.Subscriptions.findOneByRoomIdAndUserId(message.rid, message.rid.replace(message.u._id, '')).emailNotifications;
 
 					if (directMessageEmailPreference === 'nothing') {
 						return;
 					}
 
-					if ((directMessageEmailPreference === 'default' || directMessageEmailPreference == null) && userEmailPreferenceIsDisable) {
+					if ((directMessageEmailPreference === 'default' || directMessageEmailPreference == null) && userEmailPreferenceIsDisabled) {
 						return;
 					}
 				}


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #8619

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
PR #8810 fixed an issue with DM email notifications always being sent regardless of account setting. This had an issue though if the subscription had never been set (alluded to in a comment https://github.com/RocketChat/Rocket.Chat/pull/8810#issuecomment-343900445

This PR should fix that lingering issue.