### PR TITLE
[FIX] Fixing Jitsi call ended Issue.

### DIFF
--- a/app/ui-sidenav/client/roomList.js
+++ b/app/ui-sidenav/client/roomList.js
@@ -146,6 +146,7 @@ const mergeSubRoom = (subscription) => {
 			usernames: 1,
 			topic: 1,
 			encrypted: 1,
+			jitsiTimeout: 1,
 			// autoTranslate: 1,
 			// autoTranslateLanguage: 1,
 			description: 1,
@@ -182,6 +183,7 @@ const mergeSubRoom = (subscription) => {
 		teamMain,
 		uids,
 		usernames,
+		jitsiTimeout,
 
 		v,
 		transcriptRequest,
@@ -214,6 +216,7 @@ const mergeSubRoom = (subscription) => {
 		teamMain,
 		uids,
 		usernames,
+		jitsiTimeout,
 
 		v,
 		transcriptRequest,
@@ -251,6 +254,7 @@ const mergeRoomSub = (room) => {
 		teamMain,
 		uids,
 		usernames,
+		jitsiTimeout,
 
 		v,
 		transcriptRequest,
@@ -296,6 +300,7 @@ const mergeRoomSub = (room) => {
 			responseBy,
 			priorityId,
 			livechatData,
+			jitsiTimeout,
 			ts,
 			...getLowerCaseNames(room, sub.name, sub.fname),
 		},

--- a/client/views/room/contextualBar/Call/Jitsi/lib/JitsiBridge.js
+++ b/client/views/room/contextualBar/Call/Jitsi/lib/JitsiBridge.js
@@ -17,6 +17,7 @@ export class JitsiBridge extends Emitter {
 		this.desktopSharingChromeExtId = desktopSharingChromeExtId;
 		this.name = name;
 		this.heartbeat = heartbeat;
+		this.window = undefined;
 	}
 
 	start(domTarget) {
@@ -59,7 +60,7 @@ export class JitsiBridge extends Emitter {
 			}, 1000);
 
 			this.once('dispose', () => clearTimeout(timer));
-
+			this.window = newWindow;
 			return newWindow.focus();
 		}
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->
  - [x] I have read the Contributing Guide
  - [x] I have signed the CLA
  - [x] Lint and unit tests pass locally with my changes
  - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
  - [ ] I have added necessary documentation (if applicable)
  - [ ] Any dependent changes have been merged and published in downstream modules

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
The new rewrite in react of contextual call component broke the Jitsi "click to join" messages. The issue being after 10 seconds of initiating the call, the message "click to join" always returned "Call Ended" even if the call was still going on.
This was due to the fact that after closing the contextual bar, the react component gets unmounted and we are not able to keep track of ongoing call and increase jitsi room timeout. 

This PR solves this issue by using the setInterval methods on component will unmount. When the call component unmounts, we keep on checking the state of jitsi call and based on conditions increase the jitsi room timeout. After the call is ended all setInterval calls are closed.

This PR also removes the implementation of HEARTBEAT events of JitsiBridge. This is because this is no longer needed and all logic is being taken care of by the unmount function.
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
#21055 
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
