### PR TITLE
Regression: Broken Search if users without DM subscriptions are listed

### DIFF
--- a/app/lib/lib/roomTypes/direct.js
+++ b/app/lib/lib/roomTypes/direct.js
@@ -181,9 +181,14 @@ export class DirectMessageRoomType extends RoomTypeConfig {
 	}
 
 	getAvatarPath(roomData, subData) {
-		if (roomData && this.isGroupChat(roomData)) {
+		if (this.isGroupChat(roomData)) {
 			return getAvatarURL({ username: roomData.uids.length + roomData.usernames.join() });
 		}
+
+		if (roomData) {
+			return getUserAvatarURL(roomData.name || this.roomName(roomData));
+		}
+
 		const sub = subData || Subscriptions.findOne({ rid: roomData._id }, { fields: { name: 1 } });
 		return getUserAvatarURL(sub.name || this.roomName(roomData));
 	}
@@ -193,6 +198,6 @@ export class DirectMessageRoomType extends RoomTypeConfig {
 	}
 
 	isGroupChat(room) {
-		return room.uids && room.uids.length > 2;
+		return room && room.uids && room.uids.length > 2;
 	}
 }


### PR DESCRIPTION
An error was thrown when getting the avatars and listing the chat room items of search results.