### PR TITLE
Increment user counter on DMs

### DIFF
--- a/app/theme/client/imports/components/badge.css
+++ b/app/theme/client/imports/components/badge.css
@@ -22,10 +22,6 @@
 		background-color: var(--badge-unread-background);
 	}
 
-	&--dm {
-		background-color: var(--badge-dm-background);
-	}
-
 	&--user-mentions {
 		background-color: var(--badge-user-mentions-background);
 	}

--- a/app/theme/client/imports/general/variables.css
+++ b/app/theme/client/imports/general/variables.css
@@ -281,7 +281,6 @@
 	--badge-text-size: 0.75rem;
 	--badge-background: var(--rc-color-primary-dark);
 	--badge-unread-background: var(--rc-color-primary-dark);
-	--badge-dm-background: var(--rc-color-primary-dark);
 	--badge-user-mentions-background: var(--color-dark-blue);
 	--badge-group-mentions-background: var(--rc-color-primary-dark);
 

--- a/app/ui-sidenav/client/sidebarItem.js
+++ b/app/ui-sidenav/client/sidebarItem.js
@@ -42,11 +42,12 @@ Template.sidebarItem.helpers({
 
 		if (unread) {
 			badges.push('badge--unread');
+			if (t === 'd') {
+				badges.push('badge--dm');
+			}
 		}
 
-		if (unread && t === 'd') {
-			badges.push('badge--dm');
-		} else if (userMentions) {
+		if (userMentions) {
 			badges.push('badge--user-mentions');
 		} else if (groupMentions) {
 			badges.push('badge--group-mentions');

--- a/private/client/imports/general/variables.css
+++ b/private/client/imports/general/variables.css
@@ -281,7 +281,6 @@
 	--badge-text-size: 0.75rem;
 	--badge-background: var(--rc-color-primary-dark);
 	--badge-unread-background: var(--rc-color-primary-dark);
-	--badge-dm-background: var(--rc-color-primary-dark);
 	--badge-user-mentions-background: var(--color-dark-blue);
 	--badge-group-mentions-background: var(--rc-color-primary-dark);
 


### PR DESCRIPTION
Before now, all messages on DMs would should a "black" badge showing how many messages were sent.

This PR changes that behavior to show the badge as blue if a mention is sent inside the DM, like in the image below:

![image](https://user-images.githubusercontent.com/8591547/56368026-fc8f8e80-61cc-11e9-9117-2ef3d4dde6c5.png)
