### PR TITLE
[FIX]Add time format for latest message on the sidebar

### DIFF
--- a/app/lib/client/lib/formatDate.js
+++ b/app/lib/client/lib/formatDate.js
@@ -45,7 +45,7 @@ const sameElse = function(now) {
 
 export const timeAgo = (date) => moment(date).calendar(null, {
 	lastDay: `[${ lastDay }]`,
-	sameDay,
+	sameDay: settings.get('Message_TimeFormat'),
 	lastWeek: 'dddd',
 	sameElse,
 });

--- a/app/lib/client/lib/formatDate.js
+++ b/app/lib/client/lib/formatDate.js
@@ -13,7 +13,7 @@ const dayFormat = ['h:mm A', 'H:mm'];
 
 Meteor.startup(() => Tracker.autorun(() => {
 	clockMode = getUserPreference(Meteor.userId(), 'clockMode', false);
-	sameDay = dayFormat[clockMode - 1] || 'h:mm A';
+	sameDay = dayFormat[clockMode - 1] || settings.get('Message_TimeFormat');
 	lastDay = t('yesterday');
 }));
 
@@ -45,7 +45,7 @@ const sameElse = function(now) {
 
 export const timeAgo = (date) => moment(date).calendar(null, {
 	lastDay: `[${ lastDay }]`,
-	sameDay: settings.get('Message_TimeFormat'),
+	sameDay,
 	lastWeek: 'dddd',
 	sameElse,
 });


### PR DESCRIPTION


<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #15857 

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
The sidebar time fomat was static and thus not dependent on the time format set by the user . Made changes so that it depends on user time format
![image](https://user-images.githubusercontent.com/43509699/70297024-78991e00-1812-11ea-8196-43bbe54819e9.png)
For Format HH:mm:ss
![image](https://user-images.githubusercontent.com/43509699/70297113-b433e800-1812-11ea-95d8-3da3786ab39e.png)
For HH:mm
etc