### PR TITLE
[FIX] Public channel cannot be accessed via URL when 'Allow Anonymous Read' is active

### DIFF
--- a/app/ui-utils/client/lib/openRoom.js
+++ b/app/ui-utils/client/lib/openRoom.js
@@ -48,6 +48,9 @@ export const openRoom = function(type, name) {
 		}
 
 		if (RoomManager.open(type + name).ready() !== true) {
+			if (settings.get('Accounts_AllowAnonymousRead')) {
+				BlazeLayout.render('main');
+			}
 			replaceCenterDomBy(getDomOfLoading());
 			return;
 		}


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #16791

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
### Description:
The main issue here is that `const mainNode (line 31)` is null if anonymous read is allowed in the scenario mentioned in the issue.
![Screenshot from 2020-03-18 01-30-46](https://user-images.githubusercontent.com/43786728/76896597-24ddac80-68b8-11ea-91fc-51767dd9d638.png)



Therefore solved this by adding `BlazeLayout.render('main'); (line 52)` if anonymous read is allowed.

![Screenshot from 2020-03-18 00-18-21](https://user-images.githubusercontent.com/43786728/76890866-1d190a80-68ae-11ea-8611-6e195c880ef7.png)


### After fix:
![11](https://user-images.githubusercontent.com/43786728/76891380-e68fbf80-68ae-11ea-8a55-b14c5eb1e5a3.gif)

