### PR TITLE
[New] Attachment action buttons now wrap instead of stack

### DIFF
--- a/packages/rocketchat-message-action/client/stylesheets/messageAction.css
+++ b/packages/rocketchat-message-action/client/stylesheets/messageAction.css
@@ -1,5 +1,6 @@
 .attachment {
 	& .action {
+		display: inline;
 		margin-top: 2px;
 	}
 


### PR DESCRIPTION
**Before Change:** 
![image](https://user-images.githubusercontent.com/6295044/48332083-8e90db00-e620-11e8-8104-2ff548d9b425.png)
**After Change:**
![image](https://user-images.githubusercontent.com/6295044/48332105-9c466080-e620-11e8-9273-03bf63009dbc.png)


