### PR TITLE
[FIX] Messages can't be quoted sometimes

### DIFF
--- a/packages/rocketchat-integrations/server/processWebhookMessage.js
+++ b/packages/rocketchat-integrations/server/processWebhookMessage.js
@@ -50,7 +50,7 @@ this.processWebhookMessage = function(messageObj, user, defaultValues = { channe
 		const message = {
 			alias: messageObj.username || messageObj.alias || defaultValues.alias,
 			msg: s.trim(messageObj.text || messageObj.msg || ''),
-			attachments: messageObj.attachments,
+			attachments: messageObj.attachments || [],
 			parseUrls: messageObj.parseUrls !== undefined ? messageObj.parseUrls : !messageObj.attachments,
 			bot: messageObj.bot,
 			groupable: (messageObj.groupable !== undefined) ? messageObj.groupable : false

--- a/packages/rocketchat-oembed/server/jumpToMessage.js
+++ b/packages/rocketchat-oembed/server/jumpToMessage.js
@@ -5,7 +5,7 @@ import QueryString from 'querystring';
 
 const recursiveRemove = (message, deep = 1) => {
 	if (message) {
-		if ('attachments' in message && deep < RocketChat.settings.get('Message_QuoteChainLimit')) {
+		if ('attachments' in message && message.attachments !== null && deep < RocketChat.settings.get('Message_QuoteChainLimit')) {
 			message.attachments.map((msg) => recursiveRemove(msg, deep + 1));
 		} else {
 			delete(message.attachments);


### PR DESCRIPTION
@RocketChat/core 

If you tried to quote a message sent by: 
* integration
* anything that touched: processWebHookMessage (so both message sending endpoints)

and those messages didn't have attachments and the attachment property was null... you'd get this exception:

```
TypeError: Cannot read property 'map' of null
    at recursiveRemove (/app/bundle/programs/server/packages/rocketchat_oembed.js:589:24)
    at msg.urls.forEach.item (/app/bundle/programs/server/packages/rocketchat_oembed.js:609:29)
    at Array.forEach (<anonymous>:null:null)
    at RocketChat.callbacks.add.msg (/app/bundle/programs/server/packages/rocketchat_oembed.js:600:12)
    at /app/bundle/programs/server/packages/rocketchat_lib.js:1157:27
    at Array.reduce (<anonymous>:null:null)
    at Object.RocketChat.callbacks.run (/app/bundle/programs/server/packages/rocketchat_lib.js:1150:6)
    at EventEmitter.RocketChat.sendMessage (/app/bundle/programs/server/packages/rocketchat_lib.js:5158:33)
    at DDPCommon.MethodInvocation.sendMessage (/app/bundle/programs/server/packages/rocketchat_lib.js:15419:21)
    at DDPCommon.MethodInvocation.methodsMap.(anonymous function) (/app/bundle/programs/server/packages/rocketchat_lib.js:2134:26)
    at DDPCommon.MethodInvocation.methodMap.(anonymous function) (packages/rocketchat_monitoring.js:2731:30)
    at maybeAuditArgumentChecks (/app/bundle/programs/server/packages/ddp-server.js:1826:12)
    at DDP._CurrentMethodInvocation.withValue (/app/bundle/programs/server/packages/ddp-server.js:892:126)
    at Meteor.EnvironmentVariable.EVp.withValue (packages/meteor.js:1186:15)
    at DDPServer._CurrentWriteFence.withValue (/app/bundle/programs/server/packages/ddp-server.js:892:98)
    at Meteor.EnvironmentVariable.EVp.withValue (packages/meteor.js:1186:15)
    at Promise (/app/bundle/programs/server/packages/ddp-server.js:892:46)
    at new Promise (<anonymous>:null:null)
    at Session.method (/app/bundle/programs/server/packages/ddp-server.js:865:23)
    at /app/bundle/programs/server/packages/ddp-server.js:744:85
```