### PR TITLE
Regression: Rocket.Chat Webapp not loading.

### DIFF
--- a/apps/meteor/package.json
+++ b/apps/meteor/package.json
@@ -344,7 +344,7 @@
 		"underscore.string": "^3.3.6",
 		"universal-perf-hooks": "^1.0.1",
 		"url-polyfill": "^1.1.12",
-		"use-subscription": "^1.6.0",
+		"use-subscription": "~1.6.0",
 		"uuid": "^3.4.0",
 		"webdav": "^2.10.2",
 		"xml-crypto": "^2.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4062,7 +4062,7 @@ __metadata:
     underscore.string: ^3.3.6
     universal-perf-hooks: ^1.0.1
     url-polyfill: ^1.1.12
-    use-subscription: ^1.6.0
+    use-subscription: ~1.6.0
     uuid: ^3.4.0
     webdav: ^2.10.2
     webpack: ^4.44.1
@@ -28072,7 +28072,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-subscription@npm:^1.6.0":
+"use-subscription@npm:~1.6.0":
   version: 1.6.0
   resolution: "use-subscription@npm:1.6.0"
   peerDependencies:


### PR DESCRIPTION
React's `use-subscription` package had a new minor update with breaking changes that caused Rocket.Chat app to stop working.