### PR TITLE
[FIX] Livechat agent joining on pick from guest pool

### DIFF
--- a/packages/rocketchat-livechat/.app/client/lib/_livechat.js
+++ b/packages/rocketchat-livechat/.app/client/lib/_livechat.js
@@ -49,7 +49,7 @@ this.Livechat = new (class Livechat {
 						this._agent.set(result);
 					}
 				});
-				this.stream.on(this._room.get(), { visitorToken: visitor.getToken() }, (eventData) => {
+				this.stream.on(this._room.get(), { token: visitor.getToken() }, (eventData) => {
 					if (!eventData || !eventData.type) {
 						return;
 					}


### PR DESCRIPTION
## What this fixes

As a guest's conversation is picked from the livechat queue, the agent is getting assigned to the room.
However, this was not properly subscribed to on the widget.
This lead to multiple issues:

- The agent's name was not depicted on the header of the livechat window
- The full name of the agent was not displayed but his username

![livechat fixed bugs](https://user-images.githubusercontent.com/17176678/45707955-7fd9fa80-bb80-11e8-9522-f4c9424cffd6.png)

## What's been done

The streamer subscription had a filter which did not match the actual property of the room.

It's a one-liner, but has quite nasty side-effects - and was tedious to fix. Any efforts on providing integration tests for livechat on the horizon?