### PR TITLE
[FIX] Empty panel after changing a user's username

### DIFF
--- a/packages/rocketchat-ui-flextab/client/tabs/userInfo.js
+++ b/packages/rocketchat-ui-flextab/client/tabs/userInfo.js
@@ -137,6 +137,7 @@ Template.userInfo.helpers({
 
 	userToEdit() {
 		const instance = Template.instance();
+		const data = Template.currentData();
 		return {
 			user: instance.user.get(),
 			back(username) {
@@ -145,6 +146,8 @@ Template.userInfo.helpers({
 				if (username != null) {
 					const user = instance.user.get();
 					if ((user != null ? user.username : undefined) !== username) {
+						
+						data.username = username;
 						return instance.loadedUsername.set(username);
 					}
 				}

--- a/packages/rocketchat-ui-flextab/client/tabs/userInfo.js
+++ b/packages/rocketchat-ui-flextab/client/tabs/userInfo.js
@@ -146,7 +146,6 @@ Template.userInfo.helpers({
 				if (username != null) {
 					const user = instance.user.get();
 					if ((user != null ? user.username : undefined) !== username) {
-						
 						data.username = username;
 						return instance.loadedUsername.set(username);
 					}


### PR DESCRIPTION
Closes #9930

When you change the username of a user through the administration, the web interface was failing to load the user data in the userInfo view.