### PR TITLE
[FIX] Spotlight search when view-outside-room is false (#14930)

### DIFF
--- a/server/publications/spotlight.js
+++ b/server/publications/spotlight.js
@@ -95,6 +95,27 @@ Meteor.methods({
 				fields: userOptions.fields,
 				sort: userOptions.sort,
 			}).fetch();
+		} else if (type.users === true) {
+			const userSubscriptions = Subscriptions.findByUserId(userId, { rid: true })
+				.fetch()
+				.map((x) => x.rid);
+
+			const usersWithSameSubscriptions = Subscriptions.find({
+				rid: { $in: userSubscriptions },
+				'u._id': { $ne: userId },
+			})
+				.fetch()
+				.map(({ u }) => u._id);
+
+			result.users = Users.find({
+				active: true,
+				_id: { $in: usersWithSameSubscriptions },
+				username: { $regex: regex },
+			}, {
+				fields: userOptions.fields,
+				sort: userOptions.sort,
+				limit: userOptions.limit,
+			}).fetch();
 		}
 
 		return result;


### PR DESCRIPTION
[FIX] For bug fixes 

Closes #14930

When view-outside-room is set to false, the spotlight search will now return search users who are subscribed to the same rooms as the logged in user. 
 
Previous behaviour was to always return empty results, because the variable rid was never set.  
