### PR TITLE
[FIX] Wrong switch button border color

### DIFF
--- a/packages/rocketchat-theme/client/imports/forms/switch.css
+++ b/packages/rocketchat-theme/client/imports/forms/switch.css
@@ -18,7 +18,7 @@
 		& .rc-switch__input {
 			&:checked {
 				& + .rc-switch__button {
-				 border-color: #1757B7;
+				 border-color: var(--button-primary-background);
 				 background-color: var(--button-primary-background);
 			 }
 			}


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #10057 

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Switch button border-color same as that of its background.

Earlier:
![earlier](https://user-images.githubusercontent.com/8899152/37217350-46a46fb4-23e3-11e8-9993-2b7745ce1066.png)

Now:
![on-off-button](https://user-images.githubusercontent.com/8899152/37217248-14bc93d2-23e3-11e8-8bd8-c60c24d03019.png)
