### PR TITLE
[FIX] API: findChannelByIdOrName returns error for private room

### DIFF
--- a/packages/rocketchat-api/server/v1/channels.js
+++ b/packages/rocketchat-api/server/v1/channels.js
@@ -18,7 +18,7 @@ function findChannelByIdOrName({ params, checkedArchived = true, returnUsernames
 		room = RocketChat.models.Rooms.findOneByName(params.roomName, { fields });
 	}
 
-	if (!room || room.t !== 'c') {
+	if (!room || !(room.t === 'c' || room.t === 'p')) {
 		throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any channel');
 	}
 


### PR DESCRIPTION
@RocketChat/core 

Closes #10175 

In API, findChannelByIdOrName function returned 'invalid room' error for private rooms, affecting all API routes that use it to validate room id. This pr fixes this.