### PR TITLE
[FIX] Video message sent to wrong room

### DIFF
--- a/app/ui-vrecord/client/VRecDialog.js
+++ b/app/ui-vrecord/client/VRecDialog.js
@@ -9,17 +9,12 @@ export const VRecDialog = new class {
 
 	dialogView = null;
 
-	width = 400;
-
-	height = 290;
-
-
 	init() {
 		this.dialogView = Blaze.render(Template.vrecDialog, document.body);
 	}
 
 	open(source, { rid, tmid }) {
-		if (!this.initiated) {
+		if (!this.dialogView) {
 			this.init();
 		}
 
@@ -31,7 +26,7 @@ export const VRecDialog = new class {
 
 		this.source = source;
 		const dialog = $('.vrec-dialog');
-		this.setPosition(dialog, source);
+		this.dialogView.templateInstance().setPosition(dialog, source);
 		dialog.addClass('show');
 		this.opened = true;
 
@@ -41,38 +36,9 @@ export const VRecDialog = new class {
 	close() {
 		$('.vrec-dialog').removeClass('show');
 		this.opened = false;
-		$(window).off('resize', this.remove);
 		if (this.video != null) {
 			return VideoRecorder.stop();
 		}
-	}
-
-	setPosition(dialog, source, anchor = 'left') {
-		const _set = () => {
-			const sourcePos = $(source).offset();
-			let top = sourcePos.top - this.height - 5;
-
-			if (top < 0) {
-				top = 10;
-			}
-			if (anchor === 'left') {
-				let right = window.innerWidth - (sourcePos.left + source.offsetWidth - 25);
-				if (right < 0) {
-					right = 10;
-				}
-				return dialog.css({ top: `${ top }px`, right: `${ right }px` });
-			}
-			let left = (sourcePos.left - this.width) + 100;
-			if (left < 0) {
-				left = 10;
-			}
-			return dialog.css({ top: `${ top }px`, left: `${ left }px` });
-		};
-
-		const set = _.debounce(_set, 2000);
-		_set();
-		this.remove = set;
-		$(window).on('resize', set);
 	}
 
 	initializeCamera() {

--- a/app/ui-vrecord/client/VRecDialog.js
+++ b/app/ui-vrecord/client/VRecDialog.js
@@ -1,6 +1,5 @@
 import { Blaze } from 'meteor/blaze';
 import { Template } from 'meteor/templating';
-import _ from 'underscore';
 
 import { VideoRecorder } from '../../ui';
 

--- a/app/ui-vrecord/client/VRecDialog.js
+++ b/app/ui-vrecord/client/VRecDialog.js
@@ -5,26 +5,29 @@ import _ from 'underscore';
 import { VideoRecorder } from '../../ui';
 
 export const VRecDialog = new class {
-	constructor() {
-		this.opened = false;
-		this.initiated = false;
-		this.width = 400;
-		this.height = 290;
-	}
+	opened = false;
 
-	init(templateData) {
-		if (this.initiated) {
-			return;
-		}
+	dialogView = null;
 
-		this.initiated = true;
-		return Blaze.renderWithData(Template.vrecDialog, templateData, document.body);
+	width = 400;
+
+	height = 290;
+
+
+	init() {
+		this.dialogView = Blaze.render(Template.vrecDialog, document.body);
 	}
 
 	open(source, { rid, tmid }) {
 		if (!this.initiated) {
-			this.init({ rid, tmid, input: source.querySelector('.js-input-message') });
+			this.init();
 		}
+
+		this.dialogView.templateInstance().update({
+			rid,
+			tmid,
+			input: source.querySelector('.js-input-message'),
+		});
 
 		this.source = source;
 		const dialog = $('.vrec-dialog');

--- a/app/ui-vrecord/client/vrecord.js
+++ b/app/ui-vrecord/client/vrecord.js
@@ -1,8 +1,7 @@
 import { Template } from 'meteor/templating';
 import { TAPi18n } from 'meteor/rocketchat:tap-i18n';
-import { ReactiveDict } from 'meteor/reactive-dict';
 import { ReactiveVar } from 'meteor/reactive-var';
-import { VariableContext } from 'twilio/lib/rest/serverless/v1/service/environment/variable';
+import _ from 'underscore';
 
 import { VRecDialog } from './VRecDialog';
 import { VideoRecorder, fileUpload } from '../../ui';
@@ -53,6 +52,9 @@ Template.vrecDialog.events({
 });
 
 Template.vrecDialog.onCreated(function() {
+	this.width = 400;
+	this.height = 290;
+
 	this.rid = new ReactiveVar();
 	this.tmid = new ReactiveVar();
 	this.input = new ReactiveVar();
@@ -61,4 +63,36 @@ Template.vrecDialog.onCreated(function() {
 		this.tmid.set(tmid);
 		this.input.set(input);
 	};
+
+	this.setPosition = function(dialog, source, anchor = 'left') {
+		const _set = () => {
+			const sourcePos = $(source).offset();
+			let top = sourcePos.top - this.height - 5;
+
+			if (top < 0) {
+				top = 10;
+			}
+			if (anchor === 'left') {
+				let right = window.innerWidth - (sourcePos.left + source.offsetWidth - 25);
+				if (right < 0) {
+					right = 10;
+				}
+				return dialog.css({ top: `${ top }px`, right: `${ right }px` });
+			}
+			let left = (sourcePos.left - this.width) + 100;
+			if (left < 0) {
+				left = 10;
+			}
+			return dialog.css({ top: `${ top }px`, left: `${ left }px` });
+		};
+
+		const set = _.debounce(_set, 2000);
+		_set();
+		this.remove = set;
+		$(window).on('resize', set);
+	};
+});
+
+Template.vrecDialog.onDestroyed(function() {
+	$(window).off('resize', this.remove);
 });

--- a/app/ui-vrecord/client/vrecord.js
+++ b/app/ui-vrecord/client/vrecord.js
@@ -1,5 +1,8 @@
 import { Template } from 'meteor/templating';
 import { TAPi18n } from 'meteor/rocketchat:tap-i18n';
+import { ReactiveDict } from 'meteor/reactive-dict';
+import { ReactiveVar } from 'meteor/reactive-var';
+import { VariableContext } from 'twilio/lib/rest/serverless/v1/service/environment/variable';
 
 import { VRecDialog } from './VRecDialog';
 import { VideoRecorder, fileUpload } from '../../ui';
@@ -39,12 +42,23 @@ Template.vrecDialog.events({
 		}
 	},
 
-	'click .vrec-dialog .ok'() {
-		const { rid, tmid, input } = this;
+	'click .vrec-dialog .ok'(e, instance) {
+		const [rid, tmid, input] = [instance.rid.get(), instance.tmid.get(), instance.input.get()];
 		const cb = (blob) => {
 			fileUpload([{ file: blob, type: 'video', name: `${ TAPi18n.__('Video record') }.webm` }], input, { rid, tmid });
 			VRecDialog.close();
 		};
 		VideoRecorder.stop(cb);
 	},
+});
+
+Template.vrecDialog.onCreated(function() {
+	this.rid = new ReactiveVar();
+	this.tmid = new ReactiveVar();
+	this.input = new ReactiveVar();
+	this.update = ({ rid, tmid, input }) => {
+		this.rid.set(rid);
+		this.tmid.set(tmid);
+		this.input.set(input);
+	};
 });


### PR DESCRIPTION
Closes #14872

When recording a video, if trying to record a new one on another room (direct, channel, group), sending the video would upload it to the first channel the video recorder rendered.
Changed data to reactive vars and moved some code to a more appropriate place.