### PR TITLE
[FIX] Not escaping special chars on mentions

### DIFF
--- a/packages/rocketchat-mentions/Mentions.js
+++ b/packages/rocketchat-mentions/Mentions.js
@@ -45,7 +45,7 @@ export default class {
 			}
 			const name = this.useRealName && mentionObj && mentionObj.name;
 
-			return `<a class="mention-link ${ username === me ? 'mention-link-me background-primary-action-color':'' }" data-username="${ username }" title="${ name ? username : '' }">${ name || match }</a>`;
+			return `<a class="mention-link ${ username === me ? 'mention-link-me background-primary-action-color':'' }" data-username="${ username }" title="${ name ? username : '' }">${ _.escapeHTML(name) || match }</a>`;
 		});
 	}
 	replaceChannels(str, message) {

--- a/packages/rocketchat-mentions/Mentions.js
+++ b/packages/rocketchat-mentions/Mentions.js
@@ -3,6 +3,7 @@
 * @param {Object} message - The message object
 */
 import _ from 'underscore';
+import s from 'underscore.string';
 export default class {
 	constructor({pattern, useRealName, me}) {
 		this.pattern = pattern;
@@ -43,9 +44,9 @@ export default class {
 			if (message.temp == null && mentionObj == null) {
 				return match;
 			}
-			const name = this.useRealName && mentionObj && mentionObj.name;
+			const name = this.useRealName && mentionObj && s.escapeHTML(mentionObj.name);
 
-			return `<a class="mention-link ${ username === me ? 'mention-link-me background-primary-action-color':'' }" data-username="${ username }" title="${ name ? username : '' }">${ _.escapeHTML(name) || match }</a>`;
+			return `<a class="mention-link ${ username === me ? 'mention-link-me background-primary-action-color':'' }" data-username="${ username }" title="${ name ? username : '' }">${ name || match }</a>`;
 		});
 	}
 	replaceChannels(str, message) {

--- a/packages/rocketchat-mentions/tests/client.tests.js
+++ b/packages/rocketchat-mentions/tests/client.tests.js
@@ -183,7 +183,7 @@ describe('Mention', function() {
 
 });
 const message = {
-	mentions:[{username:'rocket.cat', name: 'Rocket.Cat'}, {username:'admin', name: 'Admin'}, {username: 'me', name: 'Me'}],
+	mentions:[{username:'rocket.cat', name: 'Rocket.Cat'}, {username:'admin', name: 'Admin'}, {username: 'me', name: 'Me'}, {username: 'specialchars', name:'<img onerror=alert(hello)>'}],
 	channels: [{name: 'general'}, {name: 'rocket.cat'}]
 };
 describe('replace methods', function() {
@@ -227,11 +227,18 @@ describe('replace methods', function() {
 			const result = mention.replaceUsers('@rocket.cat', message, 'me');
 			assert.equal(result, `<a class="mention-link " data-username="${ str2.replace('@', '') }" title="${ str2.replace('@', '') }">${ str2Name }</a>`);
 		});
-
 		it(`should render for "hello ${ str2 }"`, () => {
 			const result = mention.replaceUsers(`hello ${ str2 }`, message, 'me');
 			assert.equal(result, `hello <a class="mention-link " data-username="${ str2.replace('@', '') }" title="${ str2.replace('@', '') }">${ str2Name }</a>`);
 		});
+
+		const specialchars = '@specialchars';
+		const specialcharsName = '&lt;img onerror=alert(hello)&gt;';
+		it(`should escape special characters in "hello ${ specialchars }"`, () => {
+			const result = mention.replaceUsers(`hello ${ specialchars }`, message, 'me');
+			assert.equal(result, `hello <a class="mention-link " data-username="${ specialchars.replace('@', '') }" title="${ specialchars.replace('@', '') }">${ specialcharsName }</a>`);
+		});
+
 		it('should render for unknow/private user "hello @unknow"', () => {
 			const result = mention.replaceUsers('hello @unknow', message, 'me');
 			assert.equal(result, 'hello @unknow');
@@ -254,7 +261,6 @@ describe('replace methods', function() {
 		});
 		it(`should render for "hello ${ str2 }"`, () => {
 			const result = mention.replaceChannels(`hello ${ str2 }`, message);
-			console.log('result', result);
 			assert.equal(result, `hello <a class="mention-link" data-channel="${ str2.replace('#', '') }">${ str2 }</a>`);
 		});
 		it('should render for unknow/private channel "hello #unknow"', () => {


### PR DESCRIPTION
One of the XSS is happening when the "Use Real Name" setting is enabled. You can change your display name to this for example:
`<svg onload=alert(69)>`
And then mention yourself with @ in a room. Everybody in the room will execute the code. Exfiltrating the data is left to the reader as an excercise.

I have no instance to test this but I think it should work.

Timeline:
20.04.2018 - Send two XSS two security@rocket.chat, Received link to HackerOne but issues are deactivated
11.05.2018 - asked for update
17.05.2018 - no answer, so created this PR

I found this bug together with @Faradax during our work at [G Data - Advanced Analytics](https://www.gdata-advancedanalytics.de/)