### PR TITLE
[FIX] Default value of the Livechat WebhookUrl setting

### DIFF
--- a/app/livechat/server/config.js
+++ b/app/livechat/server/config.js
@@ -146,7 +146,7 @@ Meteor.startup(function() {
 		i18nLabel: 'Accept_new_livechats_when_agent_is_idle',
 	});
 
-	settings.add('Livechat_webhookUrl', false, {
+	settings.add('Livechat_webhookUrl', '', {
 		type: 'string',
 		group: 'Livechat',
 		section: 'CRM_Integration',

--- a/server/startup/migrations/index.js
+++ b/server/startup/migrations/index.js
@@ -167,4 +167,5 @@ import './v166';
 import './v167';
 import './v168';
 import './v169';
+import './v170';
 import './xrun';

--- a/server/startup/migrations/v170.js
+++ b/server/startup/migrations/v170.js
@@ -1,0 +1,18 @@
+import { Migrations } from '../../../app/migrations/server';
+import { Settings } from '../../../app/models/server';
+
+Migrations.add({
+	version: 170,
+	up() {
+		const _id = 'Livechat_webhookUrl';
+		const setting = Settings.findOne({ _id });
+		if (setting && setting.value === false) {
+			Settings.update({ _id }, {
+				$set: {
+					value: '',
+					packageValue: '',
+				},
+			});
+		}
+	},
+});


### PR DESCRIPTION
The default value of the `Livechat_webhookUrl` setting was defined as `false`, but it's a `string` setting, so the webhook was being fired unnecessarily. 