### PR TITLE
[IMPROVE] Add missing indices used by read receipts

### DIFF
--- a/app/models/server/models/ReadReceipts.js
+++ b/app/models/server/models/ReadReceipts.js
@@ -11,6 +11,10 @@ export class ReadReceipts extends Base {
 		}, {
 			unique: 1,
 		});
+
+		this.tryEnsureIndex({
+			messageId: 1,
+		});
 	}
 
 	findByMessageId(messageId) {

--- a/app/models/server/models/Subscriptions.js
+++ b/app/models/server/models/Subscriptions.js
@@ -15,8 +15,8 @@ export class Subscriptions extends Base {
 		this.tryEnsureIndex({ rid: 1, ls: 1 });
 		this.tryEnsureIndex({ rid: 1, 'u._id': 1 }, { unique: 1 });
 		this.tryEnsureIndex({ rid: 1, 'u._id': 1, open: 1 });
-		this.tryEnsureIndex({ rid: 1, 'u._id': 1, alert: 1 });
 		this.tryEnsureIndex({ rid: 1, 'u.username': 1 });
+		this.tryEnsureIndex({ rid: 1, alert: 1, 'u._id': 1 });
 		this.tryEnsureIndex({ rid: 1, roles: 1 });
 		this.tryEnsureIndex({ 'u._id': 1, name: 1, t: 1 });
 		this.tryEnsureIndex({ open: 1 });

--- a/app/models/server/models/Subscriptions.js
+++ b/app/models/server/models/Subscriptions.js
@@ -11,16 +11,16 @@ export class Subscriptions extends Base {
 	constructor(...args) {
 		super(...args);
 
+		this.tryEnsureIndex({ rid: 1 });
+		this.tryEnsureIndex({ rid: 1, ls: 1 });
 		this.tryEnsureIndex({ rid: 1, 'u._id': 1 }, { unique: 1 });
+		this.tryEnsureIndex({ rid: 1, 'u._id': 1, open: 1 });
+		this.tryEnsureIndex({ rid: 1, 'u._id': 1, alert: 1 });
 		this.tryEnsureIndex({ rid: 1, 'u.username': 1 });
-		this.tryEnsureIndex({ rid: 1, alert: 1, 'u._id': 1 });
 		this.tryEnsureIndex({ rid: 1, roles: 1 });
 		this.tryEnsureIndex({ 'u._id': 1, name: 1, t: 1 });
 		this.tryEnsureIndex({ open: 1 });
 		this.tryEnsureIndex({ alert: 1 });
-
-		this.tryEnsureIndex({ rid: 1, 'u._id': 1, open: 1 });
-
 		this.tryEnsureIndex({ ts: 1 });
 		this.tryEnsureIndex({ ls: 1 });
 		this.tryEnsureIndex({ audioNotifications: 1 }, { sparse: 1 });


### PR DESCRIPTION
Adds two missing indices on Subscriptions collection used by read receipts queries:
```
{ rid: 1 }
{ rid: 1, ls: 1 }
```

And another on on ReadReceipts collection used to see who read a message:
```
{ messageId: 1 }
```