### PR TITLE
[FIX] Reset password URL incorrect

### DIFF
--- a/server/lib/accounts.js
+++ b/server/lib/accounts.js
@@ -68,7 +68,7 @@ Accounts.emailTemplates.verifyEmail.html = function(user, url) {
 };
 
 Accounts.urls.resetPassword = function(token) {
-	return Meteor.absoluteUrl('reset-password/${token}');
+	return Meteor.absoluteUrl(`reset-password/${token}`);
 };
 
 Accounts.emailTemplates.resetPassword.html = Accounts.emailTemplates.resetPassword.text;

--- a/server/lib/accounts.js
+++ b/server/lib/accounts.js
@@ -68,7 +68,7 @@ Accounts.emailTemplates.verifyEmail.html = function(user, url) {
 };
 
 Accounts.urls.resetPassword = function(token) {
-	return Meteor.absoluteUrl(`reset-password/${token}`);
+	return Meteor.absoluteUrl(`reset-password/${ token }`);
 };
 
 Accounts.emailTemplates.resetPassword.html = Accounts.emailTemplates.resetPassword.text;

--- a/server/lib/accounts.js
+++ b/server/lib/accounts.js
@@ -68,8 +68,8 @@ Accounts.emailTemplates.verifyEmail.html = function(user, url) {
 };
 
 Accounts.urls.resetPassword = function(token) {
-	return Meteor.absoluteUrl('reset-password/' + token);
-}
+	return Meteor.absoluteUrl('reset-password/${token}');
+};
 
 Accounts.emailTemplates.resetPassword.html = Accounts.emailTemplates.resetPassword.text;
 

--- a/server/lib/accounts.js
+++ b/server/lib/accounts.js
@@ -67,12 +67,11 @@ Accounts.emailTemplates.verifyEmail.html = function(user, url) {
 	return verifyEmailHtml(user, url);
 };
 
-const resetPasswordHtml = Accounts.emailTemplates.resetPassword.text;
+Accounts.urls.resetPassword = function(token) {
+	return Meteor.absoluteUrl('reset-password/' + token);
+}
 
-Accounts.emailTemplates.resetPassword.html = function(user, url) {
-	url = url.replace(/\/#\//, '/');
-	return resetPasswordHtml(user, url);
-};
+Accounts.emailTemplates.resetPassword.html = Accounts.emailTemplates.resetPassword.text;
 
 Accounts.emailTemplates.enrollAccount.subject = function(user = {}) {
 	let subject;

--- a/server/methods/sendForgotPasswordEmail.js
+++ b/server/methods/sendForgotPasswordEmail.js
@@ -22,7 +22,6 @@ Meteor.methods({
 				};
 
 				Accounts.emailTemplates.resetPassword.html = function(userModel, url) {
-					url = url.replace('/#/', '/');
 					return html.replace(/\[Forgot_Password_Url]/g, url);
 				};
 			}


### PR DESCRIPTION
Closes #3883
Closes #9863
Closes #8650
Closes #9923

This PR removes the hash/fragment identifier from the password reset url by overriding the base url.

**Before:**
![screen shot 2018-05-06 at 14 07 30](https://user-images.githubusercontent.com/4711233/39884324-d0abd946-5489-11e8-9975-cc6fd1a10a5b.png)

**After:**
![screen shot 2018-05-06 at 14 06 06](https://user-images.githubusercontent.com/4711233/39884337-d832cd82-5489-11e8-9fb7-33e3495b6318.png)
