### PR TITLE
[IMPROVE] Show more information related to the Omnichannel room closing data

### DIFF
--- a/app/livechat/client/views/app/tabbar/visitorInfo.html
+++ b/app/livechat/client/views/app/tabbar/visitorInfo.html
@@ -40,7 +40,7 @@
 						{{#if sms}}<li><i class="i con-mobile"></i>{{_ "SMS_Enabled"}}</li>{{/if}}
 						{{#if topic}}<li><strong>{{_ "Topic"}}</strong>: {{{RocketChatMarkdown topic}}}</li>{{/if}}
 						{{#if tags}}<li><strong>{{_ "Tags"}}</strong>: {{joinTags}}</li>{{/if}}
-						{{#if closedAt}}<li><strong>{{_ "Closed_At"}}</strong>: {{roomClosedDateTime}} {{_ "by"}}: {{roomClosedBy}}</li>{{/if}}
+						{{#if closedAt}}<li><strong>{{_ "Closed_At"}}</strong>: {{roomClosedDateTime}} <strong>{{_ "by"}}:</strong> {{roomClosedBy}}</li>{{/if}}
 					{{/with}}
 					{{#with department}}
 						{{#if name}}<li><strong>{{_ "Department"}}</strong>: {{name}}</li>{{/if}}

--- a/app/livechat/client/views/app/tabbar/visitorInfo.html
+++ b/app/livechat/client/views/app/tabbar/visitorInfo.html
@@ -40,6 +40,7 @@
 						{{#if sms}}<li><i class="i con-mobile"></i>{{_ "SMS_Enabled"}}</li>{{/if}}
 						{{#if topic}}<li><strong>{{_ "Topic"}}</strong>: {{{RocketChatMarkdown topic}}}</li>{{/if}}
 						{{#if tags}}<li><strong>{{_ "Tags"}}</strong>: {{joinTags}}</li>{{/if}}
+						{{#if closedAt}}<li><strong>{{_ "Closed_At"}}</strong>: {{roomClosedDateTime}} {{_ "by"}}: {{roomClosedBy}}</li>{{/if}}
 					{{/with}}
 					{{#with department}}
 						{{#if name}}<li><strong>{{_ "Department"}}</strong>: {{name}}</li>{{/if}}

--- a/app/livechat/client/views/app/tabbar/visitorInfo.js
+++ b/app/livechat/client/views/app/tabbar/visitorInfo.js
@@ -210,7 +210,7 @@ Template.visitorInfo.helpers({
 		let { closer } = this;
 
 		if (closer === 'user') {
-			if  (servedBy._id !== closedBy._id) {
+			if (servedBy._id !== closedBy._id) {
 				return closedBy.username;
 			}
 

--- a/app/livechat/client/views/app/tabbar/visitorInfo.js
+++ b/app/livechat/client/views/app/tabbar/visitorInfo.js
@@ -206,9 +206,15 @@ Template.visitorInfo.helpers({
 	},
 
 	roomClosedBy() {
-		const { closer, closedBy = {}, servedBy = {} } = this;
-		if (closer === 'user' && servedBy._id !== closedBy._id) {
-			return closedBy.username;
+		const { closedBy = {}, servedBy = {} } = this;
+		let { closer } = this;
+
+		if (closer === 'user') {
+			if  (servedBy._id !== closedBy._id) {
+				return closedBy.username;
+			}
+
+			closer = 'agent';
 		}
 
 		const closerLabel = closer.charAt(0).toUpperCase() + closer.slice(1);

--- a/app/livechat/client/views/app/tabbar/visitorInfo.js
+++ b/app/livechat/client/views/app/tabbar/visitorInfo.js
@@ -17,6 +17,7 @@ import { hasRole, hasPermission, hasAtLeastOnePermission } from '../../../../../
 import './visitorInfo.html';
 import { APIClient } from '../../../../../utils/client';
 import { RoomManager } from '../../../../../ui-utils/client';
+import { DateFormat } from '../../../../../lib/client';
 
 const isSubscribedToRoom = () => {
 	const data = Template.currentData();
@@ -197,6 +198,21 @@ Template.visitorInfo.helpers({
 
 	canForwardGuest() {
 		return hasPermission('transfer-livechat-guest');
+	},
+
+	roomClosedDateTime() {
+		const { closedAt } = this;
+		return DateFormat.formatDateAndTime(closedAt);
+	},
+
+	roomClosedBy() {
+		const { closer, closedBy = {}, servedBy = {} } = this;
+		if (closer === 'user' && servedBy._id !== closedBy._id) {
+			return closedBy.username;
+		}
+
+		const closerLabel = closer.charAt(0).toUpperCase() + closer.slice(1);
+		return t(`${ closerLabel }`);
 	},
 });
 

--- a/app/livechat/server/lib/Livechat.js
+++ b/app/livechat/server/lib/Livechat.js
@@ -355,10 +355,10 @@ export const Livechat = {
 		// Retreive the closed room
 		room = LivechatRooms.findOneByIdOrName(rid);
 
-		sendMessage(user, message, room);
+		sendMessage(user || visitor, message, room);
 
 		if (servedBy) {
-			Subscriptions.hideByRoomIdAndUserId(rid, servedBy._id);
+			Subscriptions.removeByRoomIdAndUserId(rid, servedBy._id);
 		}
 		Messages.createCommandWithRoomIdAndUser('promptTranscript', rid, closeData.closedBy);
 

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -655,6 +655,7 @@
   "Cloud_workspace_connected_without_account": "Your workspace is now connected to the Rocket.Chat Cloud. If you would like, you can login to the Rocket.Chat Cloud and associate your workspace with your Cloud account.",
   "close-others-livechat-room_description": "Permission to close other LiveChat channels",
   "Closed": "Closed",
+  "Closed_At": "Closed at",
   "Closed_by_visitor": "Closed by visitor",
   "Closing_chat": "Closing chat",
   "Cloud": "Cloud",

--- a/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
@@ -620,6 +620,7 @@
   "Cloud_workspace_connected_without_account": "Seu workspace está agora conectado ao Rocket.Chat Cloud. Se desejar, você pode fazer o login no Rocket.Chat Cloud e associar seu workspace à sua conta do Cloud.",
   "close-others-livechat-room_description": "Permissão para fechar outros canais LiveChat",
   "Closed": "Fechado",
+  "Closed_At": "Encerrado em",
   "Closed_by_visitor": "Encerrado pelo visitante",
   "Closing_chat": "Encerrando chat",
   "Cloud": "Nuvem",

--- a/packages/rocketchat-i18n/i18n/pt.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pt.i18n.json
@@ -609,6 +609,7 @@
   "Cloud_workspace_connected_without_account": "O seu espaço de trabalho está agora conectado ao Rocket.Chat Cloud. ",
   "close-others-livechat-room_description": "Permissão para fechar outros canais de conferência",
   "Closed": "Encerrado",
+  "Closed_At": "Encerrado em",
   "Closed_by_visitor": "Encerrado pelo convidado",
   "Closing_chat": "A encerrar chat",
   "Cloud": "Nuvem",


### PR DESCRIPTION
- Display the Omnichannel room closing data on the `Visitor Info` panel
<img width="300" alt="Screen Shot 2020-02-01 at 18 28 41" src="https://user-images.githubusercontent.com/59577424/73599381-ad2f0a80-4521-11ea-92b8-2b683eef3776.png">

- Send a system message to display who closed the room when the author is the **visitor**(or external systems). This process wasn't working because the `sendMessage` method was expecting a valid **user** and the **visitor** wasn't being considered.

<img width="381" alt="Screen Shot 2020-02-01 at 18 26 17" src="https://user-images.githubusercontent.com/59577424/73599443-40684000-4522-11ea-87bf-bf58a8e3cfe2.png">

- Also, now the `subscription` will be removed after the room is closed. The `Agent` doesn't need the `subscription` anymore.