### PR TITLE
[FIX] Livechat build without NodeJS installed

### DIFF
--- a/packages/rocketchat-livechat/plugin/build.sh
+++ b/packages/rocketchat-livechat/plugin/build.sh
@@ -18,6 +18,6 @@ cd $LIVECHAT_DIR
 cp -a $ROOT/node_modules/\@rocket.chat/livechat/build/. ./
 # change to lowercase so all injected junk from rocket.chat is not sent: https://github.com/meteorhacks/meteor-inject-initial/blob/master/lib/inject-core.js#L10
 # this is not harmful since doctype is case-insesitive: https://www.w3.org/TR/html5/syntax.html#the-doctype
-node -e 'fs.writeFileSync("index.html", fs.readFileSync("index.html").toString().replace("<!DOCTYPE", "<!doctype"));'
+meteor node -e 'fs.writeFileSync("index.html", fs.readFileSync("index.html").toString().replace("<!DOCTYPE", "<!doctype"));'
 cd $ROOT/$LIVECHAT_ASSETS_DIR
 cp ../../public/livechat/index.html .


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #15889

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

Fixes `packages/rocketchat-livechat/plugin/build.sh: node: not found` when building bundle.
