### PR TITLE
[FIX] Emit livechat events to instace only

### DIFF
--- a/app/livechat/server/lib/stream/queueManager.js
+++ b/app/livechat/server/lib/stream/queueManager.js
@@ -10,7 +10,7 @@ queueDataStreamer.allowRead(function() {
 	return this.userId ? hasPermission(this.userId, 'view-l-room') : false;
 });
 
-const emitQueueDataEvent = (event, data) => queueDataStreamer.emit(event, data);
+const emitQueueDataEvent = (event, data) => queueDataStreamer.emitWithoutBroadcast(event, data);
 const mountDataToEmit = (type, data) => ({ type, ...data });
 
 LivechatInquiry.on('change', ({ clientAction, id: _id, data: record }) => {

--- a/server/stream/rooms/index.js
+++ b/server/stream/rooms/index.js
@@ -35,5 +35,5 @@ export function emitRoomDataEvent(id, data) {
 		return;
 	}
 
-	roomDataStream.emit(id, data);
+	roomDataStream.emitWithoutBroadcast(id, data);
 }


### PR DESCRIPTION
The rule of thumb is: events from oplog should be emitted without broadcast.