### PR TITLE
FIX Issue #5453: add thumbsup emoji in place of (Y)

### DIFF
--- a/app/emoji/client/emojiParser.js
+++ b/app/emoji/client/emojiParser.js
@@ -22,6 +22,9 @@ Tracker.autorun(() => {
 			// &#39; to apostrophe (') for emojis such as :')
 			html = html.replace(/&#39;/g, '\'');
 
+			// convert (Y) to thumbsup emoji
+			html = html.replace(/(^|\s)\(Y\)(\s|$)/ig, ' :thumbsup: ');
+
 			// '<br>' to ' <br> ' for emojis such at line breaks
 			html = html.replace(/<br>/g, ' <br> ');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2694,6 +2694,11 @@
 				"uuid": "^3.2.1"
 			},
 			"dependencies": {
+				"adm-zip": {
+					"version": "0.4.13",
+					"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
+					"integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
+				},
 				"typescript": {
 					"version": "2.9.2",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",


### PR DESCRIPTION
Closes #5453

Previously, only (y) `small-y` works for the :+1: emoji and (Y) `caps-Y` which is commonly used in platforms like Skype was missing.
Tried to solve this issue by replacing (Y) with thumbs-up emoji.