### PR TITLE
[FIX] Fix the pagination of channels.members endpoint

### DIFF
--- a/tests/end-to-end/api/02-channels.js
+++ b/tests/end-to-end/api/02-channels.js
@@ -409,6 +409,24 @@ describe('[Channels]', function() {
 			.end(done);
 	});
 
+	it('/channels.members', (done) => {
+		request.get(api('channels.members'))
+			.set(credentials)
+			.query({
+				roomId: channel._id
+			})
+			.expect('Content-Type', 'application/json')
+			.expect(200)
+			.expect((res) => {
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('members').and.to.be.an('array');
+				expect(res.body).to.have.property('count');
+				expect(res.body).to.have.property('total');
+				expect(res.body).to.have.property('offset');
+			})
+			.end(done);
+	});
+
 	it('/channels.rename', async(done) => {
 		const roomInfo = await getRoomInfo(channel._id);
 


### PR DESCRIPTION
Closes #9987.

Changed the sort order of the member list, members list size, and added tests to channels.members endpoint.
