### PR TITLE
Fix: 2FA DDP method not getting code on API call that doesn’t requires 2FA

### DIFF
--- a/app/2fa/server/code/index.ts
+++ b/app/2fa/server/code/index.ts
@@ -120,6 +120,11 @@ function _checkCodeForUser({ user, code, method, options = {}, connection }: ICh
 		user = getUserForCheck(user);
 	}
 
+	if (!code && !method && connection?.httpHeaders?.['x-2fa-code'] && connection.httpHeaders['x-2fa-method']) {
+		code = connection.httpHeaders['x-2fa-code'];
+		method = connection.httpHeaders['x-2fa-method'];
+	}
+
 	if (connection && isAuthorizedForToken(connection, user, options)) {
 		return true;
 	}


### PR DESCRIPTION
When a DDP method that requires 2FA is called from inside an API without 2FA required the code verification wasn't possible to happen since the API didn't set the context as authorized and the method didn't have access to the headers to execute the authorization process.

This change makes it possible by getting the information from the connection headers if not passed to the 2FA process, it's only possible for this type of call since the connection originates from the API and the headers refer to the call.