### PR TITLE
[FIX] Duplicate email and auto-join on mentions

### DIFF
--- a/packages/rocketchat-lib/server/functions/notifications/index.js
+++ b/packages/rocketchat-lib/server/functions/notifications/index.js
@@ -58,9 +58,9 @@ export function messageContainsHighlight(message, highlights) {
 	});
 }
 
-export function callJoinRoom(user, rid) {
+export function callJoinRoom(userId, rid) {
 	return new Promise((resolve, reject) => {
-		Meteor.runAsUser(user._id, () => Meteor.call('joinRoom', rid, (error, result) => {
+		Meteor.runAsUser(userId, () => Meteor.call('joinRoom', rid, (error, result) => {
 			if (error) {
 				return reject(error);
 			}

--- a/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
+++ b/packages/rocketchat-lib/server/lib/sendNotificationsOnMessage.js
@@ -243,23 +243,39 @@ function sendAllNotifications(message, room) {
 
 	// on public channels, if a mentioned user is not member of the channel yet, he will first join the channel and then be notified based on his preferences.
 	if (room.t === 'c') {
-		const mentions = message.mentions.filter(({ _id }) => _id !== 'here' && _id !== 'all').map(({ _id }) => _id);
-		Promise.all(RocketChat.models.Subscriptions.findByRoomIdAndUserIds(room._id, mentions)
-			.fetch()
-			.map(async(subscription) => {
-				await callJoinRoom(subscription.u, room._id);
-				return subscription;
-			})).then((subscriptions) => subscriptions.forEach((subscription) =>
-			sendNotification({
-				subscription,
-				sender,
-				hasMentionToAll,
-				hasMentionToHere,
-				message,
-				notificationMessage,
-				room,
-				mentionIds,
-			})));
+		// get subscriptions from users already in room (to not send them a notification)
+		const mentions = [...mentionIdsWithoutGroups];
+		RocketChat.models.Subscriptions.findByRoomIdAndUserIds(room._id, mentionIdsWithoutGroups, { fields: { 'u._id': 1 } }).forEach((subscription) => {
+			const index = mentions.indexOf(subscription.u._id);
+			if (index !== -1) {
+				mentions.splice(index, 1);
+			}
+		});
+
+		Promise.all(mentions
+			.map(async(userId) => {
+				await callJoinRoom(userId, room._id);
+
+				return userId;
+			})
+		).then((users) => {
+			users.forEach((userId) => {
+				const subscription = RocketChat.models.Subscriptions.findOneByRoomIdAndUserId(room._id, userId);
+
+				sendNotification({
+					subscription,
+					sender,
+					hasMentionToAll,
+					hasMentionToHere,
+					message,
+					notificationMessage,
+					room,
+					mentionIds,
+				});
+			});
+		}).catch((error) => {
+			throw new Meteor.Error(error);
+		});
 	}
 
 	return message;

--- a/packages/rocketchat-lib/server/models/Subscriptions.js
+++ b/packages/rocketchat-lib/server/models/Subscriptions.js
@@ -158,7 +158,7 @@ class ModelSubscriptions extends RocketChat.models._Base {
 		return subscription && subscription.ls;
 	}
 
-	findByRoomIdAndUserIds(roomId, userIds) {
+	findByRoomIdAndUserIds(roomId, userIds, options) {
 		const query = {
 			rid: roomId,
 			'u._id': {
@@ -166,7 +166,7 @@ class ModelSubscriptions extends RocketChat.models._Base {
 			},
 		};
 
-		return this.find(query);
+		return this.find(query, options);
 	}
 
 	findByRoomIdAndUserIdsOrAllMessages(roomId, userIds) {


### PR DESCRIPTION
Currently, mentions on public channels to users already in the room are sending two emails.
If the user is not already in the room, the user does not join automatically.