### PR TITLE
Regression: Fix app storage migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10903,6 +10903,15 @@
       "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
       "dev": true
     },
+    "@types/adm-zip": {
+      "version": "0.4.34",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.4.34.tgz",
+      "integrity": "sha512-8ToYLLAYhkRfcmmljrKi22gT2pqu7hGMDtORP1emwIEGmgUTZOsaDjzWFzW5N2frcFRz/50CWt4zA1CxJ73pmQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/agenda": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@types/agenda/-/agenda-2.0.9.tgz",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		"@storybook/addon-postcss": "^2.0.0",
 		"@storybook/addons": "^6.3.6",
 		"@storybook/react": "^6.3.8",
+		"@types/adm-zip": "^0.4.34",
 		"@types/agenda": "^2.0.9",
 		"@types/bad-words": "^3.0.1",
 		"@types/bcrypt": "^5.0.0",

--- a/server/startup/migrations/v238.ts
+++ b/server/startup/migrations/v238.ts
@@ -1,3 +1,5 @@
+import AdmZip from 'adm-zip';
+
 import { AppManager } from '@rocket.chat/apps-engine/server/AppManager';
 
 import { addMigration } from '../../lib/migrations';
@@ -11,9 +13,36 @@ addMigration({
 		const apps = Apps._model.find().fetch();
 
 		for (const app of apps) {
-			const zipFile = Buffer.from(app.zip, 'base64');
+			const zipFile = isPreCompilerRemoval(app) ? repackageAppZip(app) : Buffer.from(app.zip, 'base64');
 			Promise.await((Apps._manager as AppManager).update(zipFile, app.permissionsGranted, { loadApp: false }));
 			Promise.await(Apps._model.update({ id: app.id }, { $unset: { zip: 1, compiled: 1 } }));
 		}
 	},
 });
+
+function isPreCompilerRemoval(app: any): boolean {
+  const fileNames = Object.keys(app.compiled);
+  return fileNames.some(file => file.endsWith('$ts')) ;
+}
+
+function repackageAppZip(app: any): Buffer {
+  const zip = new AdmZip();
+
+  const sourceFiles: string[] = [];
+
+  Object.entries(app.compiled).forEach(([key, value]) => {
+    const actualFileName = key.endsWith('$ts') ? key.replace(/\$ts$/, '.js') : key;
+    sourceFiles.push(actualFileName);
+    zip.addFile(actualFileName, Buffer.from(value as string, 'utf8'));
+  });
+
+  const zipToRead = new AdmZip(Buffer.from(app.zip, 'base64'));
+
+  zipToRead.forEach((entry: any) => {
+    if (!sourceFiles.includes(entry.entryName)) {
+      zip.addFile(entry.entryName, entry.getData());
+    }
+  });
+
+  return zip.toBuffer();
+}

--- a/server/startup/migrations/v238.ts
+++ b/server/startup/migrations/v238.ts
@@ -1,9 +1,35 @@
 import AdmZip from 'adm-zip';
 
 import { AppManager } from '@rocket.chat/apps-engine/server/AppManager';
-
 import { addMigration } from '../../lib/migrations';
 import { Apps } from '../../../app/apps/server';
+
+function isPreCompilerRemoval(app: any): boolean {
+	const fileNames = Object.keys(app.compiled);
+	return fileNames.some((file) => file.endsWith('$ts'));
+}
+
+function repackageAppZip(app: any): Buffer {
+	const zip = new AdmZip();
+
+	const sourceFiles: string[] = [];
+
+	Object.entries(app.compiled).forEach(([key, value]) => {
+		const actualFileName = key.endsWith('$ts') ? key.replace(/\$ts$/, '.js') : key;
+		sourceFiles.push(actualFileName);
+		zip.addFile(actualFileName, Buffer.from(value as string, 'utf8'));
+	});
+
+	const zipToRead = new AdmZip(Buffer.from(app.zip, 'base64'));
+
+	zipToRead.forEach((entry: any) => {
+		if (!sourceFiles.includes(entry.entryName)) {
+			zip.addFile(entry.entryName, entry.getData());
+		}
+	});
+
+	return zip.toBuffer();
+}
 
 addMigration({
 	version: 238,
@@ -19,30 +45,3 @@ addMigration({
 		}
 	},
 });
-
-function isPreCompilerRemoval(app: any): boolean {
-  const fileNames = Object.keys(app.compiled);
-  return fileNames.some(file => file.endsWith('$ts')) ;
-}
-
-function repackageAppZip(app: any): Buffer {
-  const zip = new AdmZip();
-
-  const sourceFiles: string[] = [];
-
-  Object.entries(app.compiled).forEach(([key, value]) => {
-    const actualFileName = key.endsWith('$ts') ? key.replace(/\$ts$/, '.js') : key;
-    sourceFiles.push(actualFileName);
-    zip.addFile(actualFileName, Buffer.from(value as string, 'utf8'));
-  });
-
-  const zipToRead = new AdmZip(Buffer.from(app.zip, 'base64'));
-
-  zipToRead.forEach((entry: any) => {
-    if (!sourceFiles.includes(entry.entryName)) {
-      zip.addFile(entry.entryName, entry.getData());
-    }
-  });
-
-  return zip.toBuffer();
-}

--- a/server/startup/migrations/v238.ts
+++ b/server/startup/migrations/v238.ts
@@ -22,7 +22,7 @@ function repackageAppZip(app: any): Buffer {
 
 	const zipToRead = new AdmZip(Buffer.from(app.zip, 'base64'));
 
-	zipToRead.forEach((entry: any) => {
+	zipToRead.getEntries().forEach((entry: any) => {
 		if (!sourceFiles.includes(entry.entryName)) {
 			zip.addFile(entry.entryName, entry.getData());
 		}

--- a/server/startup/migrations/v238.ts
+++ b/server/startup/migrations/v238.ts
@@ -1,6 +1,6 @@
 import AdmZip from 'adm-zip';
-
 import { AppManager } from '@rocket.chat/apps-engine/server/AppManager';
+
 import { addMigration } from '../../lib/migrations';
 import { Apps } from '../../../app/apps/server';
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
The previous version of this migration didn't take into consideration apps that were installed prior to [Rocket.Chat@3.8.0](https://github.com/RocketChat/Rocket.Chat/releases/tag/3.8.0), which [removed the typescript compiler from the server](https://github.com/RocketChat/Rocket.Chat/pull/18687) and into the CLI. As a result, the zip files inside each installed app's document in the database had typescript files in them instead of the now required javascript files.

As the new strategy of source code storage for apps changes the way the app is loaded, those zip files containing the source code are read everytime the app is started (or [in this particular case, updated](https://github.com/RocketChat/Rocket.Chat/pull/23286/files#diff-caf9f7a22478639e58d6514be039140a42ce1ab2d999c3efe5678c38ee36d0ccR43)), and as the zips' contents were wrong, the operation was failing.

The fix extract the data from old apps and creates new zip files with the compiled `js` already present.

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
