### PR TITLE
[IMPROVE] Preview message URLs only once

### DIFF
--- a/app/lib/server/functions/insertMessage.js
+++ b/app/lib/server/functions/insertMessage.js
@@ -119,7 +119,7 @@ export const insertMessage = function(user, message, rid, upsert = false) {
 
 		const urls = message.html.match(/([A-Za-z]{3,9}):\/\/([-;:&=\+\$,\w]+@{1})?([-A-Za-z0-9\.]+)+:?(\d+)?((\/[-\+=!:~%\/\.@\,\(\)\w]*)?\??([-\+=&!:;%@\/\.\,\w]+)?(?:#([^\s\)]+))?)?/g);
 		if (urls) {
-			message.urls = urls.map((url) => ({ url }));
+			message.urls = [...new Set(urls)].map((url) => ({ url }));
 		}
 
 		message = Markdown.mountTokensBack(message, false);

--- a/app/lib/server/functions/parseUrlsInMessage.js
+++ b/app/lib/server/functions/parseUrlsInMessage.js
@@ -10,7 +10,7 @@ export const parseUrlsInMessage = (message) => {
 
 	const urls = message.html.match(/([A-Za-z]{3,9}):\/\/([-;:&=\+\$,\w]+@{1})?([-A-Za-z0-9\.]+)+:?(\d+)?((\/[-\+=!:~%\/\.@\,\w]*)?\??([-\+=&!:;%@\/\.\,\w]+)?(?:#([^\s\)]+))?)?/g) || [];
 	if (urls) {
-		message.urls = urls.map((url) => ({ url }));
+		message.urls = [...new Set(urls)].map((url) => ({ url }));
 	}
 
 	message = Markdown.mountTokensBack(message, false);


### PR DESCRIPTION
If a message lists the same URL twice, the URL would be previewed twice.
This includes Markdown code explicitly using the URL as the link text.
e.g.
        ```
        [http://example.com/](http://example.com/)
        ```

Strip out duplicate URLs when parsing them out, so we only show a single preview.

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

