### PR TITLE
[NEW] Assume that Rocket.Chat runs behind one proxy by default (HTTP_FORWARDED_COUNT=1)

### DIFF
--- a/packages/rocketchat-mongo-config/server/index.js
+++ b/packages/rocketchat-mongo-config/server/index.js
@@ -6,3 +6,5 @@ if (typeof mongoOptionStr !== 'undefined') {
 
 	Mongo.setConnectionOptions(mongoOptions);
 }
+
+process.env.HTTP_FORWARDED_COUNT = process.env.HTTP_FORWARDED_COUNT || '1';


### PR DESCRIPTION
Closes #15017

Since we always suggest to run Rocket.Chat behind a proxy this PR enforce the environment variable `HTTP_FORWARDED_COUNT` to have value `1` if not set preventing false limits due to use the proxy IP instead of the client IP.

More information [here](https://github.com/RocketChat/Rocket.Chat/issues/15002#issuecomment-513468261)