### PR TITLE
[FIX] Incorrect german translation of user online status

### DIFF
--- a/packages/rocketchat-i18n/i18n/de.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de.i18n.json
@@ -1440,7 +1440,7 @@
   "Offline_unavailable": "offline - nicht verfügbar",
   "On": "Ein",
   "Online": "Online",
-  "online": "Online-",
+  "online": "online",
   "Only_authorized_users_can_write_new_messages": "Nur Authentifizierte Benutzer können neue Nachrichten schreiben",
   "Only_On_Desktop": "Desktop Modus (senden mit der Eingabeaste nur auf dem Desktop PC)",
   "Only_you_can_see_this_message": "Nur Sie können diese Nachricht sehen",


### PR DESCRIPTION
@RocketChat/core 

Closes #10338 

I've also fixed the translation in the LingoHub Project :)