### PR TITLE
[FIX] Only escape HTML from details in toast error messages

### DIFF
--- a/client/lib/handleError.js
+++ b/client/lib/handleError.js
@@ -12,7 +12,15 @@ this.handleError = function(error, useToastr = true) {
 	}
 
 	if (useToastr) {
-		return toastr.error(s.escapeHTML(TAPi18n.__(error.error, error.details)), error.details && error.details.errorTitle ? s.escapeHTML(TAPi18n.__(error.details.errorTitle)) : null);
+		const details = Object.entries(error.details || {})
+			.reduce((obj, [ key, value ]) => {
+				obj[key] = s.escapeHTML(value);
+				return obj;
+			}, {});
+		const message = TAPi18n.__(error.error, details);
+		const title = details.errorTitle && TAPi18n.__(details.errorTitle);
+
+		return toastr.error(message, title);
 	}
 
 	return s.escapeHTML(TAPi18n.__(error.error, error.details));


### PR DESCRIPTION
Closes #11422 