### PR TITLE
[FIX] login via GitLab

### DIFF
--- a/app/gitlab/lib/common.js
+++ b/app/gitlab/lib/common.js
@@ -6,8 +6,9 @@ import { CustomOAuth } from '../../custom-oauth';
 
 const config = {
 	serverURL: 'https://gitlab.com',
-	identityPath: '/api/v3/user',
+	identityPath: '/api/v4/user',
 	scope: 'read_user',
+	mergeUsers: true,
 	addAutopublishFields: {
 		forLoggedInUser: ['services.gitlab'],
 		forOtherUsers: ['services.gitlab.username'],


### PR DESCRIPTION
* Update identityPath as API v3 was removed from Gitlab 11
* Enable mergeUsers

Closes #14307

API v3 removal: https://gitlab.com/gitlab-org/gitlab-ce/issues/36819
Without enabling mergeUsers we experience issues where users can no longer login, `User with username xyz already exists`