### PR TITLE
[NEW] added ability to match incomplete words without regex

### DIFF
--- a/packages/rocketchat-ui-flextab/client/tabs/messageSearch.js
+++ b/packages/rocketchat-ui-flextab/client/tabs/messageSearch.js
@@ -111,7 +111,15 @@ Template.messageSearch.onCreated(function() {
 
 	return this.search = (globalSearch = false) => {
 		this.ready.set(false);
-		const value = this.$('#message-search').val();
+		let value = this.$('#message-search').val();
+		const regexBeginTest = RegExp('^\\/');
+		if (!regexBeginTest.test(value)) {
+			const regexTest = RegExp('^\\/.+(\\/[g|i|m|u|y]*$)');
+			if (!regexTest.test(value)) {
+				value = `/${ value }/`;
+			}
+		}
+		console.log(value);
 		return Tracker.nonreactive(() => {
 			return Meteor.call('messageSearch', value, (globalSearch) ? undefined: Session.get('openedRoom'), this.limit.get(), (error, result) => {
 				this.currentSearchTerm.set(value);


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #9647 
<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
In this PR a search query that is not regex (or in the midst of typing such string) are given '/''s to mimic regex behaviour.  This has the effect of enabling a non savvy user the power of incomplete word search, and savvy users to continue on matching.