### PR TITLE
[FIX] Missing i18n translation key for "Unread"

### DIFF
--- a/packages/rocketchat-i18n/i18n/de.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de.i18n.json
@@ -2011,6 +2011,7 @@
   "Unmute_user": "Benutzern das Chatten erlauben",
   "Unnamed": "Unbenannt",
   "Unpin_Message": "Nachricht nicht mehr anheften",
+  "Unread": "Ungelesene Nachrichten",
   "Unread_on_top": "Oben ungelesen",
   "Unread_Count": "Zählen ungelesener Nachrichten",
   "Unread_Count_DM": "Zählen ungelesener Direktnachrichten",

--- a/packages/rocketchat-i18n/i18n/de.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de.i18n.json
@@ -2011,7 +2011,7 @@
   "Unmute_user": "Benutzern das Chatten erlauben",
   "Unnamed": "Unbenannt",
   "Unpin_Message": "Nachricht nicht mehr anheften",
-  "Unread": "Ungelesene",
+  "Unread": "Ungelesen",
   "Unread_on_top": "Oben ungelesen",
   "Unread_Count": "Zählen ungelesener Nachrichten",
   "Unread_Count_DM": "Zählen ungelesener Direktnachrichten",

--- a/packages/rocketchat-i18n/i18n/de.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de.i18n.json
@@ -2011,7 +2011,7 @@
   "Unmute_user": "Benutzern das Chatten erlauben",
   "Unnamed": "Unbenannt",
   "Unpin_Message": "Nachricht nicht mehr anheften",
-  "Unread": "Ungelesene Nachrichten",
+  "Unread": "Ungelesene",
   "Unread_on_top": "Oben ungelesen",
   "Unread_Count": "Zählen ungelesener Nachrichten",
   "Unread_Count_DM": "Zählen ungelesener Direktnachrichten",

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -2017,6 +2017,7 @@
   "Unmute_user": "Unmute user",
   "Unnamed": "Unnamed",
   "Unpin_Message": "Unpin Message",
+  "Unread": "Unread",
   "Unread_on_top": "Unread on top",
   "Unread_Count": "Unread Count",
   "Unread_Count_DM": "Unread Count for Direct Messages",

--- a/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
@@ -2011,6 +2011,7 @@
   "Unmute_user": "Permitir que o usuário fale",
   "Unnamed": "Sem nome",
   "Unpin_Message": "Desafixar Mensagem ",
+  "Unread": "Mensagens Não Lidas",
   "Unread_on_top": "Não lido no topo",
   "Unread_Count": "Contagem não lida",
   "Unread_Count_DM": "Contagem não lida para mensagens diretas",

--- a/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
@@ -2011,7 +2011,7 @@
   "Unmute_user": "Permitir que o usuário fale",
   "Unnamed": "Sem nome",
   "Unpin_Message": "Desafixar Mensagem ",
-  "Unread": "Mensagens Não Lidas",
+  "Unread": "Não Lidas",
   "Unread_on_top": "Não lido no topo",
   "Unread_Count": "Contagem não lida",
   "Unread_Count_DM": "Contagem não lida para mensagens diretas",

--- a/packages/rocketchat-i18n/i18n/pt.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pt.i18n.json
@@ -2011,6 +2011,7 @@
   "Unmute_user": "Permitir que o usuário fale",
   "Unnamed": "Sem nome",
   "Unpin_Message": "Desafixar Mensagem ",
+  "Unread": "Mensagens Não Lidas",
   "Unread_on_top": "Não lido no topo",
   "Unread_Count": "Contagem não lida",
   "Unread_Count_DM": "Contagem não lida para mensagens diretas",

--- a/packages/rocketchat-i18n/i18n/pt.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pt.i18n.json
@@ -2011,7 +2011,7 @@
   "Unmute_user": "Permitir que o usuário fale",
   "Unnamed": "Sem nome",
   "Unpin_Message": "Desafixar Mensagem ",
-  "Unread": "Mensagens Não Lidas",
+  "Unread": "Não Lidas",
   "Unread_on_top": "Não lido no topo",
   "Unread_Count": "Contagem não lida",
   "Unread_Count_DM": "Contagem não lida para mensagens diretas",


### PR DESCRIPTION
Closes #10385 

Added missing "Unread" key to the i18n files.