### PR TITLE
[FIX] Double send bug on message box

### DIFF
--- a/app/ui-message/client/messageBox/messageBox.js
+++ b/app/ui-message/client/messageBox/messageBox.js
@@ -83,6 +83,8 @@ Template.messageBox.onCreated(function() {
 		autogrow.update();
 	};
 
+	let isSending = false;
+
 	this.send = (event) => {
 		const { input } = this;
 
@@ -93,9 +95,16 @@ Template.messageBox.onCreated(function() {
 		const { autogrow, data: { rid, tmid, onSend } } = this;
 		const { value } = input;
 		this.set('');
-		onSend && onSend.call(this.data, event, { rid, tmid, value }, () => {
+
+		if (!onSend || isSending) {
+			return;
+		}
+
+		isSending = true;
+		onSend.call(this.data, event, { rid, tmid, value }, () => {
 			autogrow.update();
 			input.focus();
+			isSending = false;
 		});
 	};
 });

--- a/app/ui/client/lib/chatMessages.js
+++ b/app/ui/client/lib/chatMessages.js
@@ -298,10 +298,13 @@ export class ChatMessages {
 
 				this.resetToDraft(this.editing.id);
 				this.confirmDeleteMsg(message, done);
+				return;
 			} catch (error) {
 				handleError(error);
 			}
 		}
+
+		return done();
 	}
 
 	async processMessageSend(message) {


### PR DESCRIPTION
It adds a binary semaphore to the send event, avoiding trigger the message deletion modal when editing a message.