### PR TITLE
[FIX] Change old 'rocketbot' username to 'InternalHubot_Username' setting

### DIFF
--- a/packages/rocketchat-internal-hubot/hubot.js
+++ b/packages/rocketchat-internal-hubot/hubot.js
@@ -105,7 +105,7 @@ class RocketChatAdapter extends Hubot.Adapter {
 			if (DEBUG) { console.log(`priv ${ envelope.room }: ${ string } (${ envelope.user.id })`); }
 			return Meteor.call('sendMessage', {
 				u: {
-					username: 'rocketbot'
+					username: RocketChat.settings.get('InternalHubot_Username')
 				},
 				to: `${ envelope.user.id }`,
 				msg: string,

--- a/packages/rocketchat-internal-hubot/settings.js
+++ b/packages/rocketchat-internal-hubot/settings.js
@@ -1,6 +1,6 @@
 RocketChat.settings.addGroup('InternalHubot', function() {
 	this.add('InternalHubot_Enabled', false, { type: 'boolean', i18nLabel: 'Enabled' });
-	this.add('InternalHubot_Username', 'rocket.cat', { type: 'string', i18nLabel: 'Username', i18nDescription: 'InternalHubot_Username_Description' });
+	this.add('InternalHubot_Username', 'rocket.cat', { type: 'string', i18nLabel: 'Username', i18nDescription: 'InternalHubot_Username_Description', 'public': true });
 	this.add('InternalHubot_ScriptsToLoad', '', { type: 'string'});
 	this.add('InternalHubot_PathToLoadCustomScripts', '', { type: 'string' });
 	// this.add('InternalHubot_reload', 'reloadInternalHubot', {

--- a/packages/rocketchat-ui/client/lib/chatMessages.js
+++ b/packages/rocketchat-ui/client/lib/chatMessages.js
@@ -244,7 +244,7 @@ this.ChatMessages = class ChatMessages {
 								ts: new Date,
 								msg: TAPi18n.__('No_such_command', { command: match[1] }),
 								u: {
-									username: 'rocketbot'
+									username: RocketChat.settings.get('InternalHubot_Username')
 								},
 								private: true
 							};


### PR DESCRIPTION
@RocketChat/core

### Before : 
when typing an unknown command, `rocketbot` respond, we're expecting `InternalHubot_Username`

<img width="773" alt="capture d ecran 2017-11-23 a 09 47 41" src="https://user-images.githubusercontent.com/9569590/33166934-d90ce862-d033-11e7-96b1-263bf725b1b0.png">

### After : 

<img width="752" alt="capture d ecran 2017-11-23 a 09 52 29" src="https://user-images.githubusercontent.com/9569590/33167005-130a7c46-d034-11e7-9f35-fb922f7c701b.png">





