### PR TITLE
[FIX] Make Channel Export attachment download async

### DIFF
--- a/app/file-upload/server/lib/FileUpload.js
+++ b/app/file-upload/server/lib/FileUpload.js
@@ -405,6 +405,18 @@ export const FileUpload = {
 		store.copy(file, buffer);
 	},
 
+	copyWithStream(file, out) {
+		const store = this.getStoreByName(file.store);
+		file = FileUpload.addExtensionTo(file);
+
+		if (store.copy) {
+			store.copy(file, out);
+			return true;
+		}
+
+		return false;
+	},
+
 	copy(file, targetFile) {
 		const store = this.getStoreByName(file.store);
 		const out = fs.createWriteStream(targetFile);

--- a/app/user-data-download/server/cronProcessDownloads.js
+++ b/app/user-data-download/server/cronProcessDownloads.js
@@ -272,6 +272,31 @@ export const sendEmail = function(userData, subject, body) {
 	});
 };
 
+export const copyFileSync = function(attachmentData, assetsPath) {
+	const file = Uploads.findOneById(attachmentData._id);
+	if (!file) {
+		return;
+	}
+
+	return new Promise((resolve, reject) => {
+		const out = fs.createWriteStream(path.join(assetsPath, `${ attachmentData._id }-${ attachmentData.name }`));
+
+		out.on('warning', function(err) {
+		  if (err.code === 'ENOENT') {
+		    console.log("copyFileSync warning: " + err);
+		  } else {
+		    // throw error
+		    console.log("copyFileSync warning: " + err);
+		  }
+		});
+
+		out.on('error', (err) => reject(err));
+		out.on("close", () => resolve('copyFileSync: done!'));
+
+		FileUpload.copyWithStream(file, out);
+	});
+};
+
 export const makeZipFile = function(folderToZip, targetFile) {
 	return new Promise((resolve, reject) => {
 		const output = fs.createWriteStream(targetFile);

--- a/server/lib/channelExport.ts
+++ b/server/lib/channelExport.ts
@@ -11,7 +11,7 @@ import { settings } from '../../app/settings/server';
 import { Message } from '../../app/ui-utils/server';
 import {
 	exportRoomMessagesToFile,
-	copyFile,
+	copyFileSync,
 	getRoomData,
 	makeZipFile,
 	sendEmail,
@@ -154,9 +154,9 @@ export const sendFile = async (data: ExportFile, user: IUser): Promise<void> => 
 
 	await exportMessages();
 
-	fullFileList.forEach((attachmentData: any) => {
-		copyFile(attachmentData, assetsPath);
-	});
+	await Promise.all(fullFileList.map(async (attachmentData: any) => {
+	    await copyFileSync(attachmentData, assetsPath);
+    }));
 
 	const exportFile = `${ baseDir }-export.zip`;
 	await makeZipFile(exportPath, exportFile);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
<!-- Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->

This change improves the Channel Export feature when attachments are present in the channel history. The export now waits until all attachments are completely copied from the channel history date range before creating the export archive zip file on the server. Previously, the export zip would be created without waiting for the attachment downloads to fully complete. This resulted in an inconsistent assets/ directory in the zip archive. Many times, all attachments in the assets/ export directory were 0 bytes. Again, this is because the actual archive step was not waiting until the attachment copy was successfully completed before starting.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

Go to a channel with attachments in its history. Choose channel export and a date range that covers the attachment history. Sometimes the attachments will be correctly present in the assets/ directory of the export, but most times they will be inconsistently archived into assets/, resulting in 0 byte attachment files in the export.

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Hotfix (a major bugfix that has to be merged asap)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Changelog
<!-- CHANGELOG -->
<!-- Enter HERE a brief text that would go up on the changelog on our releases page -->
<!-- END CHANGELOG -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

