### PR TITLE
[FIX] Invalid permalink URLs for Direct Messages

### DIFF
--- a/packages/rocketchat-lib/client/MessageAction.js
+++ b/packages/rocketchat-lib/client/MessageAction.js
@@ -117,7 +117,11 @@ RocketChat.MessageAction = new class {
 		if (!roomData) {
 			throw new Error('room-not-found');
 		}
-		const routePath = RocketChat.roomTypes.getRouteLink(roomData.t, roomData);
+
+		const subData = RocketChat.models.Subscriptions.findOne({rid: roomData._id, 'u._id': Meteor.userId()});
+		const subOrRoomData = subData ? subData : roomData;
+
+		const routePath = RocketChat.roomTypes.getRouteLink(roomData.t, subOrRoomData);
 		return `${ Meteor.absoluteUrl().replace(/\/$/, '') + routePath }?msg=${ msgId }`;
 	}
 };

--- a/packages/rocketchat-lib/client/MessageAction.js
+++ b/packages/rocketchat-lib/client/MessageAction.js
@@ -120,7 +120,7 @@ RocketChat.MessageAction = new class {
 
 		const subData = RocketChat.models.Subscriptions.findOne({rid: roomData._id, 'u._id': Meteor.userId()});
 		const routePath = RocketChat.roomTypes.getRouteLink(roomData.t, subData || roomData);
-		return `${ Meteor.absoluteUrl().replace(/\/$/, '') + routePath }?msg=${ msgId }`;
+		return `${ Meteor.absoluteUrl(routePath.replace(/^\//, '')) }?msg=${ msgId }`;
 	}
 };
 

--- a/packages/rocketchat-lib/client/MessageAction.js
+++ b/packages/rocketchat-lib/client/MessageAction.js
@@ -119,9 +119,7 @@ RocketChat.MessageAction = new class {
 		}
 
 		const subData = RocketChat.models.Subscriptions.findOne({rid: roomData._id, 'u._id': Meteor.userId()});
-		const subOrRoomData = subData ? subData : roomData;
-
-		const routePath = RocketChat.roomTypes.getRouteLink(roomData.t, subOrRoomData);
+		const routePath = RocketChat.roomTypes.getRouteLink(roomData.t, subData || roomData);
 		return `${ Meteor.absoluteUrl().replace(/\/$/, '') + routePath }?msg=${ msgId }`;
 	}
 };

--- a/packages/rocketchat-lib/lib/roomTypes/direct.js
+++ b/packages/rocketchat-lib/lib/roomTypes/direct.js
@@ -18,16 +18,6 @@ export class DirectMessageRoomRoute extends RoomTypeRouteConfig {
 	}
 }
 
-const call = (method, ...args) => new Promise((resolve, reject) => {
-	Meteor.call(method, ...args, function(err, data) {
-		if (err) {
-			return reject(err);
-		}
-		resolve(data);
-	});
-});
-const getSingleMessage = async(msgId) => await call('getSingleMessage', msgId);
-
 export class DirectMessageRoomType extends RoomTypeConfig {
 	constructor() {
 		super({
@@ -43,23 +33,6 @@ export class DirectMessageRoomType extends RoomTypeConfig {
 			t: 'd',
 			name: identifier
 		};
-
-		//If the link is to a direct message to the user itself, check if there's a msgId included
-		//If there's a msgId, pick the user from the message instead.
-		const userData = Meteor.user();
-		if (query.name === userData.username && FlowRouter.getQueryParam('msg')) {
-			const msgId = FlowRouter.getQueryParam('msg');
-			const msg = RocketChat.models.Messages.findOne(msgId) || getSingleMessage(msgId);
-			if (msg && msg.rid && msg.rid.indexOf(userData._id) >= 0) {
-				const otherUserId = msg.rid.replace(userData._id, '');
-				if (otherUserId !== userData._id) {
-					const otherUserData = RocketChat.models.Users.findOneById(otherUserId);
-					if (otherUserData) {
-						query.name = otherUserData.username;
-					}
-				}
-			}
-		}
 
 		const subscription = RocketChat.models.Subscriptions.findOne(query);
 		if (subscription && subscription.rid) {

--- a/packages/rocketchat-ui/client/lib/RoomHistoryManager.js
+++ b/packages/rocketchat-ui/client/lib/RoomHistoryManager.js
@@ -161,6 +161,9 @@ export const RoomHistoryManager = new class {
 		if (ChatMessage.findOne(message._id)) {
 			const wrapper = $('.messages-box .wrapper');
 			const msgElement = $(`#${ message._id }`, wrapper);
+			if (msgElement.length === 0) {
+				return;
+			}
 			const pos = (wrapper.scrollTop() + msgElement.offset().top) - (wrapper.height()/2);
 			wrapper.animate({
 				scrollTop: pos
@@ -190,7 +193,10 @@ export const RoomHistoryManager = new class {
 			}
 
 			return Meteor.call('loadSurroundingMessages', message, limit, function(err, result) {
-				for (const msg of Array.from((result != null ? result.messages : undefined) || [])) {
+				if (!result || result.messages) {
+					return;
+				}
+				for (const msg of Array.from(result.messages)) {
 					if (msg.t !== 'command') {
 						upsertMessage({msg, subscription});
 					}


### PR DESCRIPTION
Closes #11400

This PR makes two changes: First, it fixes the "Permalink" option to generate valid URLs on direct messages, where it was broken.

The second change is to make it so that permalinks on DMs work for both users on the conversation, regardless of which username is on the URL itself.