### PR TITLE
[FIX] VoIP button gets disabled whenever user status changes

### DIFF
--- a/client/providers/CallProvider/hooks/useVoipClient.ts
+++ b/client/providers/CallProvider/hooks/useVoipClient.ts
@@ -35,15 +35,16 @@ export const useVoipClient = (): UseVoipClientResult => {
 	const user = useUser();
 	const iceServers = useWebRtcServers();
 
+	const [userId, setUserId] = useSafely(useState<string | null>(null));
 	const [result, setResult] = useSafely(useState<UseVoipClientResult>({}));
 
 	useEffect(() => {
-		if (!user || !user?._id || !voipEnabled) {
+		if (!userId || !voipEnabled) {
 			setResult({});
 			return;
 		}
 
-		registrationInfo({ id: user._id }).then(
+		registrationInfo({ id: userId }).then(
 			(data) => {
 				let parsedData: IRegistrationInfo;
 				if (isSignedResponse(data)) {
@@ -82,7 +83,14 @@ export const useVoipClient = (): UseVoipClientResult => {
 			// client?.disconnect();
 			// TODO how to close the client? before creating a new one?
 		};
-	}, [user, iceServers, registrationInfo, setResult, membership, voipEnabled]);
+	}, [userId, iceServers, registrationInfo, setResult, membership, voipEnabled]);
 
+	useEffect(() => {
+		if (!user || !user?._id) {
+			setResult({});
+			return;
+		}
+		setUserId(user._id);
+	}, [setResult, setUserId, user]);
 	return result;
 };


### PR DESCRIPTION

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
Whenever the user state is changed (Explicitly or automatically by the virtue of user's inactivity)
Voip component gets reloaded. Also during the reload of the page, the Voip component gets initialised multiple times, causing multiple websockets opened to asterisk.
This happens because of the following facts:

1. The useEffect of useVoipClient, which creates the Voip component had user in its dependency list.
2. Whenever any user property changes, it would cause the useEffect to trigger and execute the entire initialisation of voip component.
3. When state change happens, it triggers update on all the components. So OmnichannelCallToggleReady gets re-rendered, also useVoipClient causes reinitialisation (user state change).
4. Now, when the useEffect of OmnichannelCallToggleReady gets executed, voipClient.getRegistrarState() returns the value which is not |registered| because the state change has caused reinitialisation of the voip client  which is not yet registered.
5. So again, the phone button value gets reset and disabled, the agent becomes unavailable.

Fix:
Even though the user state may change, user identity does not change. SIP client reinitialisation should happen only when userId changes.
So in summary the fix is not to add the entire user Object in the dependency list of the useEffect of useVoipClient hook in useVoipClient hook file. Instead

1. Create a state userId.
2. Add another useEffect watching the user. Whenever user becomes available or any user change happens, update the userId
3. The useEffect which does the voip client initialisation, should have the userId in the dependency list.

When this is done, the Voip initialisation will happen only when userId changes.


<!-- END CHANGELOG -->

## Issue(s)
[<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->](https://app.clickup.com/t/25jwe53)

## Steps to test or reproduce

1. Configure Voip, assign extension to the user, login to the extension
2. Change the state from available to busy, this should disable the button.
3. login to the extension.
4. Goto My Account -> Preferences -> User Preferences
5. change the "Idle Time Limit" to some small value (1 min is minimum)
6. Do not interact with the page for 1 minute, whenever the user becomes idle, it should disable the voip button.

## Further comments
Test cases :
Configure Voip, Assign extension to the user.
1. When page is loaded, refresh the page couple of times. Verify on asterisk that you see "_WebSocket connection from 'Your public IP:port' for protocol 'sip' accepted using version '13'_" is displayed only once per reload.
2. Change the user state explicitly. Verify that if the user is available for taking calls, he/she remains in the same state. Verify this by calling the user.
3. Do not interact with the agent's ui for the timelimit mentioned in above section ("Idle Time Limit"). Verify that if the user is available for taking calls, he/she remains in the same state. Verify this by calling the user.
