### PR TITLE
[FIX] Unlimited upload file size not working

### DIFF
--- a/packages/rocketchat-file-upload/globalFileRestrictions.js
+++ b/packages/rocketchat-file-upload/globalFileRestrictions.js
@@ -15,7 +15,7 @@ const slingShotConfig = {
 
 		const maxFileSize = RocketChat.settings.get('FileUpload_MaxFileSize');
 
-		if (maxFileSize >= -1 && maxFileSize < file.size) {
+		if (maxFileSize > -1 && maxFileSize < file.size) {
 			throw new Meteor.Error(TAPi18n.__('File_exceeds_allowed_size_of_bytes', { size: filesize(maxFileSize) }));
 		}
 

--- a/packages/rocketchat-file-upload/lib/FileUpload.js
+++ b/packages/rocketchat-file-upload/lib/FileUpload.js
@@ -30,20 +30,11 @@ FileUpload = {
 		}
 
 		// -1 maxFileSize means there is no limit
-		if (maxFileSize >= -1 && file.size > maxFileSize) {
+		if (maxFileSize > -1 && file.size > maxFileSize) {
 			const reason = TAPi18n.__('File_exceeds_allowed_size_of_bytes', {
 				size: filesize(maxFileSize)
 			}, language);
 			throw new Meteor.Error('error-file-too-large', reason);
-		}
-
-		if (maxFileSize > 0) {
-			if (file.size > maxFileSize) {
-				const reason = TAPi18n.__('File_exceeds_allowed_size_of_bytes', {
-					size: filesize(maxFileSize)
-				}, language);
-				throw new Meteor.Error('error-file-too-large', reason);
-			}
 		}
 
 		if (!RocketChat.fileUploadIsValidContentType(file.type)) {

--- a/packages/rocketchat-file-upload/server/startup/settings.js
+++ b/packages/rocketchat-file-upload/server/startup/settings.js
@@ -6,7 +6,8 @@ RocketChat.settings.addGroup('FileUpload', function() {
 
 	this.add('FileUpload_MaxFileSize', 2097152, {
 		type: 'int',
-		public: true
+		public: true,
+		i18nDescription: 'FileUpload_MaxFileSizeDescription'
 	});
 
 	this.add('FileUpload_MediaTypeWhiteList', 'image/*,audio/*,video/*,application/zip,application/x-rar-compressed,application/pdf,text/plain,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document', {

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -1134,6 +1134,7 @@
   "FileUpload_GoogleStorage_Secret": "Google Storage Secret",
   "FileUpload_GoogleStorage_Secret_Description": "Please follow <a href=\"https://github.com/CulturalMe/meteor-slingshot#google-cloud\">these instructions</a> and paste the result here.",
   "FileUpload_MaxFileSize": "Maximum File Upload Size (in bytes)",
+  "FileUpload_MaxFileSizeDescription": "Set it to -1 to remove the file size limitation.",
   "FileUpload_MediaType_NotAccepted": "Media Types Not Accepted",
   "FileUpload_MediaTypeWhiteList": "Accepted Media Types",
   "FileUpload_MediaTypeWhiteListDescription": "Comma-separated list of media types. Leave it blank for accepting all media types.",

--- a/packages/rocketchat-livechat/imports/server/rest/upload.js
+++ b/packages/rocketchat-livechat/imports/server/rest/upload.js
@@ -70,7 +70,7 @@ RocketChat.API.v1.addRoute('livechat/upload/:rid', {
 		});
 
 		// -1 maxFileSize means there is no limit
-		if (maxFileSize >= -1 && file.fileBuffer.length > maxFileSize) {
+		if (maxFileSize > -1 && file.fileBuffer.length > maxFileSize) {
 			return RocketChat.API.v1.failure({
 				reason: 'error-size-not-allowed',
 				sizeAllowed: filesize(maxFileSize)


### PR DESCRIPTION
This PR fixes a problem where instances configured to have unlimited uploads were failing to upload every file.

This might be the problem causing #10278, but further testing is needed. 