### PR TITLE
[FIX] Use full width for Message Fields Attachments

### DIFF
--- a/client/components/Message/Attachments/Attachment.tsx
+++ b/client/components/Message/Attachments/Attachment.tsx
@@ -3,7 +3,6 @@ import { ActionButton, Box, BoxProps, ButtonProps, Avatar } from '@rocket.chat/f
 
 import { useFormatMemorySize } from '../../../hooks/useFormatMemorySize';
 import Image, { ImageProps } from './components/Image';
-import { useAttachmentDimensions } from './context/AttachmentContext';
 import { useTranslation } from '../../../contexts/TranslationContext';
 
 export type AttachmentPropsBase = {
@@ -68,10 +67,8 @@ export const Attachment: FC<BoxProps> & {
 	Thumb: FC<{ url: string }>;
 
 	Download: FC<ButtonProps & { href: string }>;
-} = (props) => {
-	const { width } = useAttachmentDimensions();
-	return <Box rcx-message-attachment mb='x4' maxWidth={width} width='full' display='flex' overflow='hidden' flexDirection='column' {...props}/>;
-};
+} = (props) => <Box rcx-message-attachment mb='x4' maxWidth='full' width='full' display='flex' overflow='hidden' flexDirection='column' {...props}/>;
+
 
 Attachment.Image = Image;
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
In Rocket.Chat 3.10, the "fields" attachments used the full width. Like here: 
![3 10 5](https://user-images.githubusercontent.com/1096435/107205604-585c8480-69fe-11eb-99f2-1af72388a743.png)

In Rocket.Chat 3.11, it doesn't use the full width (maxWidth seems to be limited at 480 px) which leads to large blocks of lost place:
![3 11 0 default](https://user-images.githubusercontent.com/1096435/107205738-7aee9d80-69fe-11eb-8a62-5086352ac408.png)

This PR fixes this by using the whole width again:
![3 11 0 full width](https://user-images.githubusercontent.com/1096435/107205798-89d55000-69fe-11eb-8a1b-e9b80b8a3712.png)
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->


## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Send a message with a field attachment via WebHook and notice the lost place.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
