### PR TITLE
[FIX] mention-here is missing i18n text #9455

### DIFF
--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -1198,6 +1198,8 @@
   "Members_List": "Members List",
   "mention-all": "Mention All",
   "mention-all_description": "Permission to use the @all mention",
+  "mention-here": "Mention Here",
+  "mention-here_description": "Permission to use the @here mention",
   "Mentions": "Mentions",
   "Mentions_default": "Mentions (default)",
   "Mentions_only": "Mentions only",


### PR DESCRIPTION
Added text for mention-here in admin panel.

Closes #9455

Signed-off-by: Ry Jones <ry@walledcity.org>

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #9455

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
I overlooked i18n text for initial implementation of ACL for at-here. Here is the fixed version:
<img width="242" alt="mention-here-fix" src="https://user-images.githubusercontent.com/466142/35191082-b5fbd074-fe26-11e7-8e78-16d3c551aff0.png">
