### PR TITLE
[FIX] user query by username and service name

### DIFF
--- a/app/models/server/models/Users.js
+++ b/app/models/server/models/Users.js
@@ -447,7 +447,7 @@ export class Users extends Base {
 			username = new RegExp(`^${ s.escapeRegExp(username) }$`, 'i');
 		}
 
-		const query = { username, [`services.${ serviceName }.id`]: serviceName };
+		const query = { username, [`services.${ serviceName }.id`]: username };
 
 		return this.findOne(query, options);
 	}


### PR DESCRIPTION
This method is called from the custom_oauth_server.js file here:  https://github.com/RocketChat/Rocket.Chat/blob/develop/app/custom-oauth/server/custom_oauth_server.js#L369

It should verify if the user already exists, but it has been failing consistently.  It was passing the wrong variable inside the query and this PR fixes that. 