### PR TITLE
[FIX] Session with loginToken not being saved after login

### DIFF
--- a/apps/meteor/app/statistics/server/lib/SAUMonitor.ts
+++ b/apps/meteor/app/statistics/server/lib/SAUMonitor.ts
@@ -138,7 +138,7 @@ export class SAUMonitorClass {
 		if (!data) {
 			return;
 		}
-		await Sessions.createOrUpdate(data);
+		await Sessions.insertOne({ ...data, createdAt: new Date() });
 	}
 
 	private async _finishSessionsFromDate(yesterday: Date, today: Date): Promise<void> {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

1. 1 Login with your account
1.1. Check collection rocketchat_sessions and there we found 2 documents related to this session started.
2. Click on logout button
3. Login again
3.1. Check rocketchat_sessions again and there is 1 document related to this session started. 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Why do we need 2 documents?
1st sends the object resume with a username and password
2nd sends the object resume with token only after processed login with success.

*both documents are sent by Meteor.Account
**This token is an important key to filtering all opened sessions.