### PR TITLE
[FIX] Wrong filter field when filtering current Livechats

### DIFF
--- a/app/livechat/server/publications/livechatRooms.js
+++ b/app/livechat/server/publications/livechatRooms.js
@@ -23,7 +23,7 @@ Meteor.publish('livechat:rooms', function(filter = {}, offset = 0, limit = 20) {
 
 	const query = {};
 	if (filter.name) {
-		query.label = new RegExp(filter.name, 'i');
+		query.fname = new RegExp(filter.name, 'i');
 	}
 	if (filter.agent) {
 		query['servedBy._id'] = filter.agent;


### PR DESCRIPTION
CLOSES #14395.

The `label` property is not used anymore in Livechat rooms. The right property to filter `rooms` by name is `fname`.