### PR TITLE
Settings: disable reset button

### DIFF
--- a/app/federation/server/federation-settings.js
+++ b/app/federation/server/federation-settings.js
@@ -33,6 +33,7 @@ Meteor.startup(function() {
 			i18nLabel: 'FEDERATION_Domain',
 			i18nDescription: 'FEDERATION_Domain_Description',
 			alert: 'FEDERATION_Domain_Alert',
+			disableReset: true,
 		});
 
 		this.add('FEDERATION_Public_Key', federationPublicKey, {

--- a/app/ui-admin/client/admin.js
+++ b/app/ui-admin/client/admin.js
@@ -346,7 +346,7 @@ Template.admin.helpers({
 	},
 	showResetButton() {
 		const setting = TempSettings.findOne({ _id: this._id }, { fields: { value: 1, packageValue: 1 } });
-		return !this.readonly && this.type !== 'asset' && setting.value !== setting.packageValue && !this.blocked;
+		return !this.disableReset && !this.readonly && this.type !== 'asset' && setting.value !== setting.packageValue && !this.blocked;
 	},
 });
 

--- a/app/ui-admin/client/admin.js
+++ b/app/ui-admin/client/admin.js
@@ -346,7 +346,7 @@ Template.admin.helpers({
 	},
 	showResetButton() {
 		const setting = TempSettings.findOne({ _id: this._id }, { fields: { value: 1, packageValue: 1 } });
-		return this.type !== 'asset' && setting.value !== setting.packageValue && !this.blocked;
+		return !this.readonly && this.type !== 'asset' && setting.value !== setting.packageValue && !this.blocked;
 	},
 });
 
@@ -384,7 +384,8 @@ Template.admin.events({
 			changed: true,
 		};
 		const rcSettings = TempSettings.find(query, {
-			fields: { _id: 1, value: 1, packageValue: 1 } }).fetch();
+			fields: { _id: 1, value: 1, packageValue: 1 },
+		}).fetch();
 		rcSettings.forEach(function(setting) {
 			const oldSetting = settings.collectionPrivate.findOne({ _id: setting._id }, { fields: { value: 1, type: 1, editor: 1 } });
 			setFieldValue(setting._id, oldSetting.value, oldSetting.type, oldSetting.editor);


### PR DESCRIPTION
This is a proposal to allow disabling the `reset` button on some settings.

The motivation is that some settings are not useful on their default state, so I think that having a reset button might mislead the user.

Just FYI, I based this branch of off #14025.