### PR TITLE
[FIX] `stdout` streamer infinite loop

### DIFF
--- a/app/logger/server/streamer.js
+++ b/app/logger/server/streamer.js
@@ -60,7 +60,7 @@ stdoutStreamer.allowRead(function() {
 
 Meteor.startup(() => {
 	const handler = (string, item) => {
-		stdoutStreamer.emit('stdout', {
+		stdoutStreamer.emitWithoutBroadcast('stdout', {
 			...item,
 		});
 	};


### PR DESCRIPTION
The new `stdout` streamer was in infinite loop when log level was 2 and running in multiple instances.