### PR TITLE
[FIX] wrong width/height for tile_70 (mstile 70x70 (png))

### DIFF
--- a/app/assets/server/assets.js
+++ b/app/assets/server/assets.js
@@ -130,8 +130,8 @@ const assets = {
 		constraints: {
 			type: 'image',
 			extensions: ['png'],
-			width: 144,
-			height: 144,
+			width: 70,
+			height: 70,
 		},
 	},
 	tile_144: {


### PR DESCRIPTION
I assume it is a c&p error in the tile_70 file the upload from the file always shows the error "Invalid file width" with a file which is 70x70 because the width and height was copied from the file below and is still 144x144 instead of 70x70.
