### PR TITLE
[FIX] updating a message from apps if keep history is on

### DIFF
--- a/packages/rocketchat-lib/server/functions/deleteMessage.js
+++ b/packages/rocketchat-lib/server/functions/deleteMessage.js
@@ -15,7 +15,7 @@ RocketChat.deleteMessage = function(message, user) {
 
 	if (keepHistory) {
 		if (showDeletedStatus) {
-			RocketChat.models.Messages.cloneAndSaveAsHistoryById(message._id);
+			RocketChat.models.Messages.cloneAndSaveAsHistoryById(message._id, user._id);
 		} else {
 			RocketChat.models.Messages.setHiddenById(message._id, true);
 		}

--- a/packages/rocketchat-lib/server/functions/updateMessage.js
+++ b/packages/rocketchat-lib/server/functions/updateMessage.js
@@ -25,7 +25,7 @@ RocketChat.updateMessage = function(message, user, originalMessage) {
 
 	// If we keep history of edits, insert a new message to store history information
 	if (RocketChat.settings.get('Message_KeepHistory')) {
-		RocketChat.models.Messages.cloneAndSaveAsHistoryById(message._id);
+		RocketChat.models.Messages.cloneAndSaveAsHistoryById(message._id, user._id);
 	}
 
 	message.editedAt = new Date();

--- a/packages/rocketchat-message-pin/server/pinMessage.js
+++ b/packages/rocketchat-message-pin/server/pinMessage.js
@@ -56,7 +56,7 @@ Meteor.methods({
 
 		// If we keep history of edits, insert a new message to store history information
 		if (RocketChat.settings.get('Message_KeepHistory')) {
-			RocketChat.models.Messages.cloneAndSaveAsHistoryById(message._id);
+			RocketChat.models.Messages.cloneAndSaveAsHistoryById(message._id, userId);
 		}
 		const room = Meteor.call('canAccessRoom', message.rid, Meteor.userId());
 		const me = RocketChat.models.Users.findOneById(userId);
@@ -139,7 +139,7 @@ Meteor.methods({
 
 		// If we keep history of edits, insert a new message to store history information
 		if (RocketChat.settings.get('Message_KeepHistory')) {
-			RocketChat.models.Messages.cloneAndSaveAsHistoryById(originalMessage._id);
+			RocketChat.models.Messages.cloneAndSaveAsHistoryById(originalMessage._id, Meteor.userId());
 		}
 
 		const me = RocketChat.models.Users.findOneById(Meteor.userId());

--- a/packages/rocketchat-message-snippet/server/methods/snippetMessage.js
+++ b/packages/rocketchat-message-snippet/server/methods/snippetMessage.js
@@ -22,7 +22,7 @@ Meteor.methods({
 
 		// If we keep history of edits, insert a new message to store history information
 		if (RocketChat.settings.get('Message_KeepHistory')) {
-			RocketChat.models.Messages.cloneAndSaveAsHistoryById(message._id);
+			RocketChat.models.Messages.cloneAndSaveAsHistoryById(message._id, Meteor.userId());
 		}
 
 		const me = RocketChat.models.Users.findOneById(Meteor.userId());

--- a/packages/rocketchat-models/server/models/Messages.js
+++ b/packages/rocketchat-models/server/models/Messages.js
@@ -1,4 +1,3 @@
-import { Meteor } from 'meteor/meteor';
 import { Match } from 'meteor/check';
 import { settings } from 'meteor/rocketchat:settings';
 import { Base } from './_Base';
@@ -369,14 +368,14 @@ export class Messages extends Base {
 		return this.findOne(query, options);
 	}
 
-	cloneAndSaveAsHistoryById(_id) {
-		const me = Users.findOneById(Meteor.userId());
+	cloneAndSaveAsHistoryById(_id, userId) {
+		const me = Users.findOneById(userId);
 		const record = this.findOneById(_id);
 		record._hidden = true;
 		record.parent = record._id;
 		record.editedAt = new Date;
 		record.editedBy = {
-			_id: Meteor.userId(),
+			_id: userId,
 			username: me.username,
 		};
 		delete record._id;
@@ -520,7 +519,7 @@ export class Messages extends Base {
 		} else {
 			update = {
 				$pull: {
-					starred: { _id: Meteor.userId() },
+					starred: { _id: userId },
 				},
 			};
 		}


### PR DESCRIPTION
This is a fix for a release `0.74.4` that's why it is targeting `master` branch.

The issue is `cloneAndSaveAsHistoryById` is calling `Meteor.userId()` which will only work when invoked by a Meteor method. But Apps also update messages, so `Meteor.userId()` will fail.