### PR TITLE
[FIX] Corrected timefield comparison for message retention policy cron

### DIFF
--- a/packages/rocketchat-retention-policy/server/cronPruneMessages.js
+++ b/packages/rocketchat-retention-policy/server/cronPruneMessages.js
@@ -25,7 +25,7 @@ function job() {
 
 		RocketChat.models.Rooms.find({
 			t: type,
-			_updatedAt: { $gte: lastPrune },
+			ts: { $gte: lastPrune },
 			$or: [{'retention.enabled': { $eq: true } }, { 'retention.enabled': { $exists: false } }],
 			'retention.overrideGlobal': { $ne: true }
 		}).forEach(({ _id: rid }) => {
@@ -37,7 +37,7 @@ function job() {
 		'retention.enabled': { $eq: true },
 		'retention.overrideGlobal': { $eq: true },
 		'retention.maxAge': { $gte: 0 },
-		_updatedAt: { $gte: lastPrune }
+		ts: { $gte: lastPrune }
 	}).forEach(room => {
 		const { maxAge = 30, filesOnly, excludePinned } = room.retention;
 		const latest = new Date(now.getTime() - maxAge * toDays);


### PR DESCRIPTION
@vynmera I think it would be better to compare the room "ts" timefield not the _updatedAt field for various reasons:

If a users change the name or description of the channel the _updatedAt field is touched and the messages in this channel gets not cleared

I found this issue after enabling the retention policy for our system with 365 days retention time - but it doesnt clean any messages. If I take the manual wizard it is cleaning messages.

The ground zero for this is, we migrated our instance to LDAP and renamed ALL user accounts - this results in that the _updatedAt field of all channels got updated - unfortunately this timefield is now not older than the 365 days, but messages in it are older than that.