### PR TITLE
[FIX] Remove sharp's deprecation warnings on image upload

### DIFF
--- a/packages/rocketchat-file-upload/server/lib/FileUpload.js
+++ b/packages/rocketchat-file-upload/server/lib/FileUpload.js
@@ -129,8 +129,7 @@ Object.assign(FileUpload, {
 		const image = FileUpload.getStore('Uploads')._store.getReadStream(file._id, file);
 
 		const transformer = sharp()
-			.resize(32, 32)
-			.max()
+			.resize({ width: 32, height: 32, fit: 'inside' })
 			.jpeg()
 			.blur();
 		const result = transformer.toBuffer().then((out) => out.toString('base64'));


### PR DESCRIPTION
Since version [0.21.0](http://sharp.pixelplumbing.com/en/stable/changelog/#v0210-4th-october-2018), `sharp` changed its API for resizing images, deprecating methods like `max()`. This deprecation could be seen on logs:

    (STDERR) (node:4540) DeprecationWarning: max() is deprecated, use resize({ fit: "inside" }) instead

This PR replaces the `sharp` API calls.