### PR TITLE
Regression: Fix incompatibility of apps http requests

### DIFF
--- a/app/apps/server/bridges/http.ts
+++ b/app/apps/server/bridges/http.ts
@@ -6,6 +6,8 @@ import { IHttpBridgeRequestInfo } from '@rocket.chat/apps-engine/server/bridges'
 import { AppServerOrchestrator } from '../orchestrator';
 import { getUnsafeAgent } from '../../../../server/lib/getUnsafeAgent';
 
+const isGetOrHead = (method: string): boolean => ['GET', 'HEAD'].includes(method.toUpperCase());
+
 export class AppHttpBridge extends HttpBridge {
 	// eslint-disable-next-line no-empty-function
 	constructor(private readonly orch: AppServerOrchestrator) {
@@ -38,7 +40,7 @@ export class AppHttpBridge extends HttpBridge {
 
 		let paramsForBody;
 
-		if (content || method === 'get' || method === 'head') {
+		if (content || isGetOrHead(method)) {
 			if (request.params) {
 				Object.keys(request.params).forEach((key) => {
 					if (request.params?.[key]) {
@@ -57,6 +59,10 @@ export class AppHttpBridge extends HttpBridge {
 			});
 			content = data.toString();
 			headers['Content-Type'] = 'application/x-www-form-urlencoded';
+		}
+
+		if (isGetOrHead(method)) {
+			content = undefined;
 		}
 
 		// end comptability with old HTTP.call API


### PR DESCRIPTION


<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
HTTP GET and HEAD requests made with an empty object as `data` were breaking, as the bridge converted this to the request's body as `'{}'` but meteor's new lib doesn't allow for body content on either of this request methods.

To maintain compatibility, we forced an empty body whenever we have a GET or HEAD request. This was probably the case previously, with the body of requests made with this methods being ignored either before being sent or in the third party server receiving the request
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
