### PR TITLE
Update preview Dockerfile to use Stretch dependencies

### DIFF
--- a/.docker-mongo/Dockerfile
+++ b/.docker-mongo/Dockerfile
@@ -6,8 +6,8 @@ ADD entrypoint.sh /app/bundle/
 MAINTAINER buildmaster@rocket.chat
 
 RUN set -x \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5 \
- && echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.6 main" | tee /etc/apt/sources.list.d/mongodb-org-3.6.list \
+ && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4 \
+ && echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/4.0 main" | tee /etc/apt/sources.list.d/mongodb-org-4.0.list \
  && apt-get update \
  && apt-get install -y --force-yes pwgen mongodb-org \
  && echo "mongodb-org hold" | dpkg --set-selections \


### PR DESCRIPTION
Since our base image is now using Stretch, the packages installed should use same sources.

Also, updated to MongoDB 4.0