### PR TITLE
[FIX] add toast message

### DIFF
--- a/app/ui/client/views/app/videoCall/videoCall.html
+++ b/app/ui/client/views/app/videoCall/videoCall.html
@@ -36,28 +36,28 @@
 				</div>
 				<div class="rc-button__group rc-button__group--wrap rc-button__group--stretch">
 					{{#if videoActive}}
-						<button class="rc-button stop-call"><i class="icon-stop"></i>{{_ "Stop"}}</button>
+						<button class="rc-button stop-call" title="{{_ 'End Call'}}" aria-label="{{_ 'End Call'}}"><i class="icon-stop"></i>{{_ "Stop"}}</button>
 						{{#if audioEnabled}}
 							<button class="rc-button disable-audio" title="{{_ 'Mute'}}" aria-label="{{_ 'Mute'}}"><i class="icon-mute"></i></button>
 						{{else}}
 							<button class="rc-button enable-audio" title="{{_ 'Unmute'}}" aria-label="{{_ 'Unmute'}}"><i class="icon-mic"></i></button>
 						{{/if}}
 						{{#if videoEnabled}}
-							<button class="rc-button disable-video"><i class="icon-eye-off"></i></button>
+							<button class="rc-button disable-video" title="{{_ 'Hide Video'}}" aria-label="{{_ 'Hide Video'}}"><i class="icon-eye-off"></i></button>
 						{{else}}
-							<button class="rc-button enable-video"><i class="icon-eye"></i></button>
+							<button class="rc-button enable-video" title="{{_ 'Show Video'}}" aria-label="{{_ 'Show Video'}}"><i class="icon-eye"></i></button>
 						{{/if}}
 						{{#if screenShareAvailable}}
 							{{#if screenShareEnabled}}
-								<button class="rc-button disable-screen-share"><i class="icon-desktop"></i></button>
+								<button class="rc-button disable-screen-share" title="{{_ 'Stop Screen Share'}}" aria-label="{{_ 'Stop Screen Share'}}"><i class="icon-desktop"></i></button>
 							{{else}}
-								<button class="rc-button enable-screen-share"><i class="icon-desktop"></i></button>
+								<button class="rc-button enable-screen-share" title="{{_ 'Start Screen Share'}}" aria-label="{{_ 'Start Screen Share'}}"><i class="icon-desktop"></i></button>
 							{{/if}}
 						{{/if}}
 						{{#if overlayEnabled}}
-							<button class="rc-button disable-overlay"><i class="icon-resize-small"></i></button>
+							<button class="rc-button disable-overlay" title="{{_ 'Disable Overlay'}}" aria-label="{{_ 'Disable Overlay'}}"><i class="icon-resize-small"></i></button>
 						{{else}}
-							<button class="rc-button enable-overlay"><i class="icon-resize-full-alt"></i></button>
+							<button class="rc-button enable-overlay" title="{{_ 'Enable Overlay'}}" aria-label="{{_ 'Enable Overlay'}}"><i class="icon-resize-full-alt"></i></button>
 						{{/if}}
 					{{/if}}
 				</div>


### PR DESCRIPTION
FIX issue #22078 
In a video call started with rocket.chat meet, if you hover over a button, now it's showing a toast message for that respective button as like it was doing earlier for audio button.

Additional context:

https://user-images.githubusercontent.com/56799414/118860957-9882ab80-b8f9-11eb-80d8-32b4233443fb.mov


