### PR TITLE
[FIX] `Disabled` word translation to Chinese

### DIFF
--- a/packages/rocketchat-i18n/i18n/zh.i18n.json
+++ b/packages/rocketchat-i18n/i18n/zh.i18n.json
@@ -912,7 +912,7 @@
   "Disable_Facebook_integration": "禁用Facebook集成",
   "Disable_Notifications": "禁用通知",
   "Disable_two-factor_authentication": "禁用双因素身份验证",
-  "Disabled": "残疾人",
+  "Disabled": "已禁用",
   "Disallow_reacting": "禁止反应",
   "Disallow_reacting_Description": "不允许反应",
   "Display_offline_form": "显示离线表单",


### PR DESCRIPTION
The word 'Disabled' original translation '残疾人' means 'disabled man' in English, which should be translated to '已禁用' in Chinese.

See the screenshot below. 

![temp](https://user-images.githubusercontent.com/7791517/46469247-7057e400-c805-11e8-80a5-867b847cb51e.jpg)

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
