### PR TITLE
fix: admin room checkbox and refactor

### DIFF
--- a/apps/meteor/app/api/server/lib/rooms.ts
+++ b/apps/meteor/app/api/server/lib/rooms.ts
@@ -27,7 +27,6 @@ export async function findAdminRooms({
 	const name = filter?.trim();
 	const discussion = types?.includes('discussions');
 	const includeTeams = types?.includes('teams');
-	const showOnlyTeams = types.length === 1 && types.includes('teams');
 	const typesToRemove = ['discussions', 'teams'];
 	const showTypes = Array.isArray(types) ? types.filter((type) => !typesToRemove.includes(type)) : [];
 	const options = {
@@ -36,14 +35,7 @@ export async function findAdminRooms({
 		limit: count,
 	};
 
-	let result;
-	if (name && showTypes.length) {
-		result = Rooms.findByNameOrFnameContainingAndTypes(name, showTypes, discussion, includeTeams, showOnlyTeams, options);
-	} else if (showTypes.length) {
-		result = Rooms.findByTypes(showTypes, discussion, includeTeams, showOnlyTeams, options);
-	} else {
-		result = Rooms.findByNameOrFnameContaining(name, discussion, includeTeams, showOnlyTeams, options);
-	}
+	const result = Rooms.findByNameOrFnameContainingAndTypes(name, showTypes, discussion, includeTeams, options);
 
 	const { cursor, totalCount } = result;
 

--- a/packages/model-typings/src/models/IRoomsModel.ts
+++ b/packages/model-typings/src/models/IRoomsModel.ts
@@ -17,13 +17,8 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 		types: any,
 		discussion?: boolean,
 		teams?: boolean,
-		showOnlyTeams?: boolean,
 		options?: any,
 	): any;
-
-	findByTypes(types: any, discussion?: boolean, teams?: boolean, onlyTeams?: boolean, options?: any): any;
-
-	findByNameOrFnameContaining(name: any, discussion?: boolean, teams?: boolean, onlyTeams?: boolean, options?: any): any;
 
 	findByTeamId(teamId: any, options?: any): any;
 


### PR DESCRIPTION
## Description:
Discussion filter is being prioritized on the filter - even if the user selects more the one it will only return discussion if the checkbox is selected

## Preconditions:
Have created dm’s, channels, and teams before starting the testing

## Steps to reproduce:
- Go to Admin -> Rooms
- Select all the checkboxes

## Expected Behavior:
It should filter by all of the filters selected 

## Actual Behavior:
If the user selects discussion, it only filters by discussion - ignoring all the other checkboxes