### PR TITLE
Fix dependency issue in redhat image

### DIFF
--- a/.docker/Dockerfile.rhel
+++ b/.docker/Dockerfile.rhel
@@ -32,6 +32,10 @@ VOLUME /opt/app-root/src/uploads
 
 WORKDIR /opt/app-root/src/bundle
 
+# Hack needed to force use of bundled library instead of system level outdated library
+# https://github.com/lovell/sharp/issues/892
+ENV LD_PRELOAD=/opt/app-root/src/bundle/programs/server/npm/node_modules/sharp/vendor/lib/libz.so
+
 ENV DEPLOY_METHOD=docker-redhat \
     NODE_ENV=production \
     MONGO_URL=mongodb://mongo:27017/rocketchat \


### PR DESCRIPTION
Will close: https://bugzilla.redhat.com/show_bug.cgi?id=1570462

Also trick here might help with others having issues with sharp on centos.

No release needs to happen, but would be great to have merged down so the redhat build service can auto build again.

@RocketChat/core 