### PR TITLE
[FIX] Federation issues

### DIFF
--- a/app/federation/server/endpoints/dispatch.js
+++ b/app/federation/server/endpoints/dispatch.js
@@ -444,7 +444,7 @@ const eventHandlers = {
 	},
 };
 
-API.v1.addRoute('federation.events.dispatch', { authRequired: false }, {
+API.v1.addRoute('federation.events.dispatch', { authRequired: false, rateLimiterOptions: { numRequestsAllowed: 30, intervalTimeInMS: 1000 } }, {
 	async post() {
 		if (!isFederationEnabled()) {
 			return API.v1.failure('Federation not enabled');

--- a/app/federation/server/handler/index.js
+++ b/app/federation/server/handler/index.js
@@ -67,10 +67,7 @@ export function dispatchEvents(domains, events) {
 }
 
 export function dispatchEvent(domains, event) {
-	// Ensure the domain list is distinct to avoid excessive events
-	const distinctDomains = [...new Set(domains)].filter((domain) => domain === event.origin);
-
-	dispatchEvents(distinctDomains, [event]);
+	dispatchEvents([...new Set(domains)], [event]);
 }
 
 export function getUpload(domain, fileId) {

--- a/app/federation/server/lib/callbacks.js
+++ b/app/federation/server/lib/callbacks.js
@@ -1,14 +1,23 @@
 import { callbacks } from '../../../callbacks/server';
+import { settings } from '../../../settings/server';
 
 const callbackDefinitions = [];
 
-export function registerCallback(callbackDefition) {
-	callbackDefinitions.push(callbackDefition);
+function enableCallback(definition) {
+	callbacks.add(definition.hook, definition.callback, callbacks.priority.LOW, definition.id);
+}
+
+export function registerCallback(callbackDefinition) {
+	callbackDefinitions.push(callbackDefinition);
+
+	if (settings.get('FEDERATION_Enabled')) {
+		enableCallback(callbackDefinition);
+	}
 }
 
 export function enableCallbacks() {
 	for (const definition of callbackDefinitions) {
-		callbacks.add(definition.hook, definition.callback, callbacks.priority.LOW, definition.id);
+		enableCallback(definition);
 	}
 }
 


### PR DESCRIPTION
Fixes:

- Federation was not working at all on newer versions, callbacks were not being correctly registered due to the new file import order throughout the system;
- Some issues were introduced by this line [Dispatch Event L71](https://github.com/RocketChat/Rocket.Chat/blob/1cfd8201112b654a1c53696e5ed6eb6b88b882a9/app/federation/server/handler/index.js#L71)
- Adjusted the rate limiter for federation requests;