### PR TITLE
Fixed Line break incorrectly being called apostrophe in code

### DIFF
--- a/app/emoji/client/emojiParser.js
+++ b/app/emoji/client/emojiParser.js
@@ -74,7 +74,7 @@ Tracker.autorun(() => {
 			// apostrophe (') back to &#39;
 			html = html.replace(/\'/g, '&#39;');
 
-			// apostrophe ' <br> ' back to '<br>'
+			// line breaks ' <br> ' back to '<br>'
 			html = html.replace(/ <br> /g, '<br>');
 		}
 


### PR DESCRIPTION
Small correction in a comment.
Noticed while looking for emoji parser regex.
