### PR TITLE
[NEW] Guess a user's name from SAML credentials

### DIFF
--- a/app/meteor-accounts-saml/server/saml_server.js
+++ b/app/meteor-accounts-saml/server/saml_server.js
@@ -106,6 +106,14 @@ Accounts.normalizeUsername = function(name) {
 };
 
 Accounts.registerLoginHandler(function(loginRequest) {
+	const _guessNameFromUsername = function(username) {
+		return username
+			.replace(/\W/g, ' ')
+			.replace(/\s(.)/g, function($1) { return $1.toUpperCase(); })
+			.replace(/^(.)/, function($1) { return $1.toLowerCase(); })
+			.replace(/^\w/, function($1) { return $1.toUpperCase(); });
+	};
+
 	if (!loginRequest.saml || !loginRequest.credentialToken) {
 		return undefined;
 	}
@@ -186,6 +194,7 @@ Accounts.registerLoginHandler(function(loginRequest) {
 			if (username) {
 				newUser.username = username;
 			}
+			newUser.name = newUser.name || _guessNameFromUsername(newUser.username); // Make sure every user has a name as well
 
 			const userId = Accounts.insertUserDoc({}, newUser);
 			user = Meteor.users.findOne(userId);

--- a/app/meteor-accounts-saml/server/saml_server.js
+++ b/app/meteor-accounts-saml/server/saml_server.js
@@ -193,8 +193,8 @@ Accounts.registerLoginHandler(function(loginRequest) {
 
 			if (username) {
 				newUser.username = username;
+				newUser.name = newUser.name || _guessNameFromUsername(username);
 			}
-			newUser.name = newUser.name || _guessNameFromUsername(newUser.username); // Make sure every user has a name as well
 
 			const userId = Accounts.insertUserDoc({}, newUser);
 			user = Meteor.users.findOne(userId);

--- a/app/meteor-accounts-saml/server/saml_server.js
+++ b/app/meteor-accounts-saml/server/saml_server.js
@@ -105,15 +105,14 @@ Accounts.normalizeUsername = function(name) {
 	return name;
 };
 
-Accounts.registerLoginHandler(function(loginRequest) {
-	const _guessNameFromUsername = function(username) {
-		return username
-			.replace(/\W/g, ' ')
-			.replace(/\s(.)/g, function($1) { return $1.toUpperCase(); })
-			.replace(/^(.)/, function($1) { return $1.toLowerCase(); })
-			.replace(/^\w/, function($1) { return $1.toUpperCase(); });
-	};
+const guessNameFromUsername = (username) =>
+	username
+		.replace(/\W/g, ' ')
+		.replace(/\s(.)/g, (u) => u.toUpperCase())
+		.replace(/^(.)/, (u) => u.toLowerCase())
+		.replace(/^\w/, (u) => u.toUpperCase());
 
+Accounts.registerLoginHandler(function(loginRequest) {
 	if (!loginRequest.saml || !loginRequest.credentialToken) {
 		return undefined;
 	}
@@ -193,7 +192,7 @@ Accounts.registerLoginHandler(function(loginRequest) {
 
 			if (username) {
 				newUser.username = username;
-				newUser.name = newUser.name || _guessNameFromUsername(username);
+				newUser.name = newUser.name || guessNameFromUsername(username);
 			}
 
 			const userId = Accounts.insertUserDoc({}, newUser);


### PR DESCRIPTION
## What this adds

When authenticated using SAML, users get a username but not a (full) name. That has a couple of nasty side effects since `name` is expected to be available for authenticated users.
This PR adds a determination to the user registration via SAML.

## How it's done

The username is split by non-word-characters (e. g. the very common `.`) and each resulting word is capitalized.

We've been running this for a long time on our branch and did only experience positive effects ;)

Fixes #15236