### PR TITLE
[FIX] Additional scroll when contextual bar is open

### DIFF
--- a/app/theme/client/imports/general/base_old.css
+++ b/app/theme/client/imports/general/base_old.css
@@ -1954,7 +1954,9 @@ rc-old select,
 	&-wrapper {
 		display: flex;
 
-		height: calc(100% - 76px);
+		--header-height: 76px; 
+		height: calc(100% - var(--header-height)); /* TODO */
+
 		flex-grow: 1;
 	}
 

--- a/app/theme/client/imports/general/base_old.css
+++ b/app/theme/client/imports/general/base_old.css
@@ -1954,10 +1954,9 @@ rc-old select,
 	&-wrapper {
 		display: flex;
 
-		--header-height: 76px; 
-		height: calc(100% - var(--header-height)); /* TODO */
+		flex: 1 1 auto;
 
-		flex-grow: 1;
+		height: 1%;
 	}
 
 	&-main {

--- a/app/theme/client/imports/general/base_old.css
+++ b/app/theme/client/imports/general/base_old.css
@@ -1954,7 +1954,7 @@ rc-old select,
 	&-wrapper {
 		display: flex;
 
-		height: calc(100% - 61px);
+		height: calc(100% - 76px);
 		flex-grow: 1;
 	}
 


### PR DESCRIPTION
When the content from the contextual bar is bigger than its container, an additional scroll bar for the entire room would appear.

![image](https://user-images.githubusercontent.com/40830821/74950888-8f491d00-53de-11ea-8251-92cf5c87109c.png)

