### PR TITLE
[FIX] no id of room closer in livechat-close message

### DIFF
--- a/app/apps/server/bridges/livechat.ts
+++ b/app/apps/server/bridges/livechat.ts
@@ -111,7 +111,7 @@ export class AppLivechatBridge extends LivechatBridge {
 	protected async closeRoom(room: ILivechatRoom, comment: string, closer: IUser | undefined, appId: string): Promise<boolean> {
 		this.orch.debugLog(`The App ${appId} is closing a livechat room.`);
 
-		const user = closer && this.orch.getConverters()?.get('users').convertById(closer.id);
+		const user = closer && this.orch.getConverters()?.get('users').convertToRocketChat(closer);
 		const visitor = this.orch.getConverters()?.get('visitors').convertAppVisitor(room.visitor);
 
 		const closeData: any = {


### PR DESCRIPTION
In `app/apps/server/bridges/livechat.ts:114`, we converted the user to app interface and the use that user for Rocket.Chat method. Due to the unmatch interface, this cause some troubles.
We should use method `convertToRocketChat` instead