### PR TITLE
[FIX] Can't click on room's actions menu of sidebar list when in search mode

### DIFF
--- a/app/ui-message/client/popup/messagePopup.js
+++ b/app/ui-message/client/popup/messagePopup.js
@@ -288,12 +288,16 @@ Template.messagePopup.events({
 		const template = Template.instance();
 		template.clickingItem = true;
 	},
-	'mouseup .popup-item, touchend .popup-item'() {
+	'mouseup .popup-item, touchend .popup-item'(e) {
+		e.stopPropagation();
 		const template = Template.instance();
+		const wasMenuIconClicked = e.target.classList.contains('sidebar-item__menu-icon');
 		template.clickingItem = false;
-		template.value.set(this._id);
-		template.enterValue();
-		template.open.set(false);
+		if (!wasMenuIconClicked) {
+			template.value.set(this._id);
+			template.enterValue();
+			template.open.set(false);
+		}
 	},
 });
 


### PR DESCRIPTION
Initially the action clicking action button of any search result made the list disappear.
Now the the list doesn't go off and user can perform actions using the button.
Fixes #16436 
Then:
![ezgif com-video-to-gif(3)](https://user-images.githubusercontent.com/34532173/74184351-a6646e00-4c6c-11ea-90ef-b94b0cb938a0.gif)
Now:
![ezgif com-video-to-gif(9)](https://user-images.githubusercontent.com/34532173/74184381-b54b2080-4c6c-11ea-9b87-9e8ca4a2bc47.gif)
