### PR TITLE
[FIX] Rooms model's collection name

### DIFF
--- a/packages/rocketchat-models/server/models/Rooms.js
+++ b/packages/rocketchat-models/server/models/Rooms.js
@@ -806,4 +806,4 @@ export class Rooms extends Base {
 	}
 }
 
-export default new Rooms('rooms', true);
+export default new Rooms('room', true);


### PR DESCRIPTION
Current model name is incorrect causing all previous rooms to be not accessible.