### PR TITLE
[FIX] Messages was grouping wrong some times when server is slow

### DIFF
--- a/packages/rocketchat-ui-message/client/message.js
+++ b/packages/rocketchat-ui-message/client/message.js
@@ -372,7 +372,7 @@ Template.message.onViewRendered = function(context) {
 			if (nextDataset.groupable !== 'false') {
 				if (nextDataset.username !== currentDataset.username || parseInt(nextDataset.timestamp) - parseInt(currentDataset.timestamp) > RocketChat.settings.get('Message_GroupingPeriod') * 1000) {
 					$nextNode.removeClass('sequential');
-				} else if (!$nextNode.hasClass('new-day')) {
+				} else if (!$nextNode.hasClass('new-day') && !$currentNode.hasClass('temp')) {
 					$nextNode.addClass('sequential');
 				}
 			}

--- a/packages/rocketchat-ui-message/client/message.js
+++ b/packages/rocketchat-ui-message/client/message.js
@@ -339,7 +339,20 @@ Template.message.onViewRendered = function(context) {
 	return this._domrange.onAttached(function(domRange) {
 		const currentNode = domRange.lastNode();
 		const currentDataset = currentNode.dataset;
-		const previousNode = currentNode.previousElementSibling;
+		const getPreviousSentMessage = (currentNode) => {
+			if ($(currentNode).hasClass('temp')) {
+				return currentNode.previousElementSibling;
+			} else if (currentNode.previousElementSibling != null) {
+				let previousValid = currentNode.previousElementSibling;
+				while (previousValid != null && $(previousValid).hasClass('temp')) {
+					previousValid = previousValid.previousElementSibling;
+				}
+				return previousValid;
+			} else {
+				return null;
+			}
+		};
+		const previousNode = getPreviousSentMessage(currentNode);//currentNode.previousElementSibling; //getPreviousSentMessage(currentNode);
 		const nextNode = currentNode.nextElementSibling;
 		const $currentNode = $(currentNode);
 		const $nextNode = $(nextNode);

--- a/packages/rocketchat-ui-message/client/message.js
+++ b/packages/rocketchat-ui-message/client/message.js
@@ -342,17 +342,16 @@ Template.message.onViewRendered = function(context) {
 		const getPreviousSentMessage = (currentNode) => {
 			if ($(currentNode).hasClass('temp')) {
 				return currentNode.previousElementSibling;
-			} else if (currentNode.previousElementSibling != null) {
+			}
+			if (currentNode.previousElementSibling != null) {
 				let previousValid = currentNode.previousElementSibling;
 				while (previousValid != null && $(previousValid).hasClass('temp')) {
 					previousValid = previousValid.previousElementSibling;
 				}
 				return previousValid;
-			} else {
-				return null;
 			}
 		};
-		const previousNode = getPreviousSentMessage(currentNode);//currentNode.previousElementSibling; //getPreviousSentMessage(currentNode);
+		const previousNode = getPreviousSentMessage(currentNode);
 		const nextNode = currentNode.nextElementSibling;
 		const $currentNode = $(currentNode);
 		const $nextNode = $(nextNode);

--- a/packages/rocketchat-ui/client/lib/RoomManager.js
+++ b/packages/rocketchat-ui/client/lib/RoomManager.js
@@ -223,7 +223,7 @@ const RoomManager = new function() {
 };
 
 const loadMissedMessages = function(rid) {
-	const lastMessage = ChatMessage.findOne({rid}, {sort: {ts: -1}, limit: 1});
+	const lastMessage = ChatMessage.findOne({rid, temp: { $exists: false } }, {sort: {ts: -1}, limit: 1});
 	if (lastMessage == null) {
 		return;
 	}


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #9926

Tested locally with @geekgonecrazy's script for load testing and this seems to fix most of the issues.

Reproducing while offline (Messages on the right are grouped with the wrong user)
![image](http://g.recordit.co/thnVuLeH3g.gif)

After fix:
![image](http://g.recordit.co/XyooSOQeOD.gif)
Even though the timestamp is not respected, the messages are grouped correctly.