### PR TITLE
Fix grammatical typo if only 1 message is pruned

### DIFF
--- a/client/views/room/contextualBar/PruneMessages/PruneMessages.js
+++ b/client/views/room/contextualBar/PruneMessages/PruneMessages.js
@@ -219,11 +219,11 @@ export default ({
 				throw new Error(t('No_messages_found_to_prune'));
 			}
 			if (result === 1) {
-				dispatchToastMessage({ type: 'success', message: `${ result } ${ t('message_pruned') }` });
+				dispatchToastMessage({ type: 'success', message: `${ result } ${ t('msg_pruned') }` });
 			} else {
 				dispatchToastMessage({ type: 'success', message: `${ result } ${ t('messages_pruned') }` });
 			}
-			
+
 			closeModal();
 			reset();
 		} catch (error) {

--- a/client/views/room/contextualBar/PruneMessages/PruneMessages.js
+++ b/client/views/room/contextualBar/PruneMessages/PruneMessages.js
@@ -218,8 +218,12 @@ export default ({
 			if (result < 1) {
 				throw new Error(t('No_messages_found_to_prune'));
 			}
-
-			dispatchToastMessage({ type: 'success', message: `${ result } ${ t('messages_pruned') }` });
+			if (result === 1) {
+				dispatchToastMessage({ type: 'success', message: `${ result } ${ t('message_pruned') }` });
+			} else {
+				dispatchToastMessage({ type: 'success', message: `${ result } ${ t('messages_pruned') }` });
+			}
+			
 			closeModal();
 			reset();
 		} catch (error) {

--- a/client/views/room/contextualBar/PruneMessages/PruneMessages.js
+++ b/client/views/room/contextualBar/PruneMessages/PruneMessages.js
@@ -219,7 +219,7 @@ export default ({
 				throw new Error(t('No_messages_found_to_prune'));
 			}
 			if (result === 1) {
-				dispatchToastMessage({ type: 'success', message: `${ result } ${ t('msg_pruned') }` });
+				dispatchToastMessage({ type: 'success', message: `${ result } ${ t('message_pruned') }` });
 			} else {
 				dispatchToastMessage({ type: 'success', message: `${ result } ${ t('messages_pruned') }` });
 			}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
Whenever only 1 message is pruned it says '1 messages pruned' instead of '1 message pruned' in the  toast message
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Try to prune only  1 message check the toast message

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
