### PR TITLE
[FIX] Gifs not rendering

### DIFF
--- a/app/custom-oauth/client/custom_oauth_client.js
+++ b/app/custom-oauth/client/custom_oauth_client.js
@@ -5,6 +5,7 @@ import { Random } from 'meteor/random';
 import { ServiceConfiguration } from 'meteor/service-configuration';
 import { OAuth } from 'meteor/oauth';
 import s from 'underscore.string';
+import { isURL } from '../../utils/lib/isURL';
 
 // Request custom OAuth credentials for the user
 // @param options {optional}
@@ -47,7 +48,7 @@ export class CustomOAuth {
 		this.authorizePath = options.authorizePath;
 		this.scope = options.scope;
 
-		if (!/^https?:\/\/.+/.test(this.authorizePath)) {
+		if (!isURL(this.authorizePath)) {
 			this.authorizePath = this.serverURL + this.authorizePath;
 		}
 	}

--- a/app/custom-oauth/server/custom_oauth_server.js
+++ b/app/custom-oauth/server/custom_oauth_server.js
@@ -7,6 +7,7 @@ import { ServiceConfiguration } from 'meteor/service-configuration';
 import { Logger } from '../../logger';
 import { Users } from '../../models';
 import _ from 'underscore';
+import { isURL } from '../../utils/lib/isURL';
 
 const logger = new Logger('CustomOAuth');
 
@@ -70,11 +71,11 @@ export class CustomOAuth {
 			this.identityTokenSentVia = this.tokenSentVia;
 		}
 
-		if (!/^https?:\/\/.+/.test(this.tokenPath)) {
+		if (!isURL(this.tokenPath)) {
 			this.tokenPath = this.serverURL + this.tokenPath;
 		}
 
-		if (!/^https?:\/\/.+/.test(this.identityPath)) {
+		if (!isURL(this.identityPath)) {
 			this.identityPath = this.serverURL + this.identityPath;
 		}
 

--- a/app/oembed/server/server.js
+++ b/app/oembed/server/server.js
@@ -11,6 +11,7 @@ import iconv from 'iconv-lite';
 import ipRangeCheck from 'ip-range-check';
 import he from 'he';
 import jschardet from 'jschardet';
+import { isURL } from '../../utils/lib/isURL';
 
 const request = HTTPInternals.NpmModules.request.module;
 const OEmbed = {};
@@ -254,7 +255,7 @@ OEmbed.rocketUrlParser = function(message) {
 			if (item.ignoreParse === true) {
 				return;
 			}
-			if (!/^https?:\/\//i.test(item.url)) {
+			if (!isURL(item.url)) {
 				return;
 			}
 			const data = OEmbed.getUrlMetaWithCache(item.url);

--- a/app/ui/client/views/app/room.js
+++ b/app/ui/client/views/app/room.js
@@ -32,6 +32,7 @@ import Clipboard from 'clipboard';
 import { lazyloadtick } from '../../../../lazy-load';
 import { ChatMessages } from '../../lib/chatMessages';
 import { fileUpload } from '../../lib/fileUpload';
+import { isURL } from '../../../../utils/lib/isURL';
 
 export const chatMessages = {};
 
@@ -560,7 +561,7 @@ Template.room.events({
 			return;
 		}
 
-		if (e.target && (e.target.nodeName === 'A') && /^https?:\/\/.+/.test(e.target.getAttribute('href'))) {
+		if (e.target && (e.target.nodeName === 'A') && isURL(e.target.getAttribute('href'))) {
 			e.preventDefault();
 			e.stopPropagation();
 		}
@@ -589,7 +590,7 @@ Template.room.events({
 			return;
 		}
 
-		if (e.target && (e.target.nodeName === 'A') && /^https?:\/\/.+/.test(e.target.getAttribute('href'))) {
+		if (e.target && (e.target.nodeName === 'A') && isURL(e.target.getAttribute('href'))) {
 			if (touchMoved === true) {
 				e.preventDefault();
 				e.stopPropagation();

--- a/app/utils/lib/getURL.js
+++ b/app/utils/lib/getURL.js
@@ -1,8 +1,13 @@
 import { Meteor } from 'meteor/meteor';
 import { settings } from '../../settings';
 import s from 'underscore.string';
+import { isURL } from './isURL';
 
 export const getURL = (path, { cdn = true, full = false } = {}) => {
+	if (isURL(path)) {
+		return path;
+	}
+
 	const cdnPrefix = s.rtrim(s.trim(settings.get('CDN_PREFIX') || ''), '/');
 	const pathPrefix = s.rtrim(s.trim(__meteor_runtime_config__.ROOT_URL_PATH_PREFIX || ''), '/');
 

--- a/app/utils/lib/isURL.js
+++ b/app/utils/lib/isURL.js
@@ -1,0 +1,1 @@
+export const isURL = (str) => /^https?:\/\//.test(str);


### PR DESCRIPTION
The problem was the function `getURL` being introduced on the `messageAttachment` template in order to resolve the `image_url` field from the `attachment`. The function is currently prepending the URL provided with the `CDN_PREFIX` setting.

This PR simply introduces a way for the `getURL` function to identify absolute URLs, so that it doesn't prepend the path received when that's the case