### PR TITLE
[FIX] Message quote button inside threads

### DIFF
--- a/app/ui-utils/client/lib/MessageAction.js
+++ b/app/ui-utils/client/lib/MessageAction.js
@@ -192,7 +192,7 @@ Meteor.startup(async function() {
 		context: ['message', 'message-mobile', 'threads'],
 		action() {
 			const { msg: message } = messageArgs(this);
-			const { input } = chatMessages[message.rid];
+			const { input } = chatMessages[message.rid + (message.tmid ? `-${ message.tmid }` : '')];
 			const $input = $(input);
 
 			let messages = $input.data('reply') || [];


### PR DESCRIPTION
Previously, when trying to quote messages inside threads, the quote would be sent to room instead to the thread.