### PR TITLE
fix: Handle AWS S3 Re-Authentication via s3.getSignedUrlPromise

### DIFF
--- a/apps/meteor/app/file-upload/ufs/AmazonS3/server.ts
+++ b/apps/meteor/app/file-upload/ufs/AmazonS3/server.ts
@@ -80,7 +80,7 @@ class AmazonS3Store extends UploadFS.Store {
 				ResponseContentDisposition: `${forceDownload ? 'attachment' : 'inline'}; filename="${encodeURI(file.name || '')}"`,
 			};
 
-			return s3.getSignedUrl('getObject', params);
+			return s3.getSignedUrlPromise('getObject', params);
 		};
 
 		/**


### PR DESCRIPTION
AWS credentials have a limited lifespan.  If the credentials have expired when you call `s3.getSignedUrl`, the call will fail, although it will eventually succeed after the credentials are refreshed in the background.  Passing a `callback` argument to `getSignedUrl`, however, will cause `s3` to refresh the credentials before continuing on with the callback.

Commit 90238b9c153 (PR #28711) refactored the `callback`-oriented definition of `getRedirectURL` in `apps/meteor/app/file-upload/ufs/AmazonS3/server.ts` to use async/await instead.  In the process, the callback argument was dropped, breaking the auto-refreshing of expired authentication tokens, and resulting in `s3.getSignedUrl` returning a bogus value.

## Proposed changes (including videos or screenshots)
We can restore the auto-refreshing of expired authentication tokens by calling the _promise-oriented_ version of getSignedUrl,  `s3.getSignedUrlPromise`.

<!-- CHANGELOG -->
Fix auto-refreshing of expired authentication tokens when loading assets from S3.
<!-- END CHANGELOG -->

## Further comments
h/t to @rodrigok who brought `s3.getSignedUrlPromise` to my attention