### PR TITLE
[FIX] Update check not able to be disabled

### DIFF
--- a/app/version-check/server/addSettings.js
+++ b/app/version-check/server/addSettings.js
@@ -6,5 +6,13 @@ settings.addGroup('General', function() {
 			type: 'string',
 			readonly: true,
 		});
+
+		this.add('Update_EnableChecker', true, {
+			type: 'boolean',
+			enableQuery: {
+				_id: 'Register_Server',
+				value: true,
+			},
+		});
 	});
 });

--- a/app/version-check/server/index.js
+++ b/app/version-check/server/index.js
@@ -32,7 +32,7 @@ settings.get('Register_Server', (key, value) => {
 		return;
 	}
 
-	if (value) {
+	if (value && settings.get('Update_EnableChecker')) {
 		addVersionCheckJob();
 		return;
 	}

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -3646,6 +3646,7 @@
   "Unstar_Message": "Remove Star",
   "Update": "Update",
   "Update_LatestAvailableVersion": "Update Latest Available Version",
+  "Update_EnableChecker": "Enable the Update Checker",
   "Update_to_version": "Update to __version__",
   "Update_your_RocketChat": "Update your Rocket.Chat",
   "Updated_at": "Updated at",


### PR DESCRIPTION
## Proposed changes
Way back in v0.62.0 an update check was implemented into Rocket.Chat (https://github.com/RocketChat/Rocket.Chat/commit/b81b3668e077b7b762f0c29265efe56c9373d8ad). The concept behind this update checker was to notify Rocket.Chat server administrators about new releases and security releases. Neither the server side update notification nor the alert server were ever implemented up until the end of May 2020. Up until now, there was no way, inside Rocket.Chat, to disable this update/alert checker. Moving forward, this will require that people select `Register Server` in the setup wizard in order for this update check to be enabled. Disabling it is as simple as going into Rocket.Chat's settings and disabling the registration of the server in the Wizard settings. Thus, this requires that an administrator of the server intentionally enable this and we will not have it enabled by default anymore nor will we make the decision of whether to enable or disable it: the choice is in the hands of the server administrator.

Here is the data sent:
https://github.com/RocketChat/Rocket.Chat/blob/ba749969ca06e3cae07431d845907b5e118ac976/app/version-check/server/functions/getNewUpdates.js#L14-L25

## Items Left To Do:
- [x] New setting underneath the `General -> Update`
- [x] Add it in additional to the check for the intent to register your server

## Issue(s)
Closes #18331 

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat)
- [x] Lint and unit tests pass locally with my changes

## Changelog
<!-- CHANGELOG -->
Update checker can now be disabled.
<!-- END CHANGELOG -->