### PR TITLE
Revert "[FIX] Apostrophe-containing URL misparsed"

### DIFF
--- a/packages/rocketchat-autolinker/client/client.js
+++ b/packages/rocketchat-autolinker/client/client.js
@@ -7,14 +7,7 @@ import s from 'underscore.string';
 
 import Autolinker from 'autolinker';
 
-function htmlDecode(input) {
-	const e = document.createElement('div');
-	e.innerHTML = input;
-	return e.childNodes.length === 0 ? '' : e.childNodes[0].nodeValue;
-}
-
 function AutoLinker(message) {
-	message.html = htmlDecode(message.html);
 	if (RocketChat.settings.get('AutoLinker') !== true) {
 		return message;
 	}


### PR DESCRIPTION
Reverts RocketChat/Rocket.Chat#9739

Because it is not parsing correctly messages enclosed completely by an HTML element, like the message `_oops_`.. that would be then parsed to `<em>oops</em>` and `htmlDecode` will return an _empty string_ .