### PR TITLE
feat: Implement user profile click functionality

### DIFF
--- a/apps/meteor/client/components/avatar/BaseAvatar.tsx
+++ b/apps/meteor/client/components/avatar/BaseAvatar.tsx
@@ -15,8 +15,6 @@ const BaseAvatar: FC<BaseAvatarProps> = ({ onError, ...props }) => {
 	}
 	const toolbox = useRoomToolbox();
 	const { actions, openTab } = toolbox;
-	console.log(actions);
-	console.log(props);
 	const handleClick = () => {
 		openTab(actions[0]?.id);
 	}

--- a/apps/meteor/client/components/avatar/BaseAvatar.tsx
+++ b/apps/meteor/client/components/avatar/BaseAvatar.tsx
@@ -2,19 +2,29 @@ import type { AvatarProps } from '@rocket.chat/fuselage';
 import { Avatar, Skeleton } from '@rocket.chat/fuselage';
 import type { FC } from 'react';
 import React, { useState } from 'react';
+import { useRoomToolbox } from '../../views/room/contexts/RoomToolboxContext';
+import { useTranslation } from '@rocket.chat/ui-contexts';
 
 export type BaseAvatarProps = Omit<AvatarProps, 'is'>;
 
 const BaseAvatar: FC<BaseAvatarProps> = ({ onError, ...props }) => {
 	const [isLoading, setIsLoading] = useState<unknown>(false);
-
+	const t = useTranslation();
 	if (isLoading) {
 		return <Skeleton aria-hidden variant='rect' onError={onError} {...props} />;
 	}
-
+	const toolbox = useRoomToolbox();
+	const { actions, openTab } = toolbox;
+	console.log(actions);
+	console.log(props);
+	const handleClick = () => {
+		openTab(actions[0]?.id);
+	}
 	return (
 		<Avatar
 			aria-hidden
+			title={t(actions[0]?.title)}
+			onClick={handleClick}
 			onError={(event) => {
 				setIsLoading(true);
 				onError?.(event);


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Implement the ability to view a user's profile by clicking on their profile image. This enhancement provides a more intuitive way for users to access user information directly from the chat navigation bar.

- Implemented profile click on the user's profile image in the navigation bar.

[screencast-github.com-2024.01.30-11_19_38.webm](https://github.com/RocketChat/Rocket.Chat/assets/74670675/05ad1e9a-da16-46dd-a9f0-0ed62f879fd9)


Closes #31542 
