### PR TITLE
[FIX] [Re #9998] Displays the quoted or replied message above instead of below

### DIFF
--- a/packages/rocketchat-ui-message/client/message.html
+++ b/packages/rocketchat-ui-message/client/message.html
@@ -59,15 +59,15 @@
 			{{#if isSnippet}}
 				<div class="snippet-name">{{_ "Snippet_name"}}: {{snippetName}}</div>
 			{{/if}}
+			{{#each attachments}}
+				{{injectIndex . @index}} {{> messageAttachment}}
+			{{/each}}
 			{{{body}}}
 			{{#if hasOembed}}
 				{{#each urls}}
 					{{injectIndex . @index}} {{> oembedBaseWidget}}
 				{{/each}}
 			{{/if}}
-			{{#each attachments}}
-				{{injectIndex . @index}} {{> messageAttachment}}
-			{{/each}}
 		</div>
 		{{#with readReceipt}}
 		<div class="read-receipt {{readByEveryone}}">


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->
Closes #9799
When replying to or quoting a message the quoted text appears above and the reply message below it, similar to WhatsApp.
![screenshot from 2018-04-18 23-28-11](https://user-images.githubusercontent.com/22556377/38949587-6b84d5d4-4360-11e8-96f1-3361fff4a436.png)

The attachments are still placed as they were before.

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
