### PR TITLE
[FIX] Make the AppLivechatBridge.createMessage works properly as a promise

### DIFF
--- a/app/apps/server/bridges/livechat.js
+++ b/app/apps/server/bridges/livechat.js
@@ -32,7 +32,7 @@ export class AppLivechatBridge {
 			message: this.orch.getConverters().get('messages').convertAppMessage(message),
 		};
 
-		const msg = Livechat.sendMessage(data);
+		const msg = await Livechat.sendMessage(data);
 
 		return msg._id;
 	}


### PR DESCRIPTION
There was a `await` statement missing, so the Apps weren't getting the expected return value.