### PR TITLE
[FIX] Escape trademark sign

### DIFF
--- a/lib/escapeHTML.spec.ts
+++ b/lib/escapeHTML.spec.ts
@@ -10,7 +10,7 @@ describe('escapeHTML', () => {
 		assert.strictEqual(escapeHTML('&lt;'), '&amp;lt;');
 		assert.strictEqual(escapeHTML(' '), ' ');
 		assert.strictEqual(escapeHTML('¢'), '&cent;');
-		assert.strictEqual(escapeHTML('¢ £ ¥ € © ®'), '&cent; &pound; &yen; &euro; &copy; &reg;');
+		assert.strictEqual(escapeHTML('¢ £ ¥ € © ® ™'), '&cent; &pound; &yen; &euro; &copy; &reg; &trade;');
 		assert.strictEqual(escapeHTML(5 as unknown as string), '5');
 		assert.strictEqual(escapeHTML(''), '');
 		assert.strictEqual(escapeHTML(null as unknown as string), '');

--- a/lib/escapeHTML.ts
+++ b/lib/escapeHTML.ts
@@ -5,6 +5,7 @@ const characterToHtmlEntityCode = {
 	'€': 'euro',
 	'©': 'copy',
 	'®': 'reg',
+	'™': 'trade',
 	'<': 'lt',
 	'>': 'gt',
 	'"': 'quot',

--- a/lib/unescapeHTML.spec.ts
+++ b/lib/unescapeHTML.spec.ts
@@ -24,6 +24,7 @@ describe('unescapeHTML', () => {
 		assert.strictEqual(unescapeHTML('&nbsp;'), ' ');
 		assert.strictEqual(unescapeHTML('what is the &yen; to &pound; to &euro; conversion process?'), 'what is the ¥ to £ to € conversion process?');
 		assert.strictEqual(unescapeHTML('&reg; trademark'), '® trademark');
+		assert.strictEqual(unescapeHTML('&trade; unregistered trademark'), '™ unregistered trademark');
 		assert.strictEqual(unescapeHTML('&copy; 1992. License available for 50 &cent;'), '© 1992. License available for 50 ¢');
 		assert.strictEqual(unescapeHTML('&nbsp;'), ' ');
 		assert.strictEqual(unescapeHTML('&nbsp;'), ' ');

--- a/lib/unescapeHTML.ts
+++ b/lib/unescapeHTML.ts
@@ -6,6 +6,7 @@ const htmlEntityCodeToCharacter = {
 	euro: '€',
 	copy: '©',
 	reg: '®',
+	trade: '™',
 	lt: '<',
 	gt: '>',
 	quot: '"',


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Checklist remark
Since this change is so small, repeating existing patterns and I currently don't have a test environment set up, I dared to not test it on my local machine and hope when reviewing this, it doesn't provide significant additional work to test this insignificant fix.

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
Before this, the trademark character (™) was automatically replaced with :tm: , showing the trademark symbol in a totally unfitting size for most contexts. This commit avoids that by replacing the sign with its HTML escaped version before further replacements e.g. via emojione are applied (as can be seen in `Rocket.Chat/client/lib/renderMessageBody.ts`).

This is identical to how e.g. the registered trademark sign is currently handled.
<!-- END CHANGELOG -->

Before fix:
![image](https://user-images.githubusercontent.com/31772910/116283105-ce65c180-a78b-11eb-88b0-0baaaf80aac0.png)

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Fixes #7386.

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Send the following message:
```
™ example
® example
```

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Escaping symbols like ® in `escapeHTML` already looks like a workaround around a bug in emojione/https://github.com/RocketChat/Rocket.Chat/blob/develop/app/emoji-emojione/lib/rocketchat.js for me, since I don't know of an other reason to escape these characters this way other than preventing emojione from picking them up. Since this is the approach that is already in use, I just continue this approach logically for one more symbol.
