### PR TITLE
fix: missing suggestions from list of suggested emojis in Emoji Popup

### DIFF
--- a/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
+++ b/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
@@ -157,24 +157,27 @@ const ComposerPopupProvider = ({ children, room }: { children: ReactNode; room: 
 					const seeColor = new RegExp('_t(?:o|$)(?:n|$)(?:e|$)(?:[1-5]|$)(?::|$)$');
 
 					const emojiSort = (recents: string[]) => (a: { _id: string }, b: { _id: string }) => {
-						let idA = a._id;
-						let idB = a._id;
+						const aExact = a._id === key ? 2 : 0;
+						const bExact = b._id === key ? 2 : 0;
+						const aPartial = a._id.startsWith(key) ? 1 : 0;
+						const bPartial = b._id.startsWith(key) ? 1 : 0;
+
+						let aScore = aExact + aPartial;
+						let bScore = bExact + bPartial;
 
 						if (recents.includes(a._id)) {
-							idA = recents.indexOf(a._id) + idA;
+							aScore += recents.indexOf(a._id) + 1;
 						}
 						if (recents.includes(b._id)) {
-							idB = recents.indexOf(b._id) + idB;
+							bScore += recents.indexOf(b._id) + 1;
 						}
 
-						if (idA < idB) {
+						if (aScore > bScore) {
 							return -1;
 						}
-
-						if (idA > idB) {
+						if (aScore < bScore) {
 							return 1;
 						}
-
 						return 0;
 					};
 					const filterRegex = new RegExp(escapeRegExp(filter), 'i');


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
When a user typed "heart" wrapped in ":" the Emoji Suggestion Popup did not suggest :heart: . This was because the emoji list is sliced to show only 10 emojis in ComposerPopupProvider (apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx).

After:

[heart.webm](https://user-images.githubusercontent.com/79307894/232035111-9d920620-d22f-4e9b-8221-8127322c727a.webm)

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Closes #28842 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
I added scores based on exact/partial matches and used that for sorting the list of emojis
If emoji is in "recents" it will get a higher priority (i.e. top of the list)

[with_frequently_use.webm](https://user-images.githubusercontent.com/79307894/232035593-a2c7dc51-7106-4f79-ba1a-d97b25e17f8a.webm)


But if there is an exact match available it will get higher priority than the emoji in "recents", so that users who already know the shortcuts won't be suggested random emojis.

[priority_exact_match.webm](https://user-images.githubusercontent.com/79307894/232035586-c0195062-da1e-4a27-8b73-883c5cd8c102.webm)