### PR TITLE
[FIX] Return correct registration state in connector.extension.list API

### DIFF
--- a/definition/IVoipExtension.ts
+++ b/definition/IVoipExtension.ts
@@ -4,6 +4,8 @@ export enum EndpointState {
 	UNKNOWN = 'unknown',
 	REGISTERED = 'registered',
 	UNREGISTERED = 'unregistered',
+	RINGING = 'ringing',
+	BUSY = 'busy',
 }
 export interface IVoipExtensionBase {
 	extension: string;

--- a/server/services/voip/connector/asterisk/ami/PJSIPEndpoint.ts
+++ b/server/services/voip/connector/asterisk/ami/PJSIPEndpoint.ts
@@ -28,7 +28,7 @@
  * 7. Important to note that the intermediate events containing a result part for an execution of a particular command
  *    have same actionid, which is received by this class as a successful execution of a command in actionResultCallback.
  */
-import { _ } from 'meteor/underscore';
+import _ from 'underscore';
 
 import { Command, CommandType } from '../Command';
 import { Logger } from '../../../../../lib/logger/Logger';
@@ -123,7 +123,6 @@ export class PJSIPEndpoint extends Command {
 		const extensions = _.sortBy(this.result.endpoints, function (o: any) {
 			return o.extension;
 		});
-		this.logger.debug({ msg: `onEndpointListComplete() Complete. Data = ${JSON.stringify(extensions)}` });
 		this.returnResolve({ result: extensions } as IVoipConnectorResult);
 	}
 

--- a/server/services/voip/connector/asterisk/ami/PJSIPEndpoint.ts
+++ b/server/services/voip/connector/asterisk/ami/PJSIPEndpoint.ts
@@ -120,7 +120,6 @@ export class PJSIPEndpoint extends Command {
 			return;
 		}
 		this.resetEventHandlers();
-		// const { result } = this;
 		const extensions = _.sortBy(this.result.endpoints, function (o: any) {
 			return o.extension;
 		});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
Before this fix, connector has been parsing the devicestate parameter incorrectly. This parameter comes as a response to command |pjsipshowendpoints| which is used for getting the list of the endpoints from the server. Parsing error happens in function getState. This function has been fixed. devicestate hold few values such as |unavailable|, |not in use|, |ringing|, |busy|. Out of these unavailable represents unregistered endpoint and "not in use" represents the endpoint which is just logged in. Rest of the values are self-explanatory. This fix returns following values based on the device state
 |unavailable|  : UNREGISTERED
 |not in use|: REGISTERED
|ringing| : RINGING
|busy| : BUSY
Anythingelse : UNKNOWN

## Issue(s)
https://app.clickup.com/t/1y2pz2p
## Steps to test or reproduce
1. Register the endpoint with the server.
2. Call endpoing GET connector.extension.list
3. Observe the state of the endpoint that is just registered.

## Further comments
Testing Notes :
Following test scenarios should be executed to verify this fix 
1. Simply register the endpoint and observe the response of GET connector.extension.list. in response state = REGISTERED.
2. Call the registered endpoint. While the phone is ringing observe the response of GET connector.extension.list. in response state = RINGING.
3. Answer the call. Observe the GET connector.extension.list. in response state = BUSY.
4. Unregister the endpoint. Observe the GET connector.extension.list. in response state = UNREGISTERED.

