### PR TITLE
[FIX] Date range check on livechat analytics

### DIFF
--- a/packages/rocketchat-livechat/client/lib/dateHandler.js
+++ b/packages/rocketchat-livechat/client/lib/dateHandler.js
@@ -13,7 +13,7 @@ export const checkDaterangeValue = (value, from, to) => {
 	if (moment().startOf('day').isSame(from) && moment().startOf('day').isSame(to)) {
 		return 'today';
 	}
-	if (moment().startOf('day').subtract(1, 'days').isSame(from) && moment().startOf('day').subtract(1, 'days').isSame(from)) {
+	if (moment().startOf('day').subtract(1, 'days').isSame(from) && moment().startOf('day').subtract(1, 'days').isSame(to)) {
 		return 'yesterday';
 	}
 	if (moment().startOf('week').isSame(from) && moment().endOf('week').isSame(to)) {


### PR DESCRIPTION
The check on the left and right hand side of `&&` is identical. From the surrounding code, it looks like the second part should be `isSame(to)`.