### PR TITLE
fix: change default text color in homepage custom content block

### DIFF
--- a/apps/meteor/client/views/home/cards/CustomContentCard.tsx
+++ b/apps/meteor/client/views/home/cards/CustomContentCard.tsx
@@ -58,12 +58,7 @@ const CustomContentCard = (): ReactElement | null => {
 						{willNotShowCustomContent ? t('Not_Visible_To_Workspace') : t('Visible_To_Workspace')}
 					</Tag>
 				</Card.Title>
-				<Box
-					mb='x8'
-					role='status'
-					color='info'
-					aria-label={isCustomContentBodyEmpty ? t('Homepage_Custom_Content_Default_Message') : customContentBody}
-				>
+				<Box mb='x8' role='status' aria-label={isCustomContentBodyEmpty ? t('Homepage_Custom_Content_Default_Message') : customContentBody}>
 					{isCustomContentBodyEmpty ? t('Homepage_Custom_Content_Default_Message') : <CustomHomepageContent />}
 				</Box>
 				<Card.FooterWrapper>
@@ -97,7 +92,7 @@ const CustomContentCard = (): ReactElement | null => {
 	if (!willNotShowCustomContent && !isCustomContentOnly) {
 		return (
 			<Card>
-				<Box mb='x8' color='info'>
+				<Box mb='x8'>
 					<CustomHomepageContent role='status' aria-label={customContentBody} />
 				</Box>
 			</Card>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

- The default text (if there is no content or the admin just adds text without style) color in the homepage custom content block was blue (due to `color="info"`), but should actually be black

Before:

<img width="613" alt="Screen Shot 2023-03-29 at 12 14 47" src="https://user-images.githubusercontent.com/48109548/228594931-379f4df6-89f1-411d-9226-76ad9abe1c02.png">


After:

<img width="605" alt="Screen Shot 2023-03-29 at 12 47 55" src="https://user-images.githubusercontent.com/48109548/228594967-6a2ceb9f-6422-4b85-8021-653ae9a3e4f6.png">


<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
