### PR TITLE
[FIX] Shrug missing backslash character

### DIFF
--- a/apps/meteor/app/slashcommand-asciiarts/lib/shrug.ts
+++ b/apps/meteor/app/slashcommand-asciiarts/lib/shrug.ts
@@ -10,7 +10,7 @@ slashCommands.add({
 	command: 'shrug',
 	callback: (_command: 'shrug', params, item): void => {
 		const msg = item;
-		msg.msg = `${params} ¯\\_(ツ)_/¯`;
+		msg.msg = `${params} ¯\\\\_(ツ)_/¯`;
 		Meteor.call('sendMessage', msg);
 	},
 	options: {

--- a/apps/meteor/ee/server/services/package.json
+++ b/apps/meteor/ee/server/services/package.json
@@ -21,7 +21,7 @@
 		"@rocket.chat/apps-engine": "^1.32.0",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/emitter": "0.31.21",
-		"@rocket.chat/message-parser": "0.31.21",
+		"@rocket.chat/message-parser": "next",
 		"@rocket.chat/model-typings": "workspace:^",
 		"@rocket.chat/models": "workspace:^",
 		"@rocket.chat/rest-typings": "workspace:^",

--- a/apps/meteor/package.json
+++ b/apps/meteor/package.json
@@ -221,7 +221,7 @@
 		"@rocket.chat/layout": "next",
 		"@rocket.chat/logo": "0.31.21",
 		"@rocket.chat/memo": "0.31.21",
-		"@rocket.chat/message-parser": "0.31.21",
+		"@rocket.chat/message-parser": "next",
 		"@rocket.chat/model-typings": "workspace:^",
 		"@rocket.chat/models": "workspace:^",
 		"@rocket.chat/mp3-encoder": "0.24.0",

--- a/packages/core-typings/package.json
+++ b/packages/core-typings/package.json
@@ -24,7 +24,7 @@
 	"dependencies": {
 		"@rocket.chat/apps-engine": "^1.32.0",
 		"@rocket.chat/icons": "0.31.21",
-		"@rocket.chat/message-parser": "0.31.21",
+		"@rocket.chat/message-parser": "next",
 		"@rocket.chat/ui-kit": "0.31.21"
 	}
 }

--- a/packages/gazzodown/package.json
+++ b/packages/gazzodown/package.json
@@ -9,7 +9,7 @@
 		"@rocket.chat/css-in-js": "0.31.21",
 		"@rocket.chat/fuselage": "0.31.21",
 		"@rocket.chat/fuselage-tokens": "0.31.21",
-		"@rocket.chat/message-parser": "0.31.21",
+		"@rocket.chat/message-parser": "next",
 		"@rocket.chat/styled": "0.31.21",
 		"@rocket.chat/ui-client": "workspace:^",
 		"@rocket.chat/ui-contexts": "workspace:^",

--- a/packages/rest-typings/package.json
+++ b/packages/rest-typings/package.json
@@ -26,7 +26,7 @@
 	"dependencies": {
 		"@rocket.chat/apps-engine": "^1.32.0",
 		"@rocket.chat/core-typings": "workspace:^",
-		"@rocket.chat/message-parser": "0.31.21",
+		"@rocket.chat/message-parser": "next",
 		"@rocket.chat/ui-kit": "0.31.21",
 		"ajv": "^8.11.0"
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5465,7 +5465,7 @@ __metadata:
     "@rocket.chat/apps-engine": ^1.32.0
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/icons": 0.31.21
-    "@rocket.chat/message-parser": 0.31.21
+    "@rocket.chat/message-parser": next
     "@rocket.chat/ui-kit": 0.31.21
     eslint: ^8.20.0
     mongodb: ^4.3.1
@@ -5788,7 +5788,7 @@ __metadata:
     "@rocket.chat/css-in-js": 0.31.21
     "@rocket.chat/fuselage": 0.31.21
     "@rocket.chat/fuselage-tokens": 0.31.21
-    "@rocket.chat/message-parser": 0.31.21
+    "@rocket.chat/message-parser": next
     "@rocket.chat/styled": 0.31.21
     "@rocket.chat/ui-client": "workspace:^"
     "@rocket.chat/ui-contexts": "workspace:^"
@@ -5961,10 +5961,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rocket.chat/message-parser@npm:0.31.21":
-  version: 0.31.21
-  resolution: "@rocket.chat/message-parser@npm:0.31.21"
-  checksum: 396f69a9b8f24c06f0912c21ec8a447cc8ee67ade323a07accea8d536f827ef66d57a798c9d69591bb0b72ffa90c29749990702b8c3834d822d98afddda7ba1c
+"@rocket.chat/message-parser@npm:next":
+  version: 0.32.0-dev.145
+  resolution: "@rocket.chat/message-parser@npm:0.32.0-dev.145"
+  checksum: 72f0f1a6cf7d5ec2fd1fd7e0916e46e3f38a714ba8c0b90a378a1591eda3aa2e69f86bb6a11a5b642db8be78a2650d634f8cb2b883e78ca5f7bc6c211b7470c0
   languageName: node
   linkType: hard
 
@@ -6013,7 +6013,7 @@ __metadata:
     "@rocket.chat/livechat": "workspace:^"
     "@rocket.chat/logo": 0.31.21
     "@rocket.chat/memo": 0.31.21
-    "@rocket.chat/message-parser": 0.31.21
+    "@rocket.chat/message-parser": next
     "@rocket.chat/model-typings": "workspace:^"
     "@rocket.chat/models": "workspace:^"
     "@rocket.chat/mp3-encoder": 0.24.0
@@ -6436,7 +6436,7 @@ __metadata:
     "@rocket.chat/apps-engine": ^1.32.0
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/eslint-config": "workspace:^"
-    "@rocket.chat/message-parser": 0.31.21
+    "@rocket.chat/message-parser": next
     "@rocket.chat/ui-kit": 0.31.21
     "@types/jest": ^27.4.1
     ajv: ^8.11.0
@@ -23469,7 +23469,7 @@ __metadata:
       optional: true
   bin:
     lessc: ./bin/lessc
-  checksum: 61568b56b5289fdcfe3d51baf3c13e7db7140022c0a37ef0ae343169f0de927a4b4f4272bc10c20101796e8ee79e934e024051321bba93b3ae071f734309bd98
+  checksum: c9b8c0e865427112c48a9cac36f14964e130577743c29d56a6d93b5812b70846b04ccaa364acf1e8d75cee3855215ec0a2d8d9de569c80e774f10b6245f39b7d
   languageName: node
   linkType: hard
 
@@ -30787,7 +30787,7 @@ __metadata:
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/emitter": 0.31.21
     "@rocket.chat/icons": 0.31.21
-    "@rocket.chat/message-parser": 0.31.21
+    "@rocket.chat/message-parser": next
     "@rocket.chat/model-typings": "workspace:^"
     "@rocket.chat/models": "workspace:^"
     "@rocket.chat/rest-typings": "workspace:^"


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
Previously the escape character `\` was escaping everything.

To avoid unexpected text formatting errors it was restricted to only escape curtains chars like: * _ ~ ` # . 
Doing so the Shrug had to change in the code to display the correct ASCII Art
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

closes https://github.com/RocketChat/Rocket.Chat/issues/26907
closes https://github.com/RocketChat/Rocket.Chat/issues/26800

## Steps to reproduce:

1. Create a message using `/shrug`.

### Expected behavior:

The kaomoji being rendered looks as follows: ` ¯\_(ツ)_/¯ `

### Actual behavior:

The kaomoji is missing an arm: ` ¯_(ツ)_/¯ `

![image](https://user-images.githubusercontent.com/404840/188320706-b93fe29d-6c50-4b14-a429-3d6106fe21be.png)

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

The Shrug issue will be fixed after this Pull Request and https://github.com/RocketChat/fuselage/pull/899 are released

TC-99