### PR TITLE
[IMPROVE] Limit the number of typing users shown (#8722)

### DIFF
--- a/packages/rocketchat-ui-message/client/messageBox.js
+++ b/packages/rocketchat-ui-message/client/messageBox.js
@@ -223,6 +223,7 @@ Template.messageBox.helpers({
 	},
 	/* globals MsgTyping*/
 	usersTyping() {
+		const maxUsernames = 4;
 		const users = MsgTyping.get(this._id);
 		if (users.length === 0) {
 			return;
@@ -235,10 +236,10 @@ Template.messageBox.helpers({
 			};
 		}
 		let last = users.pop();
-		if (users.length > 4) {
+		if (users.length >= maxUsernames) {
 			last = t('others');
 		}
-		let usernames = users.join(', ');
+		let usernames = users.slice(0, maxUsernames - 1).join(', ');
 		usernames = [usernames, last];
 		return {
 			multi: true,


### PR DESCRIPTION
It limits the number of usernames shown above the textbox when people
are typing.

If the number of typing users isn't greater than 4, then the text will
show all usernames:
`username1, username2, username3 and username4 are typing`

But, if the number of typing users is greater than 4, then the last
username will be replaced by `others`, like this:
`username1, username2, username3 and others are typing`

The number 4 was chosen because it was already in the code

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #8722 

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
