### PR TITLE
[FIX] Duplicate label 'Hide Avatars' in accounts

### DIFF
--- a/app/lib/server/startup/settings.js
+++ b/app/lib/server/startup/settings.js
@@ -356,7 +356,7 @@ settings.addGroup('Accounts', function() {
 		this.add('Accounts_Default_User_Preferences_sidebarHideAvatar', false, {
 			type: 'boolean',
 			public: true,
-			i18nLabel: 'Hide_Avatars',
+			i18nLabel: 'Hide_Avatars_Sidebar',
 		});
 		this.add('Accounts_Default_User_Preferences_sidebarShowUnread', false, {
 			type: 'boolean',

--- a/app/ui-account/client/accountPreferences.html
+++ b/app/ui-account/client/accountPreferences.html
@@ -237,11 +237,11 @@
 							</div>
 						</div>
 
-						<div class="input-line double-col" id="hideAvatars">
+						<div class="input-line double-col" id="sidebarHideAvatar">
 							<label class="setting-label">{{_ "Hide_Avatars_Sidebar"}}</label>
 							<div class="setting-field">
-								<label><input type="radio" name="hideAvatars" value="true" checked="{{checked 'hideAvatars' true}}"/> {{_ "True"}}</label>
-								<label><input type="radio" name="hideAvatars" value="false" checked="{{checked 'hideAvatars' false}}"/> {{_ "False"}}</label>
+								<label><input type="radio" name="sidebarHideAvatar" value="true" checked="{{checked 'hideAvatars' true}}"/> {{_ "True"}}</label>
+								<label><input type="radio" name="sidebarHideAvatar" value="false" checked="{{checked 'hideAvatars' false}}"/> {{_ "False"}}</label>
 							</div>
 						</div>
 						<div class="input-line double-col" id="messageViewMode">

--- a/app/ui-account/client/accountPreferences.html
+++ b/app/ui-account/client/accountPreferences.html
@@ -236,6 +236,14 @@
 								<label><input type="radio" name="hideAvatars" value="false" checked="{{checked 'hideAvatars' false}}"/> {{_ "False"}}</label>
 							</div>
 						</div>
+
+						<div class="input-line double-col" id="hideAvatars">
+							<label class="setting-label">{{_ "Hide_Avatars_Sidebar"}}</label>
+							<div class="setting-field">
+								<label><input type="radio" name="hideAvatars" value="true" checked="{{checked 'hideAvatars' true}}"/> {{_ "True"}}</label>
+								<label><input type="radio" name="hideAvatars" value="false" checked="{{checked 'hideAvatars' false}}"/> {{_ "False"}}</label>
+							</div>
+						</div>
 						<div class="input-line double-col" id="messageViewMode">
 							<label class="setting-label">{{_ "View_mode"}}</label>
 							<div class="setting-field">

--- a/app/ui-account/client/accountPreferences.js
+++ b/app/ui-account/client/accountPreferences.js
@@ -167,6 +167,7 @@ Template.accountPreferences.onCreated(function() {
 		data.messageViewMode = parseInt($('#messageViewMode').find('select').val());
 		data.hideFlexTab = JSON.parse($('#hideFlexTab').find('input:checked').val());
 		data.hideAvatars = JSON.parse($('#hideAvatars').find('input:checked').val());
+		data.sidebarHideAvatars = JSON.parse($('#sidebarHideAvatars').find('input:checked').val());
 		data.sendOnEnter = $('#sendOnEnter').find('select').val();
 		data.autoImageLoad = JSON.parse($('input[name=autoImageLoad]:checked').val());
 		data.emailNotificationMode = $('select[name=emailNotificationMode]').val();

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -1560,6 +1560,7 @@
   "Hidden": "Hidden",
   "Hide": "Hide",
   "Hide_Avatars": "Hide Avatars",
+  "Hide_Avatars_Sidebar": "Hide Avatars Sidebar",
   "Hide_counter": "Hide counter",
   "Hide_flextab": "Hide Right Sidebar with Click",
   "Hide_Group_Warning": "Are you sure you want to hide the group \"%s\"?",

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -1560,7 +1560,7 @@
   "Hidden": "Hidden",
   "Hide": "Hide",
   "Hide_Avatars": "Hide Avatars",
-  "Hide_Avatars_Sidebar": "Hide Avatars Sidebar",
+  "Hide_Avatars_Sidebar": "Hide Avatars in Sidebar",
   "Hide_counter": "Hide counter",
   "Hide_flextab": "Hide Right Sidebar with Click",
   "Hide_Group_Warning": "Are you sure you want to hide the group \"%s\"?",


### PR DESCRIPTION
The labels were of two different nature, for hiding avatars and to hide avatars in room view.

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #15585

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
![Screenshot from 2019-10-29 20-34-57](https://user-images.githubusercontent.com/33062425/67780093-99d85300-fa8b-11e9-9b6d-bde149c0677f.png)

- Changed the name of the labels to `Hide Avatars` and `Hide Avatars Sidebar`