### PR TITLE
[FIX] Cannot edit Profile when Full Name is empty and not required

### DIFF
--- a/app/lib/server/startup/settings.js
+++ b/app/lib/server/startup/settings.js
@@ -125,7 +125,7 @@ settings.addGroup('Accounts', function() {
 		this.add('Accounts_DefaultUsernamePrefixSuggestion', 'user', {
 			type: 'string',
 		});
-		this.add('Accounts_RequireNameForSignUp', true, {
+		this.add('Accounts_RequireNameForSignUp', true, { // TODO rename to Accounts_RequireFullName
 			type: 'boolean',
 			public: true,
 		});

--- a/app/ui-account/client/accountProfile.js
+++ b/app/ui-account/client/accountProfile.js
@@ -19,7 +19,7 @@ const validateUsername = (username) => {
 	const reg = new RegExp(`^${ settings.get('UTF8_Names_Validation') }$`);
 	return reg.test(username);
 };
-const validateName = (name) => name && name.length;
+const validateName = (name) => (name && name.length) || !settings.get('Accounts_RequireNameForSignUp');
 const validateStatusMessage = (statusMessage) => {
 	if (!statusMessage || statusMessage.length <= 120 || statusMessage.length === 0) {
 		return true;

--- a/server/methods/saveUserProfile.js
+++ b/server/methods/saveUserProfile.js
@@ -41,7 +41,7 @@ Meteor.methods({
 			return true;
 		}
 
-		if (settings.realname) {
+		if (settings.realname || (!settings.realname && !rcSettings.get('Accounts_RequireNameForSignUp'))) {
 			Meteor.call('setRealName', settings.realname);
 		}
 


### PR DESCRIPTION
Closes #16740
Closes #16747

When Require Name For Signup was set to false, it was impossible to change anything regarding the user Account if the Name field was empty (even though not required).