### PR TITLE
[FIX] Enabling `Collapse Embedded Media by Default` was hiding replies and quotes

### DIFF
--- a/packages/rocketchat-message-attachments/client/messageAttachment.html
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.html
@@ -45,22 +45,24 @@
 				</div>
 			{{/if}}
 
-			<div class="attachment-flex">
-				{{#if thumb_url}}
-					<div class="attachment-thumb">
-						<img src="{{fixCordova thumb_url}}">
-					</div>
-				{{/if}}
+			{{#unless collapsed}}
+				<div class="attachment-flex">
+					{{#if thumb_url}}
+						<div class="attachment-thumb">
+							<img src="{{fixCordova thumb_url}}">
+						</div>
+					{{/if}}
 
-				{{#if text}}
-					<div class="attachment-flex-column-grow attachment-text">
-						{{{parsedText}}}
-					</div>
-				{{/if}}
-			</div>
+					{{#if text}}
+						<div class="attachment-flex-column-grow attachment-text">
+							{{{parsedText}}}
+						</div>
+					{{/if}}
+				</div>
+			{{/unless}}
 
 			{{#if image_url}}
-				{{#unless collapsed}}
+				{{#unless mediaCollapsed}}
 					<div class="attachment-image">
 					{{#if loadImage}}
 						<figure>
@@ -89,7 +91,7 @@
 			{{/if}}
 
 			{{#if audio_url}}
-				{{#unless collapsed}}
+				{{#unless mediaCollapsed}}
 					<div class="attachment-audio">
 						<audio controls>
 							<source src="{{fixCordova audio_url}}" type="{{audio_type}}" data-description="{{description}}">
@@ -100,7 +102,7 @@
 			{{/if}}
 
 			{{#if video_url}}
-				{{#unless collapsed}}
+				{{#unless mediaCollapsed}}
 					<div class="attachment-video">
 						<video controls class="inline-video">
 							<source src="{{fixCordova video_url}}" type="{{video_type}}" data-description="{{description}}">

--- a/packages/rocketchat-message-attachments/client/messageAttachment.html
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.html
@@ -45,21 +45,19 @@
 				</div>
 			{{/if}}
 
-			{{#unless collapsed}}
-				<div class="attachment-flex">
-					{{#if thumb_url}}
-						<div class="attachment-thumb">
-							<img src="{{fixCordova thumb_url}}">
-						</div>
-					{{/if}}
+			<div class="attachment-flex">
+				{{#if thumb_url}}
+					<div class="attachment-thumb">
+						<img src="{{fixCordova thumb_url}}">
+					</div>
+				{{/if}}
 
-					{{#if text}}
-						<div class="attachment-flex-column-grow attachment-text">
-							{{{parsedText}}}
-						</div>
-					{{/if}}
-				</div>
-			{{/unless}}
+				{{#if text}}
+					<div class="attachment-flex-column-grow attachment-text">
+						{{{parsedText}}}
+					</div>
+				{{/if}}
+			</div>
 
 			{{#if image_url}}
 				{{#unless collapsed}}

--- a/packages/rocketchat-message-attachments/client/messageAttachment.js
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.js
@@ -54,6 +54,12 @@ Template.messageAttachment.helpers({
 	collapsed() {
 		if (this.collapsed != null) {
 			return this.collapsed;
+		}
+		return false;
+	},
+	mediaCollapsed() {
+		if (this.collapsed != null) {
+			return this.collapsed;
 		} else {
 			const user = Meteor.user();
 			return RocketChat.getUserPreference(user, 'collapseMediaByDefault') === true;


### PR DESCRIPTION
Closes #10424 

Enabling the setting "Collapse Embedded Media by Default" was hiding replies and quotes as well. This pr fixes this.

![image](https://user-images.githubusercontent.com/23701803/38632644-fc5dd2e4-3dda-11e8-8f48-a39e45f93118.png)

