### PR TITLE
[FIX] FileUpload.getBuffer was not working through the Apps-Engine

### DIFF
--- a/app/apps/server/bridges/uploads.js
+++ b/app/apps/server/bridges/uploads.js
@@ -14,8 +14,10 @@ export class AppUploadBridge {
 	getBuffer(upload, appId) {
 		this.orch.debugLog(`The App ${ appId } is getting the upload: "${ upload.id }"`);
 
+		const rocketChatUpload = this.orch.getConverters().get('uploads').convertToRocketChat(upload);
+
 		return new Promise((resolve, reject) => {
-			FileUpload.getBuffer(upload, (error, result) => {
+			FileUpload.getBuffer(rocketChatUpload, (error, result) => {
 				if (error) {
 					return reject(error);
 				}


### PR DESCRIPTION
There was a `converter` missing when calling the `FileUpload.getBuffer` from the`Apps-Engine`.
Due to that the `File Buffer` returned was always the same, because of the `_id` of the file was missing in the payload provided by the `Apps-Engine`.