### PR TITLE
[FIX] Federation attachments with GridFS

### DIFF
--- a/packages/meteor-jalik-ufs/ufs-store.js
+++ b/packages/meteor-jalik-ufs/ufs-store.js
@@ -253,9 +253,6 @@ export class Store {
 						size += data.length;
 					}));
 					readStream.on('end', Meteor.bindEnvironment(function() {
-						if (file.complete) {
-							return;
-						}
 						// Set file attribute
 						file.complete = true;
 						file.etag = UploadFS.generateEtag();


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Removing these three lines causes the code to exit the function early on federated messages and will skip crucial parts of the code thus not saving the file/link in the data store.
Without this fix files send via Federation are lost without trace or any log message.

## Issue(s)
#22999

## Steps to test or reproduce
Setup two RocketChat instances with GridFS and federation between them.
Try to send an attachments via federation.
The attachments goes seems to be sent on one side but nothing shows up at the receiving end.

## Further comments
Fixes attachments via Federation in 3.18.3
This again breaks after Updating to 4.1.2. Another pull request is coming to fix this aswell and will be linked here

As a note the image preview feature will not work with federated messages and this fix in place.
Seems to be a problem with federated attachments being links to the other sever instead of local files at the receiving end.