### PR TITLE
 fix: Tooltip position of Sound in Livechat Popup mode fixed

### DIFF
--- a/packages/livechat/src/components/Tooltip/index.js
+++ b/packages/livechat/src/components/Tooltip/index.js
@@ -56,7 +56,7 @@ export class TooltipContainer extends Component {
 		placement: null,
 	};
 
-	showTooltip = (event, { content, placement = 'bottom', childIndex }) => {
+	showTooltip = (event, { content, placement = 'bottom-left', childIndex }) => {
 		const triggerBounds = event.target.getBoundingClientRect();
 		this.setState({
 			tooltip: (


### PR DESCRIPTION
Tooltip position of Sound in Livechat Popup mode fixed.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
#28115 
