### PR TITLE
[FIX] Typo in a configuration key for SlackBridge excluded bot names

### DIFF
--- a/packages/rocketchat-slackbridge/server/SlackAdapter.js
+++ b/packages/rocketchat-slackbridge/server/SlackAdapter.js
@@ -779,7 +779,7 @@ export default class SlackAdapter {
 	}
 
 	processBotMessage(rocketChannel, slackMessage) {
-		const excludeBotNames = RocketChat.settings.get('SlackBridge_Botnames');
+		const excludeBotNames = RocketChat.settings.get('SlackBridge_ExcludeBotnames');
 		if (slackMessage.username !== undefined && excludeBotNames && slackMessage.username.match(excludeBotNames)) {
 			return;
 		}


### PR DESCRIPTION
The code looked for the key `SlackBridge_Botnames`, which is not referenced
anywhere else. Instead, it now looks for the key `SlackBridge_ExcludeBotnames`.