### PR TITLE
[IMPROVE] Allow e-mail channel to be used without default department.

### DIFF
--- a/app/livechat/server/lib/Livechat.js
+++ b/app/livechat/server/lib/Livechat.js
@@ -319,6 +319,8 @@ export const Livechat = {
 
 	setDepartmentForGuest({ token, department } = {}) {
 		check(token, String);
+		check(department, String);
+
 		Livechat.logger.debug(`Switching departments for user with token ${ token } (to ${ department })`);
 
 		const updateUser = {

--- a/server/email/IMAPInterceptor.ts
+++ b/server/email/IMAPInterceptor.ts
@@ -57,7 +57,7 @@ export class IMAPInterceptor extends EventEmitter {
 		});
 
 		this.imap.on('error', (err: Error) => {
-			this.log('Error occurred ...');
+			this.log('Error occurred: ', err);
 			throw err;
 		});
 	}

--- a/server/features/EmailInbox/EmailInbox_Incoming.ts
+++ b/server/features/EmailInbox/EmailInbox_Incoming.ts
@@ -36,13 +36,18 @@ function getGuestByEmail(email: string, name: string, department = ''): any {
 
 	if (guest) {
 		logger.debug(`Guest with email ${ email } found with id ${ guest._id }`);
-		if (!!department && guest.department !== department) {
+		if (guest.department !== department) {
 			logger.debug({
 				msg: 'Switching departments for guest',
 				guest,
 				previousDepartment: guest.department,
 				newDepartment: department,
 			});
+			if (!department) {
+				LivechatVisitors.removeDepartmentById(guest._id);
+				delete guest.department;
+				return guest;
+			}
 			Livechat.setDepartmentForGuest({ token: guest.token, department });
 			return LivechatVisitors.findOneById(guest._id, {});
 		}

--- a/server/features/EmailInbox/EmailInbox_Incoming.ts
+++ b/server/features/EmailInbox/EmailInbox_Incoming.ts
@@ -30,13 +30,13 @@ type FileAttachment = {
 const language = settings.get<string>('Language') || 'en';
 const t = (s: string): string => TAPi18n.__(s, { lng: language });
 
-function getGuestByEmail(email: string, name: string, department?: string): any {
+function getGuestByEmail(email: string, name: string, department = ''): any {
 	logger.debug(`Attempt to register a guest for ${ email } on department: ${ department }`);
 	const guest = LivechatVisitors.findOneGuestByEmailAddress(email);
 
 	if (guest) {
 		logger.debug(`Guest with email ${ email } found with id ${ guest._id }`);
-		if (guest.department !== department) {
+		if (!!department && guest.department !== department) {
 			logger.debug({
 				msg: 'Switching departments for guest',
 				guest,
@@ -120,7 +120,7 @@ async function uploadAttachment(attachment: Attachment, rid: string, visitorToke
 	});
 }
 
-export async function onEmailReceived(email: ParsedMail, inbox: string, department?: string): Promise<void> {
+export async function onEmailReceived(email: ParsedMail, inbox: string, department = ''): Promise<void> {
 	logger.debug(`New email conversation received on inbox ${ inbox }. Will be assigned to department ${ department }`);
 	if (!email.from?.value?.[0]?.address) {
 		return;
@@ -134,6 +134,7 @@ export async function onEmailReceived(email: ParsedMail, inbox: string, departme
 	const guest = getGuestByEmail(email.from.value[0].address, email.from.value[0].name, department);
 
 	logger.debug(`Guest ${ guest._id } obtained. Attempting to find or create a room on department ${ department }`);
+
 	let room = LivechatRooms.findOneByVisitorTokenAndEmailThreadAndDepartment(guest.token, thread, department, {});
 
 	logger.debug({


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
Due to a missing condition in the e-mail input processing, Rocket.Chat was unable to receive e-mails from e-mail channels that did not have a default department.

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
The following error is raised when an email message is sent to an email account without default department

W20211206-13:46:39.202(-3)? (STDERR) === UnHandledPromiseRejection ===
W20211206-13:46:39.204(-3)? (STDERR) errorClass [Error]: Provided department does not exists [invalid-department]
W20211206-13:46:39.204(-3)? (STDERR)     at Object.setDepartmentForGuest (app/livechat/server/lib/Livechat.js:332:10)
W20211206-13:46:39.204(-3)? (STDERR)     at getGuestByEmail (server/features/EmailInbox/EmailInbox_Incoming.ts:46:13)
W20211206-13:46:39.204(-3)? (STDERR)     at server/features/EmailInbox/EmailInbox_Incoming.ts:134:16
W20211206-13:46:39.204(-3)? (STDERR)     at /Users/renatobecker/.meteor/packages/promise/.0.11.2.q9g02k.d69vo++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/fiber_pool.js:43:40 {
W20211206-13:46:39.204(-3)? (STDERR)   isClientSafe: true,
W20211206-13:46:39.204(-3)? (STDERR)   error: 'invalid-department',
W20211206-13:46:39.205(-3)? (STDERR)   reason: 'Provided department does not exists',
W20211206-13:46:39.205(-3)? (STDERR)   details: { method: 'setDepartmentForGuest' },
W20211206-13:46:39.205(-3)? (STDERR)   errorType: 'Meteor.Error'
W20211206-13:46:39.205(-3)? (STDERR) }
W20211206-13:46:39.205(-3)? (STDERR) ---------------------------------
W20211206-13:46:39.205(-3)? (STDERR) Errors like this can cause oplog processing errors.
W20211206-13:46:39.205(-3)? (STDERR) Setting EXIT_UNHANDLEDPROMISEREJECTION will cause the process to exit allowing your service to automatically restart the process
W20211206-13:46:39.205(-3)? (STDERR) Future node.js versions will automatically exit the process
W20211206-13:46:39.205(-3)? (STDERR) =================================

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

By creating an e-mail channel and not giving it a default department the above error would occur, dropping e-mail messages from Rocket.Chat, with only a console log for an error.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->