### PR TITLE
[FIX] Converted mongodb deploymentconfig to statefullset to support mongodb replicaset

### DIFF
--- a/.openshift/rocket-chat-persistent.json
+++ b/.openshift/rocket-chat-persistent.json
@@ -1,470 +1,474 @@
 {
-    "kind": "Template",
-    "apiVersion": "v1",
-    "metadata": {
-        "name": "rocket-chat",
-        "annotations": {
-            "description": "Rocket.Chat with a MongoDB database running with a Persistent storage. Use this template if you want to run Rocket.Chat in production.",
-            "tags": "quickstart,nodejs,mongodb,instant-app",
-            "iconClass": "icon-nodejs"
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "rocket-chat",
+    "annotations": {
+      "description": "Rocket.Chat with a MongoDB database running with a Persistent storage. Use this template if you want to run Rocket.Chat in production.",
+      "tags": "quickstart,nodejs,mongodb,instant-app",
+      "iconClass": "icon-nodejs"
+    }
+  },
+  "objects": [
+    {
+      "kind": "StatefulSet",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "${MONGODB_SERVICE_NAME}",
+        "labels": {
+          "template": "mongodb-persistent-template"
         }
-    },
-    "objects": [
-        {
-            "kind": "PersistentVolumeClaim",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "${DATABASE_SERVICE_NAME}"
-            },
-            "spec": {
-                "accessModes": [
-                    "ReadWriteOnce"
+      },
+      "spec": {
+        "selector": {
+          "matchLabels": {
+            "name": "${MONGODB_SERVICE_NAME}"
+          }
+        },
+        "serviceName": "${MONGODB_SERVICE_NAME}",
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "${MONGODB_SERVICE_NAME}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "mongo-container",
+                "image": "centos/mongodb-32-centos7",
+                "ports": [
+                  {
+                    "containerPort": 27017
+                  }
+                ],
+                "args": [
+                  "run-mongod-pet"
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "mongo-data",
+                    "mountPath": "/var/lib/mongodb/data"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "MONGODB_USER",
+                    "value": "${MONGODB_USER}"
+                  },
+                  {
+                    "name": "MONGODB_PASSWORD",
+                    "value": "${MONGODB_PASSWORD}"
+                  },
+                  {
+                    "name": "MONGODB_DATABASE",
+                    "value": "${MONGODB_DATABASE}"
+                  },
+                  {
+                    "name": "MONGODB_ADMIN_PASSWORD",
+                    "value": "${MONGODB_ADMIN_PASSWORD}"
+                  },
+                  {
+                    "name": "MONGODB_REPLICA_NAME",
+                    "value": "${MONGODB_REPLICA_NAME}"
+                  },
+                  {
+                    "name": "MONGODB_KEYFILE_VALUE",
+                    "value": "${MONGODB_KEYFILE_VALUE}"
+                  },
+                  {
+                    "name": "MONGODB_SERVICE_NAME",
+                    "value": "${MONGODB_SERVICE_NAME}"
+                  }
                 ],
                 "resources": {
-                    "requests": {
-                        "storage": "${VOLUME_CAPACITY}"
-                    }
+                  "limits": {
+                    "memory": "${MEMORY_LIMIT}"
+                  }
+                },
+                "readinessProbe": {
+                  "exec": {
+                    "command": [
+                      "stat",
+                      "/tmp/initialized"
+                    ]
+                  }
                 }
+              }
+            ]
+          }
+        },
+        "volumeClaimTemplates": [
+          {
+            "metadata": {
+              "name": "mongo-data"
+            },
+            "spec": {
+              "accessModes": [
+                "ReadWriteOnce"
+              ],
+              "resources": {
+                "requests": {
+                  "storage": "${VOLUME_CAPACITY}"
+                }
+              }
             }
-        },
-        {
-            "kind": "DeploymentConfig",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "mongodb",
-                "labels": {
-                    "template": "mongodb-persistent-template"
-                }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "rocketchat"
+      },
+      "spec": {
+        "dockerImageRepository": "${ROCKETCHAT_IMAGE}",
+        "tags": [
+          {
+            "name": "latest",
+            "annotations": {
+              "description": "Provides a Rocket.Chat application",
+              "iconClass": "icon-nodejs",
+              "tags": "rocketchat"
             },
-            "spec": {
-                "strategy": {
-                    "type": "Recreate",
-                    "recreateParams": {
-                        "timeoutSeconds": 600
-                    }
-                },
-                "triggers": [
-                    {
-                        "type": "ImageChange",
-                        "imageChangeParams": {
-                            "automatic": true,
-                            "containerNames": [
-                                "mongodb"
-                            ],
-                            "from": {
-                                "kind": "ImageStreamTag",
-                                "namespace": "openshift",
-                                "name": "mongodb:latest"
-                            }
-                        }
-                    },
-                    {
-                        "type": "ConfigChange"
-                    }
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "latest"
+            },
+            "generation": 1,
+            "importPolicy": {
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "rocketchat",
+        "creationTimestamp": null,
+        "labels": {
+          "app": "rocketchat"
+        },
+        "annotations": {
+          "openshift.io/generated-by": "OpenShiftNewApp"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "type": "Rolling",
+          "rollingParams": {
+            "updatePeriodSeconds": 1,
+            "intervalSeconds": 1,
+            "timeoutSeconds": 600,
+            "maxUnavailable": "25%",
+            "maxSurge": "25%"
+          },
+          "resources": {
+          }
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "rocketchat"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "rocketchat:latest"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "app": "rocketchat",
+          "deploymentconfig": "rocketchat"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "app": "rocketchat",
+              "deploymentconfig": "rocketchat"
+            },
+            "annotations": {
+              "openshift.io/container.rocketchat.image.entrypoint": "[\"node\",\"main.js\"]",
+              "openshift.io/generated-by": "OpenShiftNewApp"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "rocketchat-volume-1",
+                "emptyDir": {
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "rocketchat",
+                "image": "${ROCKETCHAT_IMAGE}:latest",
+                "ports": [
+                  {
+                    "containerPort": 3000,
+                    "protocol": "TCP"
+                  }
                 ],
-                "replicas": 1,
-                "test": false,
-                "selector": {
-                    "name": "mongodb"
+                "env": [
+                  {
+                    "name": "MONGO_URL",
+                    "value": "mongodb://${MONGODB_USER}:${MONGODB_PASSWORD}@mongodb:27017/${MONGODB_DATABASE}?replicaSet=${MONGODB_REPLICA_NAME}"
+                  },
+                  {
+                    "name": "MONGO_OPLOG_URL",
+                    "value": "mongodb://${MONGODB_USER}:${MONGODB_PASSWORD}@mongodb:27017/local?authSource=${MONGODB_DATABASE}?replicaSet=${MONGODB_REPLICA_NAME}"
+                  }
+                ],
+                "resources": {
                 },
-                "template": {
-                    "metadata": {
-                        "creationTimestamp": null,
-                        "labels": {
-                            "name": "mongodb"
-                        }
-                    },
-                    "spec": {
-                        "containers": [
-                            {
-                                "name": "mongodb",
-                                "image": "registry.access.redhat.com/rhscl/mongodb-26-rhel7:latest",
-                                "ports": [
-                                    {
-                                        "containerPort": 27017,
-                                        "protocol": "TCP"
-                                    }
-                                ],
-                                "env": [
-                                    {
-                                        "name": "MONGODB_USER",
-                                        "value": "${MONGODB_USER}"
-                                    },
-                                    {
-                                        "name": "MONGODB_PASSWORD",
-                                        "value": "${MONGODB_PASSWORD}"
-                                    },
-                                    {
-                                        "name": "MONGODB_DATABASE",
-                                        "value": "${MONGODB_DATABASE}"
-                                    },
-                                    {
-                                        "name": "MONGODB_ADMIN_PASSWORD",
-                                        "value": "${MONGODB_ADMIN_PASSWORD}"
-                                    }
-                                ],
-                                "resources": {
-                                    "limits": {
-                                        "memory": "${MEMORY_LIMIT}"
-                                    }
-                                },
-                                "volumeMounts": [
-                                    {
-                                        "name": "mongodb-data",
-                                        "mountPath": "/var/lib/mongodb/data"
-                                    }
-                                ],
-                                "livenessProbe": {
-                                    "tcpSocket": {
-                                        "port": 27017
-                                    },
-                                    "initialDelaySeconds": 30,
-                                    "timeoutSeconds": 1,
-                                    "periodSeconds": 10,
-                                    "successThreshold": 1,
-                                    "failureThreshold": 3
-                                },
-                                "readinessProbe": {
-                                    "exec": {
-                                        "command": [
-                                            "/bin/sh",
-                                            "-i",
-                                            "-c",
-                                            "mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD --eval=\"quit()\""
-                                        ]
-                                    },
-                                    "initialDelaySeconds": 3,
-                                    "timeoutSeconds": 1,
-                                    "periodSeconds": 10,
-                                    "successThreshold": 1,
-                                    "failureThreshold": 3
-                                },
-                                "terminationMessagePath": "/dev/termination-log",
-                                "imagePullPolicy": "IfNotPresent",
-                                "securityContext": {
-                                    "capabilities": {},
-                                    "privileged": false
-                                }
-                            }
-                        ],
-                        "volumes": [
-                            {
-                                "name": "${DATABASE_SERVICE_NAME}-data",
-                                "persistentVolumeClaim": {
-                                    "claimName": "${DATABASE_SERVICE_NAME}"
-                                }
-                            }
-                        ],
-                        "restartPolicy": "Always",
-                        "terminationGracePeriodSeconds": 30,
-                        "dnsPolicy": "ClusterFirst",
-                        "securityContext": {}
-                    }
-                }
-            },
-            "status": {}
-        },
-        {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "rocketchat"
-            },
-            "spec": {
-                "dockerImageRepository": "${ROCKETCHAT_IMAGE}",
-                "tags": [
-                    {
-                        "name": "latest",
-                        "annotations": {
-                            "description": "Provides a Rocket.Chat application",
-                            "iconClass": "icon-nodejs",
-                            "tags": "rocketchat"
-                        },
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "latest"
-                        },
-                        "generation": 1,
-                        "importPolicy": {}
-                    }
+                "volumeMounts": [
+                  {
+                    "name": "rocketchat-volume-1",
+                    "mountPath": "/app/uploads"
+                  }
+                ],
+                "readinessProbe": {
+                  "httpGet": {
+                    "path": "/api/v1/info",
+                    "port": 3000,
+                    "scheme": "HTTP"
+                  },
+                  "initialDelaySeconds": 5,
+                  "timeoutSeconds": 1,
+                  "periodSeconds": 10,
+                  "successThreshold": 1,
+                  "failureThreshold": 3
+                },
+                "livenessProbe": {
+                  "httpGet": {
+                    "path": "/api/v1/info",
+                    "port": 3000,
+                    "scheme": "HTTP"
+                  },
+                  "initialDelaySeconds": 30,
+                  "timeoutSeconds": 1,
+                  "periodSeconds": 10,
+                  "successThreshold": 1,
+                  "failureThreshold": 3
+                },
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "Always"
+              }
+            ],
+            "restartPolicy": "Always",
+            "initContainers": [
+              {
+                "name": "init",
+                "image": "centos/mongodb-32-centos7",
+                "command": [
+                  "/bin/bash",
+                  "-c"
+                ],
+                "args": [
+                  "echo \"db = db.getSiblingDB('${MONGODB_DATABASE}')\" > /opt/app-root/src/permissions.js && echo \"db.grantRolesToUser('${MONGODB_USER}', [ 'readWrite' , { role: 'readWrite', db: 'local' } ])\" >> /opt/app-root/src/permissions.js && cat /opt/app-root/src/permissions.js && mongo --host ${MONGODB_SERVICE_NAME}:27017 -u admin -p ${MONGODB_ADMIN_PASSWORD} admin  < /opt/app-root/src/permissions.js"
                 ]
+              }
+            ],
+            "terminationGracePeriodSeconds": 30,
+            "dnsPolicy": "ClusterFirst",
+            "securityContext": {
             }
-        },
-        {
-            "kind": "DeploymentConfig",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "rocketchat",
-                "creationTimestamp": null,
-                "labels": {
-                    "app": "rocketchat"
-                },
-                "annotations": {
-                    "openshift.io/generated-by": "OpenShiftNewApp"
-                }
-            },
-            "spec": {
-                "strategy": {
-                    "type": "Rolling",
-                    "rollingParams": {
-                        "updatePeriodSeconds": 1,
-                        "intervalSeconds": 1,
-                        "timeoutSeconds": 600,
-                        "maxUnavailable": "25%",
-                        "maxSurge": "25%"
-                    },
-                    "resources": {}
-                },
-                "triggers": [
-                    {
-                        "type": "ConfigChange"
-                    },
-                    {
-                        "type": "ImageChange",
-                        "imageChangeParams": {
-                            "automatic": true,
-                            "containerNames": [
-                                "rocketchat"
-                            ],
-                            "from": {
-                                "kind": "ImageStreamTag",
-                                "name": "rocketchat:latest"
-                            }
-                        }
-                    }
-                ],
-                "replicas": 1,
-                "test": false,
-                "selector": {
-                    "app": "rocketchat",
-                    "deploymentconfig": "rocketchat"
-                },
-                "template": {
-                    "metadata": {
-                        "creationTimestamp": null,
-                        "labels": {
-                            "app": "rocketchat",
-                            "deploymentconfig": "rocketchat"
-                        },
-                        "annotations": {
-                            "openshift.io/container.rocketchat.image.entrypoint": "[\"node\",\"main.js\"]",
-                            "openshift.io/generated-by": "OpenShiftNewApp"
-                        }
-                    },
-                    "spec": {
-                        "volumes": [
-                            {
-                                "name": "rocketchat-volume-1",
-                                "emptyDir": {}
-                            }
-                        ],
-                        "containers": [
-                            {
-                                "name": "rocketchat",
-                                "image": "${ROCKETCHAT_IMAGE}:latest",
-                                "ports": [
-                                    {
-                                        "containerPort": 3000,
-                                        "protocol": "TCP"
-                                    }
-                                ],
-                                "env": [
-                                    {
-                                        "name": "MONGO_URL",
-                                        "value": "mongodb://${MONGODB_USER}:${MONGODB_PASSWORD}@mongodb:27017/${MONGODB_DATABASE}"
-                                    }
-                                ],
-                                "resources": {},
-                                "volumeMounts": [
-                                    {
-                                        "name": "rocketchat-volume-1",
-                                        "mountPath": "/app/uploads"
-                                    }
-                                ],
-                                "readinessProbe": {
-                                    "httpGet": {
-                                        "path": "/api/v1/info",
-                                        "port": 3000,
-                                        "scheme": "HTTP"
-                                    },
-                                    "initialDelaySeconds": 5,
-                                    "timeoutSeconds": 1,
-                                    "periodSeconds": 10,
-                                    "successThreshold": 1,
-                                    "failureThreshold": 3
-                                },
-                                "livenessProbe": {
-                                    "httpGet": {
-                                        "path": "/api/v1/info",
-                                        "port": 3000,
-                                        "scheme": "HTTP"
-                                    },
-                                    "initialDelaySeconds": 30,
-                                    "timeoutSeconds": 1,
-                                    "periodSeconds": 10,
-                                    "successThreshold": 1,
-                                    "failureThreshold": 3
-                                },
-                                "terminationMessagePath": "/dev/termination-log",
-                                "imagePullPolicy": "Always"
-                            }
-                        ],
-                        "restartPolicy": "Always",
-                        "terminationGracePeriodSeconds": 30,
-                        "dnsPolicy": "ClusterFirst",
-                        "securityContext": {}
-                    }
-                }
-            },
-            "status": {}
-        },
-        {
-            "kind": "Route",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "rocketchat",
-                "creationTimestamp": null,
-                "labels": {
-                    "app": "rocketchat"
-                },
-                "annotations": {
-                    "openshift.io/host.generated": "true"
-                }
-            },
-            "spec": {
-                "to": {
-                    "kind": "Service",
-                    "name": "rocketchat"
-                },
-                "port": {
-                    "targetPort": "3000-tcp"
-                }
-            },
-            "status": {
-                "ingress": null
-            }
-        },
-        {
-            "kind": "Service",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "mongodb",
-                "creationTimestamp": null,
-                "labels": {
-                    "template": "mongodb-persistent-template"
-                }
-            },
-            "spec": {
-                "ports": [
-                    {
-                        "name": "mongo",
-                        "protocol": "TCP",
-                        "port": 27017,
-                        "targetPort": 27017
-                    }
-                ],
-                "selector": {
-                    "name": "mongodb"
-                },
-                "type": "ClusterIP",
-                "sessionAffinity": "None"
-            },
-            "status": {
-                "loadBalancer": {}
-            }
-        },
-        {
-            "kind": "Service",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "rocketchat",
-                "creationTimestamp": null,
-                "labels": {
-                    "app": "rocketchat"
-                },
-                "annotations": {
-                    "openshift.io/generated-by": "OpenShiftNewApp"
-                }
-            },
-            "spec": {
-                "ports": [
-                    {
-                        "name": "3000-tcp",
-                        "protocol": "TCP",
-                        "port": 3000,
-                        "targetPort": 3000
-                    }
-                ],
-                "selector": {
-                    "app": "rocketchat",
-                    "deploymentconfig": "rocketchat"
-                },
-                "type": "ClusterIP",
-                "sessionAffinity": "None"
-            },
-            "status": {
-                "loadBalancer": {}
-            }
+          }
         }
-    ],
-    "parameters": [
-        {
-            "name": "MEMORY_LIMIT",
-            "displayName": "Memory Limit",
-            "description": "Maximum amount of memory the container can use.",
-            "value": "512Mi"
+      },
+      "status": {
+      }
+    },
+    {
+      "kind": "Route",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "rocketchat",
+        "creationTimestamp": null,
+        "labels": {
+          "app": "rocketchat"
         },
-        {
-            "name": "DATABASE_SERVICE_NAME",
-            "displayName": "Database Service Name",
-            "description": "The name of the OpenShift Service exposed for the database.",
-            "value": "mongodb",
-            "required": true
-        },
-        {
-            "name": "MONGODB_USER",
-            "displayName": "MongoDB User",
-            "description": "Username for MongoDB user that will be used for accessing the database.",
-            "generate": "expression",
-            "from": "user[A-Z0-9]{3}",
-            "required": true
-        },
-        {
-            "name": "MONGODB_PASSWORD",
-            "displayName": "MongoDB Password",
-            "description": "Password for the MongoDB user.",
-            "generate": "expression",
-            "from": "[a-zA-Z0-9]{16}",
-            "required": true
-        },
-        {
-            "name": "MONGODB_DATABASE",
-            "displayName": "MongoDB Database Name",
-            "description": "Name of the MongoDB database accessed.",
-            "value": "rocketchatdb",
-            "required": true
-        },
-        {
-            "name": "MONGODB_ADMIN_PASSWORD",
-            "displayName": "MongoDB Admin Password",
-            "description": "Password for the database admin user.",
-            "generate": "expression",
-            "from": "[a-zA-Z0-9]{16}",
-            "required": true
-        },
-        {
-            "name": "ROCKETCHAT_IMAGE",
-            "displayName": "RocketChat Image",
-            "description": "The RocketChat image to use for this deployment",
-            "required": true,
-            "value": "rocketchat/rocket.chat"
-        },
-        {
-            "name": "VOLUME_CAPACITY",
-            "displayName": "Volume Capacity",
-            "description": "Volume space available for data, e.g. 512Mi, 2Gi.",
-            "value": "1Gi",
-            "required": true
+        "annotations": {
+          "openshift.io/host.generated": "true"
         }
-    ]
+      },
+      "spec": {
+        "to": {
+          "kind": "Service",
+          "name": "rocketchat"
+        },
+        "port": {
+          "targetPort": "3000-tcp"
+        }
+      },
+      "status": {
+        "ingress": null
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${MONGODB_SERVICE_NAME}",
+        "annotations": {
+          "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true"
+        },
+        "creationTimestamp": null,
+        "labels": {
+          "template": "mongodb-persistent-template"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "mongo",
+            "protocol": "TCP",
+            "port": 27017,
+            "targetPort": 27017
+          }
+        ],
+        "selector": {
+          "name": "${MONGODB_SERVICE_NAME}"
+        },
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {
+        }
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "rocketchat",
+        "creationTimestamp": null,
+        "labels": {
+          "app": "rocketchat"
+        },
+        "annotations": {
+          "openshift.io/generated-by": "OpenShiftNewApp"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "3000-tcp",
+            "protocol": "TCP",
+            "port": 3000,
+            "targetPort": 3000
+          }
+        ],
+        "selector": {
+          "app": "rocketchat",
+          "deploymentconfig": "rocketchat"
+        },
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {
+        }
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "description": "Maximum amount of memory the container can use.",
+      "value": "512Mi"
+    },
+    {
+      "name": "DATABASE_SERVICE_NAME",
+      "displayName": "Database Service Name",
+      "description": "The name of the OpenShift Service exposed for the database.",
+      "value": "mongodb",
+      "required": true
+    },
+    {
+      "name": "MONGODB_USER",
+      "displayName": "MongoDB User",
+      "description": "Username for MongoDB user that will be used for accessing the database.",
+      "generate": "expression",
+      "from": "user[A-Z0-9]{3}",
+      "required": true
+    },
+    {
+      "name": "MONGODB_PASSWORD",
+      "displayName": "MongoDB Password",
+      "description": "Password for the MongoDB user.",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{16}",
+      "required": true
+    },
+    {
+      "name": "MONGODB_DATABASE",
+      "displayName": "MongoDB Database Name",
+      "description": "Name of the MongoDB database accessed.",
+      "value": "rocketchatdb",
+      "required": true
+    },
+    {
+      "name": "MONGODB_ADMIN_PASSWORD",
+      "displayName": "MongoDB Admin Password",
+      "description": "Password for the database admin user.",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{16}",
+      "required": true
+    },
+    {
+      "name": "ROCKETCHAT_IMAGE",
+      "displayName": "RocketChat Image",
+      "description": "The RocketChat image to use for this deployment",
+      "required": true,
+      "value": "rocketchat/rocket.chat"
+    },
+    {
+      "name": "VOLUME_CAPACITY",
+      "displayName": "Volume Capacity",
+      "description": "Volume space available for data, e.g. 512Mi, 2Gi.",
+      "value": "1Gi",
+      "required": true
+    },
+    {
+      "name": "MONGODB_REPLICA_NAME",
+      "displayName": "Replica Set Name",
+      "description": "The name of the replica set.",
+      "value": "rs0",
+      "required": true
+    },
+    {
+      "name": "MONGODB_KEYFILE_VALUE",
+      "displayName": "Keyfile Content",
+      "description": "The value of the MongoDB keyfile (https://docs.mongodb.com/manual/core/security-internal-authentication/#internal-auth-keyfile).",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{255}",
+      "required": true
+    },
+    {
+      "name": "MONGODB_SERVICE_NAME",
+      "displayName": "OpenShift Service Name",
+      "description": "The name of the OpenShift Service exposed for the database.",
+      "value": "mongodb",
+      "required": true
+    }
+  ]
 }


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes  #14670

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

The RocketChat OpenShift template specify an older, deprecated mongoDB image. The current rocketchat software requires that the mongodb backend is running in replicaset mode. This is not supported with the specified mongodb container image. Upon running the container the user would receive the following error:

```
LocalStore: store created at 
LocalStore: store created at 
LocalStore: store created at 
LocalStore: store created at 
LocalStore: store created at 
LocalStore: store created at 
Setting default file store to GridFS
Setting default file store to GridFS
Warning: connect.session() MemoryStore is not
designed for a production environment, as it will leak
memory, and will not scale past a single process.
{"line":"120","file":"migrations.js","message":"Migrations: Not migrating, already at version 145","time":{"$date":1559116269150},"level":"info"}
ufs: temp directory created at "/tmp/ufs"
Loaded the Apps Framework and loaded a total of 0 Apps!
Updating process.env.MAIL_URL
Using GridFS for custom sounds storage
Using GridFS for custom emoji storage
➔ server.js:207 System ➔ error
➔ +---------------------------------------------------------------------------+
➔ |                                SERVER ERROR                               |
➔ +---------------------------------------------------------------------------+
➔ |                                                                           |
➔ |  Rocket.Chat Version: 1.1.0                                               |
➔ |       NodeJS Version: 8.11.4 - x64                                        |
➔ |      MongoDB Version: 3.6.3                                               |
➔ |       MongoDB Engine: unknown                                             |
➔ |             Platform: linux                                               |
➔ |         Process Port: 3000                                                |
➔ |             Site URL: http://localhost:3000                                |
➔ |     ReplicaSet OpLog: Disabled                                            |
➔ |          Commit Hash: 484ee10c2b                                          |
➔ |        Commit Branch: HEAD                                                |
➔ |                                                                           |
➔ |  OPLOG / REPLICASET IS REQUIRED TO RUN ROCKET.CHAT, MORE INFORMATION AT:  |
➔ |  https://go.rocket.chat/i/oplog-required                                   |
➔ |                                                                           |
➔ +---------------------------------------------------------------------------+
```

This fix uses a statefulSet with an up-to-date mongoDB container image which runs in replica mode. 
An init container is used to update the correct permissions in the mongoDB container.
The result is that the rocketchat container starts up without any errors:


```
$ oc logs -f rocketchat-1-b8rfd
LocalStore: store created at 
LocalStore: store created at 
LocalStore: store created at 
Setting default file store to GridFS
Warning: connect.session() MemoryStore is not
designed for a production environment, as it will leak
memory, and will not scale past a single process.
ufs: temp directory created at "/tmp/ufs"
Loaded the Apps Framework and loaded a total of 0 Apps!
Using GridFS for custom sounds storage
Using GridFS for custom emoji storage
Updating process.env.MAIL_URL
➔ System ➔ startup
➔ +----------------------------------------------+
➔ |                SERVER RUNNING                |
➔ +----------------------------------------------+
➔ |                                              |
➔ |  Rocket.Chat Version: 1.2.3                  |
➔ |       NodeJS Version: 8.11.4 - x64           |
➔ |      MongoDB Version: 3.2.10                 |
➔ |       MongoDB Engine: unknown                |
➔ |             Platform: linux                  |
➔ |         Process Port: 3000                   |
➔ |             Site URL: http://localhost:3000  |
➔ |     ReplicaSet OpLog: Enabled                |
➔ |          Commit Hash: d3e690ad7f             |
➔ |        Commit Branch: HEAD                   |
➔ |                                              |
➔ +----------------------------------------------+
```


