### PR TITLE
[FIX] video message recording, issue #11651

### DIFF
--- a/packages/rocketchat-ui-vrecord/client/vrecord.html
+++ b/packages/rocketchat-ui-vrecord/client/vrecord.html
@@ -9,7 +9,7 @@
 			</button>
 			<span class="buttons__wrapper">
 				<button class="rc-button rc-button--nude rc-button--small cancel">{{_ "Cancel"}}</button>
-				<button class="rc-button rc-button--primary record rc-button--small ok {{okDisabled}}" {{okDisabled}}>{{_ "Ok"}}</button>
+				<button class="rc-button rc-button--primary rc-button--small ok {{okDisabled}}" {{okDisabled}}>{{_ "Ok"}}</button>
 			</span>
 		</div>
 	</div>

--- a/packages/rocketchat-ui/client/lib/recorderjs/videoRecorder.js
+++ b/packages/rocketchat-ui/client/lib/recorderjs/videoRecorder.js
@@ -43,7 +43,11 @@ this.VideoRecorder = new class {
 
 	startUserMedia(stream) {
 		this.stream = stream;
-		this.videoel.src = URL.createObjectURL(stream);
+		try {
+			this.videoel.srcObject = stream;
+		} catch (_e) {
+			this.videoel.src = URL.createObjectURL(stream);
+		}
 		this.videoel.onloadedmetadata = () => this.videoel.play();
 
 		this.started = true;


### PR DESCRIPTION
Closes #11651 

This was broken by adding a wrong css class in [this commit](https://github.com/RocketChat/Rocket.Chat/commit/831f757f12a7d646a8f3819cd2f3f5af3cecd1c1#diff-ff868971f6509568c40009e48cbae836), causing the wrong click handler to be executed.

Also removed a warning about the deprecated api `createObjectURL`.
