### PR TITLE
[FIX] LDAP Unique Identifier Field can not use operational attributes

### DIFF
--- a/app/ldap/server/ldap.js
+++ b/app/ldap/server/ldap.js
@@ -275,7 +275,7 @@ export default class LDAP {
 		const searchOptions = {
 			filter,
 			scope: 'sub',
-			attributes: ['*','+']
+			attributes: ['*','+'],
 		};
 
 		logger.search.info('Searching by id', id);

--- a/app/ldap/server/ldap.js
+++ b/app/ldap/server/ldap.js
@@ -275,7 +275,7 @@ export default class LDAP {
 		const searchOptions = {
 			filter,
 			scope: 'sub',
-			attributes: ['*','+'],
+			attributes: ['*', '+']
 		};
 
 		logger.search.info('Searching by id', id);

--- a/app/ldap/server/ldap.js
+++ b/app/ldap/server/ldap.js
@@ -275,7 +275,7 @@ export default class LDAP {
 		const searchOptions = {
 			filter,
 			scope: 'sub',
-			attributes: ['*', '+']
+			attributes: ['*', '+'],
 		};
 
 		logger.search.info('Searching by id', id);

--- a/app/ldap/server/ldap.js
+++ b/app/ldap/server/ldap.js
@@ -275,6 +275,7 @@ export default class LDAP {
 		const searchOptions = {
 			filter,
 			scope: 'sub',
+			attributes: ['*','+']
 		};
 
 		logger.search.info('Searching by id', id);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
<!-- Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
OpenLDAP uses *entryUUID* as a Unique id for each ldap entry. This attribute is hidden from normal search. Adding attributes: ['*','+'] to searchOptions will allow use them to get unique ids for each ldap entry.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
If I set *entryUUID* in **Unique Identifier Field**, LDAP search will use only uid as idAttribute for LDAP users in mongoDB.

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Set **Unique Identifier Field** value to *entryUUID*, then run **Execute Synchronization Now** in LDAP Administration page

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Hotfix (a major bugfix that has to be merged asap)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Changelog
<!-- CHANGELOG -->
<!-- Enter HERE a brief text that would go up on the changelog on our releases page -->
<!-- END CHANGELOG -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

