### PR TITLE
[FIX] Broken search results

### DIFF
--- a/app/search/client/provider/result.html
+++ b/app/search/client/provider/result.html
@@ -14,7 +14,7 @@
 				<div class="flex-tab__result js-list">
 					<ul class="list clearfix">
 						{{# with messageContext}}
-							{{#each msg in result.message.docs}}{{> message msg=(messageParse msg) room=room subscription=subscription settings=settings u=u}}{{/each}}
+							{{#each msg in result.message.docs}}{{> message msg=(messageParse msg) room=room subscription=subscription settings=settings u=u isSearchResult=true}}{{/each}}
 						{{/with}}
 					</ul>
 				</div>

--- a/app/ui-message/client/message.html
+++ b/app/ui-message/client/message.html
@@ -1,6 +1,6 @@
 <template name="message">
 	<li id="{{templatePrefix}}{{msg._id}}" data-id="{{msg._id}}" data-context={{actionContext}} class="message {{ignoredClass}} {{system}} {{t}} {{own}} {{isTemp}} {{chatops}} {{collapsed}} {{customClass}}" data-username="{{msg.u.username}}" data-tmid="{{msg.tmid}}" data-groupable="{{isGroupable}}" data-date="{{date}}" data-timestamp="{{timestamp}}" data-alias="{{msg.alias}}">
-		{{#if isThreadReply}}
+		{{#if renderAsThreadReply}}
 			{{> messageThread parentMessage=parentMessage threadMessage=threadMessage following=msg.following avatar=msg.u.username msg=msg body=body class=bodyClass}}
 		{{else}}
 			{{#if msg.avatar}}

--- a/app/ui-message/client/message.js
+++ b/app/ui-message/client/message.js
@@ -407,9 +407,10 @@ Template.message.helpers({
 		const { msg } = this;
 		return msg.actionContext === 'snippeted';
 	},
-	isThreadReply() {
+	renderAsThreadReply() {
 		const { groupable, msg: { tmid, t, groupable: _groupable }, settings: { showreply } } = this;
-		return !(groupable === true || _groupable === true) && !!(tmid && showreply && (!t || t === 'e2e'));
+		const isThreadReply = !(groupable === true || _groupable === true) && !!(tmid && showreply && (!t || t === 'e2e'));
+		return isThreadReply && !this.isSearchResult;
 	},
 	collapsed() {
 		const { msg: { tmid, collapsed }, settings: { showreply }, shouldCollapseReplies } = this;


### PR DESCRIPTION
Thread replies when searching messages were broke.

## Before:
![image](https://user-images.githubusercontent.com/40830821/75683034-30ed2b80-5c75-11ea-9a08-95da9e25fe24.png)

## After:
![image](https://user-images.githubusercontent.com/40830821/75682929-f8e5e880-5c74-11ea-91fc-6a51b9f4bd81.png)
