### PR TITLE
fix: `default` field is not returned from the `setDefault` endpoint when setting to false

### DIFF
--- a/.changeset/real-pets-visit.md
+++ b/.changeset/real-pets-visit.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/meteor": patch
+"@rocket.chat/core-typings": patch
+---
+
+Fixed `default` field not being returned from the `setDefault` endpoints when setting to false

--- a/apps/meteor/server/models/raw/Rooms.ts
+++ b/apps/meteor/server/models/raw/Rooms.ts
@@ -1348,7 +1348,7 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			t: {
 				$in: types,
 			},
-			...(defaultValue ? { default: true } : { default: { $exists: false } }),
+			...(defaultValue ? { default: true } : { default: { $ne: true } }),
 		};
 
 		return this.find(query, options);
@@ -1738,17 +1738,11 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 	saveDefaultById(_id: IRoom['_id'], defaultValue: boolean): Promise<UpdateResult> {
 		const query: Filter<IRoom> = { _id };
 
-		const update: UpdateFilter<IRoom> = defaultValue
-			? {
-					$set: {
-						default: true,
-					},
-			  }
-			: {
-					$unset: {
-						default: 1,
-					},
-			  };
+		const update: UpdateFilter<IRoom> = {
+			$set: {
+				default: defaultValue,
+			},
+		};
 
 		return this.updateOne(query, update);
 	}

--- a/apps/meteor/tests/end-to-end/api/02-channels.js
+++ b/apps/meteor/tests/end-to-end/api/02-channels.js
@@ -1573,25 +1573,49 @@ describe('[Channels]', function () {
 			});
 	});
 
-	it('/channels.setDefault', async () => {
-		const roomInfo = await getRoomInfo(channel._id);
+	describe('/channels.setDefault', () => {
+		it('should set channel as default', async () => {
+			const roomInfo = await getRoomInfo(channel._id);
 
-		return request
-			.post(api('channels.setDefault'))
-			.set(credentials)
-			.send({
-				roomId: channel._id,
-				default: true,
-			})
-			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-				expect(res.body).to.have.nested.property('channel._id');
-				expect(res.body).to.have.nested.property('channel.name', `EDITED${apiPublicChannelName}`);
-				expect(res.body).to.have.nested.property('channel.t', 'c');
-				expect(res.body).to.have.nested.property('channel.msgs', roomInfo.channel.msgs);
-			});
+			return request
+				.post(api('channels.setDefault'))
+				.set(credentials)
+				.send({
+					roomId: channel._id,
+					default: true,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.nested.property('channel._id');
+					expect(res.body).to.have.nested.property('channel.name', `EDITED${apiPublicChannelName}`);
+					expect(res.body).to.have.nested.property('channel.t', 'c');
+					expect(res.body).to.have.nested.property('channel.msgs', roomInfo.channel.msgs);
+					expect(res.body).to.have.nested.property('channel.default', true);
+				});
+		});
+		it('should unset channel as default', async () => {
+			const roomInfo = await getRoomInfo(channel._id);
+
+			return request
+				.post(api('channels.setDefault'))
+				.set(credentials)
+				.send({
+					roomId: channel._id,
+					default: false,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.nested.property('channel._id');
+					expect(res.body).to.have.nested.property('channel.name', `EDITED${apiPublicChannelName}`);
+					expect(res.body).to.have.nested.property('channel.t', 'c');
+					expect(res.body).to.have.nested.property('channel.msgs', roomInfo.channel.msgs);
+					expect(res.body).to.have.nested.property('channel.default', false);
+				});
+		});
 	});
 
 	it('/channels.leave', async () => {

--- a/packages/core-typings/src/IRoom.ts
+++ b/packages/core-typings/src/IRoom.ts
@@ -23,7 +23,7 @@ export interface IRoom extends IRocketChatRecord {
 	name?: string;
 	fname?: string;
 	msgs: number;
-	default?: true;
+	default?: boolean;
 	broadcast?: true;
 	featured?: true;
 	announcement?: string;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
 - Do not remove the `default` field from rooms when it's set to `false` (since this would cause a breaking change in the `.setDefault` endpoints).

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Introduced in #28260

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Use the `channels.setDefault` endpoint to make a room default in the workspace. Then use it again to _unset_ it as default.
**Current behavior:** the `default` field is not returned in the response when setting it to `false`.
**Expected behavior:** the `default` field should be returned (with `false` as its value)

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
TC-930

It'd be a nice change not to store the default field with `false` value, though (since we never check for a `false` value in this field). Let's keep this a to-do for the next major release.