### PR TITLE
[IMPROVE] Remove too specific helpers isFirefox() and isChrome()

### DIFF
--- a/app/ui/client/components/icon.js
+++ b/app/ui/client/components/icon.js
@@ -1,10 +1,23 @@
 import { FlowRouter } from 'meteor/kadira:flow-router';
 import { Template } from 'meteor/templating';
 
-import { isChrome, isFirefox } from '../../../utils';
+import './icon.html';
+
 
 const baseUrlFix = () => `${ document.baseURI }${ FlowRouter.current().path.substring(1) }`;
 
+const isMozillaFirefoxBelowVersion = (upperVersion) => {
+	const [, version] = navigator.userAgent.match(/Firefox\/(\d+)\.\d/) || [];
+	return parseInt(version, 10) < upperVersion;
+};
+
+const isGoogleChromeBelowVersion = (upperVersion) => {
+	const [, version] = navigator.userAgent.match(/Chrome\/(\d+)\.\d/) || [];
+	return parseInt(version, 10) < upperVersion;
+};
+
+const isBaseUrlFixNeeded = () => isMozillaFirefoxBelowVersion(55) || isGoogleChromeBelowVersion(55);
+
 Template.icon.helpers({
-	baseUrl: (isFirefox && isFirefox[1] < 55) || (isChrome && isChrome[1] < 55) ? baseUrlFix : undefined,
+	baseUrl: isBaseUrlFixNeeded() ? baseUrlFix : undefined,
 });

--- a/app/ui/client/index.js
+++ b/app/ui/client/index.js
@@ -44,7 +44,6 @@ import './views/app/secretURL';
 import './views/app/videoCall/videoButtons';
 import './views/app/videoCall/videoCall';
 import './views/app/photoswipe';
-import './components/icon.html';
 import './components/icon';
 import './components/table.html';
 import './components/table';

--- a/app/utils/client/index.js
+++ b/app/utils/client/index.js
@@ -1,5 +1,4 @@
 export { t, isRtl } from '../lib/tapi18n';
-export { isChrome, isFirefox } from './lib/browsers';
 export { getDefaultSubscriptionPref } from '../lib/getDefaultSubscriptionPref';
 export { Info } from '../rocketchat.info';
 export { isEmail } from '../lib/isEmail';

--- a/app/utils/client/lib/browsers.js
+++ b/app/utils/client/lib/browsers.js
@@ -1,2 +1,0 @@
-export const isFirefox = navigator.userAgent.match(/Firefox\/(\d+)\.\d/);
-export const isChrome = navigator.userAgent.match(/Chrome\/(\d+)\.\d/);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "Rocket.Chat",
-	"version": "1.2.0-develop",
+	"version": "1.3.0-develop",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
Since those helpers are specific to solve bugs related to SVG XLink on `icon` template, there is no need to make them global. Also, it discourages using browser hacks.