### PR TITLE
[FIX] Omnichannel endpoint `inquiries.getOne` returning only queued inquiries

### DIFF
--- a/app/livechat/server/api/lib/inquiries.js
+++ b/app/livechat/server/api/lib/inquiries.js
@@ -64,6 +64,6 @@ export async function findOneInquiryByRoomId({ userId, roomId }) {
 	}
 
 	return {
-		inquiry: await LivechatInquiry.findOneQueuedByRoomId(roomId),
+		inquiry: await LivechatInquiry.findOneByRoomId(roomId),
 	};
 }

--- a/app/models/server/raw/LivechatInquiry.js
+++ b/app/models/server/raw/LivechatInquiry.js
@@ -15,5 +15,4 @@ export class LivechatInquiryRaw extends BaseRaw {
 		};
 		return this.findOne(query);
 	}
-
 }

--- a/app/models/server/raw/LivechatInquiry.js
+++ b/app/models/server/raw/LivechatInquiry.js
@@ -8,4 +8,12 @@ export class LivechatInquiryRaw extends BaseRaw {
 		};
 		return this.findOne(query);
 	}
+
+	findOneByRoomId(rid) {
+		const query = {
+			rid,
+		};
+		return this.findOne(query);
+	}
+
 }


### PR DESCRIPTION
![Screen Shot 2020-04-01 at 19 41 18](https://user-images.githubusercontent.com/59577424/78193393-ccc6ae80-7450-11ea-9b7a-b8c9504f0990.png)

When an agent takes a new chat, the server was returning `null` to the client, which was bringing a very bad UX to the agent that had to refresh the page to be able to start chatting.
This was happening because the endpoint that was returning the inquiry was filtering only inquiries with the `status = queued`, but when the agent takes the inquiry its status changes to `taken`.
