### PR TITLE
[FIX] Language country has been ignored on translation load

### DIFF
--- a/app/ui-account/client/accountPreferences.js
+++ b/app/ui-account/client/accountPreferences.js
@@ -49,7 +49,7 @@ Template.accountPreferences.helpers({
 		const languages = TAPi18n.getLanguages();
 
 		const result = Object.entries(languages)
-			.map(([key, language]) => ({ ...language, key: key.toLowerCase() }))
+			.map(([key, language]) => ({ ...language, key }))
 			.sort((a, b) => a.key - b.key);
 
 		result.unshift({
@@ -62,7 +62,7 @@ Template.accountPreferences.helpers({
 	},
 	isUserLanguage(key) {
 		const languageKey = Meteor.user().language;
-		return typeof languageKey === 'string' && languageKey.toLowerCase() === key;
+		return typeof languageKey === 'string' && languageKey.toLowerCase() === key.toLowerCase();
 	},
 	ifThenElse(condition, val, not = '') {
 		return condition ? val : not;

--- a/client/startup/i18n.js
+++ b/client/startup/i18n.js
@@ -47,6 +47,10 @@ Meteor.startup(() => {
 	});
 
 	const applyLanguage = (language = 'en') => {
+		if (language.includes('-')) {
+			language = language.replace(/-.+/, `-${ language.split('-')[1].toUpperCase() }`);
+		}
+
 		language = filterLanguage(language);
 
 		if (!availableLanguages[language]) {

--- a/client/startup/i18n.js
+++ b/client/startup/i18n.js
@@ -21,7 +21,7 @@ Meteor.startup(() => {
 		const regex = /([a-z]{2,3})-([a-z]{2,4})/;
 		const matches = regex.exec(language);
 		if (matches) {
-			return `${ matches[1] }-${ matches[2].toLowerCase() }`;
+			return `${ matches[1] }-${ matches[2].toUpperCase() }`;
 		}
 
 		return language;
@@ -47,10 +47,6 @@ Meteor.startup(() => {
 	});
 
 	const applyLanguage = (language = 'en') => {
-		if (language.includes('-')) {
-			language = language.replace(/-.+/, `-${ language.split('-')[1].toUpperCase() }`);
-		}
-
 		language = filterLanguage(language);
 
 		if (!availableLanguages[language]) {


### PR DESCRIPTION
<!-- CHANGELOG -->
<!-- Each line of the changelog description will be converted to a list of bullets  -->
Languages including country variations like `pt-BR` were ignoring the country party because the user's preference has been saved in lowercase `pt-br` causing the language to not match the available languages. Now we enforce the uppercase of the country part when loading the language.
<!-- END CHANGELOG -->
