### PR TITLE
[NEW] Added meta referrer tag

### DIFF
--- a/packages/rocketchat-ui-master/server/inject.js
+++ b/packages/rocketchat-ui-master/server/inject.js
@@ -27,6 +27,7 @@ RocketChat.models.Settings.find({_id:/theme-color-rc/i}, {fields: { value: 1}}).
 	changed: renderDynamicCssList
 });
 
+Inject.rawHead('noreferrer', '<meta name="referrer" content="origin-when-crossorigin">');
 Inject.rawHead('dynamic', `<script>${ Assets.getText('server/dynamic-css.js') }</script>`);
 
 Inject.rawBody('icons', Assets.getText('public/icons.svg'));


### PR DESCRIPTION
This meta tag will change the referrer of all cross origin links to send only the origin part of the url (dropping the params).