### PR TITLE
[NEW] SAML parameter 'language' to set interface language for new users

### DIFF
--- a/app/meteor-accounts-saml/server/saml_server.js
+++ b/app/meteor-accounts-saml/server/saml_server.js
@@ -3,6 +3,7 @@ import { Accounts } from 'meteor/accounts-base';
 import { Random } from 'meteor/random';
 import { WebApp } from 'meteor/webapp';
 import { RoutePolicy } from 'meteor/routepolicy';
+import { TAPi18n } from 'meteor/tap:i18n';
 import { CredentialTokens } from '../../models';
 import { generateUsernameSuggestion } from '../../lib';
 import { SAML } from './saml_utils';
@@ -133,6 +134,11 @@ Accounts.registerLoginHandler(function(loginRequest) {
 				}
 			} else if (loginResult.profile.username) {
 				newUser.username = loginResult.profile.username;
+			}
+
+			const languages = TAPi18n.getLanguages();
+			if (languages[loginResult.profile.language]) {
+				newUser.language = loginResult.profile.language;
 			}
 
 			const userId = Accounts.insertUserDoc({}, newUser);


### PR DESCRIPTION
Closes #14191

When logging in a new user via SAML, the user's preferred language may already be known by the IDP. This PR adds support for a 'language' SAML attribute, that, if present, selects a user's language when they login for the first time.