### PR TITLE
[FIX] Typo on french translation for "Open"

### DIFF
--- a/packages/rocketchat-i18n/i18n/fr.i18n.json
+++ b/packages/rocketchat-i18n/i18n/fr.i18n.json
@@ -1042,7 +1042,7 @@
   "Only_On_Desktop": "Mode Bureau (envoyé seulement quand Entrée sur le bureau)",
   "Only_you_can_see_this_message": "Vous seul pouvez voir ce message",
   "Oops!": "Oups",
-  "Open": "Ouvrerture",
+  "Open": "Ouverture",
   "Open_days_of_the_week": "Jours d'ouverture",
   "Open_Livechats": "Ouvrir les chats en direct",
   "Opened": "Ouvert",


### PR DESCRIPTION
Correcting the typo "Ouvrerture" to "Ouverture"which is the correct french word :)

![image](https://user-images.githubusercontent.com/807535/36758881-a338bb84-1be3-11e8-81e0-a7850cdb6d4a.png)

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
