### PR TITLE
[IMPROVE] Show Online Users First in Admin User's Table

### DIFF
--- a/client/views/admin/users/UsersTable.js
+++ b/client/views/admin/users/UsersTable.js
@@ -65,7 +65,7 @@ export function UsersTable() {
 	const t = useTranslation();
 
 	const [params, setParams] = useState({ text: '', current: 0, itemsPerPage: 25 });
-	const [sort, setSort] = useState([['status','desc'],['name', 'asc'], ['usernames', 'asc'],]);
+	const [sort, setSort] = useState([['status', 'desc'], ['name', 'asc'], ['usernames', 'asc']]);
 
 	const debouncedParams = useDebouncedValue(params, 500);
 	const debouncedSort = useDebouncedValue(sort, 500);

--- a/client/views/admin/users/UsersTable.js
+++ b/client/views/admin/users/UsersTable.js
@@ -65,7 +65,7 @@ export function UsersTable() {
 	const t = useTranslation();
 
 	const [params, setParams] = useState({ text: '', current: 0, itemsPerPage: 25 });
-	const [sort, setSort] = useState([['name', 'asc'], ['usernames', 'asc']]);
+	const [sort, setSort] = useState([['status','desc'],['name', 'asc'], ['usernames', 'asc'],]);
 
 	const debouncedParams = useDebouncedValue(params, 500);
 	const debouncedSort = useDebouncedValue(sort, 500);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

Show users **with status online first** in the user's table in the Admin Panel by default.

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Go to `/admin/users`.
2. The offline and the online users are not sorted by default.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

![show_online_users_first](https://user-images.githubusercontent.com/55396651/109824796-26d28400-7c5f-11eb-8a6a-f3d4967fdce6.gif)
