### PR TITLE
Regression: Fix announcement bar being displayed without content

### DIFF
--- a/packages/rocketchat-ui/client/views/app/room.js
+++ b/packages/rocketchat-ui/client/views/app/room.js
@@ -214,7 +214,7 @@ Template.room.helpers({
 	showAnnouncement() {
 		const roomData = Session.get(`roomData${ this._id }`);
 		if (!roomData) { return false; }
-		return roomData.announcement != null;
+		return roomData.announcement != null && roomData.announcement !== '';
 	},
 
 	messageboxData() {


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

Fix the rc1 regression bug that causes the announcement bar to be displayed even when the content is empty.