### PR TITLE
[FIX] Blocked Show_Setup_Wizard Option

### DIFF
--- a/app/lib/server/startup/settings.js
+++ b/app/lib/server/startup/settings.js
@@ -718,6 +718,7 @@ settings.addGroup('General', function() {
 	this.add('Show_Setup_Wizard', 'pending', {
 		type: 'select',
 		public: true,
+		blocked: true,
 		values: [
 			{
 				key: 'pending',


### PR DESCRIPTION
As described in issue #13840, if the Show Setup Wizard option is changed to pending, no one can enter the server anymore.

Blocked the option in the admin UI so it only shows the status.
