### PR TITLE
[IMPROVE] Remove global Blaze helpers

### DIFF
--- a/app/integrations/client/views/integrationsOutgoing.html
+++ b/app/integrations/client/views/integrationsOutgoing.html
@@ -2,9 +2,9 @@
 	<section class="page-container page-home page-static page-settings">
 		{{#header sectionName=pageTitle buttons=true}}
 			<div class="rc-header__section-button">
-				<button class="rc-button rc-button--secondary history" disabled="{{not showHistoryButton}}">{{_ "History"}}</button>
-				<button class="rc-button rc-button--cancel delete" disabled="{{not canDelete}}"><span>{{_ "Delete"}}</span></button>
-				<button class="rc-button rc-button--primary save" disabled="{{not hasTypeSelected}}"><span>{{_ "Save_changes"}}</span></button>
+				<button class="rc-button rc-button--secondary history" disabled="{{$not showHistoryButton}}">{{_ "History"}}</button>
+				<button class="rc-button rc-button--cancel delete" disabled="{{$not canDelete}}"><span>{{_ "Delete"}}</span></button>
+				<button class="rc-button rc-button--primary save" disabled="{{$not hasTypeSelected}}"><span>{{_ "Save_changes"}}</span></button>
 			</div>
 		{{/header}}
 

--- a/app/ui-admin/client/admin.html
+++ b/app/ui-admin/client/admin.html
@@ -6,7 +6,7 @@
 					{{#if hasChanges}}
 						<button class="rc-button rc-button--cancel discard"><span>{{_ "Cancel"}}</span></button>
 					{{/if}}
-					<button class="rc-button rc-button--primary save" disabled="{{not hasChanges}}"><span>{{_ "Save_changes"}}</span></button>
+					<button class="rc-button rc-button--primary save" disabled="{{$not hasChanges}}"><span>{{_ "Save_changes"}}</span></button>
 					{{#if $eq _id 'OAuth'}}
 						<button class="rc-button rc-button--secondary refresh-oauth"><span>{{_ "Refresh_oauth_services"}}</span></button>
 						<button class="rc-button rc-button--secondary add-custom-oauth"><span>{{_ "Add_custom_oauth"}}</span></button>

--- a/app/ui-admin/client/users/adminUsers.html
+++ b/app/ui-admin/client/users/adminUsers.html
@@ -77,7 +77,7 @@
 									</div>
 								</td>
 								<td width="20%">
-									<div class="rc-table-wrapper">{{#if not active}}{{_"deactivated"}}{{else}}{{status}}{{/if}}</div>
+									<div class="rc-table-wrapper">{{#if $not active}}{{_"deactivated"}}{{else}}{{status}}{{/if}}</div>
 								</td>
 							</tr>
 							{{else}} {{# with searchText}}

--- a/app/ui-flextab/client/tabs/uploadedFilesList.js
+++ b/app/ui-flextab/client/tabs/uploadedFilesList.js
@@ -49,6 +49,9 @@ Template.uploadedFilesList.helpers({
 			return getURL(this.url);
 		}
 	},
+
+	escapeCssUrl: (url) => url.replace(/(['"])/g, '\\$1'),
+
 	limit() {
 		return Template.instance().state.get('limit');
 	},

--- a/client/templateHelpers/escapeCssUrl.js
+++ b/client/templateHelpers/escapeCssUrl.js
@@ -1,3 +1,0 @@
-import { Template } from 'meteor/templating';
-
-Template.registerHelper('escapeCssUrl', (url) => url.replace(/(['"])/g, '\\$1'));

--- a/client/templateHelpers/index.js
+++ b/client/templateHelpers/index.js
@@ -1,3 +1,2 @@
-import './escapeCssUrl';
 import './log';
 import './pathFor';

--- a/client/templateHelpers/index.js
+++ b/client/templateHelpers/index.js
@@ -1,4 +1,3 @@
 import './escapeCssUrl';
 import './log';
-import './not';
 import './pathFor';

--- a/client/templateHelpers/not.js
+++ b/client/templateHelpers/not.js
@@ -1,3 +1,0 @@
-import { Template } from 'meteor/templating';
-
-Template.registerHelper('not', (value) => !value);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4904,7 +4904,7 @@
 		},
 		"colors": {
 			"version": "1.1.2",
-			"resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
 			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
 			"dev": true
 		},
@@ -8393,7 +8393,7 @@
 		},
 		"get-stream": {
 			"version": "3.0.0",
-			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"get-value": {
@@ -12528,7 +12528,7 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -12550,7 +12550,7 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"requires": {
 						"safe-buffer": "~5.1.0"
@@ -12699,7 +12699,7 @@
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -13616,7 +13616,7 @@
 		"npmlog": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -14309,7 +14309,7 @@
 				},
 				"tough-cookie": {
 					"version": "2.3.4",
-					"resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
 					"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 					"dev": true,
 					"requires": {


### PR DESCRIPTION
- `not` could be replaced with `$not` from `raix:handlebar-helpers`
- `escapeCssUrl` was used only in one template