### PR TITLE
[FIX] Add Content-Type for public files with JWT

### DIFF
--- a/app/file-upload/server/lib/requests.js
+++ b/app/file-upload/server/lib/requests.js
@@ -17,6 +17,9 @@ WebApp.connectHandlers.use(FileUpload.getPath(), function(req, res, next) {
 
 			res.setHeader('Content-Security-Policy', 'default-src \'none\'');
 			res.setHeader('Cache-Control', 'max-age=31536000');
+			if (file.type) {
+				res.setHeader('Content-Type', file.type);
+			}
 			return FileUpload.get(file, req, res, next);
 		}
 	}


### PR DESCRIPTION
When I requested file by publicFileUrl with JWT in query paramenter, the response doesn't contain Content-Type Header 