### PR TITLE
[FIX] Missing attachment description when Rocket.Chat Apps were enabled

### DIFF
--- a/packages/rocketchat-apps/server/converters/messages.js
+++ b/packages/rocketchat-apps/server/converters/messages.js
@@ -129,7 +129,9 @@ export class AppMessagesConverter {
 				image_url: attachment.imageUrl,
 				audio_url: attachment.audioUrl,
 				video_url: attachment.videoUrl,
-				fields: attachment.fields
+				fields: attachment.fields,
+				type: attachment.type,
+				description: attachment.description
 			};
 		}).map((a) => {
 			Object.keys(a).forEach((k) => {
@@ -178,7 +180,9 @@ export class AppMessagesConverter {
 				imageUrl: attachment.image_url,
 				audioUrl: attachment.audio_url,
 				videoUrl: attachment.video_url,
-				fields: attachment.fields
+				fields: attachment.fields,
+				type: attachment.type,
+				description: attachment.description
 			};
 		});
 	}


### PR DESCRIPTION
Closes #10671 

Fixes the problem of missing data on message attachments when Apps are enabled.