### PR TITLE
fix: language overwriting in workspace settings

### DIFF
--- a/.changeset/brave-donuts-clap.md
+++ b/.changeset/brave-donuts-clap.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fix language priority order that was overwriting the workspace language when refreshing the browser.

--- a/apps/meteor/client/providers/TranslationProvider.tsx
+++ b/apps/meteor/client/providers/TranslationProvider.tsx
@@ -120,7 +120,7 @@ const useI18next = (lng: string): typeof i18next => {
 const useAutoLanguage = () => {
 	const serverLanguage = useSetting<string>('Language');
 	const browserLanguage = normalizeLanguage(window.navigator.userLanguage ?? window.navigator.language);
-	const defaultUserLanguage = browserLanguage || serverLanguage || 'en';
+	const defaultUserLanguage = serverLanguage || browserLanguage || 'en';
 
 	// if the language is supported, if not remove the region
 	const suggestedLanguage = languages.includes(defaultUserLanguage) ? defaultUserLanguage : defaultUserLanguage.split('-').shift() ?? 'en';

--- a/apps/meteor/tests/e2e/administration.spec.ts
+++ b/apps/meteor/tests/e2e/administration.spec.ts
@@ -163,8 +163,10 @@ test.describe.parallel('administration', () => {
 
 			test('expect to change the language to pt-BR', async ({ page, api }) => {
 				expect((await setSettingValueById(api, 'Language', 'pt-BR')).status()).toBe(200);
+				expect((await api.get('/i18n/pt-BR.json')).status()).toBe(200);
 
 				await page.reload();
+				await expect(page.locator('html')).toHaveAttribute('lang', 'pt-BR');
 				await expect(page.locator('h1')).toHaveText('Geral');
 			});
 		});

--- a/apps/meteor/tests/e2e/administration.spec.ts
+++ b/apps/meteor/tests/e2e/administration.spec.ts
@@ -4,6 +4,7 @@ import { IS_EE } from './config/constants';
 import { Users } from './fixtures/userStates';
 import { Admin } from './page-objects';
 import { createTargetChannel } from './utils';
+import { setSettingValueById } from './utils/setSettingValueById';
 import { test, expect } from './utils/test';
 
 test.use({ storageState: Users.admin.state });
@@ -151,9 +152,20 @@ test.describe.parallel('administration', () => {
 				await page.goto('/admin/settings/General');
 			});
 
+			test.afterAll(async ({ api }) => {
+				await setSettingValueById(api, 'Language', 'en')
+			});
+
 			test('expect be able to reset a setting after a change', async () => {
 				await poAdmin.inputSiteURL.type('any_text');
 				await poAdmin.btnResetSiteURL.click();
+			});
+
+			test('expect to change the language to pt-BR', async ({ page, api }) => {
+				expect((await setSettingValueById(api, 'Language', 'pt-BR')).status()).toBe(200);
+
+				await page.reload();
+				await expect(page.locator('h1')).toHaveText('Geral');
 			});
 		});
 	});


### PR DESCRIPTION
Fix language priority order in the workspace settings that was causing losing the workspace language when refreshing the browser given that the browser language was having a higher priority over the language chosen by the user. 

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
[https://rocketchat.atlassian.net/browse/SUP-493](https://rocketchat.atlassian.net/browse/SUP-493)

## Steps to test or reproduce
1. Go to workspace settings.
2. Go to general.
3. Change the language and restart the page.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
