### PR TITLE
[IMPROVE] Return room type field on Livechat findRoom method

### DIFF
--- a/packages/rocketchat-livechat/server/api/lib/livechat.js
+++ b/packages/rocketchat-livechat/server/api/lib/livechat.js
@@ -28,6 +28,7 @@ export function findGuest(token) {
 
 export function findRoom(token, rid) {
 	const fields = {
+		t: 1,
 		departmentId: 1,
 		servedBy: 1,
 		open: 1,

--- a/packages/rocketchat-livechat/server/api/v1/room.js
+++ b/packages/rocketchat-livechat/server/api/v1/room.js
@@ -37,8 +37,7 @@ RocketChat.API.v1.addRoute('livechat/room.close', {
 				token: String,
 			});
 
-			const { rid } = this.bodyParams;
-			const { token } = this.bodyParams;
+			const { rid, token } = this.bodyParams;
 
 			const visitor = findGuest(token);
 			if (!visitor) {
@@ -77,8 +76,7 @@ RocketChat.API.v1.addRoute('livechat/room.transfer', {
 				department: String,
 			});
 
-			const { rid } = this.bodyParams;
-			const { token, department } = this.bodyParams;
+			const { rid, token, department } = this.bodyParams;
 
 			const guest = findGuest(token);
 			if (!guest) {
@@ -117,8 +115,7 @@ RocketChat.API.v1.addRoute('livechat/room.survey', {
 				})],
 			});
 
-			const { rid } = this.bodyParams;
-			const { token, data } = this.bodyParams;
+			const { rid, token, data } = this.bodyParams;
 
 			const visitor = findGuest(token);
 			if (!visitor) {


### PR DESCRIPTION
To close Livechat rooms through `RocketChat.Livechat.closeRoom` method, the room type field is required on the object passed by parameter.
The `livechat/room.close` endpoint gets the room data through the `findRoom` method, but it wasn't returning the room type field and, because of this, the `livechat/room.close` endpoint was not being able to close Livechat rooms.
