### PR TITLE
[IMPROVE] "Add Custom Emoji" special characters check

### DIFF
--- a/client/views/admin/customEmoji/AddCustomEmoji.js
+++ b/client/views/admin/customEmoji/AddCustomEmoji.js
@@ -2,12 +2,14 @@ import { Box, Button, ButtonGroup, Margins, TextInput, Field, Icon } from '@rock
 import React, { useCallback, useState } from 'react';
 
 import VerticalBar from '../../../components/VerticalBar';
+import { useToastMessageDispatch } from '../../../contexts/ToastMessagesContext';
 import { useTranslation } from '../../../contexts/TranslationContext';
 import { useEndpointUpload } from '../../../hooks/useEndpointUpload';
 import { useFileInput } from '../../../hooks/useFileInput';
 
 function AddCustomEmoji({ close, onChange, ...props }) {
 	const t = useTranslation();
+	const dispatchToastMessage = useToastMessageDispatch();
 
 	const [name, setName] = useState('');
 	const [aliases, setAliases] = useState('');
@@ -30,14 +32,23 @@ function AddCustomEmoji({ close, onChange, ...props }) {
 
 	const handleSave = useCallback(async () => {
 		const formData = new FormData();
-		formData.append('emoji', emojiFile);
-		formData.append('name', name);
-		formData.append('aliases', aliases);
-		const result = await saveAction(formData);
 
-		if (result.success) {
-			onChange();
-			close();
+		const regExp = new RegExp('^[a-zA-Z0-9_]+$');
+		formData.append('emoji', emojiFile);
+
+		if (regExp.test(name) && regExp.test(aliases)) {
+			formData.append('name', name);
+			formData.append('aliases', aliases);
+			const result = await saveAction(formData);
+			if (result.success) {
+				onChange();
+				close();
+			}
+		} else {
+			dispatchToastMessage({
+				type: 'error',
+				message: t('You_Can_not_use_special_characters_in_custom_emoji'),
+			});
 		}
 	}, [emojiFile, name, aliases, saveAction, onChange, close]);
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For a improvement (performance or little improvements) in existent features
  [FIX] For bug fixes that affects the end user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

- [x] I have read the Contributing Guide
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules

## Proposed changes (including videos or screenshots)

While adding a custom Emoji i noticed that if a "custom emoji's" name contains a special character it gets encoded to a different character or a string. In some special cases where "emoji's name" is just a single character, it get's encoded to an empty string and is displayed like that with no name what so ever.

<!-- CHANGELOG -->

I've added a function that's checks for any special character before sending the request so that it's ensured that no unexpected results( like name being saved as an empty string) occur.
 I've also added a toast which appears when user adds a special character to the emoji name.

Previously

https://user-images.githubusercontent.com/69837339/116076994-95a5e980-a6b2-11eb-8502-1e6c9c8e8c5e.mov

Now

<img width="446" alt="Screenshot 2021-04-26 at 5 16 32 PM" src="https://user-images.githubusercontent.com/69837339/116077608-49a77480-a6b3-11eb-929e-74e807649b81.png">

## Issue(s)


## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
