### PR TITLE
[FIX] Livechat open room method

### DIFF
--- a/packages/rocketchat-livechat/server/models/Rooms.js
+++ b/packages/rocketchat-livechat/server/models/Rooms.js
@@ -60,22 +60,7 @@ RocketChat.models.Rooms.findLivechatById = function(_id, fields) {
 		_id,
 	};
 
-	return this.findOne(query, options);
-};
-
-RocketChat.models.Rooms.findLivechatById = function(_id, fields) {
-	const options = {};
-
-	if (fields) {
-		options.fields = fields;
-	}
-
-	const query = {
-		t: 'l',
-		_id,
-	};
-
-	return this.findOne(query, options);
+	return this.find(query, options);
 };
 
 /**

--- a/packages/rocketchat-livechat/server/startup.js
+++ b/packages/rocketchat-livechat/server/startup.js
@@ -1,5 +1,5 @@
 Meteor.startup(() => {
-	RocketChat.roomTypes.setRoomFind('l', (_id) => RocketChat.models.Rooms.findLivechatById(_id));
+	RocketChat.roomTypes.setRoomFind('l', (_id) => RocketChat.models.Rooms.findLivechatById(_id).fetch());
 
 	RocketChat.authz.addRoomAccessValidator(function(room, user) {
 		return room && room.t === 'l' && user && RocketChat.authz.hasPermission(user._id, 'view-livechat-rooms');


### PR DESCRIPTION
Closes #11777

This PR fixes the Livechat open room method that was not returning an array when calling the `RoomFind` method.
Because of this, when the Livechat Manager attempted to open a Livechat Room on admin panel, the method was returning `room not found`.