### PR TITLE
[FIX] Fix crowd sync by using correct logging method

### DIFF
--- a/packages/rocketchat-crowd/server/crowd.js
+++ b/packages/rocketchat-crowd/server/crowd.js
@@ -147,7 +147,7 @@ export class CROWD {
 
 				const response = self.crowdClient.searchSync('user', `email=" ${ email } "`);
 				if (!response || response.users.length === 0) {
-					logger.warning('Could not find user in CROWD with username or email:', username, email);
+					logger.warn('Could not find user in CROWD with username or email:', username, email);
 					return;
 				}
 				username = response.users[0].name;


### PR DESCRIPTION
Fixes crowd sync.

Currently the crowd sync contains a method call to `logger.warning`. The `warning` function does not exist, but has to be `.warn` instead.
This is a bug introduced by myself and fixed with this PR.

Closes #14356



