### PR TITLE
[FIX] Notification Preferences when user is not joined

### DIFF
--- a/client/views/room/contextualBar/NotificationPreferences/NotificationPreferences.js
+++ b/client/views/room/contextualBar/NotificationPreferences/NotificationPreferences.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, ButtonGroup, FieldGroup, Icon } from '@rocket.chat/fuselage';
+import { Button, ButtonGroup, FieldGroup, Icon, Box } from '@rocket.chat/fuselage';
 import { useMutableCallback } from '@rocket.chat/fuselage-hooks';
 
 import { useForm } from '../../../../hooks/useForm';
@@ -21,8 +21,21 @@ export const NotificationPreferences = ({
 	handlePlaySound,
 	handleOptions,
 	handleSaveButton,
+	hasSubscription,
 }) => {
 	const t = useTranslation();
+	if (!hasSubscription) {
+		return <>
+			<VerticalBar.Header>
+				<VerticalBar.Icon name='bell'/>
+				<VerticalBar.Text>{t('Notifications_Preferences')}</VerticalBar.Text>
+				{handleClose && <VerticalBar.Close onClick={handleClose}/>}
+			</VerticalBar.Header>
+			<VerticalBar.ScrollableContent>
+				<Box>{t('error-user-not-in-room')}</Box>
+			</VerticalBar.ScrollableContent>
+		</>;
+	}
 	return <>
 		<VerticalBar.Header>
 			<VerticalBar.Icon name='bell'/>
@@ -62,13 +75,20 @@ export const NotificationPreferences = ({
 
 export default React.memo(({ rid }) => {
 	const t = useTranslation();
+	const handleClose = useTabBarClose();
 
 	const subscription = useUserSubscription(rid);
+	if (!subscription) {
+		return (
+			<NotificationPreferences
+				hasSubscription={false}
+				handleClose={handleClose}
+			/>
+		);
+	}
 
 	const customSound = useCustomSound();
-	const handleClose = useTabBarClose();
 	const saveSettings = useEndpointActionExperimental('POST', 'rooms.saveNotification', t('Room_updated_successfully'));
-
 	const { values, handlers, hasUnsavedChanges, commit } = useForm(
 		{
 			turnOn: !subscription.disableNotifications,
@@ -123,7 +143,6 @@ export default React.memo(({ rid }) => {
 		commit();
 	});
 
-
 	return (
 		<NotificationPreferences
 			handleClose={handleClose}
@@ -133,6 +152,7 @@ export default React.memo(({ rid }) => {
 			handlePlaySound={handlePlaySound}
 			handleOptions={handleOptions}
 			handleSaveButton={handleSaveButton}
+			hasSubscription={true}
 		/>
 	);
 });


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
I've added a BOX element for Notification Preferences tab which will display 'error-user-not-in-room' when someone opens the tab before joining the channel/discussion
![image](https://user-images.githubusercontent.com/24871407/111141406-89097e00-85a9-11eb-845d-4d613c94c441.png)

If the user is joined, it works as before
![image](https://user-images.githubusercontent.com/24871407/111141476-9cb4e480-85a9-11eb-86b9-56351ea5fb4d.png)
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
fixes: #21118 (actual reproduce steps are here) , #21102

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Notification Preferences Tab screen will be affected for users accessing it without joining.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
