### PR TITLE
[FIX] Livechat-jitsi-call

### DIFF
--- a/app/livechat/server/api/v1/videoCall.js
+++ b/app/livechat/server/api/v1/videoCall.js
@@ -2,7 +2,6 @@ import { Meteor } from 'meteor/meteor';
 import { Match, check } from 'meteor/check';
 import { Random } from 'meteor/random';
 
-import { Messages } from '../../../../models';
 import { settings as rcSettings } from '../../../../settings';
 import { API } from '../../../../api/server';
 import { findGuest, getRoom, settings } from '../lib/livechat';
@@ -33,9 +32,6 @@ API.v1.addRoute('livechat/video.call/:token', {
 				throw new Meteor.Error('invalid-livechat-config');
 			}
 
-			Messages.createWithTypeRoomIdMessageAndUser('livechat_video_call', room._id, '', guest, {
-				actionLinks: config.theme.actionLinks,
-			});
 			let rname;
 			if (rcSettings.get('Jitsi_URL_Room_Hash')) {
 				rname = rcSettings.get('uniqueID') + rid;


### PR DESCRIPTION
Current if you make get request http://localhost:3000/api/v1/livechat/video.call/: token with Livechat.videoCall() at widget side, it was showing bad request because there was some error at rc-core server file. But after doing changes at rc-core server side and making an api call with Livechat.videoCall , now I am getting the expected result at widget side as shown in the image below.
<img width="761" alt="Screenshot 2021-07-15 at 1 19 11 PM" src="https://user-images.githubusercontent.com/56799414/125803311-35197dec-2de4-4e93-8db4-9a5837972fe9.png">


