### PR TITLE
[FIX] Not showing local app on App Details

### DIFF
--- a/app/apps/client/admin/appManage.js
+++ b/app/apps/client/admin/appManage.js
@@ -29,7 +29,7 @@ function getApps(instance) {
 			return Promise.resolve({ app: undefined });
 		})
 		.then((remote) => {
-			if (!remote.app.bundledIn || remote.app.bundledIn.length === 0) {
+			if (!remote.app || !remote.app.bundledIn || remote.app.bundledIn.length === 0) {
 				return remote;
 			}
 


### PR DESCRIPTION
Currently, when the App Details page sends a request to the marketplace to get the app data, it errors out when the marketplace can't find data for a local app (i.e. that is not published) and leaves with a blank page.

This PR fixes this behavior so that the App Details page keeps showing the content correctly even if the marketplace returns an error