### PR TITLE
fix: close image gallery on backdrop click

### DIFF
--- a/apps/meteor/client/components/ImageGallery/ImageGallery.tsx
+++ b/apps/meteor/client/components/ImageGallery/ImageGallery.tsx
@@ -109,10 +109,10 @@ const ImageGallery = () => {
 	return createPortal(
 		<FocusScope contain restoreFocus autoFocus>
 			<Box className={swiperStyle}>
-				<div className='swiper-container'>
+				<div className='swiper-container' onClick={onClose}>
 					<IconButton icon='cross' aria-label='Close gallery' className='rcx-swiper-close-button' onClick={onClose} />
-					<IconButton icon='chevron-right' className='rcx-swiper-prev-button' />
-					<IconButton icon='chevron-left' className='rcx-swiper-next-button' />
+					<IconButton icon='chevron-right' className='rcx-swiper-prev-button' onClick={(e) => e.stopPropagation()} />
+					<IconButton icon='chevron-left' className='rcx-swiper-next-button' onClick={(e) => e.stopPropagation()} />
 					<Swiper
 						ref={swiperRef}
 						navigation={{
@@ -131,7 +131,7 @@ const ImageGallery = () => {
 						{images?.map(({ _id, url }) => (
 							<SwiperSlide key={_id}>
 								<div className='swiper-zoom-container'>
-									<img src={url} loading='lazy' />
+									<img src={url} loading='lazy' onClick={(e) => e.stopPropagation()} />
 									<div className='rcx-lazy-preloader'>
 										<Throbber inheritColor />
 									</div>


### PR DESCRIPTION
Proposed changes (including videos or screenshots)
BEFORE THE FIX
https://github.com/RocketChat/Rocket.Chat/assets/112304873/c3948a9b-21c0-40f9-8f4c-97e79909a698


AFTER THE FIX
https://github.com/RocketChat/Rocket.Chat/assets/112304873/c7a48b70-4951-43e3-9e35-a879107d61de


REASON BEHIND CHANGES
There are far better ways to implement this but with this configuration,this is the best way to implement this feature

Issue(s)
This should close issues :-
closes https://github.com/RocketChat/Rocket.Chat/issues/31341

Steps to test or reproduce

Login to rocket chat.
Go to any Community chat.
Click on any media