### PR TITLE
chore: Unnecessary useQuery refetch

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMainMessageQuery.ts
+++ b/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMainMessageQuery.ts
@@ -93,27 +93,31 @@ export const useThreadMainMessageQuery = (
 		};
 	}, []);
 
-	return useQuery(['rooms', room._id, 'threads', tmid, 'main-message'] as const, async ({ queryKey }) => {
-		const message = await getMessage(tmid);
+	return useQuery(
+		['rooms', room._id, 'threads', tmid, 'main-message'] as const,
+		async ({ queryKey }) => {
+			const message = await getMessage(tmid);
 
-		const mainMessage = (await onClientMessageReceived(message)) || message;
+			const mainMessage = (await onClientMessageReceived(message)) || message;
 
-		if (!mainMessage && !isThreadMainMessage(mainMessage)) {
-			throw new Error('Invalid main message');
-		}
+			if (!mainMessage && !isThreadMainMessage(mainMessage)) {
+				throw new Error('Invalid main message');
+			}
 
-		unsubscribeRef.current?.();
+			unsubscribeRef.current?.();
 
-		unsubscribeRef.current = subscribeToMessage(mainMessage, {
-			onMutate: () => {
-				queryClient.invalidateQueries(queryKey, { exact: true });
-			},
-			onDelete: () => {
-				onDelete?.();
-				queryClient.invalidateQueries(queryKey, { exact: true });
-			},
-		});
+			unsubscribeRef.current = subscribeToMessage(mainMessage, {
+				onMutate: () => {
+					queryClient.invalidateQueries(queryKey, { exact: true });
+				},
+				onDelete: () => {
+					onDelete?.();
+					queryClient.invalidateQueries(queryKey, { exact: true });
+				},
+			});
 
-		return mainMessage;
-	});
+			return mainMessage;
+		},
+		{ refetchOnWindowFocus: false },
+	);
 };

--- a/apps/meteor/ee/client/hooks/useHasLicenseModule.ts
+++ b/apps/meteor/ee/client/hooks/useHasLicenseModule.ts
@@ -9,6 +9,7 @@ export const useHasLicenseModule = (licenseName: BundleFeature): 'loading' | boo
 
 	const features = useQuery(['ee.features'], method, {
 		enabled: !!uid,
+		refetchOnWindowFocus: false,
 	});
 
 	return features.data?.includes(licenseName) ?? 'loading';


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->


<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
Sometimes when the user focuses on the window that is running the Rocket.Chat some queries are triggered again without a reason, to prevent this to happen I added a option to `useQuery` hook, `refetchOnWindowFocus: false`

**Queries impacted:**
- useThreadMainMessageQuery.ts - called when has to get the thread main message, for e.g in thread preview reply
- useHasLicenseModule.ts - called when the client starts to show/hide certain areas that are restricted by licenses, this don't change very often


<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Open Rocket.Chat
2. Open network tab
3. Changing tab or clicking outside tab window triggers some requests

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
