### PR TITLE
[FIX] Push notifications stuck after db failure

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -183,7 +183,7 @@ ostrio:cookies
 pauli:accounts-linkedin
 percolate:synced-cron
 raix:handlebar-helpers
-raix:push
+rocketchat:push
 raix:ui-dropped-event
 steffo:meteor-accounts-saml
 todda00:friendly-slugs

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -116,7 +116,7 @@ promise@0.10.2
 raix:eventemitter@0.1.3
 raix:eventstate@0.0.4
 raix:handlebar-helpers@0.2.5
-raix:push@3.3.0
+rocketchat:push@3.3.1
 raix:ui-dropped-event@0.0.7
 random@1.1.0
 rate-limit@1.0.9

--- a/packages/rocketchat-ui/package.js
+++ b/packages/rocketchat-ui/package.js
@@ -22,7 +22,7 @@ Package.onUse(function(api) {
 		'templating',
 		'rocketchat:lib',
 		'rocketchat:ui-master',
-		'raix:push',
+		'rocketchat:push',
 		'raix:ui-dropped-event',
 		'rocketchat:lazy-load'
 	]);

--- a/server/lib/cordova.js
+++ b/server/lib/cordova.js
@@ -159,7 +159,7 @@ function configurePush() {
 			apn,
 			gcm,
 			production: RocketChat.settings.get('Push_production'),
-			sendInterval: 1000,
+			sendInterval: 5000,
 			sendBatchSize: 10
 		});
 


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
While this https://github.com/raix/push/pull/344 isn't merged I have [forked](https://github.com/RocketChat/push) that package and released a new version with that fix.

The fix prevents a failure on polling query from preventing to send push notifications.

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
