### PR TITLE
[NEW] Add internal API to handle room announcements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -163,12 +163,12 @@
 		"@protobufjs/base64": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-			"integrity": "sha1-TIVzDlm5ofHzSQR9vyQpYDS7JzU="
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
 		},
 		"@protobufjs/codegen": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-			"integrity": "sha1-fvN/DQEPsCitGtWXIuUG2SYoFcs="
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
 		},
 		"@protobufjs/eventemitter": {
 			"version": "1.1.0",
@@ -212,7 +212,7 @@
 		"@types/long": {
 			"version": "3.0.32",
 			"resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
-			"integrity": "sha1-9OWvMenpsZbY5fyopeLiCqPWC2k="
+			"integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA=="
 		},
 		"@types/node": {
 			"version": "8.9.4",
@@ -1726,7 +1726,7 @@
 		"bcrypt": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-1.0.3.tgz",
-			"integrity": "sha512-pRyDdo73C8Nim3jwFJ7DWe3TZCgwDfWZ6nHS5LSdU77kWbj1frruvdndP02AOavtD4y8v6Fp2dolbHgp4SDrfg==",
+			"integrity": "sha1-sC3cbAtS6ha40883XVoy54DatUg=",
 			"requires": {
 				"nan": "2.6.2",
 				"node-pre-gyp": "0.6.36"
@@ -2629,7 +2629,7 @@
 		"configstore": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-			"integrity": "sha1-CU7mYquD+tmRdnjeEU+q6o/NypA=",
+			"integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
 			"requires": {
 				"dot-prop": "4.2.0",
 				"graceful-fs": "4.1.11",
@@ -3473,7 +3473,7 @@
 		"diff": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-			"integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
+			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
 			"dev": true
 		},
 		"diff-match-patch": {
@@ -3493,7 +3493,7 @@
 		"doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-			"integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 			"dev": true,
 			"requires": {
 				"esutils": "2.0.2"
@@ -3663,7 +3663,6 @@
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
 			"integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
-			"optional": true,
 			"requires": {
 				"prr": "1.0.1"
 			}
@@ -3928,7 +3927,7 @@
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha1-PzGA+y4pEBdxastMnW1bXDSmqB0=",
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
 			"dev": true
 		},
 		"espree": {
@@ -5494,7 +5493,7 @@
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -5659,7 +5658,7 @@
 		"growl": {
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-			"integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
+			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
 			"dev": true
 		},
 		"grpc": {
@@ -8380,7 +8379,7 @@
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
 			"requires": {
 				"brace-expansion": "1.1.11"
 			}
@@ -8493,7 +8492,7 @@
 		"modelo": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/modelo/-/modelo-4.2.3.tgz",
-			"integrity": "sha1-snhYik24f8HlEHrjonfAh2842JQ="
+			"integrity": "sha512-9DITV2YEMcw7XojdfvGl3gDD8J9QjZTJ7ZOUuSAkP+F3T6rDbzMJuPktxptsdHYEvZcmXrCD3LMOhdSAEq6zKA=="
 		},
 		"modify-values": {
 			"version": "1.0.0",
@@ -8633,8 +8632,7 @@
 		"natives": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
-			"integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
-			"optional": true
+			"integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA=="
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -8760,7 +8758,7 @@
 		"npmlog": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
 			"requires": {
 				"are-we-there-yet": "1.1.4",
 				"console-control-strings": "1.1.0",
@@ -9269,7 +9267,7 @@
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
 			"dev": true
 		},
 		"poplib": {
@@ -9953,7 +9951,7 @@
 		"postcss-sorting": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-3.1.0.tgz",
-			"integrity": "sha1-r3yQ7nOtElaaV2ZOrwZzXC4lvsA=",
+			"integrity": "sha512-YCPTcJwGIInF1LpMD1lIYvMHTGUL4s97o/OraA6eKvoauhhk6vjwOWDDjm6uRKqug/kyDPMKEzmYZ6FtW6RDgw==",
 			"dev": true,
 			"requires": {
 				"lodash": "4.17.5",
@@ -10000,7 +9998,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"supports-color": {
@@ -10178,7 +10176,7 @@
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
 			"requires": {
 				"asap": "2.0.6"
 			}
@@ -10225,8 +10223,7 @@
 		"prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-			"optional": true
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
 		"pump": {
 			"version": "2.0.1",
@@ -10699,7 +10696,7 @@
 		"resolve": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-			"integrity": "sha1-HwmsznlsmnYlefMbLBzEw83fnzY=",
+			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
 			"dev": true,
 			"requires": {
 				"path-parse": "1.0.5"
@@ -11425,7 +11422,7 @@
 		"split": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
 			"dev": true,
 			"requires": {
 				"through": "2.3.8"
@@ -11443,7 +11440,7 @@
 		"split2": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-			"integrity": "sha1-GGsldbz4PoW30YRldWI47k7kJJM=",
+			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
 			"dev": true,
 			"requires": {
 				"through2": "2.0.3"
@@ -11595,7 +11592,7 @@
 		"string-format-obj": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string-format-obj/-/string-format-obj-1.1.1.tgz",
-			"integrity": "sha1-x2EspOKtkjgSqB2xktwpGFCqH2U="
+			"integrity": "sha512-Mm+sROy+pHJmx0P/0Bs1uxIX6UhGJGj6xDGQZ5zh9v/SZRmLGevp+p0VJxV7lirrkAmQ2mvva/gHKpnF/pTb+Q=="
 		},
 		"string-width": {
 			"version": "1.0.2",
@@ -12326,7 +12323,7 @@
 		"text-extensions": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
-			"integrity": "sha1-+qq6JiXtdG1WiiPk0KrNm/CKizk=",
+			"integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
 			"dev": true
 		},
 		"text-table": {
@@ -13204,7 +13201,7 @@
 		"wide-align": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+			"integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
 			"requires": {
 				"string-width": "1.0.2"
 			}
@@ -13270,7 +13267,7 @@
 		"write-file-atomic": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-			"integrity": "sha1-H/YVdcLipOjlENb6TiQ8zhg5mas=",
+			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"imurmurhash": "0.1.4",
@@ -13621,7 +13618,7 @@
 		"xpath.js": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-			"integrity": "sha1-OBakTtS7NSCRCD0AKjg91RBKX/E="
+			"integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
 		},
 		"xtend": {
 			"version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 		"@google-cloud/common": {
 			"version": "0.16.1",
 			"resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.16.1.tgz",
-			"integrity": "sha512-1sufDsSfgJ7fuBLq+ux8t3TlydMlyWl9kPZx2WdLINkGtf5RjvXX6EWYZiCMKe8flJ3oC0l95j5atN2uX5n3rg==",
+			"integrity": "sha1-4fn8SVUzYpl+H7/3N0RPG0YN7Xg=",
 			"requires": {
 				"array-uniq": "1.0.3",
 				"arrify": "1.0.1",
@@ -41,7 +41,7 @@
 		"@google-cloud/language": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@google-cloud/language/-/language-1.1.0.tgz",
-			"integrity": "sha512-CcCc2zgX3M1X+rn+zy38QjCY/1R9CBCRd3cCqzIefZL16QgBod3ATPtVEHQG4KCyjnvCkMNMTQdYRCcsXs4wLw==",
+			"integrity": "sha1-ykV5nwpiN9HqQs0Y7v59MdG1Bys=",
 			"requires": {
 				"google-gax": "0.14.5",
 				"lodash.merge": "4.6.1"
@@ -50,7 +50,7 @@
 		"@google-cloud/storage": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.6.0.tgz",
-			"integrity": "sha512-yQ63bJYoiwY220gn/KdTLPoHppAPwFHfG7VFLPwJ+1R5U1eqUN5XV2a7uPj1szGF8/gxlKm2UbE8DgoJJ76DFw==",
+			"integrity": "sha1-Pep0DiS/CX2R8WWW4pFQUpB2eaI=",
 			"requires": {
 				"@google-cloud/common": "0.16.1",
 				"arrify": "1.0.1",
@@ -78,14 +78,14 @@
 				"mime": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/mime/-/mime-2.2.0.tgz",
-					"integrity": "sha512-0Qz9uF1ATtl8RKJG4VRfOymh7PyEor6NbrI/61lRfuRe4vx9SNATrvAeTj2EWVRKjEQGskrzWkJBBY5NbaVHIA=="
+					"integrity": "sha1-Fh5UGWVVHTtUn6ERQ5Hjo9Vbkjs="
 				}
 			}
 		},
 		"@google-cloud/vision": {
 			"version": "0.15.2",
 			"resolved": "https://registry.npmjs.org/@google-cloud/vision/-/vision-0.15.2.tgz",
-			"integrity": "sha512-SqirvZHIX95q24RIGGucVI4oS3FMZSnEXqw4SK8C6MlEfV3C0zn59eT1W8zcYvvFnR90+mHgw2PC2Z4ZMav/LQ==",
+			"integrity": "sha1-ZSeKujCKUWfpGOfZ+ZYzyIqh6j0=",
 			"requires": {
 				"@google-cloud/common": "0.16.1",
 				"async": "2.6.0",
@@ -163,12 +163,12 @@
 		"@protobufjs/base64": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+			"integrity": "sha1-TIVzDlm5ofHzSQR9vyQpYDS7JzU="
 		},
 		"@protobufjs/codegen": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+			"integrity": "sha1-fvN/DQEPsCitGtWXIuUG2SYoFcs="
 		},
 		"@protobufjs/eventemitter": {
 			"version": "1.1.0",
@@ -212,12 +212,12 @@
 		"@types/long": {
 			"version": "3.0.32",
 			"resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
-			"integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA=="
+			"integrity": "sha1-9OWvMenpsZbY5fyopeLiCqPWC2k="
 		},
 		"@types/node": {
 			"version": "8.9.4",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.4.tgz",
-			"integrity": "sha512-dSvD36qnQs78G1BPsrZFdPpvLgMW/dnvr5+nTW2csMs5TiP9MOXrjUbnMZOEwnIuBklXtn7b6TPA2Cuq07bDHA=="
+			"integrity": "sha1-39MnWCoGwRTrbgRB+j1vqzXtrUg="
 		},
 		"JSONStream": {
 			"version": "1.3.2",
@@ -552,7 +552,7 @@
 		"autolinker": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/autolinker/-/autolinker-1.6.2.tgz",
-			"integrity": "sha512-IKLGtYFb3jzGTtgCpb4bm//1sXmmmgmr0msKshhYoc7EsWmLCFvuyxLcEIfcZ5gbCgZGXrnXkOkcBblOFEnlog=="
+			"integrity": "sha1-Z66donLoCODY644Cy8jN4wOUdFc="
 		},
 		"autoprefixer": {
 			"version": "8.0.0",
@@ -618,7 +618,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
 					"dev": true
 				},
 				"supports-color": {
@@ -651,7 +651,7 @@
 				"uuid": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-					"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+					"integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
 				},
 				"xml2js": {
 					"version": "0.4.17",
@@ -2268,7 +2268,7 @@
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -2301,7 +2301,7 @@
 				"mocha": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-					"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+					"integrity": "sha1-fYbPvPNcuCnidUwy4XNV7AUzh5Q=",
 					"dev": true,
 					"requires": {
 						"browser-stdout": "1.3.0",
@@ -2319,13 +2319,13 @@
 						"commander": {
 							"version": "2.11.0",
 							"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-							"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+							"integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
 							"dev": true
 						},
 						"glob": {
 							"version": "7.1.2",
 							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-							"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+							"integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
 							"dev": true,
 							"requires": {
 								"fs.realpath": "1.0.0",
@@ -2353,7 +2353,7 @@
 				"supports-color": {
 					"version": "4.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+					"integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
 					"dev": true,
 					"requires": {
 						"has-flag": "2.0.0"
@@ -2469,7 +2469,7 @@
 		"codemirror": {
 			"version": "5.35.0",
 			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.35.0.tgz",
-			"integrity": "sha512-8HQICjZlDfe1ai7bvU6m2uHxuZuFgsUCdDRU9OHVB+2RTRd+FftN1ezVCqbquG0Fyq+wETqyadKhUX46DswSUQ=="
+			"integrity": "sha1-KAZT1JVFW8ZqqH5ihCkrAndbqHg="
 		},
 		"coffeescript": {
 			"version": "1.12.7",
@@ -2629,7 +2629,7 @@
 		"configstore": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-			"integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+			"integrity": "sha1-CU7mYquD+tmRdnjeEU+q6o/NypA=",
 			"requires": {
 				"dot-prop": "4.2.0",
 				"graceful-fs": "4.1.11",
@@ -3473,7 +3473,7 @@
 		"diff": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+			"integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
 			"dev": true
 		},
 		"diff-match-patch": {
@@ -3493,7 +3493,7 @@
 		"doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
 			"dev": true,
 			"requires": {
 				"esutils": "2.0.2"
@@ -3663,6 +3663,7 @@
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
 			"integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
+			"optional": true,
 			"requires": {
 				"prr": "1.0.1"
 			}
@@ -3870,7 +3871,7 @@
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -3879,7 +3880,7 @@
 				"globals": {
 					"version": "11.3.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
-					"integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+					"integrity": "sha1-4E/be5eW2K2snI9kwUg3sjEzeLA=",
 					"dev": true
 				},
 				"has-flag": {
@@ -3927,7 +3928,7 @@
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"integrity": "sha1-PzGA+y4pEBdxastMnW1bXDSmqB0=",
 			"dev": true
 		},
 		"espree": {
@@ -4234,7 +4235,7 @@
 		"file-type": {
 			"version": "7.6.0",
 			"resolved": "https://registry.npmjs.org/file-type/-/file-type-7.6.0.tgz",
-			"integrity": "sha512-EAogdjMKf0PEU26Wk+N/Qkg8JXpMRo9t70dg7+t9QvcYUZb/XfA66Hdt15g4xRdam4wgiQsg/qycKUIuZQDJog=="
+			"integrity": "sha1-s9v8gCkUjobzB2GyElNWKUPSHwY="
 		},
 		"filename-regex": {
 			"version": "2.0.1",
@@ -4245,7 +4246,7 @@
 		"filesize": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.0.tgz",
-			"integrity": "sha512-g5OWtoZWcPI56js1DFhIEqyG9tnu/7sG3foHwgS9KGYFMfsYguI3E+PRVCmtmE96VajQIEMRU2OhN+ME589Gdw=="
+			"integrity": "sha1-ItB5YVYku2/TwEAmEgYopBs/Tvo="
 		},
 		"fill-keys": {
 			"version": "1.0.2",
@@ -4411,7 +4412,7 @@
 		"fs-minipass": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-			"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+			"integrity": "sha1-BsJ3IYRU7CiN93raVKA7hwKqy50=",
 			"requires": {
 				"minipass": "2.2.1"
 			}
@@ -5394,7 +5395,7 @@
 		"gcs-resumable-upload": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.9.0.tgz",
-			"integrity": "sha512-+Zrmr0JKO2y/2mg953TW6JLu+NAMHqQsKzqCm7CIT24gMQakolPJCMzDleVpVjXAqB7ZCD276tcUq2ebOfqTug==",
+			"integrity": "sha1-ZEICFJaWrRFDWLweDPQ6YLXsBFQ=",
 			"requires": {
 				"buffer-equal": "1.0.0",
 				"configstore": "3.1.1",
@@ -5609,7 +5610,7 @@
 		"google-gax": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.14.5.tgz",
-			"integrity": "sha512-3A6KbrtLDavrqZnnzurnSydRIJnyH+2Sm56fAvXciQ/62aEnSDaR43MCgWhtReCLVjeFjBiCEIdX5zV0LVLVBg==",
+			"integrity": "sha1-ssc8Yd9s6tlPkEIdF/RP8WH2I8c=",
 			"requires": {
 				"extend": "3.0.1",
 				"globby": "7.1.1",
@@ -5634,7 +5635,7 @@
 		"google-proto-files": {
 			"version": "0.14.2",
 			"resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.14.2.tgz",
-			"integrity": "sha512-wwm2TIlfTgAjDbjrxAb3akznO7vBM0PRLS6Xf2QfR3L7b0p+szD3iwOW0wMSFl3B0UbLv27hUVk+clePqCVmXA==",
+			"integrity": "sha1-lYz/6n6IiOALmmxV7RNiwGtCb0w=",
 			"requires": {
 				"globby": "7.1.1",
 				"power-assert": "1.4.4",
@@ -5658,13 +5659,13 @@
 		"growl": {
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+			"integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
 			"dev": true
 		},
 		"grpc": {
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/grpc/-/grpc-1.7.3.tgz",
-			"integrity": "sha512-7zXQJlDXMr/ZaDqdaIchgclViyoWo8GQxZSmFUAxR8GwSr28b6/BTgF221WG+2W693jpp74XJ/+I9DcPXsgt9Q==",
+			"integrity": "sha1-ydA0Mk4uyKBs+qV3oEShFvlsjJA=",
 			"requires": {
 				"arguejs": "0.2.3",
 				"lodash": "4.17.5",
@@ -6903,7 +6904,7 @@
 				"domutils": {
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-					"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+					"integrity": "sha1-Vuo0HoNOBuZ0ivehyyXaZ+qfjCo=",
 					"requires": {
 						"dom-serializer": "0.1.0",
 						"domelementtype": "1.3.0"
@@ -7505,7 +7506,7 @@
 		"is-resolvable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
 			"dev": true
 		},
 		"is-stream": {
@@ -8028,7 +8029,7 @@
 		"lodash.merge": {
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+			"integrity": "sha1-rcJdnLmbk5HFliTzefu6YNcRHVQ="
 		},
 		"lodash.template": {
 			"version": "4.4.0",
@@ -8161,7 +8162,7 @@
 		"mailparser": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/mailparser/-/mailparser-2.2.0.tgz",
-			"integrity": "sha512-HVaPa+5xQtG3CQ5SUxbDuJMRnDANC8WllUKXHm46v0tKu3I4YaUlBxg4Lpkvf+qF+kOn0lGcnQgvM6xY5mYALw==",
+			"integrity": "sha1-48TZUE1KX6W92C6N4tQm105F42c=",
 			"requires": {
 				"addressparser": "1.0.1",
 				"he": "1.1.1",
@@ -8176,7 +8177,7 @@
 		"mailsplit": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/mailsplit/-/mailsplit-4.1.2.tgz",
-			"integrity": "sha512-5UWjUfhKlC4OR5PqZKcl4h7vnz2EP4M3Zg2SBbrztvAYX5lM/rA7tvaXkZ6zRcvK32Uul0GkRA037icDbiJIOw==",
+			"integrity": "sha1-xhi8MRpM/IOyJqHtwbUD9akk0IM=",
 			"requires": {
 				"libbase64": "1.0.2",
 				"libmime": "3.1.0",
@@ -8186,7 +8187,7 @@
 				"libbase64": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.0.2.tgz",
-					"integrity": "sha512-CyPjvTFbsGps2Sdvy9GVjSRPvUGpji8Hxb+iunp466guzxcd3QaK0k8Hur1sPkgD9FonW8V1z2F1y066YiliEg=="
+					"integrity": "sha1-L/E//mmx5AFZ9JNo4w0N2LsWNbU="
 				}
 			}
 		},
@@ -8337,7 +8338,7 @@
 		"mime-db": {
 			"version": "1.33.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+			"integrity": "sha1-o0kgUKXLm2NFBUHjnZeI0icng9s="
 		},
 		"mime-type": {
 			"version": "3.0.5",
@@ -8402,7 +8403,7 @@
 		"minipass": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.1.tgz",
-			"integrity": "sha512-u1aUllxPJUI07cOqzR7reGmQxmCqlH88uIIsf6XZFEWgw7gXKpJdR+5R9Y3KEDmWYkdIz9wXZs3C0jOPxejk/Q==",
+			"integrity": "sha1-WtqXU4sQJ7TPchNDJChXjLVkAR8=",
 			"requires": {
 				"yallist": "3.0.2"
 			},
@@ -8417,7 +8418,7 @@
 		"minizlib": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-			"integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+			"integrity": "sha1-EeE2WM5GvDpwomeqxYNZ0eDCnOs=",
 			"requires": {
 				"minipass": "2.2.1"
 			}
@@ -8451,13 +8452,13 @@
 				"commander": {
 					"version": "2.11.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+					"integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
 					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -8472,7 +8473,7 @@
 				"supports-color": {
 					"version": "4.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+					"integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
 					"dev": true,
 					"requires": {
 						"has-flag": "2.0.0"
@@ -8492,7 +8493,7 @@
 		"modelo": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/modelo/-/modelo-4.2.3.tgz",
-			"integrity": "sha512-9DITV2YEMcw7XojdfvGl3gDD8J9QjZTJ7ZOUuSAkP+F3T6rDbzMJuPktxptsdHYEvZcmXrCD3LMOhdSAEq6zKA=="
+			"integrity": "sha1-snhYik24f8HlEHrjonfAh2842JQ="
 		},
 		"modify-values": {
 			"version": "1.0.0",
@@ -8632,7 +8633,8 @@
 		"natives": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
-			"integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA=="
+			"integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
+			"optional": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -9032,7 +9034,7 @@
 		"path-type": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+			"integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
 			"requires": {
 				"pify": "3.0.0"
 			}
@@ -9267,7 +9269,7 @@
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
 			"dev": true
 		},
 		"poplib": {
@@ -9400,7 +9402,7 @@
 		"postcss-import": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-11.1.0.tgz",
-			"integrity": "sha512-5l327iI75POonjxkXgdRCUS+AlzAdBx4pOvMEhTKTCjb1p8IEeVR9yx3cPbmN7LIWJLbfnIXxAhoB4jpD0c/Cw==",
+			"integrity": "sha1-Vck2LJGSmU7GiGXSJEGd8dspgfA=",
 			"dev": true,
 			"requires": {
 				"postcss": "6.0.17",
@@ -9449,7 +9451,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
 					"dev": true
 				},
 				"supports-color": {
@@ -9951,7 +9953,7 @@
 		"postcss-sorting": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-3.1.0.tgz",
-			"integrity": "sha512-YCPTcJwGIInF1LpMD1lIYvMHTGUL4s97o/OraA6eKvoauhhk6vjwOWDDjm6uRKqug/kyDPMKEzmYZ6FtW6RDgw==",
+			"integrity": "sha1-r3yQ7nOtElaaV2ZOrwZzXC4lvsA=",
 			"dev": true,
 			"requires": {
 				"lodash": "4.17.5",
@@ -9998,7 +10000,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
 					"dev": true
 				},
 				"supports-color": {
@@ -10176,7 +10178,7 @@
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
 			"requires": {
 				"asap": "2.0.6"
 			}
@@ -10223,12 +10225,13 @@
 		"prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+			"optional": true
 		},
 		"pump": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
 			"requires": {
 				"end-of-stream": "1.4.1",
 				"once": "1.4.0"
@@ -10237,7 +10240,7 @@
 		"pumpify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
-			"integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+			"integrity": "sha1-gLfF334kFT0D8OesigWl0Gi9B/s=",
 			"requires": {
 				"duplexify": "3.5.3",
 				"inherits": "2.0.3",
@@ -10458,7 +10461,7 @@
 		"redis": {
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-			"integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+			"integrity": "sha1-ICKI4/WMSfYHnZevehDhMDrhSwI=",
 			"requires": {
 				"double-ended-queue": "2.1.0-0",
 				"redis-commands": "1.3.1",
@@ -10696,7 +10699,7 @@
 		"resolve": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+			"integrity": "sha1-HwmsznlsmnYlefMbLBzEw83fnzY=",
 			"dev": true,
 			"requires": {
 				"path-parse": "1.0.5"
@@ -10748,7 +10751,7 @@
 		"retry-request": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.1.tgz",
-			"integrity": "sha512-PjAmtWIxjNj4Co/6FRtBl8afRP3CxrrIAnUzb1dzydfROd+6xt7xAebFeskgQgkfFf8NmzrXIoaB3HxmswXyxw==",
+			"integrity": "sha1-+3EnYjWmF+l1Uem+c3q1uRWR+54=",
 			"requires": {
 				"request": "2.83.0",
 				"through2": "2.0.3"
@@ -11242,7 +11245,7 @@
 		"simple-get": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz",
-			"integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg==",
+			"integrity": "sha1-rTf5JtCBKSN/8IxPLt/W8Q4DgLU=",
 			"requires": {
 				"decompress-response": "3.3.0",
 				"once": "1.4.0",
@@ -11261,7 +11264,7 @@
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -11422,7 +11425,7 @@
 		"split": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
 			"dev": true,
 			"requires": {
 				"through": "2.3.8"
@@ -11440,7 +11443,7 @@
 		"split2": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+			"integrity": "sha1-GGsldbz4PoW30YRldWI47k7kJJM=",
 			"dev": true,
 			"requires": {
 				"through2": "2.0.3"
@@ -11592,7 +11595,7 @@
 		"string-format-obj": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string-format-obj/-/string-format-obj-1.1.1.tgz",
-			"integrity": "sha512-Mm+sROy+pHJmx0P/0Bs1uxIX6UhGJGj6xDGQZ5zh9v/SZRmLGevp+p0VJxV7lirrkAmQ2mvva/gHKpnF/pTb+Q=="
+			"integrity": "sha1-x2EspOKtkjgSqB2xktwpGFCqH2U="
 		},
 		"string-width": {
 			"version": "1.0.2",
@@ -11751,7 +11754,7 @@
 				"autoprefixer": {
 					"version": "7.2.6",
 					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
-					"integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
+					"integrity": "sha1-JWZy+G98c12oScTwfQCKuwVgZ9w=",
 					"dev": true,
 					"requires": {
 						"browserslist": "2.11.3",
@@ -11765,7 +11768,7 @@
 				"browserslist": {
 					"version": "2.11.3",
 					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-					"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+					"integrity": "sha1-/jYWeu0bvN5IJ+v+cTR6LMcLmbI=",
 					"dev": true,
 					"requires": {
 						"caniuse-lite": "1.0.30000808",
@@ -11998,7 +12001,7 @@
 		"stylelint-order": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-0.8.1.tgz",
-			"integrity": "sha512-8mp1P2wnI9XShYXVXDsxVigE2eXnc0C2O4ktbwUvTBwjCP4xZskIbUVxp1evSG3OK4R7hXVNl/2BnJCZkrcc/w==",
+			"integrity": "sha1-Nfca86FZVBVODpnlZGuj1vvjT40=",
 			"dev": true,
 			"requires": {
 				"lodash": "4.17.5",
@@ -12035,7 +12038,7 @@
 				"postcss": {
 					"version": "6.0.19",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-					"integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+					"integrity": "sha1-dqeDhvZwudlJSmVb8jrAEu/9FVU=",
 					"dev": true,
 					"requires": {
 						"chalk": "2.3.1",
@@ -12046,7 +12049,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
 					"dev": true
 				},
 				"supports-color": {
@@ -12323,7 +12326,7 @@
 		"text-extensions": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
-			"integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
+			"integrity": "sha1-+qq6JiXtdG1WiiPk0KrNm/CKizk=",
 			"dev": true
 		},
 		"text-table": {
@@ -12361,7 +12364,7 @@
 		"tlds": {
 			"version": "1.199.0",
 			"resolved": "https://registry.npmjs.org/tlds/-/tlds-1.199.0.tgz",
-			"integrity": "sha512-NM0jUhibJjEX4g0+1ETxOhuODIDpyvCC0A2BjxrTfMUMZ+uRZc6ZnJl9SmFtAW1s5iQgQIxezFpUij6/6OiRbg=="
+			"integrity": "sha1-pPyMMFghZIioCqrrtCeSUAflUhc="
 		},
 		"tmp": {
 			"version": "0.0.33",
@@ -12701,7 +12704,7 @@
 		"uc.micro": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
-			"integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg=="
+			"integrity": "sha1-DGXxX4FaoItWCmHOi023/8P0U3Y="
 		},
 		"uglify-js": {
 			"version": "2.8.29",
@@ -13267,7 +13270,7 @@
 		"write-file-atomic": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"integrity": "sha1-H/YVdcLipOjlENb6TiQ8zhg5mas=",
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"imurmurhash": "0.1.4",
@@ -13319,7 +13322,7 @@
 		"xml2js": {
 			"version": "0.4.19",
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+			"integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
 			"requires": {
 				"sax": "1.2.1",
 				"xmlbuilder": "9.0.7"
@@ -13618,7 +13621,7 @@
 		"xpath.js": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-			"integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
+			"integrity": "sha1-OBakTtS7NSCRCD0AKjg91RBKX/E="
 		},
 		"xtend": {
 			"version": "4.0.1",

--- a/packages/rocketchat-channel-settings/client/views/channelSettings.js
+++ b/packages/rocketchat-channel-settings/client/views/channelSettings.js
@@ -118,6 +118,9 @@ Template.channelSettingsEditing.onCreated(function() {
 		announcement: {
 			type: 'markdown',
 			label: 'Announcement',
+			getValue() {
+				return Template.instance().room.announcement && Template.instance().room.announcement.message;
+			},
 			canView() {
 				return RocketChat.roomTypes.roomTypes[room.t].allowRoomSettingChange(room, RoomSettingsEnum.ANNOUNCEMENT);
 			},
@@ -450,7 +453,7 @@ Template.channelSettingsInfo.helpers({
 		return Template.instance().room.description;
 	},
 	announcement() {
-		return Template.instance().room.announcement;
+		return Template.instance().room.announcement ? Template.instance().room.announcement.message : '';
 	},
 	topic() {
 		return Template.instance().room.topic;

--- a/packages/rocketchat-channel-settings/server/functions/saveRoomAnnouncement.js
+++ b/packages/rocketchat-channel-settings/server/functions/saveRoomAnnouncement.js
@@ -4,11 +4,16 @@ RocketChat.saveRoomAnnouncement = function(rid, roomAnnouncement, user, sendMess
 	if (!Match.test(rid, String)) {
 		throw new Meteor.Error('invalid-room', 'Invalid room', { function: 'RocketChat.saveRoomAnnouncement' });
 	}
+	const announcementObject = typeof roomAnnouncement === 'object' ?
+		roomAnnouncement :
+		{
+			message: roomAnnouncement
+		};
 
-	roomAnnouncement = s.escapeHTML(roomAnnouncement);
-	const updated = RocketChat.models.Rooms.setAnnouncementById(rid, roomAnnouncement);
+	const escapedMessage = s.escapeHTML(announcementObject.message);
+	const updated = RocketChat.models.Rooms.setAnnouncementById(rid, {...announcementObject, message: escapedMessage});
 	if (updated && sendMessage) {
-		RocketChat.models.Messages.createRoomSettingsChangedWithTypeRoomIdMessageAndUser('room_changed_announcement', rid, roomAnnouncement, user);
+		RocketChat.models.Messages.createRoomSettingsChangedWithTypeRoomIdMessageAndUser('room_changed_announcement', rid, escapedMessage, user);
 	}
 
 	return updated;

--- a/packages/rocketchat-lib/client/lib/RocketChatAnnouncement.js
+++ b/packages/rocketchat-lib/client/lib/RocketChatAnnouncement.js
@@ -1,4 +1,4 @@
-export class RocketChatRoomAnnouncement {
+export class RocketChatAnnouncement {
 	constructor(args={}) {
 		this.room = new ReactiveVar(args.room);
 		this.message = new ReactiveVar(args.message);

--- a/packages/rocketchat-lib/client/lib/RocketChatAnnouncement.js
+++ b/packages/rocketchat-lib/client/lib/RocketChatAnnouncement.js
@@ -3,9 +3,19 @@ export class RocketChatAnnouncement {
 		this.room = new ReactiveVar(args.room);
 		this.message = new ReactiveVar(args.message);
 		this.callback = new ReactiveVar(args.callback);
+		this.style = new ReactiveVar(args.style);
 	}
 	save() {
-		const announcementObject = { message: this.message.get(), callback: this.callback.get() };
+		const announcementObject = { message: this.message.get(), callback: this.callback.get(), style: this.style.get() };
 		Meteor.call('saveRoomSettings', this.room.get(), 'roomAnnouncement', announcementObject);
+	}
+	getMessage() {
+		return this.message.get();
+	}
+	getCallback() {
+		return this.callback.get();
+	}
+	getStyle() {
+		return this.callback.get();
 	}
 }

--- a/packages/rocketchat-lib/client/lib/RocketChatAnnouncement.js
+++ b/packages/rocketchat-lib/client/lib/RocketChatAnnouncement.js
@@ -1,0 +1,11 @@
+export class RocketChatRoomAnnouncement {
+	constructor(args={}) {
+		this.room = new ReactiveVar(args.room);
+		this.message = new ReactiveVar(args.message);
+		this.callback = new ReactiveVar(args.callback);
+	}
+	save() {
+		const announcementObject = { message: this.message.get(), callback: this.callback.get() };
+		Meteor.call('saveRoomSettings', this.room.get(), 'roomAnnouncement', announcementObject);
+	}
+}

--- a/packages/rocketchat-lib/client/lib/index.js
+++ b/packages/rocketchat-lib/client/lib/index.js
@@ -7,6 +7,7 @@
 */
 
 import { RocketChatTabBar } from './RocketChatTabBar';
+import { RocketChatAnnouncement } from './RocketChatAnnouncement';
 import { RoomSettingsEnum, RoomTypeConfig, RoomTypeRouteConfig, UiTextContext } from '../../lib/RoomTypeConfig';
 import { hide, leave, erase } from './ChannelActions';
 import { call } from './callMethod';
@@ -20,5 +21,6 @@ export {
 	RoomSettingsEnum,
 	RoomTypeConfig,
 	RoomTypeRouteConfig,
-	UiTextContext
+	UiTextContext,
+	RocketChatAnnouncement
 };

--- a/packages/rocketchat-lib/package.js
+++ b/packages/rocketchat-lib/package.js
@@ -201,6 +201,7 @@ Package.onUse(function(api) {
 	api.addFiles('client/lib/RestApiClient.js', 'client');
 	api.addFiles('client/lib/TabBar.js', 'client');
 	api.addFiles('client/lib/RocketChatTabBar.js', 'client');
+	api.addFiles('client/lib/RocketChatAnnouncement.js', 'client');
 	api.addFiles('client/lib/RestApiClient.js', 'client');
 	api.addFiles('client/lib/cachedCollection.js', 'client');
 	api.addFiles('client/lib/openRoom.js', 'client');

--- a/packages/rocketchat-theme/server/colors.less
+++ b/packages/rocketchat-theme/server/colors.less
@@ -950,4 +950,10 @@ label.required::after {
 
 .announcement {
 	background-color: @primary-background-color;
+	&.warning {
+		background-color: var(--rc-color-alert);
+	}
+	&.error {
+		background-color: var(--rc-color-alert-message-warning);
+	}
 }

--- a/packages/rocketchat-ui/client/views/app/room.html
+++ b/packages/rocketchat-ui/client/views/app/room.html
@@ -20,7 +20,7 @@
 					<div class="messages-container-main">
 						{{#unless embeddedVersion}}
 							{{#if showAnnouncement}}
-							<div class="fixed-title announcement" aria-label="{{RocketChatMarkdown roomAnnouncement}}">
+							<div class="fixed-title announcement {{getAnnouncementStyle}}" aria-label="{{RocketChatMarkdown roomAnnouncement}}">
 								{{{RocketChatMarkdown roomAnnouncement}}}
 							</div>
 							{{/if}}

--- a/packages/rocketchat-ui/client/views/app/room.js
+++ b/packages/rocketchat-ui/client/views/app/room.js
@@ -238,6 +238,12 @@ Template.room.helpers({
 		return roomData.announcement && roomData.announcement.message;
 	},
 
+	getAnnouncementStyle() {
+		const roomData = Session.get(`roomData${ this._id }`);
+		if (!roomData) { return ''; }
+		return roomData.announcement && roomData.announcement.style !== undefined ? roomData.announcement.style : '';
+	},
+
 	roomIcon() {
 		const roomData = Session.get(`roomData${ this._id }`);
 		if (!(roomData != null ? roomData.t : undefined)) { return ''; }

--- a/packages/rocketchat-ui/client/views/app/room.js
+++ b/packages/rocketchat-ui/client/views/app/room.js
@@ -217,7 +217,7 @@ Template.room.helpers({
 	showAnnouncement() {
 		const roomData = Session.get(`roomData${ this._id }`);
 		if (!roomData) { return false; }
-		return (roomData.announcement !== undefined) && (roomData.announcement !== '');
+		return (roomData.announcement !== undefined) && (roomData.announcement.message !== '');
 	},
 
 	messageboxData() {
@@ -235,7 +235,7 @@ Template.room.helpers({
 	roomAnnouncement() {
 		const roomData = Session.get(`roomData${ this._id }`);
 		if (!roomData) { return ''; }
-		return roomData.announcement;
+		return roomData.announcement && roomData.announcement.message;
 	},
 
 	roomIcon() {
@@ -704,13 +704,21 @@ Template.room.events({
 		}
 	},
 	'click .announcement'(e) {
-		modal.open({
-			title: t('Announcement'),
-			text: $(e.target).attr('aria-label'),
-			showConfirmButton: false,
-			showCancelButton: true,
-			cancelButtonText: t('Close')
-		});
+		const roomData = Session.get(`roomData${ this._id }`);
+		if (!roomData) { return false; }
+		if (roomData.announcement !== undefined && roomData.announcement.callback !== undefined) {
+			return RocketChat.callbacks.run(roomData.announcement.callback, this._id);
+		} else {
+			modal.open({
+				title: t('Announcement'),
+				text: $(e.target).attr('aria-label'),
+				showConfirmButton: false,
+				showCancelButton: true,
+				cancelButtonText: t('Close')
+			});
+
+		}
+
 	}
 });
 


### PR DESCRIPTION
Adds some form of modularity to the Room Announcements so they can be changed easily by other packages and even other Apps.

Room Announcement example:
```
import { RocketChatAnnouncement } from 'meteor/rocketchat:lib';

const newAnnouncement = new RocketChatAnnouncement({
   room: _rid, // REQUIRED: The room ID which the announcement is set
   message: "New Room Announcement", // REQUIRED: the message displayed, currently does not support markdown
   callback: "myCustomCallback", // OPTIONAL: a callback implemented by your app/feature that triggers when the user clicks the Announcement
   style: "" // OPTIONAL: currently supports the default (when style is null/undefined), warning and error
})
newAnnouncement.save(); //updates the room with the new announcement

```
Result:
![image](https://user-images.githubusercontent.com/6303966/38593636-c0c175c8-3d18-11e8-9dbf-3b98e85bf044.png)

With `style: "error"`
![image](https://user-images.githubusercontent.com/6303966/38593543-3b582080-3d18-11e8-847d-dd79f6d692d4.png)

With `style: "warning"`
![image](https://user-images.githubusercontent.com/6303966/38594233-c00b4688-3d1b-11e8-95f7-40b729a18d0a.png)
