### PR TITLE
[FIX] Some typos in the error message names

### DIFF
--- a/packages/rocketchat-assets/server/assets.js
+++ b/packages/rocketchat-assets/server/assets.js
@@ -396,7 +396,7 @@ Meteor.methods({
 
 		const hasPermission = RocketChat.authz.hasPermission(Meteor.userId(), 'manage-assets');
 		if (!hasPermission) {
-			throw new Meteor.Error('error-action-now-allowed', 'Managing assets not allowed', {
+			throw new Meteor.Error('error-action-not-allowed', 'Managing assets not allowed', {
 				method: 'refreshClients',
 				action: 'Managing_assets'
 			});
@@ -414,7 +414,7 @@ Meteor.methods({
 
 		const hasPermission = RocketChat.authz.hasPermission(Meteor.userId(), 'manage-assets');
 		if (!hasPermission) {
-			throw new Meteor.Error('error-action-now-allowed', 'Managing assets not allowed', {
+			throw new Meteor.Error('error-action-not-allowed', 'Managing assets not allowed', {
 				method: 'unsetAsset',
 				action: 'Managing_assets'
 			});
@@ -432,7 +432,7 @@ Meteor.methods({
 
 		const hasPermission = RocketChat.authz.hasPermission(Meteor.userId(), 'manage-assets');
 		if (!hasPermission) {
-			throw new Meteor.Error('error-action-now-allowed', 'Managing assets not allowed', {
+			throw new Meteor.Error('error-action-not-allowed', 'Managing assets not allowed', {
 				method: 'setAsset',
 				action: 'Managing_assets'
 			});

--- a/packages/rocketchat-autotranslate/server/methods/getSupportedLanguages.js
+++ b/packages/rocketchat-autotranslate/server/methods/getSupportedLanguages.js
@@ -1,7 +1,7 @@
 Meteor.methods({
 	'autoTranslate.getSupportedLanguages'(targetLanguage) {
 		if (!RocketChat.authz.hasPermission(Meteor.userId(), 'auto-translate')) {
-			throw new Meteor.Error('error-action-now-allowed', 'Auto-Translate is not allowed', { method: 'autoTranslate.saveSettings'});
+			throw new Meteor.Error('error-action-not-allowed', 'Auto-Translate is not allowed', { method: 'autoTranslate.saveSettings'});
 		}
 
 		return RocketChat.AutoTranslate.getSupportedLanguages(targetLanguage);

--- a/packages/rocketchat-autotranslate/server/methods/saveSettings.js
+++ b/packages/rocketchat-autotranslate/server/methods/saveSettings.js
@@ -5,7 +5,7 @@ Meteor.methods({
 		}
 
 		if (!RocketChat.authz.hasPermission(Meteor.userId(), 'auto-translate')) {
-			throw new Meteor.Error('error-action-now-allowed', 'Auto-Translate is not allowed', { method: 'autoTranslate.saveSettings'});
+			throw new Meteor.Error('error-action-not-allowed', 'Auto-Translate is not allowed', { method: 'autoTranslate.saveSettings'});
 		}
 
 		check(rid, String);


### PR DESCRIPTION
Some places were returning `error-action-now-allowed` instead of `error-action-not-allowed`, which is all a bit confusing but definitely should not be the case.