### PR TITLE
[FIX] Merge user custom fields on LDAP sync

### DIFF
--- a/app/ldap/server/sync.js
+++ b/app/ldap/server/sync.js
@@ -358,6 +358,9 @@ export function syncUserData(user, ldapUser, ldap) {
 			_setRealName(user._id, userData.name);
 			delete userData.name;
 		}
+		userData.customFields = {
+			...user.customFields, ...userData.customFields,
+		};
 		Meteor.users.update(user._id, { $set: userData });
 		user = Meteor.users.findOne({ _id: user._id });
 	}


### PR DESCRIPTION
Closes #15374

This fixes the mentioned issue by merging the current `customFields` with the changes from LDAP.