### PR TITLE
Regression: Fix mem usage with more than one argument

### DIFF
--- a/app/authorization/server/functions/hasPermission.js
+++ b/app/authorization/server/functions/hasPermission.js
@@ -3,15 +3,18 @@ import mem from 'mem';
 import { Permissions, Users, Subscriptions } from '../../../models/server/raw';
 
 const rolesHasPermission = mem(async (permission, roles) => {
-	const result = await Permissions.findOne({ _id: permission, roles: { $in: roles } });
+	const result = await Permissions.findOne({ _id: permission, roles: { $in: roles } }, { projection: { _id: 1 } });
 	return !!result;
-}, process.env.TEST_MODE === 'true' ? { maxAge: 0 } : undefined);
+}, {
+	cacheKey: JSON.stringify,
+	...process.env.TEST_MODE === 'true' && { maxAge: 0 },
+});
 
 const getRoles = mem(async (uid, scope) => {
-	const { roles: userRoles = [] } = await Users.findOne({ _id: uid });
-	const { roles: subscriptionsRoles = [] } = (scope && await Subscriptions.findOne({ rid: scope, 'u._id': uid }, { fields: { roles: 1 } })) || {};
+	const { roles: userRoles = [] } = await Users.findOne({ _id: uid }, { projection: { roles: 1 } });
+	const { roles: subscriptionsRoles = [] } = (scope && await Subscriptions.findOne({ rid: scope, 'u._id': uid }, { projection: { roles: 1 } })) || {};
 	return [...userRoles, ...subscriptionsRoles].sort((a, b) => a.localeCompare(b));
-}, { maxAge: 1000 });
+}, { maxAge: 1000, cacheKey: JSON.stringify });
 
 export const clearCache = () => {
 	mem.clear(getRoles);

--- a/app/models/client/models/Subscriptions.js
+++ b/app/models/client/models/Subscriptions.js
@@ -19,7 +19,7 @@ Object.assign(Subscriptions, {
 		const subscription = this.findOne(query, { fields: { roles: 1 } });
 
 		return subscription && Array.isArray(subscription.roles) && subscription.roles.includes(roleName);
-	}, { maxAge: 1000 }),
+	}, { maxAge: 1000, cacheKey: JSON.stringify }),
 
 	findUsersInRoles: mem(function(roles, scope, options) {
 		roles = [].concat(roles);
@@ -41,7 +41,7 @@ Object.assign(Subscriptions, {
 		}));
 
 		return Users.find({ _id: { $in: users } }, options);
-	}, { maxAge: 1000 }),
+	}, { maxAge: 1000, cacheKey: JSON.stringify }),
 });
 
 export { Subscriptions };

--- a/app/ui-utils/client/lib/MessageAction.js
+++ b/app/ui-utils/client/lib/MessageAction.js
@@ -59,7 +59,7 @@ export const MessageAction = new class {
 		}
 
 		if (config.condition) {
-			config.condition = mem(config.condition, { maxAge: 1000 });
+			config.condition = mem(config.condition, { maxAge: 1000, cacheKey: JSON.stringify });
 		}
 
 		return Tracker.nonreactive(() => {


### PR DESCRIPTION
`mem` version [v6](https://github.com/sindresorhus/mem/releases/tag/v6.0.0) has changed the default cache strategy and now it caches only the first argument by default.

So I have changed `cacheKey` where we use `mem` for functions with more than one argument to use `JSON.stringify`

I have also improved to get only the needed fields on has permission functions.