### PR TITLE
[FIX] Wrong token name was generating error on Gitlab OAuth login

### DIFF
--- a/app/gitlab/lib/common.js
+++ b/app/gitlab/lib/common.js
@@ -11,7 +11,7 @@ const config = {
 		forLoggedInUser: ['services.gitlab'],
 		forOtherUsers: ['services.gitlab.username'],
 	},
-	accessTokenParam: 'private_token',
+	accessTokenParam: 'access_token',
 };
 
 const Gitlab = new CustomOAuth('gitlab', config);


### PR DESCRIPTION
Closes https://github.com/RocketChat/Rocket.Chat/issues/14307
According to [OAuth Gitlab's docs](https://docs.gitlab.com/ee/api/README.html#oauth2-tokens) the correct name for token is `access_token`.