### PR TITLE
[FIX] Scrolling-up moves to unexpected position

### DIFF
--- a/app/ui-utils/client/lib/RoomHistoryManager.js
+++ b/app/ui-utils/client/lib/RoomHistoryManager.js
@@ -235,6 +235,7 @@ export const RoomHistoryManager = new (class extends Emitter {
 		waitAfterFlush(() => {
 			const heightDiff = wrapper.scrollHeight - previousHeight;
 			wrapper.scrollTop = scroll + heightDiff;
+			lastMessage && document.getElementById(lastMessage._id).scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'nearest' });
 		});
 
 		room.isLoading.set(false);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
On the channel or teams page having more than 50+ chats, when a user scrolls to load old messages calling the `loadHistory()` method, once the messages are fetched and rendered, the scroll position moves out of the current viewport to a random message instead of the last seen message.
This PR implements a `scrollIntoView` method on the last appeared message, which scrolls the message viewport such that the last seen message always appears at the bottom for every load of old messages.

Here is a clip showing the made changes, 

https://user-images.githubusercontent.com/61188295/154330267-59006ea9-7e5c-448e-95fc-78d6d511c3f0.mp4


During the first call to load history messages, the last seen message was "52" after the old messages are loaded the chat window is scrolled back to the position where "52" is at the bottom.

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
#23029 
#19871 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Mentioned in issue #23029 the affected screens would be the `message wrapper`

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
