### PR TITLE
[FIX] Custom OAuth Bug

### DIFF
--- a/app/custom-oauth/server/custom_oauth_server.js
+++ b/app/custom-oauth/server/custom_oauth_server.js
@@ -402,7 +402,7 @@ export class CustomOAuth {
 			}
 
 			if (serviceData.username) {
-				const user = Users.findOneByUsernameAndServiceNameIgnoringCase(serviceData.username, serviceName);
+				const user = Users.findOneByUsernameAndServiceNameIgnoringCase(serviceData.username, serviceData._id, serviceName);
 				if (!user) {
 					return;
 				}

--- a/app/models/server/models/Users.js
+++ b/app/models/server/models/Users.js
@@ -449,12 +449,12 @@ export class Users extends Base {
 		return this.findOne(query, options);
 	}
 
-	findOneByUsernameAndServiceNameIgnoringCase(username, serviceName, options) {
+	findOneByUsernameAndServiceNameIgnoringCase(username, userId, serviceName, options) {
 		if (typeof username === 'string') {
 			username = new RegExp(`^${ s.escapeRegExp(username) }$`, 'i');
 		}
 
-		const query = { username, [`services.${ serviceName }.id`]: serviceName };
+		const query = { username, [`services.${ serviceName }.id`]: userId };
 
 		return this.findOne(query, options);
 	}


### PR DESCRIPTION
This pull request fixes a bug in Custom OAuth flow of Rocket.Chat. Custom OAuth right now depends upon the **services** block of user data to validate and find user from the database. Following is a sample services block, with `alexapnr` as **OAuth servicename**:

```
services: {
  password: {
    bcrypt: '$2b$10$dWQ7Vjfb8jRaT15/wpqdZOZXLmHOM.rx69GQjos.cUM4Oqyszr.ry',
    reset: [ Object ]
  },
  email: {
    verificationTokens: [ Array ]
  },
  resume: {
    loginTokens: [ Array ]
  },
  alexapnr: {
    id: 'Dv8cbqqFYuG6cvmWP',
    accessToken: '57fbbe8c1a16d4b2181e12fc52cfd6e634eaede5',
    email: 'ravalprajval@gmail.com',
    expiresAt: 1583579264954,
    name: 'Prajval Raval',
    roles: [ Array ],
    username: 'prajval.raval'
  }
}
```
In the above block you can see, the data is stored as `services.[serviceName].id: userId` but in current Rocket Chat code, we are sending the query as:

```
const query = { username, [`services.${ serviceName }.id`]: serviceName };
```

instead of,

```
const query = { username, [`services.${ serviceName }.id`]: userId };
```