### PR TITLE
Fix: chat.react api not accepting previous emojis

### DIFF
--- a/packages/rocketchat-api/server/v1/chat.js
+++ b/packages/rocketchat-api/server/v1/chat.js
@@ -267,7 +267,11 @@ RocketChat.API.v1.addRoute('chat.react', { authRequired: true }, {
 			throw new Meteor.Error('error-message-not-found', 'The provided "messageId" does not match any existing message.');
 		}
 
-		const emoji = this.bodyParams.emoji;
+		const emoji = this.bodyParams.emoji || this.bodyParams.reaction;
+
+		if (!emoji) {
+			throw new Meteor.Error('error-emoji-param-not-provided', 'The required "emoji" param is missing.');
+		}
 
 		Meteor.runAsUser(this.userId, () => Meteor.call('setReaction', emoji, msg._id));
 

--- a/packages/rocketchat-reactions/setReaction.js
+++ b/packages/rocketchat-reactions/setReaction.js
@@ -39,8 +39,6 @@ Meteor.methods({
 			return false;
 		}
 
-		reaction = `:${ reaction.replace(/:/g, '') }:`;
-
 		if (message.reactions && message.reactions[reaction] && message.reactions[reaction].usernames.indexOf(user.username) !== -1) {
 			message.reactions[reaction].usernames.splice(message.reactions[reaction].usernames.indexOf(user.username), 1);
 

--- a/packages/rocketchat-reactions/setReaction.js
+++ b/packages/rocketchat-reactions/setReaction.js
@@ -19,6 +19,8 @@ Meteor.methods({
 			throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'setReaction' });
 		}
 
+		reaction = `:${ reaction.replace(/:/g, '') }:`;
+
 		if (!RocketChat.emoji.list[reaction] && RocketChat.models.EmojiCustom.findByNameOrAlias(reaction).count() === 0) {
 			throw new Meteor.Error('error-not-allowed', 'Invalid emoji provided.', { method: 'setReaction' });
 		}

--- a/tests/end-to-end/api/05-chat.js
+++ b/tests/end-to-end/api/05-chat.js
@@ -193,6 +193,36 @@ describe('[Chat]', function() {
 				})
 				.end(done);
 		});
+
+		it('should return statusCode: 200 when the emoji is valid and has no colons', (done) => {
+			request.post(api('chat.react'))
+				.set(credentials)
+				.send({
+					emoji: 'bee',
+					messageId: message._id
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+				})
+				.end(done);
+		});
+
+		it('should return statusCode: 200 for reaction property when the emoji is valid', (done) => {
+			request.post(api('chat.react'))
+				.set(credentials)
+				.send({
+					reaction: 'ant',
+					messageId: message._id
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+				})
+				.end(done);
+		});
 	});
 
 	describe('[/chat.getMessageReadReceipts]', () => {


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #10286

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

This happened because verification was added which checked if the emoji passed actually is one. However, this verification did not account for missing colons which has a very high chance to break existing systems.