### PR TITLE
[FIX] Close popover on shortcuts and writing

### DIFF
--- a/packages/rocketchat-ui-master/client/main.js
+++ b/packages/rocketchat-ui-master/client/main.js
@@ -1,4 +1,4 @@
-/* globals toolbarSearch, menu, fireGlobalEvent, CachedChatSubscription, DynamicCss */
+/* globals toolbarSearch, menu, fireGlobalEvent, CachedChatSubscription, DynamicCss, popover */
 import Clipboard from 'clipboard';
 import s from 'underscore.string';
 
@@ -53,11 +53,15 @@ Template.body.onRendered(function() {
 	$(document.body).on('keydown', function(e) {
 		const target = e.target;
 		if (e.ctrlKey === true || e.metaKey === true) {
+			popover.close();
 			return;
 		}
 		if (!(e.keyCode > 45 && e.keyCode < 91 || e.keyCode === 8)) {
 			return;
 		}
+
+		popover.close();
+
 		if (/input|textarea|select/i.test(target.tagName)) {
 			return;
 		}


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #8503

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

This pr makes it so that popovers close on 2 kinds of events:

Whenever someone uses a shortcut (like `cmd+k` for example);

Or when someone press a key that will trigger a `.focus()` on the `rc-message-box`, so it won't affect navigation with `tab` for example.
