### PR TITLE
Use version 2 of the DeepL API

### DIFF
--- a/app/autotranslate/server/deeplTranslate.js
+++ b/app/autotranslate/server/deeplTranslate.js
@@ -26,7 +26,7 @@ class DeeplAutoTranslate extends AutoTranslate {
 	constructor() {
 		super();
 		this.name = 'deepl-translate';
-		this.apiEndPointUrl = 'https://api.deepl.com/v1/translate';
+		this.apiEndPointUrl = 'https://api.deepl.com/v2/translate';
 		// Get the service provide API key.
 		settings.get('AutoTranslate_DeepLAPIKey', (key, value) => {
 			this.apiKey = value;


### PR DESCRIPTION
The API Version for the DeepL translation has been changed. And it is recommended to use the api version 2.

As per the [DeepL documentation](https://www.deepl.com/de/docs-api.html?part=accessing)

> Please note that:
> 
> Version 1 (v1) of the DeepL API is not supported by the DeepL API plan available from October 2018. Please use version 2 for all new products other than CAT tool integrations.
> Version 2 (v2) of the DeepL API is not compatible with CAT tools and is not included in DeepL plans for CAT tool users. If you intend to integrate DeepL Pro into a CAT tool or another tool assisting translation, please contact support@DeepL.com