### PR TITLE
[BREAK] Prevent start if incompatible mongo version

### DIFF
--- a/server/startup/serverRunning.js
+++ b/server/startup/serverRunning.js
@@ -16,6 +16,8 @@ Meteor.startup(function() {
 		}
 	}
 
+	const mongoDbVersion = MongoInternals.NpmModules.mongodb.version;
+
 	const desiredNodeVersion = semver.clean(fs.readFileSync(path.join(process.cwd(), '../../.node_version.txt')).toString());
 	const desiredNodeVersionMajor = String(semver.parse(desiredNodeVersion).major);
 
@@ -23,6 +25,7 @@ Meteor.startup(function() {
 		let msg = [
 			`Rocket.Chat Version: ${ Info.version }`,
 			`     NodeJS Version: ${ process.versions.node } - ${ process.arch }`,
+			`    MongoDB Version: ${ mongoDbVersion }`,
 			`           Platform: ${ process.platform }`,
 			`       Process Port: ${ process.env.PORT }`,
 			`           Site URL: ${ settings.get('Site_Url') }`,


### PR DESCRIPTION
<img width="564" alt="image" src="https://user-images.githubusercontent.com/51996/55125238-0eeb4080-50d7-11e9-8c37-3d69aba17a7c.png">

I thought about showing an alert.. but i'm not sure how we are injecting .node_version.txt or i'd try to do the same for mongodb.

I thought about hard coding `^3.2.0` but meteor cli doesn't even ship with that yet 🤦‍♂️ 