### PR TITLE
[WIP][FIX] Removes thread button for deleted messages

### DIFF
--- a/app/models/server/models/Messages.js
+++ b/app/models/server/models/Messages.js
@@ -528,6 +528,22 @@ export class Messages extends Base {
 		return this.update(query, update);
 	}
 
+	deleteWhenParentOfThread(_id) {
+		const query = { _id };
+
+		if (settings.get('Message_ShowDeletedStatus')) {
+			return;
+		}
+
+		const update = {
+			$set: {
+				msg: 'deleted message',
+			},
+		};
+
+		return this.update(query, update);
+	}
+
 	setAsDeletedByIdAndUser(_id, user) {
 		const query = { _id };
 

--- a/app/threads/server/hooks/afterdeletemessage.js
+++ b/app/threads/server/hooks/afterdeletemessage.js
@@ -14,7 +14,7 @@ Meteor.startup(function() {
 
 		// is a thread
 		if (message.tcount) {
-			Messages.removeThreadRefByThreadId(message._id);
+			Messages.deleteWhenParentOfThread(message._id);
 		}
 
 		return message;

--- a/app/ui-message/client/message.html
+++ b/app/ui-message/client/message.html
@@ -112,17 +112,15 @@
 					<span class="discussion-reply-lm">{{ formatDateAndTime msg.dlm }}</span>
 				</div>
 			{{/if}}
-
-			{{#if msg.msg.length}}
-				{{#if and settings.showReplyButton msg.tcount}}
-					<div class="message-discussion">
-						<button class="js-open-thread rc-button rc-button--primary rc-button--small" data-rid={{roomId}}>
-							{{> icon icon="thread"}}
-							<span>{{{_ 'reply_counter' counter=i18nReplyCounter count=msg.tcount }}}</span>
-						</button>
-						<span class="discussion-reply-lm">{{ formatDateAndTime msg.tlm}}</span>
-					</div>
-				{{/if}}
+		
+			{#if and settings.showReplyButton msg.tcount}}
+				<div class="message-discussion">
+					<button class="js-open-thread rc-button rc-button--primary rc-button--small" data-rid={{roomId}}>
+						{{> icon icon="thread"}}
+						<span>{{{_ 'reply_counter' counter=i18nReplyCounter count=msg.tcount }}}</span>
+					</button>
+					<span class="discussion-reply-lm">{{ formatDateAndTime msg.tlm}}</span>
+				</div>
 			{{/if}}
 			
 			{{#with readReceipt}}

--- a/app/ui-message/client/message.html
+++ b/app/ui-message/client/message.html
@@ -113,16 +113,18 @@
 				</div>
 			{{/if}}
 
-			{{#if and settings.showReplyButton msg.tcount}}
-				<div class="message-discussion">
-					<button class="js-open-thread rc-button rc-button--primary rc-button--small" data-rid={{roomId}}>
-						{{> icon icon="thread"}}
-						<span>{{{_ 'reply_counter' counter=i18nReplyCounter count=msg.tcount }}}</span>
-					</button>
-					<span class="discussion-reply-lm">{{ formatDateAndTime msg.tlm}}</span>
-				</div>
+			{{#if msg.msg.length}}
+				{{#if and settings.showReplyButton msg.tcount}}
+					<div class="message-discussion">
+						<button class="js-open-thread rc-button rc-button--primary rc-button--small" data-rid={{roomId}}>
+							{{> icon icon="thread"}}
+							<span>{{{_ 'reply_counter' counter=i18nReplyCounter count=msg.tcount }}}</span>
+						</button>
+						<span class="discussion-reply-lm">{{ formatDateAndTime msg.tlm}}</span>
+					</div>
+				{{/if}}
 			{{/if}}
-
+			
 			{{#with readReceipt}}
 				<div class="read-receipt {{readByEveryone}}">
 					{{> icon icon="check" }}


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #16320 

This pull request checks whether the message body has length greater than zero to check if message exists and only when it exists does it show the replies button. This way, when a message that had replies is deleted by a user, the removed message will show no replies (unlike what we had previously) whereas the replies to the said removed message will become normal messages (like what was happening before).
<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->
### What happened before:
![Screenshot from 2020-02-25 00-00-26](https://user-images.githubusercontent.com/52909743/75180880-1392fb80-5763-11ea-8847-7ac1d271059e.png)
![Screenshot from 2020-02-25 00-00-48](https://user-images.githubusercontent.com/52909743/75180883-168dec00-5763-11ea-8ebc-d9dbe9baf0b1.png)
![Screenshot from 2020-02-25 00-00-57](https://user-images.githubusercontent.com/52909743/75180891-17bf1900-5763-11ea-9766-b5faac148f50.png)

### What happens now:
![Screenshot from 2020-02-25 00-08-12](https://user-images.githubusercontent.com/52909743/75180916-26a5cb80-5763-11ea-9f46-c0792855b600.png)
![Screenshot from 2020-02-25 00-08-24](https://user-images.githubusercontent.com/52909743/75180918-27d6f880-5763-11ea-9503-a5b877834c09.png)


<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
