### PR TITLE
[FIX] users.setStatus REST endpoint not allowing reset status message

### DIFF
--- a/app/api/server/v1/users.js
+++ b/app/api/server/v1/users.js
@@ -369,7 +369,7 @@ API.v1.addRoute('users.setStatus', { authRequired: true }, {
 		}
 
 		Meteor.runAsUser(user._id, () => {
-			if (this.bodyParams.message) {
+			if (this.bodyParams.message || this.bodyParams.message.length === 0) {
 				setStatusText(user._id, this.bodyParams.message);
 			}
 			if (this.bodyParams.status) {


### PR DESCRIPTION
Not being able to send an empty string means the message cannot go back to the regular "online", "away", etc.