### PR TITLE
fix: Message tool menu accessibility issue

### DIFF
--- a/apps/meteor/client/components/message/toolbox/DesktopToolboxDropdown.tsx
+++ b/apps/meteor/client/components/message/toolbox/DesktopToolboxDropdown.tsx
@@ -22,14 +22,16 @@ const useDropdownPosition = (reference: RefObject<HTMLElement>, target: RefObjec
 	const boundingRect = innerContainer.getBoundingClientRect();
 
 	const { style } = usePosition(reference, target, {
-		placement: 'bottom-end',
+		placement: 'top-end',
 		container: innerContainer,
 	});
 
 	const left = `${parseFloat(String(style?.left ?? '0')) - boundingRect.left}px`;
 	const top = `${parseFloat(String(style?.top ?? '0')) - boundingRect.top}px`;
+	const maxHeight = "40vh";
+	const overflow = "scroll";
 
-	return useMemo(() => ({ ...style, left, top }), [style, left, top]);
+	return useMemo(() => ({ ...style, left, top, maxHeight, overflow}), [style, left, top, maxHeight, overflow]);
 };
 
 type DesktopToolboxDropdownProps = {


### PR DESCRIPTION
- Fixes #29575 
- pop over message toolbox biased towards opening above the message
- before fix
![Screenshot (21)](https://github.com/RocketChat/Rocket.Chat/assets/97937213/87e36a27-797c-4f26-9181-9adc3df7fe1f)
![Screenshot (22)](https://github.com/RocketChat/Rocket.Chat/assets/97937213/6b961b9f-445c-4e86-bd0c-16c997e9ec0e)
- after fix
![Screenshot (19)](https://github.com/RocketChat/Rocket.Chat/assets/97937213/c1eddd71-5be9-449b-ba74-5bd278de874f)
![Screenshot (20)](https://github.com/RocketChat/Rocket.Chat/assets/97937213/545d7397-3bd0-48db-b0f4-66083965b37f)

