### PR TITLE
fix: add min-width to userstatus indicator to prevent that it is hidden

### DIFF
--- a/packages/rocketchat-theme/client/imports/components/sidebar/sidebar-item.css
+++ b/packages/rocketchat-theme/client/imports/components/sidebar/sidebar-item.css
@@ -140,6 +140,7 @@
 	}
 
 	&__user-status {
+		min-width: var(--sidebar-item-user-status-size);
 		width: var(--sidebar-item-user-status-size);
 		height: var(--sidebar-item-user-status-size);
 


### PR DESCRIPTION
There is no min-width on the userstatus and when the username is too long the userstatus indicator collapses due to the flexbox properties (which are not enough, there are some flexbox properties missing in general).

![bildschirmfoto 2018-03-07 um 08 59 40](https://user-images.githubusercontent.com/827205/37080962-4898eb58-21e8-11e8-8c2e-a3b418e95677.png)
