### PR TITLE
[FIX] User Real Name being erased when not modified

### DIFF
--- a/app/lib/server/functions/saveUser.js
+++ b/app/lib/server/functions/saveUser.js
@@ -244,7 +244,9 @@ export const saveUser = function(userId, userData) {
 		setUsername(userData._id, userData.username);
 	}
 
-	setRealName(userData._id, userData.name);
+	if (userData.hasOwnProperty('name')) {
+		setRealName(userData._id, userData.name);
+	}
 
 	if (userData.email) {
 		const shouldSendVerificationEmailToUser = userData.verified !== true;


### PR DESCRIPTION
If your server is configured to not require user's real name and an admin modifies anything else on the user's data, the real name is being erased.