### PR TITLE
[FIX] Loading avatar suggestions with no internet connection

### DIFF
--- a/packages/rocketchat-ui-account/client/accountProfile.html
+++ b/packages/rocketchat-ui-account/client/accountProfile.html
@@ -33,40 +33,40 @@
 									{{/unless}}
 								</div>
 									{{#if allowAvatarChange}}
-										{{#if suggestions.ready}}
-											<div class="rc-select-avatar__list">
-												<div class="rc-select-avatar__list-item rc-tooltip js-select-avatar-initials" aria-label="{{_ "initials_avatar" }}">
-													{{> avatar username=initialsUsername }}
-												</div>
-												<div class="rc-select-avatar__list-item rc-tooltip js-select-avatar-upload" aria-label="{{_ "Upload_user_avatar" }}">
-													<label class="rc-select-avatar__upload-label avatar" for="upload-avatar">
-														{{> icon block="rc-select-avatar__upload-icon" icon="upload"}}
-													</label>
-													<input type="file" name="" value="" id="upload-avatar" style="display:none;" accept="image/x-png,image/gif,image/jpeg">
-												</div>
-												<div class="rc-select-avatar__list-item rc-tooltip js-select-avatar-url {{selectUrl}}"  aria-label="{{_ "Use_url_for_avatar" }}">
-													<label class="rc-select-avatar__upload-label avatar">
-														{{> icon block="rc-select-avatar__upload-icon" icon="permalink"}}
-													</label>
-												</div>
+										<div class="rc-select-avatar__list">
+											<div class="rc-select-avatar__list-item rc-tooltip js-select-avatar-initials" aria-label="{{_ "initials_avatar" }}">
+												{{> avatar username=initialsUsername }}
+											</div>
+											<div class="rc-select-avatar__list-item rc-tooltip js-select-avatar-upload" aria-label="{{_ "Upload_user_avatar" }}">
+												<label class="rc-select-avatar__upload-label avatar" for="upload-avatar">
+													{{> icon block="rc-select-avatar__upload-icon" icon="upload"}}
+												</label>
+												<input type="file" name="" value="" id="upload-avatar" style="display:none;" accept="image/x-png,image/gif,image/jpeg">
+											</div>
+											<div class="rc-select-avatar__list-item rc-tooltip js-select-avatar-url {{selectUrl}}"	aria-label="{{_ "Use_url_for_avatar" }}">
+												<label class="rc-select-avatar__upload-label avatar">
+													{{> icon block="rc-select-avatar__upload-icon" icon="permalink"}}
+												</label>
+											</div>
+											{{#if suggestions.ready}}
 												{{#each service in services}}
 													{{ > avatarService service}}
 												{{/each}}
-												<div class="rc-input">
-
-													<label class="rc-input__label">
-														<div class="rc-input__title">{{_ "Use_url_for_avatar"}}</div>
-														<div class="rc-input__wrapper">
-															<input name="avatar_url" class="rc-input__element js-avatar-url-input" placeholder="{{_ "Use_url_for_avatar"}}">
-														</div>
-													</label>
+											{{else}}
+												<div class="rc-select-avatar__loading">
+													{{_ "Loading_suggestion"}}
 												</div>
+											{{/if}}
+											<div class="rc-input">
+
+												<label class="rc-input__label">
+													<div class="rc-input__title">{{_ "Use_url_for_avatar"}}</div>
+													<div class="rc-input__wrapper">
+														<input name="avatar_url" class="rc-input__element js-avatar-url-input" placeholder="{{_ "Use_url_for_avatar"}}">
+													</div>
+												</label>
 											</div>
-										{{else}}
-											<div class="rc-select-avatar__loading">
-												{{_ "Loading_suggestion"}}
-											</div>
-										{{/if}}
+										</div>
 									{{/if}}
 							</div>
 						</div>


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #8992

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Allow changing avatar by using initials, uploading or external URL while RC is trying to load suggestions.

This is a quickfix for #8992 where users cannot change their avatar if RC has no internet access. This will also help if avatar services act very slow.

Before
![](http://fs5.directupload.net/images/180302/ghmcklwh.png)

After
![](http://fs5.directupload.net/images/180302/s63ncwpq.png)