### PR TITLE
Regression: Create new loggers based on server log level

### DIFF
--- a/server/lib/logger/Logger.ts
+++ b/server/lib/logger/Logger.ts
@@ -65,6 +65,14 @@ export class Logger {
 		this.logger.info(msg, ...args);
 	}
 
+	startup<T extends object>(obj: T, ...args: any[]): void;
+
+	startup(msg: string, ...args: any[]): void;
+
+	startup(msg: string, ...args: any[]): void {
+		this.logger.startup(msg, ...args);
+	}
+
 	success<T extends object>(obj: T, ...args: any[]): void;
 
 	success(msg: string, ...args: any[]): void;

--- a/server/lib/logger/Logger.ts
+++ b/server/lib/logger/Logger.ts
@@ -12,11 +12,15 @@ const getLevel = (level: LogLevelSetting): string => {
 	}
 };
 
+let defaultLevel = 'info';
+
+logLevel.once('changed', (level) => { defaultLevel = getLevel(level); });
+
 export class Logger {
 	readonly logger: P.Logger;
 
 	constructor(loggerLabel: string) {
-		this.logger = getPino(loggerLabel);
+		this.logger = getPino(loggerLabel, defaultLevel);
 
 		logLevel.on('changed', (level) => {
 			this.logger.level = getLevel(level);

--- a/server/lib/logger/Logger.ts
+++ b/server/lib/logger/Logger.ts
@@ -12,7 +12,7 @@ const getLevel = (level: LogLevelSetting): string => {
 	}
 };
 
-let defaultLevel = 'info';
+let defaultLevel = 'warn';
 
 logLevel.once('changed', (level) => { defaultLevel = getLevel(level); });
 

--- a/server/lib/logger/getPino.ts
+++ b/server/lib/logger/getPino.ts
@@ -13,7 +13,7 @@ function logMethod(this: P.Logger, args: unknown[], method: any): void {
 	return method.apply(this, args);
 }
 
-export function getPino(name: string, level = 'info'): P.Logger {
+export function getPino(name: string, level = 'warn'): P.Logger {
 	return pino({
 		name,
 		hooks: { logMethod },

--- a/server/lib/logger/getPino.ts
+++ b/server/lib/logger/getPino.ts
@@ -21,6 +21,7 @@ export function getPino(name: string, level = 'info'): P.Logger {
 			http: 35,
 			method: 35,
 			subscription: 35,
+			startup: 51,
 		},
 		level,
 		timestamp: pino.stdTimeFunctions.isoTime,

--- a/server/lib/logger/getPino.ts
+++ b/server/lib/logger/getPino.ts
@@ -13,7 +13,7 @@ function logMethod(this: P.Logger, args: unknown[], method: any): void {
 	return method.apply(this, args);
 }
 
-export function getPino(name: string): P.Logger {
+export function getPino(name: string, level = 'info'): P.Logger {
 	return pino({
 		name,
 		hooks: { logMethod },
@@ -22,6 +22,7 @@ export function getPino(name: string): P.Logger {
 			method: 35,
 			subscription: 35,
 		},
+		level,
 		timestamp: pino.stdTimeFunctions.isoTime,
 		...process.env.NODE_ENV !== 'production' ? { prettyPrint: { colorize: true } } : {},
 	});

--- a/server/lib/migrations.ts
+++ b/server/lib/migrations.ts
@@ -133,7 +133,7 @@ function migrate(direction: 'up' | 'down', migration: IMigration): void {
 		throw new Error(`Cannot migrate ${ direction } on version ${ migration.version }`);
 	}
 
-	log.info(`Running ${ direction }() on version ${ migration.version }${ migration.name ? `(${ migration.name })` : '' }`);
+	log.startup(`Running ${ direction }() on version ${ migration.version }${ migration.name ? `(${ migration.name })` : '' }`);
 
 	migration[direction]?.(migration);
 }
@@ -150,7 +150,7 @@ export function migrateDatabase(targetVersion: 'latest' | number, subcommands?: 
 	const orderedMigrations = getOrderedMigrations();
 
 	if (orderedMigrations.length === 0) {
-		log.info('No migrations to run');
+		log.startup('No migrations to run');
 		return true;
 	}
 
@@ -199,7 +199,7 @@ export function migrateDatabase(targetVersion: 'latest' | number, subcommands?: 
 	}
 
 	if (subcommands?.includes('rerun')) {
-		log.info(`Rerunning version ${ targetVersion }`);
+		log.startup(`Rerunning version ${ targetVersion }`);
 		const migration = orderedMigrations.find((migration) => migration.version === targetVersion);
 
 		if (!migration) {
@@ -213,13 +213,13 @@ export function migrateDatabase(targetVersion: 'latest' | number, subcommands?: 
 			log.error({ err: e });
 			process.exit(1);
 		}
-		log.info('Finished migrating.');
+		log.startup('Finished migrating.');
 		unlock(currentVersion);
 		return true;
 	}
 
 	if (currentVersion === version) {
-		log.info(`Not migrating, already at version ${ version }`);
+		log.startup(`Not migrating, already at version ${ version }`);
 		unlock(currentVersion);
 		return true;
 	}
@@ -234,7 +234,7 @@ export function migrateDatabase(targetVersion: 'latest' | number, subcommands?: 
 		throw new Error(`Can't find migration version ${ version }`);
 	}
 
-	log.info(`Migrating from version ${ orderedMigrations[startIdx].version } -> ${ orderedMigrations[endIdx].version }`);
+	log.startup(`Migrating from version ${ orderedMigrations[startIdx].version } -> ${ orderedMigrations[endIdx].version }`);
 
 	try {
 		if (currentVersion < version) {
@@ -261,7 +261,7 @@ export function migrateDatabase(targetVersion: 'latest' | number, subcommands?: 
 	}
 
 	unlock(orderedMigrations[endIdx].version);
-	log.info('Finished migrating.');
+	log.startup('Finished migrating.');
 
 	// remember to run meteor with --once otherwise it will restart
 	if (subcommands?.includes('exit')) {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->
After startup, when the settings are all cached, new loggers were being created with `INFO` level, because that's the pino's default level, even though the server setting was set to `ERROR`. This commit fix that https://github.com/RocketChat/Rocket.Chat/commit/21d73a318e43611429b8e78d9fdc01051c9dc208

[The other commit](https://github.com/RocketChat/Rocket.Chat/commit/1993a1835a5e66ca45db96529d762603e557762f) basically creates a startup level, so startup message can always be shown, even if `ERROR` is the default log level.

[Changing the default log level to warn](https://github.com/RocketChat/Rocket.Chat/pull/23297/commits/214e066e9022d48dac53b5ed728f5e8c2cdcb5d3) will kinda restore the old behavior as before pino was introduced.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
