### PR TITLE
[FIX] LDAP background sync imported new users even as it was set to "False"

### DIFF
--- a/packages/rocketchat-ldap/server/sync.js
+++ b/packages/rocketchat-ldap/server/sync.js
@@ -326,7 +326,7 @@ export function importNewUsers(ldap) {
 	}));
 }
 
-function sync() {
+export function sync() {
 	if (RocketChat.settings.get('LDAP_Enable') !== true) {
 		return;
 	}

--- a/packages/rocketchat-ldap/server/syncUsers.js
+++ b/packages/rocketchat-ldap/server/syncUsers.js
@@ -1,4 +1,4 @@
-import { importNewUsers } from './sync';
+import { sync } from './sync';
 
 Meteor.methods({
 	ldap_sync_now() {
@@ -17,7 +17,7 @@ Meteor.methods({
 
 		this.unblock();
 
-		importNewUsers();
+		sync();
 
 		return {
 			message: 'Sync_in_progress',


### PR DESCRIPTION
Closes #9470 
Closes #10602
Closes #8728 -> only that behavior https://github.com/RocketChat/Rocket.Chat/issues/8728#issuecomment-341130691

When Button "Background Sync Now" (on Administation > LDAP > Sync / Import page) was clicked, only new users where imported from the LDAP. Not as the description says

> Will execute the **Background Sync** now rather than wait the **Sync Interval** even if **Background Sync** is False.
> This Action is asynchronous, please see the logs for more information about the process

a background sync was done.

With this PR the `sync` function is called instead of `importNewUsers` which is the actual function that is called by a background task.