### PR TITLE
[FIX] Push settings enabled when push gateway is selected

### DIFF
--- a/app/lib/server/startup/settings.js
+++ b/app/lib/server/startup/settings.js
@@ -1228,39 +1228,111 @@ settings.addGroup('Push', function() {
 	this.section('Certificates_and_Keys', function() {
 		this.add('Push_apn_passphrase', '', {
 			type: 'string',
+			enableQuery: [
+				{
+					_id: 'Push_enable',
+					value: true,
+				}, {
+					_id: 'Push_enable_gateway',
+					value: false,
+				},
+			],
 			secret: true,
 		});
 		this.add('Push_apn_key', '', {
 			type: 'string',
 			multiline: true,
+			enableQuery: [
+				{
+					_id: 'Push_enable',
+					value: true,
+				}, {
+					_id: 'Push_enable_gateway',
+					value: false,
+				},
+			],
 			secret: true,
 		});
 		this.add('Push_apn_cert', '', {
 			type: 'string',
 			multiline: true,
+			enableQuery: [
+				{
+					_id: 'Push_enable',
+					value: true,
+				}, {
+					_id: 'Push_enable_gateway',
+					value: false,
+				},
+			],
 			secret: true,
 		});
 		this.add('Push_apn_dev_passphrase', '', {
 			type: 'string',
+			enableQuery: [
+				{
+					_id: 'Push_enable',
+					value: true,
+				}, {
+					_id: 'Push_enable_gateway',
+					value: false,
+				},
+			],
 			secret: true,
 		});
 		this.add('Push_apn_dev_key', '', {
 			type: 'string',
 			multiline: true,
+			enableQuery: [
+				{
+					_id: 'Push_enable',
+					value: true,
+				}, {
+					_id: 'Push_enable_gateway',
+					value: false,
+				},
+			],
 			secret: true,
 		});
 		this.add('Push_apn_dev_cert', '', {
 			type: 'string',
 			multiline: true,
+			enableQuery: [
+				{
+					_id: 'Push_enable',
+					value: true,
+				}, {
+					_id: 'Push_enable_gateway',
+					value: false,
+				},
+			],
 			secret: true,
 		});
 		this.add('Push_gcm_api_key', '', {
 			type: 'string',
+			enableQuery: [
+				{
+					_id: 'Push_enable',
+					value: true,
+				}, {
+					_id: 'Push_enable_gateway',
+					value: false,
+				},
+			],
 			secret: true,
 		});
 		return this.add('Push_gcm_project_number', '', {
 			type: 'string',
 			public: true,
+			enableQuery: [
+				{
+					_id: 'Push_enable',
+					value: true,
+				}, {
+					_id: 'Push_enable_gateway',
+					value: false,
+				},
+			],
 			secret: true,
 		});
 	});

--- a/app/lib/server/startup/settings.js
+++ b/app/lib/server/startup/settings.js
@@ -1173,6 +1173,16 @@ settings.addGroup('Mobile', function() {
 	});
 });
 
+const pushEnabledWithoutGateway = [
+	{
+		_id: 'Push_enable',
+		value: true,
+	}, {
+		_id: 'Push_enable_gateway',
+		value: false,
+	},
+];
+
 settings.addGroup('Push', function() {
 	this.add('Push_enable', true, {
 		type: 'boolean',
@@ -1207,15 +1217,7 @@ settings.addGroup('Push', function() {
 		type: 'boolean',
 		public: true,
 		alert: 'Push_Setting_Requires_Restart_Alert',
-		enableQuery: [
-			{
-				_id: 'Push_enable',
-				value: true,
-			}, {
-				_id: 'Push_enable_gateway',
-				value: false,
-			},
-		],
+		enableQuery: pushEnabledWithoutGateway,
 	});
 	this.add('Push_test_push', 'push_test', {
 		type: 'action',
@@ -1228,111 +1230,47 @@ settings.addGroup('Push', function() {
 	this.section('Certificates_and_Keys', function() {
 		this.add('Push_apn_passphrase', '', {
 			type: 'string',
-			enableQuery: [
-				{
-					_id: 'Push_enable',
-					value: true,
-				}, {
-					_id: 'Push_enable_gateway',
-					value: false,
-				},
-			],
+			enableQuery: pushEnabledWithoutGateway,
 			secret: true,
 		});
 		this.add('Push_apn_key', '', {
 			type: 'string',
 			multiline: true,
-			enableQuery: [
-				{
-					_id: 'Push_enable',
-					value: true,
-				}, {
-					_id: 'Push_enable_gateway',
-					value: false,
-				},
-			],
+			enableQuery: pushEnabledWithoutGateway,
 			secret: true,
 		});
 		this.add('Push_apn_cert', '', {
 			type: 'string',
 			multiline: true,
-			enableQuery: [
-				{
-					_id: 'Push_enable',
-					value: true,
-				}, {
-					_id: 'Push_enable_gateway',
-					value: false,
-				},
-			],
+			enableQuery: pushEnabledWithoutGateway,
 			secret: true,
 		});
 		this.add('Push_apn_dev_passphrase', '', {
 			type: 'string',
-			enableQuery: [
-				{
-					_id: 'Push_enable',
-					value: true,
-				}, {
-					_id: 'Push_enable_gateway',
-					value: false,
-				},
-			],
+			enableQuery: pushEnabledWithoutGateway,
 			secret: true,
 		});
 		this.add('Push_apn_dev_key', '', {
 			type: 'string',
 			multiline: true,
-			enableQuery: [
-				{
-					_id: 'Push_enable',
-					value: true,
-				}, {
-					_id: 'Push_enable_gateway',
-					value: false,
-				},
-			],
+			enableQuery: pushEnabledWithoutGateway,
 			secret: true,
 		});
 		this.add('Push_apn_dev_cert', '', {
 			type: 'string',
 			multiline: true,
-			enableQuery: [
-				{
-					_id: 'Push_enable',
-					value: true,
-				}, {
-					_id: 'Push_enable_gateway',
-					value: false,
-				},
-			],
+			enableQuery: pushEnabledWithoutGateway,
 			secret: true,
 		});
 		this.add('Push_gcm_api_key', '', {
 			type: 'string',
-			enableQuery: [
-				{
-					_id: 'Push_enable',
-					value: true,
-				}, {
-					_id: 'Push_enable_gateway',
-					value: false,
-				},
-			],
+			enableQuery: pushEnabledWithoutGateway,
 			secret: true,
 		});
 		return this.add('Push_gcm_project_number', '', {
 			type: 'string',
 			public: true,
-			enableQuery: [
-				{
-					_id: 'Push_enable',
-					value: true,
-				}, {
-					_id: 'Push_enable_gateway',
-					value: false,
-				},
-			],
+			enableQuery: pushEnabledWithoutGateway,
 			secret: true,
 		});
 	});


### PR DESCRIPTION
This should reduce confusion.  If push gateway is selected setting the other push settings are pointless.  So this will help reflect that when gateway is selected these settings can't be used.


![image](https://user-images.githubusercontent.com/51996/81448488-0f606280-9144-11ea-8318-094c6bb80eeb.png)

![image](https://user-images.githubusercontent.com/51996/81448506-17200700-9144-11ea-99d3-8291a3a3f400.png)
