### PR TITLE
[FIX] Channel name of messages in global search

### DIFF
--- a/app/ui-message/client/message.js
+++ b/app/ui-message/client/message.js
@@ -384,9 +384,8 @@ Template.message.helpers({
 		return this.msg.className;
 	},
 	channelName() {
-		const { subscription } = this;
-		// const subscription = Subscriptions.findOne({ rid: this.rid });
-		return subscription && subscription.name;
+		const { msg } = this;
+		return msg.r.name;
 	},
 	roomIcon() {
 		const { room } = this;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

On searching for a message in global search the name of the current channel was being shown even if the message belonged to different channels.

### Initially

![Screenshot from 2021-02-04 12-01-59](https://user-images.githubusercontent.com/28918901/106855231-9a29ba00-66e2-11eb-87ec-1c68de36c0bf.png)

### Now

![Screenshot from 2021-02-04 12-03-08](https://user-images.githubusercontent.com/28918901/106855253-a281f500-66e2-11eb-85a5-3d508ac0afdb.png)

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

Fixes #20574 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Enable Global Search (under Settings > Search)
2. Go back to the UI, and select a room
3. Search for a string that is located in a room other than the current room.
