### PR TITLE
[FIX] Replace findOne with findOneById methods (Omnichannel)

### DIFF
--- a/app/livechat/server/lib/QueueManager.js
+++ b/app/livechat/server/lib/QueueManager.js
@@ -27,8 +27,8 @@ export const QueueManager = {
 		const { rid } = message;
 		const name = (roomInfo && roomInfo.fname) || guest.name || guest.username;
 
-		const room = LivechatRooms.findOne(createLivechatRoom(rid, name, guest, roomInfo));
-		let inquiry = LivechatInquiry.findOne(createLivechatInquiry(rid, name, guest, message));
+		const room = LivechatRooms.findOneById(createLivechatRoom(rid, name, guest, roomInfo));
+		let inquiry = LivechatInquiry.findOneById(createLivechatInquiry(rid, name, guest, message));
 
 		LivechatRooms.updateRoomCount();
 


### PR DESCRIPTION
The related methods were waiting for an `id` value, not a query object.