### PR TITLE
[FIX] Broken links in search bar

### DIFF
--- a/app/ui-message/client/message.js
+++ b/app/ui-message/client/message.js
@@ -48,7 +48,7 @@ const renderBody = (msg, settings) => {
 	}
 
 	if (searchedText) {
-		msg = msg.replace(new RegExp(searchedText, 'gi'), (str) => `<mark>${str}</mark>`);
+		msg = msg.replace(new RegExp(`(?!href=".)${searchedText}(?!.*")`, 'gi'), (str) => `<mark>${str}</mark>`);
 	}
 
 	return msg;


### PR DESCRIPTION
This is fixed using a more narrow regex search, added precise regex to check and replace the searched text with a highlight.

## Before :

https://user-images.githubusercontent.com/76220055/150274051-bf93e5f8-6c60-4f84-a59b-fa7a61c6d66d.mp4


## After : 

https://user-images.githubusercontent.com/76220055/150274065-808dc721-a89c-4d61-a60b-a653293da60a.mp4


## Issue(s)

Closes #24198 

