### PR TITLE
[FIX] Message update not working in some cases

### DIFF
--- a/ee/app/canned-responses/server/hooks/onMessageSentParsePlaceholder.ts
+++ b/ee/app/canned-responses/server/hooks/onMessageSentParsePlaceholder.ts
@@ -1,7 +1,7 @@
 import get from 'lodash.get';
 
 import { callbacks } from '../../../../../app/callbacks/server';
-import { Users, LivechatVisitors } from '../../../../../app/models/server';
+import { Users, LivechatVisitors, Rooms } from '../../../../../app/models/server';
 import { IMessage } from '../../../../../definition/IMessage';
 import { IOmnichannelRoom, isOmnichannelRoom } from '../../../../../definition/IRoom';
 
@@ -28,7 +28,12 @@ const placeholderFields = {
 	},
 };
 
-callbacks.add('beforeSaveMessage', (message: IMessage, room: IOmnichannelRoom): any => {
+callbacks.add('beforeSaveMessage', (message: IMessage): any => {
+	if (!message.msg || message.msg === '') {
+		return message;
+	}
+
+	const room: IOmnichannelRoom = Rooms.findOneById(message.rid);
 	if (!isOmnichannelRoom(room)) {
 		return message;
 	}

--- a/ee/app/canned-responses/server/hooks/onMessageSentParsePlaceholder.ts
+++ b/ee/app/canned-responses/server/hooks/onMessageSentParsePlaceholder.ts
@@ -1,5 +1,6 @@
 import get from 'lodash.get';
 
+import { settings } from '../../../../../app/settings/server';
 import { callbacks } from '../../../../../app/callbacks/server';
 import { Users, LivechatVisitors, Rooms } from '../../../../../app/models/server';
 import { IMessage } from '../../../../../definition/IMessage';
@@ -28,12 +29,12 @@ const placeholderFields = {
 	},
 };
 
-callbacks.add('beforeSaveMessage', (message: IMessage): any => {
+const handleBeforeSaveMessage = (message: IMessage, room: IOmnichannelRoom): any => {
 	if (!message.msg || message.msg === '') {
 		return message;
 	}
 
-	const room: IOmnichannelRoom = Rooms.findOneById(message.rid);
+	room = room?._id ? room : Rooms.findOneById(message.rid);
 	if (!isOmnichannelRoom(room)) {
 		return message;
 	}
@@ -56,4 +57,13 @@ callbacks.add('beforeSaveMessage', (message: IMessage): any => {
 
 	message.msg = messageText;
 	return message;
-}, callbacks.priority.LOW, 'canned-responses-replace-placeholders');
+};
+
+settings.get('Canned_Responses_Enable', function(_, value) {
+	if (!value) {
+		callbacks.remove('beforeSaveMessage', 'canned-responses-replace-placeholders');
+		return;
+	}
+
+	callbacks.add('beforeSaveMessage', handleBeforeSaveMessage, callbacks.priority.MEDIUM, 'canned-responses-replace-placeholders');
+});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
Duplicate of PR #22856 for patch release

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
```
 "{\"stack\":\"TypeError: Cannot read property 't' of undefined\\n    at isOmnichannelRoom (definition/IRoom.ts:96:90)\\n    at ee/app/canned-responses/server/hooks/onMessageSentParsePlaceholder.ts:32:7\\n    at callbacks.runItem (app/callbacks/lib/callbacks.js:111:70)\\n    at Object.callbacks.runItem (app/metrics/server/callbacksMetrics.js:24:20)\\n    at app/callbacks/lib/callbacks.js:39:35\\n    at app/callbacks/lib/callbacks.js:45:45\\n    at app/callbacks/lib/callbacks.js:45:47\\n    at callbacks.run (app/callbacks/lib/callbacks.js:127:9)\\n    at Object.callbacks.run (app/metrics/server/callbacksMetrics.js:14:17)\\n    at updateMessage (app/lib/server/functions/updateMessage.js:48:22)\\n    at app/apps/server/bridges/messages.ts:50:3\\n    at /app/bundle/programs/server/npm/node_modules/meteor/promise/node_modules/meteor-promise/fiber_pool.js:43:40\",\"message\":\"Cannot read property 't' of undefined\"}"
```
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
