### PR TITLE
[FIX] Sorting users by 'status' is broken in Administration -> Users

### DIFF
--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -439,7 +439,11 @@ API.v1.addRoute(
 				throw new Meteor.Error('error-invalid-query', isValidQuery.errors.join('\n'));
 			}
 
-			const actualSort = sort?.name ? { nameInsensitive: sort.name, ...sort } : sort || { username: 1 };
+			const actualSort = sort?.status
+				? { active: sort.status, ...sort }
+				: sort?.name
+				? { nameInsensitive: sort.name, ...sort }
+				: sort || { username: 1 };
 
 			const limit =
 				count !== 0


### PR DESCRIPTION
## Issue Description
When trying to filter based on the status it is not displaying "Disabled" accounts in alphabetical order and does not even group statuses close to each other.
When the new users should be approved manually and it is a big workspace with thousand of users after their registration is hard to find each other by typing and would be easier if it will be grouped or sorted.

## Steps to Reproduce
Go to Administration → users
You should have at least 3 or 4 disabled users in order to reproduce the issue
Try to filter by “status” or “username”
One or a few users with online/offline statuses appear in between the disabled users

## Expected Behavior
All users with the status “disabled' should be grouped close to each other

## Actual Behavior
One or a few users with online/offline statuses appear in between the disabled users

TC-123