### PR TITLE
[FIX] Add the URL suffix back to the 'GO TO MESSAGE' E-Mail button

### DIFF
--- a/packages/rocketchat-lib/server/functions/notifications/email.js
+++ b/packages/rocketchat-lib/server/functions/notifications/email.js
@@ -81,7 +81,13 @@ function getMessageLink(room, sub) {
 		'text-decoration: none;'
 	].join(' ');
 	const message = TAPi18n.__('Offline_Link_Message');
-	return `<p style="text-align:center;margin-bottom:8px;"><a style="${ style }" href="${ path }">${ message }</a>`;
+    let linkSuffix;
+    if (room.t === 'd') {
+        linkSuffix = `/${ room.username }`;
+    } else if (room.t === 'c') {
+		linkSuffix = `/${ room.name }`;
+    }
+	return `<p style="text-align:center;margin-bottom:8px;"><a style="${ style }" href="${ path }${ linkSuffix }">${ message }</a>`;
 }
 
 export function sendEmail({ message, user, subscription, room, emailAddress, toAll }) {


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes 10897

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

I'm honestly not sure if this is the right way to fix this, I tried a few ways and this seemed to be the simplest and works reliably. 

Please close if this is not suitable, otherwise would appreciate some feedback on the correct way to do this. 

Currently, the 'Go to Message' link in the E-mail notifications is missing the actual room/user part, so they are coming through http://rocket.chat/direct/ without the username (same for room/group messages)