### PR TITLE
[IMPROVE] Update to MongoDB 4.0 in docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - "traefik.frontend.rule=Host: your.domain.tld"
 
   mongo:
-    image: mongo:3.6
+    image: mongo:4.0
     restart: unless-stopped
     volumes:
      - ./data/db:/data/db
@@ -35,7 +35,7 @@ services:
   # this container's job is just run the command to initialize the replica set.
   # it will run the command and remove himself (it will not stay running)
   mongo-init-replica:
-    image: mongo:3.6
+    image: mongo:4.0
     command: 'mongo mongo/rocketchat --eval "rs.initiate({ _id: ''rs0'', members: [ { _id: 0, host: ''localhost:27017'' } ]})"'
     depends_on:
       - mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - "traefik.frontend.rule=Host: your.domain.tld"
 
   mongo:
-    image: mongo:3.2
+    image: mongo:3.6
     restart: unless-stopped
     volumes:
      - ./data/db:/data/db
@@ -35,7 +35,7 @@ services:
   # this container's job is just run the command to initialize the replica set.
   # it will run the command and remove himself (it will not stay running)
   mongo-init-replica:
-    image: mongo:3.2
+    image: mongo:3.6
     command: 'mongo mongo/rocketchat --eval "rs.initiate({ _id: ''rs0'', members: [ { _id: 0, host: ''localhost:27017'' } ]})"'
     depends_on:
       - mongo


### PR DESCRIPTION
The current recommendation of Rocket.Chat is MongoDB 3.6.

Initializing a Docker Compose Setup with MongoDB 3.2 would require a step by step upgrade via MongoDB 3.4. See the release notes of Mongo DB:
* [3.4](https://docs.mongodb.com/manual/release-notes/3.4-upgrade-standalone/)
* [3.6](https://docs.mongodb.com/manual/release-notes/3.6-upgrade-standalone/)

This can be skipped by just using a more recent version of MongoDB.
