### PR TITLE
[NEW] update on mongo, node and caddy on snap

### DIFF
--- a/.snapcraft/resources/prepareRocketChat
+++ b/.snapcraft/resources/prepareRocketChat
@@ -29,4 +29,6 @@ execstack --clear-execstack npm/node_modules/sharp/vendor/lib/librsvg-2.so*
 # Having to manually remove because of latest warning
 rm -rf npm/node_modules/meteor/konecty_user-presence/node_modules/colors/lib/.colors.js.swp
 rm -rf node_modules/node-pre-gyp/node_modules/tar/lib/.mkdir.js.swp
+rm -rf npm/node_modules/sharp/node_modules/semver/bin/.semver.js.swp
+rm -rf npm/node_modules/tar/lib/.mkdir.js.swp
 

--- a/.snapcraft/resources/preparecaddy
+++ b/.snapcraft/resources/preparecaddy
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-caddy_version="v0.11.0"
+caddy_version="v1.0.4"
 
 caddy_bin="caddy"
 caddy_dl_ext=".tar.gz"

--- a/.snapcraft/resources/preparemongo
+++ b/.snapcraft/resources/preparemongo
@@ -2,8 +2,8 @@
 
 if [[ $(uname -m) == "x86_64" ]]
 then
-    wget --backups=0 "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.4.20.tgz"
-    tar -zxf ./mongodb-linux-x86_64-3.4.20.tgz --strip-components=1
+    wget --backups=0 "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.6.14.tgz"
+    tar -zxf ./mongodb-linux-x86_64-3.6.14.tgz --strip-components=1
 else
     IFS=" " read -a links <<< $(apt-get -y --print-uris install mongodb | egrep -o "https?://[^']+")
     for link in ${links[@]}

--- a/.snapcraft/resources/preparenode
+++ b/.snapcraft/resources/preparenode
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-node_version="v8.17.0"
+node_version="v8.15.1"
 
 unamem="$(uname -m)"
 if [[ $unamem == *aarch64* ]]; then

--- a/.snapcraft/resources/startRocketChat
+++ b/.snapcraft/resources/startRocketChat
@@ -4,6 +4,14 @@ function start_rocketchat {
 	echo "Checking if oplog has been enabled, and enabling if not"
 	LC_ALL=C mongo $SNAP/bin/initreplset.js
 	
+	echo "Checking if mongo featureCompatibilityVersion is correct, changing if not"
+        db_version=$(mongo --eval "printjson(db.version())" |tail -1 |tr -d '"' |cut -d. -f1,2)
+        db_comp_version=$(mongo --eval "printjson(db.adminCommand ({getParameter: 1, featureCompatibilityVersion: 1}))"|grep '"version" :' |cut -d: -f3 |cut -d} -f1|tr -d '[:space:]'|tr -d '"')
+        db_featureCompatibilityVersion="$(snapctl get db-feature-compatibility-version)"
+        if [[ $db_version == "3.6" ]] && [[ $db_comp_version == "3.4" ]] && [[ $db_featureCompatibilityVersion == "3.6" ]]; then
+            LC_ALL=C mongo --eval "printjson(db.adminCommand ({ setFeatureCompatibilityVersion: \"3.6\" }))"
+        fi
+	
 	## For making fonts work for sharp
 	export XDG_DATA_HOME=$SNAP/usr/share
 
@@ -40,6 +48,11 @@ sleep_time=5
 try_times=0
 
 function try_start {
+
+        refreshing="$(snapctl get snap-refreshing)"
+        if [ $refreshing == "true" ]; then
+            exit 0
+        fi
 
 	search=$(ps --pid $(cat $SNAP_COMMON/mongod.pid) -o comm=)
 

--- a/.snapcraft/snap/hooks/configure
+++ b/.snapcraft/snap/hooks/configure
@@ -120,3 +120,26 @@ else
   fi
 fi
 
+# Obtain backup value
+backup="$(snapctl get backup-on-refresh)"
+# Validate it
+backup_regex='((enable)|(disable))'
+if ! [[ $backup =~ $backup_regex ]] ; then
+    echo "\"$backup\" should be enable or disable" >&2
+    exit 1
+fi
+
+# Obtain db featureCompatibilityVersion
+db_featureCompatibilityVersion="$(snapctl get db-feature-compatibility-version)"
+db_featureCompatibilityVersion_regex='^3\.[4,6]$'
+if ! [[ $db_featureCompatibilityVersion =~ $db_featureCompatibilityVersion_regex ]] ; then
+    echo "\"$db_featureCompatibilityVersion\" should be 3.4 or 3.6" >&2
+    exit 1
+else
+    db_version=$(mongo --eval "printjson(db.version())" |tail -1 |tr -d '"' |cut -d. -f1,2)
+    if [[ $db_version == "3.6" ]] && [[ $db_featureCompatibilityVersion == "3.4" ]]; then
+        mongo --eval "printjson(db.adminCommand ({ setFeatureCompatibilityVersion: \"3.4\" }))"
+    elif [[ $db_version == "3.6" ]] && [[ $db_featureCompatibilityVersion == "3.6" ]]; then
+        mongo --eval "printjson(db.adminCommand ({ setFeatureCompatibilityVersion: \"3.6\" }))"
+    fi
+fi

--- a/.snapcraft/snap/hooks/install
+++ b/.snapcraft/snap/hooks/install
@@ -14,3 +14,13 @@ snapctl set mongo-oplog-url=mongodb://localhost:27017/local
 
 # Initialize the protocol to a default
 snapctl set https=disable
+
+# Initialize backup to a default
+snapctl set backup-on-refresh=disable
+
+# Initialize snap-refreshing to false
+snapctl set snap-refreshing=false
+
+# Initialize db-feature-compatibility-version to 3.6
+snapctl set db-feature-compatibility-version=3.6
+

--- a/.snapcraft/snap/hooks/post-refresh
+++ b/.snapcraft/snap/hooks/post-refresh
@@ -30,3 +30,18 @@ if [ -z "$https" ]; then
   snapctl set https=disable
 fi
 
+# Initialize backup to a default
+backup="$(snapctl get backup-on-refresh)"
+if [ -z "$backup" ]; then
+  snapctl set backup-on-refresh=disable
+fi
+
+# Set back snap-refreshing to false
+snapctl set snap-refreshing=false
+
+# Initialize db-feature-compatibility-version to a default
+db_featureCompatibilityVersion="$(snapctl get db-feature-compatibility-version)"
+if [ -z "$db_featureCompatibilityVersion" ]; then
+  snapctl set db-feature-compatibility-version=3.6
+fi
+

--- a/.snapcraft/snap/hooks/pre-refresh
+++ b/.snapcraft/snap/hooks/pre-refresh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu"
+export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+
+TIMESTAMP=$(date +"%Y%m%d.%H%M")
+
+# stop rocketchat
+snapctl set snap-refreshing=true
+
+rocketchatpid=$(pgrep -f "node $SNAP/main.js")
+kill -9 $rocketchatpid
+if ! [ $? == 0 ]; then
+    echo "Failed to stop rocketchat service" > $SNAP_COMMON/refresh_${TIMESTAMP}.log
+fi
+
+backup="$(snapctl get backup-on-refresh)"
+if [ $backup == "enable" ]; then
+    backupdb
+    if ! [ $? == 0 ]; then
+        echo "Failed rocketchat database backup before refresh" >> $SNAP_COMMON/refresh_${TIMESTAMP}.log
+    fi
+fi
+

--- a/.snapcraft/snap/snapcraft.yaml
+++ b/.snapcraft/snap/snapcraft.yaml
@@ -7,7 +7,7 @@
 # 5.  `snapcraft snap`
 
 name: rocketchat-server
-version: #{RC_VERSION}
+version: #{RC_VERSION} 
 summary: Rocket.Chat server
 description: Have your own Slack like online chat, built with Meteor. https://rocket.chat/
 confinement: strict
@@ -39,6 +39,8 @@ apps:
 hooks:
     configure:
         plugs: [network]
+    pre-refresh:
+        plugs: [network]
 parts:
     node:
         plugin: dump 
@@ -64,6 +66,7 @@ parts:
             - .node_version.txt
             - etc
             - usr
+            - star.json
     mongodb:
         build-packages:
             - wget

--- a/.snapcraft/snap/snapcraft.yaml
+++ b/.snapcraft/snap/snapcraft.yaml
@@ -7,7 +7,7 @@
 # 5.  `snapcraft snap`
 
 name: rocketchat-server
-version: #{RC_VERSION} 
+version: #{RC_VERSION}
 summary: Rocket.Chat server
 description: Have your own Slack like online chat, built with Meteor. https://rocket.chat/
 confinement: strict


### PR DESCRIPTION
updates:
mongodb: 3.4 to 3.6
node: 8.11 to 8.15
caddy: 0.11 to 1.0

plus pre-refresh hook to backup rocketchat mongo db