### PR TITLE
[IMPROVE] Extract federation config to its own file

### DIFF
--- a/app/federation/server/PeerServer/routes/events.js
+++ b/app/federation/server/PeerServer/routes/events.js
@@ -4,7 +4,7 @@ import { API } from '../../../../api';
 import { FederationKeys } from '../../../../models';
 import { Federation } from '../..';
 
-const routeMethods = {
+API.v1.addRoute('federation.events', { authRequired: false }, {
 	post() {
 		if (!Federation.peerServer.enabled) {
 			return API.v1.failure('Not found');
@@ -112,8 +112,4 @@ const routeMethods = {
 			return API.v1.failure(`Error handling event:${ e.t } - ${ err.toString() }`, err.error || 'unknown-error');
 		}
 	},
-};
-
-Meteor.startup(() => {
-	API.v1.addRoute('federation.events', { authRequired: false }, routeMethods);
 });

--- a/app/federation/server/PeerServer/routes/uploads.js
+++ b/app/federation/server/PeerServer/routes/uploads.js
@@ -5,7 +5,7 @@ import { Uploads } from '../../../../models';
 import { FileUpload } from '../../../../file-upload';
 import { Federation } from '../..';
 
-const routeMethods = {
+API.v1.addRoute('federation.uploads', { authRequired: false }, {
 	get() {
 		if (!Federation.peerServer.enabled) {
 			return API.v1.failure('Not found');
@@ -25,8 +25,4 @@ const routeMethods = {
 
 		return API.v1.success({ upload, buffer });
 	},
-};
-
-Meteor.startup(() => {
-	API.v1.addRoute('federation.uploads', { authRequired: false }, routeMethods);
 });

--- a/app/federation/server/PeerServer/routes/users.js
+++ b/app/federation/server/PeerServer/routes/users.js
@@ -1,11 +1,9 @@
-import { Meteor } from 'meteor/meteor';
-
 import { API } from '../../../../api';
 import { Users } from '../../../../models';
 import { FederatedUser } from '../../federatedResources';
 import { Federation } from '../..';
 
-const routeMethods = {
+API.v1.addRoute('federation.users', { authRequired: false }, {
 	get() {
 		if (!Federation.peerServer.enabled) {
 			return API.v1.failure('Not found');
@@ -47,8 +45,4 @@ const routeMethods = {
 
 		return API.v1.success({ federatedUsers });
 	},
-};
-
-Meteor.startup(() => {
-	API.v1.addRoute('federation.users', { authRequired: false }, routeMethods);
 });

--- a/app/federation/server/config.js
+++ b/app/federation/server/config.js
@@ -1,0 +1,74 @@
+import mem from 'mem';
+
+import { getWorkspaceAccessToken } from '../../cloud/server';
+import { FederationKeys } from '../../models/server';
+import { settings } from '../../settings/server';
+import * as SettingsUpdater from './settingsUpdater';
+import { logger } from './logger';
+
+const defaultConfig = {
+	hub: {
+		active: null,
+		url: null,
+	},
+	peer: {
+		uniqueId: null,
+		domain: null,
+		url: null,
+		public_key: null,
+	},
+	cloud: {
+		token: null,
+	},
+};
+
+const getConfigLocal = () => {
+	const _enabled = settings.get('FEDERATION_Enabled');
+
+	if (!_enabled) { return defaultConfig; }
+
+	// If it is enabled, check if the settings are there
+	const _uniqueId = settings.get('FEDERATION_Unique_Id');
+	const _domain = settings.get('FEDERATION_Domain');
+	const _discoveryMethod = settings.get('FEDERATION_Discovery_Method');
+	const _hubUrl = settings.get('FEDERATION_Hub_URL');
+	const _peerUrl = settings.get('Site_Url');
+
+	if (!_domain || !_discoveryMethod || !_hubUrl || !_peerUrl) {
+		SettingsUpdater.updateStatus('Could not enable, settings are not fully set');
+
+		logger.setup.error('Could not enable Federation, settings are not fully set');
+
+		return defaultConfig;
+	}
+
+	logger.setup.info('Updating settings...');
+
+	// Normalize the config values
+	return {
+		hub: {
+			active: _discoveryMethod === 'hub',
+			url: _hubUrl.replace(/\/+$/, ''),
+		},
+		peer: {
+			uniqueId: _uniqueId,
+			domain: _domain.replace('@', '').trim(),
+			url: _peerUrl.replace(/\/+$/, ''),
+			public_key: FederationKeys.getPublicKeyString(),
+		},
+		cloud: {
+			token: getWorkspaceAccessToken(),
+		},
+	};
+};
+
+export const getConfig = mem(getConfigLocal);
+
+const updateValue = () => mem.clear(getConfig);
+
+settings.get('FEDERATION_Enabled', updateValue);
+settings.get('FEDERATION_Unique_Id', updateValue);
+settings.get('FEDERATION_Domain', updateValue);
+settings.get('FEDERATION_Status', updateValue);
+settings.get('FEDERATION_Discovery_Method', updateValue);
+settings.get('FEDERATION_Hub_URL', updateValue);

--- a/app/federation/server/index.js
+++ b/app/federation/server/index.js
@@ -13,9 +13,9 @@ import './methods/dashboard';
 import { addUser } from './methods/addUser';
 import { searchUsers } from './methods/searchUsers';
 import { ping } from './methods/ping';
-import { getWorkspaceAccessToken } from '../../cloud/server';
 import { FederationKeys } from '../../models';
 import { settings } from '../../settings';
+import { getConfig } from './config';
 
 const peerClient = new PeerClient();
 const peerDNS = new PeerDNS();
@@ -73,39 +73,7 @@ const updateSettings = _.debounce(Meteor.bindEnvironment(function() {
 
 	if (!_enabled) { return; }
 
-	// If it is enabled, check if the settings are there
-	const _uniqueId = settings.get('FEDERATION_Unique_Id');
-	const _domain = settings.get('FEDERATION_Domain');
-	const _discoveryMethod = settings.get('FEDERATION_Discovery_Method');
-	const _hubUrl = settings.get('FEDERATION_Hub_URL');
-	const _peerUrl = settings.get('Site_Url');
-
-	if (!_domain || !_discoveryMethod || !_hubUrl || !_peerUrl) {
-		SettingsUpdater.updateStatus('Could not enable, settings are not fully set');
-
-		logger.setup.error('Could not enable Federation, settings are not fully set');
-
-		return;
-	}
-
-	logger.setup.info('Updating settings...');
-
-	// Normalize the config values
-	const config = {
-		hub: {
-			active: _discoveryMethod === 'hub',
-			url: _hubUrl.replace(/\/+$/, ''),
-		},
-		peer: {
-			uniqueId: _uniqueId,
-			domain: _domain.replace('@', '').trim(),
-			url: _peerUrl.replace(/\/+$/, ''),
-			public_key: FederationKeys.getPublicKeyString(),
-		},
-		cloud: {
-			token: getWorkspaceAccessToken(),
-		},
-	};
+	const config = getConfig();
 
 	// If the settings are correctly set, let's update the configuration
 


### PR DESCRIPTION
This PR changes the improvements from #14972 to better organize the code, keeping the standards adopted in the code base regarding route definitions for the REST APIs.

With the changes implemented in this PR, whenever someone needs to know only the config for the Federation module, they'll be able to include only the file that exports those configs.

Thanks @sampaiodiego for the help with this 🤗 