### PR TITLE
[FIX] Enable and disable LDAP users on sync

### DIFF
--- a/app/ldap/server/sync.js
+++ b/app/ldap/server/sync.js
@@ -178,6 +178,15 @@ export function syncUserData(user, ldapUser) {
 	logger.debug('user', { email: user.email, _id: user._id });
 	logger.debug('ldapUser', ldapUser.object);
 
+	//Disable users when userAccountControl has flag 0x002. Only working with Microsoft ActiveDirectory
+	if (user.active && (ldapUser["userAccountControl"] & 0x0002)) {
+		logger.debug('Disabling user', user._id);
+		Meteor.users.update(user._id, { $set: { active: false } });
+	} else if (!user.active && (!(ldapUser["userAccountControl"] & 0x0002))) {
+		logger.debug('Enabling user', user._id);
+		Meteor.users.update(user._id, { $set: { active: true } });
+	}
+
 	const userData = getDataToSyncUserData(ldapUser, user);
 	if (user && user._id && userData) {
 		logger.debug('setting', JSON.stringify(userData, null, 2));


### PR DESCRIPTION
Closes #9916

This small PR fixes that users are not disabled when they are disabled in Microsoft Active Directory and you are running a background sync. The fix checks for the value of the userAccountControl (https://support.microsoft.com/en-gb/help/305144/how-to-use-useraccountcontrol-to-manipulate-user-account-properties) and bitwise compares with 0x002.

It either disables or re-enables a user, depending on the value of your userAccountControl.

