### PR TITLE
[FIX] Delete user without username was removing direct rooms of all users

### DIFF
--- a/packages/rocketchat-cors/cors.js
+++ b/packages/rocketchat-cors/cors.js
@@ -3,10 +3,17 @@ import _ from 'underscore';
 
 import url from 'url';
 
+import { Mongo } from 'meteor/mongo';
 import tls from 'tls';
 // FIX For TLS error see more here https://github.com/RocketChat/Rocket.Chat/issues/9316
 // TODO: Remove after NodeJS fix it, more information https://github.com/nodejs/node/issues/16196 https://github.com/nodejs/node/pull/16853
 tls.DEFAULT_ECDH_CURVE = 'auto';
+
+// Revert change from Meteor 1.6.1 who set ignoreUndefined: true
+// more information https://github.com/meteor/meteor/pull/9444
+Mongo.setConnectionOptions({
+	ignoreUndefined: false
+});
 
 WebApp.rawConnectHandlers.use(Meteor.bindEnvironment(function(req, res, next) {
 	if (req._body) {

--- a/packages/rocketchat-cors/package.js
+++ b/packages/rocketchat-cors/package.js
@@ -8,7 +8,8 @@ Package.describe({
 Package.onUse(function(api) {
 	api.use([
 		'ecmascript',
-		'webapp'
+		'webapp',
+		'mongo'
 	]);
 
 	api.addFiles('cors.js', 'server');

--- a/packages/rocketchat-lib/server/functions/deleteUser.js
+++ b/packages/rocketchat-lib/server/functions/deleteUser.js
@@ -1,30 +1,33 @@
 RocketChat.deleteUser = function(userId) {
 	const user = RocketChat.models.Users.findOneById(userId);
 
-	RocketChat.models.Messages.removeByUserId(userId); // Remove user messages
-	RocketChat.models.Subscriptions.db.findByUserId(userId).forEach((subscription) => {
-		const room = RocketChat.models.Rooms.findOneById(subscription.rid);
-		if (room) {
-			if (room.t !== 'c' && room.usernames.length === 1) {
-				RocketChat.models.Rooms.removeById(subscription.rid); // Remove non-channel rooms with only 1 user (the one being deleted)
+	// Users without username can't do anything, so there is nothing to remove
+	if (user.username != null) {
+		RocketChat.models.Messages.removeByUserId(userId); // Remove user messages
+		RocketChat.models.Subscriptions.db.findByUserId(userId).forEach((subscription) => {
+			const room = RocketChat.models.Rooms.findOneById(subscription.rid);
+			if (room) {
+				if (room.t !== 'c' && room.usernames.length === 1) {
+					RocketChat.models.Rooms.removeById(subscription.rid); // Remove non-channel rooms with only 1 user (the one being deleted)
+				}
+				if (room.t === 'd') {
+					RocketChat.models.Subscriptions.removeByRoomId(subscription.rid);
+					RocketChat.models.Messages.removeByRoomId(subscription.rid);
+				}
 			}
-			if (room.t === 'd') {
-				RocketChat.models.Subscriptions.removeByRoomId(subscription.rid);
-				RocketChat.models.Messages.removeByRoomId(subscription.rid);
-			}
+		});
+
+		RocketChat.models.Subscriptions.removeByUserId(userId); // Remove user subscriptions
+		RocketChat.models.Rooms.removeByTypeContainingUsername('d', user.username); // Remove direct rooms with the user
+		RocketChat.models.Rooms.removeUsernameFromAll(user.username); // Remove user from all other rooms
+
+		// removes user's avatar
+		if (user.avatarOrigin === 'upload' || user.avatarOrigin === 'url') {
+			FileUpload.getStore('Avatars').deleteByName(user.username);
 		}
-	});
 
-	RocketChat.models.Subscriptions.removeByUserId(userId); // Remove user subscriptions
-	RocketChat.models.Rooms.removeByTypeContainingUsername('d', user.username); // Remove direct rooms with the user
-	RocketChat.models.Rooms.removeUsernameFromAll(user.username); // Remove user from all other rooms
-
-	// removes user's avatar
-	if (user.avatarOrigin === 'upload' || user.avatarOrigin === 'url') {
-		FileUpload.getStore('Avatars').deleteByName(user.username);
+		RocketChat.models.Integrations.disableByUserId(userId); // Disables all the integrations which rely on the user being deleted.
 	}
-
-	RocketChat.models.Integrations.disableByUserId(userId); // Disables all the integrations which rely on the user being deleted.
 
 	RocketChat.models.Users.removeById(userId); // Remove user from users database
 };


### PR DESCRIPTION
Meteor 1.6.1 [introduced](https://github.com/meteor/meteor/pull/7277) a new default setting to MongoDB driver `ignoreUndefined: true` which can remove fields with `undefined` values from the query, that execute a different behavior than expected when deleting users without usernames executing the deletion agains all direct rooms with the query:
```javascript
{
  t: 'd'
}
```
rather than
```javascript
{
  t: 'd',
  usernames: undefined
}
```

This PR rollback that MongoDB option and does not tries to remove data for users without username cuz they can't have message, subscriptions, rooms, etc before set their username.