### PR TITLE
[NEW] customFields from text type will render as href if the text is a url

### DIFF
--- a/app/ui-flextab/client/tabs/userInfo.html
+++ b/app/ui-flextab/client/tabs/userInfo.html
@@ -101,7 +101,11 @@
 							{{#each customField}}
 								<div class="rc-user-info-details__item">
 									<label class="rc-user-info-details__label">{{label}}</label>
-									<p class="rc-user-info-details__info">{{value}}</p>
+									{{#if customFieldIsUrl value}}
+                                                                                <p class="rc-user-info-details__info"><a href="{{value}}" target="_blank">{{value}}</a></p>
+                                                                        {{else}}
+                                                                                <p class="rc-user-info-details__info">{{value}}</p>
+                                                                        {{/if}}
 								</div>
 							{{/each}}
 							<div class="rc-user-info-details__item">

--- a/app/ui-flextab/client/tabs/userInfo.js
+++ b/app/ui-flextab/client/tabs/userInfo.js
@@ -70,6 +70,16 @@ Template.userInfo.helpers({
 		return customFields;
 	},
 
+	customFieldIsUrl(str) {
+		const pattern = new RegExp('^(https?:\\/\\/)?' // protocol
+         + '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' // domain name
+         + '((\\d{1,3}\\.){3}\\d{1,3}))' // OR ip (v4) address
+         + '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' // port and path
+         + '(\\?[;&a-z\\d%_.~+=-]*)?' // query string
+         + '(\\#[-a-z\\d_]*)?$', 'i'); // fragment locator
+		return !!pattern.test(str);
+	},
+
 	name() {
 		const user = Template.instance().user.get();
 		return user && user.name ? user.name : TAPi18n.__('Unnamed');


### PR DESCRIPTION
Closes #15394

I'll add if needed a short hint in the customFields documentation (https://rocket.chat/docs/administrator-guides/custom-fields/)

customFields from type "text" can now contain a url - this text will now be a href/clickable if you click on userInfo for more information please look at the issue