### PR TITLE
Fix invalid develop payload to release service

### DIFF
--- a/.circleci/update-releases.sh
+++ b/.circleci/update-releases.sh
@@ -3,7 +3,7 @@ set -euvo pipefail
 IFS=$'\n\t'
 
 curl -H "Content-Type: application/json" -H "X-Update-Token: $UPDATE_TOKEN" -d \
-    "{\"commit\": \"$CIRCLE_SHA1\", \"tag\": \"$CIRCLE_TAG\", \"branch\": \"$CIRCLE_BRANCH\", \"artifactName\": \"$ARTIFACT_NAME\", \"releaseType\": \"$RC_RELEASE\" }" \
+    "{\"commit\": \"$CIRCLE_SHA1\", \"tag\": \"$RC_VERSION\", \"branch\": \"$CIRCLE_BRANCH\", \"artifactName\": \"$ARTIFACT_NAME\", \"releaseType\": \"$RC_RELEASE\" }" \
     https://releases.rocket.chat/update
 
 # Makes build fail if the release isn't there


### PR DESCRIPTION
The payload sent to the release service contains an invalid reference to the tag/version and wasn't working when building develop branch.