### PR TITLE
[FIX] Add a Open button and a onClick listener inside the ThreadMetrics.tsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can follow these instructions to setup a dev environment:
 ### Starting Rocket.Chat
 
 ```
-yarn dsv
+yarn dev
 ```
 
 After initialized, you can access the server at http://localhost:3000

--- a/apps/meteor/client/components/message/content/ThreadMetrics.tsx
+++ b/apps/meteor/client/components/message/content/ThreadMetrics.tsx
@@ -59,8 +59,11 @@ const ThreadMetrics = ({
 				<MessageMetricsReply data-rid={rid} data-mid={mid} onClick={openThread}>
 					{t('Reply')}
 				</MessageMetricsReply>
+				<MessageMetricsReply data-rid={rid} data-mid={mid} onClick={openThread}>
+					{t('Open')}
+				</MessageMetricsReply>
 				<MessageMetricsItem title={t('Replies')}>
-					<MessageMetricsItem.Icon name='thread' />
+					<MessageMetricsItem.Icon name='thread' onClick={openThread} />
 					<MessageMetricsItem.Label>{counter}</MessageMetricsItem.Label>
 				</MessageMetricsItem>
 				{!!participants && (


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

- Previously, whenever a chat was going on in a thread, the 3rd person was not able decide where to click to check what messages are inside that thread.
- There was a button named "Reply", which means that the 3rd person wants to reply on that thread.
- What if the 3rd person don't want to reply, and was just roaming around to check the discussion going inside the thread.
- Thus, I added an "Open" button, which makes it easy for the user to click it and open the thread. The functionality is same as the "Reply" button, but now, the user wouldn't search around the way to open the thread.
- Also, added the onClick listener inside the 'Thread' icon besides the message counter. This will further improve the user experience.

## Here is what is looks now.
![Now](https://i.imgur.com/UaZxgND.png)

Previously, there was no "Open" button.

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
I have tested the UI of web client on Desktop PC (1920x1080 res) 

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

I decided to add this fix because when I was first roaming inside the chat interface, I was so much confused, like where to click to open the discussion going inside the threads. The thread counter was making me more anxious, as I don't wanted to click "Reply" button to open the thread, because, I was not doing any reply, but was just reading the discussion going inside that thread.
Like me, many more people would be confused, thus, added a button to open the thread.
