### PR TITLE
Regression: No audio when call comes from Skype/IP phone

### DIFF
--- a/client/lib/voip/Stream.ts
+++ b/client/lib/voip/Stream.ts
@@ -58,6 +58,11 @@ export default class Stream {
 	 */
 
 	init(rmElement: HTMLMediaElement): void {
+		if (this.renderingMediaElement) {
+			// Someone already has setup the stream and initializing it once again
+			// Clear the existing stream object
+			this.renderingMediaElement.srcObject == null;
+		}
 		this.renderingMediaElement = rmElement;
 	}
 	/**

--- a/client/lib/voip/VoIPUser.ts
+++ b/client/lib/voip/VoIPUser.ts
@@ -241,7 +241,6 @@ export class VoIPUser extends Emitter<VoipEvents> implements OutgoingRequestDele
 
 		this.remoteStream = new Stream(remoteStream);
 		const mediaElement = this.mediaStreamRendered?.remoteMediaElement;
-
 		if (mediaElement) {
 			this.remoteStream.init(mediaElement);
 			this.remoteStream.onTrackAdded(this.onTrackAdded.bind(this));
@@ -614,5 +613,18 @@ export class VoIPUser extends Emitter<VoipEvents> implements OutgoingRequestDele
 	/* CallEventDelegate implementation end */
 	isReady(): boolean {
 		return this.state.isReady;
+	}
+
+	/**
+	 * This function allows to change the media renderer media elements.
+	 */
+	switchMediaRenderer(mediaRenderer: IMediaStreamRenderer): void {
+		if (this.remoteStream) {
+			this.mediaStreamRendered = mediaRenderer;
+			this.remoteStream.init(mediaRenderer.remoteMediaElement);
+			this.remoteStream.onTrackAdded(this.onTrackAdded.bind(this));
+			this.remoteStream.onTrackRemoved(this.onTrackRemoved.bind(this));
+			this.remoteStream.play();
+		}
 	}
 }

--- a/client/providers/CallProvider/CallProvider.tsx
+++ b/client/providers/CallProvider/CallProvider.tsx
@@ -99,6 +99,55 @@ export const CallProvider: FC = ({ children }) => {
 		handleCallHangup,
 	]);
 
+	useEffect(() => {
+		if (isUseVoipClientResultError(result)) {
+			return;
+		}
+
+		if (isUseVoipClientResultLoading(result)) {
+			return;
+		}
+		/**
+		 * This code may need a revisit when we handle callinqueue differently.
+		 * Check clickup taks for more details
+		 * https://app.clickup.com/t/22hy1k4
+		 * When customer called a queue (Either using skype or using internal number), call would get established
+		 * customer would hear agent's voice but agent would not hear anything from customer.
+		 * This issue was observed on unstable. It was found to be incosistent to reproduce.
+		 * On some developer env, it would happen randomly. On Safari it did not happen if
+		 * user refreshes before taking every call.
+		 *
+		 * The reason behind this was as soon as agent accepts a call, queueCounter would change.
+		 * This change will trigger re-rendering of media and creation of audio element.
+		 * This audio element gets used by voipClient to render the remote audio.
+		 * Because the re-render happend, it would hold a stale reference.
+		 *
+		 * If the dom is inspected, audio element just before body is usually created by this class.
+		 * this audio element.srcObject contains null value. In working case, it should display
+		 * valid stream object.
+		 *
+		 * Reason for inconsistecies :
+		 * This element is utilised in VoIPUser::setupRemoteMedia
+		 * This function is called when webRTC receives a remote track event. i.e when the webrtc's peer connection
+		 * starts receiving media. This event call back depends on several factors. How does asterisk setup streams.
+		 * How does it creates a bridge which patches up the agent and customer (Media is flowing thru asterisk).
+		 * When it works in de-environment, it was observed that the audio element in dom and the audio element hold
+		 * by VoIPUser is different. Nonetheless, this stale audio element holds valid media stream, which is being played.
+		 * Hence sometimes the audio is heard.
+		 *
+		 * Ideally call component once gets stable, should not get rerendered. Queue, Room creation are the parameters
+		 * which should be independent and should not control the call component.
+		 *
+		 * Solution :
+		 * Either make the audio elemenent rendered independent of rest of the DOM.
+		 * or implement useEffect. This useEffect will reset the rendering elements with the latest audio tag.
+		 *
+		 * Note : If this code gets refactor, revisit the line below to check if this call is needed.
+		 *
+		 */
+		remoteAudioMediaRef.current && result.voipClient.switchMediaRenderer({ remoteMediaElement: remoteAudioMediaRef.current });
+	});
+
 	const visitorEndpoint = useEndpoint('POST', 'livechat/visitor');
 	const voipEndpoint = useEndpoint('GET', 'voip/room');
 	const voipCloseRoomEndpoint = useEndpoint('POST', 'voip/room.close');


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
The audio was not rendered because of re-rendering of react element based on
queueCounter and roomInfo. queueCounter and roomInfo cause the dom to re-render when call gets accepted
because after accepting call, queueCounter changes or a room gets created.
The audio element gets recreated. But VoIP user probably holds the old one.
The behaviour is not predictable when such case happens. If everything gets cleanly setup,
even if the audio element goes headless, it still continues to play the remote audio.
But in other cases, it is unreferenced the one on dom has its srcObject as null.
This causes no audio.

This fix provides a way to re-initialise the rendering elements in VoIP user
and calls this function on useEffect() if the re-render has happen.

<!-- END CHANGELOG -->

## Issue(s)
https://app.clickup.com/t/22hy1k4

## Steps to test or reproduce
The issue is not consistently reproduced. Usually it is difficult to reproduce on local setup. It does not happen on Safari if the browser is refreshed for every call. But the reproducibility is > 40%.
1. Login on rocket.chat agent. 
2. Use Provider trunk to call from cellphone/skype or use internal queue extension.
3. Call the queue. 
4. Expect that MOH is heard.
5. Call should ring on agent's console.
6. When agent accepts the call, there is no audio.
7. Customer can hear agent's audio but the agent does not hear customer's.



## Further comments
This reloading of DOM happens for room creation as well. But the problem is not that significant. 
