### PR TITLE
fix: fix a bug rocket.cat help command not showing the shortcut for one 

### DIFF
--- a/apps/meteor/app/slashcommands-help/server/server.ts
+++ b/apps/meteor/app/slashcommands-help/server/server.ts
@@ -56,15 +56,19 @@ slashCommands.add({
 				command: 'Shift + Enter',
 			},
 		];
-		keys.forEach((key) => {
+    switch (_command) {
+		case 'help':
+		  keys.forEach((key) => {
 			void api.broadcast('notify.ephemeralMessage', userId, item.rid, {
-				msg: TAPi18n.__(key.key, {
-					postProcess: 'sprintf',
-					sprintf: [key.command],
-					lng: user?.language || settings.get('Language') || 'en',
-				}),
+			  msg: TAPi18n.__(key.key, {
+				postProcess: 'sprintf',
+				sprintf: [key.command],
+				lng: user?.language || settings.get('Language') || 'en',
+			  }),
 			});
-		});
+		  });
+		  break;
+	  }
 	},
 	options: {
 		description: 'Show_the_keyboard_shortcut_list',


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
adds a `help` command to list keyboard shortcuts in the chat UI.

  I've introduced a new slash command to the Rocket.Chat application in this pull request to allow users to easily access a list of keyboard shortcuts. This feature will enhance the user experience by making it simple to learn and remember shortcuts for commonly performed actions. When you type "/help" in the chat input box, a list of shortcuts will appear in an ephemeral message accessible only to the user who prompted the command.

This pull request contains no particular bug fixes or feature requests. But, I feel that this feature will be a useful addition to the program and that the user community would welcome it.


<!-- END CHANGELOG -->

## Issue(s)
No issue is related to this PR.

## Steps to test or reproduce
Type `/help` command in the chat input and verify if the keyboard shortcuts are shown in the message area.

## Further comments
 No further comment.