### PR TITLE
[FIX] Rename method to clean history of messages

### DIFF
--- a/packages/rocketchat-api/server/helpers/deprecationWarning.js
+++ b/packages/rocketchat-api/server/helpers/deprecationWarning.js
@@ -2,7 +2,10 @@ RocketChat.API.helperMethods.set('deprecationWarning', function _deprecationWarn
 	const warningMessage = `The endpoint "${ endpoint }" is deprecated and will be removed after version ${ versionWillBeRemove }`;
 	console.warn(warningMessage);
 	if (process.env.NODE_ENV === 'development') {
-		response.warning = warningMessage;
+		return {
+			warning: warningMessage,
+			...response
+		};
 	}
 
 	return response;

--- a/packages/rocketchat-api/server/v1/channels.js
+++ b/packages/rocketchat-api/server/v1/channels.js
@@ -83,6 +83,10 @@ RocketChat.API.v1.addRoute('channels.archive', { authRequired: true }, {
 	}
 });
 
+/**
+ DEPRECATED
+ // TODO: Remove this after three versions have been released. That means at 0.67 this should be gone.
+ **/
 RocketChat.API.v1.addRoute('channels.cleanHistory', { authRequired: true }, {
 	post() {
 		const findResult = findChannelByIdOrName({ params: this.requestParams() });
@@ -107,7 +111,10 @@ RocketChat.API.v1.addRoute('channels.cleanHistory', { authRequired: true }, {
 			Meteor.call('cleanChannelHistory', { roomId: findResult._id, latest, oldest, inclusive });
 		});
 
-		return RocketChat.API.v1.success();
+		return RocketChat.API.v1.success(this.deprecationWarning({
+			endpoint: 'channels.cleanHistory',
+			versionWillBeRemove: 'v0.67'
+		}));
 	}
 });
 
@@ -519,7 +526,11 @@ RocketChat.API.v1.addRoute('channels.members', { authRequired: true }, {
 
 RocketChat.API.v1.addRoute('channels.messages', { authRequired: true }, {
 	get() {
-		const findResult = findChannelByIdOrName({ params: this.requestParams(), checkedArchived: false, returnUsernames: true });
+		const findResult = findChannelByIdOrName({
+			params: this.requestParams(),
+			checkedArchived: false,
+			returnUsernames: true
+		});
 		const { offset, count } = this.getPaginationItems();
 		const { sort, fields, query } = this.parseJsonQuery();
 

--- a/packages/rocketchat-api/server/v1/rooms.js
+++ b/packages/rocketchat-api/server/v1/rooms.js
@@ -155,3 +155,31 @@ RocketChat.API.v1.addRoute('rooms.favorite', { authRequired: true }, {
 	}
 });
 
+RocketChat.API.v1.addRoute('rooms.cleanHistory', { authRequired: true }, {
+	post() {
+		const findResult = findRoomByIdOrName({ params: this.bodyParams });
+
+		if (!this.bodyParams.latest) {
+			return RocketChat.API.v1.failure('Body parameter "latest" is required.');
+		}
+
+		if (!this.bodyParams.oldest) {
+			return RocketChat.API.v1.failure('Body parameter "oldest" is required.');
+		}
+
+		const latest = new Date(this.bodyParams.latest);
+		const oldest = new Date(this.bodyParams.oldest);
+
+		let inclusive = false;
+		if (typeof this.bodyParams.inclusive !== 'undefined') {
+			inclusive = this.bodyParams.inclusive;
+		}
+
+		Meteor.runAsUser(this.userId, () => {
+			Meteor.call('cleanRoomHistory', { roomId: findResult._id, latest, oldest, inclusive });
+		});
+
+		return RocketChat.API.v1.success();
+	}
+});
+

--- a/packages/rocketchat-lib/package.js
+++ b/packages/rocketchat-lib/package.js
@@ -151,6 +151,7 @@ Package.onUse(function(api) {
 	api.addFiles('server/methods/checkRegistrationSecretURL.js', 'server');
 	api.addFiles('server/methods/checkUsernameAvailability.js', 'server');
 	api.addFiles('server/methods/cleanChannelHistory.js', 'server');
+	api.addFiles('server/methods/cleanRoomHistory.js', 'server');
 	api.addFiles('server/methods/createChannel.js', 'server');
 	api.addFiles('server/methods/createToken.js', 'server');
 	api.addFiles('server/methods/createPrivateGroup.js', 'server');

--- a/packages/rocketchat-lib/server/methods/cleanChannelHistory.js
+++ b/packages/rocketchat-lib/server/methods/cleanChannelHistory.js
@@ -1,34 +1,10 @@
 Meteor.methods({
-	cleanChannelHistory({roomId, latest, oldest, inclusive}) {
-		check(roomId, String);
-		check(latest, Date);
-		check(oldest, Date);
-		check(inclusive, Boolean);
-
-		if (!Meteor.userId()) {
-			throw new Meteor.Error('error-invalid-user', 'Invalid user', { method: 'cleanChannelHistory' });
-		}
-
-		if (!RocketChat.authz.hasPermission(Meteor.userId(), 'clean-channel-history')) {
-			throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'cleanChannelHistory' });
-		}
-
-		if (inclusive) {
-			RocketChat.models.Messages.remove({
-				rid: roomId,
-				ts: {
-					$gte: oldest,
-					$lte: latest
-				}
-			});
-		} else {
-			RocketChat.models.Messages.remove({
-				rid: roomId,
-				ts: {
-					$gt: oldest,
-					$lt: latest
-				}
-			});
-		}
+	/**
+	 DEPRECATED
+	 // TODO: Remove this after three versions have been released. That means at 0.67 this should be gone.
+	 */
+	cleanChannelHistory({ roomId, latest, oldest, inclusive }) {
+		console.warn('The method "cleanChannelHistory" is deprecated and will be removed after version 0.67, please use "cleanRoomHistory" instead');
+		Meteor.call('cleanRoomHistory', { roomId, latest, oldest, inclusive });
 	}
 });

--- a/packages/rocketchat-lib/server/methods/cleanRoomHistory.js
+++ b/packages/rocketchat-lib/server/methods/cleanRoomHistory.js
@@ -1,0 +1,34 @@
+Meteor.methods({
+	cleanRoomHistory({ roomId, latest, oldest, inclusive }) {
+		check(roomId, String);
+		check(latest, Date);
+		check(oldest, Date);
+		check(inclusive, Boolean);
+
+		if (!Meteor.userId()) {
+			throw new Meteor.Error('error-invalid-user', 'Invalid user', { method: 'cleanRoomHistory' });
+		}
+
+		if (!RocketChat.authz.hasPermission(Meteor.userId(), 'clean-channel-history')) {
+			throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'cleanRoomHistory' });
+		}
+
+		if (inclusive) {
+			RocketChat.models.Messages.remove({
+				rid: roomId,
+				ts: {
+					$gte: oldest,
+					$lte: latest
+				}
+			});
+		} else {
+			RocketChat.models.Messages.remove({
+				rid: roomId,
+				ts: {
+					$gt: oldest,
+					$lt: latest
+				}
+			});
+		}
+	}
+});

--- a/tests/end-to-end/api/02-channels.js
+++ b/tests/end-to-end/api/02-channels.js
@@ -290,6 +290,8 @@ describe('[Channels]', function() {
 			.end(done);
 	});
 
+	//DEPRECATED
+	// TODO: Remove this after three versions have been released. That means at 0.67 this should be gone.
 	it('/channels.cleanHistory', (done) => {
 		request.post(api('channels.cleanHistory'))
 			.set(credentials)

--- a/tests/end-to-end/api/09-rooms.js
+++ b/tests/end-to-end/api/09-rooms.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* globals expect */
 
-import { getCredentials, api, request, credentials } from '../../data/api-data.js';
+import { getCredentials, api, request, credentials} from '../../data/api-data.js';
 
 describe('[Rooms]', function() {
 	this.retries(0);
@@ -151,6 +151,94 @@ describe('[Rooms]', function() {
 				.expect((res) => {
 					expect(res.body).to.have.property('success', false);
 					expect(res.body).to.have.property('error');
+				})
+				.end(done);
+		});
+	});
+
+	describe('[/rooms.cleanHistory]', () => {
+		let publicChannel;
+		let privateChannel;
+		let directMessageChannel;
+		it('create a public channel', (done) => {
+			request.post(api('channels.create'))
+				.set(credentials)
+				.send({
+					name: `testeChannel${ +new Date() }`
+				})
+				.end((err, res) => {
+					publicChannel = res.body.channel;
+					done();
+				});
+		});
+		it('create a private channel', (done) => {
+			request.post(api('groups.create'))
+				.set(credentials)
+				.send({
+					name: `testPrivateChannel${ +new Date() }`
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					privateChannel = res.body.group;
+				})
+				.end(done);
+		});
+		it('create a direct message', (done) => {
+			request.post(api('im.create'))
+				.set(credentials)
+				.send({
+					username: 'rocket.cat'
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					directMessageChannel = res.body.room;
+				})
+				.end(done);
+		});
+		it('should return success when send a valid public channel', (done) => {
+			request.post(api('rooms.cleanHistory'))
+				.set(credentials)
+				.send({
+					roomId: publicChannel._id,
+					latest: '2016-12-09T13:42:25.304Z',
+					oldest: '2016-08-30T13:42:25.304Z'
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+				})
+				.end(done);
+		});
+		it('should return success when send a valid private channel', (done) => {
+			request.post(api('rooms.cleanHistory'))
+				.set(credentials)
+				.send({
+					roomId: privateChannel._id,
+					latest: '2016-12-09T13:42:25.304Z',
+					oldest: '2016-08-30T13:42:25.304Z'
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+				})
+				.end(done);
+		});
+		it('should return success when send a valid Direct Message channel', (done) => {
+			request.post(api('rooms.cleanHistory'))
+				.set(credentials)
+				.send({
+					roomId: directMessageChannel._id,
+					latest: '2016-12-09T13:42:25.304Z',
+					oldest: '2016-08-30T13:42:25.304Z'
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
 				})
 				.end(done);
 		});


### PR DESCRIPTION
Rename endpoint to clean history messages, from `/channels.cleanHistory` to `rooms.cleanHistory`.
Refs #2355.