### PR TITLE
[IMPROVE] Disabled favourite toggle switch when default is off

### DIFF
--- a/client/views/admin/rooms/EditRoom.js
+++ b/client/views/admin/rooms/EditRoom.js
@@ -221,7 +221,7 @@ function EditRoom({ room, onChange }) {
 				<Field.Row>
 					<Box display='flex' flexDirection='row' justifyContent='space-between' flexGrow={1}>
 						<Field.Label>{t('Favorite')}</Field.Label>
-						<ToggleSwitch disabled={deleted} checked={favorite} onChange={handleFavorite} />
+						<ToggleSwitch disabled={deleted || !isDefault} checked={favorite} onChange={handleFavorite} />
 					</Box>
 				</Field.Row>
 			</Field>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->
## Before
When default is not ON

https://user-images.githubusercontent.com/76481696/147928771-7c3e678d-0f60-4e91-af98-ab7359d9d702.mp4

When default is ON


https://user-images.githubusercontent.com/76481696/147928915-e1bad198-59d0-4899-bc6b-aed985c4c42a.mp4


## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
I am unsure if it is a bug or not but looking at the code seems like it is intentional because when you mark it as default, the user should be auto added to the room. While added, this room should be added to favorite or not. If it is intentional, then i think the favorite button should be disabled when the default is OFF which would lead to less confusion. 
In this PR I added a conditional check which would disable the favorite switch whenever default switch is off.

### Now

https://user-images.githubusercontent.com/76481696/147930182-af996d20-95f3-459b-a4a7-9b297888dcf1.mp4


<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Go to admin
2. Then go to rooms
3. Click on any room to edit it
4. Switch the default and favorite buttons

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
I am also unsure if i should have done something which would let this option to appear only when default is ON rather than disabling it but i thought it would be better if i ask here before doing anything like making an option disappear :bug:. Do let me know if you need to make any changes.