### PR TITLE
Submit a payload to the release service when a release happens

### DIFF
--- a/.circleci/update-releases.sh
+++ b/.circleci/update-releases.sh
@@ -2,9 +2,9 @@
 set -euvo pipefail
 IFS=$'\n\t'
 
-curl -X POST \
--H "X-Update-Token: ${UPDATE_TOKEN}" \
-https://releases.rocket.chat/update
+curl -H "Content-Type: application/json" -H "X-Update-Token: $UPDATE_TOKEN" -d \
+    "{\"commit\": \"$CIRCLE_SHA1\", \"tag\": \"$CIRCLE_TAG\", \"branch\": \"$CIRCLE_BRANCH\", \"artifactName\": \"$ARTIFACT_NAME\", \"releaseType\": \"$RC_RELEASE\" }" \
+    https://releases.rocket.chat/update
 
 # Makes build fail if the release isn't there
 curl --fail https://releases.rocket.chat/$RC_VERSION/info


### PR DESCRIPTION
## Proposed changes
We are switching up our internal release service and in order to improve the efficiency of it we are now expecting a payload to be sent to the release service so we don't have to make multiple round trip calls. This PR changes the `update-release.sh` script to provide the said payload.

## How to test or reproduce
Run the new release service locally (private repository), set the expected variables to values they would be, and then run the changed command.

Environmental variables are set here: https://github.com/RocketChat/Rocket.Chat/blob/0d2723f3196242b1f9e3fb45c868899065e52b70/.github/workflows/build_and_test.yml#L368-L397