### PR TITLE
Chore: fix zapier doc link at integrations page

### DIFF
--- a/apps/meteor/client/views/admin/integrations/new/NewZapier.js
+++ b/apps/meteor/client/views/admin/integrations/new/NewZapier.js
@@ -31,21 +31,5 @@ export default function NewZapier({ ...props }) {
 		return () => script && script.parentNode.removeChild(script);
 	}, [script]);
 
-	return (
-		<>
-			<Box pb='x20' fontScale='h4' dangerouslySetInnerHTML={{ __html: t('additional_integrations_Zapier') }} />
-			{!script && (
-				<Box display='flex' flexDirection='column' alignItems='stretch' mbs={10}>
-					<Margins blockEnd={14}>
-						<Skeleton variant='rect' height={71} />
-						<Skeleton variant='rect' height={71} />
-						<Skeleton variant='rect' height={71} />
-						<Skeleton variant='rect' height={71} />
-						<Skeleton variant='rect' height={71} />
-					</Margins>
-				</Box>
-			)}
-			<Box id='zapier-goes-here' {...props} />
-		</>
-	);
+	return <Box pb='x20' fontScale='h4' dangerouslySetInnerHTML={{ __html: t('additional_integrations_Zapier') }} />;
 }

--- a/apps/meteor/packages/rocketchat-i18n/i18n/af.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/af.i18n.json
@@ -216,7 +216,7 @@
   "Additional_emails": "Bykomende e-posse",
   "Additional_Feedback": "Bykomende terugvoer",
   "additional_integrations_Bots": "As jy op soek is na hoe om jou eie bot te integreer, kyk dan nie verder as ons Hubot-adapter nie. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat </a>",
-  "additional_integrations_Zapier": "Is jy op soek na ander sagteware en toepassings met Rocket.Chat te integreer, maar jy het nie die tyd om dit handmatig te doen nie? Dan stel ons voor om Zapier te gebruik wat ons ten volle ondersteun. Lees meer hieroor op ons dokumentasie. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/ </a>",
+  "additional_integrations_Zapier": "Is jy op soek na ander sagteware en toepassings met Rocket.Chat te integreer, maar jy het nie die tyd om dit handmatig te doen nie? Dan stel ons voor om Zapier te gebruik wat ons ten volle ondersteun. Lees meer hieroor op ons dokumentasie. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/ </a>",
   "Admin_Info": "Admin Info",
   "Administration": "administrasie",
   "Adult_images_are_not_allowed": "Volwasse beelde word nie toegelaat nie",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/ar.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/ar.i18n.json
@@ -294,7 +294,7 @@
   "Additional_emails": "رسائل بريد إلكتروني إضافية",
   "Additional_Feedback": "ملاحظات إضافية",
   "additional_integrations_Bots": "إذا كنت تبحث عن كيفية دمج الروبوت الخاص بك، فلن تجد أفضل من محول Hubot الخاص بنا. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "هل تتطلع إلى دمج البرامج والتطبيقات الأخرى مع Rocket.Chat ولكن ليس لديك الوقت للقيام بذلك يدويًا؟ ننصحك باستخدام Zapier الذي ندعمه بالكامل. يمكنك قراءة المزيد عنه على وثائقنا. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "هل تتطلع إلى دمج البرامج والتطبيقات الأخرى مع Rocket.Chat ولكن ليس لديك الوقت للقيام بذلك يدويًا؟ ننصحك باستخدام Zapier الذي ندعمه بالكامل. يمكنك قراءة المزيد عنه على وثائقنا. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "لم يقوم المسؤول لديك بتمكين التشفير بين الوحدات الطرفية.",
   "Admin_Info": "معلومات المسؤول",
   "Administration": "الإدارة",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/az.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/az.i18n.json
@@ -216,7 +216,7 @@
   "Additional_emails": "Əlavə e-poçtlar",
   "Additional_Feedback": "Əlavə Əlaqə",
   "additional_integrations_Bots": "Öz botunuzu necə birləşdirə bilərsinizsə, onda Hubot adapterimizdən daha çox baxın. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Digər proqram və proqramları Rocket.Chat ilə inteqrasiya etmək istəyirsənsə, ancaq bunu elle etmək üçün vaxtınız yoxdur? Sonra biz tam dəstəkləyən Zapier-dən istifadə etməyi təklif edirik. Bu barədə bizim sənədlərimiz haqqında ətraflı məlumat əldə edin. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Digər proqram və proqramları Rocket.Chat ilə inteqrasiya etmək istəyirsənsə, ancaq bunu elle etmək üçün vaxtınız yoxdur? Sonra biz tam dəstəkləyən Zapier-dən istifadə etməyi təklif edirik. Bu barədə bizim sənədlərimiz haqqında ətraflı məlumat əldə edin. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_Info": "Admin məlumatı",
   "Administration": "İdarə",
   "Adult_images_are_not_allowed": "Yetkin görünüşlərə icazə verilmir",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/be-BY.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/be-BY.i18n.json
@@ -218,7 +218,7 @@
   "Additional_emails": "Дадатковыя паведамленні электроннай пошты",
   "Additional_Feedback": "Дадатковая сувязь",
   "additional_integrations_Bots": "Калі вы шукаеце, як інтэграваць свой уласны бот, то глядзець не далей, чым наш Hubot адаптар. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Вы хочаце інтэграваць іншае праграмнае забеспячэнне і прыкладанні з Rocket.Chat, але ў вас няма часу, каб ўручную зрабіць гэта? Тады мы прапануем выкарыстоўваць Zapier, які мы цалкам падтрымліваем. Падрабязней пра гэта ў нашай дакументацыі.<a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a> ",
+  "additional_integrations_Zapier": "Вы хочаце інтэграваць іншае праграмнае забеспячэнне і прыкладанні з Rocket.Chat, але ў вас няма часу, каб ўручную зрабіць гэта? Тады мы прапануем выкарыстоўваць Zapier, які мы цалкам падтрымліваем. Падрабязней пра гэта ў нашай дакументацыі.<a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a> ",
   "Admin_Info": "адмін інфармацыя",
   "Administration": "адміністрацыя",
   "Adult_images_are_not_allowed": "Выявы для дарослых не дапускаюцца",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/bg.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/bg.i18n.json
@@ -216,7 +216,7 @@
   "Additional_emails": "Допълнителни имейли",
   "Additional_Feedback": "Допълнителни обратни връзки",
   "additional_integrations_Bots": "Ако търсите как да интегрирате собствения си бот, не търсете нищо повече от нашия адаптер Хъбот. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Търсите ли да интегрирате друг софтуер и приложения с Rocket.Chat, но нямате време да го направите ръчно? След това предлагаме да използвате Запир, което напълно подкрепяме. Прочетете повече за това в нашата документация. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Търсите ли да интегрирате друг софтуер и приложения с Rocket.Chat, но нямате време да го направите ръчно? След това предлагаме да използвате Запир, което напълно подкрепяме. Прочетете повече за това в нашата документация. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_Info": "Администраторска информация",
   "Administration": "администрация",
   "Adult_images_are_not_allowed": "Възрастните изображения не са разрешени",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/bs.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/bs.i18n.json
@@ -216,7 +216,7 @@
   "Additional_emails": "Dodatni Emailovi",
   "Additional_Feedback": "Dodatne povratne informacije",
   "additional_integrations_Bots": "Ako tražite kako integrirati svoj bot, nemojte gledati dalje od našeg Hubot adaptera. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Tražite li integrirati drugi softver i aplikacije s Rocket.Chat, ali nemate vremena za ručno raditi? Onda predlažemo da koristite Zapier koji u potpunosti podržavamo. Pročitajte više o našoj dokumentaciji. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Tražite li integrirati drugi softver i aplikacije s Rocket.Chat, ali nemate vremena za ručno raditi? Onda predlažemo da koristite Zapier koji u potpunosti podržavamo. Pročitajte više o našoj dokumentaciji. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_Info": "Informacije o administratoru",
   "Administration": "Administracija",
   "Adult_images_are_not_allowed": "Slike za odrasle nisu dopuštene",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/ca.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/ca.i18n.json
@@ -294,7 +294,7 @@
   "Additional_emails": "Correus electrònics addicionals",
   "Additional_Feedback": "Retroalimentació addicional",
   "additional_integrations_Bots": "Si esteu buscant com integrar el vostre propi bot, no busqueu més que el nostre adaptador Hubot. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Està buscant integrar un altre programari i aplicacions amb Rocket.Chat però no té temps per fer-ho manualment? Llavors, suggerim utilitzar Zapier, que és totalment compatible. Llegiu més sobre això a la nostra documentació <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Està buscant integrar un altre programari i aplicacions amb Rocket.Chat però no té temps per fer-ho manualment? Llavors, suggerim utilitzar Zapier, que és totalment compatible. Llegiu més sobre això a la nostra documentació <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "El seu administrador no va habilitar encriptació E2E",
   "Admin_Info": "Informació d'administrador",
   "Administration": "Administració",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/cs.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/cs.i18n.json
@@ -269,7 +269,7 @@
   "Additional_emails": "Další e-maily",
   "Additional_Feedback": "Dodatečný Feedback",
   "additional_integrations_Bots": "Hledáte způsob jak implementovat vlastního bota? Nehledejte dál a podívejte se na náš Hubot adaptér <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": " Chcete integrovat software či aplikaci s Rocket.Chat ale nevíte jak na to? Doporučujeme použít Zapier, který plně podporujeme. Pro více informací si přečtěte naši dokumentaci <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": " Chcete integrovat software či aplikaci s Rocket.Chat ale nevíte jak na to? Doporučujeme použít Zapier, který plně podporujeme. Pro více informací si přečtěte naši dokumentaci <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "Váš správce nepovolil šifrování E2E.",
   "Admin_Info": "Admin informace",
   "Administration": "Administrace",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/da.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/da.i18n.json
@@ -268,7 +268,7 @@
   "Additional_emails": "Yderligere e-mails",
   "Additional_Feedback": "Yderligere feedback",
   "additional_integrations_Bots": "Hvis du gerne vil integrere din egen bot, skal du bare bruge vores Hubot-adapter: <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Hvis du gerne vil integrere anden software og andre applikationer med Rocket.Chat, men ikke har tid , forslår vi, at du bruger Zapier, som vi fuldt ud understøtter. Du kan læse mere om det i vores dokumentation: <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Hvis du gerne vil integrere anden software og andre applikationer med Rocket.Chat, men ikke har tid , forslår vi, at du bruger Zapier, som vi fuldt ud understøtter. Du kan læse mere om det i vores dokumentation: <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "Din administrator har ikke aktiveret E2E-kryptering",
   "Admin_Info": "Administratorinfo",
   "Administration": "Administration",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/de-AT.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/de-AT.i18n.json
@@ -216,7 +216,7 @@
   "Additional_emails": "Zusätzliche E-Mails",
   "Additional_Feedback": "Zusätzliches Feedback",
   "additional_integrations_Bots": "Wenn Sie nach der Integration Ihres eigenen Bot suchen, dann suchen Sie nicht weiter als unseren Hubot-Adapter. <a href='https://github.com/RocketChat/hubot-rocketchat' Ziel = '_ leer'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Möchten Sie andere Software und Anwendungen mit Rocket.Chat integrieren, aber Sie haben nicht die Zeit, es manuell zu tun? Dann empfehlen wir die Verwendung von Zapier, die wir voll unterstützen. Lesen Sie mehr darüber in unserer Dokumentation. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Möchten Sie andere Software und Anwendungen mit Rocket.Chat integrieren, aber Sie haben nicht die Zeit, es manuell zu tun? Dann empfehlen wir die Verwendung von Zapier, die wir voll unterstützen. Lesen Sie mehr darüber in unserer Dokumentation. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_Info": "Admin-Info",
   "Administration": "Administration",
   "Adult_images_are_not_allowed": "Erwachsene Bilder sind nicht erlaubt",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/de-IN.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/de-IN.i18n.json
@@ -224,7 +224,7 @@
   "Additional_emails": "Zusätzliche E-Mails",
   "Additional_Feedback": "Zusätzliches Feedback",
   "additional_integrations_Bots": "Wenn Du auf der Suche nach der Integration Deines eigenen Bot bist, dann ist unser Hubot-Adapter genau das Richtige für Dich. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Du möchtest andere Software und Anwendungen in Rocket.Chat integrieren, hast aber nicht die Zeit, dies manuell zu tun? Dann empfehlen wir die Verwendung von Zapier, das wir voll unterstützen. Lies mehr darüber in unserer Dokumentation. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Du möchtest andere Software und Anwendungen in Rocket.Chat integrieren, hast aber nicht die Zeit, dies manuell zu tun? Dann empfehlen wir die Verwendung von Zapier, das wir voll unterstützen. Lies mehr darüber in unserer Dokumentation. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "Dein Administrator hat Ende-zu-Ende-Verschlüsselung nicht aktiviert",
   "Admin_Info": "Admin-Info",
   "Administration": "Administration",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/de.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/de.i18n.json
@@ -293,7 +293,7 @@
   "Additional_emails": "Zusätzliche E-Mails",
   "Additional_Feedback": "Zusätzliches Feedback",
   "additional_integrations_Bots": "Wenn Sie nach der Integration Ihres eigenen Bot suchen, dann suchen Sie nicht weiter als unseren Hubot-Adapter. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Möchten Sie andere Software und Anwendungen mit Rocket.Chat integrieren, aber Sie haben nicht die Zeit, es manuell zu tun? Dann empfehlen wir die Verwendung von Zapier, die wir vollständig unterstützen. Lesen Sie mehr darüber in unserer Dokumentation. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Möchten Sie andere Software und Anwendungen mit Rocket.Chat integrieren, aber Sie haben nicht die Zeit, es manuell zu tun? Dann empfehlen wir die Verwendung von Zapier, die wir vollständig unterstützen. Lesen Sie mehr darüber in unserer Dokumentation. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "Ihr Administrator hat Ende-zu-Ende-Verschlüsselung nicht aktiviert.",
   "Admin_Info": "Admin-Info",
   "Administration": "Administration",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/el.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/el.i18n.json
@@ -222,7 +222,7 @@
   "Additional_emails": "Πρόσθετες Διευθύνσεις E-mail",
   "Additional_Feedback": "Πρόσθετα Σχόλια",
   "additional_integrations_Bots": "Αν ψάχνετε για το πώς να ενσωματώσετε το δικό σας bot, τότε μην κοιτάξετε περισσότερο από τον προσαρμογέα Hubot. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Ψάχνετε να ενσωματώσετε άλλα λογισμικά και εφαρμογές με το Rocket.Chat αλλά δεν έχετε το χρόνο να το κάνετε χειροκίνητα; Στη συνέχεια, προτείνουμε τη χρήση του Zapier, την οποία υποστηρίζουμε πλήρως. Διαβάστε περισσότερα σχετικά με την τεκμηρίωσή μας. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Ψάχνετε να ενσωματώσετε άλλα λογισμικά και εφαρμογές με το Rocket.Chat αλλά δεν έχετε το χρόνο να το κάνετε χειροκίνητα; Στη συνέχεια, προτείνουμε τη χρήση του Zapier, την οποία υποστηρίζουμε πλήρως. Διαβάστε περισσότερα σχετικά με την τεκμηρίωσή μας. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_Info": "Πληροφορίες διαχειριστή",
   "Administration": "Διαχείριση",
   "Adult_images_are_not_allowed": "Ακατάλληλες φωτογραφίες δεν επιτρέπονται",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -300,7 +300,7 @@
   "Additional_emails": "Additional Emails",
   "Additional_Feedback": "Additional Feedback",
   "additional_integrations_Bots": "If you are looking for how to integrate your own bot, then look no further than our Hubot adapter. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Are you looking to integrate other software and applications with Rocket.Chat but you don't have the time to manually do it? Then we suggest using Zapier which we fully support. Read more about it on our documentation. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Are you looking to integrate other software and applications with Rocket.Chat but you don't have the time to manually do it? Then we suggest using Zapier which we fully support. Read more about it on our documentation. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "Your administrator did not enable E2E encryption.",
   "Admin_Info": "Admin Info",
   "admin-no-active-video-conf-provider": "**Conference call not enabled**: Configure conference calls in order to make it available on this workspace.",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/eo.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/eo.i18n.json
@@ -216,7 +216,7 @@
   "Additional_emails": "Aldonaj retpoŝtoj",
   "Additional_Feedback": "Pliaj rimarkoj",
   "additional_integrations_Bots": "Se vi serĉas kiel integri vian propran boton, tiam rigardu ne plu ol nia Hubot-adaptilo. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Ĉu vi volas integri aliajn programojn kaj programojn kun Rocket.Chat sed vi ne havas la tempon por permane fari ĝin? Tiam ni sugestas uzi Zapier, kiun ni plene subtenas. Legu pli pri ĝi pri nia dokumentado. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Ĉu vi volas integri aliajn programojn kaj programojn kun Rocket.Chat sed vi ne havas la tempon por permane fari ĝin? Tiam ni sugestas uzi Zapier, kiun ni plene subtenas. Legu pli pri ĝi pri nia dokumentado. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_Info": "Admin Informoj",
   "Administration": "Administrado",
   "Adult_images_are_not_allowed": "Plenkreskulaj bildoj ne estas permesataj",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/es.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/es.i18n.json
@@ -293,7 +293,7 @@
   "Additional_emails": "Correos electrónicos adicionales",
   "Additional_Feedback": "Comentarios adicionales",
   "additional_integrations_Bots": "Si estás buscando cómo integrar tu propio bot, nuestro adaptador Hubot es lo que necesitas. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "¿Quieres integrar otro software y otras aplicaciones con Rocket.Chat pero no tienes tiempo para hacerlo manualmente? Si es así, te sugerimos que uses Zapier, que es totalmente compatible. Consulta nuestra documentación para obtener más información al respecto. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "¿Quieres integrar otro software y otras aplicaciones con Rocket.Chat pero no tienes tiempo para hacerlo manualmente? Si es así, te sugerimos que uses Zapier, que es totalmente compatible. Consulta nuestra documentación para obtener más información al respecto. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "Tu administrador no ha habilitado el cifrado E2E",
   "Admin_Info": "Información de administración",
   "Administration": "Administración",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/fa.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/fa.i18n.json
@@ -245,7 +245,7 @@
   "Additional_emails": "ایمیل های اضافی",
   "Additional_Feedback": "بازخورد اضافی",
   "additional_integrations_Bots": "اگر به دنبال چگونگی ادغام ربات خود هستید ، به دنبال آداپتور Hubot ما نباشید. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "آیا می خواهید نرم افزار و برنامه های دیگر را با Rocket.Chat ادغام کنید اما زمان لازم برای انجام این کار را ندارید؟ ما پیشنهاد می کنیم از Zapier استفاده کنید که ما به طور کامل آن را پشتیبانی می کنیم. در  مورد اسناد ما بیشتر بخوانید. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "آیا می خواهید نرم افزار و برنامه های دیگر را با Rocket.Chat ادغام کنید اما زمان لازم برای انجام این کار را ندارید؟ ما پیشنهاد می کنیم از Zapier استفاده کنید که ما به طور کامل آن را پشتیبانی می کنیم. در  مورد اسناد ما بیشتر بخوانید. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "ادمین شما رمزگذاری E2E را فعال نکرده.",
   "Admin_Info": "اطلاعات مدیریت",
   "Administration": "مدیریت",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/fi.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/fi.i18n.json
@@ -216,7 +216,7 @@
   "Additional_emails": "Lisäsähköpostit",
   "Additional_Feedback": "Lisäpalaute",
   "additional_integrations_Bots": "Jos etsit oman bottien integrointia, katso sitten Hubot-sovitinta. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Haluatko integroida muita ohjelmia ja sovelluksia Rocket.Chatin kanssa, mutta sinulla ei ole aikaa tehdä sitä manuaalisesti? Sitten suosittelemme Zapierin käyttöä, jota kannatamme täysin. Lue lisää dokumentaatiosta. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Haluatko integroida muita ohjelmia ja sovelluksia Rocket.Chatin kanssa, mutta sinulla ei ole aikaa tehdä sitä manuaalisesti? Sitten suosittelemme Zapierin käyttöä, jota kannatamme täysin. Lue lisää dokumentaatiosta. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_Info": "Järjestelmänvalvojan tiedot",
   "Administration": "Ylläpito",
   "Adult_images_are_not_allowed": "Aikuisten kuvat eivät ole sallittuja",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/fr.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/fr.i18n.json
@@ -294,7 +294,7 @@
   "Additional_emails": "Adresses e-mail supplémentaires",
   "Additional_Feedback": "Commentaires supplémentaires",
   "additional_integrations_Bots": "Si vous cherchez à intégrer votre propre bot, alors ne cherchez pas plus loin que notre adaptateur Hubot. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Vous voulez intégrer d'autres logiciels et applications avec Rocket.Chat mais vous n'avez pas le temps de le faire manuellement ? Nous vous suggérons d'utiliser Zapier, que nous prenons entièrement en charge. Consultez notre documentation pour en savoir plus. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Vous voulez intégrer d'autres logiciels et applications avec Rocket.Chat mais vous n'avez pas le temps de le faire manuellement ? Nous vous suggérons d'utiliser Zapier, que nous prenons entièrement en charge. Consultez notre documentation pour en savoir plus. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "Votre administrateur n'a pas activé le chiffrement de bout en bout (E2E).",
   "Admin_Info": "Infos admin.",
   "Administration": "Administration",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/hr.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/hr.i18n.json
@@ -225,7 +225,7 @@
   "Additional_emails": "Dodatni Emailovi",
   "Additional_Feedback": "Dodatne povratne informacije",
   "additional_integrations_Bots": "Ako tražite kako integrirati svoj bot, nemojte gledati dalje od našeg Hubot adaptera. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Tražite li integrirati drugi softver i aplikacije s Rocket.Chat, ali nemate vremena za ručno raditi? Onda predlažemo da koristite Zapier koji u potpunosti podržavamo. Pročitajte više o našoj dokumentaciji. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Tražite li integrirati drugi softver i aplikacije s Rocket.Chat, ali nemate vremena za ručno raditi? Onda predlažemo da koristite Zapier koji u potpunosti podržavamo. Pročitajte više o našoj dokumentaciji. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "Vaš administrator nije omogućio E2E šifriranje.",
   "Admin_Info": "Informacije o administratoru",
   "Administration": "Administracija",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/hu.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/hu.i18n.json
@@ -278,7 +278,7 @@
   "Additional_emails": "További e-mail-címek",
   "Additional_Feedback": "További visszajelzés",
   "additional_integrations_Bots": "Ha azt keresi, hogy saját botokat hogyan lehet integrálni, akkor ne keresse tovább, hanem nézze meg a Hubot adapterünket: <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Szeretne más szoftvereket és alkalmazásokat integrálni a Rocket.Chat programmal, de nincs ideje kézzel megcsinálni? Akkor a Zapier használatát javasoljuk, amelyet teljes mértékben támogatunk. Tudjon meg többet róla a dokumentációnkból: <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Szeretne más szoftvereket és alkalmazásokat integrálni a Rocket.Chat programmal, de nincs ideje kézzel megcsinálni? Akkor a Zapier használatát javasoljuk, amelyet teljes mértékben támogatunk. Tudjon meg többet róla a dokumentációnkból: <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "Az adminisztrátor nem engedélyezte a végpontok közötti titkosítást.",
   "Admin_Info": "Adminisztrátor információk",
   "Administration": "Adminisztráció",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/id.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/id.i18n.json
@@ -216,7 +216,7 @@
   "Additional_emails": "Email tambahan",
   "Additional_Feedback": "tambahan Masukan",
   "additional_integrations_Bots": "Jika Anda mencari cara mengintegrasikan bot Anda sendiri, maka tidak perlu mencari lebih jauh dari adaptor Hubot kami. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Apakah Anda ingin mengintegrasikan perangkat lunak dan aplikasi lain dengan Rocket.Chat tetapi Anda tidak punya waktu untuk melakukannya secara manual? Kemudian kami sarankan menggunakan Zapier yang kami dukung sepenuhnya. Baca lebih lanjut tentang itu di dokumentasi kami. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations / zapier / menggunakan-zaps /</a>",
+  "additional_integrations_Zapier": "Apakah Anda ingin mengintegrasikan perangkat lunak dan aplikasi lain dengan Rocket.Chat tetapi Anda tidak punya waktu untuk melakukannya secara manual? Kemudian kami sarankan menggunakan Zapier yang kami dukung sepenuhnya. Baca lebih lanjut tentang itu di dokumentasi kami. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations / zapier / menggunakan-zaps /</a>",
   "Admin_Info": "Info Admin",
   "Administration": "Administrasi",
   "Adult_images_are_not_allowed": "Gambar dewasa tidak diperbolehkan",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/it.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/it.i18n.json
@@ -225,7 +225,7 @@
   "Additional_emails": "Email aggiuntive",
   "Additional_Feedback": "Feedback aggiuntivo",
   "additional_integrations_Bots": "Se stai cercando come integrare il tuo bot, non cercare oltre il nostro adattatore Hubot. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Stai cercando di integrare altri software e applicazioni con Rocket.Chat ma non hai il tempo di farlo manualmente? Quindi ti suggeriamo di utilizzare Zapier che supportiamo pienamente. Leggi di più sulla nostra documentazione. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Stai cercando di integrare altri software e applicazioni con Rocket.Chat ma non hai il tempo di farlo manualmente? Quindi ti suggeriamo di utilizzare Zapier che supportiamo pienamente. Leggi di più sulla nostra documentazione. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "Il tuo amministratotre non ha abilitato la criptazione E2E",
   "Admin_Info": "Informazioni di amministrazione",
   "Administration": "Amministrazione",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/ja.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/ja.i18n.json
@@ -293,7 +293,7 @@
   "Additional_emails": "追加のメールアドレス",
   "Additional_Feedback": "その他のフィードバック",
   "additional_integrations_Bots": "自前のボットを統合する方法をお探しの場合は、当社のHubotアダプターをご使用ください。<a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "他のソフトウェアやアプリケーションをRocket.Chatと統合しようとしていますが、手作業で行う時間がない場合は、当社が完全にサポートしているZapierを使用することをお勧めします。詳細については、ドキュメントを参照してください。 <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "他のソフトウェアやアプリケーションをRocket.Chatと統合しようとしていますが、手作業で行う時間がない場合は、当社が完全にサポートしているZapierを使用することをお勧めします。詳細については、ドキュメントを参照してください。 <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "管理者はE2E暗号化を有効にしていません。",
   "Admin_Info": "管理者情報",
   "Administration": "管理",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/ka-GE.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/ka-GE.i18n.json
@@ -263,7 +263,7 @@
   "Additional_emails": "დამატებითი ელ.ფოსტები",
   "Additional_Feedback": "დამატებითი უკუკავშირი",
   "additional_integrations_Bots": "თუ თქვენ ეძებთ თუ როგორ ჩაამატოთ თქვენი საკუთარი ბოტი, მაშინ ნახეთ ჩვენი ჰაბოტ გადამყვანი. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\"> https://github.com/RocketChat/hubot-rocketchat </a>",
-  "additional_integrations_Zapier": "გსურთ სხვა პროგრამული უზრუნველყოფისა და პროგრამების Rocket.Chat– ში ინტეგრაცია, მაგრამ ამის ხელით სკეთებლად დრო არ გაქვთ?  ჩვენ გთავაზობთ Zapier გამოყენებას, რომელსაც ჩვენ სრულად ვუჭერთ მხარს. დაწვრილებით ამის შესახებ ჩვენს დოკუმენტაციაზე წაიკითხეთ. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\"> https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/ </a>",
+  "additional_integrations_Zapier": "გსურთ სხვა პროგრამული უზრუნველყოფისა და პროგრამების Rocket.Chat– ში ინტეგრაცია, მაგრამ ამის ხელით სკეთებლად დრო არ გაქვთ?  ჩვენ გთავაზობთ Zapier გამოყენებას, რომელსაც ჩვენ სრულად ვუჭერთ მხარს. დაწვრილებით ამის შესახებ ჩვენს დოკუმენტაციაზე წაიკითხეთ. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\"> https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/ </a>",
   "Admin_disabled_encryption": "თქვენს ადმინისტრატორს არ გაუაქტიურებია E2E დაშიფვრა.",
   "Admin_Info": "ადმინისტრატორის ინფორმაცია",
   "Administration": "ადმინისტრაცია",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/km.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/km.i18n.json
@@ -246,7 +246,7 @@
   "Additional_emails": "បន្ថែមអ៊ីមែល",
   "Additional_Feedback": "មតិបន្ថែម",
   "additional_integrations_Bots": "ប្រសិនបើអ្នកកំពុងស្វែងរកវិធីបញ្ចូលប៊ិចផ្ទាល់ខ្លួនរបស់អ្នកនោះអ្នកនឹងរកមើលបន្ថែមទៀតមិនមែនអាដាប់ធ័រ Hubot របស់យើងទេ។ <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "តើអ្នកកំពុងសម្លឹងរកមើលការរួមបញ្ចូលកម្មវិធីនិងកម្មវិធីផ្សេងៗជាមួយ Rocket.Chat ប៉ុន្តែអ្នកមិនមានពេលធ្វើដោយដៃទេ? បន្ទាប់យើងស្នើឱ្យប្រើ Zapier ដែលយើងគាំទ្រយ៉ាងពេញទំហឹង។ អានបន្ថែមអំពីវានៅលើឯកសាររបស់យើង។ <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "តើអ្នកកំពុងសម្លឹងរកមើលការរួមបញ្ចូលកម្មវិធីនិងកម្មវិធីផ្សេងៗជាមួយ Rocket.Chat ប៉ុន្តែអ្នកមិនមានពេលធ្វើដោយដៃទេ? បន្ទាប់យើងស្នើឱ្យប្រើ Zapier ដែលយើងគាំទ្រយ៉ាងពេញទំហឹង។ អានបន្ថែមអំពីវានៅលើឯកសាររបស់យើង។ <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "អ្នកគ្រប់គ្រងមិនបានបើកដំណើរការ ការបំលែងកូដ E2E។",
   "Admin_Info": "ព័ត៌មានអ្នកគ្រប់គ្រង",
   "Administration": "រដ្ឋបាល",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/ko.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/ko.i18n.json
@@ -281,7 +281,7 @@
   "Additional_emails": "추가 이메일",
   "Additional_Feedback": "추가 의견",
   "additional_integrations_Bots": "직접 만든 봇을 통합하는 방법을 찾고 있다면 Hubot 어댑터를 사용해보세요. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "다른 소프트웨어 및 응용 프로그램을 Rocket.Chat과 통합하려고하지만 수동으로 수행 할 시간이 없습니까? 우리가 완전히 지원하는 Zapier를 사용하는 것이 좋습니다. 자세한 내용은 설명서를 참조하십시오. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "다른 소프트웨어 및 응용 프로그램을 Rocket.Chat과 통합하려고하지만 수동으로 수행 할 시간이 없습니까? 우리가 완전히 지원하는 Zapier를 사용하는 것이 좋습니다. 자세한 내용은 설명서를 참조하십시오. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "관리자가 E2E 암호화를 활성화하지 않았습니다.",
   "Admin_Info": "관리자 정보",
   "Administration": "관리",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/ku.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/ku.i18n.json
@@ -216,7 +216,7 @@
   "Additional_emails": "Additional E-mailên",
   "Additional_Feedback": "Feedback Additional",
   "additional_integrations_Bots": "Ger hûn li benda ku hûn çawa botê xwe bine hevgirtin, lê hingê bila adapterê Hubot nabînin. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</A>",
-  "additional_integrations_Zapier": "Ma hûn li benda ku hûn bi Rocket re hevpeymanên din re bicih bikin. Lê belê wextê we ne ku mirov bixwe bikî? Piştre em bi karanîna Zapierê dikin ku em bi tevahî piştgirî dikin. Di derbarê belgeyên me de bêtir bixwînin. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations / zapier / bikaranîna zaps /</A>",
+  "additional_integrations_Zapier": "Ma hûn li benda ku hûn bi Rocket re hevpeymanên din re bicih bikin. Lê belê wextê we ne ku mirov bixwe bikî? Piştre em bi karanîna Zapierê dikin ku em bi tevahî piştgirî dikin. Di derbarê belgeyên me de bêtir bixwînin. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations / zapier / bikaranîna zaps /</A>",
   "Admin_Info": "Agahdariya Rêveberiyê",
   "Administration": "Birêvebirî",
   "Adult_images_are_not_allowed": "Wêneyên mezin têne destûr kirin",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/lo.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/lo.i18n.json
@@ -227,7 +227,7 @@
   "Additional_emails": "ອີເມລເພີ່ມເຕີມ",
   "Additional_Feedback": "ຜົນຕອບຮັບເພີ່ມເຕີມ",
   "additional_integrations_Bots": "ຖ້າທ່ານກໍາລັງຊອກຫາວິທີການບູລະນາການຂອງຕົນເອງ, ຫຼັງຈາກນັ້ນເບິ່ງບໍ່ມີຫຍັງອີກຕໍ່ໄປກ່ວາຕົວປ່ຽນ Hubot ຂອງພວກເຮົາ. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "ທ່ານກໍາລັງຊອກຫາການເຊື່ອມໂຍງກັບຊອບແວແລະແອັບພລິເຄຊັນອື່ນໆທີ່ມີ RocketChat ແຕ່ທ່ານບໍ່ມີເວລາທີ່ຈະເຮັດມັນດ້ວຍຕົນເອງບໍ? ຫຼັງຈາກນັ້ນ, ພວກເຮົາແນະນໍາໃຫ້ນໍາໃຊ້ Zapier ທີ່ພວກເຮົາສະຫນັບສະຫນູນຢ່າງເຕັມສ່ວນ. ອ່ານເພີ່ມເຕີມກ່ຽວກັບເອກະສານຂອງພວກເຮົາ. <a href='https: //rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps /' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "ທ່ານກໍາລັງຊອກຫາການເຊື່ອມໂຍງກັບຊອບແວແລະແອັບພລິເຄຊັນອື່ນໆທີ່ມີ RocketChat ແຕ່ທ່ານບໍ່ມີເວລາທີ່ຈະເຮັດມັນດ້ວຍຕົນເອງບໍ? ຫຼັງຈາກນັ້ນ, ພວກເຮົາແນະນໍາໃຫ້ນໍາໃຊ້ Zapier ທີ່ພວກເຮົາສະຫນັບສະຫນູນຢ່າງເຕັມສ່ວນ. ອ່ານເພີ່ມເຕີມກ່ຽວກັບເອກະສານຂອງພວກເຮົາ. <a href='https: //rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps /' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_Info": "Admin Info",
   "Administration": "ການບໍລິຫານ",
   "Adult_images_are_not_allowed": "ຮູບພາບຜູ້ໃຫຍ່ບໍ່ໄດ້ອະນຸຍາດໃຫ້",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/lt.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/lt.i18n.json
@@ -248,7 +248,7 @@
   "Additional_emails": "Papildomi el. Laiškai",
   "Additional_Feedback": "Papildoma nuomonė",
   "additional_integrations_Bots": "Jei ieškote, kaip integruoti savo robotą, tada atrodykite ne toliau, kaip mūsų Hubot adapteris. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Ar norite integruoti kitą programinę įrangą ir programas su \"Rocket.Chat\", bet jūs neturite laiko rankiniu būdu tai padaryti? Tada mes rekomenduojame naudoti \"Zapier\", kurį mes visiškai palaikome. Skaitykite daugiau apie tai mūsų dokumentuose. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Ar norite integruoti kitą programinę įrangą ir programas su \"Rocket.Chat\", bet jūs neturite laiko rankiniu būdu tai padaryti? Tada mes rekomenduojame naudoti \"Zapier\", kurį mes visiškai palaikome. Skaitykite daugiau apie tai mūsų dokumentuose. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_Info": "Administratoriaus informacija",
   "Administration": "Administracija",
   "Adult_images_are_not_allowed": "Suaugusieji vaizdai neleidžiami",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/lv.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/lv.i18n.json
@@ -220,7 +220,7 @@
   "Additional_emails": "Papildu e-pasta ziņojumi",
   "Additional_Feedback": "Papildu atsauksmes",
   "additional_integrations_Bots": "Ja Jūs meklējat, kā integrēt savu botu, tad varat nemeklēt tālāk par mūsu Hubot adapteri. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\"> https://github.com/RocketChat/hubot-rocketchat </a>",
-  "additional_integrations_Zapier": "Vai Jūs vēlaties integrēt citu programmatūru un lietotnes ar Rocket.Chat, bet jums nav laika to izdarīt manuāli? Tad mēs iesakām izmantot Zapier, kuru mēs pilnībā atbalstām. Uzziniet vairāk par to mūsu dokumentācijā. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\"> https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Vai Jūs vēlaties integrēt citu programmatūru un lietotnes ar Rocket.Chat, bet jums nav laika to izdarīt manuāli? Tad mēs iesakām izmantot Zapier, kuru mēs pilnībā atbalstām. Uzziniet vairāk par to mūsu dokumentācijā. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\"> https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_Info": "Aministratora info",
   "Administration": "Administrācija",
   "Adult_images_are_not_allowed": "Pieauguša satura attēli nav atļauti",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/ms-MY.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/ms-MY.i18n.json
@@ -214,7 +214,7 @@
   "Additional_emails": "Tambahan E-mel",
   "Additional_Feedback": "Maklum balas tambahan",
   "additional_integrations_Bots": "Sekiranya anda sedang mencari cara mengintegrasikan bot anda sendiri, maka jangan lagi melihat penyesuai Hubot kami. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Adakah anda ingin mengintegrasikan perisian dan aplikasi lain dengan Rocket.Chat tetapi anda tidak mempunyai masa untuk melakukannya secara manual? Kemudian kami cadangkan menggunakan Zapier yang kami menyokong sepenuhnya. Baca lebih lanjut mengenai dokumentasi kami. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations / zapier / menggunakan-zaps /</a>",
+  "additional_integrations_Zapier": "Adakah anda ingin mengintegrasikan perisian dan aplikasi lain dengan Rocket.Chat tetapi anda tidak mempunyai masa untuk melakukannya secara manual? Kemudian kami cadangkan menggunakan Zapier yang kami menyokong sepenuhnya. Baca lebih lanjut mengenai dokumentasi kami. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations / zapier / menggunakan-zaps /</a>",
   "Admin_Info": "Maklumat Admin",
   "Administration": "Pentadbiran",
   "Adult_images_are_not_allowed": "Imej dewasa tidak dibenarkan",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/nl.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/nl.i18n.json
@@ -294,7 +294,7 @@
   "Additional_emails": "Extra e-mails",
   "Additional_Feedback": "Extra feedback",
   "additional_integrations_Bots": "Als je op zoek bent naar het integreren van je eigen bot, zoek dan niet verder dan onze Hubot-adapter. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Wilt u andere software en applicaties integreren met Rocket.Chat, maar heeft u geen tijd om het handmatig te doen? Dan stellen we voor om Zapier te gebruiken die we volledig ondersteunen. Lees er meer over in onze documentatie. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Wilt u andere software en applicaties integreren met Rocket.Chat, maar heeft u geen tijd om het handmatig te doen? Dan stellen we voor om Zapier te gebruiken die we volledig ondersteunen. Lees er meer over in onze documentatie. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "Uw beheerder heeft E2E-codering niet ingeschakeld.",
   "Admin_Info": "Admin info",
   "Administration": "Administratie",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/no.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/no.i18n.json
@@ -250,7 +250,7 @@
   "Additional_emails": "Ekstra e-postadresser",
   "Additional_Feedback": "Ekstra tilbakemelding",
   "additional_integrations_Bots": "Hvis du leter etter hvordan du integrerer din egen bot, så se ikke lenger enn vår Hubot-adapter. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Ser du etter å integrere annen programvare og applikasjoner med Rocket.Chat, men du har ikke tid til å manuelt gjøre det? Da foreslår vi å bruke Zapier som vi støtter fullt ut. Les mer om det på vår dokumentasjon. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Ser du etter å integrere annen programvare og applikasjoner med Rocket.Chat, men du har ikke tid til å manuelt gjøre det? Da foreslår vi å bruke Zapier som vi støtter fullt ut. Les mer om det på vår dokumentasjon. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "Din administrator har ikke aktivert ende-til-ende kryptering.",
   "Admin_Info": "Admin Info",
   "Administration": "Administrasjon",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/pl.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/pl.i18n.json
@@ -293,7 +293,7 @@
   "Additional_emails": "Dodatkowe adresy e-mail",
   "Additional_Feedback": "Dodatkowy komentarz",
   "additional_integrations_Bots": "Jeśli szukasz sposobu na zintegrowanie własnego bota, nie szukaj dalej niż nasz adapter Hubota. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Czy chcesz zintegrować inne oprogramowanie i aplikacje z Rocket.Chat, ale nie masz czasu, aby zrobić to ręcznie? Proponujemy użycie narzędzia Zapier, które w pełni obsługujemy. Przeczytaj więcej na ten temat w naszej dokumentacji. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Czy chcesz zintegrować inne oprogramowanie i aplikacje z Rocket.Chat, ale nie masz czasu, aby zrobić to ręcznie? Proponujemy użycie narzędzia Zapier, które w pełni obsługujemy. Przeczytaj więcej na ten temat w naszej dokumentacji. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "Administrator nie włączył szyfrowania E2E",
   "Admin_Info": "Informacje administracyjne",
   "Administration": "Administracja",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/pt-BR.i18n.json
@@ -294,7 +294,7 @@
   "Additional_emails": "E-mails adicionais",
   "Additional_Feedback": "Comentários Adicionais",
   "additional_integrations_Bots": "Se você está procurando como integrar seu próprio bot, então não procure além de nosso adaptador Hubot. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat </a>",
-  "additional_integrations_Zapier": "Está procurando a integração de outros softwares e aplicações com o Rocket.Chat, mas não tem tempo para o fazer manualmente? Sugerimos usar o Zapier, que apoiamos totalmente. Leia mais sobre isto na nossa documentação. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/ </a>",
+  "additional_integrations_Zapier": "Está procurando a integração de outros softwares e aplicações com o Rocket.Chat, mas não tem tempo para o fazer manualmente? Sugerimos usar o Zapier, que apoiamos totalmente. Leia mais sobre isto na nossa documentação. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/ </a>",
   "Admin_disabled_encryption": "Seu administrador não ativou a criptografia E2E.",
   "Admin_Info": "Informação de administração",
   "Administration": "Administração",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/pt.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/pt.i18n.json
@@ -251,7 +251,7 @@
   "Additional_emails": "E-mails adicionais",
   "Additional_Feedback": "Comentários Adicionais",
   "additional_integrations_Bots": "Está a procurar integrar integrar seu próprio bot, então não procure mais do que o nosso adaptador Hubot. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat </a>",
-  "additional_integrations_Zapier": "Está a procurar integrar outros softwares e aplicações com o Rocket.Chat, mas não tem tempo para o fazer manualmente? Sugerimos usar o Zapier, que apoiamos totalmente. Leia mais sobre isto na nossa documentação. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/ </a>",
+  "additional_integrations_Zapier": "Está a procurar integrar outros softwares e aplicações com o Rocket.Chat, mas não tem tempo para o fazer manualmente? Sugerimos usar o Zapier, que apoiamos totalmente. Leia mais sobre isto na nossa documentação. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/ </a>",
   "Admin_disabled_encryption": "Seu administrador não ativou a criptografia E2E.",
   "Admin_Info": "Informação de administração",
   "Administration": "Administração",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/ro.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/ro.i18n.json
@@ -216,7 +216,7 @@
   "Additional_emails": "E-mail-uri suplimentare",
   "Additional_Feedback": "Feedback suplimentar",
   "additional_integrations_Bots": "Dacă sunteți în căutarea pentru modul în care să vă integrați propriul bot, atunci nu căutați mai departe decât adaptorul nostru Hubot. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Încercați să integrați alte aplicații și aplicații cu Rocket.Chat, dar nu aveți timp să faceți acest lucru manual? Apoi vă sugerăm să utilizați Zapier pe care îl susținem pe deplin. Citiți mai multe despre documentația noastră. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Încercați să integrați alte aplicații și aplicații cu Rocket.Chat, dar nu aveți timp să faceți acest lucru manual? Apoi vă sugerăm să utilizați Zapier pe care îl susținem pe deplin. Citiți mai multe despre documentația noastră. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_Info": "Admin Info",
   "Administration": "Administrare",
   "Adult_images_are_not_allowed": "Imaginile adulte nu sunt permise",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/ru.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/ru.i18n.json
@@ -294,7 +294,7 @@
   "Additional_emails": "Дополнительные адреса электронной почты",
   "Additional_Feedback": "Дополнительная обратная связь",
   "additional_integrations_Bots": "Если вы ищете, как интегрировать собственного бота, посмотрите наш адаптер Hubot. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Вы хотите интегрировать другое программное обеспечение или приложения с Rocket.Chat, но у вас нет времени, чтобы сделать это вручную? Мы предлагаем вам использовать Zapier, который мы полностью поддерживаем. Подробнее об этом читайте в нашей документации. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/ </a>",
+  "additional_integrations_Zapier": "Вы хотите интегрировать другое программное обеспечение или приложения с Rocket.Chat, но у вас нет времени, чтобы сделать это вручную? Мы предлагаем вам использовать Zapier, который мы полностью поддерживаем. Подробнее об этом читайте в нашей документации. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/ </a>",
   "Admin_disabled_encryption": "Ваш администратор не включил шифрование E2E.",
   "Admin_Info": "Информация Администратора",
   "Administration": "Администрирование",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/sk-SK.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/sk-SK.i18n.json
@@ -219,7 +219,7 @@
   "Additional_emails": "Ďalšie e-maily",
   "Additional_Feedback": "Ďalšia spätná väzba",
   "additional_integrations_Bots": "Ak hľadáte spôsob, ako integrovať svojho vlastného bota, potom nehľadajte nič iné než náš adaptér Hubot. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\"> https://github.com/RocketChat/hubot-rocketchat </a>",
-  "additional_integrations_Zapier": "Hľadáte integráciu iného softvéru a aplikácií s Rocket.Chat, ale nemáte čas to manuálne zariadiť? V takom prípade odporúčame použiť Zapier, ktorý plne podporujeme. Prečítajte si viac o ňom v našej dokumentácii. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Hľadáte integráciu iného softvéru a aplikácií s Rocket.Chat, ale nemáte čas to manuálne zariadiť? V takom prípade odporúčame použiť Zapier, ktorý plne podporujeme. Prečítajte si viac o ňom v našej dokumentácii. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_Info": "Informácia o Adminovi",
   "Administration": "Administrácia",
   "Adult_images_are_not_allowed": "Obrázky pre dospelých nie sú povolené",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/sq.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/sq.i18n.json
@@ -216,7 +216,7 @@
   "Additional_emails": "Shtesë E-mail",
   "Additional_Feedback": "Feedback shtesë",
   "additional_integrations_Bots": "Nëse jeni duke kërkuar për integrimin e botit tuaj, atëherë shikoni më tej se adaptori ynë Hubot. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "A jeni duke kërkuar për të integruar programe dhe aplikacione të tjera me Rocket.Chat, por ju nuk keni kohë për ta bërë atë manualisht? Pastaj ne sugjerojmë përdorimin e Zapier të cilën e mbështesim plotësisht. Lexoni më shumë në lidhje me dokumentacionin tonë. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "A jeni duke kërkuar për të integruar programe dhe aplikacione të tjera me Rocket.Chat, por ju nuk keni kohë për ta bërë atë manualisht? Pastaj ne sugjerojmë përdorimin e Zapier të cilën e mbështesim plotësisht. Lexoni më shumë në lidhje me dokumentacionin tonë. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_Info": "Info Admin",
   "Administration": "administratë",
   "Adult_images_are_not_allowed": "Imazhet e të rriturve nuk lejohen",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/sv.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/sv.i18n.json
@@ -234,7 +234,7 @@
   "Additional_emails": "Ytterligare e-post",
   "Additional_Feedback": "Ytterligare feedback",
   "additional_integrations_Bots": "Om du letar efter hur du integrerar din egen bot, kika på vår Hubot-adapter. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Vill du integrera andra program och applikationer med Rocket.Chat, men du har inte tid att göra det för hand? Då föreslår vi att du använder Zapier som har fullt stöd. Läs mer om det i dokumentationen. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Vill du integrera andra program och applikationer med Rocket.Chat, men du har inte tid att göra det för hand? Då föreslår vi att du använder Zapier som har fullt stöd. Läs mer om det i dokumentationen. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "Administratören har inte aktiverat E2E-kryptering.",
   "Admin_Info": "Admin Info",
   "Administration": "Administrering",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/ta-IN.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/ta-IN.i18n.json
@@ -216,7 +216,7 @@
   "Additional_emails": "கூடுதல் மின் அஞ்சல்",
   "Additional_Feedback": "கூடுதல் கருத்துத்",
   "additional_integrations_Bots": "உங்கள் சொந்த பாட்டை ஒருங்கிணைக்க எப்படி தேடுகிறீர்கள் எனில், எங்கள் Hubot adapter ஐப் பார்க்க வேண்டாம். <a href='https://github.com/RocketChat/hubot-rocketchat' இலக்கு = '_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "நீங்கள் Rocket.Chat மற்ற மென்பொருள் மற்றும் பயன்பாடுகள் ஒருங்கிணைக்க பார்க்கிறாய் ஆனால் நீங்கள் கைமுறையாக அதை செய்ய நேரம் இல்லை? பின்னர் நாம் முழுமையாக ஆதரிக்கும் Zapier ஐப் பரிந்துரைக்கிறோம். எங்கள் ஆவணத்தில் அதைப் பற்றி மேலும் அறியவும். <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' இலக்கு = '_blank'>https://rocket.chat/docs/administrator-guides/integrations / ஜாப்பியர் / யூஸ்-ஜாப்ஸ் /</a>",
+  "additional_integrations_Zapier": "நீங்கள் Rocket.Chat மற்ற மென்பொருள் மற்றும் பயன்பாடுகள் ஒருங்கிணைக்க பார்க்கிறாய் ஆனால் நீங்கள் கைமுறையாக அதை செய்ய நேரம் இல்லை? பின்னர் நாம் முழுமையாக ஆதரிக்கும் Zapier ஐப் பரிந்துரைக்கிறோம். எங்கள் ஆவணத்தில் அதைப் பற்றி மேலும் அறியவும். <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' இலக்கு = '_blank'>https://rocket.chat/docs/administrator-guides/integrations / ஜாப்பியர் / யூஸ்-ஜாப்ஸ் /</a>",
   "Admin_Info": "நிர்வாகம் தகவல்",
   "Administration": "நிர்வாகம்",
   "Adult_images_are_not_allowed": "வயது வந்தோருக்கான படங்கள் அனுமதிக்கப்படவில்லை",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/th-TH.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/th-TH.i18n.json
@@ -215,7 +215,7 @@
   "Additional_emails": "อีเมลเพิ่มเติม",
   "Additional_Feedback": "ข้อเสนอแนะเพิ่มเติม",
   "additional_integrations_Bots": "หากคุณกำลังมองหาวิธีการรวมบอทของคุณเองออกไปให้ดูที่ Hubot adapter ของเรา <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "คุณต้องการผสานรวมซอฟต์แวร์และแอพพลิเคชันอื่นเข้ากับ Rocket.Chat แต่คุณไม่มีเวลาทำด้วยตนเองหรือไม่? จากนั้นเราขอแนะนำให้ใช้ Zapier ซึ่งเราสนับสนุนอย่างเต็มที่ อ่านเพิ่มเติมเกี่ยวกับเรื่องนี้ในเอกสารของเรา <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "คุณต้องการผสานรวมซอฟต์แวร์และแอพพลิเคชันอื่นเข้ากับ Rocket.Chat แต่คุณไม่มีเวลาทำด้วยตนเองหรือไม่? จากนั้นเราขอแนะนำให้ใช้ Zapier ซึ่งเราสนับสนุนอย่างเต็มที่ อ่านเพิ่มเติมเกี่ยวกับเรื่องนี้ในเอกสารของเรา <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_Info": "ข้อมูลผู้ดูแลระบบ",
   "Administration": "การบริหาร",
   "Adult_images_are_not_allowed": "ภาพผู้ใหญ่ไม่ได้รับอนุญาต",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/tr.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/tr.i18n.json
@@ -240,7 +240,7 @@
   "Additional_emails": "Ek E-postalar",
   "Additional_Feedback": "Ek Geri Bildirim",
   "additional_integrations_Bots": "Kendi botunuzu nasıl entegre edeceğinizi arıyorsanız, o zaman Hubot adaptörümüzden başka bir yere bakmayın. <a href='https://github.com/RocketChat/hubot-rocketchat' target='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Diğer yazılımları ve uygulamaları Rocket ile entegre etmek istiyor musunuz.Ancak, ancak bunu elle yapmak için zamanınız yok mu? Sonra tamamen desteklediğimiz Zapier'i kullanmanızı öneririz. Dokümanlarımızda daha fazla bilgi edinin. <a href='https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/' target='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Diğer yazılımları ve uygulamaları Rocket ile entegre etmek istiyor musunuz.Ancak, ancak bunu elle yapmak için zamanınız yok mu? Sonra tamamen desteklediğimiz Zapier'i kullanmanızı öneririz. Dokümanlarımızda daha fazla bilgi edinin. <a href='https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/' target='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "Yöneticiniz uçtan uca şifrelemeyi devre dışı bıraktı.",
   "Admin_Info": "Yönetici Bilgisi",
   "Administration": "Yönetim",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/uk.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/uk.i18n.json
@@ -272,7 +272,7 @@
   "Additional_emails": "Додаткові електронні адреси",
   "Additional_Feedback": "Додатковий зворотній зв'язок",
   "additional_integrations_Bots": "Якщо ви шукаєте, як інтегрувати свій власний бот, то шукайте не більше, ніж наш адаптер Hubot. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Ви хочете інтегрувати інше програмне забезпечення та програми з Rocket.Chat, але у вас немає часу вручну зробити це? Тоді ми пропонуємо використовувати Zapier, який ми повністю підтримуємо. Докладніше про це читайте в нашій документації. <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "Ви хочете інтегрувати інше програмне забезпечення та програми з Rocket.Chat, але у вас немає часу вручну зробити це? Тоді ми пропонуємо використовувати Zapier, який ми повністю підтримуємо. Докладніше про це читайте в нашій документації. <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "Ваш адміністратор не ввімкнув шифрування E2E.",
   "Admin_Info": "Інформація адміністратора",
   "Administration": "Адміністрування",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/vi-VN.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/vi-VN.i18n.json
@@ -269,7 +269,7 @@
   "Additional_emails": "Email bổ sung",
   "Additional_Feedback": "Phản hồi bổ sung",
   "additional_integrations_Bots": "Nếu bạn đang tìm cách để tích hợp Bot của riêng bạn vậy thì bạn nên xem qua phần Hubot adapter. <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "Có phải bạn đang tìm cách tích hợp các phần mềm và ứng dụng khác vào Rocket.Chat nhưng lại không có thời gian để tự tay thực hiện nó? Nếu đúng như thế, chúng tôi nghĩ bạn nên sử dụng một công cụ được chúng tôi hỗ trợ đó là Zapier. Bạn có thể đọc thêm về Zapier ở đây <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\"></a>",
+  "additional_integrations_Zapier": "Có phải bạn đang tìm cách tích hợp các phần mềm và ứng dụng khác vào Rocket.Chat nhưng lại không có thời gian để tự tay thực hiện nó? Nếu đúng như thế, chúng tôi nghĩ bạn nên sử dụng một công cụ được chúng tôi hỗ trợ đó là Zapier. Bạn có thể đọc thêm về Zapier ở đây <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\"></a>",
   "Admin_disabled_encryption": "Quản trị viên của bạn không bật mã hóa E2E.",
   "Admin_Info": "Thông tin quản trị",
   "Administration": "Quản trị",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/zh-HK.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/zh-HK.i18n.json
@@ -229,7 +229,7 @@
   "Additional_emails": "其他电子邮件",
   "Additional_Feedback": "其他反馈",
   "additional_integrations_Bots": "如果你正在寻找如何整合你自己的机器人，那么看看我们的Hubot适配器。 <a href ='https：//github.com/RocketChat/hubot-rocketchat'target ='_blank'>https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "您是否希望将其他软件和应用程序与Rocket.Chat集成，但您没有时间手动完成它？那么我们建议使用我们完全支持的Zapier。请阅读我们的文档了解更多信息。 <a href ='https：//rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/'target ='_blank'>https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "您是否希望将其他软件和应用程序与Rocket.Chat集成，但您没有时间手动完成它？那么我们建议使用我们完全支持的Zapier。请阅读我们的文档了解更多信息。 <a href ='https：//rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/'target ='_blank'>https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_Info": "管理员信息",
   "Administration": "管理",
   "Adult_images_are_not_allowed": "成人图像是不允许的",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/zh-TW.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/zh-TW.i18n.json
@@ -293,7 +293,7 @@
   "Additional_emails": "其他電子郵件",
   "Additional_Feedback": "其他意見",
   "additional_integrations_Bots": "如果您正在尋找如何整合自己的機器人，那麼請選擇我們的Hubot介面。 <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat </a>",
-  "additional_integrations_Zapier": "您是否希望將其他軟體和應用程式與Rocket.Chat整合，但您沒有時間手動執行此動作？然後我們建議使用我們完全支援的Zapier。在我們的文件中閱讀更多相關訊息。 <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/ </a>",
+  "additional_integrations_Zapier": "您是否希望將其他軟體和應用程式與Rocket.Chat整合，但您沒有時間手動執行此動作？然後我們建議使用我們完全支援的Zapier。在我們的文件中閱讀更多相關訊息。 <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/ </a>",
   "Admin_disabled_encryption": "您的管理員無法啟用 E2E 加密。",
   "Admin_Info": "管理員訊息",
   "Administration": "管理",

--- a/apps/meteor/packages/rocketchat-i18n/i18n/zh.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/zh.i18n.json
@@ -276,7 +276,7 @@
   "Additional_emails": "其他 Email",
   "Additional_Feedback": "其他反馈",
   "additional_integrations_Bots": "如果你正在研究如何整合你自己的机器人，那么可以看看我们的 Hubot 适配器。 <a href=\"https://github.com/RocketChat/hubot-rocketchat\" target=\"_blank\">https://github.com/RocketChat/hubot-rocketchat</a>",
-  "additional_integrations_Zapier": "您是否希望将其他软件和应用程序与 Rocket.Chat 集成，但您没有时间手动完成？那么我们建议使用我们完全支持的 Zapier。请阅读我们的文档了解更多信息。 <a href=\"https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/\" target=\"_blank\">https://rocket.chat/docs/administrator-guides/integrations/zapier/using-zaps/</a>",
+  "additional_integrations_Zapier": "您是否希望将其他软件和应用程序与 Rocket.Chat 集成，但您没有时间手动完成？那么我们建议使用我们完全支持的 Zapier。请阅读我们的文档了解更多信息。 <a href=\"https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/\" target=\"_blank\">https://docs.rocket.chat/guides/administration/admin-panel/integrations/zapier/</a>",
   "Admin_disabled_encryption": "您的管理员并没有启用端到端加密",
   "Admin_Info": "管理员信息",
   "Administration": "管理",


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
the zapier link was pointing to the wrong URL and there was some loading external content that no longer works.

**BEFORE:**
![image](https://user-images.githubusercontent.com/1761174/179057330-31d3c55d-3fba-4029-bcb9-27a5b41cea81.png)

**AFTER**
![image](https://user-images.githubusercontent.com/1761174/179057427-3aa0b96c-766e-46db-9d35-ffb4c9270b08.png)