### PR TITLE
[WIP] Create rocketchat webdav package for webdav integration

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -151,6 +151,7 @@ rocketchat:ui-vrecord
 rocketchat:user-data-download
 rocketchat:version
 rocketchat:videobridge
+rocketchat:webdav
 rocketchat:webrtc
 rocketchat:wordpress
 rocketchat:nrr

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -244,6 +244,7 @@ rocketchat:user-data-download@1.0.0
 rocketchat:version@1.0.0
 rocketchat:version-check@0.0.1
 rocketchat:videobridge@0.2.0
+rocketchat:webdav@0.0.1
 rocketchat:webrtc@0.0.1
 rocketchat:wordpress@0.0.1
 routepolicy@1.0.13

--- a/packages/rockethat-webdav/README.md
+++ b/packages/rockethat-webdav/README.md
@@ -1,0 +1,3 @@
+# RocketChat WebDAV
+
+Package for RocketChat users to interact with WebDAV servers (Tested with ownCloud and Nextcloud).

--- a/packages/rockethat-webdav/package.js
+++ b/packages/rockethat-webdav/package.js
@@ -1,0 +1,20 @@
+Package.describe({
+	name: 'rocketchat:webdav',
+	version: '0.0.1',
+
+	summary: 'Package for RocketChat users to interact with WebDAV servers.',
+
+	git: '',
+
+	documentation: 'README.md'
+});
+
+Package.onUse(function(api) {
+	api.use('ecmascript');
+	api.use('mongo');
+	api.use('rocketchat:lib');
+	api.use('rocketchat:api');
+	api.use('rocketchat:grant');
+
+	api.addFiles('startup/messageBoxActions.js', 'client');
+});

--- a/packages/rockethat-webdav/startup/messageBoxActions.js
+++ b/packages/rockethat-webdav/startup/messageBoxActions.js
@@ -1,0 +1,24 @@
+/* globals fileUpload modal */
+
+RocketChat.messageBox.actions.add('Add_files_from', 'WebDAV', {
+	id: 'webdav-upload',
+	icon: 'webdav',
+	condition: () => RocketChat.settings.get('FileUpload_Enabled'),
+	action() {
+		const text = `<div class="upload-preview"><div class="upload-preview-file"</div></div>`;
+		modal.open({
+			title: t('Webdav_File_Picker'),
+			text: '',
+			showCancelButton: true,
+			closeOnConfirm: true,
+			closeOnCancel: true,
+			html: true,
+		}, function(isConfirm) {
+			if (isConfirm !== true) {
+				return;
+			}
+		});
+	}
+});
+
+


### PR DESCRIPTION
This PR will allow users to upload a file from their webdav server instance to a rocketchat channel. I have some questions about the best way to achieve that, any idea is welcome;

1- Should we add an admin section for enabling/disabling this integration? 
2- How should the authentication mechanism work? Oauth or username and password are the options that I found. 
Since all the WebDAV servers have not Oauth authenticator ability, starting with username and password is easier in my opinion. We can add a section to account preferences and take necessary inputs to connect users WebDAV instance.

Things to do:
- [ ] implement authentication mechanism to connect users webdav instance
- [ ] create file picker template
- [ ] test with various webdav server
- [ ] write documentation
