### PR TITLE
[FIX] Break message-attachment text to the next line

### DIFF
--- a/app/message-attachments/client/stylesheets/messageAttachments.css
+++ b/app/message-attachments/client/stylesheets/messageAttachments.css
@@ -130,6 +130,7 @@ html.rtl .attachment {
 		align-items: flex-start;
 
 		& .attachment-flex-column-grow {
+			word-break: break-word;
 			flex-grow: 1;
 		}
 	}


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #16034 

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
![image](https://user-images.githubusercontent.com/43509699/71312218-47456280-244e-11ea-8f04-d4a503dd868a.png)
Pushed the overflowing content to the next line, content is still responsive