### PR TITLE
[FIX] Permission check for teams.listRoomsOfUser

### DIFF
--- a/app/api/server/v1/teams.ts
+++ b/app/api/server/v1/teams.ts
@@ -175,7 +175,7 @@ API.v1.addRoute('teams.listRoomsOfUser', { authRequired: true }, {
 
 		const allowPrivateTeam = hasPermission(this.userId, 'view-all-teams', team.roomId);
 
-		if (!hasPermission(this.userId, 'view-all-team-channels', team.roomId)) {
+		if (!(this.userId === userId || hasPermission(this.userId, 'view-all-team-channels', team.roomId))) {
 			return API.v1.unauthorized();
 		}
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
If the user is trying to list his own channels, the permission check is skipped.
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Try to leave a team with a user that has no privileges (eg. is not owner/leader nor admin)
- The users joined channels should be displayed even if he does not has the `view-all-team-channels` permission.
PS.: If the user has not joined any additional rooms inside the team, the first step of the modal is not displayed.
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
