### PR TITLE
fix: Thread Participant Count Fails to Update on Complete Deletion of User Messages.

### DIFF
--- a/apps/meteor/app/lib/server/functions/deleteMessage.ts
+++ b/apps/meteor/app/lib/server/functions/deleteMessage.ts
@@ -43,6 +43,10 @@ export async function deleteMessage(message: IMessage, user: IUser): Promise<voi
 	}
 
 	if (deletedMsg?.tmid) {
+		const threadMsgCounts = await Messages.countDocuments({ 'tmid': deletedMsg.tmid, 'u._id': deletedMsg.u._id });
+		if (threadMsgCounts === 1) {
+			await Messages.removeThreadFollowerByThreadId(deletedMsg.tmid, deletedMsg.u._id);
+		}
 		await Messages.decreaseReplyCountById(deletedMsg.tmid, -1);
 	}
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
1. Resolved the issue of participant count not updating accurately in a thread.

Video for the final functionality

https://github.com/RocketChat/Rocket.Chat/assets/64376712/b9145c13-715c-4c7f-ae6f-2a15a8e267cd


## Issue(s)
Closes #31633 

## Steps to test or reproduce
## Further comments