### PR TITLE
[BREAK] Remove support to MongoDB 3.2 and deprecate MongoDB 3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/node:8.11-stretch
-      - image: mongo:3.2
+      - image: mongo:3.4
 
     steps:
       - checkout
@@ -182,14 +182,6 @@ jobs:
 
       - store_artifacts:
           path: /tmp/build
-
-
-  test-with-oplog-mongo-3-2:
-    <<: *test-with-oplog
-    docker:
-      - image: *test-docker-image
-      - image: mongo:3.2
-        command: [mongod, --noprealloc, --smallfiles, --replSet=rs0]
 
   test-with-oplog-mongo-3-4:
     <<: *test-with-oplog
@@ -446,25 +438,16 @@ workflows:
           filters:
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      - test-with-oplog-mongo-3-2: &test-mongo
-          requires:
-            - build
-          filters:
-            tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
       - test-with-oplog-mongo-3-4: &test-mongo-no-pr
           requires:
             - build
           filters:
-            branches:
-              only: develop
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
       - test-with-oplog-mongo-3-6: *test-mongo-no-pr
       - test-with-oplog-mongo-4-0: *test-mongo
       - deploy:
           requires:
-            - test-with-oplog-mongo-3-2
             - test-with-oplog-mongo-3-4
             - test-with-oplog-mongo-3-6
             - test-with-oplog-mongo-4-0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,7 @@ jobs:
       - store_artifacts:
           path: /tmp/build
 
+
   test-with-oplog-mongo-3-4:
     <<: *test-with-oplog
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -439,13 +439,20 @@ workflows:
           filters:
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      - test-with-oplog-mongo-3-4: &test-mongo-no-pr
+      - test-with-oplog-mongo-3-4: &test-mongo
           requires:
             - build
           filters:
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
-      - test-with-oplog-mongo-3-6: *test-mongo-no-pr
+      - test-with-oplog-mongo-3-6: &test-mongo-no-pr
+          requires:
+            - build
+          filters:
+            branches:
+              only: develop
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:rc|beta)\.[0-9]+)?$/
       - test-with-oplog-mongo-4-0: *test-mongo
       - deploy:
           requires:

--- a/server/startup/serverRunning.js
+++ b/server/startup/serverRunning.js
@@ -10,6 +10,14 @@ import { settings } from '../../app/settings';
 import { Info, getMongoInfo } from '../../app/utils';
 import { Roles, Users } from '../../app/models/server';
 
+const exitIfNotBypassed = (ignore, errorCode = 1) => {
+	if (typeof ignore === 'string' && ['yes', 'true'].includes(ignore.toLowerCase())) {
+		return;
+	}
+
+	process.exit(errorCode);
+};
+
 Meteor.startup(function() {
 	const { oplogEnabled, mongoVersion, mongoStorageEngine } = getMongoInfo();
 
@@ -42,28 +50,28 @@ Meteor.startup(function() {
 			msg += ['', '', 'OPLOG / REPLICASET IS REQUIRED TO RUN ROCKET.CHAT, MORE INFORMATION AT:', 'https://go.rocket.chat/i/oplog-required'].join('\n');
 			SystemLogger.error_box(msg, 'SERVER ERROR');
 
-			return process.exit(1);
+			exitIfNotBypassed(process.env.BYPASS_OPLOG_VALIDATION);
 		}
 
 		if (!semver.satisfies(process.versions.node, desiredNodeVersionMajor)) {
 			msg += ['', '', 'YOUR CURRENT NODEJS VERSION IS NOT SUPPORTED,', `PLEASE UPGRADE / DOWNGRADE TO VERSION ${ desiredNodeVersionMajor }.X.X`].join('\n');
 			SystemLogger.error_box(msg, 'SERVER ERROR');
 
-			return process.exit(1);
+			exitIfNotBypassed(process.env.BYPASS_NODEJS_VALIDATION);
 		}
 
-		if (!semver.satisfies(semver.coerce(mongoVersion), '>=3.2.0')) {
-			msg += ['', '', 'YOUR CURRENT MONGODB VERSION IS NOT SUPPORTED,', 'PLEASE UPGRADE TO VERSION 3.2 OR LATER'].join('\n');
+		if (!semver.satisfies(semver.coerce(mongoVersion), '>=3.4.0')) {
+			msg += ['', '', 'YOUR CURRENT MONGODB VERSION IS NOT SUPPORTED,', 'PLEASE UPGRADE TO VERSION 3.4 OR LATER'].join('\n');
 			SystemLogger.error_box(msg, 'SERVER ERROR');
 
-			return process.exit(1);
+			exitIfNotBypassed(process.env.BYPASS_MONGO_VALIDATION);
 		}
 
 		SystemLogger.startup_box(msg, 'SERVER RUNNING');
 
 		// Deprecation
-		if (!semver.satisfies(semver.coerce(mongoVersion), '>=3.4.0')) {
-			msg = [`YOUR CURRENT MONGODB VERSION (${ mongoVersion }) IS DEPRECATED.`, 'IT WILL NOT BE SUPPORTED ON ROCKET.CHAT VERSION 2.0.0 AND GREATER,', 'PLEASE UPGRADE MONGODB TO VERSION 3.4 OR GREATER'].join('\n');
+		if (!semver.satisfies(semver.coerce(mongoVersion), '>=3.6.0')) {
+			msg = [`YOUR CURRENT MONGODB VERSION (${ mongoVersion }) IS DEPRECATED.`, 'IT WILL NOT BE SUPPORTED ON ROCKET.CHAT VERSION 4.0.0 AND GREATER,', 'PLEASE UPGRADE MONGODB TO VERSION 3.6 OR GREATER'].join('\n');
 			SystemLogger.deprecation_box(msg, 'DEPRECATION');
 
 			const id = `mongodbDeprecation_${ mongoVersion.replace(/[^0-9]/g, '_') }`;


### PR DESCRIPTION
Also add env var flags to bypass validations:

- `BYPASS_OPLOG_VALIDATION`
- `BYPASS_NODEJS_VALIDATION`
- `BYPASS_MONGO_VALIDATION`

Where do you guys think we can add those to our docs?