### PR TITLE
[FIX] Fixes timestamp link of expanded permalink

### DIFF
--- a/packages/rocketchat-message-attachments/client/messageAttachment.html
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.html
@@ -12,7 +12,15 @@
 						{{/if}}
 						<a href="{{fixCordova author_link}}" target="_blank" rel="noopener noreferrer">{{author_name}}</a>
 						{{#if ts}}
-							<span class="time">{{#if message_link}}<a href="{{message_link}}" rel="noopener noreferrer">{{time}}</a>{{else}}{{time}}{{/if}}</span>
+							{{#if message_link}}
+								<span class="time-link">
+									<a href="{{message_link}}" rel="noopener noreferrer">{{time}}</a>
+								</span>
+							{{else}}
+								<span class="time">
+									{{time}}
+								</span>
+							{{/if}}
 						{{/if}}
 					</div>
 				{{else}}
@@ -22,7 +30,15 @@
 						{{/if}}
 						{{author_name}}
 					{{#if ts}}
-						<span class="time">{{#if message_link}}<a href="{{message_link}}" rel="noopener noreferrer">{{time}}</a>{{else}}{{time}}{{/if}}</span>
+						{{#if message_link}}
+								<span class="time-link">
+									<a href="{{message_link}}" rel="noopener noreferrer">{{time}}</a>
+								</span>
+							{{else}}
+								<span class="time">
+									{{time}}
+								</span>
+							{{/if}}
 					{{/if}}
 					</div>
 				{{/if}}

--- a/packages/rocketchat-message-attachments/client/stylesheets/messageAttachments.css
+++ b/packages/rocketchat-message-attachments/client/stylesheets/messageAttachments.css
@@ -57,7 +57,7 @@ html.rtl .attachment {
 			margin-bottom: -2px;
 		}
 
-		& .time {
+		& .time, .time-link {
 			font-size: 0.8em;
 			font-weight: normal;
 		}


### PR DESCRIPTION

@RocketChat/core 

Closes #9810
Timestamp link was broken for permalink.

Earlier:
![broken-permalink](https://user-images.githubusercontent.com/23701803/37415366-49eb4d36-27d1-11e8-94a9-5e39323beed5.gif)

Now:
![fixed-permalink](https://user-images.githubusercontent.com/23701803/37415390-546e13a6-27d1-11e8-9a64-970baad6ab5f.gif)

