### PR TITLE
[FIX] Room Header - UserStatusText to be displayed in Direct Chat

### DIFF
--- a/client/views/room/Header/Header.js
+++ b/client/views/room/Header/Header.js
@@ -52,7 +52,7 @@ const RoomHeader = ({ room }) => {
 	const liveOtherUserStatusText = useUserData(otherUserQuery?.userId)?.statusText;
 
 	// if the other is offline, then liveOtherUserStatusText is undefined
-	const { value: data } = useEndpointData('users.info', otherUserQuery);
+	const { value: data } = useEndpointData('users.info', liveOtherUserStatusText === undefined ? otherUserQuery : null);
 
 	const roomTopic = liveOtherUserStatusText || data?.user?.statusText || room.topic;
 

--- a/client/views/room/Header/Header.js
+++ b/client/views/room/Header/Header.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 import { useMutableCallback } from '@rocket.chat/fuselage-hooks';
 import { ActionButton } from '@rocket.chat/fuselage';
@@ -14,6 +14,9 @@ import { useLayout } from '../../../contexts/LayoutContext';
 import Burger from './Burger';
 import { useTranslation } from '../../../contexts/TranslationContext';
 import MarkdownText from '../../../components/MarkdownText';
+import { useUser } from '../../../contexts/UserContext';
+import { useUserData } from '../../../hooks/useUserData';
+import { useEndpointData } from '../../../hooks/useEndpointData';
 
 export default React.memo(({ room }) => {
 	const { isEmbedded, showTopNavbarEmbeddedLayout } = useLayout();
@@ -34,6 +37,25 @@ const BackToRoom = React.memo(({ small, prid }) => {
 
 const RoomHeader = ({ room }) => {
 	const icon = useRoomIcon(room);
+
+	const user = useUser();
+
+	const otherUserQuery = useMemo(() => {
+		// check if room is direct message with 2 members
+		if (room.t === 'd' && room.uids?.length === 2) {
+			const userId = room.uids.find((uid) => uid !== user._id);
+			return { userId };
+		}
+		return null;
+	}, [room, user]);
+
+	const liveOtherUserStatusText = useUserData(otherUserQuery?.userId)?.statusText;
+
+	// if the other is offline, then liveOtherUserStatusText is undefined
+	const { value: data } = useEndpointData('users.info', otherUserQuery);
+
+	const roomTopic = liveOtherUserStatusText || data?.user?.statusText || room.topic;
+
 	const { isMobile } = useLayout();
 	const avatar = <RoomAvatar room={room}/>;
 	return <Header>
@@ -51,7 +73,7 @@ const RoomHeader = ({ room }) => {
 				<Translate room={room} />
 			</Header.Content.Row>
 			<Header.Content.Row>
-				<Header.Subtitle>{room.topic && <MarkdownText withRichContent={false} content={room.topic}/>}</Header.Subtitle>
+				<Header.Subtitle>{roomTopic && <MarkdownText withRichContent={false} content={roomTopic}/>}</Header.Subtitle>
 			</Header.Content.Row>
 		</Header.Content>
 		<Header.ToolBox>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

In a **2-person direct message**, the status of the other user could not be seen in the Header.
It has been fixed by fetching the other user's status-text in a 2-person direct message room.

https://user-images.githubusercontent.com/55396651/106849155-35696200-66d8-11eb-803a-1d18d0153ea1.mp4


<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

Closes #20197 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

Same as mentioned in #20197 

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

This Pull Request introduces the same feature as in #20257 , but with lesser changes.
As Pull Request #20584 introduces the new `useUserData` hook it was possible to get the *live user status text* in a single file change.
