### PR TITLE
Check for user permissions in addition

### DIFF
--- a/packages/rocketchat-lib/server/functions/saveUser.js
+++ b/packages/rocketchat-lib/server/functions/saveUser.js
@@ -179,35 +179,35 @@ RocketChat.saveUser = function(userId, userData) {
 
 		return _id;
 	} else {
-		if (!RocketChat.settings.get('Accounts_AllowUserProfileChange')) {
+		if (!RocketChat.settings.get('Accounts_AllowUserProfileChange') && !RocketChat.authz.hasPermission(userId, 'edit-other-user-info') && !RocketChat.authz.hasPermission(userId, 'edit-other-user-password')) {
 			throw new Meteor.Error('error-action-not-allowed', 'Edit user profile is not allowed', {
 				method: 'insertOrUpdateUser',
 				action: 'Update_user',
 			});
 		}
 
-		if (userData.username && !RocketChat.settings.get('Accounts_AllowUsernameChange')) {
+		if (userData.username && !RocketChat.settings.get('Accounts_AllowUsernameChange') && !RocketChat.authz.hasPermission(userId, 'edit-other-user-info')) {
 			throw new Meteor.Error('error-action-not-allowed', 'Edit username is not allowed', {
 				method: 'insertOrUpdateUser',
 				action: 'Update_user',
 			});
 		}
 
-		if (userData.name && !RocketChat.settings.get('Accounts_AllowRealNameChange')) {
+		if (userData.name && !RocketChat.settings.get('Accounts_AllowRealNameChange') && !RocketChat.authz.hasPermission(userId, 'edit-other-user-info')) {
 			throw new Meteor.Error('error-action-not-allowed', 'Edit user real name is not allowed', {
 				method: 'insertOrUpdateUser',
 				action: 'Update_user',
 			});
 		}
 
-		if (userData.email && !RocketChat.settings.get('Accounts_AllowEmailChange')) {
+		if (userData.email && !RocketChat.settings.get('Accounts_AllowEmailChange') && !RocketChat.authz.hasPermission(userId, 'edit-other-user-info')) {
 			throw new Meteor.Error('error-action-not-allowed', 'Edit user email is not allowed', {
 				method: 'insertOrUpdateUser',
 				action: 'Update_user',
 			});
 		}
 
-		if (userData.password && !RocketChat.settings.get('Accounts_AllowPasswordChange')) {
+		if (userData.password && !RocketChat.settings.get('Accounts_AllowPasswordChange') && !RocketChat.authz.hasPermission(userId, 'edit-other-user-password')) {
 			throw new Meteor.Error('error-action-not-allowed', 'Edit user password is not allowed', {
 				method: 'insertOrUpdateUser',
 				action: 'Update_user',


### PR DESCRIPTION
Closes #11884

The checks @MarcosSpessatto introduced in #11474 do not take into account the permissions of the performing user.

IMO this should be reviewed and released asap, as it's not possible to change any user information as an administrator when some fields are disabled in the account page.

Thanks,
Kai

 // CC: @sampaiodiego