### PR TITLE
[FIX] Desktop notifications not displayed when agent has not focussed the browser

### DIFF
--- a/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
@@ -164,7 +164,7 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room, userId) {
 
 	const pushUsernames = {};
 
-	const user = RocketChat.models.Users.findOneById(message.u._id);
+	const user = (room.t !== 'l') ? RocketChat.models.Users.findOneById(message.u._id) : room.v;
 
 	// might be a livechat visitor
 	if (!user) {

--- a/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
@@ -166,7 +166,6 @@ RocketChat.callbacks.add('afterSaveMessage', function(message, room, userId) {
 
 	const user = (room.t !== 'l') ? RocketChat.models.Users.findOneById(message.u._id) : room.v;
 
-	// might be a livechat visitor
 	if (!user) {
 		return message;
 	}


### PR DESCRIPTION
@RocketChat/core 

Closes #10074 

This PR fixes the bug related to desktop notifications in LiveChat rooms. When a visitor was sending messages and the agent was not focused on the browser, desktop notifications were not displayed to the agent.