### PR TITLE
Remove users.info being called without need

### DIFF
--- a/app/ui-flextab/client/tabs/userInfo.js
+++ b/app/ui-flextab/client/tabs/userInfo.js
@@ -284,6 +284,8 @@ Template.userInfo.onCreated(function() {
 			params.userId = _id;
 		} else if (username != null) {
 			params.username = username;
+		} else {
+			return;
 		}
 
 		const { user } = await APIClient.v1.get('users.info', params);


### PR DESCRIPTION
The endpoint was being called when opening Members List without any arguments thus giving an error.

Related to https://github.com/RocketChat/Rocket.Chat/pull/16495