### PR TITLE
fix: Incorrect name by rocket.cat bot while archiving a discussion using slash-commands

### DIFF
--- a/apps/meteor/app/slashcommands-archiveroom/server/server.ts
+++ b/apps/meteor/app/slashcommands-archiveroom/server/server.ts
@@ -61,7 +61,7 @@ slashCommands.add({
 			void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 				msg: i18n.t('Duplicate_archived_channel_name', {
 					postProcess: 'sprintf',
-					sprintf: [channel],
+					sprintf: [room.fname],
 					lng: settings.get('Language') || 'en',
 				}),
 			});
@@ -73,7 +73,7 @@ slashCommands.add({
 		void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 			msg: i18n.t('Channel_Archived', {
 				postProcess: 'sprintf',
-				sprintf: [channel],
+				sprintf: [room.fname],
 				lng: settings.get('Language') || 'en',
 			}),
 		});

--- a/apps/meteor/app/slashcommands-unarchiveroom/server/server.ts
+++ b/apps/meteor/app/slashcommands-unarchiveroom/server/server.ts
@@ -60,7 +60,7 @@ slashCommands.add({
 			void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 				msg: i18n.t('Channel_already_Unarchived', {
 					postProcess: 'sprintf',
-					sprintf: [channel],
+					sprintf: [room.fname],
 					lng: settings.get('Language') || 'en',
 				}),
 			});
@@ -72,7 +72,7 @@ slashCommands.add({
 		void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 			msg: i18n.t('Channel_Unarchived', {
 				postProcess: 'sprintf',
-				sprintf: [channel],
+				sprintf: [room.fname],
 				lng: settings.get('Language') || 'en',
 			}),
 		});


### PR DESCRIPTION
## Proposed changes (includes videos)

While using slash commands `/archive` and `/unarchive` to archive and unarchive discussions, after successfully archiving or unarchiving, rocket.cat bot displays incorrect name which can be misleading. Since we can have multiple discussions with same name within a channel, the ids displayed instead of name was to uniquely identify each discussion. However, in my opinion notifying users with the id of that discussion is not a feasible solution.

## Supporting proof

https://github.com/RocketChat/Rocket.Chat/assets/69050987/ee4227cd-29ce-4167-a4f6-d0d30679256c

## Steps to reproduce
1. Goto any room other than the Discussion room which you want to archive
2. Try typing `/archive #discussion_name` in the chat
3. rocket.cat bot displays successfully archived but with a incorrect name, specifically the _id of that discussion room
4. Similarly try the steps for `/unarchive #discussion_name`

## Steps taken to resolve this issue
While using `api.broadcast` for cases where we are using `/archive` for:
1. Discussion room is in unarchived state
2. Discussion room is in archived state

Instead of passing channel to `msg`'s `sprintf `property, we should pass `room.fname` which is the actual name of that discussion

We can do similarly for `/unarchive` slash command

## Proof of Work

https://github.com/RocketChat/Rocket.Chat/assets/69050987/bc3e8296-b87f-44fa-933b-272b65399046

This PR closes #31730


