### PR TITLE
[FIX] Initialize/connect LDAP & add userdn to filter template vars isUserInLDAPGroup

### DIFF
--- a/app/ldap/server/sync.js
+++ b/app/ldap/server/sync.js
@@ -28,9 +28,17 @@ export function isUserInLDAPGroup(ldap, ldapUser, user, ldapGroup) {
 		return false;
 	}
 	const searchOptions = {
-		filter: syncUserRolesFilter.replace(/#{username}/g, user.username).replace(/#{groupName}/g, ldapGroup),
+		filter: syncUserRolesFilter.replace(/#{username}/g, user.username).replace(/#{groupName}/g, ldapGroup).replace(/#{userdn}/g, ldapUser.dn),
 		scope: 'sub',
 	};
+
+	if (!ldap) {
+		ldap = new LDAP();
+	}
+
+	if (!ldap.connected) {
+		ldap.connectSync();
+	}
 
 	const result = ldap.searchAllSync(syncUserRolesBaseDN, searchOptions);
 	if (!Array.isArray(result) || result.length === 0) {


### PR DESCRIPTION
Closes #17016

Fixes errors occurring when the ldap object passed to function isUserInLDAPGroup is undefined or not connected. I don't know why this happens in the first place, the code I copied comes from importNewUsers.

I have also added an additional template variable, userdn, to syncUserRolesFilter which allows matching group members by the user object's DN. This is required for using Active Directory's variation of LDAP, because group objects are mapped to users in this way:

```
dn: CN=MyGroup,OU=Gruppen,DC=iwt,DC=zz 
objectClass: top 
objectClass: group 
cn: MyGroup 
member: CN=Foo Bar,OU=Users,OU=Dept,DC=iwt,DC=zz
```
