### PR TITLE
[FIX] Livechat taking inquiry leading to 404 page

### DIFF
--- a/packages/rocketchat-livechat/server/lib/Livechat.js
+++ b/packages/rocketchat-livechat/server/lib/Livechat.js
@@ -314,7 +314,7 @@ RocketChat.Livechat = {
 
 	forwardOpenChats(userId) {
 		RocketChat.models.Rooms.findOpenByAgent(userId).forEach((room) => {
-			const guest = RocketChat.models.Users.findOneById(room.v._id);
+			const guest = LivechatVisitors.findOneById(room.v._id);
 			this.transfer(room, guest, { departmentId: guest.department });
 		});
 	},

--- a/packages/rocketchat-livechat/server/methods/takeInquiry.js
+++ b/packages/rocketchat-livechat/server/methods/takeInquiry.js
@@ -61,6 +61,6 @@ Meteor.methods({
 		});
 
 		// return room corresponding to inquiry (for redirecting agent to the room route)
-		return room;
+		return inquiry;
 	}
 });


### PR DESCRIPTION
Closes #11347 

When the Livechat routing method is `Guest Pool` and an agent takes an incoming Livechat, the route link is breaking.