### PR TITLE
[Fix] closing user being transmitted in close by visitor

### DIFF
--- a/packages/rocketchat-livechat/server/methods/closeByVisitor.js
+++ b/packages/rocketchat-livechat/server/methods/closeByVisitor.js
@@ -13,6 +13,7 @@ Meteor.methods({
 		const language = (visitor && visitor.language) || RocketChat.settings.get('language') || 'en';
 
 		return RocketChat.Livechat.closeRoom({
+			user: Meteor.user(),
 			visitor,
 			room,
 			comment: TAPi18n.__('Closed_by_visitor', { lng: language })


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #9673 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
This fixes a "syntax error" violating the `closeRoom` method signature.

@sampaiodiego: is it semantically correct to pass `Meteor.user()` as closing use or should this also be the `visitor`