### PR TITLE
[FIX] Adding a password change verification before perform profile update. (15569)

### DIFF
--- a/server/main.js
+++ b/server/main.js
@@ -22,6 +22,7 @@ import './methods/afterVerifyEmail';
 import './methods/browseChannels';
 import './methods/canAccessRoom';
 import './methods/channelsList';
+import './methods/comparePassword';
 import './methods/createDirectMessage';
 import './methods/deleteFileMessage';
 import './methods/deleteUser';

--- a/server/methods/comparePassword.js
+++ b/server/methods/comparePassword.js
@@ -1,0 +1,55 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+import { SHA256 } from 'meteor/sha';
+import bcrypt from 'bcrypt';
+
+import { settings as rcSettings } from '../../app/settings';
+import { Users } from '../../app/models';
+
+Meteor.methods({
+
+	/**
+     * Check if the current user's password is the same of given password.
+     * @returns True when the given password is not equal to current password.
+     */
+	comparePassword(password) {
+		check(password, String);
+
+		// Basic checks
+		if (!rcSettings.get('Accounts_AllowUserProfileChange')) {
+			throw new Meteor.Error('error-not-allowed', 'Not allowed', {
+				method: 'comparePassword',
+			});
+		}
+
+		if (!Meteor.userId()) {
+			throw new Meteor.Error('error-invalid-user', 'Invalid user', {
+				method: 'comparePassword',
+			});
+		}
+
+		const user = Users.findOneById(Meteor.userId());
+
+		if (!user.services || !user.services.password
+            || (!user.services.password.bcrypt && !user.services.password.srp)) {
+			// User has no password set
+			return true;
+		}
+
+		const bcryptCompare = Meteor.wrapAsync(bcrypt.compare);
+		const formattedPassword = SHA256(password).toLowerCase();
+		const hash = user.services.password.bcrypt;
+
+		// Compare if given password is equal to the current
+		if (bcryptCompare(formattedPassword, hash)) {
+			// I could throw error
+			// throw new Meteor.Error('error-same-password', 'Could not change password. The provided password is the same as your current password.', {
+			//     method: 'comparePassword',
+			// });
+
+			return false;
+		}
+
+		return true;
+	},
+});


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #15569

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Hey, first PR here,

This PR is a possible solution for the [15569](https://github.com/RocketChat/Rocket.Chat/issues/15569) issue. 
Basically, I added a comparative method in the server that checks the current password hash with the new password digest.
In the client, when user perform profile update in **My Account >Profile**, the 'comparison function' is called.

This happens before opening the password confirmation modal window:
- request to the server if the new password is not the same as the previous one
- if yes, opens the confirmation window
- otherwise, throw a toast error

