### PR TITLE
[FIX] Integrations page pagination

### DIFF
--- a/app/integrations/client/views/integrations.js
+++ b/app/integrations/client/views/integrations.js
@@ -46,7 +46,7 @@ Template.integrations.onCreated(async function() {
 
 	this.autorun(async () => {
 		const offset = this.offset.get();
-		const { integrations, total } = await APIClient.v1.get(`integrations.list?count=${ ITEMS_COUNT }&offset=${ offset }`);
+		const { integrations, total } = await APIClient.v1.get(`integrations.list?sort={"type":1}&count=${ ITEMS_COUNT }&offset=${ offset }`);
 		this.total.set(total);
 		this.integrations.set(this.integrations.get().concat(integrations));
 	});

--- a/app/models/server/models/Integrations.js
+++ b/app/models/server/models/Integrations.js
@@ -5,6 +5,8 @@ import { Base } from './_Base';
 export class Integrations extends Base {
 	constructor() {
 		super('integrations');
+
+		this.tryEnsureIndex({ type: 1 });
 	}
 
 	findByType(type, options) {


### PR DESCRIPTION
Integrations were being requested out of order, so when requesting new items after getting to the bottom of the list, if an incoming webhook is returned it will not be placed at the end of the list, resulting in weird results.