### PR TITLE
Fix SAML logout response issues

### DIFF
--- a/app/meteor-accounts-saml/server/saml_server.js
+++ b/app/meteor-accounts-saml/server/saml_server.js
@@ -592,6 +592,7 @@ const middleware = function(req, res, next) {
 						const { response } = _saml.generateLogoutResponse({
 							nameID: result.nameID,
 							sessionIndex: result.idpSession,
+							ID: result.ID,
 						});
 
 						_saml.logoutResponseToUrl(response, function(err, url) {

--- a/app/meteor-accounts-saml/server/saml_utils.js
+++ b/app/meteor-accounts-saml/server/saml_utils.js
@@ -123,7 +123,7 @@ SAML.prototype.generateLogoutResponse = function() {
 		+ `Destination="${ this.options.idpSLORedirectURL }" `
 		+ '>'
 		+ `<saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">${ this.options.issuer }</saml:Issuer>`
-		+ '<samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>'
+		+ '<samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>'
 		+ '</samlp:LogoutResponse>';
 
 	debugLog('------- SAML Logout response -----------');

--- a/app/meteor-accounts-saml/server/saml_utils.js
+++ b/app/meteor-accounts-saml/server/saml_utils.js
@@ -111,16 +111,16 @@ SAML.prototype.generateAuthorizeRequest = function(req) {
 	return request;
 };
 
-SAML.prototype.generateLogoutResponse = function() {
+SAML.prototype.generateLogoutResponse = function(options) {
 	const id = `_${ this.generateUniqueID() }`;
 	const instant = this.generateInstant();
-
 
 	const response = `${ '<samlp:LogoutResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"  '
 		+ 'ID="' }${ id }" `
 		+ 'Version="2.0" '
 		+ `IssueInstant="${ instant }" `
 		+ `Destination="${ this.options.idpSLORedirectURL }" `
+		+ `${ options.ID ? `InResponseTo="${ options.ID }" ` : '' }`
 		+ '>'
 		+ `<saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">${ this.options.issuer }</saml:Issuer>`
 		+ '<samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>'
@@ -389,6 +389,7 @@ SAML.prototype.validateLogoutRequest = function(samlRequest, callback) {
 		try {
 			const sessionNode = request.getElementsByTagNameNS('*', 'SessionIndex')[0];
 			const nameIdNode = request.getElementsByTagNameNS('*', 'NameID')[0];
+			const ID = request.getAttribute('ID');
 
 			if (!nameIdNode) {
 				throw new Error('SAML Logout Request: No NameID node found');
@@ -397,7 +398,7 @@ SAML.prototype.validateLogoutRequest = function(samlRequest, callback) {
 			const idpSession = sessionNode.childNodes[0].nodeValue;
 			const nameID = nameIdNode.childNodes[0].nodeValue;
 
-			return callback(null, { idpSession, nameID });
+			return callback(null, { idpSession, nameID, ID });
 		} catch (e) {
 			console.error(e);
 			debugLog(`Caught error: ${ e }`);


### PR DESCRIPTION
The SAML logout is currently broken in 2 ways:
* invalid XML generation in `<samlp:LogoutResponse>` which doesn't enclose `<samlp:StatusCode/>` into `<samlp:Status/>`
* missing `InResponseTo="$IDofRequest"` attribute in the `<samlp:LogoutResponse>` which must be filled with the `ID` attribute from the `<samlp:LogoutRequest>`.