### PR TITLE
Regression: Fix time fields and wrap up in Voip Room Contexual bar

### DIFF
--- a/client/views/omnichannel/directory/calls/contextualBar/VoipInfo.tsx
+++ b/client/views/omnichannel/directory/calls/contextualBar/VoipInfo.tsx
@@ -63,7 +63,7 @@ export const VoipInfo = ({ room, onClickClose /* , onClickReport, onClickCall */
 					<InfoField label={t('Hold_Time')} info={hold || t('Not_Available')} />
 					{(lastMessage || tags) && (
 						<InfoPanel.Field>
-							<InfoPanel.Label>{!lastMessage && tags ? t('Tags') : t('Wrap_Up_Note')}</InfoPanel.Label>
+							<InfoPanel.Label>{!lastMessage && tags ? t('Tags') : t('Wrap_Up_Notes')}</InfoPanel.Label>
 							<InfoPanel.Text>{lastMessage?.msg}</InfoPanel.Text>
 							<InfoPanel.Text>
 								{tags?.map((tag: string) => (
@@ -75,8 +75,6 @@ export const VoipInfo = ({ room, onClickClose /* , onClickReport, onClickCall */
 						</InfoPanel.Field>
 					)}
 				</InfoPanel>
-
-				{/* <InfoField label={t('Wrap_Up_Note')} info={guest.holdTime} /> */}
 			</VerticalBar.ScrollableContent>
 			<VerticalBar.Footer>
 				{/* TODO: Introduce this buttons [Not part of MVP] */}

--- a/client/views/omnichannel/directory/calls/contextualBar/VoipInfo.tsx
+++ b/client/views/omnichannel/directory/calls/contextualBar/VoipInfo.tsx
@@ -1,4 +1,4 @@
-import { Box, Icon } from '@rocket.chat/fuselage';
+import { Box, Icon, Chip } from '@rocket.chat/fuselage';
 import moment from 'moment';
 import React, { ReactElement } from 'react';
 
@@ -22,10 +22,10 @@ type VoipInfoPropsType = {
 export const VoipInfo = ({ room, onClickClose /* , onClickReport, onClickCall */ }: VoipInfoPropsType): ReactElement => {
 	const t = useTranslation();
 
-	const { servedBy, queue, v, fname, name, callDuration, callTotalHoldTime, callEndedAt, callWaitingTime } = room;
-	const duration = callDuration && moment.duration(callDuration / 1000, 'seconds').humanize();
-	const waiting = callWaitingTime && moment.duration(callWaitingTime / 1000, 'seconds').humanize();
-	const hold = callTotalHoldTime && moment.duration(callTotalHoldTime, 'seconds').humanize();
+	const { servedBy, queue, v, fname, name, callDuration, callTotalHoldTime, callEndedAt, callWaitingTime, tags, lastMessage } = room;
+	const duration = callDuration && moment.utc(callDuration).format('HH:mm:ss');
+	const waiting = callWaitingTime && moment.utc(callWaitingTime).format('HH:mm:ss');
+	const hold = callTotalHoldTime && moment.utc(callTotalHoldTime).format('HH:mm:ss');
 	const endedAt = callEndedAt && moment(callEndedAt).format('LLL');
 	const phoneNumber = Array.isArray(v?.phone) ? v?.phone[0]?.phoneNumber : v?.phone;
 
@@ -61,6 +61,19 @@ export const VoipInfo = ({ room, onClickClose /* , onClickReport, onClickCall */
 					<InfoField label={t('Waiting_Time')} info={waiting || t('Not_Available')} />
 					<InfoField label={t('Talk_Time')} info={duration || t('Not_Available')} />
 					<InfoField label={t('Hold_Time')} info={hold || t('Not_Available')} />
+					{(lastMessage || tags) && (
+						<InfoPanel.Field>
+							<InfoPanel.Label>{!lastMessage && tags ? t('Tags') : t('Wrap_Up_Note')}</InfoPanel.Label>
+							<InfoPanel.Text>{lastMessage?.msg}</InfoPanel.Text>
+							<InfoPanel.Text>
+								{tags?.map((tag: string) => (
+									<Chip mie='x4' key={tag} value={tag}>
+										{tag}
+									</Chip>
+								))}
+							</InfoPanel.Text>
+						</InfoPanel.Field>
+					)}
 				</InfoPanel>
 
 				{/* <InfoField label={t('Wrap_Up_Note')} info={guest.holdTime} /> */}

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -4795,6 +4795,7 @@
   "Would_you_like_to_return_the_queue": "Would you like to move back this room to the queue? All conversation history will be kept on the room.",
   "Would_you_like_to_place_chat_on_hold": "Would you like to place this chat On-Hold?",
   "Wrap_Up_the_Call": "Wrap Up the Call",
+  "Wrap_Up_Notes": "Wrap Up Notes",
   "Yes": "Yes",
   "Yes_archive_it": "Yes, archive it!",
   "Yes_clear_all": "Yes, clear all!",


### PR DESCRIPTION
this fixes:
- Wrap-up and tags fields are not displayed
- Don't use humanize() to display time fields, they should be displayed as regular time fields.
