### PR TITLE
[FIX] Force enable Livechat Facebook integration on specific errors

### DIFF
--- a/packages/rocketchat-livechat/client/views/app/integrations/livechatIntegrationFacebook.js
+++ b/packages/rocketchat-livechat/client/views/app/integrations/livechatIntegrationFacebook.js
@@ -33,6 +33,19 @@ Template.livechatIntegrationFacebook.onCreated(function() {
 
 	this.result = (successFn, errorFn = () => {}) => {
 		return (error, result) => {
+			// fix the state where user it was enabled on admin
+			if (error && error.error) {
+				switch (error.error) {
+					case 'invalid-facebook-token':
+					case 'invalid-instance-url':
+					case 'integration-disabled':
+						return Meteor.call('livechat:facebook', { action: 'enable' }, this.result(() => {
+							this.enabled.set(true);
+							this.loadPages();
+						}, () => this.loadPages()));
+				}
+			}
+
 			if (result && result.success === false && (result.type === 'OAuthException' || typeof result.url !== 'undefined')) {
 				const oauthWindow = window.open(result.url, 'facebook-integration-oauth', 'width=600,height=400');
 

--- a/packages/rocketchat-livechat/server/methods/facebook.js
+++ b/packages/rocketchat-livechat/server/methods/facebook.js
@@ -44,11 +44,16 @@ Meteor.methods({
 				}
 			}
 		} catch (e) {
-			if (e.response && e.response.data && e.response.data.error && e.response.data.error.response) {
-				throw new Meteor.Error('integration-error', e.response.data.error.response.error.message);
-			}
-			if (e.response && e.response.data && e.response.data.error && e.response.data.error.message) {
-				throw new Meteor.Error('integration-error', e.response.data.error.message);
+			if (e.response && e.response.data && e.response.data.error) {
+				if (e.response.data.error.error) {
+					throw new Meteor.Error(e.response.data.error.error, e.response.data.error.message);
+				}
+				if (e.response.data.error.response) {
+					throw new Meteor.Error('integration-error', e.response.data.error.response.error.message);
+				}
+				if (e.response.data.error.message) {
+					throw new Meteor.Error('integration-error', e.response.data.error.message);
+				}
 			}
 			console.error('Error contacting omni.rocket.chat:', e);
 			throw new Meteor.Error('integration-error', e.error);


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
This should improve livechat integration UX.

If it was the first time you're using it and you have enabled it from the admin panel you should end on an errored state and see no pages at integration page. This PR will force to fix this errored state and the user will just have to reload the pages.
<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

This helps preventing the behavior described by https://github.com/RocketChat/Rocket.Chat/issues/9266#issuecomment-354486645