### PR TITLE
ci: skip ci on release publish

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,7 +3,7 @@ name: Publish Final Release
 on:
   push:
     branches:
-      - release-automation
+      - master
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/packages/release-action/src/bumpNextVersion.ts
+++ b/packages/release-action/src/bumpNextVersion.ts
@@ -78,7 +78,7 @@ export async function bumpNextVersion({
 
 		core.info('creating pull request');
 		await octokit.rest.pulls.create({
-			base: 'release-automation',
+			base: 'master',
 			head: newBranch,
 			title: finalPrTitle,
 			body: prBody,

--- a/packages/release-action/src/publishRelease.ts
+++ b/packages/release-action/src/publishRelease.ts
@@ -78,7 +78,7 @@ export async function publishRelease({
 	core.info('update version in all files to new');
 	await bumpFileVersions(cwd, currentVersion, newVersion);
 
-	await commitChanges(`Release ${newVersion}`);
+	await commitChanges(`Release ${newVersion}\n\n[no ci]`);
 
 	if (mergeFinal) {
 		// get current branch name

--- a/packages/release-action/src/startPatchRelease.ts
+++ b/packages/release-action/src/startPatchRelease.ts
@@ -48,7 +48,7 @@ export async function startPatchRelease({
 
 		core.info('creating pull request');
 		await octokit.rest.pulls.create({
-			base: 'release-automation',
+			base: 'master',
 			head: newBranch,
 			title: finalPrTitle,
 			body: '',


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->
Adding `[no ci]` to the commit message makes it possible to use only the `master` branch without having to worry about the automation running more than once.. doing so there is no need to use the `release-automation` to run the automation.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
