### PR TITLE
chore: Bump up apps-engine

### DIFF
--- a/apps/meteor/ee/server/services/package.json
+++ b/apps/meteor/ee/server/services/package.json
@@ -18,7 +18,7 @@
 	"author": "Rocket.Chat",
 	"license": "MIT",
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.39.1",
+		"@rocket.chat/apps-engine": "1.40.0",
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/emitter": "next",

--- a/apps/meteor/package.json
+++ b/apps/meteor/package.json
@@ -220,7 +220,7 @@
 		"@rocket.chat/account-utils": "workspace:^",
 		"@rocket.chat/agenda": "workspace:^",
 		"@rocket.chat/api-client": "workspace:^",
-		"@rocket.chat/apps-engine": "1.40.0-alpha.280",
+		"@rocket.chat/apps-engine": "1.40.0",
 		"@rocket.chat/base64": "workspace:^",
 		"@rocket.chat/cas-validate": "workspace:^",
 		"@rocket.chat/core-services": "workspace:^",

--- a/ee/apps/ddp-streamer/package.json
+++ b/ee/apps/ddp-streamer/package.json
@@ -15,7 +15,7 @@
 	],
 	"author": "Rocket.Chat",
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.39.1",
+		"@rocket.chat/apps-engine": "1.40.0",
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/emitter": "next",

--- a/ee/packages/presence/package.json
+++ b/ee/packages/presence/package.json
@@ -6,7 +6,7 @@
 		"@babel/core": "~7.22.5",
 		"@babel/preset-env": "~7.22.5",
 		"@babel/preset-typescript": "~7.22.5",
-		"@rocket.chat/apps-engine": "1.39.1",
+		"@rocket.chat/apps-engine": "1.40.0",
 		"@rocket.chat/eslint-config": "workspace:^",
 		"@rocket.chat/rest-typings": "workspace:^",
 		"@types/node": "^14.18.51",

--- a/packages/core-services/package.json
+++ b/packages/core-services/package.json
@@ -31,7 +31,7 @@
 		"/dist"
 	],
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.39.1",
+		"@rocket.chat/apps-engine": "1.40.0",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/icons": "next",
 		"@rocket.chat/message-parser": "next",

--- a/packages/core-typings/package.json
+++ b/packages/core-typings/package.json
@@ -21,7 +21,7 @@
 		"/dist"
 	],
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.39.1",
+		"@rocket.chat/apps-engine": "1.40.0",
 		"@rocket.chat/icons": "next",
 		"@rocket.chat/message-parser": "next",
 		"@rocket.chat/ui-kit": "next"

--- a/packages/fuselage-ui-kit/package.json
+++ b/packages/fuselage-ui-kit/package.json
@@ -55,7 +55,7 @@
     "react-dom": "*"
   },
   "devDependencies": {
-    "@rocket.chat/apps-engine": "1.39.1",
+    "@rocket.chat/apps-engine": "1.40.0",
     "@rocket.chat/eslint-config": "workspace:^",
     "@rocket.chat/fuselage": "next",
     "@rocket.chat/fuselage-hooks": "next",

--- a/packages/rest-typings/package.json
+++ b/packages/rest-typings/package.json
@@ -24,7 +24,7 @@
 		"/dist"
 	],
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.39.1",
+		"@rocket.chat/apps-engine": "1.40.0",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/message-parser": "next",
 		"@rocket.chat/ui-kit": "next",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9475,9 +9475,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rocket.chat/apps-engine@npm:1.39.1":
-  version: 1.39.1
-  resolution: "@rocket.chat/apps-engine@npm:1.39.1"
+"@rocket.chat/apps-engine@npm:1.40.0":
+  version: 1.40.0
+  resolution: "@rocket.chat/apps-engine@npm:1.40.0"
   dependencies:
     adm-zip: ^0.5.9
     cryptiles: ^4.1.3
@@ -9489,25 +9489,7 @@ __metadata:
     vm2: ^3.9.19
   peerDependencies:
     "@rocket.chat/ui-kit": "*"
-  checksum: f42f2c93f872b04fedd88fc08ac1223db2140036c2e9cb336e01fc58fd2fd347a747b657009a5efd785bdfa858331a91ec56b94abe997e5bddeee03b7e8c4280
-  languageName: node
-  linkType: hard
-
-"@rocket.chat/apps-engine@npm:1.40.0-alpha.280":
-  version: 1.40.0-alpha.280
-  resolution: "@rocket.chat/apps-engine@npm:1.40.0-alpha.280"
-  dependencies:
-    adm-zip: ^0.5.9
-    cryptiles: ^4.1.3
-    jose: ^4.11.1
-    lodash.clonedeep: ^4.5.0
-    semver: ^5.7.1
-    stack-trace: 0.0.10
-    uuid: ^3.4.0
-    vm2: ^3.9.19
-  peerDependencies:
-    "@rocket.chat/ui-kit": "*"
-  checksum: e52495051a4f245ee04794a88df6f0c771f16367448290a8e83603ddc9341585d62699c84e829515ca43afe3e19135d38b205019a3ad611e7cbcbe45e5de978e
+  checksum: 868c5f8b53860ed18a54fb57299f1906c09a22242a3e1fafddf62c77860bc57dcc285ff9077aefbedc3697000a6412fad2b0ecf19d35c5fd71d498e256cec496
   languageName: node
   linkType: hard
 
@@ -9577,7 +9559,7 @@ __metadata:
     "@babel/core": ^7.21.4
     "@babel/preset-env": ^7.21.4
     "@babel/preset-typescript": ^7.21.4
-    "@rocket.chat/apps-engine": 1.39.1
+    "@rocket.chat/apps-engine": 1.40.0
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/icons": next
@@ -9603,7 +9585,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/core-typings@workspace:packages/core-typings"
   dependencies:
-    "@rocket.chat/apps-engine": 1.39.1
+    "@rocket.chat/apps-engine": 1.40.0
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/icons": next
     "@rocket.chat/message-parser": next
@@ -9692,7 +9674,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/ddp-streamer@workspace:ee/apps/ddp-streamer"
   dependencies:
-    "@rocket.chat/apps-engine": 1.39.1
+    "@rocket.chat/apps-engine": 1.40.0
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/emitter": next
@@ -9885,7 +9867,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/fuselage-ui-kit@workspace:packages/fuselage-ui-kit"
   dependencies:
-    "@rocket.chat/apps-engine": 1.39.1
+    "@rocket.chat/apps-engine": 1.40.0
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/fuselage": next
     "@rocket.chat/fuselage-hooks": next
@@ -9927,9 +9909,9 @@ __metadata:
     "@rocket.chat/icons": "*"
     "@rocket.chat/prettier-config": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-contexts": 1.0.0-rc.4
+    "@rocket.chat/ui-contexts": 1.0.0-rc.5
     "@rocket.chat/ui-kit": "*"
-    "@rocket.chat/ui-video-conf": 1.0.0-rc.4
+    "@rocket.chat/ui-video-conf": 1.0.0-rc.5
     "@tanstack/react-query": "*"
     react: "*"
     react-dom: "*"
@@ -10011,14 +9993,14 @@ __metadata:
     ts-jest: ~29.0.5
     typescript: ~5.1.3
   peerDependencies:
-    "@rocket.chat/core-typings": 6.3.0-rc.4
+    "@rocket.chat/core-typings": 6.3.0-rc.5
     "@rocket.chat/css-in-js": "*"
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-tokens": "*"
     "@rocket.chat/message-parser": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-client": 1.0.0-rc.4
-    "@rocket.chat/ui-contexts": 1.0.0-rc.4
+    "@rocket.chat/ui-client": 1.0.0-rc.5
+    "@rocket.chat/ui-contexts": 1.0.0-rc.5
     katex: "*"
     react: "*"
   languageName: unknown
@@ -10235,7 +10217,7 @@ __metadata:
     "@rocket.chat/account-utils": "workspace:^"
     "@rocket.chat/agenda": "workspace:^"
     "@rocket.chat/api-client": "workspace:^"
-    "@rocket.chat/apps-engine": 1.40.0-alpha.280
+    "@rocket.chat/apps-engine": 1.40.0
     "@rocket.chat/base64": "workspace:^"
     "@rocket.chat/cas-validate": "workspace:^"
     "@rocket.chat/core-services": "workspace:^"
@@ -10799,7 +10781,7 @@ __metadata:
     "@babel/core": ~7.22.5
     "@babel/preset-env": ~7.22.5
     "@babel/preset-typescript": ~7.22.5
-    "@rocket.chat/apps-engine": 1.39.1
+    "@rocket.chat/apps-engine": 1.40.0
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/eslint-config": "workspace:^"
@@ -10898,7 +10880,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/rest-typings@workspace:packages/rest-typings"
   dependencies:
-    "@rocket.chat/apps-engine": 1.39.1
+    "@rocket.chat/apps-engine": 1.40.0
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/message-parser": next
@@ -11081,7 +11063,7 @@ __metadata:
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-contexts": 1.0.0-rc.4
+    "@rocket.chat/ui-contexts": 1.0.0-rc.5
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -11235,7 +11217,7 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-contexts": 1.0.0-rc.4
+    "@rocket.chat/ui-contexts": 1.0.0-rc.5
     react: ^17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -11301,7 +11283,7 @@ __metadata:
     typescript: ~5.1.3
   peerDependencies:
     "@rocket.chat/layout": "*"
-    "@rocket.chat/ui-contexts": 1.0.0-rc.4
+    "@rocket.chat/ui-contexts": 1.0.0-rc.5
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"
@@ -36739,7 +36721,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "rocketchat-services@workspace:apps/meteor/ee/server/services"
   dependencies:
-    "@rocket.chat/apps-engine": 1.39.1
+    "@rocket.chat/apps-engine": 1.40.0
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/emitter": next


### PR DESCRIPTION
Update Apps-Engine version from 1.40.0 alpha to latest - https://github.com/RocketChat/Rocket.Chat.Apps-engine/releases/tag/v1.40.0