### PR TITLE
[FIX] Push: fix notification priority for google (FCM)

### DIFF
--- a/app/push-notifications/server/lib/PushNotification.js
+++ b/app/push-notifications/server/lib/PushNotification.js
@@ -33,6 +33,7 @@ export class PushNotification {
 			from: 'push',
 			badge,
 			sound: 'default',
+			priority: 10,
 			title,
 			text: message,
 			payload,


### PR DESCRIPTION
Currently Rocket.Chat is sending notifications using FCM by the default priority of data messages [1]. Those messages have no service-level objective. This PR changes the priority to '10' which should be the default for instant messaging (as defined in the FCM documentation). The same priority of '10' is also recommended for apple [2]. However for some reason the "push" lib already defaults to '10' for apple [3]. This change relies on [4] to be functional. Yet, it shouldn't brick anything without it.

[1] https://firebase.google.com/docs/cloud-messaging/http-server-ref
[2] https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns
[3] https://github.com/RocketChat/push/blob/master/lib/server/push.api.js#L185
[4] https://github.com/RocketChat/push/pull/2