### PR TITLE
[NEW] Sort by user roles

### DIFF
--- a/app/ui-flextab/client/tabs/membersList.html
+++ b/app/ui-flextab/client/tabs/membersList.html
@@ -13,9 +13,10 @@
 
 				</div>
 				<label class="rc-select">
-					<select class="rc-select__element js-type" name="status-type">
+					<select class="rc-select__element js-type" name="status-type" id="status-type">
 						<option value="online">{{_ 'online'}}</option>
 						<option value="all">{{_ 'All_users'}}</option>
+						<option value="showUserRoles">{{_ 'Users_in_role'}}</option>
 					</select>
 					{{> icon block="rc-select__arrow" icon="arrow-down" }}
 				</label>
@@ -37,7 +38,7 @@
 							{{> avatar username=user.username}}
 							<div class="rc-member-list__username">
 								<div class="rc-member-list__status rc-member-list__status--{{status}}"></div>
-								{{ignored}} {{displayName}} {{utcOffset}}
+								{{ignored}} {{displayName}} {{utcOffset}} ({{roles}})
 								</div>
 							{{> icon user=. block="rc-member-list__menu js-more" icon="menu" }}
 						</li>

--- a/app/ui-flextab/client/tabs/membersList.html
+++ b/app/ui-flextab/client/tabs/membersList.html
@@ -38,7 +38,7 @@
 							{{> avatar username=user.username}}
 							<div class="rc-member-list__username">
 								<div class="rc-member-list__status rc-member-list__status--{{status}}"></div>
-								{{ignored}} {{displayName}} {{utcOffset}} {{#if showUserRoles}} ({{roles}}) {{/if}}
+								{{ignored}} {{displayName}} {{utcOffset}} {{#if showUserRoles}} {{#if roles}} ({{roles}}) {{/if}}{{/if}}
 								</div>
 							{{> icon user=. block="rc-member-list__menu js-more" icon="menu" }}
 						</li>

--- a/app/ui-flextab/client/tabs/membersList.html
+++ b/app/ui-flextab/client/tabs/membersList.html
@@ -38,7 +38,7 @@
 							{{> avatar username=user.username}}
 							<div class="rc-member-list__username">
 								<div class="rc-member-list__status rc-member-list__status--{{status}}"></div>
-								{{ignored}} {{displayName}} {{utcOffset}} ({{roles}})
+								{{ignored}} {{displayName}} {{utcOffset}} {{#if showUserRoles}} ({{roles}}) {{/if}}
 								</div>
 							{{> icon user=. block="rc-member-list__menu js-more" icon="menu" }}
 						</li>

--- a/app/ui-flextab/client/tabs/membersList.js
+++ b/app/ui-flextab/client/tabs/membersList.js
@@ -102,9 +102,11 @@ Template.membersList.helpers({
 			};
 		});
 
-		users = _.sortBy(users, function(user) {
-			return user.rank;
-		});
+		//if(document.getElementById('status-type').selectedIndex === 2) {
+			users = _.sortBy(users, function(user) {
+				return user.rank;
+			});
+		//}
 
 		const usersTotal = users.length;
 		const { total, loading, usersLimit, loadingMore } = Template.instance();
@@ -121,6 +123,10 @@ Template.membersList.helpers({
 			hasMore,
 			rid: this.rid,
 		};
+	},
+
+	showUserRoles() {
+		return (Template.instance().sortingMode.get() === 'showUserRoles');
 	},
 
 	canAddUser() {
@@ -206,6 +212,7 @@ Template.membersList.events({
 	'change .js-type'(e, instance) {
 		instance.showAllUsers.set(e.currentTarget.value === 'all');
 		instance.usersLimit.set(100);
+		instance.sortingMode.set(e.currentTarget.value);
 	},
 	'click .js-more'(e, instance) {
 		e.currentTarget.parentElement.classList.add('active');
@@ -307,6 +314,7 @@ Template.membersList.onCreated(function() {
 	this.total = new ReactiveVar;
 	this.loading = new ReactiveVar(true);
 	this.loadingMore = new ReactiveVar(false);
+	this.sortingMode = new ReactiveVar('online');
 
 	this.tabBar = this.data.tabBar;
 

--- a/app/ui-flextab/client/tabs/membersList.js
+++ b/app/ui-flextab/client/tabs/membersList.js
@@ -8,6 +8,7 @@ import { settings } from '../../../settings';
 import { t, isRtl, handleError, roomTypes } from '../../../utils';
 import { WebRTC } from '../../../webrtc/client';
 import { getActions } from './userActions';
+import _ from 'underscore';
 
 Template.membersList.helpers({
 	ignored() {
@@ -34,10 +35,9 @@ Template.membersList.helpers({
 		const room = ChatRoom.findOne(this.rid);
 		const roomMuted = (room != null ? room.muted : undefined) || [];
 		const userUtcOffset = Meteor.user() && Meteor.user().utcOffset;
-		const hierarchy = ['admin', 'owner', 'leader'];
+		const hierarchy = ['admin', 'owner', 'leader', 'moderator', 'Rocket.Chat team'];
 		let totalOnline = 0;
 		let users = roomUsers;
-		
 
 		let userRoles = [];
 		let roomRoles = [];
@@ -75,7 +75,7 @@ Template.membersList.helpers({
 			userRoles = UserRoles.findOne(user._id) || {};
 			roomRoles = RoomRoles.findOne({ 'u._id': user._id, rid: Session.get('openedRoom') }) || {};
 			roles = _.union(userRoles.roles || [], roomRoles.roles || []);
-			roles = _.sortBy(roles, function(role) {				
+			roles = _.sortBy(roles, function(role) {
 				return (hierarchy.indexOf(role) === -1) ? 50 : hierarchy.indexOf(role);
 			});
 
@@ -89,7 +89,6 @@ Template.membersList.helpers({
 				// sending the ones without an assigned role at the end of list
 				rank = 1000;
 			}
-			
 
 			console.log(user.username, roles, rank);
 			return {
@@ -102,11 +101,11 @@ Template.membersList.helpers({
 			};
 		});
 
-		//if(document.getElementById('status-type').selectedIndex === 2) {
+		if (Template.instance().sortingMode.get() === 'showUserRoles') {
 			users = _.sortBy(users, function(user) {
 				return user.rank;
 			});
-		//}
+		}
 
 		const usersTotal = users.length;
 		const { total, loading, usersLimit, loadingMore } = Template.instance();

--- a/app/ui-flextab/client/tabs/membersList.js
+++ b/app/ui-flextab/client/tabs/membersList.js
@@ -90,7 +90,6 @@ Template.membersList.helpers({
 				rank = 1000;
 			}
 
-			console.log(user.username, roles, rank);
 			return {
 				user,
 				status: (onlineUsers[user.username] != null ? onlineUsers[user.username].status : 'offline'),
@@ -209,9 +208,9 @@ Template.membersList.events({
 		instance.filter.set(e.target.value.trim());
 	},
 	'change .js-type'(e, instance) {
-		instance.showAllUsers.set(e.currentTarget.value === 'all');
-		instance.usersLimit.set(100);
+		instance.showAllUsers.set(e.currentTarget.value !== 'online');
 		instance.sortingMode.set(e.currentTarget.value);
+		instance.usersLimit.set(100);
 	},
 	'click .js-more'(e, instance) {
 		e.currentTarget.parentElement.classList.add('active');
@@ -363,7 +362,7 @@ Template.membersList.onRendered(function() {
 		const showAllUsers = this.showAllUsers.get();
 		const statusTypeSelect = this.find('.js-type');
 		if (statusTypeSelect) {
-			statusTypeSelect.value = showAllUsers ? 'all' : 'online';
+			statusTypeSelect.value = this.sortingMode.get();
 		}
 	});
 });

--- a/app/ui-flextab/client/tabs/membersList.js
+++ b/app/ui-flextab/client/tabs/membersList.js
@@ -359,7 +359,7 @@ Template.membersList.onCreated(function() {
 
 Template.membersList.onRendered(function() {
 	this.autorun(() => {
-		const showAllUsers = this.showAllUsers.get();
+		// const showAllUsers = this.showAllUsers.get();
 		const statusTypeSelect = this.find('.js-type');
 		if (statusTypeSelect) {
 			statusTypeSelect.value = this.sortingMode.get();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "Rocket.Chat",
-	"version": "1.0.0-develop",
+	"version": "1.1.0-develop",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -3936,16 +3936,6 @@
 			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
 			"dev": true
 		},
-		"camel-case": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-			"dev": true,
-			"requires": {
-				"no-case": "^2.2.0",
-				"upper-case": "^1.1.1"
-			}
-		},
 		"camelcase": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -4272,13 +4262,11 @@
 				"chromedriver": "^2.35",
 				"colors": "1.1.2",
 				"commander": "^2.9.0",
-				"cucumber": "github:xolvio/cucumber-js#cf953cb5b5de30dbcc279f59e4ebff3aa040071c",
 				"deep-extend": "^0.4.1",
 				"exit": "^0.1.2",
 				"fibers": "^1.0.14",
 				"freeport": "~1.0.5",
 				"fs-extra": "^1.0.0",
-				"glob": "github:lucetius/node-glob#51c7ca6e69bfbd17db5f1ea710e3f2a7a457d9ce",
 				"hapi": "8.8.0",
 				"jasmine": "^2.4.1",
 				"loglevel": "~1.4.0",
@@ -4316,6 +4304,27 @@
 						"type-detect": "^4.0.0"
 					}
 				},
+				"cucumber": {
+					"version": "github:xolvio/cucumber-js#cf953cb5b5de30dbcc279f59e4ebff3aa040071c",
+					"from": "github:xolvio/cucumber-js#cf953cb5b5de30dbcc279f59e4ebff3aa040071c",
+					"requires": {
+						"camel-case": "^3.0.0",
+						"cli-table": "^0.3.1",
+						"co": "^4.6.0",
+						"colors": "^1.1.2",
+						"commander": "^2.9.0",
+						"duration": "^0.2.0",
+						"fibers": "^1.0.7",
+						"figures": "1.7.0",
+						"gherkin": "4.0.0",
+						"glob": "^7.0.0",
+						"is-generator": "^1.0.2",
+						"lodash": "^4.0.0",
+						"meteor-promise": "^0.8.0",
+						"stack-chain": "^1.3.5",
+						"stacktrace-js": "^1.3.0"
+					}
+				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -4334,13 +4343,11 @@
 				"fibers": {
 					"version": "1.0.15",
 					"resolved": "https://registry.npmjs.org/fibers/-/fibers-1.0.15.tgz",
-					"integrity": "sha1-IvA5yPGLhWGQ+75N7PBWFUwerpw=",
-					"dev": true
+					"integrity": "sha1-IvA5yPGLhWGQ+75N7PBWFUwerpw="
 				},
 				"glob": {
-					"version": "github:lucetius/node-glob#51c7ca6e69bfbd17db5f1ea710e3f2a7a457d9ce",
-					"from": "github:lucetius/node-glob#chimp",
-					"dev": true,
+					"version": "7.1.1",
+					"resolved": "github:lucetius/node-glob#51c7ca6e69bfbd17db5f1ea710e3f2a7a457d9ce",
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -4417,8 +4424,7 @@
 				"once": {
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/once/-/once-1.3.0.tgz",
-					"integrity": "sha1-FRr4a/wfCMS58H0GqyUP/L61ZYE=",
-					"dev": true
+					"integrity": "sha1-FRr4a/wfCMS58H0GqyUP/L61ZYE="
 				},
 				"progress": {
 					"version": "1.1.8",
@@ -4564,23 +4570,6 @@
 				"restore-cursor": "^2.0.0"
 			}
 		},
-		"cli-table": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-			"integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-			"dev": true,
-			"requires": {
-				"colors": "1.0.3"
-			},
-			"dependencies": {
-				"colors": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-					"dev": true
-				}
-			}
-		},
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
@@ -4698,8 +4687,7 @@
 		"colors": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-			"dev": true
+			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
 		},
 		"colour": {
 			"version": "0.7.1",
@@ -5121,36 +5109,6 @@
 			"integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
 			"dev": true
 		},
-		"cucumber": {
-			"version": "github:xolvio/cucumber-js#cf953cb5b5de30dbcc279f59e4ebff3aa040071c",
-			"from": "github:xolvio/cucumber-js#v1.3.0-chimp.6",
-			"dev": true,
-			"requires": {
-				"camel-case": "^3.0.0",
-				"cli-table": "^0.3.1",
-				"co": "^4.6.0",
-				"colors": "^1.1.2",
-				"commander": "^2.9.0",
-				"duration": "^0.2.0",
-				"fibers": "^1.0.7",
-				"figures": "1.7.0",
-				"gherkin": "4.0.0",
-				"glob": "^7.0.0",
-				"is-generator": "^1.0.2",
-				"lodash": "^4.0.0",
-				"meteor-promise": "^0.8.0",
-				"stack-chain": "^1.3.5",
-				"stacktrace-js": "^1.3.0"
-			},
-			"dependencies": {
-				"fibers": {
-					"version": "1.0.15",
-					"resolved": "https://registry.npmjs.org/fibers/-/fibers-1.0.15.tgz",
-					"integrity": "sha1-IvA5yPGLhWGQ+75N7PBWFUwerpw=",
-					"dev": true
-				}
-			}
-		},
 		"cuid": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/cuid/-/cuid-1.3.8.tgz",
@@ -5187,15 +5145,6 @@
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
 			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
 			"dev": true
-		},
-		"d": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-			"dev": true,
-			"requires": {
-				"es5-ext": "^0.10.9"
-			}
 		},
 		"dashdash": {
 			"version": "1.14.1",
@@ -5634,16 +5583,6 @@
 				"stream-shift": "^1.0.0"
 			}
 		},
-		"duration": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
-			"integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
-			"dev": true,
-			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.46"
-			}
-		},
 		"eastasianwidth": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -5818,15 +5757,6 @@
 				}
 			}
 		},
-		"error-stack-parser": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
-			"integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
-			"dev": true,
-			"requires": {
-				"stackframe": "^0.3.1"
-			}
-		},
 		"es-abstract": {
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
@@ -5849,28 +5779,6 @@
 				"is-symbol": "^1.0.2"
 			}
 		},
-		"es5-ext": {
-			"version": "0.10.48",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.48.tgz",
-			"integrity": "sha512-CdRvPlX/24Mj5L4NVxTs4804sxiS2CjVprgCmrgoDkdmjdY4D+ySHa7K3jJf8R40dFg0tIm3z/dk326LrnuSGw==",
-			"dev": true,
-			"requires": {
-				"es6-iterator": "~2.0.3",
-				"es6-symbol": "~3.1.1",
-				"next-tick": "1"
-			}
-		},
-		"es6-iterator": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-			"dev": true,
-			"requires": {
-				"d": "1",
-				"es5-ext": "^0.10.35",
-				"es6-symbol": "^3.1.1"
-			}
-		},
 		"es6-promise": {
 			"version": "4.2.5",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
@@ -5882,16 +5790,6 @@
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"requires": {
 				"es6-promise": "^4.0.3"
-			}
-		},
-		"es6-symbol": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-			"dev": true,
-			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
 			}
 		},
 		"escape-html": {
@@ -6853,16 +6751,6 @@
 			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
 			"dev": true
 		},
-		"figures": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-			"dev": true,
-			"requires": {
-				"escape-string-regexp": "^1.0.5",
-				"object-assign": "^4.1.0"
-			}
-		},
 		"file-entry-cache": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
@@ -7195,12 +7083,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -7215,17 +7105,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -7342,7 +7235,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -7354,6 +7248,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -7368,6 +7263,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -7375,12 +7271,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -7399,6 +7297,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -7479,7 +7378,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -7491,6 +7391,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -7612,6 +7513,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -7775,12 +7677,6 @@
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
-		},
-		"gherkin": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/gherkin/-/gherkin-4.0.0.tgz",
-			"integrity": "sha1-edzgTRIj6kO0hip2vlzo+JwSwyw=",
-			"dev": true
 		},
 		"github-from-package": {
 			"version": "0.0.0",
@@ -8888,6 +8784,18 @@
 						"hoek": "2.x.x",
 						"joi": "6.x.x",
 						"wreck": "5.x.x"
+					},
+					"dependencies": {
+						"wreck": {
+							"version": "5.6.1",
+							"resolved": "https://registry.npmjs.org/wreck/-/wreck-5.6.1.tgz",
+							"integrity": "sha1-r/ADBAATiJ11YZtccYcN0qjdBpo=",
+							"dev": true,
+							"requires": {
+								"boom": "2.x.x",
+								"hoek": "2.x.x"
+							}
+						}
 					}
 				},
 				"heavy": {
@@ -8899,6 +8807,20 @@
 						"boom": "2.x.x",
 						"hoek": "2.x.x",
 						"joi": "5.x.x"
+					},
+					"dependencies": {
+						"joi": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+							"integrity": "sha1-FSrQfbjunGQBmX/1/SwSiWBwv1g=",
+							"dev": true,
+							"requires": {
+								"hoek": "^2.2.x",
+								"isemail": "1.x.x",
+								"moment": "2.x.x",
+								"topo": "1.x.x"
+							}
+						}
 					}
 				},
 				"hoek": {
@@ -10043,12 +9965,6 @@
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
-		},
-		"is-generator": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz",
-			"integrity": "sha1-wUwhBX7TbjKNuANHlmxpP4hjifM=",
-			"dev": true
 		},
 		"is-glob": {
 			"version": "4.0.0",
@@ -11198,12 +11114,6 @@
 				"signal-exit": "^3.0.0"
 			}
 		},
-		"lower-case": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-			"dev": true
-		},
 		"lru-cache": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -11698,8 +11608,7 @@
 		"meteor-promise": {
 			"version": "0.8.6",
 			"resolved": "https://registry.npmjs.org/meteor-promise/-/meteor-promise-0.8.6.tgz",
-			"integrity": "sha512-HP6tOr67z/9XU2Dr0F2SSr8WRTuE23AG9Dj578DCJPEYHs67OLKBviU8A8rwvbwMD7Lu2+Of+yAMz2Wd8r4yxg==",
-			"dev": true
+			"integrity": "sha512-HP6tOr67z/9XU2Dr0F2SSr8WRTuE23AG9Dj578DCJPEYHs67OLKBviU8A8rwvbwMD7Lu2+Of+yAMz2Wd8r4yxg=="
 		},
 		"methods": {
 			"version": "1.1.2",
@@ -12206,25 +12115,10 @@
 			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
 			"dev": true
 		},
-		"next-tick": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-			"dev": true
-		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-		},
-		"no-case": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-			"dev": true,
-			"requires": {
-				"lower-case": "^1.1.1"
-			}
 		},
 		"node-abi": {
 			"version": "2.7.1",
@@ -15363,68 +15257,10 @@
 				"figgy-pudding": "^3.5.1"
 			}
 		},
-		"stack-chain": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-			"integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=",
-			"dev": true
-		},
-		"stack-generator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-1.1.0.tgz",
-			"integrity": "sha1-NvapIHUabBD0maE8Msu19RoLiyU=",
-			"dev": true,
-			"requires": {
-				"stackframe": "^1.0.2"
-			},
-			"dependencies": {
-				"stackframe": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
-					"integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==",
-					"dev": true
-				}
-			}
-		},
 		"stack-trace": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
 			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
-		},
-		"stackframe": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
-			"integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=",
-			"dev": true
-		},
-		"stacktrace-gps": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-2.4.4.tgz",
-			"integrity": "sha1-acgn6dbW9Bz0ONfxleLjy/zyjEQ=",
-			"dev": true,
-			"requires": {
-				"source-map": "0.5.6",
-				"stackframe": "~0.3"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.5.6",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-					"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-					"dev": true
-				}
-			}
-		},
-		"stacktrace-js": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-1.3.1.tgz",
-			"integrity": "sha1-Z8qyWJr1xBe5Yvc2mUAne7O2oYs=",
-			"dev": true,
-			"requires": {
-				"error-stack-parser": "^1.3.6",
-				"stack-generator": "^1.0.7",
-				"stacktrace-gps": "^2.4.3"
-			}
 		},
 		"starttls": {
 			"version": "1.0.1",
@@ -16700,12 +16536,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
 			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
-			"dev": true
-		},
-		"upper-case": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
 			"dev": true
 		},
 		"uri-js": {


### PR DESCRIPTION
Closes issue #13967. Currently, under Members' List we only have a single option to filter users (bases on their online status) and no option for sorting. This PR enables a user to sort the members of a room based on their user roles. 

![RC sort-by-user-roles](https://user-images.githubusercontent.com/32139782/56931898-4c405500-6aff-11e9-9fd8-b179ad3dafcf.gif)

The sorting is based on a `hierarchy`, which is an array of `userRoles` arranged in decreasing order of "importance/responsibility".

![RC sort-by-user-roles-hierarchy](https://user-images.githubusercontent.com/32139782/56932158-3a12e680-6b00-11e9-86bd-64f6d2911d5f.png)

Thus, the admins appear first in the sorted list, then owners, moderators and so on. Simply swap two roles in the array to change the sorting order.


This is a new PR which does the same as PR #13976, closed the earlier one as suggested by mentors.

