### PR TITLE
[FIX] Unable to send messages in a room when press ESCAPE key (during message as attachment)

### DIFF
--- a/app/ui/client/lib/chatMessages.js
+++ b/app/ui/client/lib/chatMessages.js
@@ -65,8 +65,6 @@ const messageBoxState = {
 
 callbacks.add('afterLogoutCleanUp', messageBoxState.purgeAll, callbacks.priority.MEDIUM, 'chatMessages-after-logout-cleanup');
 
-const showModal = (config) => new Promise((resolve, reject) => modal.open(config, resolve, reject));
-
 export class ChatMessages {
 	editing = {}
 
@@ -356,25 +354,22 @@ export class ChatMessages {
 			throw new Error({ error: 'Message_too_long' });
 		}
 
-		try {
-			await showModal({
-				text: t('Message_too_long_as_an_attachment_question'),
-				title: '',
-				type: 'warning',
-				showCancelButton: true,
-				confirmButtonText: t('Yes'),
-				cancelButtonText: t('No'),
-				closeOnConfirm: true,
-			});
-
+		modal.open({
+			text: t('Message_too_long_as_an_attachment_question'),
+			title: '',
+			type: 'warning',
+			showCancelButton: true,
+			confirmButtonText: t('Yes'),
+			cancelButtonText: t('No'),
+			closeOnConfirm: true,
+		}, () => {
 			const contentType = 'text/plain';
 			const messageBlob = new Blob([msg], { type: contentType });
 			const fileName = `${ Meteor.user().username } - ${ new Date() }.txt`;
 			const file = new File([messageBlob], fileName, { type: contentType, lastModified: Date.now() });
 			fileUpload([{ file, name: fileName }], this.input, { rid, tmid });
-		} catch (e) {
 			return true;
-		}
+		}, () => true);
 		return true;
 	}
 


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #16339
### Steps to reproduce:
(1) Type a very long message in a room.
(2) Press send
(3) Send message as an attachment modal pops up.
(4) Press escape key or click anywhere outside
(5) Now you cannot send any further message.

### Description:
Unable to send a message in a room when press ESCAPE key or click outside of modal during message as an attachment pop up arrive when we type a long message.

This issue is not just limited to ESCAPE button but to every button and outside the modal clicks too.

### Before changes:
![zzzzzzzzzzzzzzzzzzzzzzzzzz](https://user-images.githubusercontent.com/43786728/73453343-d0c34b00-4391-11ea-9144-b6fdb17e3be0.gif)


### After changes:
![1111](https://user-images.githubusercontent.com/43786728/73217770-8fa71d00-417e-11ea-9cc1-89b9e711813d.gif)


