### PR TITLE
[FIX] fix escaping for shrug command

### DIFF
--- a/app/slashcommand-asciiarts/lib/shrug.js
+++ b/app/slashcommand-asciiarts/lib/shrug.js
@@ -10,7 +10,7 @@ import { slashCommands } from '../../utils';
 function Shrug(command, params, item) {
 	if (command === 'shrug') {
 		const msg = item;
-		msg.msg = `${ params } ¯\\_(ツ)_/¯`;
+		msg.msg = `${ params } ¯\\\_(ツ)\_/¯`;
 		Meteor.call('sendMessage', msg);
 	}
 }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
<!-- Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
Currently, the `/shrug` command is missing part of the arm when it's used in chat, it turns out looking like ¯_(ツ)_/¯. Testing escaping the arm in Rocket Chat turned out to be what is suggested in my PR, `¯\\\_(ツ)\_/¯`, which will display the arm, and not italicize the body. I noticed that there were i18n files that describe the command. My PR does not update those files, but I can do it manually if necessary for this PR to pass.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Type `/shrug` in Rocket Chat, the left arm is missing.

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Hotfix (a major bugfix that has to be merged asap)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Changelog
<!-- CHANGELOG -->
<!-- Enter HERE a brief text that would go up on the changelog on our releases page -->
<!-- END CHANGELOG -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
