### PR TITLE
Fix github actions accessing the github registry

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -331,7 +331,7 @@ jobs:
 
         export OWNER="${GITHUB_REPOSITORY%/*}"
 
-        docker login docker.pkg.github.com -u "${OWNER}" -p "${GITHUB_TOKEN}"
+        docker login docker.pkg.github.com -u "${GITHUB_ACTOR}" -p "${GITHUB_TOKEN}"
 
         cp $GITHUB_WORKSPACE/.docker/Dockerfile .
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -328,9 +328,7 @@ jobs:
         VERSION: pr-${{ github.event.number }}
       run: |
         cd /tmp/build-pr
-
-        export OWNER="${GITHUB_REPOSITORY%/*}"
-
+        
         docker login docker.pkg.github.com -u "${GITHUB_ACTOR}" -p "${GITHUB_TOKEN}"
 
         cp $GITHUB_WORKSPACE/.docker/Dockerfile .

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -328,7 +328,7 @@ jobs:
         VERSION: pr-${{ github.event.number }}
       run: |
         cd /tmp/build-pr
-        
+
         docker login docker.pkg.github.com -u "${GITHUB_ACTOR}" -p "${GITHUB_TOKEN}"
 
         cp $GITHUB_WORKSPACE/.docker/Dockerfile .


### PR DESCRIPTION
When building PR images, the docker authentication fails once an organization (and not an individual user) is creating the PR, see https://github.com/assistify/Rocket.Chat/runs/431633181

## Reason

The docker login needs to use credentials matching `GITHUB_TOKEN`

## After the fix

https://github.com/assistify/Rocket.Chat/runs/432851281