### PR TITLE
[NEW] Allow custom mapping for roles from OAuth providers to RocketChat roles

### DIFF
--- a/app/custom-oauth/server/custom_oauth_server.js
+++ b/app/custom-oauth/server/custom_oauth_server.js
@@ -178,6 +178,8 @@ export class CustomOAuth {
 		this.avatarField = (options.avatarField || '').trim();
 		this.mergeUsers = options.mergeUsers;
 		this.mergeRoles = options.mergeRoles || false;
+		this.mergeRolesUseMap = options.mergeRolesUseMap || false;
+		this.mergeRolesMap = options.mergeRolesMap || {};
 		this.rolesClaim = options.rolesClaim || 'roles';
 		this.accessTokenParam = options.accessTokenParam;
 
@@ -408,7 +410,7 @@ export class CustomOAuth {
 				}
 
 				if (this.mergeRoles) {
-					updateRolesFromSSO(user, serviceData, this.rolesClaim);
+					updateRolesFromSSO(user, serviceData, this.rolesClaim, this.mergeRolesUseMap, this.mergeRolesMap);
 				}
 
 				// User already created or merged and has identical name as before
@@ -446,7 +448,7 @@ export class CustomOAuth {
 			}
 
 			if (this.mergeRoles) {
-				user.roles = mapRolesFromSSO(user.services[this.name], this.rolesClaim);
+				user.roles = mapRolesFromSSO(user.services[this.name], this.rolesClaim, this.mergeRolesUseMap, this.mergeRolesMap);
 			}
 
 			return true;

--- a/app/custom-oauth/server/oauth_helpers.js
+++ b/app/custom-oauth/server/oauth_helpers.js
@@ -1,15 +1,30 @@
 import { addUserRoles, removeUserFromRoles } from '../../authorization';
 import { Roles } from '../../models';
+import { Logger } from '../../logger';
 
+const logger = new Logger('CustomOAuth');
 
 // Returns list of roles from SSO identity
-export function mapRolesFromSSO(identity, roleClaimName) {
+export function mapRolesFromSSO(identity, roleClaimName, useMap, map) {
 	let roles = [];
 
 	if (identity && roleClaimName) {
 		// Adding roles
 		if (identity[roleClaimName] && Array.isArray(identity[roleClaimName])) {
-			roles = identity[roleClaimName].filter((val) => val !== 'offline_access' && val !== 'uma_authorization' && Roles.findOneByIdOrName(val));
+			let roleMap;
+			if (useMap) {
+				// use the specified map to map roles from the identity to RocketChat roles
+				try {
+					roleMap = JSON.parse(map);
+				} catch (err) {
+					logger.error(`Unexpected error while parsing role map: ${ err.message }`);
+					return [];
+				}
+				roles = identity[roleClaimName].filter((val) => val in roleMap && Roles.findOneByIdOrName(roleMap[val])).map((val) => roleMap[val]);
+			} else {
+				// Map the roles from the identity directly to RocketChat Roles
+				roles = identity[roleClaimName].filter((val) => val !== 'offline_access' && val !== 'uma_authorization' && Roles.findOneByIdOrName(val));
+			}
 		}
 	}
 
@@ -17,9 +32,9 @@ export function mapRolesFromSSO(identity, roleClaimName) {
 }
 
 // Updates the user with roles from SSO identity
-export function updateRolesFromSSO(user, identity, roleClaimName) {
+export function updateRolesFromSSO(user, identity, roleClaimName, useMap, map) {
 	if (user && identity && roleClaimName) {
-		const rolesFromSSO = mapRolesFromSSO(identity, roleClaimName);
+		const rolesFromSSO = mapRolesFromSSO(identity, roleClaimName, useMap, map);
 
 		if (!Array.isArray(user.roles)) {
 			user.roles = [];

--- a/app/lib/server/methods/addOAuthService.js
+++ b/app/lib/server/methods/addOAuthService.js
@@ -41,12 +41,12 @@ Meteor.methods({
 		settings.add(`Accounts_OAuth_Custom-${ name }-avatar_field`           , ''                , { type: 'string' , group: 'OAuth', section: `Custom OAuth: ${ name }`, i18nLabel: 'Accounts_OAuth_Custom_Avatar_Field', persistent: true });
 		settings.add(`Accounts_OAuth_Custom-${ name }-roles_claim`            , 'roles'           , { type: 'string' , group: 'OAuth', section: `Custom OAuth: ${ name }`, i18nLabel: 'Accounts_OAuth_Custom_Roles_Claim', persistent: true });
 		settings.add(`Accounts_OAuth_Custom-${ name }-merge_roles`	          , false             , { type: 'boolean', group: 'OAuth', section: `Custom OAuth: ${ name }`, i18nLabel: 'Accounts_OAuth_Custom_Merge_Roles', persistent: true });
-		settings.add(`Accounts_OAuth_Custom-${ name }-merge_roles_use_map`    , false             , { type: 'boolean', group: 'OAuth', section: `Custom OAuth: ${ name }`, i18nLabel: 'Accounts_OAuth_Custom_Merge_Roles_Use_Map', persistent: true });
+		settings.add(`Accounts_OAuth_Custom-${ name }-merge_roles_use_map`    , false             , { type: 'boolean', group: 'OAuth', section: `Custom OAuth: ${ name }`, i18nLabel: 'Accounts_OAuth_Custom_Use_Custom_Map_To_Merge_Roles', persistent: true });
 		settings.add(`Accounts_OAuth_Custom-${ name }-merge_roles_map`, '{\n\t"rocket-admin": "admin",\n\t"tech-support": "support"\n}', {
 			type: 'code',
 			group: 'OAuth',
 			section: `Custom OAuth: ${ name }`,
-			i18nLabel: 'Accounts_OAuth_Custom_Merge_Roles_Map',
+			i18nLabel: 'Accounts_OAuth_Custom_Custom_Map_Used_To_Merge_Roles',
 			persistent: true,
 			multiline: true,
 			public: false,

--- a/app/lib/server/methods/addOAuthService.js
+++ b/app/lib/server/methods/addOAuthService.js
@@ -41,6 +41,17 @@ Meteor.methods({
 		settings.add(`Accounts_OAuth_Custom-${ name }-avatar_field`           , ''                , { type: 'string' , group: 'OAuth', section: `Custom OAuth: ${ name }`, i18nLabel: 'Accounts_OAuth_Custom_Avatar_Field', persistent: true });
 		settings.add(`Accounts_OAuth_Custom-${ name }-roles_claim`            , 'roles'           , { type: 'string' , group: 'OAuth', section: `Custom OAuth: ${ name }`, i18nLabel: 'Accounts_OAuth_Custom_Roles_Claim', persistent: true });
 		settings.add(`Accounts_OAuth_Custom-${ name }-merge_roles`	          , false             , { type: 'boolean', group: 'OAuth', section: `Custom OAuth: ${ name }`, i18nLabel: 'Accounts_OAuth_Custom_Merge_Roles', persistent: true });
+		settings.add(`Accounts_OAuth_Custom-${ name }-merge_roles_use_map`    , false             , { type: 'boolean', group: 'OAuth', section: `Custom OAuth: ${ name }`, i18nLabel: 'Accounts_OAuth_Custom_Merge_Roles_Use_Map', persistent: true });
+		settings.add(`Accounts_OAuth_Custom-${ name }-merge_roles_map`, '{\n\t"rocket-admin": "admin",\n\t"tech-support": "support"\n}', {
+			type: 'code',
+			group: 'OAuth',
+			section: `Custom OAuth: ${ name }`,
+			i18nLabel: 'Accounts_OAuth_Custom_Merge_Roles_Map',
+			persistent: true,
+			multiline: true,
+			public: false,
+			code: 'application/json',
+		});
 		settings.add(`Accounts_OAuth_Custom-${ name }-merge_users`            , false             , { type: 'boolean', group: 'OAuth', section: `Custom OAuth: ${ name }`, i18nLabel: 'Accounts_OAuth_Custom_Merge_Users', persistent: true });
 		settings.add(`Accounts_OAuth_Custom-${ name }-show_button`            , true              , { type: 'boolean', group: 'OAuth', section: `Custom OAuth: ${ name }`, i18nLabel: 'Accounts_OAuth_Custom_Show_Button_On_Login_Page', persistent: true });
 	},

--- a/app/lib/server/methods/removeOAuthService.js
+++ b/app/lib/server/methods/removeOAuthService.js
@@ -39,6 +39,8 @@ Meteor.methods({
 		settings.removeById(`Accounts_OAuth_Custom-${ name }-avatar_field`);
 		settings.removeById(`Accounts_OAuth_Custom-${ name }-roles_claim`);
 		settings.removeById(`Accounts_OAuth_Custom-${ name }-merge_roles`);
+		settings.removeById(`Accounts_OAuth_Custom-${ name }-merge_roles_use_map`);
+		settings.removeById(`Accounts_OAuth_Custom-${ name }-merge_roles_map`);
 		settings.removeById(`Accounts_OAuth_Custom-${ name }-merge_users`);
 		settings.removeById(`Accounts_OAuth_Custom-${ name }-show_button`);
 	},

--- a/app/lib/server/startup/oAuthServicesUpdate.js
+++ b/app/lib/server/startup/oAuthServicesUpdate.js
@@ -52,6 +52,8 @@ function _OAuthServicesUpdate() {
 				data.rolesClaim = settings.get(`${ service.key }-roles_claim`);
 				data.mergeUsers = settings.get(`${ service.key }-merge_users`);
 				data.mergeRoles = settings.get(`${ service.key }-merge_roles`);
+				data.mergeRolesUseMap = settings.get(`${ service.key }-merge_roles_use_map`);
+				data.mergeRolesMap = settings.get(`${ service.key }-merge_roles_map`);
 				data.showButton = settings.get(`${ service.key }-show_button`);
 				new CustomOAuth(serviceName.toLowerCase(), {
 					serverURL: data.serverURL,
@@ -68,6 +70,8 @@ function _OAuthServicesUpdate() {
 					rolesClaim: data.rolesClaim,
 					mergeUsers: data.mergeUsers,
 					mergeRoles: data.mergeRoles,
+					mergeRolesUseMap: data.mergeRolesUseMap,
+					mergeRolesMap: data.mergeRolesMap,
 					accessTokenParam: data.accessTokenParam,
 					showButton: data.showButton,
 				});

--- a/packages/rocketchat-i18n/i18n/de.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de.i18n.json
@@ -102,6 +102,8 @@
   "Accounts_OAuth_Custom_Name_Field": "Namensfeld",
   "Accounts_OAuth_Custom_Roles_Claim": "Rollen/Gruppen Feld Name",
   "Accounts_OAuth_Custom_Merge_Roles": "Übernehme Rollen von SSO",
+  "Accounts_OAuth_Custom_Use_Custom_Map_To_Merge_Roles": "Nutze eigene Zuordnung der Rollen von SSO",
+  "Accounts_OAuth_Custom_Custom_Map_Used_To_Merge_Roles": "Eigene Zuordnung der Rollen von SSO",
   "Accounts_OAuth_Drupal": "Anmeldung über Drupal",
   "Accounts_OAuth_Drupal_callback_url": "Drupal OAuth Redirect Url",
   "Accounts_OAuth_Drupal_id": "Drupal oAuth2 Client ID",

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -102,6 +102,8 @@
   "Accounts_OAuth_Custom_Name_Field": "Name field",
   "Accounts_OAuth_Custom_Roles_Claim": "Roles/Groups field name",
   "Accounts_OAuth_Custom_Merge_Roles": "Merge Roles from SSO",
+  "Accounts_OAuth_Custom_Use_Custom_Map_To_Merge_Roles": "Use custom map to merge Roles from SSO",
+  "Accounts_OAuth_Custom_Custom_Map_Used_To_Merge_Roles": "Custom map used to merge Roles from SSO",
   "Accounts_OAuth_Drupal": "Drupal Login Enabled",
   "Accounts_OAuth_Drupal_callback_url": "Drupal oAuth2 Redirect URI",
   "Accounts_OAuth_Drupal_id": "Drupal oAuth2 Client ID",


### PR DESCRIPTION
This feature is similar to the already existing functionality from the LDAP authentication, where a custom mapping can be specified to "rename" the roles from LDAP so that they match the roles in RocketChat.

This mapping is specified as a JSON dict, where the key corresponds to the entry obtained from the OAuth2 provider and the value is the role in RocketChat.

If there is anything that should be changed, please let me know.