### PR TITLE
[FIX] While removing an agent association, extension status remains same.

### DIFF
--- a/client/views/admin/settings/groups/voip/VoipExtensionsPage.tsx
+++ b/client/views/admin/settings/groups/voip/VoipExtensionsPage.tsx
@@ -86,7 +86,11 @@ const VoipExtensionsPage: FC = () => {
 						{queues?.length > 2 && `+${(queues.length - 2).toString()}`}
 					</Box>
 				</Table.Cell>
-				{username ? <RemoveAgentButton username={username} reload={reload} /> : <AssignAgentButton extension={extension} reload={reload} />}
+				{username ? (
+					<RemoveAgentButton username={username} reload={reload} extension={extension} />
+				) : (
+					<AssignAgentButton extension={extension} reload={reload} />
+				)}
 			</Table.Row>
 		),
 		[reload, t],

--- a/definition/voip/IEvents.ts
+++ b/definition/voip/IEvents.ts
@@ -60,6 +60,14 @@ export interface IContactStatus extends IEventBase {
 	roundtripusec: string;
 }
 
+export interface IDeviceStateChangeEvent extends IEventBase {
+	event: 'DeviceStateChange';
+	privilege: string;
+	systemname: string;
+	device: string;
+	state: string;
+}
+
 export interface IAgentConnectEvent extends IQueueEvent {
 	event: 'AgentConnect';
 	holdtime: string;
@@ -115,3 +123,4 @@ export const isICallOnHoldEvent = (v: any): v is ICallOnHold => v?.event === 'Ho
 export const isICallUnHoldEvent = (v: any): v is ICallUnHold => v?.event === 'Unhold';
 export const isIContactStatusEvent = (v: any): v is IContactStatus => v?.event === 'ContactStatus';
 export const isICallHangupEvent = (v: any): v is ICallHangup => v?.event === 'Hangup';
+export const isIDeviceStateChangeEvent = (v: any): v is IDeviceStateChangeEvent => v?.event === 'DeviceStateChange';

--- a/server/modules/listeners/listeners.module.ts
+++ b/server/modules/listeners/listeners.module.ts
@@ -290,40 +290,8 @@ export class ListenersModule {
 			notifications.notifyUserInThisInstance(userId, 'callabandoned', { queuename, queuedcallafterabandon });
 		});
 
-		service.onEvent('notify.desktop', (uid, notification): void => {
-			notifications.notifyUserInThisInstance(uid, 'notification', notification);
-		});
-
-		service.onEvent('notify.uiInteraction', (uid, interaction): void => {
-			notifications.notifyUserInThisInstance(uid, 'uiInteraction', interaction);
-		});
-
-		service.onEvent('notify.updateInvites', (uid, data): void => {
-			notifications.notifyUserInThisInstance(uid, 'updateInvites', data);
-		});
-
-		service.onEvent('notify.webdav', (uid, data): void => {
-			notifications.notifyUserInThisInstance(uid, 'webdav', data);
-		});
-
-		service.onEvent('notify.e2e.keyRequest', (rid, data): void => {
-			notifications.notifyRoomInThisInstance(rid, 'e2e.keyRequest', data);
-		});
-
-		service.onEvent('notify.deleteMessage', (rid, data): void => {
-			notifications.notifyRoomInThisInstance(rid, 'deleteMessage', data);
-		});
-
-		service.onEvent('notify.deleteMessageBulk', (rid, data): void => {
-			notifications.notifyRoomInThisInstance(rid, 'deleteMessageBulk', data);
-		});
-
-		service.onEvent('notify.deleteCustomSound', (data): void => {
-			notifications.notifyAllInThisInstance('deleteCustomSound', data);
-		});
-
-		service.onEvent('notify.updateCustomSound', (data): void => {
-			notifications.notifyAllInThisInstance('updateCustomSound', data);
+		service.onEvent('agent.voipextensionstatechange', (userId, extension: string, state: string): void => {
+			notifications.notifyUserInThisInstance(userId, 'voipextensionstatechange', { userId, extension, state });
 		});
 	}
 }

--- a/server/sdk/lib/Events.ts
+++ b/server/sdk/lib/Events.ts
@@ -1,28 +1,22 @@
-import { IUIKitInteraction } from '@rocket.chat/apps-engine/definition/uikit';
-
-import { IEmailInbox } from '../../../definition/IEmailInbox';
-import { IEmoji } from '../../../definition/IEmoji';
 import { IInquiry } from '../../../definition/IInquiry';
-import { IInstanceStatus } from '../../../definition/IInstanceStatus';
-import { IIntegration } from '../../../definition/IIntegration';
-import { IIntegrationHistory } from '../../../definition/IIntegrationHistory';
-import { ILivechatDepartmentAgents } from '../../../definition/ILivechatDepartmentAgents';
-import { ILoginServiceConfiguration } from '../../../definition/ILoginServiceConfiguration';
 import { IMessage } from '../../../definition/IMessage';
-import { INotificationDesktop } from '../../../definition/INotification';
-import { IPbxEvent } from '../../../definition/IPbxEvent';
 import { IRole } from '../../../definition/IRole';
 import { IRoom } from '../../../definition/IRoom';
 import { ISetting } from '../../../definition/ISetting';
-import { ISocketConnection } from '../../../definition/ISocketConnection';
 import { ISubscription } from '../../../definition/ISubscription';
 import { IUser } from '../../../definition/IUser';
-import { IUserSession } from '../../../definition/IUserSession';
+import { IEmoji } from '../../../definition/IEmoji';
 import { IUserStatus } from '../../../definition/IUserStatus';
+import { IUserSession } from '../../../definition/IUserSession';
+import { ILoginServiceConfiguration } from '../../../definition/ILoginServiceConfiguration';
+import { IInstanceStatus } from '../../../definition/IInstanceStatus';
+import { IIntegrationHistory } from '../../../definition/IIntegrationHistory';
+import { ILivechatDepartmentAgents } from '../../../definition/ILivechatDepartmentAgents';
+import { IIntegration } from '../../../definition/IIntegration';
+import { IEmailInbox } from '../../../definition/IEmailInbox';
+import { ISocketConnection } from '../../../definition/ISocketConnection';
+import { IPbxEvent } from '../../../definition/IPbxEvent';
 import { AutoUpdateRecord } from '../types/IMeteor';
-import { IInvite } from '../../../definition/IInvite';
-import { IWebdavAccount } from '../../../definition/IWebdavAccount';
-import { ICustomSound } from '../../../definition/ICustomSound';
 
 type ClientAction = 'inserted' | 'updated' | 'removed' | 'changed';
 
@@ -43,36 +37,7 @@ export type EventSignatures = {
 	'livechat-inquiry-queue-observer'(data: { action: string; inquiry: IInquiry }): void;
 	'message'(data: { action: string; message: IMessage }): void;
 	'meteor.clientVersionUpdated'(data: AutoUpdateRecord): void;
-	'notify.desktop'(uid: string, data: INotificationDesktop): void;
-	'notify.uiInteraction'(uid: string, data: IUIKitInteraction): void;
-	'notify.updateInvites'(uid: string, data: { invite: IInvite }): void;
 	'notify.ephemeralMessage'(uid: string, rid: string, message: Partial<IMessage>): void;
-	'notify.webdav'(
-		uid: string,
-		data:
-			| {
-					type: 'changed';
-					account: Partial<IWebdavAccount>;
-			  }
-			| {
-					type: 'removed';
-					account: { _id: IWebdavAccount['_id'] };
-			  },
-	): void;
-	'notify.e2e.keyRequest'(rid: string, data: IRoom['e2eKeyId']): void;
-	'notify.deleteMessage'(rid: string, data: { _id: string }): void;
-	'notify.deleteMessageBulk'(
-		rid: string,
-		data: {
-			rid: string;
-			excludePinned: boolean;
-			ignoreDiscussion: boolean;
-			ts: Record<string, Date>;
-			users: string[];
-		},
-	): void;
-	'notify.deleteCustomSound'(data: { soundData: ICustomSound }): void;
-	'notify.updateCustomSound'(data: { soundData: ICustomSound }): void;
 	'permission.changed'(data: { clientAction: ClientAction; data: any }): void;
 	'room'(data: { action: string; room: Partial<IRoom> }): void;
 	'room.avatarUpdate'(room: Partial<IRoom>): void;
@@ -127,5 +92,6 @@ export type EventSignatures = {
 	'queue.queuememberadded'(userid: string, queuename: string, queuedcalls: string): void;
 	'queue.queuememberremoved'(userid: string, queuename: string, queuedcalls: string): void;
 	'queue.callabandoned'(userid: string, queuename: string, queuedcallafterabandon: string): void;
+	'agent.voipextensionstatechange'(userid: string, extension: string, state: string): void;
 	'watch.pbxevents'(data: { clientAction: ClientAction; data: Partial<IPbxEvent>; id: string }): void;
 };


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
Clickup task : https://app.clickup.com/t/23zh1kx

This issue happens because of the async nature of the things.
When association is dropped, agent triggers unregister. But agent and admin are 2 different entities.
On admin, whenever the association is deleted, the reload() function gets called. This requeries the endpoints again.

While on agent, whenever it sees that the user does not have the extension anymore, it stops the SIP user agent.
Which calls unregister and then disconnects the web socket.

In all practical cases, agent and admin will be different entities. So as soon as admin disassociates the extension, it is impossible to get the correct state of
endpoint because the admin queries the endpoint list before the unregistration is completed by the agent.

Solution :
We need to implement a notification mechanism where such async race conditions are handled. For this particular case,
we are going to notify all the admin users whenever the device state changes. The device state change event is sent by asterisk to the connector
when device is unregistered. When server receives this event from asterisk, it notifies all the admin users.

The admin user which is in the process of disassociation in (client/views/admin/settings/groups/voip/RemoveAgentButton.tsx) waits for this event.
Once this event is received, it calls reload.

If the admin navigates away from the "Extensions" tab and comes back to it, the status will be restored.

Note :

Stale status condition will be true for the following scenario.

Admin is on extension tab. Agent is on another window. Agent registers/unregisters.
Admin will not get this status.

<!-- END CHANGELOG -->

## Issue(s)
Clickup task : https://app.clickup.com/t/23zh1kx
## Steps to test or reproduce
1. Login as admin.
2. Associate agent with an extension.
3. From agent, "Enable Voice Operations" (Register to asterisk by clicking up the phone icon)
4. From admin, delete the association for the user.
5. Notice that the state of the deleted association. The extension is still shown as registered.
## Further comments
Stale status condition will be true for the following scenario.

Admin is on extension tab. Agent is on another window. Agent registers/unregisters.
Admin will not get this status.
