### PR TITLE
[NEW] Shows user's real name on autocomplete popup

### DIFF
--- a/packages/rocketchat-ui/client/components/popupList.html
+++ b/packages/rocketchat-ui/client/components/popupList.html
@@ -19,6 +19,10 @@
 		 <span class="rc-popup-list__item-image">
 			 {{>avatar username=item.username}}
 		 </span>
-		 <span class="rc-popup-list__item-name">{{{modifier item.username}}}</span>
+		 {{#if showRealNames}}
+		 	<span class="rc-popup-list__item-name">{{item.name}} ({{{modifier item.username}}})</span>
+		 {{else}}
+		 	<span class="rc-popup-list__item-name">{{{modifier item.username}}}</span>
+		 {{/if}}
 	</li>
 </template>

--- a/packages/rocketchat-ui/client/components/popupList.js
+++ b/packages/rocketchat-ui/client/components/popupList.js
@@ -29,3 +29,9 @@ Template.popupList_default.helpers({
 		};
 	}
 });
+
+Template.popupList_item_default.helpers({
+	showRealNames() {
+		return RocketChat.settings.get('UI_Use_Real_Name');
+	}
+});


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #9890

This change adds the real name to the user popup list (used for inviting users to channels) when the admin has set the option to Use Real Names.

![image](https://user-images.githubusercontent.com/6303966/38739914-9db94b28-3f0c-11e8-972b-894ad53f233a.png)
