### PR TITLE
[FIX] README: Badly cropped Ubuntu logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Install Rocket.Chat in seconds on Linux (Ubuntu and others) with:
 sudo snap install rocketchat-server
 ```
 
-[![Rocket.Chat Snap is recommended for Linux deployments](https://github.com/Sing-Li/bbug/raw/master/images/ubuntulogo.png)](https://uappexplorer.com/snap/ubuntu/rocketchat-server)
+[![Rocket.Chat Snap is recommended for Linux deployments](https://github.com/vynmera/img/raw/master/ubuntu.png)](https://uappexplorer.com/snap/ubuntu/rocketchat-server)
 
 Installing snaps is very quick. By running that command you have your full Rocket.Chat server up and running. Snaps are secure. They are isolated with all of their dependencies. Snaps also auto update when we release new versions.
 


### PR DESCRIPTION
Call me a perfectionist, but the cropping on the Ubuntu logo looks off. There's a grey line above the logo, the logo is too far to the right, and a bit of the letter U is still visible.
![2018-06-21_22-46-35](https://user-images.githubusercontent.com/39674991/41744818-3e289446-75a5-11e8-92fe-89938c14e08e.png)

Now it looks good.
![2018-06-21_22-46-40](https://user-images.githubusercontent.com/39674991/41744824-44cc18cc-75a5-11e8-8c5f-ff5dc4d3c459.png)

Might leave a better impression to those who first see this project.