### PR TITLE
[FIX] LDAP/AD is not importing all users

### DIFF
--- a/packages/rocketchat-ldap/server/ldap.js
+++ b/packages/rocketchat-ldap/server/ldap.js
@@ -371,6 +371,17 @@ export default class LDAP {
 	searchAllPaged(BaseDN, options, page) {
 		this.bindIfNecessary();
 
+		const processPage = ({entries, title, end, next}) => {
+			logger.search.info(title);
+			// Force LDAP idle to wait the record processing
+			this.client._updateIdle(true);
+			page(null, entries, {end, next: () => {
+				// Reset idle timer
+				this.client._updateIdle();
+				next && next();
+			}});
+		};
+
 		this.client.search(BaseDN, options, (error, res) => {
 			if (error) {
 				logger.search.error(error);
@@ -392,33 +403,42 @@ export default class LDAP {
 				entries.push(this.extractLdapEntryData(entry));
 
 				if (entries.length >= internalPageSize) {
-					logger.search.info('Internal Page');
-					this.client._updateIdle(true);
-					page(null, entries, {end: false, next: () => {
-						// Reset idle timer
-						this.client._updateIdle();
-					}});
+					processPage({
+						entries,
+						title: 'Internal Page',
+						end: false
+					});
 					entries = [];
 				}
 			});
 
 			res.on('page', (result, next) => {
 				if (!next) {
-					logger.search.debug('Final Page');
 					this.client._updateIdle(true);
-					page(null, entries, {end: true, next: () => {
-						// Reset idle timer
-						this.client._updateIdle();
-					}});
+					processPage({
+						entries,
+						title: 'Final Page',
+						end: true
+					});
 				} else if (entries.length) {
 					logger.search.info('Page');
-					// Force LDAP idle to wait the record processing
-					this.client._updateIdle(true);
-					page(null, entries, {end: !next, next: () => {
-						// Reset idle timer
-						this.client._updateIdle();
-						next();
-					}});
+					processPage({
+						entries,
+						title: 'Page',
+						end: false,
+						next
+					});
+					entries = [];
+				}
+			});
+
+			res.on('end', () => {
+				if (entries.length) {
+					processPage({
+						entries,
+						title: 'Final Page',
+						end: true
+					});
 					entries = [];
 				}
 			});


### PR DESCRIPTION
LDAP/AD is only importing multiple of 500 users, the internal pagination system is not processing the rest of the records.

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->


<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Closes #9279