### PR TITLE
Static props for Administration route components

### DIFF
--- a/app/ui-admin/client/components/AdministrationRouter.js
+++ b/app/ui-admin/client/components/AdministrationRouter.js
@@ -3,13 +3,13 @@ import React, { lazy, useMemo, Suspense } from 'react';
 import { useAdminSideNav } from '../hooks/useAdminSideNav';
 import PageSkeleton from './PageSkeleton';
 
-function AdministrationRouter({ lazyRouteComponent }) {
+function AdministrationRouter({ lazyRouteComponent, ...props }) {
 	useAdminSideNav();
 
 	const LazyRouteComponent = useMemo(() => lazy(lazyRouteComponent), [lazyRouteComponent]);
 
 	return <Suspense fallback={<PageSkeleton />}>
-		<LazyRouteComponent />
+		<LazyRouteComponent {...props} />
 	</Suspense>;
 }
 

--- a/app/ui-admin/client/routes.js
+++ b/app/ui-admin/client/routes.js
@@ -9,7 +9,7 @@ const routeGroup = FlowRouter.group({
 	prefix: '/admin',
 });
 
-export const registerAdminRoute = (path, { lazyRouteComponent, action, ...options } = {}) => {
+export const registerAdminRoute = (path, { lazyRouteComponent, props, action, ...options } = {}) => {
 	routeGroup.route(path, {
 		...options,
 		action: (params, queryParams) => {
@@ -21,7 +21,7 @@ export const registerAdminRoute = (path, { lazyRouteComponent, action, ...option
 			renderRouteComponent(() => import('./components/AdministrationRouter'), {
 				template: 'main',
 				region: 'center',
-				propsFn: () => ({ lazyRouteComponent, ...options, params, queryParams }),
+				propsFn: () => ({ lazyRouteComponent, ...options, params, queryParams, ...props }),
 			});
 		},
 	});


### PR DESCRIPTION
Some distinct routes can render the same component but with different props. This PR enables it.