### PR TITLE
[FIX] Autocomplete component is not working property when searching channels in the Livechat Departments form

### DIFF
--- a/app/api/server/lib/rooms.js
+++ b/app/api/server/lib/rooms.js
@@ -99,7 +99,7 @@ export async function findChannelAndPrivateAutocomplete({ uid, selector }) {
 		},
 	};
 
-	const rooms = await Rooms.findChannelAndPrivateByNameStarting(selector.term, options).toArray();
+	const rooms = await Rooms.findChannelAndPrivateByNameStarting(selector.name, options).toArray();
 
 	return {
 		items: rooms,

--- a/app/api/server/lib/rooms.js
+++ b/app/api/server/lib/rooms.js
@@ -99,7 +99,7 @@ export async function findChannelAndPrivateAutocomplete({ uid, selector }) {
 		},
 	};
 
-	const rooms = await Rooms.findChannelAndPrivateByNameStarting(selector.name, options).toArray();
+	const rooms = await Rooms.findChannelAndPrivateByNameStarting(selector.term, options).toArray();
 
 	return {
 		items: rooms,

--- a/app/livechat/client/views/app/livechatDepartmentForm.html
+++ b/app/livechat/client/views/app/livechatDepartmentForm.html
@@ -64,6 +64,7 @@
 											templateItem="popupList_item_channel"
 											modifier=offlineMessageChannelModifier
 											showLabel=true
+											selector=channelSelector
 										}}
 									</div>
 									<div class="input-line">

--- a/app/livechat/client/views/app/livechatDepartmentForm.js
+++ b/app/livechat/client/views/app/livechatDepartmentForm.js
@@ -106,6 +106,9 @@ Template.livechatDepartmentForm.helpers({
 			return `#${ f.length === 0 ? text : text.replace(new RegExp(filter.get()), (part) => `<strong>${ part }</strong>`) }`;
 		};
 	},
+	channelSelector() {
+		return (expression) => ({ name: expression });
+	},
 });
 
 Template.livechatDepartmentForm.events({


### PR DESCRIPTION
Closes #17902 #17914
The Autocomplete component used to search channels in the `Livechat Department Form` is not working properly because the search term passed to the endpoint is wrong.

![Screen Shot 2020-06-19 at 15 33 01](https://user-images.githubusercontent.com/59577424/85169448-35e4e380-b242-11ea-8f2d-cb9148e635ba.png)
