### PR TITLE
[FIX] Horizontally align items in preview message

### DIFF
--- a/packages/rocketchat-theme/client/imports/general/base_old.css
+++ b/packages/rocketchat-theme/client/imports/general/base_old.css
@@ -2616,6 +2616,16 @@
 	position: relative;
 }
 
+.rc-old .message-popup-items.preview-items {
+	display: flex;
+	overflow-y: auto;
+}
+
+.rc-old .preview-items .popup-item {
+	padding: 5px;
+	line-height: unset;
+}
+
 .rc-old .rc-message-box .reply-preview {
 	display: flex;
 	position: relative;

--- a/packages/rocketchat-ui-message/client/popup/messagePopupSlashCommandPreview.html
+++ b/packages/rocketchat-ui-message/client/popup/messagePopupSlashCommandPreview.html
@@ -12,7 +12,7 @@
 						<div class="message-popup-title secondary-background-color border-component-color">
 							{{_ i18nTitle}} <strong>{{ getArgs }}</strong>
 						</div>
-						<div class="message-popup-items">
+						<div class="message-popup-items preview-items">
 							{{#each items}}
 								<div class="popup-item" data-id="{{id}}">
 									{{#if isType 'image' type}}


### PR DESCRIPTION
Slash commands preview now align horizontally.

![image](https://user-images.githubusercontent.com/6303966/40571550-f471bf74-6070-11e8-89b2-1dfe3bb72a69.png)

Based on https://github.com/RocketChat/Rocket.Chat/pull/6090#issuecomment-281163639