### PR TITLE
regression: `Not authorized` error when loading a room

### DIFF
--- a/apps/meteor/app/lib/server/functions/loadMessageHistory.ts
+++ b/apps/meteor/app/lib/server/functions/loadMessageHistory.ts
@@ -14,7 +14,8 @@ export async function loadMessageHistory({
 	showThreadMessages = true,
 	offset = 0,
 }: {
-	userId: string;
+	// userId is undefined if user is reading anonymously
+	userId?: string;
 	rid: string;
 	end: Date | undefined;
 	limit?: number;

--- a/apps/meteor/app/utils/server/lib/normalizeMessagesForUser.ts
+++ b/apps/meteor/app/utils/server/lib/normalizeMessagesForUser.ts
@@ -3,7 +3,10 @@ import { Users } from '@rocket.chat/models';
 
 import { settings } from '../../../settings/server';
 
-const filterStarred = (message: IMessage, uid: string): IMessage => {
+const filterStarred = (message: IMessage, uid?: string): IMessage => {
+	// if Allow_anonymous_read is enabled, uid will be undefined
+	if (!uid) return message;
+
 	// only return starred field if user has it starred
 	if (message.starred && Array.isArray(message.starred)) {
 		message.starred = message.starred.filter((star) => star._id === uid);
@@ -17,7 +20,7 @@ function getNameOfUsername(users: Map<string, string>, username: string): string
 	return users.get(username) || username;
 }
 
-export const normalizeMessagesForUser = async (messages: IMessage[], uid: string): Promise<IMessage[]> => {
+export const normalizeMessagesForUser = async (messages: IMessage[], uid?: string): Promise<IMessage[]> => {
 	// if not using real names, there is nothing else to do
 	if (!settings.get('UI_Use_Real_Name')) {
 		return messages.map((message) => filterStarred(message, uid));

--- a/apps/meteor/client/views/room/hooks/useOpenRoom.ts
+++ b/apps/meteor/client/views/room/hooks/useOpenRoom.ts
@@ -21,6 +21,7 @@ export function useOpenRoom({ type, reference }: { type: RoomType; reference: st
 	const directRoute = useRoute('direct');
 
 	return useQuery(
+		// we need to add uid and username here because `user` is not loaded all at once (see UserProvider -> Meteor.user())
 		['rooms', { type, reference }, { uid: user?._id, username: user?.username }] as const,
 		async (): Promise<{ rid: IRoom['_id'] }> => {
 			if ((user && !user.username) || (!user && !allowAnonymousRead)) {

--- a/apps/meteor/client/views/room/hooks/useOpenRoom.ts
+++ b/apps/meteor/client/views/room/hooks/useOpenRoom.ts
@@ -21,7 +21,7 @@ export function useOpenRoom({ type, reference }: { type: RoomType; reference: st
 	const directRoute = useRoute('direct');
 
 	return useQuery(
-		['rooms', { type, reference }] as const,
+		['rooms', { type, reference }, { uid: user?._id, username: user?.username }] as const,
 		async (): Promise<{ rid: IRoom['_id'] }> => {
 			if ((user && !user.username) || (!user && !allowAnonymousRead)) {
 				throw new NotAuthorizedError();


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
Listen for changes in the `user` object from `useUser`
This also fixes some logic regarding anonymous reading. (Also a regression)
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Login with a user, open a room and refresh without cache. It happens only sometimes, but most times this error appears.
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This happened because the `user` object comes from `Meteor.user()` and we provide it in a context above the Room. Unfortunately, this user depends on meteor reactivity, and `username` is left out on the first load, meaning the checks inside `useOpenRoom` fail, even though milliseconds after it runs, username is present.

[SUP-75]

[SUP-75]: https://rocketchat.atlassian.net/browse/SUP-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ