### PR TITLE
Regression: fix close flextab on click outside the container

### DIFF
--- a/apps/meteor/client/views/room/components/body/RoomBody.tsx
+++ b/apps/meteor/client/views/room/components/body/RoomBody.tsx
@@ -11,7 +11,7 @@ import {
 	useUser,
 	useUserPreference,
 } from '@rocket.chat/ui-contexts';
-import type { ReactElement, UIEvent } from 'react';
+import type { MouseEventHandler, ReactElement, UIEvent } from 'react';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSyncExternalStore } from 'use-sync-external-store/shim';
 
@@ -532,6 +532,21 @@ const RoomBody = (): ReactElement => {
 		chat.uploads.wipeFailedOnes();
 	}, [chat]);
 
+	const handleCloseFlexTab: MouseEventHandler<HTMLElement> = useCallback(
+		(e): void => {
+			if (!hideFlexTab) {
+				return;
+			}
+
+			if (e.target instanceof HTMLButtonElement) {
+				return;
+			}
+
+			toolbox.close();
+		},
+		[toolbox, hideFlexTab],
+	);
+
 	return (
 		<>
 			{!isLayoutEmbedded && room.announcement && <Announcement announcement={room.announcement} announcementDetails={undefined} />}
@@ -540,7 +555,7 @@ const RoomBody = (): ReactElement => {
 					className={`messages-container flex-tab-main-content ${admin ? 'admin' : ''}`}
 					id={`chat-window-${room._id}`}
 					aria-label={t('Channel')}
-					onClick={hideFlexTab ? toolbox.close : undefined}
+					onClick={handleCloseFlexTab}
 				>
 					<div className='messages-container-wrapper'>
 						<div className='messages-container-main' {...fileUploadTriggerProps}>

--- a/apps/meteor/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -2350,7 +2350,7 @@
   "Hidden": "Hidden",
   "Hide": "Hide",
   "Hide_counter": "Hide counter",
-  "Hide_flextab": "Hide Right Sidebar with Click",
+  "Hide_flextab": "Hide Contextual Bar by clicking outside of it",
   "Hide_Group_Warning": "Are you sure you want to hide the group \"%s\"?",
   "Hide_Livechat_Warning": "Are you sure you want to hide the chat with \"%s\"?",
   "Hide_Private_Warning": "Are you sure you want to hide the discussion with \"%s\"?",

--- a/apps/meteor/tests/e2e/message-actions.spec.ts
+++ b/apps/meteor/tests/e2e/message-actions.spec.ts
@@ -84,7 +84,7 @@ test.describe.serial('message-actions', () => {
 		await page.locator('[data-qa-id="permalink"]').click();
 	});
 
-	test.describe('Preference Hide Right Sidebar with Click Enabled', () => {
+	test.describe('Preference Hide Contextual Bar by clicking outside of it Enabled', () => {
 		let adminPage: Page;
 
 		test.beforeAll(async ({ browser }) => {
@@ -92,7 +92,7 @@ test.describe.serial('message-actions', () => {
 
 			await adminPage.goto('/account/preferences');
 			await adminPage.locator('role=heading[name="Messages"]').click();
-			await adminPage.locator('text="Hide Right Sidebar with Click"').click();
+			await adminPage.locator('text="Hide Contextual Bar by clicking outside of it"').click();
 		});
 
 		test.afterAll(async ({ browser }) => {
@@ -100,7 +100,7 @@ test.describe.serial('message-actions', () => {
 
 			await adminPage.goto('/account/preferences');
 			await adminPage.locator('role=heading[name="Messages"]').click();
-			await adminPage.locator('text="Hide Right Sidebar with Click"').click();
+			await adminPage.locator('text="Hide Contextual Bar by clicking outside of it"').click();
 			await adminPage.close();
 		});
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
