### PR TITLE
Chore: index cleansing omnichannel

### DIFF
--- a/app/models/server/models/LivechatAgentActivity.js
+++ b/app/models/server/models/LivechatAgentActivity.js
@@ -4,9 +4,10 @@ export class LivechatAgentActivity extends Base {
 	constructor(...args) {
 		super(...args);
 
-		this.tryEnsureIndex({ date: 1 });
+		// this.tryEnsureIndex({ date: 1 });
 		this.tryEnsureIndex({ agentId: 1, date: 1 }, { unique: true });
-		this.tryEnsureIndex({ agentId: 1 });
+		this.tryEnsureIndex({ lastStoppedAt: 1 });
+		// this.tryEnsureIndex({ agentId: 1 });
 	}
 
 	createOrUpdate(data = {}) {

--- a/app/models/server/models/LivechatAgentActivity.js
+++ b/app/models/server/models/LivechatAgentActivity.js
@@ -4,10 +4,8 @@ export class LivechatAgentActivity extends Base {
 	constructor(...args) {
 		super(...args);
 
-		// this.tryEnsureIndex({ date: 1 });
 		this.tryEnsureIndex({ agentId: 1, date: 1 }, { unique: true });
 		this.tryEnsureIndex({ lastStoppedAt: 1 });
-		// this.tryEnsureIndex({ agentId: 1 });
 	}
 
 	createOrUpdate(data = {}) {

--- a/app/models/server/models/LivechatDepartment.js
+++ b/app/models/server/models/LivechatDepartment.js
@@ -16,6 +16,7 @@ export class LivechatDepartment extends Base {
 			numAgents: 1,
 			enabled: 1,
 		});
+		this.tryEnsureIndex({ parentId: 1 }, { sparse: true });
 	}
 
 	// FIND

--- a/app/models/server/models/LivechatDepartmentAgents.js
+++ b/app/models/server/models/LivechatDepartmentAgents.js
@@ -11,6 +11,7 @@ export class LivechatDepartmentAgents extends Base {
 		super('livechat_department_agents');
 
 		this.tryEnsureIndex({ username: 1 });
+		this.tryEnsureIndex({ departmentId: 1 });
 		this.tryEnsureIndex({ agentId: 1, departmentId: 1 });
 
 		const collectionObj = this.model.rawCollection();

--- a/app/models/server/models/LivechatDepartmentAgents.js
+++ b/app/models/server/models/LivechatDepartmentAgents.js
@@ -10,10 +10,11 @@ export class LivechatDepartmentAgents extends Base {
 	constructor() {
 		super('livechat_department_agents');
 
-		this.tryEnsureIndex({ departmentId: 1 });
-		this.tryEnsureIndex({ departmentEnabled: 1 });
-		this.tryEnsureIndex({ agentId: 1 });
+		// this.tryEnsureIndex({ departmentId: 1 }); prefer compound index
+		// this.tryEnsureIndex({ departmentEnabled: 1 }); index on an index with only 2 possible fields :(
+		// this.tryEnsureIndex({ agentId: 1 }); prefer compound index
 		this.tryEnsureIndex({ username: 1 });
+		this.tryEnsureIndex({ agentId: 1, departmentId: 1 });
 
 		const collectionObj = this.model.rawCollection();
 		this.findAndModify = Meteor.wrapAsync(collectionObj.findAndModify, collectionObj);

--- a/app/models/server/models/LivechatDepartmentAgents.js
+++ b/app/models/server/models/LivechatDepartmentAgents.js
@@ -10,9 +10,6 @@ export class LivechatDepartmentAgents extends Base {
 	constructor() {
 		super('livechat_department_agents');
 
-		// this.tryEnsureIndex({ departmentId: 1 }); prefer compound index
-		// this.tryEnsureIndex({ departmentEnabled: 1 }); index on an index with only 2 possible fields :(
-		// this.tryEnsureIndex({ agentId: 1 }); prefer compound index
 		this.tryEnsureIndex({ username: 1 });
 		this.tryEnsureIndex({ agentId: 1, departmentId: 1 });
 

--- a/app/models/server/models/LivechatInquiry.js
+++ b/app/models/server/models/LivechatInquiry.js
@@ -4,12 +4,8 @@ export class LivechatInquiry extends Base {
 	constructor() {
 		super('livechat_inquiry');
 
-		this.tryEnsureIndex({ rid: 1 }); // room id corresponding to this inquiry
-		// this.tryEnsureIndex({ name: 1 }); // name of the inquiry (client name for now)
-		// this.tryEnsureIndex({ message: 1 }); // message sent by the client
-		this.tryEnsureIndex({ ts: 1 }); // timestamp
-		// this.tryEnsureIndex({ department: 1 });
-		// this.tryEnsureIndex({ status: 1 }); // 'ready', 'queued', 'taken'
+		this.tryEnsureIndex({ rid: 1 });
+		this.tryEnsureIndex({ ts: 1 });
 		this.tryEnsureIndex({ queueOrder: 1, estimatedWaitingTimeQueue: 1, estimatedServiceTimeAt: 1 });
 		this.tryEnsureIndex({ status: 1, department: 1 });
 		this.tryEnsureIndex({ 'v.token': 1, status: 1 });

--- a/app/models/server/models/LivechatInquiry.js
+++ b/app/models/server/models/LivechatInquiry.js
@@ -5,12 +5,14 @@ export class LivechatInquiry extends Base {
 		super('livechat_inquiry');
 
 		this.tryEnsureIndex({ rid: 1 }); // room id corresponding to this inquiry
-		this.tryEnsureIndex({ name: 1 }); // name of the inquiry (client name for now)
-		this.tryEnsureIndex({ message: 1 }); // message sent by the client
+		// this.tryEnsureIndex({ name: 1 }); // name of the inquiry (client name for now)
+		// this.tryEnsureIndex({ message: 1 }); // message sent by the client
 		this.tryEnsureIndex({ ts: 1 }); // timestamp
-		this.tryEnsureIndex({ department: 1 });
-		this.tryEnsureIndex({ status: 1 }); // 'ready', 'queued', 'taken'
+		// this.tryEnsureIndex({ department: 1 });
+		// this.tryEnsureIndex({ status: 1 }); // 'ready', 'queued', 'taken'
 		this.tryEnsureIndex({ queueOrder: 1, estimatedWaitingTimeQueue: 1, estimatedServiceTimeAt: 1 });
+		this.tryEnsureIndex({ status: 1, department: 1 });
+		this.tryEnsureIndex({ 'v.token': 1, status: 1 });
 	}
 
 	findOneById(inquiryId) {
@@ -240,40 +242,6 @@ export class LivechatInquiry extends Base {
 
 		this.remove(query);
 	}
-
-	getUnnatendedQueueItems(date) {
-		const query = {
-			status: 'queued',
-			estimatedInactivityCloseTimeAt: { $lte: new Date(date) },
-		};
-		return this.find(query);
-	}
-
-	setEstimatedInactivityCloseTime(_id, date) {
-		return this.update({ _id }, {
-			$set: {
-				estimatedInactivityCloseTimeAt: new Date(date),
-			},
-		});
-	}
-
-	// This is a better solution, but update pipelines are not supported until version 4.2 of mongo
-	// leaving this here for when the time comes
-	/* updateEstimatedInactivityCloseTime(milisecondsToAdd) {
-		return this.model.rawCollection().updateMany(
-			{ status: 'queued' },
-			[{
-				// in case this field doesn't exists, set at the last time the item was modified (updatedAt)
-				$set: { estimatedInactivityCloseTimeAt: '$_updatedAt' },
-			}, {
-				$set: {
-					estimatedInactivityCloseTimeAt: {
-						$add: ['$estimatedInactivityCloseTimeAt', milisecondsToAdd],
-					},
-				},
-			}],
-		);
-	} */
 }
 
 export default new LivechatInquiry();

--- a/app/models/server/models/LivechatRooms.js
+++ b/app/models/server/models/LivechatRooms.js
@@ -9,7 +9,6 @@ export class LivechatRooms extends Base {
 	constructor(...args) {
 		super(...args);
 
-		// this.tryEnsureIndex({ open: 1 }, { sparse: true }); covered by compound index
 		this.tryEnsureIndex({ departmentId: 1 }, { sparse: true });
 		this.tryEnsureIndex({ 'metrics.chatDuration': 1 }, { sparse: true });
 		this.tryEnsureIndex({ 'metrics.serviceTimeDuration': 1 }, { sparse: true });
@@ -17,7 +16,6 @@ export class LivechatRooms extends Base {
 		this.tryEnsureIndex({ 'omnichannel.predictedVisitorAbandonmentAt': 1 }, { sparse: true });
 		this.tryEnsureIndex({ closedAt: 1 }, { sparse: true });
 		this.tryEnsureIndex({ servedBy: 1 }, { sparse: true });
-		// this.tryEnsureIndex({ 'v.token': 1 }, { sparse: true }); covered by following index
 		this.tryEnsureIndex({ 'v.token': 1, 'email.thread': 1 }, { sparse: true });
 		this.tryEnsureIndex({ 'v._id': 1 }, { sparse: true });
 		this.tryEnsureIndex({ t: 1, departmentId: 1, closedAt: 1 }, { partialFilterExpression: { closedAt: { $exists: true } } });

--- a/app/models/server/models/LivechatRooms.js
+++ b/app/models/server/models/LivechatRooms.js
@@ -19,7 +19,7 @@ export class LivechatRooms extends Base {
 		this.tryEnsureIndex({ 'v.token': 1, 'email.thread': 1 }, { sparse: true });
 		this.tryEnsureIndex({ 'v._id': 1 }, { sparse: true });
 		this.tryEnsureIndex({ t: 1, departmentId: 1, closedAt: 1 }, { partialFilterExpression: { closedAt: { $exists: true } } });
-		this.tryEnsureIndex({ 'v.token': 1, open: 1 }, { sparse: true });
+		this.tryEnsureIndex({ open: 1, 'v.token': 1 }, { sparse: true });
 	}
 
 	findLivechat(filter = {}, offset = 0, limit = 20) {

--- a/app/models/server/models/LivechatRooms.js
+++ b/app/models/server/models/LivechatRooms.js
@@ -9,7 +9,7 @@ export class LivechatRooms extends Base {
 	constructor(...args) {
 		super(...args);
 
-		this.tryEnsureIndex({ open: 1 }, { sparse: true });
+		// this.tryEnsureIndex({ open: 1 }, { sparse: true }); covered by compound index
 		this.tryEnsureIndex({ departmentId: 1 }, { sparse: true });
 		this.tryEnsureIndex({ 'metrics.chatDuration': 1 }, { sparse: true });
 		this.tryEnsureIndex({ 'metrics.serviceTimeDuration': 1 }, { sparse: true });
@@ -17,10 +17,11 @@ export class LivechatRooms extends Base {
 		this.tryEnsureIndex({ 'omnichannel.predictedVisitorAbandonmentAt': 1 }, { sparse: true });
 		this.tryEnsureIndex({ closedAt: 1 }, { sparse: true });
 		this.tryEnsureIndex({ servedBy: 1 }, { sparse: true });
-		this.tryEnsureIndex({ 'v.token': 1 }, { sparse: true });
+		// this.tryEnsureIndex({ 'v.token': 1 }, { sparse: true }); covered by following index
 		this.tryEnsureIndex({ 'v.token': 1, 'email.thread': 1 }, { sparse: true });
 		this.tryEnsureIndex({ 'v._id': 1 }, { sparse: true });
 		this.tryEnsureIndex({ t: 1, departmentId: 1, closedAt: 1 }, { partialFilterExpression: { closedAt: { $exists: true } } });
+		this.tryEnsureIndex({ 'v.token': 1, open: 1 }, { sparse: true });
 	}
 
 	findLivechat(filter = {}, offset = 0, limit = 20) {

--- a/app/models/server/models/LivechatVisitors.js
+++ b/app/models/server/models/LivechatVisitors.js
@@ -11,6 +11,7 @@ export class LivechatVisitors extends Base {
 
 		this.tryEnsureIndex({ token: 1 });
 		this.tryEnsureIndex({ 'phone.phoneNumber': 1 }, { sparse: true });
+		this.tryEnsureIndex({ 'visitorEmails.address': 1 }, { sparse: true });
 	}
 
 	/**

--- a/server/startup/migrations/index.ts
+++ b/server/startup/migrations/index.ts
@@ -68,4 +68,5 @@ import './v241';
 import './v242';
 import './v243';
 import './v244';
+import './v245';
 import './xrun';

--- a/server/startup/migrations/v245.ts
+++ b/server/startup/migrations/v245.ts
@@ -1,0 +1,22 @@
+import { addMigration } from '../../lib/migrations';
+import { LivechatAgentActivity, LivechatDepartmentAgents, LivechatInquiry, LivechatRooms } from '../../../app/models/server';
+
+addMigration({
+	version: 245,
+	up() {
+		// remove unused omnichannel indexes
+		LivechatAgentActivity.tryDropIndex({ date: 1 });
+		LivechatAgentActivity.tryDropIndex({ agentId: 1 });
+
+		LivechatDepartmentAgents.tryDropIndex({ departmentId: 1 });
+		LivechatDepartmentAgents.tryDropIndex({ departmentEnabled: 1 });
+		LivechatDepartmentAgents.tryDropIndex({ agentId: 1 });
+
+		LivechatInquiry.tryDropIndex({ name: 1 });
+		LivechatInquiry.tryDropIndex({ message: 1 });
+		LivechatInquiry.tryDropIndex({ status: 1 });
+
+		LivechatRooms.tryDropIndex({ open: 1 });
+		LivechatRooms.tryDropIndex({ 'v.token': 1 });
+	},
+});

--- a/server/startup/migrations/v245.ts
+++ b/server/startup/migrations/v245.ts
@@ -8,7 +8,6 @@ addMigration({
 		LivechatAgentActivity.tryDropIndex({ date: 1 });
 		LivechatAgentActivity.tryDropIndex({ agentId: 1 });
 
-		LivechatDepartmentAgents.tryDropIndex({ departmentId: 1 });
 		LivechatDepartmentAgents.tryDropIndex({ departmentEnabled: 1 });
 		LivechatDepartmentAgents.tryDropIndex({ agentId: 1 });
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
Reasoning behind index removals:

- AgentActivity { date } => replaced by compound index
- AgentActivity { agentId } => replaced by compound index
- DepartmentAgents { agentId } => replaced by compound index
- DepartmentAgents { departmentEnabled } => index on a property with just 2 possible values, not adding much value
- Inquiry { message } => not being used
- Inquiry { name } => not being used
- Inquiry { status } => replaced by compound index
- Room { open } => replaced by compound
- 'v.token' => replaced by compound index

Why?
- The unused indexes were measured on conditions on 100k rooms + 20k inquiries.
- The preffered usage of compound indexes over normal indexes is based on https://docs.mongodb.com/manual/core/index-compound/#prefixes (I'm adjusting to validate all removed indexes are covered with a compound prefix 👀 )
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Pls let me know any suggestions 👀 or another things that can be added/removed