### PR TITLE
[FIX] Change input type of e2e to password

### DIFF
--- a/packages/rocketchat-e2e/client/rocketchat.e2e.js
+++ b/packages/rocketchat-e2e/client/rocketchat.e2e.js
@@ -347,7 +347,7 @@ class E2E {
 				modal.open({
 					title: TAPi18n.__('Enter_E2E_password_to_decode_your_key'),
 					type: 'input',
-					inputType: 'text',
+					inputType: 'password',
 					html: true,
 					text: `<div>${ TAPi18n.__('E2E_password_request_text') }</div>`,
 					showConfirmButton: true,


### PR DESCRIPTION
@tassoevan @geekgonecrazy 

Closes #12203 

This PR makes the input type of the input field to enter e2e password of 'password' type. Earlier it was a simple text field, making it unsuitable for passwords.


