### PR TITLE
[FIX] for issue 10931

### DIFF
--- a/packages/meteor-accounts-saml/saml_utils.js
+++ b/packages/meteor-accounts-saml/saml_utils.js
@@ -395,10 +395,12 @@ SAML.prototype.validateResponse = function(samlResponse, relayState, callback) {
 				if (attributes) {
 					attributes.forEach(function(attribute) {
 						const value = self.getElement(attribute, 'AttributeValue');
+						let key = attribute.$.Name.value;
+						key=key.replace(/\./g, '-');
 						if (typeof value[0] === 'string') {
-							profile[attribute.$.Name.value] = value[0];
+							profile[key] = value[0];
 						} else {
-							profile[attribute.$.Name.value] = value[0]._;
+							profile[key] = value[0]._;
 						}
 					});
 				}


### PR DESCRIPTION
Closes #10931 

Mongo DB don't support "." as key so replace in attributes urn:oid the "." to "-"
https://stackoverflow.com/questions/12397118/mongodb-dot-in-key-name


