### PR TITLE
[FIX] Switch oplog required doc link to more accurate link

### DIFF
--- a/server/startup/serverRunning.js
+++ b/server/startup/serverRunning.js
@@ -49,7 +49,7 @@ Meteor.startup(function() {
 		msg = msg.join('\n');
 
 		if (!isOplogEnabled) {
-			msg += ['', '', 'OPLOG / REPLICASET IS REQUIRED TO RUN ROCKET.CHAT, MORE INFORMATION AT:', 'https://rocket.chat/docs/installation/docker-containers/high-availability-install'].join('\n');
+			msg += ['', '', 'OPLOG / REPLICASET IS REQUIRED TO RUN ROCKET.CHAT, MORE INFORMATION AT:', 'https://go.rocket.chat/i/100'].join('\n');
 			SystemLogger.error_box(msg, 'SERVER ERROR');
 
 			return process.exit(1);

--- a/server/startup/serverRunning.js
+++ b/server/startup/serverRunning.js
@@ -49,7 +49,7 @@ Meteor.startup(function() {
 		msg = msg.join('\n');
 
 		if (!isOplogEnabled) {
-			msg += ['', '', 'OPLOG / REPLICASET IS REQUIRED TO RUN ROCKET.CHAT, MORE INFORMATION AT:', 'https://go.rocket.chat/i/100'].join('\n');
+			msg += ['', '', 'OPLOG / REPLICASET IS REQUIRED TO RUN ROCKET.CHAT, MORE INFORMATION AT:', 'https://go.rocket.chat/i/oplog-required'].join('\n');
 			SystemLogger.error_box(msg, 'SERVER ERROR');
 
 			return process.exit(1);


### PR DESCRIPTION
Switching to short link to redirect.  This will let us direct to the 1.0 upgrade document and then in the future we can redirect to a specific doc with out having to modify this again.