### PR TITLE
[IMPROVE] Add template tag #{userdn} to filter LDAP group member format

### DIFF
--- a/packages/rocketchat-ldap/server/ldap.js
+++ b/packages/rocketchat-ldap/server/ldap.js
@@ -314,7 +314,7 @@ export default class LDAP {
 		return result[0];
 	}
 
-	isUserInGroup(username) {
+	isUserInGroup(username, userdn) {
 		if (!this.options.group_filter_enabled) {
 			return true;
 		}
@@ -335,7 +335,7 @@ export default class LDAP {
 		filter.push(')');
 
 		const searchOptions = {
-			filter: filter.join('').replace(/#{username}/g, username),
+			filter: filter.join('').replace(/#{username}/g, username).replace(/#{userdn}/g, userdn),
 			scope: 'sub'
 		};
 

--- a/packages/rocketchat-ldap/server/loginHandler.js
+++ b/packages/rocketchat-ldap/server/loginHandler.js
@@ -52,7 +52,7 @@ Accounts.registerLoginHandler('ldap', function(loginRequest) {
 		}
 
 		if (ldap.authSync(users[0].dn, loginRequest.ldapPass) === true) {
-			if (ldap.isUserInGroup (loginRequest.username)) {
+			if (ldap.isUserInGroup (loginRequest.username, users[0].dn)) {
 				ldapUser = users[0];
 			} else {
 				throw new Error('User not in a valid group');


### PR DESCRIPTION
In some cases (including mine) LDAP servers use the full user dn to filter members belonging to a group.
Here by adding a template tag `#{userdn}` composed of the complete DN of the user, we can easily translate this into the group member format to find it :

![image](https://user-images.githubusercontent.com/1951866/43610786-67e966a2-96a7-11e8-9144-324b547b042b.png)

Ping @rodrigok :)