### PR TITLE
[FIX] Fallback content-type as application/octet-stream for FileSystem uploads

### DIFF
--- a/app/file-upload/server/config/FileSystem.js
+++ b/app/file-upload/server/config/FileSystem.js
@@ -21,7 +21,7 @@ const FileSystemUploads = new FileUploadClass({
 				file = FileUpload.addExtensionTo(file);
 				res.setHeader('Content-Disposition', `attachment; filename*=UTF-8''${ encodeURIComponent(file.name) }`);
 				res.setHeader('Last-Modified', file.uploadedAt.toUTCString());
-				res.setHeader('Content-Type', file.type);
+				res.setHeader('Content-Type', file.type || 'application/octet-stream');
 				res.setHeader('Content-Length', file.size);
 
 				this.store.getReadStream(file._id, file).pipe(res);


### PR DESCRIPTION
…m upload location

Pull #13033 only fixed the issue for GridFS. This commit adds the same
fix for FileSystem location.

<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->


<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
