### PR TITLE
[NEW] Body of the payload on an incoming webhook is included on the request object

### DIFF
--- a/packages/rocketchat-integrations/server/api/api.js
+++ b/packages/rocketchat-integrations/server/api/api.js
@@ -198,6 +198,7 @@ function executeIntegrationRest() {
 			content: this.bodyParams,
 			content_raw: this.request._readableState && this.request._readableState.buffer && this.request._readableState.buffer.toString(),
 			headers: this.request.headers,
+			body: this.request.body,
 			user: {
 				_id: this.user._id,
 				name: this.user.name,


### PR DESCRIPTION
@RocketChat/core 

When using content-type as application/json, the raw content is not available to the user, as it has already been read. This PR adds the body (parsed JSON) to the request object so it can be used instead.