### PR TITLE
[FIX] Broken logo on setup wizard

### DIFF
--- a/packages/rocketchat-setup-wizard/client/setupWizard.html
+++ b/packages/rocketchat-setup-wizard/client/setupWizard.html
@@ -39,7 +39,7 @@
 <template name="setupWizardInfo">
 	<section class="setup-wizard-info">
 		<header class="setup-wizard-info__header">
-			<img class="setup-wizard-info__header-logo" src="images/logo/logo-black.svg">
+			<img class="setup-wizard-info__header-logo" src="images/logo/logo.svg">
 			<span class="setup-wizard-info__header-tag">{{_ "Setup Wizard"}}</span>
 		</header>
 		<div class="setup-wizard-info__content">

--- a/packages/rocketchat-theme/client/imports/components/setup-wizard.css
+++ b/packages/rocketchat-theme/client/imports/components/setup-wizard.css
@@ -25,6 +25,7 @@
 
 			&-logo {
 				margin: 0 0.375rem;
+				height: 1.5rem;
 			}
 
 			&-tag {


### PR DESCRIPTION
Currently (broken):
![image](https://user-images.githubusercontent.com/8591547/43839581-dc71808a-9af4-11e8-8f59-f45e45ada4d1.png)

Before (old logo):
![image](https://user-images.githubusercontent.com/8591547/43839290-1d057706-9af4-11e8-9293-2c1aa9eb3b0c.png)

New:
![image](https://user-images.githubusercontent.com/8591547/43839207-ed8c2d3a-9af3-11e8-9808-59905f3d457d.png)
