### PR TITLE
Regression: Add support to filter on `teams.listRooms` endpoint

### DIFF
--- a/app/api/server/v1/teams.ts
+++ b/app/api/server/v1/teams.ts
@@ -128,6 +128,7 @@ API.v1.addRoute('teams.listRooms', { authRequired: true }, {
 	get() {
 		const { teamId } = this.queryParams;
 		const { offset, count } = this.getPaginationItems();
+		const { query } = this.parseJsonQuery();
 
 		const allowPrivateTeam = hasPermission(this.userId, 'view-all-teams');
 
@@ -136,7 +137,7 @@ API.v1.addRoute('teams.listRooms', { authRequired: true }, {
 			getAllRooms = true;
 		}
 
-		const { records, total } = Promise.await(Team.listRooms(this.userId, teamId, getAllRooms, allowPrivateTeam, { offset, count }));
+		const { records, total } = Promise.await(Team.listRooms(this.userId, teamId, getAllRooms, allowPrivateTeam, { offset, count }, { query }));
 
 		return API.v1.success({
 			rooms: records,

--- a/app/models/server/raw/Rooms.js
+++ b/app/models/server/raw/Rooms.js
@@ -109,15 +109,16 @@ export class RoomsRaw extends BaseRaw {
 		return this.find(query, options);
 	}
 
-	findByTeamId(teamId, options = {}) {
-		const query = {
+	findByTeamId(teamId, options = {}, query = {}) {
+		const myQuery = {
 			teamId,
+			...query,
 			teamMain: {
 				$exists: false,
 			},
 		};
 
-		return this.find(query, options);
+		return this.find(myQuery, options);
 	}
 
 	findByTeamIdAndRoomsId(teamId, rids, options = {}) {

--- a/app/models/server/raw/Rooms.js
+++ b/app/models/server/raw/Rooms.js
@@ -111,8 +111,8 @@ export class RoomsRaw extends BaseRaw {
 
 	findByTeamId(teamId, options = {}, query = {}) {
 		const myQuery = {
-			teamId,
 			...query,
+			teamId,
 			teamMain: {
 				$exists: false,
 			},

--- a/server/sdk/types/ITeamService.ts
+++ b/server/sdk/types/ITeamService.ts
@@ -44,7 +44,7 @@ export interface ITeamService {
 	addRoom(uid: string, rid: string, teamId: string, isDefault: boolean): Promise<IRoom>;
 	addRooms(uid: string, rooms: Array<string>, teamId: string): Promise<Array<IRoom>>;
 	removeRoom(uid: string, rid: string, teamId: string, canRemoveAnyRoom: boolean): Promise<IRoom>;
-	listRooms(uid: string, teamId: string, getAllRooms: boolean, allowPrivateTeam: boolean, pagination: IPaginationOptions): Promise<IRecordsWithTotal<IRoom>>;
+	listRooms(uid: string, teamId: string, getAllRooms: boolean, allowPrivateTeam: boolean, pagination: IPaginationOptions, queryOptions: IQueryOptions<IRoom>): Promise<IRecordsWithTotal<IRoom>>;
 	listRoomsOfUser(uid: string, teamId: string, userId: string, allowPrivateTeam: boolean, pagination: IPaginationOptions): Promise<IRecordsWithTotal<IRoom>>;
 	updateRoom(uid: string, rid: string, isDefault: boolean, canUpdateAnyRoom: boolean): Promise<IRoom>;
 	list(uid: string, paginationOptions?: IPaginationOptions, queryOptions?: IQueryOptions<ITeam>): Promise<IRecordsWithTotal<ITeam>>;

--- a/server/services/team/service.ts
+++ b/server/services/team/service.ts
@@ -1,4 +1,4 @@
-import { Db, FindOneOptions } from 'mongodb';
+import { Db, FindOneOptions, FilterQuery } from 'mongodb';
 
 import { TeamRaw } from '../../../app/models/server/raw/Team';
 import { ITeam, ITeamMember, TEAM_TYPE, IRecordsWithTotal, IPaginationOptions, IQueryOptions, ITeamStats } from '../../../definition/ITeam';
@@ -383,7 +383,7 @@ export class TeamService extends ServiceClass implements ITeamService {
 		};
 	}
 
-	async listRooms(uid: string, teamId: string, getAllRooms: boolean, allowPrivateTeam: boolean, { offset: skip, count: limit }: IPaginationOptions = { offset: 0, count: 50 }): Promise<IRecordsWithTotal<IRoom>> {
+	async listRooms(uid: string, teamId: string, getAllRooms: boolean, allowPrivateTeam: boolean, { offset: skip, count: limit }: IPaginationOptions = { offset: 0, count: 50 }, { query }: IQueryOptions<IRoom>): Promise<IRecordsWithTotal<IRoom>> {
 		if (!teamId) {
 			throw new Error('missing-teamId');
 		}
@@ -396,13 +396,13 @@ export class TeamService extends ServiceClass implements ITeamService {
 			throw new Error('user-not-on-private-team');
 		}
 		if (getAllRooms) {
-			const teamRoomsCursor = this.RoomsModel.findByTeamId(teamId, { skip, limit });
+			const teamRoomsCursor = this.RoomsModel.findByTeamId(teamId, { skip, limit }, query as FilterQuery<IRoom>);
 			return {
 				total: await teamRoomsCursor.count(),
 				records: await teamRoomsCursor.toArray(),
 			};
 		}
-		const teamRooms = await this.RoomsModel.findByTeamId(teamId, { projection: { _id: 1, t: 1 } }).toArray();
+		const teamRooms = await this.RoomsModel.findByTeamId(teamId, { skip, limit, projection: { _id: 1, t: 1 } }, query as FilterQuery<IRoom>).toArray();
 		const privateTeamRoomIds = teamRooms.filter((room) => room.t === 'p').map((room) => room._id);
 		const publicTeamRoomIds = teamRooms.filter((room) => room.t === 'c').map((room) => room._id);
 

--- a/server/services/team/service.ts
+++ b/server/services/team/service.ts
@@ -1,4 +1,4 @@
-import { Db, FindOneOptions, FilterQuery } from 'mongodb';
+import { Db, FindOneOptions } from 'mongodb';
 
 import { TeamRaw } from '../../../app/models/server/raw/Team';
 import { ITeam, ITeamMember, TEAM_TYPE, IRecordsWithTotal, IPaginationOptions, IQueryOptions, ITeamStats } from '../../../definition/ITeam';
@@ -396,13 +396,13 @@ export class TeamService extends ServiceClass implements ITeamService {
 			throw new Error('user-not-on-private-team');
 		}
 		if (getAllRooms) {
-			const teamRoomsCursor = this.RoomsModel.findByTeamId(teamId, { skip, limit }, query as FilterQuery<IRoom>);
+			const teamRoomsCursor = this.RoomsModel.findByTeamId(teamId, { skip, limit }, query);
 			return {
 				total: await teamRoomsCursor.count(),
 				records: await teamRoomsCursor.toArray(),
 			};
 		}
-		const teamRooms = await this.RoomsModel.findByTeamId(teamId, { skip, limit, projection: { _id: 1, t: 1 } }, query as FilterQuery<IRoom>).toArray();
+		const teamRooms = await this.RoomsModel.findByTeamId(teamId, { skip, limit, projection: { _id: 1, t: 1 } }, query).toArray();
 		const privateTeamRoomIds = teamRooms.filter((room) => room.t === 'p').map((room) => room._id);
 		const publicTeamRoomIds = teamRooms.filter((room) => room.t === 'c').map((room) => room._id);
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
- Add support for queries (within the `query` parameter);
- Add support to pagination (`offset` and `count`) when an user doesn't have the permission to get all rooms.
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[Task - ClickUp](https://app.clickup.com/t/3z2qq8)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
**Example input (using cURL):**
```
curl -G 'http://localhost:3000/api/v1/teams.listRooms?teamId=60538ebf22ff2e119e52f086' \
  --data-urlencode 'query={"ts":{"$gt":{"$date":"2021-03-26T19:46:38.143Z"}}}' \
  -H 'X-Auth-Token: c3rQDH_Fpa7JHSgUrWvlpxwIi1AAu4qTnfAF4SFgWkB' \
  -H 'X-User-Id: dizcH9Edm8hC7ziDX' \
  -H 'Content-Type: application/json'
```

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
