### PR TITLE
[NEW] Add list of participants to Realtime rooms API

### DIFF
--- a/server/publications/room.js
+++ b/server/publications/room.js
@@ -7,7 +7,7 @@ const fields = {
 	t: 1,
 	cl: 1,
 	u: 1,
-	// usernames: 1,
+	usernames: 1,
 	topic: 1,
 	announcement: 1,
 	muted: 1,


### PR DESCRIPTION
@RocketChat/core 

**Use Case**
- We're using the Rocket.Chat Realtime API for building an on-site chat client written in JavaScript.
- For each open room (a.k.a. private group chat), we need to **display the list of participants**.

**Problems**
- The Realtime API `rooms/get` does **not** return the user list (REST API **do** have this information).
- Connecting the REST API as well, for just the user list, seems to be very bloated.

**Solution**
- Exposing the user list in the `rooms/get` response has been [commented out](https://github.com/RocketChat/Rocket.Chat/blob/develop/server/publications/room.js#L10) for quite some time
- Using `usernames: 1` in fact works for us and returns the full list of participants.

**Questions**
- Could you tell me the reason for commenting out the `usernames: 1` (if there's a bug I had expected the line to be removed)?
- Why is the information available via REST, but not via the Realtime API? Is there a general recommendation on when to use REST / Realtime?