### PR TITLE
New history source format & add Node and NPM versions

### DIFF
--- a/.github/history.json
+++ b/.github/history.json
@@ -1,14749 +1,15371 @@
 {
-  "0.55.0-rc.0": [
-    {
-      "pr": "6614",
-      "title": "Add candidate snap channel",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.55.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6597",
-      "title": "Add `fname` to subscriptions in memory",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.0",
-      "contributors": [
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6608",
-      "title": "[New] Switch Snaps to use oplog",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6576",
-      "title": "Convert Message Pin Package to JS",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "6585",
-      "title": "Move room display name logic to roomType definition",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.55.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6598",
-      "title": "[FIX] Large files crashed browser when trying to show preview",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.55.0",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "6600",
-      "title": "[FIX] messageBox: put \"joinCodeRequired\" back",
-      "userLogin": "karlprieb",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "6594",
-      "title": "[FIX] Do not add default roles for users without services field",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.55.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6596",
-      "title": "Only configure LoggerManager on server",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.55.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6298",
-      "title": "POC Google Natural Language integration",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.55.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6591",
-      "title": "Fix recently introduced bug: OnePassword not defined",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6553",
-      "title": "rocketchat-lib part1",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6590",
-      "title": "[FIX] Accounts from LinkedIn OAuth without name",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.0",
-      "contributors": [
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6584",
-      "title": "dependencies upgrade",
-      "userLogin": "engelgabriel",
-      "milestone": "0.55.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "6580",
-      "title": "fixed typo in readme.md",
-      "userLogin": "sezinkarli",
-      "milestone": "0.55.0",
-      "contributors": [
-        "sezinkarli",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6565",
-      "title": "[NEW] Add shield.svg api route to generate custom shields/badges",
-      "userLogin": "alexbrazier",
-      "milestone": "0.55.0",
-      "contributors": [
-        "alexbrazier"
-      ]
-    },
-    {
-      "pr": "6575",
-      "title": "[FIX] Usage of subtagged languages",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "3851",
-      "title": "Use real name instead of username for messages and direct messages list",
-      "userLogin": "alexbrazier",
-      "milestone": "0.55.0",
-      "contributors": [
-        "alexbrazier"
-      ]
-    },
-    {
-      "pr": "6561",
-      "title": "Convert Ui-Login Package to Js",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6577",
-      "title": "[NEW] resolve merge share function",
-      "userLogin": "karlprieb",
-      "milestone": "0.55.0",
-      "contributors": [
-        "tgxn",
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "6551",
-      "title": "rocketchat-channel-settings coffee to js",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6571",
-      "title": "Move wordpress packages client files to client folder",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "6539",
-      "title": "convert rocketchat-ui part 2",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6541",
-      "title": "rocketchat-channel-settings-mail-messages coffee to js",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6574",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "6567",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "6562",
-      "title": "[FIX] UTC offset missing UTC text when positive",
-      "userLogin": "alexbrazier",
-      "milestone": "0.55.0",
-      "contributors": [
-        "alexbrazier"
-      ]
-    },
-    {
-      "pr": "6554",
-      "title": "[New] Added oauth2 userinfo endpoint",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.55.0",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "6531",
-      "title": "[FIX] can not get access_token when using custom oauth",
-      "userLogin": "fengt",
-      "milestone": "0.55.0",
-      "contributors": [
-        "fengt"
-      ]
-    },
-    {
-      "pr": "6540",
-      "title": "Remove Deprecated Shared Secret Package",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "6542",
-      "title": "Remove coffeescript package from ui-sidenav",
-      "userLogin": "Kiran-Rao",
-      "milestone": "0.55.0",
-      "contributors": [
-        "Kiran-Rao",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6543",
-      "title": "Remove coffeescript package from ui-flextab",
-      "userLogin": "Kiran-Rao",
-      "milestone": "0.55.0",
-      "contributors": [
-        "Kiran-Rao",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6476",
-      "title": "[NEW] Two Factor Auth",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.0",
-      "contributors": [
-        "sampaiodiego",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6478",
-      "title": "[FIX] Outgoing webhooks which have an error and they're retrying would still retry even if the integration was disabled`",
-      "userLogin": "graywolf336",
-      "milestone": "0.55.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "6491",
-      "title": "Convert Theme Package to JS",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "6487",
-      "title": "Fix typo of the safari pinned tab label",
-      "userLogin": "qge",
-      "milestone": "0.55.0",
-      "contributors": [
-        "qge",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6493",
-      "title": "fix channel merge option of user preferences",
-      "userLogin": "billtt",
-      "milestone": "0.55.0",
-      "contributors": [
-        "billtt"
-      ]
-    },
-    {
-      "pr": "6495",
-      "title": "converted Rocketchat logger coffee to js",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6502",
-      "title": "converted rocketchat-integrations coffee to js",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6522",
-      "title": "'allow reacting' should be a toggle option.otherwise, the style will display an error",
-      "userLogin": "szluohua",
-      "milestone": "0.55.0",
-      "contributors": [
-        "szluohua",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6280",
-      "title": "Clipboard [Firefox version < 50]",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6473",
-      "title": "Convert ui-vrecord Package to JS",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "6474",
-      "title": "converted slashcommands-mute coffee to js",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6494",
-      "title": "Convert Version Package to JS",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6498",
-      "title": "Convert Ui-Master Package to Js",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6500",
-      "title": "converted messageAttachment coffee to js",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6503",
-      "title": "Convert File Package to js",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6505",
-      "title": "Create groups.addAll endpoint and add activeUsersOnly param.",
-      "userLogin": "nathanmarcos",
-      "milestone": "0.55.0",
-      "contributors": [
-        "nathanmarcos",
-        null
-      ]
-    },
-    {
-      "pr": "6351",
-      "title": "New feature: Room announcement",
-      "userLogin": "billtt",
-      "milestone": "0.55.0",
-      "contributors": [
-        "billtt"
-      ]
-    },
-    {
-      "pr": "6468",
-      "title": "converted slashcommand-me coffee to js",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6469",
-      "title": "converted slashcommand-join coffee to js",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6470",
-      "title": "converted slashcommand-leave coffee to js",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6471",
-      "title": "convert mapview package to js",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6496",
-      "title": "converted getAvatarUrlFromUsername",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6497",
-      "title": "converted slashcommand-invite coffee to js",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6499",
-      "title": "Convert Wordpress Package to js",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "6501",
-      "title": "converted slashcommand-msg coffee to js",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6504",
-      "title": "rocketchat-ui coffee to js part1",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6467",
-      "title": "converted rocketchat-mentions coffee to js",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6479",
-      "title": "ESLint add rule `no-void`",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6456",
-      "title": "Add ESLint rules `prefer-template` and `template-curly-spacing`",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.0",
-      "contributors": [
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6466",
-      "title": "Fix livechat permissions",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6457",
-      "title": "Add ESLint rule `object-shorthand`",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.0",
-      "contributors": [
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6459",
-      "title": "Add ESLint rules `one-var` and `no-var`",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6458",
-      "title": "Add ESLint rule `one-var`",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6274",
-      "title": "Side-nav CoffeeScript to JavaScript III ",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6277",
-      "title": "Flex-Tab CoffeeScript to JavaScript II",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6430",
-      "title": "[NEW] Permission `join-without-join-code` assigned to admins and bots by default",
-      "userLogin": "graywolf336",
-      "milestone": "0.55.0",
-      "contributors": [
-        "graywolf336",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6420",
-      "title": "[NEW] Integrations, both incoming and outgoing, now have access to the models. Example: `Users.findOneById(id)`",
-      "userLogin": "graywolf336",
-      "milestone": "0.55.0",
-      "contributors": [
-        "graywolf336",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6266",
-      "title": "Side-nav CoffeeScript to JavaScript II",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6035",
-      "title": "Allow Livechat visitors to switch the department",
-      "userLogin": "drallgood",
-      "milestone": "0.55.0",
-      "contributors": [
-        "drallgood",
-        "web-flow",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6122",
-      "title": "fix livechat widget on small screens",
-      "userLogin": "karlprieb",
-      "milestone": "0.55.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "6180",
-      "title": "Allow livechat managers to transfer chats",
-      "userLogin": "drallgood",
-      "milestone": "0.55.0",
-      "contributors": [
-        "drallgood",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6257",
-      "title": "focus first textbox element",
-      "userLogin": "a5his",
-      "milestone": "0.55.0",
-      "contributors": [
-        "a5his"
-      ]
-    },
-    {
-      "pr": "6268",
-      "title": "Join command",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6419",
-      "title": "Fix visitor ending livechat if multiples still open",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.55.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6319",
-      "title": "Password reset Cleaner text",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6400",
-      "title": "Add permission check to the import methods and not just the UI",
-      "userLogin": "graywolf336",
-      "milestone": "0.55.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "6409",
-      "title": "Max textarea height",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6413",
-      "title": "Livechat fix office hours order",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.55.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6449",
-      "title": "Convert Spotify Package to JS",
-      "userLogin": "MartinSchoeler",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6422",
-      "title": "Make favicon package easier to read.",
-      "userLogin": "Kiran-Rao",
-      "milestone": "0.55.0",
-      "contributors": [
-        "Kiran-Rao"
-      ]
-    },
-    {
-      "pr": "6426",
-      "title": "Just admins can change a Default Channel to Private (the channel will be a non default channel)",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6429",
-      "title": "Hide email settings on Sandstorm",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.55.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6432",
-      "title": "Do not show reset button for hidden settings",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.55.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6427",
-      "title": "Convert Dolphin Package to JavaScript",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6445",
-      "title": "converted rocketchat-message-mark-as-unread coffee/js",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6453",
-      "title": "converted rocketchat-slashcommands-kick coffee to js",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6450",
-      "title": "converted meteor-accounts-saml coffee to js",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6447",
-      "title": "Convert Statistics Package to JS",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6425",
-      "title": "Convert ChatOps Package to JavaScript",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "6410",
-      "title": "Change all instances of Meteor.Collection for Mongo.Collection",
-      "userLogin": "marceloschmidt",
-      "milestone": "0.55.0",
-      "contributors": [
-        "marceloschmidt"
-      ]
-    },
-    {
-      "pr": "6278",
-      "title": "Flex-Tab CoffeeScript to JavaScript III",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6276",
-      "title": "Flex-Tab CoffeeScript to JavaScript I ",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "6264",
-      "title": "Side-nav CoffeeScript to JavaScript",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6446",
-      "title": "Convert Tutum Package to JS",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.55.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    }
-  ],
-  "0.55.0-rc.1": [
-    {
-      "pr": "6620",
-      "title": "[FIX] Incorrect curl command being generated on incoming integrations",
-      "userLogin": "graywolf336",
-      "milestone": "0.55.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "6617",
-      "title": "[FIX] arguments logger",
-      "userLogin": "ggazzo",
-      "milestone": "0.55.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6616",
-      "title": "[NEW] 'users.resetAvatar' rest api endpoint",
-      "userLogin": "graywolf336",
-      "milestone": "0.55.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    }
-  ],
-  "0.55.0-rc.2": [
-    {
-      "pr": "6632",
-      "title": "[NEW] Drupal oAuth Integration for Rocketchat",
-      "userLogin": "Lawri-van-Buel",
-      "milestone": "0.55.0",
-      "contributors": [
-        "Lawri-van-Buel",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6634",
-      "title": "[NEW] Add monitoring package",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6650",
-      "title": "[FIX] Improve markdown code",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6651",
-      "title": "[FIX] Encode avatar url to prevent CSS injection",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6649",
-      "title": "Added Deploy method and platform to stats",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6648",
-      "title": "[FIX] Do not escaping markdown on message attachments",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6647",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.55.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "6631",
-      "title": "meteor update",
-      "userLogin": "engelgabriel",
-      "milestone": "0.55.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    }
-  ],
-  "0.55.0-rc.3": [
-    {
-      "pr": "6658",
-      "title": "[FIX] Revert unwanted UI changes",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    }
-  ],
-  "0.55.0-rc.4": [
-    {
-      "pr": "6682",
-      "title": "[FIX] Fix Logger stdout publication",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.55.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6680",
-      "title": "[FIX] Downgrade email package to from 1.2.0 to 1.1.18",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.55.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6681",
-      "title": "[NEW] Expose Livechat to Incoming Integrations and allow response",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6659",
-      "title": "[FIX] Administrators being rate limited when editing users data",
-      "userLogin": "graywolf336",
-      "milestone": "0.55.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "6674",
-      "title": "[FIX] Make sure username exists in findByActiveUsersExcept",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.55.0",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    }
-  ],
-  "0.55.0-rc.5": [
-    {
-      "pr": "6686",
-      "title": "[FIX] Update server cache indexes on record updates",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6684",
-      "title": "[FIX] Allow question on OAuth token path",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.55.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6163",
-      "title": "Env override initial setting",
-      "userLogin": "mrsimpson",
-      "milestone": "0.55.0",
-      "contributors": [
-        "mrsimpson",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6683",
-      "title": "[FIX] Error when returning undefined from incoming intergation’s script",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.55.0-rc.6": [
-    {
-      "pr": "6704",
-      "title": "[FIX] Fix message types",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.55.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    }
-  ],
-  "0.55.0": [
-    {
-      "pr": "6709",
-      "title": "[FIX] emoji picker exception",
-      "userLogin": "gdelavald",
-      "milestone": "0.55.0",
-      "contributors": [
-        "gdelavald",
-        "rodrigok",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.55.1": [
-    {
-      "pr": "6734",
-      "title": "[Fix] Bug with incoming integration (0.55.1)",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.56.0-rc.0": [
-    {
-      "pr": "6881",
-      "title": "[NEW] Add a pointer cursor to message images",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.56.0",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6842",
-      "title": "[New] Snap arm support",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.56.0",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6861",
-      "title": "[FIX] start/unstar message",
-      "userLogin": "karlprieb",
-      "milestone": "0.56.0",
-      "contributors": [
-        null
-      ]
-    },
-    {
-      "pr": "6858",
-      "title": "Meteor update",
-      "userLogin": "engelgabriel",
-      "milestone": "0.56.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "6845",
-      "title": "[FIX] Added helper for testing if the current user matches the params",
-      "userLogin": "abrom",
-      "milestone": "0.56.0",
-      "contributors": [
-        "abrom"
-      ]
-    },
-    {
-      "pr": "6827",
-      "title": "[NEW] Make channels.info accept roomName, just like groups.info",
-      "userLogin": "reist",
-      "milestone": "0.56.0",
-      "contributors": [
-        "reist"
-      ]
-    },
-    {
-      "pr": "6672",
-      "title": "Converted rocketchat-lib 3",
-      "userLogin": "ggazzo",
-      "milestone": "0.56.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6781",
-      "title": "Convert Message-Star Package to js ",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.0",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6780",
-      "title": "Convert Mailer Package to Js",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.56.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "6796",
-      "title": "[FIX] REST API user.update throwing error due to rate limiting",
-      "userLogin": "graywolf336",
-      "milestone": "0.56.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "6797",
-      "title": "[NEW] Option to allow to signup as anonymous",
-      "userLogin": "rodrigok",
-      "milestone": "0.56.0",
-      "contributors": [
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6816",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.56.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "6807",
-      "title": "[NEW] create a method 'create token'",
-      "userLogin": "ggazzo",
-      "milestone": "0.56.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6804",
-      "title": "Missing useful fields in admin user list #5110",
-      "userLogin": "vlogic",
-      "milestone": "0.56.0",
-      "contributors": [
-        null,
-        "vlogic"
-      ]
-    },
-    {
-      "pr": "6790",
-      "title": "[FIX] fix german translation",
-      "userLogin": "sscholl",
-      "milestone": "0.56.0",
-      "contributors": [
-        "sscholl",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6793",
-      "title": "[FIX] Improve and correct Iframe Integration help text",
-      "userLogin": "antgel",
-      "milestone": "0.56.0",
-      "contributors": [
-        null
-      ]
-    },
-    {
-      "pr": "6800",
-      "title": "[FIX] Quoted and replied messages not retaining the original message's alias",
-      "userLogin": "graywolf336",
-      "milestone": "0.56.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "6798",
-      "title": "[FIX] Fix iframe wise issues",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.56.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6747",
-      "title": "[FIX] Incorrect error message when creating channel",
-      "userLogin": "gdelavald",
-      "milestone": "0.56.0",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "6760",
-      "title": "[FIX] Hides nav buttons when selecting own profile",
-      "userLogin": "gdelavald",
-      "milestone": "0.56.0",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "6767",
-      "title": "[FIX] Search full name on client side",
-      "userLogin": "alexbrazier",
-      "milestone": "0.56.0",
-      "contributors": [
-        "alexbrazier"
-      ]
-    },
-    {
-      "pr": "6758",
-      "title": "[FIX] Sort by real name if use real name setting is enabled",
-      "userLogin": "alexbrazier",
-      "milestone": "0.56.0",
-      "contributors": [
-        "alexbrazier"
-      ]
-    },
-    {
-      "pr": "6671",
-      "title": "Convert Katex Package to Js",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.56.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "6688",
-      "title": "Convert Oembed Package to Js",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.56.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "6689",
-      "title": "Convert Mentions-Flextab Package to Js",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.56.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "6768",
-      "title": "[FIX] CSV importer: require that there is some data in the zip, not ALL data",
-      "userLogin": "reist",
-      "milestone": "0.56.0",
-      "contributors": [
-        "reist"
-      ]
-    },
-    {
-      "pr": "5986",
-      "title": "Anonymous use",
-      "userLogin": "rodrigok",
-      "milestone": "0.56.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6368",
-      "title": "Breaking long URLS to prevent overflow",
-      "userLogin": "robertdown",
-      "milestone": "0.56.0",
-      "contributors": [
-        "robertdown"
-      ]
-    },
-    {
-      "pr": "6737",
-      "title": "[FIX] Archiving Direct Messages",
-      "userLogin": "graywolf336",
-      "milestone": "0.56.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "5373",
-      "title": "[NEW] Add option on Channel Settings: Hide Notifications and Hide Unread Room Status (#2707, #2143)",
-      "userLogin": "marceloschmidt",
-      "milestone": "0.56.0",
-      "contributors": [
-        "marceloschmidt",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6593",
-      "title": "Rocketchat lib2",
-      "userLogin": "ggazzo",
-      "milestone": "0.56.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6734",
-      "title": "[Fix] Bug with incoming integration (0.55.1)",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6722",
-      "title": "[NEW] Remove lesshat",
-      "userLogin": "karlprieb",
-      "milestone": "0.56.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "6654",
-      "title": "disable proxy configuration",
-      "userLogin": "glehmann",
-      "milestone": "0.56.0",
-      "contributors": [
-        "glehmann"
-      ]
-    },
-    {
-      "pr": "6721",
-      "title": "[FIX] Fix Caddy by forcing go 1.7 as needed by one of caddy's dependencies",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "6694",
-      "title": "Convert markdown to js",
-      "userLogin": "ehkasper",
-      "milestone": "0.56.0",
-      "contributors": [
-        "ehkasper"
-      ]
-    },
-    {
-      "pr": "6715",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.56.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "6709",
-      "title": "[FIX] emoji picker exception",
-      "userLogin": "gdelavald",
-      "milestone": "0.55.0",
-      "contributors": [
-        "gdelavald",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6692",
-      "title": "[NEW] Use tokenSentVia parameter for clientid/secret to token endpoint",
-      "userLogin": "intelradoux",
-      "milestone": "0.56.0",
-      "contributors": [
-        "intelradoux"
-      ]
-    },
-    {
-      "pr": "6706",
-      "title": "meteor update to 1.4.4",
-      "userLogin": "engelgabriel",
-      "milestone": "0.56.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "6704",
-      "title": "[FIX] Fix message types",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.55.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6703",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "6615",
-      "title": "[NEW] Add a setting to not run outgoing integrations on message edits",
-      "userLogin": "graywolf336",
-      "milestone": "0.56.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "6734",
-      "title": "[Fix] Bug with incoming integration (0.55.1)",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.56.0-rc.1": [
-    {
-      "pr": "6896",
-      "title": "[FIX] Users status on main menu always offline",
-      "userLogin": "rodrigok",
-      "milestone": "0.56.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.56.0-rc.2": [
-    {
-      "pr": "6923",
-      "title": "[FIX] Not showing unread count on electron app’s icon",
-      "userLogin": "rodrigok",
-      "milestone": "0.56.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.56.0-rc.3": [
-    {
-      "pr": "6939",
-      "title": "[FIX] Compile CSS color variables",
-      "userLogin": "karlprieb",
-      "milestone": "0.56.0",
-      "contributors": [
-        null
-      ]
-    },
-    {
-      "pr": "6938",
-      "title": "[NEW] Improve CI/Docker build/release",
-      "userLogin": "rodrigok",
-      "milestone": "0.56.0",
-      "contributors": [
-        "rodrigok",
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6940",
-      "title": "[NEW] Add SMTP settings for Protocol and Pool",
-      "userLogin": "rodrigok",
-      "milestone": "0.56.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.56.0-rc.4": [
-    {
-      "pr": "6953",
-      "title": "[NEW] Show info about multiple instances at admin page",
-      "userLogin": "rodrigok",
-      "milestone": "0.56.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.56.0-rc.5": [
-    {
-      "pr": "6955",
-      "title": "[FIX] Remove spaces from env PORT and INSTANCE_IP",
-      "userLogin": "rodrigok",
-      "milestone": "0.56.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6935",
-      "title": "[Fix] Error when trying to show preview of undefined filetype",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.57.0",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    }
-  ],
-  "0.56.0-rc.6": [],
-  "0.56.0-rc.7": [
-    {
-      "pr": "6968",
-      "title": "[FIX] make channels.create API check for create-c",
-      "userLogin": "reist",
-      "milestone": "0.56.0",
-      "contributors": [
-        "reist"
-      ]
-    }
-  ],
-  "0.56.0": [
-    {
-      "pr": "6734",
-      "title": "[Fix] Bug with incoming integration (0.55.1)",
-      "userLogin": "rodrigok",
-      "milestone": "0.55.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.57.0-rc.0": [
-    {
-      "pr": "7146",
-      "title": "Convert hipchat importer to js",
-      "userLogin": "rodrigok",
-      "milestone": "0.57.0",
-      "contributors": [
-        "rodrigok",
-        "geekgonecrazy",
-        "sampaiodiego",
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7145",
-      "title": "Convert file unsubscribe.coffee to js",
-      "userLogin": "rodrigok",
-      "milestone": "0.57.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6991",
-      "title": "[FIX] Fix highlightjs bug",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.57.0",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6788",
-      "title": "[NEW] New avatar storage types",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.0",
-      "contributors": [
-        "sampaiodiego",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7095",
-      "title": "[BREAK] Internal hubot does not load hubot-scripts anymore, it loads scripts from custom folders",
-      "userLogin": "ggazzo",
-      "milestone": "0.57.0",
-      "contributors": [
-        "ggazzo",
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6690",
-      "title": "[NEW] Show full name in mentions if use full name setting enabled",
-      "userLogin": "alexbrazier",
-      "milestone": "0.57.0",
-      "contributors": [
-        "alexbrazier"
-      ]
-    },
-    {
-      "pr": "7017",
-      "title": "Convert oauth2-server-config package  to js",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.0",
-      "contributors": [
-        "MartinSchoeler",
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7022",
-      "title": "Convert irc package to js",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.0",
-      "contributors": [
-        "MartinSchoeler",
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7055",
-      "title": "Ldap: User_Data_FieldMap description",
-      "userLogin": "bbrauns",
-      "milestone": "0.57.0",
-      "contributors": [
-        "bbrauns"
-      ]
-    },
-    {
-      "pr": "7030",
-      "title": "[FIX] do only store password if LDAP_Login_Fallback is on",
-      "userLogin": "pmb0",
-      "milestone": "0.57.0",
-      "contributors": [
-        "pmb0"
-      ]
-    },
-    {
-      "pr": "7059",
-      "title": "[NEW] Increase unread message count on @here mention",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7062",
-      "title": "Remove Useless Jasmine Tests ",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7121",
-      "title": "[FIX] fix bug in preview image",
-      "userLogin": "ggazzo",
-      "milestone": "0.57.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "7094",
-      "title": "[FIX]Fix the failing tests ",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7085",
-      "title": "[NEW] API method and REST Endpoint for getting a single message by id",
-      "userLogin": "graywolf336",
-      "milestone": "0.57.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "7084",
-      "title": "[FIX] Add option to ignore TLS in SMTP server settings",
-      "userLogin": "colin-campbell",
-      "milestone": "0.57.0",
-      "contributors": [
-        "colin-campbell"
-      ]
-    },
-    {
-      "pr": "7072",
-      "title": "[FIX] Add support for carriage return in markdown code blocks",
-      "userLogin": "jm-factorin",
-      "milestone": "0.57.0",
-      "contributors": [
-        "jm-factorin"
-      ]
-    },
-    {
-      "pr": "7014",
-      "title": "[FIX] Parse HTML on admin setting's descriptions",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7018",
-      "title": "converted rocketchat-importer",
-      "userLogin": "ggazzo",
-      "milestone": "0.57.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "7114",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "7105",
-      "title": "[FIX] edit button on firefox",
-      "userLogin": "karlprieb",
-      "milestone": "0.57.0",
-      "contributors": [
-        null
-      ]
-    },
-    {
-      "pr": "7104",
-      "title": "[FIX] Fix missing CSS files on production builds",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego",
-        null
-      ]
-    },
-    {
-      "pr": "7103",
-      "title": "[FIX] clipboard (permalink, copy, pin, star buttons)",
-      "userLogin": "karlprieb",
-      "contributors": [
-        null
-      ]
-    },
-    {
-      "pr": "7096",
-      "title": "Convert Livechat from Coffeescript to JavaScript",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7092",
-      "title": "[FIX]Fixed typo hmtl -> html",
-      "userLogin": "jautero",
-      "contributors": [
-        "jautero"
-      ]
-    },
-    {
-      "pr": "7080",
-      "title": "[NEW] Migration to add <html> tags to email header and footer",
-      "userLogin": "karlprieb",
-      "milestone": "0.57.0",
-      "contributors": [
-        null
-      ]
-    },
-    {
-      "pr": "7025",
-      "title": "[FIX] Add <html> and </html> to header and footer",
-      "userLogin": "ExTechOp",
-      "milestone": "0.57.0",
-      "contributors": [
-        "ExTechOp",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7033",
-      "title": "[FIX] Prevent Ctrl key on message field from reloading messages list",
-      "userLogin": "ggazzo",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "7044",
-      "title": "[FIX] New screen sharing Chrome extension checking method",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6982",
-      "title": "[NEW] postcss parser and cssnext implementation",
-      "userLogin": "karlprieb",
-      "contributors": [
-        null,
-        "rodrigok",
-        "web-flow",
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7049",
-      "title": "[FIX] Improve Tests",
-      "userLogin": "MartinSchoeler",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7045",
-      "title": "[FIX] Fix avatar upload via users.setAvatar REST endpoint",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7023",
-      "title": "[FIX] Sidenav roomlist",
-      "userLogin": "karlprieb",
-      "contributors": [
-        null,
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7012",
-      "title": "[FIX] video message recording dialog is shown in an incorrect position",
-      "userLogin": "flaviogrossi",
-      "milestone": "0.57.0",
-      "contributors": [
-        "flaviogrossi"
-      ]
-    },
-    {
-      "pr": "7006",
-      "title": "Rocketchat ui3",
-      "userLogin": "ggazzo",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6836",
-      "title": "converted rocketchat-ui coffee to js part 2",
-      "userLogin": "ggazzo",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6912",
-      "title": "[FIX] Remove room from roomPick setting",
-      "userLogin": "marceloschmidt",
-      "milestone": "0.57.0",
-      "contributors": [
-        "marceloschmidt",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6605",
-      "title": "[NEW] Start running unit tests",
-      "userLogin": "ggazzo",
-      "milestone": "0.57.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow",
-        "rodrigok",
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "6997",
-      "title": "[FIX] Parse markdown links last",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6999",
-      "title": "[FIX] overlapping text for users-typing-message",
-      "userLogin": "darkv",
-      "milestone": "0.57.0",
-      "contributors": [
-        "darkv"
-      ]
-    },
-    {
-      "pr": "7005",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "6735",
-      "title": "rocketchat-lib[4] coffee to js",
-      "userLogin": "ggazzo",
-      "milestone": "0.57.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6987",
-      "title": "rocketchat-importer-slack coffee to js",
-      "userLogin": "ggazzo",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6911",
-      "title": "Convert ui-admin package to js",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.0",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6857",
-      "title": "[NEW] Make channel/group delete call answer to roomName",
-      "userLogin": "reist",
-      "milestone": "0.57.0",
-      "contributors": [
-        "reist"
-      ]
-    },
-    {
-      "pr": "6903",
-      "title": "[FIX] Updating Incoming Integration Post As Field Not Allowed",
-      "userLogin": "graywolf336",
-      "milestone": "0.57.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "6972",
-      "title": "[FIX] Fix error handling for non-valid avatar URL",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6914",
-      "title": "Rocketchat ui message",
-      "userLogin": "ggazzo",
-      "milestone": "0.57.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "6921",
-      "title": "[New] LDAP: Use variables in User_Data_FieldMap for name mapping",
-      "userLogin": "bbrauns",
-      "milestone": "0.57.0",
-      "contributors": [
-        "bbrauns"
-      ]
-    },
-    {
-      "pr": "6961",
-      "title": "[FIX] SAML: Only set KeyDescriptor when non empty",
-      "userLogin": "sathieu",
-      "milestone": "0.57.0",
-      "contributors": [
-        "sathieu"
-      ]
-    },
-    {
-      "pr": "6986",
-      "title": "[FIX] Fix the other tests failing due chimp update",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "6936",
-      "title": "Convert meteor-autocomplete package to js",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "6795",
-      "title": "Convert Ui Account Package to Js",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "6950",
-      "title": "[FIX] Fix badge counter on iOS push notifications",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6974",
-      "title": "[FIX] Fix login with Meteor saving an object as email address",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6840",
-      "title": "[FIX] Check that username is not in the room when being muted / unmuted",
-      "userLogin": "matthewshirley",
-      "milestone": "0.57.0",
-      "contributors": [
-        "matthewshirley",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6947",
-      "title": "[FIX] Use AWS Signature Version 4 signed URLs for uploads",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "6978",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.57.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "6976",
-      "title": "fix the crashing tests",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.0",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6968",
-      "title": "[FIX] make channels.create API check for create-c",
-      "userLogin": "reist",
-      "milestone": "0.56.0",
-      "contributors": [
-        "reist"
-      ]
-    },
-    {
-      "pr": "6775",
-      "title": "Convert WebRTC Package to Js",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "6935",
-      "title": "[Fix] Error when trying to show preview of undefined filetype",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.57.0",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "6953",
-      "title": "[NEW] Show info about multiple instances at admin page",
-      "userLogin": "rodrigok",
-      "milestone": "0.56.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6938",
-      "title": "[NEW] Improve CI/Docker build/release",
-      "userLogin": "rodrigok",
-      "milestone": "0.56.0",
-      "contributors": [
-        "rodrigok",
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6919",
-      "title": "[NEW] Feature/delete any message permission",
-      "userLogin": "phutchins",
-      "milestone": "0.57.0",
-      "contributors": [
-        "phutchins"
-      ]
-    },
-    {
-      "pr": "6904",
-      "title": "[FIX] Bugs in `isUserFromParams` helper",
-      "userLogin": "abrom",
-      "milestone": "0.57.0",
-      "contributors": [
-        "abrom"
-      ]
-    },
-    {
-      "pr": "6910",
-      "title": "[FIX] Allow image insert from slack through slackbridge",
-      "userLogin": "marceloschmidt",
-      "milestone": "0.57.0",
-      "contributors": [
-        "marceloschmidt"
-      ]
-    },
-    {
-      "pr": "6913",
-      "title": "[FIX] Slackbridge text replacements",
-      "userLogin": "marceloschmidt",
-      "milestone": "0.57.0",
-      "contributors": [
-        "marceloschmidt"
-      ]
-    }
-  ],
-  "0.57.0-rc.1": [
-    {
-      "pr": "7157",
-      "title": "[FIX] Fix all reactions having the same username",
-      "userLogin": "MartinSchoeler",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7154",
-      "title": "Remove missing CoffeeScript dependencies",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7158",
-      "title": "Switch logic of artifact name",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.57.0-rc.2": [
-    {
-      "pr": "7200",
-      "title": "[FIX] Fix editing others messages",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7208",
-      "title": "[FIX] Fix oembed previews not being shown",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7215",
-      "title": "Fix the Zapier oAuth return url to the new one",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "7209",
-      "title": "[FIX] \"requirePasswordChange\" property not being saved when set to false",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "7196",
-      "title": "Fix the admin oauthApps view not working",
-      "userLogin": "graywolf336",
-      "milestone": "0.57.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "7160",
-      "title": "[FIX] Removing the kadira package install from example build script.",
-      "userLogin": "JSzaszvari",
-      "contributors": [
-        "JSzaszvari",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7159",
-      "title": "Fix forbidden error on setAvatar REST endpoint",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7196",
-      "title": "Fix the admin oauthApps view not working",
-      "userLogin": "graywolf336",
-      "milestone": "0.57.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "7177",
-      "title": "Fix mobile avatars",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.57.0-rc.3": [
-    {
-      "pr": "7358",
-      "title": "[FIX] Fix user's customFields not being saved correctly",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7352",
-      "title": "[FIX] Improve avatar migration",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7311",
-      "title": "[NEW] Force use of MongoDB for spotlight queries",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7320",
-      "title": "[FIX] Fix jump to unread button",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7345",
-      "title": "[FIX] click on image in a message",
-      "userLogin": "ggazzo",
-      "milestone": "0.57.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "7304",
-      "title": "[FIX] Proxy upload to correct instance",
-      "userLogin": "rodrigok",
-      "milestone": "0.57.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7321",
-      "title": "[FIX] Fix Secret Url",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    }
-  ],
-  "0.57.0": [
-    {
-      "pr": "7379",
-      "title": "[FIX] Message being displayed unescaped",
-      "userLogin": "gdelavald",
-      "milestone": "0.58.0",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "7102",
-      "title": "add server methods getRoomNameById",
-      "userLogin": "thinkeridea",
-      "milestone": "0.57.0",
-      "contributors": [
-        "thinkeridea"
-      ]
-    }
-  ],
-  "0.57.1": [
-    {
-      "pr": "7428",
-      "title": "[FIX] Fix migration of avatars from version 0.57.0",
-      "userLogin": "rodrigok",
-      "milestone": "0.57.1",
-      "contributors": [
-        "sampaiodiego",
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.57.2": [
-    {
-      "pr": "7431",
-      "title": "[FIX] Fix Emails in User Admin View",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.2",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7472",
-      "title": "[FIX] Always set LDAP properties on login",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7403",
-      "title": "[FIX] Fix Unread Bar Disappearing",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.2",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7469",
-      "title": "[FIX] Fix file upload on Slack import",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7432",
-      "title": "[FIX] Fix Private Channel List Submit",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.2",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7443",
-      "title": "[FIX] S3 uploads not working for custom URLs",
-      "userLogin": "rodrigok",
-      "milestone": "0.57.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.57.3": [
-    {
-      "pr": "7212",
-      "title": "[Fix] Users and Channels list not respecting permissions",
-      "userLogin": "graywolf336",
-      "milestone": "0.57.3",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "7325",
-      "title": "[FIX] Modernize rate limiting of sendMessage",
-      "userLogin": "jangmarker",
-      "milestone": "0.57.3",
-      "contributors": [
-        "jangmarker"
-      ]
-    },
-    {
-      "pr": "7390",
-      "title": "[FIX] custom soundEdit.html",
-      "userLogin": "rasos",
-      "milestone": "0.57.3",
-      "contributors": [
-        "rasos",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7394",
-      "title": "[FIX] Use UTF8 setting for /create command",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.3",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7395",
-      "title": "[FIX] file upload broken when running in subdirectory https://github.com…",
-      "userLogin": "ryoshimizu",
-      "milestone": "0.57.3",
-      "contributors": [
-        "ryoshimizu"
-      ]
-    },
-    {
-      "pr": "7444",
-      "title": "[FIX] Fix Anonymous User",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.3",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7533",
-      "title": "[FIX] Missing eventName in unUser",
-      "userLogin": "Darkneon",
-      "milestone": "0.57.3",
-      "contributors": [
-        "Darkneon"
-      ]
-    },
-    {
-      "pr": "7535",
-      "title": "[FIX] Fix Join Channel Without Preview Room Permission",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.3",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7555",
-      "title": "[FIX] Improve build script example",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.3",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    }
-  ],
-  "0.57.4": [
-    {
-      "pr": "8390",
-      "title": "[FIX] Slack import failing and not being able to be restarted",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8408",
-      "title": "[FIX] Duplicate code in rest api letting in a few bugs with the rest api",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8389",
-      "title": "[FIX] Add needed dependency for snaps",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    }
-  ],
-  "0.58.0-rc.0": [
-    {
-      "pr": "8390",
-      "title": "[FIX] Slack import failing and not being able to be restarted",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8408",
-      "title": "[FIX] Duplicate code in rest api letting in a few bugs with the rest api",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8389",
-      "title": "[FIX] Add needed dependency for snaps",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "7212",
-      "title": "[Fix] Users and Channels list not respecting permissions",
-      "userLogin": "graywolf336",
-      "milestone": "0.57.3",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "7325",
-      "title": "[FIX] Modernize rate limiting of sendMessage",
-      "userLogin": "jangmarker",
-      "milestone": "0.57.3",
-      "contributors": [
-        "jangmarker"
-      ]
-    },
-    {
-      "pr": "7390",
-      "title": "[FIX] custom soundEdit.html",
-      "userLogin": "rasos",
-      "milestone": "0.57.3",
-      "contributors": [
-        "rasos",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7394",
-      "title": "[FIX] Use UTF8 setting for /create command",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.3",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7395",
-      "title": "[FIX] file upload broken when running in subdirectory https://github.com…",
-      "userLogin": "ryoshimizu",
-      "milestone": "0.57.3",
-      "contributors": [
-        "ryoshimizu"
-      ]
-    },
-    {
-      "pr": "7444",
-      "title": "[FIX] Fix Anonymous User",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.3",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7533",
-      "title": "[FIX] Missing eventName in unUser",
-      "userLogin": "Darkneon",
-      "milestone": "0.57.3",
-      "contributors": [
-        "Darkneon"
-      ]
-    },
-    {
-      "pr": "7535",
-      "title": "[FIX] Fix Join Channel Without Preview Room Permission",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.3",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7555",
-      "title": "[FIX] Improve build script example",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.3",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7624",
-      "title": "[FIX] Error when updating message with an empty attachment array",
-      "userLogin": "graywolf336",
-      "milestone": "0.58.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "7623",
-      "title": "[FIX] Uploading an unknown file type erroring out",
-      "userLogin": "graywolf336",
-      "milestone": "0.58.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "7622",
-      "title": "[FIX] Error when acessing settings before ready",
-      "userLogin": "rodrigok",
-      "milestone": "0.58.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7608",
-      "title": "Add missing parts of `one click to direct message`",
-      "userLogin": "rodrigok",
-      "milestone": "0.58.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7621",
-      "title": "[FIX] Message box on safari",
-      "userLogin": "rodrigok",
-      "milestone": "0.58.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7620",
-      "title": "[FIX] The username not being allowed to be passed into the user.setAvatar",
-      "userLogin": "graywolf336",
-      "milestone": "0.58.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "7613",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "7617",
-      "title": "[FIX] Fix Custom Fields Crashing on Register",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.58.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7615",
-      "title": "Improve link parser using tokens",
-      "userLogin": "rodrigok",
-      "milestone": "0.58.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7616",
-      "title": "Improve login error messages",
-      "userLogin": "rodrigok",
-      "milestone": "0.58.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7595",
-      "title": "[NEW] Allow special chars on room names",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.58.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7594",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.58.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "7479",
-      "title": "[NEW] Add admin and user setting for notifications #4339",
-      "userLogin": "stalley",
-      "milestone": "0.58.0",
-      "contributors": [
-        "stalley",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7309",
-      "title": "[NEW] Edit user permissions",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.58.0",
-      "contributors": [
-        "MartinSchoeler",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7324",
-      "title": "[NEW] Adding support for piwik sub domain settings",
-      "userLogin": "ruKurz",
-      "milestone": "0.58.0",
-      "contributors": [
-        "ruKurz"
-      ]
-    },
-    {
-      "pr": "7578",
-      "title": "Improve room leader",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.58.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7582",
-      "title": "[FIX] Fix admin room list show the correct i18n type",
-      "userLogin": "ccfang",
-      "milestone": "0.58.0",
-      "contributors": [
-        "ccfang",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6753",
-      "title": "[NEW] Add setting to change User Agent of OEmbed calls",
-      "userLogin": "AhmetS",
-      "milestone": "0.58.0",
-      "contributors": [
-        "AhmetS",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7517",
-      "title": "[NEW] Configurable Volume for Notifications #6087",
-      "userLogin": "lindoelio",
-      "milestone": "0.58.0",
-      "contributors": [
-        "lindoelio"
-      ]
-    },
-    {
-      "pr": "7590",
-      "title": "Develop sync",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6564",
-      "title": "[NEW] Add customFields in rooms/get method",
-      "userLogin": "borsden",
-      "milestone": "0.58.0",
-      "contributors": [
-        "borsden"
-      ]
-    },
-    {
-      "pr": "7589",
-      "title": "[NEW] Option to select unread count style",
-      "userLogin": "rodrigok",
-      "milestone": "0.58.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7580",
-      "title": "[NEW] Show different shape for alert numbers when have mentions",
-      "userLogin": "rodrigok",
-      "milestone": "0.58.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7533",
-      "title": "[FIX] Missing eventName in unUser",
-      "userLogin": "Darkneon",
-      "milestone": "0.57.3",
-      "contributors": [
-        "Darkneon"
-      ]
-    },
-    {
-      "pr": "7569",
-      "title": "[NEW] Add reaction to the last message when get the shortcut +:",
-      "userLogin": "danilomiranda",
-      "milestone": "0.58.0",
-      "contributors": [
-        "danilomiranda",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7513",
-      "title": "[Fix] Don't save user to DB when a custom field is invalid",
-      "userLogin": "Darkneon",
-      "milestone": "0.58.0",
-      "contributors": [
-        "Darkneon"
-      ]
-    },
-    {
-      "pr": "7538",
-      "title": "[FIX] URL parse error fix for issue #7169",
-      "userLogin": "satyapramodh",
-      "milestone": "0.58.0",
-      "contributors": [
-        "satyapramodh",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7559",
-      "title": "[NEW] Show emojis and file uploads on notifications",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.58.0",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7561",
-      "title": "[NEW] Closes tab bar on mobile when leaving room",
-      "userLogin": "gdelavald",
-      "milestone": "0.58.0",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "7572",
-      "title": "[FIX] User avatar image background",
-      "userLogin": "filipedelimabrito",
-      "milestone": "0.58.0",
-      "contributors": [
-        "filipedelimabrito",
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7564",
-      "title": "[NEW] Adds preference to one-click-to-direct-message and basic functionality",
-      "userLogin": "gdelavald",
-      "milestone": "0.58.0",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "7555",
-      "title": "[FIX] Improve build script example",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.3",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7535",
-      "title": "[FIX] Fix Join Channel Without Preview Room Permission",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.3",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7334",
-      "title": "[NEW] Search users also by email in toolbar",
-      "userLogin": "shahar3012",
-      "milestone": "0.58.0",
-      "contributors": [
-        "shahar3012"
-      ]
-    },
-    {
-      "pr": "7326",
-      "title": "[NEW] Do not rate limit bots on createDirectMessage",
-      "userLogin": "jangmarker",
-      "milestone": "0.58.0",
-      "contributors": [
-        "jangmarker"
-      ]
-    },
-    {
-      "pr": "7214",
-      "title": "[NEW] Allow channel property in the integrations returned content",
-      "userLogin": "graywolf336",
-      "milestone": "0.58.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "7212",
-      "title": "[Fix] Users and Channels list not respecting permissions",
-      "userLogin": "graywolf336",
-      "milestone": "0.57.3",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "7554",
-      "title": "[FIX] Look for livechat visitor IP address on X-Forwarded-For header",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.58.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7556",
-      "title": "[BREAK] Remove Sandstorm login method",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.58.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7557",
-      "title": "[FIX] Revert emojione package version upgrade",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.58.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7562",
-      "title": "[FIX] Stop logging mentions object to console",
-      "userLogin": "gdelavald",
-      "milestone": "0.58.0",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "7500",
-      "title": "Develop sync",
-      "userLogin": "rodrigok",
-      "milestone": "0.58.0",
-      "contributors": [
-        "thinkeridea",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7520",
-      "title": "[NEW] Add room type identifier to room list header",
-      "userLogin": "danischreiber",
-      "milestone": "0.58.0",
-      "contributors": [
-        "danischreiber",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7523",
-      "title": "[NEW] Room type and recipient data for global event",
-      "userLogin": "danischreiber",
-      "milestone": "0.58.0",
-      "contributors": [
-        "danischreiber"
-      ]
-    },
-    {
-      "pr": "7526",
-      "title": "[NEW] Show room leader at top of chat when user scrolls down. Set and unset leader as admin.",
-      "userLogin": "danischreiber",
-      "milestone": "0.58.0",
-      "contributors": [
-        "danischreiber"
-      ]
-    },
-    {
-      "pr": "7525",
-      "title": "[NEW] Add toolbar buttons for iframe API",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.58.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7492",
-      "title": "Better Issue Template",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.58.0",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow",
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "7529",
-      "title": "[NEW] Add close button to flex tabs",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.58.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7496",
-      "title": "[NEW] Update meteor to 1.5.1",
-      "userLogin": "engelgabriel",
-      "milestone": "0.58.0",
-      "contributors": [
-        "engelgabriel",
-        "MartinSchoeler",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7486",
-      "title": "[FIX] Fix hiding flex-tab on embedded view",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.58.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7195",
-      "title": "[FIX] Fix emoji picker translations",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.58.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7325",
-      "title": "[FIX] Modernize rate limiting of sendMessage",
-      "userLogin": "jangmarker",
-      "milestone": "0.57.3",
-      "contributors": [
-        "jangmarker"
-      ]
-    },
-    {
-      "pr": "7390",
-      "title": "[FIX] custom soundEdit.html",
-      "userLogin": "rasos",
-      "milestone": "0.57.3",
-      "contributors": [
-        "rasos",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7394",
-      "title": "[FIX] Use UTF8 setting for /create command",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.3",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7395",
-      "title": "[FIX] file upload broken when running in subdirectory https://github.com…",
-      "userLogin": "ryoshimizu",
-      "milestone": "0.57.3",
-      "contributors": [
-        "ryoshimizu"
-      ]
-    },
-    {
-      "pr": "7444",
-      "title": "[FIX] Fix Anonymous User",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.3",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7471",
-      "title": "[FIX] Issue #7365: added check for the existence of a parameter in the CAS URL",
-      "userLogin": "wsw70",
-      "milestone": "0.58.0",
-      "contributors": [
-        "wsw70"
-      ]
-    },
-    {
-      "pr": "7392",
-      "title": "[FIX] Fix Word Placement Anywhere on WebHooks",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.58.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7487",
-      "title": "[FIX] Prevent new room status from playing when user status changes",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.58.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7443",
-      "title": "[FIX] S3 uploads not working for custom URLs",
-      "userLogin": "rodrigok",
-      "milestone": "0.57.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7432",
-      "title": "[FIX] Fix Private Channel List Submit",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.2",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7469",
-      "title": "[FIX] Fix file upload on Slack import",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7403",
-      "title": "[FIX] Fix Unread Bar Disappearing",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.2",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7472",
-      "title": "[FIX] Always set LDAP properties on login",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7448",
-      "title": "[NEW] flex-tab now is side by side with message list",
-      "userLogin": "ggazzo",
-      "milestone": "0.58.0",
-      "contributors": [
-        "ggazzo",
-        "karlprieb",
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7477",
-      "title": "[NEW] Option to select unread count behavior",
-      "userLogin": "rodrigok",
-      "milestone": "0.58.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7205",
-      "title": "[FIX] url click events in the cordova app open in external browser or not at all",
-      "userLogin": "flaviogrossi",
-      "milestone": "0.58.0",
-      "contributors": [
-        "flaviogrossi"
-      ]
-    },
-    {
-      "pr": "7431",
-      "title": "[FIX] Fix Emails in User Admin View",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.2",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7428",
-      "title": "[FIX] Fix migration of avatars from version 0.57.0",
-      "userLogin": "rodrigok",
-      "milestone": "0.57.1",
-      "contributors": [
-        "sampaiodiego",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6340",
-      "title": "Add helm chart kubernetes deployment",
-      "userLogin": "pierreozoux",
-      "milestone": "0.58.0",
-      "contributors": [
-        "pierreozoux"
-      ]
-    },
-    {
-      "pr": "7404",
-      "title": "[FIX] sweetalert alignment on mobile",
-      "userLogin": "karlprieb",
-      "milestone": "0.58.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7376",
-      "title": "[FIX] Sweet-Alert modal popup position on mobile devices",
-      "userLogin": "Oliver84",
-      "milestone": "0.58.0",
-      "contributors": [
-        "Oliver84",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7355",
-      "title": "[FIX] Update node-engine in Snap to latest v4 LTS relase: 4.8.3",
-      "userLogin": "al3x",
-      "milestone": "0.58.0",
-      "contributors": [
-        "al3x"
-      ]
-    },
-    {
-      "pr": "7354",
-      "title": "[FIX] Remove warning about 2FA support being unavailable in mobile apps",
-      "userLogin": "al3x",
-      "milestone": "0.58.0",
-      "contributors": [
-        "al3x"
-      ]
-    },
-    {
-      "pr": "7363",
-      "title": "Develop sync",
-      "userLogin": "rodrigok",
-      "milestone": "0.58.0",
-      "contributors": [
-        "rodrigok",
-        "geekgonecrazy",
-        "JSzaszvari",
-        "MartinSchoeler",
-        "graywolf336",
-        "sampaiodiego",
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7308",
-      "title": "Escape error messages",
-      "userLogin": "rodrigok",
-      "milestone": "0.57.0",
-      "contributors": [
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7322",
-      "title": "[FIX] Fix geolocation button",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.58.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7207",
-      "title": "[FIX] Fix Block Delete Message After (n) Minutes",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7311",
-      "title": "[NEW] Force use of MongoDB for spotlight queries",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7320",
-      "title": "[FIX] Fix jump to unread button",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7321",
-      "title": "[FIX] Fix Secret Url",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7199",
-      "title": "[FIX] Use I18n on \"File Uploaded\"",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.58.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7287",
-      "title": "update meteor to 1.5.0",
-      "userLogin": "engelgabriel",
-      "milestone": "0.58.0",
-      "contributors": [
-        "engelgabriel",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7215",
-      "title": "Fix the Zapier oAuth return url to the new one",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "7209",
-      "title": "[FIX] \"requirePasswordChange\" property not being saved when set to false",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "7211",
-      "title": "[New] Add instance id to response headers",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "7184",
-      "title": "[NEW] Add healthchecks in OpenShift templates",
-      "userLogin": "jfchevrette",
-      "contributors": [
-        "jfchevrette"
-      ]
-    },
-    {
-      "pr": "7208",
-      "title": "[FIX] Fix oembed previews not being shown",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7200",
-      "title": "[FIX] Fix editing others messages",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7187",
-      "title": "[FIX] Fix error on image preview due to undefined description|title ",
-      "userLogin": "ggazzo",
-      "contributors": [
-        "ggazzo"
-      ]
-    }
-  ],
-  "0.58.0-rc.1": [
-    {
-      "pr": "7629",
-      "title": "[FIX] Fix messagebox growth",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.58.0-rc.1",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7630",
-      "title": "[FIX] Wrong render of snippet’s name",
-      "userLogin": "rodrigok",
-      "milestone": "0.58.0-rc.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7658",
-      "title": "[NEW] Add unread options for direct messages",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.58.0-rc.1",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7687",
-      "title": "[FIX] Fix room load on first hit",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.58.0-rc.1",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7644",
-      "title": "[FIX] Markdown noopener/noreferrer: use correct HTML attribute",
-      "userLogin": "jangmarker",
-      "milestone": "0.58.0-rc.1",
-      "contributors": [
-        "jangmarker"
-      ]
-    },
-    {
-      "pr": "7652",
-      "title": "Only use \"File Uploaded\" prefix on files",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.58.0-rc.1",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7639",
-      "title": "[FIX] Wrong email subject when \"All Messages\" setting enabled",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.58.0-rc.1",
-      "contributors": [
-        "MartinSchoeler",
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.58.0-rc.2": [
-    {
-      "pr": "7456",
-      "title": "[FIX] Csv importer: work with more problematic data",
-      "userLogin": "reist",
-      "milestone": "0.58.0-rc.2",
-      "contributors": [
-        "reist"
-      ]
-    }
-  ],
-  "0.58.0-rc.3": [
-    {
-      "pr": "7738",
-      "title": "[FIX] make flex-tab visible again when reduced width",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.58.0-rc.3",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    }
-  ],
-  "0.58.0": [
-    {
-      "pr": "7752",
-      "title": "Release 0.58.0",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "ryoshimizu",
-        "rodrigok",
-        "web-flow",
-        "MartinSchoeler",
-        "karlprieb",
-        "engelgabriel",
-        "sampaiodiego",
-        "pierreozoux",
-        "geekgonecrazy",
-        "jangmarker",
-        "flaviogrossi",
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "7690",
-      "title": "Sync Master with 0.57.3",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7212",
-      "title": "[Fix] Users and Channels list not respecting permissions",
-      "userLogin": "graywolf336",
-      "milestone": "0.57.3",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "7325",
-      "title": "[FIX] Modernize rate limiting of sendMessage",
-      "userLogin": "jangmarker",
-      "milestone": "0.57.3",
-      "contributors": [
-        "jangmarker"
-      ]
-    },
-    {
-      "pr": "7390",
-      "title": "[FIX] custom soundEdit.html",
-      "userLogin": "rasos",
-      "milestone": "0.57.3",
-      "contributors": [
-        "rasos",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7394",
-      "title": "[FIX] Use UTF8 setting for /create command",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.3",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7395",
-      "title": "[FIX] file upload broken when running in subdirectory https://github.com…",
-      "userLogin": "ryoshimizu",
-      "milestone": "0.57.3",
-      "contributors": [
-        "ryoshimizu"
-      ]
-    },
-    {
-      "pr": "7444",
-      "title": "[FIX] Fix Anonymous User",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.3",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7533",
-      "title": "[FIX] Missing eventName in unUser",
-      "userLogin": "Darkneon",
-      "milestone": "0.57.3",
-      "contributors": [
-        "Darkneon"
-      ]
-    },
-    {
-      "pr": "7535",
-      "title": "[FIX] Fix Join Channel Without Preview Room Permission",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.57.3",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7555",
-      "title": "[FIX] Improve build script example",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.57.3",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    }
-  ],
-  "0.58.1": [
-    {
-      "pr": "7782",
-      "title": "Release 0.58.1",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7781",
-      "title": "[FIX] Fix flex tab not opening and getting offscreen",
-      "userLogin": "MartinSchoeler",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    }
-  ],
-  "0.58.2": [
-    {
-      "pr": "7841",
-      "title": "Release 0.58.2",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.58.2",
-      "contributors": [
-        "snoozan",
-        "geekgonecrazy"
-      ]
-    }
-  ],
-  "0.58.3": [],
-  "0.58.4": [
-    {
-      "pr": "8408",
-      "title": "[FIX] Duplicate code in rest api letting in a few bugs with the rest api",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8390",
-      "title": "[FIX] Slack import failing and not being able to be restarted",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8389",
-      "title": "[FIX] Add needed dependency for snaps",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    }
-  ],
-  "0.59.0-rc.0": [
-    {
-      "pr": "8408",
-      "title": "[FIX] Duplicate code in rest api letting in a few bugs with the rest api",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8390",
-      "title": "[FIX] Slack import failing and not being able to be restarted",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8389",
-      "title": "[FIX] Add needed dependency for snaps",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "7864",
-      "title": "[NEW] Replace message cog for vertical menu",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0",
-      "contributors": [
-        "karlprieb",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7865",
-      "title": "Mobile sidenav",
-      "userLogin": "ggazzo",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "7830",
-      "title": "[NEW] block users to mention unknow users",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "7614",
-      "title": "[NEW] Allow ldap mapping of customFields",
-      "userLogin": "goiaba",
-      "milestone": "0.59.0",
-      "contributors": [
-        "goiaba",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7853",
-      "title": "[NEW] Create a standard for our svg icons",
-      "userLogin": "karlprieb",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7565",
-      "title": "[NEW] Allows admin to list all groups with API",
-      "userLogin": "mboudet",
-      "contributors": [
-        "mboudet",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7855",
-      "title": "[FIX] File upload on multi-instances using a path prefix",
-      "userLogin": "Darkneon",
-      "milestone": "0.59.0",
-      "contributors": [
-        "Darkneon"
-      ]
-    },
-    {
-      "pr": "7863",
-      "title": "[FIX] Fix migration 100",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7852",
-      "title": "[NEW] Add markdown parser \"marked\"",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0",
-      "contributors": [
-        "nishimaki10",
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7817",
-      "title": "[NEW] Audio Notification updated in sidebar",
-      "userLogin": "aditya19496",
-      "milestone": "0.59.0",
-      "contributors": [
-        "maarten-v",
-        "web-flow",
-        "aditya19496",
-        "engelgabriel",
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "7846",
-      "title": "[FIX] Email message forward error",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7854",
-      "title": "[FIX] Add CSS support for Safari versions > 7",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7612",
-      "title": "[NEW] Search users by fields defined by admin",
-      "userLogin": "goiaba",
-      "milestone": "0.59.0",
-      "contributors": [
-        "goiaba"
-      ]
-    },
-    {
-      "pr": "7688",
-      "title": "[NEW] Template to show Custom Fields in user info view",
-      "userLogin": "goiaba",
-      "milestone": "0.59.0",
-      "contributors": [
-        "goiaba"
-      ]
-    },
-    {
-      "pr": "7842",
-      "title": "npm deps update",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "7168",
-      "title": "[FIX] Fix black background on transparent avatars",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0",
-      "contributors": [
-        "ggazzo",
-        "sampaiodiego",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7711",
-      "title": "[NEW] Add room type as a class to the ul-group of rooms",
-      "userLogin": "danischreiber",
-      "milestone": "0.59.0",
-      "contributors": [
-        "danischreiber",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7636",
-      "title": "[NEW] Add classes to notification menu so they can be hidden in css",
-      "userLogin": "danischreiber",
-      "milestone": "0.59.0",
-      "contributors": [
-        "danischreiber"
-      ]
-    },
-    {
-      "pr": "5902",
-      "title": "[NEW] Adds a Keyboard Shortcut option to the flextab",
-      "userLogin": "cnash",
-      "milestone": "0.59.0",
-      "contributors": [
-        "cnash",
-        "web-flow",
-        "karlprieb",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7342",
-      "title": "[NEW] Integrated personal email gateway (GSoC'17)",
-      "userLogin": "pkgodara",
-      "milestone": "0.59.0",
-      "contributors": [
-        "pkgodara",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7803",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "7825",
-      "title": "[FIX] Google vision NSFW tag",
-      "userLogin": "marceloschmidt",
-      "milestone": "0.59.0",
-      "contributors": [
-        "marceloschmidt"
-      ]
-    },
-    {
-      "pr": "7793",
-      "title": "Additions to the REST API",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "6301",
-      "title": "[NEW] Add tags to uploaded images using Google Cloud Vision API",
-      "userLogin": "marceloschmidt",
-      "milestone": "0.59.0",
-      "contributors": [
-        "marceloschmidt",
-        "karlprieb",
-        "engelgabriel",
-        "web-flow",
-        "sampaiodiego",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "6700",
-      "title": "[NEW] Package to render issue numbers into links to an issue tracker.",
-      "userLogin": "TobiasKappe",
-      "milestone": "0.59.0",
-      "contributors": [
-        "TobiasKappe",
-        "TAdeJong"
-      ]
-    },
-    {
-      "pr": "7721",
-      "title": "[FIX] meteor-accounts-saml issue with ns0,ns1 namespaces, makes it compatible with pysaml2 lib",
-      "userLogin": "arminfelder",
-      "milestone": "0.59.0",
-      "contributors": [
-        "arminfelder"
-      ]
-    },
-    {
-      "pr": "7823",
-      "title": "[FIX] Fix new-message button showing on search",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "7350",
-      "title": "[NEW] Automatically select the first channel",
-      "userLogin": "antaryami-sahoo",
-      "milestone": "0.59.0",
-      "contributors": [
-        "antaryami-sahoo",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7779",
-      "title": "[FIX] Settings not getting applied from Meteor.settings and process.env ",
-      "userLogin": "Darkneon",
-      "milestone": "0.59.0",
-      "contributors": [
-        "Darkneon"
-      ]
-    },
-    {
-      "pr": "7748",
-      "title": "[FIX] scroll on flex-tab",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "7755",
-      "title": "npm deps update",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "7728",
-      "title": "FIX: Error when starting local development environment",
-      "userLogin": "rdebeasi",
-      "milestone": "0.59.0",
-      "contributors": [
-        "rdebeasi"
-      ]
-    },
-    {
-      "pr": "7815",
-      "title": "[FIX] Dutch translations",
-      "userLogin": "maarten-v",
-      "contributors": [
-        "maarten-v",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7814",
-      "title": "[FIX] Fix Dutch translation",
-      "userLogin": "maarten-v",
-      "contributors": [
-        "maarten-v",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7778",
-      "title": "[FIX] Update Snap links",
-      "userLogin": "MichaelGooden",
-      "contributors": [
-        "MichaelGooden",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7809",
-      "title": "[FIX] Remove redundant \"do\" in \"Are you sure ...?\" messages.",
-      "userLogin": "xurizaemon",
-      "contributors": [
-        "xurizaemon"
-      ]
-    },
-    {
-      "pr": "7758",
-      "title": "[FIX] Fixed function closure syntax allowing validation emails to be sent.",
-      "userLogin": "snoozan",
-      "milestone": "0.58.2",
-      "contributors": [
-        "snoozan"
-      ]
-    },
-    {
-      "pr": "7739",
-      "title": "Remove CircleCI",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7643",
-      "title": "[NEW] Rocket.Chat UI Redesign",
-      "userLogin": "MartinSchoeler",
-      "contributors": [
-        null,
-        "ggazzo",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7677",
-      "title": "Meteor packages and npm dependencies update",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "7456",
-      "title": "[FIX] Csv importer: work with more problematic data",
-      "userLogin": "reist",
-      "milestone": "0.58.0-rc.2",
-      "contributors": [
-        "reist"
-      ]
-    },
-    {
-      "pr": "7656",
-      "title": "[FIX] Fix avatar upload fail on Cordova app",
-      "userLogin": "ccfang",
-      "milestone": "0.58.0",
-      "contributors": [
-        "ccfang"
-      ]
-    },
-    {
-      "pr": "7679",
-      "title": "[FIX] Make link inside YouTube preview open in new tab",
-      "userLogin": "1lann",
-      "milestone": "0.59.0",
-      "contributors": [
-        "1lann",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7664",
-      "title": "[MOVE] Client folder rocketchat-colors",
-      "userLogin": "Kiran-Rao",
-      "milestone": "0.59.0",
-      "contributors": [
-        "Kiran-Rao"
-      ]
-    },
-    {
-      "pr": "7665",
-      "title": "[MOVE] Client folder rocketchat-custom-oauth",
-      "userLogin": "Kiran-Rao",
-      "milestone": "0.59.0",
-      "contributors": [
-        "Kiran-Rao"
-      ]
-    },
-    {
-      "pr": "7666",
-      "title": "[MOVE] Client folder rocketchat-tooltip",
-      "userLogin": "Kiran-Rao",
-      "milestone": "0.59.0",
-      "contributors": [
-        "Kiran-Rao"
-      ]
-    },
-    {
-      "pr": "7667",
-      "title": "[MOVE] Client folder rocketchat-autolinker",
-      "userLogin": "Kiran-Rao",
-      "milestone": "0.59.0",
-      "contributors": [
-        "Kiran-Rao"
-      ]
-    },
-    {
-      "pr": "7668",
-      "title": "[MOVE] Client folder rocketchat-cas",
-      "userLogin": "Kiran-Rao",
-      "milestone": "0.59.0",
-      "contributors": [
-        "Kiran-Rao"
-      ]
-    },
-    {
-      "pr": "7669",
-      "title": "[MOVE] Client folder rocketchat-highlight-words",
-      "userLogin": "Kiran-Rao",
-      "milestone": "0.59.0",
-      "contributors": [
-        "Kiran-Rao"
-      ]
-    },
-    {
-      "pr": "7670",
-      "title": "[MOVE] Client folder rocketchat-custom-sounds",
-      "userLogin": "Kiran-Rao",
-      "milestone": "0.59.0",
-      "contributors": [
-        "Kiran-Rao"
-      ]
-    },
-    {
-      "pr": "7671",
-      "title": "[MOVE] Client folder rocketchat-emoji",
-      "userLogin": "Kiran-Rao",
-      "milestone": "0.59.0",
-      "contributors": [
-        "Kiran-Rao"
-      ]
-    },
-    {
-      "pr": "7672",
-      "title": "[FIX] Remove references to non-existent tests",
-      "userLogin": "Kiran-Rao",
-      "milestone": "0.59.0",
-      "contributors": [
-        "Kiran-Rao"
-      ]
-    },
-    {
-      "pr": "7673",
-      "title": "[FIX] Example usage of unsubscribe.js",
-      "userLogin": "Kiran-Rao",
-      "milestone": "0.59.0",
-      "contributors": [
-        "Kiran-Rao"
-      ]
-    },
-    {
-      "pr": "7639",
-      "title": "[FIX] Wrong email subject when \"All Messages\" setting enabled",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.58.0-rc.1",
-      "contributors": [
-        "MartinSchoeler",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7652",
-      "title": "Only use \"File Uploaded\" prefix on files",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.58.0-rc.1",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7644",
-      "title": "[FIX] Markdown noopener/noreferrer: use correct HTML attribute",
-      "userLogin": "jangmarker",
-      "milestone": "0.58.0-rc.1",
-      "contributors": [
-        "jangmarker"
-      ]
-    },
-    {
-      "pr": "7687",
-      "title": "[FIX] Fix room load on first hit",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.58.0-rc.1",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7658",
-      "title": "[NEW] Add unread options for direct messages",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.58.0-rc.1",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7661",
-      "title": "Fix typo in generated URI",
-      "userLogin": "Rohlik",
-      "contributors": [
-        "Rohlik",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7625",
-      "title": "Bump version to 0.59.0-develop",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7630",
-      "title": "[FIX] Wrong render of snippet’s name",
-      "userLogin": "rodrigok",
-      "milestone": "0.58.0-rc.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7629",
-      "title": "[FIX] Fix messagebox growth",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.58.0-rc.1",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "2",
-      "title": "implemented new page-loader animated icon",
-      "userLogin": "rcaferati",
-      "contributors": [
-        null
-      ]
-    }
-  ],
-  "0.59.0-rc.1": [
-    {
-      "pr": "7880",
-      "title": "[FIX] sidebar paddings",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7878",
-      "title": "[FIX] Adds default search text padding for emoji search",
-      "userLogin": "gdelavald",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "7881",
-      "title": "[FIX] search results position on sidebar",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7882",
-      "title": "[FIX] hyperlink style on sidebar footer",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7883",
-      "title": "[FIX] popover position on mobile",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7885",
-      "title": "[FIX] message actions over unread bar",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7886",
-      "title": "[FIX] livechat icon",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7887",
-      "title": "[FIX] Makes text action menu width based on content size",
-      "userLogin": "gdelavald",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "7888",
-      "title": "[FIX] sidebar buttons and badge paddings",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    }
-  ],
-  "0.59.0-rc.2": [
-    {
-      "pr": "7912",
-      "title": "[FIX] Fix google play logo on repo README",
-      "userLogin": "luizbills",
-      "milestone": "0.59.0-rc.2",
-      "contributors": [
-        "luizbills",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7904",
-      "title": "[FIX] Fix livechat toggle UI issue",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.0-rc.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7895",
-      "title": "[FIX] Remove break change in Realtime API",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7894",
-      "title": "Hide flex-tab close button",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.2",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7893",
-      "title": "[FIX] Window exception when parsing Markdown on server",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.59.0-rc.3": [
-    {
-      "pr": "7985",
-      "title": "[FIX] Text area buttons and layout on mobile ",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "7927",
-      "title": "[FIX] Double scroll on 'keyboard shortcuts' menu in sidepanel",
-      "userLogin": "aditya19496",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "aditya19496"
-      ]
-    },
-    {
-      "pr": "7944",
-      "title": "[FIX] Broken embedded view layout",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7986",
-      "title": "[FIX] Textarea on firefox",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "MartinSchoeler",
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7984",
-      "title": "[FIX] Chat box no longer auto-focuses when typing",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7971",
-      "title": "[FIX] Add padding on messages to allow space to the action buttons",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "7970",
-      "title": "[FIX] Small alignment fixes",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "7965",
-      "title": "[FIX] Markdown being rendered in code tags",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7963",
-      "title": "[FIX] Fix the status on the members list",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7960",
-      "title": "[FIX] status and active room colors on sidebar",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7954",
-      "title": "[FIX] OTR buttons padding",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7953",
-      "title": "[FIX] username ellipsis on firefox",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7948",
-      "title": "[FIX] Document README.md. Drupal repo out of date",
-      "userLogin": "Lawri-van-Buel",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "Lawri-van-Buel"
-      ]
-    },
-    {
-      "pr": "7945",
-      "title": "[FIX] Fix placeholders in account profile",
-      "userLogin": "josiasds",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "josiasds"
-      ]
-    },
-    {
-      "pr": "7943",
-      "title": "[FIX] Broken emoji picker on firefox",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7942",
-      "title": "[FIX] Create channel button on Firefox",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7941",
-      "title": "Update BlackDuck URL",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7909",
-      "title": "[DOCS] Add native mobile app links into README and update button images",
-      "userLogin": "rafaelks",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "rafaelks",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7712",
-      "title": "[FIX] Show leader on first load",
-      "userLogin": "danischreiber",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "danischreiber",
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.59.0-rc.4": [
-    {
-      "pr": "7988",
-      "title": "[FIX] Vertical menu on flex-tab",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "ggazzo",
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8048",
-      "title": "[FIX] Invisible leader bar on hover",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "8046",
-      "title": "[FIX] Prevent autotranslate tokens race condition",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8039",
-      "title": "[FIX] copy to clipboard and update clipboard.js library",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8019",
-      "title": "[FIX] message-box autogrow",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8018",
-      "title": "[FIX] search results height",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "karlprieb",
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "8017",
-      "title": "[FIX] room icon on header",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8014",
-      "title": "[FIX] Hide scrollbar on login page if not necessary",
-      "userLogin": "alexbrazier",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "alexbrazier"
-      ]
-    },
-    {
-      "pr": "8001",
-      "title": "[FIX] Error when translating message",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7998",
-      "title": "[FIX] Recent emojis not updated when adding via text",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7989",
-      "title": "[FIX][PL] Polish translation",
-      "userLogin": "Rzeszow",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "Rzeszow",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7754",
-      "title": "[FIX] Fix email on mention",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    }
-  ],
-  "0.59.0-rc.5": [
-    {
-      "pr": "8112",
-      "title": "[FIX] RTL",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.5",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "8101",
-      "title": "[FIX] Dynamic popover",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.5",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8122",
-      "title": "[FIX] Settings description not showing",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.5",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8099",
-      "title": "[FIX] Fix setting user avatar on LDAP login",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.0-rc.5",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8059",
-      "title": "[FIX] Not sending email to mentioned users with unchanged preference",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.5",
-      "contributors": [
-        "MartinSchoeler",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8054",
-      "title": "Remove unnecessary returns in cors common",
-      "userLogin": "Kiran-Rao",
-      "milestone": "0.59.0-rc.5",
-      "contributors": [
-        "Kiran-Rao",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8047",
-      "title": "[FIX] Scroll on messagebox",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.5",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    }
-  ],
-  "0.59.0-rc.6": [
-    {
-      "pr": "8172",
-      "title": "[FIX] Allow unknown file types if no allowed whitelist has been set (#7074)",
-      "userLogin": "TriPhoenix",
-      "milestone": "0.59.0-rc.6",
-      "contributors": [
-        "TriPhoenix"
-      ]
-    },
-    {
-      "pr": "8167",
-      "title": "[FIX] Issue #8166 where empty analytics setting breaks to load Piwik script",
-      "userLogin": "ruKurz",
-      "milestone": "0.59.0-rc.6",
-      "contributors": [
-        "ruKurz"
-      ]
-    },
-    {
-      "pr": "8154",
-      "title": "[FIX] Sidebar and RTL alignments",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.6",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8147",
-      "title": "[FIX] \"*.members\" rest api being useless and only returning usernames",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0-rc.6",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8146",
-      "title": "[FIX] Fix iframe login API response (issue #8145)",
-      "userLogin": "astax-t",
-      "milestone": "0.59.0-rc.6",
-      "contributors": [
-        "astax-t"
-      ]
-    },
-    {
-      "pr": "8159",
-      "title": "[FIX] Text area lost text when page reloads",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.6",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8144",
-      "title": "[FIX] Fix new room sound being played too much",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.0-rc.6",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8094",
-      "title": "[FIX] Add admin audio preferences translations",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.0-rc.6",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8073",
-      "title": "[NEW] Upgrade to meteor 1.5.2",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.6",
-      "contributors": [
-        "engelgabriel"
-      ]
-    }
-  ],
-  "0.59.0-rc.7": [
-    {
-      "pr": "8213",
-      "title": "[FIX] Leave and hide buttons was removed",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.7",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8211",
-      "title": "[FIX] Incorrect URL for login terms when using prefix",
-      "userLogin": "Darkneon",
-      "milestone": "0.59.0-rc.7",
-      "contributors": [
-        "Darkneon"
-      ]
-    },
-    {
-      "pr": "8210",
-      "title": "[FIX] User avatar in DM list.",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.7",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "8197",
-      "title": "npm deps update",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.7",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8194",
-      "title": "Fix more rtl issues",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.7",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8190",
-      "title": "[FIX] Scrollbar not using new style",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.7",
-      "contributors": [
-        "ggazzo",
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.59.0-rc.8": [
-    {
-      "pr": "8253",
-      "title": "readme-file: fix broken link",
-      "userLogin": "vcapretz",
-      "milestone": "0.59.0-rc.8",
-      "contributors": [
-        "vcapretz"
-      ]
-    },
-    {
-      "pr": "8257",
-      "title": "[FIX] sidenav colors, hide and leave, create channel on safari",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.8",
-      "contributors": [
-        "ggazzo",
-        "karlprieb",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8262",
-      "title": "[FIX] make sidebar item animation fast",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.8",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8261",
-      "title": "[FIX] RTL on reply",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.8",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8260",
-      "title": "[NEW] Enable read only channel creation",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.8",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8259",
-      "title": "[FIX] clipboard and permalink on new popover",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.8",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8252",
-      "title": "[FIX] sidenav mentions on hover",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.8",
-      "contributors": [
-        "ggazzo",
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8244",
-      "title": "Disable perfect scrollbar",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.8",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8243",
-      "title": "Fix `leave and hide` click, color and position",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.8",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8241",
-      "title": "[FIX] Api groups.files is always returning empty",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.8",
-      "contributors": [
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8216",
-      "title": "[FIX] Case insensitive SAML email check",
-      "userLogin": "arminfelder",
-      "milestone": "0.59.0-rc.8",
-      "contributors": [
-        "arminfelder"
-      ]
-    }
-  ],
-  "0.59.0-rc.9": [
-    {
-      "pr": "8310",
-      "title": "[FIX] Execute meteor reset on TRAVIS_TAG builds",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8307",
-      "title": "[FIX] Call buttons with wrong margin on RTL",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8304",
-      "title": "[NEW] Add RD Station integration to livechat",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8300",
-      "title": "[FIX] Emoji Picker hidden for reactions in RTL",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8299",
-      "title": " [FIX] Amin menu not showing all items & File list breaking line",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "ggazzo",
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8298",
-      "title": "[FIX] TypeError: Cannot read property 't' of undefined",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8296",
-      "title": "[FIX] Wrong file name when upload to AWS S3",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8295",
-      "title": "[FIX] Check attachments is defined before accessing first element",
-      "userLogin": "Darkneon",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "Darkneon"
-      ]
-    },
-    {
-      "pr": "8286",
-      "title": "[FIX] Missing placeholder translations",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8282",
-      "title": "[FIX] fix color on unread messages",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "8278",
-      "title": "[FIX] \"Cancel button\" on modal in RTL in Firefox 55",
-      "userLogin": "cyclops24",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "cyclops24"
-      ]
-    },
-    {
-      "pr": "8273",
-      "title": "Deps update",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8271",
-      "title": "[FIX] Attachment icons alignment in LTR and RTL",
-      "userLogin": "cyclops24",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "cyclops24"
-      ]
-    },
-    {
-      "pr": "8270",
-      "title": "[FIX] [i18n] My Profile & README.md links",
-      "userLogin": "Rzeszow",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "Rzeszow",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8269",
-      "title": "[FIX] some placeholder and phrase traslation fix",
-      "userLogin": "cyclops24",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "cyclops24"
-      ]
-    },
-    {
-      "pr": "8266",
-      "title": "[FIX] \"Channel Setting\" buttons alignment in RTL",
-      "userLogin": "cyclops24",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "cyclops24"
-      ]
-    },
-    {
-      "pr": "8237",
-      "title": "[FIX] Removing pipe and commas from custom emojis (#8168)",
-      "userLogin": "matheusml",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "matheusml"
-      ]
-    }
-  ],
-  "0.59.0-rc.10": [
-    {
-      "pr": "8355",
-      "title": "Update meteor to 1.5.2.2-rc.0",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.10",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8314",
-      "title": "[FIX] After deleting the room, cache is not synchronizing",
-      "userLogin": "szluohua",
-      "milestone": "0.59.0-rc.10",
-      "contributors": [
-        "szluohua"
-      ]
-    },
-    {
-      "pr": "8334",
-      "title": "[FIX] Remove sidebar header on admin embedded version",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.10",
-      "contributors": [
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8331",
-      "title": "[FIX-RC] Mobile file upload not working",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.10",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8317",
-      "title": "[FIX] Email Subjects not being sent",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.10",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8315",
-      "title": "[FIX] Put delete action on another popover group",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.10",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8316",
-      "title": "[FIX] Mention unread indicator was removed",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.10",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.59.0-rc.11": [
-    {
-      "pr": "8375",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8372",
-      "title": "[FIX] Various LDAP issues & Missing pagination",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8364",
-      "title": "Update Meteor to 1.5.2.2",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8363",
-      "title": "Sync translations from LingoHub",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8358",
-      "title": "[FIX] remove accountBox from admin menu",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "engelgabriel",
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8361",
-      "title": "[NEW] Unify unread and mentions badge",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8362",
-      "title": "[NEW] make sidebar item width 100%",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8360",
-      "title": "[NEW] Smaller accountBox",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8357",
-      "title": "[FIX] Missing i18n translations",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "8345",
-      "title": "Remove field `lastActivity` from subscription data",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "ggazzo"
-      ]
-    }
-  ],
-  "0.59.0-rc.12": [
-    {
-      "pr": "8416",
-      "title": "Fix: Account menu position on RTL",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8417",
-      "title": "Fix: Missing LDAP option to show internal logs",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8414",
-      "title": "Fix: Missing LDAP reconnect setting",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8389",
-      "title": "[FIX] Add needed dependency for snaps",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "8390",
-      "title": "[FIX] Slack import failing and not being able to be restarted",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8397",
-      "title": "[FIX] Sidebar item menu position in RTL",
-      "userLogin": "cyclops24",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "cyclops24"
-      ]
-    },
-    {
-      "pr": "8386",
-      "title": "[FIX] disabled katex tooltip on messageBox",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "8394",
-      "title": "Add i18n Title to snippet messages",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8408",
-      "title": "[FIX] Duplicate code in rest api letting in a few bugs with the rest api",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8398",
-      "title": "Fix: Missing settings to configure LDAP size and page limits",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.59.0-rc.13": [
-    {
-      "pr": "8459",
-      "title": "[NEW] Setting to disable MarkDown and enable AutoLinker",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.13",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8457",
-      "title": "[FIX] LDAP memory issues when pagination is not available",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.13",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8451",
-      "title": "Improve markdown parser code",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.13",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.59.0-rc.14": [
-    {
-      "pr": "8515",
-      "title": "Change artifact path",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "8463",
-      "title": "Color variables migration",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.14",
-      "contributors": [
-        "ggazzo",
-        "rodrigok",
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8516",
-      "title": "Fix: Change password not working in new UI",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.14",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8514",
-      "title": "[FIX] Uncessary route reload break some routes",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.14",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8491",
-      "title": "[FIX] Invalid Code message for password protected channel",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.14",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8489",
-      "title": "[FIX] Wrong message when reseting password and 2FA is enabled",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.14",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8490",
-      "title": "Enable AutoLinker back",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.14",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.59.0-rc.15": [
-    {
-      "pr": "8518",
-      "title": "Fix artifact path",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "8520",
-      "title": "Fix high CPU load when sending messages on large rooms (regression)",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.59.0-rc.16": [
-    {
-      "pr": "8527",
-      "title": "[FIX] Do not send joinCode field to clients",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    }
-  ],
-  "0.59.0-rc.17": [
-    {
-      "pr": "8529",
-      "title": "Improve room sync speed",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.59.0": [
-    {
-      "pr": "8420",
-      "title": "Merge 0.58.4 to master",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8335",
-      "title": "0.58.3",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8408",
-      "title": "[FIX] Duplicate code in rest api letting in a few bugs with the rest api",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8390",
-      "title": "[FIX] Slack import failing and not being able to be restarted",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8389",
-      "title": "[FIX] Add needed dependency for snaps",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    }
-  ],
-  "0.59.1": [
-    {
-      "pr": "8543",
-      "title": "[FIX] Color reset when default value editor is different",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.1",
-      "contributors": [
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8547",
-      "title": "[FIX] Wrong colors after migration 103",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8541",
-      "title": "[FIX] LDAP login error regression at 0.59.0",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8544",
-      "title": "[FIX] Migration 103 wrong converting primrary colors",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.59.2": [
-    {
-      "pr": "8637",
-      "title": "[FIX] Missing scroll at create channel page",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.2",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8634",
-      "title": "[FIX] Message popup menu on mobile/cordova",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.2",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8635",
-      "title": "[FIX] API channel/group.members not sorting",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8613",
-      "title": "[FIX] LDAP not merging existent users && Wrong id link generation",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8551",
-      "title": "[FIX] encode filename in url to prevent links breaking",
-      "userLogin": "joesitton",
-      "milestone": "0.59.2",
-      "contributors": [
-        "joesitton",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8577",
-      "title": "[FIX] Fix guest pool inquiry taking",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    }
-  ],
-  "0.59.3": [
-    {
-      "pr": "8593",
-      "title": "[FIX] AmazonS3: Quote file.name for ContentDisposition for files with commas",
-      "userLogin": "xenithorb",
-      "milestone": "0.59.3",
-      "contributors": [
-        "xenithorb"
-      ]
-    },
-    {
-      "pr": "8434",
-      "title": "removing a duplicate line",
-      "userLogin": "vikaskedia",
-      "milestone": "0.59.3",
-      "contributors": [
-        "vikaskedia",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8645",
-      "title": "[FIX] Fix e-mail message forward",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.3",
-      "contributors": [
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8648",
-      "title": "[FIX] Audio message icon",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8431",
-      "title": "[FIX] Highlighted color height issue",
-      "userLogin": "cyclops24",
-      "milestone": "0.59.3",
-      "contributors": [
-        "cyclops24"
-      ]
-    },
-    {
-      "pr": "8655",
-      "title": "[FIX] Update pt-BR translation",
-      "userLogin": "rodorgas",
-      "milestone": "0.59.3",
-      "contributors": [
-        "rodorgas"
-      ]
-    },
-    {
-      "pr": "8679",
-      "title": "[FIX] Fix typos",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.3",
-      "contributors": [
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8653",
-      "title": "install grpc package manually to fix snap armhf build",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.59.3",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "8691",
-      "title": "[FIX] LDAP not respecting UTF8 characters & Sync Interval not working",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.3",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.59.4": [
-    {
-      "pr": "8967",
-      "title": "Release/0.59.4",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "cpitman",
-        "geekgonecrazy",
-        "karlprieb",
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8685",
-      "title": "Add CircleCI",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "sampaiodiego",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8753",
-      "title": "[FIX] Channel settings buttons",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb",
-        "geekgonecrazy",
-        "web-flow",
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.59.5": [
-    {
-      "pr": "8972",
-      "title": "Fix CircleCI deploy filter",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    }
-  ],
-  "0.59.6": [
-    {
-      "pr": "8973",
-      "title": "Fix tag build",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    }
-  ],
-  "0.60.0-rc.0": [
-    {
-      "pr": "9084",
-      "title": "Fix tag build",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7285",
-      "title": "[NEW] Allow user's default preferences configuration",
-      "userLogin": "goiaba",
-      "milestone": "0.60.0",
-      "contributors": [
-        "goiaba",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8925",
-      "title": "[FIX] Can't react on Read Only rooms even when enabled",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb",
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9068",
-      "title": "Turn off prettyJson if the node environment isn't development",
-      "userLogin": "graywolf336",
-      "milestone": "0.60.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "9049",
-      "title": "Fix api regression (exception when deleting user)",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8654",
-      "title": "[FIX] CAS does not share secrets when operating multiple server instances",
-      "userLogin": "AmShaegar13",
-      "milestone": "0.60.0",
-      "contributors": [
-        "AmShaegar13"
-      ]
-    },
-    {
-      "pr": "8937",
-      "title": "[FIX] Snippetted messages not working",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8915",
-      "title": "[NEW]  Add \"Favorites\" and \"Mark as read\" options to the room list",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8807",
-      "title": "[NEW] Facebook livechat integration",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.0",
-      "contributors": [
-        "sampaiodiego",
-        "ggazzo",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9022",
-      "title": "[FIX] Added afterUserCreated trigger after first CAS login",
-      "userLogin": "AmShaegar13",
-      "milestone": "0.60.0",
-      "contributors": [
-        "AmShaegar13"
-      ]
-    },
-    {
-      "pr": "8902",
-      "title": "[NEW] Added support for Dataporten's userid-feide scope",
-      "userLogin": "torgeirl",
-      "milestone": "0.60.0",
-      "contributors": [
-        "torgeirl",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8828",
-      "title": "[FIX] Notification is not sent when a video conference start",
-      "userLogin": "seainside75",
-      "milestone": "0.60.0",
-      "contributors": [
-        "stefanoverducci",
-        "deepseainside75"
-      ]
-    },
-    {
-      "pr": "8868",
-      "title": "[FIX] long filename overlaps cancel button in progress bar",
-      "userLogin": "joesitton",
-      "milestone": "0.60.0",
-      "contributors": [
-        "joesitton",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8924",
-      "title": "[NEW] Describe file uploads when notifying by email",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9012",
-      "title": "[FIX] Changed oembedUrlWidget to prefer og:image and twitter:image over msapplication-TileImage",
-      "userLogin": "wferris722",
-      "milestone": "0.60.0",
-      "contributors": [
-        "wferris722",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9046",
-      "title": "[FIX] Update insecure moment.js dependency",
-      "userLogin": "robbyoconnor",
-      "milestone": "0.60.0",
-      "contributors": [
-        "robbyoconnor"
-      ]
-    },
-    {
-      "pr": "8149",
-      "title": "[NEW] Feature/livechat hide email",
-      "userLogin": "icosamuel",
-      "milestone": "0.60.0",
-      "contributors": [
-        "sarbasamuel",
-        "icosamuel",
-        "web-flow",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7999",
-      "title": "[NEW] Sender's name in email notifications.",
-      "userLogin": "pkgodara",
-      "milestone": "0.60.0",
-      "contributors": [
-        "pkgodara",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7922",
-      "title": "Use real names for user and room in emails",
-      "userLogin": "danischreiber",
-      "milestone": "0.60.0",
-      "contributors": [
-        "danischreiber",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9034",
-      "title": "[FIX] Custom OAuth: Not able to set different token place for routes",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9044",
-      "title": "[FIX] Can't use OAuth login against a Rocket.Chat OAuth server",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.60.0",
-      "contributors": [
-        "geekgonecrazy",
-        "graywolf336",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9042",
-      "title": "[FIX] Notification sound is not disabling when busy",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.60.0",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8739",
-      "title": "[NEW] Add \"real name change\" setting",
-      "userLogin": "AmShaegar13",
-      "milestone": "0.60.0",
-      "contributors": [
-        "AmShaegar13"
-      ]
-    },
-    {
-      "pr": "8433",
-      "title": "[NEW] Use enter separator rather than comma in highlight preferences + Auto refresh after change highlighted words",
-      "userLogin": "cyclops24",
-      "milestone": "0.60.0",
-      "contributors": [
-        "cyclops24",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7641",
-      "title": "[NEW] Adds admin option to globally set mobile devices to always be notified regardless of presence status.",
-      "userLogin": "stalley",
-      "milestone": "0.60.0",
-      "contributors": [
-        "stalley",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9024",
-      "title": "[FIX] Use encodeURI in AmazonS3 contentDisposition file.name to prevent fail",
-      "userLogin": "paulovitin",
-      "milestone": "0.60.0",
-      "contributors": [
-        "paulovitin",
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9029",
-      "title": "[FIX] snap install by setting grpc package used by google/vision to 1.6.6",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.60.0",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8142",
-      "title": "[MOVE] Move mentions files to client/server",
-      "userLogin": "vcapretz",
-      "milestone": "0.60.0",
-      "contributors": [
-        "vcapretz",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8947",
-      "title": "[NEW] Add new API endpoints",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok",
-        "graywolf336",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8671",
-      "title": "[FIX] Enable CORS for Restivus",
-      "userLogin": "mrsimpson",
-      "milestone": "0.60.0",
-      "contributors": [
-        "mrsimpson",
-        "engelgabriel",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8966",
-      "title": "[FIX] Importers failing when usernames exists but cases don't match and improve the importer framework's performance",
-      "userLogin": "graywolf336",
-      "milestone": "0.60.0",
-      "contributors": [
-        "graywolf336",
-        "geekgonecrazy",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9023",
-      "title": "[FIX] Error when saving integration with symbol as only trigger",
-      "userLogin": "graywolf336",
-      "milestone": "0.60.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8006",
-      "title": "[FIX] Sync of non existent field throws exception",
-      "userLogin": "goiaba",
-      "milestone": "0.60.0",
-      "contributors": [
-        "goiaba",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9018",
-      "title": "Update multiple-instance-status package",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9007",
-      "title": "Use redhat official image with openshift",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.60.0",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8107",
-      "title": "[FIX] Autoupdate of CSS does not work when using a prefix",
-      "userLogin": "Darkneon",
-      "milestone": "0.60.0",
-      "contributors": [
-        "Darkneon",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8656",
-      "title": "[FIX] Contextual errors for this and RegExp declarations in IRC module",
-      "userLogin": "Pharserror",
-      "milestone": "0.60.0",
-      "contributors": [
-        "Pharserror",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8029",
-      "title": "[NEW] Option to enable/disable auto away and configure timer",
-      "userLogin": "armand1m",
-      "milestone": "0.60.0",
-      "contributors": [
-        "armand1m",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9013",
-      "title": "[FIX] Wrong room counter name",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8975",
-      "title": "Added d2c.io to deployment",
-      "userLogin": "mastappl",
-      "contributors": [
-        "mastappl",
-        "web-flow",
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "8882",
-      "title": "[NEW] New Modal component",
-      "userLogin": "ggazzo",
-      "milestone": "0.60.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow",
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8932",
-      "title": "[FIX] Message-box autogrow flick",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9009",
-      "title": "[NEW] Improve room types API and usages",
-      "userLogin": "graywolf336",
-      "milestone": "0.60.0",
-      "contributors": [
-        "mrsimpson",
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8812",
-      "title": "[FIX] Don't strip trailing slash on autolinker urls",
-      "userLogin": "jwilkins",
-      "milestone": "0.60.0",
-      "contributors": [
-        "jwilkins",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8831",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.60.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8866",
-      "title": "[NEW] Room counter sidebar preference",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8883",
-      "title": "[FIX] Change the unread messages style",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8884",
-      "title": "[FIX] Missing sidebar footer padding",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8907",
-      "title": "[FIX] Long room announcement cut off",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8917",
-      "title": "[FIX] DM email notifications always being sent regardless of account setting",
-      "userLogin": "ashward",
-      "milestone": "0.60.0",
-      "contributors": [
-        null,
-        "ashward",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8938",
-      "title": "[FIX] Typo Fix",
-      "userLogin": "seangeleno",
-      "milestone": "0.60.0",
-      "contributors": [
-        "seangeleno",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8948",
-      "title": "[FIX] Katex markdown link changed",
-      "userLogin": "mritunjaygoutam12",
-      "milestone": "0.60.0",
-      "contributors": [
-        "mritunjaygoutam12",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8979",
-      "title": "[NEW] Save room's last message",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.0",
-      "contributors": [
-        "sampaiodiego",
-        "karlprieb",
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9000",
-      "title": "[FIX] if ogImage exists use it over image in oembedUrlWidget",
-      "userLogin": "satyapramodh",
-      "milestone": "0.60.0",
-      "contributors": [
-        "satyapramodh"
-      ]
-    },
-    {
-      "pr": "8060",
-      "title": "[NEW] Token Controlled Access channels",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.0",
-      "contributors": [
-        "lindoelio",
-        "sampaiodiego",
-        "web-flow",
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8889",
-      "title": "[FIX] Cannot edit or delete custom sounds",
-      "userLogin": "ccfang",
-      "milestone": "0.60.0",
-      "contributors": [
-        "ccfang",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8928",
-      "title": "[FIX] Change old 'rocketbot' username to 'InternalHubot_Username' setting",
-      "userLogin": "ramrami",
-      "milestone": "0.60.0",
-      "contributors": [
-        "ramrami",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8985",
-      "title": "[FIX] Link for channels are not rendering correctly",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8968",
-      "title": "[FIX]  Xenforo [BD]API for 'user.user_id; instead of 'id'",
-      "userLogin": "wesnspace",
-      "milestone": "0.60.0",
-      "contributors": [
-        "wesnspace",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8994",
-      "title": "[FIX] flextab height on smaller screens",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8931",
-      "title": "[FIX] Check for mention-all permission in room scope",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8905",
-      "title": "[NEW] Send category and title fields to iOS push notification",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8981",
-      "title": "Fix snap download url",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.60.0",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8753",
-      "title": "[FIX] Channel settings buttons",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb",
-        "geekgonecrazy",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8906",
-      "title": "Add a few dots in readme.md",
-      "userLogin": "dusta",
-      "contributors": [
-        "dusta",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8872",
-      "title": "Changed wording for \"Maximum Allowed Message Size\"",
-      "userLogin": "HammyHavoc",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8822",
-      "title": "[FIX] fix emoji package path so they show up correctly in browser",
-      "userLogin": "ryoshimizu",
-      "milestone": "0.60.0",
-      "contributors": [
-        "ryoshimizu"
-      ]
-    },
-    {
-      "pr": "8857",
-      "title": "[NEW] code to get the updated messages",
-      "userLogin": "ggazzo",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "8862",
-      "title": "Fix Docker image build",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8531",
-      "title": "[NEW] Rest API endpoints to list, get, and run commands",
-      "userLogin": "graywolf336",
-      "milestone": "0.60.0",
-      "contributors": [
-        "graywolf336",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8830",
-      "title": "[FIX] Set correct Twitter link",
-      "userLogin": "jotafeldmann",
-      "contributors": [
-        "jotafeldmann",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8829",
-      "title": "Fix link to .asc file on S3",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8820",
-      "title": "Bump version to 0.60.0-develop",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "rodrigok",
-        "karlprieb",
-        "gdelavald",
-        "ggazzo",
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8819",
-      "title": "Update path for s3 redirect in circle ci",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8810",
-      "title": "[FIX] User email settings on DM",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8721",
-      "title": "[FIX] i18n'd Resend_verification_mail, username_initials, upload avatar",
-      "userLogin": "arungalva",
-      "milestone": "0.60.0",
-      "contributors": [
-        "arungalva",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8716",
-      "title": "[FIX] Username clipping on firefox",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8742",
-      "title": "Remove chatops package",
-      "userLogin": "engelgabriel",
-      "milestone": "0.60.0",
-      "contributors": [
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8743",
-      "title": "Removed tmeasday:crypto-md5",
-      "userLogin": "engelgabriel",
-      "milestone": "0.60.0",
-      "contributors": [
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8802",
-      "title": "Update meteor package to 1.8.1",
-      "userLogin": "engelgabriel",
-      "milestone": "0.60.0",
-      "contributors": [
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8795",
-      "title": "[FIX] Improved grammar and made it clearer to the user",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.60.0",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8705",
-      "title": "Fix typo",
-      "userLogin": "rmetzler",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rmetzler",
-        "geekgonecrazy",
-        "web-flow",
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8718",
-      "title": "[FIX] Show real name of current user at top of side nav if setting enabled",
-      "userLogin": "alexbrazier",
-      "milestone": "0.60.0",
-      "contributors": [
-        "alexbrazier",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8441",
-      "title": "[FIX] Range Slider Value label has bug in RTL",
-      "userLogin": "cyclops24",
-      "milestone": "0.60.0",
-      "contributors": [
-        "cyclops24",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8413",
-      "title": "[Fix] Store Outgoing Integration Result as String in Mongo",
-      "userLogin": "cpitman",
-      "milestone": "0.60.0",
-      "contributors": [
-        "cpitman",
-        "graywolf336",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8708",
-      "title": "[FIX] Add historic chats icon in Livechat",
-      "userLogin": "mrsimpson",
-      "milestone": "0.60.0",
-      "contributors": [
-        "mrsimpson",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8717",
-      "title": "[FIX] Sort direct messages by full name if show real names setting enabled",
-      "userLogin": "alexbrazier",
-      "milestone": "0.60.0",
-      "contributors": [
-        "alexbrazier",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8793",
-      "title": "Update DEMO to OPEN links",
-      "userLogin": "engelgabriel",
-      "milestone": "0.60.0",
-      "contributors": [
-        "engelgabriel",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8796",
-      "title": "[FIX] Improving consistency of UX",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.60.0",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8787",
-      "title": "[FIX] fixed some typos",
-      "userLogin": "TheReal1604",
-      "milestone": "0.60.0",
-      "contributors": [
-        "TheReal1604",
-        "web-flow",
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8715",
-      "title": "[NEW] Upgrade Meteor to 1.6",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok",
-        "geekgonecrazy",
-        "karlprieb",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8685",
-      "title": "Add CircleCI",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "sampaiodiego",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8750",
-      "title": "Fix Travis CI build",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8719",
-      "title": "Updated comments.",
-      "userLogin": "jasonjyu",
-      "contributors": [
-        "jasonjyu",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8434",
-      "title": "removing a duplicate line",
-      "userLogin": "vikaskedia",
-      "milestone": "0.59.3",
-      "contributors": [
-        "vikaskedia",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8645",
-      "title": "[FIX] Fix e-mail message forward",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.3",
-      "contributors": [
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8648",
-      "title": "[FIX] Audio message icon",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8431",
-      "title": "[FIX] Highlighted color height issue",
-      "userLogin": "cyclops24",
-      "milestone": "0.59.3",
-      "contributors": [
-        "cyclops24"
-      ]
-    },
-    {
-      "pr": "8593",
-      "title": "[FIX] AmazonS3: Quote file.name for ContentDisposition for files with commas",
-      "userLogin": "xenithorb",
-      "milestone": "0.59.3",
-      "contributors": [
-        "xenithorb"
-      ]
-    },
-    {
-      "pr": "8655",
-      "title": "[FIX] Update pt-BR translation",
-      "userLogin": "rodorgas",
-      "milestone": "0.59.3",
-      "contributors": [
-        "rodorgas"
-      ]
-    },
-    {
-      "pr": "8679",
-      "title": "[FIX] Fix typos",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.3",
-      "contributors": [
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8653",
-      "title": "install grpc package manually to fix snap armhf build",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.59.3",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "8691",
-      "title": "[FIX] LDAP not respecting UTF8 characters & Sync Interval not working",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.3",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8637",
-      "title": "[FIX] Missing scroll at create channel page",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.2",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8634",
-      "title": "[FIX] Message popup menu on mobile/cordova",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.2",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8635",
-      "title": "[FIX] API channel/group.members not sorting",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8613",
-      "title": "[FIX] LDAP not merging existent users && Wrong id link generation",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8551",
-      "title": "[FIX] encode filename in url to prevent links breaking",
-      "userLogin": "joesitton",
-      "milestone": "0.59.2",
-      "contributors": [
-        "joesitton",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8577",
-      "title": "[FIX] Fix guest pool inquiry taking",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8589",
-      "title": "Fix community links in readme",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8588",
-      "title": "[FIX] Changed all rocket.chat/docs/ to docs.rocket.chat/",
-      "userLogin": "RekkyRek",
-      "contributors": [
-        "RekkyRek",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8543",
-      "title": "[FIX] Color reset when default value editor is different",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.1",
-      "contributors": [
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8547",
-      "title": "[FIX] Wrong colors after migration 103",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8541",
-      "title": "[FIX] LDAP login error regression at 0.59.0",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8544",
-      "title": "[FIX] Migration 103 wrong converting primrary colors",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8529",
-      "title": "Improve room sync speed",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8527",
-      "title": "[FIX] Do not send joinCode field to clients",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8520",
-      "title": "Fix high CPU load when sending messages on large rooms (regression)",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8515",
-      "title": "Change artifact path",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "8463",
-      "title": "Color variables migration",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.14",
-      "contributors": [
-        "ggazzo",
-        "rodrigok",
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8516",
-      "title": "Fix: Change password not working in new UI",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.14",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8514",
-      "title": "[FIX] Uncessary route reload break some routes",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.14",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8491",
-      "title": "[FIX] Invalid Code message for password protected channel",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.14",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8489",
-      "title": "[FIX] Wrong message when reseting password and 2FA is enabled",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.14",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8490",
-      "title": "Enable AutoLinker back",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.14",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8459",
-      "title": "[NEW] Setting to disable MarkDown and enable AutoLinker",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.13",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8457",
-      "title": "[FIX] LDAP memory issues when pagination is not available",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.13",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8451",
-      "title": "Improve markdown parser code",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.13",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8066",
-      "title": "[NEW] Add settings for allow user direct messages to yourself",
-      "userLogin": "lindoelio",
-      "milestone": "0.60.0",
-      "contributors": [
-        "lindoelio"
-      ]
-    },
-    {
-      "pr": "8108",
-      "title": "[NEW] Add sweet alert to video call tab",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.60.0",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "8143",
-      "title": "[NEW] Displays QR code for manually entering when enabling 2fa",
-      "userLogin": "marceloschmidt",
-      "milestone": "0.60.0",
-      "contributors": [
-        "marceloschmidt"
-      ]
-    },
-    {
-      "pr": "8077",
-      "title": "[MOVE] Move favico to client folder",
-      "userLogin": "vcapretz",
-      "milestone": "0.60.0",
-      "contributors": [
-        "vcapretz"
-      ]
-    },
-    {
-      "pr": "8078",
-      "title": "[MOVE] Move files from emojione to client/server folders",
-      "userLogin": "vcapretz",
-      "milestone": "0.60.0",
-      "contributors": [
-        "vcapretz"
-      ]
-    },
-    {
-      "pr": "8084",
-      "title": "[MOVE] Move files from slashcommands-unarchive to client/server folders",
-      "userLogin": "vcapretz",
-      "milestone": "0.60.0",
-      "contributors": [
-        "vcapretz"
-      ]
-    },
-    {
-      "pr": "8132",
-      "title": "[MOVE] Move slashcommands-open to client folder",
-      "userLogin": "vcapretz",
-      "milestone": "0.60.0",
-      "contributors": [
-        "vcapretz"
-      ]
-    },
-    {
-      "pr": "8135",
-      "title": "[MOVE] Move kick command to client/server folders",
-      "userLogin": "vcapretz",
-      "milestone": "0.60.0",
-      "contributors": [
-        "vcapretz"
-      ]
-    },
-    {
-      "pr": "8136",
-      "title": "[MOVE] Move join command to client/server folder",
-      "userLogin": "vcapretz",
-      "milestone": "0.60.0",
-      "contributors": [
-        "vcapretz"
-      ]
-    },
-    {
-      "pr": "8137",
-      "title": "[MOVE] Move inviteall command to client/server folder",
-      "userLogin": "vcapretz",
-      "milestone": "0.60.0",
-      "contributors": [
-        "vcapretz"
-      ]
-    },
-    {
-      "pr": "8138",
-      "title": "[MOVE] Move invite command to client/server folder",
-      "userLogin": "vcapretz",
-      "milestone": "0.60.0",
-      "contributors": [
-        "vcapretz"
-      ]
-    },
-    {
-      "pr": "8139",
-      "title": "[MOVE] Move create command to client/server folder",
-      "userLogin": "vcapretz",
-      "milestone": "0.60.0",
-      "contributors": [
-        "vcapretz"
-      ]
-    },
-    {
-      "pr": "8140",
-      "title": "[MOVE] Move archiveroom command to client/server folders",
-      "userLogin": "vcapretz",
-      "milestone": "0.60.0",
-      "contributors": [
-        "vcapretz"
-      ]
-    },
-    {
-      "pr": "8141",
-      "title": "[MOVE] Move slackbridge to client/server folders",
-      "userLogin": "vcapretz",
-      "milestone": "0.60.0",
-      "contributors": [
-        "vcapretz"
-      ]
-    },
-    {
-      "pr": "8150",
-      "title": "[MOVE] Move logger files to client/server folders",
-      "userLogin": "vcapretz",
-      "milestone": "0.60.0",
-      "contributors": [
-        "vcapretz"
-      ]
-    },
-    {
-      "pr": "8152",
-      "title": "[MOVE] Move timesync files to client/server folders",
-      "userLogin": "vcapretz",
-      "milestone": "0.60.0",
-      "contributors": [
-        "vcapretz"
-      ]
-    },
-    {
-      "pr": "8416",
-      "title": "Fix: Account menu position on RTL",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8417",
-      "title": "Fix: Missing LDAP option to show internal logs",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8414",
-      "title": "Fix: Missing LDAP reconnect setting",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8389",
-      "title": "[FIX] Add needed dependency for snaps",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "8390",
-      "title": "[FIX] Slack import failing and not being able to be restarted",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8397",
-      "title": "[FIX] Sidebar item menu position in RTL",
-      "userLogin": "cyclops24",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "cyclops24"
-      ]
-    },
-    {
-      "pr": "8386",
-      "title": "[FIX] disabled katex tooltip on messageBox",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "8394",
-      "title": "Add i18n Title to snippet messages",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8408",
-      "title": "[FIX] Duplicate code in rest api letting in a few bugs with the rest api",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8398",
-      "title": "Fix: Missing settings to configure LDAP size and page limits",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.12",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8375",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8372",
-      "title": "[FIX] Various LDAP issues & Missing pagination",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8364",
-      "title": "Update Meteor to 1.5.2.2",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8363",
-      "title": "Sync translations from LingoHub",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8358",
-      "title": "[FIX] remove accountBox from admin menu",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "engelgabriel",
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8361",
-      "title": "[NEW] Unify unread and mentions badge",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8362",
-      "title": "[NEW] make sidebar item width 100%",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8360",
-      "title": "[NEW] Smaller accountBox",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8357",
-      "title": "[FIX] Missing i18n translations",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "8345",
-      "title": "Remove field `lastActivity` from subscription data",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.11",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "8355",
-      "title": "Update meteor to 1.5.2.2-rc.0",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.10",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8314",
-      "title": "[FIX] After deleting the room, cache is not synchronizing",
-      "userLogin": "szluohua",
-      "milestone": "0.59.0-rc.10",
-      "contributors": [
-        "szluohua"
-      ]
-    },
-    {
-      "pr": "8334",
-      "title": "[FIX] Remove sidebar header on admin embedded version",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.10",
-      "contributors": [
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8331",
-      "title": "[FIX-RC] Mobile file upload not working",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.10",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8317",
-      "title": "[FIX] Email Subjects not being sent",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.10",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8315",
-      "title": "[FIX] Put delete action on another popover group",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.10",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8316",
-      "title": "[FIX] Mention unread indicator was removed",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.10",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8304",
-      "title": "[NEW] Add RD Station integration to livechat",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8310",
-      "title": "[FIX] Execute meteor reset on TRAVIS_TAG builds",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8296",
-      "title": "[FIX] Wrong file name when upload to AWS S3",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8298",
-      "title": "[FIX] TypeError: Cannot read property 't' of undefined",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8295",
-      "title": "[FIX] Check attachments is defined before accessing first element",
-      "userLogin": "Darkneon",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "Darkneon"
-      ]
-    },
-    {
-      "pr": "8299",
-      "title": " [FIX] Amin menu not showing all items & File list breaking line",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "ggazzo",
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8307",
-      "title": "[FIX] Call buttons with wrong margin on RTL",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8300",
-      "title": "[FIX] Emoji Picker hidden for reactions in RTL",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8273",
-      "title": "Deps update",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8282",
-      "title": "[FIX] fix color on unread messages",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "8286",
-      "title": "[FIX] Missing placeholder translations",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8278",
-      "title": "[FIX] \"Cancel button\" on modal in RTL in Firefox 55",
-      "userLogin": "cyclops24",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "cyclops24"
-      ]
-    },
-    {
-      "pr": "8271",
-      "title": "[FIX] Attachment icons alignment in LTR and RTL",
-      "userLogin": "cyclops24",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "cyclops24"
-      ]
-    },
-    {
-      "pr": "8270",
-      "title": "[FIX] [i18n] My Profile & README.md links",
-      "userLogin": "Rzeszow",
-      "milestone": "0.59.0-rc.9",
-      "contributors": [
-        "Rzeszow",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8211",
-      "title": "[FIX] Incorrect URL for login terms when using prefix",
-      "userLogin": "Darkneon",
-      "milestone": "0.59.0-rc.7",
-      "contributors": [
-        "Darkneon"
-      ]
-    },
-    {
-      "pr": "8194",
-      "title": "Fix more rtl issues",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.7",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8190",
-      "title": "[FIX] Scrollbar not using new style",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.7",
-      "contributors": [
-        "ggazzo",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8210",
-      "title": "[FIX] User avatar in DM list.",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.7",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "8197",
-      "title": "npm deps update",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.7",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8146",
-      "title": "[FIX] Fix iframe login API response (issue #8145)",
-      "userLogin": "astax-t",
-      "milestone": "0.59.0-rc.6",
-      "contributors": [
-        "astax-t"
-      ]
-    },
-    {
-      "pr": "8167",
-      "title": "[FIX] Issue #8166 where empty analytics setting breaks to load Piwik script",
-      "userLogin": "ruKurz",
-      "milestone": "0.59.0-rc.6",
-      "contributors": [
-        "ruKurz"
-      ]
-    },
-    {
-      "pr": "8154",
-      "title": "[FIX] Sidebar and RTL alignments",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.6",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8147",
-      "title": "[FIX] \"*.members\" rest api being useless and only returning usernames",
-      "userLogin": "graywolf336",
-      "milestone": "0.59.0-rc.6",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "8159",
-      "title": "[FIX] Text area lost text when page reloads",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.6",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8094",
-      "title": "[FIX] Add admin audio preferences translations",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.0-rc.6",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8073",
-      "title": "[NEW] Upgrade to meteor 1.5.2",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.6",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "8112",
-      "title": "[FIX] RTL",
-      "userLogin": "ggazzo",
-      "milestone": "0.59.0-rc.5",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "8122",
-      "title": "[FIX] Settings description not showing",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.5",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8059",
-      "title": "[FIX] Not sending email to mentioned users with unchanged preference",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.5",
-      "contributors": [
-        "MartinSchoeler",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8101",
-      "title": "[FIX] Dynamic popover",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.5",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8099",
-      "title": "[FIX] Fix setting user avatar on LDAP login",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.0-rc.5",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8054",
-      "title": "Remove unnecessary returns in cors common",
-      "userLogin": "Kiran-Rao",
-      "milestone": "0.59.0-rc.5",
-      "contributors": [
-        "Kiran-Rao",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8047",
-      "title": "[FIX] Scroll on messagebox",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.5",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "8048",
-      "title": "[FIX] Invisible leader bar on hover",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7754",
-      "title": "[FIX] Fix email on mention",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "8046",
-      "title": "[FIX] Prevent autotranslate tokens race condition",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7988",
-      "title": "[FIX] Vertical menu on flex-tab",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "ggazzo",
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8019",
-      "title": "[FIX] message-box autogrow",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8039",
-      "title": "[FIX] copy to clipboard and update clipboard.js library",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "8037",
-      "title": "[NEW] Add yunohost.org installation method to Readme.md",
-      "userLogin": "selamanse",
-      "contributors": [
-        "selamanse",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8036",
-      "title": "Adding: How to Install in WeDeploy",
-      "userLogin": "thompsonemerson",
-      "contributors": [
-        "thompsonemerson",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7998",
-      "title": "[FIX] Recent emojis not updated when adding via text",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7989",
-      "title": "[FIX][PL] Polish translation",
-      "userLogin": "Rzeszow",
-      "milestone": "0.59.0-rc.4",
-      "contributors": [
-        "Rzeszow",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7984",
-      "title": "[FIX] Chat box no longer auto-focuses when typing",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7963",
-      "title": "[FIX] Fix the status on the members list",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "7965",
-      "title": "[FIX] Markdown being rendered in code tags",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7983",
-      "title": "Revert \"npm deps update\"",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7923",
-      "title": "[FIX] Email verification indicator added",
-      "userLogin": "aditya19496",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "aditya19496",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7712",
-      "title": "[FIX] Show leader on first load",
-      "userLogin": "danischreiber",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "danischreiber",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7909",
-      "title": "[DOCS] Add native mobile app links into README and update button images",
-      "userLogin": "rafaelks",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "rafaelks",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7971",
-      "title": "[FIX] Add padding on messages to allow space to the action buttons",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "7970",
-      "title": "[FIX] Small alignment fixes",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "7969",
-      "title": "npm deps update",
-      "userLogin": "engelgabriel",
-      "milestone": "0.60.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "7953",
-      "title": "[FIX] username ellipsis on firefox",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7948",
-      "title": "[FIX] Document README.md. Drupal repo out of date",
-      "userLogin": "Lawri-van-Buel",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "Lawri-van-Buel"
-      ]
-    },
-    {
-      "pr": "7927",
-      "title": "[FIX] Double scroll on 'keyboard shortcuts' menu in sidepanel",
-      "userLogin": "aditya19496",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "aditya19496"
-      ]
-    },
-    {
-      "pr": "7943",
-      "title": "[FIX] Broken emoji picker on firefox",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7944",
-      "title": "[FIX] Broken embedded view layout",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7945",
-      "title": "[FIX] Fix placeholders in account profile",
-      "userLogin": "josiasds",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "josiasds"
-      ]
-    },
-    {
-      "pr": "7954",
-      "title": "[FIX] OTR buttons padding",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7960",
-      "title": "[FIX] status and active room colors on sidebar",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7941",
-      "title": "Update BlackDuck URL",
-      "userLogin": "engelgabriel",
-      "milestone": "0.59.0-rc.3",
-      "contributors": [
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7912",
-      "title": "[FIX] Fix google play logo on repo README",
-      "userLogin": "luizbills",
-      "milestone": "0.59.0-rc.2",
-      "contributors": [
-        "luizbills",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7904",
-      "title": "[FIX] Fix livechat toggle UI issue",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.59.0-rc.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7895",
-      "title": "[FIX] Remove break change in Realtime API",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7893",
-      "title": "[FIX] Window exception when parsing Markdown on server",
-      "userLogin": "rodrigok",
-      "milestone": "0.59.0-rc.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "7894",
-      "title": "Hide flex-tab close button",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.2",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7888",
-      "title": "[FIX] sidebar buttons and badge paddings",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7882",
-      "title": "[FIX] hyperlink style on sidebar footer",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7886",
-      "title": "[FIX] livechat icon",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7887",
-      "title": "[FIX] Makes text action menu width based on content size",
-      "userLogin": "gdelavald",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "7885",
-      "title": "[FIX] message actions over unread bar",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7883",
-      "title": "[FIX] popover position on mobile",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7881",
-      "title": "[FIX] search results position on sidebar",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7880",
-      "title": "[FIX] sidebar paddings",
-      "userLogin": "karlprieb",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "7878",
-      "title": "[FIX] Adds default search text padding for emoji search",
-      "userLogin": "gdelavald",
-      "milestone": "0.59.0-rc.1",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "6606",
-      "title": "Added RocketChatLauncher (SaaS)",
-      "userLogin": "designgurudotorg",
-      "milestone": "0.59.0",
-      "contributors": [
-        "designgurudotorg",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7866",
-      "title": "Develop sync",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok",
-        "web-flow",
-        "geekgonecrazy",
-        "engelgabriel",
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "8973",
-      "title": "Fix tag build",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8972",
-      "title": "Fix CircleCI deploy filter",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8967",
-      "title": "Release/0.59.4",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "cpitman",
-        "geekgonecrazy",
-        "karlprieb",
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8685",
-      "title": "Add CircleCI",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "sampaiodiego",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8753",
-      "title": "[FIX] Channel settings buttons",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb",
-        "geekgonecrazy",
-        "web-flow",
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.60.0-rc.1": [
-    {
-      "pr": "9092",
-      "title": "[NEW] Modal",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9111",
-      "title": "Fix: users listed as online after API login",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9110",
-      "title": "Fix regression in api channels.members",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9108",
-      "title": "[FIX] REST API file upload not respecting size limit",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9109",
-      "title": "[FIX] Creating channels on Firefox",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9095",
-      "title": "[FIX] Some UI problems on 0.60",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9094",
-      "title": "[FIX] Update rocketchat:streamer to be compatible with previous version",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    }
-  ],
-  "0.60.0-rc.2": [
-    {
-      "pr": "9137",
-      "title": "Fix: Clear all unreads modal not closing after confirming",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9138",
-      "title": "Fix: Message action quick buttons drops if \"new message\" divider is being shown",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9136",
-      "title": "Fix: Confirmation modals showing `Send` button",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9134",
-      "title": "[FIX] Importers not recovering when an error occurs",
-      "userLogin": "graywolf336",
-      "milestone": "0.60.0",
-      "contributors": [
-        "graywolf336",
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9121",
-      "title": "[FIX] Do not block room while loading history",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9120",
-      "title": "Fix: Multiple unread indicators",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9091",
-      "title": "[FIX] Channel page error",
-      "userLogin": "ggrish",
-      "milestone": "0.60.0",
-      "contributors": [
-        "ggrish",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.60.0-rc.3": [
-    {
-      "pr": "9144",
-      "title": "Fix: Messages being displayed in reverse order",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9062",
-      "title": "[FIX] Update Rocket.Chat for sandstorm",
-      "userLogin": "peterlee0127",
-      "milestone": "0.60.0",
-      "contributors": [
-        "peterlee0127",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.60.0-rc.4": [
-    {
-      "pr": "9171",
-      "title": "[FIX] modal data on enter and modal style for file preview",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9170",
-      "title": "[FIX] show oauth logins when adblock is used",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9169",
-      "title": "[FIX] Last sent message reoccurs in textbox",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9166",
-      "title": "Fix: UI: Descenders of glyphs are cut off",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9165",
-      "title": "Fix: Click on channel name - hover area bigger than link area",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9162",
-      "title": "Fix: Can’t login using LDAP via REST",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9149",
-      "title": "Fix: Unread line",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9146",
-      "title": "Fix test without oplog by waiting a successful login on changing users",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    }
-  ],
-  "0.60.0-rc.5": [
-    {
-      "pr": "9200",
-      "title": "Replace postcss-nesting with postcss-nested",
-      "userLogin": "engelgabriel",
-      "milestone": "0.60.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "9197",
-      "title": "Dependencies Update",
-      "userLogin": "engelgabriel",
-      "milestone": "0.60.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "9196",
-      "title": "Fix: Rooms and users are using different avatar style",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9193",
-      "title": "[FIX] Made welcome emails more readable",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.60.0",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9190",
-      "title": "Typo: German language file",
-      "userLogin": "TheReal1604",
-      "milestone": "0.60.0",
-      "contributors": [
-        "TheReal1604"
-      ]
-    },
-    {
-      "pr": "9188",
-      "title": "[FIX] Unread bar position when room have announcement",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9186",
-      "title": "[FIX] Emoji size on last message preview",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9185",
-      "title": "[FIX] Cursor position when reply on safari",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9184",
-      "title": "Fix: Snippet name to not showing in snippet list",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9183",
-      "title": "Fix/api me only return verified",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.60.0",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9182",
-      "title": "[FIX] \"Use Emoji\" preference not working",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9181",
-      "title": "Fix: UI: Descenders of glyphs are cut off",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9176",
-      "title": "[FIX] make the cross icon on user selection at channel creation page work",
-      "userLogin": "vitor-nagao",
-      "milestone": "0.60.0",
-      "contributors": [
-        "vitor-nagao",
-        "karlprieb",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9172",
-      "title": "[FIX] go to replied message",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9168",
-      "title": "[FIX] channel create scroll on small screens",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9066",
-      "title": "[NEW] Make Custom oauth accept nested usernameField",
-      "userLogin": "pierreozoux",
-      "milestone": "0.60.0",
-      "contributors": [
-        "pierreozoux",
-        "web-flow",
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "9040",
-      "title": "[FIX] Error when user roles is missing or is invalid",
-      "userLogin": "paulovitin",
-      "milestone": "0.60.0",
-      "contributors": [
-        "paulovitin",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8922",
-      "title": "[FIX] Make mentions and menu icons color darker",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb",
-        "rodrigok",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.60.0-rc.6": [
-    {
-      "pr": "9241",
-      "title": "[FIX] Show modal with announcement",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9240",
-      "title": "Fix: Unneeded warning in payload of REST API calls",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9229",
-      "title": "Fix: Missing option to set user's avatar from a url",
-      "userLogin": "ggazzo",
-      "milestone": "0.60.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "9227",
-      "title": "Fix: updating last message on message edit or delete",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9217",
-      "title": "Fix: Username find is matching partially",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9215",
-      "title": "Fix: Upload access control too distributed",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9206",
-      "title": "[FIX] File upload not working on IE and weird on Chrome",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9194",
-      "title": "[FIX] \"Enter usernames\" placeholder is cutting in \"create channel\" view",
-      "userLogin": "TheReal1604",
-      "milestone": "0.60.0",
-      "contributors": [
-        "TheReal1604"
-      ]
-    }
-  ],
-  "0.60.0-rc.7": [
-    {
-      "pr": "9243",
-      "title": "[FIX] Move emojipicker css to theme package",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    }
-  ],
-  "0.60.0-rc.8": [
-    {
-      "pr": "9257",
-      "title": "Do not change room icon color when room is unread",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9256",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.60.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "9248",
-      "title": "Add curl, its missing on worker nodes so has to be explicitly added",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.60.0",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "9247",
-      "title": "Fix: Sidebar item on rtl and small devices",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    }
-  ],
-  "0.60.0": [
-    {
-      "pr": "9259",
-      "title": "Release 0.60.0",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "graywolf336",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8973",
-      "title": "Fix tag build",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8972",
-      "title": "Fix CircleCI deploy filter",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8967",
-      "title": "Release/0.59.4",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "cpitman",
-        "geekgonecrazy",
-        "karlprieb",
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "8685",
-      "title": "Add CircleCI",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "sampaiodiego",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8753",
-      "title": "[FIX] Channel settings buttons",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb",
-        "geekgonecrazy",
-        "web-flow",
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.60.1": [
-    {
-      "pr": "9262",
-      "title": "[FIX] File access not working when passing credentials via querystring",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.60.2": [
-    {
-      "pr": "9280",
-      "title": "Release 0.60.2",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9277",
-      "title": "[FIX] Restore translations from other languages",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9274",
-      "title": "[FIX] Remove sweetalert from livechat facebook integration page",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9272",
-      "title": "[FIX] Missing translations",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.60.3": [
-    {
-      "pr": "9320",
-      "title": "Release 0.60.3",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok",
-        "HammyHavoc"
-      ]
-    },
-    {
-      "pr": "9314",
-      "title": "[FIX] custom emoji size on sidebar item",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9311",
-      "title": "[FIX] svg render on firefox",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9249",
-      "title": "[FIX] sidebar footer padding",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9309",
-      "title": "[FIX] LDAP/AD is not importing all users",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.3",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9299",
-      "title": "Fix: English language improvements",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.60.3",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9291",
-      "title": "Fix: Change 'Wordpress' to 'WordPress",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.60.3",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9290",
-      "title": "Fix: Improved README.md",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.60.3",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9289",
-      "title": "[FIX] Wrong position of notifications alert in accounts preference page",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.60.3",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9286",
-      "title": "Fix: README typo",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.60.3",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9285",
-      "title": "[FIX] English Typos",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.60.3",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.60.4-rc.0": [
-    {
-      "pr": "9343",
-      "title": "[FIX] LDAP TLS not working in some cases",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.4",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9320",
-      "title": "Release 0.60.3",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok",
-        "HammyHavoc"
-      ]
-    }
-  ],
-  "0.60.4-rc.1": [
-    {
-      "pr": "9328",
-      "title": "[FIX] popover on safari for iOS",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.4",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9330",
-      "title": "[FIX] announcement hyperlink color",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.4",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9335",
-      "title": "[FIX] Deleting message with store last message not removing",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.4",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9345",
-      "title": "[FIX] last message cutting on bottom",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.4",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9346",
-      "title": "Update Marked dependecy to 0.3.9",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.4",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.60.4": [
-    {
-      "pr": "9377",
-      "title": "Release 0.60.4",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.4",
-      "contributors": [
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9320",
-      "title": "Release 0.60.3",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok",
-        "HammyHavoc"
-      ]
-    }
-  ],
-  "0.61.0-rc.0": [
-    {
-      "pr": "8411",
-      "title": "[NEW] Contextual Bar Redesign",
-      "userLogin": "ggazzo",
-      "milestone": "0.61.0",
-      "contributors": [
-        "geekgonecrazy",
-        "sampaiodiego",
-        "MartinSchoeler",
-        "ggazzo",
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9369",
-      "title": "[FIX][i18n] add room type translation support for room-changed-privacy message",
-      "userLogin": "cyclops24",
-      "milestone": "0.61.0",
-      "contributors": [
-        "cyclops24"
-      ]
-    },
-    {
-      "pr": "9442",
-      "title": "[NEW] Update documentation: provide example for multiple basedn",
-      "userLogin": "rndmh3ro",
-      "milestone": "0.61.0",
-      "contributors": [
-        "mms-segu"
-      ]
-    },
-    {
-      "pr": "9452",
-      "title": "[FIX] Fix livechat register form",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.61.0",
-      "contributors": [
-        "sampaiodiego",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9451",
-      "title": "[FIX] Fix livechat build",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.61.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9164",
-      "title": "[FIX] Fix closing livechat inquiry",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.61.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9439",
-      "title": "Add community bot",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9435",
-      "title": "[FIX] Slash command 'unarchive' throws exception if the channel does not exist ",
-      "userLogin": "ramrami",
-      "milestone": "0.61.0",
-      "contributors": [
-        "ramrami",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9428",
-      "title": "[FIX] Slash command 'archive' throws exception if the channel does not exist",
-      "userLogin": "ramrami",
-      "milestone": "0.61.0",
-      "contributors": [
-        "ramrami",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9432",
-      "title": "[FIX] Subscriptions not removed when removing user",
-      "userLogin": "rodrigok",
-      "milestone": "0.61.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9216",
-      "title": "[NEW] Sidebar menu option to mark room as unread",
-      "userLogin": "karlprieb",
-      "milestone": "0.61.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9228",
-      "title": "[NEW] Add mention-here permission #7631",
-      "userLogin": "ryjones",
-      "milestone": "0.61.0",
-      "contributors": [
-        "ryjones",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9234",
-      "title": "[NEW] Indicate the Self DM room",
-      "userLogin": "rodrigok",
-      "milestone": "0.61.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9245",
-      "title": "[NEW] new layout for emojipicker",
-      "userLogin": "karlprieb",
-      "milestone": "0.61.0",
-      "contributors": [
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9364",
-      "title": "[FIX] Highlight setting not working correctly",
-      "userLogin": "cyclops24",
-      "milestone": "0.60.4",
-      "contributors": [
-        "cyclops24"
-      ]
-    },
-    {
-      "pr": "9366",
-      "title": "[NEW] add /home link to sidenav footer logo",
-      "userLogin": "cyclops24",
-      "contributors": [
-        "cyclops24"
-      ]
-    },
-    {
-      "pr": "9356",
-      "title": "Use correct version of Mailparser module",
-      "userLogin": "rodrigok",
-      "milestone": "0.61.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9330",
-      "title": "[FIX] announcement hyperlink color",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.4",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9328",
-      "title": "[FIX] popover on safari for iOS",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.4",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9345",
-      "title": "[FIX] last message cutting on bottom",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.4",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9346",
-      "title": "Update Marked dependecy to 0.3.9",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.4",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9335",
-      "title": "[FIX] Deleting message with store last message not removing",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.4",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9314",
-      "title": "[FIX] custom emoji size on sidebar item",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9311",
-      "title": "[FIX] svg render on firefox",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9249",
-      "title": "[FIX] sidebar footer padding",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.3",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9309",
-      "title": "[FIX] LDAP/AD is not importing all users",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.3",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9299",
-      "title": "Fix: English language improvements",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.60.3",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9291",
-      "title": "Fix: Change 'Wordpress' to 'WordPress",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.60.3",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9290",
-      "title": "Fix: Improved README.md",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.60.3",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9289",
-      "title": "[FIX] Wrong position of notifications alert in accounts preference page",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.60.3",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9286",
-      "title": "Fix: README typo",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.60.3",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9285",
-      "title": "[FIX] English Typos",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.60.3",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9277",
-      "title": "[FIX] Restore translations from other languages",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9274",
-      "title": "[FIX] Remove sweetalert from livechat facebook integration page",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9272",
-      "title": "[FIX] Missing translations",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9264",
-      "title": "[FIX] File access not working when passing credentials via querystring",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9135",
-      "title": "[NEW] Livechat extract lead data from message",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9107",
-      "title": "[NEW] Add impersonate option for livechat triggers",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9053",
-      "title": "[NEW] Add support to external livechat queue service provider",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9048",
-      "title": "[BREAK] Decouple livechat visitors from regular users",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9260",
-      "title": "Develop sync - Bump version to 0.61.0-develop",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "cpitman",
-        "geekgonecrazy",
-        "karlprieb",
-        "rodrigok",
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9257",
-      "title": "Do not change room icon color when room is unread",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9256",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.60.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "9247",
-      "title": "Fix: Sidebar item on rtl and small devices",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9248",
-      "title": "Add curl, its missing on worker nodes so has to be explicitly added",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.60.0",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "9243",
-      "title": "[FIX] Move emojipicker css to theme package",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9241",
-      "title": "[FIX] Show modal with announcement",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9240",
-      "title": "Fix: Unneeded warning in payload of REST API calls",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9229",
-      "title": "Fix: Missing option to set user's avatar from a url",
-      "userLogin": "ggazzo",
-      "milestone": "0.60.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "9215",
-      "title": "Fix: Upload access control too distributed",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9217",
-      "title": "Fix: Username find is matching partially",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9227",
-      "title": "Fix: updating last message on message edit or delete",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9194",
-      "title": "[FIX] \"Enter usernames\" placeholder is cutting in \"create channel\" view",
-      "userLogin": "TheReal1604",
-      "milestone": "0.60.0",
-      "contributors": [
-        "TheReal1604"
-      ]
-    },
-    {
-      "pr": "9206",
-      "title": "[FIX] File upload not working on IE and weird on Chrome",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9176",
-      "title": "[FIX] make the cross icon on user selection at channel creation page work",
-      "userLogin": "vitor-nagao",
-      "milestone": "0.60.0",
-      "contributors": [
-        "vitor-nagao",
-        "karlprieb",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9196",
-      "title": "Fix: Rooms and users are using different avatar style",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9200",
-      "title": "Replace postcss-nesting with postcss-nested",
-      "userLogin": "engelgabriel",
-      "milestone": "0.60.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "9197",
-      "title": "Dependencies Update",
-      "userLogin": "engelgabriel",
-      "milestone": "0.60.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "9193",
-      "title": "[FIX] Made welcome emails more readable",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.60.0",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9190",
-      "title": "Typo: German language file",
-      "userLogin": "TheReal1604",
-      "milestone": "0.60.0",
-      "contributors": [
-        "TheReal1604"
-      ]
-    },
-    {
-      "pr": "9184",
-      "title": "Fix: Snippet name to not showing in snippet list",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9183",
-      "title": "Fix/api me only return verified",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.60.0",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9185",
-      "title": "[FIX] Cursor position when reply on safari",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9186",
-      "title": "[FIX] Emoji size on last message preview",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9188",
-      "title": "[FIX] Unread bar position when room have announcement",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9040",
-      "title": "[FIX] Error when user roles is missing or is invalid",
-      "userLogin": "paulovitin",
-      "milestone": "0.60.0",
-      "contributors": [
-        "paulovitin",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8922",
-      "title": "[FIX] Make mentions and menu icons color darker",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9182",
-      "title": "[FIX] \"Use Emoji\" preference not working",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9181",
-      "title": "Fix: UI: Descenders of glyphs are cut off",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9066",
-      "title": "[NEW] Make Custom oauth accept nested usernameField",
-      "userLogin": "pierreozoux",
-      "milestone": "0.60.0",
-      "contributors": [
-        "pierreozoux",
-        "web-flow",
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "9168",
-      "title": "[FIX] channel create scroll on small screens",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9172",
-      "title": "[FIX] go to replied message",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9173",
-      "title": "[Fix] oauth not working because of email array",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.60.0",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9171",
-      "title": "[FIX] modal data on enter and modal style for file preview",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9170",
-      "title": "[FIX] show oauth logins when adblock is used",
-      "userLogin": "karlprieb",
-      "milestone": "0.60.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9165",
-      "title": "Fix: Click on channel name - hover area bigger than link area",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9166",
-      "title": "Fix: UI: Descenders of glyphs are cut off",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9169",
-      "title": "[FIX] Last sent message reoccurs in textbox",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9162",
-      "title": "Fix: Can’t login using LDAP via REST",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9149",
-      "title": "Fix: Unread line",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9146",
-      "title": "Fix test without oplog by waiting a successful login on changing users",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9062",
-      "title": "[FIX] Update Rocket.Chat for sandstorm",
-      "userLogin": "peterlee0127",
-      "milestone": "0.60.0",
-      "contributors": [
-        "peterlee0127",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9144",
-      "title": "Fix: Messages being displayed in reverse order",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9137",
-      "title": "Fix: Clear all unreads modal not closing after confirming",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9138",
-      "title": "Fix: Message action quick buttons drops if \"new message\" divider is being shown",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9136",
-      "title": "Fix: Confirmation modals showing `Send` button",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9134",
-      "title": "[FIX] Importers not recovering when an error occurs",
-      "userLogin": "graywolf336",
-      "milestone": "0.60.0",
-      "contributors": [
-        "graywolf336",
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9121",
-      "title": "[FIX] Do not block room while loading history",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9120",
-      "title": "Fix: Multiple unread indicators",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9091",
-      "title": "[FIX] Channel page error",
-      "userLogin": "ggrish",
-      "milestone": "0.60.0",
-      "contributors": [
-        "ggrish",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9377",
-      "title": "Release 0.60.4",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.4",
-      "contributors": [
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9320",
-      "title": "Release 0.60.3",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok",
-        "HammyHavoc"
-      ]
-    },
-    {
-      "pr": "9277",
-      "title": "[FIX] Restore translations from other languages",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9274",
-      "title": "[FIX] Remove sweetalert from livechat facebook integration page",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9272",
-      "title": "[FIX] Missing translations",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9262",
-      "title": "[FIX] File access not working when passing credentials via querystring",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.61.0-rc.1": [
-    {
-      "pr": "9469",
-      "title": "[DOCS] Update the links of our Mobile Apps in Features topic",
-      "userLogin": "rafaelks",
-      "contributors": [
-        "rafaelks",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9490",
-      "title": "Update license",
-      "userLogin": "frdmn",
-      "contributors": [
-        "frdmn",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9481",
-      "title": "[FIX] Contextual bar redesign",
-      "userLogin": "ggazzo",
-      "milestone": "0.61.0",
-      "contributors": [
-        "ggazzo",
-        "karlprieb",
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "9456",
-      "title": "[FIX] mention-here is missing i18n text #9455",
-      "userLogin": "ryjones",
-      "contributors": [
-        "ryjones"
-      ]
-    }
-  ],
-  "0.61.0-rc.2": [
-    {
-      "pr": "9506",
-      "title": "[FIX] Fix livechat visitor edit",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.61.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9510",
-      "title": "[NEW] Contextual bar mail messages",
-      "userLogin": "karlprieb",
-      "milestone": "0.61.0",
-      "contributors": [
-        "karlprieb",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9504",
-      "title": "Prevent NPM package-lock inside livechat",
-      "userLogin": "rodrigok",
-      "milestone": "0.61.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9493",
-      "title": "[FIX] large names on userinfo, and admin user bug on users with no usernames",
-      "userLogin": "ggazzo",
-      "milestone": "0.61.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow",
-        "gdelavald"
-      ]
-    }
-  ],
-  "0.61.0": [
-    {
-      "pr": "9533",
-      "title": "Release 0.61.0",
-      "userLogin": "rodrigok",
-      "milestone": "0.61.0",
-      "contributors": [
-        "rodrigok",
-        "karlprieb",
-        "web-flow",
-        "geekgonecrazy",
-        "engelgabriel",
-        "sampaiodiego",
-        "ryjones"
-      ]
-    },
-    {
-      "pr": "9377",
-      "title": "Release 0.60.4",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.4",
-      "contributors": [
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9320",
-      "title": "Release 0.60.3",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok",
-        "HammyHavoc"
-      ]
-    },
-    {
-      "pr": "9277",
-      "title": "[FIX] Restore translations from other languages",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9274",
-      "title": "[FIX] Remove sweetalert from livechat facebook integration page",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.60.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9272",
-      "title": "[FIX] Missing translations",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9262",
-      "title": "[FIX] File access not working when passing credentials via querystring",
-      "userLogin": "rodrigok",
-      "milestone": "0.60.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.61.1": [
-    {
-      "pr": "9721",
-      "title": "Release 0.61.1",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.61.2": [
-    {
-      "pr": "9786",
-      "title": "Release 0.61.2",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9750",
-      "title": "[FIX] Livechat issues on external queue and lead capture",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.61.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9776",
-      "title": "[FIX] Emoji rendering on last message",
-      "userLogin": "ggazzo",
-      "milestone": "0.61.2",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9772",
-      "title": "[FIX] Livechat conversation not receiving messages when start without form",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.61.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    }
-  ],
-  "0.62.0-rc.0": [
-    {
-      "pr": "9796",
-      "title": "Sync from Master",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok",
-        "web-flow",
-        "HammyHavoc"
-      ]
-    },
-    {
-      "pr": "9793",
-      "title": "[NEW] Version update check",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9778",
-      "title": "[NEW] General alert banner",
-      "userLogin": "ggazzo",
-      "milestone": "0.62.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9642",
-      "title": "[NEW] Browse more channels / Directory",
-      "userLogin": "ggazzo",
-      "milestone": "0.62.0",
-      "contributors": [
-        "ggazzo",
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9665",
-      "title": "[FIX] Wrong behavior of rooms info's *Read Only* and *Collaborative* buttons",
-      "userLogin": "karlprieb",
-      "milestone": "0.62.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9457",
-      "title": "[NEW] Add user settings / preferences API endpoint",
-      "userLogin": "jgtoriginal",
-      "milestone": "0.62.0",
-      "contributors": [
-        "jgtoriginal",
-        "MarcosSpessatto",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9608",
-      "title": "[NEW] New sidebar layout",
-      "userLogin": "ggazzo",
-      "milestone": "0.62.0",
-      "contributors": [
-        "karlprieb",
-        "ggazzo",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9662",
-      "title": "[FIX] Close button on file upload bar was not working",
-      "userLogin": "karlprieb",
-      "milestone": "0.62.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9717",
-      "title": "[NEW] Message read receipts",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.62.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "7098",
-      "title": "[NEW] Alert admins when user requires approval & alert users when the account is approved/activated/deactivated",
-      "userLogin": "luisfn",
-      "milestone": "0.62.0",
-      "contributors": [
-        "luisfn"
-      ]
-    },
-    {
-      "pr": "9666",
-      "title": "[OTHER] Rocket.Chat Apps",
-      "userLogin": "graywolf336",
-      "milestone": "0.62.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "9772",
-      "title": "[FIX] Livechat conversation not receiving messages when start without form",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.61.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9776",
-      "title": "[FIX] Emoji rendering on last message",
-      "userLogin": "ggazzo",
-      "milestone": "0.61.2",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9753",
-      "title": "Move NRR package to inside the project and convert from CoffeeScript",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.0",
-      "contributors": [
-        "rodrigok",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9527",
-      "title": "[NEW] Allow configuration of SAML logout behavior",
-      "userLogin": "mrsimpson",
-      "milestone": "0.62.0",
-      "contributors": [
-        "mrsimpson",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9560",
-      "title": "[FIX] Chrome 64 breaks jitsi-meet iframe",
-      "userLogin": "speedy01",
-      "milestone": "0.62.0",
-      "contributors": [
-        "speedy01",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9697",
-      "title": "[FIX] Harmonize channel-related actions",
-      "userLogin": "mrsimpson",
-      "milestone": "0.62.0",
-      "contributors": [
-        "mrsimpson",
-        "engelgabriel",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9676",
-      "title": "[FIX] Custom emoji was cropping sometimes",
-      "userLogin": "anu-007",
-      "milestone": "0.62.0",
-      "contributors": [
-        "anu-007"
-      ]
-    },
-    {
-      "pr": "9696",
-      "title": "[FIX] Show custom room types icon in channel header",
-      "userLogin": "mrsimpson",
-      "milestone": "0.62.0",
-      "contributors": [
-        "mrsimpson",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8933",
-      "title": "[NEW] Internal hubot support for Direct Messages and Private Groups",
-      "userLogin": "ramrami",
-      "milestone": "0.62.0",
-      "contributors": [
-        "ramrami",
-        "web-flow",
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "9424",
-      "title": "[FIX] 'Query' support for channels.list.joined, groups.list, groups.listAll, im.list",
-      "userLogin": "xbolshe",
-      "milestone": "0.62.0",
-      "contributors": [
-        "xbolshe",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9298",
-      "title": "[NEW] Improved default welcome message",
-      "userLogin": "HammyHavoc",
-      "milestone": "0.62.0",
-      "contributors": [
-        "HammyHavoc",
-        "web-flow",
-        "engelgabriel",
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "9750",
-      "title": "[FIX] Livechat issues on external queue and lead capture",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.61.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9746",
-      "title": "[NEW] Makes shield icon configurable",
-      "userLogin": "c0dzilla",
-      "milestone": "0.62.0",
-      "contributors": [
-        "c0dzilla",
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9747",
-      "title": "[FIX] DeprecationWarning: prom-client ... when starting Rocket Chat server",
-      "userLogin": "jgtoriginal",
-      "milestone": "0.62.0",
-      "contributors": [
-        "jgtoriginal",
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9737",
-      "title": "[FIX] API to retrive rooms was returning empty objects",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.0",
-      "contributors": [
-        "rodrigok",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9687",
-      "title": "[NEW] Global message search (beta: disabled by default)",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.0",
-      "contributors": [
-        "cyberhck",
-        "savikko",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9487",
-      "title": "[FIX] Chat Message Reactions REST API End Point",
-      "userLogin": "jgtoriginal",
-      "milestone": "0.62.0",
-      "contributors": [
-        "jgtoriginal",
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "9312",
-      "title": "[NEW] Allow sounds when conversation is focused",
-      "userLogin": "RationalCoding",
-      "milestone": "0.62.0",
-      "contributors": [
-        "RationalCoding",
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "9519",
-      "title": "[NEW] API to fetch permissions & user roles",
-      "userLogin": "rafaelks",
-      "milestone": "0.62.0",
-      "contributors": [
-        "rafaelks",
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "9509",
-      "title": "[NEW] REST API to use Spotlight",
-      "userLogin": "rafaelks",
-      "milestone": "0.62.0",
-      "contributors": [
-        "rafaelks",
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "9546",
-      "title": "Update to meteor 1.6.1",
-      "userLogin": "engelgabriel",
-      "milestone": "0.62.0",
-      "contributors": [
-        "engelgabriel",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9720",
-      "title": "[FIX] Messages can't be quoted sometimes",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.61.1",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9716",
-      "title": "[FIX] GitLab OAuth does not work when GitLab’s URL ends with slash",
-      "userLogin": "rodrigok",
-      "milestone": "0.61.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9714",
-      "title": "[FIX] Close Livechat conversation by visitor not working in version 0.61.0",
-      "userLogin": "renatobecker",
-      "milestone": "0.61.1",
-      "contributors": [
-        "renatobecker"
-      ]
-    },
-    {
-      "pr": "9067",
-      "title": "[FIX] Formal pronouns and some small mistakes in German texts",
-      "userLogin": "AmShaegar13",
-      "milestone": "0.61.1",
-      "contributors": [
-        "AmShaegar13"
-      ]
-    },
-    {
-      "pr": "9640",
-      "title": "[FIX] Facebook integration in livechat not working on version 0.61.0",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.61.1",
-      "contributors": [
-        "sampaiodiego",
-        "web-flow",
-        "renatobecker"
-      ]
-    },
-    {
-      "pr": "9623",
-      "title": "[FIX] Weird rendering of emojis at sidebar when `last message` is activated",
-      "userLogin": "ggazzo",
-      "milestone": "0.61.1",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "9699",
-      "title": "[NEW] Option to proxy files and avatars through the server",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.0",
-      "contributors": [
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9711",
-      "title": "[BREAK] Remove Graphics/Image Magick support",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8193",
-      "title": "[NEW] Allow request avatar placeholders as PNG or JPG instead of SVG",
-      "userLogin": "lindoelio",
-      "milestone": "0.62.0",
-      "contributors": [
-        "lindoelio",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9218",
-      "title": " [NEW] Image preview as 32x32 base64 jpeg",
-      "userLogin": "jorgeluisrezende",
-      "milestone": "0.62.0",
-      "contributors": [
-        "jorgeluisrezende",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9520",
-      "title": "[FIX] Rest API helpers only applying to v1",
-      "userLogin": "graywolf336",
-      "milestone": "0.62.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "9639",
-      "title": "[FIX] Desktop notification not showing when avatar came from external storage service",
-      "userLogin": "rodrigok",
-      "milestone": "0.61.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9454",
-      "title": "[FIX] Missing link Site URLs in enrollment e-mails",
-      "userLogin": "kemitchell",
-      "milestone": "0.62.0",
-      "contributors": [
-        "kemitchell"
-      ]
-    },
-    {
-      "pr": "9610",
-      "title": "[FIX] Missing string 'Username_already_exist' on the accountProfile page",
-      "userLogin": "sumedh123",
-      "milestone": "0.62.0",
-      "contributors": [
-        "sumedh123"
-      ]
-    },
-    {
-      "pr": "9507",
-      "title": "[NEW] New REST API to mark channel as read",
-      "userLogin": "rafaelks",
-      "milestone": "0.62.0",
-      "contributors": [
-        "rafaelks",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9549",
-      "title": "[NEW] Add route to get user shield/badge",
-      "userLogin": "kb0304",
-      "milestone": "0.62.0",
-      "contributors": [
-        "kb0304",
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "9570",
-      "title": "[FIX] SVG avatars are not been displayed correctly when load in non HTML containers",
-      "userLogin": "filipedelimabrito",
-      "milestone": "0.62.0",
-      "contributors": [
-        "filipedelimabrito"
-      ]
-    },
-    {
-      "pr": "9599",
-      "title": "[FIX] Livechat is not working when running in a sub path",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "8158",
-      "title": "[NEW] GraphQL API",
-      "userLogin": "kamilkisiela",
-      "milestone": "0.62.0",
-      "contributors": [
-        "kamilkisiela",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9255",
-      "title": "[NEW] Livestream tab",
-      "userLogin": "gdelavald",
-      "milestone": "0.62.0",
-      "contributors": [
-        "gdelavald"
-      ]
-    }
-  ],
-  "0.62.0-rc.1": [
-    {
-      "pr": "9843",
-      "title": "Regression: Avatar now open account related options",
-      "userLogin": "karlprieb",
-      "milestone": "0.62.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9837",
-      "title": "Regression: Open search using ctrl/cmd + p and ctrl/cmd + k",
-      "userLogin": "karlprieb",
-      "milestone": "0.62.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9839",
-      "title": "Regression: Search bar is now full width",
-      "userLogin": "karlprieb",
-      "milestone": "0.62.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9658",
-      "title": "[NEW] Add documentation requirement to PRs",
-      "userLogin": "SeanPackham",
-      "contributors": [
-        "SeanPackham",
-        "web-flow",
-        "MartinSchoeler"
-      ]
-    },
-    {
-      "pr": "9807",
-      "title": "[NEW] Request mongoDB version in github issue template",
-      "userLogin": "TwizzyDizzy",
-      "contributors": [
-        "TwizzyDizzy",
-        "web-flow",
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "9802",
-      "title": "[FIX] Not receiving sound notifications in rooms created by new LiveChats",
-      "userLogin": "renatobecker",
-      "milestone": "0.62.0",
-      "contributors": [
-        "renatobecker"
-      ]
-    },
-    {
-      "pr": "9811",
-      "title": "Dependencies update",
-      "userLogin": "engelgabriel",
-      "milestone": "0.62.0",
-      "contributors": [
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "9821",
-      "title": "Fix: Custom fields not showing on user info panel",
-      "userLogin": "ggazzo",
-      "milestone": "0.62.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "9804",
-      "title": "Regression: Page was not respecting the window height on Firefox",
-      "userLogin": "MartinSchoeler",
-      "milestone": "0.62.0",
-      "contributors": [
-        "MartinSchoeler",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9784",
-      "title": "Update bot-config.yml",
-      "userLogin": "JSzaszvari",
-      "contributors": [
-        "JSzaszvari",
-        "web-flow",
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "9797",
-      "title": "Develop fix sync from master",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.62.0-rc.2": [
-    {
-      "pr": "9851",
-      "title": "Regression: Change create channel icon",
-      "userLogin": "karlprieb",
-      "milestone": "0.62.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9852",
-      "title": "Regression: Fix channel icons on safari",
-      "userLogin": "karlprieb",
-      "milestone": "0.62.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9845",
-      "title": "Regression: Fix admin/user settings item text",
-      "userLogin": "karlprieb",
-      "milestone": "0.62.0",
-      "contributors": [
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9858",
-      "title": "[FIX] Silence the update check error message",
-      "userLogin": "graywolf336",
-      "milestone": "0.62.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    }
-  ],
-  "0.62.0-rc.3": [
-    {
-      "pr": "9905",
-      "title": "Regression: Improve sidebar filter",
-      "userLogin": "karlprieb",
-      "milestone": "0.62.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9902",
-      "title": "[OTHER] Fix Apps not working on multi-instance deployments",
-      "userLogin": "graywolf336",
-      "milestone": "0.62.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "9877",
-      "title": "[Fix] Not Translated Phrases",
-      "userLogin": "bernardoetrevisan",
-      "milestone": "0.62.0",
-      "contributors": [
-        "bernardoetrevisan",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9884",
-      "title": "[FIX] Parsing messages with multiple markdown matches ignore some tokens",
-      "userLogin": "c0dzilla",
-      "milestone": "0.62.0",
-      "contributors": [
-        "c0dzilla"
-      ]
-    },
-    {
-      "pr": "9850",
-      "title": "[FIX] Importers no longer working due to the FileUpload changes",
-      "userLogin": "graywolf336",
-      "milestone": "0.62.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "9889",
-      "title": "Regression: Overlapping header in user profile panel",
-      "userLogin": "kaiiiiiiiii",
-      "milestone": "0.62.0",
-      "contributors": [
-        "kaiiiiiiiii"
-      ]
-    },
-    {
-      "pr": "9888",
-      "title": "[FIX] Misplaced \"Save Changes\" button in user account panel",
-      "userLogin": "kaiiiiiiiii",
-      "milestone": "0.62.0",
-      "contributors": [
-        "kaiiiiiiiii"
-      ]
-    },
-    {
-      "pr": "9897",
-      "title": "Regression: sort on room's list not working correctly",
-      "userLogin": "ggazzo",
-      "milestone": "0.62.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9879",
-      "title": "[FIX] Snap build was failing",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.62.0",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.62.0": [
-    {
-      "pr": "9935",
-      "title": "Release 0.62.0",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok",
-        "web-flow",
-        "sampaiodiego",
-        "MartinSchoeler",
-        "renatobecker",
-        "engelgabriel",
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "9934",
-      "title": "[FIX] Typo on french translation for \"Open\"",
-      "userLogin": "sizrar",
-      "milestone": "0.62.0",
-      "contributors": [
-        "sizrar",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9928",
-      "title": "Regression: Fix livechat queue link",
-      "userLogin": "karlprieb",
-      "milestone": "0.62.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9931",
-      "title": "Regression: Directory now list default channel",
-      "userLogin": "karlprieb",
-      "milestone": "0.62.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9908",
-      "title": "Improve link handling for attachments",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9883",
-      "title": "Regression: Misplaced language dropdown in user preferences panel",
-      "userLogin": "kaiiiiiiiii",
-      "milestone": "0.62.0",
-      "contributors": [
-        "kaiiiiiiiii"
-      ]
-    },
-    {
-      "pr": "9901",
-      "title": "Fix RHCC image path for OpenShift and default to the current namespace.",
-      "userLogin": "jsm84",
-      "contributors": [
-        "jsm84",
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.62.1": [
-    {
-      "pr": "9989",
-      "title": "Release 0.62.1",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9986",
-      "title": "[FIX] Delete user without username was removing direct rooms of all users",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.1",
-      "contributors": [
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9988",
-      "title": "[FIX] New channel page on medium size screens",
-      "userLogin": "karlprieb",
-      "milestone": "0.62.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9960",
-      "title": "[FIX] Empty sidenav when sorting by activity and there is a subscription without room",
-      "userLogin": "ggazzo",
-      "milestone": "0.62.1",
-      "contributors": [
-        "ggazzo",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9982",
-      "title": "[FIX] Two factor authentication modal was not showing",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.62.1",
-      "contributors": [
-        "sampaiodiego",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.62.2": [
-    {
-      "pr": "10087",
-      "title": "Release 0.62.2",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10071",
-      "title": "[FIX] Slack Import reports `invalid import file type` due to a call to BSON.native() which is now doesn't exist",
-      "userLogin": "trongthanh",
-      "milestone": "0.62.2",
-      "contributors": [
-        "trongthanh"
-      ]
-    },
-    {
-      "pr": "9719",
-      "title": "[FIX] Verified property of user is always set to false if not supplied",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.62.2",
-      "contributors": [
-        "MarcosSpessatto",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10076",
-      "title": "[FIX] Update preferences of users with settings: null was crashing the server",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10009",
-      "title": "[FIX] REST API: Can't list all public channels when user has permission `view-joined-room`",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.62.2",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10061",
-      "title": "[FIX] Message editing is crashing the server when read receipts are enabled",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.62.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10029",
-      "title": "[FIX] Download links was duplicating Sub Paths",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.63.0-rc.0": [
-    {
-      "pr": "10246",
-      "title": "[NEW] Interface to install and manage RocketChat Apps (alpha)",
-      "userLogin": "ggazzo",
-      "milestone": "0.63.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10243",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.63.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10012",
-      "title": "[FIX] \"View All Members\" button inside channel's \"User Info\" is over sized",
-      "userLogin": "karlprieb",
-      "milestone": "0.63.0",
-      "contributors": [
-        "karlprieb",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10242",
-      "title": "Revert \"[FIX] Apostrophe-containing URL misparsed\"",
-      "userLogin": "sampaiodiego",
-      "contributors": [
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10054",
-      "title": "[NEW] Livechat messages rest APIs",
-      "userLogin": "hmagarotto",
-      "milestone": "0.63.0",
-      "contributors": [
-        "hmagarotto",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9907",
-      "title": "[NEW] Endpoint to retrieve message read receipts",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.63.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10237",
-      "title": "Rename migration name on 108 to match file name",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10159",
-      "title": "Fix typo for Nextcloud login",
-      "userLogin": "pierreozoux",
-      "milestone": "0.63.0",
-      "contributors": [
-        "pierreozoux",
-        "web-flow",
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "10222",
-      "title": "[FIX] user status on sidenav",
-      "userLogin": "ggazzo",
-      "milestone": "0.63.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10152",
-      "title": "[FIX] Dynamic CSS script isn't working on older browsers",
-      "userLogin": "karlprieb",
-      "milestone": "0.63.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9816",
-      "title": "[NEW] Add option to login via REST using Facebook and Twitter tokens",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.63.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "9629",
-      "title": "[NEW] Add REST endpoint to get the list of custom emojis",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.63.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "9947",
-      "title": "[NEW] GDPR Right to be forgotten/erased",
-      "userLogin": "Hudell",
-      "milestone": "0.63.0",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "10105",
-      "title": "[NEW] Added endpoint to retrieve mentions of a channel",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.63.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10160",
-      "title": "[FIX] Extended view mode on sidebar",
-      "userLogin": "karlprieb",
-      "milestone": "0.63.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "10082",
-      "title": "[FIX] Cannot answer to a livechat as a manager if agent has not answered yet",
-      "userLogin": "kb0304",
-      "milestone": "0.63.0",
-      "contributors": [
-        "kb0304",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9584",
-      "title": "[NEW] Add leave public channel & leave private channel permissions",
-      "userLogin": "kb0304",
-      "milestone": "0.63.0",
-      "contributors": [
-        "kb0304",
-        "graywolf336",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10128",
-      "title": "[NEW] Added GET/POST channels.notifications",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.63.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10103",
-      "title": "[BREAK] Removed Private History Route",
-      "userLogin": "Hudell",
-      "milestone": "0.63.0",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "9866",
-      "title": "[FIX] User status missing on user info",
-      "userLogin": "sumedh123",
-      "milestone": "0.63.0",
-      "contributors": [
-        "sumedh123"
-      ]
-    },
-    {
-      "pr": "9672",
-      "title": "[FIX] Name of files in file upload list cuts down at bottom due to overflow",
-      "userLogin": "sumedh123",
-      "milestone": "0.63.0",
-      "contributors": [
-        "sumedh123"
-      ]
-    },
-    {
-      "pr": "9783",
-      "title": "[FIX] No pattern for user's status text capitalization",
-      "userLogin": "sumedh123",
-      "milestone": "0.63.0",
-      "contributors": [
-        "sumedh123"
-      ]
-    },
-    {
-      "pr": "9739",
-      "title": "[FIX] Apostrophe-containing URL misparsed",
-      "userLogin": "sumedh123",
-      "milestone": "0.63.0",
-      "contributors": [
-        "sumedh123"
-      ]
-    },
-    {
-      "pr": "9860",
-      "title": "[FIX] Popover divs don't scroll if they overflow the viewport",
-      "userLogin": "Joe-mcgee",
-      "milestone": "0.63.0",
-      "contributors": [
-        "Joe-mcgee",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10086",
-      "title": "[NEW] Reply preview",
-      "userLogin": "ubarsaiyan",
-      "milestone": "0.63.0",
-      "contributors": [
-        "ubarsaiyan",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10104",
-      "title": "[FIX] Reactions not working on mobile",
-      "userLogin": "ggazzo",
-      "milestone": "0.63.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10123",
-      "title": "[NEW] Support for agent's phone field",
-      "userLogin": "renatobecker",
-      "milestone": "0.63.0",
-      "contributors": [
-        "renatobecker"
-      ]
-    },
-    {
-      "pr": "9872",
-      "title": "[FIX] Broken video call accept dialog",
-      "userLogin": "ramrami",
-      "milestone": "0.63.0",
-      "contributors": [
-        "ramrami"
-      ]
-    },
-    {
-      "pr": "10081",
-      "title": "[FIX] Wrong switch button border color",
-      "userLogin": "kb0304",
-      "milestone": "0.63.0",
-      "contributors": [
-        "kb0304"
-      ]
-    },
-    {
-      "pr": "10154",
-      "title": "Add a few listener supports for the Rocket.Chat Apps",
-      "userLogin": "graywolf336",
-      "milestone": "0.63.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10148",
-      "title": "Add forums as a place to suggest, discuss and upvote features",
-      "userLogin": "SeanPackham",
-      "contributors": [
-        "SeanPackham",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10090",
-      "title": "[FIX] Nextcloud as custom oauth provider wasn't mapping data correctly",
-      "userLogin": "pierreozoux",
-      "milestone": "0.63.0",
-      "contributors": [
-        "pierreozoux",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10144",
-      "title": "[NEW] Added endpoint to get the list of available oauth services",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.63.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10016",
-      "title": "[FIX] Missing sidebar default options on admin",
-      "userLogin": "karlprieb",
-      "milestone": "0.63.0",
-      "contributors": [
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "8667",
-      "title": "[FIX] Able to react with invalid emoji",
-      "userLogin": "mutdmour",
-      "milestone": "0.63.0",
-      "contributors": [
-        "mutdmour",
-        "rodrigok",
-        "web-flow",
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "9742",
-      "title": "[NEW] REST API method to set room's announcement (channels.setAnnouncement)",
-      "userLogin": "TopHattedCat",
-      "milestone": "0.63.0",
-      "contributors": [
-        "TopHattedCat",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9726",
-      "title": "[NEW] Audio recording as mp3 and better ui for recording",
-      "userLogin": "kb0304",
-      "milestone": "0.63.0",
-      "contributors": [
-        "kb0304",
-        "rodrigok",
-        "web-flow",
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "9732",
-      "title": "[NEW] Setting to configure max delta for 2fa",
-      "userLogin": "Hudell",
-      "milestone": "0.63.0",
-      "contributors": [
-        "Hudell",
-        "web-flow",
-        "engelgabriel",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9870",
-      "title": "[NEW] Livechat webhook request on message",
-      "userLogin": "hmagarotto",
-      "milestone": "0.63.0",
-      "contributors": [
-        "hmagarotto",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10071",
-      "title": "[FIX] Slack Import reports `invalid import file type` due to a call to BSON.native() which is now doesn't exist",
-      "userLogin": "trongthanh",
-      "milestone": "0.62.2",
-      "contributors": [
-        "trongthanh"
-      ]
-    },
-    {
-      "pr": "9719",
-      "title": "[FIX] Verified property of user is always set to false if not supplied",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.62.2",
-      "contributors": [
-        "MarcosSpessatto",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10076",
-      "title": "[FIX] Update preferences of users with settings: null was crashing the server",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10065",
-      "title": "Fix tests breaking randomly",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10009",
-      "title": "[FIX] REST API: Can't list all public channels when user has permission `view-joined-room`",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.62.2",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10061",
-      "title": "[FIX] Message editing is crashing the server when read receipts are enabled",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.62.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10029",
-      "title": "[FIX] Download links was duplicating Sub Paths",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10051",
-      "title": "[FIX] User preferences can't be saved when roles are hidden in admin settings",
-      "userLogin": "Hudell",
-      "milestone": "0.63.0",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "9367",
-      "title": "[NEW] Announcement bar color wasn't using color from theming variables",
-      "userLogin": "cyclops24",
-      "milestone": "0.63.0",
-      "contributors": [
-        "cyclops24",
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9932",
-      "title": "[FIX] Browser was auto-filling values when editing another user profile",
-      "userLogin": "kaiiiiiiiii",
-      "milestone": "0.63.0",
-      "contributors": [
-        "kaiiiiiiiii"
-      ]
-    },
-    {
-      "pr": "10011",
-      "title": "[FIX] Avatar input was accepting not supported image types",
-      "userLogin": "karlprieb",
-      "milestone": "0.63.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "10028",
-      "title": "[FIX] Initial loading feedback was missing",
-      "userLogin": "karlprieb",
-      "milestone": "0.63.0",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "10036",
-      "title": "[OTHER] Reactivate all tests",
-      "userLogin": "rodrigok",
-      "milestone": "0.63.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9844",
-      "title": "[OTHER] Reactivate API tests",
-      "userLogin": "karlprieb",
-      "contributors": [
-        "karlprieb",
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "9986",
-      "title": "[FIX] Delete user without username was removing direct rooms of all users",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.1",
-      "contributors": [
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9982",
-      "title": "[FIX] Two factor authentication modal was not showing",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.62.1",
-      "contributors": [
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9960",
-      "title": "[FIX] Empty sidenav when sorting by activity and there is a subscription without room",
-      "userLogin": "ggazzo",
-      "milestone": "0.62.1",
-      "contributors": [
-        "ggazzo",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9988",
-      "title": "[FIX] New channel page on medium size screens",
-      "userLogin": "karlprieb",
-      "milestone": "0.62.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9985",
-      "title": "Start 0.63.0-develop / develop sync from master",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10087",
-      "title": "Release 0.62.2",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9986",
-      "title": "[FIX] Delete user without username was removing direct rooms of all users",
-      "userLogin": "rodrigok",
-      "milestone": "0.62.1",
-      "contributors": [
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9988",
-      "title": "[FIX] New channel page on medium size screens",
-      "userLogin": "karlprieb",
-      "milestone": "0.62.1",
-      "contributors": [
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "9960",
-      "title": "[FIX] Empty sidenav when sorting by activity and there is a subscription without room",
-      "userLogin": "ggazzo",
-      "milestone": "0.62.1",
-      "contributors": [
-        "ggazzo",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9982",
-      "title": "[FIX] Two factor authentication modal was not showing",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.62.1",
-      "contributors": [
-        "sampaiodiego",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.63.0-rc.1": [
-    {
-      "pr": "10272",
-      "title": "[FIX] File had redirect delay when using external storage services and no option to proxy only avatars",
-      "userLogin": "rodrigok",
-      "milestone": "0.63.0",
-      "contributors": [
-        "rodrigok",
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10257",
-      "title": "Fix: Renaming channels.notifications Get/Post endpoints",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.63.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10262",
-      "title": "[FIX] Missing pt-BR translations",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.63.0",
-      "contributors": [
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10240",
-      "title": "[FIX] /me REST endpoint was missing user roles and preferences",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.63.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10260",
-      "title": "Fix caddy download link to pull from github",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.63.0",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10252",
-      "title": "Fix: possible errors on rocket.chat side of the apps",
-      "userLogin": "graywolf336",
-      "milestone": "0.63.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10015",
-      "title": "Fix snap install. Remove execstack from sharp, and bypass grpc error",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.63.0",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.63.0-rc.2": [
-    {
-      "pr": "10078",
-      "title": "[FIX] Unable to mention after newline in message",
-      "userLogin": "c0dzilla",
-      "milestone": "0.63.0",
-      "contributors": [
-        "c0dzilla"
-      ]
-    },
-    {
-      "pr": "10224",
-      "title": "[FIX] Wrong pagination information on /api/v1/channels.members",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.63.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10163",
-      "title": "[FIX] Inline code following a url leads to autolinking of code with url",
-      "userLogin": "c0dzilla",
-      "milestone": "0.63.0",
-      "contributors": [
-        "c0dzilla"
-      ]
-    },
-    {
-      "pr": "10258",
-      "title": "[FIX] Incoming Webhooks were missing the raw content",
-      "userLogin": "Hudell",
-      "milestone": "0.63.0",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "10270",
-      "title": "[FIX] Missing Translation Key on Reactions",
-      "userLogin": "bernardoetrevisan",
-      "milestone": "0.63.0",
-      "contributors": [
-        "bernardoetrevisan",
-        "web-flow",
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10274",
-      "title": "Fix: inputs for rocketchat apps",
-      "userLogin": "ggazzo",
-      "milestone": "0.63.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow",
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10290",
-      "title": "Fix: chat.react api not accepting previous emojis",
-      "userLogin": "graywolf336",
-      "milestone": "0.63.0",
-      "contributors": [
-        "graywolf336",
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10300",
-      "title": "Fix: Scroll on content page",
-      "userLogin": "ggazzo",
-      "milestone": "0.63.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    }
-  ],
-  "HEAD": [],
-  "0.63.0": [
-    {
-      "pr": "10303",
-      "title": "[FIX] Audio Message UI fixes",
-      "userLogin": "kb0304",
-      "contributors": [
-        "kb0304",
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10319",
-      "title": "[NEW] Improve history generation",
-      "userLogin": "rodrigok",
-      "milestone": "0.63.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10323",
-      "title": "Fix: Reaction endpoint/api only working with regular emojis",
-      "userLogin": "graywolf336",
-      "milestone": "0.63.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10313",
-      "title": "Bump snap version to include security fix",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.63.0",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10314",
-      "title": "Update Meteor to 1.6.1.1",
-      "userLogin": "rodrigok",
-      "milestone": "0.63.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.63.1": [
-    {
-      "pr": "10348",
-      "title": "[FIX] Change deprecated Meteor._reload.reload method in favor of Reload._reload",
-      "userLogin": "tttt-conan",
-      "milestone": "0.63.1",
-      "contributors": [
-        "tttt-conan"
-      ]
-    },
-    {
-      "pr": "10351",
-      "title": "[FIX] Snaps crashing due to Node v8.11.1 Segfault",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.63.1",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10084",
-      "title": "[FIX] Add '.value' in the SAML package to fix TypeErrors on SAML token validation",
-      "userLogin": "TechyPeople",
-      "milestone": "0.63.1",
-      "contributors": [
-        "TechyPeople",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10356",
-      "title": "[FIX] Incorrect german translation of user online status",
-      "userLogin": "kaiiiiiiiii",
-      "milestone": "0.63.1",
-      "contributors": [
-        "kaiiiiiiiii"
-      ]
-    },
-    {
-      "pr": "10355",
-      "title": "[FIX] Incorrect French language usage for Disabled",
-      "userLogin": "graywolf336",
-      "milestone": "0.63.1",
-      "contributors": [
-        "graywolf336",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.63.2": [
-    {
-      "pr": "10475",
-      "title": "[FIX] Even TypeErrors with SAML",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10408",
-      "title": "add redhat dockerfile to master",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    }
-  ],
-  "0.63.3": [
-    {
-      "pr": "10485",
-      "title": "[FIX] The 'channel.messages' REST API Endpoint error",
-      "userLogin": "rafaelks",
-      "milestone": "0.64.0",
-      "contributors": [
-        "rafaelks",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10218",
-      "title": "Added one2mail.info to default blocked domains list",
-      "userLogin": "nsuchy",
-      "milestone": "0.64.0",
-      "contributors": [
-        "nsuchy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10476",
-      "title": "Release 0.63.2",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "graywolf336",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10475",
-      "title": "[FIX] Even TypeErrors with SAML",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "graywolf336"
-      ]
-    }
-  ],
-  "0.64.0-rc.0": [
-    {
-      "pr": "10532",
-      "title": "Included missing lib for migrations",
-      "userLogin": "Hudell",
-      "milestone": "0.64.0",
-      "contributors": [
-        "Hudell",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10502",
-      "title": "[NEW] Option to mute group mentions (@all and @here)",
-      "userLogin": "Hudell",
-      "milestone": "0.64.0",
-      "contributors": [
-        "Hudell",
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "9906",
-      "title": "[NEW] GDPR - Right to access and Data Portability",
-      "userLogin": "Hudell",
-      "milestone": "0.64.0",
-      "contributors": [
-        "Hudell",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9922",
-      "title": "[BREAK] Validate incoming message schema",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.64.0",
-      "contributors": [
-        "MarcosSpessatto",
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "9950",
-      "title": "[NEW] Broadcast Channels",
-      "userLogin": "ggazzo",
-      "milestone": "0.64.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow",
-        "sampaiodiego",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10480",
-      "title": "[FIX] Add user object to responses in /*.files Rest endpoints",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.64.0",
-      "contributors": [
-        "MarcosSpessatto",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10517",
-      "title": "[NEW] Option to ignore users on channels",
-      "userLogin": "ggazzo",
-      "milestone": "0.64.0",
-      "contributors": [
-        "ggazzo",
-        "gdelavald",
-        "web-flow",
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "10110",
-      "title": "[NEW] Search Provider Framework",
-      "userLogin": "tkurz",
-      "milestone": "0.64.0",
-      "contributors": [
-        "tkurz",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10473",
-      "title": "[FIX] Missing user data on files uploaded through the API",
-      "userLogin": "Hudell",
-      "milestone": "0.64.0",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "10498",
-      "title": "[FIX] Rename method to clean history of messages",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.64.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10410",
-      "title": "[FIX] REST spotlight API wasn't allowing searches with # and @",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.64.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10505",
-      "title": "Develop sync",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow",
-        "graywolf336",
-        "nsuchy",
-        "rodrigok",
-        "rafaelks",
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "10442",
-      "title": "[NEW] REST API endpoint `/directory`",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.64.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10482",
-      "title": "[FIX] Dropdown elements were using old styles",
-      "userLogin": "kaiiiiiiiii",
-      "milestone": "0.64.0",
-      "contributors": [
-        "kaiiiiiiiii"
-      ]
-    },
-    {
-      "pr": "10513",
-      "title": "Fix: Remove \"secret\" from REST endpoint /settings.oauth response",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.64.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10403",
-      "title": "[FIX] Directory sort and column sizes were wrong",
-      "userLogin": "ggazzo",
-      "milestone": "0.64.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow",
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "10299",
-      "title": "[FIX] REST API OAuth services endpoint were missing fields and flag to indicate custom services",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.64.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10446",
-      "title": "[FIX] Error messages weren't been displayed when email verification fails",
-      "userLogin": "Hudell",
-      "milestone": "0.64.0",
-      "contributors": [
-        "Hudell",
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10454",
-      "title": "[FIX] Wrong column positions in the directory search for users",
-      "userLogin": "sumedh123",
-      "milestone": "0.64.0",
-      "contributors": [
-        "sumedh123",
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10463",
-      "title": "[FIX] Custom fields was misaligned in registration form",
-      "userLogin": "dschuan",
-      "milestone": "0.64.0",
-      "contributors": [
-        "dschuan",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10341",
-      "title": "[FIX] Unique identifier file not really being unique",
-      "userLogin": "abernix",
-      "milestone": "0.64.0",
-      "contributors": [
-        "abernix",
-        "web-flow",
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "10335",
-      "title": "[OTHER] More Listeners for Apps & Utilize Promises inside Apps",
-      "userLogin": "graywolf336",
-      "milestone": "0.64.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10404",
-      "title": "[FIX] Empty panel after changing a user's username",
-      "userLogin": "Hudell",
-      "milestone": "0.64.0",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "10418",
-      "title": " [FIX] Russian translation of \"False\"",
-      "userLogin": "strangerintheq",
-      "contributors": [
-        "strangerintheq",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10496",
-      "title": "[FIX] Links being embedded inside of blockquotes",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.0",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "10485",
-      "title": "[FIX] The 'channel.messages' REST API Endpoint error",
-      "userLogin": "rafaelks",
-      "milestone": "0.64.0",
-      "contributors": [
-        "rafaelks",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10487",
-      "title": "[OTHER] Develop sync",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow",
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10358",
-      "title": "[FIX] Button on user info contextual bar scrolling with the content",
-      "userLogin": "okaybroda",
-      "milestone": "0.64.0",
-      "contributors": [
-        "okaybroda",
-        "ggazzo",
-        "web-flow",
-        "karlprieb",
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "9824",
-      "title": "[FIX] \"Idle Time Limit\" using milliseconds instead of seconds",
-      "userLogin": "kaiiiiiiiii",
-      "milestone": "0.64.0",
-      "contributors": [
-        "kaiiiiiiiii",
-        "web-flow",
-        "geekgonecrazy",
-        "sampaiodiego",
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10259",
-      "title": "[NEW] Body of the payload on an incoming webhook is included on the request object",
-      "userLogin": "Hudell",
-      "milestone": "0.64.0",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "10387",
-      "title": "[FIX] Missing i18n translation key for \"Unread\"",
-      "userLogin": "Hudell",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "9729",
-      "title": "[FIX] Owner unable to delete channel or group from APIs",
-      "userLogin": "c0dzilla",
-      "milestone": "0.64.0",
-      "contributors": [
-        "c0dzilla",
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10371",
-      "title": "[NEW] REST endpoint to recover forgotten password",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.64.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10354",
-      "title": "[NEW] REST endpoint to report messages",
-      "userLogin": "MarcosSpessatto",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10108",
-      "title": "[NEW] Livechat setting to customize ended conversation message",
-      "userLogin": "renatobecker",
-      "milestone": "0.64.0",
-      "contributors": [
-        "renatobecker"
-      ]
-    },
-    {
-      "pr": "10369",
-      "title": "[FIX] Livechat translation files being ignored",
-      "userLogin": "renatobecker",
-      "milestone": "0.64.0",
-      "contributors": [
-        "renatobecker",
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "7964",
-      "title": "[NEW] Twilio MMS support for LiveChat integration",
-      "userLogin": "t3hchipmunk",
-      "milestone": "0.64.0",
-      "contributors": [
-        "t3hchipmunk",
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "6673",
-      "title": "[FIX] Missing page \"not found\"",
-      "userLogin": "Prakharsvnit",
-      "milestone": "0.64.0",
-      "contributors": [
-        "Prakharsvnit",
-        "web-flow",
-        "geekgonecrazy",
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "10083",
-      "title": "[FIX] \"Highlight Words\" wasn't working with more than one word",
-      "userLogin": "nemaniarjun",
-      "milestone": "0.64.0",
-      "contributors": [
-        "nemaniarjun",
-        "gdelavald",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10171",
-      "title": "[FIX] Missing \"Administration\" menu for user with manage-emoji permission",
-      "userLogin": "c0dzilla",
-      "milestone": "0.64.0",
-      "contributors": [
-        "c0dzilla",
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10395",
-      "title": "[FIX] Message view mode setting was missing at user's preferences ",
-      "userLogin": "kaiiiiiiiii",
-      "milestone": "0.64.0",
-      "contributors": [
-        "kaiiiiiiiii",
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10399",
-      "title": "[FIX] Profile image was not being shown in user's directory search",
-      "userLogin": "sumedh123",
-      "milestone": "0.64.0",
-      "contributors": [
-        "sumedh123",
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10342",
-      "title": "[NEW] REST API endpoint `rooms.favorite` to favorite and unfavorite rooms",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.64.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10428",
-      "title": "[FIX] Wrong positioning of popover when using RTL languages",
-      "userLogin": "ggazzo",
-      "milestone": "0.64.0",
-      "contributors": [
-        "ggazzo",
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10472",
-      "title": "[FIX] Messages was grouping wrong some times when server is slow",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.0",
-      "contributors": [
-        "gdelavald",
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10225",
-      "title": "[FIX] GitLab authentication scope was too open, reduced to read only access",
-      "userLogin": "rafaelks",
-      "milestone": "0.64.0",
-      "contributors": [
-        "rafaelks",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10344",
-      "title": "[FIX] Renaming agent's username within Livechat's department",
-      "userLogin": "renatobecker",
-      "milestone": "0.64.0",
-      "contributors": [
-        "renatobecker"
-      ]
-    },
-    {
-      "pr": "10394",
-      "title": "[FIX] Missing RocketApps input types",
-      "userLogin": "ggazzo",
-      "milestone": "0.64.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow",
-        "graywolf336",
-        "karlprieb"
-      ]
-    },
-    {
-      "pr": "10221",
-      "title": "[FIX] Livechat desktop notifications not being displayed",
-      "userLogin": "renatobecker",
-      "milestone": "0.64.0",
-      "contributors": [
-        "renatobecker",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10336",
-      "title": "Change Docker-Compose to use mmapv1 storage engine for mongo",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.64.0",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10396",
-      "title": "[NEW] Add internal API to handle room announcements",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.0",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "10409",
-      "title": "[FIX] Autocomplete list when inviting a user was partial hidden",
-      "userLogin": "karlprieb",
-      "milestone": "0.64.0",
-      "contributors": [
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10423",
-      "title": "[FIX] Remove a user from the user's list when creating a new channel removes the wrong user",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.0",
-      "contributors": [
-        "gdelavald",
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10430",
-      "title": "[FIX] Room's name was cutting instead of having ellipses on sidebar",
-      "userLogin": "ggazzo",
-      "milestone": "0.64.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "10435",
-      "title": "Add some missing translations",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.0",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "10437",
-      "title": "[NEW] Add message preview when quoting another message",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.0",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "10438",
-      "title": "[FIX] Button to delete rooms by the owners wasn't appearing",
-      "userLogin": "ggazzo",
-      "milestone": "0.64.0",
-      "contributors": [
-        "ggazzo",
-        "karlprieb",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10439",
-      "title": "[NEW] Prevent the browser to autocomplete some setting fields",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.0",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "10441",
-      "title": "[OTHER] Removed the developer warning on the rest api",
-      "userLogin": "graywolf336",
-      "milestone": "0.64.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10444",
-      "title": "[NEW] Shows user's real name on autocomplete popup",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.0",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "10414",
-      "title": "[NEW] Automatically trigger Redhat registry build when tagging new release",
-      "userLogin": "geekgonecrazy",
-      "milestone": "0.64.0",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "10397",
-      "title": "Fix and improve vietnamese translation",
-      "userLogin": "tttt-conan",
-      "contributors": [
-        "tttt-conan",
-        "TDiNguyen",
-        "graywolf336",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10411",
-      "title": "[BREAK] The property \"settings\" is no longer available to regular users via rest api",
-      "userLogin": "graywolf336",
-      "milestone": "0.64.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "9946",
-      "title": "[FIX] Updated OpenShift Template to take an Image as a Param",
-      "userLogin": "christianh814",
-      "contributors": [
-        "christianh814",
-        "web-flow",
-        "geekgonecrazy"
-      ]
-    },
-    {
-      "pr": "10405",
-      "title": "Use Node 8.9 for CI build",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "9576",
-      "title": "[FIX] Incoming integrations being able to trigger an empty message with a GET",
-      "userLogin": "graywolf336",
-      "milestone": "0.64.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10360",
-      "title": "Update allowed labels for bot",
-      "userLogin": "TwizzyDizzy",
-      "contributors": [
-        "TwizzyDizzy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10384",
-      "title": "Remove @core team mention from Pull Request template",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.0",
-      "contributors": [
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10390",
-      "title": "[FIX] Snaps installations are breaking on avatar requests",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10234",
-      "title": "New issue template for *Release Process*",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.0",
-      "contributors": [
-        "rodrigok",
-        "geekgonecrazy",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10376",
-      "title": "Master into Develop Branch Sync",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "sampaiodiego",
-        "rodrigok",
-        "web-flow",
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10504",
-      "title": "Release 0.63.3",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "rafaelks",
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10476",
-      "title": "Release 0.63.2",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "graywolf336",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10408",
-      "title": "add redhat dockerfile to master",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    }
-  ],
-  "0.64.0-rc.1": [
-    {
-      "pr": "10545",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.64.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10544",
-      "title": "Regression: Revert announcement structure",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.0",
-      "contributors": [
-        "gdelavald",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10543",
-      "title": "Regression: Upload was not working",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.64.0-rc.2": [
-    {
-      "pr": "10549",
-      "title": "Deps update",
-      "userLogin": "engelgabriel",
-      "milestone": "0.64.0",
-      "contributors": [
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10560",
-      "title": "Regression: /api/v1/settings.oauth not returning clientId for Twitter",
-      "userLogin": "cardoso",
-      "milestone": "0.64.0",
-      "contributors": [
-        "cardoso",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10555",
-      "title": "Regression: Webhooks breaking due to restricted test",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10559",
-      "title": "Regression: Rooms and Apps weren't playing nice with each other",
-      "userLogin": "graywolf336",
-      "milestone": "0.64.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10554",
-      "title": "Regression: Fix announcement bar being displayed without content",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.0",
-      "contributors": [
-        "gdelavald"
-      ]
-    }
-  ],
-  "0.64.0-rc.3": [
-    {
-      "pr": "10550",
-      "title": "[FIX] Wordpress oAuth authentication wasn't behaving correctly",
-      "userLogin": "kaiiiiiiiii",
-      "milestone": "0.64.0",
-      "contributors": [
-        "kaiiiiiiiii"
-      ]
-    },
-    {
-      "pr": "10553",
-      "title": "Regression: Inconsistent response of settings.oauth endpoint",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.64.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10571",
-      "title": "Regression: Remove added mentions on quote/reply",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.0",
-      "contributors": [
-        "gdelavald",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10573",
-      "title": "Regression: Attachments and fields incorrectly failing on validation",
-      "userLogin": "graywolf336",
-      "milestone": "0.64.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    }
-  ],
-  "0.64.0-rc.4": [
-    {
-      "pr": "10558",
-      "title": "[FIX] Switch buttons were cutting in RTL mode",
-      "userLogin": "ggazzo",
-      "milestone": "0.64.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10574",
-      "title": "[NEW] Add information regarding Zapier and Bots to the integrations page",
-      "userLogin": "graywolf336",
-      "milestone": "0.64.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10575",
-      "title": "Regression: Rocket.Chat App author link opens in same window",
-      "userLogin": "kaiiiiiiiii",
-      "milestone": "0.64.0",
-      "contributors": [
-        "kaiiiiiiiii",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10503",
-      "title": "[FIX] Stop Firefox announcement overflowing viewport",
-      "userLogin": "brendangadd",
-      "milestone": "0.64.0",
-      "contributors": [
-        "brendangadd",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.64.0": [
-    {
-      "pr": "10591",
-      "title": "Regression: Various search provider fixes",
-      "userLogin": "tkurz",
-      "milestone": "0.64.0",
-      "contributors": [
-        "tkurz",
-        "web-flow",
-        "engelgabriel",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10596",
-      "title": "Regression: /api/v1/settings.oauth not sending needed info for SAML & CAS",
-      "userLogin": "cardoso",
-      "milestone": "0.64.0",
-      "contributors": [
-        "cardoso",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10598",
-      "title": "Regression: Apps and Livechats not getting along well with each other",
-      "userLogin": "graywolf336",
-      "milestone": "0.64.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10551",
-      "title": " [FIX] Missing \"Administration\" menu for users with some administration permissions",
-      "userLogin": "kaiiiiiiiii",
-      "milestone": "0.64.0",
-      "contributors": [
-        "kaiiiiiiiii"
-      ]
-    },
-    {
-      "pr": "10599",
-      "title": "[FIX] Member list search with no results",
-      "userLogin": "ggazzo",
-      "milestone": "0.64.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "10586",
-      "title": "Development: Add Visual Studio Code debugging configuration",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10576",
-      "title": "[FIX] Integrations with room data not having the usernames filled in",
-      "userLogin": "graywolf336",
-      "milestone": "0.64.0",
-      "contributors": [
-        "graywolf336",
-        "sampaiodiego",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.64.1": [
-    {
-      "pr": "10597",
-      "title": "[NEW] Store the last sent message to show bellow the room's name by default",
-      "userLogin": "graywolf336",
-      "milestone": "0.64.1",
-      "contributors": [
-        "graywolf336",
-        "engelgabriel",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10529",
-      "title": "Support passing extra connection options to the Mongo driver",
-      "userLogin": "saplla",
-      "milestone": "0.64.1",
-      "contributors": [
-        "saplla",
-        "web-flow",
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "10615",
-      "title": "[FIX] E-mails were hidden some information",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.1",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10611",
-      "title": "Regression: Updating an App on multi-instance servers wasn't working",
-      "userLogin": "graywolf336",
-      "milestone": "0.64.1",
-      "contributors": [
-        "graywolf336",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10627",
-      "title": "[FIX] Regression on 0.64.0 was freezing the application when posting some URLs",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.1",
-      "contributors": [
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10648",
-      "title": "Dependencies update",
-      "userLogin": "engelgabriel",
-      "milestone": "0.64.1",
-      "contributors": [
-        "engelgabriel"
-      ]
-    }
-  ],
-  "0.64.2-rc.0": [
-    {
-      "pr": "10736",
-      "title": "More improvements on send notifications logic",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10720",
-      "title": "[FIX] Send a message when muted returns inconsistent result in chat.sendMessage",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.64.2",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10733",
-      "title": "[FIX] Regression: Empty content on announcement modal",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.2",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "10607",
-      "title": "[NEW] Add REST endpoints `channels.roles` & `groups.roles`",
-      "userLogin": "cardoso",
-      "milestone": "0.64.2",
-      "contributors": [
-        "cardoso",
-        "web-flow",
-        "rafaelks"
-      ]
-    },
-    {
-      "pr": "10724",
-      "title": "[NEW] Add more options for Wordpress OAuth configuration",
-      "userLogin": "Hudell",
-      "milestone": "0.64.2",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "10523",
-      "title": "[NEW] Setup Wizard",
-      "userLogin": "karlprieb",
-      "milestone": "0.64.2",
-      "contributors": [
-        "karlprieb",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10691",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10686",
-      "title": "[NEW] Improvements to notifications logic",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.64.2",
-      "contributors": [
-        "sampaiodiego",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10705",
-      "title": "[FIX] Missing attachment description when Rocket.Chat Apps were enabled",
-      "userLogin": "Hudell",
-      "milestone": "0.64.2",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "10445",
-      "title": "[FIX] Improve desktop notification formatting",
-      "userLogin": "Sameesunkaria",
-      "milestone": "0.64.2",
-      "contributors": [
-        "Sameesunkaria",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10524",
-      "title": "Add `npm run postinstall` into example build script",
-      "userLogin": "peccu",
-      "milestone": "0.64.2",
-      "contributors": [
-        "peccu",
-        "web-flow",
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "10678",
-      "title": "[FIX] Message box emoji icon was flickering when typing a text",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.2",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "10674",
-      "title": "Correct links in README file",
-      "userLogin": "winterstefan",
-      "milestone": "0.64.2",
-      "contributors": [
-        "winterstefan"
-      ]
-    },
-    {
-      "pr": "10665",
-      "title": "[FIX] Channel owner was being set as muted when creating a read-only channel",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.64.2",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10681",
-      "title": "[FIX] SAML wasn't working correctly when running multiple instances",
-      "userLogin": "Hudell",
-      "milestone": "0.64.2",
-      "contributors": [
-        "Hudell",
-        "rodrigok",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.64.2-rc.1": [
-    {
-      "pr": "10789",
-      "title": "Prometheus: Improve metric names",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10788",
-      "title": "Improvement to push notifications on direct messages",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.64.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10786",
-      "title": "Better metric for notifications",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10779",
-      "title": "Add badge back to push notifications",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10776",
-      "title": "Wizard improvements",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10766",
-      "title": "Add setting and expose prometheus on port 9100",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10760",
-      "title": "Regression: Fix notifications for direct messages",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.64.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    }
-  ],
-  "0.64.2-rc.2": [
-    {
-      "pr": "10798",
-      "title": "Prometheus: Add metric to track hooks time",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10802",
-      "title": "Regression: Autorun of wizard was not destroyed after completion",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10803",
-      "title": "Prometheus: Fix notification metric",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10804",
-      "title": "Regression: Fix wrong wizard field name",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10793",
-      "title": "[FIX] Not escaping special chars on mentions",
-      "userLogin": "erhan-",
-      "milestone": "0.64.2",
-      "contributors": [
-        "erhan-",
-        "sampaiodiego"
-      ]
-    }
-  ],
-  "0.64.2": [
-    {
-      "pr": "10812",
-      "title": "Release 0.64.2",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "Hudell",
-        "rodrigok",
-        "web-flow",
-        "MarcosSpessatto",
-        "winterstefan",
-        "gdelavald",
-        "peccu",
-        "Sameesunkaria",
-        "sampaiodiego",
-        "engelgabriel",
-        "karlprieb",
-        "cardoso",
-        "erhan-"
-      ]
-    },
-    {
-      "pr": "10798",
-      "title": "Prometheus: Add metric to track hooks time",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10802",
-      "title": "Regression: Autorun of wizard was not destroyed after completion",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10803",
-      "title": "Prometheus: Fix notification metric",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10804",
-      "title": "Regression: Fix wrong wizard field name",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10793",
-      "title": "[FIX] Not escaping special chars on mentions",
-      "userLogin": "erhan-",
-      "milestone": "0.64.2",
-      "contributors": [
-        "erhan-",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10789",
-      "title": "Prometheus: Improve metric names",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10788",
-      "title": "Improvement to push notifications on direct messages",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.64.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10786",
-      "title": "Better metric for notifications",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10779",
-      "title": "Add badge back to push notifications",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10776",
-      "title": "Wizard improvements",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10766",
-      "title": "Add setting and expose prometheus on port 9100",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10760",
-      "title": "Regression: Fix notifications for direct messages",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.64.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10736",
-      "title": "More improvements on send notifications logic",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10720",
-      "title": "[FIX] Send a message when muted returns inconsistent result in chat.sendMessage",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.64.2",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10733",
-      "title": "[FIX] Regression: Empty content on announcement modal",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.2",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "10607",
-      "title": "[NEW] Add REST endpoints `channels.roles` & `groups.roles`",
-      "userLogin": "cardoso",
-      "milestone": "0.64.2",
-      "contributors": [
-        "cardoso",
-        "web-flow",
-        "rafaelks"
-      ]
-    },
-    {
-      "pr": "10724",
-      "title": "[NEW] Add more options for Wordpress OAuth configuration",
-      "userLogin": "Hudell",
-      "milestone": "0.64.2",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "10523",
-      "title": "[NEW] Setup Wizard",
-      "userLogin": "karlprieb",
-      "milestone": "0.64.2",
-      "contributors": [
-        "karlprieb",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10691",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10686",
-      "title": "[NEW] Improvements to notifications logic",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.64.2",
-      "contributors": [
-        "sampaiodiego",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10705",
-      "title": "[FIX] Missing attachment description when Rocket.Chat Apps were enabled",
-      "userLogin": "Hudell",
-      "milestone": "0.64.2",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "10445",
-      "title": "[FIX] Improve desktop notification formatting",
-      "userLogin": "Sameesunkaria",
-      "milestone": "0.64.2",
-      "contributors": [
-        "Sameesunkaria",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10524",
-      "title": "Add `npm run postinstall` into example build script",
-      "userLogin": "peccu",
-      "milestone": "0.64.2",
-      "contributors": [
-        "peccu",
-        "web-flow",
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "10678",
-      "title": "[FIX] Message box emoji icon was flickering when typing a text",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.2",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "10674",
-      "title": "Correct links in README file",
-      "userLogin": "winterstefan",
-      "milestone": "0.64.2",
-      "contributors": [
-        "winterstefan"
-      ]
-    },
-    {
-      "pr": "10665",
-      "title": "[FIX] Channel owner was being set as muted when creating a read-only channel",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.64.2",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10681",
-      "title": "[FIX] SAML wasn't working correctly when running multiple instances",
-      "userLogin": "Hudell",
-      "milestone": "0.64.2",
-      "contributors": [
-        "Hudell",
-        "rodrigok",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.65.0-rc.0": [
-    {
-      "pr": "10822",
-      "title": "Apps: Command Previews, Message and Room Removal Events",
-      "userLogin": "graywolf336",
-      "milestone": "0.65.0",
-      "contributors": [
-        "graywolf336",
-        "rodrigok",
-        "web-flow",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "9857",
-      "title": "[NEW] Implement a local password policy",
-      "userLogin": "graywolf336",
-      "milestone": "0.65.0",
-      "contributors": [
-        "graywolf336",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10663",
-      "title": "[FIX] Livechat managers were not being able to send messages in some cases",
-      "userLogin": "renatobecker",
-      "milestone": "0.65.0",
-      "contributors": [
-        "renatobecker"
-      ]
-    },
-    {
-      "pr": "10584",
-      "title": "[NEW] Options to enable/disable each Livechat registration form field",
-      "userLogin": "renatobecker",
-      "milestone": "0.65.0",
-      "contributors": [
-        "renatobecker",
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10612",
-      "title": "[FIX] Livechat settings not appearing correctly",
-      "userLogin": "renatobecker",
-      "milestone": "0.65.0",
-      "contributors": [
-        "renatobecker"
-      ]
-    },
-    {
-      "pr": "10677",
-      "title": "[NEW] Return the result of the `/me` endpoint within the result of the `/login` endpoint",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.65.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10815",
-      "title": "Develop sync",
-      "userLogin": "rodrigok",
-      "contributors": [
-        "geekgonecrazy",
-        "web-flow",
-        "graywolf336",
-        "nsuchy",
-        "rodrigok",
-        "rafaelks",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10608",
-      "title": "[NEW] Lazy load image attachments",
-      "userLogin": "ggazzo",
-      "milestone": "0.65.0",
-      "contributors": [
-        "ggazzo",
-        "web-flow",
-        "karlprieb",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10427",
-      "title": "[FIX] Enabling `Collapse Embedded Media by Default` was hiding replies and quotes",
-      "userLogin": "c0dzilla",
-      "milestone": "0.65.0",
-      "contributors": [
-        "c0dzilla"
-      ]
-    },
-    {
-      "pr": "10214",
-      "title": "[NEW] View pinned message's attachment",
-      "userLogin": "c0dzilla",
-      "milestone": "0.65.0",
-      "contributors": [
-        "c0dzilla",
-        "karlprieb",
-        "web-flow",
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "10704",
-      "title": "[FIX] Missing option to disable/enable System Messages",
-      "userLogin": "ggazzo",
-      "milestone": "0.65.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "10448",
-      "title": "[FIX] Remove outdated translations of Internal Hubot's description of Scripts to Load that were pointing to a non existent address",
-      "userLogin": "Hudell",
-      "milestone": "0.65.0",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "10661",
-      "title": "Major dependencies update",
-      "userLogin": "engelgabriel",
-      "milestone": "0.65.0",
-      "contributors": [
-        "engelgabriel",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10702",
-      "title": "[NEW] Add REST API endpoint `users.getUsernameSuggestion` to get username suggestion",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.65.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10488",
-      "title": "[NEW] REST API endpoint `settings` now allow set colors and trigger actions",
-      "userLogin": "ThomasRoehl",
-      "milestone": "0.65.0",
-      "contributors": [
-        "ThomasRoehl",
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10778",
-      "title": "[NEW] Add REST endpoint `subscriptions.unread` to mark messages as unread",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.65.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10662",
-      "title": "[NEW] REST API endpoint `/me` now returns all the settings, including the default values",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.65.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10741",
-      "title": "[NEW] Now is possible to access files using header authorization (`x-user-id` and `x-auth-token`)",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.65.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10564",
-      "title": "[FIX] UI was not disabling the actions when users has had no permissions to create channels or add users to rooms",
-      "userLogin": "chuckAtCataworx",
-      "milestone": "0.65.0",
-      "contributors": [
-        "cfunkles",
-        "chuckAtCataworx",
-        "web-flow",
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "9679",
-      "title": "[NEW] Add REST API endpoints `channels.counters`, `groups.counters and `im.counters`",
-      "userLogin": "xbolshe",
-      "milestone": "0.65.0",
-      "contributors": [
-        "xbolshe",
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "9733",
-      "title": "[NEW] Add REST API endpoints `channels.setCustomFields` and `groups.setCustomFields`",
-      "userLogin": "xbolshe",
-      "milestone": "0.65.0",
-      "contributors": [
-        "xbolshe",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10625",
-      "title": "[FIX] Private settings were not being cleared from client cache in some cases",
-      "userLogin": "Hudell",
-      "milestone": "0.65.0",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "10811",
-      "title": "Prevent setup wizard redirects",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10798",
-      "title": "Prometheus: Add metric to track hooks time",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10802",
-      "title": "Regression: Autorun of wizard was not destroyed after completion",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10803",
-      "title": "Prometheus: Fix notification metric",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10804",
-      "title": "Regression: Fix wrong wizard field name",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10793",
-      "title": "[FIX] Not escaping special chars on mentions",
-      "userLogin": "erhan-",
-      "milestone": "0.64.2",
-      "contributors": [
-        "erhan-",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10789",
-      "title": "Prometheus: Improve metric names",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10788",
-      "title": "Improvement to push notifications on direct messages",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.64.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10786",
-      "title": "Better metric for notifications",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10779",
-      "title": "Add badge back to push notifications",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10776",
-      "title": "Wizard improvements",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10766",
-      "title": "Add setting and expose prometheus on port 9100",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10760",
-      "title": "Regression: Fix notifications for direct messages",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.64.2",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10736",
-      "title": "More improvements on send notifications logic",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10720",
-      "title": "[FIX] Send a message when muted returns inconsistent result in chat.sendMessage",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.64.2",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10733",
-      "title": "[FIX] Regression: Empty content on announcement modal",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.2",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "10607",
-      "title": "[NEW] Add REST endpoints `channels.roles` & `groups.roles`",
-      "userLogin": "cardoso",
-      "milestone": "0.64.2",
-      "contributors": [
-        "cardoso",
-        "web-flow",
-        "rafaelks"
-      ]
-    },
-    {
-      "pr": "10724",
-      "title": "[NEW] Add more options for Wordpress OAuth configuration",
-      "userLogin": "Hudell",
-      "milestone": "0.64.2",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "10523",
-      "title": "[NEW] Setup Wizard",
-      "userLogin": "karlprieb",
-      "milestone": "0.64.2",
-      "contributors": [
-        "karlprieb",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10691",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.64.2",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10686",
-      "title": "[NEW] Improvements to notifications logic",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.64.2",
-      "contributors": [
-        "sampaiodiego",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10705",
-      "title": "[FIX] Missing attachment description when Rocket.Chat Apps were enabled",
-      "userLogin": "Hudell",
-      "milestone": "0.64.2",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "10445",
-      "title": "[FIX] Improve desktop notification formatting",
-      "userLogin": "Sameesunkaria",
-      "milestone": "0.64.2",
-      "contributors": [
-        "Sameesunkaria",
-        "engelgabriel",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10524",
-      "title": "Add `npm run postinstall` into example build script",
-      "userLogin": "peccu",
-      "milestone": "0.64.2",
-      "contributors": [
-        "peccu",
-        "web-flow",
-        "engelgabriel"
-      ]
-    },
-    {
-      "pr": "10678",
-      "title": "[FIX] Message box emoji icon was flickering when typing a text",
-      "userLogin": "gdelavald",
-      "milestone": "0.64.2",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "10674",
-      "title": "Correct links in README file",
-      "userLogin": "winterstefan",
-      "milestone": "0.64.2",
-      "contributors": [
-        "winterstefan"
-      ]
-    },
-    {
-      "pr": "10665",
-      "title": "[FIX] Channel owner was being set as muted when creating a read-only channel",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.64.2",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10681",
-      "title": "[FIX] SAML wasn't working correctly when running multiple instances",
-      "userLogin": "Hudell",
-      "milestone": "0.64.2",
-      "contributors": [
-        "Hudell",
-        "rodrigok",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10812",
-      "title": "Release 0.64.2",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "Hudell",
-        "rodrigok",
-        "web-flow",
-        "MarcosSpessatto",
-        "winterstefan",
-        "gdelavald",
-        "peccu",
-        "Sameesunkaria",
-        "sampaiodiego",
-        "engelgabriel",
-        "karlprieb",
-        "cardoso",
-        "erhan-"
-      ]
-    },
-    {
-      "pr": "10660",
-      "title": "Release 0.64.1",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.1",
-      "contributors": [
-        "saplla",
-        "web-flow",
-        "engelgabriel",
-        "graywolf336",
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10613",
-      "title": "Release 0.64.0",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.0",
-      "contributors": [
-        "rodrigok",
-        "geekgonecrazy",
-        "web-flow",
-        "graywolf336",
-        "TwizzyDizzy",
-        "christianh814",
-        "tttt-conan",
-        "gdelavald",
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "10504",
-      "title": "Release 0.63.3",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "rafaelks",
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10476",
-      "title": "Release 0.63.2",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "graywolf336",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10408",
-      "title": "add redhat dockerfile to master",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    }
-  ],
-  "0.65.0-rc.1": [
-    {
-      "pr": "10837",
-      "title": "[FIX] Internal Error when requesting user data download",
-      "userLogin": "Hudell",
-      "milestone": "0.65.0",
-      "contributors": [
-        "Hudell"
-      ]
-    },
-    {
-      "pr": "10835",
-      "title": "[FIX] Broadcast channels were showing reply button for deleted messages and generating wrong reply links some times",
-      "userLogin": "ggazzo",
-      "milestone": "0.65.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "10833",
-      "title": "Fix: Regression in REST API endpoint `/me` ",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.65.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10734",
-      "title": "[FIX] User's preference `Unread on Top` wasn't working for LiveChat rooms",
-      "userLogin": "renatobecker",
-      "milestone": "0.65.0",
-      "contributors": [
-        "renatobecker",
-        "sampaiodiego",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10753",
-      "title": "[NEW] Add permission `view-broadcast-member-list`",
-      "userLogin": "cardoso",
-      "milestone": "0.65.0",
-      "contributors": [
-        "cardoso",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10715",
-      "title": "[FIX] Cancel button wasn't working while uploading file",
-      "userLogin": "Mr-Gryphon",
-      "milestone": "0.65.0",
-      "contributors": [
-        "Mr-Gryphon",
-        "web-flow",
-        "karlprieb"
-      ]
-    }
-  ],
-  "0.65.0-rc.2": [
-    {
-      "pr": "10847",
-      "title": "Regression: Fix email notification preference not showing correct selected value",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.65.0",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10853",
-      "title": "Apps: Command previews are clickable & Apps Framework is controlled via a setting",
-      "userLogin": "graywolf336",
-      "milestone": "0.65.0",
-      "contributors": [
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10840",
-      "title": "[FIX] Missing pagination fields in the response of REST /directory endpoint",
-      "userLogin": "MarcosSpessatto",
-      "milestone": "0.65.0",
-      "contributors": [
-        "MarcosSpessatto"
-      ]
-    },
-    {
-      "pr": "10846",
-      "title": "[FIX] Layout badge cutting on unread messages for long names",
-      "userLogin": "kos4live",
-      "milestone": "0.65.0",
-      "contributors": [
-        "kos4live"
-      ]
-    },
-    {
-      "pr": "10848",
-      "title": "Regression: Make settings `Site_Name` and `Language` public again",
-      "userLogin": "rodrigok",
-      "milestone": "0.65.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10520",
-      "title": "Fix: Clarify the wording of the release issue template",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "graywolf336",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10836",
-      "title": "Fix: Regression on users avatar in admin pages",
-      "userLogin": "ggazzo",
-      "milestone": "0.65.0",
-      "contributors": [
-        "ggazzo",
-        "rodrigok",
-        "web-flow"
-      ]
-    }
-  ],
-  "0.65.0-rc.3": [
-    {
-      "pr": "10875",
-      "title": "[FIX] Slack-Bridge bug when migrating to 0.64.1",
-      "userLogin": "iliaal",
-      "milestone": "0.65.0",
-      "contributors": [
-        null
-      ]
-    },
-    {
-      "pr": "10882",
-      "title": "Fix: Manage apps layout was a bit confuse",
-      "userLogin": "gdelavald",
-      "milestone": "0.65.0",
-      "contributors": [
-        "gdelavald",
-        "ggazzo",
-        "web-flow",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10886",
-      "title": "LingoHub based on develop",
-      "userLogin": "engelgabriel",
-      "milestone": "0.65.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10887",
-      "title": "Fix: Regression Lazyload fix shuffle avatars",
-      "userLogin": "ggazzo",
-      "milestone": "0.65.0",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "10883",
-      "title": "[FIX] Horizontally align items in preview message",
-      "userLogin": "gdelavald",
-      "milestone": "0.65.0",
-      "contributors": [
-        "gdelavald"
-      ]
-    },
-    {
-      "pr": "10857",
-      "title": "Fix: typo on error message for push token API",
-      "userLogin": "rafaelks",
-      "milestone": "0.65.0",
-      "contributors": [
-        "rafaelks",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10878",
-      "title": "[FIX] The first users was not set as admin some times",
-      "userLogin": "rodrigok",
-      "milestone": "0.65.0",
-      "contributors": [
-        "rodrigok"
-      ]
-    }
-  ],
-  "0.65.0": [
-    {
-      "pr": "10812",
-      "title": "Release 0.64.2",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.2",
-      "contributors": [
-        "Hudell",
-        "rodrigok",
-        "web-flow",
-        "MarcosSpessatto",
-        "winterstefan",
-        "gdelavald",
-        "peccu",
-        "Sameesunkaria",
-        "sampaiodiego",
-        "engelgabriel",
-        "karlprieb",
-        "cardoso",
-        "erhan-"
-      ]
-    },
-    {
-      "pr": "10660",
-      "title": "Release 0.64.1",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.1",
-      "contributors": [
-        "saplla",
-        "web-flow",
-        "engelgabriel",
-        "graywolf336",
-        "rodrigok",
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10613",
-      "title": "Release 0.64.0",
-      "userLogin": "rodrigok",
-      "milestone": "0.64.0",
-      "contributors": [
-        "rodrigok",
-        "geekgonecrazy",
-        "web-flow",
-        "graywolf336",
-        "TwizzyDizzy",
-        "christianh814",
-        "tttt-conan",
-        "gdelavald",
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "10504",
-      "title": "Release 0.63.3",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "rafaelks",
-        "graywolf336"
-      ]
-    },
-    {
-      "pr": "10476",
-      "title": "Release 0.63.2",
-      "userLogin": "graywolf336",
-      "contributors": [
-        "graywolf336",
-        "web-flow"
-      ]
-    },
-    {
-      "pr": "10408",
-      "title": "add redhat dockerfile to master",
-      "userLogin": "geekgonecrazy",
-      "contributors": [
-        "geekgonecrazy"
-      ]
-    }
-  ],
-  "0.65.1": [
-    {
-      "pr": "10940",
-      "title": "[FIX] Livechat not loading",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.65.1",
-      "contributors": [
-        "sampaiodiego",
-        "rodrigok"
-      ]
-    },
-    {
-      "pr": "10934",
-      "title": "[FIX] Application crashing on startup when trying to log errors to `exceptions` channel",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.65.1",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10928",
-      "title": "[FIX] Incomplete email notification link",
-      "userLogin": "sampaiodiego",
-      "milestone": "0.65.1",
-      "contributors": [
-        "sampaiodiego"
-      ]
-    },
-    {
-      "pr": "10904",
-      "title": "[FIX] Image lazy load was breaking attachments",
-      "userLogin": "ggazzo",
-      "milestone": "0.65.1",
-      "contributors": [
-        "ggazzo"
-      ]
-    },
-    {
-      "pr": "10851",
-      "title": "[FIX] Leave room wasn't working as expected",
-      "userLogin": "ggazzo",
-      "milestone": "0.65.1",
-      "contributors": [
-        "ggazzo"
-      ]
+  "version": 1,
+  "releases": {
+    "0.55.0-rc.0": {
+      "node_version": "4.7.3",
+      "npm_version": "4.1.2",
+      "pull_requests": [
+        {
+          "pr": "6614",
+          "title": "Add candidate snap channel",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.55.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6597",
+          "title": "Add `fname` to subscriptions in memory",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.0",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6608",
+          "title": "[New] Switch Snaps to use oplog",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6576",
+          "title": "Convert Message Pin Package to JS",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "6585",
+          "title": "Move room display name logic to roomType definition",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.55.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6598",
+          "title": "[FIX] Large files crashed browser when trying to show preview",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.55.0",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "6600",
+          "title": "[FIX] messageBox: put \"joinCodeRequired\" back",
+          "userLogin": "karlprieb",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "6594",
+          "title": "[FIX] Do not add default roles for users without services field",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.55.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6596",
+          "title": "Only configure LoggerManager on server",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.55.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6298",
+          "title": "POC Google Natural Language integration",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.55.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6591",
+          "title": "Fix recently introduced bug: OnePassword not defined",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6553",
+          "title": "rocketchat-lib part1",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6590",
+          "title": "[FIX] Accounts from LinkedIn OAuth without name",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.0",
+          "contributors": [
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6584",
+          "title": "dependencies upgrade",
+          "userLogin": "engelgabriel",
+          "milestone": "0.55.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "6580",
+          "title": "fixed typo in readme.md",
+          "userLogin": "sezinkarli",
+          "milestone": "0.55.0",
+          "contributors": [
+            "sezinkarli",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6565",
+          "title": "[NEW] Add shield.svg api route to generate custom shields/badges",
+          "userLogin": "alexbrazier",
+          "milestone": "0.55.0",
+          "contributors": [
+            "alexbrazier"
+          ]
+        },
+        {
+          "pr": "6575",
+          "title": "[FIX] Usage of subtagged languages",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "3851",
+          "title": "Use real name instead of username for messages and direct messages list",
+          "userLogin": "alexbrazier",
+          "milestone": "0.55.0",
+          "contributors": [
+            "alexbrazier"
+          ]
+        },
+        {
+          "pr": "6561",
+          "title": "Convert Ui-Login Package to Js",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6577",
+          "title": "[NEW] resolve merge share function",
+          "userLogin": "karlprieb",
+          "milestone": "0.55.0",
+          "contributors": [
+            "tgxn",
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "6551",
+          "title": "rocketchat-channel-settings coffee to js",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6571",
+          "title": "Move wordpress packages client files to client folder",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "6539",
+          "title": "convert rocketchat-ui part 2",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6541",
+          "title": "rocketchat-channel-settings-mail-messages coffee to js",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6574",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "6567",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "6562",
+          "title": "[FIX] UTC offset missing UTC text when positive",
+          "userLogin": "alexbrazier",
+          "milestone": "0.55.0",
+          "contributors": [
+            "alexbrazier"
+          ]
+        },
+        {
+          "pr": "6554",
+          "title": "[New] Added oauth2 userinfo endpoint",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.55.0",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "6531",
+          "title": "[FIX] can not get access_token when using custom oauth",
+          "userLogin": "fengt",
+          "milestone": "0.55.0",
+          "contributors": [
+            "fengt"
+          ]
+        },
+        {
+          "pr": "6540",
+          "title": "Remove Deprecated Shared Secret Package",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "6542",
+          "title": "Remove coffeescript package from ui-sidenav",
+          "userLogin": "Kiran-Rao",
+          "milestone": "0.55.0",
+          "contributors": [
+            "Kiran-Rao",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6543",
+          "title": "Remove coffeescript package from ui-flextab",
+          "userLogin": "Kiran-Rao",
+          "milestone": "0.55.0",
+          "contributors": [
+            "Kiran-Rao",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6476",
+          "title": "[NEW] Two Factor Auth",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.0",
+          "contributors": [
+            "sampaiodiego",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6478",
+          "title": "[FIX] Outgoing webhooks which have an error and they're retrying would still retry even if the integration was disabled`",
+          "userLogin": "graywolf336",
+          "milestone": "0.55.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "6491",
+          "title": "Convert Theme Package to JS",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "6487",
+          "title": "Fix typo of the safari pinned tab label",
+          "userLogin": "qge",
+          "milestone": "0.55.0",
+          "contributors": [
+            "qge",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6493",
+          "title": "fix channel merge option of user preferences",
+          "userLogin": "billtt",
+          "milestone": "0.55.0",
+          "contributors": [
+            "billtt"
+          ]
+        },
+        {
+          "pr": "6495",
+          "title": "converted Rocketchat logger coffee to js",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6502",
+          "title": "converted rocketchat-integrations coffee to js",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6522",
+          "title": "'allow reacting' should be a toggle option.otherwise, the style will display an error",
+          "userLogin": "szluohua",
+          "milestone": "0.55.0",
+          "contributors": [
+            "szluohua",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6280",
+          "title": "Clipboard [Firefox version < 50]",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6473",
+          "title": "Convert ui-vrecord Package to JS",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "6474",
+          "title": "converted slashcommands-mute coffee to js",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6494",
+          "title": "Convert Version Package to JS",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6498",
+          "title": "Convert Ui-Master Package to Js",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6500",
+          "title": "converted messageAttachment coffee to js",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6503",
+          "title": "Convert File Package to js",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6505",
+          "title": "Create groups.addAll endpoint and add activeUsersOnly param.",
+          "userLogin": "nathanmarcos",
+          "milestone": "0.55.0",
+          "contributors": [
+            "nathanmarcos",
+            null
+          ]
+        },
+        {
+          "pr": "6351",
+          "title": "New feature: Room announcement",
+          "userLogin": "billtt",
+          "milestone": "0.55.0",
+          "contributors": [
+            "billtt"
+          ]
+        },
+        {
+          "pr": "6468",
+          "title": "converted slashcommand-me coffee to js",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6469",
+          "title": "converted slashcommand-join coffee to js",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6470",
+          "title": "converted slashcommand-leave coffee to js",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6471",
+          "title": "convert mapview package to js",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6496",
+          "title": "converted getAvatarUrlFromUsername",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6497",
+          "title": "converted slashcommand-invite coffee to js",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6499",
+          "title": "Convert Wordpress Package to js",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "6501",
+          "title": "converted slashcommand-msg coffee to js",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6504",
+          "title": "rocketchat-ui coffee to js part1",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6467",
+          "title": "converted rocketchat-mentions coffee to js",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6479",
+          "title": "ESLint add rule `no-void`",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6456",
+          "title": "Add ESLint rules `prefer-template` and `template-curly-spacing`",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.0",
+          "contributors": [
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6466",
+          "title": "Fix livechat permissions",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6457",
+          "title": "Add ESLint rule `object-shorthand`",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.0",
+          "contributors": [
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6459",
+          "title": "Add ESLint rules `one-var` and `no-var`",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6458",
+          "title": "Add ESLint rule `one-var`",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6274",
+          "title": "Side-nav CoffeeScript to JavaScript III ",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6277",
+          "title": "Flex-Tab CoffeeScript to JavaScript II",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6430",
+          "title": "[NEW] Permission `join-without-join-code` assigned to admins and bots by default",
+          "userLogin": "graywolf336",
+          "milestone": "0.55.0",
+          "contributors": [
+            "graywolf336",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6420",
+          "title": "[NEW] Integrations, both incoming and outgoing, now have access to the models. Example: `Users.findOneById(id)`",
+          "userLogin": "graywolf336",
+          "milestone": "0.55.0",
+          "contributors": [
+            "graywolf336",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6266",
+          "title": "Side-nav CoffeeScript to JavaScript II",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6035",
+          "title": "Allow Livechat visitors to switch the department",
+          "userLogin": "drallgood",
+          "milestone": "0.55.0",
+          "contributors": [
+            "drallgood",
+            "web-flow",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6122",
+          "title": "fix livechat widget on small screens",
+          "userLogin": "karlprieb",
+          "milestone": "0.55.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "6180",
+          "title": "Allow livechat managers to transfer chats",
+          "userLogin": "drallgood",
+          "milestone": "0.55.0",
+          "contributors": [
+            "drallgood",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6257",
+          "title": "focus first textbox element",
+          "userLogin": "a5his",
+          "milestone": "0.55.0",
+          "contributors": [
+            "a5his"
+          ]
+        },
+        {
+          "pr": "6268",
+          "title": "Join command",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6419",
+          "title": "Fix visitor ending livechat if multiples still open",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.55.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6319",
+          "title": "Password reset Cleaner text",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6400",
+          "title": "Add permission check to the import methods and not just the UI",
+          "userLogin": "graywolf336",
+          "milestone": "0.55.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "6409",
+          "title": "Max textarea height",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6413",
+          "title": "Livechat fix office hours order",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.55.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6449",
+          "title": "Convert Spotify Package to JS",
+          "userLogin": "MartinSchoeler",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6422",
+          "title": "Make favicon package easier to read.",
+          "userLogin": "Kiran-Rao",
+          "milestone": "0.55.0",
+          "contributors": [
+            "Kiran-Rao"
+          ]
+        },
+        {
+          "pr": "6426",
+          "title": "Just admins can change a Default Channel to Private (the channel will be a non default channel)",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6429",
+          "title": "Hide email settings on Sandstorm",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.55.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6432",
+          "title": "Do not show reset button for hidden settings",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.55.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6427",
+          "title": "Convert Dolphin Package to JavaScript",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6445",
+          "title": "converted rocketchat-message-mark-as-unread coffee/js",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6453",
+          "title": "converted rocketchat-slashcommands-kick coffee to js",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6450",
+          "title": "converted meteor-accounts-saml coffee to js",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6447",
+          "title": "Convert Statistics Package to JS",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6425",
+          "title": "Convert ChatOps Package to JavaScript",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "6410",
+          "title": "Change all instances of Meteor.Collection for Mongo.Collection",
+          "userLogin": "marceloschmidt",
+          "milestone": "0.55.0",
+          "contributors": [
+            "marceloschmidt"
+          ]
+        },
+        {
+          "pr": "6278",
+          "title": "Flex-Tab CoffeeScript to JavaScript III",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6276",
+          "title": "Flex-Tab CoffeeScript to JavaScript I ",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "6264",
+          "title": "Side-nav CoffeeScript to JavaScript",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6446",
+          "title": "Convert Tutum Package to JS",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.55.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        }
+      ]
+    },
+    "0.55.0-rc.1": {
+      "node_version": "4.7.3",
+      "npm_version": "4.1.2",
+      "pull_requests": [
+        {
+          "pr": "6620",
+          "title": "[FIX] Incorrect curl command being generated on incoming integrations",
+          "userLogin": "graywolf336",
+          "milestone": "0.55.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "6617",
+          "title": "[FIX] arguments logger",
+          "userLogin": "ggazzo",
+          "milestone": "0.55.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6616",
+          "title": "[NEW] 'users.resetAvatar' rest api endpoint",
+          "userLogin": "graywolf336",
+          "milestone": "0.55.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        }
+      ]
+    },
+    "0.55.0-rc.2": {
+      "node_version": "4.8.0",
+      "npm_version": "4.3.0",
+      "pull_requests": [
+        {
+          "pr": "6632",
+          "title": "[NEW] Drupal oAuth Integration for Rocketchat",
+          "userLogin": "Lawri-van-Buel",
+          "milestone": "0.55.0",
+          "contributors": [
+            "Lawri-van-Buel",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6634",
+          "title": "[NEW] Add monitoring package",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6650",
+          "title": "[FIX] Improve markdown code",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6651",
+          "title": "[FIX] Encode avatar url to prevent CSS injection",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6649",
+          "title": "Added Deploy method and platform to stats",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6648",
+          "title": "[FIX] Do not escaping markdown on message attachments",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6647",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.55.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "6631",
+          "title": "meteor update",
+          "userLogin": "engelgabriel",
+          "milestone": "0.55.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        }
+      ]
+    },
+    "0.55.0-rc.3": {
+      "node_version": "4.8.0",
+      "npm_version": "4.3.0",
+      "pull_requests": [
+        {
+          "pr": "6658",
+          "title": "[FIX] Revert unwanted UI changes",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        }
+      ]
+    },
+    "0.55.0-rc.4": {
+      "node_version": "4.8.0",
+      "npm_version": "4.3.0",
+      "pull_requests": [
+        {
+          "pr": "6682",
+          "title": "[FIX] Fix Logger stdout publication",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.55.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6680",
+          "title": "[FIX] Downgrade email package to from 1.2.0 to 1.1.18",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.55.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6681",
+          "title": "[NEW] Expose Livechat to Incoming Integrations and allow response",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6659",
+          "title": "[FIX] Administrators being rate limited when editing users data",
+          "userLogin": "graywolf336",
+          "milestone": "0.55.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "6674",
+          "title": "[FIX] Make sure username exists in findByActiveUsersExcept",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.55.0",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        }
+      ]
+    },
+    "0.55.0-rc.5": {
+      "node_version": "4.8.0",
+      "npm_version": "4.3.0",
+      "pull_requests": [
+        {
+          "pr": "6686",
+          "title": "[FIX] Update server cache indexes on record updates",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6684",
+          "title": "[FIX] Allow question on OAuth token path",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.55.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6163",
+          "title": "Env override initial setting",
+          "userLogin": "mrsimpson",
+          "milestone": "0.55.0",
+          "contributors": [
+            "mrsimpson",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6683",
+          "title": "[FIX] Error when returning undefined from incoming intergation’s script",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.55.0-rc.6": {
+      "node_version": "4.8.0",
+      "npm_version": "4.3.0",
+      "pull_requests": [
+        {
+          "pr": "6704",
+          "title": "[FIX] Fix message types",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.55.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        }
+      ]
+    },
+    "0.55.0": {
+      "node_version": "4.8.0",
+      "npm_version": "4.3.0",
+      "pull_requests": [
+        {
+          "pr": "6709",
+          "title": "[FIX] emoji picker exception",
+          "userLogin": "gdelavald",
+          "milestone": "0.55.0",
+          "contributors": [
+            "gdelavald",
+            "rodrigok",
+            "web-flow"
+          ]
+        }
+      ]
+    },
+    "0.55.1": {
+      "node_version": "4.8.0",
+      "npm_version": "4.3.0",
+      "pull_requests": [
+        {
+          "pr": "6734",
+          "title": "[Fix] Bug with incoming integration (0.55.1)",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.56.0-rc.0": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "6881",
+          "title": "[NEW] Add a pointer cursor to message images",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.56.0",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6842",
+          "title": "[New] Snap arm support",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.56.0",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6861",
+          "title": "[FIX] start/unstar message",
+          "userLogin": "karlprieb",
+          "milestone": "0.56.0",
+          "contributors": [
+            null
+          ]
+        },
+        {
+          "pr": "6858",
+          "title": "Meteor update",
+          "userLogin": "engelgabriel",
+          "milestone": "0.56.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "6845",
+          "title": "[FIX] Added helper for testing if the current user matches the params",
+          "userLogin": "abrom",
+          "milestone": "0.56.0",
+          "contributors": [
+            "abrom"
+          ]
+        },
+        {
+          "pr": "6827",
+          "title": "[NEW] Make channels.info accept roomName, just like groups.info",
+          "userLogin": "reist",
+          "milestone": "0.56.0",
+          "contributors": [
+            "reist"
+          ]
+        },
+        {
+          "pr": "6672",
+          "title": "Converted rocketchat-lib 3",
+          "userLogin": "ggazzo",
+          "milestone": "0.56.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6781",
+          "title": "Convert Message-Star Package to js ",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.0",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6780",
+          "title": "Convert Mailer Package to Js",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.56.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "6796",
+          "title": "[FIX] REST API user.update throwing error due to rate limiting",
+          "userLogin": "graywolf336",
+          "milestone": "0.56.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "6797",
+          "title": "[NEW] Option to allow to signup as anonymous",
+          "userLogin": "rodrigok",
+          "milestone": "0.56.0",
+          "contributors": [
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6816",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.56.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "6807",
+          "title": "[NEW] create a method 'create token'",
+          "userLogin": "ggazzo",
+          "milestone": "0.56.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6804",
+          "title": "Missing useful fields in admin user list #5110",
+          "userLogin": "vlogic",
+          "milestone": "0.56.0",
+          "contributors": [
+            null,
+            "vlogic"
+          ]
+        },
+        {
+          "pr": "6790",
+          "title": "[FIX] fix german translation",
+          "userLogin": "sscholl",
+          "milestone": "0.56.0",
+          "contributors": [
+            "sscholl",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6793",
+          "title": "[FIX] Improve and correct Iframe Integration help text",
+          "userLogin": "antgel",
+          "milestone": "0.56.0",
+          "contributors": [
+            null
+          ]
+        },
+        {
+          "pr": "6800",
+          "title": "[FIX] Quoted and replied messages not retaining the original message's alias",
+          "userLogin": "graywolf336",
+          "milestone": "0.56.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "6798",
+          "title": "[FIX] Fix iframe wise issues",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.56.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6747",
+          "title": "[FIX] Incorrect error message when creating channel",
+          "userLogin": "gdelavald",
+          "milestone": "0.56.0",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "6760",
+          "title": "[FIX] Hides nav buttons when selecting own profile",
+          "userLogin": "gdelavald",
+          "milestone": "0.56.0",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "6767",
+          "title": "[FIX] Search full name on client side",
+          "userLogin": "alexbrazier",
+          "milestone": "0.56.0",
+          "contributors": [
+            "alexbrazier"
+          ]
+        },
+        {
+          "pr": "6758",
+          "title": "[FIX] Sort by real name if use real name setting is enabled",
+          "userLogin": "alexbrazier",
+          "milestone": "0.56.0",
+          "contributors": [
+            "alexbrazier"
+          ]
+        },
+        {
+          "pr": "6671",
+          "title": "Convert Katex Package to Js",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.56.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "6688",
+          "title": "Convert Oembed Package to Js",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.56.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "6689",
+          "title": "Convert Mentions-Flextab Package to Js",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.56.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "6768",
+          "title": "[FIX] CSV importer: require that there is some data in the zip, not ALL data",
+          "userLogin": "reist",
+          "milestone": "0.56.0",
+          "contributors": [
+            "reist"
+          ]
+        },
+        {
+          "pr": "5986",
+          "title": "Anonymous use",
+          "userLogin": "rodrigok",
+          "milestone": "0.56.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6368",
+          "title": "Breaking long URLS to prevent overflow",
+          "userLogin": "robertdown",
+          "milestone": "0.56.0",
+          "contributors": [
+            "robertdown"
+          ]
+        },
+        {
+          "pr": "6737",
+          "title": "[FIX] Archiving Direct Messages",
+          "userLogin": "graywolf336",
+          "milestone": "0.56.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "5373",
+          "title": "[NEW] Add option on Channel Settings: Hide Notifications and Hide Unread Room Status (#2707, #2143)",
+          "userLogin": "marceloschmidt",
+          "milestone": "0.56.0",
+          "contributors": [
+            "marceloschmidt",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6593",
+          "title": "Rocketchat lib2",
+          "userLogin": "ggazzo",
+          "milestone": "0.56.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6734",
+          "title": "[Fix] Bug with incoming integration (0.55.1)",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6722",
+          "title": "[NEW] Remove lesshat",
+          "userLogin": "karlprieb",
+          "milestone": "0.56.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "6654",
+          "title": "disable proxy configuration",
+          "userLogin": "glehmann",
+          "milestone": "0.56.0",
+          "contributors": [
+            "glehmann"
+          ]
+        },
+        {
+          "pr": "6721",
+          "title": "[FIX] Fix Caddy by forcing go 1.7 as needed by one of caddy's dependencies",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "6694",
+          "title": "Convert markdown to js",
+          "userLogin": "ehkasper",
+          "milestone": "0.56.0",
+          "contributors": [
+            "ehkasper"
+          ]
+        },
+        {
+          "pr": "6715",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.56.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "6709",
+          "title": "[FIX] emoji picker exception",
+          "userLogin": "gdelavald",
+          "milestone": "0.55.0",
+          "contributors": [
+            "gdelavald",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6692",
+          "title": "[NEW] Use tokenSentVia parameter for clientid/secret to token endpoint",
+          "userLogin": "intelradoux",
+          "milestone": "0.56.0",
+          "contributors": [
+            "intelradoux"
+          ]
+        },
+        {
+          "pr": "6706",
+          "title": "meteor update to 1.4.4",
+          "userLogin": "engelgabriel",
+          "milestone": "0.56.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "6704",
+          "title": "[FIX] Fix message types",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.55.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6703",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "6615",
+          "title": "[NEW] Add a setting to not run outgoing integrations on message edits",
+          "userLogin": "graywolf336",
+          "milestone": "0.56.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "6734",
+          "title": "[Fix] Bug with incoming integration (0.55.1)",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.56.0-rc.1": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "6896",
+          "title": "[FIX] Users status on main menu always offline",
+          "userLogin": "rodrigok",
+          "milestone": "0.56.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.56.0-rc.2": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "6923",
+          "title": "[FIX] Not showing unread count on electron app’s icon",
+          "userLogin": "rodrigok",
+          "milestone": "0.56.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.56.0-rc.3": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "6939",
+          "title": "[FIX] Compile CSS color variables",
+          "userLogin": "karlprieb",
+          "milestone": "0.56.0",
+          "contributors": [
+            null
+          ]
+        },
+        {
+          "pr": "6938",
+          "title": "[NEW] Improve CI/Docker build/release",
+          "userLogin": "rodrigok",
+          "milestone": "0.56.0",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6940",
+          "title": "[NEW] Add SMTP settings for Protocol and Pool",
+          "userLogin": "rodrigok",
+          "milestone": "0.56.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.56.0-rc.4": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "6953",
+          "title": "[NEW] Show info about multiple instances at admin page",
+          "userLogin": "rodrigok",
+          "milestone": "0.56.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.56.0-rc.5": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "6955",
+          "title": "[FIX] Remove spaces from env PORT and INSTANCE_IP",
+          "userLogin": "rodrigok",
+          "milestone": "0.56.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6935",
+          "title": "[Fix] Error when trying to show preview of undefined filetype",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.57.0",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        }
+      ]
+    },
+    "0.56.0-rc.6": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": []
+    },
+    "0.56.0-rc.7": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "6968",
+          "title": "[FIX] make channels.create API check for create-c",
+          "userLogin": "reist",
+          "milestone": "0.56.0",
+          "contributors": [
+            "reist"
+          ]
+        }
+      ]
+    },
+    "0.56.0": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "6734",
+          "title": "[Fix] Bug with incoming integration (0.55.1)",
+          "userLogin": "rodrigok",
+          "milestone": "0.55.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.57.0-rc.0": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "7146",
+          "title": "Convert hipchat importer to js",
+          "userLogin": "rodrigok",
+          "milestone": "0.57.0",
+          "contributors": [
+            "rodrigok",
+            "geekgonecrazy",
+            "sampaiodiego",
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7145",
+          "title": "Convert file unsubscribe.coffee to js",
+          "userLogin": "rodrigok",
+          "milestone": "0.57.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6991",
+          "title": "[FIX] Fix highlightjs bug",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.57.0",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6788",
+          "title": "[NEW] New avatar storage types",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.0",
+          "contributors": [
+            "sampaiodiego",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7095",
+          "title": "[BREAK] Internal hubot does not load hubot-scripts anymore, it loads scripts from custom folders",
+          "userLogin": "ggazzo",
+          "milestone": "0.57.0",
+          "contributors": [
+            "ggazzo",
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6690",
+          "title": "[NEW] Show full name in mentions if use full name setting enabled",
+          "userLogin": "alexbrazier",
+          "milestone": "0.57.0",
+          "contributors": [
+            "alexbrazier"
+          ]
+        },
+        {
+          "pr": "7017",
+          "title": "Convert oauth2-server-config package  to js",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.0",
+          "contributors": [
+            "MartinSchoeler",
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7022",
+          "title": "Convert irc package to js",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.0",
+          "contributors": [
+            "MartinSchoeler",
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7055",
+          "title": "Ldap: User_Data_FieldMap description",
+          "userLogin": "bbrauns",
+          "milestone": "0.57.0",
+          "contributors": [
+            "bbrauns"
+          ]
+        },
+        {
+          "pr": "7030",
+          "title": "[FIX] do only store password if LDAP_Login_Fallback is on",
+          "userLogin": "pmb0",
+          "milestone": "0.57.0",
+          "contributors": [
+            "pmb0"
+          ]
+        },
+        {
+          "pr": "7059",
+          "title": "[NEW] Increase unread message count on @here mention",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7062",
+          "title": "Remove Useless Jasmine Tests ",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7121",
+          "title": "[FIX] fix bug in preview image",
+          "userLogin": "ggazzo",
+          "milestone": "0.57.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "7094",
+          "title": "[FIX]Fix the failing tests ",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7085",
+          "title": "[NEW] API method and REST Endpoint for getting a single message by id",
+          "userLogin": "graywolf336",
+          "milestone": "0.57.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "7084",
+          "title": "[FIX] Add option to ignore TLS in SMTP server settings",
+          "userLogin": "colin-campbell",
+          "milestone": "0.57.0",
+          "contributors": [
+            "colin-campbell"
+          ]
+        },
+        {
+          "pr": "7072",
+          "title": "[FIX] Add support for carriage return in markdown code blocks",
+          "userLogin": "jm-factorin",
+          "milestone": "0.57.0",
+          "contributors": [
+            "jm-factorin"
+          ]
+        },
+        {
+          "pr": "7014",
+          "title": "[FIX] Parse HTML on admin setting's descriptions",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7018",
+          "title": "converted rocketchat-importer",
+          "userLogin": "ggazzo",
+          "milestone": "0.57.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "7114",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "7105",
+          "title": "[FIX] edit button on firefox",
+          "userLogin": "karlprieb",
+          "milestone": "0.57.0",
+          "contributors": [
+            null
+          ]
+        },
+        {
+          "pr": "7104",
+          "title": "[FIX] Fix missing CSS files on production builds",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego",
+            null
+          ]
+        },
+        {
+          "pr": "7103",
+          "title": "[FIX] clipboard (permalink, copy, pin, star buttons)",
+          "userLogin": "karlprieb",
+          "contributors": [
+            null
+          ]
+        },
+        {
+          "pr": "7096",
+          "title": "Convert Livechat from Coffeescript to JavaScript",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7092",
+          "title": "[FIX]Fixed typo hmtl -> html",
+          "userLogin": "jautero",
+          "contributors": [
+            "jautero"
+          ]
+        },
+        {
+          "pr": "7080",
+          "title": "[NEW] Migration to add <html> tags to email header and footer",
+          "userLogin": "karlprieb",
+          "milestone": "0.57.0",
+          "contributors": [
+            null
+          ]
+        },
+        {
+          "pr": "7025",
+          "title": "[FIX] Add <html> and </html> to header and footer",
+          "userLogin": "ExTechOp",
+          "milestone": "0.57.0",
+          "contributors": [
+            "ExTechOp",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7033",
+          "title": "[FIX] Prevent Ctrl key on message field from reloading messages list",
+          "userLogin": "ggazzo",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "7044",
+          "title": "[FIX] New screen sharing Chrome extension checking method",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6982",
+          "title": "[NEW] postcss parser and cssnext implementation",
+          "userLogin": "karlprieb",
+          "contributors": [
+            null,
+            "rodrigok",
+            "web-flow",
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7049",
+          "title": "[FIX] Improve Tests",
+          "userLogin": "MartinSchoeler",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7045",
+          "title": "[FIX] Fix avatar upload via users.setAvatar REST endpoint",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7023",
+          "title": "[FIX] Sidenav roomlist",
+          "userLogin": "karlprieb",
+          "contributors": [
+            null,
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7012",
+          "title": "[FIX] video message recording dialog is shown in an incorrect position",
+          "userLogin": "flaviogrossi",
+          "milestone": "0.57.0",
+          "contributors": [
+            "flaviogrossi"
+          ]
+        },
+        {
+          "pr": "7006",
+          "title": "Rocketchat ui3",
+          "userLogin": "ggazzo",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6836",
+          "title": "converted rocketchat-ui coffee to js part 2",
+          "userLogin": "ggazzo",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6912",
+          "title": "[FIX] Remove room from roomPick setting",
+          "userLogin": "marceloschmidt",
+          "milestone": "0.57.0",
+          "contributors": [
+            "marceloschmidt",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6605",
+          "title": "[NEW] Start running unit tests",
+          "userLogin": "ggazzo",
+          "milestone": "0.57.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow",
+            "rodrigok",
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "6997",
+          "title": "[FIX] Parse markdown links last",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6999",
+          "title": "[FIX] overlapping text for users-typing-message",
+          "userLogin": "darkv",
+          "milestone": "0.57.0",
+          "contributors": [
+            "darkv"
+          ]
+        },
+        {
+          "pr": "7005",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "6735",
+          "title": "rocketchat-lib[4] coffee to js",
+          "userLogin": "ggazzo",
+          "milestone": "0.57.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6987",
+          "title": "rocketchat-importer-slack coffee to js",
+          "userLogin": "ggazzo",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6911",
+          "title": "Convert ui-admin package to js",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.0",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6857",
+          "title": "[NEW] Make channel/group delete call answer to roomName",
+          "userLogin": "reist",
+          "milestone": "0.57.0",
+          "contributors": [
+            "reist"
+          ]
+        },
+        {
+          "pr": "6903",
+          "title": "[FIX] Updating Incoming Integration Post As Field Not Allowed",
+          "userLogin": "graywolf336",
+          "milestone": "0.57.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "6972",
+          "title": "[FIX] Fix error handling for non-valid avatar URL",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6914",
+          "title": "Rocketchat ui message",
+          "userLogin": "ggazzo",
+          "milestone": "0.57.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "6921",
+          "title": "[New] LDAP: Use variables in User_Data_FieldMap for name mapping",
+          "userLogin": "bbrauns",
+          "milestone": "0.57.0",
+          "contributors": [
+            "bbrauns"
+          ]
+        },
+        {
+          "pr": "6961",
+          "title": "[FIX] SAML: Only set KeyDescriptor when non empty",
+          "userLogin": "sathieu",
+          "milestone": "0.57.0",
+          "contributors": [
+            "sathieu"
+          ]
+        },
+        {
+          "pr": "6986",
+          "title": "[FIX] Fix the other tests failing due chimp update",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "6936",
+          "title": "Convert meteor-autocomplete package to js",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "6795",
+          "title": "Convert Ui Account Package to Js",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "6950",
+          "title": "[FIX] Fix badge counter on iOS push notifications",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6974",
+          "title": "[FIX] Fix login with Meteor saving an object as email address",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6840",
+          "title": "[FIX] Check that username is not in the room when being muted / unmuted",
+          "userLogin": "matthewshirley",
+          "milestone": "0.57.0",
+          "contributors": [
+            "matthewshirley",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6947",
+          "title": "[FIX] Use AWS Signature Version 4 signed URLs for uploads",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "6978",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.57.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "6976",
+          "title": "fix the crashing tests",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.0",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6968",
+          "title": "[FIX] make channels.create API check for create-c",
+          "userLogin": "reist",
+          "milestone": "0.56.0",
+          "contributors": [
+            "reist"
+          ]
+        },
+        {
+          "pr": "6775",
+          "title": "Convert WebRTC Package to Js",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "6935",
+          "title": "[Fix] Error when trying to show preview of undefined filetype",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.57.0",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "6953",
+          "title": "[NEW] Show info about multiple instances at admin page",
+          "userLogin": "rodrigok",
+          "milestone": "0.56.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6938",
+          "title": "[NEW] Improve CI/Docker build/release",
+          "userLogin": "rodrigok",
+          "milestone": "0.56.0",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6919",
+          "title": "[NEW] Feature/delete any message permission",
+          "userLogin": "phutchins",
+          "milestone": "0.57.0",
+          "contributors": [
+            "phutchins"
+          ]
+        },
+        {
+          "pr": "6904",
+          "title": "[FIX] Bugs in `isUserFromParams` helper",
+          "userLogin": "abrom",
+          "milestone": "0.57.0",
+          "contributors": [
+            "abrom"
+          ]
+        },
+        {
+          "pr": "6910",
+          "title": "[FIX] Allow image insert from slack through slackbridge",
+          "userLogin": "marceloschmidt",
+          "milestone": "0.57.0",
+          "contributors": [
+            "marceloschmidt"
+          ]
+        },
+        {
+          "pr": "6913",
+          "title": "[FIX] Slackbridge text replacements",
+          "userLogin": "marceloschmidt",
+          "milestone": "0.57.0",
+          "contributors": [
+            "marceloschmidt"
+          ]
+        }
+      ]
+    },
+    "0.57.0-rc.1": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "7157",
+          "title": "[FIX] Fix all reactions having the same username",
+          "userLogin": "MartinSchoeler",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7154",
+          "title": "Remove missing CoffeeScript dependencies",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7158",
+          "title": "Switch logic of artifact name",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        }
+      ]
+    },
+    "0.57.0-rc.2": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "7200",
+          "title": "[FIX] Fix editing others messages",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7208",
+          "title": "[FIX] Fix oembed previews not being shown",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7215",
+          "title": "Fix the Zapier oAuth return url to the new one",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "7209",
+          "title": "[FIX] \"requirePasswordChange\" property not being saved when set to false",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "7196",
+          "title": "Fix the admin oauthApps view not working",
+          "userLogin": "graywolf336",
+          "milestone": "0.57.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "7160",
+          "title": "[FIX] Removing the kadira package install from example build script.",
+          "userLogin": "JSzaszvari",
+          "contributors": [
+            "JSzaszvari",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7159",
+          "title": "Fix forbidden error on setAvatar REST endpoint",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7196",
+          "title": "Fix the admin oauthApps view not working",
+          "userLogin": "graywolf336",
+          "milestone": "0.57.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "7177",
+          "title": "Fix mobile avatars",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.57.0-rc.3": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "7358",
+          "title": "[FIX] Fix user's customFields not being saved correctly",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7352",
+          "title": "[FIX] Improve avatar migration",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7311",
+          "title": "[NEW] Force use of MongoDB for spotlight queries",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7320",
+          "title": "[FIX] Fix jump to unread button",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7345",
+          "title": "[FIX] click on image in a message",
+          "userLogin": "ggazzo",
+          "milestone": "0.57.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "7304",
+          "title": "[FIX] Proxy upload to correct instance",
+          "userLogin": "rodrigok",
+          "milestone": "0.57.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7321",
+          "title": "[FIX] Fix Secret Url",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        }
+      ]
+    },
+    "0.57.0": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "7379",
+          "title": "[FIX] Message being displayed unescaped",
+          "userLogin": "gdelavald",
+          "milestone": "0.58.0",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "7102",
+          "title": "add server methods getRoomNameById",
+          "userLogin": "thinkeridea",
+          "milestone": "0.57.0",
+          "contributors": [
+            "thinkeridea"
+          ]
+        }
+      ]
+    },
+    "0.57.1": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "7428",
+          "title": "[FIX] Fix migration of avatars from version 0.57.0",
+          "userLogin": "rodrigok",
+          "milestone": "0.57.1",
+          "contributors": [
+            "sampaiodiego",
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.57.2": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "7431",
+          "title": "[FIX] Fix Emails in User Admin View",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.2",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7472",
+          "title": "[FIX] Always set LDAP properties on login",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7403",
+          "title": "[FIX] Fix Unread Bar Disappearing",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.2",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7469",
+          "title": "[FIX] Fix file upload on Slack import",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7432",
+          "title": "[FIX] Fix Private Channel List Submit",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.2",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7443",
+          "title": "[FIX] S3 uploads not working for custom URLs",
+          "userLogin": "rodrigok",
+          "milestone": "0.57.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.57.3": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "7212",
+          "title": "[Fix] Users and Channels list not respecting permissions",
+          "userLogin": "graywolf336",
+          "milestone": "0.57.3",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "7325",
+          "title": "[FIX] Modernize rate limiting of sendMessage",
+          "userLogin": "jangmarker",
+          "milestone": "0.57.3",
+          "contributors": [
+            "jangmarker"
+          ]
+        },
+        {
+          "pr": "7390",
+          "title": "[FIX] custom soundEdit.html",
+          "userLogin": "rasos",
+          "milestone": "0.57.3",
+          "contributors": [
+            "rasos",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7394",
+          "title": "[FIX] Use UTF8 setting for /create command",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.3",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7395",
+          "title": "[FIX] file upload broken when running in subdirectory https://github.com…",
+          "userLogin": "ryoshimizu",
+          "milestone": "0.57.3",
+          "contributors": [
+            "ryoshimizu"
+          ]
+        },
+        {
+          "pr": "7444",
+          "title": "[FIX] Fix Anonymous User",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.3",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7533",
+          "title": "[FIX] Missing eventName in unUser",
+          "userLogin": "Darkneon",
+          "milestone": "0.57.3",
+          "contributors": [
+            "Darkneon"
+          ]
+        },
+        {
+          "pr": "7535",
+          "title": "[FIX] Fix Join Channel Without Preview Room Permission",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.3",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7555",
+          "title": "[FIX] Improve build script example",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.3",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        }
+      ]
+    },
+    "0.57.4": {
+      "node_version": "4.8.2",
+      "npm_version": "4.5.0",
+      "pull_requests": [
+        {
+          "pr": "8390",
+          "title": "[FIX] Slack import failing and not being able to be restarted",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8408",
+          "title": "[FIX] Duplicate code in rest api letting in a few bugs with the rest api",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8389",
+          "title": "[FIX] Add needed dependency for snaps",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        }
+      ]
+    },
+    "0.58.0-rc.0": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8390",
+          "title": "[FIX] Slack import failing and not being able to be restarted",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8408",
+          "title": "[FIX] Duplicate code in rest api letting in a few bugs with the rest api",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8389",
+          "title": "[FIX] Add needed dependency for snaps",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "7212",
+          "title": "[Fix] Users and Channels list not respecting permissions",
+          "userLogin": "graywolf336",
+          "milestone": "0.57.3",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "7325",
+          "title": "[FIX] Modernize rate limiting of sendMessage",
+          "userLogin": "jangmarker",
+          "milestone": "0.57.3",
+          "contributors": [
+            "jangmarker"
+          ]
+        },
+        {
+          "pr": "7390",
+          "title": "[FIX] custom soundEdit.html",
+          "userLogin": "rasos",
+          "milestone": "0.57.3",
+          "contributors": [
+            "rasos",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7394",
+          "title": "[FIX] Use UTF8 setting for /create command",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.3",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7395",
+          "title": "[FIX] file upload broken when running in subdirectory https://github.com…",
+          "userLogin": "ryoshimizu",
+          "milestone": "0.57.3",
+          "contributors": [
+            "ryoshimizu"
+          ]
+        },
+        {
+          "pr": "7444",
+          "title": "[FIX] Fix Anonymous User",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.3",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7533",
+          "title": "[FIX] Missing eventName in unUser",
+          "userLogin": "Darkneon",
+          "milestone": "0.57.3",
+          "contributors": [
+            "Darkneon"
+          ]
+        },
+        {
+          "pr": "7535",
+          "title": "[FIX] Fix Join Channel Without Preview Room Permission",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.3",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7555",
+          "title": "[FIX] Improve build script example",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.3",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7624",
+          "title": "[FIX] Error when updating message with an empty attachment array",
+          "userLogin": "graywolf336",
+          "milestone": "0.58.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "7623",
+          "title": "[FIX] Uploading an unknown file type erroring out",
+          "userLogin": "graywolf336",
+          "milestone": "0.58.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "7622",
+          "title": "[FIX] Error when acessing settings before ready",
+          "userLogin": "rodrigok",
+          "milestone": "0.58.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7608",
+          "title": "Add missing parts of `one click to direct message`",
+          "userLogin": "rodrigok",
+          "milestone": "0.58.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7621",
+          "title": "[FIX] Message box on safari",
+          "userLogin": "rodrigok",
+          "milestone": "0.58.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7620",
+          "title": "[FIX] The username not being allowed to be passed into the user.setAvatar",
+          "userLogin": "graywolf336",
+          "milestone": "0.58.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "7613",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "7617",
+          "title": "[FIX] Fix Custom Fields Crashing on Register",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.58.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7615",
+          "title": "Improve link parser using tokens",
+          "userLogin": "rodrigok",
+          "milestone": "0.58.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7616",
+          "title": "Improve login error messages",
+          "userLogin": "rodrigok",
+          "milestone": "0.58.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7595",
+          "title": "[NEW] Allow special chars on room names",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.58.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7594",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.58.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "7479",
+          "title": "[NEW] Add admin and user setting for notifications #4339",
+          "userLogin": "stalley",
+          "milestone": "0.58.0",
+          "contributors": [
+            "stalley",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7309",
+          "title": "[NEW] Edit user permissions",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.58.0",
+          "contributors": [
+            "MartinSchoeler",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7324",
+          "title": "[NEW] Adding support for piwik sub domain settings",
+          "userLogin": "ruKurz",
+          "milestone": "0.58.0",
+          "contributors": [
+            "ruKurz"
+          ]
+        },
+        {
+          "pr": "7578",
+          "title": "Improve room leader",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.58.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7582",
+          "title": "[FIX] Fix admin room list show the correct i18n type",
+          "userLogin": "ccfang",
+          "milestone": "0.58.0",
+          "contributors": [
+            "ccfang",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6753",
+          "title": "[NEW] Add setting to change User Agent of OEmbed calls",
+          "userLogin": "AhmetS",
+          "milestone": "0.58.0",
+          "contributors": [
+            "AhmetS",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7517",
+          "title": "[NEW] Configurable Volume for Notifications #6087",
+          "userLogin": "lindoelio",
+          "milestone": "0.58.0",
+          "contributors": [
+            "lindoelio"
+          ]
+        },
+        {
+          "pr": "7590",
+          "title": "Develop sync",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6564",
+          "title": "[NEW] Add customFields in rooms/get method",
+          "userLogin": "borsden",
+          "milestone": "0.58.0",
+          "contributors": [
+            "borsden"
+          ]
+        },
+        {
+          "pr": "7589",
+          "title": "[NEW] Option to select unread count style",
+          "userLogin": "rodrigok",
+          "milestone": "0.58.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7580",
+          "title": "[NEW] Show different shape for alert numbers when have mentions",
+          "userLogin": "rodrigok",
+          "milestone": "0.58.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7533",
+          "title": "[FIX] Missing eventName in unUser",
+          "userLogin": "Darkneon",
+          "milestone": "0.57.3",
+          "contributors": [
+            "Darkneon"
+          ]
+        },
+        {
+          "pr": "7569",
+          "title": "[NEW] Add reaction to the last message when get the shortcut +:",
+          "userLogin": "danilomiranda",
+          "milestone": "0.58.0",
+          "contributors": [
+            "danilomiranda",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7513",
+          "title": "[Fix] Don't save user to DB when a custom field is invalid",
+          "userLogin": "Darkneon",
+          "milestone": "0.58.0",
+          "contributors": [
+            "Darkneon"
+          ]
+        },
+        {
+          "pr": "7538",
+          "title": "[FIX] URL parse error fix for issue #7169",
+          "userLogin": "satyapramodh",
+          "milestone": "0.58.0",
+          "contributors": [
+            "satyapramodh",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7559",
+          "title": "[NEW] Show emojis and file uploads on notifications",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.58.0",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7561",
+          "title": "[NEW] Closes tab bar on mobile when leaving room",
+          "userLogin": "gdelavald",
+          "milestone": "0.58.0",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "7572",
+          "title": "[FIX] User avatar image background",
+          "userLogin": "filipedelimabrito",
+          "milestone": "0.58.0",
+          "contributors": [
+            "filipedelimabrito",
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7564",
+          "title": "[NEW] Adds preference to one-click-to-direct-message and basic functionality",
+          "userLogin": "gdelavald",
+          "milestone": "0.58.0",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "7555",
+          "title": "[FIX] Improve build script example",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.3",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7535",
+          "title": "[FIX] Fix Join Channel Without Preview Room Permission",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.3",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7334",
+          "title": "[NEW] Search users also by email in toolbar",
+          "userLogin": "shahar3012",
+          "milestone": "0.58.0",
+          "contributors": [
+            "shahar3012"
+          ]
+        },
+        {
+          "pr": "7326",
+          "title": "[NEW] Do not rate limit bots on createDirectMessage",
+          "userLogin": "jangmarker",
+          "milestone": "0.58.0",
+          "contributors": [
+            "jangmarker"
+          ]
+        },
+        {
+          "pr": "7214",
+          "title": "[NEW] Allow channel property in the integrations returned content",
+          "userLogin": "graywolf336",
+          "milestone": "0.58.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "7212",
+          "title": "[Fix] Users and Channels list not respecting permissions",
+          "userLogin": "graywolf336",
+          "milestone": "0.57.3",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "7554",
+          "title": "[FIX] Look for livechat visitor IP address on X-Forwarded-For header",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.58.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7556",
+          "title": "[BREAK] Remove Sandstorm login method",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.58.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7557",
+          "title": "[FIX] Revert emojione package version upgrade",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.58.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7562",
+          "title": "[FIX] Stop logging mentions object to console",
+          "userLogin": "gdelavald",
+          "milestone": "0.58.0",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "7500",
+          "title": "Develop sync",
+          "userLogin": "rodrigok",
+          "milestone": "0.58.0",
+          "contributors": [
+            "thinkeridea",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7520",
+          "title": "[NEW] Add room type identifier to room list header",
+          "userLogin": "danischreiber",
+          "milestone": "0.58.0",
+          "contributors": [
+            "danischreiber",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7523",
+          "title": "[NEW] Room type and recipient data for global event",
+          "userLogin": "danischreiber",
+          "milestone": "0.58.0",
+          "contributors": [
+            "danischreiber"
+          ]
+        },
+        {
+          "pr": "7526",
+          "title": "[NEW] Show room leader at top of chat when user scrolls down. Set and unset leader as admin.",
+          "userLogin": "danischreiber",
+          "milestone": "0.58.0",
+          "contributors": [
+            "danischreiber"
+          ]
+        },
+        {
+          "pr": "7525",
+          "title": "[NEW] Add toolbar buttons for iframe API",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.58.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7492",
+          "title": "Better Issue Template",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.58.0",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow",
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "7529",
+          "title": "[NEW] Add close button to flex tabs",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.58.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7496",
+          "title": "[NEW] Update meteor to 1.5.1",
+          "userLogin": "engelgabriel",
+          "milestone": "0.58.0",
+          "contributors": [
+            "engelgabriel",
+            "MartinSchoeler",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7486",
+          "title": "[FIX] Fix hiding flex-tab on embedded view",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.58.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7195",
+          "title": "[FIX] Fix emoji picker translations",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.58.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7325",
+          "title": "[FIX] Modernize rate limiting of sendMessage",
+          "userLogin": "jangmarker",
+          "milestone": "0.57.3",
+          "contributors": [
+            "jangmarker"
+          ]
+        },
+        {
+          "pr": "7390",
+          "title": "[FIX] custom soundEdit.html",
+          "userLogin": "rasos",
+          "milestone": "0.57.3",
+          "contributors": [
+            "rasos",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7394",
+          "title": "[FIX] Use UTF8 setting for /create command",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.3",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7395",
+          "title": "[FIX] file upload broken when running in subdirectory https://github.com…",
+          "userLogin": "ryoshimizu",
+          "milestone": "0.57.3",
+          "contributors": [
+            "ryoshimizu"
+          ]
+        },
+        {
+          "pr": "7444",
+          "title": "[FIX] Fix Anonymous User",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.3",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7471",
+          "title": "[FIX] Issue #7365: added check for the existence of a parameter in the CAS URL",
+          "userLogin": "wsw70",
+          "milestone": "0.58.0",
+          "contributors": [
+            "wsw70"
+          ]
+        },
+        {
+          "pr": "7392",
+          "title": "[FIX] Fix Word Placement Anywhere on WebHooks",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.58.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7487",
+          "title": "[FIX] Prevent new room status from playing when user status changes",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.58.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7443",
+          "title": "[FIX] S3 uploads not working for custom URLs",
+          "userLogin": "rodrigok",
+          "milestone": "0.57.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7432",
+          "title": "[FIX] Fix Private Channel List Submit",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.2",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7469",
+          "title": "[FIX] Fix file upload on Slack import",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7403",
+          "title": "[FIX] Fix Unread Bar Disappearing",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.2",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7472",
+          "title": "[FIX] Always set LDAP properties on login",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7448",
+          "title": "[NEW] flex-tab now is side by side with message list",
+          "userLogin": "ggazzo",
+          "milestone": "0.58.0",
+          "contributors": [
+            "ggazzo",
+            "karlprieb",
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7477",
+          "title": "[NEW] Option to select unread count behavior",
+          "userLogin": "rodrigok",
+          "milestone": "0.58.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7205",
+          "title": "[FIX] url click events in the cordova app open in external browser or not at all",
+          "userLogin": "flaviogrossi",
+          "milestone": "0.58.0",
+          "contributors": [
+            "flaviogrossi"
+          ]
+        },
+        {
+          "pr": "7431",
+          "title": "[FIX] Fix Emails in User Admin View",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.2",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7428",
+          "title": "[FIX] Fix migration of avatars from version 0.57.0",
+          "userLogin": "rodrigok",
+          "milestone": "0.57.1",
+          "contributors": [
+            "sampaiodiego",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6340",
+          "title": "Add helm chart kubernetes deployment",
+          "userLogin": "pierreozoux",
+          "milestone": "0.58.0",
+          "contributors": [
+            "pierreozoux"
+          ]
+        },
+        {
+          "pr": "7404",
+          "title": "[FIX] sweetalert alignment on mobile",
+          "userLogin": "karlprieb",
+          "milestone": "0.58.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7376",
+          "title": "[FIX] Sweet-Alert modal popup position on mobile devices",
+          "userLogin": "Oliver84",
+          "milestone": "0.58.0",
+          "contributors": [
+            "Oliver84",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7355",
+          "title": "[FIX] Update node-engine in Snap to latest v4 LTS relase: 4.8.3",
+          "userLogin": "al3x",
+          "milestone": "0.58.0",
+          "contributors": [
+            "al3x"
+          ]
+        },
+        {
+          "pr": "7354",
+          "title": "[FIX] Remove warning about 2FA support being unavailable in mobile apps",
+          "userLogin": "al3x",
+          "milestone": "0.58.0",
+          "contributors": [
+            "al3x"
+          ]
+        },
+        {
+          "pr": "7363",
+          "title": "Develop sync",
+          "userLogin": "rodrigok",
+          "milestone": "0.58.0",
+          "contributors": [
+            "rodrigok",
+            "geekgonecrazy",
+            "JSzaszvari",
+            "MartinSchoeler",
+            "graywolf336",
+            "sampaiodiego",
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7308",
+          "title": "Escape error messages",
+          "userLogin": "rodrigok",
+          "milestone": "0.57.0",
+          "contributors": [
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7322",
+          "title": "[FIX] Fix geolocation button",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.58.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7207",
+          "title": "[FIX] Fix Block Delete Message After (n) Minutes",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7311",
+          "title": "[NEW] Force use of MongoDB for spotlight queries",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7320",
+          "title": "[FIX] Fix jump to unread button",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7321",
+          "title": "[FIX] Fix Secret Url",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7199",
+          "title": "[FIX] Use I18n on \"File Uploaded\"",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.58.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7287",
+          "title": "update meteor to 1.5.0",
+          "userLogin": "engelgabriel",
+          "milestone": "0.58.0",
+          "contributors": [
+            "engelgabriel",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7215",
+          "title": "Fix the Zapier oAuth return url to the new one",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "7209",
+          "title": "[FIX] \"requirePasswordChange\" property not being saved when set to false",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "7211",
+          "title": "[New] Add instance id to response headers",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "7184",
+          "title": "[NEW] Add healthchecks in OpenShift templates",
+          "userLogin": "jfchevrette",
+          "contributors": [
+            "jfchevrette"
+          ]
+        },
+        {
+          "pr": "7208",
+          "title": "[FIX] Fix oembed previews not being shown",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7200",
+          "title": "[FIX] Fix editing others messages",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7187",
+          "title": "[FIX] Fix error on image preview due to undefined description|title ",
+          "userLogin": "ggazzo",
+          "contributors": [
+            "ggazzo"
+          ]
+        }
+      ]
+    },
+    "0.58.0-rc.1": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "7629",
+          "title": "[FIX] Fix messagebox growth",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.58.0-rc.1",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7630",
+          "title": "[FIX] Wrong render of snippet’s name",
+          "userLogin": "rodrigok",
+          "milestone": "0.58.0-rc.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7658",
+          "title": "[NEW] Add unread options for direct messages",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.58.0-rc.1",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7687",
+          "title": "[FIX] Fix room load on first hit",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.58.0-rc.1",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7644",
+          "title": "[FIX] Markdown noopener/noreferrer: use correct HTML attribute",
+          "userLogin": "jangmarker",
+          "milestone": "0.58.0-rc.1",
+          "contributors": [
+            "jangmarker"
+          ]
+        },
+        {
+          "pr": "7652",
+          "title": "Only use \"File Uploaded\" prefix on files",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.58.0-rc.1",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7639",
+          "title": "[FIX] Wrong email subject when \"All Messages\" setting enabled",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.58.0-rc.1",
+          "contributors": [
+            "MartinSchoeler",
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.58.0-rc.2": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "7456",
+          "title": "[FIX] Csv importer: work with more problematic data",
+          "userLogin": "reist",
+          "milestone": "0.58.0-rc.2",
+          "contributors": [
+            "reist"
+          ]
+        }
+      ]
+    },
+    "0.58.0-rc.3": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "7738",
+          "title": "[FIX] make flex-tab visible again when reduced width",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.58.0-rc.3",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        }
+      ]
+    },
+    "0.58.0": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "7752",
+          "title": "Release 0.58.0",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "ryoshimizu",
+            "rodrigok",
+            "web-flow",
+            "MartinSchoeler",
+            "karlprieb",
+            "engelgabriel",
+            "sampaiodiego",
+            "pierreozoux",
+            "geekgonecrazy",
+            "jangmarker",
+            "flaviogrossi",
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "7690",
+          "title": "Sync Master with 0.57.3",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7212",
+          "title": "[Fix] Users and Channels list not respecting permissions",
+          "userLogin": "graywolf336",
+          "milestone": "0.57.3",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "7325",
+          "title": "[FIX] Modernize rate limiting of sendMessage",
+          "userLogin": "jangmarker",
+          "milestone": "0.57.3",
+          "contributors": [
+            "jangmarker"
+          ]
+        },
+        {
+          "pr": "7390",
+          "title": "[FIX] custom soundEdit.html",
+          "userLogin": "rasos",
+          "milestone": "0.57.3",
+          "contributors": [
+            "rasos",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7394",
+          "title": "[FIX] Use UTF8 setting for /create command",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.3",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7395",
+          "title": "[FIX] file upload broken when running in subdirectory https://github.com…",
+          "userLogin": "ryoshimizu",
+          "milestone": "0.57.3",
+          "contributors": [
+            "ryoshimizu"
+          ]
+        },
+        {
+          "pr": "7444",
+          "title": "[FIX] Fix Anonymous User",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.3",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7533",
+          "title": "[FIX] Missing eventName in unUser",
+          "userLogin": "Darkneon",
+          "milestone": "0.57.3",
+          "contributors": [
+            "Darkneon"
+          ]
+        },
+        {
+          "pr": "7535",
+          "title": "[FIX] Fix Join Channel Without Preview Room Permission",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.57.3",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7555",
+          "title": "[FIX] Improve build script example",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.57.3",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        }
+      ]
+    },
+    "0.58.1": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "7782",
+          "title": "Release 0.58.1",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7781",
+          "title": "[FIX] Fix flex tab not opening and getting offscreen",
+          "userLogin": "MartinSchoeler",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        }
+      ]
+    },
+    "0.58.2": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "7841",
+          "title": "Release 0.58.2",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.58.2",
+          "contributors": [
+            "snoozan",
+            "geekgonecrazy"
+          ]
+        }
+      ]
+    },
+    "0.58.3": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": []
+    },
+    "0.58.4": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8408",
+          "title": "[FIX] Duplicate code in rest api letting in a few bugs with the rest api",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8390",
+          "title": "[FIX] Slack import failing and not being able to be restarted",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8389",
+          "title": "[FIX] Add needed dependency for snaps",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.0": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8408",
+          "title": "[FIX] Duplicate code in rest api letting in a few bugs with the rest api",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8390",
+          "title": "[FIX] Slack import failing and not being able to be restarted",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8389",
+          "title": "[FIX] Add needed dependency for snaps",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "7864",
+          "title": "[NEW] Replace message cog for vertical menu",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0",
+          "contributors": [
+            "karlprieb",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7865",
+          "title": "Mobile sidenav",
+          "userLogin": "ggazzo",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "7830",
+          "title": "[NEW] block users to mention unknow users",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "7614",
+          "title": "[NEW] Allow ldap mapping of customFields",
+          "userLogin": "goiaba",
+          "milestone": "0.59.0",
+          "contributors": [
+            "goiaba",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7853",
+          "title": "[NEW] Create a standard for our svg icons",
+          "userLogin": "karlprieb",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7565",
+          "title": "[NEW] Allows admin to list all groups with API",
+          "userLogin": "mboudet",
+          "contributors": [
+            "mboudet",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7855",
+          "title": "[FIX] File upload on multi-instances using a path prefix",
+          "userLogin": "Darkneon",
+          "milestone": "0.59.0",
+          "contributors": [
+            "Darkneon"
+          ]
+        },
+        {
+          "pr": "7863",
+          "title": "[FIX] Fix migration 100",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7852",
+          "title": "[NEW] Add markdown parser \"marked\"",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0",
+          "contributors": [
+            "nishimaki10",
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7817",
+          "title": "[NEW] Audio Notification updated in sidebar",
+          "userLogin": "aditya19496",
+          "milestone": "0.59.0",
+          "contributors": [
+            "maarten-v",
+            "web-flow",
+            "aditya19496",
+            "engelgabriel",
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "7846",
+          "title": "[FIX] Email message forward error",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7854",
+          "title": "[FIX] Add CSS support for Safari versions > 7",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7612",
+          "title": "[NEW] Search users by fields defined by admin",
+          "userLogin": "goiaba",
+          "milestone": "0.59.0",
+          "contributors": [
+            "goiaba"
+          ]
+        },
+        {
+          "pr": "7688",
+          "title": "[NEW] Template to show Custom Fields in user info view",
+          "userLogin": "goiaba",
+          "milestone": "0.59.0",
+          "contributors": [
+            "goiaba"
+          ]
+        },
+        {
+          "pr": "7842",
+          "title": "npm deps update",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "7168",
+          "title": "[FIX] Fix black background on transparent avatars",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0",
+          "contributors": [
+            "ggazzo",
+            "sampaiodiego",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7711",
+          "title": "[NEW] Add room type as a class to the ul-group of rooms",
+          "userLogin": "danischreiber",
+          "milestone": "0.59.0",
+          "contributors": [
+            "danischreiber",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7636",
+          "title": "[NEW] Add classes to notification menu so they can be hidden in css",
+          "userLogin": "danischreiber",
+          "milestone": "0.59.0",
+          "contributors": [
+            "danischreiber"
+          ]
+        },
+        {
+          "pr": "5902",
+          "title": "[NEW] Adds a Keyboard Shortcut option to the flextab",
+          "userLogin": "cnash",
+          "milestone": "0.59.0",
+          "contributors": [
+            "cnash",
+            "web-flow",
+            "karlprieb",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7342",
+          "title": "[NEW] Integrated personal email gateway (GSoC'17)",
+          "userLogin": "pkgodara",
+          "milestone": "0.59.0",
+          "contributors": [
+            "pkgodara",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7803",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "7825",
+          "title": "[FIX] Google vision NSFW tag",
+          "userLogin": "marceloschmidt",
+          "milestone": "0.59.0",
+          "contributors": [
+            "marceloschmidt"
+          ]
+        },
+        {
+          "pr": "7793",
+          "title": "Additions to the REST API",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "6301",
+          "title": "[NEW] Add tags to uploaded images using Google Cloud Vision API",
+          "userLogin": "marceloschmidt",
+          "milestone": "0.59.0",
+          "contributors": [
+            "marceloschmidt",
+            "karlprieb",
+            "engelgabriel",
+            "web-flow",
+            "sampaiodiego",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "6700",
+          "title": "[NEW] Package to render issue numbers into links to an issue tracker.",
+          "userLogin": "TobiasKappe",
+          "milestone": "0.59.0",
+          "contributors": [
+            "TobiasKappe",
+            "TAdeJong"
+          ]
+        },
+        {
+          "pr": "7721",
+          "title": "[FIX] meteor-accounts-saml issue with ns0,ns1 namespaces, makes it compatible with pysaml2 lib",
+          "userLogin": "arminfelder",
+          "milestone": "0.59.0",
+          "contributors": [
+            "arminfelder"
+          ]
+        },
+        {
+          "pr": "7823",
+          "title": "[FIX] Fix new-message button showing on search",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "7350",
+          "title": "[NEW] Automatically select the first channel",
+          "userLogin": "antaryami-sahoo",
+          "milestone": "0.59.0",
+          "contributors": [
+            "antaryami-sahoo",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7779",
+          "title": "[FIX] Settings not getting applied from Meteor.settings and process.env ",
+          "userLogin": "Darkneon",
+          "milestone": "0.59.0",
+          "contributors": [
+            "Darkneon"
+          ]
+        },
+        {
+          "pr": "7748",
+          "title": "[FIX] scroll on flex-tab",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "7755",
+          "title": "npm deps update",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "7728",
+          "title": "FIX: Error when starting local development environment",
+          "userLogin": "rdebeasi",
+          "milestone": "0.59.0",
+          "contributors": [
+            "rdebeasi"
+          ]
+        },
+        {
+          "pr": "7815",
+          "title": "[FIX] Dutch translations",
+          "userLogin": "maarten-v",
+          "contributors": [
+            "maarten-v",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7814",
+          "title": "[FIX] Fix Dutch translation",
+          "userLogin": "maarten-v",
+          "contributors": [
+            "maarten-v",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7778",
+          "title": "[FIX] Update Snap links",
+          "userLogin": "MichaelGooden",
+          "contributors": [
+            "MichaelGooden",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7809",
+          "title": "[FIX] Remove redundant \"do\" in \"Are you sure ...?\" messages.",
+          "userLogin": "xurizaemon",
+          "contributors": [
+            "xurizaemon"
+          ]
+        },
+        {
+          "pr": "7758",
+          "title": "[FIX] Fixed function closure syntax allowing validation emails to be sent.",
+          "userLogin": "snoozan",
+          "milestone": "0.58.2",
+          "contributors": [
+            "snoozan"
+          ]
+        },
+        {
+          "pr": "7739",
+          "title": "Remove CircleCI",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7643",
+          "title": "[NEW] Rocket.Chat UI Redesign",
+          "userLogin": "MartinSchoeler",
+          "contributors": [
+            null,
+            "ggazzo",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7677",
+          "title": "Meteor packages and npm dependencies update",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "7456",
+          "title": "[FIX] Csv importer: work with more problematic data",
+          "userLogin": "reist",
+          "milestone": "0.58.0-rc.2",
+          "contributors": [
+            "reist"
+          ]
+        },
+        {
+          "pr": "7656",
+          "title": "[FIX] Fix avatar upload fail on Cordova app",
+          "userLogin": "ccfang",
+          "milestone": "0.58.0",
+          "contributors": [
+            "ccfang"
+          ]
+        },
+        {
+          "pr": "7679",
+          "title": "[FIX] Make link inside YouTube preview open in new tab",
+          "userLogin": "1lann",
+          "milestone": "0.59.0",
+          "contributors": [
+            "1lann",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7664",
+          "title": "[MOVE] Client folder rocketchat-colors",
+          "userLogin": "Kiran-Rao",
+          "milestone": "0.59.0",
+          "contributors": [
+            "Kiran-Rao"
+          ]
+        },
+        {
+          "pr": "7665",
+          "title": "[MOVE] Client folder rocketchat-custom-oauth",
+          "userLogin": "Kiran-Rao",
+          "milestone": "0.59.0",
+          "contributors": [
+            "Kiran-Rao"
+          ]
+        },
+        {
+          "pr": "7666",
+          "title": "[MOVE] Client folder rocketchat-tooltip",
+          "userLogin": "Kiran-Rao",
+          "milestone": "0.59.0",
+          "contributors": [
+            "Kiran-Rao"
+          ]
+        },
+        {
+          "pr": "7667",
+          "title": "[MOVE] Client folder rocketchat-autolinker",
+          "userLogin": "Kiran-Rao",
+          "milestone": "0.59.0",
+          "contributors": [
+            "Kiran-Rao"
+          ]
+        },
+        {
+          "pr": "7668",
+          "title": "[MOVE] Client folder rocketchat-cas",
+          "userLogin": "Kiran-Rao",
+          "milestone": "0.59.0",
+          "contributors": [
+            "Kiran-Rao"
+          ]
+        },
+        {
+          "pr": "7669",
+          "title": "[MOVE] Client folder rocketchat-highlight-words",
+          "userLogin": "Kiran-Rao",
+          "milestone": "0.59.0",
+          "contributors": [
+            "Kiran-Rao"
+          ]
+        },
+        {
+          "pr": "7670",
+          "title": "[MOVE] Client folder rocketchat-custom-sounds",
+          "userLogin": "Kiran-Rao",
+          "milestone": "0.59.0",
+          "contributors": [
+            "Kiran-Rao"
+          ]
+        },
+        {
+          "pr": "7671",
+          "title": "[MOVE] Client folder rocketchat-emoji",
+          "userLogin": "Kiran-Rao",
+          "milestone": "0.59.0",
+          "contributors": [
+            "Kiran-Rao"
+          ]
+        },
+        {
+          "pr": "7672",
+          "title": "[FIX] Remove references to non-existent tests",
+          "userLogin": "Kiran-Rao",
+          "milestone": "0.59.0",
+          "contributors": [
+            "Kiran-Rao"
+          ]
+        },
+        {
+          "pr": "7673",
+          "title": "[FIX] Example usage of unsubscribe.js",
+          "userLogin": "Kiran-Rao",
+          "milestone": "0.59.0",
+          "contributors": [
+            "Kiran-Rao"
+          ]
+        },
+        {
+          "pr": "7639",
+          "title": "[FIX] Wrong email subject when \"All Messages\" setting enabled",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.58.0-rc.1",
+          "contributors": [
+            "MartinSchoeler",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7652",
+          "title": "Only use \"File Uploaded\" prefix on files",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.58.0-rc.1",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7644",
+          "title": "[FIX] Markdown noopener/noreferrer: use correct HTML attribute",
+          "userLogin": "jangmarker",
+          "milestone": "0.58.0-rc.1",
+          "contributors": [
+            "jangmarker"
+          ]
+        },
+        {
+          "pr": "7687",
+          "title": "[FIX] Fix room load on first hit",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.58.0-rc.1",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7658",
+          "title": "[NEW] Add unread options for direct messages",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.58.0-rc.1",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7661",
+          "title": "Fix typo in generated URI",
+          "userLogin": "Rohlik",
+          "contributors": [
+            "Rohlik",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7625",
+          "title": "Bump version to 0.59.0-develop",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7630",
+          "title": "[FIX] Wrong render of snippet’s name",
+          "userLogin": "rodrigok",
+          "milestone": "0.58.0-rc.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7629",
+          "title": "[FIX] Fix messagebox growth",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.58.0-rc.1",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "2",
+          "title": "implemented new page-loader animated icon",
+          "userLogin": "rcaferati",
+          "contributors": [
+            null
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.1": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "7880",
+          "title": "[FIX] sidebar paddings",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7878",
+          "title": "[FIX] Adds default search text padding for emoji search",
+          "userLogin": "gdelavald",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "7881",
+          "title": "[FIX] search results position on sidebar",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7882",
+          "title": "[FIX] hyperlink style on sidebar footer",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7883",
+          "title": "[FIX] popover position on mobile",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7885",
+          "title": "[FIX] message actions over unread bar",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7886",
+          "title": "[FIX] livechat icon",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7887",
+          "title": "[FIX] Makes text action menu width based on content size",
+          "userLogin": "gdelavald",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "7888",
+          "title": "[FIX] sidebar buttons and badge paddings",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.2": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "7912",
+          "title": "[FIX] Fix google play logo on repo README",
+          "userLogin": "luizbills",
+          "milestone": "0.59.0-rc.2",
+          "contributors": [
+            "luizbills",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7904",
+          "title": "[FIX] Fix livechat toggle UI issue",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.0-rc.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7895",
+          "title": "[FIX] Remove break change in Realtime API",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7894",
+          "title": "Hide flex-tab close button",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.2",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7893",
+          "title": "[FIX] Window exception when parsing Markdown on server",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.3": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "7985",
+          "title": "[FIX] Text area buttons and layout on mobile ",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "7927",
+          "title": "[FIX] Double scroll on 'keyboard shortcuts' menu in sidepanel",
+          "userLogin": "aditya19496",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "aditya19496"
+          ]
+        },
+        {
+          "pr": "7944",
+          "title": "[FIX] Broken embedded view layout",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7986",
+          "title": "[FIX] Textarea on firefox",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "MartinSchoeler",
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7984",
+          "title": "[FIX] Chat box no longer auto-focuses when typing",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7971",
+          "title": "[FIX] Add padding on messages to allow space to the action buttons",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "7970",
+          "title": "[FIX] Small alignment fixes",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "7965",
+          "title": "[FIX] Markdown being rendered in code tags",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7963",
+          "title": "[FIX] Fix the status on the members list",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7960",
+          "title": "[FIX] status and active room colors on sidebar",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7954",
+          "title": "[FIX] OTR buttons padding",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7953",
+          "title": "[FIX] username ellipsis on firefox",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7948",
+          "title": "[FIX] Document README.md. Drupal repo out of date",
+          "userLogin": "Lawri-van-Buel",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "Lawri-van-Buel"
+          ]
+        },
+        {
+          "pr": "7945",
+          "title": "[FIX] Fix placeholders in account profile",
+          "userLogin": "josiasds",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "josiasds"
+          ]
+        },
+        {
+          "pr": "7943",
+          "title": "[FIX] Broken emoji picker on firefox",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7942",
+          "title": "[FIX] Create channel button on Firefox",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7941",
+          "title": "Update BlackDuck URL",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7909",
+          "title": "[DOCS] Add native mobile app links into README and update button images",
+          "userLogin": "rafaelks",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "rafaelks",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7712",
+          "title": "[FIX] Show leader on first load",
+          "userLogin": "danischreiber",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "danischreiber",
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.4": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "7988",
+          "title": "[FIX] Vertical menu on flex-tab",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "ggazzo",
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8048",
+          "title": "[FIX] Invisible leader bar on hover",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "8046",
+          "title": "[FIX] Prevent autotranslate tokens race condition",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8039",
+          "title": "[FIX] copy to clipboard and update clipboard.js library",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8019",
+          "title": "[FIX] message-box autogrow",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8018",
+          "title": "[FIX] search results height",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "karlprieb",
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "8017",
+          "title": "[FIX] room icon on header",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8014",
+          "title": "[FIX] Hide scrollbar on login page if not necessary",
+          "userLogin": "alexbrazier",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "alexbrazier"
+          ]
+        },
+        {
+          "pr": "8001",
+          "title": "[FIX] Error when translating message",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7998",
+          "title": "[FIX] Recent emojis not updated when adding via text",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7989",
+          "title": "[FIX][PL] Polish translation",
+          "userLogin": "Rzeszow",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "Rzeszow",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7754",
+          "title": "[FIX] Fix email on mention",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.5": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8112",
+          "title": "[FIX] RTL",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.5",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "8101",
+          "title": "[FIX] Dynamic popover",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.5",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8122",
+          "title": "[FIX] Settings description not showing",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.5",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8099",
+          "title": "[FIX] Fix setting user avatar on LDAP login",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.0-rc.5",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8059",
+          "title": "[FIX] Not sending email to mentioned users with unchanged preference",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.5",
+          "contributors": [
+            "MartinSchoeler",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8054",
+          "title": "Remove unnecessary returns in cors common",
+          "userLogin": "Kiran-Rao",
+          "milestone": "0.59.0-rc.5",
+          "contributors": [
+            "Kiran-Rao",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8047",
+          "title": "[FIX] Scroll on messagebox",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.5",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.6": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8172",
+          "title": "[FIX] Allow unknown file types if no allowed whitelist has been set (#7074)",
+          "userLogin": "TriPhoenix",
+          "milestone": "0.59.0-rc.6",
+          "contributors": [
+            "TriPhoenix"
+          ]
+        },
+        {
+          "pr": "8167",
+          "title": "[FIX] Issue #8166 where empty analytics setting breaks to load Piwik script",
+          "userLogin": "ruKurz",
+          "milestone": "0.59.0-rc.6",
+          "contributors": [
+            "ruKurz"
+          ]
+        },
+        {
+          "pr": "8154",
+          "title": "[FIX] Sidebar and RTL alignments",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.6",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8147",
+          "title": "[FIX] \"*.members\" rest api being useless and only returning usernames",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0-rc.6",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8146",
+          "title": "[FIX] Fix iframe login API response (issue #8145)",
+          "userLogin": "astax-t",
+          "milestone": "0.59.0-rc.6",
+          "contributors": [
+            "astax-t"
+          ]
+        },
+        {
+          "pr": "8159",
+          "title": "[FIX] Text area lost text when page reloads",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.6",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8144",
+          "title": "[FIX] Fix new room sound being played too much",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.0-rc.6",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8094",
+          "title": "[FIX] Add admin audio preferences translations",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.0-rc.6",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8073",
+          "title": "[NEW] Upgrade to meteor 1.5.2",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.6",
+          "contributors": [
+            "engelgabriel"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.7": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8213",
+          "title": "[FIX] Leave and hide buttons was removed",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.7",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8211",
+          "title": "[FIX] Incorrect URL for login terms when using prefix",
+          "userLogin": "Darkneon",
+          "milestone": "0.59.0-rc.7",
+          "contributors": [
+            "Darkneon"
+          ]
+        },
+        {
+          "pr": "8210",
+          "title": "[FIX] User avatar in DM list.",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.7",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "8197",
+          "title": "npm deps update",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.7",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8194",
+          "title": "Fix more rtl issues",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.7",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8190",
+          "title": "[FIX] Scrollbar not using new style",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.7",
+          "contributors": [
+            "ggazzo",
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.8": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8253",
+          "title": "readme-file: fix broken link",
+          "userLogin": "vcapretz",
+          "milestone": "0.59.0-rc.8",
+          "contributors": [
+            "vcapretz"
+          ]
+        },
+        {
+          "pr": "8257",
+          "title": "[FIX] sidenav colors, hide and leave, create channel on safari",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.8",
+          "contributors": [
+            "ggazzo",
+            "karlprieb",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8262",
+          "title": "[FIX] make sidebar item animation fast",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.8",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8261",
+          "title": "[FIX] RTL on reply",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.8",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8260",
+          "title": "[NEW] Enable read only channel creation",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.8",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8259",
+          "title": "[FIX] clipboard and permalink on new popover",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.8",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8252",
+          "title": "[FIX] sidenav mentions on hover",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.8",
+          "contributors": [
+            "ggazzo",
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8244",
+          "title": "Disable perfect scrollbar",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.8",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8243",
+          "title": "Fix `leave and hide` click, color and position",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.8",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8241",
+          "title": "[FIX] Api groups.files is always returning empty",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.8",
+          "contributors": [
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8216",
+          "title": "[FIX] Case insensitive SAML email check",
+          "userLogin": "arminfelder",
+          "milestone": "0.59.0-rc.8",
+          "contributors": [
+            "arminfelder"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.9": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8310",
+          "title": "[FIX] Execute meteor reset on TRAVIS_TAG builds",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8307",
+          "title": "[FIX] Call buttons with wrong margin on RTL",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8304",
+          "title": "[NEW] Add RD Station integration to livechat",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8300",
+          "title": "[FIX] Emoji Picker hidden for reactions in RTL",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8299",
+          "title": " [FIX] Amin menu not showing all items & File list breaking line",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "ggazzo",
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8298",
+          "title": "[FIX] TypeError: Cannot read property 't' of undefined",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8296",
+          "title": "[FIX] Wrong file name when upload to AWS S3",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8295",
+          "title": "[FIX] Check attachments is defined before accessing first element",
+          "userLogin": "Darkneon",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "Darkneon"
+          ]
+        },
+        {
+          "pr": "8286",
+          "title": "[FIX] Missing placeholder translations",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8282",
+          "title": "[FIX] fix color on unread messages",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "8278",
+          "title": "[FIX] \"Cancel button\" on modal in RTL in Firefox 55",
+          "userLogin": "cyclops24",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "cyclops24"
+          ]
+        },
+        {
+          "pr": "8273",
+          "title": "Deps update",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8271",
+          "title": "[FIX] Attachment icons alignment in LTR and RTL",
+          "userLogin": "cyclops24",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "cyclops24"
+          ]
+        },
+        {
+          "pr": "8270",
+          "title": "[FIX] [i18n] My Profile & README.md links",
+          "userLogin": "Rzeszow",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "Rzeszow",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8269",
+          "title": "[FIX] some placeholder and phrase traslation fix",
+          "userLogin": "cyclops24",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "cyclops24"
+          ]
+        },
+        {
+          "pr": "8266",
+          "title": "[FIX] \"Channel Setting\" buttons alignment in RTL",
+          "userLogin": "cyclops24",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "cyclops24"
+          ]
+        },
+        {
+          "pr": "8237",
+          "title": "[FIX] Removing pipe and commas from custom emojis (#8168)",
+          "userLogin": "matheusml",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "matheusml"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.10": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8355",
+          "title": "Update meteor to 1.5.2.2-rc.0",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.10",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8314",
+          "title": "[FIX] After deleting the room, cache is not synchronizing",
+          "userLogin": "szluohua",
+          "milestone": "0.59.0-rc.10",
+          "contributors": [
+            "szluohua"
+          ]
+        },
+        {
+          "pr": "8334",
+          "title": "[FIX] Remove sidebar header on admin embedded version",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.10",
+          "contributors": [
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8331",
+          "title": "[FIX-RC] Mobile file upload not working",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.10",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8317",
+          "title": "[FIX] Email Subjects not being sent",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.10",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8315",
+          "title": "[FIX] Put delete action on another popover group",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.10",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8316",
+          "title": "[FIX] Mention unread indicator was removed",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.10",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.11": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8375",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8372",
+          "title": "[FIX] Various LDAP issues & Missing pagination",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8364",
+          "title": "Update Meteor to 1.5.2.2",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8363",
+          "title": "Sync translations from LingoHub",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8358",
+          "title": "[FIX] remove accountBox from admin menu",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "engelgabriel",
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8361",
+          "title": "[NEW] Unify unread and mentions badge",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8362",
+          "title": "[NEW] make sidebar item width 100%",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8360",
+          "title": "[NEW] Smaller accountBox",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8357",
+          "title": "[FIX] Missing i18n translations",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "8345",
+          "title": "Remove field `lastActivity` from subscription data",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "ggazzo"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.12": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8416",
+          "title": "Fix: Account menu position on RTL",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8417",
+          "title": "Fix: Missing LDAP option to show internal logs",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8414",
+          "title": "Fix: Missing LDAP reconnect setting",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8389",
+          "title": "[FIX] Add needed dependency for snaps",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "8390",
+          "title": "[FIX] Slack import failing and not being able to be restarted",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8397",
+          "title": "[FIX] Sidebar item menu position in RTL",
+          "userLogin": "cyclops24",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "cyclops24"
+          ]
+        },
+        {
+          "pr": "8386",
+          "title": "[FIX] disabled katex tooltip on messageBox",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "8394",
+          "title": "Add i18n Title to snippet messages",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8408",
+          "title": "[FIX] Duplicate code in rest api letting in a few bugs with the rest api",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8398",
+          "title": "Fix: Missing settings to configure LDAP size and page limits",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.13": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8459",
+          "title": "[NEW] Setting to disable MarkDown and enable AutoLinker",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.13",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8457",
+          "title": "[FIX] LDAP memory issues when pagination is not available",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.13",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8451",
+          "title": "Improve markdown parser code",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.13",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.14": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8515",
+          "title": "Change artifact path",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "8463",
+          "title": "Color variables migration",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.14",
+          "contributors": [
+            "ggazzo",
+            "rodrigok",
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8516",
+          "title": "Fix: Change password not working in new UI",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.14",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8514",
+          "title": "[FIX] Uncessary route reload break some routes",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.14",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8491",
+          "title": "[FIX] Invalid Code message for password protected channel",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.14",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8489",
+          "title": "[FIX] Wrong message when reseting password and 2FA is enabled",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.14",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8490",
+          "title": "Enable AutoLinker back",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.14",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.15": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8518",
+          "title": "Fix artifact path",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "8520",
+          "title": "Fix high CPU load when sending messages on large rooms (regression)",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.16": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8527",
+          "title": "[FIX] Do not send joinCode field to clients",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        }
+      ]
+    },
+    "0.59.0-rc.17": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8529",
+          "title": "Improve room sync speed",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.59.0": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8420",
+          "title": "Merge 0.58.4 to master",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8335",
+          "title": "0.58.3",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8408",
+          "title": "[FIX] Duplicate code in rest api letting in a few bugs with the rest api",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8390",
+          "title": "[FIX] Slack import failing and not being able to be restarted",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8389",
+          "title": "[FIX] Add needed dependency for snaps",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        }
+      ]
+    },
+    "0.59.1": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8543",
+          "title": "[FIX] Color reset when default value editor is different",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.1",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8547",
+          "title": "[FIX] Wrong colors after migration 103",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8541",
+          "title": "[FIX] LDAP login error regression at 0.59.0",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8544",
+          "title": "[FIX] Migration 103 wrong converting primrary colors",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.59.2": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8637",
+          "title": "[FIX] Missing scroll at create channel page",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.2",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8634",
+          "title": "[FIX] Message popup menu on mobile/cordova",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.2",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8635",
+          "title": "[FIX] API channel/group.members not sorting",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8613",
+          "title": "[FIX] LDAP not merging existent users && Wrong id link generation",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8551",
+          "title": "[FIX] encode filename in url to prevent links breaking",
+          "userLogin": "joesitton",
+          "milestone": "0.59.2",
+          "contributors": [
+            "joesitton",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8577",
+          "title": "[FIX] Fix guest pool inquiry taking",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        }
+      ]
+    },
+    "0.59.3": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8593",
+          "title": "[FIX] AmazonS3: Quote file.name for ContentDisposition for files with commas",
+          "userLogin": "xenithorb",
+          "milestone": "0.59.3",
+          "contributors": [
+            "xenithorb"
+          ]
+        },
+        {
+          "pr": "8434",
+          "title": "removing a duplicate line",
+          "userLogin": "vikaskedia",
+          "milestone": "0.59.3",
+          "contributors": [
+            "vikaskedia",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8645",
+          "title": "[FIX] Fix e-mail message forward",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.3",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8648",
+          "title": "[FIX] Audio message icon",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8431",
+          "title": "[FIX] Highlighted color height issue",
+          "userLogin": "cyclops24",
+          "milestone": "0.59.3",
+          "contributors": [
+            "cyclops24"
+          ]
+        },
+        {
+          "pr": "8655",
+          "title": "[FIX] Update pt-BR translation",
+          "userLogin": "rodorgas",
+          "milestone": "0.59.3",
+          "contributors": [
+            "rodorgas"
+          ]
+        },
+        {
+          "pr": "8679",
+          "title": "[FIX] Fix typos",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.3",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8653",
+          "title": "install grpc package manually to fix snap armhf build",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.59.3",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "8691",
+          "title": "[FIX] LDAP not respecting UTF8 characters & Sync Interval not working",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.3",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.59.4": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8967",
+          "title": "Release/0.59.4",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "cpitman",
+            "geekgonecrazy",
+            "karlprieb",
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8685",
+          "title": "Add CircleCI",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8753",
+          "title": "[FIX] Channel settings buttons",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb",
+            "geekgonecrazy",
+            "web-flow",
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.59.5": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8972",
+          "title": "Fix CircleCI deploy filter",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        }
+      ]
+    },
+    "0.59.6": {
+      "node_version": "4.8.4",
+      "npm_version": "4.6.1",
+      "pull_requests": [
+        {
+          "pr": "8973",
+          "title": "Fix tag build",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        }
+      ]
+    },
+    "0.60.0-rc.0": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9084",
+          "title": "Fix tag build",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7285",
+          "title": "[NEW] Allow user's default preferences configuration",
+          "userLogin": "goiaba",
+          "milestone": "0.60.0",
+          "contributors": [
+            "goiaba",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8925",
+          "title": "[FIX] Can't react on Read Only rooms even when enabled",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb",
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9068",
+          "title": "Turn off prettyJson if the node environment isn't development",
+          "userLogin": "graywolf336",
+          "milestone": "0.60.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "9049",
+          "title": "Fix api regression (exception when deleting user)",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8654",
+          "title": "[FIX] CAS does not share secrets when operating multiple server instances",
+          "userLogin": "AmShaegar13",
+          "milestone": "0.60.0",
+          "contributors": [
+            "AmShaegar13"
+          ]
+        },
+        {
+          "pr": "8937",
+          "title": "[FIX] Snippetted messages not working",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8915",
+          "title": "[NEW]  Add \"Favorites\" and \"Mark as read\" options to the room list",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8807",
+          "title": "[NEW] Facebook livechat integration",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.0",
+          "contributors": [
+            "sampaiodiego",
+            "ggazzo",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9022",
+          "title": "[FIX] Added afterUserCreated trigger after first CAS login",
+          "userLogin": "AmShaegar13",
+          "milestone": "0.60.0",
+          "contributors": [
+            "AmShaegar13"
+          ]
+        },
+        {
+          "pr": "8902",
+          "title": "[NEW] Added support for Dataporten's userid-feide scope",
+          "userLogin": "torgeirl",
+          "milestone": "0.60.0",
+          "contributors": [
+            "torgeirl",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8828",
+          "title": "[FIX] Notification is not sent when a video conference start",
+          "userLogin": "seainside75",
+          "milestone": "0.60.0",
+          "contributors": [
+            "stefanoverducci",
+            "deepseainside75"
+          ]
+        },
+        {
+          "pr": "8868",
+          "title": "[FIX] long filename overlaps cancel button in progress bar",
+          "userLogin": "joesitton",
+          "milestone": "0.60.0",
+          "contributors": [
+            "joesitton",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8924",
+          "title": "[NEW] Describe file uploads when notifying by email",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9012",
+          "title": "[FIX] Changed oembedUrlWidget to prefer og:image and twitter:image over msapplication-TileImage",
+          "userLogin": "wferris722",
+          "milestone": "0.60.0",
+          "contributors": [
+            "wferris722",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9046",
+          "title": "[FIX] Update insecure moment.js dependency",
+          "userLogin": "robbyoconnor",
+          "milestone": "0.60.0",
+          "contributors": [
+            "robbyoconnor"
+          ]
+        },
+        {
+          "pr": "8149",
+          "title": "[NEW] Feature/livechat hide email",
+          "userLogin": "icosamuel",
+          "milestone": "0.60.0",
+          "contributors": [
+            "sarbasamuel",
+            "icosamuel",
+            "web-flow",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7999",
+          "title": "[NEW] Sender's name in email notifications.",
+          "userLogin": "pkgodara",
+          "milestone": "0.60.0",
+          "contributors": [
+            "pkgodara",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7922",
+          "title": "Use real names for user and room in emails",
+          "userLogin": "danischreiber",
+          "milestone": "0.60.0",
+          "contributors": [
+            "danischreiber",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9034",
+          "title": "[FIX] Custom OAuth: Not able to set different token place for routes",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9044",
+          "title": "[FIX] Can't use OAuth login against a Rocket.Chat OAuth server",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.60.0",
+          "contributors": [
+            "geekgonecrazy",
+            "graywolf336",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9042",
+          "title": "[FIX] Notification sound is not disabling when busy",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.60.0",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8739",
+          "title": "[NEW] Add \"real name change\" setting",
+          "userLogin": "AmShaegar13",
+          "milestone": "0.60.0",
+          "contributors": [
+            "AmShaegar13"
+          ]
+        },
+        {
+          "pr": "8433",
+          "title": "[NEW] Use enter separator rather than comma in highlight preferences + Auto refresh after change highlighted words",
+          "userLogin": "cyclops24",
+          "milestone": "0.60.0",
+          "contributors": [
+            "cyclops24",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7641",
+          "title": "[NEW] Adds admin option to globally set mobile devices to always be notified regardless of presence status.",
+          "userLogin": "stalley",
+          "milestone": "0.60.0",
+          "contributors": [
+            "stalley",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9024",
+          "title": "[FIX] Use encodeURI in AmazonS3 contentDisposition file.name to prevent fail",
+          "userLogin": "paulovitin",
+          "milestone": "0.60.0",
+          "contributors": [
+            "paulovitin",
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9029",
+          "title": "[FIX] snap install by setting grpc package used by google/vision to 1.6.6",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.60.0",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8142",
+          "title": "[MOVE] Move mentions files to client/server",
+          "userLogin": "vcapretz",
+          "milestone": "0.60.0",
+          "contributors": [
+            "vcapretz",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8947",
+          "title": "[NEW] Add new API endpoints",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok",
+            "graywolf336",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8671",
+          "title": "[FIX] Enable CORS for Restivus",
+          "userLogin": "mrsimpson",
+          "milestone": "0.60.0",
+          "contributors": [
+            "mrsimpson",
+            "engelgabriel",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8966",
+          "title": "[FIX] Importers failing when usernames exists but cases don't match and improve the importer framework's performance",
+          "userLogin": "graywolf336",
+          "milestone": "0.60.0",
+          "contributors": [
+            "graywolf336",
+            "geekgonecrazy",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9023",
+          "title": "[FIX] Error when saving integration with symbol as only trigger",
+          "userLogin": "graywolf336",
+          "milestone": "0.60.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8006",
+          "title": "[FIX] Sync of non existent field throws exception",
+          "userLogin": "goiaba",
+          "milestone": "0.60.0",
+          "contributors": [
+            "goiaba",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9018",
+          "title": "Update multiple-instance-status package",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9007",
+          "title": "Use redhat official image with openshift",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.60.0",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8107",
+          "title": "[FIX] Autoupdate of CSS does not work when using a prefix",
+          "userLogin": "Darkneon",
+          "milestone": "0.60.0",
+          "contributors": [
+            "Darkneon",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8656",
+          "title": "[FIX] Contextual errors for this and RegExp declarations in IRC module",
+          "userLogin": "Pharserror",
+          "milestone": "0.60.0",
+          "contributors": [
+            "Pharserror",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8029",
+          "title": "[NEW] Option to enable/disable auto away and configure timer",
+          "userLogin": "armand1m",
+          "milestone": "0.60.0",
+          "contributors": [
+            "armand1m",
+            null,
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9013",
+          "title": "[FIX] Wrong room counter name",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8975",
+          "title": "Added d2c.io to deployment",
+          "userLogin": "mastappl",
+          "contributors": [
+            "mastappl",
+            "web-flow",
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "8882",
+          "title": "[NEW] New Modal component",
+          "userLogin": "ggazzo",
+          "milestone": "0.60.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow",
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8932",
+          "title": "[FIX] Message-box autogrow flick",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9009",
+          "title": "[NEW] Improve room types API and usages",
+          "userLogin": "graywolf336",
+          "milestone": "0.60.0",
+          "contributors": [
+            "mrsimpson",
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8812",
+          "title": "[FIX] Don't strip trailing slash on autolinker urls",
+          "userLogin": "jwilkins",
+          "milestone": "0.60.0",
+          "contributors": [
+            "jwilkins",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8831",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.60.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8866",
+          "title": "[NEW] Room counter sidebar preference",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8883",
+          "title": "[FIX] Change the unread messages style",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8884",
+          "title": "[FIX] Missing sidebar footer padding",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8907",
+          "title": "[FIX] Long room announcement cut off",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8917",
+          "title": "[FIX] DM email notifications always being sent regardless of account setting",
+          "userLogin": "ashward",
+          "milestone": "0.60.0",
+          "contributors": [
+            null,
+            "ashward",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8938",
+          "title": "[FIX] Typo Fix",
+          "userLogin": "seangeleno",
+          "milestone": "0.60.0",
+          "contributors": [
+            "seangeleno",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8948",
+          "title": "[FIX] Katex markdown link changed",
+          "userLogin": "mritunjaygoutam12",
+          "milestone": "0.60.0",
+          "contributors": [
+            "mritunjaygoutam12",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8979",
+          "title": "[NEW] Save room's last message",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.0",
+          "contributors": [
+            "sampaiodiego",
+            "karlprieb",
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9000",
+          "title": "[FIX] if ogImage exists use it over image in oembedUrlWidget",
+          "userLogin": "satyapramodh",
+          "milestone": "0.60.0",
+          "contributors": [
+            "satyapramodh"
+          ]
+        },
+        {
+          "pr": "8060",
+          "title": "[NEW] Token Controlled Access channels",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.0",
+          "contributors": [
+            "lindoelio",
+            "sampaiodiego",
+            "web-flow",
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8889",
+          "title": "[FIX] Cannot edit or delete custom sounds",
+          "userLogin": "ccfang",
+          "milestone": "0.60.0",
+          "contributors": [
+            "ccfang",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8928",
+          "title": "[FIX] Change old 'rocketbot' username to 'InternalHubot_Username' setting",
+          "userLogin": "ramrami",
+          "milestone": "0.60.0",
+          "contributors": [
+            "ramrami",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8985",
+          "title": "[FIX] Link for channels are not rendering correctly",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8968",
+          "title": "[FIX]  Xenforo [BD]API for 'user.user_id; instead of 'id'",
+          "userLogin": "wesnspace",
+          "milestone": "0.60.0",
+          "contributors": [
+            "wesnspace",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8994",
+          "title": "[FIX] flextab height on smaller screens",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8931",
+          "title": "[FIX] Check for mention-all permission in room scope",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8905",
+          "title": "[NEW] Send category and title fields to iOS push notification",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8981",
+          "title": "Fix snap download url",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.60.0",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8753",
+          "title": "[FIX] Channel settings buttons",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb",
+            "geekgonecrazy",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8906",
+          "title": "Add a few dots in readme.md",
+          "userLogin": "dusta",
+          "contributors": [
+            "dusta",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8872",
+          "title": "Changed wording for \"Maximum Allowed Message Size\"",
+          "userLogin": "HammyHavoc",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8822",
+          "title": "[FIX] fix emoji package path so they show up correctly in browser",
+          "userLogin": "ryoshimizu",
+          "milestone": "0.60.0",
+          "contributors": [
+            "ryoshimizu"
+          ]
+        },
+        {
+          "pr": "8857",
+          "title": "[NEW] code to get the updated messages",
+          "userLogin": "ggazzo",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "8862",
+          "title": "Fix Docker image build",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8531",
+          "title": "[NEW] Rest API endpoints to list, get, and run commands",
+          "userLogin": "graywolf336",
+          "milestone": "0.60.0",
+          "contributors": [
+            "graywolf336",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8830",
+          "title": "[FIX] Set correct Twitter link",
+          "userLogin": "jotafeldmann",
+          "contributors": [
+            "jotafeldmann",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8829",
+          "title": "Fix link to .asc file on S3",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8820",
+          "title": "Bump version to 0.60.0-develop",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "rodrigok",
+            "karlprieb",
+            "gdelavald",
+            "ggazzo",
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8819",
+          "title": "Update path for s3 redirect in circle ci",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8810",
+          "title": "[FIX] User email settings on DM",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8721",
+          "title": "[FIX] i18n'd Resend_verification_mail, username_initials, upload avatar",
+          "userLogin": "arungalva",
+          "milestone": "0.60.0",
+          "contributors": [
+            "arungalva",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8716",
+          "title": "[FIX] Username clipping on firefox",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8742",
+          "title": "Remove chatops package",
+          "userLogin": "engelgabriel",
+          "milestone": "0.60.0",
+          "contributors": [
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8743",
+          "title": "Removed tmeasday:crypto-md5",
+          "userLogin": "engelgabriel",
+          "milestone": "0.60.0",
+          "contributors": [
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8802",
+          "title": "Update meteor package to 1.8.1",
+          "userLogin": "engelgabriel",
+          "milestone": "0.60.0",
+          "contributors": [
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8795",
+          "title": "[FIX] Improved grammar and made it clearer to the user",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.60.0",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8705",
+          "title": "Fix typo",
+          "userLogin": "rmetzler",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rmetzler",
+            "geekgonecrazy",
+            "web-flow",
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8718",
+          "title": "[FIX] Show real name of current user at top of side nav if setting enabled",
+          "userLogin": "alexbrazier",
+          "milestone": "0.60.0",
+          "contributors": [
+            "alexbrazier",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8441",
+          "title": "[FIX] Range Slider Value label has bug in RTL",
+          "userLogin": "cyclops24",
+          "milestone": "0.60.0",
+          "contributors": [
+            "cyclops24",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8413",
+          "title": "[Fix] Store Outgoing Integration Result as String in Mongo",
+          "userLogin": "cpitman",
+          "milestone": "0.60.0",
+          "contributors": [
+            "cpitman",
+            "graywolf336",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8708",
+          "title": "[FIX] Add historic chats icon in Livechat",
+          "userLogin": "mrsimpson",
+          "milestone": "0.60.0",
+          "contributors": [
+            "mrsimpson",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8717",
+          "title": "[FIX] Sort direct messages by full name if show real names setting enabled",
+          "userLogin": "alexbrazier",
+          "milestone": "0.60.0",
+          "contributors": [
+            "alexbrazier",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8793",
+          "title": "Update DEMO to OPEN links",
+          "userLogin": "engelgabriel",
+          "milestone": "0.60.0",
+          "contributors": [
+            "engelgabriel",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8796",
+          "title": "[FIX] Improving consistency of UX",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.60.0",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8787",
+          "title": "[FIX] fixed some typos",
+          "userLogin": "TheReal1604",
+          "milestone": "0.60.0",
+          "contributors": [
+            "TheReal1604",
+            "web-flow",
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8715",
+          "title": "[NEW] Upgrade Meteor to 1.6",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok",
+            "geekgonecrazy",
+            "karlprieb",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8685",
+          "title": "Add CircleCI",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8750",
+          "title": "Fix Travis CI build",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8719",
+          "title": "Updated comments.",
+          "userLogin": "jasonjyu",
+          "contributors": [
+            "jasonjyu",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8434",
+          "title": "removing a duplicate line",
+          "userLogin": "vikaskedia",
+          "milestone": "0.59.3",
+          "contributors": [
+            "vikaskedia",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8645",
+          "title": "[FIX] Fix e-mail message forward",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.3",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8648",
+          "title": "[FIX] Audio message icon",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8431",
+          "title": "[FIX] Highlighted color height issue",
+          "userLogin": "cyclops24",
+          "milestone": "0.59.3",
+          "contributors": [
+            "cyclops24"
+          ]
+        },
+        {
+          "pr": "8593",
+          "title": "[FIX] AmazonS3: Quote file.name for ContentDisposition for files with commas",
+          "userLogin": "xenithorb",
+          "milestone": "0.59.3",
+          "contributors": [
+            "xenithorb"
+          ]
+        },
+        {
+          "pr": "8655",
+          "title": "[FIX] Update pt-BR translation",
+          "userLogin": "rodorgas",
+          "milestone": "0.59.3",
+          "contributors": [
+            "rodorgas"
+          ]
+        },
+        {
+          "pr": "8679",
+          "title": "[FIX] Fix typos",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.3",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8653",
+          "title": "install grpc package manually to fix snap armhf build",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.59.3",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "8691",
+          "title": "[FIX] LDAP not respecting UTF8 characters & Sync Interval not working",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.3",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8637",
+          "title": "[FIX] Missing scroll at create channel page",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.2",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8634",
+          "title": "[FIX] Message popup menu on mobile/cordova",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.2",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8635",
+          "title": "[FIX] API channel/group.members not sorting",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8613",
+          "title": "[FIX] LDAP not merging existent users && Wrong id link generation",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8551",
+          "title": "[FIX] encode filename in url to prevent links breaking",
+          "userLogin": "joesitton",
+          "milestone": "0.59.2",
+          "contributors": [
+            "joesitton",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8577",
+          "title": "[FIX] Fix guest pool inquiry taking",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8589",
+          "title": "Fix community links in readme",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8588",
+          "title": "[FIX] Changed all rocket.chat/docs/ to docs.rocket.chat/",
+          "userLogin": "RekkyRek",
+          "contributors": [
+            "RekkyRek",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8543",
+          "title": "[FIX] Color reset when default value editor is different",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.1",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8547",
+          "title": "[FIX] Wrong colors after migration 103",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8541",
+          "title": "[FIX] LDAP login error regression at 0.59.0",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8544",
+          "title": "[FIX] Migration 103 wrong converting primrary colors",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8529",
+          "title": "Improve room sync speed",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8527",
+          "title": "[FIX] Do not send joinCode field to clients",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8520",
+          "title": "Fix high CPU load when sending messages on large rooms (regression)",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8515",
+          "title": "Change artifact path",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "8463",
+          "title": "Color variables migration",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.14",
+          "contributors": [
+            "ggazzo",
+            "rodrigok",
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8516",
+          "title": "Fix: Change password not working in new UI",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.14",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8514",
+          "title": "[FIX] Uncessary route reload break some routes",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.14",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8491",
+          "title": "[FIX] Invalid Code message for password protected channel",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.14",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8489",
+          "title": "[FIX] Wrong message when reseting password and 2FA is enabled",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.14",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8490",
+          "title": "Enable AutoLinker back",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.14",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8459",
+          "title": "[NEW] Setting to disable MarkDown and enable AutoLinker",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.13",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8457",
+          "title": "[FIX] LDAP memory issues when pagination is not available",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.13",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8451",
+          "title": "Improve markdown parser code",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.13",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8066",
+          "title": "[NEW] Add settings for allow user direct messages to yourself",
+          "userLogin": "lindoelio",
+          "milestone": "0.60.0",
+          "contributors": [
+            "lindoelio"
+          ]
+        },
+        {
+          "pr": "8108",
+          "title": "[NEW] Add sweet alert to video call tab",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.60.0",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "8143",
+          "title": "[NEW] Displays QR code for manually entering when enabling 2fa",
+          "userLogin": "marceloschmidt",
+          "milestone": "0.60.0",
+          "contributors": [
+            "marceloschmidt"
+          ]
+        },
+        {
+          "pr": "8077",
+          "title": "[MOVE] Move favico to client folder",
+          "userLogin": "vcapretz",
+          "milestone": "0.60.0",
+          "contributors": [
+            "vcapretz"
+          ]
+        },
+        {
+          "pr": "8078",
+          "title": "[MOVE] Move files from emojione to client/server folders",
+          "userLogin": "vcapretz",
+          "milestone": "0.60.0",
+          "contributors": [
+            "vcapretz"
+          ]
+        },
+        {
+          "pr": "8084",
+          "title": "[MOVE] Move files from slashcommands-unarchive to client/server folders",
+          "userLogin": "vcapretz",
+          "milestone": "0.60.0",
+          "contributors": [
+            "vcapretz"
+          ]
+        },
+        {
+          "pr": "8132",
+          "title": "[MOVE] Move slashcommands-open to client folder",
+          "userLogin": "vcapretz",
+          "milestone": "0.60.0",
+          "contributors": [
+            "vcapretz"
+          ]
+        },
+        {
+          "pr": "8135",
+          "title": "[MOVE] Move kick command to client/server folders",
+          "userLogin": "vcapretz",
+          "milestone": "0.60.0",
+          "contributors": [
+            "vcapretz"
+          ]
+        },
+        {
+          "pr": "8136",
+          "title": "[MOVE] Move join command to client/server folder",
+          "userLogin": "vcapretz",
+          "milestone": "0.60.0",
+          "contributors": [
+            "vcapretz"
+          ]
+        },
+        {
+          "pr": "8137",
+          "title": "[MOVE] Move inviteall command to client/server folder",
+          "userLogin": "vcapretz",
+          "milestone": "0.60.0",
+          "contributors": [
+            "vcapretz"
+          ]
+        },
+        {
+          "pr": "8138",
+          "title": "[MOVE] Move invite command to client/server folder",
+          "userLogin": "vcapretz",
+          "milestone": "0.60.0",
+          "contributors": [
+            "vcapretz"
+          ]
+        },
+        {
+          "pr": "8139",
+          "title": "[MOVE] Move create command to client/server folder",
+          "userLogin": "vcapretz",
+          "milestone": "0.60.0",
+          "contributors": [
+            "vcapretz"
+          ]
+        },
+        {
+          "pr": "8140",
+          "title": "[MOVE] Move archiveroom command to client/server folders",
+          "userLogin": "vcapretz",
+          "milestone": "0.60.0",
+          "contributors": [
+            "vcapretz"
+          ]
+        },
+        {
+          "pr": "8141",
+          "title": "[MOVE] Move slackbridge to client/server folders",
+          "userLogin": "vcapretz",
+          "milestone": "0.60.0",
+          "contributors": [
+            "vcapretz"
+          ]
+        },
+        {
+          "pr": "8150",
+          "title": "[MOVE] Move logger files to client/server folders",
+          "userLogin": "vcapretz",
+          "milestone": "0.60.0",
+          "contributors": [
+            "vcapretz"
+          ]
+        },
+        {
+          "pr": "8152",
+          "title": "[MOVE] Move timesync files to client/server folders",
+          "userLogin": "vcapretz",
+          "milestone": "0.60.0",
+          "contributors": [
+            "vcapretz"
+          ]
+        },
+        {
+          "pr": "8416",
+          "title": "Fix: Account menu position on RTL",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8417",
+          "title": "Fix: Missing LDAP option to show internal logs",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8414",
+          "title": "Fix: Missing LDAP reconnect setting",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8389",
+          "title": "[FIX] Add needed dependency for snaps",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "8390",
+          "title": "[FIX] Slack import failing and not being able to be restarted",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8397",
+          "title": "[FIX] Sidebar item menu position in RTL",
+          "userLogin": "cyclops24",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "cyclops24"
+          ]
+        },
+        {
+          "pr": "8386",
+          "title": "[FIX] disabled katex tooltip on messageBox",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "8394",
+          "title": "Add i18n Title to snippet messages",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8408",
+          "title": "[FIX] Duplicate code in rest api letting in a few bugs with the rest api",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8398",
+          "title": "Fix: Missing settings to configure LDAP size and page limits",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.12",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8375",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8372",
+          "title": "[FIX] Various LDAP issues & Missing pagination",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8364",
+          "title": "Update Meteor to 1.5.2.2",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8363",
+          "title": "Sync translations from LingoHub",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8358",
+          "title": "[FIX] remove accountBox from admin menu",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "engelgabriel",
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8361",
+          "title": "[NEW] Unify unread and mentions badge",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8362",
+          "title": "[NEW] make sidebar item width 100%",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8360",
+          "title": "[NEW] Smaller accountBox",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8357",
+          "title": "[FIX] Missing i18n translations",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "8345",
+          "title": "Remove field `lastActivity` from subscription data",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.11",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "8355",
+          "title": "Update meteor to 1.5.2.2-rc.0",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.10",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8314",
+          "title": "[FIX] After deleting the room, cache is not synchronizing",
+          "userLogin": "szluohua",
+          "milestone": "0.59.0-rc.10",
+          "contributors": [
+            "szluohua"
+          ]
+        },
+        {
+          "pr": "8334",
+          "title": "[FIX] Remove sidebar header on admin embedded version",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.10",
+          "contributors": [
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8331",
+          "title": "[FIX-RC] Mobile file upload not working",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.10",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8317",
+          "title": "[FIX] Email Subjects not being sent",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.10",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8315",
+          "title": "[FIX] Put delete action on another popover group",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.10",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8316",
+          "title": "[FIX] Mention unread indicator was removed",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.10",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8304",
+          "title": "[NEW] Add RD Station integration to livechat",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8310",
+          "title": "[FIX] Execute meteor reset on TRAVIS_TAG builds",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8296",
+          "title": "[FIX] Wrong file name when upload to AWS S3",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8298",
+          "title": "[FIX] TypeError: Cannot read property 't' of undefined",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8295",
+          "title": "[FIX] Check attachments is defined before accessing first element",
+          "userLogin": "Darkneon",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "Darkneon"
+          ]
+        },
+        {
+          "pr": "8299",
+          "title": " [FIX] Amin menu not showing all items & File list breaking line",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "ggazzo",
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8307",
+          "title": "[FIX] Call buttons with wrong margin on RTL",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8300",
+          "title": "[FIX] Emoji Picker hidden for reactions in RTL",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8273",
+          "title": "Deps update",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8282",
+          "title": "[FIX] fix color on unread messages",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "8286",
+          "title": "[FIX] Missing placeholder translations",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8278",
+          "title": "[FIX] \"Cancel button\" on modal in RTL in Firefox 55",
+          "userLogin": "cyclops24",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "cyclops24"
+          ]
+        },
+        {
+          "pr": "8271",
+          "title": "[FIX] Attachment icons alignment in LTR and RTL",
+          "userLogin": "cyclops24",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "cyclops24"
+          ]
+        },
+        {
+          "pr": "8270",
+          "title": "[FIX] [i18n] My Profile & README.md links",
+          "userLogin": "Rzeszow",
+          "milestone": "0.59.0-rc.9",
+          "contributors": [
+            "Rzeszow",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8211",
+          "title": "[FIX] Incorrect URL for login terms when using prefix",
+          "userLogin": "Darkneon",
+          "milestone": "0.59.0-rc.7",
+          "contributors": [
+            "Darkneon"
+          ]
+        },
+        {
+          "pr": "8194",
+          "title": "Fix more rtl issues",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.7",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8190",
+          "title": "[FIX] Scrollbar not using new style",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.7",
+          "contributors": [
+            "ggazzo",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8210",
+          "title": "[FIX] User avatar in DM list.",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.7",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "8197",
+          "title": "npm deps update",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.7",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8146",
+          "title": "[FIX] Fix iframe login API response (issue #8145)",
+          "userLogin": "astax-t",
+          "milestone": "0.59.0-rc.6",
+          "contributors": [
+            "astax-t"
+          ]
+        },
+        {
+          "pr": "8167",
+          "title": "[FIX] Issue #8166 where empty analytics setting breaks to load Piwik script",
+          "userLogin": "ruKurz",
+          "milestone": "0.59.0-rc.6",
+          "contributors": [
+            "ruKurz"
+          ]
+        },
+        {
+          "pr": "8154",
+          "title": "[FIX] Sidebar and RTL alignments",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.6",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8147",
+          "title": "[FIX] \"*.members\" rest api being useless and only returning usernames",
+          "userLogin": "graywolf336",
+          "milestone": "0.59.0-rc.6",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "8159",
+          "title": "[FIX] Text area lost text when page reloads",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.6",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8094",
+          "title": "[FIX] Add admin audio preferences translations",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.0-rc.6",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8073",
+          "title": "[NEW] Upgrade to meteor 1.5.2",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.6",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "8112",
+          "title": "[FIX] RTL",
+          "userLogin": "ggazzo",
+          "milestone": "0.59.0-rc.5",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "8122",
+          "title": "[FIX] Settings description not showing",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.5",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8059",
+          "title": "[FIX] Not sending email to mentioned users with unchanged preference",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.5",
+          "contributors": [
+            "MartinSchoeler",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8101",
+          "title": "[FIX] Dynamic popover",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.5",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8099",
+          "title": "[FIX] Fix setting user avatar on LDAP login",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.0-rc.5",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8054",
+          "title": "Remove unnecessary returns in cors common",
+          "userLogin": "Kiran-Rao",
+          "milestone": "0.59.0-rc.5",
+          "contributors": [
+            "Kiran-Rao",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8047",
+          "title": "[FIX] Scroll on messagebox",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.5",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "8048",
+          "title": "[FIX] Invisible leader bar on hover",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7754",
+          "title": "[FIX] Fix email on mention",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "8046",
+          "title": "[FIX] Prevent autotranslate tokens race condition",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7988",
+          "title": "[FIX] Vertical menu on flex-tab",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "ggazzo",
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8019",
+          "title": "[FIX] message-box autogrow",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8039",
+          "title": "[FIX] copy to clipboard and update clipboard.js library",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "8037",
+          "title": "[NEW] Add yunohost.org installation method to Readme.md",
+          "userLogin": "selamanse",
+          "contributors": [
+            "selamanse",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8036",
+          "title": "Adding: How to Install in WeDeploy",
+          "userLogin": "thompsonemerson",
+          "contributors": [
+            "thompsonemerson",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7998",
+          "title": "[FIX] Recent emojis not updated when adding via text",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7989",
+          "title": "[FIX][PL] Polish translation",
+          "userLogin": "Rzeszow",
+          "milestone": "0.59.0-rc.4",
+          "contributors": [
+            "Rzeszow",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7984",
+          "title": "[FIX] Chat box no longer auto-focuses when typing",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7963",
+          "title": "[FIX] Fix the status on the members list",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "7965",
+          "title": "[FIX] Markdown being rendered in code tags",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7983",
+          "title": "Revert \"npm deps update\"",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7923",
+          "title": "[FIX] Email verification indicator added",
+          "userLogin": "aditya19496",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "aditya19496",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7712",
+          "title": "[FIX] Show leader on first load",
+          "userLogin": "danischreiber",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "danischreiber",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7909",
+          "title": "[DOCS] Add native mobile app links into README and update button images",
+          "userLogin": "rafaelks",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "rafaelks",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7971",
+          "title": "[FIX] Add padding on messages to allow space to the action buttons",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "7970",
+          "title": "[FIX] Small alignment fixes",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "7969",
+          "title": "npm deps update",
+          "userLogin": "engelgabriel",
+          "milestone": "0.60.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "7953",
+          "title": "[FIX] username ellipsis on firefox",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7948",
+          "title": "[FIX] Document README.md. Drupal repo out of date",
+          "userLogin": "Lawri-van-Buel",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "Lawri-van-Buel"
+          ]
+        },
+        {
+          "pr": "7927",
+          "title": "[FIX] Double scroll on 'keyboard shortcuts' menu in sidepanel",
+          "userLogin": "aditya19496",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "aditya19496"
+          ]
+        },
+        {
+          "pr": "7943",
+          "title": "[FIX] Broken emoji picker on firefox",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7944",
+          "title": "[FIX] Broken embedded view layout",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7945",
+          "title": "[FIX] Fix placeholders in account profile",
+          "userLogin": "josiasds",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "josiasds"
+          ]
+        },
+        {
+          "pr": "7954",
+          "title": "[FIX] OTR buttons padding",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7960",
+          "title": "[FIX] status and active room colors on sidebar",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7941",
+          "title": "Update BlackDuck URL",
+          "userLogin": "engelgabriel",
+          "milestone": "0.59.0-rc.3",
+          "contributors": [
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7912",
+          "title": "[FIX] Fix google play logo on repo README",
+          "userLogin": "luizbills",
+          "milestone": "0.59.0-rc.2",
+          "contributors": [
+            "luizbills",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7904",
+          "title": "[FIX] Fix livechat toggle UI issue",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.59.0-rc.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7895",
+          "title": "[FIX] Remove break change in Realtime API",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7893",
+          "title": "[FIX] Window exception when parsing Markdown on server",
+          "userLogin": "rodrigok",
+          "milestone": "0.59.0-rc.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "7894",
+          "title": "Hide flex-tab close button",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.2",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7888",
+          "title": "[FIX] sidebar buttons and badge paddings",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7882",
+          "title": "[FIX] hyperlink style on sidebar footer",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7886",
+          "title": "[FIX] livechat icon",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7887",
+          "title": "[FIX] Makes text action menu width based on content size",
+          "userLogin": "gdelavald",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "7885",
+          "title": "[FIX] message actions over unread bar",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7883",
+          "title": "[FIX] popover position on mobile",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7881",
+          "title": "[FIX] search results position on sidebar",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7880",
+          "title": "[FIX] sidebar paddings",
+          "userLogin": "karlprieb",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "7878",
+          "title": "[FIX] Adds default search text padding for emoji search",
+          "userLogin": "gdelavald",
+          "milestone": "0.59.0-rc.1",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "6606",
+          "title": "Added RocketChatLauncher (SaaS)",
+          "userLogin": "designgurudotorg",
+          "milestone": "0.59.0",
+          "contributors": [
+            "designgurudotorg",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7866",
+          "title": "Develop sync",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok",
+            "web-flow",
+            "geekgonecrazy",
+            "engelgabriel",
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "8973",
+          "title": "Fix tag build",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8972",
+          "title": "Fix CircleCI deploy filter",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8967",
+          "title": "Release/0.59.4",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "cpitman",
+            "geekgonecrazy",
+            "karlprieb",
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8685",
+          "title": "Add CircleCI",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8753",
+          "title": "[FIX] Channel settings buttons",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb",
+            "geekgonecrazy",
+            "web-flow",
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.60.0-rc.1": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9092",
+          "title": "[NEW] Modal",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9111",
+          "title": "Fix: users listed as online after API login",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9110",
+          "title": "Fix regression in api channels.members",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9108",
+          "title": "[FIX] REST API file upload not respecting size limit",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9109",
+          "title": "[FIX] Creating channels on Firefox",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9095",
+          "title": "[FIX] Some UI problems on 0.60",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9094",
+          "title": "[FIX] Update rocketchat:streamer to be compatible with previous version",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        }
+      ]
+    },
+    "0.60.0-rc.2": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9137",
+          "title": "Fix: Clear all unreads modal not closing after confirming",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9138",
+          "title": "Fix: Message action quick buttons drops if \"new message\" divider is being shown",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9136",
+          "title": "Fix: Confirmation modals showing `Send` button",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9134",
+          "title": "[FIX] Importers not recovering when an error occurs",
+          "userLogin": "graywolf336",
+          "milestone": "0.60.0",
+          "contributors": [
+            "graywolf336",
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9121",
+          "title": "[FIX] Do not block room while loading history",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9120",
+          "title": "Fix: Multiple unread indicators",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9091",
+          "title": "[FIX] Channel page error",
+          "userLogin": "ggrish",
+          "milestone": "0.60.0",
+          "contributors": [
+            "ggrish",
+            "web-flow"
+          ]
+        }
+      ]
+    },
+    "0.60.0-rc.3": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9144",
+          "title": "Fix: Messages being displayed in reverse order",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9062",
+          "title": "[FIX] Update Rocket.Chat for sandstorm",
+          "userLogin": "peterlee0127",
+          "milestone": "0.60.0",
+          "contributors": [
+            "peterlee0127",
+            "web-flow"
+          ]
+        }
+      ]
+    },
+    "0.60.0-rc.4": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9171",
+          "title": "[FIX] modal data on enter and modal style for file preview",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9170",
+          "title": "[FIX] show oauth logins when adblock is used",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9169",
+          "title": "[FIX] Last sent message reoccurs in textbox",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9166",
+          "title": "Fix: UI: Descenders of glyphs are cut off",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9165",
+          "title": "Fix: Click on channel name - hover area bigger than link area",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9162",
+          "title": "Fix: Can’t login using LDAP via REST",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9149",
+          "title": "Fix: Unread line",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9146",
+          "title": "Fix test without oplog by waiting a successful login on changing users",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        }
+      ]
+    },
+    "0.60.0-rc.5": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9200",
+          "title": "Replace postcss-nesting with postcss-nested",
+          "userLogin": "engelgabriel",
+          "milestone": "0.60.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "9197",
+          "title": "Dependencies Update",
+          "userLogin": "engelgabriel",
+          "milestone": "0.60.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "9196",
+          "title": "Fix: Rooms and users are using different avatar style",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9193",
+          "title": "[FIX] Made welcome emails more readable",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.60.0",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9190",
+          "title": "Typo: German language file",
+          "userLogin": "TheReal1604",
+          "milestone": "0.60.0",
+          "contributors": [
+            "TheReal1604"
+          ]
+        },
+        {
+          "pr": "9188",
+          "title": "[FIX] Unread bar position when room have announcement",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9186",
+          "title": "[FIX] Emoji size on last message preview",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9185",
+          "title": "[FIX] Cursor position when reply on safari",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9184",
+          "title": "Fix: Snippet name to not showing in snippet list",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9183",
+          "title": "Fix/api me only return verified",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.60.0",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9182",
+          "title": "[FIX] \"Use Emoji\" preference not working",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9181",
+          "title": "Fix: UI: Descenders of glyphs are cut off",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9176",
+          "title": "[FIX] make the cross icon on user selection at channel creation page work",
+          "userLogin": "vitor-nagao",
+          "milestone": "0.60.0",
+          "contributors": [
+            "vitor-nagao",
+            "karlprieb",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9172",
+          "title": "[FIX] go to replied message",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9168",
+          "title": "[FIX] channel create scroll on small screens",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9066",
+          "title": "[NEW] Make Custom oauth accept nested usernameField",
+          "userLogin": "pierreozoux",
+          "milestone": "0.60.0",
+          "contributors": [
+            "pierreozoux",
+            "web-flow",
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "9040",
+          "title": "[FIX] Error when user roles is missing or is invalid",
+          "userLogin": "paulovitin",
+          "milestone": "0.60.0",
+          "contributors": [
+            "paulovitin",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8922",
+          "title": "[FIX] Make mentions and menu icons color darker",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb",
+            "rodrigok",
+            "web-flow"
+          ]
+        }
+      ]
+    },
+    "0.60.0-rc.6": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9241",
+          "title": "[FIX] Show modal with announcement",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9240",
+          "title": "Fix: Unneeded warning in payload of REST API calls",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9229",
+          "title": "Fix: Missing option to set user's avatar from a url",
+          "userLogin": "ggazzo",
+          "milestone": "0.60.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "9227",
+          "title": "Fix: updating last message on message edit or delete",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9217",
+          "title": "Fix: Username find is matching partially",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9215",
+          "title": "Fix: Upload access control too distributed",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9206",
+          "title": "[FIX] File upload not working on IE and weird on Chrome",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9194",
+          "title": "[FIX] \"Enter usernames\" placeholder is cutting in \"create channel\" view",
+          "userLogin": "TheReal1604",
+          "milestone": "0.60.0",
+          "contributors": [
+            "TheReal1604"
+          ]
+        }
+      ]
+    },
+    "0.60.0-rc.7": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9243",
+          "title": "[FIX] Move emojipicker css to theme package",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        }
+      ]
+    },
+    "0.60.0-rc.8": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9257",
+          "title": "Do not change room icon color when room is unread",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9256",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.60.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "9248",
+          "title": "Add curl, its missing on worker nodes so has to be explicitly added",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.60.0",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "9247",
+          "title": "Fix: Sidebar item on rtl and small devices",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        }
+      ]
+    },
+    "0.60.0": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9259",
+          "title": "Release 0.60.0",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "graywolf336",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8973",
+          "title": "Fix tag build",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8972",
+          "title": "Fix CircleCI deploy filter",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8967",
+          "title": "Release/0.59.4",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "cpitman",
+            "geekgonecrazy",
+            "karlprieb",
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "8685",
+          "title": "Add CircleCI",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8753",
+          "title": "[FIX] Channel settings buttons",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb",
+            "geekgonecrazy",
+            "web-flow",
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.60.1": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9262",
+          "title": "[FIX] File access not working when passing credentials via querystring",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.60.2": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9280",
+          "title": "Release 0.60.2",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9277",
+          "title": "[FIX] Restore translations from other languages",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9274",
+          "title": "[FIX] Remove sweetalert from livechat facebook integration page",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9272",
+          "title": "[FIX] Missing translations",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.60.3": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9320",
+          "title": "Release 0.60.3",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok",
+            "HammyHavoc"
+          ]
+        },
+        {
+          "pr": "9314",
+          "title": "[FIX] custom emoji size on sidebar item",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9311",
+          "title": "[FIX] svg render on firefox",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9249",
+          "title": "[FIX] sidebar footer padding",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9309",
+          "title": "[FIX] LDAP/AD is not importing all users",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.3",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9299",
+          "title": "Fix: English language improvements",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.60.3",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9291",
+          "title": "Fix: Change 'Wordpress' to 'WordPress",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.60.3",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9290",
+          "title": "Fix: Improved README.md",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.60.3",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9289",
+          "title": "[FIX] Wrong position of notifications alert in accounts preference page",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.60.3",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9286",
+          "title": "Fix: README typo",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.60.3",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9285",
+          "title": "[FIX] English Typos",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.60.3",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        }
+      ]
+    },
+    "0.60.4-rc.0": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9343",
+          "title": "[FIX] LDAP TLS not working in some cases",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.4",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9320",
+          "title": "Release 0.60.3",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok",
+            "HammyHavoc"
+          ]
+        }
+      ]
+    },
+    "0.60.4-rc.1": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9328",
+          "title": "[FIX] popover on safari for iOS",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.4",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9330",
+          "title": "[FIX] announcement hyperlink color",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.4",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9335",
+          "title": "[FIX] Deleting message with store last message not removing",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.4",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9345",
+          "title": "[FIX] last message cutting on bottom",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.4",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9346",
+          "title": "Update Marked dependecy to 0.3.9",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.4",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.60.4": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9377",
+          "title": "Release 0.60.4",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.4",
+          "contributors": [
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9320",
+          "title": "Release 0.60.3",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok",
+            "HammyHavoc"
+          ]
+        }
+      ]
+    },
+    "0.61.0-rc.0": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "8411",
+          "title": "[NEW] Contextual Bar Redesign",
+          "userLogin": "ggazzo",
+          "milestone": "0.61.0",
+          "contributors": [
+            "geekgonecrazy",
+            "sampaiodiego",
+            "MartinSchoeler",
+            "ggazzo",
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9369",
+          "title": "[FIX][i18n] add room type translation support for room-changed-privacy message",
+          "userLogin": "cyclops24",
+          "milestone": "0.61.0",
+          "contributors": [
+            "cyclops24"
+          ]
+        },
+        {
+          "pr": "9442",
+          "title": "[NEW] Update documentation: provide example for multiple basedn",
+          "userLogin": "rndmh3ro",
+          "milestone": "0.61.0",
+          "contributors": [
+            "rndmh3ro"
+          ]
+        },
+        {
+          "pr": "9452",
+          "title": "[FIX] Fix livechat register form",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.61.0",
+          "contributors": [
+            "sampaiodiego",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9451",
+          "title": "[FIX] Fix livechat build",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.61.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9164",
+          "title": "[FIX] Fix closing livechat inquiry",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.61.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9439",
+          "title": "Add community bot",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9435",
+          "title": "[FIX] Slash command 'unarchive' throws exception if the channel does not exist ",
+          "userLogin": "ramrami",
+          "milestone": "0.61.0",
+          "contributors": [
+            "ramrami",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9428",
+          "title": "[FIX] Slash command 'archive' throws exception if the channel does not exist",
+          "userLogin": "ramrami",
+          "milestone": "0.61.0",
+          "contributors": [
+            "ramrami",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9432",
+          "title": "[FIX] Subscriptions not removed when removing user",
+          "userLogin": "rodrigok",
+          "milestone": "0.61.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9216",
+          "title": "[NEW] Sidebar menu option to mark room as unread",
+          "userLogin": "karlprieb",
+          "milestone": "0.61.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9228",
+          "title": "[NEW] Add mention-here permission #7631",
+          "userLogin": "ryjones",
+          "milestone": "0.61.0",
+          "contributors": [
+            "ryjones",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9234",
+          "title": "[NEW] Indicate the Self DM room",
+          "userLogin": "rodrigok",
+          "milestone": "0.61.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9245",
+          "title": "[NEW] new layout for emojipicker",
+          "userLogin": "karlprieb",
+          "milestone": "0.61.0",
+          "contributors": [
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9364",
+          "title": "[FIX] Highlight setting not working correctly",
+          "userLogin": "cyclops24",
+          "milestone": "0.60.4",
+          "contributors": [
+            "cyclops24"
+          ]
+        },
+        {
+          "pr": "9366",
+          "title": "[NEW] add /home link to sidenav footer logo",
+          "userLogin": "cyclops24",
+          "contributors": [
+            "cyclops24"
+          ]
+        },
+        {
+          "pr": "9356",
+          "title": "Use correct version of Mailparser module",
+          "userLogin": "rodrigok",
+          "milestone": "0.61.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9330",
+          "title": "[FIX] announcement hyperlink color",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.4",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9328",
+          "title": "[FIX] popover on safari for iOS",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.4",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9345",
+          "title": "[FIX] last message cutting on bottom",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.4",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9346",
+          "title": "Update Marked dependecy to 0.3.9",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.4",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9335",
+          "title": "[FIX] Deleting message with store last message not removing",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.4",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9314",
+          "title": "[FIX] custom emoji size on sidebar item",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9311",
+          "title": "[FIX] svg render on firefox",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9249",
+          "title": "[FIX] sidebar footer padding",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.3",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9309",
+          "title": "[FIX] LDAP/AD is not importing all users",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.3",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9299",
+          "title": "Fix: English language improvements",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.60.3",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9291",
+          "title": "Fix: Change 'Wordpress' to 'WordPress",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.60.3",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9290",
+          "title": "Fix: Improved README.md",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.60.3",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9289",
+          "title": "[FIX] Wrong position of notifications alert in accounts preference page",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.60.3",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9286",
+          "title": "Fix: README typo",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.60.3",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9285",
+          "title": "[FIX] English Typos",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.60.3",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9277",
+          "title": "[FIX] Restore translations from other languages",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9274",
+          "title": "[FIX] Remove sweetalert from livechat facebook integration page",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9272",
+          "title": "[FIX] Missing translations",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9264",
+          "title": "[FIX] File access not working when passing credentials via querystring",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9135",
+          "title": "[NEW] Livechat extract lead data from message",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9107",
+          "title": "[NEW] Add impersonate option for livechat triggers",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9053",
+          "title": "[NEW] Add support to external livechat queue service provider",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9048",
+          "title": "[BREAK] Decouple livechat visitors from regular users",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9260",
+          "title": "Develop sync - Bump version to 0.61.0-develop",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "cpitman",
+            "geekgonecrazy",
+            "karlprieb",
+            "rodrigok",
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9257",
+          "title": "Do not change room icon color when room is unread",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9256",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.60.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "9247",
+          "title": "Fix: Sidebar item on rtl and small devices",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9248",
+          "title": "Add curl, its missing on worker nodes so has to be explicitly added",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.60.0",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "9243",
+          "title": "[FIX] Move emojipicker css to theme package",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9241",
+          "title": "[FIX] Show modal with announcement",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9240",
+          "title": "Fix: Unneeded warning in payload of REST API calls",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9229",
+          "title": "Fix: Missing option to set user's avatar from a url",
+          "userLogin": "ggazzo",
+          "milestone": "0.60.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "9215",
+          "title": "Fix: Upload access control too distributed",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9217",
+          "title": "Fix: Username find is matching partially",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9227",
+          "title": "Fix: updating last message on message edit or delete",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9194",
+          "title": "[FIX] \"Enter usernames\" placeholder is cutting in \"create channel\" view",
+          "userLogin": "TheReal1604",
+          "milestone": "0.60.0",
+          "contributors": [
+            "TheReal1604"
+          ]
+        },
+        {
+          "pr": "9206",
+          "title": "[FIX] File upload not working on IE and weird on Chrome",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9176",
+          "title": "[FIX] make the cross icon on user selection at channel creation page work",
+          "userLogin": "vitor-nagao",
+          "milestone": "0.60.0",
+          "contributors": [
+            "vitor-nagao",
+            "karlprieb",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9196",
+          "title": "Fix: Rooms and users are using different avatar style",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9200",
+          "title": "Replace postcss-nesting with postcss-nested",
+          "userLogin": "engelgabriel",
+          "milestone": "0.60.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "9197",
+          "title": "Dependencies Update",
+          "userLogin": "engelgabriel",
+          "milestone": "0.60.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "9193",
+          "title": "[FIX] Made welcome emails more readable",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.60.0",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9190",
+          "title": "Typo: German language file",
+          "userLogin": "TheReal1604",
+          "milestone": "0.60.0",
+          "contributors": [
+            "TheReal1604"
+          ]
+        },
+        {
+          "pr": "9184",
+          "title": "Fix: Snippet name to not showing in snippet list",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9183",
+          "title": "Fix/api me only return verified",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.60.0",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9185",
+          "title": "[FIX] Cursor position when reply on safari",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9186",
+          "title": "[FIX] Emoji size on last message preview",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9188",
+          "title": "[FIX] Unread bar position when room have announcement",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9040",
+          "title": "[FIX] Error when user roles is missing or is invalid",
+          "userLogin": "paulovitin",
+          "milestone": "0.60.0",
+          "contributors": [
+            "paulovitin",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8922",
+          "title": "[FIX] Make mentions and menu icons color darker",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9182",
+          "title": "[FIX] \"Use Emoji\" preference not working",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9181",
+          "title": "Fix: UI: Descenders of glyphs are cut off",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9066",
+          "title": "[NEW] Make Custom oauth accept nested usernameField",
+          "userLogin": "pierreozoux",
+          "milestone": "0.60.0",
+          "contributors": [
+            "pierreozoux",
+            "web-flow",
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "9168",
+          "title": "[FIX] channel create scroll on small screens",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9172",
+          "title": "[FIX] go to replied message",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9173",
+          "title": "[Fix] oauth not working because of email array",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.60.0",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9171",
+          "title": "[FIX] modal data on enter and modal style for file preview",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9170",
+          "title": "[FIX] show oauth logins when adblock is used",
+          "userLogin": "karlprieb",
+          "milestone": "0.60.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9165",
+          "title": "Fix: Click on channel name - hover area bigger than link area",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9166",
+          "title": "Fix: UI: Descenders of glyphs are cut off",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9169",
+          "title": "[FIX] Last sent message reoccurs in textbox",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9162",
+          "title": "Fix: Can’t login using LDAP via REST",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9149",
+          "title": "Fix: Unread line",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9146",
+          "title": "Fix test without oplog by waiting a successful login on changing users",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9062",
+          "title": "[FIX] Update Rocket.Chat for sandstorm",
+          "userLogin": "peterlee0127",
+          "milestone": "0.60.0",
+          "contributors": [
+            "peterlee0127",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9144",
+          "title": "Fix: Messages being displayed in reverse order",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9137",
+          "title": "Fix: Clear all unreads modal not closing after confirming",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9138",
+          "title": "Fix: Message action quick buttons drops if \"new message\" divider is being shown",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9136",
+          "title": "Fix: Confirmation modals showing `Send` button",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9134",
+          "title": "[FIX] Importers not recovering when an error occurs",
+          "userLogin": "graywolf336",
+          "milestone": "0.60.0",
+          "contributors": [
+            "graywolf336",
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9121",
+          "title": "[FIX] Do not block room while loading history",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9120",
+          "title": "Fix: Multiple unread indicators",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9091",
+          "title": "[FIX] Channel page error",
+          "userLogin": "ggrish",
+          "milestone": "0.60.0",
+          "contributors": [
+            "ggrish",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9377",
+          "title": "Release 0.60.4",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.4",
+          "contributors": [
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9320",
+          "title": "Release 0.60.3",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok",
+            "HammyHavoc"
+          ]
+        },
+        {
+          "pr": "9277",
+          "title": "[FIX] Restore translations from other languages",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9274",
+          "title": "[FIX] Remove sweetalert from livechat facebook integration page",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9272",
+          "title": "[FIX] Missing translations",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9262",
+          "title": "[FIX] File access not working when passing credentials via querystring",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.61.0-rc.1": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9469",
+          "title": "[DOCS] Update the links of our Mobile Apps in Features topic",
+          "userLogin": "rafaelks",
+          "contributors": [
+            "rafaelks",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9490",
+          "title": "Update license",
+          "userLogin": "frdmn",
+          "contributors": [
+            "frdmn",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9481",
+          "title": "[FIX] Contextual bar redesign",
+          "userLogin": "ggazzo",
+          "milestone": "0.61.0",
+          "contributors": [
+            "ggazzo",
+            "karlprieb",
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "9456",
+          "title": "[FIX] mention-here is missing i18n text #9455",
+          "userLogin": "ryjones",
+          "contributors": [
+            "ryjones"
+          ]
+        }
+      ]
+    },
+    "0.61.0-rc.2": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9506",
+          "title": "[FIX] Fix livechat visitor edit",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.61.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9510",
+          "title": "[NEW] Contextual bar mail messages",
+          "userLogin": "karlprieb",
+          "milestone": "0.61.0",
+          "contributors": [
+            "karlprieb",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9504",
+          "title": "Prevent NPM package-lock inside livechat",
+          "userLogin": "rodrigok",
+          "milestone": "0.61.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9493",
+          "title": "[FIX] large names on userinfo, and admin user bug on users with no usernames",
+          "userLogin": "ggazzo",
+          "milestone": "0.61.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow",
+            "gdelavald"
+          ]
+        }
+      ]
+    },
+    "0.61.0": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9533",
+          "title": "Release 0.61.0",
+          "userLogin": "rodrigok",
+          "milestone": "0.61.0",
+          "contributors": [
+            "rodrigok",
+            "karlprieb",
+            "web-flow",
+            "geekgonecrazy",
+            "engelgabriel",
+            "sampaiodiego",
+            "ryjones"
+          ]
+        },
+        {
+          "pr": "9377",
+          "title": "Release 0.60.4",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.4",
+          "contributors": [
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9320",
+          "title": "Release 0.60.3",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok",
+            "HammyHavoc"
+          ]
+        },
+        {
+          "pr": "9277",
+          "title": "[FIX] Restore translations from other languages",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9274",
+          "title": "[FIX] Remove sweetalert from livechat facebook integration page",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.60.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9272",
+          "title": "[FIX] Missing translations",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9262",
+          "title": "[FIX] File access not working when passing credentials via querystring",
+          "userLogin": "rodrigok",
+          "milestone": "0.60.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.61.1": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9721",
+          "title": "Release 0.61.1",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.61.2": {
+      "node_version": "8.9.3",
+      "npm_version": "5.5.1",
+      "pull_requests": [
+        {
+          "pr": "9786",
+          "title": "Release 0.61.2",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9750",
+          "title": "[FIX] Livechat issues on external queue and lead capture",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.61.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9776",
+          "title": "[FIX] Emoji rendering on last message",
+          "userLogin": "ggazzo",
+          "milestone": "0.61.2",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9772",
+          "title": "[FIX] Livechat conversation not receiving messages when start without form",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.61.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        }
+      ]
+    },
+    "0.62.0-rc.0": {
+      "node_version": "8.9.4",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "9796",
+          "title": "Sync from Master",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok",
+            "web-flow",
+            "HammyHavoc"
+          ]
+        },
+        {
+          "pr": "9793",
+          "title": "[NEW] Version update check",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9778",
+          "title": "[NEW] General alert banner",
+          "userLogin": "ggazzo",
+          "milestone": "0.62.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9642",
+          "title": "[NEW] Browse more channels / Directory",
+          "userLogin": "ggazzo",
+          "milestone": "0.62.0",
+          "contributors": [
+            "ggazzo",
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9665",
+          "title": "[FIX] Wrong behavior of rooms info's *Read Only* and *Collaborative* buttons",
+          "userLogin": "karlprieb",
+          "milestone": "0.62.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9457",
+          "title": "[NEW] Add user settings / preferences API endpoint",
+          "userLogin": "jgtoriginal",
+          "milestone": "0.62.0",
+          "contributors": [
+            "jgtoriginal",
+            "MarcosSpessatto",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9608",
+          "title": "[NEW] New sidebar layout",
+          "userLogin": "ggazzo",
+          "milestone": "0.62.0",
+          "contributors": [
+            "karlprieb",
+            "ggazzo",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9662",
+          "title": "[FIX] Close button on file upload bar was not working",
+          "userLogin": "karlprieb",
+          "milestone": "0.62.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9717",
+          "title": "[NEW] Message read receipts",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.62.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "7098",
+          "title": "[NEW] Alert admins when user requires approval & alert users when the account is approved/activated/deactivated",
+          "userLogin": "luisfn",
+          "milestone": "0.62.0",
+          "contributors": [
+            "luisfn"
+          ]
+        },
+        {
+          "pr": "9666",
+          "title": "[OTHER] Rocket.Chat Apps",
+          "userLogin": "graywolf336",
+          "milestone": "0.62.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "9772",
+          "title": "[FIX] Livechat conversation not receiving messages when start without form",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.61.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9776",
+          "title": "[FIX] Emoji rendering on last message",
+          "userLogin": "ggazzo",
+          "milestone": "0.61.2",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9753",
+          "title": "Move NRR package to inside the project and convert from CoffeeScript",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.0",
+          "contributors": [
+            "rodrigok",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9527",
+          "title": "[NEW] Allow configuration of SAML logout behavior",
+          "userLogin": "mrsimpson",
+          "milestone": "0.62.0",
+          "contributors": [
+            "mrsimpson",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9560",
+          "title": "[FIX] Chrome 64 breaks jitsi-meet iframe",
+          "userLogin": "speedy01",
+          "milestone": "0.62.0",
+          "contributors": [
+            "speedy01",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9697",
+          "title": "[FIX] Harmonize channel-related actions",
+          "userLogin": "mrsimpson",
+          "milestone": "0.62.0",
+          "contributors": [
+            "mrsimpson",
+            "engelgabriel",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9676",
+          "title": "[FIX] Custom emoji was cropping sometimes",
+          "userLogin": "anu-007",
+          "milestone": "0.62.0",
+          "contributors": [
+            "anu-007"
+          ]
+        },
+        {
+          "pr": "9696",
+          "title": "[FIX] Show custom room types icon in channel header",
+          "userLogin": "mrsimpson",
+          "milestone": "0.62.0",
+          "contributors": [
+            "mrsimpson",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8933",
+          "title": "[NEW] Internal hubot support for Direct Messages and Private Groups",
+          "userLogin": "ramrami",
+          "milestone": "0.62.0",
+          "contributors": [
+            "ramrami",
+            "web-flow",
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "9424",
+          "title": "[FIX] 'Query' support for channels.list.joined, groups.list, groups.listAll, im.list",
+          "userLogin": "xbolshe",
+          "milestone": "0.62.0",
+          "contributors": [
+            "xbolshe",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9298",
+          "title": "[NEW] Improved default welcome message",
+          "userLogin": "HammyHavoc",
+          "milestone": "0.62.0",
+          "contributors": [
+            "HammyHavoc",
+            "web-flow",
+            "engelgabriel",
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "9750",
+          "title": "[FIX] Livechat issues on external queue and lead capture",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.61.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9746",
+          "title": "[NEW] Makes shield icon configurable",
+          "userLogin": "c0dzilla",
+          "milestone": "0.62.0",
+          "contributors": [
+            "c0dzilla",
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9747",
+          "title": "[FIX] DeprecationWarning: prom-client ... when starting Rocket Chat server",
+          "userLogin": "jgtoriginal",
+          "milestone": "0.62.0",
+          "contributors": [
+            "jgtoriginal",
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9737",
+          "title": "[FIX] API to retrive rooms was returning empty objects",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.0",
+          "contributors": [
+            "rodrigok",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9687",
+          "title": "[NEW] Global message search (beta: disabled by default)",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.0",
+          "contributors": [
+            "cyberhck",
+            "savikko",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9487",
+          "title": "[FIX] Chat Message Reactions REST API End Point",
+          "userLogin": "jgtoriginal",
+          "milestone": "0.62.0",
+          "contributors": [
+            "jgtoriginal",
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "9312",
+          "title": "[NEW] Allow sounds when conversation is focused",
+          "userLogin": "RationalCoding",
+          "milestone": "0.62.0",
+          "contributors": [
+            "RationalCoding",
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "9519",
+          "title": "[NEW] API to fetch permissions & user roles",
+          "userLogin": "rafaelks",
+          "milestone": "0.62.0",
+          "contributors": [
+            "rafaelks",
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "9509",
+          "title": "[NEW] REST API to use Spotlight",
+          "userLogin": "rafaelks",
+          "milestone": "0.62.0",
+          "contributors": [
+            "rafaelks",
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "9546",
+          "title": "Update to meteor 1.6.1",
+          "userLogin": "engelgabriel",
+          "milestone": "0.62.0",
+          "contributors": [
+            "engelgabriel",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9720",
+          "title": "[FIX] Messages can't be quoted sometimes",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.61.1",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9716",
+          "title": "[FIX] GitLab OAuth does not work when GitLab’s URL ends with slash",
+          "userLogin": "rodrigok",
+          "milestone": "0.61.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9714",
+          "title": "[FIX] Close Livechat conversation by visitor not working in version 0.61.0",
+          "userLogin": "renatobecker",
+          "milestone": "0.61.1",
+          "contributors": [
+            "renatobecker"
+          ]
+        },
+        {
+          "pr": "9067",
+          "title": "[FIX] Formal pronouns and some small mistakes in German texts",
+          "userLogin": "AmShaegar13",
+          "milestone": "0.61.1",
+          "contributors": [
+            "AmShaegar13"
+          ]
+        },
+        {
+          "pr": "9640",
+          "title": "[FIX] Facebook integration in livechat not working on version 0.61.0",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.61.1",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow",
+            "renatobecker"
+          ]
+        },
+        {
+          "pr": "9623",
+          "title": "[FIX] Weird rendering of emojis at sidebar when `last message` is activated",
+          "userLogin": "ggazzo",
+          "milestone": "0.61.1",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "9699",
+          "title": "[NEW] Option to proxy files and avatars through the server",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.0",
+          "contributors": [
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9711",
+          "title": "[BREAK] Remove Graphics/Image Magick support",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8193",
+          "title": "[NEW] Allow request avatar placeholders as PNG or JPG instead of SVG",
+          "userLogin": "lindoelio",
+          "milestone": "0.62.0",
+          "contributors": [
+            "lindoelio",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9218",
+          "title": " [NEW] Image preview as 32x32 base64 jpeg",
+          "userLogin": "jorgeluisrezende",
+          "milestone": "0.62.0",
+          "contributors": [
+            "jorgeluisrezende",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9520",
+          "title": "[FIX] Rest API helpers only applying to v1",
+          "userLogin": "graywolf336",
+          "milestone": "0.62.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "9639",
+          "title": "[FIX] Desktop notification not showing when avatar came from external storage service",
+          "userLogin": "rodrigok",
+          "milestone": "0.61.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9454",
+          "title": "[FIX] Missing link Site URLs in enrollment e-mails",
+          "userLogin": "kemitchell",
+          "milestone": "0.62.0",
+          "contributors": [
+            "kemitchell"
+          ]
+        },
+        {
+          "pr": "9610",
+          "title": "[FIX] Missing string 'Username_already_exist' on the accountProfile page",
+          "userLogin": "lunaticmonk",
+          "milestone": "0.62.0",
+          "contributors": [
+            "lunaticmonk"
+          ]
+        },
+        {
+          "pr": "9507",
+          "title": "[NEW] New REST API to mark channel as read",
+          "userLogin": "rafaelks",
+          "milestone": "0.62.0",
+          "contributors": [
+            "rafaelks",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9549",
+          "title": "[NEW] Add route to get user shield/badge",
+          "userLogin": "kb0304",
+          "milestone": "0.62.0",
+          "contributors": [
+            "kb0304",
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "9570",
+          "title": "[FIX] SVG avatars are not been displayed correctly when load in non HTML containers",
+          "userLogin": "filipedelimabrito",
+          "milestone": "0.62.0",
+          "contributors": [
+            "filipedelimabrito"
+          ]
+        },
+        {
+          "pr": "9599",
+          "title": "[FIX] Livechat is not working when running in a sub path",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "8158",
+          "title": "[NEW] GraphQL API",
+          "userLogin": "kamilkisiela",
+          "milestone": "0.62.0",
+          "contributors": [
+            "kamilkisiela",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9255",
+          "title": "[NEW] Livestream tab",
+          "userLogin": "gdelavald",
+          "milestone": "0.62.0",
+          "contributors": [
+            "gdelavald"
+          ]
+        }
+      ]
+    },
+    "0.62.0-rc.1": {
+      "node_version": "8.9.4",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "9843",
+          "title": "Regression: Avatar now open account related options",
+          "userLogin": "karlprieb",
+          "milestone": "0.62.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9837",
+          "title": "Regression: Open search using ctrl/cmd + p and ctrl/cmd + k",
+          "userLogin": "karlprieb",
+          "milestone": "0.62.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9839",
+          "title": "Regression: Search bar is now full width",
+          "userLogin": "karlprieb",
+          "milestone": "0.62.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9658",
+          "title": "[NEW] Add documentation requirement to PRs",
+          "userLogin": "SeanPackham",
+          "contributors": [
+            "SeanPackham",
+            "web-flow",
+            "MartinSchoeler"
+          ]
+        },
+        {
+          "pr": "9807",
+          "title": "[NEW] Request mongoDB version in github issue template",
+          "userLogin": "TwizzyDizzy",
+          "contributors": [
+            "TwizzyDizzy",
+            "web-flow",
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "9802",
+          "title": "[FIX] Not receiving sound notifications in rooms created by new LiveChats",
+          "userLogin": "renatobecker",
+          "milestone": "0.62.0",
+          "contributors": [
+            "renatobecker"
+          ]
+        },
+        {
+          "pr": "9811",
+          "title": "Dependencies update",
+          "userLogin": "engelgabriel",
+          "milestone": "0.62.0",
+          "contributors": [
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "9821",
+          "title": "Fix: Custom fields not showing on user info panel",
+          "userLogin": "ggazzo",
+          "milestone": "0.62.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "9804",
+          "title": "Regression: Page was not respecting the window height on Firefox",
+          "userLogin": "MartinSchoeler",
+          "milestone": "0.62.0",
+          "contributors": [
+            "MartinSchoeler",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9784",
+          "title": "Update bot-config.yml",
+          "userLogin": "JSzaszvari",
+          "contributors": [
+            "JSzaszvari",
+            "web-flow",
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "9797",
+          "title": "Develop fix sync from master",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.62.0-rc.2": {
+      "node_version": "8.9.4",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "9851",
+          "title": "Regression: Change create channel icon",
+          "userLogin": "karlprieb",
+          "milestone": "0.62.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9852",
+          "title": "Regression: Fix channel icons on safari",
+          "userLogin": "karlprieb",
+          "milestone": "0.62.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9845",
+          "title": "Regression: Fix admin/user settings item text",
+          "userLogin": "karlprieb",
+          "milestone": "0.62.0",
+          "contributors": [
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9858",
+          "title": "[FIX] Silence the update check error message",
+          "userLogin": "graywolf336",
+          "milestone": "0.62.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        }
+      ]
+    },
+    "0.62.0-rc.3": {
+      "node_version": "8.9.4",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "9905",
+          "title": "Regression: Improve sidebar filter",
+          "userLogin": "karlprieb",
+          "milestone": "0.62.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9902",
+          "title": "[OTHER] Fix Apps not working on multi-instance deployments",
+          "userLogin": "graywolf336",
+          "milestone": "0.62.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "9877",
+          "title": "[Fix] Not Translated Phrases",
+          "userLogin": "bernardoetrevisan",
+          "milestone": "0.62.0",
+          "contributors": [
+            "bernardoetrevisan",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9884",
+          "title": "[FIX] Parsing messages with multiple markdown matches ignore some tokens",
+          "userLogin": "c0dzilla",
+          "milestone": "0.62.0",
+          "contributors": [
+            "c0dzilla"
+          ]
+        },
+        {
+          "pr": "9850",
+          "title": "[FIX] Importers no longer working due to the FileUpload changes",
+          "userLogin": "graywolf336",
+          "milestone": "0.62.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "9889",
+          "title": "Regression: Overlapping header in user profile panel",
+          "userLogin": "kaiiiiiiiii",
+          "milestone": "0.62.0",
+          "contributors": [
+            "kaiiiiiiiii"
+          ]
+        },
+        {
+          "pr": "9888",
+          "title": "[FIX] Misplaced \"Save Changes\" button in user account panel",
+          "userLogin": "kaiiiiiiiii",
+          "milestone": "0.62.0",
+          "contributors": [
+            "kaiiiiiiiii"
+          ]
+        },
+        {
+          "pr": "9897",
+          "title": "Regression: sort on room's list not working correctly",
+          "userLogin": "ggazzo",
+          "milestone": "0.62.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9879",
+          "title": "[FIX] Snap build was failing",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.62.0",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        }
+      ]
+    },
+    "0.62.0": {
+      "node_version": "8.9.4",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "9935",
+          "title": "Release 0.62.0",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok",
+            "web-flow",
+            "sampaiodiego",
+            "MartinSchoeler",
+            "renatobecker",
+            "engelgabriel",
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "9934",
+          "title": "[FIX] Typo on french translation for \"Open\"",
+          "userLogin": "sizrar",
+          "milestone": "0.62.0",
+          "contributors": [
+            "sizrar",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9928",
+          "title": "Regression: Fix livechat queue link",
+          "userLogin": "karlprieb",
+          "milestone": "0.62.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9931",
+          "title": "Regression: Directory now list default channel",
+          "userLogin": "karlprieb",
+          "milestone": "0.62.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9908",
+          "title": "Improve link handling for attachments",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9883",
+          "title": "Regression: Misplaced language dropdown in user preferences panel",
+          "userLogin": "kaiiiiiiiii",
+          "milestone": "0.62.0",
+          "contributors": [
+            "kaiiiiiiiii"
+          ]
+        },
+        {
+          "pr": "9901",
+          "title": "Fix RHCC image path for OpenShift and default to the current namespace.",
+          "userLogin": "jsm84",
+          "contributors": [
+            "jsm84",
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        }
+      ]
+    },
+    "0.62.1": {
+      "node_version": "8.9.4",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "9989",
+          "title": "Release 0.62.1",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9986",
+          "title": "[FIX] Delete user without username was removing direct rooms of all users",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.1",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9988",
+          "title": "[FIX] New channel page on medium size screens",
+          "userLogin": "karlprieb",
+          "milestone": "0.62.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9960",
+          "title": "[FIX] Empty sidenav when sorting by activity and there is a subscription without room",
+          "userLogin": "ggazzo",
+          "milestone": "0.62.1",
+          "contributors": [
+            "ggazzo",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9982",
+          "title": "[FIX] Two factor authentication modal was not showing",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.62.1",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow"
+          ]
+        }
+      ]
+    },
+    "0.62.2": {
+      "node_version": "8.9.4",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10087",
+          "title": "Release 0.62.2",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10071",
+          "title": "[FIX] Slack Import reports `invalid import file type` due to a call to BSON.native() which is now doesn't exist",
+          "userLogin": "trongthanh",
+          "milestone": "0.62.2",
+          "contributors": [
+            "trongthanh"
+          ]
+        },
+        {
+          "pr": "9719",
+          "title": "[FIX] Verified property of user is always set to false if not supplied",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.62.2",
+          "contributors": [
+            "MarcosSpessatto",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10076",
+          "title": "[FIX] Update preferences of users with settings: null was crashing the server",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10009",
+          "title": "[FIX] REST API: Can't list all public channels when user has permission `view-joined-room`",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.62.2",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10061",
+          "title": "[FIX] Message editing is crashing the server when read receipts are enabled",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.62.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10029",
+          "title": "[FIX] Download links was duplicating Sub Paths",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.63.0-rc.0": {
+      "node_version": "8.9.4",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10246",
+          "title": "[NEW] Interface to install and manage RocketChat Apps (alpha)",
+          "userLogin": "ggazzo",
+          "milestone": "0.63.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10243",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.63.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10012",
+          "title": "[FIX] \"View All Members\" button inside channel's \"User Info\" is over sized",
+          "userLogin": "karlprieb",
+          "milestone": "0.63.0",
+          "contributors": [
+            "karlprieb",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10242",
+          "title": "Revert \"[FIX] Apostrophe-containing URL misparsed\"",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10054",
+          "title": "[NEW] Livechat messages rest APIs",
+          "userLogin": "hmagarotto",
+          "milestone": "0.63.0",
+          "contributors": [
+            "hmagarotto",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9907",
+          "title": "[NEW] Endpoint to retrieve message read receipts",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.63.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10237",
+          "title": "Rename migration name on 108 to match file name",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10159",
+          "title": "Fix typo for Nextcloud login",
+          "userLogin": "pierreozoux",
+          "milestone": "0.63.0",
+          "contributors": [
+            "pierreozoux",
+            "web-flow",
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "10222",
+          "title": "[FIX] user status on sidenav",
+          "userLogin": "ggazzo",
+          "milestone": "0.63.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10152",
+          "title": "[FIX] Dynamic CSS script isn't working on older browsers",
+          "userLogin": "karlprieb",
+          "milestone": "0.63.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9816",
+          "title": "[NEW] Add option to login via REST using Facebook and Twitter tokens",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.63.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "9629",
+          "title": "[NEW] Add REST endpoint to get the list of custom emojis",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.63.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "9947",
+          "title": "[NEW] GDPR Right to be forgotten/erased",
+          "userLogin": "Hudell",
+          "milestone": "0.63.0",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "10105",
+          "title": "[NEW] Added endpoint to retrieve mentions of a channel",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.63.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10160",
+          "title": "[FIX] Extended view mode on sidebar",
+          "userLogin": "karlprieb",
+          "milestone": "0.63.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "10082",
+          "title": "[FIX] Cannot answer to a livechat as a manager if agent has not answered yet",
+          "userLogin": "kb0304",
+          "milestone": "0.63.0",
+          "contributors": [
+            "kb0304",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9584",
+          "title": "[NEW] Add leave public channel & leave private channel permissions",
+          "userLogin": "kb0304",
+          "milestone": "0.63.0",
+          "contributors": [
+            "kb0304",
+            "graywolf336",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10128",
+          "title": "[NEW] Added GET/POST channels.notifications",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.63.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10103",
+          "title": "[BREAK] Removed Private History Route",
+          "userLogin": "Hudell",
+          "milestone": "0.63.0",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "9866",
+          "title": "[FIX] User status missing on user info",
+          "userLogin": "lunaticmonk",
+          "milestone": "0.63.0",
+          "contributors": [
+            "lunaticmonk"
+          ]
+        },
+        {
+          "pr": "9672",
+          "title": "[FIX] Name of files in file upload list cuts down at bottom due to overflow",
+          "userLogin": "lunaticmonk",
+          "milestone": "0.63.0",
+          "contributors": [
+            "lunaticmonk"
+          ]
+        },
+        {
+          "pr": "9783",
+          "title": "[FIX] No pattern for user's status text capitalization",
+          "userLogin": "lunaticmonk",
+          "milestone": "0.63.0",
+          "contributors": [
+            "lunaticmonk"
+          ]
+        },
+        {
+          "pr": "9739",
+          "title": "[FIX] Apostrophe-containing URL misparsed",
+          "userLogin": "lunaticmonk",
+          "milestone": "0.63.0",
+          "contributors": [
+            "lunaticmonk"
+          ]
+        },
+        {
+          "pr": "9860",
+          "title": "[FIX] Popover divs don't scroll if they overflow the viewport",
+          "userLogin": "Joe-mcgee",
+          "milestone": "0.63.0",
+          "contributors": [
+            "Joe-mcgee",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10086",
+          "title": "[NEW] Reply preview",
+          "userLogin": "ubarsaiyan",
+          "milestone": "0.63.0",
+          "contributors": [
+            "ubarsaiyan",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10104",
+          "title": "[FIX] Reactions not working on mobile",
+          "userLogin": "ggazzo",
+          "milestone": "0.63.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10123",
+          "title": "[NEW] Support for agent's phone field",
+          "userLogin": "renatobecker",
+          "milestone": "0.63.0",
+          "contributors": [
+            "renatobecker"
+          ]
+        },
+        {
+          "pr": "9872",
+          "title": "[FIX] Broken video call accept dialog",
+          "userLogin": "ramrami",
+          "milestone": "0.63.0",
+          "contributors": [
+            "ramrami"
+          ]
+        },
+        {
+          "pr": "10081",
+          "title": "[FIX] Wrong switch button border color",
+          "userLogin": "kb0304",
+          "milestone": "0.63.0",
+          "contributors": [
+            "kb0304"
+          ]
+        },
+        {
+          "pr": "10154",
+          "title": "Add a few listener supports for the Rocket.Chat Apps",
+          "userLogin": "graywolf336",
+          "milestone": "0.63.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10148",
+          "title": "Add forums as a place to suggest, discuss and upvote features",
+          "userLogin": "SeanPackham",
+          "contributors": [
+            "SeanPackham",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10090",
+          "title": "[FIX] Nextcloud as custom oauth provider wasn't mapping data correctly",
+          "userLogin": "pierreozoux",
+          "milestone": "0.63.0",
+          "contributors": [
+            "pierreozoux",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10144",
+          "title": "[NEW] Added endpoint to get the list of available oauth services",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.63.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10016",
+          "title": "[FIX] Missing sidebar default options on admin",
+          "userLogin": "karlprieb",
+          "milestone": "0.63.0",
+          "contributors": [
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "8667",
+          "title": "[FIX] Able to react with invalid emoji",
+          "userLogin": "mutdmour",
+          "milestone": "0.63.0",
+          "contributors": [
+            "mutdmour",
+            "rodrigok",
+            "web-flow",
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "9742",
+          "title": "[NEW] REST API method to set room's announcement (channels.setAnnouncement)",
+          "userLogin": "TopHattedCat",
+          "milestone": "0.63.0",
+          "contributors": [
+            "TopHattedCat",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9726",
+          "title": "[NEW] Audio recording as mp3 and better ui for recording",
+          "userLogin": "kb0304",
+          "milestone": "0.63.0",
+          "contributors": [
+            "kb0304",
+            "rodrigok",
+            "web-flow",
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "9732",
+          "title": "[NEW] Setting to configure max delta for 2fa",
+          "userLogin": "Hudell",
+          "milestone": "0.63.0",
+          "contributors": [
+            "Hudell",
+            "web-flow",
+            "engelgabriel",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9870",
+          "title": "[NEW] Livechat webhook request on message",
+          "userLogin": "hmagarotto",
+          "milestone": "0.63.0",
+          "contributors": [
+            "hmagarotto",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10071",
+          "title": "[FIX] Slack Import reports `invalid import file type` due to a call to BSON.native() which is now doesn't exist",
+          "userLogin": "trongthanh",
+          "milestone": "0.62.2",
+          "contributors": [
+            "trongthanh"
+          ]
+        },
+        {
+          "pr": "9719",
+          "title": "[FIX] Verified property of user is always set to false if not supplied",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.62.2",
+          "contributors": [
+            "MarcosSpessatto",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10076",
+          "title": "[FIX] Update preferences of users with settings: null was crashing the server",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10065",
+          "title": "Fix tests breaking randomly",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10009",
+          "title": "[FIX] REST API: Can't list all public channels when user has permission `view-joined-room`",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.62.2",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10061",
+          "title": "[FIX] Message editing is crashing the server when read receipts are enabled",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.62.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10029",
+          "title": "[FIX] Download links was duplicating Sub Paths",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10051",
+          "title": "[FIX] User preferences can't be saved when roles are hidden in admin settings",
+          "userLogin": "Hudell",
+          "milestone": "0.63.0",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "9367",
+          "title": "[NEW] Announcement bar color wasn't using color from theming variables",
+          "userLogin": "cyclops24",
+          "milestone": "0.63.0",
+          "contributors": [
+            "cyclops24",
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9932",
+          "title": "[FIX] Browser was auto-filling values when editing another user profile",
+          "userLogin": "kaiiiiiiiii",
+          "milestone": "0.63.0",
+          "contributors": [
+            "kaiiiiiiiii"
+          ]
+        },
+        {
+          "pr": "10011",
+          "title": "[FIX] Avatar input was accepting not supported image types",
+          "userLogin": "karlprieb",
+          "milestone": "0.63.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "10028",
+          "title": "[FIX] Initial loading feedback was missing",
+          "userLogin": "karlprieb",
+          "milestone": "0.63.0",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "10036",
+          "title": "[OTHER] Reactivate all tests",
+          "userLogin": "rodrigok",
+          "milestone": "0.63.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9844",
+          "title": "[OTHER] Reactivate API tests",
+          "userLogin": "karlprieb",
+          "contributors": [
+            "karlprieb",
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "9986",
+          "title": "[FIX] Delete user without username was removing direct rooms of all users",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.1",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9982",
+          "title": "[FIX] Two factor authentication modal was not showing",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.62.1",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9960",
+          "title": "[FIX] Empty sidenav when sorting by activity and there is a subscription without room",
+          "userLogin": "ggazzo",
+          "milestone": "0.62.1",
+          "contributors": [
+            "ggazzo",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9988",
+          "title": "[FIX] New channel page on medium size screens",
+          "userLogin": "karlprieb",
+          "milestone": "0.62.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9985",
+          "title": "Start 0.63.0-develop / develop sync from master",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10087",
+          "title": "Release 0.62.2",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9986",
+          "title": "[FIX] Delete user without username was removing direct rooms of all users",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.1",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9988",
+          "title": "[FIX] New channel page on medium size screens",
+          "userLogin": "karlprieb",
+          "milestone": "0.62.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9960",
+          "title": "[FIX] Empty sidenav when sorting by activity and there is a subscription without room",
+          "userLogin": "ggazzo",
+          "milestone": "0.62.1",
+          "contributors": [
+            "ggazzo",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9982",
+          "title": "[FIX] Two factor authentication modal was not showing",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.62.1",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow"
+          ]
+        }
+      ]
+    },
+    "0.63.0-rc.1": {
+      "node_version": "8.9.4",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10272",
+          "title": "[FIX] File had redirect delay when using external storage services and no option to proxy only avatars",
+          "userLogin": "rodrigok",
+          "milestone": "0.63.0",
+          "contributors": [
+            "rodrigok",
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10257",
+          "title": "Fix: Renaming channels.notifications Get/Post endpoints",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.63.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10262",
+          "title": "[FIX] Missing pt-BR translations",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.63.0",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10240",
+          "title": "[FIX] /me REST endpoint was missing user roles and preferences",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.63.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10260",
+          "title": "Fix caddy download link to pull from github",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.63.0",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10252",
+          "title": "Fix: possible errors on rocket.chat side of the apps",
+          "userLogin": "graywolf336",
+          "milestone": "0.63.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10015",
+          "title": "Fix snap install. Remove execstack from sharp, and bypass grpc error",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.63.0",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        }
+      ]
+    },
+    "0.63.0-rc.2": {
+      "node_version": "8.9.4",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10078",
+          "title": "[FIX] Unable to mention after newline in message",
+          "userLogin": "c0dzilla",
+          "milestone": "0.63.0",
+          "contributors": [
+            "c0dzilla"
+          ]
+        },
+        {
+          "pr": "10224",
+          "title": "[FIX] Wrong pagination information on /api/v1/channels.members",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.63.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10163",
+          "title": "[FIX] Inline code following a url leads to autolinking of code with url",
+          "userLogin": "c0dzilla",
+          "milestone": "0.63.0",
+          "contributors": [
+            "c0dzilla"
+          ]
+        },
+        {
+          "pr": "10258",
+          "title": "[FIX] Incoming Webhooks were missing the raw content",
+          "userLogin": "Hudell",
+          "milestone": "0.63.0",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "10270",
+          "title": "[FIX] Missing Translation Key on Reactions",
+          "userLogin": "bernardoetrevisan",
+          "milestone": "0.63.0",
+          "contributors": [
+            "bernardoetrevisan",
+            "web-flow",
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10274",
+          "title": "Fix: inputs for rocketchat apps",
+          "userLogin": "ggazzo",
+          "milestone": "0.63.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow",
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10290",
+          "title": "Fix: chat.react api not accepting previous emojis",
+          "userLogin": "graywolf336",
+          "milestone": "0.63.0",
+          "contributors": [
+            "graywolf336",
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10300",
+          "title": "Fix: Scroll on content page",
+          "userLogin": "ggazzo",
+          "milestone": "0.63.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        }
+      ]
+    },
+    "0.63.0": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10324",
+          "title": "Release 0.63.0",
+          "userLogin": "rodrigok",
+          "milestone": "0.63.0",
+          "contributors": [
+            "kb0304",
+            "MarcosSpessatto",
+            "hmagarotto",
+            "engelgabriel",
+            "web-flow",
+            "TopHattedCat",
+            "karlprieb",
+            "Joe-mcgee",
+            "lunaticmonk",
+            "ramrami",
+            "kaiiiiiiiii",
+            "Hudell",
+            "ggazzo",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10087",
+          "title": "Release 0.62.2",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9986",
+          "title": "[FIX] Delete user without username was removing direct rooms of all users",
+          "userLogin": "rodrigok",
+          "milestone": "0.62.1",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9988",
+          "title": "[FIX] New channel page on medium size screens",
+          "userLogin": "karlprieb",
+          "milestone": "0.62.1",
+          "contributors": [
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "9960",
+          "title": "[FIX] Empty sidenav when sorting by activity and there is a subscription without room",
+          "userLogin": "ggazzo",
+          "milestone": "0.62.1",
+          "contributors": [
+            "ggazzo",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9982",
+          "title": "[FIX] Two factor authentication modal was not showing",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.62.1",
+          "contributors": [
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10303",
+          "title": "[FIX] Audio Message UI fixes",
+          "userLogin": "kb0304",
+          "contributors": [
+            "kb0304",
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10319",
+          "title": "[NEW] Improve history generation",
+          "userLogin": "rodrigok",
+          "milestone": "0.63.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10323",
+          "title": "Fix: Reaction endpoint/api only working with regular emojis",
+          "userLogin": "graywolf336",
+          "milestone": "0.63.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10313",
+          "title": "Bump snap version to include security fix",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.63.0",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10314",
+          "title": "Update Meteor to 1.6.1.1",
+          "userLogin": "rodrigok",
+          "milestone": "0.63.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.63.1": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10374",
+          "title": "Release 0.63.1",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "TechyPeople",
+            "web-flow",
+            "tttt-conan",
+            "rodrigok",
+            "geekgonecrazy",
+            "graywolf336",
+            "kaiiiiiiiii",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10324",
+          "title": "Release 0.63.0",
+          "userLogin": "rodrigok",
+          "milestone": "0.63.0",
+          "contributors": [
+            "kb0304",
+            "MarcosSpessatto",
+            "hmagarotto",
+            "engelgabriel",
+            "web-flow",
+            "TopHattedCat",
+            "karlprieb",
+            "Joe-mcgee",
+            "lunaticmonk",
+            "ramrami",
+            "kaiiiiiiiii",
+            "Hudell",
+            "ggazzo",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10324",
+          "title": "Release 0.63.0",
+          "userLogin": "rodrigok",
+          "milestone": "0.63.0",
+          "contributors": [
+            "kb0304",
+            "MarcosSpessatto",
+            "hmagarotto",
+            "engelgabriel",
+            "web-flow",
+            "TopHattedCat",
+            "karlprieb",
+            "Joe-mcgee",
+            "lunaticmonk",
+            "ramrami",
+            "kaiiiiiiiii",
+            "Hudell",
+            "ggazzo",
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.63.2": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10476",
+          "title": "Release 0.63.2",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "graywolf336",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10408",
+          "title": "add redhat dockerfile to master",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        }
+      ]
+    },
+    "0.63.3": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10504",
+          "title": "Release 0.63.3",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "rafaelks",
+            "graywolf336"
+          ]
+        }
+      ]
+    },
+    "0.64.0-rc.0": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10532",
+          "title": "Included missing lib for migrations",
+          "userLogin": "Hudell",
+          "milestone": "0.64.0",
+          "contributors": [
+            "Hudell",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10502",
+          "title": "[NEW] Option to mute group mentions (@all and @here)",
+          "userLogin": "Hudell",
+          "milestone": "0.64.0",
+          "contributors": [
+            "Hudell",
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "9906",
+          "title": "[NEW] GDPR - Right to access and Data Portability",
+          "userLogin": "Hudell",
+          "milestone": "0.64.0",
+          "contributors": [
+            "Hudell",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9922",
+          "title": "[BREAK] Validate incoming message schema",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.64.0",
+          "contributors": [
+            "MarcosSpessatto",
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "9950",
+          "title": "[NEW] Broadcast Channels",
+          "userLogin": "ggazzo",
+          "milestone": "0.64.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow",
+            "sampaiodiego",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10480",
+          "title": "[FIX] Add user object to responses in /*.files Rest endpoints",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.64.0",
+          "contributors": [
+            "MarcosSpessatto",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10517",
+          "title": "[NEW] Option to ignore users on channels",
+          "userLogin": "ggazzo",
+          "milestone": "0.64.0",
+          "contributors": [
+            "ggazzo",
+            "gdelavald",
+            "web-flow",
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "10110",
+          "title": "[NEW] Search Provider Framework",
+          "userLogin": "tkurz",
+          "milestone": "0.64.0",
+          "contributors": [
+            "tkurz",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10473",
+          "title": "[FIX] Missing user data on files uploaded through the API",
+          "userLogin": "Hudell",
+          "milestone": "0.64.0",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "10498",
+          "title": "[FIX] Rename method to clean history of messages",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.64.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10410",
+          "title": "[FIX] REST spotlight API wasn't allowing searches with # and @",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.64.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10505",
+          "title": "Develop sync",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow",
+            "graywolf336",
+            "nsuchy",
+            "rodrigok",
+            "rafaelks",
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "10442",
+          "title": "[NEW] REST API endpoint `/directory`",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.64.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10482",
+          "title": "[FIX] Dropdown elements were using old styles",
+          "userLogin": "kaiiiiiiiii",
+          "milestone": "0.64.0",
+          "contributors": [
+            "kaiiiiiiiii"
+          ]
+        },
+        {
+          "pr": "10513",
+          "title": "Fix: Remove \"secret\" from REST endpoint /settings.oauth response",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.64.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10403",
+          "title": "[FIX] Directory sort and column sizes were wrong",
+          "userLogin": "ggazzo",
+          "milestone": "0.64.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow",
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "10299",
+          "title": "[FIX] REST API OAuth services endpoint were missing fields and flag to indicate custom services",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.64.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10446",
+          "title": "[FIX] Error messages weren't been displayed when email verification fails",
+          "userLogin": "Hudell",
+          "milestone": "0.64.0",
+          "contributors": [
+            "Hudell",
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10454",
+          "title": "[FIX] Wrong column positions in the directory search for users",
+          "userLogin": "lunaticmonk",
+          "milestone": "0.64.0",
+          "contributors": [
+            "lunaticmonk",
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10463",
+          "title": "[FIX] Custom fields was misaligned in registration form",
+          "userLogin": "dschuan",
+          "milestone": "0.64.0",
+          "contributors": [
+            "dschuan",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10341",
+          "title": "[FIX] Unique identifier file not really being unique",
+          "userLogin": "abernix",
+          "milestone": "0.64.0",
+          "contributors": [
+            "abernix",
+            "web-flow",
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "10335",
+          "title": "[OTHER] More Listeners for Apps & Utilize Promises inside Apps",
+          "userLogin": "graywolf336",
+          "milestone": "0.64.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10404",
+          "title": "[FIX] Empty panel after changing a user's username",
+          "userLogin": "Hudell",
+          "milestone": "0.64.0",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "10418",
+          "title": " [FIX] Russian translation of \"False\"",
+          "userLogin": "strangerintheq",
+          "contributors": [
+            "strangerintheq",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10496",
+          "title": "[FIX] Links being embedded inside of blockquotes",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.0",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "10485",
+          "title": "[FIX] The 'channel.messages' REST API Endpoint error",
+          "userLogin": "rafaelks",
+          "milestone": "0.64.0",
+          "contributors": [
+            "rafaelks",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10487",
+          "title": "[OTHER] Develop sync",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow",
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10358",
+          "title": "[FIX] Button on user info contextual bar scrolling with the content",
+          "userLogin": "okaybroda",
+          "milestone": "0.64.0",
+          "contributors": [
+            "okaybroda",
+            "ggazzo",
+            "web-flow",
+            "karlprieb",
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "9824",
+          "title": "[FIX] \"Idle Time Limit\" using milliseconds instead of seconds",
+          "userLogin": "kaiiiiiiiii",
+          "milestone": "0.64.0",
+          "contributors": [
+            "kaiiiiiiiii",
+            "web-flow",
+            "geekgonecrazy",
+            "sampaiodiego",
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10259",
+          "title": "[NEW] Body of the payload on an incoming webhook is included on the request object",
+          "userLogin": "Hudell",
+          "milestone": "0.64.0",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "10387",
+          "title": "[FIX] Missing i18n translation key for \"Unread\"",
+          "userLogin": "Hudell",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "9729",
+          "title": "[FIX] Owner unable to delete channel or group from APIs",
+          "userLogin": "c0dzilla",
+          "milestone": "0.64.0",
+          "contributors": [
+            "c0dzilla",
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10371",
+          "title": "[NEW] REST endpoint to recover forgotten password",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.64.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10354",
+          "title": "[NEW] REST endpoint to report messages",
+          "userLogin": "MarcosSpessatto",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10108",
+          "title": "[NEW] Livechat setting to customize ended conversation message",
+          "userLogin": "renatobecker",
+          "milestone": "0.64.0",
+          "contributors": [
+            "renatobecker"
+          ]
+        },
+        {
+          "pr": "10369",
+          "title": "[FIX] Livechat translation files being ignored",
+          "userLogin": "renatobecker",
+          "milestone": "0.64.0",
+          "contributors": [
+            "renatobecker",
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "7964",
+          "title": "[NEW] Twilio MMS support for LiveChat integration",
+          "userLogin": "t3hchipmunk",
+          "milestone": "0.64.0",
+          "contributors": [
+            "t3hchipmunk",
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "6673",
+          "title": "[FIX] Missing page \"not found\"",
+          "userLogin": "Prakharsvnit",
+          "milestone": "0.64.0",
+          "contributors": [
+            "Prakharsvnit",
+            "web-flow",
+            "geekgonecrazy",
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "10083",
+          "title": "[FIX] \"Highlight Words\" wasn't working with more than one word",
+          "userLogin": "nemaniarjun",
+          "milestone": "0.64.0",
+          "contributors": [
+            "nemaniarjun",
+            "gdelavald",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10171",
+          "title": "[FIX] Missing \"Administration\" menu for user with manage-emoji permission",
+          "userLogin": "c0dzilla",
+          "milestone": "0.64.0",
+          "contributors": [
+            "c0dzilla",
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10395",
+          "title": "[FIX] Message view mode setting was missing at user's preferences ",
+          "userLogin": "kaiiiiiiiii",
+          "milestone": "0.64.0",
+          "contributors": [
+            "kaiiiiiiiii",
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10399",
+          "title": "[FIX] Profile image was not being shown in user's directory search",
+          "userLogin": "lunaticmonk",
+          "milestone": "0.64.0",
+          "contributors": [
+            "lunaticmonk",
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10342",
+          "title": "[NEW] REST API endpoint `rooms.favorite` to favorite and unfavorite rooms",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.64.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10428",
+          "title": "[FIX] Wrong positioning of popover when using RTL languages",
+          "userLogin": "ggazzo",
+          "milestone": "0.64.0",
+          "contributors": [
+            "ggazzo",
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10472",
+          "title": "[FIX] Messages was grouping wrong some times when server is slow",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.0",
+          "contributors": [
+            "gdelavald",
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10225",
+          "title": "[FIX] GitLab authentication scope was too open, reduced to read only access",
+          "userLogin": "rafaelks",
+          "milestone": "0.64.0",
+          "contributors": [
+            "rafaelks",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10344",
+          "title": "[FIX] Renaming agent's username within Livechat's department",
+          "userLogin": "renatobecker",
+          "milestone": "0.64.0",
+          "contributors": [
+            "renatobecker"
+          ]
+        },
+        {
+          "pr": "10394",
+          "title": "[FIX] Missing RocketApps input types",
+          "userLogin": "ggazzo",
+          "milestone": "0.64.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow",
+            "graywolf336",
+            "karlprieb"
+          ]
+        },
+        {
+          "pr": "10221",
+          "title": "[FIX] Livechat desktop notifications not being displayed",
+          "userLogin": "renatobecker",
+          "milestone": "0.64.0",
+          "contributors": [
+            "renatobecker",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10336",
+          "title": "Change Docker-Compose to use mmapv1 storage engine for mongo",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.64.0",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10396",
+          "title": "[NEW] Add internal API to handle room announcements",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.0",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "10409",
+          "title": "[FIX] Autocomplete list when inviting a user was partial hidden",
+          "userLogin": "karlprieb",
+          "milestone": "0.64.0",
+          "contributors": [
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10423",
+          "title": "[FIX] Remove a user from the user's list when creating a new channel removes the wrong user",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.0",
+          "contributors": [
+            "gdelavald",
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10430",
+          "title": "[FIX] Room's name was cutting instead of having ellipses on sidebar",
+          "userLogin": "ggazzo",
+          "milestone": "0.64.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "10435",
+          "title": "Add some missing translations",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.0",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "10437",
+          "title": "[NEW] Add message preview when quoting another message",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.0",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "10438",
+          "title": "[FIX] Button to delete rooms by the owners wasn't appearing",
+          "userLogin": "ggazzo",
+          "milestone": "0.64.0",
+          "contributors": [
+            "ggazzo",
+            "karlprieb",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10439",
+          "title": "[NEW] Prevent the browser to autocomplete some setting fields",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.0",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "10441",
+          "title": "[OTHER] Removed the developer warning on the rest api",
+          "userLogin": "graywolf336",
+          "milestone": "0.64.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10444",
+          "title": "[NEW] Shows user's real name on autocomplete popup",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.0",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "10414",
+          "title": "[NEW] Automatically trigger Redhat registry build when tagging new release",
+          "userLogin": "geekgonecrazy",
+          "milestone": "0.64.0",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "10397",
+          "title": "Fix and improve vietnamese translation",
+          "userLogin": "tttt-conan",
+          "contributors": [
+            "tttt-conan",
+            "TDiNguyen",
+            "graywolf336",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10411",
+          "title": "[BREAK] The property \"settings\" is no longer available to regular users via rest api",
+          "userLogin": "graywolf336",
+          "milestone": "0.64.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "9946",
+          "title": "[FIX] Updated OpenShift Template to take an Image as a Param",
+          "userLogin": "christianh814",
+          "contributors": [
+            "christianh814",
+            "web-flow",
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "10405",
+          "title": "Use Node 8.9 for CI build",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "9576",
+          "title": "[FIX] Incoming integrations being able to trigger an empty message with a GET",
+          "userLogin": "graywolf336",
+          "milestone": "0.64.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10360",
+          "title": "Update allowed labels for bot",
+          "userLogin": "TwizzyDizzy",
+          "contributors": [
+            "TwizzyDizzy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10384",
+          "title": "Remove @core team mention from Pull Request template",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.0",
+          "contributors": [
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10390",
+          "title": "[FIX] Snaps installations are breaking on avatar requests",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10234",
+          "title": "New issue template for *Release Process*",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.0",
+          "contributors": [
+            "rodrigok",
+            "geekgonecrazy",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10376",
+          "title": "Master into Develop Branch Sync",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "sampaiodiego",
+            "rodrigok",
+            "web-flow",
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10504",
+          "title": "Release 0.63.3",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "rafaelks",
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10476",
+          "title": "Release 0.63.2",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "graywolf336",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10408",
+          "title": "add redhat dockerfile to master",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        }
+      ]
+    },
+    "0.64.0-rc.1": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10545",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.64.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10544",
+          "title": "Regression: Revert announcement structure",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.0",
+          "contributors": [
+            "gdelavald",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10543",
+          "title": "Regression: Upload was not working",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.64.0-rc.2": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10549",
+          "title": "Deps update",
+          "userLogin": "engelgabriel",
+          "milestone": "0.64.0",
+          "contributors": [
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10560",
+          "title": "Regression: /api/v1/settings.oauth not returning clientId for Twitter",
+          "userLogin": "cardoso",
+          "milestone": "0.64.0",
+          "contributors": [
+            "cardoso",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10555",
+          "title": "Regression: Webhooks breaking due to restricted test",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10559",
+          "title": "Regression: Rooms and Apps weren't playing nice with each other",
+          "userLogin": "graywolf336",
+          "milestone": "0.64.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10554",
+          "title": "Regression: Fix announcement bar being displayed without content",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.0",
+          "contributors": [
+            "gdelavald"
+          ]
+        }
+      ]
+    },
+    "0.64.0-rc.3": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10550",
+          "title": "[FIX] Wordpress oAuth authentication wasn't behaving correctly",
+          "userLogin": "kaiiiiiiiii",
+          "milestone": "0.64.0",
+          "contributors": [
+            "kaiiiiiiiii"
+          ]
+        },
+        {
+          "pr": "10553",
+          "title": "Regression: Inconsistent response of settings.oauth endpoint",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.64.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10571",
+          "title": "Regression: Remove added mentions on quote/reply",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.0",
+          "contributors": [
+            "gdelavald",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10573",
+          "title": "Regression: Attachments and fields incorrectly failing on validation",
+          "userLogin": "graywolf336",
+          "milestone": "0.64.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        }
+      ]
+    },
+    "0.64.0-rc.4": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10558",
+          "title": "[FIX] Switch buttons were cutting in RTL mode",
+          "userLogin": "ggazzo",
+          "milestone": "0.64.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10574",
+          "title": "[NEW] Add information regarding Zapier and Bots to the integrations page",
+          "userLogin": "graywolf336",
+          "milestone": "0.64.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10575",
+          "title": "Regression: Rocket.Chat App author link opens in same window",
+          "userLogin": "kaiiiiiiiii",
+          "milestone": "0.64.0",
+          "contributors": [
+            "kaiiiiiiiii",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10503",
+          "title": "[FIX] Stop Firefox announcement overflowing viewport",
+          "userLogin": "brendangadd",
+          "milestone": "0.64.0",
+          "contributors": [
+            "brendangadd",
+            "web-flow"
+          ]
+        }
+      ]
+    },
+    "0.64.0": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10613",
+          "title": "Release 0.64.0",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.0",
+          "contributors": [
+            "rodrigok",
+            "geekgonecrazy",
+            "web-flow",
+            "graywolf336",
+            "TwizzyDizzy",
+            "christianh814",
+            "tttt-conan",
+            "gdelavald",
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "10504",
+          "title": "Release 0.63.3",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "rafaelks",
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10476",
+          "title": "Release 0.63.2",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "graywolf336",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10408",
+          "title": "add redhat dockerfile to master",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        },
+        {
+          "pr": "10591",
+          "title": "Regression: Various search provider fixes",
+          "userLogin": "tkurz",
+          "milestone": "0.64.0",
+          "contributors": [
+            "tkurz",
+            "web-flow",
+            "engelgabriel",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10596",
+          "title": "Regression: /api/v1/settings.oauth not sending needed info for SAML & CAS",
+          "userLogin": "cardoso",
+          "milestone": "0.64.0",
+          "contributors": [
+            "cardoso",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10598",
+          "title": "Regression: Apps and Livechats not getting along well with each other",
+          "userLogin": "graywolf336",
+          "milestone": "0.64.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10551",
+          "title": " [FIX] Missing \"Administration\" menu for users with some administration permissions",
+          "userLogin": "kaiiiiiiiii",
+          "milestone": "0.64.0",
+          "contributors": [
+            "kaiiiiiiiii"
+          ]
+        },
+        {
+          "pr": "10599",
+          "title": "[FIX] Member list search with no results",
+          "userLogin": "ggazzo",
+          "milestone": "0.64.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "10586",
+          "title": "Development: Add Visual Studio Code debugging configuration",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10576",
+          "title": "[FIX] Integrations with room data not having the usernames filled in",
+          "userLogin": "graywolf336",
+          "milestone": "0.64.0",
+          "contributors": [
+            "graywolf336",
+            "sampaiodiego",
+            "web-flow"
+          ]
+        }
+      ]
+    },
+    "0.64.1": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10660",
+          "title": "Release 0.64.1",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.1",
+          "contributors": [
+            "saplla",
+            "web-flow",
+            "engelgabriel",
+            "graywolf336",
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10597",
+          "title": "[NEW] Store the last sent message to show bellow the room's name by default",
+          "userLogin": "graywolf336",
+          "milestone": "0.64.1",
+          "contributors": [
+            "graywolf336",
+            "engelgabriel",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10529",
+          "title": "Support passing extra connection options to the Mongo driver",
+          "userLogin": "saplla",
+          "milestone": "0.64.1",
+          "contributors": [
+            "saplla",
+            "web-flow",
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "10615",
+          "title": "[FIX] E-mails were hidden some information",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.1",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10611",
+          "title": "Regression: Updating an App on multi-instance servers wasn't working",
+          "userLogin": "graywolf336",
+          "milestone": "0.64.1",
+          "contributors": [
+            "graywolf336",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10627",
+          "title": "[FIX] Regression on 0.64.0 was freezing the application when posting some URLs",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.1",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10648",
+          "title": "Dependencies update",
+          "userLogin": "engelgabriel",
+          "milestone": "0.64.1",
+          "contributors": [
+            "engelgabriel"
+          ]
+        }
+      ]
+    },
+    "0.64.2-rc.0": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10736",
+          "title": "More improvements on send notifications logic",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10720",
+          "title": "[FIX] Send a message when muted returns inconsistent result in chat.sendMessage",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.64.2",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10733",
+          "title": "[FIX] Regression: Empty content on announcement modal",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.2",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "10607",
+          "title": "[NEW] Add REST endpoints `channels.roles` & `groups.roles`",
+          "userLogin": "cardoso",
+          "milestone": "0.64.2",
+          "contributors": [
+            "cardoso",
+            "web-flow",
+            "rafaelks"
+          ]
+        },
+        {
+          "pr": "10724",
+          "title": "[NEW] Add more options for Wordpress OAuth configuration",
+          "userLogin": "Hudell",
+          "milestone": "0.64.2",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "10523",
+          "title": "[NEW] Setup Wizard",
+          "userLogin": "karlprieb",
+          "milestone": "0.64.2",
+          "contributors": [
+            "karlprieb",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10691",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10686",
+          "title": "[NEW] Improvements to notifications logic",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.64.2",
+          "contributors": [
+            "sampaiodiego",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10705",
+          "title": "[FIX] Missing attachment description when Rocket.Chat Apps were enabled",
+          "userLogin": "Hudell",
+          "milestone": "0.64.2",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "10445",
+          "title": "[FIX] Improve desktop notification formatting",
+          "userLogin": "Sameesunkaria",
+          "milestone": "0.64.2",
+          "contributors": [
+            "Sameesunkaria",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10524",
+          "title": "Add `npm run postinstall` into example build script",
+          "userLogin": "peccu",
+          "milestone": "0.64.2",
+          "contributors": [
+            "peccu",
+            "web-flow",
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "10678",
+          "title": "[FIX] Message box emoji icon was flickering when typing a text",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.2",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "10674",
+          "title": "Correct links in README file",
+          "userLogin": "winterstefan",
+          "milestone": "0.64.2",
+          "contributors": [
+            "winterstefan"
+          ]
+        },
+        {
+          "pr": "10665",
+          "title": "[FIX] Channel owner was being set as muted when creating a read-only channel",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.64.2",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10681",
+          "title": "[FIX] SAML wasn't working correctly when running multiple instances",
+          "userLogin": "Hudell",
+          "milestone": "0.64.2",
+          "contributors": [
+            "Hudell",
+            "rodrigok",
+            "web-flow"
+          ]
+        }
+      ]
+    },
+    "0.64.2-rc.1": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10789",
+          "title": "Prometheus: Improve metric names",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10788",
+          "title": "Improvement to push notifications on direct messages",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.64.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10786",
+          "title": "Better metric for notifications",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10779",
+          "title": "Add badge back to push notifications",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10776",
+          "title": "Wizard improvements",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10766",
+          "title": "Add setting and expose prometheus on port 9100",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10760",
+          "title": "Regression: Fix notifications for direct messages",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.64.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        }
+      ]
+    },
+    "0.64.2-rc.2": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10798",
+          "title": "Prometheus: Add metric to track hooks time",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10802",
+          "title": "Regression: Autorun of wizard was not destroyed after completion",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10803",
+          "title": "Prometheus: Fix notification metric",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10804",
+          "title": "Regression: Fix wrong wizard field name",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10793",
+          "title": "[FIX] Not escaping special chars on mentions",
+          "userLogin": "erhan-",
+          "milestone": "0.64.2",
+          "contributors": [
+            "erhan-",
+            "sampaiodiego"
+          ]
+        }
+      ]
+    },
+    "0.64.2": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10812",
+          "title": "Release 0.64.2",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "Hudell",
+            "rodrigok",
+            "web-flow",
+            "MarcosSpessatto",
+            "winterstefan",
+            "gdelavald",
+            "peccu",
+            "Sameesunkaria",
+            "sampaiodiego",
+            "engelgabriel",
+            "karlprieb",
+            "cardoso",
+            "erhan-"
+          ]
+        },
+        {
+          "pr": "10798",
+          "title": "Prometheus: Add metric to track hooks time",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10802",
+          "title": "Regression: Autorun of wizard was not destroyed after completion",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10803",
+          "title": "Prometheus: Fix notification metric",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10804",
+          "title": "Regression: Fix wrong wizard field name",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10793",
+          "title": "[FIX] Not escaping special chars on mentions",
+          "userLogin": "erhan-",
+          "milestone": "0.64.2",
+          "contributors": [
+            "erhan-",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10789",
+          "title": "Prometheus: Improve metric names",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10788",
+          "title": "Improvement to push notifications on direct messages",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.64.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10786",
+          "title": "Better metric for notifications",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10779",
+          "title": "Add badge back to push notifications",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10776",
+          "title": "Wizard improvements",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10766",
+          "title": "Add setting and expose prometheus on port 9100",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10760",
+          "title": "Regression: Fix notifications for direct messages",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.64.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10736",
+          "title": "More improvements on send notifications logic",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10720",
+          "title": "[FIX] Send a message when muted returns inconsistent result in chat.sendMessage",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.64.2",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10733",
+          "title": "[FIX] Regression: Empty content on announcement modal",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.2",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "10607",
+          "title": "[NEW] Add REST endpoints `channels.roles` & `groups.roles`",
+          "userLogin": "cardoso",
+          "milestone": "0.64.2",
+          "contributors": [
+            "cardoso",
+            "web-flow",
+            "rafaelks"
+          ]
+        },
+        {
+          "pr": "10724",
+          "title": "[NEW] Add more options for Wordpress OAuth configuration",
+          "userLogin": "Hudell",
+          "milestone": "0.64.2",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "10523",
+          "title": "[NEW] Setup Wizard",
+          "userLogin": "karlprieb",
+          "milestone": "0.64.2",
+          "contributors": [
+            "karlprieb",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10691",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10686",
+          "title": "[NEW] Improvements to notifications logic",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.64.2",
+          "contributors": [
+            "sampaiodiego",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10705",
+          "title": "[FIX] Missing attachment description when Rocket.Chat Apps were enabled",
+          "userLogin": "Hudell",
+          "milestone": "0.64.2",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "10445",
+          "title": "[FIX] Improve desktop notification formatting",
+          "userLogin": "Sameesunkaria",
+          "milestone": "0.64.2",
+          "contributors": [
+            "Sameesunkaria",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10524",
+          "title": "Add `npm run postinstall` into example build script",
+          "userLogin": "peccu",
+          "milestone": "0.64.2",
+          "contributors": [
+            "peccu",
+            "web-flow",
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "10678",
+          "title": "[FIX] Message box emoji icon was flickering when typing a text",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.2",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "10674",
+          "title": "Correct links in README file",
+          "userLogin": "winterstefan",
+          "milestone": "0.64.2",
+          "contributors": [
+            "winterstefan"
+          ]
+        },
+        {
+          "pr": "10665",
+          "title": "[FIX] Channel owner was being set as muted when creating a read-only channel",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.64.2",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10681",
+          "title": "[FIX] SAML wasn't working correctly when running multiple instances",
+          "userLogin": "Hudell",
+          "milestone": "0.64.2",
+          "contributors": [
+            "Hudell",
+            "rodrigok",
+            "web-flow"
+          ]
+        }
+      ]
+    },
+    "0.65.0-rc.0": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10822",
+          "title": "Apps: Command Previews, Message and Room Removal Events",
+          "userLogin": "graywolf336",
+          "milestone": "0.65.0",
+          "contributors": [
+            "graywolf336",
+            "rodrigok",
+            "web-flow",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "9857",
+          "title": "[NEW] Implement a local password policy",
+          "userLogin": "graywolf336",
+          "milestone": "0.65.0",
+          "contributors": [
+            "graywolf336",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10663",
+          "title": "[FIX] Livechat managers were not being able to send messages in some cases",
+          "userLogin": "renatobecker",
+          "milestone": "0.65.0",
+          "contributors": [
+            "renatobecker"
+          ]
+        },
+        {
+          "pr": "10584",
+          "title": "[NEW] Options to enable/disable each Livechat registration form field",
+          "userLogin": "renatobecker",
+          "milestone": "0.65.0",
+          "contributors": [
+            "renatobecker",
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10612",
+          "title": "[FIX] Livechat settings not appearing correctly",
+          "userLogin": "renatobecker",
+          "milestone": "0.65.0",
+          "contributors": [
+            "renatobecker"
+          ]
+        },
+        {
+          "pr": "10677",
+          "title": "[NEW] Return the result of the `/me` endpoint within the result of the `/login` endpoint",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.65.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10815",
+          "title": "Develop sync",
+          "userLogin": "rodrigok",
+          "contributors": [
+            "geekgonecrazy",
+            "web-flow",
+            "graywolf336",
+            "nsuchy",
+            "rodrigok",
+            "rafaelks",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10608",
+          "title": "[NEW] Lazy load image attachments",
+          "userLogin": "ggazzo",
+          "milestone": "0.65.0",
+          "contributors": [
+            "ggazzo",
+            "web-flow",
+            "karlprieb",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10427",
+          "title": "[FIX] Enabling `Collapse Embedded Media by Default` was hiding replies and quotes",
+          "userLogin": "c0dzilla",
+          "milestone": "0.65.0",
+          "contributors": [
+            "c0dzilla"
+          ]
+        },
+        {
+          "pr": "10214",
+          "title": "[NEW] View pinned message's attachment",
+          "userLogin": "c0dzilla",
+          "milestone": "0.65.0",
+          "contributors": [
+            "c0dzilla",
+            "karlprieb",
+            "web-flow",
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "10704",
+          "title": "[FIX] Missing option to disable/enable System Messages",
+          "userLogin": "ggazzo",
+          "milestone": "0.65.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "10448",
+          "title": "[FIX] Remove outdated translations of Internal Hubot's description of Scripts to Load that were pointing to a non existent address",
+          "userLogin": "Hudell",
+          "milestone": "0.65.0",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "10661",
+          "title": "Major dependencies update",
+          "userLogin": "engelgabriel",
+          "milestone": "0.65.0",
+          "contributors": [
+            "engelgabriel",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10702",
+          "title": "[NEW] Add REST API endpoint `users.getUsernameSuggestion` to get username suggestion",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.65.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10488",
+          "title": "[NEW] REST API endpoint `settings` now allow set colors and trigger actions",
+          "userLogin": "ThomasRoehl",
+          "milestone": "0.65.0",
+          "contributors": [
+            "ThomasRoehl",
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10778",
+          "title": "[NEW] Add REST endpoint `subscriptions.unread` to mark messages as unread",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.65.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10662",
+          "title": "[NEW] REST API endpoint `/me` now returns all the settings, including the default values",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.65.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10741",
+          "title": "[NEW] Now is possible to access files using header authorization (`x-user-id` and `x-auth-token`)",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.65.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10564",
+          "title": "[FIX] UI was not disabling the actions when users has had no permissions to create channels or add users to rooms",
+          "userLogin": "chuckAtCataworx",
+          "milestone": "0.65.0",
+          "contributors": [
+            "cfunkles",
+            "chuckAtCataworx",
+            "web-flow",
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "9679",
+          "title": "[NEW] Add REST API endpoints `channels.counters`, `groups.counters and `im.counters`",
+          "userLogin": "xbolshe",
+          "milestone": "0.65.0",
+          "contributors": [
+            "xbolshe",
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "9733",
+          "title": "[NEW] Add REST API endpoints `channels.setCustomFields` and `groups.setCustomFields`",
+          "userLogin": "xbolshe",
+          "milestone": "0.65.0",
+          "contributors": [
+            "xbolshe",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10625",
+          "title": "[FIX] Private settings were not being cleared from client cache in some cases",
+          "userLogin": "Hudell",
+          "milestone": "0.65.0",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "10811",
+          "title": "Prevent setup wizard redirects",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10798",
+          "title": "Prometheus: Add metric to track hooks time",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10802",
+          "title": "Regression: Autorun of wizard was not destroyed after completion",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10803",
+          "title": "Prometheus: Fix notification metric",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10804",
+          "title": "Regression: Fix wrong wizard field name",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10793",
+          "title": "[FIX] Not escaping special chars on mentions",
+          "userLogin": "erhan-",
+          "milestone": "0.64.2",
+          "contributors": [
+            "erhan-",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10789",
+          "title": "Prometheus: Improve metric names",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10788",
+          "title": "Improvement to push notifications on direct messages",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.64.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10786",
+          "title": "Better metric for notifications",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10779",
+          "title": "Add badge back to push notifications",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10776",
+          "title": "Wizard improvements",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10766",
+          "title": "Add setting and expose prometheus on port 9100",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10760",
+          "title": "Regression: Fix notifications for direct messages",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.64.2",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10736",
+          "title": "More improvements on send notifications logic",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10720",
+          "title": "[FIX] Send a message when muted returns inconsistent result in chat.sendMessage",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.64.2",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10733",
+          "title": "[FIX] Regression: Empty content on announcement modal",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.2",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "10607",
+          "title": "[NEW] Add REST endpoints `channels.roles` & `groups.roles`",
+          "userLogin": "cardoso",
+          "milestone": "0.64.2",
+          "contributors": [
+            "cardoso",
+            "web-flow",
+            "rafaelks"
+          ]
+        },
+        {
+          "pr": "10724",
+          "title": "[NEW] Add more options for Wordpress OAuth configuration",
+          "userLogin": "Hudell",
+          "milestone": "0.64.2",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "10523",
+          "title": "[NEW] Setup Wizard",
+          "userLogin": "karlprieb",
+          "milestone": "0.64.2",
+          "contributors": [
+            "karlprieb",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10691",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.64.2",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10686",
+          "title": "[NEW] Improvements to notifications logic",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.64.2",
+          "contributors": [
+            "sampaiodiego",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10705",
+          "title": "[FIX] Missing attachment description when Rocket.Chat Apps were enabled",
+          "userLogin": "Hudell",
+          "milestone": "0.64.2",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "10445",
+          "title": "[FIX] Improve desktop notification formatting",
+          "userLogin": "Sameesunkaria",
+          "milestone": "0.64.2",
+          "contributors": [
+            "Sameesunkaria",
+            "engelgabriel",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10524",
+          "title": "Add `npm run postinstall` into example build script",
+          "userLogin": "peccu",
+          "milestone": "0.64.2",
+          "contributors": [
+            "peccu",
+            "web-flow",
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "10678",
+          "title": "[FIX] Message box emoji icon was flickering when typing a text",
+          "userLogin": "gdelavald",
+          "milestone": "0.64.2",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "10674",
+          "title": "Correct links in README file",
+          "userLogin": "winterstefan",
+          "milestone": "0.64.2",
+          "contributors": [
+            "winterstefan"
+          ]
+        },
+        {
+          "pr": "10665",
+          "title": "[FIX] Channel owner was being set as muted when creating a read-only channel",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.64.2",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10681",
+          "title": "[FIX] SAML wasn't working correctly when running multiple instances",
+          "userLogin": "Hudell",
+          "milestone": "0.64.2",
+          "contributors": [
+            "Hudell",
+            "rodrigok",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10812",
+          "title": "Release 0.64.2",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "Hudell",
+            "rodrigok",
+            "web-flow",
+            "MarcosSpessatto",
+            "winterstefan",
+            "gdelavald",
+            "peccu",
+            "Sameesunkaria",
+            "sampaiodiego",
+            "engelgabriel",
+            "karlprieb",
+            "cardoso",
+            "erhan-"
+          ]
+        },
+        {
+          "pr": "10660",
+          "title": "Release 0.64.1",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.1",
+          "contributors": [
+            "saplla",
+            "web-flow",
+            "engelgabriel",
+            "graywolf336",
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10613",
+          "title": "Release 0.64.0",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.0",
+          "contributors": [
+            "rodrigok",
+            "geekgonecrazy",
+            "web-flow",
+            "graywolf336",
+            "TwizzyDizzy",
+            "christianh814",
+            "tttt-conan",
+            "gdelavald",
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "10504",
+          "title": "Release 0.63.3",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "rafaelks",
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10476",
+          "title": "Release 0.63.2",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "graywolf336",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10408",
+          "title": "add redhat dockerfile to master",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        }
+      ]
+    },
+    "0.65.0-rc.1": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10837",
+          "title": "[FIX] Internal Error when requesting user data download",
+          "userLogin": "Hudell",
+          "milestone": "0.65.0",
+          "contributors": [
+            "Hudell"
+          ]
+        },
+        {
+          "pr": "10835",
+          "title": "[FIX] Broadcast channels were showing reply button for deleted messages and generating wrong reply links some times",
+          "userLogin": "ggazzo",
+          "milestone": "0.65.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "10833",
+          "title": "Fix: Regression in REST API endpoint `/me` ",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.65.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10734",
+          "title": "[FIX] User's preference `Unread on Top` wasn't working for LiveChat rooms",
+          "userLogin": "renatobecker",
+          "milestone": "0.65.0",
+          "contributors": [
+            "renatobecker",
+            "sampaiodiego",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10753",
+          "title": "[NEW] Add permission `view-broadcast-member-list`",
+          "userLogin": "cardoso",
+          "milestone": "0.65.0",
+          "contributors": [
+            "cardoso",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10715",
+          "title": "[FIX] Cancel button wasn't working while uploading file",
+          "userLogin": "Mr-Gryphon",
+          "milestone": "0.65.0",
+          "contributors": [
+            "Mr-Gryphon",
+            "web-flow",
+            "karlprieb"
+          ]
+        }
+      ]
+    },
+    "0.65.0-rc.2": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10847",
+          "title": "Regression: Fix email notification preference not showing correct selected value",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.65.0",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10853",
+          "title": "Apps: Command previews are clickable & Apps Framework is controlled via a setting",
+          "userLogin": "graywolf336",
+          "milestone": "0.65.0",
+          "contributors": [
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10840",
+          "title": "[FIX] Missing pagination fields in the response of REST /directory endpoint",
+          "userLogin": "MarcosSpessatto",
+          "milestone": "0.65.0",
+          "contributors": [
+            "MarcosSpessatto"
+          ]
+        },
+        {
+          "pr": "10846",
+          "title": "[FIX] Layout badge cutting on unread messages for long names",
+          "userLogin": "kos4live",
+          "milestone": "0.65.0",
+          "contributors": [
+            "kos4live"
+          ]
+        },
+        {
+          "pr": "10848",
+          "title": "Regression: Make settings `Site_Name` and `Language` public again",
+          "userLogin": "rodrigok",
+          "milestone": "0.65.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10520",
+          "title": "Fix: Clarify the wording of the release issue template",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "graywolf336",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10836",
+          "title": "Fix: Regression on users avatar in admin pages",
+          "userLogin": "ggazzo",
+          "milestone": "0.65.0",
+          "contributors": [
+            "ggazzo",
+            "rodrigok",
+            "web-flow"
+          ]
+        }
+      ]
+    },
+    "0.65.0-rc.3": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10875",
+          "title": "[FIX] Slack-Bridge bug when migrating to 0.64.1",
+          "userLogin": "iliaal",
+          "milestone": "0.65.0",
+          "contributors": [
+            null
+          ]
+        },
+        {
+          "pr": "10882",
+          "title": "Fix: Manage apps layout was a bit confuse",
+          "userLogin": "gdelavald",
+          "milestone": "0.65.0",
+          "contributors": [
+            "gdelavald",
+            "ggazzo",
+            "web-flow",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10886",
+          "title": "LingoHub based on develop",
+          "userLogin": "engelgabriel",
+          "milestone": "0.65.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10887",
+          "title": "Fix: Regression Lazyload fix shuffle avatars",
+          "userLogin": "ggazzo",
+          "milestone": "0.65.0",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "10883",
+          "title": "[FIX] Horizontally align items in preview message",
+          "userLogin": "gdelavald",
+          "milestone": "0.65.0",
+          "contributors": [
+            "gdelavald"
+          ]
+        },
+        {
+          "pr": "10857",
+          "title": "Fix: typo on error message for push token API",
+          "userLogin": "rafaelks",
+          "milestone": "0.65.0",
+          "contributors": [
+            "rafaelks",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10878",
+          "title": "[FIX] The first users was not set as admin some times",
+          "userLogin": "rodrigok",
+          "milestone": "0.65.0",
+          "contributors": [
+            "rodrigok"
+          ]
+        }
+      ]
+    },
+    "0.65.0": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10893",
+          "title": "Release 0.65.0",
+          "userLogin": "rodrigok",
+          "milestone": "0.65.0",
+          "contributors": [
+            "Hudell",
+            "rodrigok",
+            "web-flow",
+            "MarcosSpessatto",
+            "winterstefan",
+            "gdelavald",
+            "peccu",
+            "Sameesunkaria",
+            "sampaiodiego",
+            "engelgabriel",
+            "karlprieb",
+            "cardoso",
+            "erhan-"
+          ]
+        },
+        {
+          "pr": "10812",
+          "title": "Release 0.64.2",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.2",
+          "contributors": [
+            "Hudell",
+            "rodrigok",
+            "web-flow",
+            "MarcosSpessatto",
+            "winterstefan",
+            "gdelavald",
+            "peccu",
+            "Sameesunkaria",
+            "sampaiodiego",
+            "engelgabriel",
+            "karlprieb",
+            "cardoso",
+            "erhan-"
+          ]
+        },
+        {
+          "pr": "10660",
+          "title": "Release 0.64.1",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.1",
+          "contributors": [
+            "saplla",
+            "web-flow",
+            "engelgabriel",
+            "graywolf336",
+            "rodrigok",
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10613",
+          "title": "Release 0.64.0",
+          "userLogin": "rodrigok",
+          "milestone": "0.64.0",
+          "contributors": [
+            "rodrigok",
+            "geekgonecrazy",
+            "web-flow",
+            "graywolf336",
+            "TwizzyDizzy",
+            "christianh814",
+            "tttt-conan",
+            "gdelavald",
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "10504",
+          "title": "Release 0.63.3",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "rafaelks",
+            "graywolf336"
+          ]
+        },
+        {
+          "pr": "10476",
+          "title": "Release 0.63.2",
+          "userLogin": "graywolf336",
+          "contributors": [
+            "graywolf336",
+            "web-flow"
+          ]
+        },
+        {
+          "pr": "10408",
+          "title": "add redhat dockerfile to master",
+          "userLogin": "geekgonecrazy",
+          "contributors": [
+            "geekgonecrazy"
+          ]
+        }
+      ]
+    },
+    "0.65.1": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "10940",
+          "title": "[FIX] Livechat not loading",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.65.1",
+          "contributors": [
+            "sampaiodiego",
+            "rodrigok"
+          ]
+        },
+        {
+          "pr": "10934",
+          "title": "[FIX] Application crashing on startup when trying to log errors to `exceptions` channel",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.65.1",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10928",
+          "title": "[FIX] Incomplete email notification link",
+          "userLogin": "sampaiodiego",
+          "milestone": "0.65.1",
+          "contributors": [
+            "sampaiodiego"
+          ]
+        },
+        {
+          "pr": "10904",
+          "title": "[FIX] Image lazy load was breaking attachments",
+          "userLogin": "ggazzo",
+          "milestone": "0.65.1",
+          "contributors": [
+            "ggazzo"
+          ]
+        },
+        {
+          "pr": "10851",
+          "title": "[FIX] Leave room wasn't working as expected",
+          "userLogin": "ggazzo",
+          "milestone": "0.65.1",
+          "contributors": [
+            "ggazzo"
+          ]
+        }
+      ]
+    },
+    "0.65.2": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": [
+        {
+          "pr": "9534",
+          "title": "[FIX] i18n - add semantic markup",
+          "userLogin": "brylie",
+          "contributors": [
+            "brylie",
+            "web-flow",
+            "engelgabriel"
+          ]
+        },
+        {
+          "pr": "10947",
+          "title": "Release 0.65.1",
+          "userLogin": "sampaiodiego",
+          "contributors": [
+            "rodrigok",
+            "sampaiodiego",
+            "engelgabriel"
+          ]
+        }
+      ]
+    },
+    "HEAD": {
+      "node_version": "8.11.1",
+      "npm_version": "5.6.0",
+      "pull_requests": []
     }
-  ]
+  }
 }

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,59 @@
 
+# 0.65.2
+`2018-06-16  ·  1 🐛  ·  1 🔍  ·  4 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `8.11.1`
+- NPM: `5.6.0`
+
+### 🐛 Bug fixes
+
+- i18n - add semantic markup ([#9534](https://github.com/RocketChat/Rocket.Chat/pull/9534) by [@brylie](https://github.com/brylie))
+
+<details>
+<summary>🔍 Minor changes</summary>
+
+- Release 0.65.1 ([#10947](https://github.com/RocketChat/Rocket.Chat/pull/10947))
+
+</details>
+
+### 👩‍💻👨‍💻 Contributors 😍
+
+- [@brylie](https://github.com/brylie)
+
+### 👩‍💻👨‍💻 Core Team 🤓
+
+- [@engelgabriel](https://github.com/engelgabriel)
+- [@rodrigok](https://github.com/rodrigok)
+- [@sampaiodiego](https://github.com/sampaiodiego)
+
+# 0.65.1
+`2018-05-30  ·  5 🐛  ·  3 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `8.11.1`
+- NPM: `5.6.0`
+
+### 🐛 Bug fixes
+
+- Livechat not loading ([#10940](https://github.com/RocketChat/Rocket.Chat/pull/10940))
+- Application crashing on startup when trying to log errors to `exceptions` channel ([#10934](https://github.com/RocketChat/Rocket.Chat/pull/10934))
+- Incomplete email notification link ([#10928](https://github.com/RocketChat/Rocket.Chat/pull/10928))
+- Image lazy load was breaking attachments ([#10904](https://github.com/RocketChat/Rocket.Chat/pull/10904))
+- Leave room wasn't working as expected ([#10851](https://github.com/RocketChat/Rocket.Chat/pull/10851))
+
+### 👩‍💻👨‍💻 Core Team 🤓
+
+- [@ggazzo](https://github.com/ggazzo)
+- [@rodrigok](https://github.com/rodrigok)
+- [@sampaiodiego](https://github.com/sampaiodiego)
+
 # 0.65.0
-`2018-05-27  ·  17 🎉  ·  24 🐛  ·  41 🔍  ·  29 👩‍💻👨‍💻`
+`2018-05-28  ·  17 🎉  ·  24 🐛  ·  42 🔍  ·  29 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `8.11.1`
+- NPM: `5.6.0`
 
 ### 🎉 New features
 
@@ -52,9 +105,10 @@
 <details>
 <summary>🔍 Minor changes</summary>
 
+- Release 0.65.0 ([#10893](https://github.com/RocketChat/Rocket.Chat/pull/10893) by [@Sameesunkaria](https://github.com/Sameesunkaria) & [@erhan-](https://github.com/erhan-) & [@peccu](https://github.com/peccu) & [@winterstefan](https://github.com/winterstefan))
 - Release 0.64.2 ([#10812](https://github.com/RocketChat/Rocket.Chat/pull/10812) by [@Sameesunkaria](https://github.com/Sameesunkaria) & [@erhan-](https://github.com/erhan-) & [@peccu](https://github.com/peccu) & [@winterstefan](https://github.com/winterstefan))
 - Release 0.64.1 ([#10660](https://github.com/RocketChat/Rocket.Chat/pull/10660) by [@saplla](https://github.com/saplla))
-- Release 0.64.0 ([#10613](https://github.com/RocketChat/Rocket.Chat/pull/10613) by [@TwizzyDizzy](https://github.com/TwizzyDizzy) & [@christianh814](https://github.com/christianh814) & [@tttt-conan](https://github.com/tttt-conan))
+- Release 0.64.0 ([#10613](https://github.com/RocketChat/Rocket.Chat/pull/10613) by [@christianh814](https://github.com/christianh814) & [@tttt-conan](https://github.com/tttt-conan))
 - Release 0.63.3 ([#10504](https://github.com/RocketChat/Rocket.Chat/pull/10504))
 - Release 0.63.2 ([#10476](https://github.com/RocketChat/Rocket.Chat/pull/10476))
 - add redhat dockerfile to master ([#10408](https://github.com/RocketChat/Rocket.Chat/pull/10408))
@@ -79,7 +133,7 @@
 - Correct links in README file ([#10674](https://github.com/RocketChat/Rocket.Chat/pull/10674) by [@winterstefan](https://github.com/winterstefan))
 - Release 0.64.2 ([#10812](https://github.com/RocketChat/Rocket.Chat/pull/10812) by [@Sameesunkaria](https://github.com/Sameesunkaria) & [@erhan-](https://github.com/erhan-) & [@peccu](https://github.com/peccu) & [@winterstefan](https://github.com/winterstefan))
 - Release 0.64.1 ([#10660](https://github.com/RocketChat/Rocket.Chat/pull/10660) by [@saplla](https://github.com/saplla))
-- Release 0.64.0 ([#10613](https://github.com/RocketChat/Rocket.Chat/pull/10613) by [@TwizzyDizzy](https://github.com/TwizzyDizzy) & [@christianh814](https://github.com/christianh814) & [@tttt-conan](https://github.com/tttt-conan))
+- Release 0.64.0 ([#10613](https://github.com/RocketChat/Rocket.Chat/pull/10613) by [@christianh814](https://github.com/christianh814) & [@tttt-conan](https://github.com/tttt-conan))
 - Release 0.63.3 ([#10504](https://github.com/RocketChat/Rocket.Chat/pull/10504))
 - Release 0.63.2 ([#10476](https://github.com/RocketChat/Rocket.Chat/pull/10476))
 - add redhat dockerfile to master ([#10408](https://github.com/RocketChat/Rocket.Chat/pull/10408))
@@ -101,7 +155,6 @@
 - [@Mr-Gryphon](https://github.com/Mr-Gryphon)
 - [@Sameesunkaria](https://github.com/Sameesunkaria)
 - [@ThomasRoehl](https://github.com/ThomasRoehl)
-- [@TwizzyDizzy](https://github.com/TwizzyDizzy)
 - [@c0dzilla](https://github.com/c0dzilla)
 - [@cfunkles](https://github.com/cfunkles)
 - [@christianh814](https://github.com/christianh814)
@@ -119,6 +172,7 @@
 
 - [@Hudell](https://github.com/Hudell)
 - [@MarcosSpessatto](https://github.com/MarcosSpessatto)
+- [@TwizzyDizzy](https://github.com/TwizzyDizzy)
 - [@cardoso](https://github.com/cardoso)
 - [@engelgabriel](https://github.com/engelgabriel)
 - [@gdelavald](https://github.com/gdelavald)
@@ -133,6 +187,10 @@
 
 # 0.64.2
 `2018-05-18  ·  8 🎉  ·  16 🐛  ·  31 🔍  ·  13 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `8.11.1`
+- NPM: `5.6.0`
 
 ### 🎉 New features
 
@@ -221,7 +279,11 @@
 - [@sampaiodiego](https://github.com/sampaiodiego)
 
 # 0.64.1
-`2018-05-03  ·  1 🎉  ·  2 🐛  ·  3 🔍  ·  5 👩‍💻👨‍💻`
+`2018-05-03  ·  1 🎉  ·  2 🐛  ·  4 🔍  ·  5 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `8.11.1`
+- NPM: `5.6.0`
 
 ### 🎉 New features
 
@@ -235,6 +297,7 @@
 <details>
 <summary>🔍 Minor changes</summary>
 
+- Release 0.64.1 ([#10660](https://github.com/RocketChat/Rocket.Chat/pull/10660) by [@saplla](https://github.com/saplla))
 - Support passing extra connection options to the Mongo driver ([#10529](https://github.com/RocketChat/Rocket.Chat/pull/10529) by [@saplla](https://github.com/saplla))
 - Regression: Updating an App on multi-instance servers wasn't working ([#10611](https://github.com/RocketChat/Rocket.Chat/pull/10611))
 - Dependencies update ([#10648](https://github.com/RocketChat/Rocket.Chat/pull/10648))
@@ -253,7 +316,11 @@
 - [@sampaiodiego](https://github.com/sampaiodiego)
 
 # 0.64.0
-`2018-04-28  ·  2 ️️️⚠️  ·  18 🎉  ·  44 🐛  ·  33 🔍  ·  30 👩‍💻👨‍💻`
+`2018-04-28  ·  2 ️️️⚠️  ·  18 🎉  ·  44 🐛  ·  37 🔍  ·  30 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `8.11.1`
+- NPM: `5.6.0`
 
 ### ⚠️ BREAKING CHANGES
 
@@ -294,7 +361,7 @@
 - Directory sort and column sizes were wrong ([#10403](https://github.com/RocketChat/Rocket.Chat/pull/10403))
 - REST API OAuth services endpoint were missing fields and flag to indicate custom services ([#10299](https://github.com/RocketChat/Rocket.Chat/pull/10299))
 - Error messages weren't been displayed when email verification fails ([#10446](https://github.com/RocketChat/Rocket.Chat/pull/10446))
-- Wrong column positions in the directory search for users ([#10454](https://github.com/RocketChat/Rocket.Chat/pull/10454) by [@sumedh123](https://github.com/sumedh123))
+- Wrong column positions in the directory search for users ([#10454](https://github.com/RocketChat/Rocket.Chat/pull/10454) by [@lunaticmonk](https://github.com/lunaticmonk))
 - Custom fields was misaligned in registration form ([#10463](https://github.com/RocketChat/Rocket.Chat/pull/10463) by [@dschuan](https://github.com/dschuan))
 - Unique identifier file not really being unique ([#10341](https://github.com/RocketChat/Rocket.Chat/pull/10341) by [@abernix](https://github.com/abernix))
 - Empty panel after changing a user's username ([#10404](https://github.com/RocketChat/Rocket.Chat/pull/10404))
@@ -310,7 +377,7 @@
 - "Highlight Words" wasn't working with more than one word ([#10083](https://github.com/RocketChat/Rocket.Chat/pull/10083) by [@nemaniarjun](https://github.com/nemaniarjun))
 - Missing "Administration" menu for user with manage-emoji permission ([#10171](https://github.com/RocketChat/Rocket.Chat/pull/10171) by [@c0dzilla](https://github.com/c0dzilla))
 - Message view mode setting was missing at user's preferences  ([#10395](https://github.com/RocketChat/Rocket.Chat/pull/10395) by [@kaiiiiiiiii](https://github.com/kaiiiiiiiii))
-- Profile image was not being shown in user's directory search ([#10399](https://github.com/RocketChat/Rocket.Chat/pull/10399) by [@sumedh123](https://github.com/sumedh123))
+- Profile image was not being shown in user's directory search ([#10399](https://github.com/RocketChat/Rocket.Chat/pull/10399) by [@lunaticmonk](https://github.com/lunaticmonk))
 - Wrong positioning of popover when using RTL languages ([#10428](https://github.com/RocketChat/Rocket.Chat/pull/10428))
 - Messages was grouping wrong some times when server is slow ([#10472](https://github.com/RocketChat/Rocket.Chat/pull/10472))
 - GitLab authentication scope was too open, reduced to read only access ([#10225](https://github.com/RocketChat/Rocket.Chat/pull/10225))
@@ -331,6 +398,10 @@
 <details>
 <summary>🔍 Minor changes</summary>
 
+- Release 0.64.0 ([#10613](https://github.com/RocketChat/Rocket.Chat/pull/10613) by [@christianh814](https://github.com/christianh814) & [@tttt-conan](https://github.com/tttt-conan))
+- Release 0.63.3 ([#10504](https://github.com/RocketChat/Rocket.Chat/pull/10504))
+- Release 0.63.2 ([#10476](https://github.com/RocketChat/Rocket.Chat/pull/10476))
+- add redhat dockerfile to master ([#10408](https://github.com/RocketChat/Rocket.Chat/pull/10408))
 - Regression: Various search provider fixes ([#10591](https://github.com/RocketChat/Rocket.Chat/pull/10591) by [@tkurz](https://github.com/tkurz))
 - Regression: /api/v1/settings.oauth not sending needed info for SAML & CAS ([#10596](https://github.com/RocketChat/Rocket.Chat/pull/10596))
 - Regression: Apps and Livechats not getting along well with each other ([#10598](https://github.com/RocketChat/Rocket.Chat/pull/10598))
@@ -345,7 +416,7 @@
 - [OTHER] Removed the developer warning on the rest api ([#10441](https://github.com/RocketChat/Rocket.Chat/pull/10441))
 - Fix and improve vietnamese translation ([#10397](https://github.com/RocketChat/Rocket.Chat/pull/10397) by [@TDiNguyen](https://github.com/TDiNguyen) & [@tttt-conan](https://github.com/tttt-conan))
 - Use Node 8.9 for CI build ([#10405](https://github.com/RocketChat/Rocket.Chat/pull/10405))
-- Update allowed labels for bot ([#10360](https://github.com/RocketChat/Rocket.Chat/pull/10360) by [@TwizzyDizzy](https://github.com/TwizzyDizzy))
+- Update allowed labels for bot ([#10360](https://github.com/RocketChat/Rocket.Chat/pull/10360))
 - Remove @core team mention from Pull Request template ([#10384](https://github.com/RocketChat/Rocket.Chat/pull/10384))
 - New issue template for *Release Process* ([#10234](https://github.com/RocketChat/Rocket.Chat/pull/10234))
 - Master into Develop Branch Sync ([#10376](https://github.com/RocketChat/Rocket.Chat/pull/10376))
@@ -371,18 +442,17 @@
 
 - [@Prakharsvnit](https://github.com/Prakharsvnit)
 - [@TDiNguyen](https://github.com/TDiNguyen)
-- [@TwizzyDizzy](https://github.com/TwizzyDizzy)
 - [@abernix](https://github.com/abernix)
 - [@brendangadd](https://github.com/brendangadd)
 - [@c0dzilla](https://github.com/c0dzilla)
 - [@christianh814](https://github.com/christianh814)
 - [@dschuan](https://github.com/dschuan)
 - [@kaiiiiiiiii](https://github.com/kaiiiiiiiii)
+- [@lunaticmonk](https://github.com/lunaticmonk)
 - [@nemaniarjun](https://github.com/nemaniarjun)
 - [@nsuchy](https://github.com/nsuchy)
 - [@okaybroda](https://github.com/okaybroda)
 - [@strangerintheq](https://github.com/strangerintheq)
-- [@sumedh123](https://github.com/sumedh123)
 - [@t3hchipmunk](https://github.com/t3hchipmunk)
 - [@tkurz](https://github.com/tkurz)
 - [@tttt-conan](https://github.com/tttt-conan)
@@ -391,6 +461,7 @@
 
 - [@Hudell](https://github.com/Hudell)
 - [@MarcosSpessatto](https://github.com/MarcosSpessatto)
+- [@TwizzyDizzy](https://github.com/TwizzyDizzy)
 - [@cardoso](https://github.com/cardoso)
 - [@engelgabriel](https://github.com/engelgabriel)
 - [@gdelavald](https://github.com/gdelavald)
@@ -404,24 +475,18 @@
 - [@sampaiodiego](https://github.com/sampaiodiego)
 
 # 0.63.3
-`2018-04-18  ·  2 🐛  ·  2 🔍  ·  3 👩‍💻👨‍💻`
+`2018-04-18  ·  1 🔍  ·  2 👩‍💻👨‍💻`
 
-### 🐛 Bug fixes
-
-- The 'channel.messages' REST API Endpoint error ([#10485](https://github.com/RocketChat/Rocket.Chat/pull/10485))
-- Even TypeErrors with SAML ([#10475](https://github.com/RocketChat/Rocket.Chat/pull/10475))
+### Engine versions
+- Node: `8.11.1`
+- NPM: `5.6.0`
 
 <details>
 <summary>🔍 Minor changes</summary>
 
-- Added one2mail.info to default blocked domains list ([#10218](https://github.com/RocketChat/Rocket.Chat/pull/10218) by [@nsuchy](https://github.com/nsuchy))
-- Release 0.63.2 ([#10476](https://github.com/RocketChat/Rocket.Chat/pull/10476))
+- Release 0.63.3 ([#10504](https://github.com/RocketChat/Rocket.Chat/pull/10504))
 
 </details>
-
-### 👩‍💻👨‍💻 Contributors 😍
-
-- [@nsuchy](https://github.com/nsuchy)
 
 ### 👩‍💻👨‍💻 Core Team 🤓
 
@@ -429,15 +494,16 @@
 - [@rafaelks](https://github.com/rafaelks)
 
 # 0.63.2
-`2018-04-17  ·  1 🐛  ·  1 🔍  ·  2 👩‍💻👨‍💻`
+`2018-04-17  ·  2 🔍  ·  2 👩‍💻👨‍💻`
 
-### 🐛 Bug fixes
-
-- Even TypeErrors with SAML ([#10475](https://github.com/RocketChat/Rocket.Chat/pull/10475))
+### Engine versions
+- Node: `8.11.1`
+- NPM: `5.6.0`
 
 <details>
 <summary>🔍 Minor changes</summary>
 
+- Release 0.63.2 ([#10476](https://github.com/RocketChat/Rocket.Chat/pull/10476))
 - add redhat dockerfile to master ([#10408](https://github.com/RocketChat/Rocket.Chat/pull/10408))
 
 </details>
@@ -448,30 +514,51 @@
 - [@graywolf336](https://github.com/graywolf336)
 
 # 0.63.1
-`2018-04-07  ·  5 🐛  ·  6 👩‍💻👨‍💻`
+`2018-04-07  ·  3 🔍  ·  18 👩‍💻👨‍💻`
 
-### 🐛 Bug fixes
+### Engine versions
+- Node: `8.11.1`
+- NPM: `5.6.0`
 
-- Change deprecated Meteor._reload.reload method in favor of Reload._reload ([#10348](https://github.com/RocketChat/Rocket.Chat/pull/10348) by [@tttt-conan](https://github.com/tttt-conan))
-- Snaps crashing due to Node v8.11.1 Segfault ([#10351](https://github.com/RocketChat/Rocket.Chat/pull/10351))
-- Add '.value' in the SAML package to fix TypeErrors on SAML token validation ([#10084](https://github.com/RocketChat/Rocket.Chat/pull/10084) by [@TechyPeople](https://github.com/TechyPeople))
-- Incorrect german translation of user online status ([#10356](https://github.com/RocketChat/Rocket.Chat/pull/10356) by [@kaiiiiiiiii](https://github.com/kaiiiiiiiii))
-- Incorrect French language usage for Disabled ([#10355](https://github.com/RocketChat/Rocket.Chat/pull/10355))
+<details>
+<summary>🔍 Minor changes</summary>
+
+- Release 0.63.1 ([#10374](https://github.com/RocketChat/Rocket.Chat/pull/10374) by [@TechyPeople](https://github.com/TechyPeople) & [@kaiiiiiiiii](https://github.com/kaiiiiiiiii) & [@tttt-conan](https://github.com/tttt-conan))
+- Release 0.63.0 ([#10324](https://github.com/RocketChat/Rocket.Chat/pull/10324) by [@Joe-mcgee](https://github.com/Joe-mcgee) & [@TopHattedCat](https://github.com/TopHattedCat) & [@hmagarotto](https://github.com/hmagarotto) & [@kaiiiiiiiii](https://github.com/kaiiiiiiiii) & [@kb0304](https://github.com/kb0304) & [@lunaticmonk](https://github.com/lunaticmonk) & [@ramrami](https://github.com/ramrami))
+- Release 0.63.0 ([#10324](https://github.com/RocketChat/Rocket.Chat/pull/10324) by [@Joe-mcgee](https://github.com/Joe-mcgee) & [@TopHattedCat](https://github.com/TopHattedCat) & [@hmagarotto](https://github.com/hmagarotto) & [@kaiiiiiiiii](https://github.com/kaiiiiiiiii) & [@kb0304](https://github.com/kb0304) & [@lunaticmonk](https://github.com/lunaticmonk) & [@ramrami](https://github.com/ramrami))
+
+</details>
 
 ### 👩‍💻👨‍💻 Contributors 😍
 
+- [@Joe-mcgee](https://github.com/Joe-mcgee)
 - [@TechyPeople](https://github.com/TechyPeople)
+- [@TopHattedCat](https://github.com/TopHattedCat)
+- [@hmagarotto](https://github.com/hmagarotto)
 - [@kaiiiiiiiii](https://github.com/kaiiiiiiiii)
+- [@kb0304](https://github.com/kb0304)
+- [@lunaticmonk](https://github.com/lunaticmonk)
+- [@ramrami](https://github.com/ramrami)
 - [@tttt-conan](https://github.com/tttt-conan)
 
 ### 👩‍💻👨‍💻 Core Team 🤓
 
+- [@Hudell](https://github.com/Hudell)
+- [@MarcosSpessatto](https://github.com/MarcosSpessatto)
+- [@engelgabriel](https://github.com/engelgabriel)
 - [@geekgonecrazy](https://github.com/geekgonecrazy)
+- [@ggazzo](https://github.com/ggazzo)
 - [@graywolf336](https://github.com/graywolf336)
+- [@karlprieb](https://github.com/karlprieb)
 - [@rodrigok](https://github.com/rodrigok)
+- [@sampaiodiego](https://github.com/sampaiodiego)
 
 # 0.63.0
-`2018-04-04  ·  1 ️️️⚠️  ·  18 🎉  ·  44 🐛  ·  20 🔍  ·  25 👩‍💻👨‍💻`
+`2018-04-04  ·  1 ️️️⚠️  ·  18 🎉  ·  48 🐛  ·  22 🔍  ·  25 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `8.11.1`
+- NPM: `5.6.0`
 
 ### ⚠️ BREAKING CHANGES
 
@@ -500,6 +587,10 @@
 
 ### 🐛 Bug fixes
 
+- Delete user without username was removing direct rooms of all users ([#9986](https://github.com/RocketChat/Rocket.Chat/pull/9986))
+- New channel page on medium size screens ([#9988](https://github.com/RocketChat/Rocket.Chat/pull/9988))
+- Empty sidenav when sorting by activity and there is a subscription without room ([#9960](https://github.com/RocketChat/Rocket.Chat/pull/9960))
+- Two factor authentication modal was not showing ([#9982](https://github.com/RocketChat/Rocket.Chat/pull/9982))
 - Audio Message UI fixes ([#10303](https://github.com/RocketChat/Rocket.Chat/pull/10303) by [@kb0304](https://github.com/kb0304))
 - "View All Members" button inside channel's "User Info" is over sized ([#10012](https://github.com/RocketChat/Rocket.Chat/pull/10012))
 - Apostrophe-containing URL misparsed" ([#10242](https://github.com/RocketChat/Rocket.Chat/pull/10242))
@@ -507,10 +598,10 @@
 - Dynamic CSS script isn't working on older browsers ([#10152](https://github.com/RocketChat/Rocket.Chat/pull/10152))
 - Extended view mode on sidebar ([#10160](https://github.com/RocketChat/Rocket.Chat/pull/10160))
 - Cannot answer to a livechat as a manager if agent has not answered yet ([#10082](https://github.com/RocketChat/Rocket.Chat/pull/10082) by [@kb0304](https://github.com/kb0304))
-- User status missing on user info ([#9866](https://github.com/RocketChat/Rocket.Chat/pull/9866) by [@sumedh123](https://github.com/sumedh123))
-- Name of files in file upload list cuts down at bottom due to overflow ([#9672](https://github.com/RocketChat/Rocket.Chat/pull/9672) by [@sumedh123](https://github.com/sumedh123))
-- No pattern for user's status text capitalization ([#9783](https://github.com/RocketChat/Rocket.Chat/pull/9783) by [@sumedh123](https://github.com/sumedh123))
-- Apostrophe-containing URL misparsed ([#9739](https://github.com/RocketChat/Rocket.Chat/pull/9739) by [@sumedh123](https://github.com/sumedh123))
+- User status missing on user info ([#9866](https://github.com/RocketChat/Rocket.Chat/pull/9866) by [@lunaticmonk](https://github.com/lunaticmonk))
+- Name of files in file upload list cuts down at bottom due to overflow ([#9672](https://github.com/RocketChat/Rocket.Chat/pull/9672) by [@lunaticmonk](https://github.com/lunaticmonk))
+- No pattern for user's status text capitalization ([#9783](https://github.com/RocketChat/Rocket.Chat/pull/9783) by [@lunaticmonk](https://github.com/lunaticmonk))
+- Apostrophe-containing URL misparsed ([#9739](https://github.com/RocketChat/Rocket.Chat/pull/9739) by [@lunaticmonk](https://github.com/lunaticmonk))
 - Popover divs don't scroll if they overflow the viewport ([#9860](https://github.com/RocketChat/Rocket.Chat/pull/9860) by [@Joe-mcgee](https://github.com/Joe-mcgee))
 - Reactions not working on mobile ([#10104](https://github.com/RocketChat/Rocket.Chat/pull/10104))
 - Broken video call accept dialog ([#9872](https://github.com/RocketChat/Rocket.Chat/pull/9872) by [@ramrami](https://github.com/ramrami))
@@ -548,6 +639,8 @@
 <details>
 <summary>🔍 Minor changes</summary>
 
+- Release 0.63.0 ([#10324](https://github.com/RocketChat/Rocket.Chat/pull/10324) by [@Joe-mcgee](https://github.com/Joe-mcgee) & [@TopHattedCat](https://github.com/TopHattedCat) & [@hmagarotto](https://github.com/hmagarotto) & [@kaiiiiiiiii](https://github.com/kaiiiiiiiii) & [@kb0304](https://github.com/kb0304) & [@lunaticmonk](https://github.com/lunaticmonk) & [@ramrami](https://github.com/ramrami))
+- Release 0.62.2 ([#10087](https://github.com/RocketChat/Rocket.Chat/pull/10087))
 - Fix: Reaction endpoint/api only working with regular emojis ([#10323](https://github.com/RocketChat/Rocket.Chat/pull/10323))
 - Bump snap version to include security fix ([#10313](https://github.com/RocketChat/Rocket.Chat/pull/10313))
 - Update Meteor to 1.6.1.1 ([#10314](https://github.com/RocketChat/Rocket.Chat/pull/10314))
@@ -582,9 +675,9 @@
 - [@hmagarotto](https://github.com/hmagarotto)
 - [@kaiiiiiiiii](https://github.com/kaiiiiiiiii)
 - [@kb0304](https://github.com/kb0304)
+- [@lunaticmonk](https://github.com/lunaticmonk)
 - [@mutdmour](https://github.com/mutdmour)
 - [@ramrami](https://github.com/ramrami)
-- [@sumedh123](https://github.com/sumedh123)
 - [@trongthanh](https://github.com/trongthanh)
 - [@ubarsaiyan](https://github.com/ubarsaiyan)
 
@@ -604,6 +697,10 @@
 
 # 0.62.2
 `2018-03-09  ·  6 🐛  ·  1 🔍  ·  4 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `8.9.4`
+- NPM: `5.6.0`
 
 ### 🐛 Bug fixes
 
@@ -634,6 +731,10 @@
 # 0.62.1
 `2018-03-03  ·  4 🐛  ·  1 🔍  ·  4 👩‍💻👨‍💻`
 
+### Engine versions
+- Node: `8.9.4`
+- NPM: `5.6.0`
+
 ### 🐛 Bug fixes
 
 - Delete user without username was removing direct rooms of all users ([#9986](https://github.com/RocketChat/Rocket.Chat/pull/9986))
@@ -658,6 +759,10 @@
 # 0.62.0
 `2018-02-27  ·  1 ️️️⚠️  ·  24 🎉  ·  32 🐛  ·  26 🔍  ·  39 👩‍💻👨‍💻`
 
+### Engine versions
+- Node: `8.9.4`
+- NPM: `5.6.0`
+
 ### ⚠️ BREAKING CHANGES
 
 - Remove Graphics/Image Magick support ([#9711](https://github.com/RocketChat/Rocket.Chat/pull/9711))
@@ -670,8 +775,8 @@
 - Add user settings / preferences API endpoint ([#9457](https://github.com/RocketChat/Rocket.Chat/pull/9457) by [@jgtoriginal](https://github.com/jgtoriginal))
 - New sidebar layout ([#9608](https://github.com/RocketChat/Rocket.Chat/pull/9608))
 - Message read receipts ([#9717](https://github.com/RocketChat/Rocket.Chat/pull/9717))
-- Alert admins when user requires approval & alert users when the account is approved/activated/deactivated ([#7098](https://github.com/RocketChat/Rocket.Chat/pull/7098))
-- Allow configuration of SAML logout behavior ([#9527](https://github.com/RocketChat/Rocket.Chat/pull/9527) by [@mrsimpson](https://github.com/mrsimpson))
+- Alert admins when user requires approval & alert users when the account is approved/activated/deactivated ([#7098](https://github.com/RocketChat/Rocket.Chat/pull/7098) by [@luisfn](https://github.com/luisfn))
+- Allow configuration of SAML logout behavior ([#9527](https://github.com/RocketChat/Rocket.Chat/pull/9527))
 - Internal hubot support for Direct Messages and Private Groups ([#8933](https://github.com/RocketChat/Rocket.Chat/pull/8933) by [@ramrami](https://github.com/ramrami))
 - Improved default welcome message ([#9298](https://github.com/RocketChat/Rocket.Chat/pull/9298) by [@HammyHavoc](https://github.com/HammyHavoc))
 - Makes shield icon configurable ([#9746](https://github.com/RocketChat/Rocket.Chat/pull/9746) by [@c0dzilla](https://github.com/c0dzilla))
@@ -687,7 +792,7 @@
 - GraphQL API ([#8158](https://github.com/RocketChat/Rocket.Chat/pull/8158) by [@kamilkisiela](https://github.com/kamilkisiela))
 - Livestream tab ([#9255](https://github.com/RocketChat/Rocket.Chat/pull/9255))
 - Add documentation requirement to PRs ([#9658](https://github.com/RocketChat/Rocket.Chat/pull/9658) by [@SeanPackham](https://github.com/SeanPackham))
-- Request mongoDB version in github issue template ([#9807](https://github.com/RocketChat/Rocket.Chat/pull/9807) by [@TwizzyDizzy](https://github.com/TwizzyDizzy))
+- Request mongoDB version in github issue template ([#9807](https://github.com/RocketChat/Rocket.Chat/pull/9807))
 
 ### 🐛 Bug fixes
 
@@ -697,9 +802,9 @@
 - Livechat conversation not receiving messages when start without form ([#9772](https://github.com/RocketChat/Rocket.Chat/pull/9772))
 - Emoji rendering on last message ([#9776](https://github.com/RocketChat/Rocket.Chat/pull/9776))
 - Chrome 64 breaks jitsi-meet iframe ([#9560](https://github.com/RocketChat/Rocket.Chat/pull/9560) by [@speedy01](https://github.com/speedy01))
-- Harmonize channel-related actions ([#9697](https://github.com/RocketChat/Rocket.Chat/pull/9697) by [@mrsimpson](https://github.com/mrsimpson))
+- Harmonize channel-related actions ([#9697](https://github.com/RocketChat/Rocket.Chat/pull/9697))
 - Custom emoji was cropping sometimes ([#9676](https://github.com/RocketChat/Rocket.Chat/pull/9676) by [@anu-007](https://github.com/anu-007))
-- Show custom room types icon in channel header ([#9696](https://github.com/RocketChat/Rocket.Chat/pull/9696) by [@mrsimpson](https://github.com/mrsimpson))
+- Show custom room types icon in channel header ([#9696](https://github.com/RocketChat/Rocket.Chat/pull/9696))
 - 'Query' support for channels.list.joined, groups.list, groups.listAll, im.list ([#9424](https://github.com/RocketChat/Rocket.Chat/pull/9424) by [@xbolshe](https://github.com/xbolshe))
 - Livechat issues on external queue and lead capture ([#9750](https://github.com/RocketChat/Rocket.Chat/pull/9750))
 - DeprecationWarning: prom-client ... when starting Rocket Chat server ([#9747](https://github.com/RocketChat/Rocket.Chat/pull/9747) by [@jgtoriginal](https://github.com/jgtoriginal))
@@ -714,7 +819,7 @@
 - Rest API helpers only applying to v1 ([#9520](https://github.com/RocketChat/Rocket.Chat/pull/9520))
 - Desktop notification not showing when avatar came from external storage service ([#9639](https://github.com/RocketChat/Rocket.Chat/pull/9639))
 - Missing link Site URLs in enrollment e-mails ([#9454](https://github.com/RocketChat/Rocket.Chat/pull/9454) by [@kemitchell](https://github.com/kemitchell))
-- Missing string 'Username_already_exist' on the accountProfile page ([#9610](https://github.com/RocketChat/Rocket.Chat/pull/9610) by [@sumedh123](https://github.com/sumedh123))
+- Missing string 'Username_already_exist' on the accountProfile page ([#9610](https://github.com/RocketChat/Rocket.Chat/pull/9610) by [@lunaticmonk](https://github.com/lunaticmonk))
 - SVG avatars are not been displayed correctly when load in non HTML containers ([#9570](https://github.com/RocketChat/Rocket.Chat/pull/9570))
 - Livechat is not working when running in a sub path ([#9599](https://github.com/RocketChat/Rocket.Chat/pull/9599))
 - Not receiving sound notifications in rooms created by new LiveChats ([#9802](https://github.com/RocketChat/Rocket.Chat/pull/9802))
@@ -743,7 +848,7 @@
 - Dependencies update ([#9811](https://github.com/RocketChat/Rocket.Chat/pull/9811))
 - Fix: Custom fields not showing on user info panel ([#9821](https://github.com/RocketChat/Rocket.Chat/pull/9821))
 - Regression: Page was not respecting the window height on Firefox ([#9804](https://github.com/RocketChat/Rocket.Chat/pull/9804))
-- Update bot-config.yml ([#9784](https://github.com/RocketChat/Rocket.Chat/pull/9784) by [@JSzaszvari](https://github.com/JSzaszvari))
+- Update bot-config.yml ([#9784](https://github.com/RocketChat/Rocket.Chat/pull/9784))
 - Develop fix sync from master ([#9797](https://github.com/RocketChat/Rocket.Chat/pull/9797))
 - Regression: Change create channel icon ([#9851](https://github.com/RocketChat/Rocket.Chat/pull/9851))
 - Regression: Fix channel icons on safari ([#9852](https://github.com/RocketChat/Rocket.Chat/pull/9852))
@@ -760,10 +865,8 @@
 
 - [@AmShaegar13](https://github.com/AmShaegar13)
 - [@HammyHavoc](https://github.com/HammyHavoc)
-- [@JSzaszvari](https://github.com/JSzaszvari)
 - [@RationalCoding](https://github.com/RationalCoding)
 - [@SeanPackham](https://github.com/SeanPackham)
-- [@TwizzyDizzy](https://github.com/TwizzyDizzy)
 - [@anu-007](https://github.com/anu-007)
 - [@bernardoetrevisan](https://github.com/bernardoetrevisan)
 - [@c0dzilla](https://github.com/c0dzilla)
@@ -776,18 +879,20 @@
 - [@kb0304](https://github.com/kb0304)
 - [@kemitchell](https://github.com/kemitchell)
 - [@lindoelio](https://github.com/lindoelio)
-- [@mrsimpson](https://github.com/mrsimpson)
+- [@luisfn](https://github.com/luisfn)
+- [@lunaticmonk](https://github.com/lunaticmonk)
 - [@ramrami](https://github.com/ramrami)
 - [@savikko](https://github.com/savikko)
 - [@sizrar](https://github.com/sizrar)
 - [@speedy01](https://github.com/speedy01)
-- [@sumedh123](https://github.com/sumedh123)
 - [@xbolshe](https://github.com/xbolshe)
 
 ### 👩‍💻👨‍💻 Core Team 🤓
 
+- [@JSzaszvari](https://github.com/JSzaszvari)
 - [@MarcosSpessatto](https://github.com/MarcosSpessatto)
 - [@MartinSchoeler](https://github.com/MartinSchoeler)
+- [@TwizzyDizzy](https://github.com/TwizzyDizzy)
 - [@engelgabriel](https://github.com/engelgabriel)
 - [@filipedelimabrito](https://github.com/filipedelimabrito)
 - [@gdelavald](https://github.com/gdelavald)
@@ -795,7 +900,7 @@
 - [@ggazzo](https://github.com/ggazzo)
 - [@graywolf336](https://github.com/graywolf336)
 - [@karlprieb](https://github.com/karlprieb)
-- [@luisfn](https://github.com/luisfn)
+- [@mrsimpson](https://github.com/mrsimpson)
 - [@rafaelks](https://github.com/rafaelks)
 - [@renatobecker](https://github.com/renatobecker)
 - [@rodrigok](https://github.com/rodrigok)
@@ -803,6 +908,10 @@
 
 # 0.61.2
 `2018-02-20  ·  3 🐛  ·  1 🔍  ·  3 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `8.9.3`
+- NPM: `5.5.1`
 
 ### 🐛 Bug fixes
 
@@ -826,6 +935,10 @@
 # 0.61.1
 `2018-02-14  ·  1 🔍  ·  1 👩‍💻👨‍💻`
 
+### Engine versions
+- Node: `8.9.3`
+- NPM: `5.5.1`
+
 <details>
 <summary>🔍 Minor changes</summary>
 
@@ -840,6 +953,10 @@
 # 0.61.0
 `2018-01-27  ·  1 ️️️⚠️  ·  12 🎉  ·  55 🐛  ·  43 🔍  ·  23 👩‍💻👨‍💻`
 
+### Engine versions
+- Node: `8.9.3`
+- NPM: `5.5.1`
+
 ### ⚠️ BREAKING CHANGES
 
 - Decouple livechat visitors from regular users ([#9048](https://github.com/RocketChat/Rocket.Chat/pull/9048))
@@ -847,7 +964,7 @@
 ### 🎉 New features
 
 - Contextual Bar Redesign ([#8411](https://github.com/RocketChat/Rocket.Chat/pull/8411))
-- Update documentation: provide example for multiple basedn ([#9442](https://github.com/RocketChat/Rocket.Chat/pull/9442) by [@mms-segu](https://github.com/mms-segu))
+- Update documentation: provide example for multiple basedn ([#9442](https://github.com/RocketChat/Rocket.Chat/pull/9442) by [@rndmh3ro](https://github.com/rndmh3ro))
 - Sidebar menu option to mark room as unread ([#9216](https://github.com/RocketChat/Rocket.Chat/pull/9216))
 - Add mention-here permission #7631 ([#9228](https://github.com/RocketChat/Rocket.Chat/pull/9228) by [@ryjones](https://github.com/ryjones))
 - Indicate the Self DM room ([#9234](https://github.com/RocketChat/Rocket.Chat/pull/9234))
@@ -973,10 +1090,10 @@
 - [@cpitman](https://github.com/cpitman)
 - [@cyclops24](https://github.com/cyclops24)
 - [@ggrish](https://github.com/ggrish)
-- [@mms-segu](https://github.com/mms-segu)
 - [@paulovitin](https://github.com/paulovitin)
 - [@peterlee0127](https://github.com/peterlee0127)
 - [@ramrami](https://github.com/ramrami)
+- [@rndmh3ro](https://github.com/rndmh3ro)
 - [@ryjones](https://github.com/ryjones)
 - [@vitor-nagao](https://github.com/vitor-nagao)
 
@@ -997,6 +1114,10 @@
 
 # 0.60.4
 `2018-01-10  ·  5 🐛  ·  4 🔍  ·  4 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `8.9.3`
+- NPM: `5.5.1`
 
 ### 🐛 Bug fixes
 
@@ -1028,6 +1149,10 @@
 
 # 0.60.3
 `2018-01-03  ·  6 🐛  ·  5 🔍  ·  3 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `8.9.3`
+- NPM: `5.5.1`
 
 ### 🐛 Bug fixes
 
@@ -1061,6 +1186,10 @@
 # 0.60.2
 `2017-12-29  ·  3 🐛  ·  1 🔍  ·  2 👩‍💻👨‍💻`
 
+### Engine versions
+- Node: `8.9.3`
+- NPM: `5.5.1`
+
 ### 🐛 Bug fixes
 
 - Restore translations from other languages ([#9277](https://github.com/RocketChat/Rocket.Chat/pull/9277))
@@ -1082,6 +1211,10 @@
 # 0.60.1
 `2017-12-27  ·  1 🐛  ·  1 👩‍💻👨‍💻`
 
+### Engine versions
+- Node: `8.9.3`
+- NPM: `5.5.1`
+
 ### 🐛 Bug fixes
 
 - File access not working when passing credentials via querystring ([#9262](https://github.com/RocketChat/Rocket.Chat/pull/9262))
@@ -1092,6 +1225,10 @@
 
 # 0.60.0
 `2017-12-27  ·  33 🎉  ·  174 🐛  ·  108 🔍  ·  71 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `8.9.3`
+- NPM: `5.5.1`
 
 ### 🎉 New features
 
@@ -1108,7 +1245,7 @@
 - Add new API endpoints ([#8947](https://github.com/RocketChat/Rocket.Chat/pull/8947))
 - Option to enable/disable auto away and configure timer ([#8029](https://github.com/RocketChat/Rocket.Chat/pull/8029) by [@armand1m](https://github.com/armand1m))
 - New Modal component ([#8882](https://github.com/RocketChat/Rocket.Chat/pull/8882))
-- Improve room types API and usages ([#9009](https://github.com/RocketChat/Rocket.Chat/pull/9009) by [@mrsimpson](https://github.com/mrsimpson))
+- Improve room types API and usages ([#9009](https://github.com/RocketChat/Rocket.Chat/pull/9009))
 - Room counter sidebar preference ([#8866](https://github.com/RocketChat/Rocket.Chat/pull/8866))
 - Save room's last message ([#8979](https://github.com/RocketChat/Rocket.Chat/pull/8979))
 - Token Controlled Access channels ([#8060](https://github.com/RocketChat/Rocket.Chat/pull/8060) by [@lindoelio](https://github.com/lindoelio))
@@ -1145,7 +1282,7 @@
 - Notification sound is not disabling when busy ([#9042](https://github.com/RocketChat/Rocket.Chat/pull/9042))
 - Use encodeURI in AmazonS3 contentDisposition file.name to prevent fail ([#9024](https://github.com/RocketChat/Rocket.Chat/pull/9024) by [@paulovitin](https://github.com/paulovitin))
 - snap install by setting grpc package used by google/vision to 1.6.6 ([#9029](https://github.com/RocketChat/Rocket.Chat/pull/9029))
-- Enable CORS for Restivus ([#8671](https://github.com/RocketChat/Rocket.Chat/pull/8671) by [@mrsimpson](https://github.com/mrsimpson))
+- Enable CORS for Restivus ([#8671](https://github.com/RocketChat/Rocket.Chat/pull/8671))
 - Importers failing when usernames exists but cases don't match and improve the importer framework's performance ([#8966](https://github.com/RocketChat/Rocket.Chat/pull/8966))
 - Error when saving integration with symbol as only trigger ([#9023](https://github.com/RocketChat/Rocket.Chat/pull/9023))
 - Sync of non existent field throws exception ([#8006](https://github.com/RocketChat/Rocket.Chat/pull/8006) by [@goiaba](https://github.com/goiaba))
@@ -1176,7 +1313,7 @@
 - Improved grammar and made it clearer to the user ([#8795](https://github.com/RocketChat/Rocket.Chat/pull/8795) by [@HammyHavoc](https://github.com/HammyHavoc))
 - Show real name of current user at top of side nav if setting enabled ([#8718](https://github.com/RocketChat/Rocket.Chat/pull/8718))
 - Range Slider Value label has bug in RTL ([#8441](https://github.com/RocketChat/Rocket.Chat/pull/8441) by [@cyclops24](https://github.com/cyclops24))
-- Add historic chats icon in Livechat ([#8708](https://github.com/RocketChat/Rocket.Chat/pull/8708) by [@mrsimpson](https://github.com/mrsimpson))
+- Add historic chats icon in Livechat ([#8708](https://github.com/RocketChat/Rocket.Chat/pull/8708))
 - Sort direct messages by full name if show real names setting enabled ([#8717](https://github.com/RocketChat/Rocket.Chat/pull/8717))
 - Improving consistency of UX ([#8796](https://github.com/RocketChat/Rocket.Chat/pull/8796) by [@HammyHavoc](https://github.com/HammyHavoc))
 - fixed some typos ([#8787](https://github.com/RocketChat/Rocket.Chat/pull/8787) by [@TheReal1604](https://github.com/TheReal1604))
@@ -1455,7 +1592,6 @@
 - [@luizbills](https://github.com/luizbills)
 - [@mastappl](https://github.com/mastappl)
 - [@mritunjaygoutam12](https://github.com/mritunjaygoutam12)
-- [@mrsimpson](https://github.com/mrsimpson)
 - [@paulovitin](https://github.com/paulovitin)
 - [@peterlee0127](https://github.com/peterlee0127)
 - [@pkgodara](https://github.com/pkgodara)
@@ -1491,6 +1627,7 @@
 - [@graywolf336](https://github.com/graywolf336)
 - [@karlprieb](https://github.com/karlprieb)
 - [@marceloschmidt](https://github.com/marceloschmidt)
+- [@mrsimpson](https://github.com/mrsimpson)
 - [@pierreozoux](https://github.com/pierreozoux)
 - [@rafaelks](https://github.com/rafaelks)
 - [@rodrigok](https://github.com/rodrigok)
@@ -1499,6 +1636,10 @@
 
 # 0.59.6
 `2017-11-29  ·  1 🔍  ·  1 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `4.8.4`
+- NPM: `4.6.1`
 
 <details>
 <summary>🔍 Minor changes</summary>
@@ -1514,6 +1655,10 @@
 # 0.59.5
 `2017-11-29  ·  1 🔍  ·  1 👩‍💻👨‍💻`
 
+### Engine versions
+- Node: `4.8.4`
+- NPM: `4.6.1`
+
 <details>
 <summary>🔍 Minor changes</summary>
 
@@ -1527,6 +1672,10 @@
 
 # 0.59.4
 `2017-11-29  ·  1 🐛  ·  2 🔍  ·  5 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `4.8.4`
+- NPM: `4.6.1`
 
 ### 🐛 Bug fixes
 
@@ -1553,6 +1702,10 @@
 
 # 0.59.3
 `2017-10-29  ·  7 🐛  ·  2 🔍  ·  8 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `4.8.4`
+- NPM: `4.6.1`
 
 ### 🐛 Bug fixes
 
@@ -1589,6 +1742,10 @@
 # 0.59.2
 `2017-10-25  ·  6 🐛  ·  4 👩‍💻👨‍💻`
 
+### Engine versions
+- Node: `4.8.4`
+- NPM: `4.6.1`
+
 ### 🐛 Bug fixes
 
 - Missing scroll at create channel page ([#8637](https://github.com/RocketChat/Rocket.Chat/pull/8637))
@@ -1611,6 +1768,10 @@
 # 0.59.1
 `2017-10-19  ·  4 🐛  ·  2 👩‍💻👨‍💻`
 
+### Engine versions
+- Node: `4.8.4`
+- NPM: `4.6.1`
+
 ### 🐛 Bug fixes
 
 - Color reset when default value editor is different ([#8543](https://github.com/RocketChat/Rocket.Chat/pull/8543))
@@ -1625,6 +1786,10 @@
 
 # 0.59.0
 `2017-10-18  ·  25 🎉  ·  131 🐛  ·  51 🔍  ·  46 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `4.8.4`
+- NPM: `4.6.1`
 
 ### 🎉 New features
 
@@ -1900,6 +2065,10 @@
 # 0.58.4
 `2017-10-05  ·  3 🐛  ·  2 👩‍💻👨‍💻`
 
+### Engine versions
+- Node: `4.8.4`
+- NPM: `4.6.1`
+
 ### 🐛 Bug fixes
 
 - Duplicate code in rest api letting in a few bugs with the rest api ([#8408](https://github.com/RocketChat/Rocket.Chat/pull/8408))
@@ -1913,6 +2082,10 @@
 
 # 0.58.2
 `2017-08-22  ·  1 🔍  ·  2 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `4.8.4`
+- NPM: `4.6.1`
 
 <details>
 <summary>🔍 Minor changes</summary>
@@ -1932,6 +2105,10 @@
 # 0.58.1
 `2017-08-17  ·  1 🐛  ·  1 🔍  ·  2 👩‍💻👨‍💻`
 
+### Engine versions
+- Node: `4.8.4`
+- NPM: `4.6.1`
+
 ### 🐛 Bug fixes
 
 - Fix flex tab not opening and getting offscreen ([#7781](https://github.com/RocketChat/Rocket.Chat/pull/7781))
@@ -1950,6 +2127,10 @@
 
 # 0.58.0
 `2017-08-16  ·  1 ️️️⚠️  ·  27 🎉  ·  72 🐛  ·  22 🔍  ·  33 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `4.8.4`
+- NPM: `4.6.1`
 
 ### ⚠️ BREAKING CHANGES
 
@@ -2079,7 +2260,7 @@
 - Develop sync ([#7500](https://github.com/RocketChat/Rocket.Chat/pull/7500) by [@thinkeridea](https://github.com/thinkeridea))
 - Better Issue Template ([#7492](https://github.com/RocketChat/Rocket.Chat/pull/7492))
 - Add helm chart kubernetes deployment ([#6340](https://github.com/RocketChat/Rocket.Chat/pull/6340))
-- Develop sync ([#7363](https://github.com/RocketChat/Rocket.Chat/pull/7363) by [@JSzaszvari](https://github.com/JSzaszvari))
+- Develop sync ([#7363](https://github.com/RocketChat/Rocket.Chat/pull/7363))
 - Escape error messages ([#7308](https://github.com/RocketChat/Rocket.Chat/pull/7308))
 - update meteor to 1.5.0 ([#7287](https://github.com/RocketChat/Rocket.Chat/pull/7287))
 - Fix the Zapier oAuth return url to the new one ([#7215](https://github.com/RocketChat/Rocket.Chat/pull/7215))
@@ -2092,7 +2273,6 @@
 
 - [@AhmetS](https://github.com/AhmetS)
 - [@Darkneon](https://github.com/Darkneon)
-- [@JSzaszvari](https://github.com/JSzaszvari)
 - [@Oliver84](https://github.com/Oliver84)
 - [@al3x](https://github.com/al3x)
 - [@borsden](https://github.com/borsden)
@@ -2115,6 +2295,7 @@
 
 ### 👩‍💻👨‍💻 Core Team 🤓
 
+- [@JSzaszvari](https://github.com/JSzaszvari)
 - [@MartinSchoeler](https://github.com/MartinSchoeler)
 - [@engelgabriel](https://github.com/engelgabriel)
 - [@filipedelimabrito](https://github.com/filipedelimabrito)
@@ -2130,6 +2311,10 @@
 # 0.57.4
 `2017-10-05  ·  3 🐛  ·  2 👩‍💻👨‍💻`
 
+### Engine versions
+- Node: `4.8.2`
+- NPM: `4.5.0`
+
 ### 🐛 Bug fixes
 
 - Slack import failing and not being able to be restarted ([#8390](https://github.com/RocketChat/Rocket.Chat/pull/8390))
@@ -2143,6 +2328,10 @@
 
 # 0.57.3
 `2017-08-08  ·  8 🐛  ·  1 🔍  ·  7 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `4.8.2`
+- NPM: `4.5.0`
 
 ### 🐛 Bug fixes
 
@@ -2178,6 +2367,10 @@
 # 0.57.2
 `2017-07-14  ·  6 🐛  ·  3 👩‍💻👨‍💻`
 
+### Engine versions
+- Node: `4.8.2`
+- NPM: `4.5.0`
+
 ### 🐛 Bug fixes
 
 - Fix Emails in User Admin View ([#7431](https://github.com/RocketChat/Rocket.Chat/pull/7431))
@@ -2196,6 +2389,10 @@
 # 0.57.1
 `2017-07-05  ·  1 🐛  ·  2 👩‍💻👨‍💻`
 
+### Engine versions
+- Node: `4.8.2`
+- NPM: `4.5.0`
+
 ### 🐛 Bug fixes
 
 - Fix migration of avatars from version 0.57.0 ([#7428](https://github.com/RocketChat/Rocket.Chat/pull/7428))
@@ -2207,6 +2404,10 @@
 
 # 0.57.0
 `2017-07-03  ·  1 ️️️⚠️  ·  12 🎉  ·  45 🐛  ·  31 🔍  ·  25 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `4.8.2`
+- NPM: `4.5.0`
 
 ### ⚠️ BREAKING CHANGES
 
@@ -2267,7 +2468,7 @@
 - Fix editing others messages ([#7200](https://github.com/RocketChat/Rocket.Chat/pull/7200))
 - Fix oembed previews not being shown ([#7208](https://github.com/RocketChat/Rocket.Chat/pull/7208))
 - "requirePasswordChange" property not being saved when set to false ([#7209](https://github.com/RocketChat/Rocket.Chat/pull/7209))
-- Removing the kadira package install from example build script. ([#7160](https://github.com/RocketChat/Rocket.Chat/pull/7160) by [@JSzaszvari](https://github.com/JSzaszvari))
+- Removing the kadira package install from example build script. ([#7160](https://github.com/RocketChat/Rocket.Chat/pull/7160))
 - Fix user's customFields not being saved correctly ([#7358](https://github.com/RocketChat/Rocket.Chat/pull/7358))
 - Improve avatar migration ([#7352](https://github.com/RocketChat/Rocket.Chat/pull/7352))
 - Fix jump to unread button ([#7320](https://github.com/RocketChat/Rocket.Chat/pull/7320))
@@ -2315,7 +2516,6 @@
 ### 👩‍💻👨‍💻 Contributors 😍
 
 - [@ExTechOp](https://github.com/ExTechOp)
-- [@JSzaszvari](https://github.com/JSzaszvari)
 - [@abrom](https://github.com/abrom)
 - [@bbrauns](https://github.com/bbrauns)
 - [@colin-campbell](https://github.com/colin-campbell)
@@ -2332,6 +2532,7 @@
 
 ### 👩‍💻👨‍💻 Core Team 🤓
 
+- [@JSzaszvari](https://github.com/JSzaszvari)
 - [@MartinSchoeler](https://github.com/MartinSchoeler)
 - [@alexbrazier](https://github.com/alexbrazier)
 - [@engelgabriel](https://github.com/engelgabriel)
@@ -2345,6 +2546,10 @@
 
 # 0.56.0
 `2017-05-15  ·  11 🎉  ·  21 🐛  ·  22 🔍  ·  19 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `4.8.2`
+- NPM: `4.5.0`
 
 ### 🎉 New features
 
@@ -2440,6 +2645,10 @@
 # 0.55.1
 `2017-04-19  ·  1 🔍  ·  1 👩‍💻👨‍💻`
 
+### Engine versions
+- Node: `4.8.0`
+- NPM: `4.3.0`
+
 <details>
 <summary>🔍 Minor changes</summary>
 
@@ -2453,6 +2662,10 @@
 
 # 0.55.0
 `2017-04-18  ·  1 ️️️⚠️  ·  9 🎉  ·  25 🐛  ·  87 🔍  ·  23 👩‍💻👨‍💻`
+
+### Engine versions
+- Node: `4.8.0`
+- NPM: `4.3.0`
 
 ### ⚠️ BREAKING CHANGES
 
@@ -2587,7 +2800,7 @@
 - Added Deploy method and platform to stats ([#6649](https://github.com/RocketChat/Rocket.Chat/pull/6649))
 - LingoHub based on develop ([#6647](https://github.com/RocketChat/Rocket.Chat/pull/6647))
 - meteor update ([#6631](https://github.com/RocketChat/Rocket.Chat/pull/6631))
-- Env override initial setting ([#6163](https://github.com/RocketChat/Rocket.Chat/pull/6163) by [@mrsimpson](https://github.com/mrsimpson))
+- Env override initial setting ([#6163](https://github.com/RocketChat/Rocket.Chat/pull/6163))
 
 </details>
 
@@ -2599,7 +2812,6 @@
 - [@billtt](https://github.com/billtt)
 - [@drallgood](https://github.com/drallgood)
 - [@fengt](https://github.com/fengt)
-- [@mrsimpson](https://github.com/mrsimpson)
 - [@nathanmarcos](https://github.com/nathanmarcos)
 - [@qge](https://github.com/qge)
 - [@sezinkarli](https://github.com/sezinkarli)
@@ -2617,5 +2829,6 @@
 - [@graywolf336](https://github.com/graywolf336)
 - [@karlprieb](https://github.com/karlprieb)
 - [@marceloschmidt](https://github.com/marceloschmidt)
+- [@mrsimpson](https://github.com/mrsimpson)
 - [@rodrigok](https://github.com/rodrigok)
 - [@sampaiodiego](https://github.com/sampaiodiego)


### PR DESCRIPTION
Include the nodejs and npm versions to all release notes.

We get the meteor version from `.meter/release`, get a file from meteor's repository containing the versions of the given release.