### PR TITLE
[NEW] Ability to disable user presence monitor

### DIFF
--- a/server/startup/presence.js
+++ b/server/startup/presence.js
@@ -14,5 +14,9 @@ Meteor.startup(function() {
 
 	UserPresence.start();
 
-	return UserPresenceMonitor.start();
+	const startMonitor = typeof process.env.DISABLE_PRESENCE_MONITOR === 'undefined' ||
+		!['true', 'yes'].includes(String(process.env.DISABLE_PRESENCE_MONITOR).toLowerCase());
+	if (startMonitor) {
+		UserPresenceMonitor.start();
+	}
 });


### PR DESCRIPTION
You might want to disable the user presence monitor in a multi-instance setup because you don't need to **all** instances keep monitoring each user's status.

So starting up an instance with env var `DISABLE_PRESENCE_MONITOR` as `yes` or `true` and it will be disabled.