### PR TITLE
[FIX] "User not found" for direct messages

### DIFF
--- a/app/ui/client/views/404/roomNotFound.html
+++ b/app/ui/client/views/404/roomNotFound.html
@@ -1,10 +1,10 @@
 <template name="roomNotFound">
 	<section class="page-container page-list content-background-color">
-		{{> header sectionName="Room_not_found"}}
-		<div class="content room-not-found error-color">
-			<i class="icon-attention"></i>
-			<div>
-				{{#with data}}
+		{{#with data}}
+			{{> header sectionName=headerMessage}}
+			<div class="content room-not-found error-color">
+				<i class="icon-attention"></i>
+				<div>
 					{{#if $eq type 'c'}}
 						{{{_ 'No_channel_with_name_%s_was_found' name}}}
 					{{/if}}
@@ -22,8 +22,8 @@
 							{{/if}}
 						{{/if}}
 					{{/if}}
-				{{/with}}
+				</div>
 			</div>
-		</div>
+		{{/with}}
 	</section>
 </template>

--- a/app/ui/client/views/404/roomNotFound.js
+++ b/app/ui/client/views/404/roomNotFound.js
@@ -23,10 +23,6 @@ Template.roomNotFound.helpers({
 	headerMessage() {
 		const { type } = Template.currentData();
 
-		if (type === 'd') {
-			return 'User_not_found';
-		}
-
-		return 'Room_not_found';
+		return type === 'd' ? 'User_not_found' : 'Room_not_found';
 	},
 });

--- a/app/ui/client/views/404/roomNotFound.js
+++ b/app/ui/client/views/404/roomNotFound.js
@@ -20,4 +20,13 @@ Template.roomNotFound.helpers({
 	customErrorMessage() {
 		return this.error.reason;
 	},
+	headerMessage() {
+		const { type } = Template.currentData();
+
+		if (type === 'd') {
+			return 'User_not_found';
+		}
+
+		return 'Room_not_found';
+	},
 });


### PR DESCRIPTION
Closes #8113

Changed the room header message when a User doesn't exist. Channel and Group messages persisted.
![Screenshot 2019-12-23 at 10 33 20](https://user-images.githubusercontent.com/40830821/71361181-eb272f00-2570-11ea-96e5-bb706bf08048.png)
