### PR TITLE
[IMPROVE] LDAP port setting input type to allow only numbers

### DIFF
--- a/app/ldap/server/settings.js
+++ b/app/ldap/server/settings.js
@@ -36,7 +36,7 @@ settings.addGroup('LDAP', function() {
 	this.add('LDAP_Login_Fallback', false, { type: 'boolean', enableQuery: null });
 	this.add('LDAP_Find_User_After_Login', true, { type: 'boolean', enableQuery });
 	this.add('LDAP_Host', '', { type: 'string', enableQuery });
-	this.add('LDAP_Port', '389', { type: 'string', enableQuery });
+	this.add('LDAP_Port', '389', { type: 'int', enableQuery });
 	this.add('LDAP_Reconnect', false, { type: 'boolean', enableQuery });
 	this.add('LDAP_Encryption', 'plain', { type: 'select', values: [{ key: 'plain', i18nLabel: 'No_Encryption' }, { key: 'tls', i18nLabel: 'StartTLS' }, { key: 'ssl', i18nLabel: 'SSL/LDAPS' }], enableQuery });
 	this.add('LDAP_CA_Cert', '', { type: 'string', multiline: true, enableQuery: enableTLSQuery, secret: true });


### PR DESCRIPTION
In LDAP, port input box is accepting string value as a correct input. But it should only accept integer as a correct value.

Steps to reproduce :
1. Go to administration.
2. Go to LDAP.
3. Enable the first configuration.
4. Type input in port input box. 

Before:
<img width="992" alt="Screenshot 2021-05-02 at 5 49 42 PM" src="https://user-images.githubusercontent.com/56799414/116815236-452f0000-ab7a-11eb-92a6-f9120111a23b.png">

After:
<img width="976" alt="Screenshot 2021-05-02 at 7 06 17 PM" src="https://user-images.githubusercontent.com/56799414/116815251-537d1c00-ab7a-11eb-817b-fcc17a9763a2.png">
