### PR TITLE
[FIX] Allow recording Video Messages again

### DIFF
--- a/packages/rocketchat-ui/client/lib/recorderjs/videoRecorder.js
+++ b/packages/rocketchat-ui/client/lib/recorderjs/videoRecorder.js
@@ -30,9 +30,8 @@ this.VideoRecorder = new class {
 		if (this.stream == null) {
 			return;
 		}
-		this.mediaRecorder = new MediaRecorder(this.stream);
-		this.mediaRecorder.stream = this.stream;
-		this.mediaRecorder.mimeType = 'video/webm';
+		this.mediaRecorder = new MediaRecorder(this.stream, { mimeType: 'video/webm' });
+
 		this.mediaRecorder.ondataavailable = (blobev) => {
 			this.chunks.push(blobev.data);
 			if (!this.recordingAvailable.get()) {


### PR DESCRIPTION
Closes #13290

The code in videoRecorder.js was accessing read-only variables (according to https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder ).

Fixed according to Mozilla examples: https://github.com/mozdevs/MediaRecorder-examples/blob/gh-pages/media-recorder-mimetypes.js#L56