### PR TITLE
[FIX] Corrected the user ability to view admin permissions

### DIFF
--- a/client/views/admin/permissions/PermissionsRouter.js
+++ b/client/views/admin/permissions/PermissionsRouter.js
@@ -7,10 +7,11 @@ import { usePermission } from '../../../contexts/AuthorizationContext';
 import NotAuthorizedPage from '../../../components/NotAuthorizedPage';
 
 const PermissionsRouter = () => {
-	const canViewPermission = usePermission('access-setting-permissions');
+	const canAccessSettingPermission = usePermission('access-setting-permissions');
+	const canViewPermission = usePermission('access-permissions');
 	const context = useRouteParameter('context');
 
-	if (!canViewPermission) {
+	if (!canViewPermission && !canAccessSettingPermission) {
 		return <NotAuthorizedPage />;
 	}
 

--- a/client/views/admin/permissions/PermissionsRouter.js
+++ b/client/views/admin/permissions/PermissionsRouter.js
@@ -3,9 +3,17 @@ import React from 'react';
 import { useRouteParameter } from '../../../contexts/RouterContext';
 import UsersInRole from './UsersInRole';
 import PermissionsTable from './PermissionsTable';
+import { usePermission } from '../../../contexts/AuthorizationContext';
+import NotAuthorizedPage from '../../../components/NotAuthorizedPage';
 
 const PermissionsRouter = () => {
+	const canViewPermission = usePermission('access-setting-permissions');
 	const context = useRouteParameter('context');
+
+	if (!canViewPermission) {
+		return <NotAuthorizedPage />;
+	}
+
 	if (context === 'users-in-role') {
 		return <UsersInRole />;
 	}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

  - [x] I have read the Contributing Guide -https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - [x] I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - [x] Lint and unit tests pass locally with my changes
  - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
  - [ ] I have added necessary documentation (if applicable)
  - [ ] Any dependent changes have been merged and published in downstream modules
 
## Proposed changes (including videos or screenshots)
Added a check using the 'access-setting-permissions' to prevent non-authorized users to access the permissions page. This should not be done using 'access-permissions' because it changes one's ability to **modify the permissions** instead of just **accessing the permissions page**. The labels for the settings are swapped.

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Closes #20400 

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
The labels for both the settings are actually swapped. This should be changed.
![Screenshot from 2021-01-26 22-01-35](https://user-images.githubusercontent.com/54909147/105874202-566bec00-6022-11eb-9ece-bad3f7afb1ee.png)

If one hovers over the setting, the actual function performed by that setting can be viewed.
![Screenshot from 2021-01-26 22-04-35](https://user-images.githubusercontent.com/54909147/105874396-83b89a00-6022-11eb-8e9b-c2d512e6f8ef.png)
This says "Access permissions screen", but it actually toggles the ability to **modify the permissions**, as shown in the tooltip.

![Screenshot from 2021-01-26 22-06-05](https://user-images.githubusercontent.com/54909147/105874559-b82c5600-6022-11eb-9ed6-00868911679c.png)
This says "Modify settings-based permissions", but it actually toggles the ability to **access permissions page**, as shown in the tooltip.

I have verified this. With the settings below and the changes I made, random user can access the permissions page but not change it.
![Screenshot from 2021-01-26 22-01-47](https://user-images.githubusercontent.com/54909147/105874783-02add280-6023-11eb-8d55-c512e758d313.png)

The labels should be swapped.