### PR TITLE
[FIX] Correct roomName value in Mail Messages (#12363)

### DIFF
--- a/packages/rocketchat-channel-settings-mail-messages/client/views/mailMessagesInstructions.js
+++ b/packages/rocketchat-channel-settings-mail-messages/client/views/mailMessagesInstructions.js
@@ -41,7 +41,7 @@ Template.mailMessagesInstructions.helpers({
 	},
 	roomName() {
 		const room = ChatRoom.findOne(Session.get('openedRoom'));
-		return room && room.name;
+		return room && RocketChat.roomTypes.getRoomName(room.t, room);
 	},
 	erroredEmails() {
 		const instance = Template.instance();


### PR DESCRIPTION
The input Subject in Mail Messages was receiving an __undefined__ value as room name.
This was happening whenever the open room type was Direct Messages.

To solve this, I started to get the room name value like Header and SideNav do.
These components get the room name even if the open room type is Direct Messages.
They both use `RocketChat.roomTypes.getRoomName()`.

The Header example:
https://github.com/RocketChat/Rocket.Chat/blob/develop/packages/rocketchat-ui/client/components/header/header.js#L45

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #12363 

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
