### PR TITLE
[IMPROVE] Change notification default label to Use_account_preference

### DIFF
--- a/app/push-notifications/client/views/pushNotificationsFlexTab.js
+++ b/app/push-notifications/client/views/pushNotificationsFlexTab.js
@@ -245,7 +245,7 @@ Template.pushNotificationsFlexTab.events({
 					{
 						id: 'audioNotificationValueDefault',
 						name: 'audioNotificationValue',
-						label: 'Default',
+						label: 'Use_account_preference',
 						value: '0 Default',
 					},
 					...audioAssetsArray,
@@ -255,7 +255,7 @@ Template.pushNotificationsFlexTab.events({
 				options = [{
 					id: 'desktopNotificationDuration',
 					name: 'desktopNotificationDuration',
-					label: 'Default',
+					label: 'Use_account_preference',
 					value: 0,
 				},
 				{
@@ -293,7 +293,7 @@ Template.pushNotificationsFlexTab.events({
 				options = [{
 					id: 'desktopNotificationsDefault',
 					name: 'desktopNotifications',
-					label: 'Default',
+					label: 'Use_account_preference',
 					value: 'default',
 				},
 				{


### PR DESCRIPTION
Closes #6846

I changed the label of default option in the notification right bar.

 `Default` to `Use_account_preference`

![Screenshot from 2019-10-22 22-23-44](https://user-images.githubusercontent.com/24482087/67348262-b4a24900-f51a-11e9-962e-26551bded8a8.png)

I hope this change help to "Better-explain default settings"

@MartinSchoeler, @ggazzo 