### PR TITLE
Add an index to the name field for omnichannel department

### DIFF
--- a/app/models/server/models/LivechatDepartment.js
+++ b/app/models/server/models/LivechatDepartment.js
@@ -9,6 +9,7 @@ export class LivechatDepartment extends Base {
 	constructor(modelOrName) {
 		super(modelOrName || 'livechat_department');
 
+		this.tryEnsureIndex({ name: 1 });
 		this.tryEnsureIndex({
 			numAgents: 1,
 			enabled: 1,


### PR DESCRIPTION
The use of the `name` field in the LivechatDepartment model is increasing.
Some customers are consuming the Omnichannel REST API to perform several things and this field is being used a lot, so we need to add a new index to this field in order to get better performance when fetching Omnichannel departments. 