### PR TITLE
[NEW] Adding Subscribed Channelnames Endpoint

### DIFF
--- a/app/api/server/v1/subscriptions.js
+++ b/app/api/server/v1/subscriptions.js
@@ -49,14 +49,13 @@ API.v1.addRoute('subscriptions.getOne', { authRequired: true }, {
 
 API.v1.addRoute('subscriptions.channelnames', { authRequired: true }, {
 	get() {
-		
 		let result;
 		Meteor.runAsUser(this.userId, () => { result = Meteor.call('subscriptions/get'); });
-		let subscribedChannels = result.map(item => item.name);
+		const subscribedChannels = result.map((item) => item.name);
 
 		if (Array.isArray(subscribedChannels)) {
 			result = {
-				channelnames: subscribedChannels
+				channelnames: subscribedChannels,
 			};
 		}
 
@@ -66,7 +65,6 @@ API.v1.addRoute('subscriptions.channelnames', { authRequired: true }, {
 
 /**
 	This API is suppose to mark any room as read.
-
 	Method: POST
 	Route: api/v1/subscriptions.read
 	Params:

--- a/app/api/server/v1/subscriptions.js
+++ b/app/api/server/v1/subscriptions.js
@@ -47,6 +47,23 @@ API.v1.addRoute('subscriptions.getOne', { authRequired: true }, {
 	},
 });
 
+API.v1.addRoute('subscriptions.channelnames', { authRequired: true }, {
+	get() {
+		
+		let result;
+		Meteor.runAsUser(this.userId, () => { result = Meteor.call('subscriptions/get'); });
+		let subscribedChannels = result.map(item => item.name);
+
+		if (Array.isArray(subscribedChannels)) {
+			result = {
+				channelnames: subscribedChannels
+			};
+		}
+
+		return API.v1.success(result);
+	},
+});
+
 /**
 	This API is suppose to mark any room as read.
 

--- a/tests/end-to-end/api/10-subscriptions.js
+++ b/tests/end-to-end/api/10-subscriptions.js
@@ -61,6 +61,18 @@ describe('[Subscriptions]', function() {
 				.end(done);
 		});
 	});
+	
+	it('/subscriptions.channelnames', (done) => {
+		request.get(api('subscriptions.channelnames'))
+			.set(credentials)
+			.expect('Content-Type', 'application/json')
+			.expect(200)
+			.expect((res) => {
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('channelnames');
+			})
+			.end(done);
+	});
 
 	describe('[/subscriptions.read]', () => {
 		it('should mark public channels as read', (done) => {

--- a/tests/end-to-end/api/10-subscriptions.js
+++ b/tests/end-to-end/api/10-subscriptions.js
@@ -61,7 +61,7 @@ describe('[Subscriptions]', function() {
 				.end(done);
 		});
 	});
-	
+
 	it('/subscriptions.channelnames', (done) => {
 		request.get(api('subscriptions.channelnames'))
 			.set(credentials)


### PR DESCRIPTION
# Overview

This API Endpoint is made for RC Alexa Skill. It will enable us to get a list of user subscribed channelnames which then will be used as training data for Dynamic Entities model.

# Testing

Please use the following command:

```
curl -H "X-Auth-Token: SOaK-yce2F1OGaWlBNROrHzV14yU5Rtc_2gHqR0SRIH" \
     -H "X-User-Id: Gnrknohj5kRRjTqco" \
     -H "Content-type: application/json" \
     http://localhost:3000/api/v1/subscriptions.channelnames
```