### PR TITLE
Update latest Livechat widget version(1.1.2)

### DIFF
--- a/packages/rocketchat-livechat/plugin/build.sh
+++ b/packages/rocketchat-livechat/plugin/build.sh
@@ -3,8 +3,7 @@ export LIVECHAT_DIR="../../../public/livechat"
 export BUILD_DIR="../build"
 export BUNDLE_DIR="../build/bundle/programs/web.browser.legacy"
 export LIVECHAT_ASSETS_DIR="../../../private/livechat"
-export LATEST_LIVECHAT_VERSION="1.1.0"
-export LIVECHAT_VERSION_DIR="1.0.0"
+export LATEST_LIVECHAT_VERSION="1.1.2"
 
 cd packages/rocketchat-livechat/.app
 meteor npm install --production
@@ -23,10 +22,8 @@ cp $BUNDLE_DIR/head.html $LIVECHAT_ASSETS_DIR/head.html
 rm -rf $BUILD_DIR
 
 #NEW LIVECHAT#
-echo "Installing new Livechat..."
+echo "Installing Livechat ${LATEST_LIVECHAT_VERSION}..."
 cd $LIVECHAT_DIR
-mkdir -p $LIVECHAT_VERSION_DIR
-cd $LIVECHAT_VERSION_DIR
 
 curl -sOL "https://github.com/RocketChat/Rocket.Chat.Livechat/releases/download/v${LATEST_LIVECHAT_VERSION}/build.tar.gz"
 tar -xf build.tar.gz
@@ -36,5 +33,4 @@ rm build.tar.gz
 # this is not harmful since doctype is case-insesitive: https://www.w3.org/TR/html5/syntax.html#the-doctype
 node -e 'fs.writeFileSync("index.html", fs.readFileSync("index.html").toString().replace("<!DOCTYPE", "<!doctype"));'
 
-cd $LIVECHAT_ASSETS_DIR
-cp ../../public/livechat/$LIVECHAT_VERSION_DIR/index.html .
+cp index.html ../../private/livechat


### PR DESCRIPTION
Update Livechat build file to get the latest Livechat widget version from its repo.
We're removing the `1.0.0` from the build path as well.