### PR TITLE
Regression: Fix DDP metrics

### DIFF
--- a/app/metrics/server/lib/metrics.js
+++ b/app/metrics/server/lib/metrics.js
@@ -97,9 +97,9 @@ const setPrometheusData = async () => {
 		version: Info.version,
 	});
 
-	const sessions = Object.values(Meteor.server.sessions);
+	const sessions = Array.from(Meteor.server.sessions.values());
 	const authenticatedSessions = sessions.filter((s) => s.userId);
-	metrics.ddpSessions.set(sessions.length, date);
+	metrics.ddpSessions.set(Meteor.server.sessions.size, date);
 	metrics.ddpAthenticatedSessions.set(authenticatedSessions.length, date);
 	metrics.ddpConnectedUsers.set(_.unique(authenticatedSessions.map((s) => s.userId)).length, date);
 


### PR DESCRIPTION
On Meteor 1.8.1 the variable `Meteor.server.sessions`  used to get DDP metrics has changed to a `Map`, so a tweaking was needed to get it working again.