### PR TITLE
[IMPROVE] Make push notification batchsize and interval configurable

### DIFF
--- a/app/lib/server/startup/settings.js
+++ b/app/lib/server/startup/settings.js
@@ -1160,6 +1160,24 @@ settings.addGroup('Push', function() {
 			value: true,
 		},
 	});
+	this.add('Push_send_interval', 5000, {
+		type: 'int',
+		public: true,
+		alert: 'Push_Setting_Requires_Restart_Alert',
+		enableQuery: {
+			_id: 'Push_enable',
+			value: true,
+		},
+	});
+	this.add('Push_send_batch_size', 10, {
+		type: 'int',
+		public: true,
+		alert: 'Push_Setting_Requires_Restart_Alert',
+		enableQuery: {
+			_id: 'Push_enable',
+			value: true,
+		},
+	});
 	this.add('Push_enable_gateway', true, {
 		type: 'boolean',
 		alert: 'Push_Setting_Requires_Restart_Alert',

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -2520,6 +2520,8 @@
   "Push_apn_key": "APN Key",
   "Push_apn_passphrase": "APN Passphrase",
   "Push_debug": "Debug",
+  "Push_send_interval": "Interval to check the queue for new push notifications",
+  "Push_send_batch_size": "Batch size to be processed every tick",
   "Push_enable": "Enable",
   "Push_enable_gateway": "Enable Gateway",
   "Push_gateway": "Gateway",

--- a/server/lib/cordova.js
+++ b/server/lib/cordova.js
@@ -176,8 +176,8 @@ function configurePush() {
 			apn,
 			gcm,
 			production: settings.get('Push_production'),
-			sendInterval: 5000,
-			sendBatchSize: 10,
+			sendInterval: settings.get('Push_send_interval'),
+			sendBatchSize: settings.get('Push_send_batch_size'),
 		});
 
 		if (settings.get('Push_enable_gateway') === true) {


### PR DESCRIPTION
Let the admin configure the batch size and interval of the push notification queue. Hardcoding these values assume these numbers are fine for all setups - i don't think that's a valid assumption.

Related #15791