### PR TITLE
[NEW] Livechat notifications on new incoming inquiries for guest-pool

### DIFF
--- a/packages/rocketchat-lib/server/lib/index.js
+++ b/packages/rocketchat-lib/server/lib/index.js
@@ -7,9 +7,11 @@
 */
 
 import { RoomSettingsEnum, RoomTypeConfig, RoomTypeRouteConfig } from '../../lib/RoomTypeConfig';
+import { sendNotification } from './sendNotificationsOnMessage.js';
 
 export {
 	RoomSettingsEnum,
 	RoomTypeConfig,
 	RoomTypeRouteConfig,
+	sendNotification,
 };

--- a/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
@@ -266,3 +266,5 @@ function sendAllNotifications(message, room) {
 }
 
 RocketChat.callbacks.add('afterSaveMessage', sendAllNotifications, RocketChat.callbacks.priority.LOW, 'sendNotificationsOnMessage');
+
+export {sendNotification};

--- a/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
@@ -267,4 +267,4 @@ function sendAllNotifications(message, room) {
 
 RocketChat.callbacks.add('afterSaveMessage', sendAllNotifications, RocketChat.callbacks.priority.LOW, 'sendNotificationsOnMessage');
 
-export {sendNotification};
+export { sendNotification };

--- a/packages/rocketchat-livechat/.app/i18n/de.i18n.json
+++ b/packages/rocketchat-livechat/.app/i18n/de.i18n.json
@@ -16,6 +16,7 @@
   "How_satisfied_were_you_with_this_chat": "Wie zufrieden sind Sie mit diesem Gespräch?",
   "Installation": "Installation",
   "New_messages": "Neue Nachrichten",
+  "New_livechat_in_queue": "Neuer Chat in der Wartschlange",
   "No": "Nein",
   "Options": "Optionen",
   "Please_answer_survey": "Bitte nehmen Sie sich einen Moment Zeit, um kurz einige Fragen zu dem Gespräch zu beantworten.",

--- a/packages/rocketchat-livechat/.app/i18n/en.i18n.json
+++ b/packages/rocketchat-livechat/.app/i18n/en.i18n.json
@@ -17,6 +17,7 @@
   "How_satisfied_were_you_with_this_chat": "How satisfied were you with this chat?",
   "Installation": "Installation",
   "New_messages": "New messages",
+  "New_livechat_in_queue": "New chat in queue",
   "No": "No",
   "Options": "Options",
   "Please_answer_survey": "Please take a moment to answer a quick survey about this chat",

--- a/packages/rocketchat-livechat/server/lib/QueueMethods.js
+++ b/packages/rocketchat-livechat/server/lib/QueueMethods.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import {sendNotification} from 'meteor/rocketchat:lib';
+import { sendNotification } from 'meteor/rocketchat:lib';
 
 RocketChat.QueueMethods = {
 	/* Least Amount Queuing method:
@@ -153,21 +153,21 @@ RocketChat.QueueMethods = {
 		// Alert the agents of the queued request
 		agentIds.forEach((agentId) => {
 			sendNotification({
-				//fake a subscription in order to make use of the function defined above
+				// fake a subscription in order to make use of the function defined above
 				subscription: {
 					rid: room._id,
 					t : room.t,
 					u: {
-						_id : agentId
-					}
+						_id : agentId,
+					},
 				},
 				sender: room.v,
-				hasMentionToAll: true, //consider all agents to be in the room
+				hasMentionToAll: true, // consider all agents to be in the room
 				hasMentionToHere: false,
-				message: Object.assign(message, {u: room.v}),
+				message: Object.assign(message, { u: room.v }),
 				notificationMessage: message.msg,
-				room: Object.assign(room, {name: TAPi18n.__('New_livechat_in_queue')}),
-				mentionIds: []
+				room: Object.assign(room, { name: TAPi18n.__('New_livechat_in_queue') }),
+				mentionIds: [],
 			});
 		});
 		return room;

--- a/packages/rocketchat-livechat/server/lib/QueueMethods.js
+++ b/packages/rocketchat-livechat/server/lib/QueueMethods.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import {sendNotification} from 'meteor/rocketchat:lib';
 
 RocketChat.QueueMethods = {
 	/* Least Amount Queuing method:
@@ -149,6 +150,26 @@ RocketChat.QueueMethods = {
 		RocketChat.models.LivechatInquiry.insert(inquiry);
 		RocketChat.models.Rooms.insert(room);
 
+		// Alert the agents of the queued request
+		agentIds.forEach((agentId) => {
+			sendNotification({
+				//fake a subscription in order to make use of the function defined above
+				subscription: {
+					rid: room._id,
+					t : room.t,
+					u: {
+						_id : agentId
+					}
+				},
+				sender: room.v,
+				hasMentionToAll: true, //consider all agents to be in the room
+				hasMentionToHere: false,
+				message: Object.assign(message, {u: room.v}),
+				notificationMessage: message.msg,
+				room: Object.assign(room, {name: TAPi18n.__('New_livechat_in_queue')}),
+				mentionIds: []
+			});
+		});
 		return room;
 	},
 	'External'(guest, message, roomInfo, agent) {


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #7292

This fixes desktop notifications not being created if a live chat visitor created a room by sending the first message.

## Remarks

- Notifications other than livechat and guest pool are based upon the user's subscriptions. Only for the live chat inquiries (the "requests for an agent to join"), there's a need for an alternative mechanism.
- Once an agent is joined, he's the only one to notify which matches the default: He'll have a valid subscription once joined.
- All code added is non-destructive (new functions, arrays concatenated, ...) - it will most likely not make things worse, even if it doesn't meet all the aspects
- From an architectural perspective, it would be better to have the code for creating the livechat-notifications in a separate hook defined in the livechat-package. The way it's been implemented creates a dependency from the notifications-api to the livechat-models - which is not good. On the other hand, the dependency is de-facto already there (`room.t !== 'l'`) and implementing it there has a high re-use.