### PR TITLE
Regression: Misplaced language dropdown in user preferences panel

### DIFF
--- a/packages/rocketchat-ui-account/client/accountPreferences.html
+++ b/packages/rocketchat-ui-account/client/accountPreferences.html
@@ -14,8 +14,8 @@
 						<div class="section-content border-component-color">
 							<div class="input-line double-col">
 								<label for="language">{{_ "Language"}}</label>
-								<div class="rc-select">
-									<select id="language" class="required rc-select__element">
+								<div>
+									<select id="language" class="required rc-input__element">
 										{{#each languages}}
 											<option value="{{key}}" selected="{{userLanguage key}}" dir="auto">{{name}}</option>
 										{{/each}}


### PR DESCRIPTION
@RocketChat/core 

Closes #9882

Looks like all the other dropdowns in Rocket.Chat again :)

**Before:**
![screen shot 2018-02-24 at 09 38 29](https://user-images.githubusercontent.com/4711233/36629105-d2ab6cfc-1951-11e8-97f9-62707cfb6f4a.png)

**After:**
![screen shot 2018-02-24 at 10 59 49](https://user-images.githubusercontent.com/4711233/36629108-db998ac4-1951-11e8-9e46-d11b20d1ff67.png)
