### PR TITLE
fix:  query paramters can be passed 

### DIFF
--- a/apps/meteor/app/livechat/imports/server/rest/rooms.ts
+++ b/apps/meteor/app/livechat/imports/server/rest/rooms.ts
@@ -6,6 +6,9 @@ import { getPaginationItems } from '../../../../api/server/helpers/getPagination
 import { hasPermissionAsync } from '../../../../authorization/server/functions/hasPermission';
 import { findRooms } from '../../../server/api/lib/rooms';
 
+import { IOmnichannelRoom } from '@rocket.chat/core-typings';
+import type {Filter} from 'mongodb'
+
 const validateDateParams = (property: string, date?: string) => {
 	let parsedDate: { start?: string; end?: string } | undefined = undefined;
 	if (date) {
@@ -32,6 +35,9 @@ API.v1.addRoute(
 			const { sort, fields } = await this.parseJsonQuery();
 			const { agents, departmentId, open, tags, roomName, onhold } = this.queryParams;
 			const { createdAt, customFields, closedAt } = this.queryParams;
+			
+			const {query}=this.queryParams;
+			
 
 			const createdAtParam = validateDateParams('createdAt', createdAt);
 			const closedAtParam = validateDateParams('closedAt', closedAt);
@@ -57,6 +63,19 @@ API.v1.addRoute(
 					throw new Error('The "customFields" query parameter must be a valid JSON.');
 				}
 			}
+			let parsedQ : Filter<IOmnichannelRoom>|undefined=undefined;
+			if(query){
+				try{
+					const customQuery=JSON.parse(query) as Filter<IOmnichannelRoom>;
+					parsedQ=customQuery;
+				
+				}
+				catch(e){
+					throw new Error('The "customQuery" is not defined');
+				}
+				
+				
+			}
 
 			return API.v1.success(
 				await findRooms({
@@ -70,6 +89,7 @@ API.v1.addRoute(
 					customFields: parsedCf,
 					onhold,
 					options: { offset, count, sort, fields },
+					customQuery:parsedQ,
 				}),
 			);
 		},

--- a/apps/meteor/app/livechat/server/api/lib/rooms.ts
+++ b/apps/meteor/app/livechat/server/api/lib/rooms.ts
@@ -3,7 +3,7 @@ import { LivechatRooms, LivechatDepartment } from '@rocket.chat/models';
 import type { PaginatedResult } from '@rocket.chat/rest-typings';
 
 import { callbacks } from '../../../../../lib/callbacks';
-
+import type {Filter} from 'mongodb'
 export async function findRooms({
 	agents,
 	roomName,
@@ -15,6 +15,7 @@ export async function findRooms({
 	customFields,
 	onhold,
 	options: { offset, count, fields, sort },
+	customQuery,
 }: {
 	agents?: Array<string>;
 	roomName?: string;
@@ -32,6 +33,7 @@ export async function findRooms({
 	customFields?: Record<string, string>;
 	onhold?: string | boolean;
 	options: { offset: number; count: number; fields: Record<string, number>; sort: Record<string, number> };
+	customQuery?:Filter<IOmnichannelRoom>;
 }): Promise<PaginatedResult<{ rooms: Array<IOmnichannelRoom> }>> {
 	const extraQuery = await callbacks.run('livechat.applyRoomRestrictions', {});
 	const { cursor, totalCount } = LivechatRooms.findRoomsWithCriteria({
@@ -50,7 +52,7 @@ export async function findRooms({
 			count,
 			fields,
 		},
-		extraQuery,
+		extraQuery:{...extraQuery,...customQuery},
 	});
 
 	const [rooms, total] = await Promise.all([cursor.toArray(), totalCount]);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

there are two files that are changed
apps/meteor/app/livechat/imports/server/rest/rooms.ts
and
apps/meteor/app/livechat/server/api/lib/rooms.ts

i have got the query paramter
then converted it into a parsedQ  object to be passed into the findRooms function
inside the defination of findRooms function i have recieved the object as customQuery 
they are then destructured and passed to the findRoomsWithCriteria function
 
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
#25300 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. call the endpoint api/v1/livechat/rooms
2. pass a query object as parameter

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
closes #25300 