### PR TITLE
[FIX] Additional alias names of custom emojis not accepted anymore #18264

### DIFF
--- a/apps/meteor/app/emoji-custom/server/methods/insertOrUpdateEmoji.js
+++ b/apps/meteor/app/emoji-custom/server/methods/insertOrUpdateEmoji.js
@@ -22,7 +22,6 @@ Meteor.methods({
 		}
 
 		emojiData.name = limax(emojiData.name, { replacement: '_' });
-		emojiData.aliases = limax(emojiData.aliases, { replacement: '_' });
 
 		// allow all characters except colon, whitespace, comma, >, <, &, ", ', /, \, (, )
 		// more practical than allowing specific sets of characters; also allows foreign languages
@@ -49,7 +48,7 @@ Meteor.methods({
 					field: 'Alias_Set',
 				});
 			}
-			emojiData.aliases = emojiData.aliases.split(/[\s,]/);
+			emojiData.aliases = emojiData.aliases.split(/[,]/);
 			emojiData.aliases = emojiData.aliases.filter(Boolean);
 			emojiData.aliases = _.without(emojiData.aliases, emojiData.name);
 		} else {


### PR DESCRIPTION
### **[FIX] Additional alias names of custom emojis not accepted anymore** 

For solving this issue, changes done in apps/meteor/app/emoji-custom/server/methods/insertOrUpdateEmoji.js file and checked it on my local environment and it works fine. Please review this.

## Proposed changes (including videos or screenshots)

https://user-images.githubusercontent.com/98152507/221573418-4f69c8d9-81a6-4f75-a88e-e4688f4e4240.mp4



## Issue(s)
#18264 

## Steps to test or reproduce
1. Add a new custom emoji
2. Give it multiple aliases, e.g. first second
3. Click on save button, now alias are generated in space separated format "first second" instead of underscore format "first_second".
