### PR TITLE
[FIX] Read receipts show with color gray when not read yet

### DIFF
--- a/apps/meteor/client/views/room/MessageList/components/MessageContent.tsx
+++ b/apps/meteor/client/views/room/MessageList/components/MessageContent.tsx
@@ -17,7 +17,7 @@ import { UserPresence } from '../../../../lib/presence';
 import MessageBlock from '../../../blocks/MessageBlock';
 import MessageLocation from '../../../location/MessageLocation';
 import { useMessageActions, useMessageOembedIsEnabled, useMessageRunActionLink } from '../../contexts/MessageContext';
-import { useMessageShowReadReceipt } from '../contexts/MessageListContext';
+import { useMessageListShowReadReceipt } from '../contexts/MessageListContext';
 import { isOwnUserMessage } from '../lib/isOwnUserMessage';
 import EncryptedMessageRender from './EncryptedMessageRender';
 import ReactionsList from './MessageReactionsList';
@@ -36,7 +36,7 @@ const MessageContent: FC<{ message: IMessage; sequential: boolean; subscription?
 	const runActionLink = useMessageRunActionLink();
 
 	const oembedIsEnabled = useMessageOembedIsEnabled();
-	const shouldShowReadReceipt = useMessageShowReadReceipt({ message });
+	const shouldShowReadReceipt = useMessageListShowReadReceipt({ message });
 	const user: UserPresence = { ...message.u, roles: [], ...useUserData(message.u._id) };
 	const isEncryptedMessage = isE2EEMessage(message);
 

--- a/apps/meteor/client/views/room/MessageList/components/MessageContent.tsx
+++ b/apps/meteor/client/views/room/MessageList/components/MessageContent.tsx
@@ -36,7 +36,7 @@ const MessageContent: FC<{ message: IMessage; sequential: boolean; subscription?
 	const runActionLink = useMessageRunActionLink();
 
 	const oembedIsEnabled = useMessageOembedIsEnabled();
-	const shouldShowReadReceipt = useMessageListShowReadReceipt({ message });
+	const shouldShowReadReceipt = useMessageListShowReadReceipt();
 	const user: UserPresence = { ...message.u, roles: [], ...useUserData(message.u._id) };
 	const isEncryptedMessage = isE2EEMessage(message);
 

--- a/apps/meteor/client/views/room/MessageList/components/MessageContent.tsx
+++ b/apps/meteor/client/views/room/MessageList/components/MessageContent.tsx
@@ -111,7 +111,7 @@ const MessageContent: FC<{ message: IMessage; sequential: boolean; subscription?
 
 			{oembedIsEnabled && message.urls && <PreviewList urls={message.urls} />}
 
-			{shouldShowReadReceipt && <ReadReceipt />}
+			{shouldShowReadReceipt && <ReadReceipt unread={message.unread} />}
 		</>
 	);
 };

--- a/apps/meteor/client/views/room/MessageList/components/MessageReadReceipt.tsx
+++ b/apps/meteor/client/views/room/MessageList/components/MessageReadReceipt.tsx
@@ -2,7 +2,7 @@ import { css } from '@rocket.chat/css-in-js';
 import { Box, Icon } from '@rocket.chat/fuselage';
 import React, { ReactElement } from 'react';
 
-const MessageReadReceipt = (): ReactElement | null => (
+const MessageReadReceipt = ({ unread }: { unread?: boolean }): ReactElement | null => (
 	<Box
 		position='absolute'
 		className={css`
@@ -10,7 +10,7 @@ const MessageReadReceipt = (): ReactElement | null => (
 			right: 0.5rem;
 		`}
 	>
-		<Icon name='check' size='x11' color='primary' />
+		<Icon name='check' size='x11' color={unread ? 'neutral-200' : 'primary'} />
 	</Box>
 );
 

--- a/apps/meteor/client/views/room/MessageList/components/MessageReadReceipt.tsx
+++ b/apps/meteor/client/views/room/MessageList/components/MessageReadReceipt.tsx
@@ -10,7 +10,7 @@ const MessageReadReceipt = ({ unread }: { unread?: boolean }): ReactElement | nu
 			right: 0.5rem;
 		`}
 	>
-		<Icon name='check' size='x11' color={unread ? 'neutral-200' : 'primary'} />
+		<Icon name='check' size='x11' color={unread ? 'secondary' : 'primary'} />
 	</Box>
 );
 

--- a/apps/meteor/client/views/room/MessageList/contexts/MessageListContext.tsx
+++ b/apps/meteor/client/views/room/MessageList/contexts/MessageListContext.tsx
@@ -11,6 +11,7 @@ export type MessageListContextValue = {
 	useReactToMessage: (message: IMessage) => (reaction: string) => void;
 	useReactionsFilter: (message: IMessage) => (reaction: string) => string[];
 	useOpenEmojiPicker: (message: IMessage) => (event: React.MouseEvent) => void;
+	showReadReceipt: boolean;
 	showRoles: boolean;
 	showRealName: boolean;
 	showUsername: boolean;
@@ -38,6 +39,7 @@ export const MessageListContext = createContext<MessageListContextValue>({
 		(message) =>
 		(reaction: string): string[] =>
 			message.reactions ? message.reactions[reaction]?.usernames || [] : [],
+	showReadReceipt: false,
 	showRoles: false,
 	showRealName: false,
 	showUsername: false,
@@ -51,8 +53,8 @@ export const useShowFollowing: MessageListContextValue['useShowFollowing'] = (..
 	useContext(MessageListContext).useShowFollowing(...args);
 export const useMessageDateFormatter: MessageListContextValue['useMessageDateFormatter'] = (...args) =>
 	useContext(MessageListContext).useMessageDateFormatter(...args);
-export const useMessageShowReadReceipt: MessageListContextValue['useShowReadReceipt'] = (...args) =>
-	useContext(MessageListContext).useShowReadReceipt(...args);
+export const useMessageListShowReadReceipt = (): MessageListContextValue['showReadReceipt'] =>
+	useContext(MessageListContext).showReadReceipt;
 export const useMessageListShowRoles = (): MessageListContextValue['showRoles'] => useContext(MessageListContext).showRoles;
 export const useMessageListShowRealName = (): MessageListContextValue['showRealName'] => useContext(MessageListContext).showRealName;
 export const useMessageListShowUsername = (): MessageListContextValue['showUsername'] => useContext(MessageListContext).showUsername;

--- a/apps/meteor/client/views/room/MessageList/contexts/MessageListContext.tsx
+++ b/apps/meteor/client/views/room/MessageList/contexts/MessageListContext.tsx
@@ -5,7 +5,6 @@ export type MessageListContextValue = {
 	useShowTranslated: ({ message }: { message: IMessage }) => boolean;
 	useShowStarred: ({ message }: { message: IMessage }) => boolean;
 	useShowFollowing: ({ message }: { message: IMessage }) => boolean;
-	useShowReadReceipt: ({ message }: { message: IMessage }) => boolean;
 	useMessageDateFormatter: () => (date: Date) => string;
 	useUserHasReacted: (message: IMessage) => (reaction: string) => boolean;
 	useReactToMessage: (message: IMessage) => (reaction: string) => void;
@@ -27,7 +26,6 @@ export const MessageListContext = createContext<MessageListContextValue>({
 	useShowTranslated: () => false,
 	useShowStarred: () => false,
 	useShowFollowing: () => false,
-	useShowReadReceipt: () => false,
 	useUserHasReacted: () => (): boolean => false,
 	useMessageDateFormatter:
 		() =>

--- a/apps/meteor/client/views/room/MessageList/providers/MessageListProvider.tsx
+++ b/apps/meteor/client/views/room/MessageList/providers/MessageListProvider.tsx
@@ -80,7 +80,7 @@ export const MessageListProvider: FC<{
 				() =>
 				(date: Date): string =>
 					date.toLocaleString(),
-
+			showReadReceipt,
 			showRoles,
 			showRealName,
 			showUsername,

--- a/apps/meteor/client/views/room/MessageList/providers/MessageListProvider.tsx
+++ b/apps/meteor/client/views/room/MessageList/providers/MessageListProvider.tsx
@@ -75,7 +75,6 @@ export const MessageListProvider: FC<{
 			useShowStarred: hasSubscription
 				? ({ message }): boolean => Boolean(Array.isArray(message.starred) && message.starred.find((star) => star._id === uid))
 				: (): boolean => false,
-			useShowReadReceipt: ({ message }): boolean => showReadReceipt && !message.unread,
 			useMessageDateFormatter:
 				() =>
 				(date: Date): string =>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

The read receipts were hidden before the user read, but the correct behavior is with gray color.