### PR TITLE
[FIX] No warning message is sent when user is removed from a team's main channel

### DIFF
--- a/app/api/server/v1/teams.ts
+++ b/app/api/server/v1/teams.ts
@@ -266,7 +266,7 @@ API.v1.addRoute('teams.removeMember', { authRequired: true }, {
 			return API.v1.failure('invalid-user');
 		}
 
-		if (!Promise.await(Team.removeMembers(team._id, [{ userId }]))) {
+		if (!Promise.await(Team.removeMembers(this.userId, team._id, [{ userId }]))) {
 			return API.v1.failure();
 		}
 
@@ -279,7 +279,6 @@ API.v1.addRoute('teams.removeMember', { authRequired: true }, {
 				});
 			});
 		}
-
 		return API.v1.success();
 	},
 });
@@ -290,7 +289,7 @@ API.v1.addRoute('teams.leave', { authRequired: true }, {
 
 		const team = teamId ? Promise.await(Team.getOneById(teamId)) : Promise.await(Team.getOneByName(teamName));
 
-		Promise.await(Team.removeMembers(team._id, [{
+		Promise.await(Team.removeMembers(this.userId, team._id, [{
 			userId: this.userId,
 		}]));
 
@@ -301,8 +300,6 @@ API.v1.addRoute('teams.leave', { authRequired: true }, {
 				removeUserFromRoom(rid, this.user);
 			});
 		}
-
-		removeUserFromRoom(team.roomId, this.user);
 
 		return API.v1.success();
 	},

--- a/app/models/server/raw/Users.js
+++ b/app/models/server/raw/Users.js
@@ -119,6 +119,14 @@ export class UsersRaw extends BaseRaw {
 		return this.find(query, options);
 	}
 
+	findByIds(userIds, options = {}) {
+		const query = {
+			_id: { $in: userIds },
+		};
+
+		return this.find(query, options);
+	}
+
 	findOneByUsernameIgnoringCase(username, options) {
 		if (typeof username === 'string') {
 			username = new RegExp(`^${ escapeRegExp(username) }$`, 'i');

--- a/server/sdk/types/ITeamService.ts
+++ b/server/sdk/types/ITeamService.ts
@@ -67,7 +67,7 @@ export interface ITeamService {
 	members(uid: string, teamId: string, canSeeAll: boolean, options?: IPaginationOptions, queryOptions?: IQueryOptions<ITeamMember>): Promise<IRecordsWithTotal<ITeamMemberInfo>>;
 	addMembers(uid: string, teamId: string, members: Array<ITeamMemberParams>): Promise<void>;
 	updateMember(teamId: string, members: ITeamMemberParams): Promise<void>;
-	removeMembers(teamId: string, members: Array<ITeamMemberParams>): Promise<boolean>;
+	removeMembers(uid: string, teamId: string, members: Array<ITeamMemberParams>): Promise<boolean>;
 	getInfoByName(teamName: string): Promise<Partial<ITeam> | undefined>;
 	getInfoById(teamId: string): Promise<Partial<ITeam> | undefined>;
 	deleteById(teamId: string): Promise<boolean>;

--- a/server/services/team/service.ts
+++ b/server/services/team/service.ts
@@ -590,7 +590,7 @@ export class TeamService extends ServiceClass implements ITeamService {
 		}
 
 		const membersIds = members.map((m) => m.userId);
-		const usersToRemove = await this.Users.find({ _id: { $in: membersIds } }, { projection: { _id: 1, username: 1 } }).toArray();
+		const usersToRemove = await this.Users.findByIds(membersIds, { projection: { _id: 1, username: 1 } }).toArray();
 		const byUser = await this.Users.findOneById(uid, { projection: { _id: 1, username: 1 } });
 
 		for await (const member of members) {

--- a/server/services/team/service.ts
+++ b/server/services/team/service.ts
@@ -4,7 +4,6 @@ import { checkUsernameAvailability } from '../../../app/lib/server/functions';
 import { addUserToRoom } from '../../../app/lib/server/functions/addUserToRoom';
 import { removeUserFromRoom } from '../../../app/lib/server/functions/removeUserFromRoom';
 import { getSubscribedRoomsForUserWithDetails } from '../../../app/lib/server/functions/getRoomsWithSingleOwner';
-import { Subscriptions } from '../../../app/models/server';
 import { MessagesRaw } from '../../../app/models/server/raw/Messages';
 import { RoomsRaw } from '../../../app/models/server/raw/Rooms';
 import { SubscriptionsRaw } from '../../../app/models/server/raw/Subscriptions';
@@ -584,7 +583,7 @@ export class TeamService extends ServiceClass implements ITeamService {
 		await this.TeamMembersModel.deleteByUserIdAndTeamId(userId, teamId);
 	}
 
-	async removeMembers(teamId: string, members: Array<ITeamMemberParams>): Promise<boolean> {
+	async removeMembers(uid: string, teamId: string, members: Array<ITeamMemberParams>): Promise<boolean> {
 		const team = await this.TeamModel.findOneById(teamId, { projection: { _id: 1, roomId: 1 } });
 		if (!team) {
 			throw new Error('team-does-not-exist');
@@ -609,8 +608,9 @@ export class TeamService extends ServiceClass implements ITeamService {
 			}
 
 			this.TeamMembersModel.removeById(existingMember._id);
-
-			await this.unsubscribeFromMain(team.roomId, member.userId);
+			const removedUser = await this.Users.findOneById(member.userId, { projection: { _id: 1, username: 1 } });
+			const byUser = uid !== member.userId ? await this.Users.findOneById(uid, { projection: { _id: 1, username: 1 } }) : undefined;
+			removeUserFromRoom(team.roomId, removedUser, { byUser });
 		}
 
 		return true;
@@ -820,13 +820,5 @@ export class TeamService extends ServiceClass implements ITeamService {
 		}).toArray();
 
 		return rooms;
-	}
-
-	async unsubscribeFromMain(roomId: string, userId: string): Promise<void> {
-		// we need to use the normal model here. The raw one didn't propagate the changes to the FE
-		// let me know if there's a way of doing that
-		await Subscriptions.removeByRoomIdsAndUserId([roomId], userId);
-		await this.RoomsModel.incUsersCountByIds([roomId], -1);
-		await this.Users.removeRoomsByRoomIdsAndUserId([roomId], userId);
 	}
 }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
 - Send a warning message to a team's main channel when a user is removed from the team;
 - Trigger events while removing a user from a team's main channel;
 - Fix `usersCount` field in the team's main room when a user is removed from the team (`usersCount` is now decreased by 1).

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[Task - ClickUp](https://app.clickup.com/t/4h2e5e) (no warning messages are sent)
[Task - ClickUp](https://app.clickup.com/t/4h2duk) (`usersCount` field is decreased by 2)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Create a new team and insert/remove a member. When a user is removed or leaves a team, its main channel's `usersCount` field will be decreased by 1 and a warning message will be sent.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Fixes #21901 (includes its changes)