### PR TITLE
[FIX] avoiding  messagePopup multiple bindings when rendering

### DIFF
--- a/packages/rocketchat-ui-message/client/popup/messagePopup.js
+++ b/packages/rocketchat-ui-message/client/popup/messagePopup.js
@@ -107,6 +107,27 @@ Template.messagePopup.onCreated(function() {
 			}
 		}
 	};
+
+	template.bindEventsIfNecessary = () => {
+		const events = $._data($(this.input)[0], 'events');
+
+		if (!events['keyup']) {
+			$(this.input).on('keyup', this.onInputKeyup.bind(this));
+		}
+
+		if (!events['keydown']) {
+			$(this.input).on('keydown', this.onInputKeydown.bind(this));
+		}
+
+		if (!events['focus']) {
+			$(this.input).on('focus', this.onFocus.bind(this));
+		}
+
+		if (!events['blur']) {
+			$(this.input).on('blur', this.onBlur.bind(this));
+		}
+	};
+
 	template.onInputKeydown = (event) => {
 		if (template.open.curValue !== true || template.hasData.curValue !== true) {
 			return;
@@ -258,10 +279,8 @@ Template.messagePopup.onRendered(function() {
 			$('#popup').removeClass('popup-with-reply-preview');
 		}
 	});
-	$(this.input).on('keyup', this.onInputKeyup.bind(this));
-	$(this.input).on('keydown', this.onInputKeydown.bind(this));
-	$(this.input).on('focus', this.onFocus.bind(this));
-	return $(this.input).on('blur', this.onBlur.bind(this));
+
+	return this.bindEventsIfNecessary();
 });
 
 Template.messagePopup.onDestroyed(function() {


### PR DESCRIPTION
While getting familiar with the repo I noticed that [this events](https://github.com/RocketChat/Rocket.Chat/blob/develop/packages/rocketchat-ui-message/client/popup/messagePopup.js#L261) were binded on every render because calls on template like [this one](https://github.com/RocketChat/Rocket.Chat/blob/develop/packages/rocketchat-ui-message/client/popup/messagePopupConfig.html#L7).

I added a method that tests if the events were already binded to the input before. The difference seems significative looking at the performance tab on chrome (CPU 6x slower by throttling.

Before:

![screen shot 2018-07-16 at 12 05 57 pm](https://user-images.githubusercontent.com/2047941/42766447-e2adbc7c-88f0-11e8-8d14-d7fa1ff15062.png)

After:

![screen shot 2018-07-16 at 12 06 11 pm](https://user-images.githubusercontent.com/2047941/42766458-e95bfdf4-88f0-11e8-974c-714b0a4af0f3.png)