### PR TITLE
Fix: Manage apps layout was a bit confuse

### DIFF
--- a/packages/rocketchat-apps/assets/stylesheets/apps.css
+++ b/packages/rocketchat-apps/assets/stylesheets/apps.css
@@ -18,3 +18,11 @@ div.apps-error {
 	width: 100%;
 	font-size: 45px;
 }
+
+.preferences-page--apps .rc-table-tr {
+	opacity: 0.5;
+}
+
+.preferences-page--apps .rc-table-tr.active {
+	opacity: 1;
+}

--- a/packages/rocketchat-apps/client/admin/appManage.html
+++ b/packages/rocketchat-apps/client/admin/appManage.html
@@ -6,6 +6,9 @@
 		<div class="rc-header__block rc-header__block-action">
 			<div class="rc-switch rc-switch--blue">
 				<label class="rc-switch__label">
+					<span class="rc-switch__text">
+						{{_ "Enabled"}}
+					</span>
 					<input type="checkbox" class="rc-switch__input js-input-check" id="enabled" name="enabledToggle" checked="{{isEnabled}}">
 					<span class="rc-switch__button">
 						<span class="rc-switch__button-inside"></span>

--- a/packages/rocketchat-apps/client/admin/appManage.html
+++ b/packages/rocketchat-apps/client/admin/appManage.html
@@ -6,12 +6,12 @@
 		<div class="rc-header__block rc-header__block-action">
 			<div class="rc-switch rc-switch--blue">
 				<label class="rc-switch__label">
-					<span class="rc-switch__text">
-						{{_ "Enabled"}}
-					</span>
 					<input type="checkbox" class="rc-switch__input js-input-check" id="enabled" name="enabledToggle" checked="{{isEnabled}}">
 					<span class="rc-switch__button">
 						<span class="rc-switch__button-inside"></span>
+					</span>
+					<span class="rc-switch__text">
+						{{_ "Activate"}}
 					</span>
 				</label>
 			</div>

--- a/packages/rocketchat-apps/client/admin/apps.html
+++ b/packages/rocketchat-apps/client/admin/apps.html
@@ -2,7 +2,17 @@
 	<!-- TODO: fix this class -->
 	<section class="preferences-page preferences-page--apps">
 		{{#header sectionName="Manage_Apps" hideHelp=true fixedHeight=true}}
-			<button class="rc-button rc-button--small rc-button--primary rc-directory-plus rc-tooltip rc-tooltip--down" data-button="install" aria-label="{{_ 'Install_package'}}">{{> icon icon="plus"}}</button>
+			<div class="rc-directory-header">
+				<div class="rc-input rc-input--small rc-directory-search">
+					<label class="rc-input__label">
+						<div class="rc-input__wrapper">
+							{{> icon icon="magnifier" block="rc-input__icon" }}
+							<input type="text" class="rc-input__element rc-input__element--small js-search" name="app-filter" id="app-filter" placeholder={{_ "Search"}} autocomplete="off">
+						</div>
+					</label>
+				</div>
+				<button class="rc-button rc-button--small rc-button--primary rc-directory-plus rc-tooltip rc-tooltip--down" data-button="install" aria-label="{{_ 'Install_package'}}">{{> icon icon="plus"}}</button>
+			</div>
 		{{/header}}
 		<div class="rc-directory-content">
 			{{#requiresPermission 'manage-apps'}}
@@ -17,7 +27,7 @@
 					</thead>
 					<tbody class="rc-table-body">
 						{{#each apps}}
-							<tr class="rc-table-tr" data-name="{{name}}">
+							<tr class="rc-table-tr {{activeClass status}}" data-name="{{name}}">
 								<td class="rc-table-td rc-table-td--name">
 									<div class="rc-directory-channel-wrapper">
 										<div class="rc-directory-channel-avatar" style="background-image:url({{iconFileContent}})"></div>

--- a/packages/rocketchat-apps/client/admin/apps.js
+++ b/packages/rocketchat-apps/client/admin/apps.js
@@ -1,15 +1,14 @@
 import { AppEvents } from '../communication';
-
+const ENABLED_STATUS = ['auto_enabled','manually_enabled'];
+const enabled = ({status}) => ENABLED_STATUS.includes(status);
 const sortByStatus = (a, b) => {
-	if (a.status === 'auto_enabled' || a.status === 'manually_enabled') {
-		if (b.status === 'auto_enabled' || b.status === 'manually_enabled') {
+	if (enabled(a)) {
+		if (enabled(b)) {
 			return a.name > b.name;
-		} else {
-			return -1;
 		}
-	} else {
-		return 1;
+		return -1;
 	}
+	return 1;
 };
 
 Template.apps.onCreated(function() {

--- a/packages/rocketchat-apps/client/admin/apps.js
+++ b/packages/rocketchat-apps/client/admin/apps.js
@@ -1,5 +1,5 @@
 import { AppEvents } from '../communication';
-const ENABLED_STATUS = ['auto_enabled','manually_enabled'];
+const ENABLED_STATUS = ['auto_enabled', 'manually_enabled'];
 const enabled = ({status}) => ENABLED_STATUS.includes(status);
 const sortByStatus = (a, b) => {
 	if (enabled(a)) {

--- a/packages/rocketchat-apps/client/admin/apps.js
+++ b/packages/rocketchat-apps/client/admin/apps.js
@@ -65,13 +65,15 @@ Template.apps.helpers({
 		return false;
 	},
 	apps() {
-		return Template.instance().apps.get().sort(sortByStatus).filter(({name}) => name.toLowerCase().includes(Template.instance().filter.get().toLowerCase()));
+		const instance = Template.instance();
+		const filter = instance.filter.get().toLowerCase();
+		return instance.apps.get().filter(({name}) => name.toLowerCase().includes(filter)).sort(sortByStatus);
 	},
 	parseStatus(status) {
 		return t(`App_status_${ status }`);
 	},
 	activeClass(status) {
-		return status === 'auto_enabled' || status === 'manually_enabled'? 'active' : '';
+		return enabled({status}) ? 'active' : '';
 	}
 });
 


### PR DESCRIPTION
Adds some missing interface elements to the Manage Apps page:

![image](https://user-images.githubusercontent.com/6303966/40569791-eeabc41a-605a-11e8-90db-a60a8e1eefd7.png)
![image](https://user-images.githubusercontent.com/6303966/40569800-032d2b68-605b-11e8-8c01-df607a0c5540.png)

Also adds client side filter based on App name.