### PR TITLE
ci: Improve release changelog by adding the PR to items as well as the username of the contributor

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-	"changelog": "@changesets/changelog-git",
+	"changelog": ["@rocket.chat/release-changelog", { "repo": "RocketChat/Rocket.Chat" }],
 	"commit": false,
 	"fixed": [
 		["@rocket.chat/meteor", "@rocket.chat/core-typings", "@rocket.chat/rest-typings"]

--- a/packages/release-changelog/.eslintrc.json
+++ b/packages/release-changelog/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+	"extends": ["@rocket.chat/eslint-config"],
+	"plugins": ["jest"],
+	"env": {
+		"jest/globals": true
+	},
+	"ignorePatterns": ["**/dist"]
+}

--- a/packages/release-changelog/package.json
+++ b/packages/release-changelog/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@rocket.chat/release-changelog",
+	"version": "0.1.0",
+	"private": true,
+	"scripts": {
+		"build": "tsc",
+		"lint": "eslint src"
+	},
+	"main": "dist/index.js",
+	"devDependencies": {
+		"@changesets/types": "^6.0.0",
+		"@rocket.chat/eslint-config": "workspace:^",
+		"@types/node": "^14.18.63",
+		"eslint": "~8.45.0",
+		"typescript": "~5.3.2"
+	},
+	"dependencies": {
+		"dataloader": "^1.4.0",
+		"node-fetch": "^2"
+	}
+}

--- a/packages/release-changelog/src/getGitHubInfo.ts
+++ b/packages/release-changelog/src/getGitHubInfo.ts
@@ -1,0 +1,232 @@
+import DataLoader from 'dataloader';
+import fetch from 'node-fetch';
+
+const validRepoNameRegex = /^[\w.-]+\/[\w.-]+$/;
+
+type RequestData = { kind: 'commit'; repo: string; commit: string } | { kind: 'pull'; repo: string; pull: number };
+
+type ReposWithCommitsAndPRsToFetch = Record<string, ({ kind: 'commit'; commit: string } | { kind: 'pull'; pull: number })[]>;
+
+function makeQuery(repos: ReposWithCommitsAndPRsToFetch) {
+	return `
+			query {
+				${Object.keys(repos)
+					.map(
+						(repo, i) =>
+							`a${i}: repository(
+						owner: ${JSON.stringify(repo.split('/')[0])}
+						name: ${JSON.stringify(repo.split('/')[1])}
+					) {
+						${repos[repo]
+							.map((data) =>
+								data.kind === 'commit'
+									? `a${data.commit}: object(expression: ${JSON.stringify(data.commit)}) {
+						... on Commit {
+						commitUrl
+						associatedPullRequests(first: 50) {
+							nodes {
+								number
+								url
+								mergedAt
+								authorAssociation
+								author {
+									login
+									url
+								}
+							}
+						}
+						author {
+							user {
+								login
+								url
+							}
+						}
+					}}`
+									: `pr__${data.pull}: pullRequest(number: ${data.pull}) {
+										url
+										author {
+											login
+											url
+										}
+										mergeCommit {
+											commitUrl
+											abbreviatedOid
+										}
+									}`,
+							)
+							.join('\n')}
+					}`,
+					)
+					.join('\n')}
+				}
+		`;
+}
+
+// why are we using dataloader?
+// it provides use with two things
+// 1. caching
+// since getInfo will be called inside of changeset's getReleaseLine
+// and there could be a lot of release lines for a single commit
+// caching is important so we don't do a bunch of requests for the same commit
+// 2. batching
+// getReleaseLine will be called a large number of times but it'll be called at the same time
+// so instead of doing a bunch of network requests, we can do a single one.
+const GHDataLoader = new DataLoader(async (requests: RequestData[]) => {
+	if (!process.env.GITHUB_TOKEN) {
+		throw new Error(
+			'Please create a GitHub personal access token at https://github.com/settings/tokens/new with `read:user` and `repo:status` permissions and add it as the GITHUB_TOKEN environment variable',
+		);
+	}
+	const repos: ReposWithCommitsAndPRsToFetch = {};
+	requests.forEach(({ repo, ...data }) => {
+		if (repos[repo] === undefined) {
+			repos[repo] = [];
+		}
+		repos[repo].push(data);
+	});
+
+	const data = await fetch('https://api.github.com/graphql', {
+		method: 'POST',
+		headers: {
+			Authorization: `Token ${process.env.GITHUB_TOKEN}`,
+		},
+		body: JSON.stringify({ query: makeQuery(repos) }),
+	}).then((x: any) => x.json());
+
+	if (data.errors) {
+		throw new Error(`An error occurred when fetching data from GitHub\n${JSON.stringify(data.errors, null, 2)}`);
+	}
+
+	// this is mainly for the case where there's an authentication problem
+	if (!data.data) {
+		throw new Error(`An error occurred when fetching data from GitHub\n${JSON.stringify(data)}`);
+	}
+
+	const cleanedData: Record<string, { commit: Record<string, any>; pull: Record<string, any> }> = {};
+	Object.keys(repos).forEach((repo, index) => {
+		const output: { commit: Record<string, any>; pull: Record<string, any> } = {
+			commit: {},
+			pull: {},
+		};
+		cleanedData[repo] = output;
+		Object.entries(data.data[`a${index}`]).forEach(([field, value]) => {
+			// this is "a" because that's how it was when it was first written, "a" means it's a commit not a pr
+			// we could change it to commit__ but then we have to get new GraphQL results from the GH API to put in the tests
+			if (field[0] === 'a') {
+				output.commit[field.substring(1)] = value;
+			} else {
+				output.pull[field.replace('pr__', '')] = value;
+			}
+		});
+	});
+
+	return requests.map(({ repo, ...data }) => cleanedData[repo][data.kind][data.kind === 'pull' ? data.pull : data.commit]);
+});
+
+type UserType = { login: string; association: 'CONTRIBUTOR' | 'MEMBER' | 'OWNER' } | null;
+
+export async function getInfo(request: { commit: string; repo: string }): Promise<{
+	user: UserType;
+	pull: number | null;
+	links: {
+		commit: string;
+		pull: string | null;
+		user: string | null;
+	};
+}> {
+	if (!request.commit) {
+		throw new Error('Please pass a commit SHA to getInfo');
+	}
+
+	if (!request.repo) {
+		throw new Error('Please pass a GitHub repository in the form of userOrOrg/repoName to getInfo');
+	}
+
+	if (!validRepoNameRegex.test(request.repo)) {
+		throw new Error(
+			`Please pass a valid GitHub repository in the form of userOrOrg/repoName to getInfo (it has to match the "${validRepoNameRegex.source}" pattern)`,
+		);
+	}
+
+	const data = await GHDataLoader.load({ kind: 'commit', ...request });
+	let user = null;
+	if (data.author?.user) {
+		user = { association: 'MEMBER', ...data.author.user };
+	}
+
+	const associatedPullRequest = data.associatedPullRequests?.nodes?.length
+		? (data.associatedPullRequests.nodes as any[]).sort((a, b) => {
+				if (a.mergedAt === null && b.mergedAt === null) {
+					return 0;
+				}
+				if (a.mergedAt === null) {
+					return 1;
+				}
+				if (b.mergedAt === null) {
+					return -1;
+				}
+				a = new Date(a.mergedAt);
+				b = new Date(b.mergedAt);
+
+				if (a > b) {
+					return 1;
+				}
+
+				return a < b ? -1 : 0;
+		  })[0]
+		: null;
+	if (associatedPullRequest) {
+		user = {
+			association: associatedPullRequest.authorAssociation,
+			...associatedPullRequest.author,
+		};
+	}
+	return {
+		user,
+		pull: associatedPullRequest ? associatedPullRequest.number : null,
+		links: {
+			commit: `[\`${request.commit.slice(0, 7)}\`](${data.commitUrl})`,
+			pull: associatedPullRequest ? `[#${associatedPullRequest.number}](${associatedPullRequest.url})` : null,
+			user: user ? `[@${user.login}](${user.url})` : null,
+		},
+	};
+}
+
+export async function getInfoFromPullRequest(request: { pull: number; repo: string }): Promise<{
+	user: UserType;
+	commit: string | null;
+	links: {
+		commit: string | null;
+		pull: string;
+		user: string | null;
+	};
+}> {
+	if (request.pull === undefined) {
+		throw new Error('Please pass a pull request number');
+	}
+
+	if (!request.repo) {
+		throw new Error('Please pass a GitHub repository in the form of userOrOrg/repoName to getInfo');
+	}
+
+	if (!validRepoNameRegex.test(request.repo)) {
+		throw new Error(
+			`Please pass a valid GitHub repository in the form of userOrOrg/repoName to getInfo (it has to match the "${validRepoNameRegex.source}" pattern)`,
+		);
+	}
+
+	const data = await GHDataLoader.load({ kind: 'pull', ...request });
+	const user = data?.author;
+
+	const commit = data?.mergeCommit;
+
+	return {
+		user: user ? user.login : null,
+		commit: commit ? commit.abbreviatedOid : null,
+		links: {
+			commit: commit ? `[\`${commit.abbreviatedOid.slice(0, 7)}\`](${commit.commitUrl})` : null,
+			pull: `[#${request.pull}](https://github.com/${request.repo}/pull/${request.pull})`,
+			user: user ? `[@${user.login}](${user.url})` : null,
+		},
+	};
+}

--- a/packages/release-changelog/src/index.ts
+++ b/packages/release-changelog/src/index.ts
@@ -1,0 +1,114 @@
+import type { ChangelogFunctions } from '@changesets/types';
+
+import { getInfo, getInfoFromPullRequest } from './getGitHubInfo';
+
+const changelogFunctions: ChangelogFunctions = {
+	getReleaseLine: async (changeset, _type, options) => {
+		if (!options?.repo) {
+			throw new Error(
+				'Please provide a repo to this changelog generator like this:\n"changelog": ["@rocket.chat/release-changelog", { "repo": "org/repo" }]',
+			);
+		}
+
+		let prFromSummary: number | undefined;
+		let commitFromSummary: string | undefined;
+		const usersFromSummary: string[] = [];
+
+		const replacedChangelog = changeset.summary
+			.replace(/^\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/im, (_, pr) => {
+				const num = Number(pr);
+				if (!isNaN(num)) prFromSummary = num;
+				return '';
+			})
+			.replace(/^\s*commit:\s*([^\s]+)/im, (_, commit) => {
+				commitFromSummary = commit;
+				return '';
+			})
+			.replace(/^\s*(?:author|user):\s*@?([^\s]+)/gim, (_, user) => {
+				usersFromSummary.push(user);
+				return '';
+			})
+			.trim();
+
+		const [firstLine, ...futureLines] = replacedChangelog.split('\n').map((l) => l.trimEnd());
+
+		const links = await (async () => {
+			if (prFromSummary !== undefined) {
+				const result = await getInfoFromPullRequest({
+					repo: options.repo,
+					pull: prFromSummary,
+				});
+
+				let { links } = result;
+				if (commitFromSummary) {
+					const shortCommitId = commitFromSummary.slice(0, 7);
+					links = {
+						...links,
+						commit: `[\`${shortCommitId}\`](https://github.com/${options.repo}/commit/${commitFromSummary})`,
+					};
+				}
+
+				const { user } = result;
+
+				return {
+					...links,
+					user,
+				};
+			}
+			const commitToFetchFrom = commitFromSummary || changeset.commit;
+			if (commitToFetchFrom) {
+				const { links, user } = await getInfo({
+					repo: options.repo,
+					commit: commitToFetchFrom,
+				});
+				return { ...links, user };
+			}
+			return {
+				commit: null,
+				pull: null,
+				user: null,
+			};
+		})();
+
+		const users = (() => {
+			if (usersFromSummary.length) {
+				return usersFromSummary.map((userFromSummary) => `[@${userFromSummary}](https://github.com/${userFromSummary})`).join(', ');
+			}
+
+			if (links.user?.association === 'CONTRIBUTOR') {
+				return `[@${links.user.login}](https://github.com/${links.user.login})`;
+			}
+		})();
+
+		const prefix = [
+			links.pull === null ? '' : links.pull,
+			// links.commit === null ? '' : links.commit,
+			users ? `by ${users}` : '',
+		]
+			.filter(Boolean)
+			.join(' ');
+
+		return `-${prefix ? ` (${prefix})` : ''} ${firstLine}\n${futureLines.map((l) => `  ${l}`).join('\n')}`;
+	},
+	getDependencyReleaseLine: async (changesets, dependenciesUpdated, options) => {
+		if (!options.repo) {
+			throw new Error(
+				'Please provide a repo to this changelog generator like this:\n"changelog": ["@rocket.chat/release-changelog", { "repo": "org/repo" }]',
+			);
+		}
+		if (dependenciesUpdated.length === 0) return '';
+
+		const commits = changesets
+			.map((cs) => cs.commit)
+			.filter((_) => _)
+			.join(', ');
+
+		const changesetLink = `- <details><summary>Updated dependencies [${commits}]:</summary>\n`;
+
+		const updatedDepenenciesList = dependenciesUpdated.map((dependency) => `  - ${dependency.name}@${dependency.newVersion}`);
+
+		return [changesetLink, ...updatedDepenenciesList, '  </details>'].join('\n');
+	},
+};
+
+export default changelogFunctions;

--- a/packages/release-changelog/tsconfig.json
+++ b/packages/release-changelog/tsconfig.json
@@ -1,0 +1,109 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "esnext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    "rootDir": "src/",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "dist/",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3909,6 +3909,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@changesets/types@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@changesets/types@npm:6.0.0"
+  checksum: d528b5d712f62c26ea422c7d34ccf6eac57a353c0733d96716db3c796ecd9bba5d496d48b37d5d46b784dc45b69c06ce3345fa3515df981bb68456cad68e6465
+  languageName: node
+  linkType: hard
+
 "@changesets/write@npm:^0.2.3":
   version: 0.2.3
   resolution: "@changesets/write@npm:0.2.3"
@@ -9334,16 +9341,16 @@ __metadata:
     typescript: ~5.3.2
   peerDependencies:
     "@rocket.chat/apps-engine": "*"
-    "@rocket.chat/eslint-config": 0.6.0
+    "@rocket.chat/eslint-config": 0.6.1-rc.0
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/fuselage-polyfills": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/prettier-config": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-contexts": 3.0.3
-    "@rocket.chat/ui-kit": "*"
-    "@rocket.chat/ui-video-conf": 3.0.3
+    "@rocket.chat/ui-contexts": 4.0.0-rc.4
+    "@rocket.chat/ui-kit": 0.33.0-rc.0
+    "@rocket.chat/ui-video-conf": 4.0.0-rc.4
     "@tanstack/react-query": "*"
     react: "*"
     react-dom: "*"
@@ -9425,14 +9432,14 @@ __metadata:
     ts-jest: ~29.1.1
     typescript: ~5.3.2
   peerDependencies:
-    "@rocket.chat/core-typings": 6.6.0-develop
+    "@rocket.chat/core-typings": 6.6.0-rc.4
     "@rocket.chat/css-in-js": "*"
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-tokens": "*"
     "@rocket.chat/message-parser": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-client": 3.0.3
-    "@rocket.chat/ui-contexts": 3.0.3
+    "@rocket.chat/ui-client": 4.0.0-rc.4
+    "@rocket.chat/ui-contexts": 4.0.0-rc.4
     katex: "*"
     react: "*"
   languageName: unknown
@@ -10398,6 +10405,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@rocket.chat/release-changelog@workspace:packages/release-changelog":
+  version: 0.0.0-use.local
+  resolution: "@rocket.chat/release-changelog@workspace:packages/release-changelog"
+  dependencies:
+    "@changesets/types": ^6.0.0
+    "@rocket.chat/eslint-config": "workspace:^"
+    "@types/node": ^14.18.63
+    dataloader: ^1.4.0
+    eslint: ~8.45.0
+    node-fetch: ^2
+    typescript: ~5.3.2
+  languageName: unknown
+  linkType: soft
+
 "@rocket.chat/rest-typings@workspace:^, @rocket.chat/rest-typings@workspace:packages/rest-typings":
   version: 0.0.0-use.local
   resolution: "@rocket.chat/rest-typings@workspace:packages/rest-typings"
@@ -10600,7 +10621,7 @@ __metadata:
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-contexts": 3.0.3
+    "@rocket.chat/ui-contexts": 4.0.0-rc.4
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -10775,7 +10796,7 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-contexts": 3.0.3
+    "@rocket.chat/ui-contexts": 4.0.0-rc.4
     react: ^17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -10863,8 +10884,8 @@ __metadata:
     typescript: ~5.3.2
   peerDependencies:
     "@rocket.chat/layout": "*"
-    "@rocket.chat/tools": "*"
-    "@rocket.chat/ui-contexts": 3.0.3
+    "@rocket.chat/tools": 0.2.1-rc.0
+    "@rocket.chat/ui-contexts": 4.0.0-rc.4
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"
@@ -20516,6 +20537,13 @@ __metadata:
     whatwg-mimetype: ^3.0.0
     whatwg-url: ^11.0.0
   checksum: 033fc3dd0fba6d24bc9a024ddcf9923691dd24f90a3d26f6545d6a2f71ec6956f93462f2cdf2183cc46f10dc01ed3bcb36731a8208456eb1a08147e571fe2a76
+  languageName: node
+  linkType: hard
+
+"dataloader@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "dataloader@npm:1.4.0"
+  checksum: e2c93d43afde68980efc0cd9ff48e9851116e27a9687f863e02b56d46f7e7868cc762cd6dcbaf4197e1ca850a03651510c165c2ae24b8e9843fd894002ad0e20
   languageName: node
   linkType: hard
 
@@ -31262,6 +31290,20 @@ __metadata:
     encoding:
       optional: true
   checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: d76d2f5edb451a3f05b15115ec89fc6be39de37c6089f1b6368df03b91e1633fd379a7e01b7ab05089a25034b2023d959b47e59759cb38d88341b2459e89d6e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is actually a "fork" from [@changesets/changelog-github](https://github.com/changesets/changesets/blob/main/packages/changelog-github/src/index.ts) with some key changes to be more suitable for us.

There are two main changes:

- Adds the PR number to the change
- Update dependencies are groups and collapsed by default

Below you can see a comparison of the current changelog for 6.6.0 and the new one:

![image](https://github.com/RocketChat/Rocket.Chat/assets/8591547/40fe52ca-ff34-42a0-be9e-ec807ea132a4)


![image](https://github.com/RocketChat/Rocket.Chat/assets/8591547/4e717ada-9f6d-4057-989d-23577c866a9b)

