### PR TITLE
fix: creating group with the name of an already existing room throws `internalError`

### DIFF
--- a/.changeset/dirty-rings-fry.md
+++ b/.changeset/dirty-rings-fry.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixed issue with the creation of groups with the name of an already existing room throwing `internalError`

--- a/apps/meteor/app/api/server/v1/groups.ts
+++ b/apps/meteor/app/api/server/v1/groups.ts
@@ -351,9 +351,8 @@ API.v1.addRoute(
 				if (isMeteorError(error) && error.reason === 'error-not-allowed') {
 					return API.v1.unauthorized();
 				}
+				throw error;
 			}
-
-			return API.v1.internalError();
 		},
 	},
 );

--- a/apps/meteor/tests/end-to-end/api/02-channels.js
+++ b/apps/meteor/tests/end-to-end/api/02-channels.js
@@ -61,6 +61,21 @@ describe('[Channels]', function () {
 			await deleteUser(guestUser);
 		});
 
+		it(`should fail when trying to use an existing room's name`, async () => {
+			await request
+				.post(api('channels.create'))
+				.set(credentials)
+				.send({
+					name: 'general',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', false);
+					expect(res.body).to.have.nested.property('errorType', 'error-duplicate-channel-name');
+				});
+		});
+
 		it('should not add guest users to more rooms than defined in the license', async function () {
 			// TODO this is not the right way to do it. We're doing this way for now just because we have separate CI jobs for EE and CE,
 			// ideally we should have a single CI job that adds a license and runs both CE and EE tests.

--- a/apps/meteor/tests/end-to-end/api/03-groups.js
+++ b/apps/meteor/tests/end-to-end/api/03-groups.js
@@ -171,6 +171,21 @@ describe('[Groups]', function () {
 					});
 			});
 		});
+
+		it(`should fail when trying to use an existing room's name`, async () => {
+			await request
+				.post(api('groups.create'))
+				.set(credentials)
+				.send({
+					name: 'general',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', false);
+					expect(res.body).to.have.nested.property('errorType', 'error-duplicate-channel-name');
+				});
+		});
 	});
 
 	describe('/groups.info', () => {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
 - Throw meteor error instead of `internalError` on `groups.create`.

<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Introduced by #30499

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Use the [groups.create](https://developer.rocket.chat/reference/api/rest-api/endpoints/rooms/groups-endpoints/create) endpoint to add a group named `general`.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
TC-1031