### PR TITLE
Doc: Rocket.Chat 4.0 User Friendly Docker Compose Template

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: registry.rocket.chat/rocketchat/rocket.chat:latest
     command: >
       bash -c
-        "for (( ; ; )); do
+        "for i in `seq 1 30`; do
           node main.js &&
           s=$$? && break || s=$$?;
           echo \"Could not start Rocket.Chat. Waiting 5 secs...\";
@@ -39,8 +39,7 @@ services:
     restart: unless-stopped
     volumes:
      - ./data/db:/data/db
-     # Enable (remove the #) the data dump mount below, if migration not already done, else leave it as is.
-     #- ./data/dump:/dump
+     - ./data/dump:/dump
     command: mongod --oplogSize 128 --replSet rs0
     labels:
       - "traefik.enable=false"
@@ -51,7 +50,7 @@ services:
     image: mongo:4.2
     command: >
       bash -c
-        "for (( ; ; )); do
+        "for i in `seq 1 30`; do
           mongo mongo/rocketchat --eval \"
             rs.initiate({
               _id: 'rs0',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,10 @@ services:
     image: registry.rocket.chat/rocketchat/rocket.chat:latest
     command: >
       bash -c
-        "for i in `seq 1 30`; do
+        "for (( ; ; )); do
           node main.js &&
           s=$$? && break || s=$$?;
-          echo \"Tried $$i times. Waiting 5 secs...\";
+          echo \"Could not start Rocket.Chat. Waiting 5 secs...\";
           sleep 5;
         done; (exit $$s)"
     restart: unless-stopped
@@ -31,28 +31,33 @@ services:
       - "traefik.frontend.rule=Host: your.domain.tld"
 
   mongo:
-    image: mongo:4.0
+  # If you're currently running Rocket.Chat 3.x.y, use this template only after completing MMAPv1 to WiredTiger migration.
+   # a. How-to guide: https://docs.rocket.chat/quick-start/installing-and-updating/docker-containers/mongodb-mmap-to-wiredtiger-migration
+   # b. After completing migration, replace the docker-compose.yml file used in the above guide, with this one and update accordingly.
+   # c. Run "docker-compose up -d --remove-orphans" from the compose directory "/opt/rocketchat", based on step a.
+    image: mongo:4.2
     restart: unless-stopped
     volumes:
      - ./data/db:/data/db
+     # Enable (remove the #) the data dump mount below, if migration not already done, else leave it as is.
      #- ./data/dump:/dump
-    command: mongod --smallfiles --oplogSize 128 --replSet rs0 --storageEngine=mmapv1
+    command: mongod --oplogSize 128 --replSet rs0
     labels:
       - "traefik.enable=false"
 
   # this container's job is just run the command to initialize the replica set.
-  # it will run the command and remove himself (it will not stay running)
+  # it will run the command and terminate (it will not stay running)
   mongo-init-replica:
-    image: mongo:4.0
+    image: mongo:4.2
     command: >
       bash -c
-        "for i in `seq 1 30`; do
+        "for (( ; ; )); do
           mongo mongo/rocketchat --eval \"
             rs.initiate({
               _id: 'rs0',
               members: [ { _id: 0, host: 'localhost:27017' } ]})\" &&
           s=$$? && break || s=$$?;
-          echo \"Tried $$i times. Waiting 5 secs...\";
+          echo \"Could not reach MongoDB. Waiting 5 secs ...\";
           sleep 5;
         done; (exit $$s)"
     depends_on:


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes

- Updated services `rocketchat` and `mongo-init-replica` command for loops to run endlessly (as per migration guide - linked in this template).
- Added migration guidelines for existing Rocket.Chat 3.x.y users in `mongo` service definition.
- Also, updated the `mongo` and `mongo-init-replica` service definitions to use MongoDB 4.2 which is now a minimum requirement to make a quick transition. I understand this has already been requested in PR https://github.com/RocketChat/Rocket.Chat/pull/23402
- Removed `--smallfiles` and `--storageEngine=mmapv1` deprecated options within the `mongod` database server command.

<!-- END CHANGELOG -->

## Issue(s)
https://github.com/RocketChat/Rocket.Chat/issues/23341

## Further comments

Because of the recent breaking changes on the latest version, this update really helps as a migration & upgrade friendly template based on MongoDB 4.2, with necessary guidelines as comments inside the `mongo` service. Specifying the storage engine is no longer needed since `wiredTiger` is automatically set by [default since MongoDB 3.2](https://docs.mongodb.com/manual/release-notes/3.2-compatibility/#default-storage-engine-change). The `--smallfiles` configuration option was also [MMAPv1 specific](https://docs.mongodb.com/v4.0/reference/program/mongod/index.html#cmdoption-mongod-smallfiles) (deprecated).
