### PR TITLE
[FIX] SafePorts: Ports 80, 8080 & 443 linked to respective protocols (#16108)

### DIFF
--- a/app/oembed/server/server.js
+++ b/app/oembed/server/server.js
@@ -61,7 +61,6 @@ const toUtf8 = function(contentType, body) {
 };
 
 const getUrlContent = function(urlObj, redirectCount = 5, callback) {
-	console.log("teste");
 	if (_.isString(urlObj)) {
 		urlObj = URL.parse(urlObj);
 	}
@@ -73,26 +72,15 @@ const getUrlContent = function(urlObj, redirectCount = 5, callback) {
 	};
 
 	const parsedUrl = _.pick(urlObj, ['host', 'hash', 'pathname', 'protocol', 'port', 'query', 'search', 'hostname']);
-
-	console.log("parsedUrl", parsedUrl);
 	const ignoredHosts = settings.get('API_EmbedIgnoredHosts').replace(/\s/g, '').split(',') || [];
 	if (ignoredHosts.includes(parsedUrl.hostname) || ipRangeCheck(parsedUrl.hostname, ignoredHosts)) {
 		return callback();
 	}
 
 	const safePorts = settings.get('API_EmbedSafePorts').replace(/\s/g, '').split(',') || [];
-	console.log("safePorts", safePorts);
-	console.log("teste", safePorts.some((port) => portsProtocol[port] === parsedUrl.protocol));
-
 	if (safePorts.length > 0 && ((parsedUrl.port && !safePorts.includes(parsedUrl.port)) || (!parsedUrl.port && !safePorts.some((port) => portsProtocol[port] === parsedUrl.protocol)))) {
 		return callback();
 	}
-
-	// const ignoredProtocols = ['http:', 'ftp:'];
-	// console.log(parsedUrl);
-	// if (ignoredProtocols.length > 0 && parsedUrl.protocol && ignoredProtocols.includes(parsedUrl.protocol)) {
-	// 	return callback();
-	// }
 
 	const data = callbacks.run('oembed:beforeGetUrlContent', {
 		urlObj,

--- a/app/oembed/server/server.js
+++ b/app/oembed/server/server.js
@@ -61,20 +61,38 @@ const toUtf8 = function(contentType, body) {
 };
 
 const getUrlContent = function(urlObj, redirectCount = 5, callback) {
+	console.log("teste");
 	if (_.isString(urlObj)) {
 		urlObj = URL.parse(urlObj);
 	}
 
+	const portsProtocol = {
+		80: 'http:',
+		8080: 'http:',
+		443: 'https:',
+	};
+
 	const parsedUrl = _.pick(urlObj, ['host', 'hash', 'pathname', 'protocol', 'port', 'query', 'search', 'hostname']);
+
+	console.log("parsedUrl", parsedUrl);
 	const ignoredHosts = settings.get('API_EmbedIgnoredHosts').replace(/\s/g, '').split(',') || [];
 	if (ignoredHosts.includes(parsedUrl.hostname) || ipRangeCheck(parsedUrl.hostname, ignoredHosts)) {
 		return callback();
 	}
 
 	const safePorts = settings.get('API_EmbedSafePorts').replace(/\s/g, '').split(',') || [];
-	if (parsedUrl.port && safePorts.length > 0 && !safePorts.includes(parsedUrl.port)) {
+	console.log("safePorts", safePorts);
+	console.log("teste", safePorts.some((port) => portsProtocol[port] === parsedUrl.protocol));
+
+	if (safePorts.length > 0 && ((parsedUrl.port && !safePorts.includes(parsedUrl.port)) || (!parsedUrl.port && !safePorts.some((port) => portsProtocol[port] === parsedUrl.protocol)))) {
 		return callback();
 	}
+
+	// const ignoredProtocols = ['http:', 'ftp:'];
+	// console.log(parsedUrl);
+	// if (ignoredProtocols.length > 0 && parsedUrl.protocol && ignoredProtocols.includes(parsedUrl.protocol)) {
+	// 	return callback();
+	// }
 
 	const data = callbacks.run('oembed:beforeGetUrlContent', {
 		urlObj,

--- a/app/oembed/server/server.js
+++ b/app/oembed/server/server.js
@@ -78,7 +78,12 @@ const getUrlContent = function(urlObj, redirectCount = 5, callback) {
 	}
 
 	const safePorts = settings.get('API_EmbedSafePorts').replace(/\s/g, '').split(',') || [];
-	if (safePorts.length > 0 && ((parsedUrl.port && !safePorts.includes(parsedUrl.port)) || (!parsedUrl.port && !safePorts.some((port) => portsProtocol[port] === parsedUrl.protocol)))) {
+
+	if (safePorts.length > 0 && parsedUrl.port && !safePorts.includes(parsedUrl.port)) {
+		return callback();
+	}
+
+	if (safePorts.length > 0 && !parsedUrl.port && !safePorts.some((port) => portsProtocol[port] === parsedUrl.protocol)) {
 		return callback();
 	}
 


### PR DESCRIPTION
Closes #9849

Now whenever there is no port defined in the URL, HTTP will be treated as 80, 8080, and HTTPS as 443, thus making it possible to block embedding of these ports through the "Safe Ports" setting in the admin menu.