### PR TITLE
[FIX] Snap build was failing

### DIFF
--- a/.snapcraft/snapcraft.yaml
+++ b/.snapcraft/snapcraft.yaml
@@ -49,7 +49,7 @@ parts:
         build-packages:
             - curl
         plugin: dump
-        prepare: curl -SLf "https://releases.rocket.chat/#{RC_VERSION}/download/" -o rocket.chat.tgz; tar xvf rocket.chat.tgz --strip 1; cd programs/server; npm install; cd npm/node_modules/meteor/rocketchat_google-vision; npm install grpc@1.6.6;
+        prepare: curl -SLf "https://releases.rocket.chat/#{RC_VERSION}/download/" -o rocket.chat.tgz; tar xvf rocket.chat.tgz --strip 1; cd programs/server; npm install; npm install grpc@1.6.6;
         after: [node]
         source: .
         stage-packages:


### PR DESCRIPTION
Since we flattened things a bit that folder didn't exist any more.

This will fix the snap build.

https://launchpad.net/~rocket.chat.buildmaster/+snap/candidate/+build/155010 build that succeeded after these changes.