### PR TITLE
[FIX] Wrong header at Apps admin section

### DIFF
--- a/app/apps/client/admin/apps.html
+++ b/app/apps/client/admin/apps.html
@@ -1,6 +1,6 @@
 <template name="apps">
 	<section class="rc-apps-marketplace">
-		{{#header sectionName="Marketplace" hideHelp=true fixedHeight=true fullpage=true}}
+		{{#header sectionName="Apps" hideHelp=true fixedHeight=true fullpage=true}}
 			<div class="rc-header__section-button">
 				<button class="rc-button rc-button--small rc-button--primary" data-button="install_app">
 					{{> icon icon="cloud-plus" block="rc-icon--default-size"}} {{_ "Marketplace_view_marketplace"}}


### PR DESCRIPTION
Right now is showing Marketplace in the apps section

Before:
<img width="1270" alt="image" src="https://user-images.githubusercontent.com/51996/56869187-e6e74980-69c2-11e9-9b7d-6ba44ce20bf1.png">
