### PR TITLE
[NEW] SAML config to allow clock drift

### DIFF
--- a/app/meteor-accounts-saml/server/saml_rocketchat.js
+++ b/app/meteor-accounts-saml/server/saml_rocketchat.js
@@ -182,6 +182,13 @@ Meteor.methods({
 			i18nLabel: 'SAML_Role_Attribute_Name',
 			i18nDescription: 'SAML_Role_Attribute_Name_Description',
 		});
+		settings.add(`SAML_Custom_${ name }_allowed_clock_drift`, 0, {
+			type: 'int',
+			group: 'SAML',
+			section: name,
+			i18nLabel: 'SAML_Allowed_Clock_Drift',
+			i18nDescription: 'SAML_Allowed_Clock_Drift_Description',
+		});
 	},
 });
 
@@ -222,6 +229,7 @@ const getSamlConfigs = function(service) {
 			cert: normalizeCert(settings.get(`${ service.key }_cert`)),
 		},
 		userDataFieldMap: settings.get(`${ service.key }_user_data_fieldmap`),
+		allowedClockDrift: settings.get(`${ service.key }_allowed_clock_drift`),		
 	};
 };
 
@@ -269,6 +277,7 @@ const configureSamlService = function(samlConfigs) {
 		authnContextComparison: samlConfigs.authnContextComparison,
 		defaultUserRole: samlConfigs.defaultUserRole,
 		roleAttributeName: samlConfigs.roleAttributeName,
+		allowedClockDrift: samlConfigs.allowedClockDrift,
 	};
 };
 

--- a/app/meteor-accounts-saml/server/saml_rocketchat.js
+++ b/app/meteor-accounts-saml/server/saml_rocketchat.js
@@ -229,7 +229,7 @@ const getSamlConfigs = function(service) {
 			cert: normalizeCert(settings.get(`${ service.key }_cert`)),
 		},
 		userDataFieldMap: settings.get(`${ service.key }_user_data_fieldmap`),
-		allowedClockDrift: settings.get(`${ service.key }_allowed_clock_drift`),		
+		allowedClockDrift: settings.get(`${ service.key }_allowed_clock_drift`),
 	};
 };
 

--- a/app/meteor-accounts-saml/server/saml_utils.js
+++ b/app/meteor-accounts-saml/server/saml_utils.js
@@ -49,6 +49,8 @@ SAML.prototype.initialize = function(options) {
 	if (options.authnContext === undefined) {
 		options.authnContext = 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport';
 	}
+	
+	options.allowedClockDrift = parseInt(options.allowedClockDrift) || 0;
 
 	return options;
 };
@@ -463,7 +465,10 @@ SAML.prototype.mapAttributes = function(attributeStatement, profile) {
 };
 
 SAML.prototype.validateNotBeforeNotOnOrAfterAssertions = function(element) {
-	const now = new Date();
+	const sysnow = new Date();
+        const allowedclockdrift = this.options.allowedClockDrift;
+
+        const now = new Date(sysnow.getTime() + allowedclockdrift);
 
 	if (element.hasAttribute('NotBefore')) {
 		const notBefore = element.getAttribute('NotBefore');

--- a/app/meteor-accounts-saml/server/saml_utils.js
+++ b/app/meteor-accounts-saml/server/saml_utils.js
@@ -49,7 +49,7 @@ SAML.prototype.initialize = function(options) {
 	if (options.authnContext === undefined) {
 		options.authnContext = 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport';
 	}
-	
+
 	options.allowedClockDrift = parseInt(options.allowedClockDrift) || 0;
 
 	return options;
@@ -466,9 +466,9 @@ SAML.prototype.mapAttributes = function(attributeStatement, profile) {
 
 SAML.prototype.validateNotBeforeNotOnOrAfterAssertions = function(element) {
 	const sysnow = new Date();
-        const allowedclockdrift = this.options.allowedClockDrift;
+	const allowedclockdrift = this.options.allowedClockDrift;
 
-        const now = new Date(sysnow.getTime() + allowedclockdrift);
+	const now = new Date(sysnow.getTime() + allowedclockdrift);
 
 	if (element.hasAttribute('NotBefore')) {
 		const notBefore = element.getAttribute('NotBefore');

--- a/packages/rocketchat-i18n/i18n/de.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de.i18n.json
@@ -2812,6 +2812,8 @@
   "SAML_Default_User_Role_Description": "Sie können mehrere Rollen angeben, indem Sie sie durch Kommas trennen.",
   "SAML_Role_Attribute_Name": "Rollenattributname",
   "SAML_Role_Attribute_Name_Description": "Wenn dieses Attribut in der SAML-Antwort gefunden wird, werden seine Werte als Rollennamen für neue Benutzer verwendet.",
+  "SAML_Allowed_Clock_Drift": "Erlaubte Zeitabweichung zum Identity Provider",
+  "SAML_Allowed_Clock_Drift_Description": "Die Uhrzeit des Identitätsproviders kann minimal vor der eigenen Systemzeit liegen. Um eine geringe Abweichung der Zeiten zu berücksichtigen, kann eine Zeitabweichung definiert werden. Der Wert muss in einer Anzahl von Millisekunden (ms) angegeben werden. Der angegebene Wert wird zur aktuellen Zeit, zu der die Antwort validiert wird, addiert.",
   "Saturday": "Samstag",
   "Save": "Speichern",
   "save-others-livechat-room-info": "Livechat-Informationen anderer Chats speichern",

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -2853,6 +2853,8 @@
   "SAML_Default_User_Role_Description": "You can specify multiple roles, separating them with commas.",
   "SAML_Role_Attribute_Name": "Role Attribute Name",
   "SAML_Role_Attribute_Name_Description": "If this attribute is found on the SAML response, it's values will be used as role names for new users.",
+  "SAML_Allowed_Clock_Drift": "Allowed clock drift from Identity Provider",
+  "SAML_Allowed_Clock_Drift_Description": "The clock of the Identity Provider may drift slightly ahead of your system clocks. You can allow for a small amount of clock drift. Its value must be given in a number of milliseconds (ms). The value given is added to the current time at which the response is validated.",
   "Saturday": "Saturday",
   "Save": "Save",
   "save-others-livechat-room-info": "Save Others Livechat Room Info",


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes https://github.com/RocketChat/Rocket.Chat/issues/16409

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

The clock of your Identity Provider may drift slightly ahead of your system clock. In that case you'll find something like this in your logfile and user logins are not possible:

```
Error: Unable to validate response url: Error: NotBefore / NotOnOrAfter assertion failed
```
To allow for a small amount of clock drift you can use `Allowed clock drift` within your SAML settings. Its value must be given in a number of milliseconds (ms). The value given is added to the current time at which the response is validated. The default setting is 0 milliseconds, so the new feature doesn't affect existing SAML configurations.

![grafik](https://user-images.githubusercontent.com/8544984/75568726-19832800-5a54-11ea-8580-7eabb7053937.png)
