### PR TITLE
[FIX] Remove outdated translations of Internal Hubot's description of Scripts to Load that were pointing to a non existent address

### DIFF
--- a/packages/rocketchat-i18n/i18n/ar.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ar.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "مجلد لتحميل البرامج النصية",
   "InternalHubot_reload": "أعد تحميل النصوص البرمجية",
   "InternalHubot_ScriptsToLoad": "مخطوطات لتحميل",
-  "InternalHubot_ScriptsToLoad_Description": "الرجاء إدخال قائمة مفصولة بفواصل من مخطوطات لتحميل من https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "هذا يجب أن يكون اسم مستخدم صالح من بوت مسجلة على الخادم الخاص بك.",
   "InternalHubot_EnableForChannels": "تمكين للقنوات العامة",
   "InternalHubot_EnableForDirectMessages": "تمكين للرسائل المباشرة",

--- a/packages/rocketchat-i18n/i18n/de-AT.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de-AT.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Ordner zum Laden der Skripte",
   "InternalHubot_reload": "Laden Sie die Skripts neu",
   "InternalHubot_ScriptsToLoad": "Zu ladende Skripte",
-  "InternalHubot_ScriptsToLoad_Description": "Bitte geben Sie eine durch Kommata getrennte Liste von zu ladenden Skripten von https://github.com/github/hubot-scripts/tree/master/src/scripts an.",
   "InternalHubot_Username_Description": "Dies muss ein gültiger Benutzername eines auf dem Server registrierten Bots sein.",
   "InternalHubot_EnableForChannels": "Für öffentliche Kanäle aktivieren",
   "InternalHubot_EnableForDirectMessages": "Aktivieren Sie für direkte Nachrichten",

--- a/packages/rocketchat-i18n/i18n/el.i18n.json
+++ b/packages/rocketchat-i18n/i18n/el.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Φάκελος για τη φόρτωση των σεναρίων",
   "InternalHubot_reload": "Επαναφόρτωση των σεναρίων",
   "InternalHubot_ScriptsToLoad": "Σενάρια για να φορτώσει",
-  "InternalHubot_ScriptsToLoad_Description": "Παρακαλώ εισάγετε μια λίστα χωρισμένη με κόμμα των σεναρίων για να φορτώσει από https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "Αυτό πρέπει να είναι ένα έγκυρο όνομα χρήστη ενός bot καταχωρηθεί στο διακομιστή σας.",
   "InternalHubot_EnableForChannels": "Ενεργοποίηση για δημόσια κανάλια",
   "InternalHubot_EnableForDirectMessages": "Ενεργοποίηση για απευθείας μηνύματα",

--- a/packages/rocketchat-i18n/i18n/fi.i18n.json
+++ b/packages/rocketchat-i18n/i18n/fi.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Arkistoi komentotiedostoja",
   "InternalHubot_reload": "Lataa komentosarjat uudelleen",
   "InternalHubot_ScriptsToLoad": "Ladattavat skriptit",
-  "InternalHubot_ScriptsToLoad_Description": "Syötä pilkuilla erotettu lista skripteistä, jotka ladataan sijainnista https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "Tämän on oltava voimassa oleva käyttäjätunnus rekisteröidylle bot käyttäjätunnukselle.",
   "InternalHubot_EnableForChannels": "Ota käyttöön julkisilla kanavilla",
   "InternalHubot_EnableForDirectMessages": "Ota Direct Viestit",

--- a/packages/rocketchat-i18n/i18n/fr.i18n.json
+++ b/packages/rocketchat-i18n/i18n/fr.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Dossier pour charger les scripts",
   "InternalHubot_reload": "Recharger les scripts",
   "InternalHubot_ScriptsToLoad": "Scripts à charger",
-  "InternalHubot_ScriptsToLoad_Description": "Veuillez entrer une liste de scripts séparés par des virgules à charger depuis https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "Cela doit être un nom d'utilisateur valide d'un bot enregistré sur votre serveur.",
   "InternalHubot_EnableForChannels": "Activer pour les chaînes publiques",
   "InternalHubot_EnableForDirectMessages": "Activer pour les messages directs",

--- a/packages/rocketchat-i18n/i18n/he.i18n.json
+++ b/packages/rocketchat-i18n/i18n/he.i18n.json
@@ -502,7 +502,6 @@
   "Integrations": "שילובים",
   "InternalHubot": "Hubot הפנימי",
   "InternalHubot_ScriptsToLoad": "סקריפטים לטעון",
-  "InternalHubot_ScriptsToLoad_Description": "הזן רשימה מופרדת בפסיקים של סקריפטים לטעון מן https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "זה חייב להיות שם משתמש תקין של בוט רשום בשרת שלך.",
   "Invalid_confirm_pass": "אימות הססמה אינו זהה לססמה",
   "Invalid_email": "כתובת הדוא״ל שהוזנה אינה תקינה",

--- a/packages/rocketchat-i18n/i18n/hr.i18n.json
+++ b/packages/rocketchat-i18n/i18n/hr.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Mapa za učitavanje skripti",
   "InternalHubot_reload": "Ponovno učitajte skripte",
   "InternalHubot_ScriptsToLoad": "Skripte za učitavanje",
-  "InternalHubot_ScriptsToLoad_Description": "Unesite zarezom odvojen popis skripti za učitavanje s https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "Ovo mora biti valjana korisničko ime bota registriranog na vašem poslužitelju.",
   "InternalHubot_EnableForChannels": "Omogućite za javne kanale",
   "InternalHubot_EnableForDirectMessages": "Omogućite za izravne poruke",

--- a/packages/rocketchat-i18n/i18n/hu.i18n.json
+++ b/packages/rocketchat-i18n/i18n/hu.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "A parancsfájlok betöltésére szolgáló mappa",
   "InternalHubot_reload": "Töltse újra a szkripteket",
   "InternalHubot_ScriptsToLoad": "Scripts betölteni",
-  "InternalHubot_ScriptsToLoad_Description": "Kérjük, vesszővel elválasztott listáját szkriptek betölteni https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "Ez kell, hogy legyen egy érvényes felhasználónevet egy bot van regisztrálva a szerveren.",
   "InternalHubot_EnableForChannels": "Engedélyezve a nyilvános csatornákhoz",
   "InternalHubot_EnableForDirectMessages": "Közvetlen üzenetek engedélyezése",

--- a/packages/rocketchat-i18n/i18n/id.i18n.json
+++ b/packages/rocketchat-i18n/i18n/id.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Folder untuk Load Scripts",
   "InternalHubot_reload": "Muat ulang skrip",
   "InternalHubot_ScriptsToLoad": "Script untuk memuat",
-  "InternalHubot_ScriptsToLoad_Description": "Masukkan daftar dipisahkan koma script untuk memuat dari https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "Ini harus menjadi nama pengguna yang valid dari bot terdaftar pada server Anda.",
   "InternalHubot_EnableForChannels": "Aktifkan untuk Saluran Umum",
   "InternalHubot_EnableForDirectMessages": "Aktifkan untuk Pesan Langsung",

--- a/packages/rocketchat-i18n/i18n/ja.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ja.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "スクリプトをロードするフォルダ",
   "InternalHubot_reload": "スクリプトを再読み込みする",
   "InternalHubot_ScriptsToLoad": "ロードするスクリプト",
-  "InternalHubot_ScriptsToLoad_Description": "https://github.com/github/hubot-scripts/tree/master/src/scriptsからロードするためのスクリプトのカンマ区切りリストを入力してください。",
   "InternalHubot_Username_Description": "これは、サーバーに登録されたボットの有効なユーザ名でなければなりません。",
   "InternalHubot_EnableForChannels": "パブリックチャネル用に有効にする",
   "InternalHubot_EnableForDirectMessages": "ダイレクトメッセージを有効にする",

--- a/packages/rocketchat-i18n/i18n/km.i18n.json
+++ b/packages/rocketchat-i18n/i18n/km.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "ថតដើម្បីផ្ទុកស្គ្រីប",
   "InternalHubot_reload": "ផ្ទុកស្គ្រីបឡើងវិញ",
   "InternalHubot_ScriptsToLoad": "ស្គ្រីបដើម្បីផ្ទុក",
-  "InternalHubot_ScriptsToLoad_Description": "សូមបញ្ចូលបញ្ជីបំបែកដោយសញ្ញាក្បៀសរបស់ស្គ្រីបដើម្បីផ្ទុកពី https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "នេះត្រូវតែជាឈ្មោះអ្នកប្រើត្រឹមត្រូវនៃការ Bot ដែលបានចុះបញ្ជីនៅលើម៉ាស៊ីនបម្រើរបស់អ្នក។",
   "InternalHubot_EnableForChannels": "អនុញ្ញាត​សម្រាប់​ឆា​នែ​ល​ជា​សាធារណៈ",
   "InternalHubot_EnableForDirectMessages": "អនុញ្ញាត​សម្រាប់​សារ​ដោយ​ផ្ទាល់",

--- a/packages/rocketchat-i18n/i18n/ko.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ko.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "스크립트를로드 할 폴더",
   "InternalHubot_reload": "스크립트 다시로드",
   "InternalHubot_ScriptsToLoad": "스크립트로드",
-  "InternalHubot_ScriptsToLoad_Description": "https://github.com/github/hubot-scripts/tree/master/src/scripts에서로드 스크립트의 쉼표로 구분 된 목록을 입력하세요",
   "InternalHubot_Username_Description": "이 서버에 등록 된 로봇의 유효한 사용자 이름이어야합니다.",
   "InternalHubot_EnableForChannels": "공공 채널 사용",
   "InternalHubot_EnableForDirectMessages": "직접 메시지를 사용",

--- a/packages/rocketchat-i18n/i18n/ku.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ku.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Peldanka Bi Lifşên Load Bikin",
   "InternalHubot_reload": "Rûpelê nû bike",
   "InternalHubot_ScriptsToLoad": "Nivîsandina ji bo barkirina",
-  "InternalHubot_ScriptsToLoad_Description": "Ji kerema xwe ve lîsteya bêhnok ji hev cuda yên li Skrîpta ji bo barkirina ji https://github.com/github/hubot-scripts/tree/master/src/scripts binivîse",
   "InternalHubot_Username_Description": "Ev, divê navê bikarhêner derbasdar ji bot qeydkirî li ser server te re be.",
   "InternalHubot_EnableForChannels": "Ji bo Channelsên Giştî Çalak bikin",
   "InternalHubot_EnableForDirectMessages": "Ji bo Direct Messages for Enable",

--- a/packages/rocketchat-i18n/i18n/lo.i18n.json
+++ b/packages/rocketchat-i18n/i18n/lo.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "ໂຟເດີທີ່ຈະໂຫລດສະຄິບ",
   "InternalHubot_reload": "Reload the scripts",
   "InternalHubot_ScriptsToLoad": "ອັກສອນເພື່ອການໂຫຼດ",
-  "InternalHubot_ScriptsToLoad_Description": "ກະລຸນາໃສ່ບັນຊີລາຍຊື່ຈຸດແຍກຂອງອັກ​​ສອນເພື່ອການໂຫຼດຈາກ https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "ນີ້ຈະຕ້ອງເປັນຊື່ຜູ້ໃຊ້ທີ່ຖືກຕ້ອງຂອງນາມທີ່ຈົດທະບຽນກ່ຽວກັບເຄື່ອງແມ່ຂ່າຍຂອງທ່ານ.",
   "InternalHubot_EnableForChannels": "ເປີດໃຊ້ສໍາລັບຊ່ອງສາທາລະນະ",
   "InternalHubot_EnableForDirectMessages": "ເປີດໃຊ້ສໍາລັບຂໍ້ຄວາມໂດຍກົງ",

--- a/packages/rocketchat-i18n/i18n/ms-MY.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ms-MY.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Folder untuk Memuatkan Skrip",
   "InternalHubot_reload": "Muat semula skrip",
   "InternalHubot_ScriptsToLoad": "Skrip untuk memuatkan",
-  "InternalHubot_ScriptsToLoad_Description": "Sila masukkan senarai dipisah koma skrip untuk memuatkan dari https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "Ini mesti nama pengguna yang sah daripada bot yang berdaftar pada pelayan anda.",
   "InternalHubot_EnableForChannels": "Dayakan untuk Saluran Awam",
   "InternalHubot_EnableForDirectMessages": "Dayakan Mesej Terus",

--- a/packages/rocketchat-i18n/i18n/nl.i18n.json
+++ b/packages/rocketchat-i18n/i18n/nl.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Map om de scripts te laden",
   "InternalHubot_reload": "Herlaad de scripts",
   "InternalHubot_ScriptsToLoad": "Scripts om te laden",
-  "InternalHubot_ScriptsToLoad_Description": "Geef een door komma's gescheiden lijst met scripts te laden uit https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "Dit moet een geldige gebruikersnaam van een bot geregistreerd op uw server.",
   "InternalHubot_EnableForChannels": "Inschakelen voor publieke zenders",
   "InternalHubot_EnableForDirectMessages": "Inschakelen voor Direct Messages",

--- a/packages/rocketchat-i18n/i18n/pl.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pl.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Folder do wczytywania skryptów",
   "InternalHubot_reload": "Załaduj ponownie skrypty",
   "InternalHubot_ScriptsToLoad": "Skrypty do załadowania",
-  "InternalHubot_ScriptsToLoad_Description": "Wpisz oddzielone przecinkami listę skryptów załadować z https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "To musi być prawidłowa nazwa użytkownika z botem zarejestrowany na serwerze.",
   "InternalHubot_EnableForChannels": "Zezwolenie na kanałach publicznych",
   "InternalHubot_EnableForDirectMessages": "Włącz do wiadomości bezpośrednie",

--- a/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Pasta para carregar os scripts",
   "InternalHubot_reload": "Recarregar os scripts",
   "InternalHubot_ScriptsToLoad": "Scripts para carregar",
-  "InternalHubot_ScriptsToLoad_Description": "Por favor insira uma lista separada por vírgula de scripts para carregar a partir de https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "Este deve ser um nome de usuário válido de um bot registrado em seu servidor.",
   "InternalHubot_EnableForChannels": "Habilitar para canais públicos",
   "InternalHubot_EnableForDirectMessages": "Ativar para mensagens diretas",

--- a/packages/rocketchat-i18n/i18n/pt.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pt.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Pasta para carregar os Scripts",
   "InternalHubot_reload": "Recarregar os scripts",
   "InternalHubot_ScriptsToLoad": "Scripts para carregar",
-  "InternalHubot_ScriptsToLoad_Description": "Por favor insira uma lista separada por vírgula de scripts para carregar a partir de https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "Este deve ser um nome de usuário válido de um bot registrado em seu servidor.",
   "InternalHubot_EnableForChannels": "Ativar para canais públicos",
   "InternalHubot_EnableForDirectMessages": "Ativar para mensagens diretas",

--- a/packages/rocketchat-i18n/i18n/ro.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ro.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Folder pentru încărcarea scripturilor",
   "InternalHubot_reload": "Reîncarcă scripturile",
   "InternalHubot_ScriptsToLoad": "Script-uri pentru a încărca",
-  "InternalHubot_ScriptsToLoad_Description": "Vă rugăm să introduceți o listă separată prin virgulă de script-uri pentru a încărca de la https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "Acest lucru trebuie să fie un nume de utilizator valid al unui bot înregistrat pe server.",
   "InternalHubot_EnableForChannels": "Activați pentru canale publice",
   "InternalHubot_EnableForDirectMessages": "Activați pentru mesaje directe",

--- a/packages/rocketchat-i18n/i18n/ru.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ru.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Папка для загрузки скриптов",
   "InternalHubot_reload": "Перезагрузить скрипты",
   "InternalHubot_ScriptsToLoad": "Скрипты для загрузки",
-  "InternalHubot_ScriptsToLoad_Description": "Пожалуйста, введите разделенный запятыми список скриптов для загрузки из вашей папки. Скрипты можно скачать здесь: https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "Должно быть действительным логином бота, зарегистрированным на сервере.",
   "InternalHubot_EnableForChannels": "Включить для публичных каналов",
   "InternalHubot_EnableForDirectMessages": "Включить для личных сообщений",

--- a/packages/rocketchat-i18n/i18n/sq.i18n.json
+++ b/packages/rocketchat-i18n/i18n/sq.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Dosja për të ngarkuar skriptet",
   "InternalHubot_reload": "Rifresko skriptet",
   "InternalHubot_ScriptsToLoad": "Scripts për të ngarkuar",
-  "InternalHubot_ScriptsToLoad_Description": "Ju lutem shkruani një presje të ndara listë të Scripts për të ngarkuar nga https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "Kjo duhet të jetë një emër përdoruesi i vlefshëm i një bot të regjistruar në serverin tuaj.",
   "InternalHubot_EnableForChannels": "Aktivizo për kanalet publike",
   "InternalHubot_EnableForDirectMessages": "Aktivizo për Mesazhet e Drejtpërdrejta",

--- a/packages/rocketchat-i18n/i18n/sr.i18n.json
+++ b/packages/rocketchat-i18n/i18n/sr.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Фолдер за учитавање скрипте",
   "InternalHubot_reload": "Поново учитајте скрипте",
   "InternalHubot_ScriptsToLoad": "Скрипте за учитавање",
-  "InternalHubot_ScriptsToLoad_Description": "Унесите зарезом одвојена листа сценарија за учитавање од хттпс://гитхуб.цом/гитхуб/хубот-сцриптс/трее/мастер/срц/сцриптс",
   "InternalHubot_Username_Description": "Ово мора бити валидна корисничко име бот регистрована на серверу.",
   "InternalHubot_EnableForChannels": "Омогући за јавне канале",
   "InternalHubot_EnableForDirectMessages": "Омогућите директне поруке",

--- a/packages/rocketchat-i18n/i18n/sv.i18n.json
+++ b/packages/rocketchat-i18n/i18n/sv.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Mapp för att ladda skript",
   "InternalHubot_reload": "Ladda om skript",
   "InternalHubot_ScriptsToLoad": "Skript för att ladda",
-  "InternalHubot_ScriptsToLoad_Description": "Ange en kommaseparerad lista med skript för att ladda från https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "Detta måste vara ett giltigt användarnamn av en bot är registrerad på din server.",
   "InternalHubot_EnableForChannels": "Aktivera för offentliga kanaler",
   "InternalHubot_EnableForDirectMessages": "Aktivera direktmeddelanden",

--- a/packages/rocketchat-i18n/i18n/ta-IN.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ta-IN.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "ஸ்கிரிப்ட்களை ஏற்ற கோப்புறை",
   "InternalHubot_reload": "ஸ்கிரிப்ட்களை மீண்டும் ஏற்றவும்",
   "InternalHubot_ScriptsToLoad": "ஸ்கிரிப்டை ஏற்ற",
-  "InternalHubot_ScriptsToLoad_Description": "https://github.com/github/hubot-scripts/tree/master/src/scripts இருந்து ஏற்ற தயவு செய்து திரைக்கதை ஒரு கமா பிரிக்கப்பட்ட பட்டியலில் நுழைய",
   "InternalHubot_Username_Description": "இந்த உங்கள் சர்வரில் பதிவு ஒரு பொட் சரியான பயனர் பெயர் இருக்க வேண்டும்.",
   "InternalHubot_EnableForChannels": "பொது சேனல்களுக்கு இயக்கு",
   "InternalHubot_EnableForDirectMessages": "நேரடி செய்திகளை இயக்கவும்",

--- a/packages/rocketchat-i18n/i18n/tr.i18n.json
+++ b/packages/rocketchat-i18n/i18n/tr.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Komut Dosyalarını Yüklemek İçin Klasör",
   "InternalHubot_reload": "Komut dosyalarını yeniden yükle",
   "InternalHubot_ScriptsToLoad": "Scripts yüklemek için",
-  "InternalHubot_ScriptsToLoad_Description": "https://github.com/github/hubot-scripts/tree/master/src/scripts yüklemek için komut bir virgülle ayrılmış listesini girin",
   "InternalHubot_Username_Description": "Bu sunucuda kayıtlı bir bot geçerli bir kullanıcı adı olmalıdır.",
   "InternalHubot_EnableForChannels": "Herkese Açık Kanallar için Etkinleştir",
   "InternalHubot_EnableForDirectMessages": "Doğru Mesajları Etkinleştir",

--- a/packages/rocketchat-i18n/i18n/ug.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ug.i18n.json
@@ -500,7 +500,6 @@
   "Integrations": "توپلاشتۇرۇش",
   "InternalHubot": "ئىچكى Hubot",
   "InternalHubot_ScriptsToLoad": "ئىسكىرپت تېخى يۈكلەنمىدى",
-  "InternalHubot_ScriptsToLoad_Description": "لىق ئايرىپ تۇرىدىغان ئىسكرىپت تىزىملىكىنى كىرگۈزۈڭ دىن يۈكلەڭhttps://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "بۇ چوقۇم سىزنىڭ مۇلازىمىتېردە تىزىملاتقان بىر ئىناۋەتلىك ئەزا بولۇشى كېرەك.",
   "Invalid_confirm_pass": "ئىككىنچى قېتىم كىرگۈزۈلگەن مەخپىي نومۇر بىلەن بىرىنچى قېتىم كىرگۈزۈلگىنى بىلەن ماس كەلمىدى.",
   "Invalid_email": "كىرگۈزۈلگەن ئىلخەت ئادرېسى ئىناۋەتسىز",

--- a/packages/rocketchat-i18n/i18n/uk.i18n.json
+++ b/packages/rocketchat-i18n/i18n/uk.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "Папка для завантаження скриптів",
   "InternalHubot_reload": "Перезавантажте скрипти",
   "InternalHubot_ScriptsToLoad": "Сценарії для завантаження",
-  "InternalHubot_ScriptsToLoad_Description": "Будь ласка, введіть розділений комами список скриптів для завантаження з https://github.com/github/hubot-scripts/tree/master/src/scripts",
   "InternalHubot_Username_Description": "Це повинно бути дійсним ім'ям користувача бота, зареєстрований на сервері.",
   "InternalHubot_EnableForChannels": "Увімкнути для публічних каналів",
   "InternalHubot_EnableForDirectMessages": "Увімкнути для прямих повідомлень",

--- a/packages/rocketchat-i18n/i18n/zh-TW.i18n.json
+++ b/packages/rocketchat-i18n/i18n/zh-TW.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "加載腳本的文件夾",
   "InternalHubot_reload": "重新加載腳本",
   "InternalHubot_ScriptsToLoad": "腳本加載",
-  "InternalHubot_ScriptsToLoad_Description": "請輸入一個逗號分隔的腳本列表從https://github.com/github/hubot-scripts/tree/master/src/scripts加載",
   "InternalHubot_Username_Description": "這必須是您的服務器上註冊的bot的一個有效的用戶名。",
   "InternalHubot_EnableForChannels": "啟用公共頻道",
   "InternalHubot_EnableForDirectMessages": "啟用直接消息",

--- a/packages/rocketchat-i18n/i18n/zh.i18n.json
+++ b/packages/rocketchat-i18n/i18n/zh.i18n.json
@@ -953,7 +953,6 @@
   "InternalHubot_PathToLoadCustomScripts": "加载脚本的文件夹",
   "InternalHubot_reload": "重新加载脚本",
   "InternalHubot_ScriptsToLoad": "需要加载的脚本",
-  "InternalHubot_ScriptsToLoad_Description": "请输入一个逗号分隔的脚本列表从https://github.com/github/hubot-scripts/tree/master/src/scripts加载",
   "InternalHubot_Username_Description": "这必须是您的服务器上注册的bot的一个有效的用户名。",
   "InternalHubot_EnableForChannels": "启用公共频道",
   "InternalHubot_EnableForDirectMessages": "启用直接消息",


### PR DESCRIPTION
Closes #10097 

Removed translations that were still pointing to the old hubot scripts repo, as they are now misleading.