### PR TITLE
[FIX] Set default action for Setup Wizard form submit

### DIFF
--- a/packages/rocketchat-setup-wizard/client/setupWizard.html
+++ b/packages/rocketchat-setup-wizard/client/setupWizard.html
@@ -22,7 +22,7 @@
 
 					<footer class="setup-wizard-forms__footer">
 						{{#if showBackButton}}
-							<button class="rc-button rc-button--secondary setup-wizard-forms__footer-back">
+							<button type="button" class="rc-button rc-button--secondary setup-wizard-forms__footer-back">
 								<span>{{_ "Back"}}</span>
 							</button>
 						{{/if}}


### PR DESCRIPTION
This pull request aims to fix the behavior for Setup Wizard forms when a submit action is triggered, e.g., when ENTER key is typed in a input text field.