### PR TITLE
 [FIX] Omnichannel SMS / WhatsApp integration errors due to missing location data

### DIFF
--- a/app/livechat/imports/server/rest/sms.js
+++ b/app/livechat/imports/server/rest/sms.js
@@ -40,7 +40,7 @@ const defineVisitor = (smsNumber) => {
 };
 
 const normalizeLocationSharing = (payload) => {
-	const { extra: { fromLatitude: latitude, fromLongitude: longitude } } = payload;
+	const { extra: { fromLatitude: latitude, fromLongitude: longitude } = { } } = payload;
 	if (!latitude || !longitude) {
 		return;
 	}


### PR DESCRIPTION
On the `3.1`([here](https://github.com/RocketChat/Rocket.Chat/pull/16557)) we started supporting the location sharing through the SMS/WhatsApp integration, but some providers other than Twilio may not support the `extra` property through the `parse` method.
Due to that, we need to make this property optional when extracting the location data, otherwise, an error will be raised.