### PR TITLE
[FIX] Emoji picker is not in viewport on small screens

### DIFF
--- a/packages/rocketchat-emoji/client/lib/EmojiPicker.js
+++ b/packages/rocketchat-emoji/client/lib/EmojiPicker.js
@@ -55,21 +55,23 @@ RocketChat.EmojiPicker = {
 	},
 	setPosition() {
 		const windowHeight = window.innerHeight;
+		const windowWidth = window.innerWidth;
 		const windowBorder = 10;
 		const sourcePos = $(this.source).offset();
 		const { left, top } = sourcePos;
 		const cssProperties = { top, left };
+		const isLargerThanWindow = this.width + windowBorder > windowWidth;
 
 		if (top + this.height >= windowHeight) {
 			cssProperties.top = windowHeight - this.height - windowBorder;
 		}
 
 		if (left < windowBorder) {
-			cssProperties.left = windowBorder;
+			cssProperties.left = isLargerThanWindow ? 0 : windowBorder;
 		}
 
-		if (left + this.width >= window.innerWidth) {
-			cssProperties.left = left - this.width - windowBorder;
+		if (left + this.width >= windowWidth) {
+			cssProperties.left = isLargerThanWindow ? 0 : windowWidth - this.width - windowBorder;
 		}
 
 		return $('.emoji-picker').css(cssProperties);


### PR DESCRIPTION
Closes #11128

## Before (you can see the picker shadow on the left)
<img width="379" alt="capture d ecran 2018-10-29 a 10 24 06" src="https://user-images.githubusercontent.com/9569590/47641066-fcd39900-db5c-11e8-93df-335fcb0c311f.png">

## After 
<img width="368" alt="capture d ecran 2018-10-29 a 10 25 01" src="https://user-images.githubusercontent.com/9569590/47641078-02c97a00-db5d-11e8-9eab-603a0bf3cf3e.png">

