### PR TITLE
Release 6.5.2

### DIFF
--- a/.changeset/bump-patch-1703700471583.md
+++ b/.changeset/bump-patch-1703700471583.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Bump @rocket.chat/meteor version.

--- a/.changeset/three-moles-look.md
+++ b/.changeset/three-moles-look.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixed conversations in queue being limited to 50 items

--- a/.changeset/tiny-glasses-help.md
+++ b/.changeset/tiny-glasses-help.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fix wrong value used for Workspace Registration

--- a/.github/workflows/pr-update-description.yml
+++ b/.github/workflows/pr-update-description.yml
@@ -1,0 +1,39 @@
+name: 'Release PR Description'
+
+on:
+  pull_request:
+    branches:
+      - master
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  update-pr:
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'release-')
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CI_PAT }}
+
+      - name: Setup NodeJS
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: 14.21.3
+          cache-modules: true
+          install: true
+
+      - uses: dtinth/setup-github-actions-caching-for-turbo@v1
+
+      - name: Build packages
+        run: yarn build
+
+      - name: Update PR description
+        uses: ./packages/release-action
+        with:
+          action: update-pr-description
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_PAT }}
+

--- a/apps/meteor/app/cloud/server/functions/buildRegistrationData.ts
+++ b/apps/meteor/app/cloud/server/functions/buildRegistrationData.ts
@@ -65,7 +65,7 @@ export async function buildWorkspaceRegistrationData<T extends string | undefine
 	const language = settings.get<string>('Language');
 	const organizationType = settings.get<string>('Organization_Type');
 	const industry = settings.get<string>('Industry');
-	const orgSize = settings.get<string>('Organization_Size');
+	const orgSize = settings.get<string>('Size');
 	const workspaceType = settings.get<string>('Server_Type');
 
 	const seats = await Users.getActiveLocalUserCount();

--- a/apps/meteor/client/providers/OmnichannelProvider.tsx
+++ b/apps/meteor/client/providers/OmnichannelProvider.tsx
@@ -41,7 +41,7 @@ const OmnichannelProvider: FC = ({ children }) => {
 	const omniChannelEnabled = useSetting('Livechat_enabled') as boolean;
 	const omnichannelRouting = useSetting('Livechat_Routing_Method');
 	const showOmnichannelQueueLink = useSetting('Livechat_show_queue_list_link') as boolean;
-	const omnichannelPoolMaxIncoming = useSetting('Livechat_guest_pool_max_number_incoming_livechats_displayed') as number;
+	const omnichannelPoolMaxIncoming = useSetting<number>('Livechat_guest_pool_max_number_incoming_livechats_displayed') ?? 0;
 	const omnichannelSortingMechanism = useSetting('Omnichannel_sorting_mechanism') as OmnichannelSortingMechanismSettingType;
 
 	const loggerRef = useRef(new ClientLogger('OmnichannelProvider'));
@@ -130,16 +130,13 @@ const OmnichannelProvider: FC = ({ children }) => {
 			}
 
 			return LivechatInquiry.find(
-				{
-					status: 'queued',
-					$or: [{ defaultAgent: { $exists: false } }, { 'defaultAgent.agentId': user?._id }],
-				},
+				{ status: 'queued' },
 				{
 					sort: getOmniChatSortQuery(omnichannelSortingMechanism),
 					limit: omnichannelPoolMaxIncoming,
 				},
 			).fetch();
-		}, [manuallySelected, omnichannelPoolMaxIncoming, omnichannelSortingMechanism, user?._id]),
+		}, [manuallySelected, omnichannelPoolMaxIncoming, omnichannelSortingMechanism]),
 	);
 
 	queue?.map(({ rid }) => {

--- a/packages/release-action/src/index.ts
+++ b/packages/release-action/src/index.ts
@@ -7,6 +7,7 @@ import { bumpNextVersion } from './bumpNextVersion';
 import { setupGitUser } from './gitUtils';
 import { publishRelease } from './publishRelease';
 import { startPatchRelease } from './startPatchRelease';
+import { updatePRDescription } from './updatePRDescription';
 
 // const getOptionalInput = (name: string) => core.getInput(name) || undefined;
 
@@ -45,6 +46,8 @@ import { startPatchRelease } from './startPatchRelease';
 		await bumpNextVersion({ githubToken, mainPackagePath });
 	} else if (action === 'patch') {
 		await startPatchRelease({ baseRef, githubToken, mainPackagePath });
+	} else if (action === 'update-pr-description') {
+		await updatePRDescription({ githubToken, mainPackagePath });
 	}
 })().catch((err) => {
 	core.error(err);

--- a/packages/release-action/src/updatePRDescription.ts
+++ b/packages/release-action/src/updatePRDescription.ts
@@ -1,0 +1,75 @@
+import fs from 'fs';
+import path from 'path';
+
+import * as core from '@actions/core';
+import { exec } from '@actions/exec';
+import * as github from '@actions/github';
+
+import { setupOctokit } from './setupOctokit';
+import { getChangelogEntry, getEngineVersionsMd, readPackageJson } from './utils';
+
+export async function updatePRDescription({
+	githubToken,
+	mainPackagePath,
+	cwd = process.cwd(),
+}: {
+	githubToken: string;
+	mainPackagePath: string;
+	cwd?: string;
+}) {
+	const octokit = setupOctokit(githubToken);
+
+	// generate change logs from changesets
+	await exec('yarn', ['changeset', 'version']);
+
+	// get version from main package
+	const { version: newVersion } = await readPackageJson(mainPackagePath);
+
+	const mainPackageChangelog = path.join(mainPackagePath, 'CHANGELOG.md');
+
+	const changelogContents = fs.readFileSync(mainPackageChangelog, 'utf8');
+	const changelogEntry = getChangelogEntry(changelogContents, newVersion);
+	if (!changelogEntry) {
+		// we can find a changelog but not the entry for this version
+		// if this is true, something has probably gone wrong
+		throw new Error('Could not find changelog entry for version newVersion');
+	}
+
+	const releaseBody = (await getEngineVersionsMd(cwd)) + changelogEntry.content;
+
+	core.info('get PR description');
+	const result = await octokit.rest.pulls.get({
+		pull_number: github.context.issue.number,
+		body: releaseBody,
+		...github.context.repo,
+	});
+
+	const { body: originalBody = '' } = result.data;
+
+	const cleanBody = originalBody?.replace(/<!-- release-notes-start -->.*<!-- release-notes-end -->/s, '').trim() || '';
+
+	const bodyUpdated = `${cleanBody}
+
+<!-- release-notes-start -->
+<!-- This content is automatically generated. Changing this will not reflect on the final release log -->
+
+_You can see below a preview of the release change log:_
+
+# ${newVersion}
+
+${releaseBody}
+<!-- release-notes-end -->`;
+
+	if (bodyUpdated === originalBody) {
+		core.info('no changes to PR description');
+		return;
+	}
+
+	core.info('update PR description');
+	await octokit.rest.pulls.update({
+		owner: github.context.repo.owner,
+		repo: github.context.repo.repo,
+		pull_number: github.context.issue.number,
+		body: bodyUpdated,
+	});
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8217,9 +8217,9 @@ __metadata:
     "@rocket.chat/icons": "*"
     "@rocket.chat/prettier-config": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-contexts": 3.0.0
+    "@rocket.chat/ui-contexts": 3.0.1
     "@rocket.chat/ui-kit": "*"
-    "@rocket.chat/ui-video-conf": 3.0.0
+    "@rocket.chat/ui-video-conf": 3.0.1
     "@tanstack/react-query": "*"
     react: "*"
     react-dom: "*"
@@ -8301,14 +8301,14 @@ __metadata:
     ts-jest: ~29.0.5
     typescript: ~5.2.2
   peerDependencies:
-    "@rocket.chat/core-typings": 6.5.0
+    "@rocket.chat/core-typings": 6.5.1
     "@rocket.chat/css-in-js": "*"
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-tokens": "*"
     "@rocket.chat/message-parser": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-client": 3.0.0
-    "@rocket.chat/ui-contexts": 3.0.0
+    "@rocket.chat/ui-client": 3.0.1
+    "@rocket.chat/ui-contexts": 3.0.1
     katex: "*"
     react: "*"
   languageName: unknown
@@ -9469,7 +9469,7 @@ __metadata:
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-contexts": 3.0.0
+    "@rocket.chat/ui-contexts": 3.0.1
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -9622,7 +9622,7 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-contexts": 3.0.0
+    "@rocket.chat/ui-contexts": 3.0.1
     react: ^17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -9708,7 +9708,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": "*"
-    "@rocket.chat/ui-contexts": 3.0.0
+    "@rocket.chat/ui-contexts": 3.0.1
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION


<!-- release-notes-start -->
<!-- This content is automatically generated. Changing this will not reflect on the final release log -->

_You can see below a preview of the release change log:_

# 6.5.2

### Engine versions

- Node: `14.21.3`
- MongoDB: `4.4, 5.0, 6.0`
- Apps-Engine: `1.41.0`

### Patch Changes

*   a075950e23: Bump @rocket.chat/meteor version.
*   84c4b0709e: Fixed conversations in queue being limited to 50 items
*   886d92009e: Fix wrong value used for Workspace Registration
    *   @rocket.chat/core-typings@6.5.2
    *   @rocket.chat/rest-typings@6.5.2
    *   @rocket.chat/api-client@0.1.20
    *   @rocket.chat/license@0.1.2
    *   @rocket.chat/omnichannel-services@0.1.2
    *   @rocket.chat/pdf-worker@0.0.26
    *   @rocket.chat/presence@0.1.2
    *   @rocket.chat/core-services@0.3.2
    *   @rocket.chat/cron@0.0.22
    *   @rocket.chat/gazzodown@3.0.2
    *   @rocket.chat/model-typings@0.2.2
    *   @rocket.chat/ui-contexts@3.0.2
    *   @rocket.chat/server-cloud-communication@0.0.1
    *   @rocket.chat/fuselage-ui-kit@3.0.2
    *   @rocket.chat/models@0.0.26
    *   @rocket.chat/ui-theming@0.1.1
    *   @rocket.chat/ui-client@3.0.2
    *   @rocket.chat/ui-video-conf@3.0.2
    *   @rocket.chat/web-ui-registration@3.0.2
    *   @rocket.chat/instance-status@0.0.26

<!-- release-notes-end -->