### PR TITLE
[IMPROVE] Add new acceptable header for Livechat REST requests

### DIFF
--- a/packages/rocketchat-api/server/api.js
+++ b/packages/rocketchat-api/server/api.js
@@ -386,7 +386,7 @@ const defaultOptionsEndpoint = function _defaultOptionsEndpoint() {
 		if (RocketChat.settings.get('API_Enable_CORS') === true) {
 			this.response.writeHead(200, {
 				'Access-Control-Allow-Origin': RocketChat.settings.get('API_CORS_Origin'),
-				'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Type, Accept, X-User-Id, X-Auth-Token',
+				'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Type, Accept, X-User-Id, X-Auth-Token, x-visitor-token',
 			});
 		} else {
 			this.response.writeHead(405);


### PR DESCRIPTION
This PR adds a new acceptable header('x-visitor-token') to allow Livechat REST requests when CORS is enabled.
