### PR TITLE
[FIX] Avoid creating mixed case rooms

### DIFF
--- a/packages/rocketchat-lib/server/functions/createRoom.js
+++ b/packages/rocketchat-lib/server/functions/createRoom.js
@@ -3,7 +3,7 @@ import _ from 'underscore';
 import s from 'underscore.string';
 
 RocketChat.createRoom = function(type, name, owner, members, readOnly, extraData={}) {
-	name = s.trim(name);
+	name = s.trim(name).toLowerCase();
 	owner = s.trim(owner);
 	members = [].concat(members);
 


### PR DESCRIPTION
@RocketChat/core 

Android RC+ users may create mixed case rooms, as the REST-API allows this. Force-casting them to lowercase avoids wrong use of the API.