### PR TITLE
[FIX] Role tags missing - Description field explanation

### DIFF
--- a/app/authorization/client/views/permissionsRole.html
+++ b/app/authorization/client/views/permissionsRole.html
@@ -31,8 +31,12 @@
 						</div>
 					</div>
 					<div>
-						<label for="mandatory2fa">{{_ "Users must use Two Factor Authentication"}} :</label>
+						<label for="mandatory2fa" class="message-form">{{_ "Users must use Two Factor Authentication"}} :</label>
 						<input id="mandatory2fa" type="checkbox" name="mandatory2fa" checked="{{mandatory2fa}}">
+					</div>
+
+					<div>
+						<label for="mandatory2fa" class="message-form">{{_ "Leave the description field blank if you dont want to show the role"}}.</label>
 					</div>
 
 					<div class="rc-button__group">

--- a/app/authorization/client/views/permissionsRole.html
+++ b/app/authorization/client/views/permissionsRole.html
@@ -31,14 +31,12 @@
 						</div>
 					</div>
 					<div>
-						<label for="mandatory2fa" class="message-form">{{_ "Users must use Two Factor Authentication"}} :</label>
+						<label for="mandatory2fa">{{_ "Users must use Two Factor Authentication"}} :</label>
 						<input id="mandatory2fa" type="checkbox" name="mandatory2fa" checked="{{mandatory2fa}}">
 					</div>
-
-					<div>
-						<label for="mandatory2fa" class="message-form">{{_ "Leave the description field blank if you dont want to show the role"}}.</label>
+					<div class="alert alert-warning">
+						<p for="mandatory2fa">{{_ "Leave the description field blank if you dont want to show the role"}}.</p>
 					</div>
-
 					<div class="rc-button__group">
 						{{#if editable}}
 							<button name="delete" class="rc-button rc-button--danger delete-role">{{_ "Delete"}}</button>

--- a/app/theme/client/imports/general/base_old.css
+++ b/app/theme/client/imports/general/base_old.css
@@ -163,7 +163,8 @@
 }
 
 .rc-old .alert {
-	margin-bottom: 20px;
+	margin: 1rem 0;
+	padding: 0.5rem;
 
 	border-width: 1px;
 	border-radius: var(--border-radius);

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -3377,7 +3377,7 @@
   "Users_added": "The users have been added",
   "Users_in_role": "Users in role",
   "Users must use Two Factor Authentication": "Users must use Two Factor Authentication",
-  "Leave the description field blank if you don't want to show the role": "Leave the description field blank if you dont want to show the role",
+  "Leave_the_description_field_blank_if_you_dont_want_to_show_the_role": "Leave the description field blank if you don't want to show the role",
   "Uses": "Uses",
   "Uses_left": "Uses left",
   "UTF8_Names_Slugify": "UTF8 Names Slugify",

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -3377,6 +3377,7 @@
   "Users_added": "The users have been added",
   "Users_in_role": "Users in role",
   "Users must use Two Factor Authentication": "Users must use Two Factor Authentication",
+  "Leave the description field blank if you don't want to show the role": "Leave the description field blank if you dont want to show the role",
   "Uses": "Uses",
   "Uses_left": "Uses left",
   "UTF8_Names_Slugify": "UTF8 Names Slugify",


### PR DESCRIPTION
Closes #16350

![image](https://user-images.githubusercontent.com/5263975/73285229-7c26a100-41d4-11ea-822f-1bafe447ece5.png)

Adding an alert that explains 'if you let the description field blank, the role will not be shown
