### PR TITLE
Regression: Queue counter aggregator for incoming/hanged calls

### DIFF
--- a/app/api/server/v1/voip/queues.ts
+++ b/app/api/server/v1/voip/queues.ts
@@ -4,7 +4,7 @@ import { API } from '../../api';
 import { Voip } from '../../../../../server/sdk';
 import { IVoipConnectorResult } from '../../../../../definition/IVoipConnectorResult';
 import { IQueueSummary } from '../../../../../definition/ACDQueues';
-import { IQueueMembershipDetails } from '../../../../../definition/IVoipExtension';
+import { IQueueMembershipDetails, IQueueMembershipSubscription } from '../../../../../definition/IVoipExtension';
 
 API.v1.addRoute(
 	'voip/queues.getSummary',
@@ -30,6 +30,23 @@ API.v1.addRoute(
 			);
 			const membershipDetails: IVoipConnectorResult = await Voip.getQueuedCallsForThisExtension(this.requestParams());
 			return API.v1.success(membershipDetails.result as IQueueMembershipDetails);
+		},
+	},
+);
+
+API.v1.addRoute(
+	'voip/queues.getMembershipSubscription',
+	{ authRequired: true },
+	{
+		async get() {
+			check(
+				this.requestParams(),
+				Match.ObjectIncluding({
+					extension: String,
+				}),
+			);
+			const membershipDetails: IVoipConnectorResult = await Voip.getQueueMembership(this.requestParams());
+			return API.v1.success(membershipDetails.result as IQueueMembershipSubscription);
 		},
 	},
 );

--- a/client/lib/voip/QueueAggregator.ts
+++ b/client/lib/voip/QueueAggregator.ts
@@ -1,0 +1,132 @@
+/**
+ * Class representing the agent's queue information. This class stores the information
+ * of all the queues that the agent is serving.
+ *
+ * @remarks
+ * This class stores the necessary information of agent's queue stats.
+ * It also maintains a history of agents queue operation history for current
+ * login session. (Agent logging in to rocket-chat and logging off from rocket chat.)
+ * Currently the data is stored locally but may sent back to server if such need exists.
+ */
+
+import { IQueueMembershipSubscription } from '../../../definition/IVoipExtension';
+import { ICallerInfo } from '../../../definition/voip/ICallerInfo';
+import { IQueueInfo } from '../../../definition/voip/IQueueInfo';
+
+interface IQueueServingRecord {
+	queueInfo: IQueueInfo;
+	callStarted: Date | undefined;
+	callEnded: Date | undefined;
+	callerId: ICallerInfo;
+	agentExtension: string;
+}
+/**
+ * Currently this class depends on the external users to update this class.
+ * But in theory, this class serves as
+ */
+export class QueueAggregator {
+	// Maintains the history of the queue that the agent has served
+	private sessionQueueCallServingHistory: IQueueServingRecord[];
+
+	private currentlyServing: IQueueServingRecord | undefined;
+
+	private currentQueueMembershipStatus: Record<string, IQueueInfo>;
+
+	private extension: string;
+
+	constructor() {
+		this.sessionQueueCallServingHistory = [];
+		this.currentQueueMembershipStatus = {};
+	}
+
+	private updateQueueInfo(queueName: string, queuedCalls: number): void {
+		if (!this.currentQueueMembershipStatus[queueName]) {
+			// something is wrong. Queue is not found in the membership details.
+			return;
+		}
+		this.currentQueueMembershipStatus[queueName].callsInQueue = queuedCalls;
+	}
+
+	setMembership(subscription: IQueueMembershipSubscription): void {
+		this.extension = subscription.extension;
+		for (let i = 0; i < subscription.queues.length; i++) {
+			const queue = subscription.queues[i];
+			const queueInfo: IQueueInfo = {
+				queueName: queue.name,
+				callsInQueue: 0,
+			};
+			this.currentQueueMembershipStatus[queue.name] = queueInfo;
+		}
+	}
+
+	queueJoined(joiningDetails: { queuename: string; callerid: { id: string }; queuedcalls: string }): void {
+		this.updateQueueInfo(joiningDetails.queuename, Number(joiningDetails.queuedcalls));
+	}
+
+	callPickedup(queue: { queuename: string; queuedcalls: string; waittimeinqueue: string }): void {
+		this.updateQueueInfo(queue.queuename, Number(queue.queuedcalls));
+	}
+
+	memberAdded(queue: { queuename: string; queuedcalls: string }): void {
+		// current user is added in the queue which has queue count |queuedcalls|
+		const queueInfo: IQueueInfo = {
+			queueName: queue.queuename,
+			callsInQueue: Number(queue.queuedcalls),
+		};
+		this.currentQueueMembershipStatus[queue.queuename] = queueInfo;
+	}
+
+	memberRemoved(queue: { queuename: string; queuedcalls: string }): void {
+		// current user is removed from the queue which has queue count |queuedcalls|
+		if (!this.currentQueueMembershipStatus[queue.queuename]) {
+			// something is wrong. Queue is not found in the membership details.
+			return;
+		}
+		delete this.currentQueueMembershipStatus[queue.queuename];
+	}
+
+	queueAbandoned(queue: { queuename: string; queuedcallafterabandon: string }): void {
+		this.updateQueueInfo(queue.queuename, Number(queue.queuedcallafterabandon));
+	}
+
+	getCallWaitingCount(): number {
+		let totalCallWaitingCount = 0;
+		Object.entries(this.currentQueueMembershipStatus).forEach(([, value]) => {
+			totalCallWaitingCount += value.callsInQueue;
+		});
+		return totalCallWaitingCount;
+	}
+
+	callRinging(queueInfo: { queuename: string; callerId: { id: string; name: string } }): void {
+		if (!this.currentQueueMembershipStatus[queueInfo.queuename]) {
+			// something is wrong. Queue is not found in the membership details.
+			return;
+		}
+
+		const queueServing: IQueueServingRecord = {
+			queueInfo: this.currentQueueMembershipStatus[queueInfo.queuename],
+			callerId: {
+				callerId: queueInfo.callerId.id,
+				callerName: queueInfo.callerId.name,
+			},
+			callStarted: undefined,
+			callEnded: undefined,
+			agentExtension: this.extension,
+		};
+		this.currentlyServing = queueServing;
+	}
+
+	callStarted(): void {
+		if (this.currentlyServing) {
+			this.currentlyServing.callStarted = new Date();
+		}
+	}
+
+	callEnded(): void {
+		// Latest calls are at lower index
+		if (this.currentlyServing) {
+			this.currentlyServing.callEnded = new Date();
+			this.sessionQueueCallServingHistory.unshift(this.currentlyServing);
+		}
+	}
+}

--- a/definition/IVoipConnectorResult.ts
+++ b/definition/IVoipConnectorResult.ts
@@ -1,4 +1,10 @@
-import { IVoipExtensionConfig, IVoipExtensionBase, IQueueMembershipDetails, IRegistrationInfo } from './IVoipExtension';
+import {
+	IVoipExtensionConfig,
+	IVoipExtensionBase,
+	IQueueMembershipDetails,
+	IRegistrationInfo,
+	IQueueMembershipSubscription,
+} from './IVoipExtension';
 import { IQueueDetails, IQueueSummary } from './ACDQueues';
 
 export interface IVoipConnectorResult {
@@ -8,6 +14,7 @@ export interface IVoipConnectorResult {
 		| IQueueSummary[]
 		| IQueueDetails
 		| IQueueMembershipDetails
+		| IQueueMembershipSubscription
 		| IRegistrationInfo
 		| undefined;
 }

--- a/definition/IVoipExtension.ts
+++ b/definition/IVoipExtension.ts
@@ -1,3 +1,4 @@
+import { IQueueSummary } from './ACDQueues';
 import { IUser } from './IUser';
 import { ICallServerConfigData } from './IVoipServerConfig';
 
@@ -34,6 +35,11 @@ export interface IQueueMembershipDetails {
 	extension: string;
 	queueCount: number;
 	callWaitingCount: number;
+}
+
+export interface IQueueMembershipSubscription {
+	queues: IQueueSummary[];
+	extension: string;
 }
 
 export const isIQueueMembershipDetails = (obj: any): obj is IQueueMembershipDetails =>

--- a/definition/rest/v1/voip.ts
+++ b/definition/rest/v1/voip.ts
@@ -2,7 +2,7 @@ import { IQueueSummary } from '../../ACDQueues';
 import { ILivechatAgent } from '../../ILivechatAgent';
 import { IVoipRoom } from '../../IRoom';
 import { IUser } from '../../IUser';
-import { IQueueMembershipDetails, IVoipExtensionWithAgentInfo } from '../../IVoipExtension';
+import { IQueueMembershipDetails, IQueueMembershipSubscription, IVoipExtensionWithAgentInfo } from '../../IVoipExtension';
 import { IManagementServerConnectionStatus } from '../../IVoipServerConnectivityStatus';
 import { IRegistrationInfo } from '../../voip/IRegistrationInfo';
 import { VoipClientEvents } from '../../voip/VoipClientEvents';
@@ -18,6 +18,9 @@ export type VoipEndpoints = {
 	};
 	'voip/queues.getQueuedCallsForThisExtension': {
 		GET: (params: { extension: string }) => IQueueMembershipDetails;
+	};
+	'voip/queues.getMembershipSubscription': {
+		GET: (params: { extension: string }) => IQueueMembershipSubscription;
 	};
 	'omnichannel/extensions': {
 		GET: (params: PaginatedRequest) => PaginatedResult & { extensions: IVoipExtensionWithAgentInfo[] };

--- a/definition/voip/ICallerInfo.ts
+++ b/definition/voip/ICallerInfo.ts
@@ -1,5 +1,5 @@
 export interface ICallerInfo {
 	callerId: string;
 	callerName: string;
-	host: string;
+	host?: string;
 }

--- a/definition/voip/IQueueInfo.ts
+++ b/definition/voip/IQueueInfo.ts
@@ -1,0 +1,9 @@
+/**
+ * This interface represents the agent's view of the queue
+ * @remarks
+ */
+
+export interface IQueueInfo {
+	queueName: string;
+	callsInQueue: number;
+}

--- a/definition/voip/WorkflowTypes.ts
+++ b/definition/voip/WorkflowTypes.ts
@@ -1,0 +1,11 @@
+/**
+ * Enumerator SIP User's workflow types
+ * @remarks
+ * Depending on whether the user is contact center user or a stand alone user,
+ * certain data structures will be initialised
+ */
+
+export enum WorkflowTypes {
+	STANDALONE_USER,
+	CONTACT_CENTER_USER,
+}

--- a/server/modules/listeners/listeners.module.ts
+++ b/server/modules/listeners/listeners.module.ts
@@ -271,8 +271,8 @@ export class ListenersModule {
 		service.onEvent('banner.enabled', (bannerId): void => {
 			notifications.notifyLoggedInThisInstance('banner-changed', { bannerId });
 		});
-		service.onEvent('queue.agentcalled', (userId, queuename): void => {
-			notifications.notifyUserInThisInstance(userId, 'agentcalled', { queuename });
+		service.onEvent('queue.agentcalled', (userId, queuename, callerId): void => {
+			notifications.notifyUserInThisInstance(userId, 'agentcalled', { queuename, callerId });
 		});
 		service.onEvent('queue.agentconnected', (userId, queuename: string, queuedcalls: string, waittimeinqueue: string): void => {
 			notifications.notifyUserInThisInstance(userId, 'agentconnected', { queuename, queuedcalls, waittimeinqueue });

--- a/server/sdk/types/IVoipService.ts
+++ b/server/sdk/types/IVoipService.ts
@@ -10,6 +10,7 @@ export interface IVoipService {
 	getConnectorVersion(): string;
 	getQueueSummary(): Promise<IVoipConnectorResult>;
 	getQueuedCallsForThisExtension(requestParams: any): Promise<IVoipConnectorResult>;
+	getQueueMembership(requestParams: any): Promise<IVoipConnectorResult>;
 	getExtensionList(): Promise<IVoipConnectorResult>;
 	getExtensionDetails(requestParams: any): Promise<IVoipConnectorResult>;
 	getRegistrationInfo(requestParams: any): Promise<{ result: IRegistrationInfo }>; // TODO: Check the reason behind IVoipConnectorResult

--- a/server/services/voip/connector/asterisk/ami/CallbackContext.ts
+++ b/server/services/voip/connector/asterisk/ami/CallbackContext.ts
@@ -23,7 +23,6 @@ export class CallbackContext implements ICallbackContext {
 	 */
 	call(event: any): boolean {
 		const pattern = new RegExp(this.ref.actionid);
-		// this.logger.error({ msg: 'ROCKETCHAT_DEBUG Trying', data1: this.ref.actionid, data2: event.actionid });
 		/**
 		 *
 		 * Though actionid remains unique with every action and for some


### PR DESCRIPTION


<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
Description : Agent could be a part of multiple queues. When such a case happens,
agent's console should be able to show the consolidated calls for the queue that he/she is serving.
TO achieve this, following changes have been done.
1. Added Queue aggregator class. This class is responsible for managing the subscriptions, updating it if agent gets added/removed
from the queue. It also maintains the history of call served by the agent in current login session. This class is applicable
only for contact center agent and not for any simple voip user.
2. useVoipClient hook now initialises the aggregater with login time membership subscription.
3. Voip user contains a member variable of QueueAggregator type which will be used by CallProvider to
populate the information when the it receives call activity notification.
4. Few additional definitions are added in this workspace.
5. It provides a noew API for fetching the membership details for an extension.
6. It solves a minor bug. Server crashes if the voip is not enabled. This happens because in voip/service.ts we do not
create the object of command handler. But when voip gets enabled, watcher directly calls init, which tries to
initialise command object. Changed this logic. Now command object is created always. It is initialised only if and when
voip is enabled.<!-- END CHANGELOG -->

## Issue(s)
https://app.clickup.com/t/22qhtmy


## Steps to test or reproduce
Before this workspace, agent shows queue call count only from one queue. With this work space it will show the consolidated queue count.

## Further comments
Testing Notes:
1. Verify that agent can see consolidated call when it is a member of multiple queues and those queues get a call.
2. Verify that When agent gets added or removed from the queue, its queue waiting count is consistent with its membership.
3. Verify that when the queue is abandoned by customer, the queue waiting count is consistent