### PR TITLE
[FIX] Add customFields for im.list.everyone

### DIFF
--- a/packages/rocketchat-lib/server/functions/saveCustomFieldsWithoutValidation.js
+++ b/packages/rocketchat-lib/server/functions/saveCustomFieldsWithoutValidation.js
@@ -15,7 +15,7 @@ RocketChat.saveCustomFieldsWithoutValidation = function(userId, formData) {
 
 		// Update customFields of all Direct Messages' Rooms for userId
 		RocketChat.models.Subscriptions.setCustomFieldsDirectMessagesByUserId(userId, customFields);
-		let user = RocketChat.models.Users.findOneById(userId);
+		const user = RocketChat.models.Users.findOneById(userId);
 		RocketChat.models.Rooms.setCustomFieldsDirectMessagesByUsername(user.username, customFields, 0);
 		RocketChat.models.Rooms.setCustomFieldsDirectMessagesByUsername(user.username, customFields, 1);
 

--- a/packages/rocketchat-lib/server/functions/saveCustomFieldsWithoutValidation.js
+++ b/packages/rocketchat-lib/server/functions/saveCustomFieldsWithoutValidation.js
@@ -15,6 +15,9 @@ RocketChat.saveCustomFieldsWithoutValidation = function(userId, formData) {
 
 		// Update customFields of all Direct Messages' Rooms for userId
 		RocketChat.models.Subscriptions.setCustomFieldsDirectMessagesByUserId(userId, customFields);
+		let user = RocketChat.models.Users.findOneById(userId);
+		RocketChat.models.Rooms.setCustomFieldsDirectMessagesByUsername(user.username, customFields, 0);
+		RocketChat.models.Rooms.setCustomFieldsDirectMessagesByUsername(user.username, customFields, 1);
 
 		Object.keys(customFields).forEach((fieldName) => {
 			if (!customFieldsMeta[fieldName].modifyRecordField) {

--- a/packages/rocketchat-lib/server/models/Rooms.js
+++ b/packages/rocketchat-lib/server/models/Rooms.js
@@ -766,13 +766,13 @@ class ModelRooms extends RocketChat.models._Base {
 
 	setCustomFieldsDirectMessagesByUsername(username, fields, index = 0) {
 		const values = {};
-		var query = {};
+		let query = {};
 
 		Object.keys(fields).forEach(key => {
-			values[`customFields.${index}.${key}`] = fields[key];
+			values[`customFields.${ index }.${ key }`] = fields[key];
 		});
 
-		query[`usernames.${index}`] = username;
+		query[`usernames.${ index }`] = username;
 		query['t'] = 'd';
 
 		const update = {

--- a/packages/rocketchat-lib/server/models/Rooms.js
+++ b/packages/rocketchat-lib/server/models/Rooms.js
@@ -764,6 +764,27 @@ class ModelRooms extends RocketChat.models._Base {
 		return this.update({ _id }, update);
 	}
 
+	setCustomFieldsDirectMessagesByUsername(username, fields, index = 0) {
+		const values = {};
+		var query = {};
+
+		Object.keys(fields).forEach(key => {
+			values[`customFields.${index}.${key}`] = fields[key];
+		});
+
+		query[`usernames.${index}`] = username;
+		query['t'] = 'd';
+
+		const update = {
+			$set: values
+		};
+		const options = {
+			'multi': true
+		};
+
+		return this.update(query, update, options);
+	}
+
 	// INSERT
 	createWithTypeNameUserAndUsernames(type, name, fname, user, usernames, extraData) {
 		const room = {

--- a/packages/rocketchat-lib/server/models/Rooms.js
+++ b/packages/rocketchat-lib/server/models/Rooms.js
@@ -766,7 +766,7 @@ class ModelRooms extends RocketChat.models._Base {
 
 	setCustomFieldsDirectMessagesByUsername(username, fields, index = 0) {
 		const values = {};
-		let query = {};
+		const query = {};
 
 		Object.keys(fields).forEach(key => {
 			values[`customFields.${ index }.${ key }`] = fields[key];

--- a/server/methods/createDirectMessage.js
+++ b/server/methods/createDirectMessage.js
@@ -50,7 +50,8 @@ Meteor.methods({
 			$setOnInsert: {
 				t: 'd',
 				msgs: 0,
-				ts: now
+				ts: now,
+				customFields: [me.customFields, to.customFields]
 			}
 		});
 


### PR DESCRIPTION
Signed-off-by: Eugene Bolshakov <pub@relvarsoft.com>

@RocketChat/core 

This PR extends [PR #9424](https://github.com/RocketChat/Rocket.Chat/pull/9424) to allow a search of customFields for `im.list.everyone`. It is performed by adding customFields to Direct Messages Room model and use it with `im.list.everyone`. 