### PR TITLE
Regression: wrong expression at messageBox.actions.remove()

### DIFF
--- a/app/ui-utils/client/lib/messageBox.js
+++ b/app/ui-utils/client/lib/messageBox.js
@@ -25,7 +25,8 @@ class MessageBoxActions {
 		if (!group || !this.actions[group]) {
 			return false;
 		}
-		return (this.actions[group] = this.actions[group].filter((action) => expression.test(action.id)));
+
+		return (this.actions[group] = this.actions[group].filter((action) => !expression.test(action.id)));
 	}
 
 	get(group) {


### PR DESCRIPTION
One hour debugging and one character to fix it. If Discussions are not enabled, the `discussionFromMessageBox` module accidentally remove all `Create_New` message box actions.