### PR TITLE
[FIX] Thread message icon overlapping text

### DIFF
--- a/app/theme/client/imports/general/base_old.css
+++ b/app/theme/client/imports/general/base_old.css
@@ -4846,8 +4846,10 @@ rc-old select,
 
 	& svg.thread-icons--thread {
 		left: 0;
-		margin: 0 3px;
+
 		position: relative;
+		
+		margin: 0 3px;
 	}
 }
 

--- a/app/theme/client/imports/general/base_old.css
+++ b/app/theme/client/imports/general/base_old.css
@@ -4845,10 +4845,10 @@ rc-old select,
 	}
 
 	& svg.thread-icons--thread {
+		position: relative;
+
 		left: 0;
 
-		position: relative;
-		
 		margin: 0 3px;
 	}
 }

--- a/app/theme/client/imports/general/base_old.css
+++ b/app/theme/client/imports/general/base_old.css
@@ -4844,7 +4844,7 @@ rc-old select,
 		margin-left: -5px;
 	}
 
-	& svg.thread-icons--thread {
+	& .thread-icons--thread {
 		position: relative;
 
 		left: 0;

--- a/app/theme/client/imports/general/base_old.css
+++ b/app/theme/client/imports/general/base_old.css
@@ -4843,6 +4843,12 @@ rc-old select,
 	& .user.user-card-message {
 		margin-left: -5px;
 	}
+
+	& svg.thread-icons--thread {
+		left: 0;
+		margin: 0 3px;
+		position: relative;
+	}
 }
 
 .rc-old .messages-box:not(.compact) .hide-avatars .message.sequential .info {

--- a/app/ui-message/client/messageThread.html
+++ b/app/ui-message/client/messageThread.html
@@ -1,6 +1,6 @@
 <template name="messageThread">
 	<q role="button" aria-label="{{_ " Open_thread "}}" class="thread-quote">
-			<div class="thread-quote__message js-open-thread">{{> icon icon="thread" block="thread-icons"}} <span class="message-body--unstyled">{{{parentMessage}}}</span></div>
+		<div class="thread-quote__message js-open-thread"><span class="message-body--unstyled">{{{parentMessage}}}</span> {{> icon icon="thread" block="thread-icons"}}</div>
 
 		{{# if following }}
 		<div role="button" class="rc-tooltip js-unfollow-thread" aria-label="{{_ "Following"}}">


### PR DESCRIPTION
Closes #15448

When "Hide Avatars" is set in the user's preference, the thread icon will be placed on the right of the text so that everything aligns correctly.

![Screenshot 2019-12-27 at 11 11 21](https://user-images.githubusercontent.com/40830821/71520211-a580a400-2899-11ea-86b3-586de2d6f28d.png)
