### PR TITLE
[FIX] Unnecessary hover effect when hover on user / room name in room information and user information section 

### DIFF
--- a/apps/meteor/client/components/InfoPanel/InfoPanelTitle.tsx
+++ b/apps/meteor/client/components/InfoPanel/InfoPanelTitle.tsx
@@ -10,7 +10,7 @@ type InfoPanelTitleProps = {
 const isValidIcon = (icon: ReactNode): icon is ComponentProps<typeof Icon>['name'] => typeof icon === 'string';
 
 const InfoPanelTitle: FC<InfoPanelTitleProps> = ({ title, icon }) => (
-	<Box display='flex' title={title} flexShrink={0} alignItems='center' fontScale='h4' color='default' withTruncatedText>
+	<Box display='flex' flexShrink={0} alignItems='center' fontScale='h4' color='default' withTruncatedText>
 		{isValidIcon(icon) ? <Icon name={icon} size='x22' /> : icon}
 		<Box mis='x8' flexGrow={1} withTruncatedText>
 			{title}


### PR DESCRIPTION
For solving this issue,
changes are done in  apps/meteor/client/components/InfoPanel/InfoPanelTitle.tsx  file and checked it on my local environment and it works fine. Please review this.

## Proposed changes (including videos or screenshots)


https://user-images.githubusercontent.com/98152507/223208403-ee1ff51f-911a-44b6-9c42-f44057dc8d00.mp4




## Issue(s)
closes #28299 

## Steps to test or reproduce
1. click on user information / click on room information
2. hover on user name / hover on room name
