### PR TITLE
[FIX] Invalid CSS syntax

### DIFF
--- a/app/theme/client/imports/general/forms.css
+++ b/app/theme/client/imports/general/forms.css
@@ -197,7 +197,7 @@
 .rc-button-group {
 	display: flex;
 
-	margin: 0 calc(- var(--default-small-padding) / 2);
+	margin: 0 calc(var(--default-small-padding) / -2);
 
 	& .rc-button {
 		margin: 0 calc(var(--default-small-padding) / 2);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2941,6 +2941,11 @@
 				"uuid": "^3.2.1"
 			},
 			"dependencies": {
+				"adm-zip": {
+					"version": "0.4.14",
+					"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.14.tgz",
+					"integrity": "sha512-/9aQCnQHF+0IiCl0qhXoK7qs//SwYE7zX8lsr/DNk1BRAHYxeLZPL4pguwK29gUEqasYQjqPtEpDRSWEkdHn9g=="
+				},
 				"typescript": {
 					"version": "2.9.2",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",


### PR DESCRIPTION
A broken composition of `var()` and `calc()` is failing the build.