### PR TITLE
[FIX] Channel conversation area goes blank when browsing Members list

### DIFF
--- a/client/views/room/hooks/useUserInfoActions.js
+++ b/client/views/room/hooks/useUserInfoActions.js
@@ -214,9 +214,12 @@ export const useUserInfoActions = (user = {}, rid) => {
 		action: changeModeratorAction,
 	}, [changeModeratorAction, isModerator, roomCanSetModerator, t, userCanSetModerator]);
 
-	const ignoreUser = currentSubscription ? useMethod('ignoreUser') : () =>  { throw new Error("You must join the channel first") };
+	const ignoreUser = useMethod('ignoreUser');
 	const ignoreUserAction = useMutableCallback(async () => {
 		try {
+			if (!currentSubscription) {
+				throw new Error('You must join the channel first');
+			}
 			await ignoreUser({ rid, userId: uid, ignore: !isIgnored });
 			if (isIgnored) {
 				dispatchToastMessage({ type: 'success', message: t('User_has_been_unignored') });

--- a/client/views/room/hooks/useUserInfoActions.js
+++ b/client/views/room/hooks/useUserInfoActions.js
@@ -233,7 +233,7 @@ export const useUserInfoActions = (user = {}, rid) => {
 		action: ignoreUserAction,
 	}, [ignoreUserAction, isIgnored, ownUserId, roomCanIgnore, t, uid]);
 
-	const isUserBlocked = currentSubscription.blocker;
+	const isUserBlocked = currentSubscription?.blocker;
 	const toggleBlock = useMethod(isUserBlocked ? 'unblockUser' : 'blockUser');
 	const toggleBlockUserAction = useMutableCallback(async () => {
 		try {

--- a/client/views/room/hooks/useUserInfoActions.js
+++ b/client/views/room/hooks/useUserInfoActions.js
@@ -214,7 +214,7 @@ export const useUserInfoActions = (user = {}, rid) => {
 		action: changeModeratorAction,
 	}, [changeModeratorAction, isModerator, roomCanSetModerator, t, userCanSetModerator]);
 
-	const ignoreUser = useMethod('ignoreUser');
+	const ignoreUser = currentSubscription ? useMethod('ignoreUser') : () =>  { throw new Error("You must join the channel first") };
 	const ignoreUserAction = useMutableCallback(async () => {
 		try {
 			await ignoreUser({ rid, userId: uid, ignore: !isIgnored });


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
fixes #21364 where the channel conversation area goes blank when a user browses through the member list of an unjoined channel. Additionally this fixes the errors when someone tries to see the profile of an user in a channel he's not part of, allowing them to view the profile and improves the error Toast when ignoring an user in such channels.

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
#21364 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
