### PR TITLE
Chore: fix broken mimic-fn symbolic link

### DIFF
--- a/apps/meteor/imports/client/mimic-fn/index.js
+++ b/apps/meteor/imports/client/mimic-fn/index.js
@@ -1,1 +1,1 @@
-../../../node_modules/mem/node_modules/mimic-fn/index.js
+../../../node_modules/mimic-fn/index.js


### PR DESCRIPTION
Symbolic link to `mimic-fn` was incorrectly targeting a file within `mem` node module. This was preventing execution of `yarn apps/meteor coverage`.

## Proposed changes (including videos or screenshots)
Update the link from `../../../node_modules/mem/node_modules/mimic-fn/index.js` to `../../../node_modules/mimic-fn/index.js`.

## Steps to test or reproduce
Run: `yarn apps/meteor coverage` from project root directory.