### PR TITLE
[NEW] More dynamic search for emoji Popup search

### DIFF
--- a/packages/rocketchat-ui-message/client/popup/messagePopupConfig.js
+++ b/packages/rocketchat-ui-message/client/popup/messagePopupConfig.js
@@ -318,6 +318,7 @@ Template.messagePopupConfig.helpers({
 				getInput: self.getInput,
 				getFilter(collection, filter) {
 					const key = `:${ filter }`;
+
 					if (!RocketChat.getUserPreference(Meteor.user(), 'useEmojis')) {
 						return [];
 					}
@@ -325,9 +326,6 @@ Template.messagePopupConfig.helpers({
 					if (!RocketChat.emoji.packages.emojione || RocketChat.emoji.packages.emojione.asciiList[key]) {
 						return [];
 					}
-
-
-
 
 					const colorBlind = new RegExp('_tone[1-5]:*$');
 					const seeColor = new RegExp('_t(?:o|$)(?:n|$)(?:e|$)(?:[1-5]|$)(?:\:|$)$');

--- a/packages/rocketchat-ui-message/client/popup/messagePopupConfig.js
+++ b/packages/rocketchat-ui-message/client/popup/messagePopupConfig.js
@@ -318,7 +318,6 @@ Template.messagePopupConfig.helpers({
 				getInput: self.getInput,
 				getFilter(collection, filter) {
 					const key = `:${ filter }`;
-
 					if (!RocketChat.getUserPreference(Meteor.user(), 'useEmojis')) {
 						return [];
 					}
@@ -327,6 +326,11 @@ Template.messagePopupConfig.helpers({
 						return [];
 					}
 
+
+
+
+					const colorBlind = new RegExp('_tone[1-5]:*$');
+					const seeColor = new RegExp('_t(?:o|$)(?:n|$)(?:e|$)(?:[1-5]|$)(?:\:|$)$');
 					const regExp = new RegExp(`^${ RegExp.escape(key) }`, 'i');
 					const recents = RocketChat.EmojiPicker.getRecent().map(item => `:${ item }:`);
 					return Object.keys(collection).map(key => {
@@ -337,6 +341,14 @@ Template.messagePopupConfig.helpers({
 						};
 					})
 						.filter(obj => regExp.test(obj._id))
+						.filter(obj => {
+							const queryToString = String(regExp).replace(/\//g, '').replace(/i$/, '');
+							if (seeColor.test(queryToString)) {
+								return true;
+							} else {
+								return !colorBlind.test(obj._id);
+							}
+						})
 						.sort(emojiSort(recents))
 						.slice(0, 10);
 				},


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #9898

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Currently the pop up emoji search can get clogged with tonal versions of the same emoji
![36672566-05e7fd4c-1b00-11e8-983d-7ec260c24a05](https://user-images.githubusercontent.com/24814085/37011593-168160b8-20ae-11e8-9a13-4b57b6bb17d5.png)

In this PR i propose to exclude Tonal versions of emojis from popUp until the user begins to explicitly request them
![newhand](https://user-images.githubusercontent.com/24814085/37011771-da897ed2-20ae-11e8-9782-d44ecd36a8c8.png)

This code will hides tones as shown above until the user begins typing _t (and keeps them shown through typing _tone[1-5]: as below
![handballtones](https://user-images.githubusercontent.com/24814085/37011815-0c842a22-20af-11e8-8e7b-bc35b2187fc8.png)

While not the suggested fix, perhaps this functionality is true to the intent, this way one retains full emoji power and a more powerful search, without taking the hands of the keyboard.