### PR TITLE
Fix: Message action quick buttons drops if "new message" divider is being shown

### DIFF
--- a/packages/rocketchat-theme/client/imports/components/messages.css
+++ b/packages/rocketchat-theme/client/imports/components/messages.css
@@ -79,10 +79,6 @@
 	padding: 0;
 }
 
-.first-unread .message-actions {
-	top: 18px;
-}
-
 .rtl .message-actions {
 	right: auto;
 	left: 2px;

--- a/packages/rocketchat-theme/client/imports/general/base.css
+++ b/packages/rocketchat-theme/client/imports/general/base.css
@@ -121,7 +121,7 @@ button {
 	&::before {
 		position: absolute;
 		z-index: 1;
-		top: 0;
+		top: -10px;
 		left: 0;
 
 		width: 100%;
@@ -130,12 +130,14 @@ button {
 		content: "";
 
 		background: var(--rc-color-error);
+
+		pointer-events: none;
 	}
 
 	&::after {
 		position: absolute;
 		z-index: 2;
-		top: -10px;
+		top: -20px;
 		right: 0;
 
 		padding: 0 1rem;
@@ -148,6 +150,8 @@ button {
 		background: #ffffff;
 
 		font-size: 10px;
+
+		pointer-events: none;
 	}
 }
 

--- a/packages/rocketchat-theme/client/imports/general/base_old.css
+++ b/packages/rocketchat-theme/client/imports/general/base_old.css
@@ -3093,6 +3093,11 @@
 		&:hover .edited {
 			display: none;
 		}
+
+	}
+
+	&.first-unread {
+		margin-top: 20px;
 	}
 
 	&.system .body {


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #9129

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

![screen shot 2017-12-14 at 7 11 33 pm](https://user-images.githubusercontent.com/234261/34014544-acaa25de-e102-11e7-89ed-55d5c14f66a9.png)
--
![screen shot 2017-12-14 at 7 11 20 pm](https://user-images.githubusercontent.com/234261/34014545-acce8884-e102-11e7-9ef8-60352751a581.png)
--
![screen shot 2017-12-14 at 7 10 53 pm](https://user-images.githubusercontent.com/234261/34014546-acef4c40-e102-11e7-9be2-d65ac4cd0351.png)
--
![screen shot 2017-12-14 at 7 10 39 pm](https://user-images.githubusercontent.com/234261/34014547-ad10273a-e102-11e7-9654-88fdf630d8ca.png)
--
![screen shot 2017-12-14 at 7 09 45 pm](https://user-images.githubusercontent.com/234261/34014548-ad363ba0-e102-11e7-8299-d1e5ab3cd49a.png)
--
![screen shot 2017-12-14 at 7 09 32 pm](https://user-images.githubusercontent.com/234261/34014549-ad5815c2-e102-11e7-84b3-c2bdac98df09.png)
