### PR TITLE
[FIX] Add reaction name in reaction list of a message right after user react it

### DIFF
--- a/apps/meteor/app/reactions/server/setReaction.js
+++ b/apps/meteor/app/reactions/server/setReaction.js
@@ -90,6 +90,10 @@ async function setReaction(room, user, message, reaction, shouldReact) {
 			Rooms.setReactionsInLastMessage(room._id, message);
 		}
 		callbacks.run('setReaction', message._id, reaction);
+		if (!message.reactions[reaction].names) {
+			message.reactions[reaction].names = [];
+		}
+		message.reactions[reaction].names.push(user.name);
 		callbacks.run('afterSetReaction', message, { user, reaction, shouldReact });
 
 		isReacted = true;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
Add user's full name to reaction's name list of message before sending it back to client via `afterSetReaction` so that user can see his/her name in reaction list right after reacting.
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)
Currently after reacting, user can only see his/her username in reaction list.
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
1. User react a message
2. User click on message's options and choose to see reaction list
3. User only see his/her username in reaction list instead of his/her full name (requires refreshing client to reload message so that their full names can be loaded)
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Only add name to reaction's name list after calling `setReaction` so that name list won't be saved to database