### PR TITLE
Snap update caddy and nodejs

### DIFF
--- a/.snapcraft/resources/preparecaddy
+++ b/.snapcraft/resources/preparecaddy
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-caddy_version="v0.10.12"
+caddy_version="v0.11.0"
 
 caddy_bin="caddy"
 caddy_dl_ext=".tar.gz"

--- a/.snapcraft/snapcraft.yaml
+++ b/.snapcraft/snapcraft.yaml
@@ -39,7 +39,7 @@ apps:
 parts:
     node:
         plugin: dump 
-        prepare: wget https://nodejs.org/dist/v8.9.4/node-v8.9.4-linux-x64.tar.xz; tar xvf node-v8.9.4-linux-x64.tar.xz --strip 1; 
+        prepare: wget https://nodejs.org/dist/v8.11.2/node-v8.11.2-linux-x64.tar.xz; tar xvf node-v8.11.2-linux-x64.tar.xz --strip 1; 
         build-packages:
             # For fibers
             - python


### PR DESCRIPTION
For the snap updates caddy to 0.11.0 and updates node.js to 8.11.2

I've already updated the 0.65.1 snap which is live for everyone.  This is just making these changes upstream :)