### PR TITLE
[FIX] Add services property when creating user on SAML login

### DIFF
--- a/app/meteor-accounts-saml/server/saml_server.js
+++ b/app/meteor-accounts-saml/server/saml_server.js
@@ -124,6 +124,7 @@ Accounts.registerLoginHandler(function(loginRequest) {
 					address: email,
 					verified: true,
 				})),
+				services: {},
 			};
 
 			if (Accounts.saml.settings.generateUsername === true) {


### PR DESCRIPTION
When a user is created on their first SAML login, no services property is created before attempting to access it elsewhere. This PR adds the services property, fixing the following exception that is otherwise thrown when the user attempts to login for the first time.

```
I20190419-17:43:25.233(2)? Exception while invoking method 'login' TypeError: Cannot read property 'facebook' of undefined
I20190419-17:43:25.233(2)?     at getAvatarSuggestionForUser (app/lib/server/functions/getAvatarSuggestionForUser.js:12:20)
I20190419-17:43:25.233(2)?     at AccountsServer.<anonymous> (server/lib/accounts.js:221:29)
I20190419-17:43:25.233(2)?     at executeBound (/rocketchat/node_modules/underscore/underscore.js:762:67)
I20190419-17:43:25.234(2)?     at AccountsServer.bound [as insertUserDoc] (/rocketchat/node_modules/underscore/underscore.js:793:14)
I20190419-17:43:25.234(2)?     at MethodInvocation.<anonymous> (app/meteor-accounts-saml/server/saml_server.js:139:28)
I20190419-17:43:25.234(2)?     at tryLoginMethod (packages/accounts-base/accounts_server.js:460:31)
I20190419-17:43:25.234(2)?     at tryLoginMethod (packages/accounts-base/accounts_server.js:1294:14)
I20190419-17:43:25.234(2)?     at AccountsServer._runLoginHandlers (packages/accounts-base/accounts_server.js:458:22)
I20190419-17:43:25.234(2)?     at AccountsServer.Accounts._runLoginHandlers (app/lib/server/lib/loginErrorMessageOverride.js:7:35)
I20190419-17:43:25.234(2)?     at MethodInvocation.methods.login (packages/accounts-base/accounts_server.js:518:31)
I20190419-17:43:25.234(2)?     at MethodInvocation.methodMap.(anonymous function) (packages/rocketchat_monitoring.js:2731:30)
I20190419-17:43:25.234(2)?     at maybeAuditArgumentChecks (packages/ddp-server/livedata_server.js:1767:12)
I20190419-17:43:25.234(2)?     at DDP._CurrentMethodInvocation.withValue (packages/ddp-server/livedata_server.js:719:19)
I20190419-17:43:25.234(2)?     at Meteor.EnvironmentVariable.EVp.withValue (packages/meteor.js:1304:12)
I20190419-17:43:25.234(2)?     at DDPServer._CurrentWriteFence.withValue (packages/ddp-server/livedata_server.js:717:46)
I20190419-17:43:25.235(2)?     at Meteor.EnvironmentVariable.EVp.withValue (packages/meteor.js:1304:12)
I20190419-17:43:25.235(2)?     at Promise (packages/ddp-server/livedata_server.js:715:46)
I20190419-17:43:25.235(2)?     at new Promise (<anonymous>)
I20190419-17:43:25.235(2)?     at Session.method (packages/ddp-server/livedata_server.js:689:23)
I20190419-17:43:25.235(2)?     at packages/ddp-server/livedata_server.js:559:43
```