### PR TITLE
[FIX] Incorrect use of RocketChat.placeholders

### DIFF
--- a/server/methods/registerUser.js
+++ b/server/methods/registerUser.js
@@ -64,7 +64,7 @@ Meteor.methods({
 		try {
 			if (RocketChat.settings.get('Verification_Customized')) {
 				const subject = RocketChat.placeholders.replace(RocketChat.settings.get('Verification_Email_Subject') || '');
-				const html = RocketChat.placeholders.replace(RocketChat.settings.get('Verification_Email') || '');
+				const html = RocketChat.placeholders.replace(RocketChat.settings.get('Verification_Email') || '', userData);
 				Accounts.emailTemplates.verifyEmail.subject = () => subject;
 				Accounts.emailTemplates.verifyEmail.html = (userModel, url) => html.replace(/\[Verification_Url]/g, url);
 			}

--- a/server/methods/sendConfirmationEmail.js
+++ b/server/methods/sendConfirmationEmail.js
@@ -1,3 +1,5 @@
+import s from 'underscore.string';
+
 Meteor.methods({
 	sendConfirmationEmail(email) {
 		check(email, String);
@@ -8,7 +10,10 @@ Meteor.methods({
 		if (user) {
 			if (RocketChat.settings.get('Verification_Customized')) {
 				const subject = RocketChat.placeholders.replace(RocketChat.settings.get('Verification_Email_Subject') || '');
-				const html = RocketChat.placeholders.replace(RocketChat.settings.get('Verification_Email') || '');
+				const html = RocketChat.placeholders.replace(RocketChat.settings.get('Verification_Email') || '', {
+					email: s.escapeHTML(email),
+					name: s.escapeHTML(user.name),
+				});
 
 				Accounts.emailTemplates.verifyEmail.subject = function(/* userModel*/) {
 					return subject;


### PR DESCRIPTION
Fixes incorrect use of `RocketChat.placeholders`. It's missing the `data` portion for replacing HTML content on e-mail verification.