### PR TITLE
[FIX] "Jump to message" is rendered twice when message is starred.

### DIFF
--- a/app/message-star/client/actionButton.js
+++ b/app/message-star/client/actionButton.js
@@ -72,7 +72,7 @@ Meteor.startup(function() {
 			RoomHistoryManager.getSurroundingMessages(message, 50);
 		},
 		condition({ msg, subscription, u }) {
-			if (subscription == null || !settings.get('Message_AllowStarring')) {
+			if (subscription == null || settings.get('Message_AllowStarring')) {
 				return false;
 			}
 


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #16169 

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
### Before fix (gif):
![jump](https://user-images.githubusercontent.com/43786728/72019973-bdd8c180-3290-11ea-9bcf-cda3ea5907f6.gif)

### After fix (gif):
![starrr](https://user-images.githubusercontent.com/43786728/72024151-bd452880-329a-11ea-9006-8fbf1ad079a3.gif)
