### PR TITLE
Regression: Fix notifications for direct messages

### DIFF
--- a/packages/rocketchat-lib/lib/roomTypes/direct.js
+++ b/packages/rocketchat-lib/lib/roomTypes/direct.js
@@ -34,14 +34,14 @@ export class DirectMessageRoomType extends RoomTypeConfig {
 			name: identifier
 		};
 
-		const subscription = ChatSubscription.findOne(query);
+		const subscription = RocketChat.models.Subscriptions.findOne(query);
 		if (subscription && subscription.rid) {
 			return ChatRoom.findOne(subscription.rid);
 		}
 	}
 
 	roomName(roomData) {
-		const subscription = ChatSubscription.findOne({rid: roomData._id}, {fields: {name: 1, fname: 1}});
+		const subscription = RocketChat.models.Subscriptions.findOne({rid: roomData._id}, {fields: {name: 1, fname: 1}});
 		if (!subscription) {
 			return '';
 		}
@@ -55,7 +55,7 @@ export class DirectMessageRoomType extends RoomTypeConfig {
 
 	secondaryRoomName(roomData) {
 		if (RocketChat.settings.get('UI_Use_Real_Name')) {
-			const subscription = ChatSubscription.findOne({rid: roomData._id}, {fields: {name: 1}});
+			const subscription = RocketChat.models.Subscriptions.findOne({rid: roomData._id}, {fields: {name: 1}});
 			return subscription && subscription.name;
 		}
 	}

--- a/packages/rocketchat-lib/server/functions/notifications/audio.js
+++ b/packages/rocketchat-lib/server/functions/notifications/audio.js
@@ -5,7 +5,8 @@ export function shouldNotifyAudio({
 	hasMentionToAll,
 	hasMentionToHere,
 	isHighlighted,
-	hasMentionToUser
+	hasMentionToUser,
+	roomType
 }) {
 	if (disableAllMessageNotifications && audioNotifications == null) {
 		return false;
@@ -19,7 +20,7 @@ export function shouldNotifyAudio({
 		return true;
 	}
 
-	return (!disableAllMessageNotifications && (hasMentionToAll || hasMentionToHere)) || isHighlighted || audioNotifications === 'all' || hasMentionToUser;
+	return roomType === 'd' || (!disableAllMessageNotifications && (hasMentionToAll || hasMentionToHere)) || isHighlighted || audioNotifications === 'all' || hasMentionToUser;
 }
 
 export function notifyAudioUser(userId, message, room) {

--- a/packages/rocketchat-lib/server/functions/notifications/desktop.js
+++ b/packages/rocketchat-lib/server/functions/notifications/desktop.js
@@ -51,7 +51,8 @@ export function shouldNotifyDesktop({
 	hasMentionToAll,
 	hasMentionToHere,
 	isHighlighted,
-	hasMentionToUser
+	hasMentionToUser,
+	roomType
 }) {
 	if (disableAllMessageNotifications && desktopNotifications == null) {
 		return false;
@@ -70,5 +71,5 @@ export function shouldNotifyDesktop({
 		}
 	}
 
-	return (!disableAllMessageNotifications && (hasMentionToAll || hasMentionToHere)) || isHighlighted || desktopNotifications === 'all' || hasMentionToUser;
+	return roomType === 'd' || (!disableAllMessageNotifications && (hasMentionToAll || hasMentionToHere)) || isHighlighted || desktopNotifications === 'all' || hasMentionToUser;
 }

--- a/packages/rocketchat-lib/server/functions/notifications/email.js
+++ b/packages/rocketchat-lib/server/functions/notifications/email.js
@@ -147,7 +147,8 @@ export function shouldNotifyEmail({
 	emailNotifications,
 	isHighlighted,
 	hasMentionToUser,
-	hasMentionToAll
+	hasMentionToAll,
+	roomType
 }) {
 
 	// use connected (don't need to send him an email)
@@ -172,5 +173,5 @@ export function shouldNotifyEmail({
 		}
 	}
 
-	return isHighlighted || emailNotifications === 'all' || hasMentionToUser || (!disableAllMessageNotifications && hasMentionToAll);
+	return roomType === 'd' || isHighlighted || emailNotifications === 'all' || hasMentionToUser || (!disableAllMessageNotifications && hasMentionToAll);
 }

--- a/packages/rocketchat-lib/server/functions/notifications/mobile.js
+++ b/packages/rocketchat-lib/server/functions/notifications/mobile.js
@@ -28,7 +28,7 @@ export function sendSinglePush({ room, message, userId, receiverUsername, sender
 			type: room.t,
 			name: room.name
 		},
-		roomName: RocketChat.settings.get('Push_show_username_room') ? `#${ RocketChat.roomTypes.getRoomName(room.t, room) }` : '',
+		roomName: RocketChat.settings.get('Push_show_username_room') ? `${ room.t === 'd' ? '' : '#' }${ RocketChat.roomTypes.getRoomName(room.t, room) }` : '',
 		username: RocketChat.settings.get('Push_show_username_room') ? senderUsername : '',
 		message: RocketChat.settings.get('Push_show_message') ? notificationMessage : ' ',
 		// badge: getBadgeCount(userIdToNotify),
@@ -45,7 +45,8 @@ export function shouldNotifyMobile({
 	hasMentionToAll,
 	isHighlighted,
 	hasMentionToUser,
-	statusConnection
+	statusConnection,
+	roomType
 }) {
 	if (disableAllMessageNotifications && mobilePushNotifications == null) {
 		return false;
@@ -68,5 +69,5 @@ export function shouldNotifyMobile({
 		}
 	}
 
-	return (!disableAllMessageNotifications && hasMentionToAll) || isHighlighted || mobilePushNotifications === 'all' || hasMentionToUser;
+	return roomType === 'd' || (!disableAllMessageNotifications && hasMentionToAll) || isHighlighted || mobilePushNotifications === 'all' || hasMentionToUser;
 }

--- a/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
@@ -50,6 +50,8 @@ const sendNotification = ({
 
 	const isHighlighted = messageContainsHighlight(message, subscription.userHighlights);
 
+	const roomType = room.t;
+
 	const {
 		audioNotifications,
 		desktopNotifications,
@@ -67,7 +69,8 @@ const sendNotification = ({
 		hasMentionToAll,
 		hasMentionToHere,
 		isHighlighted,
-		hasMentionToUser
+		hasMentionToUser,
+		roomType
 	})) {
 		notifyAudioUser(subscription.u._id, message, room);
 	}
@@ -80,7 +83,8 @@ const sendNotification = ({
 		hasMentionToAll,
 		hasMentionToHere,
 		isHighlighted,
-		hasMentionToUser
+		hasMentionToUser,
+		roomType
 	})) {
 		notificationSent = true;
 		notifyDesktopUser({
@@ -99,7 +103,8 @@ const sendNotification = ({
 		hasMentionToAll,
 		isHighlighted,
 		hasMentionToUser,
-		statusConnection: receiver.statusConnection
+		statusConnection: receiver.statusConnection,
+		roomType
 	})) {
 		notificationSent = true;
 
@@ -119,7 +124,8 @@ const sendNotification = ({
 		emailNotifications,
 		isHighlighted,
 		hasMentionToUser,
-		hasMentionToAll
+		hasMentionToAll,
+		roomType
 	})) {
 		receiver.emails.some((email) => {
 			if (email.verified) {
@@ -194,11 +200,13 @@ function sendAllNotifications(message, room) {
 			});
 		}
 
-		if (RocketChat.settings.get(`Accounts_Default_User_Preferences_${ notificationField }`) === 'all' && !disableAllMessageNotifications) {
+		const serverField = kind === 'email' ? 'emailNotificationMode' : `${ kind }Notifications`;
+		const serverPreference = RocketChat.settings.get(`Accounts_Default_User_Preferences_${ serverField }`);
+		if ((room.t === 'd' && serverPreference === 'mentions') || (serverPreference === 'all' && !disableAllMessageNotifications)) {
 			query.$or.push({
 				[notificationField]: { $exists: false }
 			});
-		} else if (RocketChat.settings.get(`Accounts_Default_User_Preferences_${ notificationField }`) === 'mentions' && mentionIdsWithoutGroups.length) {
+		} else if (serverPreference === 'mentions' && mentionIdsWithoutGroups.length) {
 			query.$or.push({
 				[notificationField]: { $exists: false },
 				'u._id': { $in: mentionIdsWithoutGroups }


### PR DESCRIPTION
With the new logic for sending notifications we forgot adding a specific condition to send notifications to all messages on direct messages, even if the selected preferences is `mentions`.