### PR TITLE
[FIX] Translations were not unique per app allowing conflicts among apps

### DIFF
--- a/packages/rocketchat-apps/client/admin/appManage.js
+++ b/packages/rocketchat-apps/client/admin/appManage.js
@@ -2,6 +2,7 @@ import _ from 'underscore';
 import s from 'underscore.string';
 
 import { AppEvents } from '../communication';
+import { Utilities } from '../../lib/misc/Utilities';
 
 
 Template.appManage.onCreated(function() {
@@ -16,6 +17,11 @@ Template.appManage.onCreated(function() {
 	this.loading = new ReactiveVar(false);
 
 	const id = this.id.get();
+
+	this.__ = (key) => {
+		const appKey = Utilities.getI18nKeyForApp(key, id);
+		return TAPi18next.exists(`project:${ appKey }`) ? TAPi18n.__(appKey) : TAPi18n.__(key);
+	};
 
 	function _morphSettings(settings) {
 		Object.keys(settings).forEach((k) => {
@@ -74,6 +80,9 @@ Template.apps.onDestroyed(function() {
 });
 
 Template.appManage.helpers({
+	_(key) {
+		return Template.instance().__(key);
+	},
 	languages() {
 		const languages = TAPi18n.getLanguages();
 
@@ -150,7 +159,7 @@ Template.appManage.helpers({
 		return Object.values(Template.instance().settings.get());
 	},
 	parseDescription(i18nDescription) {
-		const item = RocketChat.Markdown.parseMessageNotEscaped({ html: t(i18nDescription) });
+		const item = RocketChat.Markdown.parseMessageNotEscaped({ html: Template.instance().__(i18nDescription) });
 
 		item.tokens.forEach((t) => item.html = item.html.replace(t.token, t.text));
 

--- a/packages/rocketchat-apps/client/communication/websockets.js
+++ b/packages/rocketchat-apps/client/communication/websockets.js
@@ -48,7 +48,7 @@ export class AppWebsocketReceiver {
 
 	onAppAdded(appId) {
 		RocketChat.API.get(`apps/${ appId }/languages`).then((result) => {
-			this.orch.parseAndLoadLanguages(result.languages);
+			this.orch.parseAndLoadLanguages(result.languages, appId);
 		});
 
 		this.listeners[AppEvents.APP_ADDED].forEach((listener) => listener(appId));

--- a/packages/rocketchat-apps/client/orchestrator.js
+++ b/packages/rocketchat-apps/client/orchestrator.js
@@ -1,4 +1,5 @@
 import { AppWebsocketReceiver } from './communication';
+import { Utilities } from '../lib/misc/Utilities';
 
 class AppClientOrchestrator {
 	constructor() {
@@ -67,14 +68,20 @@ class AppClientOrchestrator {
 
 	_loadLanguages() {
 		return RocketChat.API.get('apps/languages').then((info) => {
-			info.apps.forEach((rlInfo) => this.parseAndLoadLanguages(rlInfo.languages));
+			info.apps.forEach((rlInfo) => this.parseAndLoadLanguages(rlInfo.languages, rlInfo.id));
 		});
 	}
 
-	parseAndLoadLanguages(languages) {
-		Object.keys(languages).forEach((key) => {
+	parseAndLoadLanguages(languages, id) {
+		Object.entries(languages).forEach(([language, translations]) => {
 			try {
-				TAPi18next.addResourceBundle(key, 'project', languages[key]);
+				translations = Object.entries(translations).reduce((newTranslations, [key, value]) => {
+					newTranslations[Utilities.getI18nKeyForApp(key, id)] = value;
+					return newTranslations;
+				}, {});
+
+				console.log(language, translations);
+				TAPi18next.addResourceBundle(language, 'project', translations);
 			} catch (e) {
 				// Failed to parse the json
 			}

--- a/packages/rocketchat-apps/client/orchestrator.js
+++ b/packages/rocketchat-apps/client/orchestrator.js
@@ -80,7 +80,6 @@ class AppClientOrchestrator {
 					return newTranslations;
 				}, {});
 
-				console.log(language, translations);
 				TAPi18next.addResourceBundle(language, 'project', translations);
 			} catch (e) {
 				// Failed to parse the json

--- a/packages/rocketchat-apps/lib/misc/Utilities.js
+++ b/packages/rocketchat-apps/lib/misc/Utilities.js
@@ -1,0 +1,5 @@
+export class Utilities {
+	static getI18nKeyForApp(key, appId) {
+		return key && `apps-${ appId }-${ key }`;
+	}
+}

--- a/packages/rocketchat-apps/server/bridges/commands.js
+++ b/packages/rocketchat-apps/server/bridges/commands.js
@@ -1,4 +1,5 @@
 import { SlashCommandContext } from '@rocket.chat/apps-ts-definition/slashcommands';
+import { Utilities } from '../../lib/misc/Utilities';
 
 export class AppCommandsBridge {
 	constructor(orch) {
@@ -88,8 +89,8 @@ export class AppCommandsBridge {
 
 		const item = {
 			command: command.command.toLowerCase(),
-			params: command.paramsExample,
-			description: command.i18nDescription,
+			params: Utilities.getI18nKeyForApp(command.i18nParamsExample, appId),
+			description: Utilities.getI18nKeyForApp(command.i18nDescription, appId),
 			callback: this._appCommandExecutor.bind(this),
 			providesPreview: command.providesPreview,
 			previewer: !command.previewer ? undefined : this._appCommandPreviewer.bind(this),


### PR DESCRIPTION
To prevent conflicts among apps translations we added a unique key for the apps strings changing the keys in runtime to add `apps-${ id }-` in front of them.

Example for an app with id `my-app-id`:
Registered key:
`param_description`
Will be registered internally as:
`apps-my-app-id-param_description`

The slashcomands will require app developers to provide the translation since it will not allow fallback to the i18n strings of the project, but the settings will try to find the translation first in the app and then in the project strings (using only the last part eg: `param_description`).

The app developer need to do nothing, it's just an internal change.