### PR TITLE
Fix: Reaction endpoint/api only working with regular emojis

### DIFF
--- a/packages/rocketchat-emoji-custom/server/models/EmojiCustom.js
+++ b/packages/rocketchat-emoji-custom/server/models/EmojiCustom.js
@@ -13,7 +13,13 @@ class EmojiCustom extends RocketChat.models._Base {
 	}
 
 	//find
-	findByNameOrAlias(name, options) {
+	findByNameOrAlias(emojiName, options) {
+		let name = emojiName;
+
+		if (typeof emojiName === 'string') {
+			name = emojiName.replace(/:/g, '');
+		}
+
 		const query = {
 			$or: [
 				{name},


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core The issue was that enforcing the colons only worked for regular emojis but custom emojis search requires no colons in the name passed.

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #10286 (again)

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
