### PR TITLE
Regression: Fix desktop notifications not being sent

### DIFF
--- a/app/utils/lib/RoomTypeConfig.js
+++ b/app/utils/lib/RoomTypeConfig.js
@@ -1,11 +1,13 @@
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
 
-import { settings } from '../../settings';
-
 let Users;
+let settings;
 if (Meteor.isServer) {
+	({ settings } = require('../../settings/server'));
 	Users = require('../../models/server/models/Users').default;
+} else {
+	({ settings } = require('../../settings/client'));
 }
 
 export const RoomSettingsEnum = {


### PR DESCRIPTION
Turned out there was an issue when getting the setting value.

The error on production was:

```
=== UnHandledPromiseRejection ===
TypeError: Cannot read property 'get' of undefined
    at PublicRoomType.getNotificationDetails (app/utils/lib/RoomTypeConfig.js:261:29)
    at notifyDesktopUser (app/lib/server/functions/notifications/desktop.js:23:54)
    at Promise.asyncApply (app/lib/server/lib/sendNotificationsOnMessage.js:102:3)
    at /app/bundle/programs/server/npm/node_modules/meteor/promise/node_modules/meteor-promise/fiber_pool.js:43:40
---------------------------------
Errors like this can cause oplog processing errors.
Setting EXIT_UNHANDLEDPROMISEREJECTION will cause the process to exit allowing your service to automatically restart the process
Future node.js versions will automatically exit the process
=================================
=== UnHandledPromiseRejection ===
```