### PR TITLE
[BREAK] The property "settings" is no longer available to regular users via rest api

### DIFF
--- a/packages/rocketchat-api/server/api.js
+++ b/packages/rocketchat-api/server/api.js
@@ -28,7 +28,8 @@ class API extends Restivus {
 			roles: 0,
 			statusDefault: 0,
 			_updatedAt: 0,
-			customFields: 0
+			customFields: 0,
+			settings: 0
 		};
 
 		this._config.defaultOptionsEndpoint = function _defaultOptionsEndpoint() {


### PR DESCRIPTION
Closes #10401 - regular users won't see that property on the users endpoints anymore, but administrator users will.

Detail: After we added the property `settings` to the users, we forgot to include this property in our array of fields that should not go out to regular users except for when they view their own data via the rest api. The reason this is considered breaking is because we have removed a property that was added, so if you are expecting this property to be there it won't show up. Usually we deprecate these type of things, however, due to the privacy concerns we have immediately removed it.