### PR TITLE
Release 6.6.3

### DIFF
--- a/.changeset/bump-patch-1709669273957.md
+++ b/.changeset/bump-patch-1709669273957.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Bump @rocket.chat/meteor version.

--- a/.changeset/wicked-months-laugh.md
+++ b/.changeset/wicked-months-laugh.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fix users presence stuck as online after connecting using mobile apps

--- a/apps/meteor/ee/server/startup/presence.ts
+++ b/apps/meteor/ee/server/startup/presence.ts
@@ -30,9 +30,16 @@ Meteor.startup(() => {
 	});
 
 	Accounts.onLogin((login: any): void => {
-		if (login.type !== 'resume') {
+		if (login.type !== 'resume' || !login.connection.id) {
 			return;
 		}
+
+		// validate if it is a real WS connection and is still open
+		const session = Meteor.server.sessions.get(login.connection.id);
+		if (!session) {
+			return;
+		}
+
 		void (async function () {
 			await Presence.newConnection(login.user._id, login.connection.id, nodeId);
 			updateConns();

--- a/apps/meteor/tests/end-to-end/api/01-users.js
+++ b/apps/meteor/tests/end-to-end/api/01-users.js
@@ -527,6 +527,41 @@ describe('[Users]', function () {
 				})
 				.end(done);
 		});
+
+		describe('Logging in with type: "resume"', () => {
+			let user;
+			let userCredentials;
+
+			before(async () => {
+				user = await createUser({ joinDefaultChannels: false });
+				userCredentials = await login(user.username, password);
+			});
+
+			after(async () => deleteUser(user));
+
+			it('should return "offline" after a login type "resume" via REST', async () => {
+				await request
+					.post(api('login'))
+					.send({
+						resume: userCredentials['X-Auth-Token'],
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				await request
+					.get(api('users.getPresence'))
+					.set(credentials)
+					.query({
+						userId: user._id,
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('success', true);
+						expect(res.body).to.have.nested.property('presence', 'offline');
+					});
+			});
+		});
 	});
 
 	describe('[/users.presence]', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9348,9 +9348,9 @@ __metadata:
     "@rocket.chat/icons": "*"
     "@rocket.chat/prettier-config": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-contexts": 4.0.1
+    "@rocket.chat/ui-contexts": 4.0.2
     "@rocket.chat/ui-kit": 0.33.0
-    "@rocket.chat/ui-video-conf": 4.0.1
+    "@rocket.chat/ui-video-conf": 4.0.2
     "@tanstack/react-query": "*"
     react: "*"
     react-dom: "*"
@@ -9432,14 +9432,14 @@ __metadata:
     ts-jest: ~29.1.1
     typescript: ~5.3.2
   peerDependencies:
-    "@rocket.chat/core-typings": 6.6.1
+    "@rocket.chat/core-typings": 6.6.2
     "@rocket.chat/css-in-js": "*"
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-tokens": "*"
     "@rocket.chat/message-parser": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-client": 4.0.1
-    "@rocket.chat/ui-contexts": 4.0.1
+    "@rocket.chat/ui-client": 4.0.2
+    "@rocket.chat/ui-contexts": 4.0.2
     katex: "*"
     react: "*"
   languageName: unknown
@@ -10621,7 +10621,7 @@ __metadata:
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-contexts": 4.0.1
+    "@rocket.chat/ui-contexts": 4.0.2
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -10796,7 +10796,7 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-contexts": 4.0.1
+    "@rocket.chat/ui-contexts": 4.0.2
     react: ^17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -10885,7 +10885,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.2.1
-    "@rocket.chat/ui-contexts": 4.0.1
+    "@rocket.chat/ui-contexts": 4.0.2
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION


<!-- release-notes-start -->
<!-- This content is automatically generated. Changing this will not reflect on the final release log -->

_You can see below a preview of the release change log:_

# 6.6.3

### Engine versions

- Node: `14.21.3`
- MongoDB: `4.4, 5.0, 6.0`
- Apps-Engine: `1.41.0`

### Patch Changes

*   Bump @rocket.chat/meteor version.

*   ([#31895](https://github.com/RocketChat/Rocket.Chat/pull/31895)) Fix users presence stuck as online after connecting using mobile apps

*   <details><summary>Updated dependencies []:</summary>

    *   @rocket.chat/core-typings@6.6.3
    *   @rocket.chat/rest-typings@6.6.3
    *   @rocket.chat/api-client@0.1.25
    *   @rocket.chat/license@0.1.7
    *   @rocket.chat/omnichannel-services@0.1.7
    *   @rocket.chat/pdf-worker@0.0.31
    *   @rocket.chat/presence@0.1.7
    *   @rocket.chat/core-services@0.3.7
    *   @rocket.chat/cron@0.0.27
    *   @rocket.chat/gazzodown@4.0.3
    *   @rocket.chat/model-typings@0.3.3
    *   @rocket.chat/ui-contexts@4.0.3
    *   @rocket.chat/server-cloud-communication@0.0.2
    *   @rocket.chat/fuselage-ui-kit@4.0.3
    *   @rocket.chat/models@0.0.31
    *   @rocket.chat/ui-theming@0.1.2
    *   @rocket.chat/ui-client@4.0.3
    *   @rocket.chat/ui-video-conf@4.0.3
    *   @rocket.chat/web-ui-registration@4.0.3
    *   @rocket.chat/instance-status@0.0.31

    </details>

<!-- release-notes-end -->