### PR TITLE
[FIX]  Removed mobile requirement for showing real name

### DIFF
--- a/apps/meteor/client/views/room/MessageList/providers/MessageListProvider.tsx
+++ b/apps/meteor/client/views/room/MessageList/providers/MessageListProvider.tsx
@@ -30,7 +30,7 @@ export const MessageListProvider: FC<{
 
 	const { isMobile } = useLayout();
 
-	const showRealName = Boolean(useSetting('UI_Use_Real_Name')) && !isMobile;
+	const showRealName = Boolean(useSetting('UI_Use_Real_Name'));
 	const showReadReceipt = Boolean(useSetting('Message_Read_Receipt_Enabled'));
 	const autoTranslateEnabled = useSetting('AutoTranslate_Enabled');
 	const katexEnabled = Boolean(useSetting('Katex_Enabled'));


### PR DESCRIPTION
Message headers do not follow the UI_Use_Real_Name setting when on mobile (<768px width), therefore only usernames are shown on mobile.

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
Removed the mobile requirement for allowing real names to be used in message headers.
<!-- END CHANGELOG -->

## Issue(s)
Fixes #26967

## Steps to test or reproduce
1. Set server setting `Use Real Name` to `Enabled`
2. Use a browser with a width <768px
3. All message headers will now use the username
