### PR TITLE
[FIX] Omnichannel Inquiry queues when removing chats

### DIFF
--- a/app/livechat/client/lib/stream/queueManager.js
+++ b/app/livechat/client/lib/stream/queueManager.js
@@ -15,12 +15,12 @@ const events = {
 	},
 	changed: (inquiry, collection) => {
 		if (inquiry.status !== 'queued' || (inquiry.department && !agentDepartments.includes(inquiry.department))) {
-			return collection.remove({ rid: inquiry.rid });
+			return collection.remove(inquiry._id);
 		}
 		delete inquiry.type;
-		collection.upsert({ rid: inquiry.rid }, inquiry);
+		collection.upsert({ _id: inquiry._id }, inquiry);
 	},
-	removed: (inquiry, collection) => collection.remove({ rid: inquiry.rid }),
+	removed: (inquiry, collection) => collection.remove(inquiry._id),
 };
 
 const appendListenerToDepartment = (departmentId, collection) => livechatQueueStreamer.on(`${ LIVECHAT_INQUIRY_QUEUE_STREAM_OBSERVER }/${ departmentId }`, (inquiry) => events[inquiry.type](inquiry, collection));

--- a/app/livechat/client/views/app/livechatReadOnly.js
+++ b/app/livechat/client/views/app/livechatReadOnly.js
@@ -50,9 +50,7 @@ Template.livechatReadOnly.onCreated(function() {
 	this.preparing = new ReactiveVar(true);
 
 	this.updateInquiry = (inquiry) => {
-		if (inquiry && inquiry.rid === this.rid) {
-			this.inquiry.set(inquiry);
-		}
+		this.inquiry.set(inquiry);
 	};
 
 	Meteor.call('livechat:getRoutingConfig', (err, config) => {

--- a/app/livechat/server/lib/Livechat.js
+++ b/app/livechat/server/lib/Livechat.js
@@ -370,6 +370,20 @@ export const Livechat = {
 		return true;
 	},
 
+	removeRoom(rid) {
+		check(rid, String);
+		const room = LivechatRooms.findOneById(rid);
+		if (!room) {
+			throw new Meteor.Error('error-invalid-room', 'Invalid room', { method: 'livechat:removeRoom' });
+		}
+
+		Messages.removeByRoomId(rid);
+		Subscriptions.removeByRoomId(rid);
+		LivechatInquiry.removeByRoomId(rid);
+		return LivechatRooms.removeById(rid);
+	},
+
+
 	setCustomFields({ token, key, value, overwrite } = {}) {
 		check(token, String);
 		check(key, String);
@@ -757,6 +771,7 @@ export const Livechat = {
 
 		Subscriptions.removeByVisitorToken(token);
 		LivechatRooms.removeByVisitorToken(token);
+		LivechatInquiry.removeByVisitorToken(token);
 	},
 
 	saveDepartmentAgents(_id, departmentAgents) {

--- a/app/livechat/server/methods/removeAllClosedRooms.js
+++ b/app/livechat/server/methods/removeAllClosedRooms.js
@@ -2,6 +2,7 @@ import { Meteor } from 'meteor/meteor';
 
 import { hasPermission } from '../../../authorization';
 import { LivechatRooms, Messages, Subscriptions } from '../../../models';
+import { Livechat } from '../lib/Livechat';
 
 Meteor.methods({
 	'livechat:removeAllClosedRooms'(departmentIds) {
@@ -11,10 +12,7 @@ Meteor.methods({
 
 		let count = 0;
 		LivechatRooms.findClosedRooms(departmentIds).forEach(({ _id }) => {
-			Messages.removeByRoomId(_id);
-			Subscriptions.removeByRoomId(_id);
-			LivechatRooms.removeById(_id);
-
+			Livechat.removeRoom(_id);
 			count++;
 		});
 

--- a/app/livechat/server/methods/removeAllClosedRooms.js
+++ b/app/livechat/server/methods/removeAllClosedRooms.js
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 
 import { hasPermission } from '../../../authorization';
-import { LivechatRooms, Messages, Subscriptions } from '../../../models';
+import { LivechatRooms } from '../../../models';
 import { Livechat } from '../lib/Livechat';
 
 Meteor.methods({

--- a/app/livechat/server/methods/removeRoom.js
+++ b/app/livechat/server/methods/removeRoom.js
@@ -2,6 +2,7 @@ import { Meteor } from 'meteor/meteor';
 
 import { hasPermission } from '../../../authorization';
 import { LivechatRooms, Messages, Subscriptions } from '../../../models';
+import { Livechat } from '../lib/Livechat';
 
 Meteor.methods({
 	'livechat:removeRoom'(rid) {
@@ -29,8 +30,6 @@ Meteor.methods({
 			});
 		}
 
-		Messages.removeByRoomId(rid);
-		Subscriptions.removeByRoomId(rid);
-		return LivechatRooms.removeById(rid);
+		return Livechat.removeRoom(rid);
 	},
 });

--- a/app/livechat/server/methods/removeRoom.js
+++ b/app/livechat/server/methods/removeRoom.js
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 
 import { hasPermission } from '../../../authorization';
-import { LivechatRooms, Messages, Subscriptions } from '../../../models';
+import { LivechatRooms } from '../../../models';
 import { Livechat } from '../lib/Livechat';
 
 Meteor.methods({

--- a/app/models/server/models/LivechatInquiry.js
+++ b/app/models/server/models/LivechatInquiry.js
@@ -172,6 +172,15 @@ export class LivechatInquiry extends Base {
 	removeByRoomId(rid) {
 		return this.remove({ rid });
 	}
+
+	removeByVisitorToken(token) {
+		const query = {
+			'v.token': token,
+		};
+
+		this.remove(query);
+	}
+
 }
 
 export default new LivechatInquiry();

--- a/app/models/server/models/LivechatInquiry.js
+++ b/app/models/server/models/LivechatInquiry.js
@@ -180,7 +180,6 @@ export class LivechatInquiry extends Base {
 
 		this.remove(query);
 	}
-
 }
 
 export default new LivechatInquiry();


### PR DESCRIPTION
We detected some issues related to the Omnichannel Inquiries when removing chats:
- The `streaming` was relying on the `rid` field, but when removing an `inquiry`,  only the `_id` is propagated, so it wasn't working properly.
- Also, the `inquiry` was not being removed in some events when the `room` was removed, so the `inquiry` was becoming available even without the existence of the related `room`.

Some customers have experienced issues related to this case, as shown below:

![db](https://user-images.githubusercontent.com/59577424/74551627-4d2d6080-4f32-11ea-9edf-f386c36c6336.gif)
