### PR TITLE
[FIX] LDAP handler - Pass LDAP connection to addLdapUser

### DIFF
--- a/app/ldap/server/loginHandler.js
+++ b/app/ldap/server/loginHandler.js
@@ -143,7 +143,7 @@ Accounts.registerLoginHandler('ldap', function(loginRequest) {
 	}
 
 	// Create new user
-	const result = addLdapUser(ldapUser, username, loginRequest.ldapPass);
+	const result = addLdapUser(ldapUser, username, loginRequest.ldapPass, ldap);
 
 	if (result instanceof Error) {
 		throw result;


### PR DESCRIPTION
This fixes an issue where the first login attempt fails when only using LDAP and having group sync enabled. This issue was caused by addLdapUser trying to sync user information without actually having access to the LDAP connection.
