### PR TITLE
[FIX] Bugfix markdown Marked link new tab

### DIFF
--- a/packages/rocketchat-markdown/lib/parser/marked/marked.js
+++ b/packages/rocketchat-markdown/lib/parser/marked/marked.js
@@ -62,7 +62,7 @@ renderer.blockquote = function(quote) {
 const linkRenderer = renderer.link;
 renderer.link = function(href, title, text) {
 	const html = linkRenderer.call(renderer, href, title, text);
-	return html.replace(/^<a /, '<a target="_blank" rel="nofollow" ');
+	return html.replace(/^<a /, '<a target="_blank" rel="nofollow noopener noreferrer" ');
 };
 
 const highlight = function(code, lang) {

--- a/packages/rocketchat-markdown/lib/parser/marked/marked.js
+++ b/packages/rocketchat-markdown/lib/parser/marked/marked.js
@@ -59,6 +59,12 @@ renderer.blockquote = function(quote) {
 	return `<blockquote class="background-transparent-darker-before">${ quote }</blockquote>`;
 };
 
+const linkRenderer = renderer.link;
+renderer.link = function(href, title, text) {
+	const html = linkRenderer.call(renderer, href, title, text);
+	return html.replace(/^<a /, '<a target="_blank" rel="nofollow" ');
+};
+
 const highlight = function(code, lang) {
 	if (!lang) {
 		return code;


### PR DESCRIPTION
@RocketChat/core 

Messages parsed using `Marked` as the `Markdown Parser` would contain links that would send the current window to that location. This fix makes sure those links are opened in a new tab.

This change has made my team very happy.