### PR TITLE
[FIX] Message box emoji icon was flickering when typing a text

### DIFF
--- a/packages/rocketchat-theme/client/imports/components/message-box.css
+++ b/packages/rocketchat-theme/client/imports/components/message-box.css
@@ -123,6 +123,7 @@
 
 	&__icon {
 		display: flex;
+		flex: auto 0 0;
 
 		width: 50px;
 		height: 21px;


### PR DESCRIPTION
Fixes the flickering in the message box caused by the scaling of the flex container.

Previously:
![image](http://g.recordit.co/TJ2Zyo7LiK.gif)

Fix:
![image](http://g.recordit.co/5e3spdsQFm.gif)
