### PR TITLE
Chore: Check for Cloud client secret to check if workspace is registered

### DIFF
--- a/apps/meteor/app/apps/server/communication/rest.js
+++ b/apps/meteor/app/apps/server/communication/rest.js
@@ -130,7 +130,7 @@ export class AppsRestApi {
 							return API.v1.failure({ error: 'Invalid purchase type' });
 						}
 
-						const token = getUserCloudAccessToken(this.getLoggedInUser()._id, true, 'marketplace:purchase', false);
+						const token = await getUserCloudAccessToken(this.getLoggedInUser()._id, true, 'marketplace:purchase', false);
 						if (!token) {
 							return API.v1.failure({ error: 'Unauthorized' });
 						}

--- a/apps/meteor/app/cloud/server/functions/retrieveRegistrationStatus.ts
+++ b/apps/meteor/app/cloud/server/functions/retrieveRegistrationStatus.ts
@@ -11,7 +11,7 @@ export function retrieveRegistrationStatus(): {
 } {
 	const info = {
 		connectToCloud: settings.get<boolean>('Register_Server'),
-		workspaceRegistered: !!settings.get('Cloud_Workspace_Client_Id'),
+		workspaceRegistered: !!settings.get('Cloud_Workspace_Client_Id') && !!settings.get('Cloud_Workspace_Client_Secret'),
 		workspaceId: settings.get<string>('Cloud_Workspace_Id'),
 		uniqueId: settings.get<string>('uniqueID'),
 		token: '',

--- a/apps/meteor/client/lib/userData.ts
+++ b/apps/meteor/client/lib/userData.ts
@@ -92,7 +92,7 @@ export const synchronizeUserData = async (uid: Meteor.User['_id']): Promise<RawU
 	// }
 
 	if (userData) {
-		const { email, resume, email2fa, emailCode, ...services } = rawServices || {};
+		const { email, cloud, resume, email2fa, emailCode, ...services } = rawServices || {};
 
 		updateUser({
 			...userData,
@@ -110,6 +110,14 @@ export const synchronizeUserData = async (uid: Meteor.User['_id']): Promise<RawU
 											twoFactorAuthorizedUntil: token.twoFactorAuthorizedUntil ? new Date(token.twoFactorAuthorizedUntil) : undefined,
 										})),
 									}),
+								},
+						  }
+						: {}),
+					...(cloud
+						? {
+								cloud: {
+									...cloud,
+									expiresAt: new Date(cloud.expiresAt),
 								},
 						  }
 						: {}),

--- a/packages/core-typings/src/IUser.ts
+++ b/packages/core-typings/src/IUser.ts
@@ -54,7 +54,11 @@ export interface IUserServices {
 	resume?: {
 		loginTokens?: LoginToken[];
 	};
-	cloud?: unknown;
+	cloud?: {
+		accessToken: string;
+		refreshToken: string;
+		expiresAt: Date;
+	};
 	google?: any;
 	facebook?: any;
 	github?: any;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->
The main change of this PR is to consider a workspace registered only if it has both `Cloud_Workspace_Client_Id` and `Cloud_Workspace_Client_Secret` settings saved on the server's cache [here](https://github.com/RocketChat/Rocket.Chat/pull/27229/files#diff-af33d520e198acd8dde76a05e8cb811179e281752df4d130c712d68dd1fb41ccR14).

The problem was it was checking only for `Cloud_Workspace_Client_Id` but was also using the secret to perform requests afterwards, and due to some race conditions on how settings are saved in cache, it was happening some times the `clientId` was in cache but the secret was not, so now with this additional check it will prevent those cases.

The other changes are due to TS conversion.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
ARCH-84

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
