### PR TITLE
[FIX] Apps: setting with 'code' type only saving last line

### DIFF
--- a/packages/rocketchat-apps/client/admin/appManage.html
+++ b/packages/rocketchat-apps/client/admin/appManage.html
@@ -245,7 +245,7 @@
 															<div class="rc-input__title">{{_ i18nLabel}}</div>
 															<div class="rc-input__wrapper">
 																{{#if isDisabled.disabled}}
-																{{> CodeMirror name=id options=(getEditorOptions true) code=(i18nDefaultValue) }}
+																	{{> CodeMirror name=id options=(getEditorOptions true) code=(i18nDefaultValue) }}
 																{{else}}
 																<div class="code-mirror-box" data-editor-id="{{id}}">
 																	<div class="title">

--- a/packages/rocketchat-apps/client/admin/appManage.js
+++ b/packages/rocketchat-apps/client/admin/appManage.js
@@ -388,12 +388,16 @@ Template.appManage.events({
 
 	'input input, input textarea, change input[type="color"]': _.throttle(function(e, t) {
 		let value = s.trim($(e.target).val());
+
 		switch (this.type) {
 			case 'int':
 				value = parseInt(value);
 				break;
 			case 'boolean':
 				value = value === '1';
+				break;
+			case 'code':
+				value = $(`.code-mirror-box[data-editor-id="${ this.id }"] .CodeMirror`)[0].CodeMirror.getValue();
 		}
 
 		const setting = t.settings.get()[this.id];


### PR DESCRIPTION
Making a code setting field for an app is not viable with this bug. (unless you do cmd+a in the code before saving)