### PR TITLE
fix admin/workspace item dosn't activate #31629

### DIFF
--- a/apps/meteor/client/components/Sidebar/SidebarNavigationItem.tsx
+++ b/apps/meteor/client/components/Sidebar/SidebarNavigationItem.tsx
@@ -28,7 +28,7 @@ const SidebarNavigationItem: FC<SidebarNavigationItemProps> = ({
 	badge: Badge,
 }) => {
 	const path = pathSection;
-	const isActive = !!path && currentPath?.includes(path as string);
+	const isActive = !!path && (currentPath === path || currentPath?.startsWith(`${path}/`));
 
 	if (permissionGranted === false || (typeof permissionGranted === 'function' && !permissionGranted())) {
 		return null;


### PR DESCRIPTION
In this modification, the isActive condition is adjusted to check if the currentPath exactly matches the path or if it starts with the path/. This should help ensure that the workspace item is correctly activated based on the provided paths.