### PR TITLE
Prioritize user-mentions badge

### DIFF
--- a/app/ui-sidenav/client/sidebarItem.js
+++ b/app/ui-sidenav/client/sidebarItem.js
@@ -37,13 +37,22 @@ Template.sidebarItem.helpers({
 	},
 	badgeClass() {
 		const { t, unread, userMentions, groupMentions } = this;
-		return [
-			'badge',
-			unread && 'badge--unread',
-			unread && t === 'd' && 'badge--dm',
-			userMentions && 'badge--user-mentions',
-			groupMentions && 'badge--group-mentions',
-		].filter(Boolean).join(' ');
+
+		const badges = ['badge'];
+
+		if (unread) {
+			badges.push('badge--unread');
+		}
+
+		if (unread && t === 'd') {
+			badges.push('badge--dm');
+		} else if (userMentions) {
+			badges.push('badge--user-mentions');
+		} else if (groupMentions) {
+			badges.push('badge--group-mentions');
+		}
+
+		return badges.join(' ');
 	},
 });
 


### PR DESCRIPTION
Now if there is both an `@user` and `@here` or `@all` in a channel, the badge will be blue