### PR TITLE
[IMPROVE] Show rooms with mentions on unread category even with hide counter

### DIFF
--- a/app/ui-sidenav/client/chatRoomItem.js
+++ b/app/ui-sidenav/client/chatRoomItem.js
@@ -19,8 +19,6 @@ Template.chatRoomItem.helpers({
 
 		const archivedClass = this.archived ? 'archived' : false;
 
-		this.alert = !this.hideUnreadStatus && this.alert; // && (!hasFocus || FlowRouter.getParam('_id') !== this.rid);
-
 		const icon = this.t !== 'd' && roomTypes.getIcon(this);
 		const avatar = !icon;
 

--- a/app/ui-sidenav/client/roomList.js
+++ b/app/ui-sidenav/client/roomList.js
@@ -43,7 +43,10 @@ Template.roomList.helpers({
 
 		if (this.identifier === 'unread') {
 			query.alert = true;
-			query.hideUnreadStatus = { $ne: true };
+			query.$or = [
+				{ hideUnreadStatus: { $ne: true } },
+				{ unread: { $gt: 0 } },
+			];
 
 			return ChatSubscription.find(query, { sort });
 		}
@@ -64,7 +67,7 @@ Template.roomList.helpers({
 				query.prid = { $exists: true };
 			}
 
-			if (this.identifier === 'unread' || this.identifier === 'tokens') {
+			if (this.identifier === 'tokens') {
 				types = ['c', 'p'];
 			}
 
@@ -82,7 +85,12 @@ Template.roomList.helpers({
 			if (getUserPreference(user, 'sidebarShowUnread')) {
 				query.$or = [
 					{ alert: { $ne: true } },
-					{ hideUnreadStatus: true },
+					{
+						$and: [
+							{ hideUnreadStatus: true },
+							{ unread: 0 },
+						],
+					},
 				];
 			}
 			query.t = { $in: types };

--- a/app/ui-sidenav/client/sidebarItem.html
+++ b/app/ui-sidenav/client/sidebarItem.html
@@ -9,7 +9,7 @@
 </template>
 
 <template name="sidebarItem">
-	<li class="sidebar-item{{#if or unread alert }} sidebar-item--unread{{/if}}{{#if active}} sidebar-item--active{{/if}}{{#if toolbar}} popup-item{{/if}}" data-id="{{_id}}">
+	<li class="sidebar-item{{#if showUnread }} sidebar-item--unread{{/if}}{{#if active}} sidebar-item--active{{/if}}{{#if toolbar}} popup-item{{/if}}" data-id="{{_id}}">
 		<a class="sidebar-item__link" href="{{#if route}}{{route}}{{else}}{{pathFor pathSection group=pathGroup}}{{/if}}" aria-label="{{name}}">
 			{{#unless isLivechatQueue}}
 

--- a/app/ui-sidenav/client/sidebarItem.js
+++ b/app/ui-sidenav/client/sidebarItem.js
@@ -11,10 +11,6 @@ import { hasAtLeastOnePermission } from '../../authorization';
 import { menu } from '../../ui-utils';
 
 Template.sidebarItem.helpers({
-	or(...args) {
-		args.pop();
-		return args.some((arg) => arg);
-	},
 	streaming() {
 		return this.streamingOptions && Object.keys(this.streamingOptions).length;
 	},
@@ -35,6 +31,9 @@ Template.sidebarItem.helpers({
 	},
 	isLivechatQueue() {
 		return this.pathSection === 'livechat-queue';
+	},
+	showUnread() {
+		return this.unread > 0 || (!this.hideUnreadStatus && this.alert);
 	},
 });
 


### PR DESCRIPTION
Previously when "Hide Counter" was chosen in combination with "Show Unread on Top", rooms with mentions were not being shown there, this PR fixes it by showing there.

![image](https://user-images.githubusercontent.com/8591547/55243862-cdfe4380-521e-11e9-87a1-8a5f15cb2269.png)
