### PR TITLE
Upgrade Livechat Widget version to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2810,6 +2810,11 @@
 				"uuid": "^3.2.1"
 			},
 			"dependencies": {
+				"adm-zip": {
+					"version": "0.4.14",
+					"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.14.tgz",
+					"integrity": "sha512-/9aQCnQHF+0IiCl0qhXoK7qs//SwYE7zX8lsr/DNk1BRAHYxeLZPL4pguwK29gUEqasYQjqPtEpDRSWEkdHn9g=="
+				},
 				"typescript": {
 					"version": "2.9.2",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
@@ -2894,9 +2899,9 @@
 			"integrity": "sha512-MGljJJkGVe9g3UnKq2tSnfFq1gI6nIFociIXmOx9h/ZISeRc+xL6HpJ9pnbLXubFTPppNYn8JiVDlVB8Mm0flw=="
 		},
 		"@rocket.chat/livechat": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@rocket.chat/livechat/-/livechat-1.4.0.tgz",
-			"integrity": "sha512-jOUy49njPMW0ZmL9Gk6lRv4X0WTSS9N78iSzR/p3pSV4ivEQk1LRXCi6QLknZmxEXIpe6MTJgUY/ggsORfxrDQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@rocket.chat/livechat/-/livechat-1.5.0.tgz",
+			"integrity": "sha512-Qq+kMRdY6RpZlzl5q3uM7hpAQF5tFFw+v7ON1IqBlFhkX5JA1mzpXnRWzb0si1LtuJ4NjdK2CS4xqvlaVn4A8Q==",
 			"dev": true,
 			"requires": {
 				"@kossnocorp/desvg": "^0.2.0",
@@ -2934,12 +2939,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-					"dev": true
-				},
-				"p-is-promise": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-					"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
 					"dev": true
 				},
 				"query-string": {
@@ -12975,9 +12974,9 @@
 			}
 		},
 		"date-fns": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.11.0.tgz",
-			"integrity": "sha512-8P1cDi8ebZyDxUyUprBXwidoEtiQAawYPGvpfb+Dg0G6JrQ+VozwOmm91xYC0vAv1+0VmLehEPb+isg4BGUFfA==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.14.0.tgz",
+			"integrity": "sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw==",
 			"dev": true
 		},
 		"date-now": {
@@ -20965,9 +20964,9 @@
 			"dev": true
 		},
 		"make-plural": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/make-plural/-/make-plural-6.1.0.tgz",
-			"integrity": "sha512-0ekbPHqxcdRcmjZ43TkRuejK5rXgMF1OjG4FVnVHgCvOcjrexaSX7a0dfAvqhOm1qWPgjYnXtmz3cHpHW5ZewA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.1.tgz",
+			"integrity": "sha512-AmkruwJ9EjvyTv6AM8MBMK3TAeOJvhgTv5YQXzF0EP2qawhpvMjDpHvsdOIIT0Vn+BB0+IogmYZ1z+Ulm/m0Fg==",
 			"dev": true
 		},
 		"map-age-cleaner": {
@@ -21025,9 +21024,9 @@
 			},
 			"dependencies": {
 				"entities": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-					"integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
+					"integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==",
 					"dev": true
 				}
 			}
@@ -21388,9 +21387,9 @@
 			"dev": true
 		},
 		"messageformat-parser": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.2.tgz",
-			"integrity": "sha512-7dWuifeyldz7vhEuL96Kwq1fhZXBW+TUfbnHN4UCrCxoXQTYjHnR78eI66Gk9LaLLsAvzPNVJBaa66DRfFNaiA==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
+			"integrity": "sha512-2fU3XDCanRqeOCkn7R5zW5VQHWf+T3hH65SzuqRvjatBK7r4uyFa5mEX+k6F9Bd04LVM5G4/BHBTUJsOdW7uyg==",
 			"dev": true
 		},
 		"meteor-blaze-tools": {
@@ -22772,9 +22771,9 @@
 			},
 			"dependencies": {
 				"nan": {
-					"version": "2.14.0",
-					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+					"version": "2.14.1",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+					"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
 					"dev": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"@babel/preset-react": "^7.0.0",
 		"@octokit/rest": "^16.1.0",
 		"@rocket.chat/eslint-config": "^0.3.0",
-		"@rocket.chat/livechat": "^1.4.0",
+		"@rocket.chat/livechat": "^1.5.0",
 		"@settlin/spacebars-loader": "^1.0.7",
 		"@storybook/addon-actions": "^5.3.18",
 		"@storybook/addon-knobs": "^5.3.18",


### PR DESCRIPTION
Upgrade the Livechat widget dependency to the latest version(1.5.0)

#17581 will provide some of the new resources expected on the new release.