### PR TITLE
[FIX] Improvements on LiveChat offline mode and LiveChat registration form

### DIFF
--- a/packages/rocketchat-livechat/.app/client/views/register.js
+++ b/packages/rocketchat-livechat/.app/client/views/register.js
@@ -11,7 +11,7 @@ Template.register.helpers({
 		return '';
 	},
 	showDepartments() {
-		return Department.find({ showOnRegistration: true }).count() > 1;
+		return Department.find({ showOnRegistration: true }).count() > 0;
 	},
 	departments() {
 		return Department.find({ showOnRegistration: true });
@@ -27,7 +27,7 @@ Template.register.helpers({
 	},
 	showEmailFieldRegisterForm() {
 		return Livechat.emailFieldRegistrationForm;
-	}	
+	}
 });
 
 Template.register.events({
@@ -41,10 +41,11 @@ Template.register.events({
 			}
 		};
 		const form = e.currentTarget;
-		
+
 		const fields = [];
 		let name;
 		let email;
+		let department;
 
 		if (Livechat.nameFieldRegistrationForm) {
 			fields.push('name');
@@ -56,22 +57,19 @@ Template.register.events({
 			email = instance.$('input[name=email]').val();
 		}
 
+		if (Department.find({ showOnRegistration: true }).count() > 0) {
+			fields.push('department');
+			department = instance.$('select[name=department]').val();
+		}
+
 		if (!instance.validateForm(form, fields)) {
 			return instance.showError(TAPi18n.__('You_must_complete_all_fields'));
 		} else {
-			let departmentId = instance.$('select[name=department]').val();
-			if (!departmentId) {
-				const department = Department.findOne({ showOnRegistration: true });
-				if (department) {
-					departmentId = department._id;
-				}
-			}
-
 			const guest = {
 				token: visitor.getToken(),
 				name,
 				email,
-				department: Livechat.department || departmentId
+				department: department || Livechat.department
 			};
 			Meteor.call('livechat:registerGuest', guest, function(error, result) {
 				if (error != null) {
@@ -105,7 +103,7 @@ Template.register.onCreated(function() {
 
 		return valid;
 	};
-	
+
 	this.showError = (msg) => {
 		$('.error').addClass('show');
 		this.error.set(msg);

--- a/packages/rocketchat-livechat/server/methods/getInitialData.js
+++ b/packages/rocketchat-livechat/server/methods/getInitialData.js
@@ -85,7 +85,7 @@ Meteor.methods({
 		});
 		info.allowSwitchingDepartments = initSettings.Livechat_allow_switching_departments;
 
-		info.online = RocketChat.models.Users.findOnlineAgents().count() > 0;
+		info.online = RocketChat.Livechat.getOnline();
 
 		return info;
 	}


### PR DESCRIPTION
Closes #11080

This PR adds improvements on LiveChat widget as described below:

- `Offline mode`
The LiveChat status (online / offline) will now check the status of agents related to enabled departments in the LiveChat registration form. If there is at least one department that is enabled for the LiveChat registration form, it will need at least one online agent from this department to register the visitor. If there are no online agents to serve visitors, the Offline form will be displayed (if this feature is enabled).

- `Department validation`
All LiveChat departments that are enabled for the registration form will be listed in the LiveChat widget, even if there are no online agents for some of these departments. Aiming for a better visitor experience, when a department is selected by the visitor, the widget will ensure that there is at least one agent online to start the chat. If the validation doesn't return any agent, a warning will be displayed to the visitor.