### PR TITLE
Regression: Remove reference to obsolete template helper

### DIFF
--- a/app/integrations/client/views/integrationsIncoming.html
+++ b/app/integrations/client/views/integrationsIncoming.html
@@ -2,7 +2,7 @@
 	<section class="page-container page-home page-static page-settings">
 		{{#header sectionName=pageTitle buttons=true}}
 			<div class="rc-header__section-button">
-				<button class="rc-button rc-button--cancel delete" disabled="{{not canDelete}}"><span>{{_ "Delete"}}</span></button>
+				<button class="rc-button rc-button--cancel delete" disabled="{{$not canDelete}}"><span>{{_ "Delete"}}</span></button>
 				<button class="rc-button rc-button--primary save" disabled="{{enabled}}"><span>{{_ "Save_changes"}}</span></button>
 			</div>
 		{{/header}}


### PR DESCRIPTION
The global `not` helper was deprecated in favor of `$not`.