### PR TITLE
[FIX] admin can sort users by email in directory view

### DIFF
--- a/server/methods/browseChannels.js
+++ b/server/methods/browseChannels.js
@@ -24,6 +24,10 @@ const sortChannels = function(field, direction) {
 
 const sortUsers = function(field, direction) {
 	switch (field) {
+		case 'email':
+			return {
+				'emails.address': direction === 'asc' ? 1 : -1,
+			};
 		default:
 			return {
 				[field]: direction === 'asc' ? 1 : -1,
@@ -47,7 +51,7 @@ Meteor.methods({
 			return;
 		}
 
-		if (!['name', 'createdAt', 'usersCount', ...type === 'channels' ? ['usernames'] : [], ...type === 'users' ? ['username'] : []].includes(sortBy)) {
+		if (!['name', 'createdAt', 'usersCount', ...type === 'channels' ? ['usernames'] : [], ...type === 'users' ? ['username', 'email'] : []].includes(sortBy)) {
 			return;
 		}
 


### PR DESCRIPTION
Admin users can see the email column for users in the directory view, but attempting to sort on the email column breaks the list of users. This is because the method checks to see if a field is a legal field to sort by, and email is not in that list of fields. I have added email to the list of fields, allowing it to sort on email when fetching users.

### **Before:**
<img width="453" alt="brokensort" src="https://user-images.githubusercontent.com/19230940/68907492-97256100-070d-11ea-9571-4e8840af9a7f.png">

### **After:**
<img width="688" alt="fixedsort" src="https://user-images.githubusercontent.com/19230940/68907502-a1475f80-070d-11ea-864a-a9124dc7eac3.png">
