### PR TITLE
Regression: Broken UI for messages

### DIFF
--- a/app/emoji/client/emojiParser.js
+++ b/app/emoji/client/emojiParser.js
@@ -38,7 +38,7 @@ Tracker.autorun(() => {
 					continue;
 				}
 
-				if (s.trim(childNode.innerText) === '') {
+				if (s.trim(childNode.nodeValue) === '') {
 					continue;
 				}
 

--- a/app/theme/client/imports/general/base_old.css
+++ b/app/theme/client/imports/general/base_old.css
@@ -2899,26 +2899,6 @@ rc-old select,
 
 		opacity: 1;
 
-		& .inline-image {
-			display: inline-block;
-
-			border-radius: 3px;
-			background-repeat: no-repeat;
-			background-position: center left;
-			background-size: contain;
-			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
-
-			line-height: 0;
-
-			& img {
-				max-width: 100%;
-				max-height: 200px;
-
-				cursor: pointer;
-				object-fit: contain;
-			}
-		}
-
 		& > h1 {
 			font-size: 3em;
 			line-height: 1em;
@@ -2995,6 +2975,26 @@ rc-old select,
 		padding-left: 2px;
 
 		font-weight: 400;
+	}
+
+	& .inline-image {
+		display: inline-block;
+
+		border-radius: 3px;
+		background-repeat: no-repeat;
+		background-position: center left;
+		background-size: contain;
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+
+		line-height: 0;
+
+		& img {
+			max-width: 100%;
+			max-height: 200px;
+
+			cursor: pointer;
+			object-fit: contain;
+		}
 	}
 
 	&.livechat_navigation_history {

--- a/app/threads/client/flextab/thread.html
+++ b/app/threads/client/flextab/thread.html
@@ -3,7 +3,7 @@
 		<div class="contextual-bar__header-data">
 			{{> icon block="contextual-bar__header-icon" icon='thread'}}
 			<h2 class="contextual-bar__header-title">
-				<span class="message-body--unstyled">{{threadTitle}}</span>
+				<span class="message-body--unstyled">{{{threadTitle}}}</span>
 				{{!-- <sub class="contextual-bar__header-description">{{room.fname}}</sub> --}}
 			</h2>
 		</div>


### PR DESCRIPTION
- inline images were too large
- emojis were improperly tagged as `big`
- thread title not rendered as HTML in thread tab