### PR TITLE
[FIX] SAML certificate settings don't follow a pattern

### DIFF
--- a/app/meteor-accounts-saml/server/saml_rocketchat.js
+++ b/app/meteor-accounts-saml/server/saml_rocketchat.js
@@ -110,6 +110,14 @@ Meteor.methods({
 	},
 });
 
+const normalizeCert = function(cert) {
+	if (typeof cert === 'string') {
+		return cert.replace('-----BEGIN CERTIFICATE-----', '').replace('-----END CERTIFICATE-----', '').trim();
+	}
+
+	return cert;
+};
+
 const getSamlConfigs = function(service) {
 	return {
 		buttonLabelText: settings.get(`${ service.key }_button_label_text`),
@@ -127,7 +135,8 @@ const getSamlConfigs = function(service) {
 		secret: {
 			privateKey: settings.get(`${ service.key }_private_key`),
 			publicCert: settings.get(`${ service.key }_public_cert`),
-			cert: settings.get(`${ service.key }_cert`),
+			// People often overlook the instruction to remove the header and footer of the certificate on this specific setting, so let's do it for them.
+			cert: normalizeCert(settings.get(`${ service.key }_cert`)),
 		},
 	};
 };


### PR DESCRIPTION
The default certificate setting is expected on a different format from the other certificate settings. This PR changes it to accept it on the other format as well.