### PR TITLE
[FIX] Error is raised when there's no Asterisk queue available yet

### DIFF
--- a/server/services/voip/connector/asterisk/ami/ACDQueue.ts
+++ b/server/services/voip/connector/asterisk/ami/ACDQueue.ts
@@ -57,6 +57,10 @@ export class ACDQueue extends Command {
 		}
 		this.resetEventHandlers();
 		const { result } = this;
+		if (!result.queueSummary) {
+			this.logger.info({ msg: 'No Queues available' });
+			result.queueSummary = [];
+		}
 		this.returnResolve({ result: result.queueSummary } as IVoipConnectorResult);
 	}
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
In ACDQueue.ts, when there is no queue available on asterisk, onQueueSummary never gets executed. It directly calls onQueueSummaryComplete. Because of this, result.queueSummary never got initialised, result is undefined.
This causes getQueueDetails fails as it assumes that there will be a valid queue summary. To fix this, set result.queueSummary to empty array if it does not already exist in onQueueSummaryComplete of ACDQueue.ts
## Issue(s)
https://app.clickup.com/t/29gujj8

## Steps to test or reproduce


## Further comments
Tests:
To test this, all the queues on asterisk needs to be disabled. 
1. Modify queues.conf,  From sales to Sales_FeaturesAndPricing. You can use multiline comment (;-- and --;)
2. Reload queue module module reload app_queue.so
3. On Rocket.chat Go to Administration -> Call Center -> Extensions. 
4. Verify that all the extensions are loaded properly and there is no queue reference in the "Queues" column.
