### PR TITLE
[NEW] Endpoint to anonymously read channel's messages

### DIFF
--- a/app/api/server/v1/channels.js
+++ b/app/api/server/v1/channels.js
@@ -1026,7 +1026,6 @@ API.v1.addRoute('channels.anonymousread', { authRequired: false }, {
 				method: 'channels.anonymousread',
 			});
 		}
-		
 
 		const cursor = Messages.find(ourQuery, {
 			sort: sort || { ts: -1 },

--- a/app/api/server/v1/channels.js
+++ b/app/api/server/v1/channels.js
@@ -5,6 +5,8 @@ import { Rooms, Subscriptions, Messages, Uploads, Integrations, Users } from '..
 import { hasPermission } from '../../../authorization';
 import { normalizeMessagesForUser } from '../../../utils/server/lib/normalizeMessagesForUser';
 import { API } from '../api';
+import { settings } from '../../../settings';
+
 
 // Returns the channel IF found otherwise it will return the failure of why it didn't. Check the `statusCode` property
 function findChannelByIdOrName({ params, checkedArchived = true, userId }) {
@@ -1005,5 +1007,42 @@ API.v1.addRoute('channels.removeLeader', { authRequired: true }, {
 		});
 
 		return API.v1.success();
+	},
+});
+
+API.v1.addRoute('channels.anonymousread', { authRequired: false }, {
+	get() {
+		const findResult = findChannelByIdOrName({
+			params: this.requestParams(),
+			checkedArchived: false,
+		});
+		const { offset, count } = this.getPaginationItems();
+		const { sort, fields, query } = this.parseJsonQuery();
+
+		const ourQuery = Object.assign({}, query, { rid: findResult._id });
+
+		if (!settings.get('Accounts_AllowAnonymousRead')) {
+			throw new Meteor.Error('error-not-allowed', 'Enable "Allow Anonymous Read"', {
+				method: 'channels.anonymousread',
+			});
+		}
+		
+
+		const cursor = Messages.find(ourQuery, {
+			sort: sort || { ts: -1 },
+			skip: offset,
+			limit: count,
+			fields,
+		});
+
+		const total = cursor.count();
+		const messages = cursor.fetch();
+
+		return API.v1.success({
+			messages: normalizeMessagesForUser(messages, this.userId),
+			count: messages.length,
+			offset,
+			total,
+		});
 	},
 });

--- a/tests/end-to-end/api/02-channels.js
+++ b/tests/end-to-end/api/02-channels.js
@@ -1154,6 +1154,7 @@ describe('[Channels]', function() {
 		});
 	});
 	describe('/channels.anonymousread', () => {
+		after(() => updateSetting('Accounts_AllowAnonymousRead', false));
 		it('should return an error when the setting "Accounts_AllowAnonymousRead" is disabled', (done) => {
 			updateSetting('Accounts_AllowAnonymousRead', false).then(() => {
 				request.get(api('channels.anonymousread'))


### PR DESCRIPTION
## Overview

This API Endpoint is made for RC Alexa and Google Action to allow Anonymous READ in VUI Devices without linking their accounts first to the Apps. This endpoint will enable access to messages in public channels, which are by definition public - and should be anonymous readable. In addition to that, this endpoint can be accessed by VUI user without any registration required. Also if admin has disabled anonymous read on his server, it won't work. So to summarise, after merging this API endpoint, we will be able to enable Alexa skill and Google Action to non-registered user if anonymous reading options are enabled on that server.

## Testing

* Enable `Allow Anonymous Read` inside **Administration -> Accounts**
* Now you can use this to get message anonymously
```
curl http://localhost:3000/api/v1/channels.anonymousread?roomName=general
```