### PR TITLE
[FIX] Add a validation to make sure that users be part of the direct messages channel

### DIFF
--- a/packages/rocketchat-lib/server/functions/getRoomByNameOrIdWithOptionToJoin.js
+++ b/packages/rocketchat-lib/server/functions/getRoomByNameOrIdWithOptionToJoin.js
@@ -76,5 +76,9 @@ RocketChat.getRoomByNameOrIdWithOptionToJoin = function _getRoomByNameOrIdWithOp
 		}
 	}
 
+	if (!Meteor.call('canAccessRoom', room._id, currentUserId)) {
+		throw new Meteor.Error('unauthorized');
+	}
+
 	return room;
 };


### PR DESCRIPTION
Added a validation to make sure that users who are not part of the direct messages channels are not able to query these endpoints.