### PR TITLE
Fix top bar unread message counter

### DIFF
--- a/app/ui-utils/client/lib/RoomHistoryManager.js
+++ b/app/ui-utils/client/lib/RoomHistoryManager.js
@@ -72,8 +72,9 @@ export const RoomHistoryManager = new class {
 	constructor() {
 		this.histories = {};
 	}
+
 	getRoom(rid) {
-		if ((this.histories[rid] == null)) {
+		if (!this.histories[rid]) {
 			this.histories[rid] = {
 				hasMore: new ReactiveVar(true),
 				hasMoreNext: new ReactiveVar(false),
@@ -100,7 +101,7 @@ export const RoomHistoryManager = new class {
 		const lastMessage = ChatMessage.findOne({ rid }, { sort: { ts: 1 } });
 		// lastMessage ?= ChatMessage.findOne({rid: rid}, {sort: {ts: 1}})
 
-		if (lastMessage != null) {
+		if (lastMessage) {
 			({ ts } = lastMessage);
 		} else {
 			ts = undefined;
@@ -110,12 +111,12 @@ export const RoomHistoryManager = new class {
 		let typeName = undefined;
 
 		const subscription = ChatSubscription.findOne({ rid });
-		if (subscription != null) {
+		if (subscription) {
 			({ ls } = subscription);
 			typeName = subscription.t + subscription.name;
 		} else {
 			const curRoomDoc = ChatRoom.findOne({ _id: rid });
-			typeName = (curRoomDoc != null ? curRoomDoc.t : undefined) + (curRoomDoc != null ? curRoomDoc.name : undefined);
+			typeName = (curRoomDoc ? curRoomDoc.t : undefined) + (curRoomDoc ? curRoomDoc.name : undefined);
 		}
 
 		Meteor.call('loadHistory', rid, ts, limit, ls, function(err, result) {
@@ -129,7 +130,7 @@ export const RoomHistoryManager = new class {
 			room.firstUnread.set(result.firstUnread);
 
 			const wrapper = $('.messages-box .wrapper').get(0);
-			if (wrapper != null) {
+			if (wrapper) {
 				previousHeight = wrapper.scrollHeight;
 			}
 
@@ -149,7 +150,9 @@ export const RoomHistoryManager = new class {
 			});
 
 			room.isLoading.set(false);
-			if (room.loaded == null) { room.loaded = 0; }
+			if (!room.loaded) {
+				room.loaded = 0;
+			}
 			room.loaded += messages.length;
 			if (messages.length < limit) {
 				return room.hasMore.set(false);
@@ -173,12 +176,12 @@ export const RoomHistoryManager = new class {
 		let typeName = undefined;
 
 		const subscription = ChatSubscription.findOne({ rid });
-		if (subscription != null) {
+		if (subscription) {
 			// const { ls } = subscription;
 			typeName = subscription.t + subscription.name;
 		} else {
 			const curRoomDoc = ChatRoom.findOne({ _id: rid });
-			typeName = (curRoomDoc != null ? curRoomDoc.t : undefined) + (curRoomDoc != null ? curRoomDoc.name : undefined);
+			typeName = (curRoomDoc ? curRoomDoc.t : undefined) + (curRoomDoc ? curRoomDoc.name : undefined);
 		}
 
 		const { ts } = lastMessage;
@@ -194,7 +197,9 @@ export const RoomHistoryManager = new class {
 				Meteor.defer(() => RoomManager.updateMentionsMarksOfRoom(typeName));
 
 				room.isLoading.set(false);
-				if (room.loaded == null) { room.loaded = 0; }
+				if (!room.loaded) {
+					room.loaded = 0;
+				}
 
 				room.loaded += result.messages.length;
 				if (result.messages.length < limit) {
@@ -205,7 +210,7 @@ export const RoomHistoryManager = new class {
 	}
 
 	getSurroundingMessages(message, limit = defaultLimit) {
-		if (!(message != null ? message.rid : undefined)) {
+		if (!message || !message.rid) {
 			return;
 		}
 
@@ -242,7 +247,7 @@ export const RoomHistoryManager = new class {
 				typeName = subscription.t + subscription.name;
 			} else {
 				const curRoomDoc = ChatRoom.findOne({ _id: message.rid });
-				typeName = (curRoomDoc != null ? curRoomDoc.t : undefined) + (curRoomDoc != null ? curRoomDoc.name : undefined);
+				typeName = (curRoomDoc ? curRoomDoc.t : undefined) + (curRoomDoc ? curRoomDoc.name : undefined);
 			}
 
 			return Meteor.call('loadSurroundingMessages', message, limit, function(err, result) {
@@ -276,7 +281,9 @@ export const RoomHistoryManager = new class {
 
 					return setTimeout(() => msgElement.removeClass('highlight'), 500);
 				});
-				if (room.loaded == null) { room.loaded = 0; }
+				if (!room.loaded) {
+					room.loaded = 0;
+				}
 				room.loaded += result.messages.length;
 				room.hasMore.set(result.moreBefore);
 				return room.hasMoreNext.set(result.moreAfter);
@@ -311,7 +318,7 @@ export const RoomHistoryManager = new class {
 
 	clear(rid) {
 		ChatMessage.remove({ rid });
-		if (this.histories[rid] != null) {
+		if (this.histories[rid]) {
 			this.histories[rid].hasMore.set(true);
 			this.histories[rid].isLoading.set(false);
 			return this.histories[rid].loaded = undefined;

--- a/app/ui/client/views/app/room.js
+++ b/app/ui/client/views/app/room.js
@@ -69,7 +69,7 @@ const openProfileTabOrOpenDM = (e, instance, username) => {
 				}
 			}
 
-			if ((result != null ? result.rid : undefined) != null) {
+			if (result && result.rid) {
 				FlowRouter.go('direct', { username }, FlowRouter.current().queryParams);
 			}
 		});
@@ -377,8 +377,8 @@ Template.room.helpers({
 			{ count: RoomHistoryManager.getRoom(this._id).unreadNotLoaded.get() + Template.instance().unreadCount.get() };
 
 		const room = RoomManager.getOpenedRoomByRid(this._id);
-		if (room != null) {
-			data.since = room.unreadSince != null ? room.unreadSince.get() : undefined;
+		if (room) {
+			data.since = room.unreadSince ? room.unreadSince.get() : undefined;
 		}
 
 		return data;
@@ -394,7 +394,9 @@ Template.room.helpers({
 	},
 
 	formatUnreadSince() {
-		if ((this.since == null)) { return; }
+		if (!this.since) {
+			return;
+		}
 
 		return moment(this.since).calendar(null, { sameDay: 'LT' });
 	},
@@ -467,8 +469,7 @@ Template.room.helpers({
 			return true;
 		}
 
-		return subscription != null;
-
+		return !subscription;
 	},
 	hideLeaderHeader() {
 		return Template.instance().hideLeaderHeader.get() ? 'animated-hidden' : '';
@@ -1079,12 +1080,12 @@ Template.room.onRendered(function() {
 
 	template.sendToBottomIfNecessary();
 
-	if ((window.MutationObserver == null)) {
-		wrapperUl.addEventListener('DOMSubtreeModified', () => template.sendToBottomIfNecessaryDebounced());
-	} else {
+	if (window.MutationObserver) {
 		const observer = new MutationObserver(() => template.sendToBottomIfNecessaryDebounced());
 
 		observer.observe(wrapperUl, { childList: true });
+	} else {
+		wrapperUl.addEventListener('DOMSubtreeModified', () => template.sendToBottomIfNecessaryDebounced());
 	}
 	// observer.disconnect()
 
@@ -1139,31 +1140,33 @@ Template.room.onRendered(function() {
 		}
 	};
 
-	const subscription = Subscriptions.findOne({ rid: template.data._id }, { reactive: false });
 	const updateUnreadCount = _.throttle(function() {
 		const lastInvisibleMessageOnScreen = getElementFromPoint(0) || getElementFromPoint(20) || getElementFromPoint(40);
 
-		if (lastInvisibleMessageOnScreen == null || lastInvisibleMessageOnScreen.id == null) {
+		if (!lastInvisibleMessageOnScreen || !lastInvisibleMessageOnScreen.id) {
 			return template.unreadCount.set(0);
 		}
 
 		const lastMessage = ChatMessage.findOne(lastInvisibleMessageOnScreen.id);
-		if (lastMessage == null) {
+		if (!lastMessage) {
 			return template.unreadCount.set(0);
 		}
 
+		const subscription = Subscriptions.findOne({ rid: template.data._id }, { reactive: false });
 		const count = ChatMessage.find({ rid: template.data._id, ts: { $lte: lastMessage.ts, $gt: subscription && subscription.ls } }).count();
 		template.unreadCount.set(count);
 	}, 300);
 
-	readMessage.on(template.data._id, () => template.unreadCount.set(0));
+	readMessage.on(template.data._id, () => {
+		template.unreadCount.set(0);
+	});
 
 	wrapper.addEventListener('scroll', () => updateUnreadCount());
 	// salva a data da renderização para exibir alertas de novas mensagens
 	$.data(this.firstNode, 'renderedAt', new Date);
 
 	const webrtc = WebRTC.getInstanceByRoomId(template.data._id);
-	if (webrtc != null) {
+	if (webrtc) {
 		this.autorun(() => {
 			const remoteItems = webrtc.remoteItems.get();
 			if (remoteItems && remoteItems.length > 0) {
@@ -1171,7 +1174,7 @@ Template.room.onRendered(function() {
 				this.tabBar.open();
 			}
 
-			if (webrtc.localUrl.get() != null) {
+			if (webrtc.localUrl.get()) {
 				this.tabBar.setTemplate('membersList');
 				this.tabBar.open();
 			}


### PR DESCRIPTION
The template wasn't aware of changes on field `subscription.ls` when handling the `scroll` event on the message list.