### PR TITLE
[WIP] Use the 'type' account attribute to differentiate bots from users

### DIFF
--- a/packages/rocketchat-lib/server/functions/saveUser.js
+++ b/packages/rocketchat-lib/server/functions/saveUser.js
@@ -108,6 +108,10 @@ RocketChat.saveUser = function(userId, userData) {
 			}
 		};
 
+		if (userData.roles && userData.roles.includes('bot')) {
+			updateUser.$set.type = 'bot';
+		}
+
 		if (typeof userData.requirePasswordChange !== 'undefined') {
 			updateUser.$set.requirePasswordChange = userData.requirePasswordChange;
 		}
@@ -197,6 +201,12 @@ RocketChat.saveUser = function(userId, userData) {
 
 		if (userData.roles) {
 			updateUser.$set.roles = userData.roles;
+
+			if (userData.roles.includes('bot')) {
+				updateUser.$set.type = 'bot';
+			} else {
+				updateUser.$set.type = 'user';
+			}
 		}
 
 		if (userData.settings) {


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

On the last Bot Dev meeting for the GSoC students working on bots, @timkinnane and I brought up the 'type' attribute into discussion and how it is currently used. @Sing-Li suggested a research to better understand the current situation and a PR to bring everyone into the discussion.

There is a 'type' attribute in all accounts that is basically unused, here is the list of what I've found: https://pastebin.com/ReCNKbPN. You can see that there are more occurrences of a `bot` attribute on message objects then of the `type` account attribute I was looking for. Not all mentions to `message.bot` are there.

The suggestion is to differentiate bot accounts from normal accounts, by settings `type: 'bot'` for all users that have the `'bot'` role, since I don't see why a normal user would have the `'bot'` role. This is made on the server side whenever a new account is created or a current one has its roles updated.

The change is unlikely to change anything from the user perspective even if you login into a `type: 'bot'` account, as there is apparently no code that differentiates a bot type from a user type. Its goal is to use the type atrtibute in the future for improvements on the bot integration.

Another suggestion is that all bots should also have the `BOT` tag on their messages and there are two approaches to that: Set the `bot` attribute on the message object whenever the sender has `type: 'bot'`, or have `Bot` added in the `UserRoles` client collection. I personally prefer the latter however I haven't quite understood `UserRoles` yet.

