### PR TITLE
[FIX][i18n] add room type translation support for room-changed-privacy message

### DIFF
--- a/packages/rocketchat-channel-settings/client/startup/messageTypes.js
+++ b/packages/rocketchat-channel-settings/client/startup/messageTypes.js
@@ -6,7 +6,7 @@ Meteor.startup(function() {
 		data(message) {
 			return {
 				user_by: message.u && message.u.username,
-				room_type: message.msg
+				room_type: t(message.msg)
 			};
 		}
 	});


### PR DESCRIPTION
In this PR I add translation support to `"room_changed_privacy"` message. Now it's always return **"Channel"** and ... for any language (it's a bug for non-English website) but with this PR we can translate **"Channel"** and any other room type too.
This PR can be useful for non-English users like me 😉 