### PR TITLE
Regression: Framework version being attached to a request that doesn't require it

### DIFF
--- a/app/apps/server/communication/rest.js
+++ b/app/apps/server/communication/rest.js
@@ -264,7 +264,7 @@ export class AppsRestApi {
 				if (this.queryParams.marketplace && this.queryParams.version) {
 					const baseUrl = orchestrator.getMarketplaceUrl();
 
-					const headers = getDefaultHeaders();
+					const headers = {}; // DO NOT ATTACH THE FRAMEWORK/ENGINE VERSION HERE.
 					const token = getWorkspaceAccessToken();
 					if (token) {
 						headers.Authorization = `Bearer ${ token }`;


### PR DESCRIPTION
When you visit an App's details page from the Marketplace it will request the versions from the marketplace to get more information about the App. This commit broke how it works and so this is a regression fix. https://github.com/RocketChat/Rocket.Chat/blame/develop/app/apps/server/communication/rest.js#L267