### PR TITLE
[NEW] Custom email header for send timestamp

### DIFF
--- a/app/mailer/server/api.js
+++ b/app/mailer/server/api.js
@@ -123,6 +123,14 @@ export const sendNoWrap = ({ to, from, replyTo, subject, html, text, headers }) 
 		html = undefined;
 	}
 
+	// == Email Delay ==
+	// Seeking Alpha’s LogStasher setup measures the queue wait-time
+	// between us sending email and our mail provider actually delivering it.
+	// This is reported in Kibana’s `email-*` index, in the `delay` field (measured in seconds).
+	// The calculation is based on a custom email header `X-SA-send-ts` (time_t).
+	headers = Object(headers);
+	headers['X-SA-send-ts'] = Math.round(new Date().getTime() / 1000);
+
 	Meteor.defer(() => Email.send({ to, from, replyTo, subject, html, text, headers }));
 };
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
At [Seeking Alpha](https://seekingalpha.com/), we add a custom email header to all email we send out, both from our web application and from our Rocket.Chat installation.  The custom header contains the send time as a time_t.  We use this data, along with the standard email headers added by our email provider, to measure the provider's delay in delivering the email (which unfortunately can sometimes be quite significant!)

@milton-rucks requested that I PR this patch for inclusion in the upstream (core) RC repo.  He will add additional code to make the custom header name customizable.

FOR THE CHANGELOG:
<!-- CHANGELOG -->
Add a custom email header for benchmarking a mail provider's delivery latency 
<!-- END CHANGELOG -->
