### PR TITLE
Regression: Fix LDAP 2FA not working when Login Fallback is off

### DIFF
--- a/app/2fa/client/TOTPLDAP.js
+++ b/app/2fa/client/TOTPLDAP.js
@@ -2,6 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import { Accounts } from 'meteor/accounts-base';
 
 import { Utils2fa } from './lib/2fa';
+import '../../ldap/client/loginHelper';
 
 Meteor.loginWithLDAPAndTOTP = function(...args) {
 	// Pull username and password

--- a/app/2fa/client/TOTPLDAP.js
+++ b/app/2fa/client/TOTPLDAP.js
@@ -47,5 +47,5 @@ const { loginWithLDAP } = Meteor;
 Meteor.loginWithLDAP = function(...args) {
 	const callback = typeof args[args.length - 1] === 'function' ? args.pop() : null;
 
-	Utils2fa.overrideLoginMethod(loginWithLDAP, args, callback, Meteor.loginWithLDAPAndTOTP);
+	Utils2fa.overrideLoginMethod(loginWithLDAP, args, callback, Meteor.loginWithLDAPAndTOTP, args[0]);
 };

--- a/app/2fa/client/lib/2fa.js
+++ b/app/2fa/client/lib/2fa.js
@@ -24,7 +24,7 @@ export class Utils2fa {
 		return err;
 	}
 
-	static overrideLoginMethod(loginMethod, loginArgs, cb, loginMethodTOTP) {
+	static overrideLoginMethod(loginMethod, loginArgs, cb, loginMethodTOTP, emailOrUsername = undefined) {
 		loginMethod.apply(this, loginArgs.concat([(error) => {
 			if (!error || error.error !== 'totp-required') {
 				return cb(error);
@@ -32,6 +32,7 @@ export class Utils2fa {
 
 			process2faReturn({
 				error,
+				emailOrUsername,
 				originalCallback: cb,
 				onCode: (code) => {
 					loginMethodTOTP && loginMethodTOTP.apply(this, loginArgs.concat([code, (error) => {

--- a/app/2fa/client/lib/2fa.js
+++ b/app/2fa/client/lib/2fa.js
@@ -24,7 +24,7 @@ export class Utils2fa {
 		return err;
 	}
 
-	static overrideLoginMethod(loginMethod, loginArgs, cb, loginMethodTOTP, emailOrUsername = undefined) {
+	static overrideLoginMethod(loginMethod, loginArgs, cb, loginMethodTOTP, emailOrUsername) {
 		loginMethod.apply(this, loginArgs.concat([(error) => {
 			if (!error || error.error !== 'totp-required') {
 				return cb(error);


### PR DESCRIPTION
Pior to 3.9, whenever an LDAP login resulted in a totp-required error, Rocket.Chat would assume it was a login fallback and redirect the TOTP request to a password login. Now that LDAP 2FA is implemented this should no longer be done.