### PR TITLE
[FIX] New day separator rendered over thread reply

### DIFF
--- a/app/threads/client/threads.css
+++ b/app/threads/client/threads.css
@@ -124,7 +124,7 @@
 	margin-bottom: calc(var(--default-padding) / 2);
 }
 
-.message.collapsed + .message:not(.collapsed) {
+.message.collapsed + .message:not(.collapsed):not(.new-day) {
 	margin-top: calc(var(--default-padding) / 2);
 }
 


### PR DESCRIPTION
## Before
![localhost_3000_group_QpoHjLy4BMfBWYNek](https://user-images.githubusercontent.com/234261/56967053-d22bc280-6b36-11e9-9128-af1664f87873.png)

## After
![localhost_3000_group_qM9GgxX88rk2Jsmg8](https://user-images.githubusercontent.com/234261/56967061-d657e000-6b36-11e9-8e69-8951ea87ab21.png)
