### PR TITLE
[FIX]  Xenforo [BD]API for 'user.user_id; instead of 'id'

### DIFF
--- a/packages/rocketchat-custom-oauth/server/custom_oauth_server.js
+++ b/packages/rocketchat-custom-oauth/server/custom_oauth_server.js
@@ -194,11 +194,11 @@ export class CustomOAuth {
 					identity.id = identity.user.userid;
 					identity.email = identity.user.email;
 				}
-							
+				
 				// Fix for Xenforo [BD]API plugin for 'user.user_id; instead of 'id'
 				if (identity.user && identity.user.user_id && !identity.id) {
 					identity.id = identity.user.user_id;
- 					identity.email = identity.user.user_email;
+					identity.email = identity.user.user_email;
 				}
 				
 				// Fix general 'phid' instead of 'id' from phabricator

--- a/packages/rocketchat-custom-oauth/server/custom_oauth_server.js
+++ b/packages/rocketchat-custom-oauth/server/custom_oauth_server.js
@@ -194,13 +194,11 @@ export class CustomOAuth {
 					identity.id = identity.user.userid;
 					identity.email = identity.user.email;
 				}
-				
 				// Fix for Xenforo [BD]API plugin for 'user.user_id; instead of 'id'
 				if (identity.user && identity.user.user_id && !identity.id) {
 					identity.id = identity.user.user_id;
 					identity.email = identity.user.user_email;
 				}
-				
 				// Fix general 'phid' instead of 'id' from phabricator
 				if (identity.phid && !identity.id) {
 					identity.id = identity.phid;

--- a/packages/rocketchat-custom-oauth/server/custom_oauth_server.js
+++ b/packages/rocketchat-custom-oauth/server/custom_oauth_server.js
@@ -194,7 +194,13 @@ export class CustomOAuth {
 					identity.id = identity.user.userid;
 					identity.email = identity.user.email;
 				}
-
+							
+				// Fix for Xenforo [BD]API plugin for 'user.user_id; instead of 'id'
+				if (identity.user && identity.user.user_id && !identity.id) {
+					identity.id = identity.user.user_id;
+ 					identity.email = identity.user.user_email;
+				}
+				
 				// Fix general 'phid' instead of 'id' from phabricator
 				if (identity.phid && !identity.id) {
 					identity.id = identity.phid;


### PR DESCRIPTION

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
For users of XenForo forums using [BD]API plugin for Custom OAuth services, this change will ensure the proper arguments are passed to complete the authentication process. This was provided by user HallyNoona on XenForo community threads at https://xenforo.com/community/threads/bd-api.48900/page-19