### PR TITLE
feat: Accept `settings` field in `users.create` and `users.update` endpoints

### DIFF
--- a/.changeset/fluffy-eggs-impress.md
+++ b/.changeset/fluffy-eggs-impress.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/meteor": minor
+"@rocket.chat/rest-typings": minor
+---
+
+Added support to configure the `settings` field on `users.update` and `users.create` endpoints

--- a/apps/meteor/tests/end-to-end/api/01-users.js
+++ b/apps/meteor/tests/end-to-end/api/01-users.js
@@ -140,6 +140,47 @@ describe('[Users]', function () {
 			await deleteUser(user);
 		});
 
+		it('should create a new user with language preferences', async () => {
+			await setCustomFields({ customFieldText });
+
+			const username = `languagepref_${apiUsername}`;
+			const email = `languagepref_${apiEmail}`;
+
+			let user;
+
+			await request
+				.post(api('users.create'))
+				.set(credentials)
+				.send({
+					email,
+					name: username,
+					username,
+					password,
+					active: true,
+					roles: ['user'],
+					joinDefaultChannels: true,
+					verified: true,
+					settings: {
+						preferences: { language: 'en' },
+					},
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.nested.property('user.username', username);
+					expect(res.body).to.have.nested.property('user.emails[0].address', email);
+					expect(res.body).to.have.nested.property('user.active', true);
+					expect(res.body).to.have.nested.property('user.name', username);
+					expect(res.body).to.have.nested.property('user.settings.preferences.language', 'en');
+					expect(res.body).to.not.have.nested.property('user.e2e');
+
+					user = res.body.user;
+				});
+
+			await deleteUser(user);
+		});
+
 		function failCreateUser(name) {
 			it(`should not create a new user if username is the reserved word ${name}`, (done) => {
 				request
@@ -1174,6 +1215,27 @@ describe('[Users]', function () {
 					expect(res.body).to.have.property('success', true);
 					expect(res.body).to.have.nested.property('user.nickname', 'edited-nickname-test');
 					expect(res.body).to.not.have.nested.property('user.e2e');
+				})
+				.end(done);
+		});
+
+		it("should update a user's preference by userId", (done) => {
+			request
+				.post(api('users.update'))
+				.set(credentials)
+				.send({
+					userId: targetUser._id,
+					data: {
+						settings: {
+							preferences: { testPreference: 'test' },
+						},
+					},
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.nested.property('user.settings.preferences.testPreference', 'test');
 				})
 				.end(done);
 		});

--- a/packages/rest-typings/src/v1/users/UserCreateParamsPOST.ts
+++ b/packages/rest-typings/src/v1/users/UserCreateParamsPOST.ts
@@ -1,3 +1,4 @@
+import type { IUserSettings } from '@rocket.chat/core-typings';
 import Ajv from 'ajv';
 
 const ajv = new Ajv({
@@ -20,6 +21,7 @@ export type UserCreateParamsPOST = {
 	sendWelcomeEmail?: boolean;
 	verified?: boolean;
 	customFields?: object;
+	settings?: IUserSettings;
 	/* @deprecated */
 	fields: string;
 };
@@ -42,6 +44,14 @@ const userCreateParamsPostSchema = {
 		sendWelcomeEmail: { type: 'boolean', nullable: true },
 		verified: { type: 'boolean', nullable: true },
 		customFields: { type: 'object' },
+		settings: {
+			type: 'object',
+			properties: {
+				profile: { type: 'object' },
+				preferences: { type: 'object' },
+			},
+			additionalProperties: false,
+		},
 		fields: { type: 'string', nullable: true },
 	},
 	additionalProperties: false,

--- a/packages/rest-typings/src/v1/users/UsersUpdateParamsPOST.ts
+++ b/packages/rest-typings/src/v1/users/UsersUpdateParamsPOST.ts
@@ -23,6 +23,7 @@ export type UsersUpdateParamsPOST = {
 		verified?: boolean;
 		customFields?: Record<string, unknown>;
 		status?: string;
+		settings?: { preferences?: Record<string, unknown> };
 	};
 	confirmRelinquish?: boolean;
 };
@@ -105,6 +106,14 @@ const UsersUpdateParamsPostSchema = {
 				status: {
 					type: 'string',
 					nullable: true,
+				},
+				settings: {
+					type: 'object',
+					nullable: true,
+					properties: {
+						preferences: { type: 'object' },
+						additionalProperties: false,
+					},
 				},
 			},
 			required: [],


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
 - Accept `settings` field in both `users.create` and `users.update` endpoints -- this allows users to set preferences and is already handled internally.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

[CORE-79](https://rocketchat.atlassian.net/browse/CORE-79)

[CORE-79]: https://rocketchat.atlassian.net/browse/CORE-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ