### PR TITLE
fix: solved Editing readOnly/reactWhenReadOnly that occured while making changes to broadcast rooms

### DIFF
--- a/apps/meteor/client/views/admin/rooms/EditRoom.tsx
+++ b/apps/meteor/client/views/admin/rooms/EditRoom.tsx
@@ -60,21 +60,28 @@ const EditRoom = ({ room, onChange, onDelete }: EditRoomProps): ReactElement => 
 	const dispatchToastMessage = useToastMessageDispatch();
 
 	const { values, handlers, hasUnsavedChanges, reset } = useForm(getInitialValues(room));
-
-	const [canViewName, canViewTopic, canViewAnnouncement, canViewArchived, canViewDescription, canViewType, canViewReadOnly] =
-		useMemo(() => {
-			const isAllowed = roomCoordinator.getRoomDirectives(room.t).allowRoomSettingChange;
-			return [
-				isAllowed?.(room, RoomSettingsEnum.NAME),
-				isAllowed?.(room, RoomSettingsEnum.TOPIC),
-				isAllowed?.(room, RoomSettingsEnum.ANNOUNCEMENT),
-				isAllowed?.(room, RoomSettingsEnum.ARCHIVE_OR_UNARCHIVE),
-				isAllowed?.(room, RoomSettingsEnum.DESCRIPTION),
-				isAllowed?.(room, RoomSettingsEnum.TYPE),
-				isAllowed?.(room, RoomSettingsEnum.READ_ONLY),
-				isAllowed?.(room, RoomSettingsEnum.REACT_WHEN_READ_ONLY),
-			];
-		}, [room]);
+	const [
+		canViewName,
+		canViewTopic,
+		canViewAnnouncement,
+		canViewArchived,
+		canViewDescription,
+		canViewType,
+		canViewReadOnly,
+		canViewReactWhenReadOnly,
+	] = useMemo(() => {
+		const isAllowed = roomCoordinator.getRoomDirectives(room.t).allowRoomSettingChange;
+		return [
+			isAllowed?.(room, RoomSettingsEnum.NAME),
+			isAllowed?.(room, RoomSettingsEnum.TOPIC),
+			isAllowed?.(room, RoomSettingsEnum.ANNOUNCEMENT),
+			isAllowed?.(room, RoomSettingsEnum.ARCHIVE_OR_UNARCHIVE),
+			isAllowed?.(room, RoomSettingsEnum.DESCRIPTION),
+			isAllowed?.(room, RoomSettingsEnum.TYPE),
+			isAllowed?.(room, RoomSettingsEnum.READ_ONLY),
+			isAllowed?.(room, RoomSettingsEnum.REACT_WHEN_READ_ONLY),
+		];
+	}, [room]);
 
 	const {
 		roomName,
@@ -127,11 +134,11 @@ const EditRoom = ({ room, onChange, onDelete }: EditRoomProps): ReactElement => 
 				roomName: roomType === 'd' ? undefined : roomName,
 				roomTopic,
 				roomType,
-				readOnly,
+				readOnly: room.broadcast ? undefined : readOnly,
 				default: isDefault,
 				favorite: { defaultValue: isDefault, favorite },
 				featured,
-				reactWhenReadOnly,
+				reactWhenReadOnly: room.broadcast ? undefined : reactWhenReadOnly,
 				roomDescription,
 				roomAnnouncement,
 				roomAvatar,
@@ -287,7 +294,7 @@ const EditRoom = ({ room, onChange, onDelete }: EditRoomProps): ReactElement => 
 								<Field.Hint>{t('Only_authorized_users_can_write_new_messages')}</Field.Hint>
 							</Field>
 						)}
-						{readOnly && (
+						{canViewReactWhenReadOnly && (
 							<Field>
 								<Box display='flex' flexDirection='row' justifyContent='space-between' flexGrow={1}>
 									<Field.Label>{t('React_when_read_only')}</Field.Label>

--- a/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/EditChannel.js
+++ b/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/EditChannel.js
@@ -209,6 +209,7 @@ function EditChannel({ room, onClickClose, onClickBack }) {
 		canViewReadOnly,
 		canViewHideSysMes,
 		canViewJoinCode,
+		canViewReactWhenReadOnly,
 		canViewEncrypted,
 	] = useMemo(() => {
 		const isAllowed = roomCoordinator.getRoomDirectives(room.t).allowRoomSettingChange || (() => {});
@@ -360,7 +361,7 @@ function EditChannel({ room, onClickClose, onClickBack }) {
 						<Field.Hint>{t('Only_authorized_users_can_write_new_messages')}</Field.Hint>
 					</Field>
 				)}
-				{readOnly && (
+				{canViewReactWhenReadOnly && (
 					<Field>
 						<Box display='flex' flexDirection='row' justifyContent='space-between' flexGrow={1}>
 							<Field.Label>{t('React_when_read_only')}</Field.Label>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
This PR solves 2 issues. 
1) The " Allow react "option was visible even in brodcast channel
2) Making any changes  to broadcast channel was causing error 

https://www.loom.com/share/608d0f1a3cad42ef84ea836abebb140c?sid=ca6c764f-51c0-448c-8590-0c5b35f46286
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Fixes #30288

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Create a new broadcast channel
Visit Workspace administration
Click Rooms on the left sidebar
Click on the newly created broadcast channel
Toggle "Default" to on
Attempt to save the channel
Observe the error message (Editing readOnly/reactWhenReadOnly are not allowed for broadcast rooms [error-action-not-allowed])

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
