### PR TITLE
OpenShift custom OAuth support

### DIFF
--- a/app/custom-oauth/server/custom_oauth_server.js
+++ b/app/custom-oauth/server/custom_oauth_server.js
@@ -225,6 +225,11 @@ export class CustomOAuth {
 					identity.id = identity.sub;
 				}
 
+				// Fix OpenShift identities where id is in 'metadata' object
+				if (identity.metadata.uid && !identity.id) {
+					identity.id = identity.metadata.uid;
+				}
+
 				// Fix general 'userid' instead of 'id' from provider
 				if (identity.userid && !identity.id) {
 					identity.id = identity.userid;


### PR DESCRIPTION
Search for "metadata.uid" field to support JSON responses from OpenShift's user API.

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
When adding OpenShift as a custom OAuth provider, the following error message is output:

```
Exception while invoking method 'login' Error: Service data for service openshift must include id
```

OpenShift's identity endpoint (`/oapi/v1/users/~`) returns the following:

```
{
    "kind": "User",
    "apiVersion": "v1",
    "metadata": {
        "name": "<USERNAME>",
        "selfLink": "/oapi/v1/users/<USERNAME>",
        "uid": "55c68f17-41d5-11e9-a0d2-005056a00a29",  // *this is the user ID
        "resourceVersion": "21557",
        "creationTimestamp": "2019-03-08T19:06:53Z"
    },
    "fullName": "<REDACTED>",
    "identities": [
        "LDAP:<USERNAME>"
    ],
    "groups": [
        "system:authenticated",
        "system:authenticated:oauth"
    ]
}
```

This fix provides compatibility with OpenShift's OAuth server.