### PR TITLE
Fix Livechat duplicated templates error

### DIFF
--- a/app/livechat/client/route.js
+++ b/app/livechat/client/route.js
@@ -71,6 +71,7 @@ AccountBox.addRoute({
 	sideNav: 'livechatFlex',
 	i18nPageTitle: 'Edit_Department',
 	pageTemplate: 'livechatDepartmentForm',
+	customContainer: true,
 }, livechatManagerRoutes, load);
 
 AccountBox.addRoute({
@@ -79,6 +80,7 @@ AccountBox.addRoute({
 	sideNav: 'livechatFlex',
 	i18nPageTitle: 'New_Department',
 	pageTemplate: 'livechatDepartmentForm',
+	customContainer: true,
 }, livechatManagerRoutes, load);
 
 AccountBox.addRoute({

--- a/app/livechat/client/stylesheets/livechat.less
+++ b/app/livechat/client/stylesheets/livechat.less
@@ -548,12 +548,10 @@
 	flex: 0 0 auto;
 	margin-top: 26px;
 	padding-left: 30px;
-	border-left: 1px solid #cccccc;
 
 	& > .rc-button__group {
 		margin: 0 5px;
 	}
-
 }
 
 .livechat-current-chats-tag-filter-wrapper {

--- a/app/livechat/client/views/app/livechatCurrentChats.html
+++ b/app/livechat/client/views/app/livechatCurrentChats.html
@@ -75,7 +75,7 @@
 							</div>
 
 							<div class="form-group">
-								<button class="rc-button rc-button--secondary add-filter-button livechat-current-chats-add-filter-button">{{> icon icon="plus" }}</button>
+								<button type="button" class="rc-button rc-button--secondary add-filter-button livechat-current-chats-add-filter-button">{{> icon icon="plus" }}</button>
 							</div>
 						</div>
 

--- a/app/livechat/client/views/app/livechatDepartmentForm.html
+++ b/app/livechat/client/views/app/livechatDepartmentForm.html
@@ -1,148 +1,160 @@
 <template name="livechatDepartmentForm">
 	{{#requiresPermission 'view-livechat-departments'}}
-		<form id="department-form" data-id="{{department._id}}">
-			<div class="rocket-form">
-				{{#if Template.subscriptionsReady}}
-					<fieldset>
-						{{#requiresPermission 'manage-livechat-departments'}}
-							<div class="input-line">
-								<label>{{_ "Enabled"}}</label>
-								<div>
-									<label><input type="radio" name="enabled" value="1" checked="{{$eq department.enabled true}}" /> {{_ "Yes"}}</label>
-									<label><input type="radio" name="enabled" value="0" checked="{{$eq department.enabled false}}" /> {{_ "No"}}</label>
-								</div>
-							</div>
-							<div class="input-line">
-								<label>{{_ "Name"}}</label>
-								<div>
-									<input type="text" class="rc-input__element" name="name" value="{{department.name}}" placeholder="{{_ "Name"}}" />
-								</div>
-							</div>
-							<div class="input-line">
-								<label>{{_ "Description"}}</label>
-								<div>
-									<textarea name="description" class="rc-input__element" rows="6">{{department.description}}</textarea>
-								</div>
-							</div>
-							<div class="input-line">
-								<label>{{_ "Show_on_registration_page"}}</label>
-								<div>
-									<label><input type="radio" name="showOnRegistration" value="1" checked="{{showOnRegistration true}}" /> {{_ "Yes"}}</label>
-									<label><input type="radio" name="showOnRegistration" value="0" checked="{{showOnRegistration false}}" /> {{_ "No"}}</label>
-								</div>
-							</div>
-							<div class="input-line">
-								<label>{{_ "Email"}}</label>
-								<div>
-									<input type="email" class="rc-input__element" name="email" value="{{department.email}}" placeholder="{{_ "Email"}}" />
-								</div>
-							</div>
-							<div class="input-line">
-								<label>{{_ "Show_on_offline_page"}}</label>
-								<div>
-									<label><input type="radio" name="showOnOfflineForm" value="1" checked="{{showOnOfflineForm true}}" /> {{_ "Yes"}}</label>
-									<label><input type="radio" name="showOnOfflineForm" value="0" checked="{{showOnOfflineForm false}}" /> {{_ "No"}}</label>
-								</div>
-							</div>
-							<div class="input-line">
-								<label>{{_ "Request_tag_before_closing_chat"}}</label>
-								<div>
-									<label><input type="radio" name="requestTagBeforeClosingChat" value="1" checked="{{$eq requestTagBeforeClosingChat true}}" /> {{_ "Yes"}}</label>
-									<label><input type="radio" name="requestTagBeforeClosingChat" value="0" checked="{{$eq requestTagBeforeClosingChat false}}" /> {{_ "No"}}</label>
-								</div>
-							</div>
-							{{#if customFieldsTemplate}}
-								{{> Template.dynamic template=customFieldsTemplate data=data }}
-							{{/if}}
-
-							{{#requiresPermission 'add-livechat-department-agents'}}
-								<hr />
-							{{else}}
-							{{/requiresPermission}}
-						{{else}}
-							<legend>{{department.name}}</legend>
-						{{/requiresPermission}}
-
-						{{#requiresPermission 'add-livechat-department-agents'}}
-							<h2>{{_ "Agents"}}</h2>
-
+	<div class="main-content-flex">
+		<section class="page-container flex-tab-main-content">
+			{{> header sectionName=i18nPageTitle}}
+			<div class="content">
+				<form id="department-form" data-id="{{department._id}}">
+					<div class="rocket-form">
+						{{#if Template.subscriptionsReady}}
 							<fieldset>
-								<label>{{_ "Add_agent"}}</label>
-								<div class="input-line form-inline">
-									<div class="form-group">
-										{{> livechatAutocompleteUser
-											onClickTag=onClickTagAgents
-											list=selectedAgents
-											onSelect=onSelectAgents
-											collection='UserAndRoom'
-											subscription='userAutocomplete'
-											field='username'
-											sort='username'
-											label="Search_by_username"
-											placeholder="Search_by_username"
-											name="username"
-											exceptions=exceptionsAgents
-											icon="at"
-											noMatchTemplate="userSearchEmpty"
-											templateItem="popupList_item_default"
-											modifier=agentModifier
-											conditions=agentConditions
-										}}
+								{{#requiresPermission 'manage-livechat-departments'}}
+									<div class="input-line">
+										<label>{{_ "Enabled"}}</label>
+										<div>
+											<label><input type="radio" name="enabled" value="1" checked="{{$eq department.enabled true}}" /> {{_ "Yes"}}</label>
+											<label><input type="radio" name="enabled" value="0" checked="{{$eq department.enabled false}}" /> {{_ "No"}}</label>
+										</div>
 									</div>
-									<div class="form-group">
-										<button name="add" class="rc-button rc-button--primary add-agent">{{_ "Add"}}</button>
+									<div class="input-line">
+										<label>{{_ "Name"}}</label>
+										<div>
+											<input type="text" class="rc-input__element" name="name" value="{{department.name}}" placeholder="{{_ "Name"}}" />
+										</div>
 									</div>
-								</div>
+									<div class="input-line">
+										<label>{{_ "Description"}}</label>
+										<div>
+											<textarea name="description" class="rc-input__element" rows="6">{{department.description}}</textarea>
+										</div>
+									</div>
+									<div class="input-line">
+										<label>{{_ "Show_on_registration_page"}}</label>
+										<div>
+											<label><input type="radio" name="showOnRegistration" value="1" checked="{{showOnRegistration true}}" /> {{_ "Yes"}}</label>
+											<label><input type="radio" name="showOnRegistration" value="0" checked="{{showOnRegistration false}}" /> {{_ "No"}}</label>
+										</div>
+									</div>
+									<div class="input-line">
+										<label>{{_ "Email"}}</label>
+										<div>
+											<input type="email" class="rc-input__element" name="email" value="{{department.email}}" placeholder="{{_ "Email"}}" />
+										</div>
+									</div>
+									<div class="input-line">
+										<label>{{_ "Show_on_offline_page"}}</label>
+										<div>
+											<label><input type="radio" name="showOnOfflineForm" value="1" checked="{{showOnOfflineForm true}}" /> {{_ "Yes"}}</label>
+											<label><input type="radio" name="showOnOfflineForm" value="0" checked="{{showOnOfflineForm false}}" /> {{_ "No"}}</label>
+										</div>
+									</div>
+									<div class="input-line">
+										<label>{{_ "Request_tag_before_closing_chat"}}</label>
+										<div>
+											<label><input type="radio" name="requestTagBeforeClosingChat" value="1" checked="{{$eq requestTagBeforeClosingChat true}}" /> {{_ "Yes"}}</label>
+											<label><input type="radio" name="requestTagBeforeClosingChat" value="0" checked="{{$eq requestTagBeforeClosingChat false}}" /> {{_ "No"}}</label>
+										</div>
+									</div>
+									{{#if customFieldsTemplate}}
+										{{> Template.dynamic template=customFieldsTemplate data=data }}
+									{{/if}}
+
+									{{#requiresPermission 'add-livechat-department-agents'}}
+										<hr />
+									{{else}}
+									{{/requiresPermission}}
+								{{else}}
+									<legend>{{department.name}}</legend>
+								{{/requiresPermission}}
+
+								{{#requiresPermission 'add-livechat-department-agents'}}
+									<h2>{{_ "Agents"}}</h2>
+
+									<fieldset>
+										<label>{{_ "Add_agent"}}</label>
+										<div class="input-line form-inline">
+											<div class="form-group">
+												{{> livechatAutocompleteUser
+													onClickTag=onClickTagAgents
+													list=selectedAgents
+													onSelect=onSelectAgents
+													collection='UserAndRoom'
+													subscription='userAutocomplete'
+													field='username'
+													sort='username'
+													label="Search_by_username"
+													placeholder="Search_by_username"
+													name="username"
+													exceptions=exceptionsAgents
+													icon="at"
+													noMatchTemplate="userSearchEmpty"
+													templateItem="popupList_item_default"
+													modifier=agentModifier
+													conditions=agentConditions
+												}}
+											</div>
+											<div class="form-group">
+												<button name="add" class="rc-button rc-button--primary add-agent">{{_ "Add"}}</button>
+											</div>
+										</div>
+									</fieldset>
+
+									<fieldset>
+										<legend>{{_ "Selected_agents"}}</legend>
+
+										<div class="rc-table-content">
+											{{#table fixed='true'}}
+												<thead>
+													<tr>
+														<th width="25%"><div class="table-fake-th">{{_ "Username"}}</div></th>
+														<th><div class="table-fake-th">{{_ "Count"}}</div></th>
+														<th><div class="table-fake-th">{{_ "Order"}}</div></th>
+														<th width="40px">&nbsp;</th>
+													</tr>
+												</thead>
+												<tbody>
+													{{#each departmentAgents}}
+														<tr class="agent-info">
+															<td>
+																<div class="rc-table-wrapper">
+																	<div class="rc-table-info">
+																		<span class="rc-table-title">{{username}}</span>
+																	</div>
+																</div>
+															</td>
+															<td><input type="text" class="count-{{agentId}}" name="count" value="{{count}}" size="3"></td>
+															<td><input type="text" class="order-{{agentId}}" name="order" value="{{order}}" size="3"></td>
+															<td><a href="#remove" class="remove-agent"><i class="icon-trash"></i></a></td>
+														</tr>
+													{{else}}
+														<tr>
+															<td colspan="4">{{_ "There_are_no_agents_added_to_this_department_yet"}}</td>
+														</tr>
+													{{/each}}
+												</tbody>
+											{{/table}}
+										</div>
+
+									</fieldset>
+								{{else}}
+								{{/requiresPermission}}
 							</fieldset>
-
-							<fieldset>
-								<legend>{{_ "Selected_agents"}}</legend>
-
-								<div class="rc-table-content">
-									{{#table fixed='true'}}
-										<thead>
-											<tr>
-												<th width="25%"><div class="table-fake-th">{{_ "Username"}}</div></th>
-												<th><div class="table-fake-th">{{_ "Count"}}</div></th>
-												<th><div class="table-fake-th">{{_ "Order"}}</div></th>
-												<th width="40px">&nbsp;</th>
-											</tr>
-										</thead>
-										<tbody>
-											{{#each departmentAgents}}
-												<tr class="agent-info">
-													<td>
-														<div class="rc-table-wrapper">
-															<div class="rc-table-info">
-																<span class="rc-table-title">{{username}}</span>
-															</div>
-														</div>
-													</td>
-													<td><input type="text" class="count-{{agentId}}" name="count" value="{{count}}" size="3"></td>
-													<td><input type="text" class="order-{{agentId}}" name="order" value="{{order}}" size="3"></td>
-													<td><a href="#remove" class="remove-agent"><i class="icon-trash"></i></a></td>
-												</tr>
-											{{else}}
-												<tr>
-													<td colspan="4">{{_ "There_are_no_agents_added_to_this_department_yet"}}</td>
-												</tr>
-											{{/each}}
-										</tbody>
-									{{/table}}
-								</div>
-
-							</fieldset>
+							<div class="rc-button__group">
+								<button class="rc-button back" type="button"><i class="icon-left-big"></i><span>{{_ "Back"}}</span></button>
+								<button class="rc-button rc-button--primary save"><i class="icon-floppy"></i><span>{{_ "Save"}}</span></button>
+							</div>
 						{{else}}
-						{{/requiresPermission}}
-					</fieldset>
-					<div class="rc-button__group">
-						<button class="rc-button back" type="button"><i class="icon-left-big"></i><span>{{_ "Back"}}</span></button>
-						<button class="rc-button rc-button--primary save"><i class="icon-floppy"></i><span>{{_ "Save"}}</span></button>
+							{{> loading}}
+						{{/if}}
 					</div>
-				{{else}}
-					{{> loading}}
-				{{/if}}
+				</form>
 			</div>
-		</form>
+		</section>
+		{{#if tabBarVisible}}
+			{{#with flexData}}
+				{{> flexTabBar}}
+			{{/with}}
+		{{/if}}
+	</div>
 	{{/requiresPermission}}
 </template>

--- a/app/livechat/client/views/app/livechatDepartmentForm.js
+++ b/app/livechat/client/views/app/livechatDepartmentForm.js
@@ -5,6 +5,7 @@ import { Template } from 'meteor/templating';
 import _ from 'underscore';
 import toastr from 'toastr';
 
+import { TabBar, RocketChatTabBar } from '../../../../ui-utils';
 import { t, handleError } from '../../../../utils';
 import { hasPermission } from '../../../../authorization';
 import { getCustomFormTemplate } from './customTemplates/register';
@@ -66,6 +67,17 @@ Template.livechatDepartmentForm.helpers({
 	},
 	onClickTagAgents() {
 		return Template.instance().onClickTagAgents;
+	},
+	flexData() {
+		return {
+			tabBar: Template.instance().tabBar,
+			data: Template.instance().tabBarData.get(),
+		};
+	},
+	tabBarVisible() {
+		return Object.values(TabBar.buttons.get())
+			.some((button) => button.groups
+				.some((group) => group.startsWith('livechat-department')));
 	},
 });
 
@@ -184,6 +196,9 @@ Template.livechatDepartmentForm.onCreated(async function() {
 	this.department = new ReactiveVar({ enabled: true });
 	this.departmentAgents = new ReactiveVar([]);
 	this.selectedAgents = new ReactiveVar([]);
+	this.tabBar = new RocketChatTabBar();
+	this.tabBar.showGroup(FlowRouter.current().route.name);
+	this.tabBarData = new ReactiveVar();
 
 	this.onSelectAgents = ({ item: agent }) => {
 		this.selectedAgents.set([agent]);

--- a/app/livechat/client/views/app/livechatRoomTagSelector.html
+++ b/app/livechat/client/views/app/livechatRoomTagSelector.html
@@ -1,5 +1,17 @@
 <template name="livechatRoomTagSelector">
-	<div class="rc-input__wrapper">
-		<input autocomplete="off" type="text" placeholder="{{_ "Tags"}}" class="rc-input__element" name="tags">
-	</div>
+	{{#if hasAvailableTags}}
+		<div class="rc-select">
+			<select class="rc-select__element" name="tags">
+				<option class="rc-select__option" value="">{{_ "All"}}</option>
+				{{#each availableTags}}
+					<option class="rc-select__option" value="{{name}}">{{name}}</option>
+				{{/each}}
+			</select>
+			{{> icon block="rc-select__arrow" icon="arrow-down" }}
+		</div>
+	{{else}}
+		<div class="rc-input__wrapper">
+			<input autocomplete="off" type="text" placeholder="{{_ "Tags"}}" class="rc-input__element" name="tags">
+		</div>
+	{{/if}}
 </template>

--- a/app/livechat/client/views/app/livechatRoomTagSelector.js
+++ b/app/livechat/client/views/app/livechatRoomTagSelector.js
@@ -1,12 +1,24 @@
+import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
+import { ReactiveVar } from 'meteor/reactive-var';
 
 import './livechatRoomTagSelector.html';
 
 Template.livechatRoomTagSelector.helpers({
-});
+	availableTags() {
+		return Template.instance().availableTags.get();
+	},
 
-Template.livechatRoomTagSelector.events({
+	hasAvailableTags() {
+		const tags = Template.instance().availableTags.get();
+		return tags && tags.length > 0;
+	},
 });
 
 Template.livechatRoomTagSelector.onCreated(function() {
+	this.availableTags = new ReactiveVar([]);
+
+	Meteor.call('livechat:getTagsList', (err, tagsList) => {
+		this.availableTags.set(tagsList);
+	});
 });

--- a/app/livechat/client/views/regular.js
+++ b/app/livechat/client/views/regular.js
@@ -2,7 +2,7 @@ import './app/livechatAutocompleteUser';
 import './app/livechatQueue';
 import './app/livechatReadOnly';
 import './app/livechatNotSubscribed.html';
-import './app/livechatRoomTagSelector.html';
+import './app/livechatRoomTagSelector';
 import './app/tabbar/agentEdit';
 import './app/tabbar/agentInfo';
 import './app/tabbar/externalSearch';


### PR DESCRIPTION
We're facing an issue related to Templates duplicated when running the `Enterprise` edition.
To fix it, I changed the way we're dealing with the `livechatRoomTagSelector` and `livechatDepartmentForm`. Now, instead of replacing the entire file, I'm using the same approach we've on other custom Templates, where we add custom templates inside the original one(yield approach), so the replacement of the entire files is no longer necessary.