### PR TITLE
[IMPROVE] Send `uniqueID` to all clients so Jitsi rooms can be created correctly

### DIFF
--- a/packages/rocketchat-lib/server/startup/settings.js
+++ b/packages/rocketchat-lib/server/startup/settings.js
@@ -4,7 +4,6 @@ import './email';
 // Insert server unique id if it doesn't exist
 RocketChat.settings.add('uniqueID', process.env.DEPLOYMENT_ID || Random.id(), {
 	public: true,
-	hidden: true,
 });
 
 // When you define a setting and want to add a description, you don't need to automatically define the i18nDescription


### PR DESCRIPTION
No migration is required, it will update the setting visibility on next start.