### PR TITLE
[NEW] Prevent the browser to autocomplete some setting fields

### DIFF
--- a/packages/rocketchat-lib/server/functions/settings.js
+++ b/packages/rocketchat-lib/server/functions/settings.js
@@ -74,6 +74,9 @@ RocketChat.settings.add = function(_id, value, options = {}) {
 	if (hiddenSettings[_id] != null) {
 		options.hidden = true;
 	}
+	if (options.autocomplete == null) {
+		options.autocomplete = true;
+	}
 	if (typeof process !== 'undefined' && process.env && process.env[`OVERWRITE_SETTING_${ _id }`]) {
 		let value = process.env[`OVERWRITE_SETTING_${ _id }`];
 		if (value.toLowerCase() === 'true') {

--- a/packages/rocketchat-lib/server/startup/settings.js
+++ b/packages/rocketchat-lib/server/startup/settings.js
@@ -1006,12 +1006,14 @@ RocketChat.settings.addGroup('Email', function() {
 		this.add('SMTP_Username', '', {
 			type: 'string',
 			env: true,
-			i18nLabel: 'Username'
+			i18nLabel: 'Username',
+			autocomplete: false
 		});
 		this.add('SMTP_Password', '', {
 			type: 'password',
 			env: true,
-			i18nLabel: 'Password'
+			i18nLabel: 'Password',
+			autocomplete: false
 		});
 		this.add('From_Email', '', {
 			type: 'string',

--- a/packages/rocketchat-ui-admin/client/admin.html
+++ b/packages/rocketchat-ui-admin/client/admin.html
@@ -56,25 +56,25 @@
 													{{#if multiline}}
 														<textarea class="input-monitor rc-input__element" name="{{_id}}" rows="4" style="height: auto" {{isDisabled}} {{isReadonly}}>{{value}}</textarea>
 													{{else}}
-														<input class="input-monitor rc-input__element" type="text" name="{{_id}}" value="{{value}}" placeholder="{{placeholder}}" {{isDisabled}} {{isReadonly}}/>
+														<input class="input-monitor rc-input__element" type="text" name="{{_id}}" value="{{value}}" placeholder="{{placeholder}}" {{isDisabled}} {{isReadonly}} {{canAutocomplete}}/>
 													{{/if}}
 												{{/if}}
 
 												{{#if $eq type 'relativeUrl'}}
-													<input class="input-monitor rc-input__element" type="text" name="{{_id}}" value="{{relativeUrl value}}" placeholder="{{placeholder}}" {{isDisabled}} {{isReadonly}}/>
+													<input class="input-monitor rc-input__element" type="text" name="{{_id}}" value="{{relativeUrl value}}" placeholder="{{placeholder}}" {{isDisabled}} {{isReadonly}} {{canAutocomplete}}/>
 												{{/if}}
 
 												{{#if $eq type 'password'}}
-													<input class="input-monitor rc-input__element" type="password" name="{{_id}}" value="{{value}}" placeholder="{{placeholder}}" {{isDisabled}} {{isReadonly}}/>
+													<input class="input-monitor rc-input__element" type="password" name="{{_id}}" value="{{value}}" placeholder="{{placeholder}}" {{isDisabled}} {{isReadonly}} {{canAutocomplete}}/>
 												{{/if}}
 
 												{{#if $eq type 'int'}}
-													<input class="input-monitor rc-input__element" type="number" name="{{_id}}" value="{{value}}" placeholder="{{placeholder}}" {{isDisabled}} {{isReadonly}}/>
+													<input class="input-monitor rc-input__element" type="number" name="{{_id}}" value="{{value}}" placeholder="{{placeholder}}" {{isDisabled}} {{isReadonly}} {{canAutocomplete}}/>
 												{{/if}}
 
 												{{#if $eq type 'boolean'}}
-													<label><input class="input-monitor" type="radio" name="{{_id}}" value="1" checked="{{$eq value true}}" {{isDisabled}} {{isReadonly}}/> {{_ "True"}}</label>
-													<label><input class="input-monitor" type="radio" name="{{_id}}" value="0" checked="{{$eq value false}}" {{isDisabled}} {{isReadonly}}/> {{_ "False"}}</label>
+													<label><input class="input-monitor" type="radio" name="{{_id}}" value="1" checked="{{$eq value true}}" {{isDisabled}} {{isReadonly}} {{canAutocomplete}}/> {{_ "True"}}</label>
+													<label><input class="input-monitor" type="radio" name="{{_id}}" value="0" checked="{{$eq value false}}" {{isDisabled}} {{isReadonly}} {{canAutocomplete}}/> {{_ "False"}}</label>
 												{{/if}}
 
 												{{#if $eq type 'select'}}
@@ -103,7 +103,7 @@
 														{{/if}}
 														{{#if $eq editor 'expression'}}
 															<div class="flex-grow-1">
-																<input class="input-monitor rc-input__element" type="text" name="{{_id}}" value="{{value}}" {{isDisabled}}/>
+																<input class="input-monitor rc-input__element" type="text" name="{{_id}}" value="{{value}}" {{isDisabled}} {{canAutocomplete}}/>
 															</div>
 														{{/if}}
 														<div class="color-editor ">
@@ -118,7 +118,7 @@
 												{{/if}}
 
 												{{#if $eq type 'font'}}
-													<input class="input-monitor rc-input__element" type="text" name="{{_id}}" value="{{value}}" {{isDisabled}} {{isReadonly}}/>
+													<input class="input-monitor rc-input__element" type="text" name="{{_id}}" value="{{value}}" {{isDisabled}} {{isReadonly}} {{canAutocomplete}}/>
 												{{/if}}
 
 												{{#if $eq type 'code'}}
@@ -143,7 +143,7 @@
 													{{#if hasChanges section}}
 														<span style="line-height: 40px" class="secondary-font-color">{{_ "Save_to_enable_this_action"}}</span>
 													{{else}}
-														<button type="button" class="button primary action" data-setting="{{_id}}" data-action="{{value}}" {{isDisabled}}>{{_ actionText}}</button>
+														<button type="button" class="button primary action" data-setting="{{_id}}" data-action="{{value}}" {{isDisabled}} >{{_ actionText}}</button>
 													{{/if}}
 												{{/if}}
 

--- a/packages/rocketchat-ui-admin/client/admin.js
+++ b/packages/rocketchat-ui-admin/client/admin.js
@@ -191,6 +191,13 @@ Template.admin.helpers({
 			};
 		}
 	},
+	canAutocomplete() {
+		if (this.autocomplete === false) {
+			return {
+				autocomplete: 'off'
+			};
+		}
+	},
 	hasChanges(section) {
 		const group = FlowRouter.getParam('group');
 		const query = {


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #10137

Adds the autocomplete option to settings, fixing the issue above and opens the possibility to customize the settings a little further.
The autocomplete option still has some issues since browsers do not respect it 100% (see [caniuse](https://caniuse.com/#feat=input-autocomplete-onoff) )