### PR TITLE
[FIX] Outgoing integrations were stopping the oplog tailing sometimes

### DIFF
--- a/packages/rocketchat-integrations/server/lib/triggerHandler.js
+++ b/packages/rocketchat-integrations/server/lib/triggerHandler.js
@@ -3,6 +3,8 @@ import _ from 'underscore';
 import s from 'underscore.string';
 import moment from 'moment';
 import vm from 'vm';
+import Fiber from 'fibers';
+import Future from 'fibers/future';
 
 RocketChat.integrations.triggerHandler = new class RocketChatIntegrationHandler {
 	constructor() {
@@ -202,7 +204,15 @@ RocketChat.integrations.triggerHandler = new class RocketChatIntegrationHandler 
 
 	buildSandbox(store = {}) {
 		const sandbox = {
-			_, s, console, moment,
+			scriptTimeout(reject) {
+				return setTimeout(() => reject('timed out'), 3000);
+			},
+			_,
+			s,
+			console,
+			moment,
+			Fiber,
+			Promise,
 			Store: {
 				set: (key, val) => store[key] = val,
 				get: (key) => store[key]
@@ -303,7 +313,21 @@ RocketChat.integrations.triggerHandler = new class RocketChatIntegrationHandler 
 			sandbox.params = params;
 
 			this.updateHistory({ historyId, step: `execute-script-before-running-${ method }` });
-			const result = this.vm.runInNewContext('script[method](params)', sandbox, { timeout: 3000 });
+
+			const result = Future.fromPromise(this.vm.runInNewContext(`
+				new Promise((resolve, reject) => {
+					Fiber(() => {
+						scriptTimeout(reject);
+						try {
+							resolve(script[method](params))
+						} catch(e) {
+							reject(e);
+						}
+					}).run();
+				}).catch((error) => { throw new Error(error); });
+			`, sandbox, {
+				timeout: 3000
+			})).wait();
 
 			logger.outgoing.debug(`Script method "${ method }" result of the Integration "${ integration.name }" is:`);
 			logger.outgoing.debug(result);


### PR DESCRIPTION
When the integrations has a script that access some kind of async (made sync by Fibers) method the VM timeout would be fired after the timeout time and would generate some zoombie fibers cousing the oplog tailing (that uses Fibers) to stop working util a cursor timeout.

