### PR TITLE
[FIX] Missing string 'Username_already_exist' on the accountProfile page

### DIFF
--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -2030,6 +2030,7 @@
   "Username_is_already_in_here": "`@%s` is already in here.",
   "Username_is_not_in_this_room": "The user `#%s` is not in this room.",
   "Username_Placeholder": "Please enter usernames...",
+  "Username_already_exist": "Username already exists. Please try another username.",
   "User_sent_a_message_on_channel": "<strong>__username__</strong> sent a message on <strong>__channel__</strong>:",
   "User_uploaded_a_file_on_channel": "<strong>__username__</strong> uploaded a file on <strong>__channel__</strong>:",
   "User_sent_a_message_to_you": "<strong>__username__</strong> sent you a message:",


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Fixes #9494

<img width="774" alt="screen shot 2018-02-06 at 8 12 23 pm" src="https://user-images.githubusercontent.com/17925669/35865275-19e9a132-0b7a-11e8-82cd-422bad975da6.png">
