### PR TITLE
[FIX] remove multiple options from dontAskMeAgain

### DIFF
--- a/app/ui-account/client/accountPreferences.js
+++ b/app/ui-account/client/accountPreferences.js
@@ -353,10 +353,10 @@ Template.accountPreferences.events({
 	'click .js-dont-ask-remove'(e) {
 		e.preventDefault();
 		const selectEl = document.getElementById('dont-ask');
-		const { options } = selectEl;
-		const selectedOption = selectEl.value;
-		const optionIndex = Array.from(options).findIndex((option) => option.value === selectedOption);
-
-		selectEl.remove(optionIndex);
+		for (let i = selectEl.options.length - 1; i >= 0; i--) {
+			if (selectEl.options[i].selected) {
+				selectEl.remove(i);
+			}
+		}
 	},
 });


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #17509  

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
This implements the removal of multiple options from the Don't ask me again list. Previously this was not possible but desired as the HTML of this page showed that the "select" field had the "multiple" attribute set to true. 
You can test this by adding an extra option to the don't ask me again select field in the Global section on the Preferences page.

![Screenshot 2020-05-02 at 4 29 54 PM](https://user-images.githubusercontent.com/30270349/80871737-6808a900-8cc7-11ea-80a3-55a809e67648.png)

Select multiple options and click remove. Both will be removed. 
<img width="952" alt="Screenshot 2020-05-02 at 10 54 15 PM" src="https://user-images.githubusercontent.com/30270349/80871906-0bf25480-8cc8-11ea-8950-56d1e8599e1c.png">
