### PR TITLE
Fix sending notifications to mentions on threads and discussion email sender

### DIFF
--- a/app/lib/server/functions/notifications/email.js
+++ b/app/lib/server/functions/notifications/email.js
@@ -112,8 +112,8 @@ export function sendEmail({ message, user, subscription, room, emailAddress, has
 		},
 	};
 
-	const from = room.t === 'd' ? message.u.name : room.name;	// using user full-name/channel name in from address
-	email.from = `${ String(from).replace(/@/g, '%40').replace(/[<>,]/g, '') } <${ settings.get('From_Email') }>`;
+	email.from = `${ String(username).replace(/@/g, '%40').replace(/[<>,]/g, '') } <${ settings.get('From_Email') }>`;
+
 	// If direct reply enabled, email content with headers
 	if (settings.get('Direct_Reply_Enable')) {
 		const replyto = settings.get('Direct_Reply_ReplyTo') || settings.get('Direct_Reply_Username');

--- a/app/lib/server/lib/sendNotificationsOnMessage.js
+++ b/app/lib/server/lib/sendNotificationsOnMessage.js
@@ -193,13 +193,13 @@ export async function sendMessageNotifications(message, room, usersInThread = []
 	const disableAllMessageNotifications = roomMembersCount > maxMembersForNotification && maxMembersForNotification !== 0;
 
 	const query = {
-		...(usersInThread && { 'u._id': { $in: usersInThread } }),
 		rid: room._id,
 		ignored: { $ne: sender._id },
 		disableNotifications: { $ne: true },
-		$or: [{
-			'userHighlights.0': { $exists: 1 },
-		}],
+		$or: [
+			{ 'userHighlights.0': { $exists: 1 } },
+			...(usersInThread.length > 0 ? [{ 'u._id': { $in: usersInThread } }] : []),
+		],
 	};
 
 	['audio', 'desktop', 'mobile', 'email'].forEach((kind) => {


### PR DESCRIPTION
The issue was:

If someone mentions an user that is not following the thread, that user (the user mentioned) would not get a notification.

Also fixes #14019 by always using the sender as the email `From`