### PR TITLE
[FIX] Wrong license seats number administration info panel

### DIFF
--- a/client/views/admin/info/LicenseCard.js
+++ b/client/views/admin/info/LicenseCard.js
@@ -74,7 +74,7 @@ const LicenseCard = ({ statistics, isLoading }) => {
 								? <Skeleton variant='rect' width='x112' height='x112'/>
 								: <UsagePieGraph
 									label={t('Users')}
-									used={statistics?.totalUsers}
+									used={statistics?.activeUsers}
 									total={maxActiveUsers}
 									size={112}
 									isLoading={isLoading}

--- a/ee/app/license/server/license.ts
+++ b/ee/app/license/server/license.ts
@@ -165,6 +165,7 @@ class LicenseClass {
 				}
 				if (!this._validateURL(license.url, this.url)) {
 					item.valid = false;
+					console.error(`#### License error: invalid url, licensed to ${ license.url }, used on ${ this.url }`);
 					this._invalidModules(license.modules);
 					return item;
 				}
@@ -172,12 +173,14 @@ class LicenseClass {
 
 			if (license.expiry && this._validateExpiration(license.expiry)) {
 				item.valid = false;
+				console.error(`#### License error: expired, valid until ${ license.expiry }`);
 				this._invalidModules(license.modules);
 				return item;
 			}
 
 			if (license.maxActiveUsers && !this._hasValidNumberOfActiveUsers(license.maxActiveUsers)) {
 				item.valid = false;
+				console.error(`#### License error: over seats, max allowed ${ license.maxActiveUsers }, current active users ${ Users.getActiveLocalUserCount() }`);
 				this._invalidModules(license.modules);
 				return item;
 			}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
The administration info panel was showing the *total of users* as the number counted for the usage of the license seats. Now it's showing the correct number that is *active users*. This was not affecting the license validation on the server-side, only causing confusion for the administrators to check how the usage was being counted.
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
