### PR TITLE
[IMPROVE] Exclude archived rooms from unread-message count

### DIFF
--- a/app/lib/server/functions/notifications/mobile.js
+++ b/app/lib/server/functions/notifications/mobile.js
@@ -15,7 +15,7 @@ Meteor.startup(() => {
 
 async function getBadgeCount(userId) {
 	const [result = {}] = await SubscriptionRaw.aggregate([
-		{ $match: { 'u._id': userId } },
+		{ $match: { 'u._id': userId, archived: { $ne: true } } },
 		{
 			$group: {
 				_id: 'total',

--- a/app/ui/client/views/app/burger.js
+++ b/app/ui/client/views/app/burger.js
@@ -14,6 +14,7 @@ Template.burger.helpers({
 				open: true,
 				hideUnreadStatus: { $ne: true },
 				rid: { $ne: Session.get('openedRoom') },
+				archived: { $ne: true },
 			}, {
 				fields: {
 					unread: 1,

--- a/client/startup/unread.ts
+++ b/client/startup/unread.ts
@@ -14,6 +14,7 @@ const fetchSubscriptions = (): ISubscription[] =>
 		{
 			open: true,
 			hideUnreadStatus: { $ne: true },
+			archived: { $ne: true },
 		},
 		{
 			fields: {


### PR DESCRIPTION
Removing a Chat Room lead to an unzero-able "unread messages" count,
since users couldn’t access the archived room to mark it as read.

I considered zeroing out the count when archiving the room,
however if a room would be accidentally archived and then unarchived,
state would be lost.  Archiving should really just put the room to
the side without otherwise changing it.

I also considered adding an index for `archived`.  A sparse index
shouldn’t be so expensive, but on the other hand, there will probably
not be so many room subscriptions for a given user.  Leaving it out
for now.

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

