### PR TITLE
[FIX] Fixed broken links in setup wizard

### DIFF
--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -926,7 +926,7 @@
   "Cloud_registration_required_link_text": "Click here to register your workspace.",
   "Cloud_resend_email": "Resend Email",
   "Cloud_Service_Agree_PrivacyTerms": "Cloud Service Privacy Terms Agreement",
-  "Cloud_Service_Agree_PrivacyTerms_Description": "I agree with the <a href='https://rocket.chat/terms'>Terms</a> & <a href='https://rocket.chat/privacy'>Privacy Policy</a>",
+  "Cloud_Service_Agree_PrivacyTerms_Description": "I agree with the [Terms](https://rocket.chat/terms) & [Privacy Policy](https://rocket.chat/privacy)",
   "Cloud_Service_Agree_PrivacyTerms_Login_Disabled_Warning": "You should accept the cloud privacy terms (Setup Wizard > Cloud Info > Cloud Service Privacy Terms Agreement) to connect to your cloud workspace",
   "Cloud_status_page_description": "If a particular Cloud Service is having issues you can check for known issues on our status page at",
   "Cloud_token_instructions": "To Register your workspace go to Cloud Console. Login or Create an account and click register self-managed. Paste the token provided below",


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Fixed links of Terms and Privacy Policy in Setup Wizard cloud info,as it contains <a> tag.

## Before

<img width="872" alt="150513282-77b8d758-bc7e-40cd-a0f3-bc7b33c4f652" src="https://user-images.githubusercontent.com/76220055/150523893-4a4c284d-17a0-40f7-a1a3-af705286caa8.png">


## After 

<img width="960" alt="Screenshot 2022-01-21 171816" src="https://user-images.githubusercontent.com/76220055/150523915-1e7e029a-cf4f-4e3b-8379-1386828546d5.png">


## Issue(s)

Closes #24246 

## Steps to test or reproduce
1. Go to Admin 
2. Go to Setup Wizard
3. Cloud Info
