### PR TITLE
[NEW] Deactivation of closing comment

### DIFF
--- a/app/livechat/server/config.js
+++ b/app/livechat/server/config.js
@@ -80,6 +80,13 @@ Meteor.startup(function() {
 	settings.add('Livechat_allow_switching_departments', true, { type: 'boolean', group: 'Livechat', public: true, i18nLabel: 'Allow_switching_departments' });
 	settings.add('Livechat_show_agent_email', true, { type: 'boolean', group: 'Livechat', public: true, i18nLabel: 'Show_agent_email' });
 
+	settings.add('Livechat_show_conversation_finished_message', true, {
+		type: 'boolean',
+		group: 'Livechat',
+		public: true,
+		i18nLabel: 'Show_conversation_finished_message',
+	});
+
 	settings.add('Livechat_conversation_finished_message', '', {
 		type: 'string',
 		group: 'Livechat',


### PR DESCRIPTION
Closes #12428 

![image](https://user-images.githubusercontent.com/3590693/54443878-fadb3280-4717-11e9-8ee7-86cbaf4895ee.png)

This PR provides an option for a Livechat admin to disable a closing comment when closing a conversation. The client will see the reason of a conversation closed as `COMMENT_DISABLED`.

TODO:
- [ ] label translation
