### PR TITLE
NEW: API for mass-disabling of idle users

### DIFF
--- a/app/models/server/models/Users.js
+++ b/app/models/server/models/Users.js
@@ -597,6 +597,20 @@ export class Users extends Base {
 		return this.find(query, options);
 	}
 
+	findActiveNotLoggedInAfterWithRole(latestLastLoginDate, role = 'user', options) {
+		const neverActive = { $and: [{ lastLogin: { $exists: 0 } }, { createdAt: { $lte: latestLastLoginDate } }] };
+		const idleTooLong = { lastLogin: { $lte: latestLastLoginDate } };
+		const hasRole = { roles: role };
+		const query = {
+			$and: [
+				{ $or: [neverActive, idleTooLong] },
+				hasRole,
+				{ active: true },
+			],
+		};
+		return this.find(query, options);
+	}
+
 	findByActiveUsersExcept(searchTerm, exceptions, options, forcedSearchFields, extraQuery = []) {
 		if (exceptions == null) { exceptions = []; }
 		if (options == null) { options = {}; }


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Partially Closes #9838

tl;dr

```
curl -H "X-Auth-Token: ${AUTH}" \
     -H "X-User-Id: ${USER}" \
     -H "Content-type:application/json" \
     ${HOST}/api/v1/users.deactivateIdle -d '{"daysIdle": 90}'
```
<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

## Motivation

Users which are not really using the system anymore for many reasons are a pain to operators: They complicate administration, but especially are a concern with respect to security.
This includes users who have not logged in to the application for a certain period of time as well as users which have been created long ago without ever using the system.

## What this adds

This PR brings an API for deactivating idle users. The consumer of the API can provide criteria for selecting the users based upon which they shall be deactivated.

## Implementation concerns

- Though not explicitly requested, there's the option to optionally pass a role so that you can have more strict checking for different roles, such as ` { "role": "admin", "daysIdle": 30}`
- I decided to re-use the existing method to set users inactive though it's not mass-enabled. I assume it's not a task which is performed with a high frequency.
- Users collection shall have an index on role as well as `lastUpdated`. So I assume good performance for the query itself.
- Since this majorly is a database function exposed via an API and since I don't know how mocking of the DB is done in RC nowadays, I did not implement a test. Let me know if there's a way, then I'll be happy to do this too 🤓 



