### PR TITLE
[FIX] [NEW] Warning is given to user if aliase is set same as name of emoji in Custom Emoji

### DIFF
--- a/app/emoji-custom/client/admin/emojiEdit.js
+++ b/app/emoji-custom/client/admin/emojiEdit.js
@@ -139,9 +139,19 @@ Template.emojiEdit.onCreated(function() {
 					}
 
 					if (emojiData._id) {
-						toastr.success(t('Custom_Emoji_Updated_Successfully'));
+						if (emojiData.name===emojiData.aliases) {
+							toastr.warning(TAPi18n.__('Custom_Emoji_Without_Aliases'));
+							toastr.success(t('Custom_Emoji_Updated_Successfully'));
+						} else {
+							toastr.success(t('Custom_Emoji_Updated_Successfully'));
+						}
 					} else {
-						toastr.success(t('Custom_Emoji_Added_Successfully'));
+						if (emojiData.name===emojiData.aliases) {
+							toastr.warning(TAPi18n.__('Custom_Emoji_Without_Aliases'));
+							toastr.success(t('Custom_Emoji_Added_Successfully'));
+						} else {
+							toastr.success(t('Custom_Emoji_Added_Successfully'));
+						}
 					}
 
 					this.cancel(form, emojiData.name);

--- a/app/emoji-custom/client/admin/emojiEdit.js
+++ b/app/emoji-custom/client/admin/emojiEdit.js
@@ -145,8 +145,8 @@ Template.emojiEdit.onCreated(function() {
 						} else {
 							toastr.success(t('Custom_Emoji_Updated_Successfully'));
 						}
-					} 
-					if (!emojiData._id){
+					}
+					if (!emojiData._id) {
 						if (emojiData.name === emojiData.aliases) {
 							toastr.warning(TAPi18n.__('Custom_Emoji_Without_Aliases'));
 							toastr.success(t('Custom_Emoji_Added_Successfully'));

--- a/app/emoji-custom/client/admin/emojiEdit.js
+++ b/app/emoji-custom/client/admin/emojiEdit.js
@@ -145,7 +145,8 @@ Template.emojiEdit.onCreated(function() {
 						} else {
 							toastr.success(t('Custom_Emoji_Updated_Successfully'));
 						}
-					} else {
+					} 
+					if (!emojiData._id){
 						if (emojiData.name === emojiData.aliases) {
 							toastr.warning(TAPi18n.__('Custom_Emoji_Without_Aliases'));
 							toastr.success(t('Custom_Emoji_Added_Successfully'));

--- a/app/emoji-custom/client/admin/emojiEdit.js
+++ b/app/emoji-custom/client/admin/emojiEdit.js
@@ -139,14 +139,14 @@ Template.emojiEdit.onCreated(function() {
 					}
 
 					if (emojiData._id) {
-						if (emojiData.name===emojiData.aliases) {
+						if (emojiData.name === emojiData.aliases) {
 							toastr.warning(TAPi18n.__('Custom_Emoji_Without_Aliases'));
 							toastr.success(t('Custom_Emoji_Updated_Successfully'));
 						} else {
 							toastr.success(t('Custom_Emoji_Updated_Successfully'));
 						}
 					} else {
-						if (emojiData.name===emojiData.aliases) {
+						if (emojiData.name === emojiData.aliases) {
 							toastr.warning(TAPi18n.__('Custom_Emoji_Without_Aliases'));
 							toastr.success(t('Custom_Emoji_Added_Successfully'));
 						} else {

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -927,6 +927,7 @@
   "Custom_Emoji_Has_Been_Deleted": "The custom emoji has been deleted.",
   "Custom_Emoji_Info": "Custom Emoji Info",
   "Custom_Emoji_Updated_Successfully": "Custom emoji updated successfully",
+  "Custom_Emoji_Without_Aliases": "Aliase cannot be equal to name",
   "Custom_Fields": "Custom Fields",
   "Custom_oauth_helper": "When setting up your OAuth Provider, you'll have to inform a Callback URL. Use <pre>%s</pre> .",
   "Custom_oauth_unique_name": "Custom oauth unique name",


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #13920 

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

**After Change:**

**(i) Success + Warning is given if aliase name is same as emoji name**
![Screenshot from 2019-03-27 21-53-42](https://user-images.githubusercontent.com/43786728/55093787-1c0a2e80-50db-11e9-8ccc-a11b156d0f8e.png)

**(ii) Success is given if aliase name is not same as emoji name**
![Screenshot from 2019-03-27 21-54-02](https://user-images.githubusercontent.com/43786728/55093786-1c0a2e80-50db-11e9-8012-015cd2f452a1.png)
