### PR TITLE
[FIX] Closed connections being storing on db

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -70,7 +70,7 @@ konecty:change-case@2.3.0
 konecty:delayed-task@1.0.0
 konecty:mongo-counter@0.0.5_3
 konecty:multiple-instances-status@1.1.0
-konecty:user-presence@2.1.0
+konecty:user-presence@2.2.0
 launch-screen@1.1.1
 less@2.7.12
 livedata@1.0.18
@@ -116,7 +116,6 @@ promise@0.10.2
 raix:eventemitter@0.1.3
 raix:eventstate@0.0.4
 raix:handlebar-helpers@0.2.5
-rocketchat:push@3.3.1
 raix:ui-dropped-event@0.0.7
 random@1.1.0
 rate-limit@1.0.9
@@ -199,6 +198,7 @@ rocketchat:oauth2-server-config@1.0.0
 rocketchat:oembed@0.0.1
 rocketchat:otr@0.0.1
 rocketchat:postcss@1.0.0
+rocketchat:push@3.3.1
 rocketchat:push-notifications@0.0.1
 rocketchat:reactions@0.0.1
 rocketchat:retention-policy@0.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "Rocket.Chat",
-	"version": "0.68.0-develop",
+	"version": "0.69.0-develop",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #11293

Updating user presence package with the following fix https://github.com/Konecty/meteor-user-presence/pull/31 will prevent a race condition where already closed connections are still being saved on db, and due so they never removed, causing an user status getting stuck as online until a server restart.

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
