### PR TITLE
[FIX] Markdown ampersand escape on links

### DIFF
--- a/packages/rocketchat-markdown/parser/original/markdown.js
+++ b/packages/rocketchat-markdown/parser/original/markdown.js
@@ -72,10 +72,12 @@ const parseNotEscaped = function(msg, message) {
 	// Support [Text](http://link)
 	msg = msg.replace(new RegExp(`\\[([^\\]]+)\\]\\(((?:${ schemes }):\\/\\/[^\\)]+)\\)`, 'gm'), (match, title, url) => {
 		const target = url.indexOf(Meteor.absoluteUrl()) === 0 ? '' : '_blank';
-		url = url.replace(/&amp;/g, '&');
 		title = title.replace(/&amp;/g, '&');
 
-		return addAsToken(`<a href="${ s.escapeHTML(url) }" target="${ s.escapeHTML(target) }" rel="noopener noreferrer">${ s.escapeHTML(title) }</a>`);
+		let escapedUrl = s.escapeHTML(url);
+		escapedUrl = escapedUrl.replace(/&amp;/g, '&');
+
+		return addAsToken(`<a href="${ escapedUrl }" target="${ s.escapeHTML(target) }" rel="noopener noreferrer">${ s.escapeHTML(title) }</a>`);
 	});
 
 	// Support <http://link|Text>

--- a/packages/rocketchat-markdown/parser/original/markdown.js
+++ b/packages/rocketchat-markdown/parser/original/markdown.js
@@ -72,6 +72,9 @@ const parseNotEscaped = function(msg, message) {
 	// Support [Text](http://link)
 	msg = msg.replace(new RegExp(`\\[([^\\]]+)\\]\\(((?:${ schemes }):\\/\\/[^\\)]+)\\)`, 'gm'), (match, title, url) => {
 		const target = url.indexOf(Meteor.absoluteUrl()) === 0 ? '' : '_blank';
+		url = url.replace(/&amp;/g, '&');
+		title = title.replace(/&amp;/g, '&');
+
 		return addAsToken(`<a href="${ s.escapeHTML(url) }" target="${ s.escapeHTML(target) }" rel="noopener noreferrer">${ s.escapeHTML(title) }</a>`);
 	});
 

--- a/packages/rocketchat-markdown/tests/client.tests.js
+++ b/packages/rocketchat-markdown/tests/client.tests.js
@@ -192,6 +192,7 @@ const link = {
 	'[Rocket.Chat Site](tps://rocket.chat/)': '[Rocket.Chat Site](tps://rocket.chat/)',
 	'[Open Site For Rocket.Chat](open.rocket.chat/)': '[Open Site For Rocket.Chat](open.rocket.chat/)',
 	'[Testing Entry on Rocket.Chat Docs Site](htts://rocket.chat/docs/developer-guides/testing/#testing)': '[Testing Entry on Rocket.Chat Docs Site](htts://rocket.chat/docs/developer-guides/testing/#testing)',
+	'[Text](http://link?param1=1&param2=2)': linkWrapped('http://link?param1=1&param2=2', 'Text'),
 };
 
 const inlinecode = {


### PR DESCRIPTION
Fix #6586 

I added the same example from #6586 and it's working. Added a test case to it.