### PR TITLE
[FIX] MongoError during startup saying "ns not found"

### DIFF
--- a/app/importer/server/startup/setImportsToInvalid.js
+++ b/app/importer/server/startup/setImportsToInvalid.js
@@ -34,6 +34,6 @@ Meteor.startup(function() {
 		Imports.invalidateAllOperations();
 
 		// Clean up all the raw import data
-		runDrop(() => RawImports.model.rawCollection().drop());
+		runDrop(() => RawImports.model.rawCollection().remove({}));
 	}
 });


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->
During a mutli-instance startup, if there is more than one instance being started at the same time, they will all try to execute the same drop command, but just a single one would succeed and the other ones would show the error below:

```
=== UnHandledPromiseRejection ===
MongoError: ns not found
    at MessageStream.messageHandler (/.../.meteor/packages/npm-mongo/.3.9.1.gjvjg.whtjk6++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/mongodb/lib/cmap/connection.js:272:20)
    at MessageStream.emit (events.js:314:20)
    at MessageStream.EventEmitter.emit (domain.js:483:12)
    at processIncomingData (/.../.meteor/packages/npm-mongo/.3.9.1.gjvjg.whtjk6++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/mongodb/lib/cmap/message_stream.js:144:12)
...
```

So instead of dropping the collection, I'm changing to just remove the content of the collection.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Closes #15485

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
