### PR TITLE
[FIX] Remove unique index from read receipt messageid 

### DIFF
--- a/app/models/server/models/ReadReceipts.js
+++ b/app/models/server/models/ReadReceipts.js
@@ -7,7 +7,6 @@ export class ReadReceipts extends Base {
 		this.tryEnsureIndex({
 			roomId: 1,
 			userId: 1,
-			messageId: 1,
 		}, {
 			unique: 1,
 		});


### PR DESCRIPTION
@rocketchat/backend we might have to create a migration some how to recreate this index or to remove unique from messageId?

This would fix #15484 