### PR TITLE
[FIX] Changed renderMessage priority, fixed Katex on/off setting

### DIFF
--- a/app/katex/client/index.js
+++ b/app/katex/client/index.js
@@ -187,14 +187,14 @@ class Katex {
 
 Tracker.autorun(async () => {
 	if (!settings.get('Katex_Enabled')) {
-		callbacks.remove('renderMessage', 'katex');
+		return callbacks.remove('renderMessage', 'katex');
 	}
 
 
 	const [katex] = await Promise.all([import('katex'), import('./style.css'), import('../katex.min.css')]);
 	const instance = new Katex(katex);
 
-	callbacks.add('renderMessage', instance.renderMessage, callbacks.priority.HIGH - 1, 'katex');
+	callbacks.add('renderMessage', instance.renderMessage, callbacks.priority.HIGH + 1, 'katex');
 });
 
 export default {


### PR DESCRIPTION
Wrong renderMessage priority was using katex before code block, causing some char combination to be replaced with tokens.

Additionally, it was discovered that Katex wasn't being turned off via the interface. Fixed.

Closes #15160
Closes #8640
Closes #11006
Closes #13538

Maybe related #12336 


