### PR TITLE
[FIX]  Apply server side filters on Livechat lists

### DIFF
--- a/app/livechat/client/views/app/livechatAgents.js
+++ b/app/livechat/client/views/app/livechatAgents.js
@@ -2,7 +2,6 @@ import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
 import { ReactiveVar } from 'meteor/reactive-var';
 import { ReactiveDict } from 'meteor/reactive-dict';
-import s from 'underscore.string';
 import _ from 'underscore';
 
 import { modal, call } from '../../../../ui-utils';

--- a/app/livechat/client/views/app/livechatAgents.js
+++ b/app/livechat/client/views/app/livechatAgents.js
@@ -12,7 +12,7 @@ const loadAgents = async (instance, limit = 50, text) => {
 	let baseUrl = `livechat/users/agent?count=${ limit }`;
 
 	if (text) {
-		baseUrl = baseUrl.concat(`&text=${ encodeURIComponent(text) }`);
+		baseUrl += `&text=${ encodeURIComponent(text) }`;
 	}
 
 	const { users } = await APIClient.v1.get(baseUrl);

--- a/app/livechat/client/views/app/livechatAgents.js
+++ b/app/livechat/client/views/app/livechatAgents.js
@@ -195,17 +195,4 @@ Template.livechatAgents.onCreated(function() {
 		const filter = instance.filter.get();
 		loadAgents(instance, limit, filter);
 	});
-	/*
-	this.getAgentsWithCriteria = function() {
-		let filter;
-
-		if (instance.filter && instance.filter.get()) {
-			filter = s.trim(instance.filter.get());
-		}
-		const regex = new RegExp(s.escapeRegExp(filter), 'i');
-		return instance.agents.get()
-			.filter((agent) => agent.name.match(regex)
-				|| agent.username.match(regex)
-				|| agent.emails.some((email) => email.address.match(regex)));
-	};*/
 });

--- a/app/livechat/client/views/app/livechatDepartments.js
+++ b/app/livechat/client/views/app/livechatDepartments.js
@@ -3,7 +3,6 @@ import { FlowRouter } from 'meteor/kadira:flow-router';
 import { Template } from 'meteor/templating';
 import { ReactiveVar } from 'meteor/reactive-var';
 import { ReactiveDict } from 'meteor/reactive-dict';
-import s from 'underscore.string';
 import _ from 'underscore';
 
 import { modal } from '../../../../ui-utils';

--- a/app/livechat/client/views/app/livechatDepartments.js
+++ b/app/livechat/client/views/app/livechatDepartments.js
@@ -13,7 +13,7 @@ import { APIClient } from '../../../../utils/client';
 
 Template.livechatDepartments.helpers({
 	departments() {
-		return Template.instance().getDepartmentsWithCriteria();
+		return Template.instance().departments.get();
 	},
 	isLoading() {
 		return Template.instance().state.get('loading');
@@ -98,17 +98,15 @@ Template.livechatDepartments.onCreated(function() {
 
 	this.autorun(async function() {
 		const limit = instance.limit.get();
-		const { departments } = await APIClient.v1.get(`livechat/department?count=${ limit }`);
+		const filter = instance.filter.get();
+		let baseUrl = `livechat/department?count=${ limit }`;
+
+		if (filter) {
+			baseUrl = baseUrl.concat(`&text=${ encodeURIComponent(filter) }`);
+		}
+
+		const { departments } = await APIClient.v1.get(baseUrl);
 		instance.departments.set(departments);
 		instance.ready.set(true);
 	});
-	this.getDepartmentsWithCriteria = function() {
-		let filter;
-
-		if (instance.filter && instance.filter.get()) {
-			filter = s.trim(instance.filter.get());
-		}
-		const regex = new RegExp(s.escapeRegExp(filter), 'i');
-		return instance.departments.get().filter((department) => department.name.match(regex));
-	};
 });

--- a/app/livechat/client/views/app/livechatDepartments.js
+++ b/app/livechat/client/views/app/livechatDepartments.js
@@ -101,7 +101,7 @@ Template.livechatDepartments.onCreated(function() {
 		let baseUrl = `livechat/department?count=${ limit }`;
 
 		if (filter) {
-			baseUrl = baseUrl.concat(`&text=${ encodeURIComponent(filter) }`);
+			baseUrl += `&text=${ encodeURIComponent(filter) }`;
 		}
 
 		const { departments } = await APIClient.v1.get(baseUrl);

--- a/app/livechat/imports/server/rest/departments.js
+++ b/app/livechat/imports/server/rest/departments.js
@@ -10,9 +10,11 @@ API.v1.addRoute('livechat/department', { authRequired: true }, {
 	get() {
 		const { offset, count } = this.getPaginationItems();
 		const { sort } = this.parseJsonQuery();
+		const { text } = this.queryParams;
 
 		const departments = Promise.await(findDepartments({
 			userId: this.userId,
+			text,
 			pagination: {
 				offset,
 				count,

--- a/app/livechat/imports/server/rest/users.js
+++ b/app/livechat/imports/server/rest/users.js
@@ -14,10 +14,12 @@ API.v1.addRoute('livechat/users/:type', { authRequired: true }, {
 		});
 		const { offset, count } = this.getPaginationItems();
 		const { sort } = this.parseJsonQuery();
+		const { text } = this.queryParams;
 
 		if (this.urlParams.type === 'agent') {
 			return API.v1.success(Promise.await(findAgents({
 				userId: this.userId,
+				text,
 				pagination: {
 					offset,
 					count,
@@ -28,6 +30,7 @@ API.v1.addRoute('livechat/users/:type', { authRequired: true }, {
 		if (this.urlParams.type === 'manager') {
 			return API.v1.success(Promise.await(findManagers({
 				userId: this.userId,
+				text,
 				pagination: {
 					offset,
 					count,

--- a/app/livechat/server/api/lib/departments.js
+++ b/app/livechat/server/api/lib/departments.js
@@ -1,12 +1,18 @@
+import s from 'underscore.string';
+
 import { hasPermissionAsync } from '../../../../authorization/server/functions/hasPermission';
 import { LivechatDepartment, LivechatDepartmentAgents } from '../../../../models/server/raw';
 
-export async function findDepartments({ userId, pagination: { offset, count, sort } }) {
+export async function findDepartments({ userId, text, pagination: { offset, count, sort } }) {
 	if (!await hasPermissionAsync(userId, 'view-livechat-departments') && !await hasPermissionAsync(userId, 'view-l-room')) {
 		throw new Error('error-not-authorized');
 	}
 
-	const cursor = LivechatDepartment.find({}, {
+	const query = {
+		...text && { name: new RegExp(s.escapeRegExp(text), 'i') },
+	};
+
+	const cursor = LivechatDepartment.find(query, {
 		sort: sort || { name: 1 },
 		skip: offset,
 		limit: count,

--- a/app/livechat/server/api/lib/users.js
+++ b/app/livechat/server/api/lib/users.js
@@ -1,12 +1,16 @@
+import s from 'underscore.string';
+
 import { hasPermissionAsync } from '../../../../authorization/server/functions/hasPermission';
 import { Users } from '../../../../models/server/raw';
 
-async function findUsers({ userId, role, pagination: { offset, count, sort } }) {
-	if (!await hasPermissionAsync(userId, 'view-livechat-manager') || !await hasPermissionAsync(userId, 'manage-livechat-agents')) {
-		throw new Error('error-not-authorized');
+async function findUsers({ role, text, pagination: { offset, count, sort } }) {
+	const query = {};
+	if (text) {
+		const filterReg = new RegExp(s.escapeRegExp(text), 'i');
+		Object.assign(query, { $or: [{ username: filterReg }, { name: filterReg }, { 'emails.address': filterReg }] });
 	}
 
-	const cursor = await Users.findUsersInRoles(role, undefined, {
+	const cursor = await Users.findUsersInRolesWithQuery(role, query, {
 		sort: sort || { name: 1 },
 		skip: offset,
 		limit: count,
@@ -30,10 +34,15 @@ async function findUsers({ userId, role, pagination: { offset, count, sort } }) 
 		total,
 	};
 }
-export async function findAgents({ userId, pagination: { offset, count, sort } }) {
+export async function findAgents({ userId, text, pagination: { offset, count, sort } }) {
+	if (!await hasPermissionAsync(userId, 'view-l-room')) {
+		throw new Error('error-not-authorized');
+	}
+
 	return findUsers({
 		role: 'livechat-agent',
 		userId,
+		text,
 		pagination: {
 			offset,
 			count,
@@ -42,10 +51,15 @@ export async function findAgents({ userId, pagination: { offset, count, sort } }
 	});
 }
 
-export async function findManagers({ userId, pagination: { offset, count, sort } }) {
+export async function findManagers({ userId, text, pagination: { offset, count, sort } }) {
+	if (!await hasPermissionAsync(userId, 'view-livechat-manager') || !await hasPermissionAsync(userId, 'manage-livechat-agents')) {
+		throw new Error('error-not-authorized');
+	}
+
 	return findUsers({
 		role: 'livechat-manager',
 		userId,
+		text,
 		pagination: {
 			offset,
 			count,

--- a/app/models/server/raw/Users.js
+++ b/app/models/server/raw/Users.js
@@ -13,6 +13,14 @@ export class UsersRaw extends BaseRaw {
 		return this.find(query, options);
 	}
 
+	findUsersInRolesWithQuery(roles, query, options) {
+		roles = [].concat(roles);
+
+		Object.assign(query, { roles: { $in: roles } });
+
+		return this.find(query, options);
+	}
+
 	isUserInRole(userId, roleName) {
 		const query = {
 			_id: userId,


### PR DESCRIPTION
After replacing `publications` with the` REST` approach, the filters were being applied only on the client-side, so the results reflected only on data that had been fetched from the server without any filters, based on pagination only.
Now, the filters will be sent to the server through the `REST` endpoint.