### PR TITLE
[FIX] Render Attachment Pretext When Markdown Specified

### DIFF
--- a/packages/rocketchat-message-attachments/client/messageAttachment.html
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.html
@@ -1,7 +1,11 @@
 <template name="messageAttachment">
 	<div class="attachment">
 		<!-- <div>fallback: {{fallback}}</div> -->
-		{{pretext}}
+		{{#if markdownInPretext}}
+			{{{parsedPretext}}}
+		{{else}}
+			{{pretext}}
+		{{/if}}
 		<div class="attachment-block">
 			<div class="attachment-block-border background-info-font-color" style="background-color: {{color}}"></div>
 			{{#if author_name}}

--- a/packages/rocketchat-message-attachments/client/messageAttachment.js
+++ b/packages/rocketchat-message-attachments/client/messageAttachment.js
@@ -14,6 +14,14 @@ Template.messageAttachment.helpers({
 			msg: this.text
 		});
 	},
+	markdownInPretext() {
+		return this.mrkdwn_in && this.mrkdwn_in.includes('pretext');
+	},
+	parsedPretext() {
+		return renderMessageBody({
+			msg: this.pretext
+		});
+	},
 	loadImage() {
 		if (this.downloadImages !== true) {
 			const user = RocketChat.models.Users.findOne({_id: Meteor.userId()}, {fields: {'settings.autoImageLoad' : 1}});


### PR DESCRIPTION
Render pretext as markdown when mrkdown_in contains "pretext"
Closes #3828

![image](https://user-images.githubusercontent.com/41751617/43274277-c5de8e30-90cc-11e8-8ba5-a57ad4af2571.png)
