### PR TITLE
[FIX] Error during data export for DMs

### DIFF
--- a/app/user-data-download/server/cronProcessDownloads.js
+++ b/app/user-data-download/server/cronProcessDownloads.js
@@ -47,7 +47,7 @@ const loadUserSubscriptions = function(exportOperation) {
 		const roomId = subscription.rid;
 		const roomData = Rooms.findOneById(roomId);
 		const roomName = roomData && roomData.name && subscription.t !== 'd' ? roomData.name : roomId;
-		const [userId] = subscription.t === 'd' ? roomId.uids.filter((uid) => uid !== exportUserId) : [null];
+		const [userId] = subscription.t === 'd' ? roomData.uids.filter((uid) => uid !== exportUserId) : [null];
 		const fileName = exportOperation.fullExport ? roomId : roomName;
 		const fileType = exportOperation.fullExport ? 'json' : 'html';
 		const targetFile = `${ fileName }.${ fileType }`;


### PR DESCRIPTION
```
- Change from `roomId` variable to `roomData` the value to get iterate on `uids` fields
```

# How to reproduce

1.  Have 2 users and create a DM and send some message between them in your environment;
2.  As admin user, go to "Administration" > "User Data Download" and make sure this option is enabled;
3.  As any of the users, go to "My Account" > "Preferences" and click at "Export My Data" or "Download My Data" located at the bottom of that page;
4.  When the cron runs it will fail with `"TypeError: Cannot read property 'filter' of undefined"` because `roomId` is a string and has no `uids` in it;
