### PR TITLE
[NEW] Failed login audit

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -210,3 +210,4 @@ rocketchat:notifications
 rocketchat:promises
 rocketchat:ui-utils
 rocketchat:ui-cached-collection
+rocketchat:failed-login-audit

--- a/packages/rocketchat-failed-login-audit/package.js
+++ b/packages/rocketchat-failed-login-audit/package.js
@@ -1,0 +1,16 @@
+Package.describe({
+	name: 'rocketchat:failed-login-audit',
+	version: '0.0.1',
+	summary: '',
+	git: '',
+	documentation: 'README.md',
+});
+
+Package.onUse(function(api) {
+	api.use([
+		'ecmascript',
+		'rocketchat:lib',
+		'rocketchat:settings',
+	]);
+	api.mainModule('server/index.js', 'server');
+});

--- a/packages/rocketchat-failed-login-audit/server/index.js
+++ b/packages/rocketchat-failed-login-audit/server/index.js
@@ -1,0 +1,97 @@
+import { Meteor } from 'meteor/meteor';
+import { RocketChat } from 'meteor/rocketchat:lib';
+
+RocketChat.FailedLoginAudit = {
+	enabled: false,
+	log_useragent: false,
+	log_clientip: false,
+	log_username: false,
+	log_forwarded_for_ip: false,
+};
+
+Meteor.startup(function() {
+	RocketChat.settings.addGroup('Failed Login Audit', function() {
+		this.add('FailedLoginAudit_Enabled', false, {
+			type: 'boolean',
+			i18nLabel: 'Enabled',
+		});
+		this.add('FailedLoginAudit_Log_Username', false, {
+			type: 'boolean',
+			i18nLabel: 'Write user name to logfile',
+			enableQuery: { _id: 'FailedLoginAudit_Enabled', value: true },
+		}
+		);
+
+		this.add('FailedLoginAudit_Log_UserAgent', false, {
+			type: 'boolean',
+			i18nLabel: 'Write user agent to logfile',
+			enableQuery: { _id: 'FailedLoginAudit_Enabled', value: true },
+		}
+		);
+
+		this.add('FailedLoginAudit_Log_ClientIp', false, {
+			type: 'boolean',
+			i18nLabel: 'Write client ip to logfile',
+			enableQuery: { _id: 'FailedLoginAudit_Enabled', value: true },
+		}
+		);
+
+		this.add('FailedLoginAudit_Log_ForwardedForIp', false, {
+			type: 'boolean',
+			i18nLabel: 'Write forwared for ip to logfile',
+			enableQuery: { _id: 'FailedLoginAudit_Enabled', value: true },
+		}
+		);
+
+	});
+});
+
+RocketChat.settings.get('FailedLoginAudit_Enabled', function(key, value) {
+	RocketChat.FailedLoginAudit.enabled = value;
+});
+
+RocketChat.settings.get('FailedLoginAudit_Log_Username', function(key, value) {
+	RocketChat.FailedLoginAudit.log_username = value;
+});
+
+RocketChat.settings.get('FailedLoginAudit_Log_UserAgent', function(key, value) {
+	RocketChat.FailedLoginAudit.log_useragent = value;
+});
+
+RocketChat.settings.get('FailedLoginAudit_Log_ClientIp', function(key, value) {
+	RocketChat.FailedLoginAudit.log_clientip = value;
+});
+
+RocketChat.settings.get('FailedLoginAudit_Log_ForwardedForIp', function(key, value) {
+	RocketChat.FailedLoginAudit.log_forwarded_for_ip = value;
+});
+
+RocketChat.callbacks.add('beforeValidateLogin', (login) => {
+
+	if (RocketChat.FailedLoginAudit.enabled !== true) {
+		return login;
+	}
+
+	if (login.allowed !== true) {
+		let user = 'unknown';
+		if (login.user !== undefined && RocketChat.FailedLoginAudit.log_username === true) {
+			user = login.user.username;
+		}
+		const { connection } = login;
+		let { clientAddress } = connection.clientAddress;
+		if (RocketChat.FailedLoginAudit.log_clientip !== true) {
+			clientAddress = '-';
+		}
+		let forwardedFor = connection.httpHeaders['x-forwarded-for'];
+		if (RocketChat.FailedLoginAudit.log_forwarded_for_ip !== true) {
+			forwardedFor = '-';
+		}
+		let userAgent = connection.httpHeaders['user-agent'];
+		if (RocketChat.FailedLoginAudit.log_useragent !== true) {
+			userAgent = '-';
+		}
+		console.log('Failed login detected - Username[%s] ClientAddress[%s] ForwardedFor[%s] UserAgent[%s]', user, clientAddress, forwardedFor, userAgent);
+	}
+
+	return login;
+});


### PR DESCRIPTION
Closes #2885

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

This PR adds the capability of logging failed login attempts. This can be used later for analysis / monitoring / fail2ban tooling.

The feature provides the option to

- be completely turned on / off
- select if one of the following information should be logged or not
   - Client IP
   - Forward For IP
   - UserAgent
   - Username

The log lines written are of this kind (in this example Forwarded For IP is enabled, everything else disabled)

    Failed login detected - Username[unknown] ClientAddress[undefined] ForwardedFor[127.0.0.1] UserAgent[-]