### PR TITLE
[FIX] LDAP login error on Enterprise version

### DIFF
--- a/app/ldap/server/loginHandler.js
+++ b/app/ldap/server/loginHandler.js
@@ -126,6 +126,7 @@ Accounts.registerLoginHandler('ldap', function(loginRequest) {
 		if (settings.get('LDAP_Login_Fallback') === true && typeof loginRequest.ldapPass === 'string' && loginRequest.ldapPass.trim() !== '') {
 			Accounts.setPassword(user._id, loginRequest.ldapPass, { logout: false });
 		}
+		logger.info('running afterLDAPLogin');
 		callbacks.run('afterLDAPLogin', { user, ldapUser, ldap });
 		return {
 			userId: user._id,

--- a/app/ldap/server/sync.js
+++ b/app/ldap/server/sync.js
@@ -210,6 +210,7 @@ export function mapLdapGroupsToUserRoles(ldap, ldapUser, user) {
 	const syncUserRolesFieldMap = settings.get('LDAP_Sync_User_Data_GroupsMap').trim();
 
 	if (!syncUserRoles || !syncUserRolesFieldMap) {
+		logger.debug('not syncing user roles');
 		return [];
 	}
 
@@ -296,6 +297,7 @@ export function mapLDAPGroupsToChannels(ldap, ldapUser, user) {
 
 	const userChannels = [];
 	if (!syncUserRoles || !syncUserRolesAutoChannels || !syncUserRolesChannelFieldMap) {
+		logger.debug('not syncing groups to channels');
 		return [];
 	}
 

--- a/ee/app/ldap-enterprise/server/listener.js
+++ b/ee/app/ldap-enterprise/server/listener.js
@@ -5,8 +5,8 @@ export const onLdapLogin = ({ user, ldapUser, ldap }) => {
 	const validateLdapRolesForEachLogin = settings.get('LDAP_Validate_Roles_For_Each_Login');
 	const userExists = user._id;
 	const userId = userExists ? user._id : user.userId;
-	const ldapUserRoles = getLdapRolesByUsername(ldapUser.uid, ldap);
 	if (!userExists || validateLdapRolesForEachLogin) {
+		const ldapUserRoles = getLdapRolesByUsername(ldapUser.uid, ldap);
 		const roles = getRocketChatRolesByLdapRoles(JSON.parse(settings.get('LDAP_Roles_To_Rocket_Chat_Roles')), ldapUserRoles);
 		updateUserUsingMappedLdapRoles(userId, roles);
 	}


### PR DESCRIPTION
This PR fixes an issue where the LDAP login was always trying to load user roles from LDAP on Rocket.Chat Enterprise, even when this feature is disabled.

It also adds a few additional debug logs to help identify similar issues in the future.