### PR TITLE
[NEW] Ability to sort search by Users, Rooms, LiveChat Guests

### DIFF
--- a/client/sidebar/search/SearchList.js
+++ b/client/sidebar/search/SearchList.js
@@ -104,6 +104,19 @@ const options = {
 	},
 };
 
+const searchSort = (items) => {
+	let typeDirect = 0; let typeOther = items.length - 1;
+	while (typeDirect < typeOther) {
+		if (items[typeDirect].t !== 'd') {
+			items[typeDirect] = [items[typeOther], items[typeOther] = items[typeDirect]][0];
+			typeOther--;
+		} else {
+			typeDirect++;
+		}
+	}
+	return items;
+};
+
 const useSearchItems = (filterText) => {
 	const expression = /(@|#)?(.*)/i;
 	const teste = filterText.match(expression);
@@ -149,7 +162,7 @@ const useSearchItems = (filterText) => {
 		resultsFromServer.push(...spotlight.users.filter(filterUsersUnique).filter(usersfilter).map(userMap));
 		resultsFromServer.push(...spotlight.rooms.filter(roomFilter));
 
-		return { data: Array.from(new Set([...exact, ...localRooms, ...resultsFromServer])), status };
+		return { data: searchSort(Array.from(new Set([...exact, ...localRooms, ...resultsFromServer]))), status };
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [localRooms, name, spotlight]);
 };


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

Initially, users and channels were appearing jumbled on clicking Search

![Screenshot from 2021-01-09 01-00-30](https://user-images.githubusercontent.com/28918901/104126471-c3288a80-5382-11eb-935a-1e2fd4eaf211.png)

With this PR, the direct messages get grouped first and then the channels and livechats follow:

![Screenshot from 2021-01-09 01-01-52](https://user-images.githubusercontent.com/28918901/104126494-e3f0e000-5382-11eb-9242-fc003c00db68.png)

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

Closes #13899