### PR TITLE
[FIX] Piwik (Matomo) analytics updated to implicit reference

### DIFF
--- a/packages/rocketchat-analytics/client/loadScript.js
+++ b/packages/rocketchat-analytics/client/loadScript.js
@@ -44,14 +44,14 @@ Template.body.onRendered(() => {
 							const addTrackers = JSON.parse(piwikAdditionalTracker);
 							for (let i = 0; i < addTrackers.length; i++) {
 								const tracker = addTrackers[i];
-								window._paq.push(['addTracker', `${ tracker['trackerURL'] }piwik.php`, tracker['siteId']]);
+								window._paq.push(['addTracker', `${ tracker['trackerURL'] }js/`, tracker['siteId']]);
 							}
 						}
 					} catch (e) {
 						// parsing JSON faild
 						console.log('Error while parsing JSON value of "piwikAdditionalTracker": ', e);
 					}
-					window._paq.push(['setTrackerUrl', `${ piwikUrl }piwik.php`]);
+					window._paq.push(['setTrackerUrl', `${ piwikUrl }js/`]);
 					window._paq.push(['setSiteId', Number.parseInt(piwikSiteId)]);
 					const d = document;
 					const g = d.createElement('script');
@@ -59,7 +59,7 @@ Template.body.onRendered(() => {
 					g.type = 'text/javascript';
 					g.async = true;
 					g.defer = true;
-					g.src = `${ piwikUrl }piwik.js`;
+					g.src = `${ piwikUrl }js/`;
 					s.parentNode.insertBefore(g, s);
 				})();
 			}


### PR DESCRIPTION
Piwik analytics has been updated to use an implicit reference instead of "piwik.php" and "piwik.js", as per the [documentation suggestions](https://github.com/matomo-org/matomo/blob/master/js/README.md).

Closes #10889
