### PR TITLE
[FIX] Remove Jitsi script load

### DIFF
--- a/packages/rocketchat-videobridge/client/tabBar.js
+++ b/packages/rocketchat-videobridge/client/tabBar.js
@@ -63,11 +63,6 @@ Meteor.startup(function() {
 
 	Tracker.autorun(function() {
 		if (RocketChat.settings.get('Jitsi_Enabled')) {
-			// Load from the jitsi meet instance.
-			if (typeof JitsiMeetExternalAPI === 'undefined') {
-				const prefix = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '';
-				$.getScript(`${ prefix }/packages/rocketchat_videobridge/client/public/external_api.js`);
-			}
 
 			// Compare current time to call started timeout.  If its past then call is probably over.
 			if (Session.get('openedRoom')) {


### PR DESCRIPTION
Since https://github.com/RocketChat/Rocket.Chat/pull/12881 the external Jitsi library is being exported (and consumed) as a regular module, so it was removed as asset thus the following `getScript` is failing.

The asset removal is breaking Livechat though, as it is still trying to load the asset via `getScript`:
https://github.com/RocketChat/Rocket.Chat/blob/e6d9375fe28abf907577a1e66220d23b6d2027c1/packages/rocketchat-livechat/.app/client/lib/LivechatVideoCall.js#L13