### PR TITLE
Regression: Attachment without title or description show "sent attachment" in view mode extended 

### DIFF
--- a/client/sidebar/RoomList.js
+++ b/client/sidebar/RoomList.js
@@ -90,7 +90,6 @@ export const normalizeSidebarMessage = (message, t) => {
 	if (message.attachments) {
 		const attachment = message.attachments.find((attachment) => attachment.title || attachment.description);
 
-		console.log(attachment);
 		if (attachment && attachment.description) {
 			return s.escapeHTML(attachment.description);
 		}

--- a/client/sidebar/RoomList.js
+++ b/client/sidebar/RoomList.js
@@ -82,7 +82,7 @@ export const Row = React.memo(({ data, index, style }) => {
 	return <SideBarItemTemplateWithData sidebarViewMode={sidebarViewMode} style={style} selected={item.rid === openedRoom} t={t} room={item} extended={extended} SideBarItemTemplate={SideBarItemTemplate} AvatarTemplate={AvatarTemplate} />;
 }, areEqual);
 
-export const normalizeSidebarMessage = ({ ...message }) => {
+export const normalizeSidebarMessage = (message, t) => {
 	if (message.msg) {
 		return s.escapeHTML(filterMarkdown(message.msg));
 	}
@@ -90,6 +90,7 @@ export const normalizeSidebarMessage = ({ ...message }) => {
 	if (message.attachments) {
 		const attachment = message.attachments.find((attachment) => attachment.title || attachment.description);
 
+		console.log(attachment);
 		if (attachment && attachment.description) {
 			return s.escapeHTML(attachment.description);
 		}
@@ -98,7 +99,7 @@ export const normalizeSidebarMessage = ({ ...message }) => {
 			return s.escapeHTML(attachment.title);
 		}
 
-		return 'sent atachment';
+		return t('Sent_an_attachment');
 	}
 };
 
@@ -149,15 +150,15 @@ const getMessage = (room, lastMessage, t) => {
 		return t('No_messages_yet');
 	}
 	if (!lastMessage.u) {
-		return normalizeSidebarMessage(lastMessage);
+		return normalizeSidebarMessage(lastMessage, t);
 	}
 	if (lastMessage.u?.username === room.u?.username) {
-		return `${ t('You') }: ${ normalizeSidebarMessage(lastMessage) }`;
+		return `${ t('You') }: ${ normalizeSidebarMessage(lastMessage, t) }`;
 	}
 	if (room.t === 'd' && room.uids.length <= 2) {
-		return normalizeSidebarMessage(lastMessage);
+		return normalizeSidebarMessage(lastMessage, t);
 	}
-	return `${ lastMessage.u.name || lastMessage.u.username }: ${ normalizeSidebarMessage(lastMessage) }`;
+	return `${ lastMessage.u.name || lastMessage.u.username }: ${ normalizeSidebarMessage(lastMessage, t) }`;
 };
 
 export const SideBarItemTemplateWithData = React.memo(function SideBarItemTemplateWithData({ room, id, extended, selected, SideBarItemTemplate, AvatarTemplate, t, style, sidebarViewMode, isAnonymous }) {

--- a/client/sidebar/RoomList.js
+++ b/client/sidebar/RoomList.js
@@ -97,6 +97,8 @@ export const normalizeSidebarMessage = ({ ...message }) => {
 		if (attachment && attachment.title) {
 			return s.escapeHTML(attachment.title);
 		}
+
+		return 'sent atachment';
 	}
 };
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
<!-- Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->

Fix the undefined message in view mode extended when the last message has an attachment and no title or description.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Regression

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat)

## Changelog
<!-- CHANGELOG -->
<!-- Enter HERE a brief text that would go up on the changelog on our releases page -->
<!-- END CHANGELOG -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

