### PR TITLE
[FIX] Read Receipts were not working properly with subscriptions without ls

### DIFF
--- a/app/models/server/models/Subscriptions.js
+++ b/app/models/server/models/Subscriptions.js
@@ -644,6 +644,9 @@ export class Subscriptions extends Base {
 	getMinimumLastSeenByRoomId(rid) {
 		return this.db.findOne({
 			rid,
+			ls: {
+				$exists: true,
+			},
 		}, {
 			sort: {
 				ls: 1,

--- a/imports/message-read-receipt/server/lib/ReadReceipt.js
+++ b/imports/message-read-receipt/server/lib/ReadReceipt.js
@@ -19,6 +19,10 @@ const debounceByRoomId = function(fn) {
 const updateMessages = debounceByRoomId(Meteor.bindEnvironment(({ _id, lm }) => {
 	// @TODO maybe store firstSubscription in room object so we don't need to call the above update method
 	const firstSubscription = Subscriptions.getMinimumLastSeenByRoomId(_id);
+	if (!firstSubscription) {
+		return;
+	}
+
 	Messages.setAsRead(_id, firstSubscription.ls);
 
 	if (lm <= firstSubscription.ls) {
@@ -53,7 +57,7 @@ export const ReadReceipt = {
 
 		// this will usually happens if the message sender is the only one on the room
 		const firstSubscription = Subscriptions.getMinimumLastSeenByRoomId(roomId);
-		if (message.unread && message.ts < firstSubscription.ls) {
+		if (firstSubscription && message.unread && message.ts < firstSubscription.ls) {
 			Messages.setAsReadById(message._id, firstSubscription.ls);
 		}
 


### PR DESCRIPTION
May be related to https://github.com/RocketChat/Rocket.Chat/issues/15484#issuecomment-545425902

The Read Receipts logic was getting the oldest `ls` (last seen, field where we store the time the user read the subscription last time) for the channel, so if some user, like a bot, was in the channel without that property set yet, the result could be `undefined`. If that user never enter in the channel to receive his first `ls` the read receipts would stop working (the case for the bots)