### PR TITLE
fix: No error message when uploading a file that is not allowed

### DIFF
--- a/.changeset/lemon-shrimps-draw.md
+++ b/.changeset/lemon-shrimps-draw.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixed error message when uploading a file that is not allowed

--- a/apps/meteor/client/lib/chats/flows/uploadFiles.ts
+++ b/apps/meteor/client/lib/chats/flows/uploadFiles.ts
@@ -46,7 +46,7 @@ export const uploadFiles = async (chat: ChatAPI, files: readonly File[], resetFi
 					imperativeModal.close();
 					uploadNextFile();
 				},
-				invalidContentType: Boolean(file.type && !fileUploadIsValidContentType(file.type)),
+				invalidContentType: !(file.type && fileUploadIsValidContentType(file.type)),
 			},
 		});
 	};


### PR DESCRIPTION
Proposed changes (including videos or screenshots)

BEFORE THE FIX
https://github.com/RocketChat/Rocket.Chat/assets/112304873/68e9d8d0-3ef5-411a-93e5-d009ff97c331

AFTER THE FIX
https://github.com/RocketChat/Rocket.Chat/assets/112304873/73c161a2-3658-4b76-8276-e38dbfc6f177



REASON BEHIND CHANGES
If the type of file which we want to upload is not clear then we should not allow it to be uploaded in the server

Issue(s)
This should close issues :-
closes https://github.com/RocketChat/Rocket.Chat/issues/27924

Steps to test or reproduce

1. Login to rocket chat.
2. Set "Accepted Media Types" setting in "File Upload" section. For example image/*,application/pdf,text/plain,application/msword
3. Try sending a rare file type like .har
4. The file is not loaded into the chat, and there is no error message.