### PR TITLE
[NEW] Show "New Messages" Button in RoomList

### DIFF
--- a/client/sidebar/RoomList.js
+++ b/client/sidebar/RoomList.js
@@ -114,7 +114,7 @@ export default () => {
 
 	const roomsList = useRoomList();
 
-	UnreadCounter(roomsList)
+	console.log('the room list is ',roomsList)
 
 	const itemData = createItemData(extended, t, sideBarItemTemplate, avatarTemplate, openedRoom, sidebarViewMode, isAnonymous);
 
@@ -125,8 +125,12 @@ export default () => {
 		listRef.current?.resetAfterIndex(0);
 	}, [sidebarViewMode]);
 
+	const virtuosoRef = useRef(null);
+
 	return <Box h='full' w='full' ref={ref}>
+		<UnreadCounter roomsList={roomsList} t={t} virtuosoRef={virtuosoRef}/>
 		<Virtuoso
+			ref={virtuosoRef}
 			totalCount={roomsList.length}
 			data={roomsList}
 			components={{ Scroller: ScrollerWithCustomProps }}
@@ -228,8 +232,3 @@ export const SideBarItemTemplateWithData = React.memo(function SideBarItemTempla
 
 	return true;
 });
-
-/**
- * implementation - shows `2 new unread rooms`
- * @param {[]} roomList 
- * */

--- a/client/sidebar/RoomList.js
+++ b/client/sidebar/RoomList.js
@@ -20,6 +20,7 @@ import { useRoomIcon } from '../hooks/useRoomIcon';
 import { useSidebarPaletteColor } from './hooks/useSidebarPaletteColor';
 import { escapeHTML } from '../../lib/escapeHTML';
 import ScrollableContentWrapper from '../components/ScrollableContentWrapper';
+import UnreadCounter from './components/UnreadCounter'
 
 const sections = {
 	Omnichannel,
@@ -112,6 +113,9 @@ export default () => {
 	const t = useTranslation();
 
 	const roomsList = useRoomList();
+
+	UnreadCounter(roomsList)
+
 	const itemData = createItemData(extended, t, sideBarItemTemplate, avatarTemplate, openedRoom, sidebarViewMode, isAnonymous);
 
 	usePreventDefault(ref);
@@ -224,3 +228,8 @@ export const SideBarItemTemplateWithData = React.memo(function SideBarItemTempla
 
 	return true;
 });
+
+/**
+ * implementation - shows `2 new unread rooms`
+ * @param {[]} roomList 
+ * */

--- a/client/sidebar/RoomList.js
+++ b/client/sidebar/RoomList.js
@@ -20,7 +20,7 @@ import { useRoomIcon } from '../hooks/useRoomIcon';
 import { useSidebarPaletteColor } from './hooks/useSidebarPaletteColor';
 import { escapeHTML } from '../../lib/escapeHTML';
 import ScrollableContentWrapper from '../components/ScrollableContentWrapper';
-import UnreadCounter from './components/UnreadCounter'
+import UnreadCounter from './components/UnreadCounter';
 
 const sections = {
 	Omnichannel,
@@ -113,9 +113,6 @@ export default () => {
 	const t = useTranslation();
 
 	const roomsList = useRoomList();
-
-	console.log('the room list is ',roomsList)
-
 	const itemData = createItemData(extended, t, sideBarItemTemplate, avatarTemplate, openedRoom, sidebarViewMode, isAnonymous);
 
 	usePreventDefault(ref);

--- a/client/sidebar/components/UnreadCounter.tsx
+++ b/client/sidebar/components/UnreadCounter.tsx
@@ -1,0 +1,45 @@
+import React, { FC } from "react";
+import { ISubscription } from "../../../definition/ISubscription";
+
+/**
+ * show the unread counter as a seperate component implementation
+ * - *2 new unread **private/public** rooms*
+ * - *4 new mentions from 3 rooms*
+ * - *5 new messages from 4 direct chats*
+ * @param roomList past the roomList from the useRoomList hook
+ */
+const UnreadCounter: FC<ISubscription[]> = (roomList) => {
+  let userMentions: number = 0;
+  let directNewMessages: number = 0;
+  let unreadDirectRooms: number = 0;
+  let unreadPublicRooms: number = 0;
+  let unreadPrivateRooms: number = 0;
+
+  roomList.forEach((room) => {
+    if (!((room.alert || room.unread) && !room.hideUnreadStatus)) {
+      return;
+    }
+
+    if (room.t === "c") {
+      unreadPublicRooms++;
+    }
+
+    if (room.t === "p") {
+      unreadPrivateRooms++;
+    }
+
+    if (room.t === "d") {
+      unreadDirectRooms++;
+      directNewMessages += room.unread;
+    }
+
+    userMentions += room.userMentions;
+    
+  });
+
+  console.log('you have ',userMentions,directNewMessages,unreadDirectRooms,unreadPublicRooms,unreadPrivateRooms)
+
+  return <div>awesome</div>;
+};
+
+export default UnreadCounter;

--- a/client/sidebar/components/UnreadCounter.tsx
+++ b/client/sidebar/components/UnreadCounter.tsx
@@ -1,43 +1,39 @@
-import React, { FC, MutableRefObject } from "react";
-import { Box, Button } from "@rocket.chat/fuselage";
+import React, { FC, MutableRefObject } from 'react';
+import { Box, Button } from '@rocket.chat/fuselage';
 
-import { ISubscription } from "../../../definition/ISubscription";
-import { TranslationContextValue } from "../../contexts/TranslationContext";
+import { ISubscription } from '../../../definition/ISubscription';
+import { TranslationContextValue } from '../../contexts/TranslationContext';
 
-/**
- * show the unread counter as a seperate component implementation
- * - ***New messages***
- * - ~*2 new unread **private/public** rooms*~
- * - ~*4 new mentions from 3 rooms*~
- * - ~*5 new messages from 4 direct chats*~
- * @param roomsList past the roomsList from the useRoomList hook
- */
 const UnreadCounter: FC<{
-  roomsList: ISubscription[] | undefined;
-  t: TranslationContextValue["translate"];
-  virtuosoRef: MutableRefObject<any>;
+	roomsList: ISubscription[] | undefined;
+	t: TranslationContextValue['translate'];
+	virtuosoRef: MutableRefObject<any>;
 }> = ({ roomsList, t, virtuosoRef }) => {
-  if (!roomsList || !Array.isArray(roomsList)) return null;
+	if (!roomsList || !Array.isArray(roomsList)) {
+		return null;
+	}
 
-  const hasUnread: boolean = roomsList.some(
-    (room) => (room.alert || room.unread) && !room.hideUnreadStatus
-  );
+	const hasUnread: boolean = roomsList.some(
+		(room) => (room.alert || room.unread) && !room.hideUnreadStatus,
+	);
 
-  if (!hasUnread) return null;
+	if (!hasUnread) {
+		return null;
+	}
 
-  return (
-    <Box textAlign="center" fontStyle="italic">
-      <Button
-        nude
-        info
-        onClick={() =>
-          virtuosoRef.current.scrollToIndex({ index: 0, behavior: "smooth" })
-        }
-      >
-        {t("New_messages")}
-      </Button>
-    </Box>
-  );
+	return (
+		<Box textAlign='center' fontStyle='italic'>
+			<Button
+				info
+				nude
+				onClick={(): void =>
+          virtuosoRef.current?.scrollToIndex({ index: 0, behavior: 'smooth' })
+				}
+			>
+				{t('New_messages')}
+			</Button>
+		</Box>
+	);
 };
 
 export default UnreadCounter;

--- a/client/sidebar/components/UnreadCounter.tsx
+++ b/client/sidebar/components/UnreadCounter.tsx
@@ -1,45 +1,43 @@
-import React, { FC } from "react";
+import React, { FC, MutableRefObject } from "react";
+import { Box, Button } from "@rocket.chat/fuselage";
+
 import { ISubscription } from "../../../definition/ISubscription";
+import { TranslationContextValue } from "../../contexts/TranslationContext";
 
 /**
  * show the unread counter as a seperate component implementation
- * - *2 new unread **private/public** rooms*
- * - *4 new mentions from 3 rooms*
- * - *5 new messages from 4 direct chats*
- * @param roomList past the roomList from the useRoomList hook
+ * - ***New messages***
+ * - ~*2 new unread **private/public** rooms*~
+ * - ~*4 new mentions from 3 rooms*~
+ * - ~*5 new messages from 4 direct chats*~
+ * @param roomsList past the roomsList from the useRoomList hook
  */
-const UnreadCounter: FC<ISubscription[]> = (roomList) => {
-  let userMentions: number = 0;
-  let directNewMessages: number = 0;
-  let unreadDirectRooms: number = 0;
-  let unreadPublicRooms: number = 0;
-  let unreadPrivateRooms: number = 0;
+const UnreadCounter: FC<{
+  roomsList: ISubscription[] | undefined;
+  t: TranslationContextValue["translate"];
+  virtuosoRef: MutableRefObject<any>;
+}> = ({ roomsList, t, virtuosoRef }) => {
+  if (!roomsList || !Array.isArray(roomsList)) return null;
 
-  roomList.forEach((room) => {
-    if (!((room.alert || room.unread) && !room.hideUnreadStatus)) {
-      return;
-    }
+  const hasUnread: boolean = roomsList.some(
+    (room) => (room.alert || room.unread) && !room.hideUnreadStatus
+  );
 
-    if (room.t === "c") {
-      unreadPublicRooms++;
-    }
+  if (!hasUnread) return null;
 
-    if (room.t === "p") {
-      unreadPrivateRooms++;
-    }
-
-    if (room.t === "d") {
-      unreadDirectRooms++;
-      directNewMessages += room.unread;
-    }
-
-    userMentions += room.userMentions;
-    
-  });
-
-  console.log('you have ',userMentions,directNewMessages,unreadDirectRooms,unreadPublicRooms,unreadPrivateRooms)
-
-  return <div>awesome</div>;
+  return (
+    <Box textAlign="center" fontStyle="italic">
+      <Button
+        nude
+        info
+        onClick={() =>
+          virtuosoRef.current.scrollToIndex({ index: 0, behavior: "smooth" })
+        }
+      >
+        {t("New_messages")}
+      </Button>
+    </Box>
+  );
 };
 
 export default UnreadCounter;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

There was no indication that there were unread rooms once the user scrolled to the middle/bottom of the rooms list.
This fixes it by adding a new *New Messages* indication in the top of the RoomsList. User can click it to go the the top of the list instantly.

https://user-images.githubusercontent.com/55396651/107561352-709df080-6c04-11eb-96fe-d463918a0dd7.mp4

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

Closes #19573 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

As mentioned in #19573 

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
