### PR TITLE
[FIX] Livechat conversation not receiving messages when start without form

### DIFF
--- a/packages/rocketchat-livechat/.app/client/lib/chatMessages.js
+++ b/packages/rocketchat-livechat/.app/client/lib/chatMessages.js
@@ -153,7 +153,7 @@ this.ChatMessages = class ChatMessages {
 					return showError(error.reason);
 				}
 
-				visitor.setId(result._id);
+				visitor.setId(result.userId);
 				sendMessage();
 			});
 		} else {

--- a/packages/rocketchat-livechat/.app/client/views/messages.js
+++ b/packages/rocketchat-livechat/.app/client/views/messages.js
@@ -122,7 +122,7 @@ Template.messages.events({
 					return console.log(error.reason);
 				}
 
-				visitor.setId(result._id);
+				visitor.setId(result.userId);
 				LivechatVideoCall.request();
 			});
 		} else {


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Currently if a livechat is started by visitor when there is no registration form or via a trigger, after visitor sends a message it does not receive messages back due the move of livechat visitors from users to its own collection.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
