### PR TITLE
Regression: Fix federation Matrix bridge startup

### DIFF
--- a/apps/meteor/app/federation-v2/server/bridge.ts
+++ b/apps/meteor/app/federation-v2/server/bridge.ts
@@ -1,50 +1,15 @@
 import { Bridge, AppServiceRegistration } from 'matrix-appservice-bridge';
 
+import { settings } from '../../settings/server';
 import { IMatrixEvent } from './definitions/IMatrixEvent';
 import { MatrixEventType } from './definitions/MatrixEventType';
 import { addToQueue } from './queue';
-import { config } from './config';
-
-/* eslint-disable @typescript-eslint/camelcase */
-const registrationConfig = AppServiceRegistration.fromObject({
-	id: config.id,
-	hs_token: config.hsToken,
-	as_token: config.asToken,
-	url: config.bridgeUrl,
-	sender_localpart: config.bridgeLocalpart,
-	namespaces: {
-		users: [
-			{
-				exclusive: false,
-				// Reserve these MXID's (usernames)
-				regex: `.*`,
-			},
-		],
-		aliases: [
-			{
-				exclusive: false,
-				// Reserve these room aliases
-				regex: `.*`,
-			},
-		],
-		rooms: [
-			{
-				exclusive: false,
-				// This regex is used to define which rooms we listen to with the bridge.
-				// This does not reserve the rooms like the other namespaces.
-				regex: '.*',
-			},
-		],
-	},
-	rate_limited: false,
-	protocols: null,
-});
-/* eslint-enable @typescript-eslint/camelcase */
+import { getRegistrationInfo } from './config';
 
 export const matrixBridge = new Bridge({
-	homeserverUrl: config.homeserverUrl,
-	domain: config.homeserverDomain,
-	registration: registrationConfig,
+	homeserverUrl: settings.get('Federation_Matrix_homeserver_url'),
+	domain: settings.get('Federation_Matrix_homeserver_domain'),
+	registration: AppServiceRegistration.fromObject(getRegistrationInfo()),
 	disableStores: true,
 	controller: {
 		onAliasQuery: (alias, matrixRoomId): void => {

--- a/apps/meteor/app/federation-v2/server/config.ts
+++ b/apps/meteor/app/federation-v2/server/config.ts
@@ -1,32 +1,43 @@
+import type { AppServiceOutput } from 'matrix-appservice-bridge';
+
 import { settings } from '../../settings/server';
 
-type bridgeUrlString = `${string}://${string}:${string}`;
 export type bridgeUrlTuple = [string, string, number];
 
-interface IBridgeConfig {
-	id: string;
-	hsToken: string;
-	asToken: string;
-	homeserverUrl: string;
-	homeserverDomain: string;
-	bridgeUrl: bridgeUrlString;
-	bridgeLocalpart: string;
-}
-
-function _getConfig(): IBridgeConfig {
+export function getRegistrationInfo(): AppServiceOutput {
+	/* eslint-disable @typescript-eslint/camelcase */
 	return {
-		id: settings.get('Federation_Matrix_id') as string,
-		hsToken: settings.get('Federation_Matrix_hs_token') as string,
-		asToken: settings.get('Federation_Matrix_as_token') as string,
-		homeserverUrl: settings.get('Federation_Matrix_homeserver_url') as string,
-		homeserverDomain: settings.get('Federation_Matrix_homeserver_domain') as string,
-		bridgeUrl: settings.get('Federation_Matrix_bridge_url') as bridgeUrlString,
-		bridgeLocalpart: settings.get('Federation_Matrix_bridge_localpart') as string,
-	} as IBridgeConfig;
-}
-
-export let config: IBridgeConfig = _getConfig();
-
-export function getConfig() {
-	config = _getConfig();
+		id: settings.get('Federation_Matrix_id'),
+		hs_token: settings.get('Federation_Matrix_hs_token'),
+		as_token: settings.get('Federation_Matrix_as_token'),
+		url: settings.get<string>('Federation_Matrix_bridge_url'),
+		sender_localpart: settings.get('Federation_Matrix_bridge_localpart'),
+		namespaces: {
+			users: [
+				{
+					exclusive: false,
+					// Reserve these MXID's (usernames)
+					regex: `.*`,
+				},
+			],
+			aliases: [
+				{
+					exclusive: false,
+					// Reserve these room aliases
+					regex: `.*`,
+				},
+			],
+			rooms: [
+				{
+					exclusive: false,
+					// This regex is used to define which rooms we listen to with the bridge.
+					// This does not reserve the rooms like the other namespaces.
+					regex: '.*',
+				},
+			],
+		},
+		rate_limited: false,
+		protocols: null,
+	};
+	/* eslint-enable @typescript-eslint/camelcase */
 }

--- a/apps/meteor/app/federation-v2/server/index.ts
+++ b/apps/meteor/app/federation-v2/server/index.ts
@@ -1,20 +1,2 @@
-import { matrixBridge } from './bridge';
-import { bridgeUrlTuple, config } from './config';
-import { bridgeLogger } from './logger';
 import './settings';
-import { isFederationMatrixEnabled } from './tools';
-
-((): void => {
-	if (!isFederationMatrixEnabled()) return;
-
-	bridgeLogger.info(`Running Federation V2:
-	  id: ${config.id}
-	  bridgeUrl: ${config.bridgeUrl}
-	  homeserverURL: ${config.homeserverUrl}
-	  homeserverDomain: ${config.homeserverDomain}
-	`);
-
-	const [, , port] = config.bridgeUrl.split(':') as bridgeUrlTuple;
-
-	matrixBridge.run(port);
-})();
+import './startup';

--- a/apps/meteor/app/federation-v2/server/matrix-client/user.ts
+++ b/apps/meteor/app/federation-v2/server/matrix-client/user.ts
@@ -4,9 +4,9 @@ import { IUser } from '@rocket.chat/core-typings';
 import { matrixBridge } from '../bridge';
 import { MatrixBridgedUser, MatrixBridgedRoom, Users } from '../../../models/server';
 import { addUserToRoom } from '../../../lib/server/functions';
-import { config } from '../config';
 import { matrixClient } from '.';
 import { dataInterface } from '../data-interface';
+import { settings } from '../../../settings/server';
 
 interface ICreateUserResult {
 	uid: string;
@@ -52,7 +52,7 @@ export const invite = async (inviterId: string, roomId: string, invitedId: strin
 	// Determine if the user is local or remote
 	let invitedUserMatrixId = invitedId;
 	const invitedUserDomain = invitedId.includes(':') ? invitedId.split(':').pop() : '';
-	const invitedUserIsRemote = invitedUserDomain && invitedUserDomain !== config.homeserverDomain;
+	const invitedUserIsRemote = invitedUserDomain && invitedUserDomain !== settings.get('Federation_Matrix_homeserver_domain');
 
 	// Find the invited user in Rocket.Chats users
 	let invitedUser = Users.findOneByUsername(invitedId.replace('@', ''));
@@ -100,7 +100,7 @@ export const invite = async (inviterId: string, roomId: string, invitedId: strin
 };
 
 export const createRemote = async (u: IUser): Promise<ICreateUserResult> => {
-	const matrixUserId = `@${u.username?.toLowerCase()}:${config.homeserverDomain}`;
+	const matrixUserId = `@${u.username?.toLowerCase()}:${settings.get('Federation_Matrix_homeserver_domain')}`;
 
 	console.log(`Creating remote user ${matrixUserId}...`);
 

--- a/apps/meteor/app/federation-v2/server/startup.ts
+++ b/apps/meteor/app/federation-v2/server/startup.ts
@@ -1,0 +1,26 @@
+import { settings } from '../../settings/server';
+import { matrixBridge } from './bridge';
+import { bridgeUrlTuple } from './config';
+import { bridgeLogger, setupLogger } from './logger';
+import { isFederationMatrixEnabled } from './tools';
+
+((): void => {
+	if (!isFederationMatrixEnabled()) return;
+
+	bridgeLogger.info(`Running Federation V2:
+	  id: ${settings.get('Federation_Matrix_id')}
+	  bridgeUrl: ${settings.get<string>('Federation_Matrix_bridge_url')}
+	  homeserverURL: ${settings.get('Federation_Matrix_homeserver_url')}
+	  homeserverDomain: ${settings.get('Federation_Matrix_homeserver_domain')}
+	`);
+
+	const [, , port] = settings.get<string>('Federation_Matrix_bridge_url').split(':') as bridgeUrlTuple;
+
+	matrixBridge.run(port);
+
+	// TODO: Changes here should re-initialize the bridge instead of needing a restart
+	// Add settings listeners
+	settings.watch('Federation_Matrix_enabled', (value) => {
+		setupLogger.info(`Federation Matrix is ${value ? 'enabled' : 'disabled'}`);
+	});
+})();

--- a/apps/meteor/app/federation-v2/server/tools.ts
+++ b/apps/meteor/app/federation-v2/server/tools.ts
@@ -1,4 +1,4 @@
 import { settings } from '../../settings/server';
 import { matrixBridge } from './bridge';
 
-export const isFederationMatrixEnabled = () => settings.get('Federation_Matrix_enabled') && matrixBridge;
+export const isFederationMatrixEnabled = (): boolean => !!(settings.get('Federation_Matrix_enabled') && matrixBridge);

--- a/apps/meteor/package.json
+++ b/apps/meteor/package.json
@@ -97,7 +97,6 @@
 		"@types/fibers": "^3.1.1",
 		"@types/google-libphonenumber": "^7.4.21",
 		"@types/imap": "^0.8.35",
-		"@types/js-yaml": "^4.0.5",
 		"@types/jsdom": "^16.2.12",
 		"@types/jsdom-global": "^3.0.2",
 		"@types/jsrsasign": "^9.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3690,7 +3690,6 @@ __metadata:
     "@types/fibers": ^3.1.1
     "@types/google-libphonenumber": ^7.4.21
     "@types/imap": ^0.8.35
-    "@types/js-yaml": ^4.0.5
     "@types/jsdom": ^16.2.12
     "@types/jsdom-global": ^3.0.2
     "@types/jsrsasign": ^9.0.3
@@ -5815,13 +5814,6 @@ __metadata:
   dependencies:
     "@types/sizzle": "*"
   checksum: 159d6f804ed1a204b3f79f2d591a271d82e866bd45bd49fb6ef40561a25dbe0f47ec7815681b44cc2db5598425f72811e7e80ab0e983d980470998ac56feb375
-  languageName: node
-  linkType: hard
-
-"@types/js-yaml@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "@types/js-yaml@npm:4.0.5"
-  checksum: 7dcac8c50fec31643cc9d6444b5503239a861414cdfaa7ae9a38bc22597c4d850c4b8cec3d82d73b3fbca408348ce223b0408d598b32e094470dfffc6d486b4d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->
I was getting this error during startup:
```
@rocket.chat/meteor:dev: W20220422-13:55:13.189(-3)? (STDERR) === UnHandledPromiseRejection ===
@rocket.chat/meteor:dev: W20220422-13:55:13.190(-3)? (STDERR) TypeError: Cannot read property 'includes' of undefined
@rocket.chat/meteor:dev: W20220422-13:55:13.190(-3)? (STDERR)     at app/federation-v2/server/settings.ts:85:17
@rocket.chat/meteor:dev: W20220422-13:55:13.190(-3)? (STDERR)     at /Users/diegosampaio/.meteor/packages/promise/.0.12.0.1uvcsxa.vq0s++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/fiber_pool.js:43:40
@rocket.chat/meteor:dev: W20220422-13:55:13.190(-3)? (STDERR) ---------------------------------
@rocket.chat/meteor:dev: W20220422-13:55:13.191(-3)? (STDERR) Errors like this can cause oplog processing errors.
@rocket.chat/meteor:dev: W20220422-13:55:13.191(-3)? (STDERR) Setting EXIT_UNHANDLEDPROMISEREJECTION will cause the process to exit allowing your service to automatically restart the process
@rocket.chat/meteor:dev: W20220422-13:55:13.191(-3)? (STDERR) Future node.js versions will automatically exit the process
@rocket.chat/meteor:dev: W20220422-13:55:13.191(-3)? (STDERR) =================================
```

this is probably due some race condition while trying to read the settings but they're were not created yet. since `settings.get` is cached, it doesn't add any cost calling it multiple times, just _some_ noise in the code.. but I think in the most cases it is worth it because like in this case we reduced the complexity (by removing additional `watch` or "global" variables to keep up-to-date)

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
