### PR TITLE
[FIX] Iframe flags for audio and video on the BigBlueButton integration

### DIFF
--- a/app/videobridge/client/views/bbbLiveView.html
+++ b/app/videobridge/client/views/bbbLiveView.html
@@ -1,3 +1,3 @@
 <template name="bbbLiveView">
-	<iframe allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true"  allow="geolocation; microphone; camera; display-capture" src="{{source}}" width="380" height="400" frameborder="0"></iframe>
+	<iframe allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true"  allow="microphone *; camera *; display-capture *" src="{{source}}" width="380" height="400" frameborder="0"></iframe>
 </template>


### PR DESCRIPTION
The current flags prevent audio and video to be shared in a session.