### PR TITLE
[FIX] After added channel to Favorite list favorite icon filled with wrong color 

### DIFF
--- a/apps/meteor/client/views/room/Header/icons/Favorite.js
+++ b/apps/meteor/client/views/room/Header/icons/Favorite.js
@@ -2,6 +2,7 @@ import { useMutableCallback } from '@rocket.chat/fuselage-hooks';
 import { Header } from '@rocket.chat/ui-client';
 import { useSetting, useMethod, useTranslation } from '@rocket.chat/ui-contexts';
 import React, { memo } from 'react';
+import colors from '@rocket.chat/fuselage-tokens/colors';
 
 import { useUserIsSubscribed } from '../../contexts/RoomContext';
 
@@ -29,7 +30,7 @@ const Favorite = ({ room: { _id, f: favorite = false, t: type } }) => {
 				title={favoriteLabel}
 				icon={favorite ? 'star-filled' : 'star'}
 				onClick={handleFavoriteClick}
-				color={favorite ? 'status-font-on-warning' : null}
+				color={favorite ? colors.y600: null}
 				tiny
 			/>
 		)


### PR DESCRIPTION
For solving this issue,
changes are done in apps/meteor/client/views/room/Header/icons/Favorite.js  file and checked it on my local environment and it works fine. Please review this.

## Proposed changes (including videos or screenshots)
![Screenshot1 (36)](https://user-images.githubusercontent.com/98152507/223097772-cb14ffbb-76bf-44f0-a7da-b6a853f05e6a.png)

![Screenshot (38)](https://user-images.githubusercontent.com/98152507/223097802-f60c133f-dd37-4d7a-89e1-af8146ad37ca.png)





## Issue(s)
closes #28289 

## Steps to test or reproduce
1. go to any channel
2. click on the Favorite icon
