### PR TITLE
[IMPROVE] Allow login of non LDAP users when LDAP is enabled

### DIFF
--- a/app/ldap/server/settings.js
+++ b/app/ldap/server/settings.js
@@ -33,7 +33,7 @@ settings.addGroup('LDAP', function() {
 	];
 
 	this.add('LDAP_Enable', false, { type: 'boolean', public: true });
-	this.add('LDAP_Login_Fallback', false, { type: 'boolean', enableQuery });
+	this.add('LDAP_Login_Fallback', false, { type: 'boolean', enableQuery: null });
 	this.add('LDAP_Find_User_After_Login', true, { type: 'boolean', enableQuery });
 	this.add('LDAP_Host', '', { type: 'string', enableQuery });
 	this.add('LDAP_Port', '389', { type: 'string', enableQuery });

--- a/app/ldap/server/settings.js
+++ b/app/ldap/server/settings.js
@@ -33,7 +33,7 @@ settings.addGroup('LDAP', function() {
 	];
 
 	this.add('LDAP_Enable', false, { type: 'boolean', public: true });
-	this.add('LDAP_Login_Fallback', true, { type: 'boolean', enableQuery });
+	this.add('LDAP_Login_Fallback', false, { type: 'boolean', enableQuery });
 	this.add('LDAP_Find_User_After_Login', true, { type: 'boolean', enableQuery });
 	this.add('LDAP_Host', '', { type: 'string', enableQuery });
 	this.add('LDAP_Port', '389', { type: 'string', enableQuery });


### PR DESCRIPTION
With this change, the LDAP Login Fallback isn't necessary anymore to allow system users to login (usual for admin accounts that were created before the LDAP sync). So now the LDAP Fallback is disabled by default meaning that the users' passwords will not be saved in rocket.chat by default anymore.

Closes #6144