### PR TITLE
[FIX] Code tag duplicating characters

### DIFF
--- a/packages/rocketchat-theme/client/imports/general/base_old.css
+++ b/packages/rocketchat-theme/client/imports/general/base_old.css
@@ -121,7 +121,6 @@
 
 .copyonly {
 	display: inline-block;
-	float: left;
 
 	width: 0;
 	height: 0;
@@ -131,6 +130,10 @@
 
 	font-size: 0;
 	-moz-box-orient: vertical;
+	
+	code & {
+		float: left;
+	}
 }
 
 .rc-old .text-center {


### PR DESCRIPTION
Closes #11466

**Before**
![2018-07-15_21-30-15](https://user-images.githubusercontent.com/39674991/42737662-6e93c968-8877-11e8-8ce6-236c4846a56e.png)
![2018-07-15_21-30-04](https://user-images.githubusercontent.com/39674991/42737663-6eb57b62-8877-11e8-8249-dcb4563c9225.png)
![2018-07-15_21-29-41](https://user-images.githubusercontent.com/39674991/42737667-77faefb8-8877-11e8-95f2-d28d1ed0b0e9.png)

**After**
![2018-07-15_21-32-20](https://user-images.githubusercontent.com/39674991/42737748-8aea9cf8-8878-11e8-8002-80dec6ee35bd.png)
![2018-07-15_21-32-25](https://user-images.githubusercontent.com/39674991/42737747-8acb05e6-8878-11e8-997f-b24dbf0de177.png)
![2018-07-15_21-32-14](https://user-images.githubusercontent.com/39674991/42737749-8b07bdba-8878-11e8-90db-c128a64ac8b6.png)

Affects Chromium/WebKit browsers and people relying on Rocket.Chat to just copy important IDs properly.