### PR TITLE
Fix Preview Docker image build

### DIFF
--- a/.docker-mongo/Dockerfile
+++ b/.docker-mongo/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocketchat/base:8
+FROM rocketchat/base:12.14.0
 
 ADD . /app
 ADD entrypoint.sh /app/bundle/


### PR DESCRIPTION
Current develop CI is breaking because the NodeJS version of the Dockerfile used to builde the preview image was not updated.