### PR TITLE
[FIX] Multiple file export email queues on multiple clicks.

### DIFF
--- a/client/views/room/contextualBar/ExportMessages/FileExport.js
+++ b/client/views/room/contextualBar/ExportMessages/FileExport.js
@@ -5,9 +5,11 @@ import { useEndpoint } from '../../../../contexts/ServerContext';
 import { useToastMessageDispatch } from '../../../../contexts/ToastMessagesContext';
 import { useTranslation } from '../../../../contexts/TranslationContext';
 import { useForm } from '../../../../hooks/useForm';
+import { useTabBarClose } from '../../providers/ToolboxProvider';
 
 const FileExport = ({ onCancel, rid }) => {
 	const t = useTranslation();
+	const close = useTabBarClose();
 
 	const { values, handlers } = useForm({
 		dateFrom: '',
@@ -45,6 +47,8 @@ const FileExport = ({ onCancel, rid }) => {
 				type: 'success',
 				message: t('Your_email_has_been_queued_for_sending'),
 			});
+
+			close();
 		} catch (error) {
 			dispatchToastMessage({
 				type: 'error',


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

  - [x] I have read the Contributing Guide.
  - [x] I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - [x] Lint and unit tests pass locally with my changes
  - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
  - [ ] I have added necessary documentation (if applicable)
  - [ ] Any dependent changes have been merged and published in downstream modules

## Proposed changes (including videos or screenshots)
Before: The user can queue multiple export emails by clicking on `Export` (#21792 ). 
Now, once the email is successfully queued, the ContextualBar closes.

https://user-images.githubusercontent.com/53378650/115986487-0e7f4580-a5ce-11eb-8fda-ab27e76faf66.mp4


<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Closes #21792 

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
