### PR TITLE
[FIX] Notification sound is not disabling when busy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,14 +202,8 @@ jobs:
           command: |
             for i in $(seq 1 5); do npm test && s=0 && break || s=$? && sleep 1; done; (exit $s)
 
-      # - run:
-      #     name: Build Failed
-      #     when: on_fail
-      #     command: |
-      #       cp -R .screenshots /tmp/screenshots
-
-      # - store_artifacts:
-      #     path: ~/repo/.screenshots
+      - store_artifacts:
+          path: .screenshots/
 
   deploy:
     <<: *defaults

--- a/packages/rocketchat-ui/client/lib/notification.js
+++ b/packages/rocketchat-ui/client/lib/notification.js
@@ -80,7 +80,7 @@ const KonchatNotification = {
 	},
 
 	newMessage(rid) {
-		if (!Session.equals(`user_${ Meteor.userId() }_status`, 'busy')) {
+		if (!Session.equals(`user_${ Meteor.user().username }_status`, 'busy')) {
 			const user = Meteor.user();
 			const newMessageNotification = user && user.settings && user.settings.preferences && user.settings.preferences.newMessageNotification || 'chime';
 			const audioVolume = user && user.settings && user.settings.preferences && user.settings.preferences.notificationsSoundVolume || 100;


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

When busy notifications aren't supposed to be triggered.  Which is true... but it still dings.

That's just as disturbing as a notification scrolling by when you are trying to concentrate.

related to: #8806 