### PR TITLE
[IMPROVE] Add index for room's ts

### DIFF
--- a/app/models/server/models/Rooms.js
+++ b/app/models/server/models/Rooms.js
@@ -17,6 +17,7 @@ export class Rooms extends Base {
 		this.tryEnsureIndex({ 'tokenpass.tokens.token': 1 });
 		this.tryEnsureIndex({ open: 1 }, { sparse: 1 });
 		this.tryEnsureIndex({ departmentId: 1 }, { sparse: 1 });
+		this.tryEnsureIndex({ ts: 1 });
 
 		// threads
 		this.tryEnsureIndex({ prid: 1 });


### PR DESCRIPTION
There are some queries that sort by `ts` field, specially some for livechat. Those queries are very low on large databases due to this missing index.