### PR TITLE
[FIX] HipChat importer wasn’t compatible with latest exports

### DIFF
--- a/packages/rocketchat-importer-hipchat-enterprise/info.js
+++ b/packages/rocketchat-importer-hipchat-enterprise/info.js
@@ -2,13 +2,10 @@ import { ImporterInfo } from 'meteor/rocketchat:importer';
 
 export class HipChatEnterpriseImporterInfo extends ImporterInfo {
 	constructor() {
-		super('hipchatenterprise', 'HipChat Enterprise', 'application/gzip', [
+		super('hipchatenterprise', 'HipChat (tar.gz)', 'application/gzip', [
 			{
 				text: 'Importer_HipChatEnterprise_Information',
 				href: 'https://rocket.chat/docs/administrator-guides/import/hipchat/enterprise/'
-			}, {
-				text: 'Importer_HipChatEnterprise_BetaWarning',
-				href: 'https://github.com/RocketChat/Rocket.Chat/issues/new'
 			}
 		]);
 	}

--- a/packages/rocketchat-importer-hipchat/info.js
+++ b/packages/rocketchat-importer-hipchat/info.js
@@ -2,6 +2,6 @@ import { ImporterInfo } from 'meteor/rocketchat:importer';
 
 export class HipChatImporterInfo extends ImporterInfo {
 	constructor() {
-		super('hipchat', 'HipChat', 'application/zip');
+		super('hipchat', 'HipChat (zip)', 'application/zip');
 	}
 }


### PR DESCRIPTION
The cloud export is now the same format of the enterprise one, so I changed the naming of the enterprise to `HipChat (tar.gz)` and the old hiptchat cloud to `HipChat (zip)` to try to keep compatibility with who already have the old export.

We may need to change the documentation https://rocket.chat/docs/administrator-guides/import/hipchat/enterprise/ and https://rocket.chat/docs/administrator-guides/import/hipchat/cloud/ @MartinSchoeler can you help on that? Let me know then we can discuss what to change.