### PR TITLE
Release 6.6.2

### DIFF
--- a/.changeset/bump-patch-1709141264352.md
+++ b/.changeset/bump-patch-1709141264352.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Bump @rocket.chat/meteor version.

--- a/.changeset/shy-bananas-repeat.md
+++ b/.changeset/shy-bananas-repeat.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed Federation not working with Microservice deployments

--- a/.changeset/strange-lamps-taste.md
+++ b/.changeset/strange-lamps-taste.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/ddp-client': patch
+'@rocket.chat/meteor': patch
+---
+
+Revert unintentional changes real time presence data payload

--- a/.changeset/young-doors-bathe.md
+++ b/.changeset/young-doors-bathe.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/meteor': patch
+'@rocket.chat/ddp-streamer': patch
+---
+
+Fix web UI not showing users presence updating to offline

--- a/apps/meteor/app/notifications/client/lib/Presence.ts
+++ b/apps/meteor/app/notifications/client/lib/Presence.ts
@@ -13,8 +13,5 @@ type args = [username: string, statusChanged?: UserStatus, statusText?: string];
 export const STATUS_MAP = [UserStatus.OFFLINE, UserStatus.ONLINE, UserStatus.AWAY, UserStatus.BUSY, UserStatus.DISABLED];
 
 Meteor.StreamerCentral.on('stream-user-presence', (uid: string, [username, statusChanged, statusText]: args) => {
-	if (!statusChanged) {
-		return;
-	}
 	Presence.notify({ _id: uid, username, status: STATUS_MAP[statusChanged as any], statusText });
 });

--- a/apps/meteor/app/notifications/client/lib/Presence.ts
+++ b/apps/meteor/app/notifications/client/lib/Presence.ts
@@ -1,4 +1,4 @@
-import type { UserStatus } from '@rocket.chat/core-typings';
+import { UserStatus } from '@rocket.chat/core-typings';
 import { Meteor } from 'meteor/meteor';
 
 import { Presence } from '../../../../client/lib/presence';
@@ -10,6 +10,11 @@ new Meteor.Streamer('user-presence');
 
 type args = [username: string, statusChanged?: UserStatus, statusText?: string];
 
+export const STATUS_MAP = [UserStatus.OFFLINE, UserStatus.ONLINE, UserStatus.AWAY, UserStatus.BUSY, UserStatus.DISABLED];
+
 Meteor.StreamerCentral.on('stream-user-presence', (uid: string, [username, statusChanged, statusText]: args) => {
-	Presence.notify({ _id: uid, username, status: statusChanged, statusText });
+	if (!statusChanged) {
+		return;
+	}
+	Presence.notify({ _id: uid, username, status: STATUS_MAP[statusChanged as any], statusText });
 });

--- a/apps/meteor/ee/server/local-services/federation/service.ts
+++ b/apps/meteor/ee/server/local-services/federation/service.ts
@@ -207,4 +207,12 @@ export class FederationServiceEE extends AbstractBaseFederationServiceEE impleme
 		await federationService.initialize();
 		return federationService;
 	}
+
+	async created(): Promise<void> {
+		return super.created();
+	}
+
+	async stopped(): Promise<void> {
+		return super.stopped();
+	}
 }

--- a/apps/meteor/server/modules/listeners/listeners.module.ts
+++ b/apps/meteor/server/modules/listeners/listeners.module.ts
@@ -2,7 +2,7 @@ import type { AppStatus } from '@rocket.chat/apps-engine/definition/AppStatus';
 import type { ISetting as AppsSetting } from '@rocket.chat/apps-engine/definition/settings';
 import type { IServiceClass } from '@rocket.chat/core-services';
 import { EnterpriseSettings } from '@rocket.chat/core-services';
-import { isSettingColor, isSettingEnterprise } from '@rocket.chat/core-typings';
+import { isSettingColor, isSettingEnterprise, UserStatus } from '@rocket.chat/core-typings';
 import type { IUser, IRoom, VideoConference, ISetting, IOmnichannelRoom } from '@rocket.chat/core-typings';
 import { Logger } from '@rocket.chat/logger';
 import { parse } from '@rocket.chat/message-parser';
@@ -11,6 +11,14 @@ import { settings } from '../../../app/settings/server/cached';
 import type { NotificationsModule } from '../notifications/notifications.module';
 
 const isMessageParserDisabled = process.env.DISABLE_MESSAGE_PARSER === 'true';
+
+const STATUS_MAP: Record<UserStatus, 0 | 1 | 2 | 3> = {
+	[UserStatus.OFFLINE]: 0,
+	[UserStatus.ONLINE]: 1,
+	[UserStatus.AWAY]: 2,
+	[UserStatus.BUSY]: 3,
+	[UserStatus.DISABLED]: 0,
+} as const;
 
 const minimongoChangeMap: Record<string, string> = {
 	inserted: 'added',
@@ -145,10 +153,10 @@ export class ListenersModule {
 				return;
 			}
 
-			notifications.notifyLoggedInThisInstance('user-status', [_id, username, status, statusText, name, roles]);
+			notifications.notifyLoggedInThisInstance('user-status', [_id, username, STATUS_MAP[status], statusText, name, roles]);
 
 			if (_id) {
-				notifications.sendPresence(_id, username, status, statusText);
+				notifications.sendPresence(_id, username, STATUS_MAP[status], statusText);
 			}
 		});
 

--- a/apps/meteor/server/modules/notifications/notifications.module.ts
+++ b/apps/meteor/server/modules/notifications/notifications.module.ts
@@ -1,5 +1,5 @@
 import { Authorization, VideoConf } from '@rocket.chat/core-services';
-import type { ISubscription, IOmnichannelRoom, IUser, UserStatus } from '@rocket.chat/core-typings';
+import type { ISubscription, IOmnichannelRoom, IUser } from '@rocket.chat/core-typings';
 import { Rooms, Subscriptions, Users, Settings } from '@rocket.chat/models';
 import type { StreamerCallbackArgs, StreamKeys, StreamNames } from '@rocket.chat/ui-contexts';
 import type { IStreamer, IStreamerConstructor, IPublication } from 'meteor/rocketchat:streamer';
@@ -531,7 +531,7 @@ export class NotificationsModule {
 		return this.streamUser.emitWithoutBroadcast(`${userId}/${eventName}`, ...args);
 	}
 
-	sendPresence(uid: string, ...args: [username: string, status?: UserStatus, statusText?: string]): void {
+	sendPresence(uid: string, ...args: [username: string, status?: 0 | 1 | 2 | 3, statusText?: string]): void {
 		emit(uid, [args]);
 		return this.streamPresence.emitWithoutBroadcast(uid, args);
 	}

--- a/apps/meteor/server/services/federation/service.ts
+++ b/apps/meteor/server/services/federation/service.ts
@@ -330,4 +330,12 @@ export class FederationService extends AbstractBaseFederationService implements 
 		await federationService.initialize();
 		return federationService;
 	}
+
+	public async stopped(): Promise<void> {
+		return super.stopped();
+	}
+
+	public async created(): Promise<void> {
+		return super.created();
+	}
 }

--- a/ee/apps/ddp-streamer/package.json
+++ b/ee/apps/ddp-streamer/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@rocket.chat/ddp-streamer",
 	"private": true,
-	"version": "0.2.5",
+	"version": "0.2.5-next.1",
 	"description": "Rocket.Chat DDP-Streamer service",
 	"scripts": {
 		"build": "tsc -p tsconfig.json",

--- a/ee/packages/ddp-client/src/types/streams.ts
+++ b/ee/packages/ddp-client/src/types/streams.ts
@@ -24,7 +24,6 @@ import type {
 	IBanner,
 	LicenseLimitKind,
 	ICustomUserStatus,
-	UserStatus,
 } from '@rocket.chat/core-typings';
 import type * as UiKit from '@rocket.chat/ui-kit';
 
@@ -243,7 +242,7 @@ export interface StreamerEvents {
 				[
 					uid: IUser['_id'],
 					username: IUser['username'],
-					status: UserStatus,
+					status: 0 | 1 | 2 | 3,
 					statusText: IUser['statusText'],
 					name: IUser['name'],
 					roles: IUser['roles'],
@@ -325,7 +324,7 @@ export interface StreamerEvents {
 		},
 	];
 
-	'user-presence': [{ key: string; args: [[username: string, statusChanged?: UserStatus, statusText?: string]] }];
+	'user-presence': [{ key: string; args: [[username: string, statusChanged?: 0 | 1 | 2 | 3, statusText?: string]] }];
 
 	// TODO: rename to 'integration-history'
 	'integrationHistory': [

--- a/yarn.lock
+++ b/yarn.lock
@@ -9348,9 +9348,9 @@ __metadata:
     "@rocket.chat/icons": "*"
     "@rocket.chat/prettier-config": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-contexts": 4.0.0
+    "@rocket.chat/ui-contexts": 4.0.1
     "@rocket.chat/ui-kit": 0.33.0
-    "@rocket.chat/ui-video-conf": 4.0.0
+    "@rocket.chat/ui-video-conf": 4.0.1
     "@tanstack/react-query": "*"
     react: "*"
     react-dom: "*"
@@ -9432,14 +9432,14 @@ __metadata:
     ts-jest: ~29.1.1
     typescript: ~5.3.2
   peerDependencies:
-    "@rocket.chat/core-typings": 6.6.0
+    "@rocket.chat/core-typings": 6.6.1
     "@rocket.chat/css-in-js": "*"
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-tokens": "*"
     "@rocket.chat/message-parser": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-client": 4.0.0
-    "@rocket.chat/ui-contexts": 4.0.0
+    "@rocket.chat/ui-client": 4.0.1
+    "@rocket.chat/ui-contexts": 4.0.1
     katex: "*"
     react: "*"
   languageName: unknown
@@ -10621,7 +10621,7 @@ __metadata:
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-contexts": 4.0.0
+    "@rocket.chat/ui-contexts": 4.0.1
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -10796,7 +10796,7 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-contexts": 4.0.0
+    "@rocket.chat/ui-contexts": 4.0.1
     react: ^17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -10885,7 +10885,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.2.1
-    "@rocket.chat/ui-contexts": 4.0.0
+    "@rocket.chat/ui-contexts": 4.0.1
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION


<!-- release-notes-start -->
<!-- This content is automatically generated. Changing this will not reflect on the final release log -->

_You can see below a preview of the release change log:_

# 6.6.2

### Engine versions

- Node: `14.21.3`
- MongoDB: `4.4, 5.0, 6.0`
- Apps-Engine: `1.41.0`

### Patch Changes

*   Bump @rocket.chat/meteor version.

*   ([#31844](https://github.com/RocketChat/Rocket.Chat/pull/31844)) Fixed Federation not working with Microservice deployments

*   ([#31823](https://github.com/RocketChat/Rocket.Chat/pull/31823)) Revert unintentional changes real time presence data payload

*   ([#31833](https://github.com/RocketChat/Rocket.Chat/pull/31833)) Fix web UI not showing users presence updating to offline

*   <details><summary>Updated dependencies []:</summary>

    *   @rocket.chat/ui-contexts@4.0.2
    *   @rocket.chat/ui-theming@0.1.2
    *   @rocket.chat/fuselage-ui-kit@4.0.2
    *   @rocket.chat/gazzodown@4.0.2
    *   @rocket.chat/ui-client@4.0.2
    *   @rocket.chat/ui-video-conf@4.0.2
    *   @rocket.chat/web-ui-registration@4.0.2
    *   @rocket.chat/core-typings@6.6.2
    *   @rocket.chat/rest-typings@6.6.2
    *   @rocket.chat/api-client@0.1.24
    *   @rocket.chat/license@0.1.6
    *   @rocket.chat/omnichannel-services@0.1.6
    *   @rocket.chat/pdf-worker@0.0.30
    *   @rocket.chat/presence@0.1.6
    *   @rocket.chat/core-services@0.3.6
    *   @rocket.chat/cron@0.0.26
    *   @rocket.chat/model-typings@0.3.2
    *   @rocket.chat/server-cloud-communication@0.0.2
    *   @rocket.chat/models@0.0.30
    *   @rocket.chat/instance-status@0.0.30

    </details>

<!-- release-notes-end -->