### PR TITLE
[FIX] Favicon in Safari 12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -350,15 +350,15 @@
 				"through": "2.3.8"
 			}
 		},
-		"abbrev": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-		},
 		"abab": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
 			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
+		},
+		"abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
 		},
 		"accepts": {
 			"version": "1.2.13",
@@ -14511,11 +14511,6 @@
 				"elliptic": "6.4.1",
 				"nan": "2.10.0"
 			}
-		},
-		"tlds": {
-			"version": "1.199.0",
-			"resolved": "https://registry.npmjs.org/tlds/-/tlds-1.199.0.tgz",
-			"integrity": "sha512-NM0jUhibJjEX4g0+1ETxOhuODIDpyvCC0A2BjxrTfMUMZ+uRZc6ZnJl9SmFtAW1s5iQgQIxezFpUij6/6OiRbg=="
 		},
 		"tmp": {
 			"version": "0.0.33",

--- a/packages/rocketchat-ui-master/client/main.html
+++ b/packages/rocketchat-ui-master/client/main.html
@@ -15,7 +15,6 @@
 	<meta property="twitter:image" content="assets/favicon_512.png">
 	<link rel="manifest" href="images/manifest.json" />
 	<link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/nocfbnnmjnndkbipkabodnheejiegccf" />
-	<link rel="mask-icon" href="assets/safari_pinned.svg" color="#04436a">
 	<link rel="apple-touch-icon" sizes="180x180" href="assets/touchicon_180.png" />
 	<link rel="apple-touch-icon-precomposed" href="assets/touchicon_180_pre.png">
 </head>

--- a/packages/rocketchat-ui-master/client/main.html
+++ b/packages/rocketchat-ui-master/client/main.html
@@ -1,4 +1,6 @@
 <head>
+	<!-- See inject.js file, it injects information at the top of the head tag. -->
+
 	<meta charset="utf-8" />
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta http-equiv="expires" content="-1" />

--- a/packages/rocketchat-ui-master/server/inject.js
+++ b/packages/rocketchat-ui-master/server/inject.js
@@ -58,7 +58,7 @@ if (process.env.DISABLE_ANIMATION || process.env.TEST_MODE === 'true') {
 
 RocketChat.settings.get('Assets_SvgFavicon_Enable', (key, value) => {
 	const standardFavicons = `
-		<link rel="mask-icon" href="assets/safari_pinned.svg" color="#04436a">
+		<link rel="mask-icon" href="assets/safari_pinned.svg" color="#04436A">
 		<link rel="icon" sizes="16x16" type="image/png" href="assets/favicon_16.png" />
 		<link rel="icon" sizes="32x32" type="image/png" href="assets/favicon_32.png" />`;
 

--- a/packages/rocketchat-ui-master/server/inject.js
+++ b/packages/rocketchat-ui-master/server/inject.js
@@ -60,7 +60,8 @@ RocketChat.settings.get('Assets_SvgFavicon_Enable', (key, value) => {
 	const standardFavicons = `
 		<link rel="mask-icon" href="assets/safari_pinned.svg" color="#04436A">
 		<link rel="icon" sizes="16x16" type="image/png" href="assets/favicon_16.png" />
-		<link rel="icon" sizes="32x32" type="image/png" href="assets/favicon_32.png" />`;
+		<link rel="icon" sizes="32x32" type="image/png" href="assets/favicon_32.png" />
+		<link rel="icon" sizes="any" type="image/png" href="assets/favicon.png" />`;
 
 	if (value) {
 		Inject.rawHead(key,

--- a/packages/rocketchat-ui-master/server/inject.js
+++ b/packages/rocketchat-ui-master/server/inject.js
@@ -58,6 +58,7 @@ if (process.env.DISABLE_ANIMATION || process.env.TEST_MODE === 'true') {
 
 RocketChat.settings.get('Assets_SvgFavicon_Enable', (key, value) => {
 	const standardFavicons = `
+		<link rel="mask-icon" href="assets/safari_pinned.svg" color="#04436a">
 		<link rel="icon" sizes="16x16" type="image/png" href="assets/favicon_16.png" />
 		<link rel="icon" sizes="32x32" type="image/png" href="assets/favicon_32.png" />`;
 


### PR DESCRIPTION
Closes #12157

The problem was the order of the elements. The way the inject is working, the `mask` was always the last element to be processed.

## Before:

![screen shot 2018-09-26 at 11 22 48](https://user-images.githubusercontent.com/551004/46086656-ed88b680-c17e-11e8-8ab3-1c1056d31696.png)
![screen shot 2018-09-26 at 11 22 37](https://user-images.githubusercontent.com/551004/46086657-ed88b680-c17e-11e8-9794-891d1fad178b.png)

## After

![screen shot 2018-09-26 at 12 05 12](https://user-images.githubusercontent.com/551004/46089233-78b87b00-c184-11e8-87d7-3f83aef4b892.png)
![screen shot 2018-09-26 at 12 05 00](https://user-images.githubusercontent.com/551004/46089234-78b87b00-c184-11e8-98cc-60be2fec3aec.png)