### PR TITLE
[NEW] Provide site-url to outgoing integrations

### DIFF
--- a/app/integrations/server/lib/triggerHandler.js
+++ b/app/integrations/server/lib/triggerHandler.js
@@ -414,6 +414,7 @@ integrations.triggerHandler = new class RocketChatIntegrationHandler {
 				data.user_id = message.u._id;
 				data.user_name = message.u.username;
 				data.text = message.msg;
+				data.siteUrl = settings.get('Site_Url');
 
 				if (message.alias) {
 					data.alias = message.alias;


### PR DESCRIPTION
## Motivation

When notifying foreign systems about a message, it can be desirable that the remote system responds back. In order to do that, it needs to know from which system the orginal message was issued.

## Implementation

In order to do that, the site-url shall be propagated to the webhook implementation which can then pass it on.

Of course, there are other options (such as setting the referrer in the HTTP-request), but sometimes it's handy to explicitly be able to handle it.