### PR TITLE
[FIX] Message attachment's fields with different sizes

### DIFF
--- a/packages/rocketchat-message-attachments/client/stylesheets/messageAttachments.css
+++ b/packages/rocketchat-message-attachments/client/stylesheets/messageAttachments.css
@@ -87,6 +87,7 @@ html.rtl .attachment {
 	}
 
 	& .attachment-fields {
+		display: flex;
 		margin-top: 4px;
 
 		& .attachment-field {
@@ -101,10 +102,6 @@ html.rtl .attachment {
 				line-height: 1rem;
 			}
 		}
-	}
-
-	& .attachment-field ~ .attachment-field {
-		margin-top: 8px;
 	}
 
 	& .attachment-thumb {


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Before:
![image](https://user-images.githubusercontent.com/8591547/42289167-6a57f77a-7f94-11e8-8511-9f05346a60c2.png)


After:
![image](https://user-images.githubusercontent.com/8591547/42289029-beb2a276-7f93-11e8-9387-325d954ab078.png)

Msg schema:
```javascript
{
  "_id": "bQggkDyau77q9obZX",
  "msg": "",
  "attachments": [
    {
      "fields": [
        {
          "title": "Small field",
          "value": "one line",
          "short": true
        },
        {
          "title": "Big field",
          "value": "multiple\nlines\nsee?",
          "short": true
        }
      ]
    }
  ],
  "bot": {
    "i": "EivbwgSN3eqWkENFw"
  },
  "groupable": false,
  "emoji": ":bug:",
  "ts": "2018-07-04T16:55:04.361Z",
  "u": {
    "_id": "rocket.cat",
    "username": "rocket.cat",
    "name": "Rocket.Cat"
  },
  "rid": "GENERAL",
  "_updatedAt": "2018-07-04T16:55:04.367Z"
}