### PR TITLE
[NEW] Check the Omnichannel service status per Department

### DIFF
--- a/app/apps/server/bridges/livechat.js
+++ b/app/apps/server/bridges/livechat.js
@@ -12,8 +12,8 @@ export class AppLivechatBridge {
 		this.orch = orch;
 	}
 
-	isOnline() {
-		return Livechat.online();
+	isOnline(department) {
+		return Livechat.online(department);
 	}
 
 	async createMessage(message, appId) {

--- a/app/livechat/server/api/lib/livechat.js
+++ b/app/livechat/server/api/lib/livechat.js
@@ -7,8 +7,8 @@ import { Livechat } from '../../lib/Livechat';
 import { callbacks } from '../../../../callbacks/server';
 import { normalizeAgent } from '../../lib/Helper';
 
-export function online() {
-	return Livechat.online();
+export function online(department) {
+	return Livechat.online(department);
 }
 
 export function findTriggers() {

--- a/app/livechat/server/api/v1/config.js
+++ b/app/livechat/server/api/v1/config.js
@@ -8,6 +8,7 @@ API.v1.addRoute('livechat/config', {
 		try {
 			check(this.queryParams, {
 				token: Match.Maybe(String),
+				department: Match.Maybe(String),
 			});
 
 			const config = settings();
@@ -15,9 +16,8 @@ API.v1.addRoute('livechat/config', {
 				return API.v1.success({ config: { enabled: false } });
 			}
 
-			const status = online();
-
-			const { token } = this.queryParams;
+			const { token, department } = this.queryParams;
+			const status = online(department);
 			const guest = token && findGuest(token);
 
 			let room;

--- a/app/livechat/server/lib/Livechat.js
+++ b/app/livechat/server/lib/Livechat.js
@@ -50,19 +50,19 @@ export const Livechat = {
 		},
 	}),
 
-	online() {
+	online(department) {
 		if (settings.get('Livechat_accept_chats_with_no_agents')) {
 			return true;
 		}
 
 		if (settings.get('Livechat_assign_new_conversation_to_bot')) {
-			const botAgents = Livechat.getBotAgents();
+			const botAgents = Livechat.getBotAgents(department);
 			if (botAgents && botAgents.count() > 0) {
 				return true;
 			}
 		}
 
-		const onlineAgents = Livechat.getOnlineAgents();
+		const onlineAgents = Livechat.getOnlineAgents(department);
 		return (onlineAgents && onlineAgents.count() > 0) || settings.get('Livechat_accept_chats_with_no_agents');
 	},
 

--- a/app/livechat/server/lib/QueueManager.js
+++ b/app/livechat/server/lib/QueueManager.js
@@ -9,10 +9,6 @@ import { Livechat } from './Livechat';
 
 export const QueueManager = {
 	async requestRoom({ guest, message, roomInfo, agent }) {
-		if (!Livechat.online()) {
-			throw new Meteor.Error('no-agent-online', 'Sorry, no online agents');
-		}
-
 		check(message, Match.ObjectIncluding({
 			rid: String,
 		}));
@@ -22,6 +18,10 @@ export const QueueManager = {
 			status: Match.Maybe(String),
 			department: Match.Maybe(String),
 		}));
+
+		if (!Livechat.online(guest.department)) {
+			throw new Meteor.Error('no-agent-online', 'Sorry, no online agents');
+		}
 
 		const { rid } = message;
 		const name = (roomInfo && roomInfo.fname) || guest.name || guest.username;


### PR DESCRIPTION
This PR allows checking the Omnichannel service status(online/offline) per Department.
Currently, the `Livechat.online()` method doesn't allow to pass any department to check the status of the service, so it's possible to start a new conversation associated with a specific Department that has no online agents, which provides a very bad user experience.

This change will also have an impact on Apps-Engine, we need to change it to be able to check the status of the Omnichannel service through an App too.

In addition: I have created an [issue](https://github.com/RocketChat/Rocket.Chat.Apps-engine/issues/211) on the `Apps-Engine` repo, describing this case.