### PR TITLE
[FIX] Bot Agents not being able to get Omnichannel Inquiries

### DIFF
--- a/app/livechat/server/lib/Helper.js
+++ b/app/livechat/server/lib/Helper.js
@@ -314,9 +314,5 @@ export const userCanTakeInquiry = (user) => {
 
 	const { roles, status, statusLivechat } = user;
 	// TODO: hasRole when the user has already been fetched from DB
-	if ((status === 'offline' || statusLivechat !== 'available') && !roles.includes('bot')) {
-		return false;
-	}
-
-	return true;
+	return (status !== 'offline' && statusLivechat === 'available') || roles.includes('bot');
 };

--- a/app/livechat/server/lib/Helper.js
+++ b/app/livechat/server/lib/Helper.js
@@ -7,7 +7,6 @@ import { Livechat } from './Livechat';
 import { RoutingManager } from './RoutingManager';
 import { callbacks } from '../../../callbacks/server';
 import { settings } from '../../../settings';
-import { hasRole } from '../../../authorization';
 
 export const createLivechatRoom = (rid, name, guest, roomInfo = {}, extraData = {}) => {
 	check(rid, String);
@@ -310,10 +309,12 @@ export const userCanTakeInquiry = (user) => {
 	check(user, Match.ObjectIncluding({
 		status: String,
 		statusLivechat: String,
+		roles: [String],
 	}));
 
-	const { status, statusLivechat } = user;
-	if ((status === 'offline' || statusLivechat !== 'available') && !hasRole(user._id, 'bot')) {
+	const { roles, status, statusLivechat } = user;
+	// TODO: hasRole when the user has already been fetched from DB
+	if ((status === 'offline' || statusLivechat !== 'available') && !roles.includes('bot')) {
 		return false;
 	}
 

--- a/app/livechat/server/lib/Helper.js
+++ b/app/livechat/server/lib/Helper.js
@@ -7,6 +7,7 @@ import { Livechat } from './Livechat';
 import { RoutingManager } from './RoutingManager';
 import { callbacks } from '../../../callbacks/server';
 import { settings } from '../../../settings';
+import { hasRole } from '../../../authorization';
 
 export const createLivechatRoom = (rid, name, guest, roomInfo = {}, extraData = {}) => {
 	check(rid, String);
@@ -303,4 +304,18 @@ export const checkServiceStatus = ({ guest, agent }) => {
 	}
 
 	return Livechat.online(guest.department);
+};
+
+export const userCanTakeInquiry = (user) => {
+	check(user, Match.ObjectIncluding({
+		status: String,
+		statusLivechat: String,
+	}));
+
+	const { status, statusLivechat } = user;
+	if ((status === 'offline' || statusLivechat !== 'available') && !hasRole(user._id, 'bot')) {
+		return false;
+	}
+
+	return true;
 };

--- a/app/livechat/server/methods/takeInquiry.js
+++ b/app/livechat/server/methods/takeInquiry.js
@@ -17,7 +17,7 @@ Meteor.methods({
 			throw new Meteor.Error('error-not-allowed', 'Inquiry already taken', { method: 'livechat:takeInquiry' });
 		}
 
-		const user = Users.findOneById(Meteor.userId(), { fields: { _id: 1, username: 1, status: 1, statusLivechat: 1 } });
+		const user = Users.findOneById(Meteor.userId(), { fields: { _id: 1, username: 1, roles: 1, status: 1, statusLivechat: 1 } });
 		if (!userCanTakeInquiry(user)) {
 			throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'livechat:takeInquiry' });
 		}

--- a/app/livechat/server/methods/takeInquiry.js
+++ b/app/livechat/server/methods/takeInquiry.js
@@ -3,6 +3,7 @@ import { Meteor } from 'meteor/meteor';
 import { hasPermission } from '../../../authorization';
 import { Users, LivechatInquiry } from '../../../models/server';
 import { RoutingManager } from '../lib/RoutingManager';
+import { userCanTakeInquiry } from '../lib/Helper';
 
 Meteor.methods({
 	'livechat:takeInquiry'(inquiryId) {
@@ -16,10 +17,9 @@ Meteor.methods({
 			throw new Meteor.Error('error-not-allowed', 'Inquiry already taken', { method: 'livechat:takeInquiry' });
 		}
 
-		const user = Users.findOneById(Meteor.userId());
-		const { status, statusLivechat } = user;
-		if (status === 'offline' || statusLivechat !== 'available') {
-			throw new Meteor.Error('error-agent-offline', 'Agent offline', { method: 'livechat:takeInquiry' });
+		const user = Users.findOneById(Meteor.userId(), { fields: { _id: 1, username: 1, status: 1, statusLivechat: 1 } });
+		if (!userCanTakeInquiry(user)) {
+			throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'livechat:takeInquiry' });
 		}
 
 		const agent = {


### PR DESCRIPTION
CLOSES #17405.

Since `3.1` version we only allow online agents/users to get Omnichannel Inquiries.
Unfortunately, external systems are now facing an issue because they have bot agents that get the Omnichannel Inquiries through the REST API endpoint -> `livechat/inquiries.take`.

As the current implementation doesn't check the `bot` role, the external user just can't get the inquiry because the `bot` role isn't being checked as we do in another similar process.
