### PR TITLE
Better organize package.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,6 @@ jobs:
           name: Lint
           command: |
             meteor npm run lint
-            meteor npm run stylelint
 
       - run:
           name: Unit Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ before_script:
   mongo --eval 'rs.initiate({_id:"rs0", members: [{"_id":1, "host":"localhost:27017"}]})'
 - meteor npm run lint
 - meteor npm run testunit
-- meteor npm run stylelint
 - travis_retry meteor build --headless /tmp/build
 - mkdir /tmp/build-test
 - tar -xf /tmp/build/Rocket.Chat.tar.gz -C /tmp/build-test/

--- a/package-lock.json
+++ b/package-lock.json
@@ -4592,6 +4592,7 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+			"optional": true,
 			"requires": {
 				"prr": "1.0.1"
 			}
@@ -9834,7 +9835,8 @@
 		"natives": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
-			"integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg=="
+			"integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==",
+			"optional": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -11608,7 +11610,8 @@
 		"prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+			"optional": true
 		},
 		"pseudomap": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -60,23 +60,23 @@
 		"chat"
 	],
 	"scripts": {
-		"start": "meteor npm i && meteor",
+		"start": "meteor",
 		"debug": "meteor run --inspect",
 		"debug-brk": "meteor run --inspect-brk",
-		"lint": "eslint .",
+		"lint": "meteor npm run jslint && meteor npm run stylelint",
+		"jslint": "eslint .",
 		"stylelint": "stylelint \"packages/**/*.css\"",
 		"test": "node .scripts/start.js",
-		"deploy": "npm run build && pm2 startOrRestart pm2.json",
 		"chimp-watch": "chimp --ddp=http://localhost:3000 --watch --mocha --path=tests/end-to-end",
 		"chimp-test": "chimp tests/chimp-config.js",
-		"postinstall": "cd packages/rocketchat-katex && npm i",
+		"postinstall": "cd packages/rocketchat-katex && meteor npm i",
 		"testunit-watch": "mocha --watch --opts ./mocha.opts \"`node -e \"console.log(require('./package.json').mocha.tests.join(' '))\"`\"",
 		"coverage": "nyc -r html mocha --opts ./mocha.opts \"`node -e \"console.log(require('./package.json').mocha.tests.join(' '))\"`\"",
 		"testunit": "mocha --opts ./mocha.opts \"`node -e \"console.log(require('./package.json').mocha.tests.join(' '))\"`\"",
 		"version": "node .scripts/version.js",
 		"set-version": "node .scripts/set-version.js",
-		"release": "npm run set-version --silent",
-		"prepush": "npm run lint && npm run testunit"
+		"release": "meteor npm run set-version --silent",
+		"prepush": "meteor npm run lint && meteor npm run testunit"
 	},
 	"license": "MIT",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"test": "node .scripts/start.js",
 		"chimp-watch": "chimp --ddp=http://localhost:3000 --watch --mocha --path=tests/end-to-end",
 		"chimp-test": "chimp tests/chimp-config.js",
-		"postinstall": "cd packages/rocketchat-katex && meteor npm i",
+		"postinstall": "cd packages/rocketchat-katex && npm i",
 		"testunit-watch": "mocha --watch --opts ./mocha.opts \"`node -e \"console.log(require('./package.json').mocha.tests.join(' '))\"`\"",
 		"coverage": "nyc -r html mocha --opts ./mocha.opts \"`node -e \"console.log(require('./package.json').mocha.tests.join(' '))\"`\"",
 		"testunit": "mocha --opts ./mocha.opts \"`node -e \"console.log(require('./package.json').mocha.tests.join(' '))\"`\"",


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
I've done a few things on this PR:

* Merge `eslint` and `stylelint` into `lint` npm script. This is better IMO because where ever we use `lint` script (like `husky` pre-push hook) it will validate both javascript and css.
* Changed to use Meteor's `npm` instead of installed on host. This will make sure the correct `npm` version is used to everything
* Removed `npm i` from `start` script. This doesn't make sense IMO and was causing changes to `package-lock.json` everytime `start` was called.