### PR TITLE
fix: Fixed editing the custom emoji for name field without file upload. #26980

### DIFF
--- a/apps/meteor/app/api/server/v1/emoji-custom.ts
+++ b/apps/meteor/app/api/server/v1/emoji-custom.ts
@@ -117,7 +117,7 @@ API.v1.addRoute(
 				{
 					request: this.request,
 				},
-				{ field: 'emoji', sizeLimit: settings.get('FileUpload_MaxFileSize') },
+				{ field: 'emoji', isFileRequired: false, sizeLimit: settings.get('FileUpload_MaxFileSize') },
 			);
 
 			const { fields, fileBuffer, mimetype } = emoji;
@@ -134,9 +134,9 @@ API.v1.addRoute(
 			fields.previousName = emojiToUpdate.name;
 			fields.previousExtension = emojiToUpdate.extension;
 			fields.aliases = fields.aliases || '';
-			const newFile = Boolean(emoji && fileBuffer.length);
+			const newFile = Boolean(fileBuffer?.length);
 
-			if (fields.newFile) {
+			if (newFile) {
 				const isUploadable = await Media.isImage(fileBuffer);
 				if (!isUploadable) {
 					throw new Meteor.Error('emoji-is-not-image', "Emoji file provided cannot be uploaded since it's not an image");
@@ -149,7 +149,7 @@ API.v1.addRoute(
 			}
 
 			await Meteor.callAsync('insertOrUpdateEmoji', { ...fields, newFile });
-			if (fields.newFile) {
+			if (newFile) {
 				await Meteor.callAsync('uploadEmojiCustom', fileBuffer, mimetype, { ...fields, newFile });
 			}
 			return API.v1.success();

--- a/apps/meteor/app/emoji-custom/server/startup/emoji-custom.js
+++ b/apps/meteor/app/emoji-custom/server/startup/emoji-custom.js
@@ -90,7 +90,7 @@ Meteor.startup(() => {
 			return;
 		}
 
-		res.setHeader('Cache-Control', 'public, max-age=31536000');
+		res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
 		res.setHeader('Last-Modified', fileUploadDate || new Date().toUTCString());
 		res.setHeader('Content-Length', file.length);
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
1. I added to the `getUploadFormData` function, another parameter to check if the route requires the file or not, and made the changes in the code accordingly.

2. I also changed the cache control from the emoji-custom route to none. The problem with keeping a cache-control is that if a user changes to the previous name for a particular emoji, it takes the earlier result without validating it from the server, which essentially causes another bug on the client's side.


https://github.com/RocketChat/Rocket.Chat/assets/102903554/a1b15b58-60e0-4a10-881c-f134d1ddad86



https://github.com/RocketChat/Rocket.Chat/issues/26980
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
1. `getUploadFormData` required a file for further processing along the busboy stream parser.
4. There were cache-control on the custom-emoji being send to the user. 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Add a custom emoji in case you don't already have one.
2. Select a custom emoji for editing.
4. Edit its name or aliases.
5. Click the "Save" button.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
