### PR TITLE
[FIX] VoIP disabled/enabled  sequence puts voip agent in error state

### DIFF
--- a/apps/meteor/app/voip/server/startup.ts
+++ b/apps/meteor/app/voip/server/startup.ts
@@ -2,14 +2,11 @@ import debounce from 'lodash.debounce';
 
 import { settings } from '../../settings/server';
 import { Voip } from '../../../server/sdk';
-import { api } from '../../../server/sdk/api';
 
 const debouncedRefresh = debounce(Voip.refresh, 1000);
 
-settings.watch('VoIP_Enabled', async (value: boolean) => {
-	const data = value ? await Voip.init() : Voip.stop();
-	api.broadcast('connector.statuschanged', value);
-	return data;
+settings.watch('VoIP_Enabled', (value: boolean) => {
+	return value ? Voip.init() : Voip.stop();
 });
 
 settings.changeMultiple(

--- a/apps/meteor/app/voip/server/startup.ts
+++ b/apps/meteor/app/voip/server/startup.ts
@@ -2,11 +2,14 @@ import debounce from 'lodash.debounce';
 
 import { settings } from '../../settings/server';
 import { Voip } from '../../../server/sdk';
+import { api } from '../../../server/sdk/api';
 
 const debouncedRefresh = debounce(Voip.refresh, 1000);
 
-settings.watch('VoIP_Enabled', (value: boolean) => {
-	return value ? Voip.init() : Voip.stop();
+settings.watch('VoIP_Enabled', async (value: boolean) => {
+	const data = value ? await Voip.init() : Voip.stop();
+	api.broadcast('connector.statuschanged', value);
+	return data;
 });
 
 settings.changeMultiple(

--- a/apps/meteor/client/providers/CallProvider/hooks/useVoipClient.ts
+++ b/apps/meteor/client/providers/CallProvider/hooks/useVoipClient.ts
@@ -3,7 +3,7 @@ import { useSafely } from '@rocket.chat/fuselage-hooks';
 import { KJUR } from 'jsrsasign';
 import { useEffect, useState } from 'react';
 
-import { useEndpoint } from '../../../contexts/ServerContext';
+import { useEndpoint, useStream } from '../../../contexts/ServerContext';
 import { useSetting } from '../../../contexts/SettingsContext';
 import { useUser } from '../../../contexts/UserContext';
 import { SimpleVoipUser } from '../../../lib/voip/SimpleVoipUser';
@@ -21,12 +21,24 @@ const empty = {};
 const isSignedResponse = (data: any): data is { result: string } => typeof data?.result === 'string';
 
 export const useVoipClient = (): UseVoipClientResult => {
-	const voipEnabled = useSetting('VoIP_Enabled');
+	const [voipEnabled, setVoipEnabled] = useSafely(useState(useSetting('VoIP_Enabled')));
 	const registrationInfo = useEndpoint('GET', 'connector.extension.getRegistrationInfoByUserId');
 	const membership = useEndpoint('GET', 'voip/queues.getMembershipSubscription');
 	const user = useUser();
+	const subscribeToNotifyLoggedIn = useStream('notify-logged');
 	const iceServers = useWebRtcServers();
 	const [result, setResult] = useSafely(useState<UseVoipClientResult>({}));
+
+	useEffect(() => {
+		const voipEnableEventHandler = (...args: any[]): void => {
+			let enabled = false;
+			if (args.length === 1 && args[0]) {
+				enabled = args[0];
+			}
+			setVoipEnabled(enabled);
+		};
+		return subscribeToNotifyLoggedIn(`voip.statuschanged`, voipEnableEventHandler);
+	}, [setResult, setVoipEnabled, subscribeToNotifyLoggedIn]);
 
 	useEffect(() => {
 		const uid = user?._id;

--- a/apps/meteor/client/providers/CallProvider/hooks/useVoipClient.ts
+++ b/apps/meteor/client/providers/CallProvider/hooks/useVoipClient.ts
@@ -30,11 +30,7 @@ export const useVoipClient = (): UseVoipClientResult => {
 	const [result, setResult] = useSafely(useState<UseVoipClientResult>({}));
 
 	useEffect(() => {
-		const voipEnableEventHandler = (...args: any[]): void => {
-			let enabled = false;
-			if (args.length === 1 && args[0]) {
-				enabled = args[0];
-			}
+		const voipEnableEventHandler = (enabled: boolean): void => {
 			setVoipEnabled(enabled);
 		};
 		return subscribeToNotifyLoggedIn(`voip.statuschanged`, voipEnableEventHandler);

--- a/apps/meteor/server/modules/listeners/listeners.module.ts
+++ b/apps/meteor/server/modules/listeners/listeners.module.ts
@@ -325,5 +325,9 @@ export class ListenersModule {
 		service.onEvent('notify.updateCustomSound', (data): void => {
 			notifications.notifyAllInThisInstance('updateCustomSound', data);
 		});
+
+		service.onEvent('connector.statuschanged', (enabled): void => {
+			notifications.notifyLoggedInThisInstance('voip.statuschanged', enabled);
+		});
 	}
 }

--- a/apps/meteor/server/sdk/lib/Events.ts
+++ b/apps/meteor/server/sdk/lib/Events.ts
@@ -130,4 +130,5 @@ export type EventSignatures = {
 	'queue.queuememberremoved'(userid: string, queuename: string, queuedcalls: string): void;
 	'queue.callabandoned'(userid: string, queuename: string, queuedcallafterabandon: string): void;
 	'watch.pbxevents'(data: { clientAction: ClientAction; data: Partial<IPbxEvent>; id: string }): void;
+	'connector.statuschanged'(enabled: boolean): void;
 };


### PR DESCRIPTION

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
Initially it was thought that the issue occurs because of the race condition while changing the client settings vs those settings reflected on server side. So a natural solution to solve this is to wait for setting change event 'private-settings-changed'. Then if 'VoIP_Enabled' is updated and it is true, set voipEnabled  to true in useVoipClient.ts (on client side)

It was realised that the race does not happen because of the database or server noticing the changes late. But because of the time taken to establish the AMI connection with Asterisk.

Solution:

1. Change apps/meteor/app/voip/server/startup.ts. When VoIP_Enabled is changed, await for Voip.init() to complete and then broadcast connector.statuschanged  with changed value.
2. From apps/meteor/server/modules/listeners/listeners.module.ts use notifyLoggedInThisInstance to notify all logged in users on current instance.
3. in apps/meteor/client/providers/CallProvider/hooks/useVoipClient.ts add the event handler that receives this event. Change voipEnabled from constant to state. Change this state based on the 'value' that is received by the handler.

<!-- END CHANGELOG -->

## Issue(s)
https://app.clickup.com/t/22rjza5
## Steps to test or reproduce

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
