### PR TITLE
[FIX] message count of private and public channels on the page /admin/rooms

### DIFF
--- a/app/lib/server/functions/deleteMessage.js
+++ b/app/lib/server/functions/deleteMessage.js
@@ -49,6 +49,9 @@ export const deleteMessage = function(message, user) {
 		}
 	}
 
+	// decrease message count
+	Rooms.dcrsMsgCountById(message.rid, -1);
+
 	if (showDeletedStatus) {
 		Messages.setAsDeletedByIdAndUser(message._id, user);
 	} else {

--- a/app/models/server/models/Messages.js
+++ b/app/models/server/models/Messages.js
@@ -915,7 +915,12 @@ export class Messages extends Base {
 		}
 
 		if (!limit) {
-			return this.remove(query);
+			const count = this.remove(query);
+
+			// decrease message count
+			Rooms.dcrsMsgCountById(rid, -count);
+
+			return count;
 		}
 
 		const messagesToDelete = this.find(query, {
@@ -925,11 +930,16 @@ export class Messages extends Base {
 			limit,
 		}).map(({ _id }) => _id);
 
-		return this.remove({
+		const count = this.remove({
 			_id: {
 				$in: messagesToDelete,
 			},
 		});
+
+		// decrease message count
+		Rooms.dcrsMsgCountById(rid, -count);
+
+		return count;
 	}
 
 	removeByUserId(userId) {

--- a/app/models/server/models/Rooms.js
+++ b/app/models/server/models/Rooms.js
@@ -625,6 +625,19 @@ export class Rooms extends Base {
 		return this.update(query, update);
 	}
 
+	dcrsMsgCountById(_id, dcrs) {
+		if (dcrs == null) { dcrs = -1; }
+		const query = { _id };
+
+		const update = {
+			$inc: {
+				msgs: dcrs,
+			},
+		};
+
+		return this.update(query, update);
+	}
+
 	incUsersCountById(_id, inc = 1) {
 		const query = { _id };
 


### PR DESCRIPTION
close #12610 

Previously, upon deletion/prune messages, the message count on the page https://xxxxxx/admin/rooms remains the same as the previous value.

now decreased the value of the message count variable for the roomId in which the message is being deleted/pruned.

## after changes

### 1) delete message
**count before deleting one message:- 7**

![Rocket Chat(1)](https://user-images.githubusercontent.com/43502196/74841569-e43d5280-534e-11ea-9767-cdfe2a6061b8.png)

![Rocket Chat(2)](https://user-images.githubusercontent.com/43502196/74841570-e56e7f80-534e-11ea-9302-be069a040a6e.png)

![Rocket Chat(3)](https://user-images.githubusercontent.com/43502196/74841574-e6071600-534e-11ea-999f-2ba94fb8294a.png)

![Rocket Chat(4)](https://user-images.githubusercontent.com/43502196/74841575-e69fac80-534e-11ea-8ff0-cd6a92e5af81.png)

**count after deleting one message:- 6**


### 2) prune message(user: subham sahoo)
**count before pruning one message:- 6**

![Rocket Chat(5)](https://user-images.githubusercontent.com/43502196/74841579-e7384300-534e-11ea-9965-fb113868e64e.png)

![Rocket Chat(6)](https://user-images.githubusercontent.com/43502196/74841585-e9020680-534e-11ea-9d7c-78dfdc18f5e9.png)

![Rocket Chat(7)](https://user-images.githubusercontent.com/43502196/74841606-f28b6e80-534e-11ea-8fc2-43c9cbf70d87.png)

**count after pruning one message:- 2**


