### PR TITLE
[FIX] fix bug on livechat message webhook when sending a image

### DIFF
--- a/app/livechat/server/hooks/sendToCRM.js
+++ b/app/livechat/server/hooks/sendToCRM.js
@@ -61,7 +61,8 @@ function sendToCRM(type, room, includeMessages = true) {
 				msg.attachments = message.attachments;
 			}
 
-			postData.messages.push(normalizeMessageFileUpload(msg));
+			const { u } = message;
+			postData.messages.push(normalizeMessageFileUpload({ u, ...msg }));
 		});
 	}
 

--- a/app/utils/server/functions/normalizeMessageFileUpload.js
+++ b/app/utils/server/functions/normalizeMessageFileUpload.js
@@ -2,13 +2,9 @@ import { getURL } from '../../lib/getURL';
 import { FileUpload } from '../../../file-upload/server';
 import { Uploads } from '../../../models/server';
 
-function userId(message) {
-	return message.u ? message.u._id : message.agentId;
-}
-
 export const normalizeMessageFileUpload = (message) => {
 	if (message.file && !message.fileUpload) {
-		const jwt = FileUpload.generateJWTToFileUrls({ rid: message.rid, userId: userId(message), fileId: message.file._id });
+		const jwt = FileUpload.generateJWTToFileUrls({ rid: message.rid, userId: message.u._id, fileId: message.file._id });
 		const file = Uploads.findOne({ _id: message.file._id });
 		if (!file) {
 			return message;

--- a/app/utils/server/functions/normalizeMessageFileUpload.js
+++ b/app/utils/server/functions/normalizeMessageFileUpload.js
@@ -2,9 +2,13 @@ import { getURL } from '../../lib/getURL';
 import { FileUpload } from '../../../file-upload/server';
 import { Uploads } from '../../../models/server';
 
+function userId(message) {
+	return message.u ? message.u._id : message.agentId;
+}
+
 export const normalizeMessageFileUpload = (message) => {
 	if (message.file && !message.fileUpload) {
-		const jwt = FileUpload.generateJWTToFileUrls({ rid: message.rid, userId: message.u._id, fileId: message.file._id });
+		const jwt = FileUpload.generateJWTToFileUrls({ rid: message.rid, userId: userId(message), fileId: message.file._id });
 		const file = Uploads.findOne({ _id: message.file._id });
 		if (!file) {
 			return message;


### PR DESCRIPTION
Closes #15557 

An exception was raised because of an attribute access on an undefined property who does not exists when coming from livechat message.

See how to simulate below:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/7603203/67821484-e7f55280-fa9b-11e9-960e-a51d5eefd1c1.gif)
