### PR TITLE
[FIX] Links being embedded inside of blockquotes

### DIFF
--- a/packages/rocketchat-lib/server/functions/sendMessage.js
+++ b/packages/rocketchat-lib/server/functions/sendMessage.js
@@ -26,14 +26,30 @@ RocketChat.sendMessage = function(user, message, room, upsert = false) {
 	}
 
 	if (message.parseUrls !== false) {
-		const urls = message.msg.match(/([A-Za-z]{3,9}):\/\/([-;:&=\+\$,\w]+@{1})?([-A-Za-z0-9\.]+)+:?(\d+)?((\/[-\+=!:~%\/\.@\,\(\)\w]*)?\??([-\+=&!:;%@\/\.\,\w]+)?(?:#([^\s\)]+))?)?/g);
-
+		const urlRegex = /([A-Za-z]{3,9}):\/\/([-;:&=\+\$,\w]+@{1})?([-A-Za-z0-9\.]+)+:?(\d+)?((\/[-\+=!:~%\/\.@\,\(\)\w]*)?\??([-\+=&!:;%@\/\.\,\w]+)?(?:#([^\s\)]+))?)?/g;
+		const urls = message.msg.match(urlRegex);
 		if (urls) {
-			message.urls = urls.map(function(url) {
-				return {
-					url
-				};
-			});
+			// ignoredUrls contain blocks of quotes with urls inside
+			const ignoredUrls = message.msg.match(/(?:(?:\`{1,3})(?:[\n\r]*?.*?)*?)(([A-Za-z]{3,9}):\/\/([-;:&=\+\$,\w]+@{1})?([-A-Za-z0-9\.]+)+:?(\d+)?((\/[-\+=!:~%\/\.@\,\(\)\w]*)?\??([-\+=&!:;%@\/\.\,\w]+)?(?:#([^\s\)]+))?)?)(?:(?:[\n\r]*.*?)*?(?:\`{1,3}))/gm);
+			if (ignoredUrls) {
+				ignoredUrls.forEach((url) => {
+					const shouldBeIgnored = url.match(urlRegex);
+					if (shouldBeIgnored) {
+						shouldBeIgnored.forEach((match) => {
+							const matchIndex = urls.indexOf(match);
+							urls.splice(matchIndex, 1);
+						});
+					}
+				});
+			}
+			if (urls) {
+				// use the Set to remove duplicity, so it doesn't embed the same link twice
+				message.urls = [...new Set(urls)].map(function(url) {
+					return {
+						url
+					};
+				});
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #9942 

Since Javascript Regexp currently does not support lookbehind, we needed to match all urls and urls specifically inside blockquotes so we could remove those later. Used this change to remove duplicity in links embeded when the same URL appeared more than once.

![image](http://g.recordit.co/SI8d6pcilz.gif)