### PR TITLE
[FIX] return '' when failed to create a message

### DIFF
--- a/app/apps/server/bridges/messages.js
+++ b/app/apps/server/bridges/messages.js
@@ -14,8 +14,11 @@ export class AppMessageBridge {
 		this.orch.debugLog(`The App ${ appId } is creating a new message.`);
 
 		const convertedMessage = this.orch.getConverters().get('messages').convertAppMessage(message);
-
 		const sentMessage = executeSendMessage(convertedMessage.u._id, convertedMessage);
+
+		if (!sentMessage) {
+			return '';
+		}
 
 		return sentMessage._id;
 	}

--- a/app/apps/server/bridges/messages.js
+++ b/app/apps/server/bridges/messages.js
@@ -15,12 +15,14 @@ export class AppMessageBridge {
 
 		const convertedMessage = this.orch.getConverters().get('messages').convertAppMessage(message);
 		const sentMessage = executeSendMessage(convertedMessage.u._id, convertedMessage);
+		const messageId = sentMessage ? sentMessage._id : '';
 
 		if (!sentMessage) {
-			return '';
+			const { room } = message;
+			console.warn(`The App ${ appId } failed to send a message in the room ${ room.displayName }`);
 		}
 
-		return sentMessage._id;
+		return messageId;
 	}
 
 	async getById(messageId, appId) {


### PR DESCRIPTION
This PR tries to prevent potential issue that would cause server to crash.

One situation that produces this error is apps users can listen to all the messages from the whole server but can only only allowed to send messages in the room which it belongs to. Sending messages in an unallowed room will cause sentMessage to be undefined, thus getting _id from undefined would cause server to crash.