### PR TITLE
[FIX] Fixed svg for older chrome browsers bug #11414

### DIFF
--- a/packages/rocketchat-ui-master/client/main.js
+++ b/packages/rocketchat-ui-master/client/main.js
@@ -4,7 +4,7 @@ import s from 'underscore.string';
 
 RocketChat.settings.collection.find({_id:/theme-color-rc/i}, {fields:{ value: 1 }}).observe({changed: () => { DynamicCss.run(true); }});
 
-this.isFirefox = navigator.userAgent.match(/Firefox\/(\d+)\.\d/);
+this.isFirefox = navigator.userAgent.match(/(Firefox|Chrome)\/(\d+)\.\d/);
 
 Template.body.onRendered(function() {
 	new Clipboard('.clipboard');

--- a/packages/rocketchat-ui/client/components/icon.js
+++ b/packages/rocketchat-ui/client/components/icon.js
@@ -3,5 +3,5 @@
 const firefoxBaseUrlFix = () => `${ window.location.origin }${ FlowRouter.current().path }`;
 
 Template.icon.helpers({
-	baseUrl: isFirefox && isFirefox[1] < 55 ? firefoxBaseUrlFix : undefined
+	baseUrl: isFirefox && isFirefox[2] < 55 ? firefoxBaseUrlFix : undefined
 });


### PR DESCRIPTION
Closes #11414 

Took the Pull Request #9311 and changed the two lines, so that they also apply for Google Chrome.