### PR TITLE
[NEW] Adding download button to each file on files list

### DIFF
--- a/packages/rocketchat-theme/client/imports/components/popover.css
+++ b/packages/rocketchat-theme/client/imports/components/popover.css
@@ -118,6 +118,10 @@
 		&--star-filled .rc-icon {
 			fill: currentColor;
 		}
+
+		a {
+			color: inherit;
+		}
 	}
 
 	&__label {

--- a/packages/rocketchat-ui-flextab/client/tabs/uploadedFilesList.js
+++ b/packages/rocketchat-ui-flextab/client/tabs/uploadedFilesList.js
@@ -1,3 +1,4 @@
+/* globals popover */
 import { fixCordova } from 'meteor/rocketchat:lazy-load';
 import { DateFormat } from 'meteor/rocketchat:lib';
 import _ from 'underscore';
@@ -116,4 +117,20 @@ Template.uploadedFilesList.events({
 			return t.limit.set(t.limit.get() + 50);
 		}
 	}, 200),
+
+	'click .attachments__item-link'(e, t) {
+		e.preventDefault();
+
+		const config = {
+			template: 'uploadedFilesListMenu',
+			data: {
+				file: this,
+				username: 'instance.data.username',
+			},
+			currentTarget: e.currentTarget,
+			offsetVertical: e.currentTarget.clientHeight + 5,
+		};
+
+		popover.open(config);
+	},
 });

--- a/packages/rocketchat-ui-flextab/client/tabs/uploadedFilesList.js
+++ b/packages/rocketchat-ui-flextab/client/tabs/uploadedFilesList.js
@@ -125,7 +125,6 @@ Template.uploadedFilesList.events({
 			template: 'uploadedFilesListMenu',
 			data: {
 				file: this,
-				username: 'instance.data.username',
 			},
 			currentTarget: e.currentTarget,
 			offsetVertical: e.currentTarget.clientHeight + 5,

--- a/packages/rocketchat-ui-flextab/client/tabs/uploadedFilesList.js
+++ b/packages/rocketchat-ui-flextab/client/tabs/uploadedFilesList.js
@@ -118,7 +118,7 @@ Template.uploadedFilesList.events({
 		}
 	}, 200),
 
-	'click .attachments__item-link'(e, t) {
+	'click .attachments__item-link'(e) {
 		e.preventDefault();
 
 		const config = {

--- a/packages/rocketchat-ui-flextab/client/tabs/uploadedFilesListMenu.html
+++ b/packages/rocketchat-ui-flextab/client/tabs/uploadedFilesListMenu.html
@@ -1,0 +1,9 @@
+<template name="uploadedFilesListMenu">
+  <div class="rc-popover__column">
+    <ul class="rc-popover__list">
+      <li class="rc-popover__item">
+        <a href="{{ file.url }}" target="_blank" class="rc-popover__item-text icon-download">Download</a>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/packages/rocketchat-ui-flextab/client/tabs/uploadedFilesListMenu.html
+++ b/packages/rocketchat-ui-flextab/client/tabs/uploadedFilesListMenu.html
@@ -2,7 +2,7 @@
   <div class="rc-popover__column">
     <ul class="rc-popover__list">
       <li class="rc-popover__item">
-        <a href="{{ file.url }}" target="_blank" class="rc-popover__item-text icon-download">Download</a>
+        <a href="{{ file.url }}" target="_blank" class="rc-popover__item-text icon-download">{{_ "Download"}}</a>
       </li>
     </ul>
   </div>

--- a/packages/rocketchat-ui-flextab/client/tabs/uploadedFilesListMenu.html
+++ b/packages/rocketchat-ui-flextab/client/tabs/uploadedFilesListMenu.html
@@ -1,7 +1,7 @@
 <template name="uploadedFilesListMenu">
   <div class="rc-popover__column">
     <ul class="rc-popover__list">
-      <li class="rc-popover__item">
+      <li class="rc-popover__item download-button">
         <a href="{{ file.url }}" target="_blank" class="rc-popover__item-text icon-download">{{_ "Download"}}</a>
       </li>
     </ul>

--- a/packages/rocketchat-ui-flextab/client/tabs/uploadedFilesListMenu.js
+++ b/packages/rocketchat-ui-flextab/client/tabs/uploadedFilesListMenu.js
@@ -1,0 +1,15 @@
+/* globals popover */
+
+Template.uploadedFilesListMenu.helpers({
+	file() {
+		return this.file;
+	},
+});
+
+Template.uploadedFilesListMenu.onCreated(function() {});
+
+Template.uploadedFilesListMenu.events({
+	'click .rc-popover__item'() {
+		popover.close();
+	},
+});

--- a/packages/rocketchat-ui-flextab/client/tabs/uploadedFilesListMenu.js
+++ b/packages/rocketchat-ui-flextab/client/tabs/uploadedFilesListMenu.js
@@ -9,7 +9,7 @@ Template.uploadedFilesListMenu.helpers({
 Template.uploadedFilesListMenu.onCreated(function() {});
 
 Template.uploadedFilesListMenu.events({
-	'click .rc-popover__item'() {
+	'click .download-button'() {
 		popover.close();
 	},
 });

--- a/packages/rocketchat-ui-flextab/package.js
+++ b/packages/rocketchat-ui-flextab/package.js
@@ -24,6 +24,7 @@ Package.onUse(function(api) {
 	api.addFiles('client/tabs/uploadedFilesList.html', 'client');
 	api.addFiles('client/tabs/userEdit.html', 'client');
 	api.addFiles('client/tabs/userInfo.html', 'client');
+	api.addFiles('client/tabs/uploadedFilesListMenu.html', 'client');
 
 	api.addFiles('client/flexTabBar.js', 'client');
 	api.addFiles('client/tabs/inviteUsers.js', 'client');
@@ -32,4 +33,5 @@ Package.onUse(function(api) {
 	api.addFiles('client/tabs/userEdit.js', 'client');
 	api.addFiles('client/tabs/userInfo.js', 'client');
 	api.addFiles('client/tabs/keyboardShortcuts.html', 'client');
+	api.addFiles('client/tabs/uploadedFilesListMenu.js', 'client');
 });

--- a/packages/rocketchat-ui/client/views/app/photoswipe.js
+++ b/packages/rocketchat-ui/client/views/app/photoswipe.js
@@ -85,5 +85,4 @@ Meteor.startup(() => {
 	};
 
 	$(document).on('click', '.gallery-item', createEventListenerFor('.gallery-item'));
-	$(document).on('click', '.room-files-image', createEventListenerFor('.room-files-image'));
 });


### PR DESCRIPTION
Closes #11792

The issue suggests a `Jump to message` button, but as I dig so far we don't have the reference to the message where the file was uploaded (we only have the file information), so it's not simple to call the "jump to message" method.

My suggestion is: let's open a different issue for the `Jump to message` feature

![download-button](https://user-images.githubusercontent.com/2047941/46288617-b3dbf500-c55c-11e8-9e30-6849921eec2c.gif)
