### PR TITLE
Add Cloud Info to translation dictionary

### DIFF
--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -664,6 +664,7 @@
   "Cloud_connect": "Rocket.Chat Cloud Connect",
   "Cloud_connect_support": "If you still haven't received a registration email please make sure your email is updated above.  If you still have issues you can contact support at",
   "Cloud_console": "Cloud Console",
+  "Cloud_Info": "Cloud Info",
   "Cloud_what_is_it": "What is this?",
   "Cloud_what_is_it_description": "Rocket.Chat Cloud Connect allows you to connect your self-hosted Rocket.Chat Workspace to services we provide in our Cloud.",
   "Cloud_what_is_it_services_like": "Services like:",


### PR DESCRIPTION
Cloud_Info was being displayed instead of Cloud Info

Before:
![Screenshot from 2020-01-02 08-14-01](https://user-images.githubusercontent.com/44023445/71649846-ee23db80-2d37-11ea-9fa3-e5522e3c3203.png)

After:
![Screenshot from 2020-01-02 08-12-28](https://user-images.githubusercontent.com/44023445/71649857-08f65000-2d38-11ea-9cf9-93327468f6d8.png)



