### PR TITLE
[FIX] Missing connection headers on Livechat REST API

### DIFF
--- a/app/livechat/server/api/lib/livechat.js
+++ b/app/livechat/server/api/lib/livechat.js
@@ -82,6 +82,10 @@ export function findAgent(agentId) {
 	return Users.getAgentInfo(agentId);
 }
 
+export function normalizeHttpHeaderData(headers = {}) {
+	const httpHeaders = Object.assign({}, headers);
+	return { httpHeaders };
+}
 export function settings() {
 	const initSettings = Livechat.getInitSettings();
 	const triggers = findTriggers();

--- a/app/livechat/server/api/v1/message.js
+++ b/app/livechat/server/api/v1/message.js
@@ -5,7 +5,7 @@ import { Messages, Rooms, LivechatVisitors } from '../../../../models';
 import { hasPermission } from '../../../../authorization';
 import { API } from '../../../../api';
 import { loadMessageHistory } from '../../../../lib';
-import { findGuest, findRoom } from '../lib/livechat';
+import { findGuest, findRoom, normalizeHttpHeaderData } from '../lib/livechat';
 import { Livechat } from '../../lib/Livechat';
 
 API.v1.addRoute('livechat/message', {
@@ -238,7 +238,11 @@ API.v1.addRoute('livechat/messages', { authRequired: true }, {
 			}
 		} else {
 			rid = Random.id();
-			const visitorId = Livechat.registerGuest(this.bodyParams.visitor);
+
+			const guest = this.bodyParams.visitor;
+			guest.connectionData = normalizeHttpHeaderData(this.request.headers);
+
+			const visitorId = Livechat.registerGuest(guest);
 			visitor = LivechatVisitors.findOneById(visitorId);
 		}
 

--- a/app/livechat/server/api/v1/visitor.js
+++ b/app/livechat/server/api/v1/visitor.js
@@ -3,7 +3,7 @@ import { Match, check } from 'meteor/check';
 import { Rooms, LivechatVisitors, LivechatCustomField } from '../../../../models';
 import { hasPermission } from '../../../../authorization';
 import { API } from '../../../../api';
-import { findGuest } from '../lib/livechat';
+import { findGuest, normalizeHttpHeaderData } from '../lib/livechat';
 import { Livechat } from '../../lib/Livechat';
 
 API.v1.addRoute('livechat/visitor', {
@@ -34,6 +34,7 @@ API.v1.addRoute('livechat/visitor', {
 				guest.phone = { number: this.bodyParams.visitor.phone };
 			}
 
+			guest.connectionData = normalizeHttpHeaderData(this.request.headers);
 			const visitorId = Livechat.registerGuest(guest);
 
 			let visitor = LivechatVisitors.getVisitorByToken(token);

--- a/app/livechat/server/lib/Livechat.js
+++ b/app/livechat/server/lib/Livechat.js
@@ -176,7 +176,7 @@ export const Livechat = {
 		return true;
 	},
 
-	registerGuest({ token, name, email, department, phone, username } = {}) {
+	registerGuest({ token, name, email, department, phone, username, connectionData } = {}) {
 		check(token, String);
 
 		let userId;
@@ -204,12 +204,14 @@ export const Livechat = {
 					username,
 				};
 
-				const storeHttpHeaderData = settings.get('Livechat_Allow_collect_and_store_HTTP_header_informations');
+				if (settings.get('Livechat_Allow_collect_and_store_HTTP_header_informations')) {
 
-				if (this.connection && storeHttpHeaderData) {
-					userData.userAgent = this.connection.httpHeaders['user-agent'];
-					userData.ip = this.connection.httpHeaders['x-real-ip'] || this.connection.httpHeaders['x-forwarded-for'] || this.connection.clientAddress;
-					userData.host = this.connection.httpHeaders.host;
+					const connection = this.connection || connectionData;
+					if (connection && connection.httpHeaders) {
+						userData.userAgent = connection.httpHeaders['user-agent'];
+						userData.ip = connection.httpHeaders['x-real-ip'] || connection.httpHeaders['x-forwarded-for'] || connection.clientAddress;
+						userData.host = connection.httpHeaders.host;
+					}
 				}
 
 				userId = LivechatVisitors.insert(userData);


### PR DESCRIPTION
When a guest is registered through the new Livechat widget, there is no DDP connection available yet, so we need to collect the information related to HTTP header from the REST API endpoints.