### PR TITLE
[FIX] SAML credentialToken removal was preventing mobile from being able to authenticate

### DIFF
--- a/app/meteor-accounts-saml/client/saml_client.js
+++ b/app/meteor-accounts-saml/client/saml_client.js
@@ -1,5 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { Accounts } from 'meteor/accounts-base';
+import { Random } from 'meteor/random';
 import { ServiceConfiguration } from 'meteor/service-configuration';
 
 if (!Accounts.saml) {
@@ -94,12 +95,14 @@ Accounts.saml.initiateLogin = function(options, callback, dimensions) {
 
 Meteor.loginWithSaml = function(options, callback) {
 	options = options || {};
-	options.credentialToken = Meteor.default_connection._lastSessionId;
+	const credentialToken = `id-${ Random.id() }`;
+	options.credentialToken = credentialToken;
 
 	Accounts.saml.initiateLogin(options, function(/* error, result*/) {
 		Accounts.callLoginMethod({
 			methodArguments: [{
 				saml: true,
+				credentialToken,
 			}],
 			userCallback: callback,
 		});

--- a/app/meteor-accounts-saml/server/saml_server.js
+++ b/app/meteor-accounts-saml/server/saml_server.js
@@ -92,11 +92,11 @@ Meteor.methods({
 });
 
 Accounts.registerLoginHandler(function(loginRequest) {
-	if (!loginRequest.saml) {
+	if (!loginRequest.saml || !loginRequest.credentialToken) {
 		return undefined;
 	}
 
-	const loginResult = Accounts.saml.retrieveCredential(this.connection.id);
+	const loginResult = Accounts.saml.retrieveCredential(loginRequest.credentialToken);
 	if (Accounts.saml.settings.debug) {
 		console.log(`RESULT :${ JSON.stringify(loginResult) }`);
 	}


### PR DESCRIPTION
Reverts #13791 
This makes both mobile applications not be able to authenticate. So reverting the change


ios and android both send a random token.  So we cannot simply stop accepting: https://github.com/RocketChat/Rocket.Chat.Android/pull/1326/files#diff-7274909d551b0d3613c6ba7ef386cfb1R280