### PR TITLE
[FIX] Federation Event ROOM_ADD_USER not being dispatched

### DIFF
--- a/app/federation/server/endpoints/dispatch.js
+++ b/app/federation/server/endpoints/dispatch.js
@@ -87,7 +87,7 @@ const eventHandlers = {
 	//
 	// ROOM_ADD_USER
 	//
-	async [eventTypes.ROOM_ADD_USER0](event) {
+	async [eventTypes.ROOM_ADD_USER](event) {
 		const eventResult = await FederationRoomEvents.addEvent(event.context, event);
 
 		// If the event was successfully added, handle the event locally


### PR DESCRIPTION
When adding a federated user to channel. The user on the federated server don't know about it. 