### PR TITLE
[FIX] Don't throw an error when a message is prevented from apps engine

### DIFF
--- a/app/lib/server/functions/sendMessage.js
+++ b/app/lib/server/functions/sendMessage.js
@@ -177,7 +177,7 @@ export const sendMessage = function(user, message, room, upsert = false) {
 	if (message && Apps && Apps.isLoaded()) {
 		const prevent = Promise.await(Apps.getBridges().getListenerBridge().messageEvent('IPreMessageSentPrevent', message));
 		if (prevent) {
-			throw new Meteor.Error('error-app-prevented-sending', 'A Rocket.Chat App prevented the message sending.');
+			return;
 		}
 
 		let result;

--- a/app/lib/server/functions/sendMessage.js
+++ b/app/lib/server/functions/sendMessage.js
@@ -177,6 +177,10 @@ export const sendMessage = function(user, message, room, upsert = false) {
 	if (message && Apps && Apps.isLoaded()) {
 		const prevent = Promise.await(Apps.getBridges().getListenerBridge().messageEvent('IPreMessageSentPrevent', message));
 		if (prevent) {
+			if (settings.get('Apps_Framework_Development_Mode')) {
+				console.log('A Rocket.Chat App prevented the message sending.', message);
+			}
+
 			return;
 		}
 


### PR DESCRIPTION
When using IPreMessageSentPrevent in the apps-engine, the message would be followed by an "Error".

![image](https://user-images.githubusercontent.com/6295044/69474394-b0be4c80-0d8e-11ea-9ac3-649fdfdbbb94.png)

This seems to fix the problem and the output no longer triggers an error.


