### PR TITLE
[FIX] LDAP bind to configured admin before fetching group entries 

### DIFF
--- a/app/ldap/server/ldap.js
+++ b/app/ldap/server/ldap.js
@@ -324,6 +324,7 @@ export default class LDAP {
 		if (!this.options.group_filter_enabled) {
 			return true;
 		}
+		this.bindIfNecessary();
 
 		const filter = ['(&'];
 
@@ -500,6 +501,7 @@ export default class LDAP {
 				}
 			}
 			logger.auth.info('Authenticated', dn);
+			this.disconnect();
 			return true;
 		} catch (error) {
 			logger.auth.info('Not authenticated', dn);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes 
<!-- CHANGELOG -->
Now using the configured admin LDAP user to search for groups instead of the logged in user's LDAP user (to avoid permission issues).

<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)
Closes #15621,  Closes #19461, Closes #15069, Closes #15909
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
* Connect to an OpenLDAP server using a Rocket.Chat install
* enable group and/or chat sync
* try to login 
* From the ldap log: (error 32 means in this case that the user is not allowed to search in that part of the tree)
> openldap        | 6068af91 conn=1065 op=0 BIND dn="cn=username,dc=ldap,dc=example,dc=org" mech=SIMPLE ssf=0
>  openldap        | 6068af91 conn=1065 op=1 SRCH base="dc=ldap,dc=example,dc=org" scope=2 deref=0 filter="(&(cn=possible-group)(uniqueMember=cn=username,dc=ldap,dc=example,dc=org))"
> openldap        | 6068af91 conn=1065 op=1 SEARCH RESULT tag=101 err=32 nentries=0 text=
* the login subsequently fails

## Further comments
Some LDAP implementations (such as OpenLDAP) do not allow read access by default. 
As building an ACL which allows just the right granularity of permissions for OpenLDAP is not trivial, switching back to the admin account to retrieve the required information seems like the correct behaviour.
(I've of course tested these changes in a local install and logging in using LDAP works again.)

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
