### PR TITLE
[FIX] Chat Transfer Failure due to Unrecognized stage name departmentId

### DIFF
--- a/app/models/server/models/Users.js
+++ b/app/models/server/models/Users.js
@@ -219,7 +219,7 @@ export class Users extends Base {
 		// if department is provided, remove the agents that are not from the selected department
 		const departmentFilter = departmentId ? [{
 			$lookup: {
-				from: 'rocketchat_livechat_department_agent',
+				from: 'rocketchat_livechat_department_agents',
 				let: { departmentId: '$departmentId', agentId: '$agentId' },
 				pipeline: [{
 					$match: { $expr: { $eq: ['$$agentId', '$_id'] } },
@@ -273,7 +273,7 @@ export class Users extends Base {
 					},
 				},
 			},
-			...customFilter ? [customFilter] : [],
+			...customFilter ? [{ $match: customFilter }] : [],
 			{
 				$sort: {
 					'queueInfo.chats': 1,


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR fixes typo in the collection name and modifies aggregator query to pass the customFilter properly
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)
https://open.rocket.chat/channel/omnichannel/thread/sxL6dbZBDoAoYJDqN

Because of extraQuery(customFilter) is being passed as a stage in aggregator [here](https://github.com/RocketChat/Rocket.Chat/pull/22611/files#diff-3fcd471e2731d9972594322e99cac33b2f78e05ef84e78bac061503d73180296R276), It is giving `MongoError: Unrecognized pipeline stage name: 'departmentId'`
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
Call `modify.getUpdater().getLivechatUpdater().transferVisitor` from RC App
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
