### PR TITLE
chore: allow Omnichannel Chats to be placed onHold even when the last message is not from the Agent

### DIFF
--- a/apps/meteor/client/views/room/Header/Omnichannel/QuickActions/hooks/useQuickActions.tsx
+++ b/apps/meteor/client/views/room/Header/Omnichannel/QuickActions/hooks/useQuickActions.tsx
@@ -309,7 +309,7 @@ export const useQuickActions = (): {
 	const canSendTranscriptPDF = usePermission('request-pdf-transcript');
 	const canCloseRoom = usePermission('close-livechat-room');
 	const canCloseOthersRoom = usePermission('close-others-livechat-room');
-	const canPlaceChatOnHold = Boolean(!room.onHold && room.u && !(room as any).lastMessage?.token && manualOnHoldAllowed);
+	const canPlaceChatOnHold = Boolean(!room.onHold && room.u && manualOnHoldAllowed);
 
 	const hasPermissionButtons = (id: string): boolean => {
 		switch (id) {


### PR DESCRIPTION
Currently, the behaviour of our Rocket.Chat Omnichannel only allows to place On-Hold chats where the last message was sent by the Agent. Amerisave (and other customers) asked for the ability to place chats on hold at anytime, not only when the agent was the last one that has sent a message.

The reason for this behaviour is that our code actually enforces this condition (that the agent was the last one to have sent a message) to show the option to place the chat on-hold.  

## Proposed changes 

The changes proposed on the current PR involve removing the condition (that the agent was the last one to have sent a message) from our code, more specifically in the following file :

https://github.com/RocketChat/Rocket.Chat/blob/develop/apps/meteor/client/views/room/Header/Omnichannel/QuickActions/hooks/useQuickActions.tsx#L312


ORIGINAL CODE : const canPlaceChatOnHold = Boolean(!room.onHold && room.u && **!(room as any).lastMessage?.token** && manualOnHoldAllowed);

PROPOSED CHANGE : const canPlaceChatOnHold = Boolean(!room.onHold && room.u && manualOnHoldAllowed);

<img width="1920" alt="image" src="https://github.com/RocketChat/Rocket.Chat/assets/213379/c6b816c6-671f-4da3-a1cd-3ef16e377de3">

## Issue(s)

The Jira issue that is related to this PR is #CC-13

      https://rocketchat.atlassian.net/browse/CC-13

## Steps to test or reproduce

- Deploy Rocket.Chat with an enterprise license and enable omnichannel setting to allow placing chats onHold.
- Create a new Chat (use the /livechat url) and add a user to start a conversation.
- Verify that the Agent is only able to place the chat onHold when the last message was sent by him, otherwise the action button is not visible.


## Further comments

I'm not really able to link to the issue in Jira in this PR as its not listed. Probably this PR will need to be updated.

<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
