### PR TITLE
[FIX] Search valid for emoji with dual name

### DIFF
--- a/app/emoji/client/emojiPicker.js
+++ b/app/emoji/client/emojiPicker.js
@@ -58,9 +58,10 @@ function getEmojisBySearchTerm(searchTerm) {
 
 		if (searchRegExp.test(current)) {
 			const emojiObject = emoji.list[current];
-			const { emojiPackage } = emojiObject;
+			const { emojiPackage, shortnames } = emojiObject;
 			let tone = '';
 			current = current.replace(/:/g, '');
+			const alias = shortnames[0] !== undefined ? shortnames[0].replace(/:/g, '') : shortnames[0];
 
 			if (actualTone > 0 && emoji.packages[emojiPackage].toneList.hasOwnProperty(emoji)) {
 				tone = `_tone${ actualTone }`;
@@ -71,7 +72,8 @@ function getEmojisBySearchTerm(searchTerm) {
 			for (const key in emoji.packages[emojiPackage].emojisByCategory) {
 				if (emoji.packages[emojiPackage].emojisByCategory.hasOwnProperty(key)) {
 					const contents = emoji.packages[emojiPackage].emojisByCategory[key];
-					if (contents.indexOf(current) !== -1) {
+					const searchValArray = alias !== undefined ? alias.replace(/:/g, '').split('_') : alias;
+					if (contents.indexOf(current) !== -1 || (searchValArray !== undefined && searchValArray.includes(searchTerm))) {
 						emojiFound = true;
 						break;
 					}


### PR DESCRIPTION
closes #16636

Currently, Searching for emojis produces inconsistent results(doesn't able to recognize emojis having alias name). Used the `shortnames` of each emojis to query for the correct emoji.

### current behavior

![pr6-2020-03-16_02 11 42](https://user-images.githubusercontent.com/43502196/76710628-04361b00-672f-11ea-80a2-6f9f1f64a831.gif)
