### PR TITLE
[FIX] Regression: Empty content on announcement modal

### DIFF
--- a/packages/rocketchat-ui/client/views/app/room.js
+++ b/packages/rocketchat-ui/client/views/app/room.js
@@ -714,7 +714,7 @@ Template.room.events({
 			addClass.forEach(message => $(`.messages-box #${ message }`).addClass('selected'));
 		}
 	},
-	'click .announcement'(e) {
+	'click .announcement'() {
 		const roomData = Session.get(`roomData${ this._id }`);
 		if (!roomData) { return false; }
 		if (roomData.announcementDetails != null && roomData.announcementDetails.callback != null) {
@@ -722,7 +722,7 @@ Template.room.events({
 		} else {
 			modal.open({
 				title: t('Announcement'),
-				text: $(e.target).attr('aria-label'),
+				text: roomData.announcement,
 				showConfirmButton: false,
 				showCancelButton: true,
 				cancelButtonText: t('Close')


### PR DESCRIPTION
Changes source of text for announcement modal content.

Currently:
![image](https://user-images.githubusercontent.com/6303966/39885784-dfb4c5e0-5463-11e8-9260-c20ff4c635db.png)

Fixed:
![image](https://user-images.githubusercontent.com/6303966/39885745-bc53a60c-5463-11e8-9294-fab4271615f8.png)
