### PR TITLE
Regression: Check Omnichannel routing system before emitting queue changes

### DIFF
--- a/app/livechat/client/lib/stream/queueManager.js
+++ b/app/livechat/client/lib/stream/queueManager.js
@@ -2,6 +2,7 @@ import { APIClient } from '../../../../utils/client';
 import { LivechatInquiry } from '../../collections/LivechatInquiry';
 import { inquiryDataStream } from './inquiry';
 import { hasRole } from '../../../../authorization/client';
+import { call } from '../../../../ui-utils/client';
 
 let agentDepartments = [];
 
@@ -59,6 +60,12 @@ export const initializeLivechatInquiryStream = async (userId) => {
 		removeDepartmentsListeners(agentDepartments);
 	}
 	removeGlobalListener();
+
+	const config = await call('livechat:getRoutingConfig');
+	if (config && config.autoAssignAgent) {
+		return;
+	}
+
 	await updateInquiries(await getInquiriesFromAPI('livechat/inquiries.queued?sort={"ts": 1}'));
 
 	agentDepartments = (await getAgentsDepartments(userId)).map((department) => department.departmentId);

--- a/app/livechat/server/lib/stream/queueManager.js
+++ b/app/livechat/server/lib/stream/queueManager.js
@@ -17,7 +17,7 @@ const mountDataToEmit = (type, data) => ({ type, ...data });
 LivechatInquiry.on('change', ({ clientAction, id: _id, data: record }) => {
 	if (RoutingManager.getConfig().autoAssignAgent) {
 		return;
-	};
+	}
 
 	switch (clientAction) {
 		case 'inserted':

--- a/app/livechat/server/lib/stream/queueManager.js
+++ b/app/livechat/server/lib/stream/queueManager.js
@@ -3,6 +3,7 @@ import { Meteor } from 'meteor/meteor';
 import { hasPermission } from '../../../../authorization/server';
 import { LivechatInquiry } from '../../../../models/server';
 import { LIVECHAT_INQUIRY_QUEUE_STREAM_OBSERVER } from '../../../lib/stream/constants';
+import { RoutingManager } from '../RoutingManager';
 
 const queueDataStreamer = new Meteor.Streamer(LIVECHAT_INQUIRY_QUEUE_STREAM_OBSERVER);
 queueDataStreamer.allowWrite('none');
@@ -14,6 +15,10 @@ const emitQueueDataEvent = (event, data) => queueDataStreamer.emit(event, data);
 const mountDataToEmit = (type, data) => ({ type, ...data });
 
 LivechatInquiry.on('change', ({ clientAction, id: _id, data: record }) => {
+	if (RoutingManager.getConfig().autoAssignAgent) {
+		return;
+	};
+
 	switch (clientAction) {
 		case 'inserted':
 			emitQueueDataEvent(_id, { ...record, clientAction });


### PR DESCRIPTION
The queue emitter only needs to propagate changes to the client when the agent is not automatically assigned to the chat.