### PR TITLE
[FIX] "Saves changes" button in user account settings has hardcoded max-width

### DIFF
--- a/packages/rocketchat-ui-account/client/accountPreferences.html
+++ b/packages/rocketchat-ui-account/client/accountPreferences.html
@@ -1,7 +1,7 @@
 <template name="accountPreferences">
 	<section class="page-container page-home page-static">
 		{{#header sectionName="Preferences" buttons=true}}
-		<div class="rc-header__section-button" style="max-width: 649px;">
+		<div class="rc-header__section-button">
 			<button class="rc-button rc-button--primary save"><span>{{_ "Save_changes"}}</span></button>
 		</div>
 		{{/header}}

--- a/packages/rocketchat-ui-account/client/accountProfile.html
+++ b/packages/rocketchat-ui-account/client/accountProfile.html
@@ -13,7 +13,7 @@
 <template name="accountProfile">
 	<section class="preferences-page">
 		{{#header sectionName="Profile" buttons=true}}
-			<div class="rc-header__section-button" style="max-width: 649px;">
+			<div class="rc-header__section-button">
 				<button class="rc-button rc-button--primary" name="send" type="submit" data-button="create" form="profile" {{canSave 'disabled'}}>{{_ "Save_changes"}}</button>
 			</div>
 		{{/header}}


### PR DESCRIPTION
@RocketChat/core 

Closes #9886 

This PR removes the hardcoded max-width in the user account panel which caused the save changes button to look different than in the admin ui.

**Before:**
![screen shot 2018-02-24 at 16 31 12](https://user-images.githubusercontent.com/4711233/36632139-cb1504cc-1982-11e8-9b5a-145a6837a155.png)

**After:**
![screen shot 2018-02-24 at 16 31 28](https://user-images.githubusercontent.com/4711233/36632142-d356dcaa-1982-11e8-8c62-9c7337de20df.png)

**Admin UI:**
![screen shot 2018-02-24 at 16 38 25](https://user-images.githubusercontent.com/4711233/36632147-de1a888a-1982-11e8-9e7b-e752c366922a.png)
