### PR TITLE
[FIX] Contextual Tab Bar icon color, team-icon size

### DIFF
--- a/packages/rocketchat-theme/client/imports/components/header.css
+++ b/packages/rocketchat-theme/client/imports/components/header.css
@@ -243,12 +243,18 @@
 	}
 }
 
-.tab-button-icon--star {
-	fill: none;
+
+.tab-button-icon {
+	fill: currentColor;
+
+	&--star {
+		fill: none;
+	}
 }
 
-.tab-bugtton-icon--team {
-	font-size: 28px;
+.tab-button-icon--team {
+	font-size: 26px;
+	margin-top: -1px;
 }
 
 @media (width <= 500px) {


### PR DESCRIPTION
@RocketChat/core 

Closes #9523

Made colors of all the icons in the header same, increased the size of the team icon.

![header-icons](https://user-images.githubusercontent.com/8899152/36351992-a81f66d8-14d7-11e8-86fd-c12c6ad7ef65.png)
