### PR TITLE
[FIX]: Message action popup is now responsive to width as well as hei…

### DIFF
--- a/app/ui-utils/client/lib/popover.js
+++ b/app/ui-utils/client/lib/popover.js
@@ -75,7 +75,6 @@ Template.popover.onRendered(function() {
 
 		if (position) {
 			popoverContent.style.top = `${ position.top }px`;
-			popoverContent.style.left = `${ position.left }px`;
 		} else {
 			const clientHeight = this.data.targetRect.height;
 			const popoverWidth = popoverContent.offsetWidth;
@@ -112,8 +111,9 @@ Template.popover.onRendered(function() {
 			}
 
 			popoverContent.style.top = `${ top }px`;
-			popoverContent.style.left = `${ left }px`;
 		}
+
+		popoverContent.style.right = '45px';
 
 		if (customCSSProperties) {
 			Object.keys(customCSSProperties).forEach(function(property) {


### PR DESCRIPTION
It is worth noting that the distance of message action popup is fixed from the right edge of window, all we need to make it responsive is to control margin from top.
I just made it's margin from right constant which fixes whole issue.
PS: @sampaiodiego please correct me if I am wrong.
__THEN__:
![ezgif com-video-to-gif(4)](https://user-images.githubusercontent.com/34532173/73790914-56e2f580-47c7-11ea-8fed-b739ac3037ff.gif)
__NOW__:
![ezgif com-video-to-gif(5)](https://user-images.githubusercontent.com/34532173/73791300-1041cb00-47c8-11ea-967f-e9fd37791c71.gif)
