### PR TITLE
Exclude federated and app users from active user count

### DIFF
--- a/app/models/server/models/Users.js
+++ b/app/models/server/models/Users.js
@@ -560,7 +560,6 @@ export class Users extends Base {
 		return this.find({
 			active: true,
 			type: { $nin: ['app'] },
-			emails: { $exists: true },
 		}, options);
 	}
 

--- a/app/statistics/server/lib/statistics.js
+++ b/app/statistics/server/lib/statistics.js
@@ -61,7 +61,8 @@ export const statistics = {
 		// User statistics
 		statistics.totalUsers = Users.find().count();
 		statistics.activeUsers = Users.getActiveLocalUserCount();
-		statistics.nonActiveUsers = statistics.totalUsers - statistics.activeUsers;
+		statistics.nonActiveUsers = Users.find({ active: false }).count();
+		statistics.appUsers = Users.find({ type: 'app' }).count();
 		statistics.onlineUsers = Meteor.users.find({ statusConnection: 'online' }).count();
 		statistics.awayUsers = Meteor.users.find({ statusConnection: 'away' }).count();
 		statistics.totalConnectedUsers = statistics.onlineUsers + statistics.awayUsers;

--- a/app/statistics/server/lib/statistics.js
+++ b/app/statistics/server/lib/statistics.js
@@ -59,8 +59,8 @@ export const statistics = {
 		}
 
 		// User statistics
-		statistics.totalUsers = Meteor.users.find().count();
-		statistics.activeUsers = Meteor.users.find({ active: true }).count();
+		statistics.totalUsers = Users.find().count();
+		statistics.activeUsers = Users.getActiveLocalUserCount();
 		statistics.nonActiveUsers = statistics.totalUsers - statistics.activeUsers;
 		statistics.onlineUsers = Meteor.users.find({ statusConnection: 'online' }).count();
 		statistics.awayUsers = Meteor.users.find({ statusConnection: 'away' }).count();

--- a/client/components/admin/info/UsageSection.js
+++ b/client/components/admin/info/UsageSection.js
@@ -14,6 +14,7 @@ export function UsageSection({ statistics, isLoading }) {
 		<DescriptionList data-qa='usage-list'>
 			<DescriptionList.Entry label={t('Stats_Total_Users')}>{s(() => statistics.totalUsers)}</DescriptionList.Entry>
 			<DescriptionList.Entry label={t('Stats_Active_Users')}>{s(() => statistics.activeUsers)}</DescriptionList.Entry>
+			<DescriptionList.Entry label={t('Stats_App_Users')}>{s(() => statistics.appUsers)}</DescriptionList.Entry>
 			<DescriptionList.Entry label={t('Stats_Non_Active_Users')}>{s(() => statistics.nonActiveUsers)}</DescriptionList.Entry>
 			<DescriptionList.Entry label={t('Stats_Total_Connected_Users')}>{s(() => statistics.totalConnectedUsers)}</DescriptionList.Entry>
 			<DescriptionList.Entry label={t('Stats_Online_Users')}>{s(() => statistics.onlineUsers)}</DescriptionList.Entry>

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -3047,6 +3047,7 @@
   "Statistics_reporting": "Send Statistics to Rocket.Chat",
   "Statistics_reporting_Description": "By sending your statistics, you'll help us identify how many instances of Rocket.Chat are deployed, as well as how good the system is behaving, so we can further improve it. Don't worry, as no user information is sent and all the information we receive is kept confidential.",
   "Stats_Active_Users": "Activated Users",
+  "Stats_App_Users": "Rocket.Chat App Users",
   "Stats_Avg_Channel_Users": "Average Channel Users",
   "Stats_Avg_Private_Group_Users": "Average Private Group Users",
   "Stats_Away_Users": "Away Users",

--- a/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
@@ -2784,6 +2784,7 @@
   "Statistics_reporting": "Enviar estatísticas para Rocket.Chat",
   "Statistics_reporting_Description": "Ao enviar suas estatísticas, você vai nos ajudar a identificar quantas instâncias de Rocket.Chat são implantadas, bem como o quão bom o sistema está se comportando, para que possamos melhorar ainda mais isso. Não se preocupe, pois nenhuma informação de usuário é enviado e toda a informação que recebemos é mantida em sigilo.",
   "Stats_Active_Users": "Usuários Ativos",
+  "Stats_App_Users": "Usuários de Rocket.Chat App",
   "Stats_Avg_Channel_Users": "Média de Usuários por Canal",
   "Stats_Avg_Private_Group_Users": "Média de Usuários por Grupo Privado",
   "Stats_Away_Users": "Usuários ausentes",


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->
This PR makes the active user count of the statistics stop taking app and federated users into consideration

**Before**
![image](https://user-images.githubusercontent.com/1810309/73888421-5cceea00-484c-11ea-98e1-3bc2c777b567.png)

**After**
![image](https://user-images.githubusercontent.com/1810309/73888442-65bfbb80-484c-11ea-97db-53b5fabd33c6.png)

**Criteria for active users**
![image](https://user-images.githubusercontent.com/1810309/73889142-bf74b580-484d-11ea-84a4-a1cdf82d2690.png)


Things to consider:
- Do we want the count of app + federated users to go to the **Deactivated users** count?
- Should we add **App users** and **Federated users** counts?

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->


<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
