### PR TITLE
Chore: add tests to api/instances.get endpoint 

### DIFF
--- a/tests/end-to-end/api/00-miscellaneous.js
+++ b/tests/end-to-end/api/00-miscellaneous.js
@@ -447,8 +447,37 @@ describe('miscellaneous', function() {
 		});
 	});
 
-	describe('/instances.get', () => {
-		it('should return available instances', (done) => {
+	describe('[/instances.get]', () => {
+		let unauthorizedUserCredentials;
+		before(async () => {
+			const createdUser = await createUser();
+			unauthorizedUserCredentials = await doLogin(createdUser.username, password);
+		})
+
+		it('should fail if user is logged in but is unauthorized', (done) => {
+			request.get(api('instances.get'))
+				.set(unauthorizedUserCredentials)
+				.expect('Content-Type', 'application/json')
+				.expect(403)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', false);
+					expect(res.body).to.have.property('error', 'unauthorized');
+				})
+				.end(done);
+		});
+
+		it('should fail if not logged in', (done) => {
+			request.get(api('instances.get'))
+				.expect('Content-Type', 'application/json')
+				.expect(401)
+				.expect((res) => {
+					expect(res.body).to.have.property('status', 'error');
+					expect(res.body).to.have.property('message');
+				})
+				.end(done);
+		});
+
+		it('should return instances if user is logged in and is authorized', (done) => {
 			request.get(api('instances.get'))
 				.set(credentials)
 				.expect(200)

--- a/tests/end-to-end/api/00-miscellaneous.js
+++ b/tests/end-to-end/api/00-miscellaneous.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { getCredentials, api, login, request, credentials } from '../../data/api-data.js';
 import { adminEmail, adminUsername, adminPassword, password } from '../../data/user.js';
-import {createUser, login as doLogin} from "../../../tests/data/users.helper";
+import { createUser, login as doLogin } from '../../data/users.helper';
 
 describe('miscellaneous', function() {
 	this.retries(0);
@@ -453,7 +453,7 @@ describe('miscellaneous', function() {
 		before(async () => {
 			const createdUser = await createUser();
 			unauthorizedUserCredentials = await doLogin(createdUser.username, password);
-		})
+		});
 
 		it('should fail if user is logged in but is unauthorized', (done) => {
 			request.get(api('instances.get'))

--- a/tests/end-to-end/api/00-miscellaneous.js
+++ b/tests/end-to-end/api/00-miscellaneous.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import { getCredentials, api, login, request, credentials } from '../../data/api-data.js';
 import { adminEmail, adminUsername, adminPassword, password } from '../../data/user.js';
+import {createUser, login as doLogin} from "../../../tests/data/users.helper";
 
 describe('miscellaneous', function() {
 	this.retries(0);


### PR DESCRIPTION
Adding more tests situations to the `instances.get` endpoint, mostly fails tests, for example: 

- If the user is not logged in, it should fail;
- If the user is logged in but does not have the right permission, it should fail.