### PR TITLE
fix: Ensure user always has an array of roles

### DIFF
--- a/apps/meteor/app/authentication/server/startup/index.js
+++ b/apps/meteor/app/authentication/server/startup/index.js
@@ -187,6 +187,10 @@ const onCreateUserAsync = async function (options, user = {}) {
 		await beforeCreateUserCallback.run(options, user);
 	}
 
+	if (!(user.roles && Array.isArray(user.roles))) {
+		user.roles = [];
+	}
+
 	user.status = 'offline';
 	user.active = user.active !== undefined ? user.active : !settings.get('Accounts_ManuallyApproveNewUsers');
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

There are lots of places in code where application relies on user's roles. Currently application doesn't guarantee that property `roles` exists in `user` object and that this property is an array, even if it exists. Why? Because application saves user record to database with non-existing `roles` property at first step. Then, in next steps, application updates this record in order to create proper `roles`. These updates can fail either due to admin's error (improper settings regarding default user's roles, for instance) or due to hardware or network errors just after creating user's record.

Therefore most of interactions with `user.roles` nowadays should be secured against non-existing `roles` property and its possibly improper type. Unfortunately it's not done properly in many existing places in code. Instead of continuing that error-prone securing in many places, we should try to ensure that property `roles` always exists in `user`. The best place for doing this is [the method Accounts.onCreateUser()](https://docs.meteor.com/api/accounts-multi.html#AccountsServer-onCreateUser).


## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
