### PR TITLE
[FIX] If InternalHubot_Username is undefined then rocket.cat should be default bot

### DIFF
--- a/app/ui/client/lib/chatMessages.js
+++ b/app/ui/client/lib/chatMessages.js
@@ -422,7 +422,7 @@ export class ChatMessages {
 						ts: new Date(),
 						msg: TAPi18n.__('No_such_command', { command: s.escapeHTML(match[1]) }),
 						u: {
-							username: settings.get('InternalHubot_Username'),
+							username: settings.get('InternalHubot_Username') || 'rocket.cat',
 						},
 						private: true,
 					};


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #16370 #16045

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
### Before fix:
![qwerty](https://user-images.githubusercontent.com/43786728/74234918-f63a4800-4cf3-11ea-96f9-f49abf7e7ea7.gif)

### After fix:
![rocketcat](https://user-images.githubusercontent.com/43786728/73356950-7c509a80-42c1-11ea-8cd9-68c20a709417.gif)

