### PR TITLE
[FIX] Allow badWord filter for Diacritics word

### DIFF
--- a/app/lib/server/methods/filterBadWords.js
+++ b/app/lib/server/methods/filterBadWords.js
@@ -7,7 +7,9 @@ callbacks.add('beforeSaveMessage', function(message) {
 	if (settings.get('Message_AllowBadWordsFilter')) {
 		const badWordsList = settings.get('Message_BadWordsFilterList');
 		let options;
-
+		let { msg } = message;
+		// Convert diacritics to english words
+		msg = msg.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 		// Add words to the blacklist
 		if (!!badWordsList && badWordsList.length) {
 			options = {
@@ -15,7 +17,7 @@ callbacks.add('beforeSaveMessage', function(message) {
 			};
 		}
 		const filter = new Filter(options);
-		message.msg = filter.clean(message.msg);
+		message.msg = filter.clean(msg);
 	}
 
 	return message;


### PR DESCRIPTION
closed #14283

Previously bad word filter doesn't work for diacritics(words like chó, mèo). Converted diacritics to there English form and then pass that to bad-word package. tried to solve this by regex overrides as mentioned in the official doc of badwords package which doesn't seem to work for diacritic words.

### current behavior after change

![pr8](https://user-images.githubusercontent.com/43502196/76574606-c349c680-64e2-11ea-98ad-619f54cae02f.gif)
