### PR TITLE
Regression: Revert announcement structure

### DIFF
--- a/packages/rocketchat-channel-settings/client/views/channelSettings.js
+++ b/packages/rocketchat-channel-settings/client/views/channelSettings.js
@@ -119,7 +119,7 @@ Template.channelSettingsEditing.onCreated(function() {
 			type: 'markdown',
 			label: 'Announcement',
 			getValue() {
-				return Template.instance().room.announcement && Template.instance().room.announcement.message;
+				return Template.instance().room.announcement;
 			},
 			canView() {
 				return RocketChat.roomTypes.roomTypes[room.t].allowRoomSettingChange(room, RoomSettingsEnum.ANNOUNCEMENT);
@@ -471,7 +471,7 @@ Template.channelSettingsInfo.helpers({
 		return Template.instance().room.broadcast;
 	},
 	announcement() {
-		return Template.instance().room.announcement ? Template.instance().room.announcement.message : '';
+		return Template.instance().room.announcement;
 	},
 	topic() {
 		return Template.instance().room.topic;

--- a/packages/rocketchat-channel-settings/server/functions/saveRoomAnnouncement.js
+++ b/packages/rocketchat-channel-settings/server/functions/saveRoomAnnouncement.js
@@ -4,14 +4,17 @@ RocketChat.saveRoomAnnouncement = function(rid, roomAnnouncement, user, sendMess
 	if (!Match.test(rid, String)) {
 		throw new Meteor.Error('invalid-room', 'Invalid room', { function: 'RocketChat.saveRoomAnnouncement' });
 	}
-	const announcementObject = typeof roomAnnouncement === 'object' ?
-		roomAnnouncement :
-		{
-			message: roomAnnouncement
-		};
 
-	const escapedMessage = s.escapeHTML(announcementObject.message);
-	const updated = RocketChat.models.Rooms.setAnnouncementById(rid, {...announcementObject, message: escapedMessage});
+	let message, announcementDetails;
+	if (typeof roomAnnouncement === 'string') {
+		message = roomAnnouncement;
+	} else {
+		({message, ...announcementDetails} = roomAnnouncement);
+	}
+
+	const escapedMessage = s.escapeHTML(message);
+
+	const updated = RocketChat.models.Rooms.setAnnouncementById(rid, escapedMessage, announcementDetails);
 	if (updated && sendMessage) {
 		RocketChat.models.Messages.createRoomSettingsChangedWithTypeRoomIdMessageAndUser('room_changed_announcement', rid, escapedMessage, user);
 	}

--- a/packages/rocketchat-channel-settings/server/functions/saveRoomAnnouncement.js
+++ b/packages/rocketchat-channel-settings/server/functions/saveRoomAnnouncement.js
@@ -5,7 +5,8 @@ RocketChat.saveRoomAnnouncement = function(rid, roomAnnouncement, user, sendMess
 		throw new Meteor.Error('invalid-room', 'Invalid room', { function: 'RocketChat.saveRoomAnnouncement' });
 	}
 
-	let message, announcementDetails;
+	let message;
+	let announcementDetails;
 	if (typeof roomAnnouncement === 'string') {
 		message = roomAnnouncement;
 	} else {

--- a/packages/rocketchat-lib/server/models/Rooms.js
+++ b/packages/rocketchat-lib/server/models/Rooms.js
@@ -679,12 +679,13 @@ class ModelRooms extends RocketChat.models._Base {
 		return this.update(query, update);
 	}
 
-	setAnnouncementById(_id, announcement) {
+	setAnnouncementById(_id, announcement, announcementDetails) {
 		const query = {_id};
 
 		const update = {
 			$set: {
-				announcement
+				announcement,
+				announcementDetails
 			}
 		};
 

--- a/packages/rocketchat-ui/client/views/app/room.js
+++ b/packages/rocketchat-ui/client/views/app/room.js
@@ -214,7 +214,7 @@ Template.room.helpers({
 	showAnnouncement() {
 		const roomData = Session.get(`roomData${ this._id }`);
 		if (!roomData) { return false; }
-		return (roomData.announcement !== undefined) && (roomData.announcement.message !== '');
+		return roomData.announcement != null;
 	},
 
 	messageboxData() {
@@ -232,13 +232,13 @@ Template.room.helpers({
 	roomAnnouncement() {
 		const roomData = Session.get(`roomData${ this._id }`);
 		if (!roomData) { return ''; }
-		return roomData.announcement && roomData.announcement.message;
+		return roomData.announcement;
 	},
 
 	getAnnouncementStyle() {
 		const roomData = Session.get(`roomData${ this._id }`);
 		if (!roomData) { return ''; }
-		return roomData.announcement && roomData.announcement.style !== undefined ? roomData.announcement.style : '';
+		return roomData.announcementDetails && roomData.announcementDetails.style !== undefined ? roomData.announcementDetails.style : '';
 	},
 
 	roomIcon() {
@@ -717,8 +717,8 @@ Template.room.events({
 	'click .announcement'(e) {
 		const roomData = Session.get(`roomData${ this._id }`);
 		if (!roomData) { return false; }
-		if (roomData.announcement !== undefined && roomData.announcement.callback !== undefined) {
-			return RocketChat.callbacks.run(roomData.announcement.callback, this._id);
+		if (roomData.announcementDetails != null && roomData.announcementDetails.callback != null) {
+			return RocketChat.callbacks.run(roomData.announcementDetails.callback, this._id);
 		} else {
 			modal.open({
 				title: t('Announcement'),

--- a/server/publications/room.js
+++ b/server/publications/room.js
@@ -10,6 +10,7 @@ const fields = {
 	// usernames: 1,
 	topic: 1,
 	announcement: 1,
+	announcementDetails: 1,
 	muted: 1,
 	_updatedAt: 1,
 	archived: 1,

--- a/server/startup/migrations/v115.js
+++ b/server/startup/migrations/v115.js
@@ -1,0 +1,12 @@
+RocketChat.Migrations.add({
+	version: 115,
+	up() {
+		RocketChat.models.Rooms.update({
+			'announcement.message': { $exists: true }
+		}, {
+			$unset: {announcement: 1}
+		},
+		false,
+		true);
+	}
+});

--- a/server/startup/migrations/v115.js
+++ b/server/startup/migrations/v115.js
@@ -4,9 +4,7 @@ RocketChat.Migrations.add({
 		RocketChat.models.Rooms.update({
 			'announcement.message': { $exists: true }
 		}, {
-			$unset: {announcement: 1}
-		},
-		false,
-		true);
+			$unset: { announcement: 1 }
+		}, { multi: true });
 	}
 });


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

Reverts the change made to Room Announcement structure, which broke mobile usage of the feature. This adds a new field for the announcementDetails (containing the new properties added) and reverts the message field back to be used from the `announcement` field in the Room Details.

See #10396 for more details
<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
