### PR TITLE
Revert "[BREAK] Remove REST endpoint `/api/v1/info`"

### DIFF
--- a/app/api/server/v1/misc.js
+++ b/app/api/server/v1/misc.js
@@ -16,7 +16,7 @@ import { getURL } from '../../../utils/lib/getURL';
 // Will be removed after v1.12.0
 API.v1.addRoute('info', { authRequired: false }, {
 	get() {
-		const warningMessage = 'The endpoint "/v1/info" is deprecated and will be removed after version v1.12.0';
+		const warningMessage = 'The endpoint "/v1/info" is deprecated and will be removed after version v3.0.0';
 		console.warn(warningMessage);
 		const user = this.getLoggedInUser();
 

--- a/app/api/server/v1/misc.js
+++ b/app/api/server/v1/misc.js
@@ -3,11 +3,44 @@ import { check } from 'meteor/check';
 import { TAPi18n } from 'meteor/rocketchat:tap-i18n';
 import s from 'underscore.string';
 
-import { Users } from '../../../models/server';
-import { settings } from '../../../settings/server';
+import { hasRole } from '../../../authorization';
+import { Info } from '../../../utils';
+import { Users } from '../../../models';
+import { settings } from '../../../settings';
 import { API } from '../api';
 import { getDefaultUserFields } from '../../../utils/server/functions/getDefaultUserFields';
 import { getURL } from '../../../utils/lib/getURL';
+
+
+// DEPRECATED
+// Will be removed after v1.12.0
+API.v1.addRoute('info', { authRequired: false }, {
+	get() {
+		const warningMessage = 'The endpoint "/v1/info" is deprecated and will be removed after version v1.12.0';
+		console.warn(warningMessage);
+		const user = this.getLoggedInUser();
+
+		if (user && hasRole(user._id, 'admin')) {
+			return API.v1.success(this.deprecationWarning({
+				endpoint: 'info',
+				versionWillBeRemoved: '1.12.0',
+				response: {
+					info: Info,
+				},
+			}));
+		}
+
+		return API.v1.success(this.deprecationWarning({
+			endpoint: 'info',
+			versionWillBeRemoved: '1.12.0',
+			response: {
+				info: {
+					version: Info.version,
+				},
+			},
+		}));
+	},
+});
 
 API.v1.addRoute('me', { authRequired: true }, {
 	get() {

--- a/app/api/server/v1/misc.js
+++ b/app/api/server/v1/misc.js
@@ -32,7 +32,7 @@ API.v1.addRoute('info', { authRequired: false }, {
 
 		return API.v1.success(this.deprecationWarning({
 			endpoint: 'info',
-			versionWillBeRemoved: '1.12.0',
+			versionWillBeRemoved: '3.0.0',
 			response: {
 				info: {
 					version: Info.version,

--- a/app/api/server/v1/misc.js
+++ b/app/api/server/v1/misc.js
@@ -23,7 +23,7 @@ API.v1.addRoute('info', { authRequired: false }, {
 		if (user && hasRole(user._id, 'admin')) {
 			return API.v1.success(this.deprecationWarning({
 				endpoint: 'info',
-				versionWillBeRemoved: '1.12.0',
+				versionWillBeRemoved: '3.0.0',
 				response: {
 					info: Info,
 				},

--- a/app/api/server/v1/misc.js
+++ b/app/api/server/v1/misc.js
@@ -13,7 +13,7 @@ import { getURL } from '../../../utils/lib/getURL';
 
 
 // DEPRECATED
-// Will be removed after v1.12.0
+// Will be removed after v3.0.0
 API.v1.addRoute('info', { authRequired: false }, {
 	get() {
 		const warningMessage = 'The endpoint "/v1/info" is deprecated and will be removed after version v3.0.0';


### PR DESCRIPTION
Reverts RocketChat/Rocket.Chat#15197

Will keep this endpoint as deprecated until the next major release.