### PR TITLE
[FIX] Room event emitter passing an invalid parameter when finding removed subscriptions

### DIFF
--- a/server/publications/room/emitter.js
+++ b/server/publications/room/emitter.js
@@ -26,7 +26,7 @@ Rooms.on('change', ({ clientAction, id, data }) => {
 		return;
 	}
 	if (clientAction === 'removed') {
-		getSubscriptions(clientAction, id).forEach(({ u }) => {
+		getSubscriptions(id).forEach(({ u }) => {
 			Notifications.notifyUserInThisInstance(
 				u._id,
 				'rooms-changed',


### PR DESCRIPTION
The `clientAction` value was being passed as a parameter, but the method was expecting the `room id`.