### PR TITLE
[NEW] adds possibility to decrypt encrypted assertions

### DIFF
--- a/packages/meteor-accounts-saml/saml_utils.js
+++ b/packages/meteor-accounts-saml/saml_utils.js
@@ -392,7 +392,18 @@ SAML.prototype.validateResponse = function(samlResponse, relayState, callback) {
 			if (response) {
 				debugLog('Got response');
 
-				const assertion = response.getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:assertion', 'Assertion')[0];
+				var assertion = response.getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:assertion', 'Assertion')[0];
+				const encAssertion = response.getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:assertion', 'EncryptedAssertion')[0];
+
+				var xmlenc = require('xml-encryption');
+				var options = { key: this.options.privateKey};
+
+				if (typeof encAssertion !== 'undefined') {
+					xmlenc.decrypt(encAssertion.getElementsByTagNameNS('*', 'EncryptedData')[0], options, function(err, result) {
+						assertion = new xmldom.DOMParser().parseFromString(result, 'text/xml');
+					});
+				}
+
 				if (!assertion) {
 					return callback(new Error('Missing SAML assertion'), null, false);
 				}
@@ -408,7 +419,14 @@ SAML.prototype.validateResponse = function(samlResponse, relayState, callback) {
 					profile.issuer = issuer.textContent;
 				}
 
-				const subject = assertion.getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:assertion', 'Subject')[0];
+				var subject = assertion.getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:assertion', 'Subject')[0];
+				const encSubject = assertion.getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:assertion', 'EncryptedID')[0];
+
+				if (typeof encSubject !== 'undefined') {
+					xmlenc.decrypt(encSubject.getElementsByTagNameNS('*', 'EncryptedData')[0], options, function(err, result) {
+						subject = new xmldom.DOMParser().parseFromString(result, 'text/xml');
+					});
+				}
 
 				if (subject) {
 					const nameID = subject.getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:assertion', 'NameID')[0];


### PR DESCRIPTION
Dear Rocket.Chat team,
First of all, thank you very much for providing this software as open source. Very much appreciated.

We have added the possiblity to also use encrypted assertions with the SAML login. We have developed and tested this extension on an instance with a couple of thousand users. We originally have started to develop this fix for the underlying [SAML library](https://github.com/steffow/meteor-accounts-saml) and it was **approved** [there](https://github.com/steffow/meteor-accounts-saml/pull/31). Since we discovered to late that Rocket.Chat uses a custom version of this library, our changes are kind of obsolete now. We have asked [here](https://github.com/RocketChat/Rocket.Chat/issues/9545) if a PR is welcome and herewith deliver the PR. We are aware of the fact that this might take some time. In case we can do anything to speed up this process, we are happy to help. :) 

Here is the [documentation](https://github.com/steffow/meteor-accounts-saml/blob/develop/README.md#encryption) that we added in the underlying project.

Kind regards,
Daniel (from [team netzbegruenung](https://github.com/netzbegruenung))

## Encryption
The `<EncryptedAssertion>` element represents an assertion in encrypted fashion, as defined by the XML Encryption Syntax and Processing specification [XMLEnc](http://www.w3.org/TR/2002/REC-xmlenc-core-20021210/). Encrypted assertions are intended as a confidentiality protection mechanism when the plain-text value passes through an intermediary. 

The following schema fragment defines the `<EncryptedAssertion>` element: 
```
<element name="EncryptedAssertion" type="saml:EncryptedElementType"/>
```
In case the SAML response contains an `<EncryptedAssertion>` element and the configuration key `privateKey` is set, the assertion get's decrypted and handled like it would be an unencrypted one.