### PR TITLE
[FIX] Fix ReadMe.md Hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Code Climate](https://codeclimate.com/github/RocketChat/Rocket.Chat/badges/gpa.svg)](https://codeclimate.com/github/RocketChat/Rocket.Chat)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://github.com/RocketChat/Rocket.Chat/raw/master/LICENSE)
 
-* [**NEW!** Rocket.Chat Moving to a Single Codebase](#moving-to-one-codebase) 
+* [**NEW!** Rocket.Chat Moving to a Single Codebase](#moving-to-a-single-codebase) 
 * [Community](#community)
 * [Mobile Apps](#mobile-apps)
 * [Desktop Apps](#desktop-apps)


### PR DESCRIPTION
ReadMe.md: Moving to a Single Codebase used a wrong link (#moving-to-one-codebase instead of #moving-to-a-single-codebase)