### PR TITLE
[FIX] Livechat triggers not firing

### DIFF
--- a/app/livechat/server/api/v1/agent.js
+++ b/app/livechat/server/api/v1/agent.js
@@ -60,7 +60,7 @@ API.v1.addRoute('livechat/agent.next/:token', {
 				}
 			}
 
-			const agentData = Livechat.getNextAgent(department);
+			const agentData = Promise.await(Livechat.getNextAgent(department));
 			if (!agentData) {
 				throw new Meteor.Error('agent-not-found');
 			}

--- a/app/livechat/server/methods/getNextAgent.js
+++ b/app/livechat/server/methods/getNextAgent.js
@@ -5,7 +5,7 @@ import { LivechatRooms, Users } from '../../../models';
 import { Livechat } from '../lib/Livechat';
 
 Meteor.methods({
-	'livechat:getNextAgent'({ token, department }) {
+	async 'livechat:getNextAgent'({ token, department }) {
 		check(token, String);
 
 		const room = LivechatRooms.findOpenByVisitorToken(token).fetch();
@@ -21,7 +21,7 @@ Meteor.methods({
 			}
 		}
 
-		const agent = Livechat.getNextAgent(department);
+		const agent = await Livechat.getNextAgent(department);
 		if (!agent) {
 			return;
 		}


### PR DESCRIPTION
CLOSES #15842 

The `Livechat.getNextAgent` method returns a promise, but there was a promise handler missing when calling this method inside the `livechat/agent.next` endpoint, then the expected value wasn't being returned.

