### PR TITLE
[FIX] Can't use OAuth login against a Rocket.Chat OAuth server

### DIFF
--- a/packages/rocketchat-custom-oauth/server/custom_oauth_server.js
+++ b/packages/rocketchat-custom-oauth/server/custom_oauth_server.js
@@ -216,7 +216,7 @@ export class CustomOAuth {
 
 				// Fix when authenticating from a meteor app with 'emails' field
 				if (!identity.email && (identity.emails && Array.isArray(identity.emails) && identity.emails.length >= 1)) {
-					identity.email = identity.emails[0].address ? identity.emails[0].address : undefined
+					identity.email = identity.emails[0].address ? identity.emails[0].address : undefined;
 				}
 			}
 

--- a/packages/rocketchat-custom-oauth/server/custom_oauth_server.js
+++ b/packages/rocketchat-custom-oauth/server/custom_oauth_server.js
@@ -213,6 +213,13 @@ export class CustomOAuth {
 				if (identity.userid && !identity.id) {
 					identity.id = identity.userid;
 				}
+
+				// Fix when authenticating from a meteor app with 'emails' field
+				if (!identity.email && (identity.emails && Array.isArray(identity.emails) && identity.emails.length >= 1)) {
+					if (identity.emails[0].address) {
+						identity.email = identity.emails[0].address;
+					}
+				}
 			}
 
 			// console.log 'id:', JSON.stringify identity, null, '  '

--- a/packages/rocketchat-custom-oauth/server/custom_oauth_server.js
+++ b/packages/rocketchat-custom-oauth/server/custom_oauth_server.js
@@ -216,9 +216,7 @@ export class CustomOAuth {
 
 				// Fix when authenticating from a meteor app with 'emails' field
 				if (!identity.email && (identity.emails && Array.isArray(identity.emails) && identity.emails.length >= 1)) {
-					if (identity.emails[0].address) {
-						identity.email = identity.emails[0].address;
-					}
+					identity.email = identity.emails[0].address ? identity.emails[0].address : undefined
 				}
 			}
 


### PR DESCRIPTION
@RocketChat/core 

We tried to enable oauth on unstable.rocket.chat with open.rocket.chat but couldn't because of this.