### PR TITLE
[FIX] Missing user data on files uploaded through the API

### DIFF
--- a/packages/rocketchat-api/server/v1/rooms.js
+++ b/packages/rocketchat-api/server/v1/rooms.js
@@ -76,7 +76,8 @@ RocketChat.API.v1.addRoute('rooms.upload/:rid', { authRequired: true }, {
 			name: file.filename,
 			size: file.fileBuffer.length,
 			type: file.mimetype,
-			rid: this.urlParams.rid
+			rid: this.urlParams.rid,
+			userId: this.userId
 		};
 
 		Meteor.runAsUser(this.userId, () => {

--- a/server/publications/roomFiles.js
+++ b/server/publications/roomFiles.js
@@ -7,11 +7,11 @@ Meteor.publish('roomFiles', function(rid, limit = 50) {
 
 	const cursorFileListHandle = RocketChat.models.Uploads.findNotHiddenFilesOfRoom(rid, limit).observeChanges({
 		added(_id, record) {
-			const {username, name} = RocketChat.models.Users.findOneById(record.userId);
+			const {username, name} = record.userId ? RocketChat.models.Users.findOneById(record.userId) : {};
 			return pub.added('room_files', _id, {...record, user:{username, name}});
 		},
 		changed(_id, record) {
-			const {username, name} = RocketChat.models.Users.findOneById(record.userId);
+			const {username, name} = record.userId ? RocketChat.models.Users.findOneById(record.userId) : {};
 			return pub.changed('room_files', _id, {...record, user:{username, name}});
 		},
 		removed(_id, record) {


### PR DESCRIPTION
Closes #10449 

Files uploaded through the API were missing the userId of the uploader. This caused those files to not be included in some endpoints.