### PR TITLE
[FIX] Cloud Register Allowing Empty Tokens

### DIFF
--- a/app/cloud/server/functions/connectWorkspace.js
+++ b/app/cloud/server/functions/connectWorkspace.js
@@ -13,6 +13,12 @@ export function connectWorkspace(token) {
 		Settings.updateValueById('Register_Server', true);
 	}
 
+	// shouldn't get here due to checking this on the method
+	// but this is just to double check
+	if (!token) {
+		return new Error('Invalid token; the registration token is required.');
+	}
+
 	const redirectUri = getRedirectUri();
 
 	const regInfo = {

--- a/app/cloud/server/functions/startRegisterWorkspace.js
+++ b/app/cloud/server/functions/startRegisterWorkspace.js
@@ -41,8 +41,6 @@ export function startRegisterWorkspace(resend = false) {
 		return false;
 	}
 
-	console.log('result from the start register workspace:', result);
-
 	const { data } = result;
 
 	if (!data) {

--- a/app/cloud/server/functions/startRegisterWorkspace.js
+++ b/app/cloud/server/functions/startRegisterWorkspace.js
@@ -41,6 +41,8 @@ export function startRegisterWorkspace(resend = false) {
 		return false;
 	}
 
+	console.log('result from the start register workspace:', result);
+
 	const { data } = result;
 
 	if (!data) {

--- a/app/cloud/server/methods.js
+++ b/app/cloud/server/methods.js
@@ -70,6 +70,10 @@ Meteor.methods({
 			throw new Meteor.Error('error-not-authorized', 'Not authorized', { method: 'cloud:connectServer' });
 		}
 
+		if (!token) {
+			throw new Meteor.Error('error-invalid-payload', 'Token is required.', { method: 'cloud:connectServer' });
+		}
+
 		return connectWorkspace(token);
 	},
 	'cloud:disconnectWorkspace'() {


### PR DESCRIPTION
## Proposed changes
Currently when registering your Rocket.Chat Cloud workspace, you can submit an empty token and it will fail with an ambiguous error. This fixes the error message and makes it more verbose.

## How to test or reproduce
Register/Connect your workspace and don't enter a token but click the button; see a non-descriptive message.

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Hotfix (a major bugfix that has to be merged asap)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules