### PR TITLE
[FIX]: Not show error message if try to create Custom Emoji without Aliases field #28313

### DIFF
--- a/apps/meteor/client/views/admin/customEmoji/AddCustomEmoji.tsx
+++ b/apps/meteor/client/views/admin/customEmoji/AddCustomEmoji.tsx
@@ -18,7 +18,7 @@ const AddCustomEmoji = ({ close, onChange, ...props }: AddCustomEmojiProps): Rea
 	const [aliases, setAliases] = useState('');
 	const [emojiFile, setEmojiFile] = useState<Blob>();
 	const [newEmojiPreview, setNewEmojiPreview] = useState('');
-	const [errors, setErrors] = useState({ name: false, emoji: false, aliases: false });
+	const [errors, setErrors] = useState({ name: false, emoji: false, aliases: false, same:false });
 
 	const setEmojiPreview = useCallback(
 		async (file) => {
@@ -36,8 +36,12 @@ const AddCustomEmoji = ({ close, onChange, ...props }: AddCustomEmojiProps): Rea
 			return setErrors((prevState) => ({ ...prevState, name: true }));
 		}
 
+		if(!aliases){
+			return setErrors((prevState) => ({ ...prevState, aliases: true , same:false }));
+		}
+
 		if (name === aliases) {
-			return setErrors((prevState) => ({ ...prevState, aliases: true }));
+			return setErrors((prevState) => ({ ...prevState, same: true }));
 		}
 
 		if (!emojiFile) {
@@ -88,7 +92,8 @@ const AddCustomEmoji = ({ close, onChange, ...props }: AddCustomEmojiProps): Rea
 				<Field.Row>
 					<TextInput value={aliases} onChange={handleChangeAliases} placeholder={t('Aliases')} />
 				</Field.Row>
-				{errors.aliases && <Field.Error>{t('Custom_Emoji_Error_Same_Name_And_Alias')}</Field.Error>}
+				{errors.same && <Field.Error>{t('Custom_Emoji_Error_Same_Name_And_Alias')}</Field.Error>}
+				{errors.aliases && <Field.Error>{t('error-the-field-is-required', { field: t('Aliases') })}</Field.Error>}
 			</Field>
 			<Field>
 				<Field.Label alignSelf='stretch' display='flex' justifyContent='space-between' alignItems='center'>


### PR DESCRIPTION
For solving this issue,
changes are done in  apps/meteor/client/views/admin/customEmoji/AddCustomEmoji.tsx  file and checked it on my local environment and it works fine. Please review this.

## Proposed changes (including videos or screenshots)



https://user-images.githubusercontent.com/98152507/223607925-43ed8008-e29d-428c-b5b3-1e89e2daaa2c.mp4






## Issue(s)
closes #28313 

## Steps to test or reproduce
1. in the Custom Emoji page click on the new button to create new Custom Emoji
2. try to create Custom Emoji without fill the Aliases field
