### PR TITLE
fix: HTTP timeout too short on Apps-Engine bridge

### DIFF
--- a/.changeset/red-windows-admire.md
+++ b/.changeset/red-windows-admire.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed an issue where timeout for http requests in Apps-Engine bridges was too short

--- a/apps/meteor/app/apps/server/bridges/http.ts
+++ b/apps/meteor/app/apps/server/bridges/http.ts
@@ -7,6 +7,11 @@ import type { AppServerOrchestrator } from '../../../../ee/server/apps/orchestra
 
 const isGetOrHead = (method: string): boolean => ['GET', 'HEAD'].includes(method.toUpperCase());
 
+// Previously, there was no timeout for HTTP requests.
+// We're setting the default timeout now to 3 minutes as it
+// seems to be a good balance
+const DEFAULT_TIMEOUT = 3 * 60 * 1000;
+
 export class AppHttpBridge extends HttpBridge {
 	constructor(private readonly orch: AppServerOrchestrator) {
 		super();
@@ -73,6 +78,7 @@ export class AppHttpBridge extends HttpBridge {
 					method,
 					body: content,
 					headers,
+					timeout: DEFAULT_TIMEOUT,
 				},
 				(request.hasOwnProperty('strictSSL') && !request.strictSSL) ||
 					(request.hasOwnProperty('rejectUnauthorized') && request.rejectUnauthorized),

--- a/apps/meteor/app/apps/server/bridges/http.ts
+++ b/apps/meteor/app/apps/server/bridges/http.ts
@@ -67,6 +67,8 @@ export class AppHttpBridge extends HttpBridge {
 			content = undefined;
 		}
 
+		const timeout = request.timeout || DEFAULT_TIMEOUT;
+
 		// end comptability with old HTTP.call API
 
 		this.orch.debugLog(`The App ${info.appId} is requesting from the outter webs:`, info);
@@ -78,7 +80,7 @@ export class AppHttpBridge extends HttpBridge {
 					method,
 					body: content,
 					headers,
-					timeout: DEFAULT_TIMEOUT,
+					timeout,
 				},
 				(request.hasOwnProperty('strictSSL') && !request.strictSSL) ||
 					(request.hasOwnProperty('rejectUnauthorized') && request.rejectUnauthorized),


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
Previously there was no timeout configured for HTTP requests made by apps via the Apps-Engine bridge, however the underlying library that handled this was changed and introduced a timeout of 20s - breaking compatibility to some extent. 

Here we set the timeout to 3m as it seems to be an appropriate balance.
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://github.com/RocketChat/Rocket.Chat/issues/30111

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
