### PR TITLE
[FIX] Logical corrections in regex, message suggestion popup amended.

### DIFF
--- a/app/ui-message/client/popup/messagePopup.js
+++ b/app/ui-message/client/popup/messagePopup.js
@@ -69,12 +69,12 @@ Template.messagePopup.onCreated(function() {
 	template.prefix = val(template.data.prefix, template.trigger);
 	template.suffix = val(template.data.suffix, '');
 	if (template.triggerAnywhere === true) {
-		template.matchSelectorRegex = val(template.data.matchSelectorRegex, new RegExp(`(?:^| |\n)${ template.trigger }[^\\s]*$`));
+		template.matchSelectorRegex = val(template.data.matchSelectorRegex, new RegExp(`${ template.trigger }+[^\\s@#:]*$`));
 	} else {
-		template.matchSelectorRegex = val(template.data.matchSelectorRegex, new RegExp(`(?:^)${ template.trigger }[^\\s]*$`));
+		template.matchSelectorRegex = val(template.data.matchSelectorRegex, new RegExp(`^${ template.trigger }[^\\s@#:]*$`));
 	}
-	template.selectorRegex = val(template.data.selectorRegex, new RegExp(`${ template.trigger }([^\\s]*)$`));
-	template.replaceRegex = val(template.data.replaceRegex, new RegExp(`${ template.trigger }[^\\s]*$`));
+	template.selectorRegex = val(template.data.selectorRegex, new RegExp(`${ template.trigger }+([^\\s@#:]*)$`));
+	template.replaceRegex = val(template.data.replaceRegex, new RegExp(`${ template.trigger }+[^\\s@#^]*$`));
 	template.getValue = val(template.data.getValue, function(_id) {
 		return _id;
 	});


### PR DESCRIPTION
FIxes #15695 

There were some logical error in regex of the message popup keyword finder.
1. Regex failed if there were more than one triggering characters(e.g #, :, @) 
2. Regex didn't support the patterns having characters before the triggering char.
3. Continuous triggers(eg. #####, @@@@, :::::) weren't working.
Before:


![ezgif com-video-to-gif(10)](https://user-images.githubusercontent.com/34532173/74377596-3db2f800-4e0a-11ea-9935-5fbbd301ba71.gif)
After:


![ezgif com-video-to-gif(11)](https://user-images.githubusercontent.com/34532173/74377679-6509c500-4e0a-11ea-93af-5e7e6af9af6a.gif)

__PS__: @gabriellsh @ggazzo please correct me if this is intentional.