### PR TITLE
Fix canAccessRoom validation

### DIFF
--- a/packages/rocketchat-authorization/server/functions/canAccessRoom.js
+++ b/packages/rocketchat-authorization/server/functions/canAccessRoom.js
@@ -22,7 +22,7 @@ RocketChat.authz.roomAccessValidators = [
 ];
 
 RocketChat.authz.canAccessRoom = function(room, user, extraData) {
-	return RocketChat.authz.roomAccessValidators.some((validator) => validator.call(this, room, user, extraData));
+	return RocketChat.authz.roomAccessValidators.every((validator) => validator.call(this, room, user, extraData));
 };
 
 RocketChat.authz.addRoomAccessValidator = function(validator) {


### PR DESCRIPTION
Closes #12310

The auth handling for canAccessRoom processes an array of handlers and allows access if *any* of them return true.
Should return false unless *all* of them return true.