### PR TITLE
[BREAK] Remove REST endpoint `/api/v1/emoji-custom`

### DIFF
--- a/app/api/server/v1/emoji-custom.js
+++ b/app/api/server/v1/emoji-custom.js
@@ -4,25 +4,6 @@ import Busboy from 'busboy';
 import { EmojiCustom } from '../../../models';
 import { API } from '../api';
 
-// DEPRECATED
-// Will be removed after v1.12.0
-API.v1.addRoute('emoji-custom', { authRequired: true }, {
-	get() {
-		const warningMessage = 'The endpoint "emoji-custom" is deprecated and will be removed after version v1.12.0';
-		console.warn(warningMessage);
-		const { query } = this.parseJsonQuery();
-		const emojis = Meteor.call('listEmojiCustom', query);
-
-		return API.v1.success(this.deprecationWarning({
-			endpoint: 'emoji-custom',
-			versionWillBeRemoved: '1.12.0',
-			response: {
-				emojis,
-			},
-		}));
-	},
-});
-
 API.v1.addRoute('emoji-custom.list', { authRequired: true }, {
 	get() {
 		const { query } = this.parseJsonQuery();

--- a/tests/end-to-end/api/12-emoji-custom.js
+++ b/tests/end-to-end/api/12-emoji-custom.js
@@ -8,28 +8,6 @@ describe('[EmojiCustom]', function() {
 	this.retries(0);
 
 	before((done) => getCredentials(done));
-	// DEPRECATED
-	// Will be removed after v1.12.0
-	describe('[/emoji-custom]', () => {
-		it('should return emojis', (done) => {
-			request.get(api('emoji-custom'))
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('emojis').and.to.be.a('array');
-				})
-				.end(done);
-		});
-		it('should return emojis when use "query" query parameter', (done) => {
-			request.get(api('emoji-custom?query={"_updatedAt": {"$gt": { "$date": "2018-11-27T13:52:01Z" } }}'))
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('emojis').and.to.be.a('array');
-				})
-				.end(done);
-		});
-	});
 
 	describe('[/emoji-custom.create]', () => {
 		it('should create new custom emoji', (done) => {

--- a/tests/end-to-end/api/12-emoji-custom.js
+++ b/tests/end-to-end/api/12-emoji-custom.js
@@ -59,12 +59,15 @@ describe('[EmojiCustom]', function() {
 
 	describe('[/emoji-custom.update]', () => {
 		before((done) => {
-			request.get(api('emoji-custom'))
+			request.get(api('emoji-custom.list'))
 				.set(credentials)
 				.expect(200)
 				.expect((res) => {
-					expect(res.body).to.have.property('emojis').and.to.be.a('array');
-					createdCustomEmoji = res.body.emojis.find((emoji) => emoji.name === customEmojiName);
+					expect(res.body).to.have.property('emojis').and.to.be.a('object');
+					expect(res.body.emojis).to.have.property('update').and.to.be.a('array').and.to.not.have.lengthOf(0);
+					expect(res.body.emojis).to.have.property('remove').and.to.be.a('array').and.to.have.lengthOf(0);
+
+					createdCustomEmoji = res.body.emojis.update.find((emoji) => emoji.name === customEmojiName);
 				})
 				.end(done);
 		});


### PR DESCRIPTION
Use `/api/v1/emoji-custom.list` instead. https://rocket.chat/docs/developer-guides/rest-api/emoji-custom/list/