### PR TITLE
[FIX] Livechat Widget version 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2694,6 +2694,11 @@
 				"uuid": "^3.2.1"
 			},
 			"dependencies": {
+				"adm-zip": {
+					"version": "0.4.14",
+					"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.14.tgz",
+					"integrity": "sha512-/9aQCnQHF+0IiCl0qhXoK7qs//SwYE7zX8lsr/DNk1BRAHYxeLZPL4pguwK29gUEqasYQjqPtEpDRSWEkdHn9g=="
+				},
 				"typescript": {
 					"version": "2.9.2",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
@@ -2743,9 +2748,9 @@
 			"integrity": "sha512-QMQK+fyu2cIRBzNwlOvl/zCX62TyY2EsgKc+YArBrr2kgHkpxGHy8CJIXyFg1dVOYX/LeehRNSnFW1naxCM1ww=="
 		},
 		"@rocket.chat/livechat": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@rocket.chat/livechat/-/livechat-1.3.0.tgz",
-			"integrity": "sha512-4qKRtvtFvMCNdfWm8R6GoBCyEYO8nvRXzoCGgaYjfK0d9SdSmEygMi7E3g90iWASPUXsXqe8YhEYOVtaFGmD4A==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@rocket.chat/livechat/-/livechat-1.3.1.tgz",
+			"integrity": "sha512-FlnVnAVtGbb3Gko4iLarAhpdUQia6gkO55k47+A8lSTPM8ATNsJYVUZmequq/dOWz3ZLjJcIVyVu73Q5cpoEUw==",
 			"dev": true,
 			"requires": {
 				"@kossnocorp/desvg": "^0.2.0",
@@ -2805,9 +2810,9 @@
 			}
 		},
 		"@rocket.chat/sdk": {
-			"version": "1.0.0-alpha.31",
-			"resolved": "https://registry.npmjs.org/@rocket.chat/sdk/-/sdk-1.0.0-alpha.31.tgz",
-			"integrity": "sha512-+ScMW4+Ik8n0WK1suqAI03ZFivwzwyJZeLnOXtX9hDzpRN4UOXCGh/dAhlTjS3/oaF3lmwjF00s4+UUMZBN51w==",
+			"version": "1.0.0-alpha.41",
+			"resolved": "https://registry.npmjs.org/@rocket.chat/sdk/-/sdk-1.0.0-alpha.41.tgz",
+			"integrity": "sha512-jQ+/exEQMOv+bwH+yzPTC0oJGIKj/AlMc95IvWAn/vHDLjjS3aGzpIpZhBwsMOBVvb/5N8rnq6kEleCkEJk28g==",
 			"dev": true,
 			"requires": {
 				"js-sha256": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"@babel/preset-react": "^7.0.0",
 		"@octokit/rest": "^16.1.0",
 		"@rocket.chat/eslint-config": "^0.3.0",
-		"@rocket.chat/livechat": "^1.3.0",
+		"@rocket.chat/livechat": "^1.3.1",
 		"@settlin/spacebars-loader": "^1.0.7",
 		"@storybook/addon-actions": "^5.2.8",
 		"@storybook/addon-knobs": "^5.2.8",


### PR DESCRIPTION
Update the Livechat dependency to `1.3.1` version.