### PR TITLE
[IMPROVE] Allow transfer Livechats to online agents only

### DIFF
--- a/packages/rocketchat-livechat/client/views/app/tabbar/visitorForward.js
+++ b/packages/rocketchat-livechat/client/views/app/tabbar/visitorForward.js
@@ -18,7 +18,13 @@ Template.visitorForward.helpers({
 		return LivechatDepartment.find({ enabled: true });
 	},
 	agents() {
-		return AgentUsers.find({ _id: { $ne: Meteor.userId() } }, { sort: { name: 1, username: 1 } });
+		const query = {
+			_id: { $ne: Meteor.userId() },
+			status: { $ne: 'offline' },
+			statusLivechat: 'available',
+		};
+
+		return AgentUsers.find(query, { sort: { name: 1, username: 1 } });
 	},
 	agentName() {
 		return this.name || this.username;

--- a/packages/rocketchat-livechat/server/lib/Livechat.js
+++ b/packages/rocketchat-livechat/server/lib/Livechat.js
@@ -437,13 +437,13 @@ RocketChat.Livechat = {
 
 	transfer(room, guest, transferData) {
 		let agent;
-		let user;
 
 		if (transferData.userId) {
-			user = RocketChat.models.Users.findOneOnlineAgentById(transferData.userId);
-		}
+			const user = RocketChat.models.Users.findOneOnlineAgentById(transferData.userId);
+			if (!user) {
+				return false;
+			}
 
-		if (user) {
 			const { _id: agentId, username } = user;
 			agent = Object.assign({}, { agentId, username });
 		} else if (RocketChat.settings.get('Livechat_Routing_Method') !== 'Guest_Pool') {

--- a/packages/rocketchat-livechat/server/lib/Livechat.js
+++ b/packages/rocketchat-livechat/server/lib/Livechat.js
@@ -436,7 +436,8 @@ RocketChat.Livechat = {
 	},
 
 	transfer(room, guest, transferData) {
-		let agent, user;
+		let agent;
+		let user;
 
 		if (transferData.userId) {
 			user = RocketChat.models.Users.findOneOnlineAgentById(transferData.userId);

--- a/packages/rocketchat-livechat/server/lib/Livechat.js
+++ b/packages/rocketchat-livechat/server/lib/Livechat.js
@@ -436,14 +436,15 @@ RocketChat.Livechat = {
 	},
 
 	transfer(room, guest, transferData) {
-		let agent;
+		let agent, user;
 
 		if (transferData.userId) {
-			const user = RocketChat.models.Users.findOneById(transferData.userId);
-			agent = {
-				agentId: user._id,
-				username: user.username,
-			};
+			user = RocketChat.models.Users.findOneOnlineAgentById(transferData.userId);
+		}
+
+		if (user) {
+			const { _id: agentId, username } = user;
+			agent = Object.assign({}, { agentId, username });
 		} else if (RocketChat.settings.get('Livechat_Routing_Method') !== 'Guest_Pool') {
 			agent = RocketChat.Livechat.getNextAgent(transferData.departmentId);
 		} else {

--- a/packages/rocketchat-livechat/server/models/Users.js
+++ b/packages/rocketchat-livechat/server/models/Users.js
@@ -52,6 +52,24 @@ RocketChat.models.Users.findOneOnlineAgentByUsername = function(username) {
 };
 
 /**
+ * Find an online agent by its user Id
+ * @return
+ */
+RocketChat.models.Users.findOneOnlineAgentById = function(_id) {
+	const query = {
+		_id,
+		status: {
+			$exists: true,
+			$ne: 'offline',
+		},
+		statusLivechat: 'available',
+		roles: 'livechat-agent',
+	};
+
+	return this.findOne(query);
+};
+
+/**
  * Gets all agents
  * @return
  */


### PR DESCRIPTION
Currently, when an agent wants to tranfer a Livechat to another one, all agents are displayed on the list, even offline agents.
The fact is that when a Livechat is transferred to an offline agent, the visitors on Widget side stay wanting for a response that never comes, so this situation brings a very bad user experience to Livechat users.
This PR adds some improvements related to the situation described above, such as filtering/displaying only online agents, as well as improve the transfer method, which will not accept any offline agent.

A few Livechat customers/partners are complaining about the case I just described, they're getting bad feedbacks from their clients, so would be good having this fix on our next release(`0.73`).