### PR TITLE
[IMPROVE] Added tooltip options for message menu

### DIFF
--- a/app/ui-message/client/message.html
+++ b/app/ui-message/client/message.html
@@ -148,7 +148,7 @@
 							</button>
 						{{/each}}
 					</div>
-					<div class="message-actions__menu" aria-haspopup="true" data-title="Options">
+					<div class="message-actions__menu" aria-haspopup="true" title="{{_ "More_options"}}">
 						{{> icon block="message-actions__menu-icon" icon="menu"}}
 					</div>
 				</div>

--- a/app/ui-message/client/message.html
+++ b/app/ui-message/client/message.html
@@ -148,7 +148,7 @@
 							</button>
 						{{/each}}
 					</div>
-					<div class="message-actions__menu" aria-haspopup="true">
+					<div class="message-actions__menu" aria-haspopup="true" data-title="Options">
 						{{> icon block="message-actions__menu-icon" icon="menu"}}
 					</div>
 				</div>

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -3036,6 +3036,7 @@
   "More_direct_messages": "More direct messages",
   "More_groups": "More private groups",
   "More_unreads": "More unreads",
+  "More_options": "More options",
   "Most_popular_channels_top_5": "Most popular channels (Top 5)",
   "Move_beginning_message": "`%s` - Move to the beginning of the message",
   "Move_end_message": "`%s` - Move to the end of the message",


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Added tooltip 'Options' to message menu.


## After:

https://user-images.githubusercontent.com/76220055/152799719-7f73a7c6-cf46-4a10-87de-32aad6f32585.mp4


## Issue(s)
Closes #24430 

## Steps to test or reproduce
Mention in issue
