### PR TITLE
[FIX] Sidebar presence will now correctly update for Omnichannel rooms

### DIFF
--- a/client/sidebar/RoomList.js
+++ b/client/sidebar/RoomList.js
@@ -230,6 +230,9 @@ export const SideBarItemTemplateWithData = React.memo(function SideBarItemTempla
 	if (prevProps.room.alert !== nextProps.room.alert) {
 		return false;
 	}
+	if (prevProps.room.v?.status !== nextProps.room.v?.status) {
+		return false;
+	}
 
 	return true;
 });


### PR DESCRIPTION
There was an issue where the sidebar status for Omnichannel visitors would not correctly refresh.