### PR TITLE
[FIX] ratelimit meteor user retrieve when set username

### DIFF
--- a/packages/rocketchat-lib/server/functions/setUsername.js
+++ b/packages/rocketchat-lib/server/functions/setUsername.js
@@ -80,7 +80,7 @@ RocketChat._setUsername = function(userId, u) {
 };
 
 RocketChat.setUsername = RocketChat.RateLimiter.limitFunction(RocketChat._setUsername, 1, 60000, {
-	[0](userId) {
-		return !userId || !RocketChat.authz.hasPermission(userId, 'edit-other-user-info');
-	}
+    0() {
+        return !Meteor.userId() || !RocketChat.authz.hasPermission(Meteor.userId(), 'edit-other-user-info'); // Administrators have permission to change others names, so don't limit those
+    }
 });


### PR DESCRIPTION
Wrong meteor user retrieve.
When create/update user on rest api you will get error "Error, too many requests. Please slow down. ".
Even if you have permission "edit-other-user-info".