### PR TITLE
Release 6.6.4

### DIFF
--- a/.changeset/bump-patch-1710772454766.md
+++ b/.changeset/bump-patch-1710772454766.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Bump @rocket.chat/meteor version.

--- a/.changeset/cyan-countries-impress.md
+++ b/.changeset/cyan-countries-impress.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed matrix homeserver domain setting not being visible in admin panel

--- a/.changeset/moody-ghosts-add.md
+++ b/.changeset/moody-ghosts-add.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Don't use the registration.yaml file to configure Matrix Federation anymore.

--- a/.changeset/slimy-clocks-argue.md
+++ b/.changeset/slimy-clocks-argue.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/meteor": patch
+"@rocket.chat/core-services": patch
+---
+
+`stopped` lifecycle method was unexpectedly synchronous when using microservices, causing our code to create race conditions.

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ yarn-error.log*
 .envrc
 
 *.sublime-workspace
+
+**/.vim/

--- a/apps/meteor/app/search/server/search.internalService.ts
+++ b/apps/meteor/app/search/server/search.internalService.ts
@@ -36,10 +36,10 @@ class Search extends ServiceClassInternal {
 
 const service = new Search();
 
-settings.watch('Search.Provider', () => {
+settings.watch('Search.Provider', async () => {
 	if (searchProviderService.activeProvider?.on) {
 		api.registerService(service);
 	} else {
-		api.destroyService(service);
+		await api.destroyService(service);
 	}
 });

--- a/apps/meteor/ee/server/NetworkBroker.ts
+++ b/apps/meteor/ee/server/NetworkBroker.ts
@@ -71,12 +71,12 @@ export class NetworkBroker implements IBroker {
 		return this.broker.call(method, data);
 	}
 
-	destroyService(instance: IServiceClass): void {
+	async destroyService(instance: IServiceClass): Promise<void> {
 		const name = instance.getName();
 		if (!name) {
 			return;
 		}
-		void this.broker.destroyService(name);
+		await this.broker.destroyService(name);
 		instance.removeAllListeners();
 	}
 

--- a/apps/meteor/ee/server/startup/services.ts
+++ b/apps/meteor/ee/server/startup/services.ts
@@ -33,7 +33,7 @@ if (!License.hasValidLicense()) {
 void License.onLicense('federation', async () => {
 	const federationServiceEE = await FederationServiceEE.createFederationService();
 	if (federationService) {
-		api.destroyService(federationService);
+		await api.destroyService(federationService);
 	}
 	api.registerService(federationServiceEE);
 });

--- a/apps/meteor/ee/tests/unit/server/NetworkBroker.tests.ts
+++ b/apps/meteor/ee/tests/unit/server/NetworkBroker.tests.ts
@@ -1,0 +1,39 @@
+import { ServiceClass } from '@rocket.chat/core-services';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { BrokerMocked } from '../../../../tests/mocks/server/BrokerMocked';
+import { NetworkBroker } from '../../../server/NetworkBroker';
+
+class DelayedStopBroker extends BrokerMocked {
+	async destroyService(name: string) {
+		const instance = this.services.get(name);
+
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+
+		await instance.stopped();
+
+		await super.destroyService(name);
+	}
+}
+
+const broker = new NetworkBroker(new DelayedStopBroker() as any);
+
+describe('NetworkBroker', () => {
+	it('should wait services to be fully destroyed', async () => {
+		const stoppedStub = sinon.stub();
+
+		const instance = new (class extends ServiceClass {
+			name = 'test';
+
+			async stopped() {
+				stoppedStub();
+			}
+		})();
+
+		broker.createService(instance);
+		await broker.destroyService(instance);
+
+		expect(stoppedStub.called).to.be.true;
+	});
+});

--- a/apps/meteor/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -2223,6 +2223,8 @@
   "Federation_Description": "Federation allows an unlimited number of workspaces to communicate with each other.",
   "Federation_Enable": "Enable Federation",
   "Federation_Example_matrix_server": "Example: matrix.org",
+  "Federation_Matrix_enable_ephemeral_events": "Enable Matrix ephemeral events",
+  "Federation_Matrix_enable_ephemeral_events_Alert": "This requires a restart. </br> Enabling ephemeral events like user typing indicator can affect the performance of your Matrix Homeserver and Rocket.Chat server for federated communication",
   "Federation_Federated_room_search": "Federated room search",
   "Federation_Public_key": "Public Key",
   "Federation_Search_federated_rooms": "Search federated rooms",

--- a/apps/meteor/server/services/federation/infrastructure/matrix/Bridge.ts
+++ b/apps/meteor/server/services/federation/infrastructure/matrix/Bridge.ts
@@ -714,7 +714,7 @@ export class MatrixBridge implements IFederationBridge {
 		// Dynamic import to prevent Rocket.Chat from loading the module until needed and then handle if that fails
 		const { Bridge, AppServiceRegistration, MatrixUser } = await import('@rocket.chat/forked-matrix-appservice-bridge');
 		MatrixUserInstance = MatrixUser;
-		const registrationFile = this.internalSettings.generateRegistrationFileObject();
+		const registrationFile = this.internalSettings.getAppServiceRegistrationObject();
 
 		this.bridgeInstance = new Bridge({
 			homeserverUrl: this.internalSettings.getHomeServerUrl(),
@@ -730,7 +730,7 @@ export class MatrixBridge implements IFederationBridge {
 				onLog: (line, isError) => {
 					console.log(line, isError);
 				},
-				...(this.internalSettings.generateRegistrationFileObject().enableEphemeralEvents
+				...(this.internalSettings.getAppServiceRegistrationObject().enableEphemeralEvents
 					? {
 							onEphemeralEvent: (request) => {
 								const event = request.getData() as unknown as AbstractMatrixEvent;

--- a/apps/meteor/server/services/federation/infrastructure/rocket-chat/adapters/Settings.ts
+++ b/apps/meteor/server/services/federation/infrastructure/rocket-chat/adapters/Settings.ts
@@ -237,6 +237,8 @@ export class RocketChatSettingsAdapter {
 				i18nLabel: 'Federation_Matrix_homeserver_domain',
 				i18nDescription: 'Federation_Matrix_homeserver_domain_desc',
 				alert: 'Federation_Matrix_homeserver_domain_alert',
+				group: 'Federation',
+				section: 'Matrix Bridge',
 			},
 		);
 

--- a/apps/meteor/server/services/federation/infrastructure/rocket-chat/adapters/Settings.ts
+++ b/apps/meteor/server/services/federation/infrastructure/rocket-chat/adapters/Settings.ts
@@ -1,6 +1,4 @@
 import crypto from 'crypto';
-import fs from 'fs';
-import { resolve } from 'path';
 
 import { Settings } from '@rocket.chat/models';
 import yaml from 'js-yaml';
@@ -16,7 +14,6 @@ export class RocketChatSettingsAdapter {
 	public async initialize() {
 		await this.addFederationSettings();
 		this.watchChangesAndUpdateRegistrationFile();
-		await this.updateSettingsWithProvidedConfigFileIfNecessary();
 	}
 
 	public getApplicationServiceId(): string {
@@ -65,12 +62,8 @@ export class RocketChatSettingsAdapter {
 		return settings.get('Federation_Matrix_enabled') === true;
 	}
 
-	public areEphemeralEventsEnabled(): boolean {
-		return this.isTypingStatusEnabled();
-	}
-
 	public isTypingStatusEnabled(): boolean {
-		return this.getRegistrationFileFromHomeserver()?.enableEphemeralEvents === true;
+		return settings.get('Federation_Matrix_enable_ephemeral_events') === true;
 	}
 
 	public onFederationEnabledStatusChanged(
@@ -103,19 +96,19 @@ export class RocketChatSettingsAdapter {
 					this.getHomeServerDomain(),
 					this.getBridgeUrl(),
 					this.getBridgePort(),
-					this.generateRegistrationFileObject(),
+					this.getAppServiceRegistrationObject(),
 				),
 		);
 	}
 
-	public generateRegistrationFileObject(): IFederationBridgeRegistrationFile {
+	public getAppServiceRegistrationObject(): IFederationBridgeRegistrationFile {
 		return {
 			id: this.getApplicationServiceId(),
 			homeserverToken: this.getApplicationHomeServerToken(),
 			applicationServiceToken: this.getApplicationApplicationServiceToken(),
 			bridgeUrl: this.getBridgeUrl(),
 			botName: this.getBridgeBotUsername(),
-			enableEphemeralEvents: this.areEphemeralEventsEnabled(),
+			enableEphemeralEvents: this.isTypingStatusEnabled(),
 			listenTo: {
 				users: [
 					{
@@ -140,7 +133,7 @@ export class RocketChatSettingsAdapter {
 	}
 
 	private async updateRegistrationFile(): Promise<void> {
-		const registrationFile = this.generateRegistrationFileObject();
+		const registrationFile = this.getAppServiceRegistrationObject();
 
 		await Settings.updateValueById(
 			'Federation_Matrix_registration_file',
@@ -172,9 +165,7 @@ export class RocketChatSettingsAdapter {
 	}
 
 	private async addFederationSettings(): Promise<void> {
-		const preExistingConfiguration = this.getRegistrationFileFromHomeserver();
-
-		await settingsRegistry.add('Federation_Matrix_enabled', Boolean(preExistingConfiguration), {
+		await settingsRegistry.add('Federation_Matrix_enabled', false, {
 			readonly: false,
 			type: 'boolean',
 			i18nLabel: 'Federation_Matrix_enabled',
@@ -185,11 +176,24 @@ export class RocketChatSettingsAdapter {
 			section: 'Matrix Bridge',
 		});
 
+		await settingsRegistry.add('Federation_Matrix_enable_ephemeral_events', false, {
+			readonly: false,
+			type: 'boolean',
+			i18nLabel: 'Federation_Matrix_enable_ephemeral_events',
+			i18nDescription: 'Federation_Matrix_enable_ephemeral_events_desc',
+			alert: 'Federation_Matrix_enable_ephemeral_events_Alert',
+			public: true,
+			group: 'Federation',
+			section: 'Matrix Bridge',
+		});
+
 		const uniqueId = settings.get('uniqueID') || uuidv4().slice(0, 15).replace(new RegExp('-', 'g'), '_');
 		const homeserverToken = crypto.createHash('sha256').update(`hs_${uniqueId}`).digest('hex');
 		const applicationServiceToken = crypto.createHash('sha256').update(`as_${uniqueId}`).digest('hex');
 
-		await settingsRegistry.add('Federation_Matrix_id', preExistingConfiguration?.id || `rocketchat_${uniqueId}`, {
+		const siteUrl = settings.get<string>('Site_Url');
+
+		await settingsRegistry.add('Federation_Matrix_id', `rocketchat_${uniqueId}`, {
 			readonly: true,
 			type: 'string',
 			i18nLabel: 'Federation_Matrix_id',
@@ -198,7 +202,7 @@ export class RocketChatSettingsAdapter {
 			section: 'Matrix Bridge',
 		});
 
-		await settingsRegistry.add('Federation_Matrix_hs_token', preExistingConfiguration?.homeserverToken || homeserverToken, {
+		await settingsRegistry.add('Federation_Matrix_hs_token', homeserverToken, {
 			readonly: true,
 			type: 'string',
 			i18nLabel: 'Federation_Matrix_hs_token',
@@ -207,7 +211,7 @@ export class RocketChatSettingsAdapter {
 			section: 'Matrix Bridge',
 		});
 
-		await settingsRegistry.add('Federation_Matrix_as_token', preExistingConfiguration?.applicationServiceToken || applicationServiceToken, {
+		await settingsRegistry.add('Federation_Matrix_as_token', applicationServiceToken, {
 			readonly: true,
 			type: 'string',
 			i18nLabel: 'Federation_Matrix_as_token',
@@ -216,33 +220,25 @@ export class RocketChatSettingsAdapter {
 			section: 'Matrix Bridge',
 		});
 
-		await settingsRegistry.add(
-			'Federation_Matrix_homeserver_url',
-			preExistingConfiguration?.rocketchat?.homeServerUrl || 'http://localhost:8008',
-			{
-				type: 'string',
-				i18nLabel: 'Federation_Matrix_homeserver_url',
-				i18nDescription: 'Federation_Matrix_homeserver_url_desc',
-				alert: 'Federation_Matrix_homeserver_url_alert',
-				group: 'Federation',
-				section: 'Matrix Bridge',
-			},
-		);
+		await settingsRegistry.add('Federation_Matrix_homeserver_url', 'http://localhost:8008', {
+			type: 'string',
+			i18nLabel: 'Federation_Matrix_homeserver_url',
+			i18nDescription: 'Federation_Matrix_homeserver_url_desc',
+			alert: 'Federation_Matrix_homeserver_url_alert',
+			group: 'Federation',
+			section: 'Matrix Bridge',
+		});
 
-		await settingsRegistry.add(
-			'Federation_Matrix_homeserver_domain',
-			preExistingConfiguration?.rocketchat?.domainName || 'local.rocket.chat',
-			{
-				type: 'string',
-				i18nLabel: 'Federation_Matrix_homeserver_domain',
-				i18nDescription: 'Federation_Matrix_homeserver_domain_desc',
-				alert: 'Federation_Matrix_homeserver_domain_alert',
-				group: 'Federation',
-				section: 'Matrix Bridge',
-			},
-		);
+		await settingsRegistry.add('Federation_Matrix_homeserver_domain', siteUrl, {
+			type: 'string',
+			i18nLabel: 'Federation_Matrix_homeserver_domain',
+			i18nDescription: 'Federation_Matrix_homeserver_domain_desc',
+			alert: 'Federation_Matrix_homeserver_domain_alert',
+			group: 'Federation',
+			section: 'Matrix Bridge',
+		});
 
-		await settingsRegistry.add('Federation_Matrix_bridge_url', preExistingConfiguration?.bridgeUrl || 'http://host.docker.internal:3300', {
+		await settingsRegistry.add('Federation_Matrix_bridge_url', 'http://localhost:3300', {
 			type: 'string',
 			i18nLabel: 'Federation_Matrix_bridge_url',
 			i18nDescription: 'Federation_Matrix_bridge_url_desc',
@@ -250,7 +246,7 @@ export class RocketChatSettingsAdapter {
 			section: 'Matrix Bridge',
 		});
 
-		await settingsRegistry.add('Federation_Matrix_bridge_localpart', preExistingConfiguration?.botName || 'rocket.cat', {
+		await settingsRegistry.add('Federation_Matrix_bridge_localpart', 'rocket.cat', {
 			type: 'string',
 			i18nLabel: 'Federation_Matrix_bridge_localpart',
 			i18nDescription: 'Federation_Matrix_bridge_localpart_desc',
@@ -260,7 +256,6 @@ export class RocketChatSettingsAdapter {
 
 		await settingsRegistry.add('Federation_Matrix_registration_file', '', {
 			readonly: true,
-			hidden: Boolean(preExistingConfiguration),
 			type: 'code',
 			i18nLabel: 'Federation_Matrix_registration_file',
 			i18nDescription: 'Federation_Matrix_registration_file_desc',
@@ -281,50 +276,5 @@ export class RocketChatSettingsAdapter {
 			group: 'Federation',
 			section: 'Matrix Bridge',
 		});
-	}
-
-	private getRegistrationFileFromHomeserver(): Record<string, any> | undefined {
-		try {
-			const registrationYaml = fs.readFileSync(this.getFilePathForHomeserverConfig(), 'utf8');
-
-			const parsedFile = yaml.load(registrationYaml as string) as Record<string, any>;
-			return {
-				applicationServiceToken: parsedFile.as_token,
-				bridgeUrl: parsedFile.url,
-				botName: parsedFile.sender_localpart,
-				homeserverToken: parsedFile.hs_token,
-				id: parsedFile.id,
-				listenTo: parsedFile.namespaces,
-				enableEphemeralEvents: parsedFile['de.sorunome.msc2409.push_ephemeral'],
-				rocketchat: { domainName: parsedFile.rocketchat?.homeserver_domain, homeServerUrl: parsedFile.rocketchat?.homeserver_url },
-			};
-		} catch (e) {
-			// no-op
-		}
-	}
-
-	private getFilePathForHomeserverConfig(): string {
-		return process.env.NODE_ENV === 'development'
-			? '../../../../../matrix-federation-config/registration.yaml'
-			: resolve(process.cwd(), '../../../matrix-federation-config/registration.yaml');
-	}
-
-	private async updateSettingsWithProvidedConfigFileIfNecessary() {
-		const existingConfiguration = this.getRegistrationFileFromHomeserver();
-		if (!existingConfiguration) {
-			return;
-		}
-
-		await Promise.all([
-			Settings.updateValueById('Federation_Matrix_enabled', true),
-			Settings.updateValueById('Federation_Matrix_id', existingConfiguration.id),
-			Settings.updateValueById('Federation_Matrix_hs_token', existingConfiguration.homeserverToken),
-			Settings.updateValueById('Federation_Matrix_as_token', existingConfiguration.applicationServiceToken),
-			Settings.updateValueById('Federation_Matrix_homeserver_url', existingConfiguration.rocketchat?.homeServerUrl),
-			Settings.updateValueById('Federation_Matrix_homeserver_domain', existingConfiguration.rocketchat?.domainName),
-			Settings.updateValueById('Federation_Matrix_bridge_url', existingConfiguration.bridgeUrl),
-			Settings.updateValueById('Federation_Matrix_bridge_localpart', existingConfiguration.botName),
-			Settings.update({ _id: 'Federation_Matrix_registration_file' }, { $set: { hidden: Boolean(existingConfiguration) } }),
-		]);
 	}
 }

--- a/apps/meteor/tests/mocks/server/BrokerMocked.ts
+++ b/apps/meteor/tests/mocks/server/BrokerMocked.ts
@@ -1,12 +1,14 @@
 export class BrokerMocked {
 	actions: Record<string, (...params: unknown[]) => Promise<unknown>> = {};
 
-	destroyService(): void {
-		// no op
+	services: Map<string, any> = new Map();
+
+	async destroyService(name: string): Promise<void> {
+		this.services.delete(name);
 	}
 
-	createService(): void {
-		// no op
+	createService(instance: any): void {
+		this.services.set(instance.name, instance);
 	}
 
 	async call(method: string, data: any): Promise<any> {

--- a/apps/meteor/tests/unit/server/services/messages/hooks/BeforeSaveCheckMAC.tests.ts
+++ b/apps/meteor/tests/unit/server/services/messages/hooks/BeforeSaveCheckMAC.tests.ts
@@ -36,7 +36,7 @@ const broker = new BrokerMocked();
 
 describe('Check MAC', () => {
 	before(() => {
-		api.setBroker(broker);
+		api.setBroker(broker as any);
 	});
 
 	it('should do nothing if not omnichannel room', async () => {

--- a/packages/core-services/src/LocalBroker.ts
+++ b/packages/core-services/src/LocalBroker.ts
@@ -34,7 +34,7 @@ export class LocalBroker implements IBroker {
 		return this.call(method, data);
 	}
 
-	destroyService(instance: ServiceClass): void {
+	async destroyService(instance: ServiceClass): Promise<void> {
 		const namespace = instance.getName();
 
 		instance.getEvents().forEach((event) => event.listeners.forEach((listener) => this.events.removeListener(event.eventName, listener)));
@@ -51,7 +51,7 @@ export class LocalBroker implements IBroker {
 			this.methods.delete(`${namespace}.${method}`);
 		}
 		instance.removeAllListeners();
-		instance.stopped();
+		await instance.stopped();
 	}
 
 	createService(instance: IServiceClass): void {

--- a/packages/core-services/src/lib/Api.ts
+++ b/packages/core-services/src/lib/Api.ts
@@ -15,13 +15,13 @@ export class Api implements IApiService {
 		this.services.forEach((service) => this.broker?.createService(service));
 	}
 
-	destroyService(instance: IServiceClass): void {
+	async destroyService(instance: IServiceClass): Promise<void> {
 		if (!this.services.has(instance)) {
 			return;
 		}
 
 		if (this.broker) {
-			this.broker.destroyService(instance);
+			await this.broker.destroyService(instance);
 		}
 
 		this.services.delete(instance);

--- a/packages/core-services/src/types/IApiService.ts
+++ b/packages/core-services/src/types/IApiService.ts
@@ -5,7 +5,7 @@ import type { IServiceClass } from './ServiceClass';
 export interface IApiService {
 	setBroker(broker: IBroker): void;
 
-	destroyService(instance: IServiceClass): void;
+	destroyService(instance: IServiceClass): Promise<void>;
 
 	registerService(instance: IServiceClass): void;
 

--- a/packages/core-services/src/types/IBroker.ts
+++ b/packages/core-services/src/types/IBroker.ts
@@ -48,7 +48,7 @@ export interface IServiceMetrics {
 
 export interface IBroker {
 	metrics?: IServiceMetrics;
-	destroyService(service: IServiceClass): void;
+	destroyService(service: IServiceClass): Promise<void>;
 	createService(service: IServiceClass, serviceDependencies?: string[]): void;
 	call(method: string, data: any): Promise<any>;
 	waitAndCall(method: string, data: any): Promise<any>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9348,9 +9348,9 @@ __metadata:
     "@rocket.chat/icons": "*"
     "@rocket.chat/prettier-config": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-contexts": 4.0.2
+    "@rocket.chat/ui-contexts": 4.0.3
     "@rocket.chat/ui-kit": 0.33.0
-    "@rocket.chat/ui-video-conf": 4.0.2
+    "@rocket.chat/ui-video-conf": 4.0.3
     "@tanstack/react-query": "*"
     react: "*"
     react-dom: "*"
@@ -9432,14 +9432,14 @@ __metadata:
     ts-jest: ~29.1.1
     typescript: ~5.3.2
   peerDependencies:
-    "@rocket.chat/core-typings": 6.6.2
+    "@rocket.chat/core-typings": 6.6.3
     "@rocket.chat/css-in-js": "*"
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-tokens": "*"
     "@rocket.chat/message-parser": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-client": 4.0.2
-    "@rocket.chat/ui-contexts": 4.0.2
+    "@rocket.chat/ui-client": 4.0.3
+    "@rocket.chat/ui-contexts": 4.0.3
     katex: "*"
     react: "*"
   languageName: unknown
@@ -10621,7 +10621,7 @@ __metadata:
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-contexts": 4.0.2
+    "@rocket.chat/ui-contexts": 4.0.3
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -10796,7 +10796,7 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-contexts": 4.0.2
+    "@rocket.chat/ui-contexts": 4.0.3
     react: ^17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -10885,7 +10885,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.2.1
-    "@rocket.chat/ui-contexts": 4.0.2
+    "@rocket.chat/ui-contexts": 4.0.3
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION


<!-- release-notes-start -->
<!-- This content is automatically generated. Changing this will not reflect on the final release log -->

_You can see below a preview of the release change log:_

# 6.6.4

### Engine versions

- Node: `14.21.3`
- MongoDB: `4.4, 5.0, 6.0`
- Apps-Engine: `1.41.0`

### Patch Changes

*   Bump @rocket.chat/meteor version.

*   ([#31700](https://github.com/RocketChat/Rocket.Chat/pull/31700)) Fixed matrix homeserver domain setting not being visible in admin panel

*   ([#32012](https://github.com/RocketChat/Rocket.Chat/pull/32012)) Don't use the registration.yaml file to configure Matrix Federation anymore.

*   ([#31927](https://github.com/RocketChat/Rocket.Chat/pull/31927)) `stopped` lifecycle method was unexpectedly synchronous when using microservices, causing our code to create race conditions.

*   <details><summary>Updated dependencies [c2872a93f2]:</summary>

    *   @rocket.chat/core-services@0.3.8
    *   @rocket.chat/omnichannel-services@0.1.8
    *   @rocket.chat/presence@0.1.8
    *   @rocket.chat/core-typings@6.6.4
    *   @rocket.chat/rest-typings@6.6.4
    *   @rocket.chat/api-client@0.1.26
    *   @rocket.chat/license@0.1.8
    *   @rocket.chat/pdf-worker@0.0.32
    *   @rocket.chat/cron@0.0.28
    *   @rocket.chat/gazzodown@4.0.4
    *   @rocket.chat/model-typings@0.3.4
    *   @rocket.chat/ui-contexts@4.0.4
    *   @rocket.chat/server-cloud-communication@0.0.2
    *   @rocket.chat/fuselage-ui-kit@4.0.4
    *   @rocket.chat/models@0.0.32
    *   @rocket.chat/ui-theming@0.1.2
    *   @rocket.chat/ui-client@4.0.4
    *   @rocket.chat/ui-video-conf@4.0.4
    *   @rocket.chat/web-ui-registration@4.0.4
    *   @rocket.chat/instance-status@0.0.32

    </details>

<!-- release-notes-end -->