### PR TITLE
[FIX] Manual Register use correct state for determining registered

### DIFF
--- a/app/api/server/v1/cloud.js
+++ b/app/api/server/v1/cloud.js
@@ -17,7 +17,7 @@ API.v1.addRoute('cloud.manualRegister', { authRequired: true }, {
 
 		const registrationInfo = retrieveRegistrationStatus();
 
-		if (registrationInfo.connectToCloud) {
+		if (registrationInfo.workspaceRegistered) {
 			return API.v1.failure('Workspace is already registered');
 		}
 

--- a/app/cloud/client/admin/cloud.html
+++ b/app/cloud/client/admin/cloud.html
@@ -3,7 +3,7 @@
 		<section class="page-container page-home page-static page-settings">
 			{{#header sectionName="Connectivity_Services" hideHelp=true fixedHeight=true fullpage=true}}
 				<div class="rc-header__section-button">
-					{{#unless info.connectToCloud}}
+					{{#unless info.workspaceRegistered}}
 						<button class="rc-button rc-button--small rc-button--primary rc-button--outline js-register">
 							{{_ "Cloud_Register_manually"}}
 						</button>

--- a/app/ui-utils/client/lib/modal.html
+++ b/app/ui-utils/client/lib/modal.html
@@ -6,7 +6,7 @@
 		<dialog class="rc-modal rc-modal--{{modifier}}" data-modal="modal">
 
 			{{# if template}}
-				{{> Template.dynamic template=template data=data}} -->
+				{{> Template.dynamic template=template data=data}}
 			{{else}}
 				<header class="rc-modal__header">
 					<h1 class="rc-modal__title">


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

Right now uses connectToCloud which is purely the intent to register not if its already registered
