### PR TITLE
Fix: typo on error message for push token API

### DIFF
--- a/packages/rocketchat-api/server/v1/push.js
+++ b/packages/rocketchat-api/server/v1/push.js
@@ -16,7 +16,7 @@ RocketChat.API.v1.addRoute('push.token', { authRequired: true }, {
 		}
 
 		if (!value || typeof value !== 'string') {
-			throw new Meteor.Error('error-token-param-not-valid', 'The required "token" body param is missing or invalid.');
+			throw new Meteor.Error('error-token-param-not-valid', 'The required "value" body param is missing or invalid.');
 		}
 
 		if (!appName || typeof appName !== 'string') {


### PR DESCRIPTION
Parameter name on the JSON object is `value`, not `token`.