### PR TITLE
[FIX] Missing `fname` property in Livechat rooms

### DIFF
--- a/server/startup/migrations/v132.js
+++ b/server/startup/migrations/v132.js
@@ -1,0 +1,17 @@
+RocketChat.Migrations.add({
+	version: 132,
+	up() {
+		RocketChat.models.Rooms.find({ t: 'l', label: { $exists: true }, fname: { $exists: false } }).forEach(function(room) {
+			RocketChat.models.Rooms.update({ _id: room._id }, {
+				$set: {
+					fname: room.label,
+				},
+			});
+			RocketChat.models.Subscriptions.update({ rid: room._id }, {
+				$set: {
+					fname: room.label,
+				},
+			}, { multi: true });
+		});
+	},
+});


### PR DESCRIPTION
In #10956, we replaced the `label` property with the` fname` property in Livechat rooms, but a migration was not implemented to set the value of the `label` property in the new property `fname`.