### PR TITLE
[FIX] Delete messages while searching bug

### DIFF
--- a/app/ui-utils/client/lib/RoomHistoryManager.js
+++ b/app/ui-utils/client/lib/RoomHistoryManager.js
@@ -255,8 +255,6 @@ export const RoomHistoryManager = new class {
 		}
 		const room = this.getRoom(message.rid);
 		room.isLoading.set(true);
-		ChatMessage.remove({ rid: message.rid });
-
 		let typeName = undefined;
 
 		const subscription = ChatSubscription.findOne({ rid: message.rid });
@@ -272,6 +270,7 @@ export const RoomHistoryManager = new class {
 			if (!result || !result.messages) {
 				return;
 			}
+			ChatMessage.remove({ rid: message.rid });
 			for (const msg of Array.from(result.messages)) {
 				if (msg.t !== 'command') {
 					upsertMessage({ msg, subscription });


### PR DESCRIPTION
closes  #16413

From what I understand, it try to finds the message in the room if not it fetches it deletes it and fetches it again from the backend and search for specific message.
so what i did i made the deletion part after we fetch it from the backend to make sure not to delete the whole chat.