### PR TITLE
[FIX] Snaps crashing due to Node v8.11.1 Segfault

### DIFF
--- a/.snapcraft/snapcraft.yaml
+++ b/.snapcraft/snapcraft.yaml
@@ -38,8 +38,8 @@ apps:
         command: env LC_ALL=c initcaddy
 parts:
     node:
-        plugin: nodejs
-        node-engine: 8.11.1
+        plugin: dump 
+        prepare: wget https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-x64.tar.xz; tar xvf node-v8.9.4-linux-x64.tar.xz --strip 1; 
         build-packages:
             # For fibers
             - python


### PR DESCRIPTION
8.11.1 causes segfault https://github.com/RocketChat/Rocket.Chat/issues/10331 so we had to revert to 8.9.4

For some reason just switching node-engine causes issues with the snap build.  The work around is to just install from tar 