### PR TITLE
[FIX] Unable to mention after newline in message

### DIFF
--- a/packages/rocketchat-ui-message/client/popup/messagePopup.js
+++ b/packages/rocketchat-ui-message/client/popup/messagePopup.js
@@ -65,7 +65,7 @@ Template.messagePopup.onCreated(function() {
 	template.prefix = val(template.data.prefix, template.trigger);
 	template.suffix = val(template.data.suffix, '');
 	if (template.triggerAnywhere === true) {
-		template.matchSelectorRegex = val(template.data.matchSelectorRegex, new RegExp(`(?:^| )${ template.trigger }[^\\s]*$`));
+		template.matchSelectorRegex = val(template.data.matchSelectorRegex, new RegExp(`(?:^| |\n)${ template.trigger }[^\\s]*$`));
 	} else {
 		template.matchSelectorRegex = val(template.data.matchSelectorRegex, new RegExp(`(?:^)${ template.trigger }[^\\s]*$`));
 	}


### PR DESCRIPTION
@RocketChat/core 

Closes #10021 

Fixes inability to use all mentions(user, channel, slash commands) after newline.