### PR TITLE
[FIX] Admin Users screen sorting showing deactivated users in wrong order

### DIFF
--- a/client/views/admin/users/UsersTable.js
+++ b/client/views/admin/users/UsersTable.js
@@ -44,7 +44,7 @@ const UserRow = ({ emails, _id, username, name, roles, status, avatarETag, onCli
 };
 
 
-const useQuery = ({ text, itemsPerPage, current }, sorts) => useMemo(() => ({
+const useQuery = ({ text, itemsPerPage, current }, sortFields) => useMemo(() => ({
 	fields: JSON.stringify({ name: 1, username: 1, emails: 1, roles: 1, status: 1, avatarETag: 1, active: 1 }),
 	query: JSON.stringify({
 		$or: [
@@ -53,13 +53,13 @@ const useQuery = ({ text, itemsPerPage, current }, sorts) => useMemo(() => ({
 			{ name: { $regex: text || '', $options: 'i' } },
 		],
 	}),
-	sort: JSON.stringify(sorts.reduce((agg, [column, direction]) => {
+	sort: JSON.stringify(sortFields.reduce((agg, [column, direction]) => {
 		agg[column] = sortDir(direction);
 		return agg;
 	}, {})),
 	...itemsPerPage && { count: itemsPerPage },
 	...current && { offset: current },
-}), [text, itemsPerPage, current, sorts]);
+}), [text, itemsPerPage, current, sortFields]);
 
 export function UsersTable() {
 	const t = useTranslation();


### PR DESCRIPTION
### Description:

  

Sorting Issue on USERS page

  

### Steps to reproduce:

  

1.  Go to admin
2.  Click on USERS
3.  Click on STATUS (or any column)

  

### Expected behavior:

  

Items are sorted correctly.

### Actual behavior:

  

![](https://user-images.githubusercontent.com/13898029/99430050-ad847080-28bd-11eb-93ef-df26a04c6122.png)

  

### Server Setup Information:

  

*   Version of [Rocket.Chat](http://Rocket.Chat) Server: 3.8.0
*   Operating System: Ubuntu 20.04.1
*   Deployment Method: Manual;
*   Number of Running Instances: 1
*   DB Replicaset Oplog:
*   NodeJS Version: 12.18.4
*   MongoDB Version: 4.0.21

  

### Client Setup Information

  

*   Desktop App or Browser Version: Browser (Chrome Edge)
*   Operating System: Windows 10