### PR TITLE
[FIX] snap install by setting grpc package used by google/vision to 1.6.6

### DIFF
--- a/.snapcraft/snapcraft.yaml
+++ b/.snapcraft/snapcraft.yaml
@@ -47,10 +47,9 @@ parts:
             - nodejs
     rocketchat-server:
         plugin: dump
-        prepare: cd programs/server; npm install; cd npm/node_modules/meteor/rocketchat_google-vision; npm install grpc
+        prepare: curl -SLf "https://releases.rocket.chat/#{RC_VERSION}/download/" -o rocket.chat.tgz; tar xvf rocket.chat.tgz --strip 1; cd programs/server; npm install; cd npm/node_modules/meteor/rocketchat_google-vision; npm install grpc@1.6.6; 
         after: [node]
-        source: https://releases.rocket.chat/${RC_VERSION}/download/
-        source-type: tar
+        source: .
         stage-packages:
             - graphicsmagick
         stage:

--- a/packages/rocketchat-google-vision/.npm/package/npm-shrinkwrap.json
+++ b/packages/rocketchat-google-vision/.npm/package/npm-shrinkwrap.json
@@ -353,8 +353,8 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "grpc": {
-      "version": "1.6.6,
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.6.6.tgz",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.7.2.tgz",
       "integrity": "sha512-GH6xziNGjW8LAtqQ3HmYI7Tx8BIlr46iaMRXHfh46kkaOP6PNWUx47ULNTUlXSYR3P00d0Pl8uzodTLwPk805w==",
       "dependencies": {
         "abbrev": {

--- a/packages/rocketchat-google-vision/.npm/package/npm-shrinkwrap.json
+++ b/packages/rocketchat-google-vision/.npm/package/npm-shrinkwrap.json
@@ -353,8 +353,8 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "grpc": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.7.2.tgz",
+      "version": "1.6.6,
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.6.6.tgz",
       "integrity": "sha512-GH6xziNGjW8LAtqQ3HmYI7Tx8BIlr46iaMRXHfh46kkaOP6PNWUx47ULNTUlXSYR3P00d0Pl8uzodTLwPk805w==",
       "dependencies": {
         "abbrev": {


### PR DESCRIPTION
@RocketChat/core 

Without this snap install fails.  Also something to do with launchpad now fails with our redirect, so moved to using curl to download release.
