### PR TITLE
[NEW] theoretical / experimental take on mongo-backend sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
 		"codemirror": "^5.42.0",
 		"coffeescript": "^2.3.2",
 		"connect": "^3.6.6",
+		"connect-mongodb-session": "^2.1.1",
 		"core-js": "^2.5.7",
 		"csv-parse": "^4.0.1",
 		"emailreplyparser": "^0.0.5",

--- a/packages/rocketchat-grant/server/index.js
+++ b/packages/rocketchat-grant/server/index.js
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { WebApp } from 'meteor/webapp';
 import session from 'express-session';
-import sessionStorage from 'connect-mongodb-session';
+import SessionStorage from 'connect-mongodb-session';
 import Grant from 'grant-express';
 import fiber from 'fibers';
 
@@ -12,27 +12,27 @@ import { middleware as redirect } from './redirect';
 import Providers, { middleware as providers } from './providers';
 import Settings from './settings';
 
-let grant,
-    storeAddress = process.env.SESSIONS_URL || 'mongodb://localhost:27017/rocketsession';
+let grant;
+let storeAddress = process.env.SESSIONS_URL || 'mongodb://localhost:27017/rocketsession';
 
 if (storeAddress.indexOf('connectTimeoutMS=') < 0) {
-    if (storeAddress.indexOf('?') < 0) {
-	storeAddress += '?connectTimeoutMS=1200';
-    } else {
-	storeAddress += '&connectTimeoutMS=1200';
-    }
+	if (storeAddress.indexOf('?') < 0) {
+		storeAddress += '?connectTimeoutMS=1200';
+	} else {
+		storeAddress += '&connectTimeoutMS=1200';
+	}
 }
-let store = new sessionStorage({
-	uri: storeAddress,
+const store = new SessionStorage({
+	collection: process.env.SESSION_COLLECTION || 'mySessions',
 	databaseName: process.env.SESSION_DATABASE || 'connect_mongodb_session',
-	collection: process.env.SESSION_COLLECTION || 'mySessions'
-    }, ((e) => {
-	throw new GrantError('Sessions storage initialization failure');
-    }));
+	uri: storeAddress,
+}, ((e) => {
+	throw new GrantError('Sessions storage initialization failure:', e);
+}));
 
 store.on('error', (e) => {
-	throw new GrantError('Sessions storage error caught');
-    });
+	throw new GrantError('Sessions storage error caught:', e);
+});
 
 WebApp.connectHandlers.use(session({
 	secret: 'grant',

--- a/packages/rocketchat-grant/server/index.js
+++ b/packages/rocketchat-grant/server/index.js
@@ -27,7 +27,9 @@ const store = new SessionStorage({
 	databaseName: process.env.SESSION_DATABASE || 'rocketchat',
 	uri: storeAddress,
 }, ((e) => {
-	throw new GrantError('Sessions storage initialization failure:', e);
+	if (e !== undefined) {
+		throw new GrantError('Sessions storage initialization failure:', e);
+	}
 }));
 
 store.on('error', (e) => {

--- a/packages/rocketchat-grant/server/index.js
+++ b/packages/rocketchat-grant/server/index.js
@@ -1,7 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { WebApp } from 'meteor/webapp';
 import session from 'express-session';
-import SessionStorage from 'connect-mongodb-session';
 import Grant from 'grant-express';
 import fiber from 'fibers';
 
@@ -13,7 +12,7 @@ import Providers, { middleware as providers } from './providers';
 import Settings from './settings';
 
 let grant;
-let storeAddress = process.env.SESSIONS_URL || 'mongodb://localhost:27017/rocketsession';
+let storeAddress = process.env.MONGO_URL || 'mongodb://localhost:27017/';
 
 if (storeAddress.indexOf('connectTimeoutMS=') < 0) {
 	if (storeAddress.indexOf('?') < 0) {
@@ -22,9 +21,10 @@ if (storeAddress.indexOf('connectTimeoutMS=') < 0) {
 		storeAddress += '&connectTimeoutMS=1200';
 	}
 }
+const SessionStorage = require('connect-mongodb-session')(session);
 const store = new SessionStorage({
-	collection: process.env.SESSION_COLLECTION || 'mySessions',
-	databaseName: process.env.SESSION_DATABASE || 'connect_mongodb_session',
+	collection: process.env.SESSION_COLLECTION || 'rocketchat_grant_sessions',
+	databaseName: process.env.SESSION_DATABASE || 'rocketchat',
 	uri: storeAddress,
 }, ((e) => {
 	throw new GrantError('Sessions storage initialization failure:', e);
@@ -36,7 +36,7 @@ store.on('error', (e) => {
 
 WebApp.connectHandlers.use(session({
 	secret: 'grant',
-	store,
+	store: store,
 	resave: true,
 	saveUninitialized: true,
 }));

--- a/packages/rocketchat-grant/server/index.js
+++ b/packages/rocketchat-grant/server/index.js
@@ -36,7 +36,7 @@ store.on('error', (e) => {
 
 WebApp.connectHandlers.use(session({
 	secret: 'grant',
-	store: store,
+	store,
 	resave: true,
 	saveUninitialized: true,
 }));


### PR DESCRIPTION
Eventually, would address #10714 

Didn't look at the docs yet, although there would be stuff to update.

This PR is mostly sent as a theoretical take on moving rocket's in-memory sessions storage into mongodb.

I did not test this code!

Excluding package-lock, avoiding to bump dependencies I didn't mean to upgrade in the first place, ... pending further discussions, especially regarding configuration / environment variables we'ld want to use initializing mongodb sessions store