### PR TITLE
fix: command Preview is not Visible 

### DIFF
--- a/apps/meteor/app/ui-message/client/popup/components/composerBoxPopupPreview/ComposerBoxPopupPreview.tsx
+++ b/apps/meteor/app/ui-message/client/popup/components/composerBoxPopupPreview/ComposerBoxPopupPreview.tsx
@@ -1,4 +1,4 @@
-import { Box, Skeleton, Tile } from '@rocket.chat/fuselage';
+import { Box, Skeleton, Tile, Option } from '@rocket.chat/fuselage';
 import { useUniqueId } from '@rocket.chat/fuselage-hooks';
 import { useMethod } from '@rocket.chat/ui-contexts';
 import React, { forwardRef, useEffect, useImperativeHandle } from 'react';
@@ -128,7 +128,7 @@ const ComposerBoxPopupPreview = forwardRef<
 										Your browser does not support the video element.
 									</video>
 								)}
-								{item.type === 'text' && <h4>{item.value}</h4>}
+								{item.type === 'text' && <Option>{item.value}</Option>}
 								{item.type === 'other' && <code>{item.value}</code>}
 							</Box>
 						))}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Before: 
![Screenshot from 2024-03-13 00-50-25](https://github.com/RocketChat/Rocket.Chat/assets/99081689/b5621eef-5a87-45e7-bf9a-ecda9d2367ec)

After: 
![Screenshot from 2024-03-13 00-52-26](https://github.com/RocketChat/Rocket.Chat/assets/99081689/e5121540-1901-4e11-bcbc-53afc976654d)

## Issue(s)
#30598 

## Steps to test or reproduce
[Here](https://github.com/RocketChat/Rocket.Chat/issues/30598#issuecomment-1895994392)is a Detailed explanation to reproduce it.

## Further comments
We may have to make some more changes to make the preview look like the command suggestion we have.