### PR TITLE
[FIX][ENTERPRISE] Omnichannel agent is not leaving the room when a forwarded chat is queued

### DIFF
--- a/app/livechat/server/lib/Helper.js
+++ b/app/livechat/server/lib/Helper.js
@@ -430,7 +430,6 @@ export const forwardRoomToDepartment = async (room, guest, transferData) => {
 	}
 
 	const { servedBy, chatQueued } = roomTaken;
-	logger.debug({ msg: 'New Room object properties after deletedInquiry', servedBy, chatQueued });
 	if (!chatQueued && oldServedBy && servedBy && oldServedBy._id === servedBy._id) {
 		logger.debug(`Cannot forward room ${ room._id }. Chat assigned to agent ${ servedBy._id } (Previous was ${ oldServedBy._id })`);
 		return false;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
When a chatbot forwards a chat to another department, but there's no agent available to take the chat and the Waiting Queue feature is activated.
In that case, the chat is placed in the queue, which means that as soon as an agent is available, the chat should be assigned but this is not happening because the previous agent is not leaving the conversation and is still subscribed.



## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Enable Waiting Queue Feature
2. Set Max. number of simultâneous chats per agent
3. Set up 2 different departments(A and B) with different agents within each one
4. Reach the max. number of chats per agent in one department (A)
5. Starts a new chat on department (B)
6. Forward the chat to department (A)
7. The issue takes place and the previous agent is still subscribed to the chat.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
