### PR TITLE
[NEW] Display total number of files and total upload size in admin

### DIFF
--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -2586,6 +2586,8 @@
   "Stats_Total_Private_Groups": "Total Private Groups",
   "Stats_Total_Rooms": "Total Rooms",
   "Stats_Total_Users": "Total Users",
+  "Stats_Total_Uploads": "Total Uploads",
+  "Stats_Total_Uploads_Size": "Total Uploads Size",
   "Status": "Status",
   "Step": "Step",
   "Stop_Recording": "Stop Recording",

--- a/packages/rocketchat-statistics/server/functions/get.js
+++ b/packages/rocketchat-statistics/server/functions/get.js
@@ -110,6 +110,9 @@ RocketChat.statistics.get = function _getStatistics() {
 		platform: process.env.DEPLOY_PLATFORM || 'selfinstall',
 	};
 
+	statistics.uploadsTotal = RocketChat.models.Uploads.find().count();
+	statistics.uploadsTotalSize = _.reduce(RocketChat.models.Uploads.find({}, { fields: { size: 1 } }).fetch(), function _totalStorageUsed(total, file) { return total + file.size; }, 0);
+
 	statistics.migration = RocketChat.Migrations._getControl();
 	statistics.instanceCount = InstanceStatus.getCollection().find({ _updatedAt: { $gt: new Date(Date.now() - process.uptime() * 1000 - 2000) } }).count();
 

--- a/packages/rocketchat-statistics/server/functions/get.js
+++ b/packages/rocketchat-statistics/server/functions/get.js
@@ -112,7 +112,7 @@ RocketChat.statistics.get = function _getStatistics() {
 
 	statistics.uploadsTotal = RocketChat.models.Uploads.find().count();
 	const [result] = Promise.await(RocketChat.models.Uploads.model.rawCollection().aggregate([{ $group: { _id: 'total', total: { $sum: '$size' } } }]).toArray());
-	statistics.uploadsTotalSize = result.total;
+	statistics.uploadsTotalSize = result ? result.total : 0;
 
 	statistics.migration = RocketChat.Migrations._getControl();
 	statistics.instanceCount = InstanceStatus.getCollection().find({ _updatedAt: { $gt: new Date(Date.now() - process.uptime() * 1000 - 2000) } }).count();

--- a/packages/rocketchat-statistics/server/functions/get.js
+++ b/packages/rocketchat-statistics/server/functions/get.js
@@ -111,7 +111,7 @@ RocketChat.statistics.get = async function _getStatistics() {
 	};
 
 	statistics.uploadsTotal = RocketChat.models.Uploads.find().count();
-	const [result] = await RocketChat.models.Uploads.model.rawCollection().aggregate([{ $group: { _id: 'total', total: { $sum: '$size' } } }]).toArray();
+	const [result] = Promise.await(RocketChat.models.Uploads.model.rawCollection().aggregate([{ $group: { _id: 'total', total: { $sum: '$size' } } }]).toArray());
 	statistics.uploadsTotalSize = result.total;
 
 	statistics.migration = RocketChat.Migrations._getControl();

--- a/packages/rocketchat-statistics/server/functions/get.js
+++ b/packages/rocketchat-statistics/server/functions/get.js
@@ -19,7 +19,7 @@ const wizardFields = [
 	'Allow_Marketing_Emails',
 ];
 
-RocketChat.statistics.get = function _getStatistics() {
+RocketChat.statistics.get = async function _getStatistics() {
 	const statistics = {};
 
 	// Setup Wizard
@@ -111,7 +111,8 @@ RocketChat.statistics.get = function _getStatistics() {
 	};
 
 	statistics.uploadsTotal = RocketChat.models.Uploads.find().count();
-	statistics.uploadsTotalSize = _.reduce(RocketChat.models.Uploads.find({}, { fields: { size: 1 } }).fetch(), function _totalStorageUsed(total, file) { return total + file.size; }, 0);
+	const [result] = await RocketChat.models.Uploads.model.rawCollection().aggregate([{ $group: { _id: 'total', total: { $sum: '$size' } } }]).toArray();
+	statistics.uploadsTotalSize = result.total;
 
 	statistics.migration = RocketChat.Migrations._getControl();
 	statistics.instanceCount = InstanceStatus.getCollection().find({ _updatedAt: { $gt: new Date(Date.now() - process.uptime() * 1000 - 2000) } }).count();

--- a/packages/rocketchat-statistics/server/functions/get.js
+++ b/packages/rocketchat-statistics/server/functions/get.js
@@ -19,7 +19,7 @@ const wizardFields = [
 	'Allow_Marketing_Emails',
 ];
 
-RocketChat.statistics.get = async function _getStatistics() {
+RocketChat.statistics.get = function _getStatistics() {
 	const statistics = {};
 
 	// Setup Wizard

--- a/packages/rocketchat-ui-admin/client/adminInfo.html
+++ b/packages/rocketchat-ui-admin/client/adminInfo.html
@@ -225,6 +225,15 @@
 							<th class="content-background-color border-component-color">{{_ "Stats_Total_Messages_Livechat"}}</th>
 							<td class="border-component-color">{{statistics.totalLivechatMessages}}</td>
 						</tr>
+						<tr class="admin-table-row">
+							<th class="content-background-color border-component-color">{{_ "Stats_Total_Uploads"}}</th>
+							<td class="border-component-color">{{statistics.uploadsTotal}}</td>
+						</tr>
+						<tr class="admin-table-row">
+							<th class="content-background-color border-component-color">{{_ "Stats_Total_Uploads_Size"}}</th>
+							<td class="border-component-color">{{inGB statistics.uploadsTotalSize}}</td>
+						</tr>
+
 					</table>
 
 					{{#if instances}}


### PR DESCRIPTION
This adds number of uploads and how much storage those uploads are using to the admin screen:

![image](https://user-images.githubusercontent.com/51996/51358830-9c346800-1a8a-11e9-937f-72eda8676884.png)