### PR TITLE
[NEW] Add /users.deleteOwnAccount REST endpoint to an user delete his own account

### DIFF
--- a/packages/rocketchat-api/server/v1/users.js
+++ b/packages/rocketchat-api/server/v1/users.js
@@ -59,6 +59,24 @@ RocketChat.API.v1.addRoute('users.delete', { authRequired: true }, {
 	}
 });
 
+RocketChat.API.v1.addRoute('users.deleteOwnAccount', { authRequired: true }, {
+	post() {
+		const { password } = this.bodyParams;
+		if (!password) {
+			return RocketChat.API.v1.failure('Body parameter "password" is required.');
+		}
+		if (!RocketChat.settings.get('Accounts_AllowDeleteOwnAccount')) {
+			throw new Meteor.Error('error-not-allowed', 'Not allowed');
+		}
+
+		Meteor.runAsUser(this.userId, () => {
+			Meteor.call('deleteUserOwnAccount', password);
+		});
+
+		return RocketChat.API.v1.success();
+	}
+});
+
 RocketChat.API.v1.addRoute('users.getAvatar', { authRequired: false }, {
 	get() {
 		const user = this.getUserFromParams();

--- a/tests/end-to-end/api/01-users.js
+++ b/tests/end-to-end/api/01-users.js
@@ -720,6 +720,18 @@ describe('[Users]', function() {
 				.end(done);
 		});
 
+		it('Enable "Accounts_AllowDeleteOwnAccount" setting...', (done) => {
+			request.post('/api/v1/settings/Accounts_AllowDeleteOwnAccount')
+				.set(credentials)
+				.send({'value': true})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+				})
+				.end(done);
+		});
+
 		it('should delete user own account', (done) => {
 			request.post(api('users.deleteOwnAccount'))
 				.set(userCredentials)

--- a/tests/end-to-end/api/01-users.js
+++ b/tests/end-to-end/api/01-users.js
@@ -683,4 +683,124 @@ describe('[Users]', function() {
 		});
 
 	});
+
+	describe('[/users.deleteOwnAccount]', () => {
+		const testUsername = `testuser${ +new Date() }`;
+		let targetUser;
+		let userCredentials;
+		it('register a new user...', (done) => {
+			request.post(api('users.register'))
+				.set(credentials)
+				.send({
+					email: `${ testUsername }.@teste.com`,
+					username: `${ testUsername }test`,
+					name: testUsername,
+					pass: password
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					targetUser = res.body.user;
+				})
+				.end(done);
+		});
+		it('Login...', (done) => {
+			request.post(api('login'))
+				.send({
+					user: targetUser.username,
+					password
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					userCredentials = {};
+					userCredentials['X-Auth-Token'] = res.body.data.authToken;
+					userCredentials['X-User-Id'] = res.body.data.userId;
+				})
+				.end(done);
+		});
+
+		it('should delete user own account', (done) => {
+			request.post(api('users.deleteOwnAccount'))
+				.set(userCredentials)
+				.send({
+					password: crypto.createHash('sha256').update(password, 'utf8').digest('hex')
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+				})
+				.end(done);
+		});
+
+	});
+
+	describe('[/users.delete]', () => {
+		const updatePermission = (permission, roles) => {
+			return new Promise(resolve => {
+				request.post(api('permissions.update'))
+					.set(credentials)
+					.send({ permissions: [{ _id: permission, roles }] })
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('success', true);
+					})
+					.end(resolve);
+			});
+		};
+		const testUsername = `testuser${ +new Date() }`;
+		let targetUser;
+		it('register a new user...', (done) => {
+			request.post(api('users.register'))
+				.set(credentials)
+				.send({
+					email: `${ testUsername }.@teste.com`,
+					username: `${ testUsername }test`,
+					name: testUsername,
+					pass: password
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					targetUser = res.body.user;
+				})
+				.end(done);
+		});
+		it('should return an error when trying delete user account without "delete-user" permission', (done) => {
+			updatePermission('delete-user', ['user'])
+				.then(() => {
+					request.post(api('users.delete'))
+						.set(credentials)
+						.send({
+							userId: targetUser._id
+						})
+						.expect('Content-Type', 'application/json')
+						.expect(403)
+						.expect((res) => {
+							expect(res.body).to.have.property('success', false);
+							expect(res.body).to.have.property('error', 'unauthorized');
+						})
+						.end(done);
+				});
+		});
+		it('should delete user account when logged user has "delete-user" permission', (done) => {
+			updatePermission('delete-user', ['admin'])
+				.then(() => {
+					request.post(api('users.delete'))
+						.set(credentials)
+						.send({
+							userId: targetUser._id
+						})
+						.expect('Content-Type', 'application/json')
+						.expect(200)
+						.expect((res) => {
+							expect(res.body).to.have.property('success', true);
+						})
+						.end(done);
+				});
+		});
+
+	});
 });


### PR DESCRIPTION
A dd new REST endpoint to user delete you own account without verify "delete-user" permission. Add tests for this endpoint and user.delete.

Closes #11059