### PR TITLE
[FIX]: Broken links in search

### DIFF
--- a/app/ui-message/client/message.js
+++ b/app/ui-message/client/message.js
@@ -46,7 +46,7 @@ const renderBody = (msg, settings) => {
 	}
 
 	if (searchedText) {
-		msg = msg.replace(new RegExp(searchedText, 'gi'), (str) => `<mark>${ str }</mark>`);
+		msg = msg.replace(new RegExp(`(?!href=".)${searchedText}(?!.*")`, 'gi'), (str) => `<mark>${ str }</mark>`);
 	}
 
 	return msg;


### PR DESCRIPTION
Added a more precise regex to check and replace the searched text with a highlight. (Ignoring the links in href which was causing the issue)

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

The following image is taken from the issue #23285.
![image](https://user-images.githubusercontent.com/29501260/135315451-b9e7fc37-826c-459d-958b-13ca44212a00.png)
As the user mentioned the `<a>` tag doesn't seem to get the correct URL in the `href` attribute.
The reason being that if a searched text is present in the search result it gets replaced by `<mark>text<mark>`. But this also affectes the attributes. For instance, if we searched for `google.com`, `href="google.com"` would become `href="<mark>google.com</mark>"`, which results in wrong destination.

This was fixed using a more narrow regex search. Here I look for only those matches which does not come between `href="` and  `"`
Following this change the URL points to the right link.
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
#23285 
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Reproduction steps mentioned in the issue
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
My first PR, please suggest better approaches, if any.