### PR TITLE
[NEW] Add route to get user shield/badge

### DIFF
--- a/packages/rocketchat-api/server/v1/misc.js
+++ b/packages/rocketchat-api/server/v1/misc.js
@@ -78,16 +78,16 @@ RocketChat.API.v1.addRoute('shield.svg', { authRequired: false }, {
 				text = `${ user.name }`;
 				switch (user.status) {
 					case 'online':
-						backgroundColor = '#4dff4d';
+						backgroundColor = '#1fb31f';
 						break;
 					case 'away':
-						backgroundColor = '#FCB316';
+						backgroundColor = '#dc9b01';
 						break;
 					case 'busy':
-						backgroundColor = '#BC2031';
+						backgroundColor = '#bc2031';
 						break;
 					case 'offline':
-						backgroundColor = '#ccc';
+						backgroundColor = '#a5a1a1';
 				}
 				break;
 			default:

--- a/packages/rocketchat-api/server/v1/misc.js
+++ b/packages/rocketchat-api/server/v1/misc.js
@@ -76,7 +76,7 @@ RocketChat.API.v1.addRoute('shield.svg', { authRequired: false }, {
 			case 'user':
 				const user = this.getUserFromParams();
 				text = `${ user.name }`;
-				switch(user.status){
+				switch (user.status) {
 					case 'online':
 						backgroundColor = '#4dff4d';
 						break;

--- a/packages/rocketchat-api/server/v1/misc.js
+++ b/packages/rocketchat-api/server/v1/misc.js
@@ -47,16 +47,19 @@ RocketChat.API.v1.addRoute('shield.svg', { authRequired: false }, {
 	get() {
 		const { type, channel, name, icon } = this.queryParams;
 		if (!RocketChat.settings.get('API_Enable_Shields')) {
-			throw new Meteor.Error('error-endpoint-disabled', 'This endpoint is disabled', { route: '/api/v1/shields.svg' });
+			throw new Meteor.Error('error-endpoint-disabled', 'This endpoint is disabled', { route: '/api/v1/shield.svg' });
 		}
+
 		const types = RocketChat.settings.get('API_Shield_Types');
 		if (type && (types !== '*' && !types.split(',').map((t) => t.trim()).includes(type))) {
-			throw new Meteor.Error('error-shield-disabled', 'This shield type is disabled', { route: '/api/v1/shields.svg' });
+			throw new Meteor.Error('error-shield-disabled', 'This shield type is disabled', { route: '/api/v1/shield.svg' });
 		}
+
 		const hideIcon = icon === 'false';
 		if (hideIcon && (!name || !name.trim())) {
 			return RocketChat.API.v1.failure('Name cannot be empty when icon is hidden');
 		}
+
 		let text;
 		let backgroundColor = '#4c1';
 		switch (type) {
@@ -65,17 +68,26 @@ RocketChat.API.v1.addRoute('shield.svg', { authRequired: false }, {
 					onlineCache = RocketChat.models.Users.findUsersNotOffline().count();
 					onlineCacheDate = Date.now();
 				}
+
 				text = `${ onlineCache } ${ TAPi18n.__('Online') }`;
 				break;
 			case 'channel':
 				if (!channel) {
 					return RocketChat.API.v1.failure('Shield channel is required for type "channel"');
 				}
+
 				text = `#${ channel }`;
 				break;
 			case 'user':
 				const user = this.getUserFromParams();
-				text = `${ user.name }`;
+
+				// Respect the server's choice for using their real names or not
+				if (user.name && RocketChat.settings.get('UI_Use_Real_Name')) {
+					text = `${ user.name }`;
+				} else {
+					text = `@${ user.username }`;
+				}
+
 				switch (user.status) {
 					case 'online':
 						backgroundColor = '#1fb31f';
@@ -93,6 +105,7 @@ RocketChat.API.v1.addRoute('shield.svg', { authRequired: false }, {
 			default:
 				text = TAPi18n.__('Join_Chat').toUpperCase();
 		}
+
 		const iconSize = hideIcon ? 7 : 24;
 		const leftSize = name ? name.length * 6 + 7 + iconSize : iconSize;
 		const rightSize = text.length * 6 + 20;

--- a/packages/rocketchat-api/server/v1/misc.js
+++ b/packages/rocketchat-api/server/v1/misc.js
@@ -58,6 +58,7 @@ RocketChat.API.v1.addRoute('shield.svg', { authRequired: false }, {
 			return RocketChat.API.v1.failure('Name cannot be empty when icon is hidden');
 		}
 		let text;
+		let backgroundColor = '#4c1';
 		switch (type) {
 			case 'online':
 				if (Date.now() - onlineCacheDate > cacheInvalid) {
@@ -71,6 +72,23 @@ RocketChat.API.v1.addRoute('shield.svg', { authRequired: false }, {
 					return RocketChat.API.v1.failure('Shield channel is required for type "channel"');
 				}
 				text = `#${ channel }`;
+				break;
+			case 'user':
+				const user = this.getUserFromParams();
+				text = `${ user.name }`;
+				switch(user.status){
+					case 'online':
+						backgroundColor = '#4dff4d';
+						break;
+					case 'away':
+						backgroundColor = '#FCB316';
+						break;
+					case 'busy':
+						backgroundColor = '#BC2031';
+						break;
+					case 'offline':
+						backgroundColor = '#ccc';
+				}
 				break;
 			default:
 				text = TAPi18n.__('Join_Chat').toUpperCase();
@@ -93,7 +111,7 @@ RocketChat.API.v1.addRoute('shield.svg', { authRequired: false }, {
 				  </mask>
 				  <g mask="url(#a)">
 				    <path fill="#555" d="M0 0h${ leftSize }v${ height }H0z"/>
-				    <path fill="#4c1" d="M${ leftSize } 0h${ rightSize }v${ height }H${ leftSize }z"/>
+				    <path fill="${ backgroundColor }" d="M${ leftSize } 0h${ rightSize }v${ height }H${ leftSize }z"/>
 				    <path fill="url(#b)" d="M0 0h${ width }v${ height }H0z"/>
 				  </g>
 				    ${ hideIcon ? '' : '<image x="5" y="3" width="14" height="14" xlink:href="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iTGF5ZXJfNSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSI1MTJweCIgaGVpZ2h0PSI1MTJweCIgdmlld0JveD0iMCAwIDUxMiA1MTIiIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMCAwIDUxMiA1MTIiIHhtbDpzcGFjZT0icHJlc2VydmUiPjxwYXRoIGZpbGw9IiNDMTI3MkQiIGQ9Ik01MDIuNTg2LDI1NS4zMjJjMC0yNS4yMzYtNy41NS00OS40MzYtMjIuNDQ1LTcxLjkzMmMtMTMuMzczLTIwLjE5NS0zMi4xMDktMzguMDcyLTU1LjY4Ny01My4xMzJDMzc4LjkzNywxMDEuMTgyLDMxOS4xMDgsODUuMTY4LDI1Niw4NS4xNjhjLTIxLjA3OSwwLTQxLjg1NSwxLjc4MS02Mi4wMDksNS4zMWMtMTIuNTA0LTExLjcwMi0yNy4xMzktMjIuMjMyLTQyLjYyNy0zMC41NkM2OC42MTgsMTkuODE4LDAsNTguOTc1LDAsNTguOTc1czYzLjc5OCw1Mi40MDksNTMuNDI0LDk4LjM1Yy0yOC41NDIsMjguMzEzLTQ0LjAxLDYyLjQ1My00NC4wMSw5Ny45OThjMCwwLjExMywwLjAwNiwwLjIyNiwwLjAwNiwwLjM0YzAsMC4xMTMtMC4wMDYsMC4yMjYtMC4wMDYsMC4zMzljMCwzNS41NDUsMTUuNDY5LDY5LjY4NSw0NC4wMSw5Ny45OTlDNjMuNzk4LDM5OS45NCwwLDQ1Mi4zNSwwLDQ1Mi4zNXM2OC42MTgsMzkuMTU2LDE1MS4zNjMtMC45NDNjMTUuNDg4LTguMzI3LDMwLjEyNC0xOC44NTcsNDIuNjI3LTMwLjU2YzIwLjE1NCwzLjUyOCw0MC45MzEsNS4zMSw2Mi4wMDksNS4zMWM2My4xMDgsMCwxMjIuOTM3LTE2LjAxNCwxNjguNDU0LTQ1LjA5MWMyMy41NzctMTUuMDYsNDIuMzEzLTMyLjkzNyw1NS42ODctNTMuMTMyYzE0Ljg5Ni0yMi40OTYsMjIuNDQ1LTQ2LjY5NSwyMi40NDUtNzEuOTMyYzAtMC4xMTMtMC4wMDYtMC4yMjYtMC4wMDYtMC4zMzlDNTAyLjU4LDI1NS41NDgsNTAyLjU4NiwyNTUuNDM2LDUwMi41ODYsMjU1LjMyMnoiLz48cGF0aCBmaWxsPSIjRkZGRkZGIiBkPSJNMjU2LDEyMC44NDdjMTE2Ljg1NCwwLDIxMS41ODYsNjAuNTA5LDIxMS41ODYsMTM1LjE1NGMwLDc0LjY0MS05NC43MzEsMTM1LjE1NS0yMTEuNTg2LDEzNS4xNTVjLTI2LjAxOSwwLTUwLjkzNy0zLjAwOS03My45NTktOC40OTVjLTIzLjM5NiwyOC4xNDctNzQuODY4LDY3LjI4LTEyNC44NjksNTQuNjI5YzE2LjI2NS0xNy40Nyw0MC4zNjEtNDYuOTg4LDM1LjIwMS05NS42MDNjLTI5Ljk2OC0yMy4zMjItNDcuOTU5LTUzLjE2My00Ny45NTktODUuNjg2QzQ0LjQxNCwxODEuMzU2LDEzOS4xNDUsMTIwLjg0NywyNTYsMTIwLjg0NyIvPjxnPjxnPjxjaXJjbGUgZmlsbD0iI0MxMjcyRCIgY3g9IjI1NiIgY3k9IjI2MC4zNTIiIHI9IjI4LjEwNSIvPjwvZz48Zz48Y2lyY2xlIGZpbGw9IiNDMTI3MkQiIGN4PSIzNTMuNzI4IiBjeT0iMjYwLjM1MiIgcj0iMjguMTA0Ii8+PC9nPjxnPjxjaXJjbGUgZmlsbD0iI0MxMjcyRCIgY3g9IjE1OC4yNzIiIGN5PSIyNjAuMzUyIiByPSIyOC4xMDUiLz48L2c+PC9nPjxnPjxwYXRoIGZpbGw9IiNDQ0NDQ0MiIGQ9Ik0yNTYsMzczLjM3M2MtMjYuMDE5LDAtNTAuOTM3LTIuNjA3LTczLjk1OS03LjM2MmMtMjAuNjU5LDIxLjU0LTYzLjIwOSw1MC40OTYtMTA3LjMwNyw0OS40M2MtNS44MDYsOC44MDUtMTIuMTIxLDE2LjAwNi0xNy41NjIsMjEuODVjNTAsMTIuNjUxLDEwMS40NzMtMjYuNDgxLDEyNC44NjktNTQuNjI5YzIzLjAyMyw1LjQ4Niw0Ny45NDEsOC40OTUsNzMuOTU5LDguNDk1YzExNS45MTcsMCwyMTAuMDQ4LTU5LjU1LDIxMS41NTEtMTMzLjM2NEM0NjYuMDQ4LDMyMS43NjUsMzcxLjkxNywzNzMuMzczLDI1NiwzNzMuMzczeiIvPjwvZz48L3N2Zz4="/>' }

--- a/packages/rocketchat-i18n/i18n/ca.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ca.i18n.json
@@ -212,7 +212,7 @@
   "API_Enable_Direct_Message_History_EndPoint": "Activa la consulta de l'historial de missatges directes",
   "API_Enable_Direct_Message_History_EndPoint_Description": "Això activa el `/api/v1/im.history.others` que permet veure missatges directes enviats per altres usuaris tot i no formar-ne part.",
   "API_Enable_Shields": "Activa escuts",
-  "API_Enable_Shields_Description": "Activa els escuts disponibles a `/api/v1/shields.svg`",
+  "API_Enable_Shields_Description": "Activa els escuts disponibles a `/api/v1/shield.svg`",
   "API_GitHub_Enterprise_URL": "URL del servidor",
   "API_GitHub_Enterprise_URL_Description": "Exemple: http://domain.com (sense la barra final)",
   "API_Gitlab_URL": "URL de GitLab",

--- a/packages/rocketchat-i18n/i18n/cs.i18n.json
+++ b/packages/rocketchat-i18n/i18n/cs.i18n.json
@@ -214,7 +214,7 @@
   "API_Enable_Direct_Message_History_EndPoint": "Povolit Endpoint přímých zpráv",
   "API_Enable_Direct_Message_History_EndPoint_Description": "Povolí endpoint `/api/v1/im.history.others` přes který lze stahovat přímé zprávy mezi všemi uživateli.",
   "API_Enable_Shields": "Povolit sdílecí ikony",
-  "API_Enable_Shields_Description": "Ikony dostupné na adrese `/api/v1/shields.svg`",
+  "API_Enable_Shields_Description": "Ikony dostupné na adrese `/api/v1/shield.svg`",
   "API_GitHub_Enterprise_URL": "Adresa URL serveru",
   "API_GitHub_Enterprise_URL_Description": "Příklad: http://domain.com (bez lomítka na konci)",
   "API_Gitlab_URL": "GitLab URL",

--- a/packages/rocketchat-i18n/i18n/de.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de.i18n.json
@@ -215,7 +215,7 @@
   "API_Enable_Direct_Message_History_EndPoint": "Endpunkt für den Verlauf von Direktnachrichten",
   "API_Enable_Direct_Message_History_EndPoint_Description": "Aktiviere `/api/v1/im.history.others`. Hierüber ist es möglich, Direktnachrichten einzusehen, an denen der Benutzer nicht beteiligt ist.",
   "API_Enable_Shields": "Aktiviere Shields",
-  "API_Enable_Shields_Description": "Mache Shields über `/api/v1/shields.svg` abrufbar",
+  "API_Enable_Shields_Description": "Mache Shields über `/api/v1/shield.svg` abrufbar",
   "API_GitHub_Enterprise_URL": "Server-URL",
   "API_GitHub_Enterprise_URL_Description": "Beispiel: http://domain.com (ohne Schrägstrich am Ende)",
   "API_Gitlab_URL": "GitLab-URL",

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -224,7 +224,7 @@
   "API_Enable_Direct_Message_History_EndPoint": "Enable Direct Message History Endpoint",
   "API_Enable_Direct_Message_History_EndPoint_Description": "This enables the `/api/v1/im.history.others` which allows the viewing of direct messages sent by other users that the caller is not part of.",
   "API_Enable_Shields": "Enable Shields",
-  "API_Enable_Shields_Description": "Enable shields available at `/api/v1/shields.svg`",
+  "API_Enable_Shields_Description": "Enable shields available at `/api/v1/shield.svg`",
   "API_GitHub_Enterprise_URL": "Server URL",
   "API_GitHub_Enterprise_URL_Description": "Example: http://domain.com (excluding trailing slash)",
   "API_Gitlab_URL": "GitLab URL",

--- a/packages/rocketchat-i18n/i18n/it.i18n.json
+++ b/packages/rocketchat-i18n/i18n/it.i18n.json
@@ -190,7 +190,7 @@
   "API_Enable_Direct_Message_History_EndPoint": "Abilita l'endpoint per lo storico dei messaggi diretti",
   "API_Enable_Direct_Message_History_EndPoint_Description": "Questo abilita `/api/v1/im.history.others` che permette di vedere i messaggi diretti inviati dagli altri utenti di cui il chiamante non è parte.",
   "API_Enable_Shields": "Abilita Shield",
-  "API_Enable_Shields_Description": "Abilita gli shield disponibili a `/api/v1/shields.svg`",
+  "API_Enable_Shields_Description": "Abilita gli shield disponibili a `/api/v1/shield.svg`",
   "API_GitHub_Enterprise_URL": "URL del server",
   "API_GitHub_Enterprise_URL_Description": "Esempio: http://domain.com (escludendo lo slash finale)",
   "API_Gitlab_URL": "URL GitLab",

--- a/packages/rocketchat-i18n/i18n/ko.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ko.i18n.json
@@ -190,7 +190,7 @@
   "API_Enable_Direct_Message_History_EndPoint": "Direct Message History Endpoint 활성화",
   "API_Enable_Direct_Message_History_EndPoint_Description": "소속되지 않은 다른 유저로 부터 보내진 다이렉트메시지를 보기를 허용하는 'api/v1/im.history.others' 를 활성화 합니다.",
   "API_Enable_Shields": "쉴드 활성화",
-  "API_Enable_Shields_Description": "'/api/v1/shields.svg' 에 있는 쉴드를 활성화",
+  "API_Enable_Shields_Description": "'/api/v1/shield.svg' 에 있는 쉴드를 활성화",
   "API_GitHub_Enterprise_URL": "Server URL",
   "API_GitHub_Enterprise_URL_Description": "예: http://domain.com (마지막 슬래시 제외)",
   "API_Gitlab_URL": "GitLab URL",

--- a/packages/rocketchat-i18n/i18n/ru.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ru.i18n.json
@@ -212,7 +212,7 @@
   "API_Enable_Direct_Message_History_EndPoint": "Включить конечную точку истории сообщений",
   "API_Enable_Direct_Message_History_EndPoint_Description": "Эта настройка включает `/api/v1/im.history.others`. Это разрешает просмотр сообщений из личных диалогов, в которых не участвует вызывающий.",
   "API_Enable_Shields": "Включить щиты",
-  "API_Enable_Shields_Description": "Включить щиты, доступные в `/api/v1/shields.svg`",
+  "API_Enable_Shields_Description": "Включить щиты, доступные в `/api/v1/shield.svg`",
   "API_GitHub_Enterprise_URL": "URL-адрес сервера",
   "API_GitHub_Enterprise_URL_Description": "Пример: http://domain.com (без завершающего слеша)",
   "API_Gitlab_URL": "GitLab URL",


### PR DESCRIPTION
@RocketChat/core 

Closes #9488 

Add route:
`/api/v1/shield.svg?type=user&username=USERNAME`

Displays user's `name` and `status` as follows:

![shield-online](https://user-images.githubusercontent.com/8899152/35561074-35447060-05d5-11e8-9df4-63a3f0758032.png)
![shield-away](https://user-images.githubusercontent.com/8899152/35561076-3586391e-05d5-11e8-835f-f982c6f65bdd.png)
![shield-busy](https://user-images.githubusercontent.com/8899152/35561077-35bc6200-05d5-11e8-9dc2-44c5ee01a343.png)
![shield-offline](https://user-images.githubusercontent.com/8899152/35561078-35eb2e1e-05d5-11e8-85fb-d745cdd327d7.png)

Please guide me how can I improve the code further. Thank You.