### PR TITLE
[FIX] GitLab OAuth does not work when GitLab’s URL ends with slash

### DIFF
--- a/packages/rocketchat-gitlab/common.js
+++ b/packages/rocketchat-gitlab/common.js
@@ -14,7 +14,7 @@ const Gitlab = new CustomOAuth('gitlab', config);
 if (Meteor.isServer) {
 	Meteor.startup(function() {
 		RocketChat.settings.get('API_Gitlab_URL', function(key, value) {
-			config.serverURL = value;
+			config.serverURL = value.trim().replace(/\/*$/, '');
 			Gitlab.configure(config);
 		});
 	});
@@ -22,7 +22,7 @@ if (Meteor.isServer) {
 	Meteor.startup(function() {
 		Tracker.autorun(function() {
 			if (RocketChat.settings.get('API_Gitlab_URL')) {
-				config.serverURL = RocketChat.settings.get('API_Gitlab_URL');
+				config.serverURL = RocketChat.settings.get('API_Gitlab_URL').trim().replace(/\/*$/, '');
 				Gitlab.configure(config);
 			}
 		});


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes https://github.com/RocketChat/Rocket.Chat/issues/9660

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
