### PR TITLE
[FIX] avatar?_dc=undefined

### DIFF
--- a/packages/rocketchat-ui/getAvatarUrlFromUsername.js
+++ b/packages/rocketchat-ui/getAvatarUrlFromUsername.js
@@ -1,7 +1,7 @@
 // TODO: remove global
 this.getAvatarUrlFromUsername = function(username) {
 	const key = `avatar_random_${ username }`;
-	const random = typeof Session !== 'undefined' ? Session.keys[key] : 0;
+	const random = typeof Session !== 'undefined' && typeof Session.keys[key] !== 'undefined' ? Session.keys[key] : 0;
 	if (username == null) {
 		return;
 	}


### PR DESCRIPTION
Session seems to be always defined, but the Session.keys[key] is almost never defined resulting in avatar url's that look like /avatar/username?_dc=undefined

Feelings won't be hurt by dismissing for a better way.  :) Just would like to get rid of avatars requested like this.