### PR TITLE
[FIX] Message info reacts to Date-Time settngs

### DIFF
--- a/imports/message-read-receipt/client/readReceipts.js
+++ b/imports/message-read-receipt/client/readReceipts.js
@@ -16,7 +16,7 @@ Template.readReceipts.helpers({
 		return (settings.get('UI_Use_Real_Name') && this.user.name) || this.user.username;
 	},
 	time() {
-		return moment(this.ts).format('L LTS');
+		return moment(this.ts).format(settings.get('Message_TimeAndDateFormat'));
 	},
 	isLoading() {
 		return Template.instance().loading.get();


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
Say the setting for the Time and Date Format is provided as follows in Administration->Settings->Messages
![Screenshot from 2021-01-22 19-19-45](https://user-images.githubusercontent.com/54909147/105502000-f0622a80-5cea-11eb-9c4c-594e1deff305.png)
This is a valid moment format. However, earlier this part was Hardcoded to 'L LTS' format. Now, it gets the settings that were chosen and shows the message read time accordingly.

<!-- END CHANGELOG -->

## Issue(s)
Closes #20247 

## Earlier
![Screenshot from 2021-01-22 19-20-46](https://user-images.githubusercontent.com/54909147/105502070-066feb00-5ceb-11eb-8d20-36c00f0f0e04.png)
The Time and Date format would not change

## Now
![Screenshot from 2021-01-22 19-19-58](https://user-images.githubusercontent.com/54909147/105502095-0f60bc80-5ceb-11eb-8a9f-602313490d35.png)
The Time and Date format reacts according to the settings.
