### PR TITLE
Fix: Remove "secret" from REST endpoint /settings.oauth response

### DIFF
--- a/packages/rocketchat-api/server/v1/settings.js
+++ b/packages/rocketchat-api/server/v1/settings.js
@@ -32,7 +32,7 @@ RocketChat.API.v1.addRoute('settings.public', { authRequired: false }, {
 RocketChat.API.v1.addRoute('settings.oauth', { authRequired: false }, {
 	get() {
 		const mountOAuthServices = () => {
-			const oAuthServicesEnabled = ServiceConfiguration.configurations.find({}).fetch();
+			const oAuthServicesEnabled = ServiceConfiguration.configurations.find({}, { fields: { secret: 0 } }).fetch();
 
 			return oAuthServicesEnabled.map((service) => {
 				if (service.custom) {


### PR DESCRIPTION
Remove "secret" from REST endpoint /settings.oauth response.
