### PR TITLE
[NEW] Privacy for custom user fields

### DIFF
--- a/packages/rocketchat-lib/server/functions/getFullUserData.js
+++ b/packages/rocketchat-lib/server/functions/getFullUserData.js
@@ -2,6 +2,8 @@
 import _ from 'underscore';
 import s from 'underscore.string';
 
+const logger = new Logger('getFullUserData');
+
 RocketChat.getFullUserData = function({userId, filter, limit}) {
 	let fields = {
 		name: 1,
@@ -23,11 +25,30 @@ RocketChat.getFullUserData = function({userId, filter, limit}) {
 			services: 1,
 			requirePasswordChange: 1,
 			requirePasswordChangeReason: 1,
-			roles: 1,
-			customFields: 1
+			roles: 1
 		});
 	} else if (limit !== 0) {
 		limit = 1;
+	}
+
+	const metaCustomFields = RocketChat.settings.get('Accounts_CustomFields').trim();
+
+	if (metaCustomFields !== '') {
+		try {
+			const customFields = JSON.parse(metaCustomFields);
+
+			if (customFields) {
+				Object.keys(customFields).forEach((key) => {
+					const element = customFields[key];
+
+					if ((element && element.public) || RocketChat.authz.hasPermission(userId, 'view-full-other-user-info')) {
+						fields[`customFields.${ key }`] = 1;
+					}
+				});
+			}
+		} catch (e) {
+			logger.warn(`The JSON specified for "Accounts_CustomFields" is invalid. The following error was thrown: ${ e }`);
+		}
 	}
 
 	filter = s.trim(filter);

--- a/packages/rocketchat-lib/server/models/Subscriptions.js
+++ b/packages/rocketchat-lib/server/models/Subscriptions.js
@@ -305,16 +305,11 @@ class ModelSubscriptions extends RocketChat.models._Base {
 	}
 
 	setCustomFieldsDirectMessagesByUserId(userId, fields) {
-		const values = {};
-		Object.keys(fields).forEach(key => {
-			values[`customFields.${ key }`] = fields[key];
-		});
-
 		const query = {
 			'u._id': userId,
 			't': 'd'
 		};
-		const update = { $set: values };
+		const update = { $set: { customFields: fields } };
 		const options = { 'multi': true };
 
 		return this.update(query, update, options);

--- a/packages/rocketchat-ui-flextab/client/tabs/userInfo.js
+++ b/packages/rocketchat-ui-flextab/client/tabs/userInfo.js
@@ -20,10 +20,6 @@ Template.userInfo.helpers({
 		return Template.instance().actions.get().map(action => typeof action === 'function' ? action.call(this): action).filter(action => action && (!action.condition || action.condition.call(this))).slice(0, 2);
 	},
 	customField() {
-		if (!RocketChat.authz.hasAllPermission('view-full-other-user-info')) {
-			return;
-		}
-
 		const sCustomFieldsToShow = RocketChat.settings.get('Accounts_CustomFieldsToShowInUserInfo').trim();
 		const customFields = [];
 


### PR DESCRIPTION
Related to #6515.
Recreation of #10891 as that PR got rather messy.

When using custom user fields, you might not want to expose rather private fields like `statusConnection` or their email. Currently, to view custom fields, the `view-full-other-user-info` permission is required.
This PR adds an optional `public` field to all `Accounts_CustomFields` entries, which overrides this requirement, so users without the permission can see the field.

## Setup
![2018-05-27_18-35-38](https://user-images.githubusercontent.com/39674991/40589494-7a6fa220-61ee-11e8-8acc-48cee8ed72bc.png)
![2018-05-27_18-35-46](https://user-images.githubusercontent.com/39674991/40589495-7a8aedaa-61ee-11e8-9be5-208d0a950c65.png)
_The `public` field will default to false when not specified._
## Preview
Any user can see all of their own fields.
![2018-05-27_18-36-40](https://user-images.githubusercontent.com/39674991/40589498-7ad3fd2e-61ee-11e8-9a9e-6b7411105a75.png)
However, if they do not have the `view-full-other-user-info` permission, they can only see others' public fields.
![2018-05-27_18-36-34](https://user-images.githubusercontent.com/39674991/40589497-7abb6606-61ee-11e8-9866-77f2c9bff6e3.png)
Of course, those with the `view-full-other-user-info` permission can always see all fields.
![2018-05-27_18-36-19](https://user-images.githubusercontent.com/39674991/40589496-7aa37dc0-61ee-11e8-9b37-0dbd8bbe4731.png)