### PR TITLE
[FIX] Channel already exists error contains # with channel name 

### DIFF
--- a/apps/meteor/client/sidebar/header/CreateTeam/CreateTeamModal.tsx
+++ b/apps/meteor/client/sidebar/header/CreateTeam/CreateTeamModal.tsx
@@ -49,7 +49,7 @@ const CreateTeamModal = ({ onClose }: { onClose: () => void }): ReactElement => 
 
 		const { exists } = await checkTeamNameExists({ roomName: name });
 		if (exists) {
-			return t('Teams_Errors_team_name', { name });
+			return t('Teams_Errors_Already_exists', { name });
 		}
 	};
 

--- a/apps/meteor/client/sidebar/header/CreateTeam/CreateTeamModal.tsx
+++ b/apps/meteor/client/sidebar/header/CreateTeam/CreateTeamModal.tsx
@@ -49,7 +49,7 @@ const CreateTeamModal = ({ onClose }: { onClose: () => void }): ReactElement => 
 
 		const { exists } = await checkTeamNameExists({ roomName: name });
 		if (exists) {
-			return t('Teams_Errors_Already_exists', { name });
+			return t('Teams_Errors_team_name', { name });
 		}
 	};
 

--- a/apps/meteor/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -880,7 +880,7 @@
   "Changing_email": "Changing email",
   "channel": "channel",
   "Channel": "Channel",
-  "Channel_already_exist": "The channel `#%s` already exists.",
+  "Channel_already_exist": "The channel `%s` already exists.",
   "Channel_already_exist_static": "The channel already exists.",
   "Channel_already_Unarchived": "Channel with name `#%s` is already in Unarchived state",
   "Channel_Archived": "Channel with name `#%s` has been archived successfully",


### PR DESCRIPTION
For solving this issue,
changes done in apps/meteor/packages/rocketchat-i18n/i18n/en.i18n.json file and checked it on my local environment and it works fine. Please review this.

## Proposed changes (including videos or screenshots)
![Screenshot (30)](https://user-images.githubusercontent.com/98152507/222883590-0486d688-a844-4995-91f1-9f55454b4762.png)

## Issue(s)


## Steps to test or reproduce
1. create first channel with channel name eg("test")
2. try to create second channel with channel name same as first team eg("test")
3. click on submit button now it shows message with correct format eg (The Channel 'test' already exists)
