### PR TITLE
[FIX] if ogImage exists use it over image in oembedUrlWidget

### DIFF
--- a/packages/rocketchat-oembed/client/oembedUrlWidget.html
+++ b/packages/rocketchat-oembed/client/oembedUrlWidget.html
@@ -6,7 +6,11 @@
 					{{#if meta.ogImageUserGenerated}}
 						<div>
 							<a href="{{url}}" target="{{target}}">
-								<img src="{{image}}" height="200" />
+								{{#if meta.ogImage}}
+									<img src="{{meta.ogImage}}" height="200" />
+								{{else}}
+									<img src="{{image}}" height="200" />
+								{{/if}}
 							</a>
 						</div>
 					{{else}}


### PR DESCRIPTION
@RocketChat/core 

Closes #8977 

while rendering a message via oembedUrlWidget, use ogImage if it exists over image.
