### PR TITLE
[Fix]Add custom sound form submits even without adding a file

### DIFF
--- a/client/views/admin/customSounds/AddCustomSound.js
+++ b/client/views/admin/customSounds/AddCustomSound.js
@@ -106,7 +106,7 @@ function AddCustomSound({ goToNew, close, onChange, ...props }) {
 						<Button mie='x4' onClick={close}>
 							{t('Cancel')}
 						</Button>
-						<Button primary onClick={handleSave} disabled={name === '' || typeof sound == 'undefined'}>
+						<Button primary onClick={handleSave} disabled={name === '' || typeof sound === 'undefined'}>
 							{t('Save')}
 						</Button>
 					</ButtonGroup>

--- a/client/views/admin/customSounds/AddCustomSound.js
+++ b/client/views/admin/customSounds/AddCustomSound.js
@@ -106,7 +106,11 @@ function AddCustomSound({ goToNew, close, onChange, ...props }) {
 						<Button mie='x4' onClick={close}>
 							{t('Cancel')}
 						</Button>
-						<Button primary onClick={handleSave} disabled={name === '' || typeof sound === 'undefined'}>
+						<Button
+							primary
+							onClick={handleSave}
+							disabled={name === '' || typeof sound === 'undefined'}
+						>
 							{t('Save')}
 						</Button>
 					</ButtonGroup>

--- a/client/views/admin/customSounds/AddCustomSound.js
+++ b/client/views/admin/customSounds/AddCustomSound.js
@@ -109,7 +109,7 @@ function AddCustomSound({ goToNew, close, onChange, ...props }) {
 						<Button
 							primary
 							onClick={handleSave}
-							disabled={name === '' || typeof sound === 'undefined'}
+							disabled={name.trim() === '' || typeof sound === 'undefined'}
 						>
 							{t('Save')}
 						</Button>

--- a/client/views/admin/customSounds/AddCustomSound.js
+++ b/client/views/admin/customSounds/AddCustomSound.js
@@ -106,7 +106,7 @@ function AddCustomSound({ goToNew, close, onChange, ...props }) {
 						<Button mie='x4' onClick={close}>
 							{t('Cancel')}
 						</Button>
-						<Button primary onClick={handleSave} disabled={name === ''}>
+						<Button primary onClick={handleSave} disabled={name === '' || typeof sound == 'undefined'}>
 							{t('Save')}
 						</Button>
 					</ButtonGroup>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

- [x] I have read the Contributing Guide
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules

## Proposed changes (including videos or screenshots)
Earlier the form for uploading a custom sound allowed submission even if a file isn't present. I've added a check for file , so that the submit button remains disabled unless both "name" and "file" is provided.

Previously
<img width="436" alt="Screenshot 2021-04-20 at 4 08 43 PM" src="https://user-images.githubusercontent.com/69837339/115382798-b8d42300-a1f2-11eb-9416-1a8bdd45ef1d.png">

Now
<img width="438" alt="Screenshot 2021-04-20 at 4 09 14 PM" src="https://user-images.githubusercontent.com/69837339/115382845-c5587b80-a1f2-11eb-96c4-b6b0e30e41fa.png">

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)
#21664
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
