### PR TITLE
[IMPROVE] Create CallAudioContext to hold ref of VoIP Audio streaming

### DIFF
--- a/client/contexts/CallAudioContext.ts
+++ b/client/contexts/CallAudioContext.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react';
+
+type CallAudioContextValue = {
+	value: React.RefObject<HTMLAudioElement> | null;
+};
+
+const CallAudioContextDefault: CallAudioContextValue = {
+	value: null,
+};
+
+export const CallAudioContext = createContext<CallAudioContextValue>(CallAudioContextDefault);
+
+export const useCallAudioMediaRef = (): React.RefObject<HTMLAudioElement> | null => {
+	const { value } = useContext(CallAudioContext);
+	return value;
+};

--- a/client/lib/voip/QueueAggregator.ts
+++ b/client/lib/voip/QueueAggregator.ts
@@ -98,11 +98,7 @@ export class QueueAggregator {
 	}
 
 	getCurrentQueueName(): string {
-		if (this.currentlyServing.queueInfo) {
-			return this.currentlyServing.queueInfo.queueName;
-		}
-
-		return '';
+		return this?.currentlyServing?.queueInfo?.queueName || '';
 	}
 
 	callRinging(queueInfo: { queuename: string; callerid: { id: string; name: string } }): void {

--- a/client/providers/CallProvider/CallAudioProvider.tsx
+++ b/client/providers/CallProvider/CallAudioProvider.tsx
@@ -1,0 +1,9 @@
+import React, { FC, useRef } from 'react';
+
+import { CallAudioContext } from '../../contexts/CallAudioContext';
+
+export const CallAudioProvider: FC = ({ children }) => {
+	const remoteAudioMediaRef = useRef<HTMLAudioElement>(null);
+
+	return <CallAudioContext.Provider value={{ value: remoteAudioMediaRef }}>{children}</CallAudioContext.Provider>;
+};

--- a/client/providers/CallProvider/hooks/useVoipClient.ts
+++ b/client/providers/CallProvider/hooks/useVoipClient.ts
@@ -1,4 +1,3 @@
-import { useSafely } from '@rocket.chat/fuselage-hooks';
 import { KJUR } from 'jsrsasign';
 import { useEffect, useState } from 'react';
 
@@ -19,19 +18,21 @@ type UseVoipClientResult = {
 
 const isSignedResponse = (data: any): data is { result: string } => typeof data?.result === 'string';
 
+const defaultResult = {};
+
 export const useVoipClient = (): UseVoipClientResult => {
 	const voipEnabled = useSetting('VoIP_Enabled');
 	const registrationInfo = useEndpoint('GET', 'connector.extension.getRegistrationInfoByUserId');
 	const membership = useEndpoint('GET', 'voip/queues.getMembershipSubscription');
 	const user = useUser();
 	const userId = useUserId();
-	const [extension, setExtension] = useSafely(useState<string | null>(null));
+	const [extension, setExtension] = useState<string | null>(null);
 
 	const iceServers = useWebRtcServers();
-	const [result, setResult] = useSafely(useState<UseVoipClientResult>({}));
+	const [result, setResult] = useState<UseVoipClientResult>(defaultResult);
 	useEffect(() => {
 		if (!userId || !extension || !voipEnabled) {
-			setResult({});
+			setResult(defaultResult);
 			return;
 		}
 		let client: VoIPUser;
@@ -78,7 +79,7 @@ export const useVoipClient = (): UseVoipClientResult => {
 
 	useEffect(() => {
 		if (!user) {
-			setResult({});
+			setResult(defaultResult);
 			return;
 		}
 		if (user.extension) {

--- a/client/providers/MeteorProvider.tsx
+++ b/client/providers/MeteorProvider.tsx
@@ -4,6 +4,7 @@ import AttachmentProvider from '../components/Message/Attachments/providers/Atta
 import AuthorizationProvider from './AuthorizationProvider';
 import AvatarUrlProvider from './AvatarUrlProvider';
 import { CallProvider } from './CallProvider';
+import { CallAudioProvider } from './CallProvider/CallAudioProvider';
 import ConnectionStatusProvider from './ConnectionStatusProvider';
 import CustomSoundProvider from './CustomSoundProvider';
 import LayoutProvider from './LayoutProvider';
@@ -32,13 +33,15 @@ const MeteorProvider: FC = ({ children }) => (
 											<CustomSoundProvider>
 												<UserProvider>
 													<AuthorizationProvider>
-														<CallProvider>
-															<OmnichannelProvider>
-																<ModalProvider>
-																	<AttachmentProvider>{children}</AttachmentProvider>
-																</ModalProvider>
-															</OmnichannelProvider>
-														</CallProvider>
+														<CallAudioProvider>
+															<CallProvider>
+																<OmnichannelProvider>
+																	<ModalProvider>
+																		<AttachmentProvider>{children}</AttachmentProvider>
+																	</ModalProvider>
+																</OmnichannelProvider>
+															</CallProvider>
+														</CallAudioProvider>
 													</AuthorizationProvider>
 												</UserProvider>
 											</CustomSoundProvider>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
So, long story short, the CallProvider is being refreshed a ton of times. This causes the creation of a new `<Audio>` element on each render. The previous solution was: on every re-render, switch the remote stream to play on the latest Audio element, and ignore the older.

The problem was that, for some reason, CallProvider was being updated too much, enough for React to trigger a warning on the number of re-renders the comp was having. This was caused by `useVoipClient` hook, which was setting a _new_ state value on each call (since it was returning `setResult({})` React found that the values were different and triggered an update on the comp).

This PR fixes that by creating a separate context/provider to hold the audio ref to persist it across re-renders, and also updates `useVoipClient` to not to return new objects each time it was trying to "emtpy" the state.