### PR TITLE
[FIX] Link previews not being removed from messages after removed on editing

### DIFF
--- a/packages/rocketchat-lib/server/functions/updateMessage.js
+++ b/packages/rocketchat-lib/server/functions/updateMessage.js
@@ -10,10 +10,8 @@ RocketChat.updateMessage = function(message, user) {
 		username: user.username
 	};
 
-	const urls = message.msg.match(/([A-Za-z]{3,9}):\/\/([-;:&=\+\$,\w]+@{1})?([-A-Za-z0-9\.]+)+:?(\d+)?((\/[-\+=!:~%\/\.@\,\w]*)?\??([-\+=&!:;%@\/\.\,\w]+)?(?:#([^\s\)]+))?)?/g);
-	if (urls) {
-		message.urls = urls.map((url) => { return { url }; });
-	}
+	const urls = message.msg.match(/([A-Za-z]{3,9}):\/\/([-;:&=\+\$,\w]+@{1})?([-A-Za-z0-9\.]+)+:?(\d+)?((\/[-\+=!:~%\/\.@\,\w]*)?\??([-\+=&!:;%@\/\.\,\w]+)?(?:#([^\s\)]+))?)?/g) || [];
+	message.urls = urls.map(url => ({ url }));
 
 	message = RocketChat.callbacks.run('beforeSaveMessage', message);
 


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->
Now its working properly 
> When I edit my sent message and remove a link from it, the link preview stays in the chat.
Mac App Version 1.3.1 (15)
<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #2833 


<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
