### PR TITLE
Development: Add Visual Studio Code debugging configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,94 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Attach to meteor debug",
+			"type": "node",
+			"request": "attach",
+			"port": 9229,
+			"address": "localhost",
+			"restart": false,
+			"sourceMaps": true,
+			"sourceMapPathOverrides": {
+				"meteor://💻app/packages/rocketchat:*": "${workspaceFolder}/packages/rocketchat-*"
+			},
+			"protocol": "inspector"
+		},
+		{
+			"type": "chrome",
+			"request": "launch",
+			"name": "Frontend (Chrome)",
+			"url": "http://localhost:3000",
+			"webRoot": "${workspaceFolder}",
+			"sourceMapPathOverrides": {
+				"meteor://💻app/packages/rocketchat:*": "${workspaceFolder}/packages/rocketchat-*"
+			}
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Server (debug)",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": [
+				"run",
+				"debug"
+			],
+			"port": 9229,
+			"timeout": 300000, //Rocket.Chat really takes some time to startup, so play it safe
+			"sourceMapPathOverrides": {
+				"meteor://💻app/packages/rocketchat:*": "${workspaceFolder}/packages/rocketchat-*"
+			},
+			"protocol": "inspector",
+			"env": {
+				"USE_UNRELEASED_ROCKETAPPS_FRAMEWORK": "true"
+			}
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Server (debug-brk)",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": [
+				"run",
+				"debug-brk"
+			],
+			"port": 9229,
+			"timeout": 300000, //Rocket.Chat really takes some time to startup, so play it safe
+			"sourceMapPathOverrides": {
+				"meteor://💻app/packages/rocketchat:*": "${workspaceFolder}/packages/rocketchat-*"
+			},
+			"protocol": "inspector",
+			"env": {
+				"USE_UNRELEASED_ROCKETAPPS_FRAMEWORK": "true"
+			}
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Server (Testmode)",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": [
+				"run",
+				"debug"
+			],
+			"port": 9229,
+			"timeout": 300000, //Rocket.Chat really takes some time to startup, so play it safe
+			"sourceMapPathOverrides": {
+				"meteor://💻app/packages/rocketchat:*": "${workspaceFolder}/packages/rocketchat-*"
+			},
+			"env": {
+				"TEST_MODE": "true"
+			},
+			"protocol": "inspector"
+		}
+	],
+	"compounds": [
+		{
+			"name": "Server + Frontend",
+			"configurations": [
+				"Server (debug-brk)",
+				"Frontend (Chrome)"
+			]
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 	"scripts": {
 		"start": "meteor npm i && meteor",
 		"debug": "meteor run --inspect",
+		"debug-brk": "meteor run --inspect-brk",
 		"lint": "eslint .",
 		"lint-fix": "eslint . --fix",
 		"stylelint": "stylelint packages/**/*.css",


### PR DESCRIPTION
Special thanks to @mrsimpson for his effort and research, we now have the ability to debug and step through the Rocket.Chat application via Visual Studio Code's amazing debugging!!

There are a few different configurations, so I'll explain what they are:
- `Attach to meteor debug` - use this when you have already started the application via `npm run debug`
- `Frontend (Chrome)` - this opens a new Chrome instance and allows debugging the client code inside of VSCode
- `Server (debug)` - launches the server code but it only hits breakpoints **after Meteor has started up**
- `Server (debug-brk)` - launches the server code, however it allows setting a breakpoint in code that Meteor calls during the startup phase
- `Server (Testmode)` - works like the regular debug but has the environmental variable `TEST_MODE` set to true.
- `Server + Frontend` - launches both the server and frontend, with the server being `debug-brk`

![image](https://user-images.githubusercontent.com/850391/39269719-39ea5812-4899-11e8-84e0-8673434fe906.png)

I personally use this and love it now. I nearly always start Rocket.Chat with this now ;)