### PR TITLE
[IMPROVE] Emoji search on messageBox behaving like emojiPicker's search (#9607)

### DIFF
--- a/packages/rocketchat-ui-message/client/popup/messagePopupConfig.js
+++ b/packages/rocketchat-ui-message/client/popup/messagePopupConfig.js
@@ -159,7 +159,7 @@ const getEmojis = function(collection, filter) {
 		return [];
 	}
 
-	const regExp = new RegExp(`^${ RegExp.escape(key) }`, 'i');
+	const regExp = new RegExp(RegExp.escape(filter), 'i');
 	const recents = RocketChat.EmojiPicker.getRecent().map((item) => `:${ item }:`);
 	return Object.keys(collection).map((_id) => {
 		const data = collection[key];


### PR DESCRIPTION
Based on emojiPicker's search:
https://github.com/RocketChat/Rocket.Chat/blob/dcdcbfba9eb10a4b87ad16f2628ec126444853d7/packages/rocketchat-emoji/client/emojiPicker.js#L59

Emoji search on messageBox is now looking for any occurence of search term in emoji name.
It doesn't expect anymore the emoji name starts with the search term.
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #9607 

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
