### PR TITLE
Exclude user's own password from /me endpoint

### DIFF
--- a/app/api/server/v1/misc.js
+++ b/app/api/server/v1/misc.js
@@ -49,7 +49,8 @@ API.v1.addRoute('info', { authRequired: false }, {
 
 API.v1.addRoute('me', { authRequired: true }, {
 	get() {
-		return API.v1.success(this.getUserInfo(Users.findOneById(this.userId, { fields: getDefaultUserFields() })));
+		const { 'services.password.bcrypt': password, ...fields } = getDefaultUserFields();
+		return API.v1.success(this.getUserInfo(Users.findOneById(this.userId, { fields })));
 	},
 });
 

--- a/tests/end-to-end/api/00-miscellaneous.js
+++ b/tests/end-to-end/api/00-miscellaneous.js
@@ -155,6 +155,7 @@ describe('miscellaneous', function() {
 				expect(res.body).to.have.nested.property('emails[0].address', adminEmail);
 				expect(res.body).to.have.nested.property('settings.preferences').and.to.be.an('object');
 				expect(res.body.settings.preferences).to.have.all.keys(allUserPreferencesKeys);
+				expect(res.body.services).to.not.have.property('password');
 			})
 			.end(done);
 	});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Login as X user
2. Make a GET request to `/api/v1/me`
3. In the key `services.password` you should see a property `bcrypt` with the hashed password of the current user
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
- This only affects current user
- User is not able to get info from other users
- Unit test updated to check `passowrd` key is missing. 