### PR TITLE
[FIX] Fixing translation on 'yesterday' word when calling timeAgo function

### DIFF
--- a/packages/rocketchat-ui/client/views/app/directory.js
+++ b/packages/rocketchat-ui/client/views/app/directory.js
@@ -8,8 +8,8 @@ function directorySearch(config, cb) {
 				return {
 					name: result.name,
 					users: result.usersCount || 0,
-					createdAt: timeAgo(result.ts),
-					lastMessage: result.lastMessage && timeAgo(result.lastMessage.ts),
+					createdAt: timeAgo(result.ts, t),
+					lastMessage: result.lastMessage && timeAgo(result.lastMessage.ts, t),
 					description: result.description,
 					archived: result.archived,
 					topic: result.topic,
@@ -20,7 +20,7 @@ function directorySearch(config, cb) {
 				return {
 					name: result.name,
 					username: result.username,
-					createdAt: timeAgo(result.createdAt),
+					createdAt: timeAgo(result.createdAt, t),
 				};
 			}
 			return null;

--- a/packages/rocketchat-ui/client/views/app/helpers.js
+++ b/packages/rocketchat-ui/client/views/app/helpers.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-export function timeAgo(time, now = new Date()) {
+export function timeAgo(time, t, now = new Date()) {
 	if (!time) {
 		return;
 	}
@@ -12,7 +12,7 @@ export function timeAgo(time, now = new Date()) {
 	const wasYesterday = time.getFullYear() >= yesterday.getFullYear() && time.getMonth() >= yesterday.getMonth() && time.getDate() >= yesterday.getDate();
 
 	const todayFormatted = (isToday && moment(time).format('LT'));
-	const yesterdayFormatted = (wasYesterday && 'yesterday');
+	const yesterdayFormatted = (wasYesterday && t('yesterday'));
 	const beforeFormatted = moment(time).format('MMM D, YYYY');
 
 	return todayFormatted || yesterdayFormatted || beforeFormatted;

--- a/packages/rocketchat-ui/client/views/app/tests/helpers.tests.js
+++ b/packages/rocketchat-ui/client/views/app/tests/helpers.tests.js
@@ -3,6 +3,7 @@ import 'babel-polyfill';
 import assert from 'assert';
 import { timeAgo } from '../helpers';
 
+
 describe('Helpers', () => {
 	describe('timeAgo', () => {
 		it('returns formated time when the passed value is on the same day', () => {
@@ -12,9 +13,11 @@ describe('Helpers', () => {
 			const t2 = new Date('Mon Aug 06 2018 10:00:10');
 			const t3 = new Date('Mon Aug 06 2018 14:30:10');
 
-			assert.equal(timeAgo(t1, now), '1:00 AM');
-			assert.equal(timeAgo(t2, now), '10:00 AM');
-			assert.equal(timeAgo(t3, now), '2:30 PM');
+			const func = (a) => a;
+
+			assert.equal(timeAgo(t1, func, now), '1:00 AM');
+			assert.equal(timeAgo(t2, func, now), '10:00 AM');
+			assert.equal(timeAgo(t3, func, now), '2:30 PM');
 		});
 
 		it('returns "yesterday" when the passed value is on the day before', () => {
@@ -24,9 +27,11 @@ describe('Helpers', () => {
 			const t2 = new Date('Tue Jul 02 2018 22:30:00');
 			const t3 = new Date('Tue Jul 02 2018 01:00:00');
 
-			assert.equal(timeAgo(t1, now), 'yesterday');
-			assert.equal(timeAgo(t2, now), 'yesterday');
-			assert.equal(timeAgo(t3, now), 'yesterday');
+			const func = (a) => a;
+
+			assert.equal(timeAgo(t1, func, now), 'yesterday');
+			assert.equal(timeAgo(t2, func, now), 'yesterday');
+			assert.equal(timeAgo(t3, func, now), 'yesterday');
 		});
 
 		it('returns formated date when the passed value two or more days before', () => {
@@ -38,11 +43,13 @@ describe('Helpers', () => {
 			const t4 = new Date('Sun May 20 2018 00:00:01');
 			const t5 = new Date('Fri Nov 10 2017 00:00:00');
 
-			assert.equal(timeAgo(t1, now), 'Jun 18, 2018');
-			assert.equal(timeAgo(t2, now), 'Jun 10, 2018');
-			assert.equal(timeAgo(t3, now), 'May 10, 2018');
-			assert.equal(timeAgo(t4, now), 'May 20, 2018');
-			assert.equal(timeAgo(t5, now), 'Nov 10, 2017');
+			const func = () => 'should not be called';
+
+			assert.equal(timeAgo(t1, func, now), 'Jun 18, 2018');
+			assert.equal(timeAgo(t2, func, now), 'Jun 10, 2018');
+			assert.equal(timeAgo(t3, func, now), 'May 10, 2018');
+			assert.equal(timeAgo(t4, func, now), 'May 20, 2018');
+			assert.equal(timeAgo(t5, func, now), 'Nov 10, 2017');
 		});
 	});
 });


### PR DESCRIPTION
Related with #11663, but I added a bug removing `t` function on this PR 😬 https://github.com/RocketChat/Rocket.Chat/pull/11728

Now we're translating 🗣 🌎 🌍 🌏 

![screen shot 2018-09-04 at 10 20 55 am](https://user-images.githubusercontent.com/2047941/45033836-30e28000-b02c-11e8-8726-96d8780eb92b.png)
