### PR TITLE
[FIX] Room special name in prompts

### DIFF
--- a/client/views/room/contextualBar/Info/RoomInfo/RoomInfo.js
+++ b/client/views/room/contextualBar/Info/RoomInfo/RoomInfo.js
@@ -153,7 +153,7 @@ export default ({
 	const room = useUserRoom(rid);
 	room.type = room.t;
 	room.rid = rid;
-	const { type, name, broadcast, archived, joined = true } = room; // TODO implement joined
+	const { type, fname, broadcast, archived, joined = true } = room; // TODO implement joined
 
 	const retentionPolicyEnabled = useSetting('RetentionPolicy_Enabled');
 	const retentionPolicy = {
@@ -207,7 +207,7 @@ export default ({
 		const warnText = roomTypes.getConfig(type).getUiText(UiTextContext.LEAVE_WARNING);
 
 		setModal(<WarningModal
-			text={t(warnText, name)}
+			text={t(warnText, fname)}
 			confirmText={t('Leave_room')}
 			close={closeModal}
 			cancel={closeModal}
@@ -230,7 +230,7 @@ export default ({
 		const warnText = roomTypes.getConfig(type).getUiText(UiTextContext.HIDE_WARNING);
 
 		setModal(<WarningModal
-			text={t(warnText, name)}
+			text={t(warnText, fname)}
 			confirmText={t('Yes_hide_it')}
 			close={closeModal}
 			cancel={closeModal}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
The "Hide room" and "Leave Room" confirmation prompts use the "name" key from the room info. When the setting "
Allow Special Characters in Room Names" is enabled, the prompts show the normalized names instead of those that contain the special characters.

Changed the value being used from name to fname, which always has the user-set name.

Previous:
![Screenshot from 2021-01-20 15-52-29](https://user-images.githubusercontent.com/38764067/105161642-9b31e780-5b37-11eb-8b0c-ec4b1414c948.png)

Updated:
![Screenshot from 2021-01-20 15-50-19](https://user-images.githubusercontent.com/38764067/105161627-966d3380-5b37-11eb-9812-3dd9352b4f95.png)

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Closes #20276 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Login as administrator
2. Go to Administration
3. Under "Layout", check "Allow Special Characters in Room Names"
4. Change the name of a room to "The Room ;;"
5. Try to leave the aforementioned room [ The prompt calls the room "the-room" instead of "The Room ;;" ]

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
