### PR TITLE
[FIX] Build for Sandstorm missing dependence for capnp

### DIFF
--- a/.sandstorm/build.sh
+++ b/.sandstorm/build.sh
@@ -5,6 +5,7 @@ set -euvo pipefail
 # Make meteor bundle
 sudo chown vagrant:vagrant /home/vagrant -R
 cd /opt/app
+meteor npm install capnp
 meteor npm install
 meteor build --directory /home/vagrant/
 

--- a/.sandstorm/setup.sh
+++ b/.sandstorm/setup.sh
@@ -23,11 +23,24 @@ tar xf "$CACHE_TARGET"
 # Create symlink so we can rely on the path /opt/meteor-spk
 ln -s "${PACKAGE}" meteor-spk
 
+#This will install capnp, the Cap’n Proto command-line tool.
+#It will also install libcapnp, libcapnpc, and libkj in /usr/local/lib and headers in /usr/local/include/capnp and /usr/local/include/kj.
+wget https://capnproto.org/capnproto-c++-0.5.3.tar.gz
+tar zxf capnproto-c++-0.5.3.tar.gz
+cd capnproto-c++-0.5.3
+./configure
+make -j6 check
+# inlcude libcapnp and libkj library to dependencies.
+cp .libs/* /opt/meteor-spk/meteor-spk.deps/lib/x86_64-linux-gnu/
+
 # Add bash, and its dependencies, so they get mapped into the image.
 # Bash runs the launcher script.
 cp -a /bin/bash /opt/meteor-spk/meteor-spk.deps/bin/
 cp -a /lib/x86_64-linux-gnu/libncurses.so.* /opt/meteor-spk/meteor-spk.deps/lib/x86_64-linux-gnu/
 cp -a /lib/x86_64-linux-gnu/libtinfo.so.* /opt/meteor-spk/meteor-spk.deps/lib/x86_64-linux-gnu/
+# for npm in package.json sharp.
+cp -a /lib/x86_64-linux-gnu/libresolv* /opt/meteor-spk/meteor-spk.deps/lib/x86_64-linux-gnu/
+
 
 # Unfortunately, Meteor does not explicitly make it easy to cache packages, but
 # we know experimentally that the package is mostly directly extractable to a

--- a/packages/rocketchat-sandstorm/server/lib.js
+++ b/packages/rocketchat-sandstorm/server/lib.js
@@ -5,7 +5,7 @@ import Future from 'fibers/future';
 RocketChat.Sandstorm = {};
 
 if (process.env.SANDSTORM === '1') {
-	import Capnp from 'capnp';
+	const Capnp = require('capnp');
 	const SandstormHttpBridge = Capnp.importSystem('sandstorm/sandstorm-http-bridge.capnp').SandstormHttpBridge;
 
 	let capnpConnection = null;

--- a/packages/rocketchat-sandstorm/server/lib.js
+++ b/packages/rocketchat-sandstorm/server/lib.js
@@ -5,7 +5,7 @@ import Future from 'fibers/future';
 RocketChat.Sandstorm = {};
 
 if (process.env.SANDSTORM === '1') {
-	const Capnp = require('/node_modules/capnp.js');
+	import Capnp from 'capnp';
 	const SandstormHttpBridge = Capnp.importSystem('sandstorm/sandstorm-http-bridge.capnp').SandstormHttpBridge;
 
 	let capnpConnection = null;

--- a/packages/rocketchat-sandstorm/server/powerbox.js
+++ b/packages/rocketchat-sandstorm/server/powerbox.js
@@ -3,7 +3,8 @@
 RocketChat.Sandstorm.offerUiView = function() {};
 
 if (process.env.SANDSTORM === '1') {
-	const Capnp = require('/node_modules/capnp.js');
+
+	import Capnp from 'capnp';
 	const Powerbox = Capnp.importSystem('sandstorm/powerbox.capnp');
 	const Grain = Capnp.importSystem('sandstorm/grain.capnp');
 

--- a/packages/rocketchat-sandstorm/server/powerbox.js
+++ b/packages/rocketchat-sandstorm/server/powerbox.js
@@ -3,8 +3,7 @@
 RocketChat.Sandstorm.offerUiView = function() {};
 
 if (process.env.SANDSTORM === '1') {
-
-	import Capnp from 'capnp';
+	const Capnp = require('capnp');
 	const Powerbox = Capnp.importSystem('sandstorm/powerbox.capnp');
 	const Grain = Capnp.importSystem('sandstorm/grain.capnp');
 


### PR DESCRIPTION
[FIX] update dependence for Sandstorm version.

Adding dependence. for building new version RocketChat for Sandstorm
1: install the requirement capnproto and capnp.
2: include some needed .so files.
3: fix import in rocketchat-sandstorm.

And If need any information about building for Sandstorm. I can help.