### PR TITLE
[FIX] Made user roles persistent if a user leaves a public channel

### DIFF
--- a/app/lib/server/functions/removeUserFromRoom.js
+++ b/app/lib/server/functions/removeUserFromRoom.js
@@ -26,8 +26,6 @@ export const removeUserFromRoom = function(rid, user, options = {}) {
 			Messages.createCommandWithRoomIdAndUser('survey', rid, user);
 		}
 
-		Subscriptions.removeByRoomIdAndUserId(rid, user._id);
-
 		Meteor.defer(function() {
 			// TODO: CACHE: maybe a queue?
 			callbacks.run('afterLeaveRoom', user, room);


### PR DESCRIPTION
closed #7330

Previously when a user leaves a room, the subscription for that user in that channel was also being removed, which is currently being kept to keep the user permissions.

### previous behavior

![pr6-2020-03-14_03 41 31](https://user-images.githubusercontent.com/43502196/76664273-c6f45080-65a9-11ea-8f05-f4cd388d8859.gif)

### current behavior

![pr6-2020-03-14_03 54 31](https://user-images.githubusercontent.com/43502196/76664300-dffd0180-65a9-11ea-90a8-2130a361125f.gif)
