### PR TITLE
[FIX] Remove deprecated permissions api endpoint

### DIFF
--- a/packages/rocketchat-api/server/v1/permissions.js
+++ b/packages/rocketchat-api/server/v1/permissions.js
@@ -1,10 +1,3 @@
-/**
-	This API returns all permissions that exists
-	on the server, with respective roles.
-
-	Method: GET
-	Route: api/v1/permissions
- */
 RocketChat.API.v1.addRoute('permissions.list', { authRequired: true }, {
 	get() {
 		const result = Meteor.runAsUser(this.userId, () => Meteor.call('permissions/get'));

--- a/packages/rocketchat-api/server/v1/permissions.js
+++ b/packages/rocketchat-api/server/v1/permissions.js
@@ -5,17 +5,6 @@
 	Method: GET
 	Route: api/v1/permissions
  */
-RocketChat.API.v1.addRoute('permissions', { authRequired: true }, {
-	get() {
-		const warningMessage = 'The endpoint "permissions" is deprecated and will be removed after version v0.69';
-		console.warn(warningMessage);
-
-		const result = Meteor.runAsUser(this.userId, () => Meteor.call('permissions/get'));
-
-		return RocketChat.API.v1.success(result);
-	},
-});
-
 RocketChat.API.v1.addRoute('permissions.list', { authRequired: true }, {
 	get() {
 		const result = Meteor.runAsUser(this.userId, () => Meteor.call('permissions/get'));

--- a/tests/end-to-end/api/11-permissions.js
+++ b/tests/end-to-end/api/11-permissions.js
@@ -8,26 +8,6 @@ describe('[Permissions]', function() {
 
 	before((done) => getCredentials(done));
 
-	// DEPRECATED
-	// TODO: Remove this after three versions have been released. That means at 0.69 this should be gone.
-	describe('[/permissions]', () => {
-		it('should return all permissions that exists on the server, with respective roles', (done) => {
-			request.get(api('permissions'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.be.a('array');
-
-					const firstElement = res.body[0];
-					expect(firstElement).to.have.property('_id');
-					expect(firstElement).to.have.property('roles').and.to.be.a('array');
-					expect(firstElement).to.have.property('_updatedAt');
-				})
-				.end(done);
-		});
-	});
-
 	describe('[/permissions.list]', () => {
 		it('should return all permissions that exists on the server, with respective roles', (done) => {
 			request.get(api('permissions.list'))


### PR DESCRIPTION
> The endpoint "permissions" is deprecated and will be removed after version v0.69

Cheers,
Kai
