### PR TITLE
[FIX] Fixing timeAgo function on directory

### DIFF
--- a/packages/rocketchat-ui/client/views/app/directory.js
+++ b/packages/rocketchat-ui/client/views/app/directory.js
@@ -1,16 +1,5 @@
-import moment from 'moment';
 import _ from 'underscore';
-
-function timeAgo(time) {
-	if (!time) {
-		return;
-	}
-
-	const now = new Date();
-	const yesterday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1);
-
-	return (now.getDate() === time.getDate() && moment(time).format('LT')) || (yesterday.getDate() === time.getDate() && t('yesterday')) || moment(time).format('MMM D, YYYY');
-}
+import { timeAgo } from './helpers';
 
 function directorySearch(config, cb) {
 	return Meteor.call('browseChannels', config, (err, result) => {

--- a/packages/rocketchat-ui/client/views/app/helpers.js
+++ b/packages/rocketchat-ui/client/views/app/helpers.js
@@ -1,0 +1,19 @@
+import moment from 'moment';
+
+export function timeAgo(time, now = new Date()) {
+	if (!time) {
+		return;
+	}
+
+	const yesterday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1);
+	const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+	const isToday = time.getFullYear() >= today.getFullYear() && time.getMonth() >= today.getMonth() && time.getDate() >= today.getDate();
+	const wasYesterday = time.getFullYear() >= yesterday.getFullYear() && time.getMonth() >= yesterday.getMonth() && time.getDate() >= yesterday.getDate();
+
+	const todayFormatted = (isToday && moment(time).format('LT'));
+	const yesterdayFormatted = (wasYesterday && 'yesterday');
+	const beforeFormatted = moment(time).format('MMM D, YYYY');
+
+	return todayFormatted || yesterdayFormatted || beforeFormatted;
+}

--- a/packages/rocketchat-ui/client/views/app/tests/helpers.tests.js
+++ b/packages/rocketchat-ui/client/views/app/tests/helpers.tests.js
@@ -6,11 +6,11 @@ import { timeAgo } from '../helpers';
 describe('Helpers', () => {
 	describe('timeAgo', () => {
 		it('returns formated time when the passed value is on the same day', () => {
-			const now = new Date('Mon Aug 06 2018 22:00:00 GMT-0300');
+			const now = new Date('Mon Aug 06 2018 22:00:00');
 
-			const t1 = new Date('Mon Aug 06 2018 01:00:00 GMT-0300');
-			const t2 = new Date('Mon Aug 06 2018 10:00:10 GMT-0300');
-			const t3 = new Date('Mon Aug 06 2018 14:30:10 GMT-0300');
+			const t1 = new Date('Mon Aug 06 2018 01:00:00');
+			const t2 = new Date('Mon Aug 06 2018 10:00:10');
+			const t3 = new Date('Mon Aug 06 2018 14:30:10');
 
 			assert.equal(timeAgo(t1, now), '1:00 AM');
 			assert.equal(timeAgo(t2, now), '10:00 AM');
@@ -18,11 +18,11 @@ describe('Helpers', () => {
 		});
 
 		it('returns "yesterday" when the passed value is on the day before', () => {
-			const now = new Date('Tue Jul 03 2018 23:00:00 GMT-0300');
+			const now = new Date('Tue Jul 03 2018 23:00:00');
 
-			const t1 = new Date('Tue Jul 02 2018 23:59:00 GMT-0300');
-			const t2 = new Date('Tue Jul 02 2018 22:30:00 GMT-0300');
-			const t3 = new Date('Tue Jul 02 2018 01:00:00 GMT-0300');
+			const t1 = new Date('Tue Jul 02 2018 23:59:00');
+			const t2 = new Date('Tue Jul 02 2018 22:30:00');
+			const t3 = new Date('Tue Jul 02 2018 01:00:00');
 
 			assert.equal(timeAgo(t1, now), 'yesterday');
 			assert.equal(timeAgo(t2, now), 'yesterday');
@@ -30,13 +30,13 @@ describe('Helpers', () => {
 		});
 
 		it('returns formated date when the passed value two or more days before', () => {
-			const now = new Date('Wed Jun 20 2018 00:00:01 GMT-0300');
+			const now = new Date('Wed Jun 20 2018 00:00:01');
 
-			const t1 = new Date('Mon Jun 18 2018 10:00:00 GMT-0300');
-			const t2 = new Date('Sun Jun 10 2018 00:00:00 GMT-0300');
-			const t3 = new Date('Thu May 10 2018 00:00:00 GMT-0300');
-			const t4 = new Date('Sun May 20 2018 00:00:01 GMT-0300');
-			const t5 = new Date('Fri Nov 10 2017 00:00:00 GMT-0300');
+			const t1 = new Date('Mon Jun 18 2018 10:00:00');
+			const t2 = new Date('Sun Jun 10 2018 00:00:00');
+			const t3 = new Date('Thu May 10 2018 00:00:00');
+			const t4 = new Date('Sun May 20 2018 00:00:01');
+			const t5 = new Date('Fri Nov 10 2017 00:00:00');
 
 			assert.equal(timeAgo(t1, now), 'Jun 18, 2018');
 			assert.equal(timeAgo(t2, now), 'Jun 10, 2018');

--- a/packages/rocketchat-ui/client/views/app/tests/helpers.tests.js
+++ b/packages/rocketchat-ui/client/views/app/tests/helpers.tests.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha */
+import 'babel-polyfill';
+import assert from 'assert';
+import { timeAgo } from '../helpers';
+
+describe('Helpers', () => {
+	describe('timeAgo', () => {
+		it('returns formated time when the passed value is on the same day', () => {
+			const now = new Date('Mon Aug 06 2018 22:00:00 GMT-0300');
+
+			const t1 = new Date('Mon Aug 06 2018 01:00:00 GMT-0300');
+			const t2 = new Date('Mon Aug 06 2018 10:00:10 GMT-0300');
+			const t3 = new Date('Mon Aug 06 2018 14:30:10 GMT-0300');
+
+			assert.equal(timeAgo(t1, now), '1:00 AM');
+			assert.equal(timeAgo(t2, now), '10:00 AM');
+			assert.equal(timeAgo(t3, now), '2:30 PM');
+		});
+
+		it('returns "yesterday" when the passed value is on the day before', () => {
+			const now = new Date('Tue Jul 03 2018 23:00:00 GMT-0300');
+
+			const t1 = new Date('Tue Jul 02 2018 23:59:00 GMT-0300');
+			const t2 = new Date('Tue Jul 02 2018 22:30:00 GMT-0300');
+			const t3 = new Date('Tue Jul 02 2018 01:00:00 GMT-0300');
+
+			assert.equal(timeAgo(t1, now), 'yesterday');
+			assert.equal(timeAgo(t2, now), 'yesterday');
+			assert.equal(timeAgo(t3, now), 'yesterday');
+		});
+
+		it('returns formated date when the passed value two or more days before', () => {
+			const now = new Date('Wed Jun 20 2018 00:00:01 GMT-0300');
+
+			const t1 = new Date('Mon Jun 18 2018 10:00:00 GMT-0300');
+			const t2 = new Date('Sun Jun 10 2018 00:00:00 GMT-0300');
+			const t3 = new Date('Thu May 10 2018 00:00:00 GMT-0300');
+			const t4 = new Date('Sun May 20 2018 00:00:01 GMT-0300');
+			const t5 = new Date('Fri Nov 10 2017 00:00:00 GMT-0300');
+
+			assert.equal(timeAgo(t1, now), 'Jun 18, 2018');
+			assert.equal(timeAgo(t2, now), 'Jun 10, 2018');
+			assert.equal(timeAgo(t3, now), 'May 10, 2018');
+			assert.equal(timeAgo(t4, now), 'May 20, 2018');
+			assert.equal(timeAgo(t5, now), 'Nov 10, 2017');
+		});
+	});
+});


### PR DESCRIPTION
Fix #11663 

Adding `timeAgo` function to a `helpers` file so we can test it because just importing it from the previous file will cause an error `Template is not defined`. I reproduced the mentioned case on a test.
