### PR TITLE
[FIX] Fix snap refresh hook

### DIFF
--- a/.snapcraft/snap/hooks/post-refresh
+++ b/.snapcraft/snap/hooks/post-refresh
@@ -1,16 +1,32 @@
 #!/bin/bash
 
 # Initialize the CADDY_URL to a default
-snapctl set caddy=disable
+caddy="$(snapctl get caddy)"
+if [ -z "$caddy" ]; then
+  snapctl set caddy=disable
+fi
 
 # Initialize the PORT to a default
-snapctl set port=3000
+port="$(snapctl get port)"
+if [ -z "$port" ]; then
+  snapctl set port=3000
+fi
 
 # Initialize the MONGO_URL to a default
-snapctl set mongo-url=mongodb://localhost:27017/parties
+mongourl="$(snapctl get mongo-url)"
+if [ -z "$mongourl" ]; then
+  snapctl set mongo-url=mongodb://localhost:27017/parties
+fi
 
 # Initialize the MONGO_OPLOG_URL to a default
-snapctl set mongo-oplog-url=mongodb://localhost:27017/local
+mongooplogurl="$(snapctl get mongo-oplog-url)"
+if [ -z "$mongooplogurl" ]; then
+  snapctl set mongo-oplog-url=mongodb://localhost:27017/local
+fi
 
 # Initialize the protocol to a default
-snapctl set https=disable
+https="$(snapctl get https)"
+if [ -z "$https" ]; then
+  snapctl set https=disable
+fi
+


### PR DESCRIPTION
Previous version of refresh hook force setting of default values, causing that next snap release overwrites previous configurations by users, this new refresh hook only set default values if not configured by the user before, which is still necessary for the case that the refresh happens of snap versions prior to 0.73.2

Refresh tested from 0.72 to 1, and 0.74 to 1 (pre hooks existence, and post hooks existence)