### PR TITLE
fix: In the login from placeholder is not shown in password field #28631

### DIFF
--- a/packages/web-ui-registration/src/LoginForm.tsx
+++ b/packages/web-ui-registration/src/LoginForm.tsx
@@ -132,7 +132,7 @@ export const LoginForm = ({ setLoginRoute }: { setLoginRoute: DispatchLoginRoute
 												clearErrors(['username', 'password']);
 											},
 										})}
-										placeholder={passwordPlaceholder}
+										placeholder={passwordPlaceholder || t('registration.component.form.password')}
 										error={
 											errors.password?.message ||
 											(errors.password?.type === 'required' ? t('registration.component.form.requiredField') : undefined)


### PR DESCRIPTION
For solving this issue,
changes are done in  packages/web-ui-registration/src/LoginForm.tsx  file and checked it on my local environment and it works fine. Please review this.

## Proposed changes (including videos or screenshots)

![Screenshot (103)](https://user-images.githubusercontent.com/98152507/227840437-b5bf1975-dd6e-4a1e-a13f-eafc492b2e29.png)





## Issue(s)
closes #28631 

## Steps to test or reproduce
1. go to login page