### PR TITLE
[FIX] Cannot unfollow message from thread's panel

### DIFF
--- a/app/threads/client/messageAction/follow.js
+++ b/app/threads/client/messageAction/follow.js
@@ -20,9 +20,9 @@ Meteor.startup(function() {
 				const { msg } = messageArgs(this);
 				call('followMessage', { mid: msg._id });
 			},
-			condition({ msg: { tmid, replies = [] }, u }) {
-				if (tmid) {
-					const parentMessage = Messages.findOne({ _id: tmid }, { fields: { replies: 1 } });
+			condition({ msg: { _id, tmid, replies = [] }, u }, context) {
+				if (tmid || context) {
+					const parentMessage = Messages.findOne({ _id: tmid || _id }, { fields: { replies: 1 } });
 					if (parentMessage) {
 						replies = parentMessage.replies || [];
 					}

--- a/app/threads/client/messageAction/unfollow.js
+++ b/app/threads/client/messageAction/unfollow.js
@@ -20,9 +20,9 @@ Meteor.startup(function() {
 				const { msg } = messageArgs(this);
 				call('unfollowMessage', { mid: msg._id });
 			},
-			condition({ msg: { tmid, replies = [] }, u }) {
-				if (tmid) {
-					const parentMessage = Messages.findOne({ _id: tmid }, { fields: { replies: 1 } });
+			condition({ msg: { _id, tmid, replies = [] }, u }, context) {
+				if (tmid || context) {
+					const parentMessage = Messages.findOne({ _id: tmid || _id }, { fields: { replies: 1 } });
 					if (parentMessage) {
 						replies = parentMessage.replies || [];
 					}


### PR DESCRIPTION
close #15765 

In the thread panel, the unfollow option was not there for the first message. Add checks to toggle the notification option (i.e follow/unfollow) for the thread's first message which was previously for the subsequent options in the thread.