### PR TITLE
Fix Docker image for develop commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,7 @@ workflows:
               ignore: develop
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
-      - image-build:
+      - pr-image-build:
           requires:
             - hold
           filters:


### PR DESCRIPTION
Turned out the steps on workflow were object properties and not array elements.