### PR TITLE
Regression: /api/v1/settings.oauth not returning clientId for Twitter

### DIFF
--- a/packages/rocketchat-api/server/v1/settings.js
+++ b/packages/rocketchat-api/server/v1/settings.js
@@ -41,7 +41,7 @@ RocketChat.API.v1.addRoute('settings.oauth', { authRequired: false }, {
 				return {
 					id: service._id,
 					name: service.service,
-					clientId: service.appId || service.clientId,
+					clientId: service.appId || service.clientId || service.consumerKey,
 					buttonLabelText: service.buttonLabelText || '',
 					buttonColor: service.buttonColor || '',
 					buttonLabelColor: service.buttonLabelColor || '',


### PR DESCRIPTION
Closes #10557 