### PR TITLE
[FIX] SAML logout error

### DIFF
--- a/app/meteor-accounts-saml/server/saml_server.js
+++ b/app/meteor-accounts-saml/server/saml_server.js
@@ -56,7 +56,7 @@ Meteor.methods({
 			console.log(`Logout request from ${ JSON.stringify(providerConfig) }`);
 		}
 		// This query should respect upcoming array of SAML logins
-		const user = Users.findOneByIdAndSAMLProvider(Meteor.userId(), provider);
+		const user = Users.getSAMLByIdAndSAMLProvider(Meteor.userId(), provider);
 		if (!user || !user.services || ! user.services.saml) {
 			return;
 		}

--- a/app/meteor-accounts-saml/server/saml_server.js
+++ b/app/meteor-accounts-saml/server/saml_server.js
@@ -13,6 +13,7 @@ import { SAML } from './saml_utils';
 import { Rooms, Subscriptions, CredentialTokens } from '../../models';
 import { generateUsernameSuggestion } from '../../lib';
 import { _setUsername } from '../../lib/server/functions';
+import { Users } from '../../models/server';
 
 if (!Accounts.saml) {
 	Accounts.saml = {

--- a/app/meteor-accounts-saml/server/saml_server.js
+++ b/app/meteor-accounts-saml/server/saml_server.js
@@ -55,12 +55,11 @@ Meteor.methods({
 			console.log(`Logout request from ${ JSON.stringify(providerConfig) }`);
 		}
 		// This query should respect upcoming array of SAML logins
-		const user = Meteor.users.findOne({
-			_id: Meteor.userId(),
-			'services.saml.provider': provider,
-		}, {
-			'services.saml': 1,
-		});
+		const user = Users.findOneByIdAndSAMLProvider(Meteor.userId(), provider);
+		if (!user) {
+			return;
+		}
+
 		let { nameID } = user.services.saml;
 		const sessionIndex = user.services.saml.idpSession;
 		nameID = sessionIndex;
@@ -91,7 +90,6 @@ Meteor.methods({
 		if (Accounts.saml.settings.debug) {
 			console.log(`SAML Logout Request ${ result }`);
 		}
-
 
 		return result;
 	},

--- a/app/meteor-accounts-saml/server/saml_server.js
+++ b/app/meteor-accounts-saml/server/saml_server.js
@@ -57,7 +57,7 @@ Meteor.methods({
 		}
 		// This query should respect upcoming array of SAML logins
 		const user = Users.findOneByIdAndSAMLProvider(Meteor.userId(), provider);
-		if (!user) {
+		if (!user || !user.services || ! user.services.saml) {
 			return;
 		}
 

--- a/app/models/server/models/Users.js
+++ b/app/models/server/models/Users.js
@@ -766,10 +766,6 @@ export class Users extends Base {
 		});
 	}
 
-	findOneByEppn(eppn) {
-		return this.findOne({ eppn });
-	}
-
 	// UPDATE
 	addImportIds(_id, importIds) {
 		importIds = [].concat(importIds);

--- a/app/models/server/models/Users.js
+++ b/app/models/server/models/Users.js
@@ -757,7 +757,7 @@ export class Users extends Base {
 		return this.find({ active: true, isRemote: true }, options);
 	}
 
-	findOneByIdAndSAMLProvider(_id, provider) {
+	getSAMLByIdAndSAMLProvider(_id, provider) {
 		return this.findOne({
 			_id,
 			'services.saml.provider': provider,
@@ -992,7 +992,7 @@ export class Users extends Base {
 	setPreferences(_id, preferences) {
 		const settingsObject = Object.assign(
 			{},
-			...Object.keys(preferences).map((key) => ({ [`settings.preferences.${ key }`]: preferences[key] }))
+			...Object.keys(preferences).map((key) => ({ [`settings.preferences.${ key }`]: preferences[key] })),
 		);
 
 		const update = {

--- a/app/models/server/models/Users.js
+++ b/app/models/server/models/Users.js
@@ -757,6 +757,19 @@ export class Users extends Base {
 		return this.find({ active: true, isRemote: true }, options);
 	}
 
+	findOneByIdAndSAMLProvider(_id, provider) {
+		return this.findOne({
+			_id,
+			'services.saml.provider': provider,
+		}, {
+			'services.saml': 1,
+		});
+	}
+
+	findOneByEppn(eppn) {
+		return this.findOne({ eppn });
+	}
+
 	// UPDATE
 	addImportIds(_id, importIds) {
 		importIds = [].concat(importIds);


### PR DESCRIPTION
If SAML is turned on but an user logs out without logging in with SAML before, Rocket.Chat will throw the following error:
```
I20191212-12:50:08.442(-3)? Exception while invoking method 'samlLogout' TypeError: Cannot read property 'services' of undefined
I20191212-12:50:08.443(-3)?     at MethodInvocation.samlLogout (app/meteor-accounts-saml/server/saml_server.js:64:25)
I20191212-12:50:08.443(-3)?     at MethodInvocation.methodsMap.(anonymous function) (app/lib/server/lib/debug.js:67:34)
I20191212-12:50:08.444(-3)?     at maybeAuditArgumentChecks (packages/ddp-server/livedata_server.js:1771:12)
I20191212-12:50:08.445(-3)?     at DDP._CurrentMethodInvocation.withValue (packages/ddp-server/livedata_server.js:719:19)
I20191212-12:50:08.503(-3)?     at Meteor.EnvironmentVariable.EVp.withValue (packages/meteor.js:1234:12)
I20191212-12:50:08.503(-3)?     at DDPServer._CurrentWriteFence.withValue (packages/ddp-server/livedata_server.js:717:46)
I20191212-12:50:08.504(-3)?     at Meteor.EnvironmentVariable.EVp.withValue (packages/meteor.js:1234:12)
I20191212-12:50:08.504(-3)?     at Promise (packages/ddp-server/livedata_server.js:715:46)
I20191212-12:50:08.504(-3)?     at new Promise (<anonymous>)
I20191212-12:50:08.504(-3)?     at Session.method (packages/ddp-server/livedata_server.js:689:23)
I20191212-12:50:08.504(-3)?     at packages/ddp-server/livedata_server.js:559:43
