### PR TITLE
[FIX] Regression: New 'app' role with no permissions when updating to 3.0.0

### DIFF
--- a/server/startup/migrations/index.js
+++ b/server/startup/migrations/index.js
@@ -171,4 +171,5 @@ import './v170';
 import './v171';
 import './v172';
 import './v173';
+import './v174';
 import './xrun';

--- a/server/startup/migrations/v174.js
+++ b/server/startup/migrations/v174.js
@@ -1,0 +1,26 @@
+import { Migrations } from '../../../app/migrations/server';
+import { Permissions } from '../../../app/models/server';
+
+const appRolePermissions = [
+	'api-bypass-rate-limit',
+	'create-c',
+	'create-d',
+	'create-p',
+	'join-without-join-code',
+	'leave-c',
+	'leave-p',
+	'send-many-messages',
+	'view-c-room',
+	'view-d-room',
+	'view-joined-room',
+];
+
+Migrations.add({
+	version: 174,
+	up() {
+		Permissions.update({ _id: { $in: appRolePermissions } }, { $addToSet: { roles: 'app' } }, { multi: true });
+	},
+	down() {
+		Permissions.update({ _id: { $in: appRolePermissions } }, { $pull: { roles: 'app' } }, { multi: true });
+	},
+});


### PR DESCRIPTION
Currently, the expected permissions are not added to the `app` role on the server startup for workspaces that already had been installed previously to v3.0.

This migration updates the data for all those workspaces