### PR TITLE
[FIX] Saving user preferences

### DIFF
--- a/packages/rocketchat-lib/server/models/Users.js
+++ b/packages/rocketchat-lib/server/models/Users.js
@@ -465,7 +465,7 @@ class ModelUsers extends RocketChat.models._Base {
 		const update = {
 			$set: settings,
 		};
-		if (![1, 2].includes(parseInt(settings.preferences.clockMode))) {
+		if (parseInt(preferences.clockMode) === 0) {
 			delete update.$set['settings.preferences.clockMode'];
 			update.$unset = { 'settings.preferences.clockMode': 1 };
 		}


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Saving account preferences is giving `Internal Server Error`:

```
I20180926-14:13:22.553(-3)? Exception while invoking method 'saveUserPreferences' TypeError: Cannot read property 'clockMode' of undefined
I20180926-14:13:22.554(-3)?     at ModelUsers.setPreferences (/Users/diegosampaio/dev/Rocket.Chat/.meteor/local/build/programs/server/packages/rocketchat_lib.js:11608:56)
I20180926-14:13:22.554(-3)?     at MethodInvocation.saveUserPreferences (/Users/diegosampaio/dev/Rocket.Chat/.meteor/local/build/programs/server/app/app.js:11864:29)
I20180926-14:13:22.554(-3)?     at MethodInvocation.methodMap.(anonymous function) (packages/rocketchat_monitoring.js:2731:30)
I20180926-14:13:22.554(-3)?     at MethodInvocation.methodsMap.(anonymous function) (/Users/diegosampaio/dev/Rocket.Chat/.meteor/local/build/programs/server/packages/rocketchat_lib.js:2503:36)
I20180926-14:13:22.555(-3)?     at maybeAuditArgumentChecks (/Users/diegosampaio/dev/Rocket.Chat/.meteor/local/build/programs/server/packages/ddp-server.js:1877:12)
I20180926-14:13:22.555(-3)?     at DDP._CurrentMethodInvocation.withValue (/Users/diegosampaio/dev/Rocket.Chat/.meteor/local/build/programs/server/packages/ddp-server.js:902:126)
I20180926-14:13:22.555(-3)?     at Meteor.EnvironmentVariable.EVp.withValue (packages/meteor.js:1186:12)
I20180926-14:13:22.555(-3)?     at DDPServer._CurrentWriteFence.withValue (/Users/diegosampaio/dev/Rocket.Chat/.meteor/local/build/programs/server/packages/ddp-server.js:902:98)
I20180926-14:13:22.555(-3)?     at Meteor.EnvironmentVariable.EVp.withValue (packages/meteor.js:1186:12)
I20180926-14:13:22.556(-3)?     at Promise (/Users/diegosampaio/dev/Rocket.Chat/.meteor/local/build/programs/server/packages/ddp-server.js:902:46)
I20180926-14:13:22.556(-3)?     at new Promise (<anonymous>:null:null)
I20180926-14:13:22.556(-3)?     at Session.method (/Users/diegosampaio/dev/Rocket.Chat/.meteor/local/build/programs/server/packages/ddp-server.js:875:23)
I20180926-14:13:22.556(-3)?     at /Users/diegosampaio/dev/Rocket.Chat/.meteor/local/build/programs/server/packages/ddp-server.js:754:85
```
<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
