### PR TITLE
[FIX] Katex markdown link changed

### DIFF
--- a/packages/rocketchat-ui-message/client/messageBox.js
+++ b/packages/rocketchat-ui-message/client/messageBox.js
@@ -125,7 +125,7 @@ const markdownButtons = [
 	},
 	{
 		label: katexSyntax,
-		link: 'https://github.com/Khan/KaTeX/wiki/Function-Support-in-KaTeX',
+		link: 'https://khan.github.io/KaTeX/function-support.html',
 		condition: () => RocketChat.katex.katex_enabled()
 	}
 ];


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

For small bug fix [https://github.com/RocketChat/Rocket.Chat.Electron/issues/589#issue](https://github.com/RocketChat/Rocket.Chat.Electron/issues/589#issue) .link of the KaTeX formatting was deprecated.
<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->


<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
