### PR TITLE
Fix: Add email dependency in package.js

### DIFF
--- a/packages/rocketchat-mailer/package.js
+++ b/packages/rocketchat-mailer/package.js
@@ -7,6 +7,7 @@ Package.describe({
 Package.onUse(function(api) {
 	api.use([
 		'ecmascript',
+		'email',
 		'ddp-rate-limiter',
 		'rocketchat:i18n',
 	]);


### PR DESCRIPTION
Added `email` as a dependency in `rocketchat-mailer` package. This was causing a warning while running the tests (`cannot read 'send' of undefined`). Although the package has not been modified, probably the cause of this is the conversion of packages to `mainModules`.