### PR TITLE
[FIX] set x-content-type-options header to nosniff

### DIFF
--- a/app/cors/server/cors.js
+++ b/app/cors/server/cors.js
@@ -53,6 +53,9 @@ WebApp.rawConnectHandlers.use(function(req, res, next) {
 	// XSS Protection for old browsers (IE)
 	res.setHeader('X-XSS-Protection', '1');
 
+	// X-Content-Type-Options header to prevent MIME Sniffing
+	res.setHeader('X-Content-Type-Options', 'nosniff');
+
 	if (Support_Cordova_App !== true) {
 		return next();
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18973,6 +18973,18 @@
 						"hoek": "2.x.x",
 						"joi": "6.x.x",
 						"wreck": "5.x.x"
+					},
+					"dependencies": {
+						"wreck": {
+							"version": "5.6.1",
+							"resolved": "https://registry.npmjs.org/wreck/-/wreck-5.6.1.tgz",
+							"integrity": "sha1-r/ADBAATiJ11YZtccYcN0qjdBpo=",
+							"dev": true,
+							"requires": {
+								"boom": "2.x.x",
+								"hoek": "2.x.x"
+							}
+						}
 					}
 				},
 				"heavy": {
@@ -18984,6 +18996,20 @@
 						"boom": "2.x.x",
 						"hoek": "2.x.x",
 						"joi": "5.x.x"
+					},
+					"dependencies": {
+						"joi": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+							"integrity": "sha1-FSrQfbjunGQBmX/1/SwSiWBwv1g=",
+							"dev": true,
+							"requires": {
+								"hoek": "^2.2.x",
+								"isemail": "1.x.x",
+								"moment": "2.x.x",
+								"topo": "1.x.x"
+							}
+						}
 					}
 				},
 				"hoek": {


### PR DESCRIPTION
[FIX] No X-Content-Type-Options header

Closes #15855 

Added X-Content-Type-Options response header to prevent MIME sniffing by modern browsers. This removed a possible security threat.
