### PR TITLE
[FIX] Don't give errors on outbound voip call Request Terminated

### DIFF
--- a/apps/meteor/client/providers/CallProvider/CallProvider.tsx
+++ b/apps/meteor/client/providers/CallProvider/CallProvider.tsx
@@ -397,6 +397,8 @@ export const CallProvider: FC = ({ children }) => {
 				case 'Address Incomplete':
 					openDialModal({ errorMessage: t('Dialed_number_is_incomplete') });
 					break;
+				case 'Request Terminated':
+					break;
 				default:
 					openDialModal({ errorMessage: t('Something_went_wrong_try_again_later') });
 			}


### PR DESCRIPTION
In theory terminated requests should not throw an error since usually request terminated is a response to a `CANCEL` request. 