### PR TITLE
[NEW] slack: rocket->slack attachment support

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -200,7 +200,7 @@ rocketchat:postcss@1.0.0
 rocketchat:push-notifications@0.0.1
 rocketchat:reactions@0.0.1
 rocketchat:sandstorm@0.0.1
-rocketchat:slackbridge@0.0.1
+rocketchat:slackbridge@0.0.2
 rocketchat:slashcommands-archive@0.0.1
 rocketchat:slashcommands-asciiarts@0.0.1
 rocketchat:slashcommands-create@0.0.1

--- a/packages/rocketchat-slackbridge/package.js
+++ b/packages/rocketchat-slackbridge/package.js
@@ -1,6 +1,6 @@
 Package.describe({
 	name: 'rocketchat:slackbridge',
-	version: '0.0.1',
+	version: '0.0.2',
 	summary: '',
 	git: '',
 	documentation: 'README.md'

--- a/packages/rocketchat-slackbridge/server/slackbridge.js
+++ b/packages/rocketchat-slackbridge/server/slackbridge.js
@@ -1198,6 +1198,9 @@ class SlackBridge {
 				icon_url: iconUrl,
 				link_names: 1
 			};
+			if (rocketMessage.attachments && rocketMessage.attachments[0]) {
+				data.attachments = JSON.stringify(rocketMessage.attachments);
+			}
 			logger.class.debug('Post Message To Slack', data);
 			const postResult = HTTP.post('https://slack.com/api/chat.postMessage', { params: data });
 			if (postResult.statusCode === 200 && postResult.data && postResult.data.message && postResult.data.message.bot_id && postResult.data.message.ts) {


### PR DESCRIPTION
@RocketChat/core 

This PR adds Rocket.Chat message attachments to the slackbridge. 

![Example slack image](https://i.imgur.com/uxL1ACY.png)
