### PR TITLE
[FIX] Livechat settings not appearing correctly

### DIFF
--- a/packages/rocketchat-livechat/config.js
+++ b/packages/rocketchat-livechat/config.js
@@ -4,7 +4,13 @@ Meteor.startup(function() {
 	RocketChat.settings.add('Livechat_enabled', false, { type: 'boolean', group: 'Livechat', public: true });
 
 	RocketChat.settings.add('Livechat_title', 'Rocket.Chat', { type: 'string', group: 'Livechat', public: true });
-	RocketChat.settings.add('Livechat_title_color', '#C1272D', { type: 'color', group: 'Livechat', public: true });
+	RocketChat.settings.add('Livechat_title_color', '#C1272D', {
+		type: 'color',
+		editor: 'color',
+		allowedTypes: ['color', 'expression'],
+		group: 'Livechat',
+		public: true
+	});
 
 	RocketChat.settings.add('Livechat_display_offline_form', true, {
 		type: 'boolean',
@@ -39,6 +45,8 @@ Meteor.startup(function() {
 	});
 	RocketChat.settings.add('Livechat_offline_title_color', '#666666', {
 		type: 'color',
+		editor: 'color',
+		allowedTypes: ['color', 'expression'],
 		group: 'Livechat',
 		public: true,
 		section: 'Offline',


### PR DESCRIPTION
Closes #10609 
Closes #8072

This PR fixes a bug in Livechat administrative area.
The Livechat settings of the `color` types  were not appearing correctly as seen below.

![screen shot 2018-04-27 at 3 43 33 pm](https://user-images.githubusercontent.com/2067649/39385067-5eeef584-4a45-11e8-86f9-c9bd585e13d1.png)
