### PR TITLE
[FIX] User Info in a group direct message

### DIFF
--- a/client/views/room/providers/ToolboxProvider.tsx
+++ b/client/views/room/providers/ToolboxProvider.tsx
@@ -84,14 +84,18 @@ const ToolboxProvider = ({ children, room }: { children: ReactNode; room: IRoom 
 					open('room-info', username);
 					break;
 				case 'd':
-					open('user-info', username);
+					if (room.uids && room.uids.length > 2) {
+						open('user-info-group', username);
+					} else {
+						open('user-info', username);
+					}
 					break;
 				default:
 					open('members-list', username);
 					break;
 			}
 		},
-		[room.t, open],
+		[room.t, open, room.uids],
 	);
 
 	useLayoutEffect(() => {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
Added a check to see if the users present in the dms are more than 2, which will result in opening 'user-info-group'/{username} rather than 'user-info'/{username} that was previously invoked during the calls.

Please review this PR and suggest for required changes @dougfabris @debdutdeb 

Thank you

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
Previously,

![previous-rc-user-info](https://user-images.githubusercontent.com/73601258/141653944-674eab60-fffa-458f-823d-812b58fc30d6.gif)

Now,

![after-rc-user-info](https://user-images.githubusercontent.com/73601258/141653948-a4bd3a3f-c087-489f-be64-3b1361db1d22.gif)

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
fixes #23096

