### PR TITLE
[FIX] Save password without confirmation

### DIFF
--- a/app/ui-account/client/accountProfile.js
+++ b/app/ui-account/client/accountProfile.js
@@ -138,7 +138,7 @@ Template.accountProfile.helpers({
 		if (!avatar && user.name === realname && user.username === username && getUserEmailAddress(user) === email === email && (!password || password !== confirmationPassword)) {
 			return ret;
 		}
-		if (!validateEmail(email) || (!validateUsername(username) || usernameAvaliable !== true) || !validateName(realname) || !validateStatusMessage(statusText)) {
+		if (!validateEmail(email) || !validatePassword(password, confirmationPassword) || (!validateUsername(username) || usernameAvaliable !== true) || !validateName(realname) || !validateStatusMessage(statusText)) {
 			return ret;
 		}
 	},


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #16057 

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
### Before changes (gif)
User can click "Save Profile and thus can update password"
![11](https://user-images.githubusercontent.com/43786728/71542409-3df75100-298c-11ea-9870-94138de18d96.gif)


### After changes (gif)
The "Save Profile" button is disabled if password is not equal to confirm-password
![22](https://user-images.githubusercontent.com/43786728/71542493-1e145d00-298d-11ea-88c2-0c520358f455.gif)


