### PR TITLE
Chore: Update Site Url Description. No trailing slash.

### DIFF
--- a/packages/rocketchat-i18n/i18n/af.i18n.json
+++ b/packages/rocketchat-i18n/i18n/af.i18n.json
@@ -2298,7 +2298,7 @@
   "since_creation": "sedert%s",
   "Site_Name": "Webbladnaam",
   "Site_Url": "Site-URL",
-  "Site_Url_Description": "Voorbeeld: https://chat.domain.com/",
+  "Site_Url_Description": "Voorbeeld: https://chat.domain.com",
   "Size": "grootte",
   "Skip": "Huppel",
   "Slack_Users": "Slack se gebruikers CSV",

--- a/packages/rocketchat-i18n/i18n/ar.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ar.i18n.json
@@ -3974,7 +3974,7 @@
   "since_creation": "منذ %s",
   "Site_Name": "اسم الموقع",
   "Site_Url": "عنوان URL للموقع",
-  "Site_Url_Description": "مثال: https://chat.domain.com/",
+  "Site_Url_Description": "مثال: https://chat.domain.com",
   "Size": "الحجم",
   "Skip": "تخطٍّ",
   "Slack_Users": "CSV لمستخدمي Slack",

--- a/packages/rocketchat-i18n/i18n/az.i18n.json
+++ b/packages/rocketchat-i18n/i18n/az.i18n.json
@@ -2298,7 +2298,7 @@
   "since_creation": "Çünki%s",
   "Site_Name": "Saytın adı",
   "Site_Url": "Saytın URL'si",
-  "Site_Url_Description": "Məsələn: https://chat.domain.com/",
+  "Site_Url_Description": "Məsələn: https://chat.domain.com",
   "Size": "Ölçü",
   "Skip": "Atlayın",
   "Slack_Users": "Slack istifadəçiləri CSV",

--- a/packages/rocketchat-i18n/i18n/be-BY.i18n.json
+++ b/packages/rocketchat-i18n/i18n/be-BY.i18n.json
@@ -2311,7 +2311,7 @@
   "since_creation": "так як%s",
   "Site_Name": "Назва сайта",
   "Site_Url": "URL сайта",
-  "Site_Url_Description": "Прыклад: https://chat.domain.com/",
+  "Site_Url_Description": "Прыклад: https://chat.domain.com",
   "Size": "памер",
   "Skip": "Прапусціць",
   "Slack_Users": "Слабіну ў CSV карыстальнікаў",

--- a/packages/rocketchat-i18n/i18n/bg.i18n.json
+++ b/packages/rocketchat-i18n/i18n/bg.i18n.json
@@ -2296,7 +2296,7 @@
   "since_creation": "от %s",
   "Site_Name": "Име на Сайта",
   "Site_Url": "URL адрес на сайта",
-  "Site_Url_Description": "Пример: https://chat.domain.com/",
+  "Site_Url_Description": "Пример: https://chat.domain.com",
   "Size": "размер",
   "Skip": "Прескочи",
   "Slack_Users": "Потребителите на Slack CSV",

--- a/packages/rocketchat-i18n/i18n/bs.i18n.json
+++ b/packages/rocketchat-i18n/i18n/bs.i18n.json
@@ -2292,7 +2292,7 @@
   "since_creation": "%s",
   "Site_Name": "Ime Stranice",
   "Site_Url": "Link Stranice",
-  "Site_Url_Description": "Na primjer: https://chat.domain.com/",
+  "Site_Url_Description": "Na primjer: https://chat.domain.com",
   "Size": "Veličina",
   "Skip": "Preskoči",
   "Slack_Users": "Korisnik CSV-a korisnika Slack",

--- a/packages/rocketchat-i18n/i18n/cs.i18n.json
+++ b/packages/rocketchat-i18n/i18n/cs.i18n.json
@@ -3327,7 +3327,7 @@
   "since_creation": "od %s",
   "Site_Name": "Jméno stránky",
   "Site_Url": "URL stránky",
-  "Site_Url_Description": "Například: https://chat.domain.com/",
+  "Site_Url_Description": "Například: https://chat.domain.com",
   "Size": "Velikost",
   "Skip": "Přeskočit",
   "Slack_Users": "CSV Uživatelů ze Slacku",

--- a/packages/rocketchat-i18n/i18n/cy.i18n.json
+++ b/packages/rocketchat-i18n/i18n/cy.i18n.json
@@ -2293,7 +2293,7 @@
   "since_creation": "ers %s",
   "Site_Name": "Enw'r Safle",
   "Site_Url": "URL y Safle",
-  "Site_Url_Description": "Enghraifft: https://chat.domain.com/",
+  "Site_Url_Description": "Enghraifft: https://chat.domain.com",
   "Size": "Maint",
   "Skip": "Skip",
   "Slack_Users": "Defnyddwyr Slack CSV",

--- a/packages/rocketchat-i18n/i18n/da.i18n.json
+++ b/packages/rocketchat-i18n/i18n/da.i18n.json
@@ -3348,7 +3348,7 @@
   "since_creation": "siden%s",
   "Site_Name": "Webstedet Navn",
   "Site_Url": "Webstedets webadresse",
-  "Site_Url_Description": "Eksempel: https://chat.domain.com/",
+  "Site_Url_Description": "Eksempel: https://chat.domain.com",
   "Size": "Størrelse",
   "Skip": "Spring over",
   "Slack_Users": "Slack's Users CSV",

--- a/packages/rocketchat-i18n/i18n/de-AT.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de-AT.i18n.json
@@ -2299,7 +2299,7 @@
   "since_creation": "seit %s",
   "Site_Name": "Seitenname",
   "Site_Url": "Website-URL",
-  "Site_Url_Description": "Beispiel: https://chat.domain.com/",
+  "Site_Url_Description": "Beispiel: https://chat.domain.com",
   "Size": "Größe",
   "Skip": "Überspringen",
   "Slack_Users": "Slacks Benutzer CSV",

--- a/packages/rocketchat-i18n/i18n/de-IN.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de-IN.i18n.json
@@ -2638,7 +2638,7 @@
   "since_creation": "seit %s",
   "Site_Name": "Seitenname",
   "Site_Url": "Website-URL",
-  "Site_Url_Description": "Beispiel: https://chat.domain.com/",
+  "Site_Url_Description": "Beispiel: https://chat.domain.com",
   "Size": "Größe",
   "Skip": "Überspringen",
   "Slack_Users": "Benutzer-CSV von Slack",

--- a/packages/rocketchat-i18n/i18n/de.i18n.json
+++ b/packages/rocketchat-i18n/i18n/de.i18n.json
@@ -3974,7 +3974,7 @@
   "since_creation": "seit %s",
   "Site_Name": "Seitenname",
   "Site_Url": "Website-URL",
-  "Site_Url_Description": "Beispiel: https://chat.domain.com/",
+  "Site_Url_Description": "Beispiel: https://chat.domain.com",
   "Size": "Größe",
   "Skip": "Überspringen",
   "Slack_Users": "Benutzer-CSV von Slack",

--- a/packages/rocketchat-i18n/i18n/el.i18n.json
+++ b/packages/rocketchat-i18n/i18n/el.i18n.json
@@ -2304,7 +2304,7 @@
   "since_creation": "από %s",
   "Site_Name": "Όνομα ιστοσελίδας",
   "Site_Url": "URL Ιστοσελίδας",
-  "Site_Url_Description": "Παράδειγμα: https://chat.domain.com/",
+  "Site_Url_Description": "Παράδειγμα: https://chat.domain.com",
   "Size": "Μέγεθος",
   "Skip": "Παραλείπω",
   "Slack_Users": "Χρήστες του Slack CSV",

--- a/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -3975,7 +3975,7 @@
   "since_creation": "since %s",
   "Site_Name": "Site Name",
   "Site_Url": "Site URL",
-  "Site_Url_Description": "Example: https://chat.domain.com/",
+  "Site_Url_Description": "Example: https://chat.domain.com",
   "Size": "Size",
   "Skip": "Skip",
   "Slack_Users": "Slack's Users CSV",

--- a/packages/rocketchat-i18n/i18n/eo.i18n.json
+++ b/packages/rocketchat-i18n/i18n/eo.i18n.json
@@ -2298,7 +2298,7 @@
   "since_creation": "ekde%s",
   "Site_Name": "Nomo Nomo",
   "Site_Url": "Retejo URL",
-  "Site_Url_Description": "Ekzemplo: https://chat.domain.com/",
+  "Site_Url_Description": "Ekzemplo: https://chat.domain.com",
   "Size": "Grandeco",
   "Skip": "Preterpasi",
   "Slack_Users": "Uzantoj de Slack CSV",

--- a/packages/rocketchat-i18n/i18n/fa.i18n.json
+++ b/packages/rocketchat-i18n/i18n/fa.i18n.json
@@ -2612,7 +2612,7 @@
   "since_creation": "از %s را",
   "Site_Name": "نام سایت",
   "Site_Url": "آدرس سایت",
-  "Site_Url_Description": "به عنوان مثال: https://chat.domain.com/",
+  "Site_Url_Description": "به عنوان مثال: https://chat.domain.com",
   "Size": "اندازه",
   "Skip": "گذشتن",
   "Slack_Users": "CSV کاربران Slack",

--- a/packages/rocketchat-i18n/i18n/fi.i18n.json
+++ b/packages/rocketchat-i18n/i18n/fi.i18n.json
@@ -2298,7 +2298,7 @@
   "since_creation": "Alkaen %s sitten",
   "Site_Name": "Sivuston nimi:",
   "Site_Url": "Sivuston URL-osoite",
-  "Site_Url_Description": "Esimerkiksi: https://chat.domain.com/",
+  "Site_Url_Description": "Esimerkiksi: https://chat.domain.com",
   "Size": "Koko",
   "Skip": "Ohita",
   "Slack_Users": "Slackin käyttäjät CSV",

--- a/packages/rocketchat-i18n/i18n/fr.i18n.json
+++ b/packages/rocketchat-i18n/i18n/fr.i18n.json
@@ -3974,7 +3974,7 @@
   "since_creation": "depuis %s",
   "Site_Name": "Nom du site",
   "Site_Url": "URL du site",
-  "Site_Url_Description": "Exemple : https://chat.domain.com/",
+  "Site_Url_Description": "Exemple : https://chat.domain.com",
   "Size": "Taille",
   "Skip": "Ignorer",
   "Slack_Users": "CSV des utilisateurs de Slack",

--- a/packages/rocketchat-i18n/i18n/hr.i18n.json
+++ b/packages/rocketchat-i18n/i18n/hr.i18n.json
@@ -2432,7 +2432,7 @@
   "since_creation": "%s",
   "Site_Name": "Ime Stranice",
   "Site_Url": "Link Stranice",
-  "Site_Url_Description": "Na primjer: https://chat.domain.com/",
+  "Site_Url_Description": "Na primjer: https://chat.domain.com",
   "Size": "Veličina",
   "Skip": "Preskoči",
   "Slack_Users": "Korisnik CSV-a korisnika Slack",

--- a/packages/rocketchat-i18n/i18n/hu.i18n.json
+++ b/packages/rocketchat-i18n/i18n/hu.i18n.json
@@ -3162,7 +3162,7 @@
   "since_creation": "%s óta",
   "Site_Name": "Webhely neve",
   "Site_Url": "Az oldal URL-je",
-  "Site_Url_Description": "Példa: https://chat.domain.com/",
+  "Site_Url_Description": "Példa: https://chat.domain.com",
   "Size": "Méret",
   "Skip": "Skip",
   "Slack_Users": "Slack felhasználók CSV-je",

--- a/packages/rocketchat-i18n/i18n/id.i18n.json
+++ b/packages/rocketchat-i18n/i18n/id.i18n.json
@@ -2305,7 +2305,7 @@
   "since_creation": "sejak %s",
   "Site_Name": "Nama Situs",
   "Site_Url": "URL Situs",
-  "Site_Url_Description": "Contoh: https://chat.domain.com/",
+  "Site_Url_Description": "Contoh: https://chat.domain.com",
   "Size": "Ukuran",
   "Skip": "Melewatkan",
   "Slack_Users": "Pengguna Slack CSV",

--- a/packages/rocketchat-i18n/i18n/it.i18n.json
+++ b/packages/rocketchat-i18n/i18n/it.i18n.json
@@ -2361,7 +2361,7 @@
   "since_creation": "da %s",
   "Site_Name": "Nome del sito",
   "Site_Url": "URL del sito",
-  "Site_Url_Description": "Esempio: https://chat.domain.com/",
+  "Site_Url_Description": "Esempio: https://chat.domain.com",
   "Size": "Dimensione",
   "Skip": "Salta",
   "Slack_Users": "Utenti di Slack CSV",

--- a/packages/rocketchat-i18n/i18n/ja.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ja.i18n.json
@@ -3974,7 +3974,7 @@
   "since_creation": "%s から",
   "Site_Name": "サイト名",
   "Site_Url": "サイトURL",
-  "Site_Url_Description": "例：https://chat.domain.com/",
+  "Site_Url_Description": "例：https://chat.domain.com",
   "Size": "サイズ",
   "Skip": "スキップ",
   "Slack_Users": "SlackのユーザーCSV",

--- a/packages/rocketchat-i18n/i18n/ka-GE.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ka-GE.i18n.json
@@ -3076,7 +3076,7 @@
   "since_creation": "%s -დან",
   "Site_Name": "საიტის სახელი",
   "Site_Url": "საიტის URL",
-  "Site_Url_Description": "მაგალითი:https://chat.domain.com/",
+  "Site_Url_Description": "მაგალითი:https://chat.domain.com",
   "Size": "ზომა",
   "Skip": "გამოტოვება",
   "Slack_Users": "Slack- ის მომხმარებლები CSV",

--- a/packages/rocketchat-i18n/i18n/km.i18n.json
+++ b/packages/rocketchat-i18n/i18n/km.i18n.json
@@ -2620,7 +2620,7 @@
   "since_creation": "តាំងពី %s",
   "Site_Name": "គេហទំព័រ​ឈ្មោះ",
   "Site_Url": "តំបន់ URL",
-  "Site_Url_Description": "ឧទាហរណ៍៖ https://chat.domain.com/",
+  "Site_Url_Description": "ឧទាហរណ៍៖ https://chat.domain.com",
   "Size": "ទំហំ",
   "Skip": "រំលង",
   "Slack_Users": "អ្នកប្រើរបស់ Slack CSV",

--- a/packages/rocketchat-i18n/i18n/ko.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ko.i18n.json
@@ -3388,7 +3388,7 @@
   "since_creation": "%s 이후",
   "Site_Name": "사이트명",
   "Site_Url": "사이트 URL",
-  "Site_Url_Description": "예) https://chat.domain.com/",
+  "Site_Url_Description": "예) https://chat.domain.com",
   "Size": "크기",
   "Skip": "건너뛰기",
   "Slack_Users": "Slack 사용자 CSV",

--- a/packages/rocketchat-i18n/i18n/ku.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ku.i18n.json
@@ -2290,7 +2290,7 @@
   "since_creation": "لە %s ـەوە",
   "Site_Name": "Navê Site",
   "Site_Url": "URL Site",
-  "Site_Url_Description": "Mînak: https://chat.domain.com/",
+  "Site_Url_Description": "Mînak: https://chat.domain.com",
   "Size": "Mezinayî",
   "Skip": "Hilperkîn",
   "Slack_Users": "Sêvanên Sêvê CSV",

--- a/packages/rocketchat-i18n/i18n/lo.i18n.json
+++ b/packages/rocketchat-i18n/i18n/lo.i18n.json
@@ -2331,7 +2331,7 @@
   "since_creation": "ນັບຕັ້ງແ​​ຕ່ %s",
   "Site_Name": "ຊື່ເວັບໄຊ",
   "Site_Url": "URL ຂອງເວັບໄຊ",
-  "Site_Url_Description": "ຍົກຕົວຢ່າງ: https://chat.domain.com/",
+  "Site_Url_Description": "ຍົກຕົວຢ່າງ: https://chat.domain.com",
   "Size": "ຂະຫນາດ",
   "Skip": "ຂ້າມ",
   "Slack_Users": "Slack ຂອງຜູ້ໃຊ້ CSV",

--- a/packages/rocketchat-i18n/i18n/lt.i18n.json
+++ b/packages/rocketchat-i18n/i18n/lt.i18n.json
@@ -2359,7 +2359,7 @@
   "since_creation": "nuo%s",
   "Site_Name": "Svetainės pavadinimas",
   "Site_Url": "Svetainės URL",
-  "Site_Url_Description": "Pavyzdys: https://chat.domain.com/",
+  "Site_Url_Description": "Pavyzdys: https://chat.domain.com",
   "Size": "Dydis",
   "Skip": "Praleisti",
   "Slack_Users": "Slack's Users CSV",

--- a/packages/rocketchat-i18n/i18n/lv.i18n.json
+++ b/packages/rocketchat-i18n/i18n/lv.i18n.json
@@ -2299,7 +2299,7 @@
   "since_creation": "kopš %s",
   "Site_Name": "Vietnes nosaukums",
   "Site_Url": "Vietnes URL",
-  "Site_Url_Description": "Piemērs: https://chat.domain.com/",
+  "Site_Url_Description": "Piemērs: https://chat.domain.com",
   "Size": "Izmērs",
   "Skip": "Izlaist",
   "Slack_Users": "Slack lietotāju CSV",

--- a/packages/rocketchat-i18n/i18n/mn.i18n.json
+++ b/packages/rocketchat-i18n/i18n/mn.i18n.json
@@ -2291,7 +2291,7 @@
   "since_creation": "%s оноос хойш",
   "Site_Name": "Сайтын нэр",
   "Site_Url": "Сайтын URL",
-  "Site_Url_Description": "Жишээ нь: https://chat.domain.com/",
+  "Site_Url_Description": "Жишээ нь: https://chat.domain.com",
   "Size": "Хэмжээ",
   "Skip": "Алгасах",
   "Slack_Users": "Slack-н хэрэглэгчид CSV",

--- a/packages/rocketchat-i18n/i18n/ms-MY.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ms-MY.i18n.json
@@ -2301,7 +2301,7 @@
   "since_creation": "sejak %s",
   "Site_Name": "Nama Laman:",
   "Site_Url": "URL laman",
-  "Site_Url_Description": "Contoh: https://chat.domain.com/",
+  "Site_Url_Description": "Contoh: https://chat.domain.com",
   "Size": "Saiz",
   "Skip": "Langkau",
   "Slack_Users": "Pengguna Slack CSV",

--- a/packages/rocketchat-i18n/i18n/nl.i18n.json
+++ b/packages/rocketchat-i18n/i18n/nl.i18n.json
@@ -3974,7 +3974,7 @@
   "since_creation": "sinds %s",
   "Site_Name": "Site naam",
   "Site_Url": "URL van de site",
-  "Site_Url_Description": "Voorbeeld: https://chat.domain.com/",
+  "Site_Url_Description": "Voorbeeld: https://chat.domain.com",
   "Size": "Grootte",
   "Skip": "Overslaan",
   "Slack_Users": "Slack's gebruikers CSV",

--- a/packages/rocketchat-i18n/i18n/no.i18n.json
+++ b/packages/rocketchat-i18n/i18n/no.i18n.json
@@ -2390,7 +2390,7 @@
   "since_creation": "siden%s",
   "Site_Name": "Side navn",
   "Site_Url": "Nettstedets nettadresse",
-  "Site_Url_Description": "Eksempel: https://chat.domain.com/",
+  "Site_Url_Description": "Eksempel: https://chat.domain.com",
   "Size": "Størrelse",
   "Skip": "Hopp",
   "Slack_Users": "Slack's Brukere CSV",

--- a/packages/rocketchat-i18n/i18n/pl.i18n.json
+++ b/packages/rocketchat-i18n/i18n/pl.i18n.json
@@ -3971,7 +3971,7 @@
   "since_creation": "od %s",
   "Site_Name": "Nazwa strony",
   "Site_Url": "Adres strony",
-  "Site_Url_Description": "Przykład: https://chat.domain.com/",
+  "Site_Url_Description": "Przykład: https://chat.domain.com",
   "Size": "Rozmiar",
   "Skip": "Pomiń",
   "Slack_Users": "Slack's Users CSV",

--- a/packages/rocketchat-i18n/i18n/ro.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ro.i18n.json
@@ -2296,7 +2296,7 @@
   "since_creation": "de la %s",
   "Site_Name": "Numele site-ului",
   "Site_Url": "URL-ul site-ului",
-  "Site_Url_Description": "Exemplu: https://chat.domain.com/",
+  "Site_Url_Description": "Exemplu: https://chat.domain.com",
   "Size": "mărimea",
   "Skip": "Sari peste asta",
   "Slack_Users": "Slack Utilizatorii CSV",

--- a/packages/rocketchat-i18n/i18n/ru.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ru.i18n.json
@@ -3974,7 +3974,7 @@
   "since_creation": "с %s",
   "Site_Name": "Название сайта",
   "Site_Url": "URL-адрес сайта",
-  "Site_Url_Description": "Пример: https://chat.domain.com/",
+  "Site_Url_Description": "Пример: https://chat.domain.com",
   "Size": "Размер",
   "Skip": "Пропустить",
   "Slack_Users": "Пользователи Slack",

--- a/packages/rocketchat-i18n/i18n/sl-SI.i18n.json
+++ b/packages/rocketchat-i18n/i18n/sl-SI.i18n.json
@@ -2288,7 +2288,7 @@
   "since_creation": "od %s",
   "Site_Name": "Ime strani",
   "Site_Url": "URL strani",
-  "Site_Url_Description": "Primer: https://chat.domain.com/",
+  "Site_Url_Description": "Primer: https://chat.domain.com",
   "Size": "Velikost",
   "Skip": "Preskoči",
   "Slack_Users": "CSV-ji uporabnikov Slack-a ",

--- a/packages/rocketchat-i18n/i18n/sq.i18n.json
+++ b/packages/rocketchat-i18n/i18n/sq.i18n.json
@@ -2296,7 +2296,7 @@
   "since_creation": "që nga %s",
   "Site_Name": "Emri faqes",
   "Site_Url": "Site URL",
-  "Site_Url_Description": "Shembull: https://chat.domain.com/",
+  "Site_Url_Description": "Shembull: https://chat.domain.com",
   "Size": "madhësi",
   "Skip": "Kalo",
   "Slack_Users": "Përdoruesit e xhiruar të CSV",

--- a/packages/rocketchat-i18n/i18n/sv.i18n.json
+++ b/packages/rocketchat-i18n/i18n/sv.i18n.json
@@ -2383,7 +2383,7 @@
   "since_creation": "sedan %s",
   "Site_Name": "Sidnamn",
   "Site_Url": "webbadress",
-  "Site_Url_Description": "Example: https://chat.domain.com/",
+  "Site_Url_Description": "Example: https://chat.domain.com",
   "Size": "Storlek",
   "Skip": "Hoppa över",
   "Slack_Users": "Slacks användare CSV",

--- a/packages/rocketchat-i18n/i18n/ta-IN.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ta-IN.i18n.json
@@ -2295,7 +2295,7 @@
   "since_creation": "%s முதல்",
   "Site_Name": "தளத்தின் பெயர்",
   "Site_Url": "தள URL",
-  "Site_Url_Description": "உதாரணம்: https://chat.domain.com/",
+  "Site_Url_Description": "உதாரணம்: https://chat.domain.com",
   "Size": "அளவு",
   "Skip": "செல்க",
   "Slack_Users": "ஸ்லாக்கின் பயனர்கள் CSV",

--- a/packages/rocketchat-i18n/i18n/th-TH.i18n.json
+++ b/packages/rocketchat-i18n/i18n/th-TH.i18n.json
@@ -2292,7 +2292,7 @@
   "since_creation": "ตั้งแต่%s",
   "Site_Name": "ชื่อไซต์",
   "Site_Url": "URL ของไซต์",
-  "Site_Url_Description": "ตัวอย่าง: https://chat.domain.com/",
+  "Site_Url_Description": "ตัวอย่าง: https://chat.domain.com",
   "Size": "ขนาด",
   "Skip": "กระโดด",
   "Slack_Users": "ผู้ใช้ Slack ของ CSV",

--- a/packages/rocketchat-i18n/i18n/tr.i18n.json
+++ b/packages/rocketchat-i18n/i18n/tr.i18n.json
@@ -2722,7 +2722,7 @@
   "since_creation": "tarih %s",
   "Site_Name": "Site adı",
   "Site_Url": "Site URL'si",
-  "Site_Url_Description": "Örnek: https://chat.domain.com/",
+  "Site_Url_Description": "Örnek: https://chat.domain.com",
   "Size": "Boyut",
   "Skip": "Atla",
   "Slack_Users": "Gevşek Kullanıcılar CSV",

--- a/packages/rocketchat-i18n/i18n/ug.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ug.i18n.json
@@ -970,7 +970,7 @@
   "since_creation": "دىن باشلانغان %s",
   "Site_Name": "تور نامى",
   "Site_Url": "تور ئادرېسى",
-  "Site_Url_Description": "مەسىلەن:https://chat.domain.com/",
+  "Site_Url_Description": "مەسىلەن:https://chat.domain.com",
   "Skip": "سەكرەپ يۆتكىلىش",
   "Slash_Gimme_Description": "نى كۆرسىتىڭ༼ つ ◕_◕ ༽つسىزنىڭ ئۇچۇرىڭىزنىڭ ئالدىدا",
   "Slash_LennyFace_Description": "كۆرسىتىڭ ( ͡° ͜ʖ ͡°)سىزنىڭ ئۇچۇرىڭىزنىڭ كەينىدە",

--- a/packages/rocketchat-i18n/i18n/uk.i18n.json
+++ b/packages/rocketchat-i18n/i18n/uk.i18n.json
@@ -2845,7 +2845,7 @@
   "since_creation": "з %s",
   "Site_Name": "Назва сайту",
   "Site_Url": "URL сайту",
-  "Site_Url_Description": "Приклад: https://chat.domain.com/",
+  "Site_Url_Description": "Приклад: https://chat.domain.com",
   "Size": "Розмір",
   "Skip": "Пропустити",
   "Slack_Users": "Користувачі Slack's CSV",

--- a/packages/rocketchat-i18n/i18n/vi-VN.i18n.json
+++ b/packages/rocketchat-i18n/i18n/vi-VN.i18n.json
@@ -2400,7 +2400,7 @@
   "since_creation": "vì%s",
   "Site_Name": "Tên trang web",
   "Site_Url": "URL trang web",
-  "Site_Url_Description": "Ví dụ: https://chat.domain.com/",
+  "Site_Url_Description": "Ví dụ: https://chat.domain.com",
   "Size": "Kích cỡ",
   "Skip": "Bỏ qua",
   "Slack_Users": "Người dùng của Slack CSV",

--- a/packages/rocketchat-i18n/i18n/zh-HK.i18n.json
+++ b/packages/rocketchat-i18n/i18n/zh-HK.i18n.json
@@ -2318,7 +2318,7 @@
   "since_creation": "自从%s",
   "Site_Name": "网站名称",
   "Site_Url": "网站网址",
-  "Site_Url_Description": "例如：https://chat.domain.com/",
+  "Site_Url_Description": "例如：https://chat.domain.com",
   "Size": "尺寸",
   "Skip": "跳跃",
   "Slack_Users": "Slack的用户CSV",

--- a/packages/rocketchat-i18n/i18n/zh-TW.i18n.json
+++ b/packages/rocketchat-i18n/i18n/zh-TW.i18n.json
@@ -3816,7 +3816,7 @@
   "since_creation": "來自 %s",
   "Site_Name": "網站名稱",
   "Site_Url": "網址",
-  "Site_Url_Description": "Example: https://chat.domain.com/",
+  "Site_Url_Description": "Example: https://chat.domain.com",
   "Size": "尺寸",
   "Skip": "跳過",
   "Slack_Users": "Slack 的用戶 CSV",

--- a/packages/rocketchat-i18n/i18n/zh.i18n.json
+++ b/packages/rocketchat-i18n/i18n/zh.i18n.json
@@ -3476,7 +3476,7 @@
   "since_creation": "自从 %s",
   "Site_Name": "网站名称",
   "Site_Url": "网站地址",
-  "Site_Url_Description": "例如：https://chat.domain.com/",
+  "Site_Url_Description": "例如：https://chat.domain.com",
   "Size": "尺寸",
   "Skip": "跳过",
   "Slack_Users": "Slack 的用户 CSV",


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Change site url description to not suggest leaving the trailing slash.

## Steps to test or reproduce
- Set admin > general > site url with a trailing slash
- restart the server (yes, necessary)
- go to http://localhost:3000/livechat
- Live chat will not load or not behave as expected
