### PR TITLE
[FIX] Horizontal scroll on user info tab

### DIFF
--- a/packages/rocketchat-theme/client/imports/components/modal.css
+++ b/packages/rocketchat-theme/client/imports/components/modal.css
@@ -55,6 +55,7 @@
 		position: relative;
 
 		display: flex;
+		overflow: auto;
 
 		overflow: auto;
 

--- a/packages/rocketchat-theme/client/imports/components/modal.css
+++ b/packages/rocketchat-theme/client/imports/components/modal.css
@@ -57,8 +57,6 @@
 		display: flex;
 		overflow: auto;
 
-		overflow: auto;
-
 		flex-direction: column;
 
 		min-height: 72px;

--- a/packages/rocketchat-theme/client/imports/components/userInfo.css
+++ b/packages/rocketchat-theme/client/imports/components/userInfo.css
@@ -174,8 +174,9 @@
 		justify-content: center;
 
 		&__item {
-			max-width: 45%;
 			overflow: hidden;
+
+			max-width: 45%;
 
 			margin: 0 8px;
 

--- a/packages/rocketchat-theme/client/imports/components/userInfo.css
+++ b/packages/rocketchat-theme/client/imports/components/userInfo.css
@@ -174,6 +174,7 @@
 		justify-content: center;
 
 		&__item {
+			max-width: 45%;
 			overflow: hidden;
 
 			margin: 0 8px;

--- a/packages/rocketchat-theme/client/imports/components/userInfo.css
+++ b/packages/rocketchat-theme/client/imports/components/userInfo.css
@@ -169,14 +169,13 @@
 
 	&-action {
 		display: flex;
+		overflow: hidden;
 
 		margin-bottom: var(--default-padding);
 		justify-content: center;
 
 		&__item {
 			overflow: hidden;
-
-			max-width: 45%;
 
 			margin: 0 8px;
 


### PR DESCRIPTION
Closes #11961 

I'm fixing errors on modal.css to avoid build breaking

<img width="372" alt="screen shot 2018-09-19 at 9 37 04 am" src="https://user-images.githubusercontent.com/2047941/45753800-3f19ca00-bbf0-11e8-82bb-100eebc51aea.png">
