### PR TITLE
Regression: Prevent settings from getting updated

### DIFF
--- a/app/settings/server/SettingsRegistry.ts
+++ b/app/settings/server/SettingsRegistry.ts
@@ -96,8 +96,6 @@ export class SettingsRegistry {
 			throw new Error('Invalid arguments');
 		}
 
-		const nonEmptyOptions = Object.fromEntries(Object.entries(options).filter(([, value]) => value !== undefined));
-
 		const sorterKey = group && section ? `${ group }_${ section }` : group;
 
 		if (sorterKey && this._sorter[sorterKey] == null) {
@@ -117,8 +115,8 @@ export class SettingsRegistry {
 			value,
 			sorter: sorter ?? (sorterKey?.length && this._sorter[sorterKey]++),
 			group,
-			...section && { section },
-			...nonEmptyOptions,
+			section,
+			...options,
 		}, blockedSettings, hiddenSettings, wizardRequiredSettings);
 
 		if (isSettingEnterprise(settingFromCode) && !('invalidValue' in settingFromCode)) {
@@ -147,9 +145,9 @@ export class SettingsRegistry {
 
 			this.model.upsert({ _id }, {
 				$set: { ...settingOverwrittenProps },
-				...removedKeys.length > 0 ? {
+				...removedKeys.length && {
 					$unset: removedKeys.reduce((unset, key) => ({ ...unset, [key]: 1 }), {}),
-				} : {},
+				},
 			});
 			return;
 		}

--- a/app/settings/server/functions/getSettingDefaults.tests.ts
+++ b/app/settings/server/functions/getSettingDefaults.tests.ts
@@ -85,4 +85,14 @@ describe('getSettingDefaults', () => {
 
 		expect(setting).to.have.property('blocked').to.be.equal(true);
 	});
+
+	it('should not return undefined options', () => {
+		const setting = getSettingDefaults({ _id: 'test', value: true, type: 'string', section: undefined, group: undefined }, new Set(['test']));
+
+		expect(setting).to.be.an('object');
+		expect(setting).to.have.property('_id');
+
+		expect(setting).to.not.have.property('section');
+		expect(setting).to.not.have.property('group');
+	});
 });

--- a/app/settings/server/functions/getSettingDefaults.ts
+++ b/app/settings/server/functions/getSettingDefaults.ts
@@ -6,7 +6,9 @@ export const getSettingDefaults = (
 	hiddenSettings: Set<string> = new Set(),
 	wizardRequiredSettings: Set<string> = new Set(),
 ): ISetting => {
-	const { _id, value, sorter, ...options } = setting;
+	const { _id, value, sorter, ...props } = setting;
+
+	const options = Object.fromEntries(Object.entries(props).filter(([, value]) => value !== undefined));
 
 	return {
 		_id,


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->
Fix few situations where settings were updated without need:

- `section` field was being set as `undefined`, so `compareSettings` was always returning `true` for settings without a `section`
- if a key was removed from the setting definition (like the old field `meteorSettingsValue`) that was never persisted in the database
- Remove `undefined` values from `options`

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Run with: `meteor npm run ha`
- Then open a web browser and watch WS messages
- Start a new instance with: `meteor npm run ha:add`
- You should see no more Settings being streamed over WS

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
