### PR TITLE
Update current license period

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2018 Rocket.Chat Technologies Corp.
+Copyright (c) 2015-2019 Rocket.Chat Technologies Corp.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated the current (MIT) license period to include the year 2019.