### PR TITLE
Chore: entrypoint script for docker image

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -46,4 +46,4 @@ ENV DEPLOY_METHOD=docker \
 
 EXPOSE 3000
 
-CMD ["node", "/app/entrypoint.js"]
+ENTRYPOINT ["node", "/app/entrypoint.js"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -46,4 +46,4 @@ ENV DEPLOY_METHOD=docker \
 
 EXPOSE 3000
 
-CMD ["node", "main.js"]
+CMD ["node", "/app/entrypoint.js"]

--- a/.docker/entrypoint.js
+++ b/.docker/entrypoint.js
@@ -20,9 +20,8 @@ const mongoClient = new MongoClient(connectionUri, {
 function startRocketChat() {
   const child = spawn(`node`, [`main.js`]);
 
-  child.stdout.on(`data`, (data) => process.stdout.write(data));
-
-  child.stderr.on(`data`, (data) => process.stderr.write(data));
+  child.stdout.pipe(process.stdout)
+	child.stderr.pipe(process.stderr)
 
   child.on(`exit`, (code, _) => process.exit(code));
 }
@@ -80,9 +79,8 @@ async function main() {
   if (process.argv.slice(2).length !== 0) {
     const child = exec(process.argv.slice(2).join(` `));
 
-    child.stdout.on(`data`, (data) => process.stdout.write(data));
-
-    child.stderr.on(`data`, (data) => process.stdout.write(data));
+    child.stdout.pipe(process.stdout)
+		child.stderr.pipe(process.stderr)
 
     child.on(`exit`, (code, _) => process.exit(code));
 

--- a/.docker/entrypoint.js
+++ b/.docker/entrypoint.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const {
+  MongoClient,
+  MongoNetworkError,
+  MongoServerSelectionError,
+} = require(`/app/bundle/programs/server/npm/node_modules/mongodb`);
+const { spawn } = require(`child_process`);
+
+const connectionUri = process.env.MONGO_URL;
+const mongoClient = new MongoClient(
+  connectionUri,
+  { useUnifiedTopology: true },
+  { native_parser: true },
+  { numberOfRetries: 0 },
+  { connectTimeoutMS: 5000 },
+  { noDelay: true },
+  { serverSelectionTimeoutMS: 5000 },
+  { socketTimeoutMS: 5000 },
+  { waitQueueTimeoutMS: 5000 }
+);
+
+function startRocketChat() {
+  const child = spawn(`node`, [`main.js`]);
+
+  child.stdout.on(`data`, (data) => process.stdout.write(data));
+
+  child.stderr.on(`data`, (data) => process.stderr.write(data));
+
+  child.on(`exit`, (code, _) => process.exit(code));
+}
+
+async function mongoReady() {
+  try {
+    await mongoClient.connect();
+    // connection successful
+    return { ready: true, msg: 'connection established' };
+  } catch (err) {
+    if (err instanceof MongoNetworkError) {
+      return { ready: false, msg: 'mongo server not running' };
+    }
+    if (err instanceof MongoServerSelectionError) {
+      // couldn't connect
+      return { ready: false, msg: 'mongo replicaset primary not selected' };
+    }
+    // some other error unrelated to mongod not running
+    // better exit without retrying
+    console.error(err);
+    process.exit(1);
+  }
+}
+
+async function start() {
+  const sleep = async (seconds) =>
+    await new Promise((r) => setTimeout(r, seconds * 1000));
+
+  const maxRetryCount = 30;
+	let mongoServerStatus;
+
+  for (let retryCount of Array(maxRetryCount).keys()) {
+    mongoServerStatus = await mongoReady();
+    if (mongoServerStatus.ready) {
+      break;
+    }
+    retryCount++;
+    console.log(mongoServerStatus.msg);
+    if (retryCount == maxRetryCount) {
+      console.error(
+        `max number of retries reached (${maxRetryCount}).. failed to connect.. exiting...`
+      );
+      process.exit(1);
+    }
+    console.error(
+      `failed to connect to mongod..tried ${retryCount} times.. retrying in 5 seconds...`
+    );
+    await sleep(10);
+  }
+  console.log(mongoServerStatus.msg);
+  mongoClient.close();
+  startRocketChat();
+}
+
+start();

--- a/.docker/entrypoint.js
+++ b/.docker/entrypoint.js
@@ -8,17 +8,14 @@ const {
 const { spawn, exec } = require(`child_process`);
 
 const connectionUri = process.env.MONGO_URL;
-const mongoClient = new MongoClient(
-  connectionUri,
-  { useUnifiedTopology: true },
-  { native_parser: true },
-  { numberOfRetries: 0 },
-  { connectTimeoutMS: 5000 },
-  { noDelay: true },
-  { serverSelectionTimeoutMS: 5000 },
-  { socketTimeoutMS: 5000 },
-  { waitQueueTimeoutMS: 5000 }
-);
+const mongoClient = new MongoClient(connectionUri, {
+  useUnifiedTopology: true,
+  connectTimeoutMS: 5000,
+  noDelay: true,
+  serverSelectionTimeoutMS: 5000,
+  socketTimeoutMS: 5000,
+  waitQueueTimeoutMS: 5000,
+});
 
 function startRocketChat() {
   const child = spawn(`node`, [`main.js`]);
@@ -55,7 +52,7 @@ async function start() {
     await new Promise((r) => setTimeout(r, seconds * 1000));
 
   const maxRetryCount = 30;
-	let mongoServerStatus;
+  let mongoServerStatus;
 
   for (let retryCount of Array(maxRetryCount).keys()) {
     mongoServerStatus = await mongoReady();

--- a/.docker/entrypoint.js
+++ b/.docker/entrypoint.js
@@ -73,7 +73,7 @@ async function start() {
     console.error(
       `failed to connect to mongod..tried ${retryCount} times.. retrying in 5 seconds...`
     );
-    await sleep(10);
+    await sleep(5);
   }
   console.log(mongoServerStatus.msg);
   mongoClient.close();
@@ -81,7 +81,7 @@ async function start() {
 }
 
 async function main() {
-  if (process.argv.slice(2)) {
+  if (process.argv.slice(2).length !== 0) {
     const child = exec(process.argv.slice(2).join(` `));
 
     child.stdout.on(`data`, (data) => process.stdout.write(data));

--- a/.docker/entrypoint.js
+++ b/.docker/entrypoint.js
@@ -5,7 +5,7 @@ const {
   MongoNetworkError,
   MongoServerSelectionError,
 } = require(`/app/bundle/programs/server/npm/node_modules/mongodb`);
-const { spawn } = require(`child_process`);
+const { spawn, exec } = require(`child_process`);
 
 const connectionUri = process.env.MONGO_URL;
 const mongoClient = new MongoClient(
@@ -80,4 +80,19 @@ async function start() {
   startRocketChat();
 }
 
-start();
+async function main() {
+  if (process.argv.slice(2)) {
+    const child = exec(process.argv.slice(2).join(` `));
+
+    child.stdout.on(`data`, (data) => process.stdout.write(data));
+
+    child.stderr.on(`data`, (data) => process.stdout.write(data));
+
+    child.on(`exit`, (code, _) => process.exit(code));
+
+    return;
+  }
+  await start();
+}
+
+main();

--- a/.docker/entrypoint.js
+++ b/.docker/entrypoint.js
@@ -54,12 +54,11 @@ async function start() {
   const maxRetryCount = 30;
   let mongoServerStatus;
 
-  for (let retryCount of Array(maxRetryCount).keys()) {
+  for (let retryCount = 1; retryCount <= maxRetryCount; retryCount++) {
     mongoServerStatus = await mongoReady();
     if (mongoServerStatus.ready) {
       break;
     }
-    retryCount++;
     console.log(mongoServerStatus.msg);
     if (retryCount == maxRetryCount) {
       console.error(

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -392,6 +392,9 @@ jobs:
         if [ -e ${DOCKER_PATH}/entrypoint.sh ]; then
           cp ${DOCKER_PATH}/entrypoint.sh .
         fi;
+        if [ -e ${DOCKER_PATH}/entrypoint.js ]; then
+          cp ${DOCKER_PATH}/entrypoint.js .
+        fi
 
         docker build -t $IMAGE_NAME .
         docker push $IMAGE_NAME
@@ -516,6 +519,9 @@ jobs:
         if [ -e ${DOCKER_PATH}/entrypoint.sh ]; then
           cp ${DOCKER_PATH}/entrypoint.sh .
         fi;
+        if [ -e ${DOCKER_PATH}/entrypoint.js ]; then
+          cp ${DOCKER_PATH}/entrypoint.js .
+        fi
 
     - name: Build Docker image for tag
       if: github.event_name == 'release'


### PR DESCRIPTION
The current loop assumes every error to be a connection failure, where that isn't necessarily the case.

One very common one is authentication failure. In such situations it's not quite logical to continue retrying whereas
the process should exit and let the admin fix the credentials first (or whatever the other issue should be).

This script filters out the actual connection failure & replicaset primary selection error and retries ONLY in these cases. Otherwise simply prints the issue and terminates the process.

Another benefit is by implementing the retry logic in the application container image we get rid of the necessity of implementing the same in/through different deployment methods. One immediate example that I can think of is caprover, which uses a compose like structure for its one click apps, but doesn't support the command key (iow expects the retry logic to be part of the image). 