### PR TITLE
[FIX] Star icon is visible when you hover over message

### DIFF
--- a/app/theme/client/imports/components/messages.css
+++ b/app/theme/client/imports/components/messages.css
@@ -202,6 +202,10 @@
 			& .message-actions {
 				display: flex;
 			}
+
+			& .message-indications {
+				display: flex;
+			}
 		}
 	}
 }

--- a/app/theme/client/imports/general/base_old.css
+++ b/app/theme/client/imports/general/base_old.css
@@ -2619,6 +2619,10 @@ rc-old select,
 	}
 }
 
+.message-indications {
+	display: none;
+}
+
 .message {
 	position: relative;
 	z-index: 1;
@@ -2988,7 +2992,8 @@ rc-old select,
 		& .reactions,
 		& .edited,
 		& .role-tag,
-		&:hover .message-actions {
+		&:hover .message-actions,
+		&:hover .message-indications {
 			display: none;
 		}
 	}
@@ -3044,6 +3049,10 @@ rc-old select,
 		}
 
 		&:hover .message-actions {
+			display: none;
+		}
+
+		&:hover .message-indications {
 			display: none;
 		}
 	}

--- a/app/ui-message/client/message.html
+++ b/app/ui-message/client/message.html
@@ -70,6 +70,11 @@
 					{{#if isIgnored}}
 						<span class="toggle-hidden icon-right-dir" data-message="{{msg._id}}"> {{_ "Message_Ignored"}} </span>
 					{{/if}}
+					<span class="message-indications">
+						{{#if msg.starred}}
+							<span class="icon-star"></span>
+						{{/if}}
+					</span>
 				</div>
 				<div class="body {{bodyClass}}" dir="auto" data-unread-text="{{_ "Unread_Messages"}}">
 					{{#if isSnippet}}


### PR DESCRIPTION
My Solution: 
Star appears when you hover over message. Consider the situation when all messages are starred and edited the whole page would be redundantly filled with stars and pencil icons.
That's why I propose that star should be visible when you hover over it.
Fixes #16383 