### PR TITLE
[FIX] Open CDN access in Content-Security-Policy

### DIFF
--- a/app/cors/server/cors.js
+++ b/app/cors/server/cors.js
@@ -32,7 +32,24 @@ WebApp.rawConnectHandlers.use(function(req, res, next) {
 	}
 
 	if (settings.get('Enable_CSP')) {
-		res.setHeader('Content-Security-Policy', "default-src 'self'; script-src 'self' 'unsafe-eval'; connect-src * 'self' data:; img-src data: 'self' http://* https://*; style-src 'self' 'unsafe-inline'; media-src 'self' http://* https://*; frame-src 'self' http://* https://*; font-src 'self' data:;");
+		const cdn_prefixes = [
+			settings.get('CDN_PREFIX'),
+			settings.get('CDN_PREFIX_ALL') ? null : settings.get('CDN_JSCSS_PREFIX'),
+		].filter(Boolean).join(' ');
+
+		res.setHeader(
+			'Content-Security-Policy',
+			[
+				`default-src 'self' ${ cdn_prefixes }`,
+				'connect-src * data:',
+				`font-src 'self' ${ cdn_prefixes } data:`,
+				'frame-src *',
+				'img-src * data:',
+				'media-src * data:',
+				`script-src 'self' 'unsafe-eval' ${ cdn_prefixes }`,
+				`style-src 'self' 'unsafe-inline' ${ cdn_prefixes }`,
+			].join('; '),
+		);
 	}
 
 	// Deprecated behavior


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
* The Content-Security-Policy must whitelist all resources that we wish to access, so we must explicitly list our CDNs. 
 Dynamically get CDN origins from settings.
* Simplify CSP resource list by:
  * Reducing `http://* https://*` to just `*`
    (n.b. `*` matches all URLs except for `blob:`, `data:`, and `filesystem:`)
  * Remove superfluous `'self'` when we allow `*`
<!-- END CHANGELOG -->

## Issue(s)
* Closes #22490
* Builds upon #22791 
* Builds upon #22780

## Steps to test
* Configure two CDNs: CDN_PREFIX and CDN_JSCSS_PREFIX.  Set CDN_PREFIX_ALL to false.
  * Confirm that the Content-Security-Policy HTTP header contains both the CDN_PREFIX and CDN_JSCSS_PREFIX
* Configure a single CDN.  Set CDN_JSCSS_PREFIX to a non-empty string, but set CDN_PREFIX_ALL to true.
  * Confirm that the Content-Security-Policy HTTP header contains CDN_PREFIX but does _not_ contain CDN_JSCSS_PREFIX (nor anything unexpected, like `true`)

## Further comments
Co-Authored-By: ggazzo <guilhermegazzo@gmail.com>
Co-Authored-By: gabriellsh <40830821+gabriellsh@users.noreply.github.com>