### PR TITLE
[IMPROVE] Make the agents field optional when updating Livechat departments

### DIFF
--- a/app/livechat/server/lib/Livechat.js
+++ b/app/livechat/server/lib/Livechat.js
@@ -678,12 +678,12 @@ export const Livechat = {
 
 		check(departmentData, defaultValidations);
 
-		check(departmentAgents, [
+		check(departmentAgents, Match.Maybe([
 			Match.ObjectIncluding({
 				agentId: String,
 				username: String,
 			}),
-		]);
+		]));
 
 		if (_id) {
 			const department = LivechatDepartment.findOneById(_id);


### PR DESCRIPTION
CLOSES #15337

Currently, the `agents` field is required to update Livechat departments, but there are some use cases where it's difficult to force providing the `agents` field, such as the REST API approach.
So, to support any use case, the `agents` field is no longer mandatory, we'll only deal with the `agents` field when the function parameter is a valid array, otherwise we'll just skip the updating process of Livechat `agents`.