### PR TITLE
[FIX] SAML login by giving displayName priority over userName for fullName

### DIFF
--- a/app/meteor-accounts-saml/server/saml_server.js
+++ b/app/meteor-accounts-saml/server/saml_server.js
@@ -116,7 +116,7 @@ Accounts.registerLoginHandler(function(loginRequest) {
 		const emailRegex = new RegExp(emailList.map((email) => `^${ RegExp.escape(email) }$`).join('|'), 'i');
 
 		const eduPersonPrincipalName = loginResult.profile.eppn;
-		const fullName = loginResult.profile.cn || loginResult.profile.username || loginResult.profile.displayName;
+		const fullName = loginResult.profile.cn || loginResult.profile.displayName || loginResult.profile.username;
 
 		let eppnMatch = false;
 		let user = null;


### PR DESCRIPTION
Closes #14876
