### PR TITLE
Regression: Fix migration 125 checking for settings field

### DIFF
--- a/server/startup/migrations/v125.js
+++ b/server/startup/migrations/v125.js
@@ -1,7 +1,9 @@
 RocketChat.Migrations.add({
 	version: 125,
 	up() {
-		RocketChat.models.Users.update({}, {
+		RocketChat.models.Users.update({
+			'settings.preferences.groupByType': { $exists: true }
+		}, {
 			$rename: {
 				'settings.preferences.groupByType': 'settings.preferences.sidebarGroupByType'
 			}


### PR DESCRIPTION
Closes #11353

Unfortunate seems like some databases have `settings` field on `users` as `null`, which causes migration 125 to fail.

This will fix the migration for those who have not ran it yet.

For those who are still locked on migration 125, upgrading to a new release with this fix will require the migration to be unlocked manually only using the following command:

```javascript
db.migrations.update({ version: 124, locked: true }, { $set: { version: 124, locked: false } })
```

For those who have skipped migration 125-129 manually, the recommended action is to revert back to version 125 and start the server with this fix. To revert back you can use the following command:

```javascript
db.migrations.update({ version: 129, locked: false }, { $set: { version: 124 } })
```

And finally for those still stuck with the migration locked, just updating to latest version/codebase will fix it.