### PR TITLE
[FIX] "Remove from room" visible after scrolling in user list context menu

### DIFF
--- a/client/views/room/contextualBar/RoomMembers/List/components/UserActions.js
+++ b/client/views/room/contextualBar/RoomMembers/List/components/UserActions.js
@@ -1,22 +1,37 @@
-import { Option, Menu } from '@rocket.chat/fuselage';
+import { Option, Menu, Icon } from '@rocket.chat/fuselage';
 import React from 'react';
 
+import { usePermission } from '../../../../../../contexts/AuthorizationContext';
 import { useActionSpread } from '../../../../../hooks/useActionSpread';
 import { useUserInfoActions } from '../../../../hooks/useUserInfoActions';
 
 const UserActions = ({ username, _id, rid, reload }) => {
 	const { menu: menuOptions } = useActionSpread(useUserInfoActions({ _id, username }, rid, reload), 0);
+	const userCanRemove = usePermission('remove-user', rid);
+
 	if (!menuOptions) {
 		return null;
 	}
+
 	return (
-		<Menu
-			flexShrink={0}
-			key='menu'
-			tiny
-			renderItem={({ label: { label, icon }, ...props }) => <Option {...props} label={label} icon={icon} />}
-			options={menuOptions}
-		/>
+		<div style={{ display: 'flex', alignItems: 'center' }}>
+			{userCanRemove && (
+				<Icon
+					label={menuOptions.removeUser.label.label.props.children}
+					onClick={menuOptions.removeUser.action}
+					name='sign-out'
+					size='x16'
+					color={'danger'}
+				/>
+			)}
+			<Menu
+				flexShrink={0}
+				key='menu'
+				tiny
+				renderItem={({ label: { label, icon }, ...props }) => <Option {...props} label={label} icon={icon} />}
+				options={menuOptions}
+			/>
+		</div>
 	);
 };
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

This PR introduces a remove user button alongside the user menu kebab (3-dots) icon in the members' list section. This will help the admins or moderators of the group to easily remove the members without a need to scroll down in the user context menu, which is a bit harder to notice at first glimpse. 
Below is the screenshot of the changes,
<img width="280" alt="image" src="https://user-images.githubusercontent.com/61188295/152679288-3f6f46d6-50bb-4f08-8f92-199898cd6142.png">


<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

#24156 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Open the "Members" window, by clicking the Member icon located on the top right section of the page.
2.  Hover over a user.
3.  Click the 3-dots on the end of the user name. This opens up the user context menu or user info actions.
4.  The "Remove from the room", is not visible in the current menu, the user needs to scroll down to see this option, which is generally left unnoticed by many users, so they generally think there is no such option.
(Make sure you have required permissions to remove the users from a group to view the remove option.)

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
