### PR TITLE
[FIX] Use web.browser.legacy bundle for Livechat script

### DIFF
--- a/packages/rocketchat-livechat/plugin/build.sh
+++ b/packages/rocketchat-livechat/plugin/build.sh
@@ -1,7 +1,7 @@
 export NODE_ENV="production"
 export LIVECHAT_DIR="../../../public/livechat"
 export BUILD_DIR="../build"
-export BUNDLE_DIR="../build/bundle/programs/web.browser"
+export BUNDLE_DIR="../build/bundle/programs/web.browser.legacy"
 
 cd packages/rocketchat-livechat/.app
 meteor npm install --production


### PR DESCRIPTION
Closes #12864

Ideally, we can use Meteor to decide which bundle must be served, so this fix is just a quick work around for IE 11 and other legacy browsers.