### PR TITLE
[FIX] useCurrentChatTags is not a function

### DIFF
--- a/apps/meteor/client/components/Omnichannel/Tags.tsx
+++ b/apps/meteor/client/components/Omnichannel/Tags.tsx
@@ -25,7 +25,9 @@ const Tags = ({
 
 	const { value: tagsResult, phase: stateTags } = useEndpointData('livechat/tags.list');
 
+	// TODO: Refactor the formsSubscription to use components instead of hooks (since the only thing the hook does is return a component)
 	const { useCurrentChatTags } = forms;
+	// Conditional hook was required since the whole formSubscription uses hooks in an incorrect manner
 	const EETagsComponent = useCurrentChatTags?.();
 
 	const dispatchToastMessage = useToastMessageDispatch();

--- a/apps/meteor/client/components/Omnichannel/Tags.tsx
+++ b/apps/meteor/client/components/Omnichannel/Tags.tsx
@@ -26,7 +26,7 @@ const Tags = ({
 	const { value: tagsResult, phase: stateTags } = useEndpointData('livechat/tags.list');
 
 	const { useCurrentChatTags } = forms;
-	const EETagsComponent = useCurrentChatTags();
+	const EETagsComponent = useCurrentChatTags?.();
 
 	const dispatchToastMessage = useToastMessageDispatch();
 

--- a/apps/meteor/client/views/omnichannel/currentChats/FilterByText.tsx
+++ b/apps/meteor/client/views/omnichannel/currentChats/FilterByText.tsx
@@ -66,6 +66,8 @@ const FilterByText: FilterByTextType = ({ setFilter, reload, ...props }) => {
 
 	const forms = useSubscription<any>(formsSubscription);
 
+	// TODO: Refactor the formsSubscription to use components instead of hooks (since the only thing the hook does is return a component)
+	// Conditional hook was required since the whole formSubscription uses hooks in an incorrect manner
 	const { useCurrentChatTags = (): void => undefined } = forms;
 
 	const EETagsComponent = useCurrentChatTags();


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
This should fix the error `useCurrentChatTags is not a function` when trying to close a livechat conversation