### PR TITLE
[FIX] Added hideUnreadStatus check before showing unread messages on roomList

### DIFF
--- a/client/sidebar/RoomList.js
+++ b/client/sidebar/RoomList.js
@@ -176,7 +176,8 @@ export const SideBarItemTemplateWithData = React.memo(function SideBarItemTempla
 
 	const subtitle = message ? <span className='message-body--unstyled' dangerouslySetInnerHTML={{ __html: message }}/> : null;
 	const variant = ((userMentions || tunreadUser.length) && 'danger') || (threadUnread && 'primary') || (groupMentions && 'warning') || 'ghost';
-	const badges = unread > 0 || threadUnread ? <Badge style={{ flexShrink: 0 }} variant={ variant }>{unread + tunread?.length}</Badge> : null;
+	const isUnread = unread > 0 || threadUnread;
+	const badges = !hideUnreadStatus && isUnread ? <Badge style={{ flexShrink: 0 }} variant={ variant }>{unread + tunread?.length}</Badge> : null;
 
 	return <SideBarItemTemplate
 		is='a'


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->
  - [x] I have read the Contributing Guide 
  - [x] I have signed the CLA 
  - [x] Lint and unit tests pass locally with my changes
  - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
  - [ ] I have added necessary documentation (if applicable)
  - [ ] Any dependent changes have been merged and published in downstream modules

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
Added hide unread counter check, if the show unread messages is turned off, now unread messages badge won't be shown to user.
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
fixes #20866 
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
##Before 
Even after turning off unread counter, it showed unread counter on room list.
![unread status before](https://user-images.githubusercontent.com/58601732/108758270-e8f3a280-7570-11eb-9282-8f2bf22a3b70.gif)


##After
Now added check before showing unread messages badge. If option to show counter is turned off, unread badge won't be shown.
![unread status after](https://user-images.githubusercontent.com/58601732/108758353-0294ea00-7571-11eb-8a89-edfade425ce6.gif)
