### PR TITLE
[FIX] Load whole file into memory before parsing JSON.

### DIFF
--- a/packages/rocketchat-importer-hipchat-enterprise/server/importer.js
+++ b/packages/rocketchat-importer-hipchat-enterprise/server/importer.js
@@ -33,10 +33,13 @@ export class HipChatEnterpriseImporter extends Base {
 				if (header.name.indexOf('.json') !== -1) {
 					const info = this.path.parse(header.name);
 
+          var json_data = '';
 					stream.on('data', Meteor.bindEnvironment((chunk) => {
+            json_data += chunk;
+          }));;
+					stream.on('end', Meteor.bindEnvironment(() => {
 						this.logger.debug(`Processing the file: ${ header.name }`);
-						const file = JSON.parse(chunk);
-
+						const file = JSON.parse(json_data);
 						if (info.base === 'users.json') {
 							super.updateProgress(ProgressStep.PREPARING_USERS);
 							for (const u of file) {
@@ -114,9 +117,8 @@ export class HipChatEnterpriseImporter extends Base {
 							//What are these files!?
 							this.logger.warn(`HipChat Enterprise importer doesn't know what to do with the file "${ header.name }" :o`, info);
 						}
+            next();
 					}));
-
-					stream.on('end', () => next());
 					stream.on('error', () => next());
 				} else {
 					next();


### PR DESCRIPTION
Closes #11355

# Load whole file into memory before parsing JSON.

Currently the json files are loaded in chunks and the chunks are json decoded. But if a file does not fit in a chunk only part of the file will be decoded. And then the decoding will fail as it is not correct JSON.

With this change the entire file is first loaded into memory and then JSON decoded. This will result in valid JSON. It will however require that there is enough memory to load the entire file.