### PR TITLE
[FIX] Image attachment re-renders on message update

### DIFF
--- a/app/lazy-load/client/lazyloadImage.js
+++ b/app/lazy-load/client/lazyloadImage.js
@@ -7,6 +7,7 @@ const emptyImageEncoded =
 	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8+/u3PQAJJAM0dIyWdgAAAABJRU5ErkJggg==';
 
 const imgsrcs = new Set();
+
 Template.lazyloadImage.helpers({
 	class() {
 		const loaded = Template.instance().loaded.get();

--- a/app/lazy-load/client/lazyloadImage.js
+++ b/app/lazy-load/client/lazyloadImage.js
@@ -6,6 +6,7 @@ import { addImage } from './';
 const emptyImageEncoded =
 	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8+/u3PQAJJAM0dIyWdgAAAABJRU5ErkJggg==';
 
+const imgsrcs = new Set();
 Template.lazyloadImage.helpers({
 	class() {
 		const loaded = Template.instance().loaded.get();
@@ -18,11 +19,11 @@ Template.lazyloadImage.helpers({
 
 	lazySrcUrl() {
 		const { preview, placeholder, src } = this;
-
-		if (Template.instance().loaded.get() || (!preview && !placeholder)) {
+		if (Template.instance().loaded.get() || (!preview && !placeholder) || imgsrcs.has(src)) {
 			return src;
 		}
 
+		imgsrcs.add(this.src);
 		return `data:image/png;base64,${ preview || emptyImageEncoded }`;
 	},
 });


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #5028 and #14092 

**Issue and research**: On researching and playing around with codebase a bit I found out that message is re-created everytime someone updates the message, (e.g: Starring or adding a reaction as mentioned in the issues that this PR solves.)Since it is meteor's default reactivity system because of which it is happening, my resolution is a simple work-around.

**Resolution**:  Add a `onDestroy` function to the lazyloadtemplate(This template is responsible for showing the preview of the attachment.) This template gets destroyed and recreated whenever there is some update in the message (e.g: Starring or adding a reaction). Workaround is a simple `Template.onDestroy` call that stores the value of `loaded` state before being destroyed because of the update in the message. So whenever the template is recreated, now `this.loaded` has the same state as what was before updating a message(or being destroyed). 

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
