### PR TITLE
[FIX] Federation Attachment fix

### DIFF
--- a/app/federation/server/endpoints/dispatch.js
+++ b/app/federation/server/endpoints/dispatch.js
@@ -205,7 +205,17 @@ const eventHandlers = {
 					// Update the message's attachments
 					for (const attachment of denormalizedMessage.attachments) {
 						attachment.title_link = attachment.title_link.replace(oldUploadId, upload._id);
-						attachment.image_url = attachment.image_url.replace(oldUploadId, upload._id);
+
+						if (/^image\/.+/.test(denormalizedMessage.file.type)) {
+							attachment.image_url = attachment.image_url.replace(oldUploadId, upload._id);
+						}
+						else if (/^audio\/.+/.test(denormalizedMessage.file.type)) {
+							attachment.audio_url = attachment.audio_url.replace(oldUploadId, upload._id);
+						}
+						else if (/^video\/.+/.test(denormalizedMessage.file.type)) {
+							attachment.video_url = attachment.video_url.replace(oldUploadId, upload._id);
+						}
+
 					}
 				}
 


### PR DESCRIPTION
Fix sending attachments via federation.
Currently for every attachment send via Federation on the receiving server the attribute "image_url" is read.
The problem is that this attribute only exists for images, every other data type creates an exception which result in the message not being delivered.
This fix mirrors the check which is done for image/video/audio and everything else seen in "Rocket.Chat/app/file-upload/server/methods/sendFileMessage.js:43".

This fix was successfully tested on our two server setup on the current 2.4.6 version.