### PR TITLE
[FIX] "Discussions" item in "More" menu not hidden, when Discussions are disabled (#14684)

### DIFF
--- a/app/discussion/client/tabBar.js
+++ b/app/discussion/client/tabBar.js
@@ -1,6 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 
 import { TabBar } from '../../ui-utils/client';
+import { settings } from '../../settings';
 
 Meteor.startup(function() {
 	return TabBar.addButton({
@@ -10,5 +11,6 @@ Meteor.startup(function() {
 		icon: 'discussion',
 		template: 'discussionsTabbar',
 		order: 10,
+		condition: () => settings.get('Discussion_enabled'),
 	});
 });


### PR DESCRIPTION
"Discussions" item in "More" menu not hidden, when Discussions are disabled by Administrator
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #14684 

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
