### PR TITLE
[FIX] Deactivated users should not be shown in memberlist of rooms

### DIFF
--- a/app/models/server/models/Subscriptions.js
+++ b/app/models/server/models/Subscriptions.js
@@ -16,6 +16,7 @@ export class Subscriptions extends Base {
 		this.tryEnsureIndex({ rid: 1, 'u._id': 1 }, { unique: 1 });
 		this.tryEnsureIndex({ rid: 1, 'u._id': 1, open: 1 });
 		this.tryEnsureIndex({ rid: 1, 'u.username': 1 });
+		this.tryEnsureIndex({ rid: 1, 'u.active': 1 });
 		this.tryEnsureIndex({ rid: 1, alert: 1, 'u._id': 1 });
 		this.tryEnsureIndex({ rid: 1, roles: 1 });
 		this.tryEnsureIndex({ 'u._id': 1, name: 1, t: 1 });
@@ -626,6 +627,12 @@ export class Subscriptions extends Base {
 
 	findByRoomIdWhenUsernameExists(rid, options) {
 		const query = { rid, 'u.username': { $exists: 1 } };
+
+		return this.find(query, options);
+	}
+
+	findByRoomIdWhenUsernameExistsAndUserIsActive(rid, options) {
+		const query = { rid, 'u.username': { $exists: 1 }, 'u.active': true };
 
 		return this.find(query, options);
 	}

--- a/server/methods/getUsersOfRoom.js
+++ b/server/methods/getUsersOfRoom.js
@@ -22,9 +22,10 @@ function findUsers({ rid, status, skip, limit }) {
 				'u.name': 1,
 				'u.username': 1,
 				'u.status': 1,
+				'u.active': 1,
 			},
 		},
-		...status ? [{ $match: { 'u.status': status } }] : [],
+		...status ? [{ $match: { 'u.status': status, 'u.active': true } }] : [],
 		{
 			$sort: {
 				[settings.get('UI_Use_Real_Name') ? 'u.name' : 'u.username']: 1,
@@ -37,6 +38,7 @@ function findUsers({ rid, status, skip, limit }) {
 				_id: { $arrayElemAt: ['$u._id', 0] },
 				name: { $arrayElemAt: ['$u.name', 0] },
 				username: { $arrayElemAt: ['$u.username', 0] },
+				active: { $arrayElemAt: ['$u.active', 0] },
 			},
 		},
 	]).toArray();
@@ -58,7 +60,7 @@ Meteor.methods({
 			throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'getUsersOfRoom' });
 		}
 
-		const total = Subscriptions.findByRoomIdWhenUsernameExists(rid).count();
+		const total = Subscriptions.findByRoomIdWhenUsernameExistsAndUserIsActive(rid).count();
 		const users = await findUsers({ rid, status: { $ne: 'offline' }, limit, skip });
 		if (showAll && (!limit || users.length < limit)) {
 			const offlineUsers = await findUsers({

--- a/server/methods/getUsersOfRoom.js
+++ b/server/methods/getUsersOfRoom.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 
-import { Subscriptions } from '../../app/models';
+import { Subscriptions, Users } from '../../app/models';
 import { hasPermission } from '../../app/authorization';
 import { settings } from '../../app/settings';
 

--- a/server/methods/getUsersOfRoom.js
+++ b/server/methods/getUsersOfRoom.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 
-import { Subscriptions, Users } from '../../app/models';
+import { Subscriptions } from '../../app/models';
 import { hasPermission } from '../../app/authorization';
 import { settings } from '../../app/settings';
 


### PR DESCRIPTION
<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #16574

### Description:
Since deactivated users are not appeared in search results. Same way deactivated users should not be visible in member list of rooms. Also room member count should also be updated accordingly.
![13](https://user-images.githubusercontent.com/43786728/74460754-6e02a100-4eb3-11ea-9607-3301c291bdd8.gif)


### Before:
![12](https://user-images.githubusercontent.com/43786728/74459827-f41de800-4eb1-11ea-997f-bb36eaf35d7e.gif)

### After:
![11](https://user-images.githubusercontent.com/43786728/74456236-81f6d480-4eac-11ea-800f-adcde2be2396.gif)

