### PR TITLE
Fix missing dependencies on stretch CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,9 +269,9 @@ jobs:
             if [[ $CIRCLE_PULL_REQUESTS ]]; then exit 0; fi;
 
             sudo apt-get -y -qq update
-            sudo apt-get -y -qq install python3.4-dev
+            sudo apt-get -y -qq install python3.5-dev
             curl -O https://bootstrap.pypa.io/get-pip.py
-            python3.4 get-pip.py --user
+            python3.5 get-pip.py --user
             export PATH=~/.local/bin:$PATH
             pip install awscli --upgrade --user
 


### PR DESCRIPTION
Fix `deploy` job since last update on #13906 