### PR TITLE
revert the lastMessage fix for visitor abandonment

### DIFF
--- a/ee/app/livechat-enterprise/server/lib/Helper.js
+++ b/ee/app/livechat-enterprise/server/lib/Helper.js
@@ -124,7 +124,7 @@ export const processWaitingQueue = async (department) => {
 };
 
 export const setPredictedVisitorAbandonmentTime = (room) => {
-	if (!room.v || !settings.get('Livechat_abandoned_rooms_action') || settings.get('Livechat_abandoned_rooms_action') === 'none') {
+	if (!room.v || !room.v.lastMessageTs || !settings.get('Livechat_abandoned_rooms_action') || settings.get('Livechat_abandoned_rooms_action') === 'none') {
 		return;
 	}
 
@@ -139,7 +139,7 @@ export const setPredictedVisitorAbandonmentTime = (room) => {
 		return;
 	}
 
-	const willBeAbandonedAt = moment(room.v.lastMessageTs ?? room.lastMessage.ts).add(Number(secondsToAdd), 'seconds').toDate();
+	const willBeAbandonedAt = moment(room.v.lastMessageTs).add(Number(secondsToAdd), 'seconds').toDate();
 	LivechatRooms.setPredictedVisitorAbandonment(room._id, willBeAbandonedAt);
 };
 


### PR DESCRIPTION
This PR reverts a previous fix for visitor abandonment.  The original fix did not handle the use case where the room is empty.  We will make a new PR that handles all cases and resubmit. 