### PR TITLE
[NEW]Set up livechat connections created from new client

### DIFF
--- a/app/livechat/server/index.js
+++ b/app/livechat/server/index.js
@@ -54,6 +54,7 @@ import './methods/startVideoCall';
 import './methods/startFileUploadRoom';
 import './methods/transfer';
 import './methods/webhookTest';
+import './methods/setUpConnection';
 import './methods/takeInquiry';
 import './methods/returnAsInquiry';
 import './methods/saveOfficeHours';

--- a/app/livechat/server/methods/setUpConnection.js
+++ b/app/livechat/server/methods/setUpConnection.js
@@ -11,9 +11,11 @@ Meteor.methods({
 
 		const { token } = data;
 
-		this.connection.livechatToken = token;
-		this.connection.onClose(() => {
-			Livechat.notifyGuestStatusChanged(token, 'offline');
-		});
+		if (!this.connection.livechatToken) {
+			this.connection.livechatToken = token;
+			this.connection.onClose(() => {
+				Livechat.notifyGuestStatusChanged(token, 'offline');
+			});
+		}
 	},
 });

--- a/app/livechat/server/methods/setUpConnection.js
+++ b/app/livechat/server/methods/setUpConnection.js
@@ -1,0 +1,19 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+import { Livechat } from '../lib/Livechat';
+
+Meteor.methods({
+	'livechat:setUpConnection'(data) {
+
+		check(data, {
+			token: String,
+		});
+
+		const { token } = data;
+
+		this.connection.livechatToken = token;
+		this.connection.onClose(() => {
+			Livechat.notifyGuestStatusChanged(token, 'offline');
+		});
+	},
+});


### PR DESCRIPTION
We need to handle the `onClose` connections created from the new livechat client.
Since the new Livechat client works through the REST API approach, we need to update the guest status after its connection is closed.