### PR TITLE
[FIX] Custom OAuth Login Error

### DIFF
--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import { Accounts } from 'meteor/accounts-base';
-
+import { ServiceConfiguration } from 'meteor/service-configuration';
 import { Users } from '../../app/models';
 
 const orig_updateOrCreateUserFromExternalService = Accounts.updateOrCreateUserFromExternalService;
@@ -16,7 +16,14 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 		'twitter',
 	];
 
-	if (services.includes(serviceName) === false && serviceData._OAuthCustom !== true) {
+	//To get the configurations of service named serviceName
+	let serviceConfigurations = ServiceConfiguration.configurations.findOne({service: serviceName})
+	let isCustomService
+	if(serviceConfigurations){
+		isCustomService = serviceConfigurations.custom
+	}
+
+	if (services.includes(serviceName) === false && isCustomService !== true) {
 		return orig_updateOrCreateUserFromExternalService.apply(this, [serviceName, serviceData, ...args]);
 	}
 

--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
 import { Accounts } from 'meteor/accounts-base';
+
 import { ServiceConfiguration } from 'meteor/service-configuration';
 import { Users } from '../../app/models';
 
@@ -16,11 +17,11 @@ Accounts.updateOrCreateUserFromExternalService = function(serviceName, serviceDa
 		'twitter',
 	];
 
-	//To get the configurations of service named serviceName
-	let serviceConfigurations = ServiceConfiguration.configurations.findOne({service: serviceName})
-	let isCustomService
-	if(serviceConfigurations){
-		isCustomService = serviceConfigurations.custom
+	//	To get the configurations of service named serviceName
+	const serviceConfigurations = ServiceConfiguration.configurations.findOne({ service: serviceName });
+	let isCustomService;
+	if (serviceConfigurations) {
+		isCustomService = serviceConfigurations.custom;
 	}
 
 	if (services.includes(serviceName) === false && isCustomService !== true) {

--- a/server/configuration/accounts_meld.js
+++ b/server/configuration/accounts_meld.js
@@ -1,7 +1,8 @@
 import _ from 'underscore';
-import { Accounts } from 'meteor/accounts-base';
 
+import { Accounts } from 'meteor/accounts-base';
 import { ServiceConfiguration } from 'meteor/service-configuration';
+
 import { Users } from '../../app/models';
 
 const orig_updateOrCreateUserFromExternalService = Accounts.updateOrCreateUserFromExternalService;


### PR DESCRIPTION
This PR fixes a fault in the method used to check if the OAuth service being used is custom or not.

**The current code does the following:-** 

`if (services.includes(serviceName) === false && serviceData._OAuthCustom !== true)`  

Fault:- `serviceData._OAuthCustom` is undefined

**Different approach which this PR uses:-**

```
//	To get the configurations of service named serviceName
const serviceConfigurations = ServiceConfiguration.configurations.findOne({ service: serviceName });
	let isCustomService;
	if (serviceConfigurations) {
		isCustomService = serviceConfigurations.custom;
	}

	if (services.includes(serviceName) === false && isCustomService !== true)

```
The same check was achieved using different approach

This has been tested for alexa skill