### PR TITLE
chore: add subscription metrics to ddp-streamer

### DIFF
--- a/ee/apps/ddp-streamer/src/DDPStreamer.ts
+++ b/ee/apps/ddp-streamer/src/DDPStreamer.ts
@@ -73,6 +73,15 @@ export class DDPStreamer extends ServiceClass {
 		}
 
 		metrics.register({
+			name: 'rocketchat_subscription',
+			type: 'histogram',
+			labelNames: ['subscription'],
+			description: 'Client subscriptions to Rocket.Chat',
+			unit: 'millisecond',
+			quantiles: true,
+		});
+
+		metrics.register({
 			name: 'users_connected',
 			type: 'gauge',
 			labelNames: ['nodeID'],
@@ -85,6 +94,8 @@ export class DDPStreamer extends ServiceClass {
 			labelNames: ['nodeID'],
 			description: 'Users logged by streamer',
 		});
+
+		server.setMetrics(metrics);
 
 		server.on(DDP_EVENTS.CONNECTED, () => {
 			metrics.increment('users_connected', { nodeID }, 1);

--- a/packages/core-services/src/types/IBroker.ts
+++ b/packages/core-services/src/types/IBroker.ts
@@ -27,6 +27,7 @@ export type BaseMetricOptions = {
 	labelNames?: Array<string>;
 	unit?: string;
 	aggregator?: string;
+	[key: string]: unknown;
 };
 
 export interface IServiceMetrics {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->
I chose the name `rocketchat_subscription` for the metric instead of `rocketchat_meteor_subscriptions` used on monolith because they're actually different, I had to use histogram for the new one since `moleculer` doesn't support summary.

Here is an example of the metrics that will be provided by `ddp-streamer`:

```
rocketchat_subscription{namespace="",nodeID="node",subscription="stream-notify-all",quantile="0.5"} 0.08320799999999999
rocketchat_subscription{namespace="",nodeID="node",subscription="stream-notify-all",quantile="0.9"} 0.373125
rocketchat_subscription{namespace="",nodeID="node",subscription="stream-notify-all",quantile="0.95"} 0.373125
rocketchat_subscription{namespace="",nodeID="node",subscription="stream-notify-all",quantile="0.99"} 0.373125
rocketchat_subscription{namespace="",nodeID="node",subscription="stream-notify-all",quantile="0.999"} 0.373125
rocketchat_subscription_sum{namespace="",nodeID="node",subscription="stream-notify-all"} 0.456333
rocketchat_subscription_count{namespace="",nodeID="node",subscription="stream-notify-all"} 2
rocketchat_subscription_min{namespace="",nodeID="node",subscription="stream-notify-all"} 0.08320799999999999
rocketchat_subscription_mean{namespace="",nodeID="node",subscription="stream-notify-all"} 0.2281665
rocketchat_subscription_variance{namespace="",nodeID="node",subscription="stream-notify-all"} 0.042025933444499994
rocketchat_subscription_stddev{namespace="",nodeID="node",subscription="stream-notify-all"} 0.20500227668126028
rocketchat_subscription_max{namespace="",nodeID="node",subscription="stream-notify-all"} 0.373125
rocketchat_subscription{namespace="",nodeID="node",subscription="stream-room-messages",quantile="0.5"} 3.9154159999999996
rocketchat_subscription{namespace="",nodeID="node",subscription="stream-room-messages",quantile="0.9"} 4.168291
rocketchat_subscription{namespace="",nodeID="node",subscription="stream-room-messages",quantile="0.95"} 4.168291
rocketchat_subscription{namespace="",nodeID="node",subscription="stream-room-messages",quantile="0.99"} 4.168291
rocketchat_subscription{namespace="",nodeID="node",subscription="stream-room-messages",quantile="0.999"} 4.168291
rocketchat_subscription_sum{namespace="",nodeID="node",subscription="stream-room-messages"} 8.083707
rocketchat_subscription_count{namespace="",nodeID="node",subscription="stream-room-messages"} 2
rocketchat_subscription_min{namespace="",nodeID="node",subscription="stream-room-messages"} 3.9154159999999996
rocketchat_subscription_mean{namespace="",nodeID="node",subscription="stream-room-messages"} 4.0418535
rocketchat_subscription_variance{namespace="",nodeID="node",subscription="stream-room-messages"} 0.0319728828125001
rocketchat_subscription_stddev{namespace="",nodeID="node",subscription="stream-room-messages"} 0.17880962729254848
rocketchat_subscription_max{namespace="",nodeID="node",subscription="stream-room-messages"} 4.168291
```

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
