### PR TITLE
[FIX] Starred/Pinned messages menu doesn't disappear on clicking outside/ on options

### DIFF
--- a/app/message-pin/client/views/pinnedMessages.js
+++ b/app/message-pin/client/views/pinnedMessages.js
@@ -11,8 +11,6 @@ import { getCommonRoomEvents } from '../../../ui/client/views/app/lib/getCommonR
 
 const LIMIT_DEFAULT = 50;
 
-Template.pinnedMessages.events(getCommonRoomEvents());
-
 Template.pinnedMessages.helpers({
 	hasMessages() {
 		return Template.instance().messages.find().count();

--- a/app/message-star/client/views/starredMessages.js
+++ b/app/message-star/client/views/starredMessages.js
@@ -12,7 +12,6 @@ import { getCommonRoomEvents } from '../../../ui/client/views/app/lib/getCommonR
 
 const LIMIT_DEFAULT = 50;
 
-Template.starredMessages.events(getCommonRoomEvents());
 Template.starredMessages.helpers({
 	hasMessages() {
 		return Template.instance().messages.find().count();


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
The issue was because of two option divs rendering as we are calling getCommonRoomEvents twice in both starred and pinned messages.
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
This PR closes #20503

## Now
https://user-images.githubusercontent.com/64399555/106279183-0bd8b280-6262-11eb-9b13-a7b4ada3c575.mp4

