### PR TITLE
[FIX] re-adding margin to menu icon on header

### DIFF
--- a/packages/rocketchat-theme/client/imports/components/header.css
+++ b/packages/rocketchat-theme/client/imports/components/header.css
@@ -30,7 +30,7 @@
 
 	&__block {
 		display: flex;
-
+		margin: 0 0.5rem;
 		align-items: center;
 	}
 


### PR DESCRIPTION
Fix #11672

I was checking taking a look on commit history and it seems that a margin was changed here: https://github.com/RocketChat/Rocket.Chat/commit/7145112b2f61c0a9cd5d54aa416d4afe037be8ec#diff-8058da55e1244af44de84d849f6351dcR33

Current
![screen shot 2018-08-14 at 4 05 19 pm](https://user-images.githubusercontent.com/2047941/44113661-31b4d94a-9fdf-11e8-8120-7ce2999f6984.png)

When putting it back we have:
![screen shot 2018-08-14 at 4 03 57 pm](https://user-images.githubusercontent.com/2047941/44113662-31d84de4-9fdf-11e8-949e-fedf8d7f9fdd.png)
