### PR TITLE
Use GitHub Actions to store builds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -146,13 +146,17 @@ jobs:
         cd /tmp
         tar czf Rocket.Chat.test.tar.gz ./build-test
 
-    - name: Store builds
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      run: |
-        aws s3 cp /tmp/Rocket.Chat.test.tar.gz s3://rocketchatbuild/builds/$GITHUB_SHA/
-        aws s3 cp /tmp/build/Rocket.Chat.tar.gz s3://rocketchatbuild/builds/$GITHUB_SHA/
+    - name: Store build for tests
+      uses: actions/upload-artifact@v1
+      with:
+        name: build-test
+        path: /tmp/Rocket.Chat.test.tar.gz
+
+    - name: Store build
+      uses: actions/upload-artifact@v1
+      with:
+        name: build
+        path: /tmp/build
 
   test:
     runs-on: ubuntu-16.04
@@ -170,10 +174,10 @@ jobs:
         mongoDBVersion: ${{ matrix.mongodb-version }} --noprealloc --smallfiles --replSet=rs0
 
     - name: Restore build for tests
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      run: aws s3 cp s3://rocketchatbuild/builds/$GITHUB_SHA/Rocket.Chat.test.tar.gz /tmp/
+      uses: actions/download-artifact@v1
+      with:
+        name: build-test
+        path: /tmp
 
     - name: Decompress build
       run: |
@@ -349,10 +353,10 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Restore build
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      run: aws s3 cp s3://rocketchatbuild/builds/$GITHUB_SHA/Rocket.Chat.tar.gz /tmp/build/
+      uses: actions/download-artifact@v1
+      with:
+        name: build
+        path: /tmp/build
 
     - name: Publish assets
       env:
@@ -401,10 +405,10 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Restore build
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      run: aws s3 cp s3://rocketchatbuild/builds/$GITHUB_SHA/Rocket.Chat.tar.gz /tmp/build/
+      uses: actions/download-artifact@v1
+      with:
+        name: build
+        path: /tmp/build
 
     - name: Unpack build
       env:


### PR DESCRIPTION
Need to revert this change because PRs from forks cannot use our secrets to store on our S3.