### PR TITLE
Fix: Add emoji shortnames to emoji's list

### DIFF
--- a/app/emoji-emojione/lib/rocketchat.js
+++ b/app/emoji-emojione/lib/rocketchat.js
@@ -190,6 +190,12 @@ for (const key in emojione.emojioneList) {
 		const currentEmoji = emojione.emojioneList[key];
 		currentEmoji.emojiPackage = 'emojione';
 		emoji.list[key] = currentEmoji;
+
+		if (currentEmoji.shortnames) {
+			currentEmoji.shortnames.forEach((shortname) => {
+				emoji.list[shortname] = currentEmoji;
+			});
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #14575

Some emojis where moved to `shortnames` instead of having their own item on the list, which makes sense but broke recent emoji's list for those who have one of those moved ones.