### PR TITLE
Regression: Fix omnichannel icon missing on sidebar

### DIFF
--- a/app/livechat/lib/LivechatRoomType.js
+++ b/app/livechat/lib/LivechatRoomType.js
@@ -37,8 +37,8 @@ export default class LivechatRoomType extends RoomTypeConfig {
 		super({
 			identifier: 'l',
 			order: 5,
-			icon: 'livechat',
-			label: 'Livechat',
+			icon: 'omnichannel',
+			label: 'Omnichannel',
 			route: new LivechatRoomRoute(),
 		});
 


### PR DESCRIPTION
Some resources were renamed from "livechat" to "omnichannel" in [this PR](https://github.com/RocketChat/Rocket.Chat/pull/16752), but the `icone` name had not been renamed in the Livechat RoomType.

Before:
![Screen Shot 2020-03-03 at 10 31 30](https://user-images.githubusercontent.com/59577424/75781727-7f193200-5d3c-11ea-9320-845013082d59.png)

After:
![Screen Shot 2020-03-03 at 10 47 48](https://user-images.githubusercontent.com/59577424/75781713-77f22400-5d3c-11ea-9db6-1eecd70b7d1d.png)
