### PR TITLE
[FIX] Fix small images being scaled up

### DIFF
--- a/app/message-attachments/client/messageAttachment.html
+++ b/app/message-attachments/client/messageAttachment.html
@@ -91,7 +91,7 @@
 					<div class="attachment-image inline-image">
 					{{#if loadImage}}
 						<figure>
-							{{> lazyloadImage src=(getURL image_url) preview=image_preview height=(getImageHeight image_dimensions.height) class="gallery-item" title=title description=description}}
+							{{> lazyloadImage src=(getURL image_url) preview=image_preview class="gallery-item" title=title description=description}}
 							{{#if labels}}
 								<div class="image-labels">
 									{{#each labels}}

--- a/app/oembed/client/oembedImageWidget.html
+++ b/app/oembed/client/oembedImageWidget.html
@@ -7,7 +7,7 @@
 			{{#if loadImage}}
 				<figure>
 					<div class="inline-image" style="background-image: url('{{url}}');">
-						<img src="{{url}}" rel="noopener noreferrer" height="200" class="gallery-item">
+						<img src="{{url}}" rel="noopener noreferrer" class="gallery-item">
 					</div>
 				</figure>
 			{{else}}


### PR DESCRIPTION
Closes #11513; the height attribute is not necessary as the CSS already specifies a max-height of 200, but this attribute causes images with a height less than 200px to be scaled up.

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Before:
![https://n546.qonq.gq](https://n546.qonq.gq)
After:
![https://e0oi.qonq.gq](https://e0oi.qonq.gq)

As you can see the CSS already specifies max-width: ![https://9o8w.qonq.gq](https://9o8w.qonq.gq)

Removing the height attribute fixes it:
![https://roee.qonq.gq](https://roee.qonq.gq)
While large images are still limited to 200px height.