### PR TITLE
[FIX] Fixed a bug where avatars weren't reactive after update

### DIFF
--- a/app/ui-account/client/avatar/avatar.js
+++ b/app/ui-account/client/avatar/avatar.js
@@ -15,7 +15,6 @@ Template.avatar.helpers({
 			if (username == null) {
 				return;
 			}
-			Session.get(`avatar_random_${ username }`);
 
 			if (this.roomIcon) {
 				username = `@${ username }`;

--- a/app/ui-utils/client/lib/avatar.js
+++ b/app/ui-utils/client/lib/avatar.js
@@ -28,12 +28,12 @@ export const getAvatarAsPng = function(username, cb) {
 
 export const updateAvatarOfUsername = function(username) {
 	const key = `avatar_random_${ username }`;
-	Session.set(key, Math.round(Math.random() * 1000));
+	Session.set(key, Date.now());
 
 	Object.keys(RoomManager.openedRooms).forEach((key) => {
 		const room = RoomManager.openedRooms[key];
 		const url = getAvatarUrlFromUsername(username);
-		$(room.dom).find(`.message[data-username='${ username }'] .avatar-image`).css('background-image', `url(${ url })`);
+		$(room.dom).find(`.message[data-username='${ username }'] .avatar-image`).attr('src', url);
 	});
 	return true;
 };

--- a/app/utils/lib/getAvatarUrlFromUsername.js
+++ b/app/utils/lib/getAvatarUrlFromUsername.js
@@ -7,7 +7,12 @@ export const getAvatarUrlFromUsername = function(username) {
 		return externalSource.replace('{username}', username);
 	}
 	const key = `avatar_random_${ username }`;
-	const random = typeof Session !== 'undefined' && typeof Session.keys[key] !== 'undefined' ? Session.keys[key] : 0;
+	let _dc = Session.get(key);
+	if (!_dc) {
+		const now = Date.now();
+		Session.set(key, now);
+		_dc = now;
+	}
 	if (username == null) {
 		return;
 	}
@@ -17,5 +22,5 @@ export const getAvatarUrlFromUsername = function(username) {
 	if (cdnPrefix) {
 		path = cdnPrefix + pathPrefix;
 	}
-	return `${ path }/avatar/${ encodeURIComponent(username) }?_dc=${ random }`;
+	return `${ path }/avatar/${ encodeURIComponent(username) }?_dc=${ _dc }`;
 };

--- a/packages/rocketchat-livechat/.app/client/lib/fromApp/avatar.js
+++ b/packages/rocketchat-livechat/.app/client/lib/fromApp/avatar.js
@@ -3,22 +3,27 @@ import { Session } from 'meteor/session';
 
 this.getAvatarUrlFromUsername = (username) => {
 	const key = `avatar_random_${ username }`;
-	const random = Session.keys[key] || 0;
+	let _dc = Session.get(key);
+	if (!_dc) {
+		const now = Date.now();
+		Session.set(key, now);
+		_dc = now;
+	}
 	if (!username) {
 		return;
 	}
 
-	return `${ Meteor.absoluteUrl() }avatar/${ username }.jpg?_dc=${ random }`;
+	return `${ Meteor.absoluteUrl() }avatar/${ username }.jpg?_dc=${ _dc }`;
 };
 
 this.updateAvatarOfUsername = (username) => {
 	const key = `avatar_random_${ username }`;
-	Session.set(key, Math.round(Math.random() * 1000));
+	Session.set(key, Date.now());
 
 	Object.keys(RoomManager.openedRooms).forEach((key) => {
 		const room = RoomManager.openedRooms[key];
 		const url = getAvatarUrlFromUsername(username);
-		$(room.dom).find(`.message[data-username='${ username }'] .avatar-image`).css('background-image', `url(${ url })`);
+		$(room.dom).find(`.message[data-username='${ username }'] .avatar-image`).attr('src', url);
 	});
 	return true;
 };

--- a/packages/rocketchat-livechat/.app/client/views/avatar.js
+++ b/packages/rocketchat-livechat/.app/client/views/avatar.js
@@ -1,5 +1,4 @@
 import { Meteor } from 'meteor/meteor';
-import { Session } from 'meteor/session';
 import { Template } from 'meteor/templating';
 import visitor from '../../imports/client/visitor';
 
@@ -15,8 +14,6 @@ Template.avatar.helpers({
 		if (!username || (currentUser && currentUser.username === username)) {
 			return;
 		}
-
-		Session.get(`avatar_random_${ username }`);
 
 		return `background-image:url(${ getAvatarUrlFromUsername(username) });`;
 	},


### PR DESCRIPTION
I noticed avatars weren't changing/updating correctly to other users. When you change your profile picture, you'd expect other users to see the change. 

Currently, avatars are cached at a 1-hour cache. Even if you reloaded when someone changed their avatar, it would pull from the cache because _dc always was 0.

### Before
![avatar-fix-before](https://user-images.githubusercontent.com/6295044/56089834-19436380-5e67-11e9-87bc-cb856fcde474.gif)

### After
![avatar-fix-after](https://user-images.githubusercontent.com/6295044/56089859-7fc88180-5e67-11e9-9d40-1fd6f1c631c0.gif)
