### PR TITLE
[NEW] /api/v1/spotlight: return joinCodeRequired field for rooms

### DIFF
--- a/server/publications/spotlight.js
+++ b/server/publications/spotlight.js
@@ -35,7 +35,8 @@ Meteor.methods({
 			fields: {
 				t: 1,
 				name: 1,
-				lastMessage: 1,
+				joinCodeRequired: 1,
+				lastMessage: 1
 			},
 			sort: {
 				name: 1,


### PR DESCRIPTION
This is required for us to support password protected rooms in the mobile clients