### PR TITLE
[FIX] Empty result when getting badge count notification

### DIFF
--- a/app/lib/server/functions/notifications/mobile.js
+++ b/app/lib/server/functions/notifications/mobile.js
@@ -18,7 +18,7 @@ Meteor.startup(() => {
 });
 
 async function getBadgeCount(userId) {
-	const [result] = await SubscriptionRaw.aggregate([
+	const [result = {}] = await SubscriptionRaw.aggregate([
 		{ $match: { 'u._id': userId } },
 		{
 			$group: {


### PR DESCRIPTION
Adds a default empty object when getting the badge count notification.