### PR TITLE
Regression: Fix message pinning

### DIFF
--- a/packages/rocketchat-message-pin/server/pinMessage.js
+++ b/packages/rocketchat-message-pin/server/pinMessage.js
@@ -37,7 +37,7 @@ Meteor.methods({
 			});
 		}
 
-		if (!RocketChat.authz.hasPermission(Meteor.userId(), 'pin-message')) {
+		if (!RocketChat.authz.hasPermission(Meteor.userId(), 'pin-message', message.rid)) {
 			throw new Meteor.Error('not-authorized', 'Not Authorized', { method: 'pinMessage' });
 		}
 
@@ -119,7 +119,7 @@ Meteor.methods({
 			});
 		}
 
-		if (!RocketChat.authz.hasPermission(Meteor.userId(), 'pin-message')) {
+		if (!RocketChat.authz.hasPermission(Meteor.userId(), 'pin-message', message.rid)) {
 			throw new Meteor.Error('not-authorized', 'Not Authorized', { method: 'pinMessage' });
 		}
 


### PR DESCRIPTION
PR #12739 added authentication checks for message pinning, however it does not actually work and will always error with not-authorized because it's checking a subscription-based role without providing the room ID.