### PR TITLE
[FIX] Incorrect parameter name in Livechat stream

### DIFF
--- a/packages/rocketchat-livechat/.app/client/lib/_livechat.js
+++ b/packages/rocketchat-livechat/.app/client/lib/_livechat.js
@@ -53,7 +53,7 @@ this.Livechat = new (class Livechat {
 						this._agent.set(result);
 					}
 				});
-				this.stream.on(this._room.get(), { token: visitor.getToken() }, (eventData) => {
+				this.stream.on(this._room.get(), { visitorToken: visitor.getToken() }, (eventData) => {
 					if (!eventData || !eventData.type) {
 						return;
 					}


### PR DESCRIPTION
Closes #12849.

This PR fixes a bug on Livechat stream, where a wrong parameter name is being passed over `extraData` object. Because of this, the agent data is not being updated on Livechat client when an agent takes the inquiry from the Livechat queue.

Curiously, the commit with the wrong implementation was submitted by the same community member that has detected the bug, as you can see below: 
https://github.com/RocketChat/Rocket.Chat/commit/933378a7f6939adb493d9d2d6241f3780a52fc5e#diff-cb44dc00ab056e5ec45123dcc1bbf8ec