### PR TITLE
[NEW] Add API to Expose Unread Message count

### DIFF
--- a/app/api/server/v1/users.js
+++ b/app/api/server/v1/users.js
@@ -26,6 +26,7 @@ import { resetUserE2EEncriptionKey } from '../../../../server/lib/resetUserE2EKe
 import { setUserStatus } from '../../../../imports/users-presence/server/activeUsers';
 import { resetTOTP } from '../../../2fa/server/functions/resetTOTP';
 import { Team } from '../../../../server/sdk';
+import { getBadgeCount } from '../../../lib/server/functions/notifications/mobile';
 
 API.v1.addRoute('users.create', { authRequired: true }, {
 	post() {
@@ -185,6 +186,23 @@ API.v1.addRoute('users.getPresence', { authRequired: true }, {
 
 		return API.v1.success({
 			presence: user.status,
+		});
+	},
+});
+
+API.v1.addRoute('users.unreadCount', { authRequired: true }, {
+	get() {
+		if (!hasPermission(this.userId, 'view-full-other-user-info')) {
+			return API.v1.unauthorized();
+		}
+
+		const user = this.getUserFromParams();
+		const unreadCount = Promise.await(getBadgeCount(user._id)) || 0;
+
+		return API.v1.success({
+			data: {
+				unread: unreadCount,
+			},
 		});
 	},
 });

--- a/app/lib/server/functions/notifications/mobile.js
+++ b/app/lib/server/functions/notifications/mobile.js
@@ -13,7 +13,7 @@ Meteor.startup(() => {
 	SubscriptionRaw = Subscriptions.model.rawCollection();
 });
 
-async function getBadgeCount(userId) {
+export async function getBadgeCount(userId) {
 	const [result = {}] = await SubscriptionRaw.aggregate([
 		{ $match: { 'u._id': userId, archived: { $ne: true } } },
 		{


### PR DESCRIPTION
## Proposed changes
<!-- CHANGELOG -->
Add API for getting a user’s count of unread messages.
Useful for websites that want to integrate with RocketChat,
showing the unread count _within_ the website UI and linking
to the RC web app.

![Screen Shot - Unread Messaage count in site navbar](https://user-images.githubusercontent.com/1042298/141435603-c10cee6d-9949-4bd8-ade8-f881452e42b5.png)
<!-- END CHANGELOG -->


## Further comments
In this implementation, we expose this data via new API endpoint.  An alternative approach would be to add the unread count to `users.info`.  That latter endpoint already includes unread counts on a per-room basis, which could then be summed together.

Cc: @milton-rucks