### PR TITLE
[FIX] E2E: Decrypting UTF-8 encoded messages

### DIFF
--- a/packages/rocketchat-e2e/client/rocketchat.e2e.room.js
+++ b/packages/rocketchat-e2e/client/rocketchat.e2e.room.js
@@ -285,7 +285,7 @@ export class E2ERoom {
 
 		try {
 			const result = await decryptAES(vector, this.groupSessionKey, cipherText);
-			return EJSON.parse(toString(result));
+			return EJSON.parse(new TextDecoder('UTF-8').decode(new Uint8Array(result)));
 		} catch (error) {
 			return console.error('E2E -> Error decrypting message: ', error, message);
 		}


### PR DESCRIPTION
Unlike in OTR, currently e2e rooms are not properly rendering UTF-8 encoded messages.
