### PR TITLE
[NEW] Making connector as a part of VoipService and removing earlier hardcoding for management server

### DIFF
--- a/app/api/server/v1/voip/extensions.ts
+++ b/app/api/server/v1/voip/extensions.ts
@@ -1,26 +1,22 @@
 
 import { API } from '../../api';
-import { Commands } from '../../../../../server/services/voip/connector/asterisk/Commands';
-import { CommandHandler } from '../../../../../server/services/voip/connector/asterisk/CommandHandler';
 import { Voip } from '../../../../../server/sdk';
-import { ICallServerConfigData, IVoipServerConfig, ServerType } from '../../../../../definition/IVoipServerConfig';
-import { IVoipExtensionBase, IVoipExtensionConfig } from '../../../../../definition/IVoipExtension';
+import { IVoipExtensionBase } from '../../../../../definition/IVoipExtension';
 import { IVoipConnectorResult } from '../../../../../definition/IVoipConnectorResult';
 
-const commandHandler = new CommandHandler();
+// const commandHandler: CommandHandler = Promise.await(Voip.getConnector());
 // Get the connector version and type
 API.v1.addRoute('connector.getVersion', { authRequired: true }, {
 	get() {
-		return API.v1.success(commandHandler.getVersion());
+		const version = Promise.await(Voip.getConnectorVersion());
+		return API.v1.success(version);
 	},
 });
 
 // Get the extensions available on the call server
 API.v1.addRoute('connector.extension.list', { authRequired: true }, {
 	get() {
-		const list = Promise.await(
-			commandHandler.executeCommand(Commands.extension_list, undefined),
-		) as IVoipConnectorResult;
+		const list = Promise.await(Voip.getExtensionList()) as IVoipConnectorResult;
 		const result: IVoipExtensionBase[] = list.result as IVoipExtensionBase[];
 		this.logger.debug({ msg: 'API = connector.extension.list length ', result: result.length });
 		return API.v1.success({ extensions: result });
@@ -33,13 +29,8 @@ API.v1.addRoute('connector.extension.list', { authRequired: true }, {
  */
 API.v1.addRoute('connector.extension.getDetails', { authRequired: true }, {
 	get() {
-		const endpointDetails = Promise.await(
-			commandHandler.executeCommand(
-				Commands.extension_info,
-				this.requestParams()),
-		) as IVoipConnectorResult;
+		const endpointDetails = Promise.await(Voip.getExtensionDetails(this.requestParams())) as IVoipConnectorResult;
 		this.logger.debug({ msg: 'API = connector.extension.getDetails', result: endpointDetails.result });
-
 		return API.v1.success({ ...endpointDetails.result });
 	},
 });
@@ -48,27 +39,8 @@ API.v1.addRoute('connector.extension.getDetails', { authRequired: true }, {
  */
 API.v1.addRoute('connector.extension.getRegistrationInfo', { authRequired: true }, {
 	get() {
-		const config: IVoipServerConfig = Promise.await(
-			Voip.getServerConfigData(ServerType.CALL_SERVER),
-		) as unknown as IVoipServerConfig;
-		if (!config) {
-			this.logger.warn({ msg: 'API = connector.extension.getRegistrationInfo callserver settings not found' });
-			return API.v1.notFound();
-		}
-		const endpointDetails = Promise.await(commandHandler.executeCommand(
-			Commands.extension_info,
-			this.requestParams(),
-		)) as IVoipConnectorResult;
-		const callServerConfig: ICallServerConfigData = config.configData as unknown as ICallServerConfigData;
-		const endpointInfo: IVoipExtensionConfig = endpointDetails.result as IVoipExtensionConfig;
-		const extensionRegistrationInfo = {
-			sipRegistrar: config.host,
-			websocketUri: callServerConfig.websocketPath,
-			extension: endpointInfo.name,
-			password: endpointInfo.password,
-		};
+		const endpointDetails = Promise.await(Voip.getRegistrationInfo(this.requestParams()));
 		this.logger.debug({ msg: 'API = connector.extension.getRegistrationInfo', result: endpointDetails });
-
-		return API.v1.success({ ...extensionRegistrationInfo });
+		return API.v1.success({ ...endpointDetails.result });
 	},
 });

--- a/app/api/server/v1/voip/extensions.ts
+++ b/app/api/server/v1/voip/extensions.ts
@@ -6,7 +6,6 @@ import { Voip } from '../../../../../server/sdk';
 import { IVoipExtensionBase } from '../../../../../definition/IVoipExtension';
 import { IVoipConnectorResult } from '../../../../../definition/IVoipConnectorResult';
 
-// const commandHandler: CommandHandler = Promise.await(Voip.getConnector());
 // Get the connector version and type
 API.v1.addRoute('connector.getVersion', { authRequired: true }, {
 	get() {

--- a/app/api/server/v1/voip/extensions.ts
+++ b/app/api/server/v1/voip/extensions.ts
@@ -1,4 +1,6 @@
 
+import { Match, check } from 'meteor/check';
+
 import { API } from '../../api';
 import { Voip } from '../../../../../server/sdk';
 import { IVoipExtensionBase } from '../../../../../definition/IVoipExtension';
@@ -29,6 +31,9 @@ API.v1.addRoute('connector.extension.list', { authRequired: true }, {
  */
 API.v1.addRoute('connector.extension.getDetails', { authRequired: true }, {
 	get() {
+		check(this.requestParams(), Match.ObjectIncluding({
+			extension: String,
+		}));
 		const endpointDetails = Promise.await(Voip.getExtensionDetails(this.requestParams())) as IVoipConnectorResult;
 		this.logger.debug({ msg: 'API = connector.extension.getDetails', result: endpointDetails.result });
 		return API.v1.success({ ...endpointDetails.result });
@@ -39,6 +44,9 @@ API.v1.addRoute('connector.extension.getDetails', { authRequired: true }, {
  */
 API.v1.addRoute('connector.extension.getRegistrationInfo', { authRequired: true }, {
 	get() {
+		check(this.requestParams(), Match.ObjectIncluding({
+			extension: String,
+		}));
 		const endpointDetails = Promise.await(Voip.getRegistrationInfo(this.requestParams()));
 		this.logger.debug({ msg: 'API = connector.extension.getRegistrationInfo', result: endpointDetails });
 		return API.v1.success({ ...endpointDetails.result });

--- a/app/api/server/v1/voip/queues.ts
+++ b/app/api/server/v1/voip/queues.ts
@@ -1,15 +1,10 @@
 import { API } from '../../api';
-import { Commands } from '../../../../../server/services/voip/connector/asterisk/Commands';
-import { CommandHandler } from '../../../../../server/services/voip/connector/asterisk/CommandHandler';
-import { IQueueDetails, IQueueSummary } from '../../../../../definition/ACDQueues';
+import { Voip } from '../../../../../server/sdk';
 import { IVoipConnectorResult } from '../../../../../definition/IVoipConnectorResult';
 
-const commandHandler = new CommandHandler();
 API.v1.addRoute('voip/queues.getSummary', { authRequired: true }, {
 	get() {
-		const queueSummary = Promise.await(commandHandler.executeCommand(
-			Commands.queue_summary,
-			this.requestParams())) as IVoipConnectorResult;
+		const queueSummary = Promise.await(Voip.getQueueSummary(this.requestParams())) as IVoipConnectorResult;
 		this.logger.debug({ msg: 'API = voip/queues.getSummary ', result: queueSummary });
 		return API.v1.success({ summary: queueSummary.result });
 	},
@@ -17,27 +12,8 @@ API.v1.addRoute('voip/queues.getSummary', { authRequired: true }, {
 
 API.v1.addRoute('voip/queues.getQueuedCallsForThisExtension', { authRequired: true }, {
 	get() {
-		const membershipDetails = {
-			queueCount: 0,
-			callWaitingCount: 0,
-		};
-		const queueSummary	= Promise.await(commandHandler.executeCommand(Commands.queue_summary)) as IVoipConnectorResult;
-		for (const queue of queueSummary.result as IQueueSummary[]) {
-			const queueDetails = Promise.await(commandHandler.executeCommand(
-				Commands.queue_details,
-				{ queueName: queue.name })) as IVoipConnectorResult;
-			this.logger.debug({ msg: 'API = voip/queues.getCallWaitingInQueuesForThisExtension queue details = ', result: queueDetails });
-			if ((queueDetails.result as unknown as IQueueDetails).members) {
-				const isAMember = (queueDetails.result as unknown as IQueueDetails).members.some(
-					(element) => element.name.endsWith(this.requestParams().extension),
-				);
-				if (isAMember) {
-					membershipDetails.callWaitingCount += Number((queueDetails.result as unknown as IQueueDetails).calls);
-					membershipDetails.queueCount++;
-				}
-			}
-		}
+		const membershipDetails: IVoipConnectorResult = Promise.await(Voip.getQueuedCallsForThisExtension(this.requestParams()));
 		this.logger.debug({ msg: 'API = queues.getCallWaitingInQueuesForThisExtension', result: membershipDetails });
-		return API.v1.success({ ...membershipDetails });
+		return API.v1.success({ ...membershipDetails.result });
 	},
 });

--- a/app/api/server/v1/voip/queues.ts
+++ b/app/api/server/v1/voip/queues.ts
@@ -1,10 +1,12 @@
+import { Match, check } from 'meteor/check';
+
 import { API } from '../../api';
 import { Voip } from '../../../../../server/sdk';
 import { IVoipConnectorResult } from '../../../../../definition/IVoipConnectorResult';
 
 API.v1.addRoute('voip/queues.getSummary', { authRequired: true }, {
 	get() {
-		const queueSummary = Promise.await(Voip.getQueueSummary(this.requestParams())) as IVoipConnectorResult;
+		const queueSummary = Promise.await(Voip.getQueueSummary()) as IVoipConnectorResult;
 		this.logger.debug({ msg: 'API = voip/queues.getSummary ', result: queueSummary });
 		return API.v1.success({ summary: queueSummary.result });
 	},
@@ -12,6 +14,9 @@ API.v1.addRoute('voip/queues.getSummary', { authRequired: true }, {
 
 API.v1.addRoute('voip/queues.getQueuedCallsForThisExtension', { authRequired: true }, {
 	get() {
+		check(this.requestParams(), Match.ObjectIncluding({
+			extension: String,
+		}));
 		const membershipDetails: IVoipConnectorResult = Promise.await(Voip.getQueuedCallsForThisExtension(this.requestParams()));
 		this.logger.debug({ msg: 'API = queues.getCallWaitingInQueuesForThisExtension', result: membershipDetails });
 		return API.v1.success({ ...membershipDetails.result });

--- a/client/views/voip/VoIPLayout.tsx
+++ b/client/views/voip/VoIPLayout.tsx
@@ -17,7 +17,7 @@ class VoIPLayout
 	extends React.Component<{}, IState>
 	implements IRegisterHandlerDelegate, IConnectionDelegate, ICallEventDelegate
 {
-	extensionConfig: any;
+	VoipUserIdentity: any;
 
 	userHandler: VoIPUser | undefined;
 
@@ -47,7 +47,112 @@ class VoIPLayout
 		this.webSocketPath = React.createRef();
 		this.callTypeSelection = React.createRef();
 		this.logger = new ClientLogger('VoIPLayout');
-		this.extensionConfig = null;
+		this.VoipUserIdentity = null;
+	}
+
+	private async apitest(): Promise<void> {
+		/*
+		try {
+			this.logger.info('Executing voipServerConfig.callServer');
+			const output = await APIClient.v1.post(
+				'voipServerConfig.callServer',
+				{},
+				{
+					host: 'omni-asterisk.dev.rocket.chat',
+					websocketPort: 443,
+					serverName: 'OmniAsterisk',
+					websocketPath: 'wss://omni-asterisk.dev.rocket.chat/ws',
+				},
+			);
+			this.logger.info('voipServerConfig.callServer output = ', JSON.stringify(output));
+		} catch (error) {
+			this.logger.error('error in API');
+		}
+		try {
+			this.logger.info('Executing voipServerConfig.management');
+			const output = await APIClient.v1.post(
+				'voipServerConfig.management',
+				{},
+				{
+					host: 'omni-asterisk.dev.rocket.chat',
+					port: 5038,
+					serverName: 'OmniAsterisk',
+					username: 'amol',
+					password: '1234',
+				},
+			);
+			this.logger.info('voipServerConfig.management output = ', JSON.stringify(output));
+		} catch (error) {
+			this.logger.error('error in API');
+		}
+		*/
+		try {
+			this.logger.info('Executing connector.getVersion');
+			const list = await APIClient.v1.get('connector.getVersion');
+			this.logger.info('connector.getVersion output = ', JSON.stringify(list));
+		} catch (error) {
+			this.logger.error('error in API');
+		}
+		try {
+			this.logger.info('Executing voipServerConfig.management');
+			const output = await APIClient.v1.get('voipServerConfig.management');
+			this.logger.info('voipServerConfig.management output = ', JSON.stringify(output));
+		} catch (error) {
+			this.logger.error('error in API');
+		}
+		try {
+			this.logger.info('Executing voipServerConfig.callServer');
+			const output = await APIClient.v1.get('voipServerConfig.callServer');
+			this.logger.info('voipServerConfig.callServer output = ', JSON.stringify(output));
+		} catch (error) {
+			this.logger.error('error in API');
+		}
+
+		try {
+			this.logger.info('Executing queues.getSummary');
+			const list = await APIClient.v1.get('voip/queues.getSummary');
+			this.logger.info('queues.getSummary output = ', JSON.stringify(list));
+		} catch (error) {
+			this.logger.error('error in API');
+		}
+
+		try {
+			this.logger.info('Executing queues.getQueuedCallsForThisExtension');
+			const list = await APIClient.v1.get('voip/queues.getQueuedCallsForThisExtension', {
+				extension: '80000',
+			});
+			this.logger.info('queues.getQueuedCallsForThisExtension output = ', JSON.stringify(list));
+		} catch (error) {
+			this.logger.error('error in API');
+		}
+
+		try {
+			this.logger.info('Executing connector.extension.list');
+			const list = await APIClient.v1.get('connector.extension.list');
+			this.logger.info('connector.extension.list output = ', JSON.stringify(list));
+		} catch (error) {
+			this.logger.error('error in API');
+		}
+
+		try {
+			this.logger.info('Executing connector.extension.getDetails');
+			const list = await APIClient.v1.get('connector.extension.getDetails', {
+				extension: '80000',
+			});
+			this.logger.info('connector.extension.getDetails output = ', JSON.stringify(list));
+		} catch (error) {
+			this.logger.error('error in API');
+		}
+
+		try {
+			const userIdentity = await APIClient.v1.get('connector.extension.getRegistrationInfo', {
+				extension: '80000',
+			});
+			this.logger.info('list = ', JSON.stringify(userIdentity));
+		} catch (error) {
+			this.logger.error('error in API');
+			throw error;
+		}
 	}
 
 	private async initUserAgent(): Promise<void> {
@@ -56,34 +161,34 @@ class VoIPLayout
 			extension = this.userName.current.value;
 		}
 		try {
-			this.extensionConfig = await APIClient.v1.get('connector.extension.getRegistrationInfo', {
+			this.VoipUserIdentity = await APIClient.v1.get('connector.extension.getRegistrationInfo', {
 				extension,
 			});
-			this.logger.info('list = ', JSON.stringify(this.extensionConfig));
+			this.logger.info('list = ', JSON.stringify(this.VoipUserIdentity));
 		} catch (error) {
 			this.logger.error('error in API');
 			throw error;
 		}
 
-		if (this.extensionConfig.extension && this.userName.current) {
-			this.userName.current.textContent = this.extensionConfig.extension;
+		if (this.VoipUserIdentity.extensionDetails.extension && this.userName.current) {
+			this.userName.current.textContent = this.VoipUserIdentity.extensionDetails.extension;
 			this.userName.current.disabled = true;
-			this.config.authUserName = this.extensionConfig.extension;
+			this.config.authUserName = this.VoipUserIdentity.extensionDetails.extension;
 		}
-		if (this.extensionConfig.password && this.password.current) {
-			this.password.current.value = this.extensionConfig.password;
+		if (this.VoipUserIdentity.extensionDetails.password && this.password.current) {
+			this.password.current.value = this.VoipUserIdentity.extensionDetails.password;
 			this.password.current.disabled = true;
-			this.config.authPassword = this.extensionConfig.password;
+			this.config.authPassword = this.VoipUserIdentity.extensionDetails.password;
 		}
-		if (this.extensionConfig.sipRegistrar && this.registrar.current) {
-			this.registrar.current.value = this.extensionConfig.sipRegistrar;
+		if (this.VoipUserIdentity.host && this.registrar.current) {
+			this.registrar.current.value = this.VoipUserIdentity.host;
 			this.registrar.current.disabled = true;
-			this.config.sipRegistrarHostnameOrIP = this.extensionConfig.sipRegistrar;
+			this.config.sipRegistrarHostnameOrIP = this.VoipUserIdentity.host;
 		}
-		if (this.extensionConfig.websocketUri && this.webSocketPath.current) {
-			this.webSocketPath.current.value = this.extensionConfig.websocketUri;
+		if (this.VoipUserIdentity.callServerConfig.websocketPath && this.webSocketPath.current) {
+			this.webSocketPath.current.value = this.VoipUserIdentity.callServerConfig.websocketPath;
 			this.webSocketPath.current.disabled = true;
-			this.config.webSocketURI = this.extensionConfig.websocketUri;
+			this.config.webSocketURI = this.VoipUserIdentity.callServerConfig.websocketPath;
 		}
 
 		this.config.enableVideo = this.state.enableVideo;
@@ -106,7 +211,7 @@ class VoIPLayout
 	}
 
 	private async resetUserAgent(): Promise<void> {
-		this.extensionConfig = null;
+		this.VoipUserIdentity = null;
 		if (this.userName.current) {
 			this.userName.current.textContent = '';
 			this.userName.current.disabled = false;
@@ -225,6 +330,7 @@ class VoIPLayout
 	/* CallEventDelegate implementation end */
 
 	async componentDidMount(): Promise<void> {
+		this.apitest();
 		let element = document.getElementById('register');
 		if (element) {
 			element.style.display = 'none';

--- a/client/views/voip/VoIPLayout.tsx
+++ b/client/views/voip/VoIPLayout.tsx
@@ -50,7 +50,11 @@ class VoIPLayout
 		this.VoipUserIdentity = null;
 	}
 
-	private async apitest(): Promise<void> {
+	/**
+	 * This function is just to verify all the REST APIs for the development phase.
+	 * Once we have final UI, this file will be deleted.
+	 */
+	private async apiVerificationRoutine(): Promise<void> {
 		/*
 		try {
 			this.logger.info('Executing voipServerConfig.callServer');
@@ -66,7 +70,7 @@ class VoIPLayout
 			);
 			this.logger.info('voipServerConfig.callServer output = ', JSON.stringify(output));
 		} catch (error) {
-			this.logger.error('error in API');
+			this.logger.error(`error ${error} in API voipServerConfig.callServer`);
 		}
 		try {
 			this.logger.info('Executing voipServerConfig.management');
@@ -83,7 +87,7 @@ class VoIPLayout
 			);
 			this.logger.info('voipServerConfig.management output = ', JSON.stringify(output));
 		} catch (error) {
-			this.logger.error('error in API');
+			this.logger.error(`error ${error} in API voipServerConfig.management`);
 		}
 		*/
 		try {
@@ -91,21 +95,21 @@ class VoIPLayout
 			const list = await APIClient.v1.get('connector.getVersion');
 			this.logger.info('connector.getVersion output = ', JSON.stringify(list));
 		} catch (error) {
-			this.logger.error('error in API');
+			this.logger.error(`error ${error} in API connector.getVersion`);
 		}
 		try {
 			this.logger.info('Executing voipServerConfig.management');
 			const output = await APIClient.v1.get('voipServerConfig.management');
 			this.logger.info('voipServerConfig.management output = ', JSON.stringify(output));
 		} catch (error) {
-			this.logger.error('error in API');
+			this.logger.error(`error ${error} in API voipServerConfig.management`);
 		}
 		try {
 			this.logger.info('Executing voipServerConfig.callServer');
 			const output = await APIClient.v1.get('voipServerConfig.callServer');
 			this.logger.info('voipServerConfig.callServer output = ', JSON.stringify(output));
 		} catch (error) {
-			this.logger.error('error in API');
+			this.logger.error(`error ${error} in API voipServerConfig.callServer`);
 		}
 
 		try {
@@ -113,7 +117,7 @@ class VoIPLayout
 			const list = await APIClient.v1.get('voip/queues.getSummary');
 			this.logger.info('queues.getSummary output = ', JSON.stringify(list));
 		} catch (error) {
-			this.logger.error('error in API');
+			this.logger.error(`error ${error} in API queues.getSummary`);
 		}
 
 		try {
@@ -123,7 +127,7 @@ class VoIPLayout
 			});
 			this.logger.info('queues.getQueuedCallsForThisExtension output = ', JSON.stringify(list));
 		} catch (error) {
-			this.logger.error('error in API');
+			this.logger.error(`error ${error} in API queues.getQueuedCallsForThisExtension`);
 		}
 
 		try {
@@ -131,7 +135,7 @@ class VoIPLayout
 			const list = await APIClient.v1.get('connector.extension.list');
 			this.logger.info('connector.extension.list output = ', JSON.stringify(list));
 		} catch (error) {
-			this.logger.error('error in API');
+			this.logger.error(`error ${error} in API onnector.extension.list`);
 		}
 
 		try {
@@ -141,7 +145,7 @@ class VoIPLayout
 			});
 			this.logger.info('connector.extension.getDetails output = ', JSON.stringify(list));
 		} catch (error) {
-			this.logger.error('error in API');
+			this.logger.error(`error ${error} in API connector.extension.getDetails`);
 		}
 
 		try {
@@ -150,8 +154,7 @@ class VoIPLayout
 			});
 			this.logger.info('list = ', JSON.stringify(userIdentity));
 		} catch (error) {
-			this.logger.error('error in API');
-			throw error;
+			this.logger.error(`error ${error} in API connector.extension.getRegistrationInfo`);
 		}
 	}
 
@@ -330,7 +333,7 @@ class VoIPLayout
 	/* CallEventDelegate implementation end */
 
 	async componentDidMount(): Promise<void> {
-		this.apitest();
+		this.apiVerificationRoutine();
 		let element = document.getElementById('register');
 		if (element) {
 			element.style.display = 'none';

--- a/definition/IVoipConnectorResult.ts
+++ b/definition/IVoipConnectorResult.ts
@@ -1,6 +1,6 @@
-import { IVoipExtensionConfig, IVoipExtensionBase } from './IVoipExtension';
+import { IVoipExtensionConfig, IVoipExtensionBase, IQueueMembershipDetails, IRegistrationInfo } from './IVoipExtension';
 import { IQueueDetails, IQueueSummary } from './ACDQueues';
 
 export interface IVoipConnectorResult {
-	result: IVoipExtensionConfig | IVoipExtensionBase [] | IQueueSummary [] | IQueueDetails;
+	result: IVoipExtensionConfig | IVoipExtensionBase [] | IQueueSummary [] | IQueueDetails | IQueueMembershipDetails | IRegistrationInfo;
 }

--- a/definition/IVoipExtension.ts
+++ b/definition/IVoipExtension.ts
@@ -1,3 +1,5 @@
+import { ICallServerConfigData } from './IVoipServerConfig';
+
 export enum EndpointState {
 	UNKNOWN = 'unknown',
 	REGISTERED = 'registered',
@@ -10,4 +12,23 @@ export interface IVoipExtensionBase {
 export interface IVoipExtensionConfig extends IVoipExtensionBase{
 	authType: string;
 	password: string;
+}
+
+export interface IQueueMembershipDetails {
+	extension: string;
+	queueCount: number;
+	callWaitingCount: number;
+}
+
+export interface IExtensionDetails {
+	extension: string;
+	password: string;
+	authtype: string;
+	state: string;
+}
+
+export interface IRegistrationInfo {
+	host: string;
+	callServerConfig: ICallServerConfigData;
+	extensionDetails: IExtensionDetails;
 }

--- a/server/sdk/types/IVoipService.ts
+++ b/server/sdk/types/IVoipService.ts
@@ -10,9 +10,9 @@ export interface IVoipService {
 	deactivateServerConfigDataIfAvailable(serverType: ServerType): Promise<boolean>;
 	getConnector(): Promise<CommandHandler>;
 	getConnectorVersion(): Promise<string>;
-	getQueueSummary(requestParams: any): Promise<IVoipConnectorResult>;
+	getQueueSummary(): Promise<IVoipConnectorResult>;
 	getQueuedCallsForThisExtension(requestParams: any): Promise<IVoipConnectorResult>;
 	getExtensionList(): Promise<IVoipConnectorResult>;
-	getExtensionDetails(extension: string): Promise<IVoipConnectorResult>;
-	getRegistrationInfo(agentId: string): Promise<IVoipConnectorResult>;
+	getExtensionDetails(requestParams: any): Promise<IVoipConnectorResult>;
+	getRegistrationInfo(requestParams: any): Promise<IVoipConnectorResult>;
 }

--- a/server/sdk/types/IVoipService.ts
+++ b/server/sdk/types/IVoipService.ts
@@ -1,4 +1,6 @@
 import { IVoipServerConfig, ServerType } from '../../../definition/IVoipServerConfig';
+import { CommandHandler } from '../../services/voip/connector/asterisk/CommandHandler';
+import { IVoipConnectorResult } from '../../../definition/IVoipConnectorResult';
 
 export interface IVoipService {
 	getConfiguration(): any;
@@ -6,4 +8,11 @@ export interface IVoipService {
 	addServerConfigData(config: Omit<IVoipServerConfig, '_id' | '_updatedAt'>): Promise<boolean>;
 	updateServerConfigData(config: Omit<IVoipServerConfig, '_id' | '_updatedAt'>): Promise<boolean>;
 	deactivateServerConfigDataIfAvailable(serverType: ServerType): Promise<boolean>;
+	getConnector(): Promise<CommandHandler>;
+	getConnectorVersion(): Promise<string>;
+	getQueueSummary(requestParams: any): Promise<IVoipConnectorResult>;
+	getQueuedCallsForThisExtension(requestParams: any): Promise<IVoipConnectorResult>;
+	getExtensionList(): Promise<IVoipConnectorResult>;
+	getExtensionDetails(extension: string): Promise<IVoipConnectorResult>;
+	getRegistrationInfo(agentId: string): Promise<IVoipConnectorResult>;
 }

--- a/server/services/voip/connector/asterisk/CommandHandler.ts
+++ b/server/services/voip/connector/asterisk/CommandHandler.ts
@@ -55,7 +55,7 @@ export class CommandHandler {
 		 * If we have the same type of connection already established, close it
 		 * and remove it from the map.
 		 */
-		if (this.connections.get(commandType) && this.connections.get(commandType)?.isConnected()) {
+		if (this.connections.get(commandType)?.isConnected()) {
 			this.logger.error({ msg: 'connection exists. Closing the connection.' });
 			this.connections.get(commandType)?.closeConnection();
 			this.connections.delete(commandType);
@@ -63,7 +63,8 @@ export class CommandHandler {
 		connection.connect(config.host,
 			(config.configData as IManagementConfigData).port.toString(),
 			(config.configData as IManagementConfigData).username,
-			(config.configData as IManagementConfigData).password);
+			(config.configData as IManagementConfigData).password,
+		);
 		this.connections.set(commandType, connection);
 	}
 

--- a/server/services/voip/connector/asterisk/CommandHandler.ts
+++ b/server/services/voip/connector/asterisk/CommandHandler.ts
@@ -43,11 +43,9 @@ export class CommandHandler {
 		// Initialize available connections
 		// const connection = new AMIConnection();
 		const connection = new AMIConnection();
-		let config: IVoipServerConfig | null;
+		let config: IVoipServerConfig | null = null;
 		if (commandType === CommandType.AMI) {
 			config = await this.service.getServerConfigData(ServerType.MANAGEMENT);
-		} else {
-			config = null;
 		}
 		if (!config) {
 			this.logger.warn('Management server configuration not found');

--- a/server/services/voip/connector/asterisk/ami/AMIConnection.ts
+++ b/server/services/voip/connector/asterisk/ami/AMIConnection.ts
@@ -123,7 +123,7 @@ export class AMIConnection implements IConnection {
 	}
 
 	closeConnection(): void {
-		this.logger.log({ msg: 'closeConnection()' });
+		this.logger.info({ msg: 'closeConnection()' });
 		this.connection.disconnect();
 	}
 }

--- a/server/services/voip/service.ts
+++ b/server/services/voip/service.ts
@@ -95,10 +95,8 @@ export class VoipService extends ServiceClass implements IVoipService {
 		return Promise.resolve(this.commandHandler);
 	}
 
-	async getQueueSummary(requestParams: any): Promise<IVoipConnectorResult> {
-		return this.commandHandler.executeCommand(
-			Commands.queue_summary,
-			requestParams);
+	async getQueueSummary(): Promise<IVoipConnectorResult> {
+		return this.commandHandler.executeCommand(Commands.queue_summary);
 	}
 
 	async getQueuedCallsForThisExtension(requestParams: any): Promise<IVoipConnectorResult> {

--- a/server/services/voip/service.ts
+++ b/server/services/voip/service.ts
@@ -2,20 +2,44 @@ import { Db } from 'mongodb';
 
 import { IVoipService } from '../../sdk/types/IVoipService';
 import { ServiceClass } from '../../sdk/types/ServiceClass';
+import { Logger } from '../../lib/logger/Logger';
 import { VoipServerConfigurationRaw } from '../../../app/models/server/raw/VoipServerConfiguration';
-import { ServerType, IVoipServerConfig } from '../../../definition/IVoipServerConfig';
+import { ServerType, IVoipServerConfig, ICallServerConfigData } from '../../../definition/IVoipServerConfig';
+import { CommandHandler } from './connector/asterisk/CommandHandler';
+import { CommandType } from './connector/asterisk/Command';
+import { Commands } from './connector/asterisk/Commands';
+import { IVoipConnectorResult } from '../../../definition/IVoipConnectorResult';
+import { IExtensionDetails, IQueueMembershipDetails, IRegistrationInfo } from '../../../definition/IVoipExtension';
+import { IQueueDetails, IQueueSummary } from '../../../definition/ACDQueues';
 
 export class VoipService extends ServiceClass implements IVoipService {
 	protected name = 'voip';
+
+	private logger: Logger;
 
 	// this will hold the multiple call server connection settings that can be supported
 	// They should only be modified through this service
 	private VoipServerConfiguration: VoipServerConfigurationRaw;
 
+	commandHandler: CommandHandler;
+
 	constructor(db: Db) {
 		super();
 
+		this.logger = new Logger('voip service');
 		this.VoipServerConfiguration = new VoipServerConfigurationRaw(db.collection('rocketchat_voip_server_configuration'));
+
+		this.commandHandler = new CommandHandler(this);
+		try {
+			Promise.await(this.commandHandler.initConnection(CommandType.AMI));
+		} catch (error) {
+			this.logger.error({ mst: `Error while initialising the connector. error = ${ error }` });
+		}
+	}
+
+	private async initManagementServerConnection(): Promise<void> {
+		this.logger.info({ msg: 'initialiseManagementServer() initialising the connector' });
+		await this.commandHandler.initConnection(CommandType.AMI);
 	}
 
 	async addServerConfigData(config: Omit<IVoipServerConfig, '_id' | '_updatedAt'>): Promise<boolean> {
@@ -28,7 +52,12 @@ export class VoipService extends ServiceClass implements IVoipService {
 			throw new Error(`Error! There already exists an active record of type ${ type }`);
 		}
 
-		return !!await this.VoipServerConfiguration.insertOne(config);
+		const returnValue = !!await this.VoipServerConfiguration.insertOne(config);
+		if (returnValue && type === ServerType.MANAGEMENT) {
+			// If we have added management server, initialise the connection to it.
+			Promise.await(this.initManagementServerConnection());
+		}
+		return returnValue;
 	}
 
 	async updateServerConfigData(config: Omit<IVoipServerConfig, '_id' | '_updatedAt'>): Promise<boolean> {
@@ -60,5 +89,85 @@ export class VoipService extends ServiceClass implements IVoipService {
 	// this is a dummy function to avoid having an empty IVoipService interface
 	getConfiguration(): any {
 		return {};
+	}
+
+	getConnector(): Promise<CommandHandler> {
+		return Promise.resolve(this.commandHandler);
+	}
+
+	async getQueueSummary(requestParams: any): Promise<IVoipConnectorResult> {
+		return this.commandHandler.executeCommand(
+			Commands.queue_summary,
+			requestParams);
+	}
+
+	async getQueuedCallsForThisExtension(requestParams: any): Promise<IVoipConnectorResult> {
+		const membershipDetails: IQueueMembershipDetails = {
+			queueCount: 0,
+			callWaitingCount: 0,
+			extension: '',
+		};
+		membershipDetails.extension = requestParams.extension;
+		const queueSummary	= Promise.await(this.commandHandler.executeCommand(Commands.queue_summary)) as IVoipConnectorResult;
+		for (const queue of queueSummary.result as IQueueSummary[]) {
+			const queueDetails = Promise.await(this.commandHandler.executeCommand(
+				Commands.queue_details,
+				{ queueName: queue.name })) as IVoipConnectorResult;
+			this.logger.debug({ msg: 'API = voip/queues.getCallWaitingInQueuesForThisExtension queue details = ', result: queueDetails });
+			if ((queueDetails.result as unknown as IQueueDetails).members) {
+				const isAMember = (queueDetails.result as unknown as IQueueDetails).members.some(
+					(element) => element.name.endsWith(requestParams.extension),
+				);
+				if (isAMember) {
+					membershipDetails.callWaitingCount += Number((queueDetails.result as unknown as IQueueDetails).calls);
+					membershipDetails.queueCount++;
+				}
+			}
+		}
+		const result: IVoipConnectorResult = {
+			result: membershipDetails,
+		};
+		return Promise.resolve(result);
+	}
+
+	async getConnectorVersion(): Promise<string> {
+		const version = this.commandHandler.getVersion();
+		return Promise.resolve(version);
+	}
+
+	async getExtensionList(): Promise<IVoipConnectorResult> {
+		return this.commandHandler.executeCommand(Commands.extension_list, undefined);
+	}
+
+	async getExtensionDetails(requestParams: any): Promise<IVoipConnectorResult> {
+		return this.commandHandler.executeCommand(
+			Commands.extension_info,
+			requestParams);
+	}
+
+	async getRegistrationInfo(requestParams: any): Promise<IVoipConnectorResult> {
+		const config: IVoipServerConfig = Promise.await(
+			this.getServerConfigData(ServerType.CALL_SERVER),
+		) as unknown as IVoipServerConfig;
+
+		if (!config) {
+			this.logger.warn({ msg: 'API = connector.extension.getRegistrationInfo callserver settings not found' });
+			return Promise.reject('Not found');
+		}
+
+		const endpointDetails = Promise.await(this.commandHandler.executeCommand(
+			Commands.extension_info,
+			requestParams,
+		)) as IVoipConnectorResult;
+		const callServerConfig: ICallServerConfigData = config.configData as ICallServerConfigData;
+		const extensionDetails: IExtensionDetails = endpointDetails.result as unknown as IExtensionDetails;
+		const extensionRegistrationInfo: IRegistrationInfo = {
+			host: config.host,
+			callServerConfig,
+			extensionDetails,
+		};
+		return Promise.resolve({
+			result: extensionRegistrationInfo,
+		});
 	}
 }

--- a/server/services/voip/service.ts
+++ b/server/services/voip/service.ts
@@ -108,7 +108,7 @@ export class VoipService extends ServiceClass implements IVoipService {
 			extension: '',
 		};
 		membershipDetails.extension = requestParams.extension;
-		const queueSummary	= Promise.await(this.commandHandler.executeCommand(Commands.queue_summary)) as IVoipConnectorResult;
+		const queueSummary = Promise.await(this.commandHandler.executeCommand(Commands.queue_summary)) as IVoipConnectorResult;
 		for (const queue of queueSummary.result as IQueueSummary[]) {
 			const queueDetails = Promise.await(this.commandHandler.executeCommand(
 				Commands.queue_details,


### PR DESCRIPTION
Clickup Task : https://app.clickup.com/t/7qeq76
Description :
Some background :
Issue#1 : CommandHandler class is an entry point to a connector to Asterisk. This command handler had hardcoded values till the APIs and database for the management API was getting ready.
Once it got ready there was a need to change it and use the database values. This design change is triggered by this need.
The aim for the re-design was that all the API access should happen via voip service. It was realised that |CommandHandler| gets created (Because it is declared globally in REST APIs) before the Voip service gets initialised. And because of this fact, CommandHandler does not get to read the values as the service has not yet started and initialised |VoipServerConfiguration|.

To fix this issue, |CommandHandler| has to be created after service and should be accessible only via service. So it has been moved to Voip service. Few more points to consider here is that
CommandHandler::initConnection may not work always. When Voip is getting used for the first time, the server values (management and callserver) will be empty. One has to add those values using the admin interface. So CommandHandler::initConnection failure should not cause server to crash. So errors from CommandHandler::initConnection should be written in logs and the code should move ahead.

Issue#2 : Some design refinements have been done. The intelligence in the REST APIs have been reduced. While building the code connector was exposed outside. Now connector is contained within the
service. Service contains all necessary implementation. The necessary changes have been done to support this architectural change.

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
Considering these points, following changes have been done.
1. Voip rest APIs which use CommandHandler (Queue and extension APIs) now query for the CommandHandler instead of creating it.
2. server-config.ts REST API for adding management interface reinitialises the connection after adding a management interface.
3. On the server side, Voip Service interface has been changed, to have new methods. Voip service and CommandHandler is changed to adapt to the design mentioned above.
4. Log level change in AMIConnection file.
5. Modified the IVoipService interface to contain all the necessary methods and changed service.ts to have the implementation.

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
This should be tested in couple of configurations :
1. When none of the servers (Call-server and Management server) are configured. Expectation : Server should start and allow configuring call server and management server using the REST APIs/Admin interface.
2. When either one of them is configured. Expectation : Server should start and remaining server should be configurable using the REST APIs/Admin interface.
3. When both are configured. Expectation : Endpoint should get necessary information for registration. Other management/Admin APIs should work.
4. When management server values are changed. Expectation : Reinitialisation of connector happens and the information is pulled from new management server. Verify this by having 2 asterisk servers with different configuration.

## Further comments