### PR TITLE
[NEW] Sort the Omnichannel Chat list according to the user preferences

### DIFF
--- a/app/livechat/client/views/sideNav/livechat.js
+++ b/app/livechat/client/views/sideNav/livechat.js
@@ -47,7 +47,7 @@ Template.livechat.helpers({
 
 		return ChatSubscription.find(query, {
 			sort: {
-				t: 1,
+				_updatedAt: -1,
 				fname: 1,
 			},
 		});

--- a/app/livechat/client/views/sideNav/livechat.js
+++ b/app/livechat/client/views/sideNav/livechat.js
@@ -44,7 +44,7 @@ Template.livechat.helpers({
 		}
 
 		const sortBy = getUserPreference(user, 'sidebarSortby');
-		const sort = (sortBy === 'activity') ? { _updatedAt: - 1 } : { fname: 1 };
+		const sort = sortBy === 'activity' ? { _updatedAt: - 1 } : { fname: 1 };
 
 		return ChatSubscription.find(query, { sort });
 	},

--- a/app/livechat/client/views/sideNav/livechat.js
+++ b/app/livechat/client/views/sideNav/livechat.js
@@ -37,20 +37,16 @@ Template.livechat.helpers({
 			open: true,
 		};
 
-		const user = Users.findOne(Meteor.userId(), {
-			fields: { 'settings.preferences.sidebarShowUnread': 1 },
-		});
+		const user = Meteor.userId();
 
 		if (getUserPreference(user, 'sidebarShowUnread')) {
 			query.alert = { $ne: true };
 		}
 
-		return ChatSubscription.find(query, {
-			sort: {
-				_updatedAt: -1,
-				fname: 1,
-			},
-		});
+		const sortBy = getUserPreference(user, 'sidebarSortby');
+		const sort = (sortBy === 'activity') ? { _updatedAt: - 1 } : { fname: 1 };
+
+		return ChatSubscription.find(query, { sort });
 	},
 
 	inquiries() {

--- a/app/ui-sidenav/client/sidebarItem.js
+++ b/app/ui-sidenav/client/sidebarItem.js
@@ -33,6 +33,7 @@ Template.sidebarItem.helpers({
 		return this.pathSection === 'livechat-queue';
 	},
 	showUnread() {
+		console.log(this);
 		return this.unread > 0 || (!this.hideUnreadStatus && this.alert);
 	},
 	badgeClass() {

--- a/app/ui-sidenav/client/sidebarItem.js
+++ b/app/ui-sidenav/client/sidebarItem.js
@@ -33,7 +33,6 @@ Template.sidebarItem.helpers({
 		return this.pathSection === 'livechat-queue';
 	},
 	showUnread() {
-		console.log(this);
 		return this.unread > 0 || (!this.hideUnreadStatus && this.alert);
 	},
 	badgeClass() {


### PR DESCRIPTION
This PR allows defining the order of the Omnichannel Chat list according to the user preferences as displayed below:

<img width="173" alt="Screen Shot 2020-02-03 at 12 45 02" src="https://user-images.githubusercontent.com/59577424/73667613-49bcee00-4683-11ea-9e98-6a65288670a5.png">
