### PR TITLE
[FIX] Unable to see channel member list by authorized channel roles

### DIFF
--- a/apps/meteor/app/api/server/v1/channels.js
+++ b/apps/meteor/app/api/server/v1/channels.js
@@ -683,7 +683,7 @@ API.v1.addRoute(
 				checkedArchived: false,
 			});
 
-			if (findResult.broadcast && !hasPermission(this.userId, 'view-broadcast-member-list')) {
+			if (findResult.broadcast && !hasPermission(this.userId, 'view-broadcast-member-list', findResult._id)) {
 				return API.v1.unauthorized();
 			}
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
It fixes a bug that prevents seeing a broadcast channel member list by authorized channel roles ('admin', 'owner', 'moderator')

The solution was: 
Adding a channel scope for the method `hasPermission` that handles this validation.

## Issue(s)
No issues

## Steps to test or reproduce
Steps to reproduce:

* Log in to the [rocket.chat](http://rocket.chat/) (with role user)
* Click on create a new channel/team (this user will have the role of the owner as well )
* Fill the name
* Disable the Private option to turn the room public
* Add members: add some members (2)
* Click on create
* It will open the room
* Click on the icon on the top right to access the list of members

Actual result:
* No members found
* The 403 error was displayed on the Network

Expected behavior
* The list of the users should be appear

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
