### PR TITLE
regression: workspace stats cache loading

### DIFF
--- a/apps/meteor/client/hooks/useWorkspaceInfo.ts
+++ b/apps/meteor/client/hooks/useWorkspaceInfo.ts
@@ -1,7 +1,7 @@
 import type { IStats, IWorkspaceInfo, Serialized } from '@rocket.chat/core-typings';
 import type { IInstance } from '@rocket.chat/rest-typings';
 import { useEndpoint } from '@rocket.chat/ui-contexts';
-import { useQueries } from '@tanstack/react-query';
+import { useMutation, useQueries, useQueryClient } from '@tanstack/react-query';
 
 export const useWorkspaceInfo = ({ refreshStatistics }: { refreshStatistics?: boolean } = {}) => {
 	const getStatistics = useEndpoint('GET', '/v1/statistics');
@@ -58,5 +58,12 @@ export const useWorkspaceInfo = ({ refreshStatistics }: { refreshStatistics?: bo
 				}),
 			},
 		],
+	});
+};
+
+export const useRefreshStatistics = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: () => queryClient.invalidateQueries(['info', 'statistics']),
 	});
 };

--- a/apps/meteor/client/hooks/useWorkspaceInfo.ts
+++ b/apps/meteor/client/hooks/useWorkspaceInfo.ts
@@ -1,9 +1,9 @@
 import type { IStats, IWorkspaceInfo, Serialized } from '@rocket.chat/core-typings';
 import type { IInstance } from '@rocket.chat/rest-typings';
 import { useEndpoint } from '@rocket.chat/ui-contexts';
-import { useMutation, useQueries, useQueryClient } from '@tanstack/react-query';
+import { useQueries } from '@tanstack/react-query';
 
-export const useWorkspaceInfo = () => {
+export const useWorkspaceInfo = ({ refreshStatistics }: { refreshStatistics?: boolean } = {}) => {
 	const getStatistics = useEndpoint('GET', '/v1/statistics');
 	const getInstances = useEndpoint('GET', '/v1/instances.get');
 	const getServerInfo = useEndpoint('GET', '/info');
@@ -49,7 +49,7 @@ export const useWorkspaceInfo = () => {
 			},
 			{
 				queryKey: ['info', 'statistics'],
-				queryFn: () => getStatistics({ refresh: 'true' }),
+				queryFn: () => getStatistics({ refresh: refreshStatistics ? 'true' : 'false' }),
 				staleTime: Infinity,
 				keepPreviousData: true,
 				select: (data: Serialized<IStats>) => ({
@@ -58,12 +58,5 @@ export const useWorkspaceInfo = () => {
 				}),
 			},
 		],
-	});
-};
-
-export const useRefreshStatistics = () => {
-	const queryClient = useQueryClient();
-	return useMutation({
-		mutationFn: () => queryClient.invalidateQueries(['info', 'statistics']),
 	});
 };

--- a/apps/meteor/client/views/admin/workspace/WorkspacePage.tsx
+++ b/apps/meteor/client/views/admin/workspace/WorkspacePage.tsx
@@ -15,6 +15,7 @@ type WorkspaceStatusPageProps = {
 	canViewStatistics: boolean;
 	serverInfo: IWorkspaceInfo;
 	statistics: IStats;
+	statisticsIsLoading: boolean;
 	instances: IInstance[];
 	onClickRefreshButton: () => void;
 	onClickDownloadInfo: () => void;
@@ -24,6 +25,7 @@ const WorkspacePage = ({
 	canViewStatistics,
 	serverInfo,
 	statistics,
+	statisticsIsLoading,
 	instances,
 	onClickRefreshButton,
 	onClickDownloadInfo,
@@ -40,10 +42,8 @@ const WorkspacePage = ({
 			<Page.Header title={t('Workspace')}>
 				{canViewStatistics && (
 					<ButtonGroup>
-						<Button type='button' onClick={onClickDownloadInfo}>
-							{t('Download_Info')}
-						</Button>
-						<Button type='button' onClick={onClickRefreshButton}>
+						<Button onClick={onClickDownloadInfo}>{t('Download_Info')}</Button>
+						<Button onClick={onClickRefreshButton} loading={statisticsIsLoading}>
 							{t('Refresh')}
 						</Button>
 					</ButtonGroup>

--- a/apps/meteor/client/views/admin/workspace/WorkspaceRoute.tsx
+++ b/apps/meteor/client/views/admin/workspace/WorkspaceRoute.tsx
@@ -1,11 +1,11 @@
 import { Callout, ButtonGroup, Button } from '@rocket.chat/fuselage';
 import { usePermission, useTranslation } from '@rocket.chat/ui-contexts';
 import type { ReactElement } from 'react';
-import React, { memo } from 'react';
+import React, { memo, useEffect, useState } from 'react';
 
 import Page from '../../../components/Page';
 import PageSkeleton from '../../../components/PageSkeleton';
-import { useRefreshStatistics, useWorkspaceInfo } from '../../../hooks/useWorkspaceInfo';
+import { useWorkspaceInfo } from '../../../hooks/useWorkspaceInfo';
 import { downloadJsonAs } from '../../../lib/download';
 import NotAuthorizedPage from '../../notAuthorized/NotAuthorizedPage';
 import WorkspacePage from './WorkspacePage';
@@ -14,8 +14,14 @@ const WorkspaceRoute = (): ReactElement => {
 	const t = useTranslation();
 	const canViewStatistics = usePermission('view-statistics');
 
-	const [serverInfoQuery, instancesQuery, statisticsQuery] = useWorkspaceInfo();
-	const refetchStatistics = useRefreshStatistics();
+	const [refreshStatistics, setRefreshStatistics] = useState(false);
+	const [serverInfoQuery, instancesQuery, statisticsQuery] = useWorkspaceInfo({ refreshStatistics });
+
+	useEffect(() => {
+		if (refreshStatistics && !statisticsQuery.isLoading) {
+			statisticsQuery.refetch();
+		}
+	}, [refreshStatistics]);
 
 	if (!canViewStatistics) {
 		return <NotAuthorizedPage />;
@@ -24,8 +30,9 @@ const WorkspaceRoute = (): ReactElement => {
 	if (serverInfoQuery.isLoading || instancesQuery.isLoading || statisticsQuery.isLoading) {
 		return <PageSkeleton />;
 	}
-	const handleClickRefreshButton = (): void => {
-		refetchStatistics.mutate();
+
+	const handleClickRefreshButton = async () => {
+		setRefreshStatistics(true);
 	};
 
 	if (serverInfoQuery.isError || instancesQuery.isError || statisticsQuery.isError) {
@@ -33,7 +40,7 @@ const WorkspaceRoute = (): ReactElement => {
 			<Page>
 				<Page.Header title={t('Workspace')}>
 					<ButtonGroup>
-						<Button icon='reload' primary type='button' onClick={handleClickRefreshButton}>
+						<Button icon='reload' primary type='button' onClick={handleClickRefreshButton} loading={statisticsQuery.isLoading}>
 							{t('Refresh')}
 						</Button>
 					</ButtonGroup>
@@ -54,6 +61,7 @@ const WorkspaceRoute = (): ReactElement => {
 			canViewStatistics={canViewStatistics}
 			serverInfo={serverInfoQuery.data}
 			statistics={statisticsQuery.data}
+			statisticsIsLoading={statisticsQuery.isLoading}
 			instances={instancesQuery.data}
 			onClickRefreshButton={handleClickRefreshButton}
 			onClickDownloadInfo={handleClickDownloadInfo}

--- a/apps/meteor/client/views/admin/workspace/WorkspaceRoute.tsx
+++ b/apps/meteor/client/views/admin/workspace/WorkspaceRoute.tsx
@@ -1,7 +1,7 @@
 import { Callout, ButtonGroup, Button } from '@rocket.chat/fuselage';
 import { usePermission, useTranslation } from '@rocket.chat/ui-contexts';
 import type { ReactElement } from 'react';
-import React, { memo, useEffect, useState } from 'react';
+import React, { memo, useState } from 'react';
 
 import Page from '../../../components/Page';
 import PageSkeleton from '../../../components/PageSkeleton';
@@ -17,12 +17,6 @@ const WorkspaceRoute = (): ReactElement => {
 	const [refreshStatistics, setRefreshStatistics] = useState(false);
 	const [serverInfoQuery, instancesQuery, statisticsQuery] = useWorkspaceInfo({ refreshStatistics });
 
-	useEffect(() => {
-		if (refreshStatistics && !statisticsQuery.isLoading) {
-			statisticsQuery.refetch();
-		}
-	}, [refreshStatistics]);
-
 	if (!canViewStatistics) {
 		return <NotAuthorizedPage />;
 	}
@@ -33,6 +27,7 @@ const WorkspaceRoute = (): ReactElement => {
 
 	const handleClickRefreshButton = async () => {
 		setRefreshStatistics(true);
+		statisticsQuery.refetch();
 	};
 
 	if (serverInfoQuery.isError || instancesQuery.isError || statisticsQuery.isError) {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
We were loading the endpoint `v1/statistics` without using the cache provided by the server, this causes a huge delay on bigger workspaces. 

This was fixed by implementing the correct usage of the parameter `refresh` to get the latest stats from the server
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
