### PR TITLE
Regression: Fix set name to alias validation

### DIFF
--- a/app/lib/server/functions/sendMessage.js
+++ b/app/lib/server/functions/sendMessage.js
@@ -148,7 +148,7 @@ const validateUserIdentity = (message, _id) => {
 	if (!message.alias && !message.avatar) {
 		return;
 	}
-	const forbiddenPropsToChangeWhenUserIsNotABot = ['alias', 'avatar'];
+	const forbiddenPropsToChangeWhenUserIsNotABot = ['avatar'];
 	const user = Users.findOneById(_id, { fields: { roles: 1, name: 1 } });
 	/**
 	 * If the query returns no user, the message has likely
@@ -160,7 +160,7 @@ const validateUserIdentity = (message, _id) => {
 	}
 	const userIsNotABot = !user.roles.includes('bot');
 	const messageContainsAnyForbiddenProp = Object.keys(message).some((key) => forbiddenPropsToChangeWhenUserIsNotABot.includes(key));
-	if (userIsNotABot && messageContainsAnyForbiddenProp && message.alias !== user.name) {
+	if (userIsNotABot && (messageContainsAnyForbiddenProp || (typeof message.alias !== 'undefined' && message.alias !== user.name))) {
 		throw new Error('You are not authorized to change message properties');
 	}
 };

--- a/app/lib/server/functions/sendMessage.js
+++ b/app/lib/server/functions/sendMessage.js
@@ -160,7 +160,7 @@ const validateUserIdentity = (message, _id) => {
 	}
 	const userIsNotABot = !user.roles.includes('bot');
 	const messageContainsAnyForbiddenProp = Object.keys(message).some((key) => forbiddenPropsToChangeWhenUserIsNotABot.includes(key));
-	if ((userIsNotABot && messageContainsAnyForbiddenProp) || (settings.get('Message_SetNameToAliasEnabled') && message.alias !== user.name)) {
+	if (userIsNotABot && messageContainsAnyForbiddenProp && message.alias !== user.name) {
 		throw new Error('You are not authorized to change message properties');
 	}
 };


### PR DESCRIPTION
Fix the validation that should be preventing API users to set  `alias` property to other than their names but was preventing the usage of the setting `Set a User Name to Alias in Message` instead.