### PR TITLE
Regression: Fix email notification preference not showing correct selected value

### DIFF
--- a/packages/rocketchat-lib/lib/getDefaultSubscriptionPref.js
+++ b/packages/rocketchat-lib/lib/getDefaultSubscriptionPref.js
@@ -28,4 +28,4 @@ RocketChat.getDefaultSubscriptionPref = function _getDefaultSubscriptionPref(use
 	}
 
 	return subscription;
-}
+};

--- a/packages/rocketchat-lib/lib/getDefaultSubscriptionPref.js
+++ b/packages/rocketchat-lib/lib/getDefaultSubscriptionPref.js
@@ -1,0 +1,31 @@
+RocketChat.getDefaultSubscriptionPref = function _getDefaultSubscriptionPref(userPref) {
+	const subscription = {};
+
+	const {
+		desktopNotifications,
+		mobileNotifications,
+		emailNotificationMode,
+		highlights
+	} = (userPref.settings && userPref.settings.preferences) || {};
+
+	if (Array.isArray(highlights) && highlights.length) {
+		subscription.userHighlights = highlights;
+	}
+
+	if (desktopNotifications && desktopNotifications !== 'default') {
+		subscription.desktopNotifications = desktopNotifications;
+		subscription.desktopPrefOrigin = 'user';
+	}
+
+	if (mobileNotifications && mobileNotifications !== 'default') {
+		subscription.mobilePushNotifications = mobileNotifications;
+		subscription.mobilePrefOrigin = 'user';
+	}
+
+	if (emailNotificationMode && emailNotificationMode !== 'default') {
+		subscription.emailNotifications = emailNotificationMode;
+		subscription.emailPrefOrigin = 'user';
+	}
+
+	return subscription;
+}

--- a/packages/rocketchat-lib/package.js
+++ b/packages/rocketchat-lib/package.js
@@ -58,6 +58,7 @@ Package.onUse(function(api) {
 	api.addFiles('lib/callbacks.js');
 	api.addFiles('lib/fileUploadRestrictions.js');
 	api.addFiles('lib/getAvatarColor.js');
+	api.addFiles('lib/getDefaultSubscriptionPref.js');
 	api.addFiles('lib/getValidRoomName.js');
 	api.addFiles('lib/placeholders.js');
 	api.addFiles('lib/promises.js');

--- a/packages/rocketchat-lib/server/functions/notifications/index.js
+++ b/packages/rocketchat-lib/server/functions/notifications/index.js
@@ -5,14 +5,14 @@ import s from 'underscore.string';
 *
 * @param {object} message the message to be parsed
 */
-export function parseMessageTextPerUser(message, receiver) {
+export function parseMessageTextPerUser(messageText, message, receiver) {
 	if (!message.msg && message.attachments && message.attachments[0]) {
 		const lng = receiver.language || RocketChat.settings.get('language') || 'en';
 
 		return message.attachments[0].image_type ? TAPi18n.__('User_uploaded_image', {lng}) : TAPi18n.__('User_uploaded_file', {lng});
 	}
 
-	return message;
+	return messageText;
 }
 
 /**

--- a/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
@@ -46,7 +46,7 @@ const sendNotification = ({
 		return;
 	}
 
-	notificationMessage = parseMessageTextPerUser(notificationMessage, receiver);
+	notificationMessage = parseMessageTextPerUser(notificationMessage, message, receiver);
 
 	const isHighlighted = messageContainsHighlight(message, subscription.userHighlights);
 

--- a/packages/rocketchat-lib/server/models/Subscriptions.js
+++ b/packages/rocketchat-lib/server/models/Subscriptions.js
@@ -1,5 +1,3 @@
-import _ from 'underscore';
-
 class ModelSubscriptions extends RocketChat.models._Base {
 	constructor() {
 		super(...arguments);

--- a/packages/rocketchat-lib/server/models/Subscriptions.js
+++ b/packages/rocketchat-lib/server/models/Subscriptions.js
@@ -766,36 +766,10 @@ class ModelSubscriptions extends RocketChat.models._Base {
 				_id: user._id,
 				username: user.username,
 				name: user.name
-			}
+			},
+			...RocketChat.getDefaultSubscriptionPref(user),
+			...extraData
 		};
-
-		const {
-			desktopNotifications,
-			mobileNotifications,
-			emailNotificationMode,
-			highlights
-		} = (user.settings && user.settings.preferences) || {};
-
-		if (desktopNotifications && desktopNotifications !== 'default') {
-			subscription.desktopNotifications = desktopNotifications;
-			subscription.desktopPrefOrigin = 'user';
-		}
-
-		if (mobileNotifications && mobileNotifications !== 'default') {
-			subscription.mobilePushNotifications = mobileNotifications;
-			subscription.mobilePrefOrigin = 'user';
-		}
-
-		if (emailNotificationMode && emailNotificationMode !== 'default') {
-			subscription.emailNotifications = emailNotificationMode;
-			subscription.emailPrefOrigin = 'user';
-		}
-
-		if (Array.isArray(highlights) && highlights.length) {
-			subscription.userHighlights = highlights;
-		}
-
-		_.extend(subscription, extraData);
 
 		return this.insert(subscription);
 	}

--- a/packages/rocketchat-push-notifications/server/methods/saveNotificationSettings.js
+++ b/packages/rocketchat-push-notifications/server/methods/saveNotificationSettings.js
@@ -37,12 +37,6 @@ Meteor.methods({
 						const userPref = RocketChat.getUserNotificationPreference(Meteor.userId(), 'email');
 						RocketChat.models.Subscriptions.updateEmailNotificationsById(subscription._id, userPref.origin === 'server' ? null : userPref);
 					} else {
-						// Keep compatibility with old values
-						if (value === 'all') {
-							value = 'mentions';
-						} else if (value === 'disabled') {
-							value = 'nothing';
-						}
 						RocketChat.models.Subscriptions.updateEmailNotificationsById(subscription._id, { value, origin: 'subscription' });
 					}
 				}

--- a/packages/rocketchat-ui-account/client/accountPreferences.html
+++ b/packages/rocketchat-ui-account/client/accountPreferences.html
@@ -108,7 +108,7 @@
 									<div class="rc-select">
 										<select class="input-monitor rc-select__element" name="emailNotificationMode">
 											<option value="default" selected="{{selected 'emailNotificationMode' 'default' 'default'}}">{{_ "Default"}} ({{_ defaultEmailNotification}})</option>
-											<option value="nothing" selected="{{selected 'emailNotificationMode' 'disabled'}}">{{_ "Email_Notification_Mode_Disabled"}}</option>
+											<option value="nothing" selected="{{selected 'emailNotificationMode' 'nothing'}}">{{_ "Email_Notification_Mode_Disabled"}}</option>
 											<option value="mentions" selected="{{selected 'emailNotificationMode' 'mentions'}}">{{_ "Email_Notification_Mode_All"}}</option>
 										</select>
 										{{> icon block="rc-select__arrow" icon="arrow-down" }}

--- a/server/methods/createDirectMessage.js
+++ b/server/methods/createDirectMessage.js
@@ -54,6 +54,8 @@ Meteor.methods({
 			}
 		});
 
+		const myNotificationPref = RocketChat.getDefaultSubscriptionPref(me);
+
 		// Make user I have a subcription to this room
 		const upsertSubscription = {
 			$set: {
@@ -72,7 +74,8 @@ Meteor.methods({
 				u: {
 					_id: me._id,
 					username: me.username
-				}
+				},
+				...myNotificationPref
 			}
 		};
 
@@ -84,6 +87,8 @@ Meteor.methods({
 			rid,
 			$and: [{'u._id': me._id}] // work around to solve problems with upsert and dot
 		}, upsertSubscription);
+
+		const toNotificationPref = RocketChat.getDefaultSubscriptionPref(to);
 
 		RocketChat.models.Subscriptions.upsert({
 			rid,
@@ -101,7 +106,8 @@ Meteor.methods({
 				u: {
 					_id: to._id,
 					username: to.username
-				}
+				},
+				...toNotificationPref
 			}
 		});
 

--- a/server/startup/migrations/v121.js
+++ b/server/startup/migrations/v121.js
@@ -1,0 +1,56 @@
+RocketChat.Migrations.add({
+	version: 121,
+	up() {
+
+		// set user preferences on subscriptions
+		RocketChat.models.Users.find({
+			$or: [
+				{ 'settings.preferences.desktopNotifications': { $exists: true } },
+				{ 'settings.preferences.mobileNotifications': { $exists: true } },
+				{ 'settings.preferences.emailNotificationMode': { $exists: true } }
+			]
+		}).forEach(user => {
+			if (user.settings.preferences.desktopNotifications && user.settings.preferences.desktopNotifications !== 'default') {
+				RocketChat.models.Subscriptions.update({
+					'u._id': user._id,
+					desktopPrefOrigin: { $exists: false }
+				}, {
+					$set: {
+						desktopNotifications: user.settings.preferences.desktopNotifications,
+						desktopPrefOrigin: 'user'
+					}
+				}, {
+					multi: true
+				});
+			}
+
+			if (user.settings.preferences.mobileNotifications && user.settings.preferences.mobileNotifications !== 'default') {
+				RocketChat.models.Subscriptions.update({
+					'u._id': user._id,
+					mobilePrefOrigin: { $exists: false }
+				}, {
+					$set: {
+						mobileNotifications: user.settings.preferences.mobileNotifications,
+						mobilePrefOrigin: 'user'
+					}
+				}, {
+					multi: true
+				});
+			}
+
+			if (user.settings.preferences.emailNotificationMode && user.settings.preferences.emailNotificationMode !== 'default') {
+				RocketChat.models.Subscriptions.update({
+					'u._id': user._id,
+					emailPrefOrigin: { $exists: false }
+				}, {
+					$set: {
+						emailNotifications: user.settings.preferences.emailNotificationMode === 'disabled' || user.settings.preferences.emailNotificationMode === 'nothing' ? 'nothing' : 'mentions',
+						emailPrefOrigin: 'user'
+					}
+				}, {
+					multi: true
+				});
+			}
+		});
+	}
+});


### PR DESCRIPTION
Closes #10844
Closes #10787

* The value was being saved correctly, but due a change on the value saved (from `disabled` to `nothing`) the `<select/>` element was not showing the correct selected value.
* On the [channel preferences screen](https://github.com/RocketChat/Rocket.Chat/pull/10847/files#diff-c4b149a43ae0425e6d25c114be7a6a9aL40) the value was being transformed, but there is not need for that
* Fixed an issue when creating a new room/direct message the user preferences were not being applied
* Added back the `Uploaded a file` message for push notifications