### PR TITLE
[IMPROVE] Adds the "showConnecting" property to Livechat Config payload

### DIFF
--- a/packages/rocketchat-livechat/server/api/lib/livechat.js
+++ b/packages/rocketchat-livechat/server/api/lib/livechat.js
@@ -95,6 +95,7 @@ export function settings() {
 			language: initSettings.Language,
 			transcript: initSettings.Livechat_enable_transcript,
 			historyMonitorType: initSettings.Livechat_history_monitor_type,
+			showConnecting: initSettings.Livechat_Show_Connecting,
 		},
 		theme: {
 			title: initSettings.Livechat_title,

--- a/packages/rocketchat-livechat/server/api/v1/message.js
+++ b/packages/rocketchat-livechat/server/api/v1/message.js
@@ -46,7 +46,16 @@ RocketChat.API.v1.addRoute('livechat/message', {
 
 			const result = RocketChat.Livechat.sendMessage(sendMessage);
 			if (result) {
-				const message = { _id: result._id, rid: result.rid, msg: result.msg, u: result.u, ts: result.ts };
+
+				const message = {
+					_id: result._id,
+					rid: result.rid,
+					msg: result.msg,
+					u: result.u,
+					ts: result.ts,
+					showConnecting: result.showConnecting,
+				};
+
 				return RocketChat.API.v1.success({ message });
 			}
 

--- a/packages/rocketchat-livechat/server/api/v1/message.js
+++ b/packages/rocketchat-livechat/server/api/v1/message.js
@@ -46,16 +46,7 @@ RocketChat.API.v1.addRoute('livechat/message', {
 
 			const result = RocketChat.Livechat.sendMessage(sendMessage);
 			if (result) {
-
-				const message = {
-					_id: result._id,
-					rid: result.rid,
-					msg: result.msg,
-					u: result.u,
-					ts: result.ts,
-					showConnecting: result.showConnecting,
-				};
-
+				const message = { _id: result._id, rid: result.rid, msg: result.msg, u: result.u, ts: result.ts };
 				return RocketChat.API.v1.success({ message });
 			}
 

--- a/packages/rocketchat-livechat/server/lib/Livechat.js
+++ b/packages/rocketchat-livechat/server/lib/Livechat.js
@@ -374,6 +374,8 @@ RocketChat.Livechat = {
 			settings[key] = value;
 		});
 
+		settings.Livechat_Show_Connecting = this.showConnecting();
+
 		return settings;
 	},
 


### PR DESCRIPTION
We have a setting that defines if it's necessary to display a `connecting...` message when a new livechat is started.
This setting depends on `guest pool` routing method and it wasn't being sent over the `GET` config payload.