### PR TITLE
Add curl, its missing on worker nodes so has to be explicitly added

### DIFF
--- a/.snapcraft/snapcraft.yaml
+++ b/.snapcraft/snapcraft.yaml
@@ -46,8 +46,10 @@ parts:
             - build-essential
             - nodejs
     rocketchat-server:
+        build-packages:
+            - curl
         plugin: dump
-        prepare: curl -SLf "https://releases.rocket.chat/#{RC_VERSION}/download/" -o rocket.chat.tgz; tar xvf rocket.chat.tgz --strip 1; cd programs/server; npm install; cd npm/node_modules/meteor/rocketchat_google-vision; npm install grpc@1.6.6; 
+        prepare: curl -SLf "https://releases.rocket.chat/#{RC_VERSION}/download/" -o rocket.chat.tgz; tar xvf rocket.chat.tgz --strip 1; cd programs/server; npm install; cd npm/node_modules/meteor/rocketchat_google-vision; npm install grpc@1.6.6;
         after: [node]
         source: .
         stage-packages:


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

The launchpad workers don't have curl installed by default, so has to be explicitly added. 
