### PR TITLE
Fix: Disable save button during loading state

### DIFF
--- a/apps/meteor/client/views/admin/users/AdminUserForm.tsx
+++ b/apps/meteor/client/views/admin/users/AdminUserForm.tsx
@@ -161,6 +161,7 @@ const UserForm = ({ userData, onReload, ...props }: AdminUserFormProps) => {
 	const rolesId = useUniqueId();
 	const joinDefaultChannelsId = useUniqueId();
 	const sendWelcomeEmailId = useUniqueId();
+	const isSaveUserLoading = handleCreateUser?.isLoading || handleUpdateUser?.isLoading;
 
 	return (
 		<>
@@ -488,7 +489,7 @@ const UserForm = ({ userData, onReload, ...props }: AdminUserFormProps) => {
 					>
 						{t('Reset')}
 					</Button>
-					<Button primary disabled={!isDirty} onClick={handleSubmit(handleSaveUser)}>
+					<Button primary disabled={!isDirty || isSaveUserLoading} onClick={handleSubmit(handleSaveUser)}>
 						{t('Save')}
 					</Button>
 				</ButtonGroup>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->


closes #31734 

Updated the save button behavior to disable it when the API is processing a user save/update operation, preventing multiple clicks and improving user experience.

https://github.com/RocketChat/Rocket.Chat/assets/68157847/d2cf2895-db10-47ab-81a2-c67d6b5a8db4

