### PR TITLE
[NEW] Add gateway proxy setting.

### DIFF
--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -1980,6 +1980,7 @@
   "Push_enable": "Enable",
   "Push_enable_gateway": "Enable Gateway",
   "Push_gateway": "Gateway",
+  "Push_gateway_proxy": "Gateway Proxy",
   "Push_gcm_api_key": "GCM API Key",
   "Push_gcm_project_number": "GCM Project Number",
   "Push_production": "Production",

--- a/packages/rocketchat-lib/server/startup/settings.js
+++ b/packages/rocketchat-lib/server/startup/settings.js
@@ -1503,6 +1503,18 @@ RocketChat.settings.addGroup('Push', function() {
 			}
 		]
 	});
+	this.add('Push_gateway_proxy', '', {
+		type: 'string',
+		enableQuery: [
+			{
+				_id: 'Push_enable',
+				value: true
+			}, {
+				_id: 'Push_enable_gateway',
+				value: true
+			}
+		]
+	});
 	this.add('Push_production', true, {
 		type: 'boolean',
 		'public': true,

--- a/server/lib/cordova.js
+++ b/server/lib/cordova.js
@@ -71,14 +71,20 @@ Meteor.methods({
 });
 
 function sendPush(service, token, options, tries = 0) {
-	const data = {
+	const callOptions = {
 		data: {
 			token,
 			options
 		}
 	};
 
-	return HTTP.post(`${ RocketChat.settings.get('Push_gateway') }/push/${ service }/send`, data, function(error, response) {
+	const proxy = RocketChat.settings.get('Push_gateway_proxy').replace(/\s/g, '');
+
+	if (proxy) {
+		callOptions.npmRequestOptions = {proxy};
+	}
+
+	return HTTP.post(`${ RocketChat.settings.get('Push_gateway') }/push/${ service }/send`, callOptions, function(error, response) {
 		if (response && response.statusCode === 406) {
 			console.log('removing push token', token);
 			Push.appCollection.remove({


### PR DESCRIPTION
We use Rocket Chat in a corporate network and would like to send only push notifications through our proxy. This PR adds a new field in push settings that allows to use a proxy.