### PR TITLE
[FIX]: Missing default attachment support to video and audios

### DIFF
--- a/client/components/Message/Attachments/Attachment/index.tsx
+++ b/client/components/Message/Attachments/Attachment/index.tsx
@@ -1,4 +1,6 @@
+import Audio from '../components/Audio';
 import Image from '../components/Image';
+import Video from '../components/Video';
 import Attachment from './Attachment';
 import Author from './Author';
 import AuthorAvatar from './AuthorAvatar';
@@ -18,6 +20,8 @@ import TitleLink from './TitleLink';
 
 export default Object.assign(Attachment, {
 	Image,
+	Video,
+	Audio,
 	Row,
 	Title,
 	Text,

--- a/client/components/Message/Attachments/DefaultAttachment.tsx
+++ b/client/components/Message/Attachments/DefaultAttachment.tsx
@@ -106,6 +106,11 @@ const DefaultAttachment: FC<MessageAttachmentDefault> = (attachment) => {
 								src={attachment.image_url}
 							/>
 						)}
+
+						{attachment.video_url && <Attachment.Video src={attachment.video_url} />}
+
+						{attachment.audio_url && <Attachment.Audio src={attachment.audio_url} />}
+
 						{/* DEPRECATED */}
 						{isActionAttachment(attachment) && <ActionAttachment {...attachment} />}
 					</>

--- a/client/components/Message/Attachments/components/Audio.tsx
+++ b/client/components/Message/Attachments/components/Audio.tsx
@@ -1,0 +1,17 @@
+import React, { memo, FC } from 'react';
+
+type AudioProps = {
+	src: string;
+};
+
+const Audio: FC<AudioProps> = ({ src }) => {
+	console.log('audio', src);
+	return (
+		<audio controls>
+			<source src={src} data-rel='noopener noreferrer' />
+			Your browser does not support the audio element.
+		</audio>
+	);
+};
+
+export default memo(Audio);

--- a/client/components/Message/Attachments/components/Video.tsx
+++ b/client/components/Message/Attachments/components/Video.tsx
@@ -1,0 +1,17 @@
+import React, { memo, FC } from 'react';
+
+type VideoProps = {
+	src: string;
+};
+
+const Video: FC<VideoProps> = ({ src }) => {
+	console.log('video', src);
+	return (
+		<video controls className='inline-video'>
+			<source src={src} data-rel='noopener noreferrer' />
+			Your browser does not support the video element.
+		</video>
+	);
+};
+
+export default memo(Video);

--- a/definition/IMessage/MessageAttachment/MessageAttachmentDefault.ts
+++ b/definition/IMessage/MessageAttachment/MessageAttachmentDefault.ts
@@ -18,6 +18,10 @@ export type MessageAttachmentDefault = {
 	image_url?: string;
 	image_dimensions?: Dimensions;
 
+	video_url?: string;
+
+	audio_url?: string;
+
 	mrkdwn_in?: Array<MarkdownFields>;
 	pretext?: string;
 	text?: string;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

Add video and audio support to DefaultAttachments component.

After changes:
![rocket-fixed](https://user-images.githubusercontent.com/30026625/140426536-cc7bbcbf-88a2-4c24-b7c0-43fbdf0bfa14.png)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

When creating a message through an Rocket.Chat Apps Engine Application, where attachments are created like:
`messageAttachments.push({ audioUrl: attachment.url })` or `messageAttachments.push({ videoUrl: attachment.url })`

Those attachments are not shown in the conversation, and the message becomes empty

Screenshot of the problem:
![rocket-problem](https://user-images.githubusercontent.com/30026625/140426845-53fdf02f-920d-4b8a-a35f-3a6c1633b3af.png)


## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

Through an Rocket.Chat Apps Engine application, create a message and add attachments with:
`messageAttachments.push({ audioUrl: attachment.url })` or `messageAttachments.push({ videoUrl: attachment.url })`

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
