### PR TITLE
Regression: invalid permission check.

### DIFF
--- a/app/api/server/v1/groups.js
+++ b/app/api/server/v1/groups.js
@@ -866,7 +866,7 @@ API.v1.addRoute('groups.convertToTeam', { authRequired: true }, {
 			return API.v1.failure('Private group not found');
 		}
 
-		if (!hasAllPermission(this.userId, ['create-team', 'edit-room'], room._id)) {
+		if (!hasAllPermission(this.userId, ['create-team', 'edit-room'], room.rid)) {
 			return API.v1.unauthorized();
 		}
 

--- a/app/api/server/v1/groups.js
+++ b/app/api/server/v1/groups.js
@@ -854,10 +854,6 @@ API.v1.addRoute('groups.convertToTeam', { authRequired: true }, {
 			return API.v1.failure('The parameter "roomId" or "roomName" is required');
 		}
 
-		if (!hasAllPermission(this.userId, ['create-team', 'edit-room'], roomId)) {
-			return API.v1.unauthorized();
-		}
-
 		const room = findPrivateGroupByIdOrName({
 			params: {
 				roomId,
@@ -868,6 +864,10 @@ API.v1.addRoute('groups.convertToTeam', { authRequired: true }, {
 
 		if (!room) {
 			return API.v1.failure('Private group not found');
+		}
+
+		if (!hasAllPermission(this.userId, ['create-team', 'edit-room'], room._id)) {
+			return API.v1.unauthorized();
 		}
 
 		const subscriptions = Subscriptions.findByRoomId(room.rid, {


### PR DESCRIPTION
The previous check didn't consider that the endpoint could also be called with a roomName instead of a roomId.