### PR TITLE
[FIX] Fixes displaying starred message for all users and removing star icon on unstarring

### DIFF
--- a/app/message-star/client/actionButton.js
+++ b/app/message-star/client/actionButton.js
@@ -30,7 +30,7 @@ Meteor.startup(function() {
 				return false;
 			}
 
-			return !message.starred || !message.starred.find((star) => star._id === u._id);
+			return !(message.starred ? message.starred.length !== 0 : false) || !message.starred.find((star) => star._id === u._id);
 		},
 		order: 9,
 		group: 'menu',
@@ -55,7 +55,7 @@ Meteor.startup(function() {
 				return false;
 			}
 
-			return message.starred && message.starred.find((star) => star._id === u._id);
+			return (message.starred ? message.starred.length !== 0 : false) && !!message.starred.find((star) => star._id === u._id);
 		},
 		order: 9,
 		group: 'menu',

--- a/app/ui-message/client/message.js
+++ b/app/ui-message/client/message.js
@@ -452,8 +452,8 @@ Template.message.helpers({
 		return threadMsg;
 	},
 	showStar() {
-		const { msg } = this;
-		return msg.starred && !(msg.actionContext === 'starred' || this.context === 'starred');
+		const { msg, u } = this;
+		return (msg.starred ? msg.starred.length !== 0 : false) && !!(Array.isArray(msg.starred) && msg.starred.find((star) => star._id === u._id));
 	},
 });
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

The `message.starred` value is `undefined` initially. On starring the message it becomes an array with the user IDs of all users who starred the message.

When a starred message is unstarred by **everyone** it just remains an empty array `[]`. The truth value of an empty array is `true` which causes the message to be shown as starred even though it is unstarred.

The main corrections are as follows:

```
(message.starred ? message.starred.length !== 0 : false) && !!message.starred.find((star) => star._id === u._id)
```

Part 1

`(message.starred ? message.starred.length !== 0 : false)`

This part first checks if `message.starred` is `undefined`. If it is that means it is unstarred and therefore a `false` is returned.
If `message.starred` is not `undefined`, then it checks if it is an empty array, which means the message unstarred again and therefore a `false` is returned.
In case `message.starred` is an array of values, a `true` is returned.

Part 2

`!!message.starred.find((star) => star._id === u._id)`

Since the value of `message.starred.find` is `undefined` for an empty array, initally this was returning an `undefined` instead of a boolean value. To fix this doing a `!!` would return `false` which means the message is unstarred at it should be.

In case of the `app/ui-message/client/message.js` file the `msg.actionContext` and `this.context` are `undefined` irrespective of the message being starred or unstarred. Here the above change with an additional check is needed - whether `msg.starred` is an array. This is because if `msg.starred` is true or false it would return an error since `.find()` cannot be applied to boolean values.

The fixed demo is as follows:

https://user-images.githubusercontent.com/28918901/103919603-3a1d1380-5136-11eb-810c-6fc6b96c7e3e.mp4

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Closes #20099 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
