### PR TITLE
[FIX] Fix 'GO TO MESSAGE' link in notification e-mails

### DIFF
--- a/packages/rocketchat-lib/server/functions/notifications/email.js
+++ b/packages/rocketchat-lib/server/functions/notifications/email.js
@@ -81,7 +81,13 @@ function getMessageLink(room, sub) {
 		'text-decoration: none;'
 	].join(' ');
 	const message = TAPi18n.__('Offline_Link_Message');
-	return `<p style="text-align:center;margin-bottom:8px;"><a style="${ style }" href="${ path }">${ message }</a>`;
+    let linkSuffix;
+    if (room.t === 'd') {
+        linkSuffix = `/${ room.username }`;
+    } else if (room.t === 'c') {
+		linkSuffix = `/${ room.name }`;
+    }
+	return `<p style="text-align:center;margin-bottom:8px;"><a style="${ style }" href="${ path }${ linkSuffix }">${ message }</a>`;
 }
 
 export function sendEmail({ message, user, subscription, room, emailAddress, toAll }) {

--- a/packages/rocketchat-lib/server/functions/notifications/email.js
+++ b/packages/rocketchat-lib/server/functions/notifications/email.js
@@ -81,13 +81,13 @@ function getMessageLink(room, sub) {
 		'text-decoration: none;'
 	].join(' ');
 	const message = TAPi18n.__('Offline_Link_Message');
-    let linkSuffix;
-    if (room.t === 'd') {
-        linkSuffix = `/${ room.username }`;
-    } else if (room.t === 'c') {
-		linkSuffix = `/${ room.name }`;
-    }
-	return `<p style="text-align:center;margin-bottom:8px;"><a style="${ style }" href="${ path }${ linkSuffix }">${ message }</a>`;
+	let linkSuffix;
+	if (room.t === 'd') {
+		messageSuffix = `/${ room.username }`;
+	} else if (room.t === 'c') {
+		messageSuffix = `/${ room.name }`;
+	}
+	return `<p style="text-align:center;margin-bottom:8px;"><a style="${ style }" href="${ path }${ messageSuffix }">${ message }</a>`;
 }
 
 export function sendEmail({ message, user, subscription, room, emailAddress, toAll }) {

--- a/packages/rocketchat-lib/server/functions/notifications/email.js
+++ b/packages/rocketchat-lib/server/functions/notifications/email.js
@@ -83,11 +83,11 @@ function getMessageLink(room, sub) {
 	const message = TAPi18n.__('Offline_Link_Message');
 	let linkSuffix;
 	if (room.t === 'd') {
-		messageSuffix = `/${ room.username }`;
+		linkSuffix = `/${ room.username }`;
 	} else if (room.t === 'c') {
-		messageSuffix = `/${ room.name }`;
+		linkSuffix = `/${ room.name }`;
 	}
-	return `<p style="text-align:center;margin-bottom:8px;"><a style="${ style }" href="${ path }${ messageSuffix }">${ message }</a>`;
+	return `<p style="text-align:center;margin-bottom:8px;"><a style="${ style }" href="${ path }${ linkSuffix }">${ message }</a>`;
 }
 
 export function sendEmail({ message, user, subscription, room, emailAddress, toAll }) {


### PR DESCRIPTION
Closes https://github.com/RocketChat/Rocket.Chat/issues/

I'm honestly not sure if this is the right way to fix this, I tried a few ways and this seemed to be the simplest and works reliably.

Please close if this is not suitable, otherwise would appreciate some feedback on the correct way to do this.

Currently, the 'Go to Message' link in the E-mail notifications is missing the actual room/user part, so they are coming through http://rocket.chat/direct/ without the username (same for room/group messages)