### PR TITLE
[FIX] Crowd: Error syncing user data. logger.warning is not a function

### DIFF
--- a/packages/rocketchat-crowd/server/crowd.js
+++ b/packages/rocketchat-crowd/server/crowd.js
@@ -201,7 +201,7 @@ export class CROWD {
 
 				const response = self.crowdClient.searchSync('user', `email=" ${ email } "`);
 				if (!response || response.users.length === 0) {
-					logger.warning('Could not find user in CROWD with username or email:', crowd_username, email);
+					logger.warn('Could not find user in CROWD with username or email:', crowd_username, email);
 					return;
 				}
 				crowd_username = response.users[0].name;


### PR DESCRIPTION
When a Crowd synchronization fails, the logger uses the wrong function ("warning" instead of "warn").

[FIX] Crowd: Error syncing user data. logger.warning is not a function

INSTRUCTION: You need a Crowd instance and a user who no longer exists.