### PR TITLE
[FIX] Sort RecordList items in REVERSE chronological order, not FORWARD

### DIFF
--- a/apps/meteor/client/lib/lists/RecordList.ts
+++ b/apps/meteor/client/lib/lists/RecordList.ts
@@ -24,7 +24,7 @@ export class RecordList<T extends IRocketChatRecord> extends Emitter {
 	}
 
 	protected compare(a: T, b: T): number {
-		return a._updatedAt.getTime() - b._updatedAt.getTime();
+		return b._updatedAt.getTime() - a._updatedAt.getTime();
 	}
 
 	public get phase(): AsyncStatePhase {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
Sort items in the Files sidebar in *reverse* chronological order (newest at top, oldest at bottom), as it did _before_ RC v3.11.0.  
<!-- END CHANGELOG -->

## Issue(s)
Fixes #27185

## Steps to test or reproduce
See Issue

## Further comments
RecordList is a generic widget for use in several parts of the codebase.  It remains to be seen whether Date DESC is the correct sort order for all of them, although it does seem reasonable that it ought to be.
