### PR TITLE
[FIX] Updating a message from apps if keep history is on

### DIFF
--- a/app/lib/server/functions/deleteMessage.js
+++ b/app/lib/server/functions/deleteMessage.js
@@ -20,7 +20,7 @@ export const deleteMessage = function(message, user) {
 
 	if (keepHistory) {
 		if (showDeletedStatus) {
-			Messages.cloneAndSaveAsHistoryById(message._id);
+			Messages.cloneAndSaveAsHistoryById(message._id, user);
 		} else {
 			Messages.setHiddenById(message._id, true);
 		}

--- a/app/lib/server/functions/updateMessage.js
+++ b/app/lib/server/functions/updateMessage.js
@@ -29,7 +29,7 @@ export const updateMessage = function(message, user, originalMessage) {
 
 	// If we keep history of edits, insert a new message to store history information
 	if (settings.get('Message_KeepHistory')) {
-		Messages.cloneAndSaveAsHistoryById(message._id);
+		Messages.cloneAndSaveAsHistoryById(message._id, user);
 	}
 
 	message.editedAt = new Date();

--- a/app/message-pin/server/pinMessage.js
+++ b/app/message-pin/server/pinMessage.js
@@ -58,12 +58,13 @@ Meteor.methods({
 			});
 		}
 
+		const me = Users.findOneById(userId);
+
 		// If we keep history of edits, insert a new message to store history information
 		if (settings.get('Message_KeepHistory')) {
-			Messages.cloneAndSaveAsHistoryById(message._id);
+			Messages.cloneAndSaveAsHistoryById(message._id, me);
 		}
 		const room = Meteor.call('canAccessRoom', message.rid, Meteor.userId());
-		const me = Users.findOneById(userId);
 
 		originalMessage.pinned = true;
 		originalMessage.pinnedAt = pinnedAt || Date.now;
@@ -141,12 +142,13 @@ Meteor.methods({
 			});
 		}
 
+		const me = Users.findOneById(Meteor.userId());
+
 		// If we keep history of edits, insert a new message to store history information
 		if (settings.get('Message_KeepHistory')) {
-			Messages.cloneAndSaveAsHistoryById(originalMessage._id);
+			Messages.cloneAndSaveAsHistoryById(originalMessage._id, me);
 		}
 
-		const me = Users.findOneById(Meteor.userId());
 		originalMessage.pinned = false;
 		originalMessage.pinnedBy = {
 			_id: Meteor.userId(),

--- a/app/message-snippet/server/methods/snippetMessage.js
+++ b/app/message-snippet/server/methods/snippetMessage.js
@@ -23,12 +23,12 @@ Meteor.methods({
 			return false;
 		}
 
+		const me = Users.findOneById(Meteor.userId());
+
 		// If we keep history of edits, insert a new message to store history information
 		if (settings.get('Message_KeepHistory')) {
-			Messages.cloneAndSaveAsHistoryById(message._id);
+			Messages.cloneAndSaveAsHistoryById(message._id, me);
 		}
-
-		const me = Users.findOneById(Meteor.userId());
 
 		message.snippeted = true;
 		message.snippetedAt = Date.now;

--- a/app/models/server/models/Messages.js
+++ b/app/models/server/models/Messages.js
@@ -1,8 +1,6 @@
-import { Meteor } from 'meteor/meteor';
 import { Match } from 'meteor/check';
 import { Base } from './_Base';
 import Rooms from './Rooms';
-import Users from './Users';
 import { settings } from '../../../settings/server/functions/settings';
 import { FileUpload } from '../../../file-upload/server/lib/FileUpload';
 import _ from 'underscore';
@@ -493,15 +491,14 @@ export class Messages extends Base {
 		return this.findOne(query, options);
 	}
 
-	cloneAndSaveAsHistoryById(_id) {
-		const me = Users.findOneById(Meteor.userId());
+	cloneAndSaveAsHistoryById(_id, user) {
 		const record = this.findOneById(_id);
 		record._hidden = true;
 		record.parent = record._id;
 		record.editedAt = new Date;
 		record.editedBy = {
-			_id: Meteor.userId(),
-			username: me.username,
+			_id: user._id,
+			username: user.username,
 		};
 		delete record._id;
 		return this.insert(record);
@@ -644,7 +641,7 @@ export class Messages extends Base {
 		} else {
 			update = {
 				$pull: {
-					starred: { _id: Meteor.userId() },
+					starred: { _id: userId },
 				},
 			};
 		}


### PR DESCRIPTION
Related to https://github.com/RocketChat/Rocket.Chat/pull/14127

Updating a message from Apps is currently failing if `Keep Per Message Editing History` setting is `true`, because the model is calling `Meteor.userId()`, but it doesn't the needed context if being called from an app.