### PR TITLE
tests: use npm ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,11 +91,12 @@ jobs:
       - run:
           name: Prepare build
           command: |
+            sudo npm install -g npm@latest
             mkdir /tmp/build/
             cd /tmp/build-test
             tar czf /tmp/build/Rocket.Chat.tar.gz bundle
             cd /tmp/build-test/bundle/programs/server
-            npm install
+            npm ci
 
       # - save_cache:
       #     key: node-modules-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum "package.json" }}
@@ -164,9 +165,9 @@ jobs:
             mongo --eval 'rs.status()'
 
       - run:
-          name: NPM install
+          name: NPM ci
           command: |
-            npm install
+            npm ci
 
       - run:
           name: Run Tests
@@ -193,9 +194,9 @@ jobs:
       - checkout
 
       - run:
-          name: NPM install
+          name: NPM ci
           command: |
-            npm install
+            npm ci
 
       - run:
           name: Run Tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1155,7 +1155,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
 			"integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
-			"dev": true,
 			"requires": {
 				"archiver-utils": "1.3.0",
 				"async": "2.6.0",
@@ -1171,7 +1170,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
 			"integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
-			"dev": true,
 			"requires": {
 				"glob": "7.1.2",
 				"graceful-fs": "4.1.11",
@@ -2769,8 +2767,7 @@
 		"buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-			"dev": true
+			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
 		},
 		"buffer-equal": {
 			"version": "1.0.0",
@@ -3125,6 +3122,7 @@
 				"requestretry": "1.5.0",
 				"saucelabs": "1.4.0",
 				"selenium-standalone": "6.13.0",
+				"underscore": "1.8.3",
 				"xolvio-ddp": "0.12.3",
 				"xolvio-jasmine-expect": "1.1.0",
 				"xolvio-sync-webdriverio": "9.0.1"
@@ -3256,6 +3254,12 @@
 					"requires": {
 						"has-flag": "2.0.0"
 					}
+				},
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+					"dev": true
 				}
 			}
 		},
@@ -3499,7 +3503,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
 			"integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
-			"dev": true,
 			"requires": {
 				"buffer-crc32": "0.2.13",
 				"crc32-stream": "2.0.0",
@@ -3963,14 +3966,12 @@
 		"crc": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
-			"integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ=",
-			"dev": true
+			"integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ="
 		},
 		"crc32-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
 			"integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
-			"dev": true,
 			"requires": {
 				"crc": "3.5.0",
 				"readable-stream": "2.3.4"
@@ -9350,7 +9351,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
 			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "2.3.4"
 			}
@@ -10365,7 +10365,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "1.1.0"
 			}
@@ -12311,8 +12310,7 @@
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"dev": true
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"repeat-element": {
 			"version": "1.1.2",
@@ -15698,7 +15696,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
 			"integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
-			"dev": true,
 			"requires": {
 				"archiver-utils": "1.3.0",
 				"compress-commons": "1.2.2",


### PR DESCRIPTION
`npm ci` is much faster and is meant for CI. This PR is meant for evaluating the new ci command and testig the performance and compare the logs of Travis CI.

https://docs.npmjs.com/cli/ci
http://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable