### PR TITLE
[FIX] Dropdown elements were using old styles

### DIFF
--- a/packages/rocketchat-theme/client/imports/forms/select.css
+++ b/packages/rocketchat-theme/client/imports/forms/select.css
@@ -45,6 +45,8 @@
 
 		width: 100%;
 
+		line-height: 1rem !important;
+
 		&::-ms-expand {
 			display: none;
 		}

--- a/packages/rocketchat-ui-account/client/accountPreferences.html
+++ b/packages/rocketchat-ui-account/client/accountPreferences.html
@@ -14,8 +14,8 @@
 						<div class="section-content border-component-color">
 							<div class="input-line double-col">
 								<label for="language">{{_ "Language"}}</label>
-								<div>
-									<select id="language" class="required rc-input__element">
+								<div class="rc-select">
+									<select id="language" class="required rc-select__element">
 										{{#each languages}}
 											<option value="{{key}}" selected="{{userLanguage key}}" dir="auto">{{name}}</option>
 										{{/each}}
@@ -78,8 +78,8 @@
 							</div>
 							<div class="input-line double-col" id="desktopNotifications">
 								<label>{{_ "Notification_Desktop_Default_For"}}</label>
-								<div>
-									<select class="input-monitor rc-input__element" name="desktopNotifications">
+								<div class="rc-select">
+									<select class="input-monitor rc-select__element" name="desktopNotifications">
 										<option value="default" selected="{{selected 'desktopNotifications' 'default' 'default'}}">{{_ "Default"}} ({{_ defaultDesktopNotification}})</option>
 										<option value="all" selected="{{selected 'desktopNotifications' 'all' 'default'}}">{{_ "All_messages"}}</option>
 										<option value="mentions" selected="{{selected 'desktopNotifications' 'mentions' 'default'}}">{{_ "Mentions"}}</option>
@@ -89,8 +89,8 @@
 							</div>
 							<div class="input-line double-col" id="mobileNotifications">
 								<label>{{_ "Notification_Mobile_Default_For"}}</label>
-								<div>
-									<select class="input-monitor rc-input__element" name="mobileNotifications">
+								<div class="rc-select">
+									<select class="input-monitor rc-select__element" name="mobileNotifications">
 										<option value="default" selected="{{selected 'mobileNotifications' 'default' 'default'}}">{{_ "Default"}} ({{_ defaultMobileNotification}})</option>
 										<option value="all" selected="{{selected 'mobileNotifications' 'all' 'default'}}">{{_ "All_messages"}}</option>
 										<option value="mentions" selected="{{selected 'mobileNotifications' 'mentions' 'default'}}">{{_ "Mentions"}}</option>
@@ -101,10 +101,12 @@
 							<div class="input-line double-col" id="emailNotificationMode">
 								<label>{{_ "Email_Notification_Mode"}}</label>
 								<div>
-									<select class="input-monitor rc-input__element" name="emailNotificationMode">
-										<option value="disabled" selected="{{selected 'emailNotificationMode' 'disabled'}}">{{_ "Email_Notification_Mode_Disabled"}}</option>
-										<option value="all" selected="{{selected 'emailNotificationMode' 'all'}}">{{_ "Email_Notification_Mode_All"}}</option>
-									</select>
+									<div class="rc-select">
+										<select class="input-monitor rc-select__element" name="emailNotificationMode">
+											<option value="disabled" selected="{{selected 'emailNotificationMode' 'disabled'}}">{{_ "Email_Notification_Mode_Disabled"}}</option>
+											<option value="all" selected="{{selected 'emailNotificationMode' 'all'}}">{{_ "Email_Notification_Mode_All"}}</option>
+										</select>
+									</div>
 									<div class="info">{{_ "You_need_to_verifiy_your_email_address_to_get_notications"}}</div>
 								</div>
 							</div>
@@ -208,22 +210,26 @@
 							<div class="input-line double-col" id="messageViewMode">
 								<label>{{_ "View_mode"}}</label>
 								<div>
-									<select class="input-monitor rc-input__element" name="messageViewMode">
-										<option value="0" selected="{{selected 'messageViewMode' 0}}">{{_ "Normal"}}</option>
-										<option value="1" selected="{{selected 'messageViewMode' 1}}">{{_ "Cozy"}}</option>
-										<option value="2" selected="{{selected 'messageViewMode' 2}}">{{_ "Compact"}}</option>
-									</select>
+									<div class="rc-select">
+										<select class="input-monitor rc-select__element" name="messageViewMode">
+											<option value="0" selected="{{selected 'messageViewMode' 0}}">{{_ "Normal"}}</option>
+											<option value="1" selected="{{selected 'messageViewMode' 1}}">{{_ "Cozy"}}</option>
+											<option value="2" selected="{{selected 'messageViewMode' 2}}">{{_ "Compact"}}</option>
+										</select>
+									</div>
 									<div class="info">{{_ "Message_view_mode_info"}}</div>
 								</div>
 							</div>
 							<div class="input-line double-col" id="sendOnEnter">
 								<label>{{_ "Enter_Behaviour"}}</label>
 								<div>
-									<select class="input-monitor rc-input__element" name="sendOnEnter">
-										<option value="normal" selected="{{selected 'sendOnEnter' 'normal'}}">{{_ "Enter_Normal"}}</option>
-										<option value="alternative" selected="{{selected 'sendOnEnter' 'alternative'}}">{{_ "Enter_Alternative"}}</option>
-										<option value="desktop" selected="{{selected 'sendOnEnter' 'desktop'}}">{{_ "Only_On_Desktop"}}</option>
-									</select>
+									<div class="rc-select">
+										<select class="input-monitor rc-select__element" name="sendOnEnter">
+											<option value="normal" selected="{{selected 'sendOnEnter' 'normal'}}">{{_ "Enter_Normal"}}</option>
+											<option value="alternative" selected="{{selected 'sendOnEnter' 'alternative'}}">{{_ "Enter_Alternative"}}</option>
+											<option value="desktop" selected="{{selected 'sendOnEnter' 'desktop'}}">{{_ "Only_On_Desktop"}}</option>
+										</select>
+									</div>
 									<div class="info">{{_ "Enter_Behaviour_Description"}}</div>
 								</div>
 							</div>
@@ -258,8 +264,8 @@
 						<div class="section-content border-component-color">
 							<div class="input-line double-col">
 								<label>{{_ "New_Room_Notification"}}</label>
-								<div>
-									<select name="newRoomNotification" class="audio rc-input__element">
+								<div class="rc-select">
+									<select name="newRoomNotification" class="audio rc-select__element">
 										<option value="none" selected="{{$eq newRoomNotification 'none'}}">{{_ "None"}}</option>
 										<option value="door" selected="{{$eq newRoomNotification 'door'}}">Door ({{_ "Default"}})</option>
 										{{#each audioAssets}}
@@ -270,8 +276,8 @@
 							</div>
 							<div class="input-line double-col">
 								<label>{{_ "New_Message_Notification"}}</label>
-								<div>
-									<select name="newMessageNotification" class="audio rc-input__element">
+								<div class="rc-select">
+									<select name="newMessageNotification" class="audio rc-select__element">
 										<option value="none" selected="{{$eq newMessageNotification 'none'}}">{{_ "None"}}</option>
 										<option value="chime" selected="{{$eq newMessageNotification 'chime'}}">Chime ({{_ "Default"}})</option>
 										{{#each audioAssets}}

--- a/packages/rocketchat-ui-account/client/accountPreferences.html
+++ b/packages/rocketchat-ui-account/client/accountPreferences.html
@@ -20,6 +20,7 @@
 											<option value="{{key}}" selected="{{userLanguage key}}" dir="auto">{{name}}</option>
 										{{/each}}
 									</select>
+									{{> icon block="rc-select__arrow" icon="arrow-down" }}
 								</div>
 							</div>
 						</div>
@@ -85,6 +86,7 @@
 										<option value="mentions" selected="{{selected 'desktopNotifications' 'mentions' 'default'}}">{{_ "Mentions"}}</option>
 										<option value="nothing" selected="{{selected 'desktopNotifications' 'nothing' 'default'}}">{{_ "Nothing"}}</option>
 									</select>
+									{{> icon block="rc-select__arrow" icon="arrow-down" }}
 								</div>
 							</div>
 							<div class="input-line double-col" id="mobileNotifications">
@@ -96,6 +98,7 @@
 										<option value="mentions" selected="{{selected 'mobileNotifications' 'mentions' 'default'}}">{{_ "Mentions"}}</option>
 										<option value="nothing" selected="{{selected 'mobileNotifications' 'nothing' 'default'}}">{{_ "Nothing"}}</option>
 									</select>
+									{{> icon block="rc-select__arrow" icon="arrow-down" }}
 								</div>
 							</div>
 							<div class="input-line double-col" id="emailNotificationMode">
@@ -106,6 +109,7 @@
 											<option value="disabled" selected="{{selected 'emailNotificationMode' 'disabled'}}">{{_ "Email_Notification_Mode_Disabled"}}</option>
 											<option value="all" selected="{{selected 'emailNotificationMode' 'all'}}">{{_ "Email_Notification_Mode_All"}}</option>
 										</select>
+										{{> icon block="rc-select__arrow" icon="arrow-down" }}
 									</div>
 									<div class="info">{{_ "You_need_to_verifiy_your_email_address_to_get_notications"}}</div>
 								</div>
@@ -216,6 +220,7 @@
 											<option value="1" selected="{{selected 'messageViewMode' 1}}">{{_ "Cozy"}}</option>
 											<option value="2" selected="{{selected 'messageViewMode' 2}}">{{_ "Compact"}}</option>
 										</select>
+										{{> icon block="rc-select__arrow" icon="arrow-down" }}
 									</div>
 									<div class="info">{{_ "Message_view_mode_info"}}</div>
 								</div>
@@ -229,6 +234,7 @@
 											<option value="alternative" selected="{{selected 'sendOnEnter' 'alternative'}}">{{_ "Enter_Alternative"}}</option>
 											<option value="desktop" selected="{{selected 'sendOnEnter' 'desktop'}}">{{_ "Only_On_Desktop"}}</option>
 										</select>
+										{{> icon block="rc-select__arrow" icon="arrow-down" }}
 									</div>
 									<div class="info">{{_ "Enter_Behaviour_Description"}}</div>
 								</div>
@@ -272,6 +278,7 @@
 											<option value="{{_id}}" selected="{{$eq newRoomNotification _id}}">{{name}}</option>
 										{{/each}}
 									</select>
+									{{> icon block="rc-select__arrow" icon="arrow-down" }}
 								</div>
 							</div>
 							<div class="input-line double-col">
@@ -284,6 +291,7 @@
 											<option value="{{_id}}" selected="{{$eq newMessageNotification _id}}">{{name}}</option>
 										{{/each}}
 									</select>
+									{{> icon block="rc-select__arrow" icon="arrow-down" }}
 								</div>
 							</div>
 							<div class="input-line double-col" id="muteFocusedConversations">

--- a/packages/rocketchat-ui-admin/client/admin.html
+++ b/packages/rocketchat-ui-admin/client/admin.html
@@ -78,11 +78,13 @@
 												{{/if}}
 
 												{{#if $eq type 'select'}}
-													<select class="input-monitor rc-input__element" name="{{_id}}" {{isDisabled}} {{isReadonly}}>
-														{{#each values}}
-															<option value="{{key}}" selected="{{selectedOption ../_id key}}">{{_ i18nLabel}}</option>
-														{{/each}}
-													</select>
+													<div class="rc-select">
+														<select class="input-monitor rc-select__element" name="{{_id}}" {{isDisabled}} {{isReadonly}}>
+															{{#each values}}
+																<option value="{{key}}" selected="{{selectedOption ../_id key}}">{{_ i18nLabel}}</option>
+															{{/each}}
+														</select>
+													</div>
 												{{/if}}
 
 												{{#if $eq type 'language'}}

--- a/packages/rocketchat-ui-admin/client/admin.html
+++ b/packages/rocketchat-ui-admin/client/admin.html
@@ -88,11 +88,13 @@
 												{{/if}}
 
 												{{#if $eq type 'language'}}
-													<select class="input-monitor rc-input__element" name="{{_id}}" {{isDisabled}} {{isReadonly}}>
-														{{#each languages}}
-														<option value="{{key}}" selected="{{appLanguage key}}" dir="auto">{{name}}</option>
-														{{/each}}
-													</select>
+													<div class="rc-select">
+														<select class="input-monitor rc-select__element" name="{{_id}}" {{isDisabled}} {{isReadonly}}>
+															{{#each languages}}
+															<option value="{{key}}" selected="{{appLanguage key}}" dir="auto">{{name}}</option>
+															{{/each}}
+														</select>
+													</div>
 												{{/if}}
 
 												{{#if $eq type 'color'}}

--- a/packages/rocketchat-ui-admin/client/admin.html
+++ b/packages/rocketchat-ui-admin/client/admin.html
@@ -84,6 +84,7 @@
 																<option value="{{key}}" selected="{{selectedOption ../_id key}}">{{_ i18nLabel}}</option>
 															{{/each}}
 														</select>
+														{{> icon block="rc-select__arrow" icon="arrow-down" }}
 													</div>
 												{{/if}}
 
@@ -94,6 +95,7 @@
 															<option value="{{key}}" selected="{{appLanguage key}}" dir="auto">{{name}}</option>
 															{{/each}}
 														</select>
+														{{> icon block="rc-select__arrow" icon="arrow-down" }}
 													</div>
 												{{/if}}
 


### PR DESCRIPTION
Closes [my promise](https://github.com/RocketChat/Rocket.Chat/pull/9883#issuecomment-368663288) to @karlprieb.

This PR changes all dropdown element types from rc-input__element to rc-select__element.

Two more things:
1. The dropdown has still a cut off at the bottom (like any other dropdown in RC). May someone can give me a hand with that? :)
2. Is it possible to remove the margin ("0.5rem 0") from the rc-select element? Looks a lot better without it.


**Before (User UI):**
![screen shot 2018-04-17 at 22 17 28](https://user-images.githubusercontent.com/4711233/38894346-3d32ff86-428d-11e8-8624-0fbc895740ce.png)

**After (User UI):**
![screen shot 2018-04-17 at 22 17 21](https://user-images.githubusercontent.com/4711233/38894336-373113c0-428d-11e8-93b2-94c68d27954b.png)


**Before (Admin UI):**
![screen shot 2018-04-17 at 22 17 53](https://user-images.githubusercontent.com/4711233/38894355-439a0482-428d-11e8-8803-b6f781e5aef3.png)

**After (Admin UI):**
![screen shot 2018-04-17 at 22 13 43](https://user-images.githubusercontent.com/4711233/38894359-4b185588-428d-11e8-916f-bdb54039f8f7.png)
