### PR TITLE
[FIX] users.getPreferences when the user doesn't have any preferences

### DIFF
--- a/app/api/server/v1/users.js
+++ b/app/api/server/v1/users.js
@@ -403,7 +403,7 @@ API.v1.addRoute('users.getPreferences', { authRequired: true }, {
 	get() {
 		const user = Users.findOneById(this.userId);
 		if (user.settings) {
-			const { preferences } = user.settings;
+			const { preferences = {} } = user.settings;
 			preferences.language = user.language;
 
 			return API.v1.success({


### PR DESCRIPTION
Closes #12976

When **normal users** doesn't have any preferences, `user.settings` is an empty object instead of undefined. My solution was to check both.

Maybe a better solution is all users start with settings as undefined.