### PR TITLE
[FIX] Message editing is crashing the server when read receipts are enabled

### DIFF
--- a/imports/message-read-receipt/server/hooks.js
+++ b/imports/message-read-receipt/server/hooks.js
@@ -2,6 +2,11 @@ import { ReadReceipt } from './lib/ReadReceipt';
 
 RocketChat.callbacks.add('afterSaveMessage', (message, room) => {
 
+	// skips this callback if the message was edited
+	if (message.editedAt) {
+		return message;
+	}
+
 	// set subscription as read right after message was sent
 	RocketChat.models.Subscriptions.setAsReadByRoomIdAndUserId(room._id, message.u._id);
 


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
Editing a message with read receipts enabled are throwing this error on server's console:
```
E11000 duplicate key error index: rocketchat.rocketchat_message_read_receipt.$roomId_1_userId_1_messageId_1 dup key: { : \"aTXykw9Dkk7zb3bXXrocket.cat\", : \"aTXykw9Dkk7zb3bXX\", : \"utDHRDAdAempTqbGp\" }"
```

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
