### PR TITLE
[FIX] Allow storing the navigation history of unregistered Livechat visitors

### DIFF
--- a/app/livechat/server/api/v1/pageVisited.js
+++ b/app/livechat/server/api/v1/pageVisited.js
@@ -1,9 +1,7 @@
-import { Meteor } from 'meteor/meteor';
 import { Match, check } from 'meteor/check';
 import _ from 'underscore';
 
 import { API } from '../../../../api';
-import { findGuest, findRoom } from '../lib/livechat';
 import { Livechat } from '../../lib/Livechat';
 
 API.v1.addRoute('livechat/page.visited', {

--- a/app/livechat/server/api/v1/pageVisited.js
+++ b/app/livechat/server/api/v1/pageVisited.js
@@ -11,7 +11,7 @@ API.v1.addRoute('livechat/page.visited', {
 		try {
 			check(this.bodyParams, {
 				token: String,
-				rid: String,
+				rid: Match.Maybe(String),
 				pageInfo: Match.ObjectIncluding({
 					change: String,
 					title: String,
@@ -22,17 +22,6 @@ API.v1.addRoute('livechat/page.visited', {
 			});
 
 			const { token, rid, pageInfo } = this.bodyParams;
-
-			const guest = findGuest(token);
-			if (!guest) {
-				throw new Meteor.Error('invalid-token');
-			}
-
-			const room = findRoom(token, rid);
-			if (!room) {
-				throw new Meteor.Error('invalid-room');
-			}
-
 			const obj = Livechat.savePageHistory(token, rid, pageInfo);
 			if (obj) {
 				const page = _.pick(obj, 'msg', 'navigation');


### PR DESCRIPTION
This PR implements the same behavior we had on the old Livechat widget.
We need to store the visitor's navigation history even if they are not yet registered, so we can't verify that the visitor or room exists before calling the Livechat related method.