### PR TITLE
[FIX] SAML wasn't working correctly when running multiple instances

### DIFF
--- a/packages/meteor-accounts-saml/saml_server.js
+++ b/packages/meteor-accounts-saml/saml_server.js
@@ -171,8 +171,7 @@ Accounts.registerLoginHandler(function(loginRequest) {
 });
 
 Accounts.saml.hasCredential = function(credentialToken) {
-	const data = RocketChat.models.CredentialTokens.findOneById(credentialToken);
-	return Boolean(data);
+	return RocketChat.models.CredentialTokens.findOneById(credentialToken) != null;
 };
 
 Accounts.saml.retrieveCredential = function(credentialToken) {

--- a/packages/meteor-accounts-saml/saml_server.js
+++ b/packages/meteor-accounts-saml/saml_server.js
@@ -170,17 +170,21 @@ Accounts.registerLoginHandler(function(loginRequest) {
 	}
 });
 
-Accounts.saml._loginResultForCredentialToken = {};
-
 Accounts.saml.hasCredential = function(credentialToken) {
-	return _.has(Accounts.saml._loginResultForCredentialToken, credentialToken);
+	const data = RocketChat.models.CredentialTokens.findOneById(credentialToken);
+	return Boolean(data);
 };
 
 Accounts.saml.retrieveCredential = function(credentialToken) {
 	// The credentialToken in all these functions corresponds to SAMLs inResponseTo field and is mandatory to check.
-	const result = Accounts.saml._loginResultForCredentialToken[credentialToken];
-	delete Accounts.saml._loginResultForCredentialToken[credentialToken];
-	return result;
+	const data = RocketChat.models.CredentialTokens.findOneById(credentialToken);
+	if (data) {
+		return data.userInfo;
+	}
+};
+
+Accounts.saml.storeCredential = function(credentialToken, loginResult) {
+	RocketChat.models.CredentialTokens.create(credentialToken, loginResult);
 };
 
 const closePopup = function(res, err) {
@@ -334,21 +338,21 @@ const middleware = function(req, res, next) {
 					}
 
 					const credentialToken = (profile.inResponseToId && profile.inResponseToId.value) || profile.inResponseToId || profile.InResponseTo || samlObject.credentialToken;
+					const loginResult = {
+						profile
+					};
 					if (!credentialToken) {
 						// No credentialToken in IdP-initiated SSO
 						const saml_idp_credentialToken = Random.id();
-						Accounts.saml._loginResultForCredentialToken[saml_idp_credentialToken] = {
-							profile
-						};
+						Accounts.saml.storeCredential(saml_idp_credentialToken, loginResult);
+
 						const url = `${ Meteor.absoluteUrl('home') }?saml_idp_credentialToken=${ saml_idp_credentialToken }`;
 						res.writeHead(302, {
 							'Location': url
 						});
 						res.end();
 					} else {
-						Accounts.saml._loginResultForCredentialToken[credentialToken] = {
-							profile
-						};
+						Accounts.saml.storeCredential(credentialToken, loginResult);
 						closePopup(res);
 					}
 				});


### PR DESCRIPTION
Closes #10436 

SAML login result data was previously stored in memory, which caused the login to sometimes fail when using multiple instances of Rocket.Chat. This PR moves this data to mongo to solve this problem.