### PR TITLE
[IMPROVE] Set the color of the cancel button on modals to #bdbebf for enhanced  visibiity

### DIFF
--- a/app/theme/client/imports/components/modal.css
+++ b/app/theme/client/imports/components/modal.css
@@ -145,7 +145,6 @@
 
 		padding: 16px;
 
-		background: #f7f8fa;
 		justify-content: space-between;
 
 		& > .rc-button {

--- a/app/ui-utils/client/lib/modal.html
+++ b/app/ui-utils/client/lib/modal.html
@@ -53,7 +53,7 @@
 					</section>
 					{{# if showFooter }}
 						<footer class="rc-modal__footer {{#unless showFooter}}rc-modal__footer--empty{{/unless}}">
-							<input class="rc-button rc-button--nude js-close {{#unless showCancelButton}}rc-button--invisible{{/unless}}" style="{{#if cancelButtonColor}}color: {{cancelButtonColor}}{{/if}}" type="submit" data-button="cancel" value="{{cancelButtonText}}">
+							<input class="rc-button rc-button--nude js-close {{#unless showCancelButton}}rc-button--invisible{{/unless}}" style="background-color: #bdbebf;{{#if cancelButtonColor}}color: {{cancelButtonColor}}{{/if}}" type="submit" data-button="cancel" value="{{cancelButtonText}}">
 							<input style="background-color:{{confirmButtonColor}}" class="rc-button rc-button--primary js-confirm {{#unless showConfirmButton}}rc-button--invisible{{/unless}}" type="submit" data-button="create" value="{{confirmButtonText}}">
 						</footer>
 					{{/if}}

--- a/app/ui-utils/client/lib/modal.html
+++ b/app/ui-utils/client/lib/modal.html
@@ -53,7 +53,7 @@
 					</section>
 					{{# if showFooter }}
 						<footer class="rc-modal__footer {{#unless showFooter}}rc-modal__footer--empty{{/unless}}">
-							<input class="rc-button rc-button--nude js-close {{#unless showCancelButton}}rc-button--invisible{{/unless}}" style="background-color: #bdbebf;{{#if cancelButtonColor}}color: {{cancelButtonColor}}{{/if}}" type="submit" data-button="cancel" value="{{cancelButtonText}}">
+							<input class="rc-button rc-button--secondary js-close {{#unless showCancelButton}}rc-button--invisible{{/unless}}" style="{{#if cancelButtonColor}}color: {{cancelButtonColor}}{{/if}}" type="submit" data-button="cancel" value="{{cancelButtonText}}">
 							<input style="background-color:{{confirmButtonColor}}" class="rc-button rc-button--primary js-confirm {{#unless showConfirmButton}}rc-button--invisible{{/unless}}" type="submit" data-button="create" value="{{confirmButtonText}}">
 						</footer>
 					{{/if}}


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #15588 

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
![image](https://user-images.githubusercontent.com/43509699/70121905-8b3a1880-1695-11ea-9c58-7c203eece4eb.png)
![image](https://user-images.githubusercontent.com/43509699/70121936-a1e06f80-1695-11ea-9800-16242f7c024c.png)
The cancel button  looks more pronounced and visible
