### PR TITLE
[FIX] ability to mention user not a member of private channel

### DIFF
--- a/app/models/server/models/Subscriptions.js
+++ b/app/models/server/models/Subscriptions.js
@@ -529,6 +529,17 @@ export class Subscriptions extends Base {
 		return this.find(query, options);
 	}
 
+	findByRoomIdAndTypes(roomId, types, options) {
+		const query = {
+			rid: roomId,
+			t: {
+				$in: types,
+			},
+		};
+
+		return this.find(query, options);
+	}
+
 	findByType(types, options) {
 		const query = {
 			t: {

--- a/server/publications/spotlight.js
+++ b/server/publications/spotlight.js
@@ -73,6 +73,11 @@ Meteor.methods({
 		if (hasPermission(userId, 'view-outside-room')) {
 			if (type.users === true && hasPermission(userId, 'view-d-room')) {
 				result.users = Users.findByActiveUsersExcept(text, usernames, userOptions).fetch();
+				// fetch current (private) room user's data
+				const roomUsersData = Subscriptions.findByRoomIdAndTypes(rid, ['p'], { fields: { u: 1 } }).fetch().map((user) => user.u._id);
+				if (roomUsersData.length > 0) {
+					result.users = result.users.filter((user) => roomUsersData.indexOf(user._id) !== -1);
+				}
 			}
 
 			if (type.rooms === true && hasPermission(userId, 'view-c-room')) {


### PR DESCRIPTION
closes #16427

Currently, it is possible to mention a user not a member of a private channel. Add checks in user mention to ensure that the mentioned user is a previous member of the private channel. This is required in private channels as it confuses with the present users of the private channel.

### current behavior after changes (in Private channels)

![pr6-2020-03-18_23 28 13-_online-video-cutter com_](https://user-images.githubusercontent.com/43502196/77065932-303fed80-6a08-11ea-9d8f-2081f1165f09.gif)
