### PR TITLE
[WIP][IMPROVE] Apps admin layout

### DIFF
--- a/packages/rocketchat-apps/assets/stylesheets/apps.css
+++ b/packages/rocketchat-apps/assets/stylesheets/apps.css
@@ -63,6 +63,13 @@
 		justify-content: center;
 	}
 
+	.rc-apps-loading {
+		position: relative;
+
+		height: 100%;
+		flex-grow: 1;
+	}
+
 	.rc-apps-apps {
 		display: flex;
 

--- a/packages/rocketchat-apps/assets/stylesheets/apps.css
+++ b/packages/rocketchat-apps/assets/stylesheets/apps.css
@@ -108,6 +108,8 @@
 
 						padding: 5px 10px;
 
+						text-transform: uppercase;
+
 						border-radius: 20px;
 
 						font-size: 12px;

--- a/packages/rocketchat-apps/assets/stylesheets/apps.css
+++ b/packages/rocketchat-apps/assets/stylesheets/apps.css
@@ -83,9 +83,16 @@
 			margin: 5px;
 			padding: 15px 20px;
 
+			cursor: pointer;
+
+			border: 2px solid #f3f5f8;
 			background: #f3f5f8;
 			align-items: center;
 			flex-grow: 1;
+
+			&:hover {
+				background: #f9fafc;
+			}
 
 			.rc-apps-app-content {
 				display: flex;

--- a/packages/rocketchat-apps/assets/stylesheets/apps.css
+++ b/packages/rocketchat-apps/assets/stylesheets/apps.css
@@ -123,6 +123,18 @@
 						font-weight: 500;
 						line-height: 12px;
 					}
+
+					.js-install-check {
+						.rc-apps-app-install-text-install {
+							display: none;
+						}
+					}
+
+					.js-install {
+						.rc-apps-app-install-text-free {
+							display: none;
+						}
+					}
 				}
 			}
 

--- a/packages/rocketchat-apps/assets/stylesheets/apps.css
+++ b/packages/rocketchat-apps/assets/stylesheets/apps.css
@@ -53,6 +53,116 @@
 		line-height: 20px;
 	}
 
+	.rc-apps-apps-container {
+		display: flex;
+		overflow-y: scroll;
+
+		width: 100%;
+		height: 100%;
+		align-items: start;
+		justify-content: center;
+	}
+
+	.rc-apps-apps {
+		display: flex;
+
+		width: 100%;
+		max-width: 1200px;
+		flex-wrap: wrap;
+		justify-content: center;
+
+		.rc-apps-app {
+			width: 400px;
+			margin: 5px;
+			padding: 15px 20px;
+
+			background: #f3f5f8;
+			align-items: center;
+			flex-grow: 1;
+
+			.rc-apps-app-content {
+				display: flex;
+
+				width: 100%;
+				align-items: center;
+
+				.rc-apps-app-action {
+					.rc-icon--loading {
+						display: none;
+					}
+
+					.loading {
+						& > .rc-icon--loading {
+							display: block;
+
+							animation: spin 1s linear infinite;
+						}
+
+						& > button {
+							display: none;
+						}
+					}
+
+					button {
+						min-height: 0;
+
+						padding: 5px 10px;
+
+						border-radius: 20px;
+
+						font-size: 12px;
+						font-weight: 500;
+						line-height: 12px;
+					}
+				}
+			}
+
+			.rc-apps-app-info {
+				padding: 0 10px;
+
+				line-height: 16px;
+
+				flex-grow: 1;
+
+				.rc-apps-app-info-title {
+					font-weight: 500;
+				}
+
+				.rc-apps-app-info-subtitle {
+					color: var(--rc-color-primary-light);
+				}
+			}
+
+			.rc-apps-app-categories {
+				margin-top: 5px;
+
+				padding-top: 5px;
+
+				border-top: 1px solid #e7ebf2;
+
+				line-height: 24px;
+
+				.rc-apps-app-category {
+					display: inline-block;
+
+					height: 20px;
+					padding: 0 8px;
+
+					letter-spacing: 0.5px;
+					text-transform: uppercase;
+
+					color: #6b7d99;
+
+					border-radius: 2px;
+					background-color: #e7ebf2;
+
+					font-size: 10px;
+					line-height: 20px;
+				}
+			}
+		}
+	}
+
 	.rc-apps-details {
 		margin-bottom: 0;
 		padding: 0;
@@ -139,7 +249,6 @@
 	.rc-table-avatar {
 		width: 40px;
 		height: 40px;
-		margin: 0 7px;
 	}
 
 	.rc-table-info {

--- a/packages/rocketchat-apps/client/admin/apps.html
+++ b/packages/rocketchat-apps/client/admin/apps.html
@@ -14,80 +14,69 @@
 				</label>
 			</div>
 			{{#requiresPermission 'manage-apps'}}
-				{{#table fixed='true' onScroll=onTableScroll onResize=onTableResize onSort=onTableSort}}
-					<thead>
-						<tr>
-							<th class="js-sort rc-table-td--medium {{#if searchSortBy 'name'}}is-sorting{{/if}}" data-sort="name">
-								<div class="table-fake-th">{{_ "Name"}} {{> icon icon=(sortIcon 'name')}}</div>
-							</th>
-							<th class="js-sort rc-table-td--medium {{#if searchSortBy 'category'}}is-sorting{{/if}}" data-sort="category">>
-								<div class="table-fake-th">{{_ "Category"}} {{> icon icon=(sortIcon 'category') }}</div>
-							</th>
-							<th class="rc-table-td">
-								<div class="table-fake-th">{{_ "Details"}} </div>
-							</th>
-							<th class="rc-table-td--small">
-							</th>
-						</tr>
-					</thead>
-					<tbody>
+				<div class="rc-apps-apps-container">
+					<div class="rc-apps-apps">
 						{{#each apps}}
-							<tr class="rc-table-tr manage" data-name="{{latest.name}}">
-								<td>
-									<div class="rc-table-wrapper">
+							<div class="rc-apps-app manage" data-name="{{latest.name}}">
+								<div class="rc-apps-app-content">
+									<div class="rc-apps-app-icon">
 										{{#if latest.iconFileData}}
 											<div class="rc-table-avatar" style="background-image:url(data:image/png;base64,{{latest.iconFileData}})"></div>
 										{{else}}
 											<div class="rc-table-avatar" style="background-image:url({{latest.iconFileContent}})"></div>
 										{{/if}}
-										<div class="rc-table-info">
-											<span class="rc-table-title">
-												{{latest.name}}
-											</span>
-											{{#if latest.author.name}}
-												<span class="rc-table-subtitle">by {{latest.author.name}}</span>
-											{{/if}}
-										</div>
 									</div>
-								</td>
-								<td>{{latest.categories}}</td>
-								<td>
-									<p class="rc-table-title">
-										{{#if latest.summary}}
-											{{latest.summary}}
-										{{else}}
-											{{latest.description}}
-										{{/if}}
-									</p>
-									{{#if latest.summary}}
-										<p>
-											{{latest.description}}
-										</p>
-									{{/if}}
-								</td>
-								<td>
-
-									{{#if $eq latest._installed true}}
-										{{> icon icon="checkmark-circled" block="rc-icon--default-size"}}
-									{{/if}}
-									{{#if renderDownloadButton latest}}
-										<div class="rc-apps-marketplace__wrap-actions">
-											{{> icon block="rc-icon--default-size rc-icon" icon="loading"}}
-											<button class="js-install apps-installer" data-app="{{appId}}">
-												{{> icon block="installer rc-icon--default-size" icon="circled-arrow-down"}}
-											</button>
+									<div class="rc-apps-app-info">
+										<div class="rc-apps-app-info-title">
+											{{latest.name}}
 										</div>
-									{{/if}}
-								</td>
-							</tr>
+										{{#if latest.author.name}}
+											<div class="rc-apps-app-info-subtitle">by {{latest.author.name}}</div>
+										{{/if}}
+
+										<!-- <p class="rc-table-title">
+											{{#if latest.summary}}
+												{{latest.summary}}
+											{{else}}
+												{{latest.description}}
+											{{/if}}
+										</p>
+										{{#if latest.summary}}
+											<p>
+												{{latest.description}}
+											</p>
+										{{/if}} -->
+									</div>
+									<div class="rc-apps-app-action">
+										{{#if $eq latest._installed true}}
+											<button class="js-configure rc-button rc-button--secondary rc-button--small" data-app="{{appId}}">
+												OPEN
+											</button>
+										{{/if}}
+										{{#if renderDownloadButton latest}}
+											<div class="rc-apps-app-action-install">
+												{{> icon block="rc-icon--default-size rc-icon" icon="loading"}}
+												<button class="js-install rc-button rc-button--primary rc-button--small" data-app="{{appId}}">
+													FREE
+												</button>
+											</div>
+										{{/if}}
+									</div>
+								</div>
+								<div class="rc-apps-app-categories">
+									{{#each latest.categories}}
+										<div class="rc-apps-app-category">{{.}}</div>
+									{{/each}}
+								</div>
+							</div>
 						{{/each}}
 						{{#if isLoading}}
-							<tr>
-								<td colspan="3" style="position: relative;">{{> loading}}</td>
-							</tr>
+							<div>
+								{{> loading}}
+							</div>
 						{{/if}}
-					</tbody>
-				{{/table}}
+					</div>
+				</div>
 			{{/requiresPermission}}
 		</div>
 	</section>

--- a/packages/rocketchat-apps/client/admin/apps.html
+++ b/packages/rocketchat-apps/client/admin/apps.html
@@ -5,78 +5,80 @@
 		{{/header}}
 		<div class="rc-table-content">
 			{{>tabs tabs=tabsData}}
-			<div class="rc-input rc-input--small rc-directory-search">
-				<label class="rc-input__label">
-					<div class="rc-input__wrapper">
-						{{> icon icon="magnifier" block="rc-input__icon" }}
-						<input type="text" class="rc-input__element rc-input__element--small js-search" name="message-search" id="message-search" placeholder={{#if $eq searchType 'channels'}}{{_ "Search_Channels"}}{{/if}}{{#if $eq searchType 'users'}}{{_ "Search_Users"}}{{/if}} autocomplete="off">
-					</div>
-				</label>
-			</div>
 			{{#requiresPermission 'manage-apps'}}
-				<div class="rc-apps-apps-container">
-					<div class="rc-apps-apps">
-						{{#each apps}}
-							<div class="rc-apps-app manage" data-name="{{latest.name}}">
-								<div class="rc-apps-app-content">
-									<div class="rc-apps-app-icon">
-										{{#if latest.iconFileData}}
-											<div class="rc-table-avatar" style="background-image:url(data:image/png;base64,{{latest.iconFileData}})"></div>
-										{{else}}
-											<div class="rc-table-avatar" style="background-image:url({{latest.iconFileContent}})"></div>
-										{{/if}}
-									</div>
-									<div class="rc-apps-app-info">
-										<div class="rc-apps-app-info-title">
-											{{latest.name}}
-										</div>
-										{{#if latest.author.name}}
-											<div class="rc-apps-app-info-subtitle">by {{latest.author.name}}</div>
-										{{/if}}
-
-										<!-- <p class="rc-table-title">
-											{{#if latest.summary}}
-												{{latest.summary}}
-											{{else}}
-												{{latest.description}}
-											{{/if}}
-										</p>
-										{{#if latest.summary}}
-											<p>
-												{{latest.description}}
-											</p>
-										{{/if}} -->
-									</div>
-									<div class="rc-apps-app-action">
-										{{#if $eq latest._installed true}}
-											<button class="js-configure rc-button rc-button--secondary rc-button--small" data-app="{{appId}}">
-												{{_ "Open"}}
-											</button>
-										{{/if}}
-										{{#if renderDownloadButton latest}}
-											<div class="rc-apps-app-action-install">
-												{{> icon block="rc-icon--default-size rc-icon" icon="loading"}}
-												<button class="js-install rc-button rc-button--primary rc-button--small" data-app="{{appId}}">
-													{{_ "Free"}}
-												</button>
-											</div>
-										{{/if}}
-									</div>
-								</div>
-								<div class="rc-apps-app-categories">
-									{{#each latest.categories}}
-										<div class="rc-apps-app-category">{{.}}</div>
-									{{/each}}
-								</div>
-							</div>
-						{{/each}}
-						{{#if isLoading}}
-							<div>
-								{{> loading}}
-							</div>
-						{{/if}}
+				{{#if isLoading}}
+					<div class="rc-apps-loading">
+						{{> loading}}
 					</div>
-				</div>
+				{{else}}
+					<div class="rc-input rc-input--small rc-directory-search">
+						<label class="rc-input__label">
+							<div class="rc-input__wrapper">
+								{{> icon icon="magnifier" block="rc-input__icon" }}
+								<input type="text" class="rc-input__element rc-input__element--small js-search" name="message-search" id="message-search" placeholder={{#if $eq searchType 'channels'}}{{_ "Search_Channels"}}{{/if}}{{#if $eq searchType 'users'}}{{_ "Search_Users"}}{{/if}} autocomplete="off">
+							</div>
+						</label>
+					</div>
+
+					<div class="rc-apps-apps-container">
+						<div class="rc-apps-apps">
+							{{#each apps}}
+								<div class="rc-apps-app manage" data-name="{{latest.name}}">
+									<div class="rc-apps-app-content">
+										<div class="rc-apps-app-icon">
+											{{#if latest.iconFileData}}
+												<div class="rc-table-avatar" style="background-image:url(data:image/png;base64,{{latest.iconFileData}})"></div>
+											{{else}}
+												<div class="rc-table-avatar" style="background-image:url({{latest.iconFileContent}})"></div>
+											{{/if}}
+										</div>
+										<div class="rc-apps-app-info">
+											<div class="rc-apps-app-info-title">
+												{{latest.name}}
+											</div>
+											{{#if latest.author.name}}
+												<div class="rc-apps-app-info-subtitle">by {{latest.author.name}}</div>
+											{{/if}}
+
+											<!-- <p class="rc-table-title">
+												{{#if latest.summary}}
+													{{latest.summary}}
+												{{else}}
+													{{latest.description}}
+												{{/if}}
+											</p>
+											{{#if latest.summary}}
+												<p>
+													{{latest.description}}
+												</p>
+											{{/if}} -->
+										</div>
+										<div class="rc-apps-app-action">
+											{{#if $eq latest._installed true}}
+												<button class="js-configure rc-button rc-button--secondary rc-button--small" data-app="{{appId}}">
+													{{_ "Open"}}
+												</button>
+											{{/if}}
+											{{#if renderDownloadButton latest}}
+												<div class="rc-apps-app-action-install">
+													{{> icon block="rc-icon--default-size rc-icon" icon="loading"}}
+													<button class="js-install rc-button rc-button--primary rc-button--small" data-app="{{appId}}">
+														{{_ "Free"}}
+													</button>
+												</div>
+											{{/if}}
+										</div>
+									</div>
+									<div class="rc-apps-app-categories">
+										{{#each latest.categories}}
+											<div class="rc-apps-app-category">{{.}}</div>
+										{{/each}}
+									</div>
+								</div>
+							{{/each}}
+						</div>
+					</div>
+				{{/if}}
 			{{/requiresPermission}}
 		</div>
 	</section>

--- a/packages/rocketchat-apps/client/admin/apps.html
+++ b/packages/rocketchat-apps/client/admin/apps.html
@@ -50,14 +50,14 @@
 									<div class="rc-apps-app-action">
 										{{#if $eq latest._installed true}}
 											<button class="js-configure rc-button rc-button--secondary rc-button--small" data-app="{{appId}}">
-												OPEN
+												{{_ "Open"}}
 											</button>
 										{{/if}}
 										{{#if renderDownloadButton latest}}
 											<div class="rc-apps-app-action-install">
 												{{> icon block="rc-icon--default-size rc-icon" icon="loading"}}
 												<button class="js-install rc-button rc-button--primary rc-button--small" data-app="{{appId}}">
-													FREE
+													{{_ "Free"}}
 												</button>
 											</div>
 										{{/if}}

--- a/packages/rocketchat-apps/client/admin/apps.html
+++ b/packages/rocketchat-apps/client/admin/apps.html
@@ -70,11 +70,13 @@
 											{{/if}}
 										</div>
 									</div>
-									<div class="rc-apps-app-categories">
-										{{#each latest.categories}}
-											<div class="rc-apps-app-category">{{.}}</div>
-										{{/each}}
-									</div>
+									{{#if latest.categories}}
+										<div class="rc-apps-app-categories">
+											{{#each latest.categories}}
+												<div class="rc-apps-app-category">{{.}}</div>
+											{{/each}}
+										</div>
+									{{/if}}
 								</div>
 							{{/each}}
 						</div>

--- a/packages/rocketchat-apps/client/admin/apps.html
+++ b/packages/rocketchat-apps/client/admin/apps.html
@@ -62,8 +62,9 @@
 											{{#if renderDownloadButton latest}}
 												<div class="rc-apps-app-action-install">
 													{{> icon block="rc-icon--default-size rc-icon" icon="loading"}}
-													<button class="js-install rc-button rc-button--primary rc-button--small" data-app="{{appId}}">
-														{{_ "Free"}}
+													<button class="js-install-check rc-button rc-button--primary rc-button--small" data-app="{{appId}}">
+														<span class="rc-apps-app-install-text-free">{{_ "Free"}}</span>
+														<span class="rc-apps-app-install-text-install">{{_ "Install"}}</span>
 													</button>
 												</div>
 											{{/if}}

--- a/packages/rocketchat-apps/client/admin/apps.js
+++ b/packages/rocketchat-apps/client/admin/apps.js
@@ -39,6 +39,10 @@ const getApps = (instance) => {
 	fetch(`${ HOST }/v1/apps?version=${ Info.marketplaceApiVersion }`)
 		.then((response) => response.json())
 		.then((data) => {
+			if (instance.searchType.get() !== 'marketplace') {
+				return;
+			}
+
 			const tagged = tagAlreadyInstalledApps(instance.installedApps.get(), data);
 
 			instance.isLoading.set(false);
@@ -232,6 +236,7 @@ Template.apps.helpers({
 					getApps(instance);
 				} else {
 					instance.apps.set(instance.installedApps.get());
+					instance.isLoading.set(false);
 				}
 			},
 		};

--- a/packages/rocketchat-apps/client/admin/apps.js
+++ b/packages/rocketchat-apps/client/admin/apps.js
@@ -254,6 +254,11 @@ Template.apps.events({
 	'click [data-button="install"]'() {
 		FlowRouter.go('/admin/app/install');
 	},
+	'click .js-install-check'(e) {
+		e.stopPropagation();
+
+		e.currentTarget.classList.replace('js-install-check', 'js-install');
+	},
 	'click .js-install'(e, template) {
 		e.stopPropagation();
 

--- a/packages/rocketchat-apps/client/admin/apps.js
+++ b/packages/rocketchat-apps/client/admin/apps.js
@@ -56,6 +56,8 @@ const getInstalledApps = (instance) => {
 	APIClient.get('apps').then((data) => {
 		const apps = data.apps.map((app) => ({ latest: app }));
 
+		apps.forEach((app) => app.latest._installed = true);
+
 		instance.installedApps.set(apps);
 	});
 };

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -1363,6 +1363,7 @@
   "Forward_chat": "Forward chat",
   "Forward_to_department": "Forward to department",
   "Forward_to_user": "Forward to user",
+  "Free": "Free",
   "Frequently_Used": "Frequently Used",
   "Friday": "Friday",
   "From": "From",


### PR DESCRIPTION
![screen shot 2019-03-05 at 6 31 36 pm](https://user-images.githubusercontent.com/234261/53838921-fde65e00-3f74-11e9-8bf9-8b0665b5bd2c.png)

- [x] Redesign the list
- [x] Use 2 state buttons, first click change from `FREE` to `INSTALL`, second install the app (for paid ones change from `$9.99` to `BUY APP`)
- [ ] Fix layout of app details
- [x] Add open/configure button and correct cursor for each app on installed page 
- [ ] Make manual install only available if dev mode is enabled
- [ ] Translate strings of manual install page
- [ ] Better text for manual installation button