### PR TITLE
Removed RocketChatFile from globals

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,7 +30,6 @@
 		"Package"                     : false,
 		"parentCall"                  : false,
 		"RocketChat"                  : true,
-		"RocketChatFile"              : false,
 		"RoomHistoryManager"          : false,
 		"RoomManager"                 : false,
 		"ServiceConfiguration"        : false,


### PR DESCRIPTION
Removed `RocketChatFile` from globals variables. Done in https://github.com/RocketChat/Rocket.Chat/pull/12644.