### PR TITLE
Regression: Fix Current Chats Page Issues

### DIFF
--- a/apps/meteor/client/views/omnichannel/currentChats/CurrentChatsRoute.tsx
+++ b/apps/meteor/client/views/omnichannel/currentChats/CurrentChatsRoute.tsx
@@ -131,6 +131,8 @@ const CurrentChatsRoute = (): ReactElement => {
 	const onHeaderClick = useMutableCallback((id) => {
 		if (sortBy === id) {
 			setSort(id, sortDirection === 'asc' ? 'desc' : 'asc');
+		} else {
+			setSort(id, 'asc');
 		}
 	});
 

--- a/apps/meteor/client/views/omnichannel/currentChats/CurrentChatsRoute.tsx
+++ b/apps/meteor/client/views/omnichannel/currentChats/CurrentChatsRoute.tsx
@@ -112,7 +112,7 @@ const useQuery: useQueryType = (
 
 const CurrentChatsRoute = (): ReactElement => {
 	const { sortBy, sortDirection, setSort } = useSort<'fname' | 'departmentId' | 'servedBy' | 'ts' | 'lm' | 'open'>('fname');
-	const [customFields, setCustomFields] = useState<{ [key: string]: string } | undefined>();
+	const [customFields, setCustomFields] = useState<{ [key: string]: string }>();
 	const [params, setParams] = useState({
 		guest: '',
 		fname: '',
@@ -127,14 +127,6 @@ const CurrentChatsRoute = (): ReactElement => {
 	});
 	const t = useTranslation();
 	const id = useRouteParameter('id');
-
-	const onHeaderClick = useMutableCallback((id) => {
-		if (sortBy === id) {
-			setSort(id, sortDirection === 'asc' ? 'desc' : 'asc');
-		} else {
-			setSort(id, 'asc');
-		}
-	});
 
 	const debouncedParams = useDebouncedValue(params, 500);
 	const debouncedCustomFields = useDebouncedValue(customFields, 500);
@@ -226,7 +218,7 @@ const CurrentChatsRoute = (): ReactElement => {
 								key='fname'
 								direction={sortDirection}
 								active={sortBy === 'fname'}
-								onClick={onHeaderClick}
+								onClick={setSort}
 								sort='fname'
 								data-qa='current-chats-header-name'
 							>
@@ -236,7 +228,7 @@ const CurrentChatsRoute = (): ReactElement => {
 								key='departmentId'
 								direction={sortDirection}
 								active={sortBy === 'departmentId'}
-								onClick={onHeaderClick}
+								onClick={setSort}
 								sort='departmentId'
 								data-qa='current-chats-header-department'
 							>
@@ -246,7 +238,7 @@ const CurrentChatsRoute = (): ReactElement => {
 								key='servedBy'
 								direction={sortDirection}
 								active={sortBy === 'servedBy'}
-								onClick={onHeaderClick}
+								onClick={setSort}
 								sort='servedBy'
 								data-qa='current-chats-header-servedBy'
 							>
@@ -256,7 +248,7 @@ const CurrentChatsRoute = (): ReactElement => {
 								key='ts'
 								direction={sortDirection}
 								active={sortBy === 'ts'}
-								onClick={onHeaderClick}
+								onClick={setSort}
 								sort='ts'
 								data-qa='current-chats-header-startedAt'
 							>
@@ -266,7 +258,7 @@ const CurrentChatsRoute = (): ReactElement => {
 								key='lm'
 								direction={sortDirection}
 								active={sortBy === 'lm'}
-								onClick={onHeaderClick}
+								onClick={setSort}
 								sort='lm'
 								data-qa='current-chats-header-lastMessage'
 							>
@@ -276,7 +268,7 @@ const CurrentChatsRoute = (): ReactElement => {
 								key='open'
 								direction={sortDirection}
 								active={sortBy === 'open'}
-								onClick={onHeaderClick}
+								onClick={setSort}
 								sort='open'
 								w='x100'
 								data-qa='current-chats-header-status'

--- a/apps/meteor/client/views/omnichannel/currentChats/CurrentChatsRoute.tsx
+++ b/apps/meteor/client/views/omnichannel/currentChats/CurrentChatsRoute.tsx
@@ -39,7 +39,7 @@ type useQueryType = (
 		itemsPerPage: 25 | 50 | 100;
 		current: number;
 	},
-	customFields: { [key: string]: string },
+	customFields: { [key: string]: string } | undefined,
 	[column, direction]: [string, 'asc' | 'desc'],
 ) => LivechatRoomsProps | undefined;
 
@@ -101,7 +101,7 @@ const useQuery: useQueryType = (
 		}
 
 		if (customFields && Object.keys(customFields).length > 0) {
-			const customFieldsQuery = Object.fromEntries(Object.entries(customFields).filter((item) => item[1] !== ''));
+			const customFieldsQuery = Object.fromEntries(Object.entries(customFields).filter((item) => item[1] !== undefined && item[1] !== ''));
 			if (Object.keys(customFieldsQuery).length > 0) {
 				query.customFields = JSON.stringify(customFieldsQuery);
 			}
@@ -112,7 +112,7 @@ const useQuery: useQueryType = (
 
 const CurrentChatsRoute = (): ReactElement => {
 	const { sortBy, sortDirection, setSort } = useSort<'fname' | 'departmentId' | 'servedBy' | 'ts' | 'lm' | 'open'>('fname');
-	const [customFields, setCustomFields] = useState<{ [key: string]: string }>({});
+	const [customFields, setCustomFields] = useState<{ [key: string]: string } | undefined>();
 	const [params, setParams] = useState({
 		guest: '',
 		fname: '',

--- a/apps/meteor/client/views/omnichannel/currentChats/CustomFieldsVerticalBar.tsx
+++ b/apps/meteor/client/views/omnichannel/currentChats/CustomFieldsVerticalBar.tsx
@@ -7,7 +7,7 @@ import { Controller, useForm } from 'react-hook-form';
 import VerticalBar from '../../../components/VerticalBar';
 
 type CustomFieldsVerticalBarProps = {
-	setCustomFields: Dispatch<SetStateAction<{ [key: string]: string }>>;
+	setCustomFields: Dispatch<SetStateAction<{ [key: string]: string } | undefined>>;
 	allCustomFields: OmnichannelCustomFieldEndpointPayload[];
 };
 

--- a/apps/meteor/client/views/omnichannel/currentChats/FilterByText.tsx
+++ b/apps/meteor/client/views/omnichannel/currentChats/FilterByText.tsx
@@ -13,8 +13,8 @@ import RemoveAllClosed from './RemoveAllClosed';
 
 type FilterByTextType = FC<{
 	setFilter: Dispatch<SetStateAction<any>>;
-	setCustomFields: Dispatch<SetStateAction<{ [key: string]: string }>>;
-	customFields: { [key: string]: string };
+	setCustomFields: Dispatch<SetStateAction<{ [key: string]: string } | undefined>>;
+	customFields: { [key: string]: string } | undefined;
 	hasCustomFields: boolean;
 	reload?: () => void;
 }>;
@@ -55,7 +55,7 @@ const FilterByText: FilterByTextType = ({ setFilter, reload, customFields, setCu
 		setFrom('');
 		setTo('');
 		setTags([]);
-		setCustomFields({});
+		setCustomFields(undefined);
 	});
 
 	const forms = useFormsSubscription() as any;


### PR DESCRIPTION
This fixes:

- [x] Issues with the reset button
- [x] Not being able to sort the table 

## Steps to reproduce

Reset button:
- Write anything on the current chat's filters
- Go to the `...` menu
- Select Clear Filters

Sorting
- Click on any table headers