### PR TITLE
[IMPROVE] Extended message Actions menu when shift key is pressed while hovering 

### DIFF
--- a/app/message-star/client/actionButton.js
+++ b/app/message-star/client/actionButton.js
@@ -38,7 +38,7 @@ Meteor.startup(function () {
 			return !message.starred || !message.starred.find((star) => star._id === u._id);
 		},
 		order: 9,
-		group: 'menu',
+		group: ['menu', 'extended'],
 	});
 
 	MessageAction.addButton({

--- a/app/reactions/client/init.js
+++ b/app/reactions/client/init.js
@@ -98,6 +98,6 @@ Meteor.startup(function () {
 			return true;
 		},
 		order: -2,
-		group: ['message', 'menu'],
+		group: ['message', 'menu', 'extended'],
 	});
 });

--- a/app/theme/client/imports/components/messages.css
+++ b/app/theme/client/imports/components/messages.css
@@ -2,7 +2,9 @@
 	position: relative;
 }
 
-.message-actions {
+.message-actions,
+.message-actions-default,
+.message-actions-extended {
 	position: absolute;
 	z-index: 2;
 	top: -28px;

--- a/app/threads/client/messageAction/replyInThread.js
+++ b/app/threads/client/messageAction/replyInThread.js
@@ -33,7 +33,7 @@ Meteor.startup(function () {
 				return Boolean(subscription);
 			},
 			order: -1,
-			group: ['message', 'menu'],
+			group: ['message', 'menu', 'extended'],
 		});
 	});
 });

--- a/app/ui-master/client/body.js
+++ b/app/ui-master/client/body.js
@@ -67,6 +67,23 @@ Template.body.onRendered(function () {
 	});
 
 	$(document.body).on('keydown', function (e) {
+		console.log(e);
+		if (e.shiftKey === true) {
+			e.stopPropagation();
+			$('.message-actions-default').removeClass('message-actions');
+			$('.message-actions-extended').addClass('message-actions');
+		}
+	});
+
+	$(document.body).on('keyup', function (e) {
+		if (e.originalEvent.key === 'Shift') {
+			e.stopPropagation();
+			$('.message-actions-default').addClass('message-actions');
+			$('.message-actions-extended').removeClass('message-actions');
+		}
+	});
+
+	$(document.body).on('keydown', function (e) {
 		const { target } = e;
 		if (e.ctrlKey === true || e.metaKey === true) {
 			popover.close();

--- a/app/ui-message/client/message.html
+++ b/app/ui-message/client/message.html
@@ -132,14 +132,25 @@
 				</div>
 			{{/with}}
 			{{#unless hideMessageActions}}
-				<div class="message-actions">
-
+				<div class="message-actions message-actions-default">
 					<div class="message-actions__buttons">
 						{{#each action in messageActions 'message'}}
 							<button class="message-actions__button"  data-message-action="{{action.id}}" title="{{_ action.label}}">
 									{{> icon block="message-actions__button-icon" icon=action.icon}}
 							</button>
 						{{/each}}
+					</div>
+					<div class="message-actions__menu" aria-haspopup="true">
+						{{> icon block="message-actions__menu-icon" icon="menu"}}
+					</div>
+				</div>
+				<div class="message-actions-extended">					
+					<div class="message-actions__buttons">	
+							{{#each action in messageActions 'extended'}}
+								<button class="message-actions__button"  data-message-action="{{action.id}}" title="{{_ action.label}}">
+										{{> icon block="message-actions__button-icon" icon=action.icon}}
+								</button>
+							{{/each}}
 					</div>
 					<div class="message-actions__menu" aria-haspopup="true">
 						{{> icon block="message-actions__menu-icon" icon="menu"}}

--- a/app/ui-utils/client/lib/MessageAction.js
+++ b/app/ui-utils/client/lib/MessageAction.js
@@ -188,7 +188,7 @@ Meteor.startup(async function () {
 			return true;
 		},
 		order: 0,
-		group: 'menu',
+		group: ['menu', 'extended'],
 	});
 
 	MessageAction.addButton({
@@ -219,7 +219,7 @@ Meteor.startup(async function () {
 			return true;
 		},
 		order: -3,
-		group: ['message', 'menu'],
+		group: ['message', 'menu', 'extended'],
 	});
 
 	MessageAction.addButton({
@@ -258,7 +258,7 @@ Meteor.startup(async function () {
 			return !!subscription;
 		},
 		order: 5,
-		group: 'menu',
+		group: ['menu', 'extended'],
 	});
 
 	MessageAction.addButton({
@@ -324,7 +324,7 @@ Meteor.startup(async function () {
 			});
 		},
 		order: 18,
-		group: 'menu',
+		group: ['menu', 'extended'],
 	});
 
 	MessageAction.addButton({


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->
After using RocketChat for a while , I feel that it would be really great to have this feature of showing a extended messageActions menu with delete,copy and few more buttons when a particular key like the shift key is pressed while hovering over a message.
It'll make deleting,copying and other similar actions really convenient as we'll not have to go through the menu every time for these.

I also posted it on feature request repo and after getting a positive response from @dudanogueira , started working on it.
The same can be found on https://github.com/RocketChat/feature-requests/issues/535

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
This feature adds a extended message actions menu with some additional options like delete ,reply, copy , star etc. which appears when we hover over a message while pressing shift key . This makes deleting, replying and similar actions convenient as it can be done in a single click.

https://user-images.githubusercontent.com/77742477/149315735-16eca76e-906e-45dd-aa38-3c4fa44579c6.mp4


<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This feature is work in progress and has a lot of room for improvement. So I invite the dev team and other contributors to provide their valuable feedback and suggestions.
