### PR TITLE
[FIX] Apostrophe-containing URL misparsed

### DIFF
--- a/packages/rocketchat-autolinker/client/client.js
+++ b/packages/rocketchat-autolinker/client/client.js
@@ -7,7 +7,14 @@ import s from 'underscore.string';
 
 import Autolinker from 'autolinker';
 
+function htmlDecode(input) {
+	const e = document.createElement('div');
+	e.innerHTML = input;
+	return e.childNodes.length === 0 ? '' : e.childNodes[0].nodeValue;
+}
+
 function AutoLinker(message) {
+	message.html = htmlDecode(message.html);
 	if (RocketChat.settings.get('AutoLinker') !== true) {
 		return message;
 	}


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

Closes https://github.com/RocketChat/Rocket.Chat/issues/9485 
Closes https://github.com/RocketChat/Rocket.Chat/issues/9976

Earlier when we tried to send the url like ```https://foo.com/t='a'&s=1```, it wasnt getting detected properly.
Now it gets detected correctly:
<img width="332" alt="screen shot 2018-02-16 at 1 45 12 pm" src="https://user-images.githubusercontent.com/17925669/36298788-d9fff67c-131f-11e8-956e-e799623b677d.png">
