### PR TITLE
[FIX] Resolves issue with E2E default settings on private and Direct

### DIFF
--- a/app/e2e/server/beforeCreateRoom.js
+++ b/app/e2e/server/beforeCreateRoom.js
@@ -3,7 +3,7 @@ import { settings } from '../../settings/server';
 
 callbacks.add('beforeCreateRoom', ({ type, extraData }) => {
 	if (
-		settings.get('E2E_Enabled') && ((type === 'd' && settings.get('E2E_Enabled_Default_DirectRooms'))
+		settings.get('E2E_Enable') && ((type === 'd' && settings.get('E2E_Enabled_Default_DirectRooms'))
 		|| (type === 'p' && settings.get('E2E_Enabled_Default_PrivateRooms')))
 	) {
 		extraData.encrypted = extraData.encrypted ?? true;

--- a/app/e2e/server/settings.ts
+++ b/app/e2e/server/settings.ts
@@ -11,11 +11,13 @@ settingsRegistry.addGroup('E2E Encryption', function() {
 
 	this.add('E2E_Enabled_Default_DirectRooms', false, {
 		type: 'boolean',
+                public: true,
 		enableQuery: { _id: 'E2E_Enable', value: true },
 	});
 
 	this.add('E2E_Enabled_Default_PrivateRooms', false, {
 		type: 'boolean',
+                public: true,
 		enableQuery: { _id: 'E2E_Enable', value: true },
 	});
 });


### PR DESCRIPTION
Change Log:
- Fixed Typo with E2E_Enable in the E2E server settings
- Made property public.

This has been tested and confirmed working in our internal systems. 

Additional notes:
We have further implemented Enforced E2E in our own company build for Private and DM (meaning users cannot disable). We'd be happy to upstream if there's interest as we're sure there's customers who require that as much as we did.