### PR TITLE
[FIX] Private settings were not being cleared from client cache in some cases

### DIFF
--- a/packages/rocketchat-ui-admin/client/admin.js
+++ b/packages/rocketchat-ui-admin/client/admin.js
@@ -42,7 +42,8 @@ Template.admin.onCreated(function() {
 	if (RocketChat.settings.cachedCollectionPrivate == null) {
 		RocketChat.settings.cachedCollectionPrivate = new RocketChat.CachedCollection({
 			name: 'private-settings',
-			eventType: 'onLogged'
+			eventType: 'onLogged',
+			useCache: false
 		});
 		RocketChat.settings.collectionPrivate = RocketChat.settings.cachedCollectionPrivate.collection;
 		RocketChat.settings.cachedCollectionPrivate.init();

--- a/packages/rocketchat-ui-admin/client/adminFlex.js
+++ b/packages/rocketchat-ui-admin/client/adminFlex.js
@@ -6,7 +6,8 @@ Template.adminFlex.onCreated(function() {
 	if (RocketChat.settings.cachedCollectionPrivate == null) {
 		RocketChat.settings.cachedCollectionPrivate = new RocketChat.CachedCollection({
 			name: 'private-settings',
-			eventType: 'onLogged'
+			eventType: 'onLogged',
+			useCache: false
 		});
 		RocketChat.settings.collectionPrivate = RocketChat.settings.cachedCollectionPrivate.collection;
 		RocketChat.settings.cachedCollectionPrivate.init();


### PR DESCRIPTION
This PR disables caching for private settings, so that they are not stored in the local browser storage. This is done because private settings may contain sensitive data (such as private keys).