### PR TITLE
Release 6.6.5

### DIFF
--- a/.changeset/bump-patch-1710964059521.md
+++ b/.changeset/bump-patch-1710964059521.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Bump @rocket.chat/meteor version.

--- a/.changeset/empty-hounds-jog.md
+++ b/.changeset/empty-hounds-jog.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/ddp-client": patch
+---
+
+fix: livechat sdk reconnect not resubscribing

--- a/.changeset/thin-keys-impress.md
+++ b/.changeset/thin-keys-impress.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/livechat": patch
+---
+
+Fixes issue of the `setDepartment` Livechat API method not setting the store value properly (is was only setting on the guest object)

--- a/.changeset/tough-doors-juggle.md
+++ b/.changeset/tough-doors-juggle.md
@@ -1,0 +1,9 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Introduced a new step to the queue worker: when an inquiry that's on an improper status is selected for processing, queue worker will first check its status and will attempt to fix it.
+For example, if an inquiry points to a closed room, there's no point in processing, system will now remove the inquiry
+If an inquiry is already taken, the inquiry will be updated to reflect the new status and clean the queue.
+
+This prevents issues where the queue worker attempted to process an inquiry _forever_ because it was in an improper state.

--- a/apps/meteor/server/services/omnichannel/queue.ts
+++ b/apps/meteor/server/services/omnichannel/queue.ts
@@ -1,6 +1,7 @@
-import type { InquiryWithAgentInfo, IOmnichannelQueue } from '@rocket.chat/core-typings';
+import type { IOmnichannelRoom } from '@rocket.chat/core-typings';
+import { type InquiryWithAgentInfo, type IOmnichannelQueue } from '@rocket.chat/core-typings';
 import { License } from '@rocket.chat/license';
-import { LivechatInquiry } from '@rocket.chat/models';
+import { LivechatInquiry, LivechatRooms } from '@rocket.chat/models';
 
 import { dispatchAgentDelegated } from '../../../app/livechat/server/lib/Helper';
 import { RoutingManager } from '../../../app/livechat/server/lib/RoutingManager';
@@ -92,9 +93,11 @@ export class OmnichannelQueue implements IOmnichannelQueue {
 				// Note: this removes the "one-shot" behavior of queue, allowing it to take a conversation again in the future
 				// And sorting them by _updatedAt: -1 will make it so that the oldest inquiries are taken first
 				// preventing us from playing with the same inquiry over and over again
+				queueLogger.debug(`Inquiry ${nextInquiry._id} not taken. Unlocking and re-queueing`);
 				return await LivechatInquiry.unlockAndQueue(nextInquiry._id);
 			}
 
+			queueLogger.debug(`Inquiry ${nextInquiry._id} taken successfully. Unlocking`);
 			await LivechatInquiry.unlock(nextInquiry._id);
 		} catch (e) {
 			queueLogger.error({
@@ -123,17 +126,74 @@ export class OmnichannelQueue implements IOmnichannelQueue {
 		void (routingSupportsAutoAssign ? this.start() : this.stop());
 	}
 
+	private async reconciliation(reason: 'closed' | 'taken' | 'missing', { roomId, inquiryId }: { roomId: string; inquiryId: string }) {
+		switch (reason) {
+			case 'closed': {
+				queueLogger.debug({
+					msg: 'Room closed. Removing inquiry',
+					roomId,
+					inquiryId,
+					step: 'reconciliation',
+				});
+				await LivechatInquiry.removeByRoomId(roomId);
+				break;
+			}
+			case 'taken': {
+				queueLogger.debug({
+					msg: 'Room taken. Updating inquiry status',
+					roomId,
+					inquiryId,
+					step: 'reconciliation',
+				});
+				// Reconciliate served inquiries, by updating their status to taken after queue tried to pick and failed
+				await LivechatInquiry.takeInquiry(inquiryId);
+				break;
+			}
+			case 'missing': {
+				queueLogger.debug({
+					msg: 'Room from inquiry missing. Removing inquiry',
+					roomId,
+					inquiryId,
+					step: 'reconciliation',
+				});
+				await LivechatInquiry.removeByRoomId(roomId);
+				break;
+			}
+			default: {
+				return true;
+			}
+		}
+
+		return true;
+	}
+
 	private async processWaitingQueue(department: string | undefined, inquiry: InquiryWithAgentInfo) {
 		const queue = department || 'Public';
-		queueLogger.debug(`Processing items on queue ${queue}`);
 
 		queueLogger.debug(`Processing inquiry ${inquiry._id} from queue ${queue}`);
 		const { defaultAgent } = inquiry;
-		const room = await RoutingManager.delegateInquiry(inquiry, defaultAgent);
 
-		const propagateAgentDelegated = async (rid: string, agentId: string) => {
-			await dispatchAgentDelegated(rid, agentId);
-		};
+		const roomFromDb = await LivechatRooms.findOneById<Pick<IOmnichannelRoom, '_id' | 'servedBy' | 'closedAt'>>(inquiry.rid, {
+			projection: { servedBy: 1, closedAt: 1 },
+		});
+
+		// This is a precaution to avoid taking inquiries tied to rooms that no longer exist.
+		// This should never happen.
+		if (!roomFromDb) {
+			return this.reconciliation('missing', { roomId: inquiry.rid, inquiryId: inquiry._id });
+		}
+
+		// This is a precaution to avoid taking the same inquiry multiple times. It should not happen, but it's a safety net
+		if (roomFromDb.servedBy) {
+			return this.reconciliation('taken', { roomId: inquiry.rid, inquiryId: inquiry._id });
+		}
+
+		// This is another precaution. If the room is closed, we should not take it
+		if (roomFromDb.closedAt) {
+			return this.reconciliation('closed', { roomId: inquiry.rid, inquiryId: inquiry._id });
+		}
+
+		const room = await RoutingManager.delegateInquiry(inquiry, defaultAgent);
 
 		if (room?.servedBy) {
 			const {
@@ -142,13 +202,12 @@ export class OmnichannelQueue implements IOmnichannelQueue {
 			} = room;
 			queueLogger.debug(`Inquiry ${inquiry._id} taken successfully by agent ${agentId}. Notifying`);
 			setTimeout(() => {
-				void propagateAgentDelegated(rid, agentId);
+				void dispatchAgentDelegated(rid, agentId);
 			}, 1000);
 
 			return true;
 		}
 
-		queueLogger.debug(`Inquiry ${inquiry._id} not taken by any agent. Queueing again`);
 		return false;
 	}
 }

--- a/apps/meteor/tests/unit/server/services/omnichannel/queue.tests.ts
+++ b/apps/meteor/tests/unit/server/services/omnichannel/queue.tests.ts
@@ -1,0 +1,475 @@
+import { expect } from 'chai';
+import { beforeEach, describe, after, it } from 'mocha';
+import p from 'proxyquire';
+import Sinon from 'sinon';
+
+const dispatchAgentDelegated = Sinon.stub();
+const getConfig = Sinon.stub();
+const delegateInquiry = Sinon.stub();
+const libSettings = { getInquirySortMechanismSetting: Sinon.stub().returns('timestamp') };
+const settings = {
+	get: Sinon.stub(),
+};
+
+const queueLogger = {
+	info: Sinon.stub(),
+	debug: Sinon.stub(),
+	error: Sinon.stub(),
+};
+
+const mockedInquiry = {
+	_id: 'inquiryId',
+	rid: 'rid',
+	department: 'department1',
+	ts: new Date(),
+};
+
+const models = {
+	LivechatInquiry: {
+		unlockAll: Sinon.stub(),
+		findNextAndLock: Sinon.stub(),
+		getDistinctQueuedDepartments: Sinon.stub(),
+		unlockAndQueue: Sinon.stub(),
+		unlock: Sinon.stub(),
+		removeByRoomId: Sinon.stub(),
+		takeInquiry: Sinon.stub(),
+	},
+	LivechatRooms: {
+		findOneById: Sinon.stub(),
+	},
+};
+
+const license = {
+	shouldPreventAction: Sinon.stub(),
+};
+
+const { OmnichannelQueue } = p.noCallThru().load('../../../../../server/services/omnichannel/queue', {
+	'../../../app/livechat/server/lib/Helper': {
+		dispatchAgentDelegated,
+	},
+	'../../../app/livechat/server/lib/RoutingManager': {
+		RoutingManager: {
+			getConfig,
+			delegateInquiry,
+		},
+	},
+	'../../../app/livechat/server/lib/settings': libSettings,
+	'../../../app/settings/server': { settings },
+	'./logger': { queueLogger },
+	'@rocket.chat/models': models,
+	'@rocket.chat/license': { License: license },
+});
+
+describe('Omnichannel Queue processor', () => {
+	describe('isRunning', () => {
+		it('should return the running status', () => {
+			const queue = new OmnichannelQueue();
+			expect(queue.isRunning()).to.be.false;
+		});
+		it('should return the running status', () => {
+			const queue = new OmnichannelQueue();
+			queue.running = true;
+			expect(queue.isRunning()).to.be.true;
+		});
+	});
+	describe('delay', () => {
+		after(() => {
+			settings.get.reset();
+		});
+		it('should return 5000 if setting is not set', () => {
+			settings.get.returns(undefined);
+
+			const queue = new OmnichannelQueue();
+			expect(queue.delay()).to.be.equal(5000);
+		});
+		it('should return the right value if setting has a value above 1', () => {
+			settings.get.returns(10);
+
+			const queue = new OmnichannelQueue();
+			expect(queue.delay()).to.be.equal(10000);
+		});
+	});
+	describe('getActiveQueues', () => {
+		after(() => {
+			models.LivechatInquiry.getDistinctQueuedDepartments.reset();
+		});
+		it('should return [undefined] when there is no other queues', async () => {
+			models.LivechatInquiry.getDistinctQueuedDepartments.returns([]);
+
+			const queue = new OmnichannelQueue();
+			expect(await queue.getActiveQueues()).to.be.eql([undefined]);
+		});
+		it('should return [undefined, department1] when department1 is an active queue', async () => {
+			models.LivechatInquiry.getDistinctQueuedDepartments.returns(['department1']);
+
+			const queue = new OmnichannelQueue();
+			expect(await queue.getActiveQueues()).to.be.eql([undefined, 'department1']);
+		});
+	});
+	describe('nextQueue', () => {
+		after(() => {
+			models.LivechatInquiry.getDistinctQueuedDepartments.reset();
+		});
+		it('should return undefined when thats the only queue', async () => {
+			models.LivechatInquiry.getDistinctQueuedDepartments.returns([]);
+
+			const queue = new OmnichannelQueue();
+			queue.getActiveQueues = Sinon.stub().returns([undefined]);
+			expect(await queue.nextQueue()).to.be.undefined;
+		});
+		it('should return undefined, and then the following queue', async () => {
+			models.LivechatInquiry.getDistinctQueuedDepartments.returns(['department1']);
+
+			const queue = new OmnichannelQueue();
+			queue.getActiveQueues = Sinon.stub().returns([undefined, 'department1']);
+			expect(await queue.nextQueue()).to.be.undefined;
+			expect(await queue.nextQueue()).to.be.equal('department1');
+		});
+		it('should not call getActiveQueues if there are still queues to process', async () => {
+			models.LivechatInquiry.getDistinctQueuedDepartments.returns(['department1']);
+
+			const queue = new OmnichannelQueue();
+			queue.queues = ['department1'];
+			queue.getActiveQueues = Sinon.stub();
+
+			expect(await queue.nextQueue()).to.be.equal('department1');
+			expect(queue.getActiveQueues.notCalled).to.be.true;
+		});
+	});
+	describe('checkQueue', () => {
+		let clock: any;
+		beforeEach(() => {
+			models.LivechatInquiry.findNextAndLock.resetHistory();
+			models.LivechatInquiry.takeInquiry.resetHistory();
+			models.LivechatInquiry.unlockAndQueue.resetHistory();
+			models.LivechatInquiry.unlock.resetHistory();
+			queueLogger.error.resetHistory();
+			queueLogger.info.resetHistory();
+			clock = Sinon.useFakeTimers();
+		});
+		afterEach(() => {
+			clock.restore();
+		});
+		after(() => {
+			models.LivechatInquiry.findNextAndLock.reset();
+			models.LivechatInquiry.takeInquiry.reset();
+			models.LivechatInquiry.unlockAndQueue.reset();
+			models.LivechatInquiry.unlock.reset();
+			queueLogger.error.reset();
+			queueLogger.info.reset();
+			clock.reset();
+		});
+
+		it('should return undefined when the queue is empty', async () => {
+			models.LivechatInquiry.findNextAndLock.returns(null);
+
+			const queue = new OmnichannelQueue();
+			queue.execute = Sinon.stub();
+			expect(await queue.checkQueue()).to.be.undefined;
+		});
+		it('should try to process the inquiry when there is one', async () => {
+			models.LivechatInquiry.findNextAndLock.returns(mockedInquiry);
+
+			const queue = new OmnichannelQueue();
+			queue.processWaitingQueue = Sinon.stub().throws('error');
+			queue.execute = Sinon.stub();
+			await queue.checkQueue();
+
+			expect(models.LivechatInquiry.findNextAndLock.calledOnce).to.be.true;
+			expect(queue.processWaitingQueue.calledOnce).to.be.true;
+		});
+		it('should call unlockAndRequeue when the inquiry could not be processed', async () => {
+			models.LivechatInquiry.findNextAndLock.returns(mockedInquiry);
+
+			const queue = new OmnichannelQueue();
+			queue.processWaitingQueue = Sinon.stub().returns(false);
+			queue.execute = Sinon.stub();
+			await queue.checkQueue();
+
+			expect(queue.processWaitingQueue.calledOnce).to.be.true;
+			expect(models.LivechatInquiry.unlockAndQueue.calledOnce).to.be.true;
+		});
+		it('should unlock the inquiry when it was processed succesfully', async () => {
+			models.LivechatInquiry.findNextAndLock.returns(mockedInquiry);
+
+			const queue = new OmnichannelQueue();
+			queue.processWaitingQueue = Sinon.stub().returns(true);
+			queue.execute = Sinon.stub();
+			await queue.checkQueue();
+
+			expect(queue.processWaitingQueue.calledOnce).to.be.true;
+			expect(models.LivechatInquiry.unlock.calledOnce).to.be.true;
+		});
+		it('should print a log when there was an error processing inquiry', async () => {
+			models.LivechatInquiry.findNextAndLock.throws('error');
+
+			const queue = new OmnichannelQueue();
+			queue.execute = Sinon.stub();
+			await queue.checkQueue();
+
+			expect(queueLogger.error.calledOnce).to.be.true;
+		});
+		it('should call execute after finishing', async () => {
+			models.LivechatInquiry.findNextAndLock.returns(mockedInquiry);
+
+			const queue = new OmnichannelQueue();
+			queue.processWaitingQueue = Sinon.stub().returns(true);
+			queue.execute = Sinon.stub();
+			queue.delay = Sinon.stub().returns(100);
+			await queue.checkQueue();
+			clock.tick(100);
+
+			expect(queue.execute.calledOnce).to.be.true;
+			expect(models.LivechatInquiry.unlock.calledOnce).to.be.true;
+			expect(queue.execute.calledAfter(models.LivechatInquiry.unlock)).to.be.true;
+			expect(queue.execute.calledOnce).to.be.true;
+		});
+	});
+	describe('shouldStart', () => {
+		beforeEach(() => {
+			settings.get.resetHistory();
+			getConfig.resetHistory();
+		});
+		after(() => {
+			settings.get.reset();
+			getConfig.reset();
+		});
+
+		it('should call stop if Livechat is not enabled', async () => {
+			settings.get.returns(false);
+
+			const queue = new OmnichannelQueue();
+			queue.stop = Sinon.stub();
+			await queue.shouldStart();
+
+			expect(queue.stop.calledOnce).to.be.true;
+		});
+		it('should call start if routing algorithm supports auto assignment', async () => {
+			settings.get.returns(true);
+			getConfig.returns({ autoAssignAgent: true });
+
+			const queue = new OmnichannelQueue();
+			queue.start = Sinon.stub();
+			await queue.shouldStart();
+
+			expect(queue.start.calledOnce).to.be.true;
+			expect(queue.start.calledAfter(getConfig)).to.be.true;
+		});
+		it('should call stop if routing algorithm does not support auto assignment', async () => {
+			settings.get.returns(true);
+			getConfig.returns({ autoAssignAgent: false });
+
+			const queue = new OmnichannelQueue();
+			queue.stop = Sinon.stub();
+			await queue.shouldStart();
+
+			expect(queue.stop.calledOnce).to.be.true;
+			expect(queue.stop.calledAfter(getConfig)).to.be.true;
+		});
+	});
+	describe('reconciliation', () => {
+		beforeEach(() => {
+			models.LivechatInquiry.removeByRoomId.resetHistory();
+			models.LivechatInquiry.takeInquiry.resetHistory();
+		});
+
+		it('should remove inquiries from rooms that do not exist', async () => {
+			const queue = new OmnichannelQueue();
+			await queue.reconciliation('missing', { roomId: 'rid', inquiryId: 'inquiryId' });
+
+			expect(models.LivechatInquiry.removeByRoomId.calledOnce).to.be.true;
+		});
+		it('should take an inquiry if the room was taken', async () => {
+			const queue = new OmnichannelQueue();
+			await queue.reconciliation('taken', { roomId: 'rid', inquiryId: 'inquiryId' });
+
+			expect(models.LivechatInquiry.takeInquiry.calledOnce).to.be.true;
+		});
+		it('should remove inquiries from rooms that were closed', async () => {
+			const queue = new OmnichannelQueue();
+			await queue.reconciliation('closed', { roomId: 'rid', inquiryId: 'inquiryId' });
+
+			expect(models.LivechatInquiry.removeByRoomId.calledOnce).to.be.true;
+		});
+		it('should return true for any other case', async () => {
+			const queue = new OmnichannelQueue();
+			expect(await queue.reconciliation('random', { roomId: 'rid', inquiryId: 'inquiryId' })).to.be.true;
+			expect(models.LivechatInquiry.removeByRoomId.notCalled).to.be.true;
+			expect(models.LivechatInquiry.takeInquiry.notCalled).to.be.true;
+		});
+	});
+	describe('processWaitingQueue', () => {
+		let clock: any;
+		beforeEach(() => {
+			models.LivechatRooms.findOneById.reset();
+			models.LivechatInquiry.takeInquiry.resetHistory();
+			models.LivechatInquiry.removeByRoomId.resetHistory();
+			delegateInquiry.resetHistory();
+			queueLogger.debug.resetHistory();
+			clock = Sinon.useFakeTimers();
+		});
+		afterEach(() => {
+			clock.restore();
+		});
+		after(() => {
+			models.LivechatRooms.findOneById.reset();
+			models.LivechatInquiry.takeInquiry.reset();
+			delegateInquiry.reset();
+			queueLogger.debug.reset();
+			clock.reset();
+		});
+
+		it('should process the public queue when department is undefined', async () => {
+			const queue = new OmnichannelQueue();
+
+			expect(await queue.processWaitingQueue(undefined, mockedInquiry)).to.be.true;
+			expect(queueLogger.debug.calledWith('Processing inquiry inquiryId from queue Public'));
+			expect(models.LivechatRooms.findOneById.calledOnce).to.be.true;
+		});
+		it('should call removeInquiry when findOneById returns null', async () => {
+			models.LivechatRooms.findOneById.returns(null);
+
+			const queue = new OmnichannelQueue();
+			expect(await queue.processWaitingQueue('department1', mockedInquiry)).to.be.true;
+			expect(
+				queueLogger.debug.calledWith({
+					msg: 'Room from inquiry missing. Removing inquiry',
+					roomId: 'rid',
+					inquiryId: 'inquiryId',
+					step: 'reconciliation',
+				}),
+			).to.be.true;
+			expect(models.LivechatInquiry.removeByRoomId.calledOnce).to.be.true;
+		});
+		it('should call takeInquiry when findOneById returns a room thats already being served', async () => {
+			models.LivechatRooms.findOneById.returns({ _id: 'rid', servedBy: { some: 'thing' } });
+
+			const queue = new OmnichannelQueue();
+			queue.reconciliation = Sinon.stub().returns(true);
+			expect(await queue.processWaitingQueue('department1', mockedInquiry)).to.be.true;
+			expect(queue.reconciliation.calledOnce).to.be.true;
+		});
+		it('should call removeInquiry when findOneById returns a room that was closed', async () => {
+			models.LivechatRooms.findOneById.returns({ _id: 'rid', closedAt: new Date() });
+
+			const queue = new OmnichannelQueue();
+			queue.reconciliation = Sinon.stub().returns(true);
+			expect(await queue.processWaitingQueue('department1', mockedInquiry)).to.be.true;
+			expect(queue.reconciliation.calledOnce).to.be.true;
+		});
+		it('should call delegateInquiry when prechecks are met and return false if inquiry was not served', async () => {
+			models.LivechatRooms.findOneById.returns({ _id: 'rid' });
+			delegateInquiry.returns({});
+
+			const queue = new OmnichannelQueue();
+			expect(await queue.processWaitingQueue('department1', mockedInquiry)).to.be.false;
+			expect(delegateInquiry.calledOnce).to.be.true;
+		});
+		it('should call delegateInquiry and return true if inquiry was served', async () => {
+			models.LivechatRooms.findOneById.returns({ _id: 'rid' });
+			delegateInquiry.returns({ _id: 'rid', servedBy: { _id: 'agentId' } });
+
+			const queue = new OmnichannelQueue();
+			expect(await queue.processWaitingQueue('department1', mockedInquiry)).to.be.true;
+			expect(delegateInquiry.calledOnce).to.be.true;
+		});
+		it('should call dispatchAgentDelegated if inquiry was served (after 1s)', async () => {
+			models.LivechatRooms.findOneById.returns({ _id: 'rid' });
+			delegateInquiry.returns({ _id: 'rid', servedBy: { _id: 'agentId' } });
+
+			const queue = new OmnichannelQueue();
+			expect(await queue.processWaitingQueue('department1', mockedInquiry)).to.be.true;
+			expect(delegateInquiry.calledOnce).to.be.true;
+			clock.tick(1000);
+			expect(dispatchAgentDelegated.calledOnce).to.be.true;
+		});
+	});
+	describe('execute', () => {
+		beforeEach(() => {
+			license.shouldPreventAction.reset();
+			queueLogger.debug.reset();
+		});
+
+		after(() => {
+			license.shouldPreventAction.reset();
+			queueLogger.debug.reset();
+		});
+
+		it('should return undefined if service is not running', async () => {
+			const queue = new OmnichannelQueue();
+			queue.running = false;
+			expect(await queue.execute()).to.be.undefined;
+		});
+		it('should return undefined if license is over mac limits', async () => {
+			license.shouldPreventAction.returns(true);
+
+			const queue = new OmnichannelQueue();
+			queue.running = true;
+			expect(await queue.execute()).to.be.undefined;
+			expect(license.shouldPreventAction.calledOnce).to.be.true;
+			expect(queue.running).to.be.false;
+		});
+		it('should try to process a queue if license is not over mac limits', async () => {
+			license.shouldPreventAction.returns(false);
+
+			const queue = new OmnichannelQueue();
+			queue.running = true;
+			queue.nextQueue = Sinon.stub();
+			await queue.execute();
+
+			expect(queue.nextQueue.calledOnce).to.be.true;
+			expect(queueLogger.debug.calledWith('Executing queue Public with timeout of 5000')).to.be.true;
+		});
+	});
+	describe('start', () => {
+		beforeEach(() => {
+			queueLogger.info.resetHistory();
+			queueLogger.debug.resetHistory();
+		});
+		after(() => {
+			queueLogger.info.reset();
+			queueLogger.debug.reset();
+		});
+		it('should do nothing if queue is already running', async () => {
+			const queue = new OmnichannelQueue();
+			queue.running = true;
+			queue.execute = Sinon.stub();
+			await queue.start();
+
+			expect(queue.execute.notCalled).to.be.true;
+		});
+		it('should fetch active queues and set running to true', async () => {
+			const queue = new OmnichannelQueue();
+			queue.running = false;
+			queue.getActiveQueues = Sinon.stub().returns(['department1']);
+			queue.execute = Sinon.stub();
+			await queue.start();
+
+			expect(queue.running).to.be.true;
+			expect(queue.getActiveQueues.calledOnce).to.be.true;
+			expect(queueLogger.info.calledOnce).to.be.true;
+			expect(queueLogger.info.calledWith('Service started')).to.be.true;
+			expect(queue.execute.calledOnce).to.be.true;
+		});
+	});
+	describe('stop', () => {
+		beforeEach(() => {
+			models.LivechatInquiry.unlockAll.reset();
+			queueLogger.info.resetHistory();
+		});
+		after(() => {
+			models.LivechatInquiry.unlockAll.reset();
+			queueLogger.info.reset();
+		});
+		it('should unlock all inquiries and set running to false', async () => {
+			const queue = new OmnichannelQueue();
+			queue.running = true;
+			await queue.stop();
+
+			expect(queue.running).to.be.false;
+			expect(models.LivechatInquiry.unlockAll.calledOnce).to.be.true;
+			expect(queueLogger.info.calledOnce).to.be.true;
+			expect(queueLogger.info.calledWith('Service stopped')).to.be.true;
+		});
+	});
+});

--- a/ee/packages/ddp-client/src/livechat/LivechatClientImpl.ts
+++ b/ee/packages/ddp-client/src/livechat/LivechatClientImpl.ts
@@ -381,9 +381,9 @@ export class LivechatClientImpl extends DDPSDK implements LivechatStream, Livech
 		const sdk = new LivechatClientImpl(connection, stream, account, timeoutControl, rest);
 
 		connection.on('connected', () => {
-			Object.entries(stream.subscriptions).forEach(([, sub]) => {
+			for (const [, sub] of stream.subscriptions.entries()) {
 				ddp.subscribeWithId(sub.id, sub.name, sub.params);
-			});
+			}
 		});
 
 		return sdk;

--- a/packages/livechat/src/lib/hooks.js
+++ b/packages/livechat/src/lib/hooks.js
@@ -88,6 +88,7 @@ const api = {
 		const department = departments.find((dep) => dep._id === value || dep.name === value)?._id || '';
 
 		updateIframeGuestData({ department });
+		store.setState({ department });
 
 		if (defaultAgent && defaultAgent.department !== department) {
 			store.setState({ defaultAgent: null });

--- a/packages/livechat/src/lib/room.js
+++ b/packages/livechat/src/lib/room.js
@@ -25,13 +25,13 @@ export const closeChat = async ({ transcriptRequested } = {}) => {
 		await handleTranscript();
 	}
 
-	const { config: { settings: { clearLocalStorageWhenChatEnded } = {} } = {} } = store.state;
+	const { department, config: { settings: { clearLocalStorageWhenChatEnded } = {} } = {} } = store.state;
 
 	if (clearLocalStorageWhenChatEnded) {
 		// exclude UI-affecting flags
 		const { iframe: currentIframe } = store.state;
 		const { minimized, visible, undocked, expanded, businessUnit, config, iframe, ...initial } = initialState();
-		initial.iframe = { ...currentIframe, guest: {} };
+		initial.iframe = { ...currentIframe, guest: { department } };
 		await store.setState(initial);
 	}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9348,9 +9348,9 @@ __metadata:
     "@rocket.chat/icons": "*"
     "@rocket.chat/prettier-config": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-contexts": 4.0.3
+    "@rocket.chat/ui-contexts": 4.0.4
     "@rocket.chat/ui-kit": 0.33.0
-    "@rocket.chat/ui-video-conf": 4.0.3
+    "@rocket.chat/ui-video-conf": 4.0.4
     "@tanstack/react-query": "*"
     react: "*"
     react-dom: "*"
@@ -9432,14 +9432,14 @@ __metadata:
     ts-jest: ~29.1.1
     typescript: ~5.3.2
   peerDependencies:
-    "@rocket.chat/core-typings": 6.6.3
+    "@rocket.chat/core-typings": 6.6.4
     "@rocket.chat/css-in-js": "*"
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-tokens": "*"
     "@rocket.chat/message-parser": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-client": 4.0.3
-    "@rocket.chat/ui-contexts": 4.0.3
+    "@rocket.chat/ui-client": 4.0.4
+    "@rocket.chat/ui-contexts": 4.0.4
     katex: "*"
     react: "*"
   languageName: unknown
@@ -10621,7 +10621,7 @@ __metadata:
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-contexts": 4.0.3
+    "@rocket.chat/ui-contexts": 4.0.4
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -10796,7 +10796,7 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-contexts": 4.0.3
+    "@rocket.chat/ui-contexts": 4.0.4
     react: ^17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -10885,7 +10885,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.2.1
-    "@rocket.chat/ui-contexts": 4.0.3
+    "@rocket.chat/ui-contexts": 4.0.4
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION


<!-- release-notes-start -->
<!-- This content is automatically generated. Changing this will not reflect on the final release log -->

_You can see below a preview of the release change log:_

# 6.6.5

### Engine versions

- Node: `14.21.3`
- MongoDB: `4.4, 5.0, 6.0`
- Apps-Engine: `1.41.0`

### Patch Changes

*   Bump @rocket.chat/meteor version.

*   ([#31998](https://github.com/RocketChat/Rocket.Chat/pull/31998)) Introduced a new step to the queue worker: when an inquiry that's on an improper status is selected for processing, queue worker will first check its status and will attempt to fix it.
    For example, if an inquiry points to a closed room, there's no point in processing, system will now remove the inquiry
    If an inquiry is already taken, the inquiry will be updated to reflect the new status and clean the queue.

    This prevents issues where the queue worker attempted to process an inquiry *forever* because it was in an improper state.

*   <details><summary>Updated dependencies []:</summary>

    *   @rocket.chat/ui-contexts@4.0.5
    *   @rocket.chat/ui-theming@0.1.2
    *   @rocket.chat/fuselage-ui-kit@4.0.5
    *   @rocket.chat/gazzodown@4.0.5
    *   @rocket.chat/ui-client@4.0.5
    *   @rocket.chat/ui-video-conf@4.0.5
    *   @rocket.chat/web-ui-registration@4.0.5
    *   @rocket.chat/core-typings@6.6.5
    *   @rocket.chat/rest-typings@6.6.5
    *   @rocket.chat/api-client@0.1.27
    *   @rocket.chat/license@0.1.9
    *   @rocket.chat/omnichannel-services@0.1.9
    *   @rocket.chat/pdf-worker@0.0.33
    *   @rocket.chat/presence@0.1.9
    *   @rocket.chat/core-services@0.3.9
    *   @rocket.chat/cron@0.0.29
    *   @rocket.chat/model-typings@0.3.5
    *   @rocket.chat/server-cloud-communication@0.0.2
    *   @rocket.chat/models@0.0.33
    *   @rocket.chat/instance-status@0.0.33

    </details>

<!-- release-notes-end -->