### PR TITLE
[FIX] Using to.username on fname when upserting to avoid real name on sidebar

### DIFF
--- a/server/methods/createDirectMessage.js
+++ b/server/methods/createDirectMessage.js
@@ -62,7 +62,6 @@ Meteor.methods({
 		});
 
 		const myNotificationPref = RocketChat.getDefaultSubscriptionPref(me);
-
 		// Make user I have a subcription to this room
 		const upsertSubscription = {
 			$set: {
@@ -71,7 +70,7 @@ Meteor.methods({
 				open: true,
 			},
 			$setOnInsert: {
-				fname: to.name,
+				fname: to.username,
 				name: to.username,
 				t: 'd',
 				alert: false,


### PR DESCRIPTION
Closes #11913 

At this point, I dig this issue enough and could reproduce the related behaviour but it seems that used to work like this even before `0.68.3`. If someone could test it locally I would appreciate a lot 🙂 

before:

![screen shot 2018-09-12 at 4 37 40 pm](https://user-images.githubusercontent.com/2047941/45450166-c07fd280-b6ad-11e8-8c7e-9a304cd3973c.png)

after:

![screen shot 2018-09-12 at 5 02 27 pm](https://user-images.githubusercontent.com/2047941/45450175-c970a400-b6ad-11e8-9963-e263668e0a74.png)
