### PR TITLE
German translation typo fix for Reacted_with

### DIFF
--- a/packages/rocketchat-i18n/i18n/de-AT.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de-AT.i18n.json
@@ -2057,7 +2057,7 @@
   "RDStation_Token": "RD Station Token",
   "React_when_read_only": "Erlaube das Reagieren",
   "React_when_read_only_changed_successfully": "Erlaube reagieren, wenn nur Lesen erfolgreich geändert wurde",
-  "Reacted_with": "Reagierte mit",
+  "Reacted_with": "Reagierten mit",
   "Reactions": "Reaktionen",
   "Read_by": "Gelesen von",
   "Read_only": "Schreibgeschützt",

--- a/packages/rocketchat-i18n/i18n/de-IN.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de-IN.i18n.json
@@ -2089,7 +2089,7 @@
   "RDStation_Token": "RD Station Token",
   "React_when_read_only_changed_successfully": "Reaktionen erlauben, wenn ein Kanal schreibgeschützt wurde",
   "React_when_read_only": "Reaktionen erlauben",
-  "Reacted_with": "Reagierte mit",
+  "Reacted_with": "Reagierten mit",
   "Reactions": "Reaktionen",
   "Read_by": "Gelesen von",
   "Read_only_changed_successfully": "Erfolgreich schreibgeschützt",

--- a/packages/rocketchat-i18n/i18n/de.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de.i18n.json
@@ -2085,7 +2085,7 @@
   "RDStation_Token": "RD Station Token",
   "React_when_read_only": "Reaktionen erlauben",
   "React_when_read_only_changed_successfully": "Reaktionen erlauben, wenn ein Kanal schreibgeschützt wurde",
-  "Reacted_with": "Reagierte mit",
+  "Reacted_with": "Reagierten mit",
   "Reactions": "Reaktionen",
   "Read_by": "Gelesen von",
   "Read_only": "Schreibgeschützt",


### PR DESCRIPTION
Closes https://github.com/RocketChat/Rocket.Chat/issues/12720

Just a small fix for a typo in German translation for Reacted_with ("you reacted with")