### PR TITLE
Refactor: Utilize path.join for File Paths in translationDiff.js

### DIFF
--- a/apps/meteor/.scripts/translationDiff.js
+++ b/apps/meteor/.scripts/translationDiff.js
@@ -23,8 +23,8 @@ async function translationDiff(source, target) {
 		return diff;
 	}
 
-	const sourceTranslations = JSON.parse(await readFile(`${translationDir}/${source}.i18n.json`, 'utf8'));
-	const targetTranslations = JSON.parse(await readFile(`${translationDir}/${target}.i18n.json`, 'utf8'));
+	const sourceTranslations = JSON.parse(await readFile(path.join(translationDir, $.source.i18n.json), 'utf8'));
+	const targetTranslations = JSON.parse(await readFile(path.join(translationDir, $.target.i18n.json), 'utf8'));
 
 	return diffKeys(sourceTranslations, targetTranslations);
 }

--- a/apps/meteor/.scripts/translationDiff.js
+++ b/apps/meteor/.scripts/translationDiff.js
@@ -23,10 +23,16 @@ async function translationDiff(source, target) {
 		return diff;
 	}
 
-	const sourceTranslations = JSON.parse(await readFile(path.join(translationDir, $.source.i18n.json), 'utf8'));
-	const targetTranslations = JSON.parse(await readFile(path.join(translationDir, $.target.i18n.json), 'utf8'));
+	try {
+		const sourceTranslations = JSON.parse(await readFile(path.join(translationDir, `${source}.i18n.json`), 'utf8'));
+		const targetTranslations = JSON.parse(await readFile(path.join(translationDir, `${target}.i18n.json`), 'utf8'));
 
-	return diffKeys(sourceTranslations, targetTranslations);
+		return diffKeys(sourceTranslations, targetTranslations);
+	} catch (error) {
+		console.error('Error:', error.message);
+		// rethrow the error to indicate failure
+		throw error;
+	}
 }
 
 console.log('Note: You can set the source and target language of the comparison with env-variables SOURCE/TARGET_LANGUAGE');


### PR DESCRIPTION
## Refactor: Utilize `path.join` for File Paths in translationDiff.js
## Proposed changes

This pull request addresses the issue in the `apps>meteor>.script>translationDiff.js` file, specifically in the use of file paths. The changes aim to enhance the reliability and cross-platform compatibility by replacing manual path concatenation with the `path.join` method.

I have updated the relevant code block as follows:

```javascript
try {
    const sourceTranslations = JSON.parse(await readFile(path.join(translationDir, `${source}.i18n.json`), 'utf8'));
    const targetTranslations = JSON.parse(await readFile(path.join(translationDir, `${target}.i18n.json`), 'utf8'));

    return diffKeys(sourceTranslations, targetTranslations);
} catch (error) {
    console.error('Error:', error.message);
    throw error; // rethrow the error to indicate failure
}
```

## Issue(s)

Closes: #31140 

## Steps to test or reproduce

1. Navigate to the `apps>meteor>.script` directory.
2. Open the `translationDiff.js` file.
3. Verify that the changes utilize `path.join` for file paths.
4. Test the functionality of the script with different source and target translations.

## Further comments

I addressed the issue by replacing manual concatenation of file paths with the `path.join` method. This modification enhances the reliability of the code, particularly in cross-platform scenarios, where manual concatenation may lead to issues. The changes aim to improve maintainability and reduce the likelihood of path-related errors.

I have ensured that the lint and unit tests pass locally with these changes. Additionally, I have added this information to the pull request template and signed the CLA. Please review and merge this pull request at your earliest convenience. If you have any questions or suggestions, feel free to let me know.