### PR TITLE
[FIX] Integrations with room data not having the usernames filled in

### DIFF
--- a/packages/rocketchat-integrations/server/lib/triggerHandler.js
+++ b/packages/rocketchat-integrations/server/lib/triggerHandler.js
@@ -84,7 +84,7 @@ RocketChat.integrations.triggerHandler = new class RocketChatIntegrationHandler 
 		}
 
 		if (data) {
-			history.data = data;
+			history.data = _.clone(data);
 
 			if (data.user) {
 				history.data.user = _.omit(data.user, ['meta', '$loki', 'services']);

--- a/packages/rocketchat-integrations/server/lib/triggerHandler.js
+++ b/packages/rocketchat-integrations/server/lib/triggerHandler.js
@@ -84,7 +84,7 @@ RocketChat.integrations.triggerHandler = new class RocketChatIntegrationHandler 
 		}
 
 		if (data) {
-			history.data = _.clone(data);
+			history.data = { ...data };
 
 			if (data.user) {
 				history.data.user = _.omit(data.user, ['meta', '$loki', 'services']);


### PR DESCRIPTION
Closes #10416

Also, this fixes an issue happening inside of Zapier.

Basically we are writing to history and doing it by reference then updating the reference of the rooms. So, we are now cloning the data going onto history due to us adjusting the data stored three.

cc: @mrsimpson 