### PR TITLE
[FIX] Unnecessary horizontal scroll in some pages

### DIFF
--- a/packages/rocketchat-theme/client/imports/components/header.css
+++ b/packages/rocketchat-theme/client/imports/components/header.css
@@ -9,7 +9,7 @@
 
 	display: flex;
 
-	margin: 0 -0.5rem;
+	margin: 0;
 
 	padding: var(--header-padding);
 


### PR DESCRIPTION
@RocketChat/core 

Closes #9722 , #10254 

Earlier:
![scroll](https://user-images.githubusercontent.com/23701803/36260134-7ad96aaa-1286-11e8-8032-2fc140e9bc88.png)

Now:
![hidden](https://user-images.githubusercontent.com/23701803/36260185-9c9dd266-1286-11e8-8a4e-82ff4ebff0bb.png)
