### PR TITLE
Replace postcss-nesting with postcss-nested

### DIFF
--- a/.postcssrc
+++ b/.postcssrc
@@ -6,7 +6,7 @@
 		},
 		"postcss-media-minmax": {},
 		"postcss-selector-not": {},
-		"postcss-nesting": {},
+		"postcss-nested": {},
 		"autoprefixer": {
 			"browsers": [
 				"ie > 10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7283,13 +7283,27 @@
       "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
       "dev": true
     },
-    "postcss-nesting": {
+    "postcss-nested": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-3.0.0.tgz",
-      "integrity": "sha512-ijQlEXUcYXXNPdLMFcMEr4i5SEPRKR8fq/Iya4L0mQbNOCz+szTGCBlf0Cvu2HiQLjCNqLnGO4fKFLbNnXe7Ag==",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-3.0.0.tgz",
+      "integrity": "sha512-1xxmLHSfubuUi6xZZ0zLsNoiKfk3BWQj6fkNMaBJC529wKKLcdeCxXt6KJmDLva+trNyQNwEaE/ZWMA7cve1fA==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.13"
+        "postcss": "6.0.14",
+        "postcss-selector-parser": "3.1.1"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "source-map": "0.6.1",
+            "supports-color": "4.5.0"
+          }
+        }
       }
     },
     "postcss-reporter": {
@@ -7354,6 +7368,17 @@
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         }
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+      "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+      "dev": true,
+      "requires": {
+        "dot-prop": "4.2.0",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
       }
     },
     "postcss-sorting": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"postcss-custom-properties": "^6.2.0",
 		"postcss-import": "^11.0.0",
 		"postcss-media-minmax": "^3.0.0",
-		"postcss-nesting": "^3.0.0",
+		"postcss-nested": "^3.0.0",
 		"postcss-selector-not": "^3.0.1",
 		"proxyquire": "^1.8.0",
 		"simple-git": "^1.85.0",


### PR DESCRIPTION
postcss-nesting uses the CSS rules, that are incompatible with BEM
postcss-nested uses SASS rules