### PR TITLE
[FIX] Custom sound uploader not working in Firefox and IE

### DIFF
--- a/packages/rocketchat-custom-sounds/client/admin/soundEdit.html
+++ b/packages/rocketchat-custom-sounds/client/admin/soundEdit.html
@@ -13,7 +13,7 @@
 				</div>
 				<div class="input-line">
 					<label for="image">{{_ "Sound_File_mp3"}}</label>
-					<input id="image" type="file" accept="audio/mp3,audio/mpeg"/>
+					<input id="image" type="file" accept="audio/mp3,audio/mpeg,audio/x-mpeg,audio/mpeg3,audio/x-mpeg-3,.mp3"/>
 				</div>
 				<nav>
 					<button class='button button-block cancel' type="button"><span>{{_ "Cancel"}}</span></button>

--- a/packages/rocketchat-custom-sounds/client/admin/soundEdit.js
+++ b/packages/rocketchat-custom-sounds/client/admin/soundEdit.js
@@ -93,7 +93,7 @@ Template.soundEdit.onCreated(function() {
 		}
 
 		if (this.soundFile) {
-			if (!/audio\/mp3/.test(this.soundFile.type)) {
+			if (!/audio\/mp3/.test(this.soundFile.type) && !/audio\/mpeg/.test(this.soundFile.type) && !/audio\/x-mpeg/.test(this.soundFile.type)) {
 				errors.push('FileType');
 				toastr.error(TAPi18n.__('error-invalid-file-type'));
 			}


### PR DESCRIPTION
Closes #8460
_Actually_ closes #6200

A fix that was made before only fixed half of the issue, sadly.
Now it is fully fixed and happy, and you can silently change your coworker's notification sound to the loudest version of the Monopoly theme you can find on the internet, all from Firefox.

Oh yeah, Firefox wasn't showing the file picker properly either, it let you select non-mp3 files. So that's fixed too, in case you find yourself confusing .mp3 and .png far too often. :-)

Before:
![2018-06-13_22-53-56](https://user-images.githubusercontent.com/39674991/41377664-17028208-6f5d-11e8-8a14-f0ca29d8db61.png)

After:
![2018-06-13_22-53-42](https://user-images.githubusercontent.com/39674991/41377674-1c91f4d8-6f5d-11e8-8b02-bd7877c8c2ec.png)