### PR TITLE
Regression: fix admin instances info page

### DIFF
--- a/client/components/admin/info/InstancesSection.js
+++ b/client/components/admin/info/InstancesSection.js
@@ -17,8 +17,8 @@ export function InstancesSection({ instances }) {
 		{instances.map(({ address, broadcastAuth, currentStatus, instanceRecord }, i) =>
 			<InformationList key={i}>
 				<InformationEntry label={t('Address')}>{address}</InformationEntry>
-				<InformationEntry label={t('Auth')}>{broadcastAuth}</InformationEntry>
-				<InformationEntry label={<>{t('Current_Status')} > {t('Connected')}</>}>{currentStatus.connected}</InformationEntry>
+				<InformationEntry label={t('Auth')}>{broadcastAuth ? 'true' : 'false'}</InformationEntry>
+				<InformationEntry label={<>{t('Current_Status')} > {t('Connected')}</>}>{currentStatus.connected ? 'true' : 'false'}</InformationEntry>
 				<InformationEntry label={<>{t('Current_Status')} > {t('Retry_Count')}</>}>{currentStatus.retryCount}</InformationEntry>
 				<InformationEntry label={<>{t('Current_Status')} > {t('Status')}</>}>{currentStatus.status}</InformationEntry>
 				<InformationEntry label={<>{t('Instance_Record')} > {t('ID')}</>}>{instanceRecord._id}</InformationEntry>


### PR DESCRIPTION
The `boolean` data was missing after moving to React components.