### PR TITLE
[FIX] Start Livechat room with empty message count

### DIFF
--- a/packages/rocketchat-livechat/server/lib/QueueMethods.js
+++ b/packages/rocketchat-livechat/server/lib/QueueMethods.js
@@ -18,7 +18,7 @@ RocketChat.QueueMethods = {
 
 		const room = _.extend({
 			_id: message.rid,
-			msgs: 1,
+			msgs: 0,
 			usersCount: 1,
 			lm: new Date(),
 			fname: (roomInfo && roomInfo.fname) || guest.name || guest.username,
@@ -120,7 +120,7 @@ RocketChat.QueueMethods = {
 
 		const room = _.extend({
 			_id: message.rid,
-			msgs: 1,
+			msgs: 0,
 			usersCount: 0,
 			lm: new Date(),
 			fname: guest.name || guest.username,


### PR DESCRIPTION
we are creating Livechat rooms with the prop `msgs: 1`, but testing the PR related to Livechat analytics I noticed that after creating a room, the message count was 2 instead of 1.
This is happening because even the room is created when a visitor starts the chat by sending a message, we have the `afterSaveMessage` callback where the `RocketChat.models.Rooms.incMsgCountById` is called, so the number of room messages will be duplicated.