### PR TITLE
Regression: sidebar sorting was being wrong in some cases where the rooms records were returned before the subscriptions

### DIFF
--- a/packages/rocketchat-lib/client/lib/cachedCollection.js
+++ b/packages/rocketchat-lib/client/lib/cachedCollection.js
@@ -110,7 +110,7 @@ class CachedCollection {
 		listenChangesForLoggedUsersOnly = false,
 		useSync = true,
 		useCache = true,
-		version = 7,
+		version = 8,
 		maxCacheTime = 60*60*24*30,
 		onSyncData = (/* action, record */) => {}
 	}) {

--- a/packages/rocketchat-lib/client/lib/cachedCollection.js
+++ b/packages/rocketchat-lib/client/lib/cachedCollection.js
@@ -110,7 +110,7 @@ class CachedCollection {
 		listenChangesForLoggedUsersOnly = false,
 		useSync = true,
 		useCache = true,
-		version = 8,
+		version = 7,
 		maxCacheTime = 60*60*24*30,
 		onSyncData = (/* action, record */) => {}
 	}) {

--- a/packages/rocketchat-ui-sidenav/client/roomList.js
+++ b/packages/rocketchat-ui-sidenav/client/roomList.js
@@ -1,6 +1,5 @@
 /* globals RocketChat */
 import { UiTextContext } from 'meteor/rocketchat:lib';
-import _ from 'underscore';
 
 Template.roomList.helpers({
 	rooms() {

--- a/packages/rocketchat-ui-sidenav/client/roomList.js
+++ b/packages/rocketchat-ui-sidenav/client/roomList.js
@@ -122,8 +122,17 @@ const mergeRoomSub = room => {
 	if (!sub) {
 		return room;
 	}
-	const $set = {lastMessage : room.lastMessage, lm: room._updatedAt, ...getLowerCaseNames(room, sub.name)};
-	RocketChat.models.Subscriptions.update({ rid: room._id }, {$set});
+
+	RocketChat.models.Subscriptions.update({
+		rid: room._id
+	}, {
+		$set: {
+			lastMessage: room.lastMessage,
+			lm: room._updatedAt,
+			...getLowerCaseNames(room, sub.name)
+		}
+	});
+
 	return room;
 };
 


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
