### PR TITLE
[FIX] The setting Accounts_DefaultUsernamePrefixSuggestion was not working

### DIFF
--- a/apps/meteor/app/lib/server/functions/getUsernameSuggestion.ts
+++ b/apps/meteor/app/lib/server/functions/getUsernameSuggestion.ts
@@ -59,14 +59,17 @@ export function generateUsernameSuggestion(user: Pick<IUser, 'name' | 'emails' |
 	}
 
 	usernames = usernames.filter((e) => e);
+	
+	const prefixSuggestion = settings.get('Accounts_DefaultUsernamePrefixSuggestion')
+	if(prefixSuggestion && user.name) {
+		usernames.unshift(prefixSuggestion+user.name);
+	}
 
 	for (const item of usernames) {
 		if (usernameIsAvailable(item)) {
 			return item;
 		}
 	}
-
-	usernames.push(settings.get('Accounts_DefaultUsernamePrefixSuggestion'));
 
 	let index = Users.find({ username: new RegExp(`^${usernames[0]}-[0-9]+`) }).count();
 	const username = '';


### PR DESCRIPTION

## Proposed changes (including videos or screenshots)
Dear RocketChat,

I noticed that this setting is not working according to the description in the documentation:

**Default username prefix suggestion**: This is the prefix that will be suggested when a user is creating a username. Default is `user`.
(https://docs.rocket.chat/guides/administration/admin-panel/settings/account-settings#registration)

There is no difference if you change the prefix suggestion, when registering a user what happens is that it suggests his name.

## Issue(s)

## Steps to test or reproduce
1. Set the "Default Username Prefix Suggestion"
2. Register a new account

## Further comments