### PR TITLE
[FIX] CustomOauth Identity Step errors displayed in HTML format

### DIFF
--- a/app/custom-oauth/server/custom_oauth_server.js
+++ b/app/custom-oauth/server/custom_oauth_server.js
@@ -151,6 +151,7 @@ export class CustomOAuth {
 		const params = {};
 		const headers = {
 			'User-Agent': this.userAgent, // http://doc.gitlab.com/ce/api/users.html#Current-user
+			Accept: 'application/json',
 		};
 
 		if (this.identityTokenSentVia === 'header') {


### PR DESCRIPTION
For the identity step, Rocket.Chat is not asking for a JSON response. This is not a problem in case of success (as the user is redirected and the result doesn't matter), but in case of failure it generates a hard to read log.

This may the fix needed on #13331 as well.

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
