### PR TITLE
Chore: Remove trash collection from models when not used

### DIFF
--- a/apps/meteor/server/models/Avatars.ts
+++ b/apps/meteor/server/models/Avatars.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { AvatarsRaw } from './raw/Avatars';
 
-registerModel('IAvatarsModel', new AvatarsRaw(db, trashCollection));
+registerModel('IAvatarsModel', new AvatarsRaw(db));

--- a/apps/meteor/server/models/Banners.ts
+++ b/apps/meteor/server/models/Banners.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { BannersRaw } from './raw/Banners';
 
-registerModel('IBannersModel', new BannersRaw(db, trashCollection));
+registerModel('IBannersModel', new BannersRaw(db));

--- a/apps/meteor/server/models/BannersDismiss.ts
+++ b/apps/meteor/server/models/BannersDismiss.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { BannersDismissRaw } from './raw/BannersDismiss';
 
-registerModel('IBannersDismissModel', new BannersDismissRaw(db, trashCollection));
+registerModel('IBannersDismissModel', new BannersDismissRaw(db));

--- a/apps/meteor/server/models/CredentialTokens.ts
+++ b/apps/meteor/server/models/CredentialTokens.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { CredentialTokensRaw } from './raw/CredentialTokens';
 
-registerModel('ICredentialTokensModel', new CredentialTokensRaw(db, trashCollection));
+registerModel('ICredentialTokensModel', new CredentialTokensRaw(db));

--- a/apps/meteor/server/models/CustomSounds.ts
+++ b/apps/meteor/server/models/CustomSounds.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { CustomSoundsRaw } from './raw/CustomSounds';
 
-registerModel('ICustomSoundsModel', new CustomSoundsRaw(db, trashCollection));
+registerModel('ICustomSoundsModel', new CustomSoundsRaw(db));

--- a/apps/meteor/server/models/CustomUserStatus.ts
+++ b/apps/meteor/server/models/CustomUserStatus.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { CustomUserStatusRaw } from './raw/CustomUserStatus';
 
-registerModel('ICustomUserStatusModel', new CustomUserStatusRaw(db, trashCollection));
+registerModel('ICustomUserStatusModel', new CustomUserStatusRaw(db));

--- a/apps/meteor/server/models/EmailInbox.ts
+++ b/apps/meteor/server/models/EmailInbox.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { EmailInboxRaw } from './raw/EmailInbox';
 
-registerModel('IEmailInboxModel', new EmailInboxRaw(db, trashCollection));
+registerModel('IEmailInboxModel', new EmailInboxRaw(db));

--- a/apps/meteor/server/models/EmailMessageHistory.ts
+++ b/apps/meteor/server/models/EmailMessageHistory.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { EmailMessageHistoryRaw } from './raw/EmailMessageHistory';
 
-registerModel('IEmailMessageHistoryModel', new EmailMessageHistoryRaw(db, trashCollection));
+registerModel('IEmailMessageHistoryModel', new EmailMessageHistoryRaw(db));

--- a/apps/meteor/server/models/ExportOperations.ts
+++ b/apps/meteor/server/models/ExportOperations.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { ExportOperationsRaw } from './raw/ExportOperations';
 
-registerModel('IExportOperationsModel', new ExportOperationsRaw(db, trashCollection));
+registerModel('IExportOperationsModel', new ExportOperationsRaw(db));

--- a/apps/meteor/server/models/FederationKeys.ts
+++ b/apps/meteor/server/models/FederationKeys.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { FederationKeysRaw } from './raw/FederationKeys';
 
-registerModel('IFederationKeysModel', new FederationKeysRaw(db, trashCollection));
+registerModel('IFederationKeysModel', new FederationKeysRaw(db));

--- a/apps/meteor/server/models/FederationServers.ts
+++ b/apps/meteor/server/models/FederationServers.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { FederationServersRaw } from './raw/FederationServers';
 
-registerModel('IFederationServersModel', new FederationServersRaw(db, trashCollection));
+registerModel('IFederationServersModel', new FederationServersRaw(db));

--- a/apps/meteor/server/models/ImportData.ts
+++ b/apps/meteor/server/models/ImportData.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { ImportDataRaw } from './raw/ImportData';
 
-registerModel('IImportDataModel', new ImportDataRaw(db, trashCollection));
+registerModel('IImportDataModel', new ImportDataRaw(db));

--- a/apps/meteor/server/models/Integrations.ts
+++ b/apps/meteor/server/models/Integrations.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { IntegrationsRaw } from './raw/Integrations';
 
-registerModel('IIntegrationsModel', new IntegrationsRaw(db, trashCollection));
+registerModel('IIntegrationsModel', new IntegrationsRaw(db));

--- a/apps/meteor/server/models/Invites.ts
+++ b/apps/meteor/server/models/Invites.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { InvitesRaw } from './raw/Invites';
 
-registerModel('IInvitesModel', new InvitesRaw(db, trashCollection));
+registerModel('IInvitesModel', new InvitesRaw(db));

--- a/apps/meteor/server/models/LivechatAgentActivity.ts
+++ b/apps/meteor/server/models/LivechatAgentActivity.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { LivechatAgentActivityRaw } from './raw/LivechatAgentActivity';
 
-registerModel('ILivechatAgentActivityModel', new LivechatAgentActivityRaw(db, trashCollection));
+registerModel('ILivechatAgentActivityModel', new LivechatAgentActivityRaw(db));

--- a/apps/meteor/server/models/LivechatBusinessHours.ts
+++ b/apps/meteor/server/models/LivechatBusinessHours.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { LivechatBusinessHoursRaw } from './raw/LivechatBusinessHours';
 
-registerModel('ILivechatBusinessHoursModel', new LivechatBusinessHoursRaw(db, trashCollection));
+registerModel('ILivechatBusinessHoursModel', new LivechatBusinessHoursRaw(db));

--- a/apps/meteor/server/models/LivechatCustomField.ts
+++ b/apps/meteor/server/models/LivechatCustomField.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { LivechatCustomFieldRaw } from './raw/LivechatCustomField';
 
-registerModel('ILivechatCustomFieldModel', new LivechatCustomFieldRaw(db, trashCollection));
+registerModel('ILivechatCustomFieldModel', new LivechatCustomFieldRaw(db));

--- a/apps/meteor/server/models/LivechatTrigger.ts
+++ b/apps/meteor/server/models/LivechatTrigger.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { LivechatTriggerRaw } from './raw/LivechatTrigger';
 
-registerModel('ILivechatTriggerModel', new LivechatTriggerRaw(db, trashCollection));
+registerModel('ILivechatTriggerModel', new LivechatTriggerRaw(db));

--- a/apps/meteor/server/models/LivechatVisitors.ts
+++ b/apps/meteor/server/models/LivechatVisitors.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { LivechatVisitorsRaw } from './raw/LivechatVisitors';
 
-registerModel('ILivechatVisitorsModel', new LivechatVisitorsRaw(db, trashCollection));
+registerModel('ILivechatVisitorsModel', new LivechatVisitorsRaw(db));

--- a/apps/meteor/server/models/LoginServiceConfiguration.ts
+++ b/apps/meteor/server/models/LoginServiceConfiguration.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { LoginServiceConfigurationRaw } from './raw/LoginServiceConfiguration';
 
-registerModel('ILoginServiceConfigurationModel', new LoginServiceConfigurationRaw(db, trashCollection));
+registerModel('ILoginServiceConfigurationModel', new LoginServiceConfigurationRaw(db));

--- a/apps/meteor/server/models/NotificationQueue.ts
+++ b/apps/meteor/server/models/NotificationQueue.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { NotificationQueueRaw } from './raw/NotificationQueue';
 
-registerModel('INotificationQueueModel', new NotificationQueueRaw(db, trashCollection));
+registerModel('INotificationQueueModel', new NotificationQueueRaw(db));

--- a/apps/meteor/server/models/Nps.ts
+++ b/apps/meteor/server/models/Nps.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { NpsRaw } from './raw/Nps';
 
-registerModel('INpsModel', new NpsRaw(db, trashCollection));
+registerModel('INpsModel', new NpsRaw(db));

--- a/apps/meteor/server/models/NpsVote.ts
+++ b/apps/meteor/server/models/NpsVote.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { NpsVoteRaw } from './raw/NpsVote';
 
-registerModel('INpsVoteModel', new NpsVoteRaw(db, trashCollection));
+registerModel('INpsVoteModel', new NpsVoteRaw(db));

--- a/apps/meteor/server/models/OAuthApps.ts
+++ b/apps/meteor/server/models/OAuthApps.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { OAuthAppsRaw } from './raw/OAuthApps';
 
-registerModel('IOAuthAppsModel', new OAuthAppsRaw(db, trashCollection));
+registerModel('IOAuthAppsModel', new OAuthAppsRaw(db));

--- a/apps/meteor/server/models/OEmbedCache.ts
+++ b/apps/meteor/server/models/OEmbedCache.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { OEmbedCacheRaw } from './raw/OEmbedCache';
 
-registerModel('IOEmbedCacheModel', new OEmbedCacheRaw(db, trashCollection));
+registerModel('IOEmbedCacheModel', new OEmbedCacheRaw(db));

--- a/apps/meteor/server/models/PbxEvents.ts
+++ b/apps/meteor/server/models/PbxEvents.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { PbxEventsRaw } from './raw/PbxEvents';
 
-registerModel('IPbxEventsModel', new PbxEventsRaw(db, trashCollection));
+registerModel('IPbxEventsModel', new PbxEventsRaw(db));

--- a/apps/meteor/server/models/ReadReceipts.ts
+++ b/apps/meteor/server/models/ReadReceipts.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { ReadReceiptsRaw } from './raw/ReadReceipts';
 
-registerModel('IReadReceiptsModel', new ReadReceiptsRaw(db, trashCollection));
+registerModel('IReadReceiptsModel', new ReadReceiptsRaw(db));

--- a/apps/meteor/server/models/Reports.ts
+++ b/apps/meteor/server/models/Reports.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { ReportsRaw } from './raw/Reports';
 
-registerModel('IReportsModel', new ReportsRaw(db, trashCollection));
+registerModel('IReportsModel', new ReportsRaw(db));

--- a/apps/meteor/server/models/ServerEvents.ts
+++ b/apps/meteor/server/models/ServerEvents.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { ServerEventsRaw } from './raw/ServerEvents';
 
-registerModel('IServerEventsModel', new ServerEventsRaw(db, trashCollection));
+registerModel('IServerEventsModel', new ServerEventsRaw(db));

--- a/apps/meteor/server/models/Sessions.ts
+++ b/apps/meteor/server/models/Sessions.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { SessionsRaw } from './raw/Sessions';
 
-registerModel('ISessionsModel', new SessionsRaw(db, trashCollection));
+registerModel('ISessionsModel', new SessionsRaw(db));

--- a/apps/meteor/server/models/SmarshHistory.ts
+++ b/apps/meteor/server/models/SmarshHistory.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { SmarshHistoryRaw } from './raw/SmarshHistory';
 
-registerModel('ISmarshHistoryModel', new SmarshHistoryRaw(db, trashCollection));
+registerModel('ISmarshHistoryModel', new SmarshHistoryRaw(db));

--- a/apps/meteor/server/models/Statistics.ts
+++ b/apps/meteor/server/models/Statistics.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { StatisticsRaw } from './raw/Statistics';
 
-registerModel('IStatisticsModel', new StatisticsRaw(db, trashCollection));
+registerModel('IStatisticsModel', new StatisticsRaw(db));

--- a/apps/meteor/server/models/Team.ts
+++ b/apps/meteor/server/models/Team.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { TeamRaw } from './raw/Team';
 
-registerModel('ITeamModel', new TeamRaw(db, trashCollection));
+registerModel('ITeamModel', new TeamRaw(db));

--- a/apps/meteor/server/models/TeamMember.ts
+++ b/apps/meteor/server/models/TeamMember.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { TeamMemberRaw } from './raw/TeamMember';
 
-registerModel('ITeamMemberModel', new TeamMemberRaw(db, trashCollection));
+registerModel('ITeamMemberModel', new TeamMemberRaw(db));

--- a/apps/meteor/server/models/Uploads.ts
+++ b/apps/meteor/server/models/Uploads.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { UploadsRaw } from './raw/Uploads';
 
-registerModel('IUploadsModel', new UploadsRaw(db, trashCollection));
+registerModel('IUploadsModel', new UploadsRaw(db));

--- a/apps/meteor/server/models/UserDataFiles.ts
+++ b/apps/meteor/server/models/UserDataFiles.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { UserDataFilesRaw } from './raw/UserDataFiles';
 
-registerModel('IUserDataFilesModel', new UserDataFilesRaw(db, trashCollection));
+registerModel('IUserDataFilesModel', new UserDataFilesRaw(db));

--- a/apps/meteor/server/models/Users.ts
+++ b/apps/meteor/server/models/Users.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { UsersRaw } from './raw/Users';
 
-registerModel('IUsersModel', new UsersRaw(db, trashCollection));
+registerModel('IUsersModel', new UsersRaw(db));

--- a/apps/meteor/server/models/UsersSessions.ts
+++ b/apps/meteor/server/models/UsersSessions.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { UsersSessionsRaw } from './raw/UsersSessions';
 
-registerModel('IUsersSessionsModel', new UsersSessionsRaw(db, trashCollection));
+registerModel('IUsersSessionsModel', new UsersSessionsRaw(db));

--- a/apps/meteor/server/models/VideoConference.ts
+++ b/apps/meteor/server/models/VideoConference.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { VideoConferenceRaw } from './raw/VideoConference';
 
-registerModel('IVideoConferenceModel', new VideoConferenceRaw(db, trashCollection));
+registerModel('IVideoConferenceModel', new VideoConferenceRaw(db));

--- a/apps/meteor/server/models/WebdavAccounts.ts
+++ b/apps/meteor/server/models/WebdavAccounts.ts
@@ -1,7 +1,6 @@
 import { registerModel } from '@rocket.chat/models';
 
-import { trashCollection } from '../database/trash';
 import { db } from '../database/utils';
 import { WebdavAccountsRaw } from './raw/WebdavAccounts';
 
-registerModel('IWebdavAccountsModel', new WebdavAccountsRaw(db, trashCollection));
+registerModel('IWebdavAccountsModel', new WebdavAccountsRaw(db));

--- a/apps/meteor/server/models/raw/Statistics.ts
+++ b/apps/meteor/server/models/raw/Statistics.ts
@@ -1,12 +1,12 @@
-import type { IStats, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
+import type { IStats } from '@rocket.chat/core-typings';
 import type { IStatisticsModel } from '@rocket.chat/model-typings';
-import type { Collection, Db, IndexDescription } from 'mongodb';
+import type { Db, IndexDescription } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
 export class StatisticsRaw extends BaseRaw<IStats> implements IStatisticsModel {
-	constructor(db: Db, trashCollection: Collection<RocketChatRecordDeleted<IStats>>) {
-		super(db, 'statistics', trashCollection);
+	constructor(db: Db) {
+		super(db, 'statistics');
 	}
 
 	protected modelIndexes(): IndexDescription[] {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->
When a `trashCollection` is provided to a model, all removed records from that collection/model are also stored in the "trash collection", but this has a cost, every delete operation now has to perform a `find` before actually removing the records.

The issue is that very few places were actually fetching records from the trash collection.. So all this extra cost was actually wasted.

This PR removes the `trashCollection` from all models that are NOT performing a `trashFind`.

I can foresee immediate performance gain by removing the trash param from some collections with high amount of records removal like `NotificationQueue`, `UsersSessions` and `Sessions` .

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
