### PR TITLE
[BREAK][ENTERPRISE] CSV file from the Engagement Dashboard's "Users by time of day" section is missing headers

### DIFF
--- a/ee/app/engagement-dashboard/client/components/UsersTab/UsersByTimeOfTheDaySection.js
+++ b/ee/app/engagement-dashboard/client/components/UsersTab/UsersByTimeOfTheDaySection.js
@@ -101,18 +101,21 @@ const UsersByTimeOfTheDaySection = ({ timezone }) => {
 	}, [data, period.end, period.start, utc]);
 
 	const downloadData = () => {
-		const _data = data.week.map(({
-			users,
-			hour,
-			day,
-			month,
-			year,
-		}) => ({
-			date: moment([year, month - 1, day, hour, 0, 0, 0]),
-			users,
-		}))
-			.sort((a, b) => a > b)
-			.map(({ date, users }) => [date.toISOString(), users]);
+		const _data = [
+			['Date', 'Users'],
+			...data.week.map(({
+				users,
+				hour,
+				day,
+				month,
+				year,
+			}) => ({
+				date: moment([year, month - 1, day, hour, 0, 0, 0]),
+				users,
+			}))
+				.sort((a, b) => a > b)
+				.map(({ date, users }) => [date.toISOString(), users]),
+		];
 		downloadCsvAs(_data, `UsersByTimeOfTheDaySection_start_${ params.start }_end_${ params.end }`);
 	};
 	return <Section


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
 - Add headers to the CSV file downloaded from the Engagement Dashboard's "Users by time of day" section.

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[Task - ClickUp](https://app.clickup.com/t/de29fd)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Go to **Administration > Engagement Dashboard > Download CSV** (in the "Users by time of day" section). The downloaded CSV file should contain the "Date" and "User" headers.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
