### PR TITLE
[FIX] Increasing unread counter twice for new threads in DMs or with mentions

### DIFF
--- a/app/lib/server/lib/notifyUsersOnMessage.js
+++ b/app/lib/server/lib/notifyUsersOnMessage.js
@@ -92,7 +92,8 @@ export function updateUsersSubscriptions(message, room) {
 		}
 
 		// this shouldn't run only if has group mentions because it will already exclude mentioned users from the query
-		if (!toAll && !toHere && unreadCount === 'all_messages') {
+		// don't notify subscription if the message is a thread message
+		if (!toAll && !toHere && unreadCount === 'all_messages' && !message.tmid) {
 			Subscriptions.incUnreadForRoomIdExcludingUserIds(room._id, [...userIds, message.u._id]);
 		}
 	}

--- a/app/lib/server/lib/notifyUsersOnMessage.js
+++ b/app/lib/server/lib/notifyUsersOnMessage.js
@@ -69,7 +69,8 @@ const getUserIdsFromHighlights = (rid, message) => {
 };
 
 export function updateUsersSubscriptions(message, room) {
-	if (room != null) {
+	// Don't increase unread counter on thread messages
+	if (room != null && !message.tmid) {
 		const {
 			toAll,
 			toHere,
@@ -92,8 +93,7 @@ export function updateUsersSubscriptions(message, room) {
 		}
 
 		// this shouldn't run only if has group mentions because it will already exclude mentioned users from the query
-		// don't notify subscription if the message is a thread message
-		if (!toAll && !toHere && unreadCount === 'all_messages' && !message.tmid) {
+		if (!toAll && !toHere && unreadCount === 'all_messages') {
 			Subscriptions.incUnreadForRoomIdExcludingUserIds(room._id, [...userIds, message.u._id]);
 		}
 	}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
- Unread messages count won't be incremented when the message sent is on a thread (thread count is treated different)

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
- No open issue. 
- Issue description: when a user answers a direct message by answering in a thread, the `unread` counter next to user's name will mark 2 instead of 1.

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Start a direct conversation with another person
- After the first message from the other one, instead of answering to the main conversation, write your reply in a thread\
- The other person will see a badge of `2` unread messages instead of `1` (since we sent just one message)

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
