### PR TITLE
[FIX] User preferences can't be saved when roles are hidden in admin settings

### DIFF
--- a/packages/rocketchat-ui-account/client/accountPreferences.js
+++ b/packages/rocketchat-ui-account/client/accountPreferences.js
@@ -135,7 +135,6 @@ Template.accountPreferences.onCreated(function() {
 		data.muteFocusedConversations = JSON.parse($('#muteFocusedConversations').find('input:checked').val());
 		data.viewMode = parseInt($('#viewMode').find('select').val());
 		data.hideUsernames = JSON.parse($('#hideUsernames').find('input:checked').val());
-		data.hideRoles = JSON.parse($('#hideRoles').find('input:checked').val());
 		data.hideFlexTab = JSON.parse($('#hideFlexTab').find('input:checked').val());
 		data.hideAvatars = JSON.parse($('#hideAvatars').find('input:checked').val());
 		data.sendOnEnter = $('#sendOnEnter').find('select').val();
@@ -152,6 +151,10 @@ Template.accountPreferences.onCreated(function() {
 		}));
 
 		let reload = false;
+
+		if (RocketChat.settings.get('UI_DisplayRoles')) {
+			data.hideRoles = JSON.parse($('#hideRoles').find('input:checked').val());
+		}
 
 		// if highlights changed we need page reload
 		const highlights = RocketChat.getUserPreference(Meteor.user(), 'highlights');


### PR DESCRIPTION
@RocketChat/core 

Closes #10049
Closes #10001 

Fixed issue that caused user preferences to not be saved when roles are hidden in the admin settings