### PR TITLE
Regression: OAuthApps are added with empty string `_id` field

### DIFF
--- a/apps/meteor/app/oauth2-server-config/server/admin/functions/addOAuthApp.ts
+++ b/apps/meteor/app/oauth2-server-config/server/admin/functions/addOAuthApp.ts
@@ -54,7 +54,6 @@ export async function addOAuthApp(applicationParams: OauthAppsAddParams, uid: IU
 			_id: user._id,
 			username: user.username,
 		},
-		_id: '',
 	};
 
 	if (application.redirectUri.length === 0) {
@@ -63,6 +62,8 @@ export async function addOAuthApp(applicationParams: OauthAppsAddParams, uid: IU
 		});
 	}
 
-	application._id = (await OAuthApps.insertOne(application)).insertedId;
-	return application;
+	return {
+		...application,
+		_id: (await OAuthApps.insertOne(application)).insertedId,
+	};
 }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
 - Fix OAuthApps added to the database with a empty string `_id` field.

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Introduced in #28085

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Go to Workspace > OAuthApps > New Application. Adding a first application works, but its added in the database with a empty string `_id` field. No other OAuthApp can be added later since RC throws a "duplicated key" error (it attempts to insert all OAuthApps with a empty string idd)

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
TC-517