### PR TITLE
[FIX] Incomplete email notification link

### DIFF
--- a/packages/rocketchat-push-notifications/server/models/Subscriptions.js
+++ b/packages/rocketchat-push-notifications/server/models/Subscriptions.js
@@ -225,7 +225,16 @@ RocketChat.models.Subscriptions.findNotificationPreferencesByRoom = function(que
 
 	return this._db.find(query, {
 		fields: {
-			'u._id': 1,
+
+			// fields needed for notifications
+			rid: 1,
+			t: 1,
+			u: 1,
+			name: 1,
+			fname: 1,
+			code: 1,
+
+			// fields to define if should send a notification
 			audioNotifications: 1,
 			audioNotificationValue: 1,
 			desktopNotificationDuration: 1,


### PR DESCRIPTION
`Go to message` email links were incomplete due to lack of data when generating the links.. this fixes that.