### PR TITLE
[FIX] Guest's name field missing when forwarding livechat rooms

### DIFF
--- a/app/livechat/server/lib/Helper.js
+++ b/app/livechat/server/lib/Helper.js
@@ -273,7 +273,7 @@ export const normalizeTransferredByData = (transferredBy, room) => {
 	return {
 		_id,
 		username,
-		name,
+		...name && { name },
 		type,
 	};
 };

--- a/app/livechat/server/lib/Livechat.js
+++ b/app/livechat/server/lib/Livechat.js
@@ -478,7 +478,7 @@ export const Livechat = {
 		check(transferredBy, Match.ObjectIncluding({
 			_id: String,
 			username: String,
-			name: String,
+			name: Match.Maybe(String),
 			type: String,
 		}));
 


### PR DESCRIPTION
CLOSES #15923 

Since the Guest's name field is not mandatory, the check validation needs to be optional on this field to allow transferring livechat rooms from the REST API endpoint. 