### PR TITLE
Regression: Remove deprecated Omnichannel setting used to fetch the queue data through subscription 

### DIFF
--- a/app/livechat/client/collections/LivechatInquiry.js
+++ b/app/livechat/client/collections/LivechatInquiry.js
@@ -1,11 +1,3 @@
 import { Mongo } from 'meteor/mongo';
 
-import { settings } from '../../../settings/client';
-
-let collection;
-export const getLivechatInquiryCollection = () => {
-	if (!collection) {
-		collection = new Mongo.Collection(settings.get('Livechat_enable_inquiry_fetch_by_stream') ? null : 'rocketchat_livechat_inquiry');
-	}
-	return collection;
-};
+export const LivechatInquiry = new Mongo.Collection(null);

--- a/app/livechat/client/lib/stream/queueManager.js
+++ b/app/livechat/client/lib/stream/queueManager.js
@@ -53,6 +53,8 @@ const removeGlobalListener = () => {
 };
 
 export const initializeLivechatInquiryStream = async (userId) => {
+	LivechatInquiry.remove({});
+
 	if (agentDepartments.length) {
 		removeDepartmentsListeners(agentDepartments);
 	}

--- a/app/livechat/client/lib/stream/queueManager.js
+++ b/app/livechat/client/lib/stream/queueManager.js
@@ -1,24 +1,23 @@
 import { APIClient } from '../../../../utils/client';
-import { getLivechatInquiryCollection } from '../../collections/LivechatInquiry';
+import { LivechatInquiry } from '../../collections/LivechatInquiry';
 import { inquiryDataStream } from './inquiry';
 import { hasRole } from '../../../../authorization/client';
 
 let agentDepartments = [];
-const collection = getLivechatInquiryCollection();
 
 const events = {
 	added: (inquiry) => {
 		delete inquiry.type;
-		collection.insert(inquiry);
+		LivechatInquiry.insert(inquiry);
 	},
 	changed: (inquiry) => {
 		if (inquiry.status !== 'queued' || (inquiry.department && !agentDepartments.includes(inquiry.department))) {
-			return collection.remove(inquiry._id);
+			return LivechatInquiry.remove(inquiry._id);
 		}
 		delete inquiry.type;
-		collection.upsert({ _id: inquiry._id }, inquiry);
+		LivechatInquiry.upsert({ _id: inquiry._id }, inquiry);
 	},
-	removed: (inquiry) => collection.remove(inquiry._id),
+	removed: (inquiry) => LivechatInquiry.remove(inquiry._id),
 };
 
 const updateCollection = (inquiry) => { events[inquiry.type](inquiry); };
@@ -31,7 +30,7 @@ const getInquiriesFromAPI = async (url) => {
 };
 
 const updateInquiries = async (inquiries) => {
-	(inquiries || []).forEach((inquiry) => collection.upsert({ _id: inquiry._id }, inquiry));
+	(inquiries || []).forEach((inquiry) => LivechatInquiry.upsert({ _id: inquiry._id }, inquiry));
 };
 
 const getAgentsDepartments = async (userId) => {
@@ -54,12 +53,12 @@ const removeGlobalListener = () => {
 };
 
 export const initializeLivechatInquiryStream = async (userId) => {
-	collection.remove({});
 	if (agentDepartments.length) {
 		removeDepartmentsListeners(agentDepartments);
 	}
 	removeGlobalListener();
 	await updateInquiries(await getInquiriesFromAPI('livechat/inquiries.queued?sort={"ts": 1}'));
+
 	agentDepartments = (await getAgentsDepartments(userId)).map((department) => department.departmentId);
 	await addListenerForeachDepartment(userId, agentDepartments);
 	if (agentDepartments.length === 0 || hasRole(userId, 'livechat-manager')) {

--- a/app/livechat/client/views/sideNav/livechat.js
+++ b/app/livechat/client/views/sideNav/livechat.js
@@ -9,7 +9,7 @@ import { KonchatNotification } from '../../../../ui';
 import { settings } from '../../../../settings';
 import { hasPermission } from '../../../../authorization';
 import { t, handleError, getUserPreference } from '../../../../utils';
-import { getLivechatInquiryCollection } from '../../collections/LivechatInquiry';
+import { LivechatInquiry } from '../../collections/LivechatInquiry';
 import { Notifications } from '../../../../notifications/client';
 import { initializeLivechatInquiryStream } from '../../lib/stream/queueManager';
 
@@ -50,7 +50,7 @@ Template.livechat.helpers({
 	},
 
 	inquiries() {
-		const inqs = getLivechatInquiryCollection().find({
+		const inqs = LivechatInquiry.find({
 			status: 'queued',
 		}, {
 			sort: {
@@ -131,11 +131,8 @@ Template.livechat.onCreated(function() {
 			this.statusLivechat.set();
 		}
 	});
-	if (!settings.get('Livechat_enable_inquiry_fetch_by_stream')) {
-		this.subscribe('livechat:inquiry');
-	} else {
-		initializeLivechatInquiryStream(Meteor.userId());
-	}
+
+	initializeLivechatInquiryStream(Meteor.userId());
 	this.updateAgentDepartments = () => initializeLivechatInquiryStream(Meteor.userId());
 	this.autorun(() => this.inquiriesLimit.set(settings.get('Livechat_guest_pool_max_number_incoming_livechats_displayed')));
 

--- a/app/livechat/lib/LivechatRoomType.js
+++ b/app/livechat/lib/LivechatRoomType.js
@@ -8,9 +8,9 @@ import { openRoom } from '../../ui-utils';
 import { RoomSettingsEnum, UiTextContext, RoomTypeRouteConfig, RoomTypeConfig } from '../../utils';
 import { getAvatarURL } from '../../utils/lib/getAvatarURL';
 
-let getLivechatInquiryCollection;
+let LivechatInquiry;
 if (Meteor.isClient) {
-	({ getLivechatInquiryCollection } = require('../client/collections/LivechatInquiry'));
+	({ LivechatInquiry } = require('../client/collections/LivechatInquiry'));
 }
 
 class LivechatRoomRoute extends RoomTypeRouteConfig {
@@ -72,7 +72,7 @@ export default class LivechatRoomType extends RoomTypeConfig {
 		if (room) {
 			return room.v && room.v.status;
 		}
-		const inquiry = getLivechatInquiryCollection().findOne({ rid });
+		const inquiry = LivechatInquiry.findOne({ rid });
 		return inquiry && inquiry.v && inquiry.v.status;
 	}
 
@@ -102,7 +102,7 @@ export default class LivechatRoomType extends RoomTypeConfig {
 			return true;
 		}
 
-		const inquiry = getLivechatInquiryCollection().findOne({ rid }, { fields: { status: 1 } });
+		const inquiry = LivechatInquiry.findOne({ rid }, { fields: { status: 1 } });
 		if (inquiry && inquiry.status === 'queued') {
 			return true;
 		}

--- a/app/livechat/server/config.js
+++ b/app/livechat/server/config.js
@@ -526,13 +526,4 @@ Meteor.startup(function() {
 		i18nLabel: 'How_long_to_wait_to_consider_visitor_abandonment',
 		i18nDescription: 'Time_in_seconds',
 	});
-
-	settings.add('Livechat_enable_inquiry_fetch_by_stream', true, {
-		type: 'boolean',
-		group: 'Omnichannel',
-		section: 'Routing',
-		public: true,
-		i18nLabel: 'Enable_inquiry_fetch_by_stream',
-		enableQuery: { _id: 'Livechat_Routing_Method', value: 'Manual_Selection' },
-	});
 });

--- a/server/startup/migrations/index.js
+++ b/server/startup/migrations/index.js
@@ -175,4 +175,5 @@ import './v174';
 import './v175';
 import './v176';
 import './v177';
+import './v178';
 import './xrun';

--- a/server/startup/migrations/v178.js
+++ b/server/startup/migrations/v178.js
@@ -1,0 +1,14 @@
+import {
+	Migrations,
+} from '../../../app/migrations';
+import {
+	Settings,
+} from '../../../app/models';
+
+
+Migrations.add({
+	version: 178,
+	up() {
+		Settings.remove({ _id: 'Livechat_enable_inquiry_fetch_by_stream' });
+	},
+});


### PR DESCRIPTION
The Omnichannel setting -> `Livechat_enable_inquiry_fetch_by_stream` is no longer necessary since we removed the subscription that was used to fetch the queue data from the client-side.
Now, the Omnichannel queue works through the `stream` approach, only.