### PR TITLE
[FIX] Admins can't update or reset user avatars when the "Allow User Avatar Change" setting is off

### DIFF
--- a/server/methods/resetAvatar.js
+++ b/server/methods/resetAvatar.js
@@ -14,8 +14,9 @@ Meteor.methods({
 				method: 'resetAvatar',
 			});
 		}
+		const canEditOtherUserAvatar = hasPermission(Meteor.userId(), 'edit-other-user-avatar');
 
-		if (!settings.get('Accounts_AllowUserAvatarChange')) {
+		if (!settings.get('Accounts_AllowUserAvatarChange') && !canEditOtherUserAvatar) {
 			throw new Meteor.Error('error-not-allowed', 'Not allowed', {
 				method: 'resetAvatar',
 			});
@@ -24,7 +25,7 @@ Meteor.methods({
 		let user;
 
 		if (userId && userId !== Meteor.userId()) {
-			if (!hasPermission(Meteor.userId(), 'edit-other-user-avatar')) {
+			if (!canEditOtherUserAvatar) {
 				throw new Meteor.Error('error-unauthorized', 'Unauthorized', {
 					method: 'resetAvatar',
 				});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
- Allow admins (or any other user with the `edit-other-user-avatar` permission) to update or reset user avatars even when the "Allow User Avatar Change" setting is off.

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[Task - ClickUp](https://app.clickup.com/t/69cygr)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Go to **Administration > Accounts** and turn the "Allow User Avatar Change" setting off. Still logged in as an admin, go to **Administration > Users**, select a user, upload a custom avatar and save the changes. Then, select the same user and reset its avatar to the default option.
Both actions should be performed succesfullly.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
