### PR TITLE
[IMPROVE] Add CTRL modifier for keyboard shortcut

### DIFF
--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -1757,6 +1757,7 @@
   "MapView_Enabled_Description": "Enabling mapview will display a location share button on the left of the chat input field.",
   "MapView_GMapsAPIKey": "Google Static Maps API Key",
   "MapView_GMapsAPIKey_Description": "This can be obtained from the Google Developers Console for free.",
+  "Mark_all_as_read": "Mark all messages as read",
   "Mark_as_read": "Mark As Read",
   "Mark_as_unread": "Mark As Unread",
   "Markdown_Headers": "Allow Markdown headers in messages",

--- a/packages/rocketchat-slashcommands-help/server.js
+++ b/packages/rocketchat-slashcommands-help/server.js
@@ -14,6 +14,9 @@ RocketChat.slashCommands.add('help', function Help(command, params, item) {
 		Open_channel_user_search: 'Command (or Ctrl) + p OR Command (or Ctrl) + k',
 	},
 	{
+		Mark_all_as_read: 'Shift (or Ctrl) + ESC',
+	},
+	{
 		Edit_previous_message: 'Up Arrow',
 	},
 	{

--- a/packages/rocketchat-ui-master/client/main.js
+++ b/packages/rocketchat-ui-master/client/main.js
@@ -24,7 +24,7 @@ Template.body.onRendered(function() {
 			toolbarSearch.focus(true);
 		}
 		const unread = Session.get('unread');
-		if (e.keyCode === 27 && e.shiftKey === true && (unread != null) && unread !== '') {
+		if (e.keyCode === 27 && (e.shiftKey === true || e.ctrlKey === true) && (unread != null) && unread !== '') {
 			e.preventDefault();
 			e.stopPropagation();
 			modal.open({


### PR DESCRIPTION
As pointed out in #12519 Chrome already uses `Shift+ESC`, colliding
with the 'mark all messages as read' keyboard shortcut in
RocketChat. This change adds the `CTRL` modifier to the shortcut,
i.e. mapping

     Shift+ESC | CTRL+ESC

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #12519 

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
