### PR TITLE
[FIX] Slack Import reports `invalid import file type` due to a call to BSON.native() which is now doesn't exist

### DIFF
--- a/packages/rocketchat-importer/server/classes/ImporterBase.js
+++ b/packages/rocketchat-importer/server/classes/ImporterBase.js
@@ -26,7 +26,7 @@ export class Base {
 	 * @static
 	 */
 	static getBSONSize(item) {
-		const { BSON } = require('bson').native();
+		const { BSON } = require('bson');
 		const bson = new BSON();
 		return bson.calculateObjectSize(item);
 	}


### PR DESCRIPTION
And fix slack import error

@RocketChat/core 

Closes #10050
