### PR TITLE
[NEW] Omnichannel channel definitions

### DIFF
--- a/definition/IOmnichannelVisitor.ts
+++ b/definition/IOmnichannelVisitor.ts
@@ -1,0 +1,61 @@
+
+export enum ChannelType {
+	LIVECHAT = 'livechat',
+	EMAIL = 'email',
+	SMS = 'sms',
+	WHATSAPP = 'whatsapp',
+	TWITTER = 'twitter',
+	FACEBOOK_MESSENGER = 'facebook-messenger',
+	TELEGRAM = 'telegram',
+	INSTAGRAM = 'instagram',
+	APPLE = 'apple'
+}
+
+export interface IOmnichannelVisitor {
+	_id: string;
+	username: string;
+	token: string;
+
+	name?: string;
+
+	channels?: Array<IOmnichannelChannel>;
+
+	ts: Date;
+	_updatedAt: Date;
+}
+
+export interface IOmnichannelChannel {
+	type: ChannelType;
+}
+
+export interface IWhatsAppChannel {
+	type: ChannelType.WHATSAPP;
+	phoneNumber: string;
+	name?: string;
+}
+
+export interface ITwitterChannel {
+	type: ChannelType.TWITTER;
+	id: string;
+	username?: string;
+	name?: string;
+	profilePic?: string;
+}
+
+export interface IFacebookMessengerChannel {
+	type: ChannelType.FACEBOOK_MESSENGER;
+	userId: string; // the PSID (Page scoped user ID) of a visitor
+	name?: string;
+	profilePic?: string;
+}
+
+export interface ITelegramChannel {
+	userId: string;
+	firstName?: string;
+	lastName?: string;
+}
+
+export interface IInstagramChannel {
+	userId: string; // IGSID - Instagram (IG)-scoped ID
+	name?: string;
+}

--- a/definition/IOmnichannelVisitor.ts
+++ b/definition/IOmnichannelVisitor.ts
@@ -18,44 +18,87 @@ export interface IOmnichannelVisitor {
 
 	name?: string;
 
-	channels?: Array<IOmnichannelChannel>;
+	channels?: Array<IIncomingChannel>;
 
 	ts: Date;
 	_updatedAt: Date;
 }
 
-export interface IOmnichannelChannel {
+export interface IIncomingChannel {
 	type: ChannelType;
 }
 
-export interface IWhatsAppChannel {
+export interface IIncomingChannelWithSource extends IIncomingChannel {
+	source: any;
+}
+
+export interface IWhatsAppChannel extends IIncomingChannel {
 	type: ChannelType.WHATSAPP;
 	phoneNumber: string;
 	name?: string;
 }
 
-export interface ITwitterChannel {
+export interface IWhatsAppChannelWithSource extends IWhatsAppChannel, IIncomingChannelWithSource {
+	type: ChannelType.WHATSAPP;
+	source: {
+		incomingPhoneNumber: string;
+	};
+}
+
+export interface ITwitterChannel extends IIncomingChannel {
 	type: ChannelType.TWITTER;
-	id: string;
+	userId: string;
 	username?: string;
 	name?: string;
 	profilePic?: string;
 }
 
-export interface IFacebookMessengerChannel {
+export interface ITwitterChannelWithSource extends ITwitterChannel, IIncomingChannelWithSource {
+	type: ChannelType.TWITTER;
+	source: {
+		incomingUserId: string;
+	};
+}
+
+export interface IFacebookMessengerChannel extends IIncomingChannel {
 	type: ChannelType.FACEBOOK_MESSENGER;
 	userId: string; // the PSID (Page scoped user ID) of a visitor
 	name?: string;
 	profilePic?: string;
 }
 
-export interface ITelegramChannel {
+export interface IFacebookMessengerChannelWithSource extends IFacebookMessengerChannel, IIncomingChannelWithSource {
+	type: ChannelType.FACEBOOK_MESSENGER;
+	source: {
+		incomingPageId: string;
+	};
+}
+
+export interface ITelegramChannel extends IIncomingChannel {
+	type: ChannelType.TELEGRAM;
 	userId: string;
 	firstName?: string;
 	lastName?: string;
 }
 
-export interface IInstagramChannel {
+export interface ITelegramChannelWithSource extends ITelegramChannel, IIncomingChannelWithSource {
+	type: ChannelType.TELEGRAM;
+	source: {
+		incomingUserId: string;
+	};
+}
+
+
+export interface IInstagramChannel extends IIncomingChannel {
+	type: ChannelType.INSTAGRAM;
 	userId: string; // IGSID - Instagram (IG)-scoped ID
 	name?: string;
+	profilePic?: string;
+}
+
+export interface IInstagramChannelWithSource extends IInstagramChannel, IIncomingChannelWithSource {
+	type: ChannelType.INSTAGRAM;
+	source: {
+		incomingUserId: string; // note, we can either FB page ID over here or the Instagram Account ID since both of them have one-to-one relationship
+	};
 }

--- a/definition/IRoom.ts
+++ b/definition/IRoom.ts
@@ -1,6 +1,7 @@
 import { IRocketChatRecord } from './IRocketChatRecord';
 import { IMessage } from './IMessage';
 import { IUser, Username } from './IUser';
+import { IIncomingChannelWithSource } from './IOmnichannelVisitor';
 
 type RoomType = 'c' | 'd' | 'p' | 'l';
 
@@ -91,6 +92,8 @@ export interface IOmnichannelRoom extends Omit<IRoom, 'default' | 'featured' | '
 	responseBy: any;
 	priorityId: any;
 	livechatData: any;
+
+	channel?: IIncomingChannelWithSource;
 }
 
 export const isOmnichannelRoom = (room: IRoom): room is IOmnichannelRoom & IRoom => room.t === 'l';


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
As we're planning to improve the visibility of source channel inside Omnichannel, we'd need to store these channel definitions within Visitor and Room objects on the core. So in this PR, I'm proposing the new definitions for this feature 

- [ ] Livechat
- [ ] Email
- [ ] SMS
- [x] WhatsApp
- [x] Twitter
- [x] Facebook Messenger
- [x] Telegram
- [x] Instagram
- [ ] Apple

A general comment wrt these 2 general interfaces - `IIncomingChannel` and  `IIncomingChannelWithSource`. 
- In  former, we only store details on the visitor who is contacting us via any channel. So eg, if a chat is coming from WhatsApp, we'd only store the phoneNo of visitor in this interface
- In later however, we also store the source info. To understand what I mean by source here, we need to understand that on RC, we have certain channels which allow users to connect their multiple accounts. Eg, a user can connect multiple Whatsapp nos to their single RC server. In this situation, the source info would contain info about what account the visitor has contacted to. So incase of our WhatsApp example, it would contain the phoneNumber of whatsApp account **TO WHICH** the visitor sent the message. Note: all `IIncomingChannelWithSource` objects would be stored within the Room object and not on the Visitor object

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
