### PR TITLE
[NEW] Added method to change channel's custom fields

### DIFF
--- a/packages/rocketchat-api/server/v1/channels.js
+++ b/packages/rocketchat-api/server/v1/channels.js
@@ -780,6 +780,24 @@ RocketChat.API.v1.addRoute('channels.setType', { authRequired: true }, {
 	}
 });
 
+RocketChat.API.v1.addRoute('channels.setCustomFields', { authRequired: true }, {
+	post() {
+		if (!this.bodyParams.customFields) {
+			return RocketChat.API.v1.failure('The bodyParam "customFields" is required');
+		}
+
+		const findResult = findChannelByIdOrName({ params: this.requestParams() });
+
+		Meteor.runAsUser(this.userId, () => {
+			Meteor.call('saveRoomSettings', findResult._id, 'customFields', this.bodyParams.customFields);
+		});
+
+		return RocketChat.API.v1.success({
+			channel: RocketChat.models.Rooms.findOneById(findResult._id, { fields: RocketChat.API.v1.defaultFieldsToExclude })
+		});
+	}
+});
+
 RocketChat.API.v1.addRoute('channels.unarchive', { authRequired: true }, {
 	post() {
 		const findResult = findChannelByIdOrName({ params: this.requestParams(), checkedArchived: false });

--- a/packages/rocketchat-api/server/v1/groups.js
+++ b/packages/rocketchat-api/server/v1/groups.js
@@ -632,6 +632,24 @@ RocketChat.API.v1.addRoute('groups.setType', { authRequired: true }, {
 	}
 });
 
+RocketChat.API.v1.addRoute('groups.setCustomFields', { authRequired: true }, {
+	post() {
+		if (!this.bodyParams.customFields) {
+			return RocketChat.API.v1.failure('The bodyParam "customFields" is required');
+		}
+
+		const findResult = findPrivateGroupByIdOrName({ params: this.requestParams(), userId: this.userId });
+
+		Meteor.runAsUser(this.userId, () => {
+			Meteor.call('saveRoomSettings', findResult.rid, 'customFields', this.bodyParams.customFields);
+		});
+
+		return RocketChat.API.v1.success({
+			group: RocketChat.models.Rooms.findOneById(findResult.rid, { fields: RocketChat.API.v1.defaultFieldsToExclude })
+		});
+	}
+});
+
 RocketChat.API.v1.addRoute('groups.unarchive', { authRequired: true }, {
 	post() {
 		const findResult = findPrivateGroupByIdOrName({ params: this.requestParams(), userId: this.userId, checkedArchived: false });

--- a/packages/rocketchat-channel-settings/server/methods/saveRoomSettings.js
+++ b/packages/rocketchat-channel-settings/server/methods/saveRoomSettings.js
@@ -1,4 +1,4 @@
-const fields = ['roomName', 'roomTopic', 'roomAnnouncement', 'roomDescription', 'roomType', 'readOnly', 'reactWhenReadOnly', 'systemMessages', 'default', 'joinCode', 'tokenpass', 'streamingOptions'];
+const fields = ['roomName', 'roomTopic', 'roomAnnouncement', 'roomDescription', 'roomType', 'readOnly', 'reactWhenReadOnly', 'systemMessages', 'default', 'joinCode', 'tokenpass', 'streamingOptions', 'customFields'];
 Meteor.methods({
 	saveRoomSettings(rid, settings, value) {
 		if (!Meteor.userId()) {
@@ -119,6 +119,9 @@ Meteor.methods({
 					break;
 				case 'joinCode':
 					RocketChat.models.Rooms.setJoinCodeById(rid, String(value));
+					break;
+				case 'customFields':
+					RocketChat.models.Rooms.setCustomFields(rid, value);
 					break;
 				case 'default':
 					RocketChat.models.Rooms.saveDefaultById(rid, value);

--- a/packages/rocketchat-lib/server/models/Rooms.js
+++ b/packages/rocketchat-lib/server/models/Rooms.js
@@ -764,6 +764,18 @@ class ModelRooms extends RocketChat.models._Base {
 		return this.update({ _id }, update);
 	}
 
+	setCustomFields(_id, customFields) {
+		const query = {_id};
+
+		const update = {
+			$set: {
+				customFields
+			}
+		};
+
+		return this.update(query, update);
+	}
+
 	// INSERT
 	createWithTypeNameUserAndUsernames(type, name, fname, user, usernames, extraData) {
 		const room = {


### PR DESCRIPTION
@RocketChat/core 

Existing methods allow setting channel's custom fields on insert. I added a method to update them later on. Editing the custom fields is restricted to the channel owner, admins and moderators.

This is directly useful for custom scripts making use of the custom fields functionality.