### PR TITLE
[FIX] Default filters on Omnichannel Current Chats screen not showing on first load

### DIFF
--- a/app/livechat/client/views/app/livechatCurrentChats.js
+++ b/app/livechat/client/views/app/livechatCurrentChats.js
@@ -506,8 +506,6 @@ Template.livechatCurrentChats.onCreated(async function() {
 			this.customFields.set(customFields);
 		}
 	});
-
-	this.loadDefaultFilters();
 });
 
 Template.livechatCurrentChats.onRendered(function() {
@@ -516,4 +514,6 @@ Template.livechatCurrentChats.onRendered(function() {
 		todayHighlight: true,
 		format: moment.localeData().longDateFormat('L').toLowerCase(),
 	});
+
+	this.loadDefaultFilters();
 });


### PR DESCRIPTION
The default filters on the `Omnichannel Current Chats` template weren't working properly because the values were being loaded on the `onCreated` instead of the `onRendered` event, but the components/selectors may not exist until the creating process is completed.