### PR TITLE
[IMPROVE] Set default max upload size to 100mb

### DIFF
--- a/packages/rocketchat-file-upload/server/startup/settings.js
+++ b/packages/rocketchat-file-upload/server/startup/settings.js
@@ -4,7 +4,7 @@ RocketChat.settings.addGroup('FileUpload', function() {
 		public: true
 	});
 
-	this.add('FileUpload_MaxFileSize', 2097152, {
+	this.add('FileUpload_MaxFileSize', 1073741824, {
 		type: 'int',
 		public: true
 	});

--- a/packages/rocketchat-file-upload/server/startup/settings.js
+++ b/packages/rocketchat-file-upload/server/startup/settings.js
@@ -4,7 +4,7 @@ RocketChat.settings.addGroup('FileUpload', function() {
 		public: true
 	});
 
-	this.add('FileUpload_MaxFileSize', 1073741824, {
+	this.add('FileUpload_MaxFileSize', 104857600, {
 		type: 'int',
 		public: true
 	});


### PR DESCRIPTION
The current default experience (2mb max upload size) is confusing for users of other chat platforms. (eg. Slack allows 1gb uploads in their free plan)

Rationale for 100mb is 1 min video output from iPhone X