### PR TITLE
[FIX] app status inconsistencies when running multiple instances in a cluster

### DIFF
--- a/apps/meteor/app/apps/server/bridges/activation.ts
+++ b/apps/meteor/app/apps/server/bridges/activation.ts
@@ -11,12 +11,19 @@ export class AppActivationBridge extends ActivationBridge {
 		super();
 	}
 
-	protected async appAdded(app: ProxiedApp): Promise<void> {
-		await this.orch.getNotifier().appAdded(app.getID());
+	protected async appAdded(_app: ProxiedApp): Promise<void> {
+		// await this.orch.getNotifier().appAdded(app.getID());
+
+		// Calls made via AppActivationBridge should NOT go through
+		// View https://github.com/RocketChat/Rocket.Chat/pull/29180 for details
+		return undefined;
 	}
 
-	protected async appUpdated(app: ProxiedApp): Promise<void> {
-		await this.orch.getNotifier().appUpdated(app.getID());
+	protected async appUpdated(_app: ProxiedApp): Promise<void> {
+		// Calls made via AppActivationBridge should NOT go through
+		// View https://github.com/RocketChat/Rocket.Chat/pull/29180 for details
+		// await this.orch.getNotifier().appUpdated(app.getID());
+		return undefined;
 	}
 
 	protected async appRemoved(app: ProxiedApp): Promise<void> {

--- a/apps/meteor/ee/server/apps/communication/rest.js
+++ b/apps/meteor/ee/server/apps/communication/rest.js
@@ -407,7 +407,7 @@ export class AppsRestApi {
 						info.status = success ? AppStatus.AUTO_ENABLED : info.status;
 					}
 
-					void orchestrator.getNotifier().appAdded(info.id);
+					orchestrator.getNotifier().appAdded(info.id);
 
 					return API.v1.success({
 						app: info,
@@ -743,7 +743,7 @@ export class AppsRestApi {
 
 					notifyAppInstall(orchestrator.getMarketplaceUrl(), 'update', info);
 
-					void orchestrator.getNotifier().appUpdated(info.id);
+					orchestrator.getNotifier().appUpdated(info.id);
 
 					return API.v1.success({
 						app: info,

--- a/apps/meteor/ee/server/apps/communication/rest.js
+++ b/apps/meteor/ee/server/apps/communication/rest.js
@@ -407,6 +407,8 @@ export class AppsRestApi {
 						info.status = success ? AppStatus.AUTO_ENABLED : info.status;
 					}
 
+					void orchestrator.getNotifier().appAdded(info.id);
+
 					return API.v1.success({
 						app: info,
 						implemented: aff.getImplementedInferfaces(),
@@ -740,6 +742,8 @@ export class AppsRestApi {
 					info.status = aff.getApp().getStatus();
 
 					notifyAppInstall(orchestrator.getMarketplaceUrl(), 'update', info);
+
+					void orchestrator.getNotifier().appUpdated(info.id);
 
 					return API.v1.success({
 						app: info,

--- a/apps/meteor/ee/server/apps/communication/websockets.ts
+++ b/apps/meteor/ee/server/apps/communication/websockets.ts
@@ -40,7 +40,7 @@ export class AppServerListener {
 	}
 
 	async onAppAdded(appId: string): Promise<void> {
-		await (this.orch.getManager()! as any).loadOne(appId); // TO-DO: fix type
+		await (this.orch.getManager()! as any).addLocal(appId); // TO-DO: fix type
 		this.clientStreamer.emitWithoutBroadcast(AppEvents.APP_ADDED, appId);
 	}
 

--- a/apps/meteor/ee/server/services/package.json
+++ b/apps/meteor/ee/server/services/package.json
@@ -18,7 +18,7 @@
 	"author": "Rocket.Chat",
 	"license": "MIT",
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.37.3",
+		"@rocket.chat/apps-engine": "1.37.4",
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/emitter": "next",

--- a/apps/meteor/package.json
+++ b/apps/meteor/package.json
@@ -211,7 +211,7 @@
 		"@react-pdf/renderer": "^3.1.3",
 		"@rocket.chat/agenda": "workspace:^",
 		"@rocket.chat/api-client": "workspace:^",
-		"@rocket.chat/apps-engine": "1.37.3",
+		"@rocket.chat/apps-engine": "1.37.4",
 		"@rocket.chat/cas-validate": "workspace:^",
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",

--- a/ee/apps/ddp-streamer/package.json
+++ b/ee/apps/ddp-streamer/package.json
@@ -15,7 +15,7 @@
 	],
 	"author": "Rocket.Chat",
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.37.3",
+		"@rocket.chat/apps-engine": "1.37.4",
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/emitter": "next",

--- a/ee/packages/presence/package.json
+++ b/ee/packages/presence/package.json
@@ -6,7 +6,7 @@
 		"@babel/core": "^7.20.5",
 		"@babel/preset-env": "^7.20.2",
 		"@babel/preset-typescript": "^7.18.6",
-		"@rocket.chat/apps-engine": "1.37.3",
+		"@rocket.chat/apps-engine": "1.37.4",
 		"@rocket.chat/eslint-config": "workspace:^",
 		"@rocket.chat/rest-typings": "workspace:^",
 		"@types/node": "^14.18.21",

--- a/packages/core-services/package.json
+++ b/packages/core-services/package.json
@@ -22,7 +22,7 @@
 		"/dist"
 	],
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.37.3",
+		"@rocket.chat/apps-engine": "1.37.4",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/icons": "next",
 		"@rocket.chat/message-parser": "next",

--- a/packages/core-typings/package.json
+++ b/packages/core-typings/package.json
@@ -22,7 +22,7 @@
 		"/dist"
 	],
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.37.3",
+		"@rocket.chat/apps-engine": "1.37.4",
 		"@rocket.chat/icons": "next",
 		"@rocket.chat/message-parser": "next",
 		"@rocket.chat/ui-kit": "next"

--- a/packages/fuselage-ui-kit/package.json
+++ b/packages/fuselage-ui-kit/package.json
@@ -54,7 +54,7 @@
     "react-dom": "*"
   },
   "devDependencies": {
-    "@rocket.chat/apps-engine": "1.37.3",
+    "@rocket.chat/apps-engine": "1.37.4",
     "@rocket.chat/eslint-config": "workspace:^",
     "@rocket.chat/fuselage": "next",
     "@rocket.chat/fuselage-hooks": "next",

--- a/packages/rest-typings/package.json
+++ b/packages/rest-typings/package.json
@@ -24,7 +24,7 @@
 		"/dist"
 	],
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.37.3",
+		"@rocket.chat/apps-engine": "1.37.4",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/message-parser": "next",
 		"@rocket.chat/ui-kit": "next",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26380,7 +26380,7 @@ __metadata:
   resolution: "lamejs@https://github.com/zhuker/lamejs.git#commit=582bbba6a12f981b984d8fb9e1874499fed85675"
   dependencies:
     use-strict: 1.0.1
-  checksum: fa829e0c170a65573e653b4d908a44aaf06a50e1bbade3b1217a300a03ccd59a537e294e2d924a584f9d70c7726a12d4c3af9c675436d48d08be5fb94b5eb400
+  checksum: ed7f6f1c9629b53c17023eb04b4fc5a222e9c34fcb4a2f61214488fc64e5cfea825e4588d959c5fb20f3a91f0120103fa60307dd43df995d498ff5ddb6200cd9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6548,6 +6548,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rocket.chat/apps-engine@npm:1.37.4":
+  version: 1.37.4
+  resolution: "@rocket.chat/apps-engine@npm:1.37.4"
+  dependencies:
+    adm-zip: ^0.5.9
+    cryptiles: ^4.1.3
+    jose: ^4.11.1
+    lodash.clonedeep: ^4.5.0
+    semver: ^5.7.1
+    stack-trace: 0.0.10
+    uuid: ^3.4.0
+    vm2: ^3.9.17
+  peerDependencies:
+    "@rocket.chat/ui-kit": "*"
+  checksum: 63181279b6ac5d771bfc902335a5a7a9d79d0119b4b60ce78a6083c1db4e59e660433a8dbababf611097099e02200c5908d836ccf87ca0d27ba787ba27b21885
+  languageName: node
+  linkType: hard
+
 "@rocket.chat/authorization-service@workspace:ee/apps/authorization-service":
   version: 0.0.0-use.local
   resolution: "@rocket.chat/authorization-service@workspace:ee/apps/authorization-service"
@@ -7237,7 +7255,7 @@ __metadata:
     "@react-pdf/renderer": ^3.1.3
     "@rocket.chat/agenda": "workspace:^"
     "@rocket.chat/api-client": "workspace:^"
-    "@rocket.chat/apps-engine": 1.37.3
+    "@rocket.chat/apps-engine": 1.37.4
     "@rocket.chat/cas-validate": "workspace:^"
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6530,24 +6530,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rocket.chat/apps-engine@npm:1.37.3":
-  version: 1.37.3
-  resolution: "@rocket.chat/apps-engine@npm:1.37.3"
-  dependencies:
-    adm-zip: ^0.5.9
-    cryptiles: ^4.1.3
-    jose: ^4.11.1
-    lodash.clonedeep: ^4.5.0
-    semver: ^5.7.1
-    stack-trace: 0.0.10
-    uuid: ^3.4.0
-    vm2: ^3.9.17
-  peerDependencies:
-    "@rocket.chat/ui-kit": "*"
-  checksum: bebcd9cb458a6e8e449628b9a519bda91c8aaf3c48b21b9518d5a9c8dbf35bccbfaca36ae1b620c5a64f2ee5e085e0bd0bc20865eb95424be65005f4e65c1387
-  languageName: node
-  linkType: hard
-
 "@rocket.chat/apps-engine@npm:1.37.4":
   version: 1.37.4
   resolution: "@rocket.chat/apps-engine@npm:1.37.4"
@@ -6613,7 +6595,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/core-services@workspace:packages/core-services"
   dependencies:
-    "@rocket.chat/apps-engine": 1.37.3
+    "@rocket.chat/apps-engine": 1.37.4
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/icons": next
@@ -6634,7 +6616,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/core-typings@workspace:packages/core-typings"
   dependencies:
-    "@rocket.chat/apps-engine": 1.37.3
+    "@rocket.chat/apps-engine": 1.37.4
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/icons": next
     "@rocket.chat/message-parser": next
@@ -6729,7 +6711,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/ddp-streamer@workspace:ee/apps/ddp-streamer"
   dependencies:
-    "@rocket.chat/apps-engine": 1.37.3
+    "@rocket.chat/apps-engine": 1.37.4
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/emitter": next
@@ -6920,7 +6902,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/fuselage-ui-kit@workspace:packages/fuselage-ui-kit"
   dependencies:
-    "@rocket.chat/apps-engine": 1.37.3
+    "@rocket.chat/apps-engine": 1.37.4
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/fuselage": next
     "@rocket.chat/fuselage-hooks": next
@@ -7784,7 +7766,7 @@ __metadata:
     "@babel/core": ^7.20.5
     "@babel/preset-env": ^7.20.2
     "@babel/preset-typescript": ^7.18.6
-    "@rocket.chat/apps-engine": 1.37.3
+    "@rocket.chat/apps-engine": 1.37.4
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/eslint-config": "workspace:^"
@@ -7845,7 +7827,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/rest-typings@workspace:packages/rest-typings"
   dependencies:
-    "@rocket.chat/apps-engine": 1.37.3
+    "@rocket.chat/apps-engine": 1.37.4
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/message-parser": next
@@ -33975,7 +33957,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "rocketchat-services@workspace:apps/meteor/ee/server/services"
   dependencies:
-    "@rocket.chat/apps-engine": 1.37.3
+    "@rocket.chat/apps-engine": 1.37.4
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/emitter": next


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
App status inconsistencies between multiple instances in a cluster boil down to the fact that the Apps-Engine is currently responsible for orchestrating when these events are triggered and is overly verbose in doing so.

Upon analysis, the framework itself _should not_ have the concept of "other instances" - this is a deployment detail of the host system, and as such should be controlled by the host. The correct solution for this problem is to review this notification system, potentially removing it from the framework and leaving the responsibility solely for Rocket.Chat.

However, this is hindering the current app management experience for workspaces, so this PR cuts the control of some notifications that come from the framework (the more problematic ones) and moves the control over to RC in a short and practical way.

This is done by turning the methods of the most problematic events in the `AppActivationBridge` into no-ops, and instead triggering the `AppServerNotifier` directly in the api endpoints that are applicable.

It is _not_ the most correct solution to the problem, but due to time constraints and urgency this will be applied first so we can move with the correct solution in a future point.
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1 - Setup a clustered deployment (6.x), either micro-services or high availability;
2 - Install an app on instance A
3 - App will not be available in other instances

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->