### PR TITLE
[FIX] Move the set Avatar call on user creation to make sure the user has username

### DIFF
--- a/server/lib/accounts.js
+++ b/server/lib/accounts.js
@@ -194,6 +194,20 @@ Accounts.insertUserDoc = _.wrap(Accounts.insertUserDoc, function(insertUserDoc, 
 				return callbacks.run('afterCreateUser', user);
 			});
 		}
+		if (settings.get('Accounts_SetDefaultAvatar') === true) {
+			const avatarSuggestions = getAvatarSuggestionForUser(user);
+			Object.keys(avatarSuggestions).some((service) => {
+				const avatarData = avatarSuggestions[service];
+				if (service !== 'gravatar') {
+					Meteor.runAsUser(_id, function() {
+						return Meteor.call('setAvatarFromService', avatarData.blob, '', service);
+					});
+					return true;
+				}
+
+				return false;
+			});
+		}
 	}
 
 	if (roles.length === 0) {
@@ -217,21 +231,6 @@ Accounts.insertUserDoc = _.wrap(Accounts.insertUserDoc, function(insertUserDoc, 
 	}
 
 	addUserRoles(_id, roles);
-
-	if (settings.get('Accounts_SetDefaultAvatar') === true) {
-		const avatarSuggestions = getAvatarSuggestionForUser(user);
-		Object.keys(avatarSuggestions).some((service) => {
-			const avatarData = avatarSuggestions[service];
-			if (service !== 'gravatar') {
-				Meteor.runAsUser(_id, function() {
-					return Meteor.call('setAvatarFromService', avatarData.blob, '', service);
-				});
-				return true;
-			}
-
-			return false;
-		});
-	}
 
 	return _id;
 });


### PR DESCRIPTION
Closes https://github.com/RocketChat/Rocket.Chat/issues/14637
Closes https://github.com/RocketChat/Rocket.Chat/issues/14755
We must the [`username` property to be able to set the user avatar](https://github.com/RocketChat/Rocket.Chat/blob/develop/app/file-upload/server/lib/FileUpload.js#L283). Otherwise we'll get an [error for trying to set the avatar name to `undefined`](https://github.com/RocketChat/Rocket.Chat/blob/develop/app/models/server/models/Avatars.js#L70). 
Previously this worked due to the fact that MongoDB accept `undefined` fields, behavior removed in [this PR](https://github.com/RocketChat/Rocket.Chat/pull/13586/files#diff-9c2d4074b56b688a6e8079932226d8a2L6).
