### PR TITLE
[IMPROVE] Add new index to speed up the Livechat navigation history query's 

### DIFF
--- a/app/models/server/models/Messages.js
+++ b/app/models/server/models/Messages.js
@@ -31,6 +31,8 @@ export class Messages extends Base {
 		// threads
 		this.tryEnsureIndex({ tmid: 1 }, { sparse: true });
 		this.tryEnsureIndex({ tcount: 1, tlm: 1 }, { sparse: true });
+		// livechat
+		this.tryEnsureIndex({ 'navigation.token': 1 }, { sparse: true });
 	}
 
 	setReactions(messageId, reactions) {


### PR DESCRIPTION
CLOSES #14809.

When a new Livechat session starts we update the records(documents) related to the visitor navigation history because we track/store its navigation even when the visitor is not yet registered.
Due to that, we need to update those data, assigning the new `rid` related to the new livechat room, but we detected that there is a high latency happening during this process because there is not an `index` for the field -> `navigation.token`.