### PR TITLE
[NEW] Deprecate MongoDB version 3.2

### DIFF
--- a/app/logger/server/server.js
+++ b/app/logger/server/server.js
@@ -87,6 +87,11 @@ const defaultTypes = {
 		color: 'red',
 		level: 0,
 	},
+	deprecation: {
+		name: 'warn',
+		color: 'magenta',
+		level: 0,
+	},
 };
 
 class _Logger {

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -2091,6 +2091,8 @@
   "Monday": "Monday",
   "Mongo_version": "Mongo Version",
   "Mongo_storageEngine": "Mongo Storage Engine",
+  "MongoDB_Deprecated": "MongoDB Deprecated",
+  "MongoDB_version_s_is_deprecated_please_upgrade_your_installation": "MongoDB version %s is deprecated, please upgrade your installation.",
   "Monitor_history_for_changes_on": "Monitor History for Changes on",
   "More": "More",
   "More_channels": "More channels",


### PR DESCRIPTION
Support for MongoDB 3.2 will be removed on version 2.0 scheduled for October 2019.

The deprecation warning will be shown at:
- Logs in a box just after `SERVER RUNNING`
- Top banner for admins
- Direct message from Rocket.Cat to admins