### PR TITLE
[FIX] Jitsi share screen from contextual bar

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/VideoConference/Jitsi/lib/Jitsi.js
+++ b/apps/meteor/client/views/room/contextualBar/VideoConference/Jitsi/lib/Jitsi.js
@@ -164,7 +164,7 @@ export function JitsiMeetExternalAPI(
 	this.frame.width = '100%';
 	this.frame.height = '100%';
 	this.frame.setAttribute('allowFullScreen', 'true');
-	this.frame.setAttribute('allow', 'microphone; camera');
+	this.frame.setAttribute('allow', 'microphone; camera; display-capture');
 	this.frame = this.iframeHolder.appendChild(this.frame);
 	this.postis = postis({
 		window: this.frame.contentWindow,


### PR DESCRIPTION
fix JITSI sharing screen 

from issue #25112

Description:

When starting a video conference via Jitsi from the contextual bar (iframe) it is not possible to share your desktop. Microphone and Camera work fine.
Steps to reproduce:

```
Configure Jitsi Integration
Enter Channel and start Video conference
Click on Share Desktop Button

```

Expected behavior:

My desktop (or parts of it) are shared to all other participants.