### PR TITLE
Fix notification migration

### DIFF
--- a/server/startup/migrations/v161.js
+++ b/server/startup/migrations/v161.js
@@ -8,11 +8,15 @@ Migrations.add({
 		const mobileNotifications = Settings.findOne({ _id: 'Accounts_Default_User_Preferences_mobileNotifications' });
 
 		if (desktopNotifications && desktopNotifications.value === 'mentions') {
-			Settings.update({ _id: 'Accounts_Default_User_Preferences_desktopNotifications' }, { value: 'all' });
+			Settings.update({ _id: 'Accounts_Default_User_Preferences_desktopNotifications' }, {
+				$set: { value: 'all' },
+			});
 		}
 
 		if (mobileNotifications && mobileNotifications.value === 'mentions') {
-			Settings.update({ _id: 'Accounts_Default_User_Preferences_mobileNotifications' }, { value: 'all' });
+			Settings.update({ _id: 'Accounts_Default_User_Preferences_mobileNotifications' }, {
+				$set: { value: 'all' },
+			});
 		}
 	},
 	down() {


### PR DESCRIPTION
This was causing both settings to not being displayed on admin panel after an upgrade to version `2.1.1` or `2.2.0`.

This change will prevent it from happen if upgrading straight from 2.0.0 to 2.3.0