### PR TITLE
Doc: Update URLs in GitHub Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,9 +6,9 @@ about: Create a report to help us improve
 
 <!-- 
 
-Please see our guide for opening issues: https://rocket.chat/docs/contributing/reporting-issues
+Please see our guide for opening issues: https://docs.rocket.chat/contributors/contributing/reporting-issues
 
-If you have questions or are looking for help/support please see: https://rocket.chat/docs/getting-support
+If you have questions or are looking for help/support please see: https://docs.rocket.chat/getting-support
 
 If you are experiencing a bug please search our issues to be sure it is not already present: https://github.com/RocketChat/Rocket.Chat/issues
 


### PR DESCRIPTION
The URLs in the GitHub Issue Template were outdated and sent users to a generic start page.

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->
