### PR TITLE
[FIX] Federation attachments userId unset

### DIFF
--- a/packages/meteor-jalik-ufs/ufs-store.js
+++ b/packages/meteor-jalik-ufs/ufs-store.js
@@ -338,6 +338,9 @@ export class Store {
 
 			// Code executed before inserting file
 			collection.before.insert(function(userId, file) {
+				if (userId === undefined && file.userId) {
+					userId = file.userId;
+				}
 				if (!self.permissions.checkInsert(userId, file)) {
 					throw new Meteor.Error('forbidden', 'Forbidden');
 				}
@@ -345,6 +348,9 @@ export class Store {
 
 			// Code executed before updating file
 			collection.before.update(function(userId, file, fields, modifiers) {
+				if (userId === undefined && file.userId) {
+					userId = file.userId;
+				}
 				if (!self.permissions.checkUpdate(userId, file, fields, modifiers)) {
 					throw new Meteor.Error('forbidden', 'Forbidden');
 				}
@@ -352,6 +358,9 @@ export class Store {
 
 			// Code executed before removing file
 			collection.before.remove(function(userId, file) {
+				if (userId === undefined && file.userId) {
+					userId = file.userId;
+				}
 				if (!self.permissions.checkRemove(userId, file)) {
 					throw new Meteor.Error('forbidden', 'Forbidden');
 				}


### PR DESCRIPTION
When sending attachments via Federation and with the GridFS datastore enabled the attachments fail to be properly send as the userId attribute is not set.
With federated messages the userId attribute can extracted from the file itself.

## Proposed changes (including videos or screenshots)
In the part of the gridfs code where an attachment is inserted, updated or removed the userId attribute is not set when dealing with federated attachments.
In this case the userId attribute has to be set from file.userId if it exists and userId itself is not set.

<!-- END CHANGELOG -->

## Issue(s)
#22999

## Steps to test or reproduce
Setup two RocketChat instances with GridFS and federation between them
Try to send files between them

