### PR TITLE
[FIX] Slash command 'unarchive' throws exception if the channel does not exist 

### DIFF
--- a/packages/rocketchat-slashcommands-unarchiveroom/server/server.js
+++ b/packages/rocketchat-slashcommands-unarchiveroom/server/server.js
@@ -14,12 +14,24 @@ function Unarchive(command, params, item) {
 		room = RocketChat.models.Rooms.findOneByName(channel);
 	}
 
+	const user = Meteor.users.findOne(Meteor.userId());
+
+	if (!room) {
+		return RocketChat.Notifications.notifyUser(Meteor.userId(), 'message', {
+			_id: Random.id(),
+			rid: item.rid,
+			ts: new Date(),
+			msg: TAPi18n.__('Channel_doesnt_exist', {
+				postProcess: 'sprintf',
+				sprintf: [channel]
+			}, user.language)
+		});
+	}
+
 	// You can not archive direct messages.
 	if (room.t === 'd') {
 		return;
 	}
-
-	const user = Meteor.users.findOne(Meteor.userId());
 
 	if (!room.archived) {
 		RocketChat.Notifications.notifyUser(Meteor.userId(), 'message', {


### PR DESCRIPTION
@RocketChat/core

Same as #9428

When submitting a message like : `/unarchive #channel-that-dont-exist`
An exception is thrown on the server :

`Exception while invoking method 'slashCommand' TypeError: Cannot read property 't' of undefined`