### PR TITLE
[FIX] Corrects UI background of forced F2A Authentication

### DIFF
--- a/packages/rocketchat_theme/client/imports/general/forms.css
+++ b/packages/rocketchat_theme/client/imports/general/forms.css
@@ -250,6 +250,8 @@
 	display: flex;
 	flex-direction: column;
 
+	background-color: white;
+
 	height: 100%;
 
 	&--new {

--- a/packages/rocketchat_theme/client/imports/general/forms.css
+++ b/packages/rocketchat_theme/client/imports/general/forms.css
@@ -250,9 +250,9 @@
 	display: flex;
 	flex-direction: column;
 
-	background-color: white;
-
 	height: 100%;
+
+	background-color: white;
 
 	&--new {
 		padding: 0 1.5rem;


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->
Adds the standard white background used to security tab in the css file general/forms.css
Closes #13645 

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

Initial State:
![Screenshot from 2019-03-09 02-38-02](https://user-images.githubusercontent.com/40834245/54059325-bd117200-421e-11e9-9644-3ae877a2defc.png)

Final State:
![Screenshot from 2019-03-09 03-26-28](https://user-images.githubusercontent.com/40834245/54059333-c4388000-421e-11e9-9ef3-d60791aef931.png)

