### PR TITLE
[Fix] oauth not working because of email array

### DIFF
--- a/packages/rocketchat-api/server/v1/misc.js
+++ b/packages/rocketchat-api/server/v1/misc.js
@@ -20,17 +20,21 @@ RocketChat.API.v1.addRoute('info', { authRequired: false }, {
 
 RocketChat.API.v1.addRoute('me', { authRequired: true }, {
 	get() {
-		return RocketChat.API.v1.success(_.pick(this.user, [
+		const me = _.pick(this.user, [
 			'_id',
 			'name',
 			'emails',
-			'status',
-			'statusConnection',
-			'username',
+		 	'status',
+		 	'statusConnection',
+		 	'username',
 			'utcOffset',
 			'active',
 			'language'
-		]));
+		]);
+
+		me.email = (this.user.emails.length) ? this.user.emails[0].address : undefined;
+
+		return RocketChat.API.v1.success(me);
 	}
 });
 

--- a/packages/rocketchat-api/server/v1/misc.js
+++ b/packages/rocketchat-api/server/v1/misc.js
@@ -24,15 +24,15 @@ RocketChat.API.v1.addRoute('me', { authRequired: true }, {
 			'_id',
 			'name',
 			'emails',
-		 	'status',
-		 	'statusConnection',
-		 	'username',
+			'status',
+			'statusConnection',
+			'username',
 			'utcOffset',
 			'active',
 			'language'
 		]);
 
-		me.email = (this.user.emails.length) ? this.user.emails[0].address : undefined;
+		me.email = (me.emails.length) ? me.emails[0].address : undefined;
 
 		return RocketChat.API.v1.success(me);
 	}

--- a/packages/rocketchat-api/server/v1/misc.js
+++ b/packages/rocketchat-api/server/v1/misc.js
@@ -32,7 +32,7 @@ RocketChat.API.v1.addRoute('me', { authRequired: true }, {
 			'language'
 		]);
 
-		me.email = (me.emails.length) ? me.emails[0].address : undefined;
+		me.email = me.emails.length ? me.emails[0].address : undefined;
 
 		return RocketChat.API.v1.success(me);
 	}


### PR DESCRIPTION
@RocketChat/core 

Pretty much no oauth integration supports doing something like emails[0].address to grab the email address out of the /api/v1/me response.  So grabbing the email and surfacing as a property 
