### PR TITLE
[FIX]  Fallback to mongo version that doesn't require clusterMonitor role

### DIFF
--- a/app/statistics/server/functions/get.js
+++ b/app/statistics/server/functions/get.js
@@ -2,7 +2,6 @@ import _ from 'underscore';
 import os from 'os';
 
 import { Meteor } from 'meteor/meteor';
-import { MongoInternals } from 'meteor/mongo';
 import { InstanceStatus } from 'meteor/konecty:multiple-instances-status';
 
 import {
@@ -16,7 +15,7 @@ import {
 	LivechatVisitors,
 } from '../../../models/server';
 import { settings } from '../../../settings/server';
-import { Info } from '../../../utils/server';
+import { Info, getMongoInfo } from '../../../utils/server';
 import { Migrations } from '../../../migrations/server';
 
 import { statistics } from '../statisticsNamespace';
@@ -136,30 +135,10 @@ statistics.get = function _getStatistics() {
 	statistics.migration = Migrations._getControl();
 	statistics.instanceCount = InstanceStatus.getCollection().find({ _updatedAt: { $gt: new Date(Date.now() - process.uptime() * 1000 - 2000) } }).count();
 
-	const { mongo } = MongoInternals.defaultRemoteCollectionDriver();
-
-	if (mongo._oplogHandle && mongo._oplogHandle.onOplogEntry) {
-		statistics.oplogEnabled = true;
-	}
-
-	try {
-		const { version, storageEngine } = Promise.await(mongo.db.command({ serverStatus: 1 }));
-		statistics.mongoVersion = version;
-		statistics.mongoStorageEngine = storageEngine.name;
-	} catch (e) {
-		console.error('=== Error getting MongoDB info ===');
-		console.error(e && e.toString());
-		console.error('----------------------------------');
-		console.error('Without mongodb version we can\'t ensure you are running a compatible version.');
-		console.error('If you are running your mongodb with auth enabled and an user different from admin');
-		console.error('you may need to grant permissions for this user to check cluster data.');
-		console.error('You can do it via mongo shell running the following command replacing');
-		console.error('the string YOUR_USER by the correct user\'s name:');
-		console.error('');
-		console.error('   db.runCommand({ grantRolesToUser: "YOUR_USER" , roles: [{role: "clusterMonitor", db: "admin"}]})');
-		console.error('');
-		console.error('==================================');
-	}
+	const { oplogEnabled, mongoVersion, mongoStorageEngine } = getMongoInfo();
+	statistics.oplogEnabled = oplogEnabled;
+	statistics.mongoVersion = mongoVersion;
+	statistics.mongoStorageEngine = mongoStorageEngine;
 
 	statistics.uniqueUsersOfYesterday = Sessions.getUniqueUsersOfYesterday();
 	statistics.uniqueUsersOfLastMonth = Sessions.getUniqueUsersOfLastMonth();

--- a/app/utils/server/functions/getMongoInfo.js
+++ b/app/utils/server/functions/getMongoInfo.js
@@ -1,0 +1,54 @@
+import { MongoInternals } from 'meteor/mongo';
+
+function fallbackMongoInfo() {
+	let mongoVersion;
+	let mongoStorageEngine;
+
+	const { mongo } = MongoInternals.defaultRemoteCollectionDriver();
+
+	const oplogEnabled = Boolean(mongo._oplogHandle && mongo._oplogHandle.onOplogEntry);
+
+	try {
+		const { version } = Promise.await(mongo.db.command({ buildinfo: 1 }));
+		mongoVersion = version;
+		mongoStorageEngine = 'unknown';
+	} catch (e) {
+		console.error('=== Error getting MongoDB info ===');
+		console.error(e && e.toString());
+		console.error('----------------------------------');
+		console.error('Without mongodb version we can\'t ensure you are running a compatible version.');
+		console.error('If you are running your mongodb with auth enabled and an user different from admin');
+		console.error('you may need to grant permissions for this user to check cluster data.');
+		console.error('You can do it via mongo shell running the following command replacing');
+		console.error('the string YOUR_USER by the correct user\'s name:');
+		console.error('');
+		console.error('   db.runCommand({ grantRolesToUser: "YOUR_USER" , roles: [{role: "clusterMonitor", db: "admin"}]})');
+		console.error('');
+		console.error('==================================');
+	}
+
+	return { oplogEnabled, mongoVersion, mongoStorageEngine };
+}
+
+export function getMongoInfo() {
+	let mongoVersion;
+	let mongoStorageEngine;
+
+	const { mongo } = MongoInternals.defaultRemoteCollectionDriver();
+
+	const oplogEnabled = Boolean(mongo._oplogHandle && mongo._oplogHandle.onOplogEntry);
+
+	try {
+		const { version, storageEngine } = Promise.await(mongo.db.command({ serverStatus: 1 }));
+
+		mongoVersion = version;
+		mongoStorageEngine = storageEngine.name;
+
+	} catch (e) {
+		return fallbackMongoInfo();
+	}
+
+	return { oplogEnabled, mongoVersion, mongoStorageEngine };
+}
+
+

--- a/app/utils/server/index.js
+++ b/app/utils/server/index.js
@@ -7,6 +7,7 @@ export { roomTypes } from './lib/roomTypes';
 export { RoomTypeRouteConfig, RoomTypeConfig, RoomSettingsEnum, UiTextContext } from '../lib/RoomTypeConfig';
 export { RoomTypesCommon } from '../lib/RoomTypesCommon';
 export { isDocker } from './functions/isDocker';
+export { getMongoInfo } from './functions/getMongoInfo';
 export { getUserAvatarURL } from '../lib/getUserAvatarURL';
 export { slashCommands } from '../lib/slashCommand';
 export { getUserNotificationPreference } from '../lib/getUserNotificationPreference';

--- a/server/startup/serverRunning.js
+++ b/server/startup/serverRunning.js
@@ -1,39 +1,13 @@
 import { Meteor } from 'meteor/meteor';
-import { MongoInternals } from 'meteor/mongo';
 import { SystemLogger } from '../../app/logger';
 import { settings } from '../../app/settings';
-import { Info } from '../../app/utils';
+import { Info, getMongoInfo } from '../../app/utils';
 import fs from 'fs';
 import path from 'path';
 import semver from 'semver';
 
 Meteor.startup(function() {
-	const { mongo } = MongoInternals.defaultRemoteCollectionDriver();
-
-	const isOplogEnabled = Boolean(mongo._oplogHandle && mongo._oplogHandle.onOplogEntry);
-
-	let mongoDbVersion;
-	let mongoDbEngine;
-	try {
-		const { version, storageEngine } = Promise.await(mongo.db.command({ serverStatus: 1 }));
-		mongoDbVersion = version;
-		mongoDbEngine = storageEngine.name;
-	} catch (e) {
-		mongoDbVersion = 'Error getting version';
-
-		console.error('=== Error getting MongoDB info ===');
-		console.error(e && e.toString());
-		console.error('----------------------------------');
-		console.error('Without mongodb version we can\'t ensure you are running a compatible version.');
-		console.error('If you are running your mongodb with auth enabled and an user different from admin');
-		console.error('you may need to grant permissions for this user to check cluster data.');
-		console.error('You can do it via mongo shell running the following command replacing');
-		console.error('the string YOUR_USER by the correct user\'s name:');
-		console.error('');
-		console.error('   db.runCommand({ grantRolesToUser: "YOUR_USER" , roles: [{role: "clusterMonitor", db: "admin"}]})');
-		console.error('');
-		console.error('==================================');
-	}
+	const { oplogEnabled, mongoVersion, mongoStorageEngine } = getMongoInfo();
 
 	const desiredNodeVersion = semver.clean(fs.readFileSync(path.join(process.cwd(), '../../.node_version.txt')).toString());
 	const desiredNodeVersionMajor = String(semver.parse(desiredNodeVersion).major);
@@ -42,12 +16,12 @@ Meteor.startup(function() {
 		let msg = [
 			`Rocket.Chat Version: ${ Info.version }`,
 			`     NodeJS Version: ${ process.versions.node } - ${ process.arch }`,
-			`    MongoDB Version: ${ mongoDbVersion }`,
-			`     MongoDB Engine: ${ mongoDbEngine }`,
+			`    MongoDB Version: ${ mongoVersion }`,
+			`     MongoDB Engine: ${ mongoStorageEngine }`,
 			`           Platform: ${ process.platform }`,
 			`       Process Port: ${ process.env.PORT }`,
 			`           Site URL: ${ settings.get('Site_Url') }`,
-			`   ReplicaSet OpLog: ${ isOplogEnabled ? 'Enabled' : 'Disabled' }`,
+			`   ReplicaSet OpLog: ${ oplogEnabled ? 'Enabled' : 'Disabled' }`,
 		];
 
 		if (Info.commit && Info.commit.hash) {
@@ -60,7 +34,7 @@ Meteor.startup(function() {
 
 		msg = msg.join('\n');
 
-		if (!isOplogEnabled) {
+		if (!oplogEnabled) {
 			msg += ['', '', 'OPLOG / REPLICASET IS REQUIRED TO RUN ROCKET.CHAT, MORE INFORMATION AT:', 'https://go.rocket.chat/i/oplog-required'].join('\n');
 			SystemLogger.error_box(msg, 'SERVER ERROR');
 
@@ -74,7 +48,7 @@ Meteor.startup(function() {
 			return process.exit(1);
 		}
 
-		if (!semver.satisfies(semver.coerce(mongoDbVersion), '>=3.2.0')) {
+		if (!semver.satisfies(semver.coerce(mongoVersion), '>=3.2.0')) {
 			msg += ['', '', 'YOUR CURRENT MONGODB VERSION IS NOT SUPPORTED,', 'PLEASE UPGRADE TO VERSION 3.2 OR LATER'].join('\n');
 			SystemLogger.error_box(msg, 'SERVER ERROR');
 


### PR DESCRIPTION
Falls back to old way and just sets engine to unknown if it can't get it.

cc @LuluGO this will help with helm chart once merged