### PR TITLE
fix: Trigger app post user created event correctly

### DIFF
--- a/.changeset/slow-lizards-breathe.md
+++ b/.changeset/slow-lizards-breathe.md
@@ -2,4 +2,4 @@
 '@rocket.chat/meteor': patch
 ---
 
-Fix Apps-Engine event `IPostUserCreated` execution
+Fixed Apps-Engine event `IPostUserCreated` execution

--- a/.changeset/slow-lizards-breathe.md
+++ b/.changeset/slow-lizards-breathe.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fix Apps-Engine event `IPostUserCreated` execution

--- a/apps/meteor/app/authentication/server/startup/index.js
+++ b/apps/meteor/app/authentication/server/startup/index.js
@@ -343,10 +343,12 @@ const insertUserDocAsync = async function (options, user) {
 		}
 	}
 
-	// `post` triggered events don't need to wait for the promise to resolve
-	Apps.triggerEvent(AppEvents.IPostUserCreated, { user, performedBy: await safeGetMeteorUser() }).catch((e) => {
-		Apps.getRocketChatLogger().error('Error while executing post user created event:', e);
-	});
+	if (!options.skipAppsEngineEvent) {
+		// `post` triggered events don't need to wait for the promise to resolve
+		Apps.triggerEvent(AppEvents.IPostUserCreated, { user, performedBy: await safeGetMeteorUser() }).catch((e) => {
+			Apps.getRocketChatLogger().error('Error while executing post user created event:', e);
+		});
+	}
 
 	return _id;
 };


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
Apps-engine event `IPostUserCreated` was being triggered right _before_ the user was created
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Kudos to @pierre-lehnen-rc for spotting this one out