### PR TITLE
[FIX] Emails being sent with HTML entities getting escaped multiple times

### DIFF
--- a/app/lib/server/functions/saveUser.js
+++ b/app/lib/server/functions/saveUser.js
@@ -11,7 +11,6 @@ import { passwordPolicy } from '../lib/passwordPolicy';
 import { validateEmailDomain } from '../lib';
 import { validateUserRoles } from '../../../../ee/app/authorization/server/validateUserRoles';
 import { saveUserIdentity } from './saveUserIdentity';
-import { escapeHTML } from '../../../../lib/escapeHTML';
 
 import { checkEmailAvailability, checkUsernameAvailability, setUserAvatar, setEmail, setStatusText } from '.';
 
@@ -34,13 +33,13 @@ function _sendUserEmail(subject, html, userData) {
 		subject,
 		html,
 		data: {
-			email: escapeHTML(userData.email),
-			password: escapeHTML(userData.password),
+			email: userData.email,
+			password: userData.password,
 		},
 	};
 
 	if (typeof userData.name !== 'undefined') {
-		email.data.name = escapeHTML(userData.name);
+		email.data.name = userData.name;
 	}
 
 	try {

--- a/app/mailer/server/api.js
+++ b/app/mailer/server/api.js
@@ -25,11 +25,10 @@ settings.get('Language', (key, value) => {
 	lng = value || 'en';
 });
 
-const nonEscapeKeys = ['room_path', 'password'];
 
 export const replacekey = (str, key, value = '') => str.replace(
 	new RegExp(`(\\[${ key }\\]|__${ key }__)`, 'igm'),
-	nonEscapeKeys.includes(key) ? value : escapeHTML(value),
+	value,
 );
 
 export const translate = (str) => replaceVariables(str, (match, key) => TAPi18n.__(key, { lng }));
@@ -50,6 +49,8 @@ export const replace = function replace(str, data = {}) {
 	return Object.entries(options).reduce((ret, [key, value]) => replacekey(ret, key, value), translate(str));
 };
 
+const nonEscapeKeys = ['room_path'];
+
 export const replaceEscaped = (str, data = {}) => replace(str, {
 	Site_Name: escapeHTML(settings.get('Site_Name')),
 	Site_Url: escapeHTML(settings.get('Site_Url')),
@@ -58,6 +59,7 @@ export const replaceEscaped = (str, data = {}) => replace(str, {
 		return ret;
 	}, {}),
 });
+
 export const wrap = (html, data = {}) => {
 	if (settings.get('email_plain_text_only')) {
 		return replace(html, data);

--- a/app/mailer/server/api.js
+++ b/app/mailer/server/api.js
@@ -25,7 +25,13 @@ settings.get('Language', (key, value) => {
 	lng = value || 'en';
 });
 
-export const replacekey = (str, key, value = '') => str.replace(new RegExp(`(\\[${ key }\\]|__${ key }__)`, 'igm'), escapeHTML(value));
+const nonEscapeKeys = ['room_path', 'password'];
+
+export const replacekey = (str, key, value = '') => str.replace(
+	new RegExp(`(\\[${ key }\\]|__${ key }__)`, 'igm'),
+	nonEscapeKeys.includes(key) ? value : escapeHTML(value),
+);
+
 export const translate = (str) => replaceVariables(str, (match, key) => TAPi18n.__(key, { lng }));
 export const replace = function replace(str, data = {}) {
 	if (!str) {
@@ -43,8 +49,6 @@ export const replace = function replace(str, data = {}) {
 	};
 	return Object.entries(options).reduce((ret, [key, value]) => replacekey(ret, key, value), translate(str));
 };
-
-const nonEscapeKeys = ['room_path'];
 
 export const replaceEscaped = (str, data = {}) => replace(str, {
 	Site_Name: escapeHTML(settings.get('Site_Name')),


### PR DESCRIPTION

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
fixes an issue where if password contains special HTML character like &, in the email it would end up something like `&amp;amp;`

<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
--> 
password was going through multiple escapeHTML function calls
`secure&123 => secure&amp;123 => secure&amp;amp;123
`

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Closes #21986 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
edit user from admin panel
enable the option "Set random password and send by email"
check your email or see logs for email html 

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
