### PR TITLE
[FIX] Less space between Email and Joined at column in users table #28283

### DIFF
--- a/apps/meteor/client/views/directory/tabs/users/UsersTable/UsersTable.tsx
+++ b/apps/meteor/client/views/directory/tabs/users/UsersTable/UsersTable.tsx
@@ -45,7 +45,7 @@ const UsersTable = ({ workspace = 'local' }): ReactElement => {
 						active={sortBy === 'email'}
 						onClick={setSort}
 						sort='email'
-						width='x200'
+						width='x250'
 					>
 						{t('Email')}
 					</GenericTableHeaderCell>


### PR DESCRIPTION
For solving this issue,
changes are done in apps/meteor/client/views/directory/tabs/users/UsersTable/UsersTable.tsx  file and checked it on my local environment and it works fine. Please review this.

## Proposed changes (including videos or screenshots)
![Screenshot (35)](https://user-images.githubusercontent.com/98152507/222979632-6997c7fb-c409-455e-be08-d3a51b01692d.png)



## Issue(s)
closes #28283 

## Steps to test or reproduce
1. click on the Directory icon and select the user section
