### PR TITLE
[FIX] REST endpoint `users.updateOwnBasicInfo` was not returning errors for invalid names and trying to save custom fields when empty

### DIFF
--- a/server/methods/saveUserProfile.js
+++ b/server/methods/saveUserProfile.js
@@ -1,6 +1,7 @@
 Meteor.methods({
 	saveUserProfile(settings, customFields) {
 		check(settings, Object);
+		check(customFields, Match.Maybe(Object));
 
 		if (!RocketChat.settings.get('Accounts_AllowUserProfileChange')) {
 			throw new Meteor.Error('error-not-allowed', 'Not allowed', {
@@ -33,7 +34,9 @@ Meteor.methods({
 		}
 
 		if (settings.realname) {
-			RocketChat.setRealName(Meteor.userId(), settings.realname);
+			if (!RocketChat.setRealName(Meteor.userId(), settings.realname)) {
+				throw new Meteor.Error('error-could-not-change-name', 'Could not change name', { method: 'saveUserProfile' });
+			}
 		}
 
 		if (settings.username) {
@@ -67,7 +70,9 @@ Meteor.methods({
 
 		RocketChat.models.Users.setProfile(Meteor.userId(), {});
 
-		RocketChat.saveCustomFields(Meteor.userId(), customFields);
+		if (customFields && Object.keys(customFields).length) {
+			RocketChat.saveCustomFields(Meteor.userId(), customFields);
+		}
 
 		return true;
 	}

--- a/tests/end-to-end/api/01-users.js
+++ b/tests/end-to-end/api/01-users.js
@@ -396,6 +396,22 @@ describe('[Users]', function() {
 				.end(done);
 		});
 
+		it('should throw an error when the name is only whitespaces', (done) => {
+			request.post(api('users.updateOwnBasicInfo'))
+				.set(credentials)
+				.send({
+					data: {
+						name: '  '
+					}
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', false);
+				})
+				.end(done);
+		});
+
 		it('should set new email as \'unverified\'', (done) => {
 			request.post(api('users.updateOwnBasicInfo'))
 				.set(userCredentials)


### PR DESCRIPTION
Closes: #10917 and #11154