### PR TITLE
Fix: addRoomAccessValidator method created for Threads

### DIFF
--- a/app/threading/server/authorization.js
+++ b/app/threading/server/authorization.js
@@ -4,6 +4,6 @@ import { Rooms } from '../../models';
 
 Meteor.startup(() => {
 	addRoomAccessValidator(function(room, user) {
-		return room.prid && canAccessRoom(Rooms.findOne(room.prid), user);
+		return room && room.prid && canAccessRoom(Rooms.findOne(room.prid), user);
 	});
 });


### PR DESCRIPTION
The Livechat fileupload was breaking because the validation method was not checking the `room` object.