### PR TITLE
[FIX] Added context check for closing active tabbar for member-list

### DIFF
--- a/client/views/room/providers/ToolboxProvider.tsx
+++ b/client/views/room/providers/ToolboxProvider.tsx
@@ -77,7 +77,7 @@ export const ToolboxProvider = ({ children, room }: { children: ReactNode; room:
 	});
 
 	const open = useMutableCallback((actionId, context) => {
-		if (actionId === activeTabBar[0]?.id) {
+		if (actionId === activeTabBar[0]?.id && context === undefined) {
 			return close();
 		}
 		router.push({


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->
  - [x] I have read the Contributing Guide 
  - [x] I have signed the CLA 
  - [x] Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
When we click on a username and then click on see user's full profile, a tab gets active and shows us the user's profile, the problem occurs when the tab is still active and we try to see another user's profile. In this case, tabbar gets closed.
To resolve this, added context check for closing action of active tabbar.
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
fixes #20227
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Refer issue #20227 
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
We are checking active tabbar action id, in order to close the active tab if any action like clicking button member-list is performed twice. But this creates an issue if we try to see user's info back to back because the action id remains same which causes the tab to close. So included a check for context. If the context is undefined, then only close the tab. The context will be undefined if we click on the members button, which will close the tab as it should.

![after-tabbar](https://user-images.githubusercontent.com/58601732/104816913-25cacc00-5844-11eb-8f6d-6fbdcf747bd1.gif)
