### PR TITLE
Regression: Fix defaultFields for null values

### DIFF
--- a/app/models/server/models/_BaseDb.js
+++ b/app/models/server/models/_BaseDb.js
@@ -145,14 +145,17 @@ export class BaseDb extends EventEmitter {
 
 	_doNotMixInclusionAndExclusionFields(options) {
 		const optionsDef = this._ensureDefaultFields(options);
-
-		if (optionsDef && optionsDef.fields) {
-			const keys = Object.keys(optionsDef.fields);
-			const removeKeys = keys.filter((key) => optionsDef.fields[key] === 0);
-			if (keys.length > removeKeys.length) {
-				removeKeys.forEach((key) => delete optionsDef.fields[key]);
-			}
+		if (!optionsDef?.fields) {
+			return optionsDef;
 		}
+
+		const keys = Object.keys(optionsDef.fields);
+		const removeKeys = keys.filter((key) => optionsDef.fields[key] === 0);
+		if (keys.length > removeKeys.length) {
+			removeKeys.forEach((key) => delete optionsDef.fields[key]);
+		}
+
+		return optionsDef;
 	}
 
 	find(query = {}, options = {}) {

--- a/app/models/server/models/_BaseDb.js
+++ b/app/models/server/models/_BaseDb.js
@@ -125,26 +125,39 @@ export class BaseDb extends EventEmitter {
 	}
 
 	_ensureDefaultFields(options) {
-		if ((options?.fields == null || Object.keys(options?.fields).length === 0) && this.baseModel.defaultFields) {
-			options.fields = this.baseModel.defaultFields;
+		if (!this.baseModel.defaultFields) {
+			return options;
 		}
+
+		if (!options) {
+			return { fields: this.baseModel.defaultFields };
+		}
+
+		if (options.fields != null && Object.keys(options.fields).length > 0) {
+			return options;
+		}
+
+		return {
+			...options,
+			fields: this.baseModel.defaultFields,
+		};
 	}
 
 	_doNotMixInclusionAndExclusionFields(options) {
-		this._ensureDefaultFields(options);
+		const optionsDef = this._ensureDefaultFields(options);
 
-		if (options && options.fields) {
-			const keys = Object.keys(options.fields);
-			const removeKeys = keys.filter((key) => options.fields[key] === 0);
+		if (optionsDef && optionsDef.fields) {
+			const keys = Object.keys(optionsDef.fields);
+			const removeKeys = keys.filter((key) => optionsDef.fields[key] === 0);
 			if (keys.length > removeKeys.length) {
-				removeKeys.forEach((key) => delete options.fields[key]);
+				removeKeys.forEach((key) => delete optionsDef.fields[key]);
 			}
 		}
 	}
 
 	find(query = {}, options = {}) {
-		this._doNotMixInclusionAndExclusionFields(options);
-		return this.model.find(query, options);
+		const optionsDef = this._doNotMixInclusionAndExclusionFields(options);
+		return this.model.find(query, optionsDef);
 	}
 
 	findById(_id, options) {
@@ -152,8 +165,8 @@ export class BaseDb extends EventEmitter {
 	}
 
 	findOne(query = {}, options = {}) {
-		this._doNotMixInclusionAndExclusionFields(options);
-		return this.model.findOne(query, options);
+		const optionsDef = this._doNotMixInclusionAndExclusionFields(options);
+		return this.model.findOne(query, optionsDef);
 	}
 
 	findOneById(_id, options) {

--- a/app/models/server/raw/BaseRaw.js
+++ b/app/models/server/raw/BaseRaw.js
@@ -4,9 +4,24 @@ export class BaseRaw {
 	}
 
 	_ensureDefaultFields(options) {
-		if ((options?.fields == null || Object.keys(options?.fields).length === 0) && this.defaultFields) {
-			options.fields = this.defaultFields;
+		if (!this.defaultFields) {
+			return options;
 		}
+
+		if (!options) {
+			return { projection: this.defaultFields };
+		}
+
+		// TODO: change all places using "fields" for raw models and remove the additional condition here
+		if ((options.projection != null && Object.keys(options.projection).length > 0)
+		|| (options.fields != null && Object.keys(options.fields).length > 0)) {
+			return options;
+		}
+
+		return {
+			...options,
+			projection: this.defaultFields,
+		};
 	}
 
 	findOneById(_id, options = {}) {
@@ -14,8 +29,8 @@ export class BaseRaw {
 	}
 
 	findOne(query = {}, options = {}) {
-		this._ensureDefaultFields(options);
-		return this.col.findOne(query, options);
+		const optionsDef = this._ensureDefaultFields(options);
+		return this.col.findOne(query, optionsDef);
 	}
 
 	findUsersInRoles() {
@@ -23,8 +38,8 @@ export class BaseRaw {
 	}
 
 	find(query = {}, options = {}) {
-		this._ensureDefaultFields(options);
-		return this.col.find(query, options);
+		const optionsDef = this._ensureDefaultFields(options);
+		return this.col.find(query, optionsDef);
 	}
 
 	update(...args) {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
<!-- Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
I'm proposing the following changes:

* support `null` as options on models (see logs below)
* do not change `options` object as they are passed as reference
* fix cases in Raw Models where it were mixing both `fields` and `projection` options, in this case mongodb driver gives preference to the latter, possibly causing issues by not returning desired fields.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Hotfix (a major bugfix that has to be merged asap)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Changelog
<!-- CHANGELOG -->
<!-- Enter HERE a brief text that would go up on the changelog on our releases page -->
<!-- END CHANGELOG -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[This particular case](https://github.com/RocketChat/Rocket.Chat/blob/e73b7cb2f34a2358cfcee8c597e7d6485fa9ab3b/app/models/server/raw/Users.js#L22) was forcing `options` to be `null`, causing the following error:
```
I20200722-11:37:06.974(-3)? Exception while invoking method 'login' TypeError: Cannot set property 'fields' of null
I20200722-11:37:06.974(-3)?     at UsersRaw._ensureDefaultFields (app/models/server/raw/BaseRaw.js:8:4)
I20200722-11:37:06.974(-3)?     at UsersRaw.findOne (app/models/server/raw/BaseRaw.js:17:8)
I20200722-11:37:06.974(-3)?     at UsersRaw.findOneByUsername (app/models/server/raw/Users.js:25:15)
I20200722-11:37:06.974(-3)?     at app/authentication/server/lib/restrictLoginAttempts.ts:54:41
I20200722-11:37:06.975(-3)?     at /Users/diegosampaio/.meteor/packages/promise/.0.11.2.1xavwef.9sbp++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/fiber_pool.js:43:40
I20200722-11:37:06.975(-3)?  => awaited here:
I20200722-11:37:06.975(-3)?     at Function.Promise.await (/Users/diegosampaio/.meteor/packages/promise/.0.11.2.1xavwef.9sbp++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/promise_server.js:56:12)
I20200722-11:37:06.975(-3)?     at app/authentication/server/startup/index.js:306:15
I20200722-11:37:06.975(-3)?     at packages/callback-hook/hook.js:131:22
I20200722-11:37:06.975(-3)?     at packages/accounts-base/accounts_server.js:154:15
I20200722-11:37:06.975(-3)?     at Hook.each (packages/callback-hook/hook.js:109:15)
I20200722-11:37:06.975(-3)?     at AccountsServer._validateLogin (packages/accounts-base/accounts_server.js:151:29)
I20200722-11:37:06.975(-3)?     at AccountsServer._attemptLogin (packages/accounts-base/accounts_server.js:340:10)
I20200722-11:37:06.976(-3)?     at MethodInvocation.methods.login (packages/accounts-base/accounts_server.js:522:23)
I20200722-11:37:06.976(-3)?     at maybeAuditArgumentChecks (packages/ddp-server/livedata_server.js:1771:12)
I20200722-11:37:06.976(-3)?     at packages/ddp-server/livedata_server.js:719:19
I20200722-11:37:06.976(-3)?     at Meteor.EnvironmentVariable.EVp.withValue (packages/meteor.js:1234:12)
I20200722-11:37:06.976(-3)?     at packages/ddp-server/livedata_server.js:717:46
I20200722-11:37:06.976(-3)?     at Meteor.EnvironmentVariable.EVp.withValue (packages/meteor.js:1234:12)
I20200722-11:37:06.976(-3)?     at packages/ddp-server/livedata_server.js:715:46
I20200722-11:37:06.976(-3)?     at new Promise (<anonymous>)
I20200722-11:37:06.976(-3)?     at Session.method (packages/ddp-server/livedata_server.js:689:23)
I20200722-11:37:06.976(-3)?     at packages/ddp-server/livedata_server.js:559:43
```
