### PR TITLE
[FIX] Resolving console errors Administration

### DIFF
--- a/client/components/admin/settings/GroupPage.js
+++ b/client/components/admin/settings/GroupPage.js
@@ -1,4 +1,4 @@
-import { Accordion, Button, Paragraph, Headline, Skeleton } from '@rocket.chat/fuselage';
+import { Accordion, Button, Paragraph, Skeleton } from '@rocket.chat/fuselage';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -69,7 +69,7 @@ GroupPage.Skeleton = function GroupPageSkeleton() {
 	const t = useTranslation();
 
 	return <div className='page-container'>
-		<Header rawSectionName={<Headline style={{ width: '20rem' }}><Skeleton /></Headline>}>
+		<Header rawSectionName={<Skeleton style={{ width: '20rem' }}/>}>
 			<Header.ButtonSection>
 				<Button
 					children={t('Save_changes')}
@@ -81,7 +81,7 @@ GroupPage.Skeleton = function GroupPageSkeleton() {
 
 		<div className='content'>
 			<Wrapper>
-				<Paragraph.Skeleton animated />
+				<Paragraph.Skeleton />
 
 				<Accordion className='page-settings'>
 					<Section.Skeleton />


### PR DESCRIPTION
Resolving console errors Administration -> Message related to Skeleton (Received `true` for a non-boolean attribute `animated`) and  validateDOMNesting (h1 cannot appear as a child of h1).