### PR TITLE
[NEW] Automatically trigger Redhat registry build when tagging new release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,6 +247,7 @@ jobs:
             bash .circleci/update-releases.sh
             bash .circleci/docker.sh
             bash .circleci/snap.sh
+            bash .circleci/redhat-registry.sh
 
 workflows:
   version: 2

--- a/.circleci/redhat-registry.sh
+++ b/.circleci/redhat-registry.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euvo pipefail
+IFS=$'\n\t'
+
+if [[ $CIRCLE_TAG ]]; then
+  curl -X POST \
+  https://connect.redhat.com/api/v2/projects/$REDHAT_REGISTRY_PID/build \
+  -H "Authorization: Bearer $REDHAT_REGISTRY_KEY" \
+  -H 'Cache-Control: no-cache' \
+  -H 'Content-Type: application/json' \
+  -d '{"tag":"'$CIRCLE_TAG'"}'
+fi


### PR DESCRIPTION
Hits redhat certified image registry to build newly tagged release.