### PR TITLE
[FIX] German translation for for API_EmbedIgnoredHosts label

### DIFF
--- a/packages/rocketchat-i18n/i18n/de-AT.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de-AT.i18n.json
@@ -264,7 +264,7 @@
   "API_EmbedCacheExpirationDays": "Einbetten von Cache-Ablauftagen",
   "API_EmbedDisabledFor": "Einbettungen für Benutzer deaktivieren",
   "API_EmbedDisabledFor_Description": "Durch Kommata getrennte Liste von Benutzernamen",
-  "API_EmbedIgnoredHosts": "Ignorierte Hosts einbetten",
+  "API_EmbedIgnoredHosts": "Einbettungen für Hosts deaktivieren",
   "API_EmbedIgnoredHosts_Description": "Kommagetrennte Liste von Hosts oder CIDR-Adressen, z. B. localhost, 127.0.0.1, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16",
   "API_EmbedSafePorts": "Sichere Ports",
   "API_EmbedSafePorts_Description": "Kommagetrennte Liste der Ports für die eine Vorschau erlaubt ist.",

--- a/packages/rocketchat-i18n/i18n/de-IN.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de-IN.i18n.json
@@ -267,7 +267,7 @@
   "API_EmbedDisabledFor_Description": "Kommaseparierte Liste von Benutzernamen zum Einbetten von Link-Vorschauen",
   "API_EmbedDisabledFor": "Einbettungen für Benutzer deaktivieren",
   "API_EmbedIgnoredHosts_Description": "Kommagetrennte Liste von Hosts oder CIDR-Adressen, z. B. localhost, 127.0.0.1, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16",
-  "API_EmbedIgnoredHosts": "Ignorierte Hosts einbetten",
+  "API_EmbedIgnoredHosts": "Einbettungen für Hosts deaktivieren",
   "API_EmbedSafePorts_Description": "Kommagetrennte Liste der Ports, für die eine Vorschau erlaubt ist.",
   "API_EmbedSafePorts": "Sichere Ports",
   "API_Enable_CORS": "CORS",

--- a/packages/rocketchat-i18n/i18n/de.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de.i18n.json
@@ -265,7 +265,7 @@
   "API_EmbedCacheExpirationDays": "Tage bis zum Ablauf den eingebetteten Caches",
   "API_EmbedDisabledFor": "Einbettungen für Benutzer deaktivieren",
   "API_EmbedDisabledFor_Description": "Kommaseparierte Liste von Benutzernamen zum Einbetten von Link-Vorschauen",
-  "API_EmbedIgnoredHosts": "Ignorierte Hosts einbetten",
+  "API_EmbedIgnoredHosts": "Einbettungen für Hosts deaktivieren",
   "API_EmbedIgnoredHosts_Description": "Kommagetrennte Liste von Hosts oder CIDR-Adressen, z. B. localhost, 127.0.0.1, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16",
   "API_EmbedSafePorts": "Sichere Ports",
   "API_EmbedSafePorts_Description": "Kommagetrennte Liste der Ports, für die eine Vorschau erlaubt ist.",


### PR DESCRIPTION
This translation was too literal and didn't take the meaning and context into account.