### PR TITLE
docs(README): remove rocket chat launcher link

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,6 @@ Deploy to a DigitalOcean droplet with our one-click install listing from the Dig
 
 [![do-btn-blue](https://user-images.githubusercontent.com/51996/58146107-50512580-7c1a-11e9-8ec9-e032ba387c2a.png)](https://marketplace.digitalocean.com/apps/rocket-chat?action=deploy&refcode=1940fe28bd31)
 
-## RocketChatLauncher
-
-Focus on your team/community and not on servers or code - the Launcher provides RocketChat-as-a-Service on a monthly subscription model.
-
-[![RocketChatLauncher](https://rocketchatlauncher.com/wp-content/uploads/2017/03/cropped-rcl-small-type.png)](https://rocketchatlauncher.com)
 
 ## Layershift
 


### PR DESCRIPTION
The link reference about RocketChatLauncher not work, and can be cause confusing, I think that is better remove

