### PR TITLE
Regression: Fix icon for DMs

### DIFF
--- a/packages/rocketchat-channel-settings/client/views/channelSettings.js
+++ b/packages/rocketchat-channel-settings/client/views/channelSettings.js
@@ -6,7 +6,7 @@ import toastr from 'toastr';
 import moment from 'moment';
 import s from 'underscore.string';
 import { modal, popover, call, erase, hide, leave } from 'meteor/rocketchat:ui-utils';
-import { ChatRoom, Rooms } from 'meteor/rocketchat:models';
+import { ChatRoom } from 'meteor/rocketchat:models';
 import { settings } from 'meteor/rocketchat:settings';
 import { callbacks } from 'meteor/rocketchat:callbacks';
 import { hasPermission, hasAllPermission, hasRole, hasAtLeastOnePermission } from 'meteor/rocketchat:authorization';
@@ -694,21 +694,6 @@ Template.channelSettingsEditing.helpers({
 	},
 	equal(text = '', text2 = '', ret = '*') {
 		return text === text2 ? '' : ret;
-	},
-	getIcon(room) {
-		const roomType = Rooms.findOne(room._id).t;
-		switch (roomType) {
-			case 'd':
-				return 'at';
-			case 'p':
-				return 'lock';
-			case 'c':
-				return 'hashtag';
-			case 'l':
-				return 'livechat';
-			default:
-				return null;
-		}
 	},
 	settings() {
 		return Template.instance().settings;

--- a/packages/rocketchat-lib/lib/roomTypes/direct.js
+++ b/packages/rocketchat-lib/lib/roomTypes/direct.js
@@ -28,6 +28,7 @@ export class DirectMessageRoomType extends RoomTypeConfig {
 		super({
 			identifier: 'd',
 			order: 50,
+			icon: 'at',
 			label: 'Direct_Messages',
 			route: new DirectMessageRoomRoute(),
 		});

--- a/packages/rocketchat-ui-sidenav/client/chatRoomItem.js
+++ b/packages/rocketchat-ui-sidenav/client/chatRoomItem.js
@@ -21,7 +21,7 @@ Template.chatRoomItem.helpers({
 
 		this.alert = !this.hideUnreadStatus && this.alert; // && (!hasFocus || FlowRouter.getParam('_id') !== this.rid);
 
-		const icon = roomTypes.getIcon(this);
+		const icon = this.t !== 'd' && roomTypes.getIcon(this);
 		const avatar = !icon;
 
 		const name = roomTypes.getRoomName(this.t, this);


### PR DESCRIPTION
The icon `@` was missing on room header:

![image](https://user-images.githubusercontent.com/8591547/54199002-9ebda780-44a6-11e9-9f51-bb44125f40b1.png)

added it back:

![image](https://user-images.githubusercontent.com/8591547/54198970-88afe700-44a6-11e9-8ba6-9e66f3242fad.png)
