### PR TITLE
[FIX] Spotlight being called while in background

### DIFF
--- a/packages/rocketchat-ui-message/client/popup/messagePopup.js
+++ b/packages/rocketchat-ui-message/client/popup/messagePopup.js
@@ -4,7 +4,6 @@
 
 import { Meteor } from 'meteor/meteor';
 import { ReactiveVar } from 'meteor/reactive-var';
-import { Tracker } from 'meteor/tracker';
 import { Template } from 'meteor/templating';
 import _ from 'underscore';
 import { lazyloadtick } from 'meteor/rocketchat:lazy-load';
@@ -218,10 +217,7 @@ Template.messagePopup.onCreated(function() {
 		return setCursorPosition(template.input, firstPartValue.length);
 	};
 	template.records = new ReactiveVar([]);
-	Tracker.autorun(function() {
-		if (template.data.collection.findOne != null) {
-			template.data.collection.find().count();
-		}
+	template.autorun(function() {
 		const filter = template.textFilter.get();
 		if (filter != null) {
 			const filterCallback = (result) => {
@@ -268,14 +264,14 @@ Template.messagePopup.onRendered(function() {
 	$(this.input).on('keyup', this.onInputKeyup.bind(this));
 	$(this.input).on('keydown', this.onInputKeydown.bind(this));
 	$(this.input).on('focus', this.onFocus.bind(this));
-	return $(this.input).on('blur', this.onBlur.bind(this));
+	$(this.input).on('blur', this.onBlur.bind(this));
 });
 
 Template.messagePopup.onDestroyed(function() {
 	$(this.input).off('keyup', this.onInputKeyup);
 	$(this.input).off('keydown', this.onInputKeydown);
 	$(this.input).off('focus', this.onFocus);
-	return $(this.input).off('blur', this.onBlur);
+	$(this.input).off('blur', this.onBlur);
 });
 
 Template.messagePopup.events({


### PR DESCRIPTION
Currently there are many situations where `spotlight` can be called even if it's closed.

This PR fixes it by adding the reactivity only to the template, so when it's destroyed, the reactivity is destroyed as well.

There are still other times that it's called unnecessarily, like if you click on a result from a toolbar search it will be called again after you click. But this fix prevent many calls like when you search from someone it will call `spotlight` on background for every message you receive.