### PR TITLE
[FIX] Threads contextual bar button visible even with threads disabled

### DIFF
--- a/app/ui-flextab/client/flexTabBar.js
+++ b/app/ui-flextab/client/flexTabBar.js
@@ -8,6 +8,7 @@ import _ from 'underscore';
 import { hasAllPermission } from '../../authorization';
 import { popover, TabBar, Layout } from '../../ui-utils';
 import { t } from '../../utils';
+import { settings } from '../../settings';
 
 const commonHelpers = {
 	title() {
@@ -53,6 +54,9 @@ const filterButtons = (button, anonymous, rid) => {
 		return false;
 	}
 	if (button.id === 'addUsers' && !canShowAddUsersButton(rid)) {
+		return false;
+	}
+	if (button.id === 'thread' && !settings.get('Threads_enabled')) {
 		return false;
 	}
 	return true;

--- a/app/ui-flextab/client/tabs/inviteUsers.js
+++ b/app/ui-flextab/client/tabs/inviteUsers.js
@@ -138,9 +138,7 @@ Template.inviteUsers.onCreated(function() {
 	this.ac = new AutoComplete({
 		selector: {
 			item: '.rc-popup-list__item',
-			container: '.rc-popup-list__list',
 		},
-		position: 'fixed',
 		limit: 10,
 		inputDelay: 300,
 		rules: [{

--- a/app/ui-flextab/client/tabs/inviteUsers.js
+++ b/app/ui-flextab/client/tabs/inviteUsers.js
@@ -138,7 +138,9 @@ Template.inviteUsers.onCreated(function() {
 	this.ac = new AutoComplete({
 		selector: {
 			item: '.rc-popup-list__item',
+			container: '.rc-popup-list__list',
 		},
+		position: 'fixed',
 		limit: 10,
 		inputDelay: 300,
 		rules: [{


### PR DESCRIPTION
Closes #14796
This change hides the Threads button when threads are disabled.
