### PR TITLE
[NEW] Multi-language support in usernames

### DIFF
--- a/packages/rocketchat-lib/server/startup/settings.js
+++ b/packages/rocketchat-lib/server/startup/settings.js
@@ -687,7 +687,7 @@ RocketChat.settings.addGroup('General', function() {
 		i18nDescription: 'Store_Last_Message_Sent_per_Room'
 	});
 	this.section('UTF8', function() {
-		this.add('UTF8_Names_Validation', '[0-9a-zA-Z-_.]+', {
+		this.add('UTF8_Names_Validation', '[0-9a-zA-Z-_.&#;]+', {
 			type: 'string',
 			'public': true,
 			i18nDescription: 'UTF8_Names_Validation_Description'

--- a/packages/rocketchat-mentions/Mentions.js
+++ b/packages/rocketchat-mentions/Mentions.js
@@ -34,7 +34,7 @@ export default class {
 		return new RegExp(`^#(${ this.pattern })| #(${ this.pattern })`, 'gm');
 	}
 	replaceUsers(str, message, me) {
-		return str.replace(this.userMentionRegex, (match, username) => {
+		return str.replace(/&amp;/g, '&').replace(this.userMentionRegex, (match, username) => {
 			if (['all', 'here'].includes(username)) {
 				return `<a class="mention-link mention-link-me mention-link-all background-attention-color">${ match }</a>`;
 			}
@@ -44,8 +44,8 @@ export default class {
 				return match;
 			}
 			const name = this.useRealName && mentionObj && mentionObj.name;
-
-			return `<a class="mention-link ${ username === me ? 'mention-link-me background-primary-action-color':'' }" data-username="${ username }" title="${ name ? username : '' }">${ name || match }</a>`;
+			username = username.replace(/&/g, '&amp;');
+			return `<a class="mention-link ${ username === me.replace(/&/g, '&amp;') ? 'mention-link-me background-primary-action-color':'' }" data-username="${ username }" title="${ name ? username : '' }">${ name || match }</a>`;
 		});
 	}
 	replaceChannels(str, message) {

--- a/packages/rocketchat-ui-flextab/client/tabs/membersList.js
+++ b/packages/rocketchat-ui-flextab/client/tabs/membersList.js
@@ -158,7 +158,7 @@ Template.membersList.helpers({
 			return this.user.name;
 		}
 
-		return this.user.username;
+		return jQuery.trim(jQuery.parseHTML(this.user.username)[0].data);
 	}});
 
 Template.membersList.events({

--- a/packages/rocketchat-ui-flextab/client/tabs/userInfo.html
+++ b/packages/rocketchat-ui-flextab/client/tabs/userInfo.html
@@ -24,7 +24,7 @@
 							{{> avatar username=username}}
 						</div>
 						<h3 title="{{name}}" class="rc-user-info__name"><i class="status-{{status}}"></i> {{name}}</h3>
-						{{#if username}}<p class="rc-user-info__username">@{{username}}</p>{{/if}}
+						{{#if username}}<p class="rc-user-info__username">@{{decodedUsername}}</p>{{/if}}
 					</div>
 
 					<div class="rc-user-info-action">

--- a/packages/rocketchat-ui-flextab/client/tabs/userInfo.js
+++ b/packages/rocketchat-ui-flextab/client/tabs/userInfo.js
@@ -62,6 +62,11 @@ Template.userInfo.helpers({
 		return user && user.username;
 	},
 
+	decodedUsername() {
+		const user = Template.instance().user.get();
+		return user && jQuery.trim(jQuery.parseHTML(user.username)[0].data);
+	},
+
 	email() {
 		const user = Template.instance().user.get();
 		return user && user.emails && user.emails[0] && user.emails[0].address;

--- a/packages/rocketchat-ui-message/client/message.js
+++ b/packages/rocketchat-ui-message/client/message.js
@@ -66,7 +66,7 @@ Template.message.helpers({
 		if (!this.u) {
 			return '';
 		}
-		return (RocketChat.settings.get('UI_Use_Real_Name') && this.u.name) || this.u.username;
+		return (RocketChat.settings.get('UI_Use_Real_Name') && this.u.name) || jQuery.trim(jQuery.parseHTML(this.u.username)[0].data);
 	},
 	showUsername() {
 		return this.alias || RocketChat.settings.get('UI_Use_Real_Name') && this.u && this.u.name;

--- a/packages/rocketchat-ui-sidenav/client/chatRoomItem.js
+++ b/packages/rocketchat-ui-sidenav/client/chatRoomItem.js
@@ -23,6 +23,8 @@ Template.chatRoomItem.helpers({
 
 		const icon = RocketChat.roomTypes.getIcon(this.t);
 		const avatar = !icon;
+		// Unicode decoding in room name
+		name = jQuery.trim(jQuery.parseHTML(this.name)[0].data);
 
 		const roomData = {
 			...this,

--- a/packages/rocketchat-ui/client/components/header/header.js
+++ b/packages/rocketchat-ui/client/components/header/header.js
@@ -39,7 +39,7 @@ Template.header.helpers({
 		const roomData = Session.get(`roomData${ this._id }`);
 		if (!roomData) { return ''; }
 
-		return RocketChat.roomTypes.getRoomName(roomData.t, roomData);
+		return jQuery.trim(jQuery.parseHTML(RocketChat.roomTypes.getRoomName(roomData.t, roomData))[0].data);
 	},
 
 	secondaryName() {


### PR DESCRIPTION
@RocketChat/core 

Closes #5224

This pr allows and renders usernames containing hex values of unicodes, allowing usernames in different languages.

Some shots:

1.
![unicode](https://user-images.githubusercontent.com/23701803/36726602-5f93fa36-1be0-11e8-8d0a-2b11c1c24a7f.png)

2.
![unicodemsg](https://user-images.githubusercontent.com/23701803/36728617-5bffc722-1be7-11e8-9306-21f9961c28b7.png)

3.
![unicode2](https://user-images.githubusercontent.com/23701803/36726613-6a7b0b1a-1be0-11e8-8b7e-05856987f84c.png)






