### PR TITLE
[FIX] docker-compose.yml mongo:4.0 is deprecated in the latest version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   rocketchat:
-    image: registry.rocket.chat/rocketchat/rocket.chat:latest
+    image: registry.rocket.chat/rocketchat/rocket.chat:4.5.0
     command: >
       bash -c
         "for i in `seq 1 30`; do
@@ -32,12 +32,12 @@ services:
       - "traefik.frontend.rule=Host: your.domain.tld"
 
   mongo:
-    image: mongo:4.0
+    image: mongo:4.2
     restart: unless-stopped
     volumes:
      - ./data/db:/data/db
      #- ./data/dump:/dump
-    command: mongod --smallfiles --oplogSize 128 --replSet rs0 --storageEngine=mmapv1
+    command: mongod --oplogSize 128 --replSet rs0 --storageEngine=mmapv1
     labels:
       - "traefik.enable=false"
 


### PR DESCRIPTION
The rocketchat:latest  is not supported mongo:4.0 now. Using rocketchat:4.5.0 and mongo:4.2 can fix it.

## Proposed changes (including videos or screenshots)

## Issue(s)

## Steps to test or reproduce

## Further comments
