### PR TITLE
Release 6.6.6

### DIFF
--- a/.changeset/bump-patch-1711139853086.md
+++ b/.changeset/bump-patch-1711139853086.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Bump @rocket.chat/meteor version.

--- a/.changeset/chatty-suits-dance.md
+++ b/.changeset/chatty-suits-dance.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fix an issue affecting Rocket.Chat Apps utilizing the OAuth 2 library from Apps Engine, ensuring that apps like Google Drive and Google Calendar are operational once more.

--- a/.changeset/thirty-ducks-smell.md
+++ b/.changeset/thirty-ducks-smell.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/models": patch
+---
+
+Fix proxified model props were missing context before attribution

--- a/.changeset/twenty-dolls-obey.md
+++ b/.changeset/twenty-dolls-obey.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fix error during migration 304. Throwing `Cannot read property 'finally' of undefined` error.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,6 +29,7 @@
 		"oauthapps",
 		"omnichannel",
 		"photoswipe",
+		"proxify",
 		"searchbox",
 		"tmid",
 		"tshow"

--- a/apps/meteor/ee/server/services/package.json
+++ b/apps/meteor/ee/server/services/package.json
@@ -18,7 +18,7 @@
 	"author": "Rocket.Chat",
 	"license": "MIT",
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.41.0",
+		"@rocket.chat/apps-engine": "^1.41.1",
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/emitter": "~0.31.25",

--- a/apps/meteor/package.json
+++ b/apps/meteor/package.json
@@ -229,7 +229,7 @@
 		"@rocket.chat/account-utils": "workspace:^",
 		"@rocket.chat/agenda": "workspace:^",
 		"@rocket.chat/api-client": "workspace:^",
-		"@rocket.chat/apps-engine": "1.41.0",
+		"@rocket.chat/apps-engine": "^1.41.1",
 		"@rocket.chat/base64": "workspace:^",
 		"@rocket.chat/cas-validate": "workspace:^",
 		"@rocket.chat/core-services": "workspace:^",

--- a/ee/apps/ddp-streamer/package.json
+++ b/ee/apps/ddp-streamer/package.json
@@ -15,7 +15,7 @@
 	],
 	"author": "Rocket.Chat",
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.41.0",
+		"@rocket.chat/apps-engine": "^1.41.1",
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/emitter": "~0.31.25",

--- a/ee/packages/presence/package.json
+++ b/ee/packages/presence/package.json
@@ -6,7 +6,7 @@
 		"@babel/core": "~7.22.20",
 		"@babel/preset-env": "~7.22.20",
 		"@babel/preset-typescript": "~7.22.15",
-		"@rocket.chat/apps-engine": "1.41.0",
+		"@rocket.chat/apps-engine": "^1.41.1",
 		"@rocket.chat/eslint-config": "workspace:^",
 		"@rocket.chat/rest-typings": "workspace:^",
 		"@types/node": "^14.18.63",

--- a/packages/core-services/package.json
+++ b/packages/core-services/package.json
@@ -34,7 +34,7 @@
 		"extends": "../../package.json"
 	},
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.41.0",
+		"@rocket.chat/apps-engine": "^1.41.1",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/icons": "^0.33.0",
 		"@rocket.chat/message-parser": "~0.31.28",

--- a/packages/core-typings/package.json
+++ b/packages/core-typings/package.json
@@ -23,7 +23,7 @@
 		"/dist"
 	],
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.41.0",
+		"@rocket.chat/apps-engine": "^1.41.1",
 		"@rocket.chat/icons": "^0.33.0",
 		"@rocket.chat/message-parser": "~0.31.28",
 		"@rocket.chat/ui-kit": "workspace:~"

--- a/packages/fuselage-ui-kit/package.json
+++ b/packages/fuselage-ui-kit/package.json
@@ -60,7 +60,7 @@
     "@babel/preset-env": "~7.22.20",
     "@babel/preset-react": "~7.22.15",
     "@babel/preset-typescript": "~7.22.15",
-    "@rocket.chat/apps-engine": "1.41.0",
+    "@rocket.chat/apps-engine": "^1.41.1",
     "@rocket.chat/eslint-config": "workspace:^",
     "@rocket.chat/fuselage": "^0.45.0",
     "@rocket.chat/fuselage-hooks": "^0.33.0",

--- a/packages/models/jest.config.ts
+++ b/packages/models/jest.config.ts
@@ -1,0 +1,14 @@
+export default {
+	preset: 'ts-jest',
+	errorOnDeprecated: true,
+	testEnvironment: 'jsdom',
+	modulePathIgnorePatterns: ['<rootDir>/dist/'],
+	testMatch: ['**/**.spec.ts'],
+	transform: {
+		'^.+\\.(t|j)sx?$': '@swc/jest',
+	},
+	moduleNameMapper: {
+		'\\.css$': 'identity-obj-proxy',
+	},
+	collectCoverage: true,
+};

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -3,6 +3,8 @@
 	"version": "0.0.33",
 	"private": true,
 	"devDependencies": {
+		"@swc/core": "^1.3.95",
+		"@swc/jest": "^0.2.29",
 		"@types/jest": "~29.5.7",
 		"eslint": "~8.45.0",
 		"jest": "~29.6.4",
@@ -17,7 +19,9 @@
 		"lint:fix": "eslint --ext .js,.jsx,.ts,.tsx . --fix",
 		"test": "jest",
 		"dev": "tsc --watch --preserveWatchOutput -p tsconfig.json",
-		"build": "rm -rf dist && tsc -p tsconfig.json"
+		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"unit": "jest",
+		"testunit": "jest"
 	},
 	"main": "./dist/index.js",
 	"typings": "./dist/index.d.ts",

--- a/packages/models/src/proxify.spec.ts
+++ b/packages/models/src/proxify.spec.ts
@@ -1,0 +1,91 @@
+import { proxify, registerModel } from './proxify';
+
+type MockedModel = {
+	method: () => MockedModel;
+};
+
+describe('non lazy proxify', () => {
+	it('should keep this inside functions', () => {
+		const collectionMocked = proxify('collection') as MockedModel;
+		const collection = {
+			method() {
+				return this;
+			},
+		};
+		registerModel<any>('collection', collection);
+
+		expect(collectionMocked.method()).toBe(collection);
+	});
+	it('should throw an error if the model is not found', () => {
+		const collectionMocked = proxify('collection-not-found') as MockedModel;
+		expect(() => collectionMocked.method()).toThrowError('Model collection-not-found not found');
+	});
+
+	it('should return a proxified property', () => {
+		const collectionMocked = proxify('collection-prop') as {
+			prop: string;
+		};
+		const collection = {
+			prop: 'value',
+		};
+		registerModel<any>('collection-prop', collection);
+		expect(collectionMocked.prop).toBe('value');
+	});
+
+	it('should throw an error if trying to set a property from the proxified object', () => {
+		const collectionMocked = proxify('collection-prop') as {
+			prop: string;
+		};
+		const collection = {
+			prop: 'value',
+		};
+		registerModel<any>('collection-prop', collection);
+		expect(() => {
+			collectionMocked.prop = 'new value';
+		}).toThrowError('Models accessed via proxify are read-only, use the model instance directly to modify it.');
+	});
+});
+
+describe('lazy proxify', () => {
+	it('should keep this inside functions', () => {
+		const collectionMocked = proxify('collection-lazy') as MockedModel;
+		const collection = {
+			method() {
+				return this;
+			},
+		};
+
+		registerModel<any>('collection-lazy', () => collection);
+
+		expect(collectionMocked.method()).toBe(collection);
+	});
+
+	it('should throw an error if the model is not found', () => {
+		const collectionMocked = proxify('collection-not-found') as MockedModel;
+		expect(() => collectionMocked.method()).toThrowError('Model collection-not-found not found');
+	});
+
+	it('should return a proxified property', () => {
+		const collectionMocked = proxify('collection-prop') as {
+			prop: string;
+		};
+		const collection = {
+			prop: 'value',
+		};
+		registerModel<any>('collection-prop', () => collection);
+		expect(collectionMocked.prop).toBe('value');
+	});
+
+	it('should throw an error if trying to set a property from the proxified object', () => {
+		const collectionMocked = proxify('collection-prop') as {
+			prop: string;
+		};
+		const collection = {
+			prop: 'value',
+		};
+		registerModel<any>('collection-prop', () => collection);
+		expect(() => {
+			collectionMocked.prop = 'new value';
+		}).toThrowError('Models accessed via proxify are read-only, use the model instance directly to modify it.');
+	});
+});

--- a/packages/rest-typings/package.json
+++ b/packages/rest-typings/package.json
@@ -25,7 +25,7 @@
 		"/dist"
 	],
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.41.0",
+		"@rocket.chat/apps-engine": "^1.41.1",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/message-parser": "~0.31.28",
 		"@rocket.chat/ui-kit": "workspace:~",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10103,6 +10103,8 @@ __metadata:
   resolution: "@rocket.chat/models@workspace:packages/models"
   dependencies:
     "@rocket.chat/model-typings": "workspace:^"
+    "@swc/core": ^1.3.95
+    "@swc/jest": ^0.2.29
     "@types/jest": ~29.5.7
     eslint: ~8.45.0
     jest: ~29.6.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -8919,9 +8919,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rocket.chat/apps-engine@npm:1.41.0":
-  version: 1.41.0
-  resolution: "@rocket.chat/apps-engine@npm:1.41.0"
+"@rocket.chat/apps-engine@npm:^1.41.1":
+  version: 1.41.1
+  resolution: "@rocket.chat/apps-engine@npm:1.41.1"
   dependencies:
     adm-zip: ^0.5.9
     cryptiles: ^4.1.3
@@ -8933,7 +8933,7 @@ __metadata:
     vm2: ^3.9.19
   peerDependencies:
     "@rocket.chat/ui-kit": "*"
-  checksum: 2e7fa2856bdbdc6b0dd2456e9aa5e5804a4198f8df0306a002c5e71681466d3fc2cb0a1253668d5e24fa21345a7dd7eed3458a257e1e4cc59a4e8a3876579aa5
+  checksum: 3134570898516f5d40ae66be3841d5987daeceb3a8f04ee85b0bf2bf079a24198ec9026863cb1ba4ed3d171ac67c4feda17948b1357315fe5ec427f342a70ec1
   languageName: node
   linkType: hard
 
@@ -9005,7 +9005,7 @@ __metadata:
     "@babel/core": ~7.22.20
     "@babel/preset-env": ~7.22.20
     "@babel/preset-typescript": ~7.22.15
-    "@rocket.chat/apps-engine": 1.41.0
+    "@rocket.chat/apps-engine": ^1.41.1
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/icons": ^0.33.0
@@ -9031,7 +9031,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/core-typings@workspace:packages/core-typings"
   dependencies:
-    "@rocket.chat/apps-engine": 1.41.0
+    "@rocket.chat/apps-engine": ^1.41.1
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/icons": ^0.33.0
     "@rocket.chat/message-parser": ~0.31.28
@@ -9107,7 +9107,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/ddp-streamer@workspace:ee/apps/ddp-streamer"
   dependencies:
-    "@rocket.chat/apps-engine": 1.41.0
+    "@rocket.chat/apps-engine": ^1.41.1
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/emitter": ~0.31.25
@@ -9302,7 +9302,7 @@ __metadata:
     "@babel/preset-env": ~7.22.20
     "@babel/preset-react": ~7.22.15
     "@babel/preset-typescript": ~7.22.15
-    "@rocket.chat/apps-engine": 1.41.0
+    "@rocket.chat/apps-engine": ^1.41.1
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/fuselage": ^0.45.0
     "@rocket.chat/fuselage-hooks": ^0.33.0
@@ -9709,7 +9709,7 @@ __metadata:
     "@rocket.chat/account-utils": "workspace:^"
     "@rocket.chat/agenda": "workspace:^"
     "@rocket.chat/api-client": "workspace:^"
-    "@rocket.chat/apps-engine": 1.41.0
+    "@rocket.chat/apps-engine": ^1.41.1
     "@rocket.chat/base64": "workspace:^"
     "@rocket.chat/cas-validate": "workspace:^"
     "@rocket.chat/core-services": "workspace:^"
@@ -10310,7 +10310,7 @@ __metadata:
     "@babel/core": ~7.22.20
     "@babel/preset-env": ~7.22.20
     "@babel/preset-typescript": ~7.22.15
-    "@rocket.chat/apps-engine": 1.41.0
+    "@rocket.chat/apps-engine": ^1.41.1
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/eslint-config": "workspace:^"
@@ -10425,7 +10425,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/rest-typings@workspace:packages/rest-typings"
   dependencies:
-    "@rocket.chat/apps-engine": 1.41.0
+    "@rocket.chat/apps-engine": ^1.41.1
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/message-parser": ~0.31.28
@@ -36570,7 +36570,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "rocketchat-services@workspace:apps/meteor/ee/server/services"
   dependencies:
-    "@rocket.chat/apps-engine": 1.41.0
+    "@rocket.chat/apps-engine": ^1.41.1
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/emitter": ~0.31.25

--- a/yarn.lock
+++ b/yarn.lock
@@ -9348,9 +9348,9 @@ __metadata:
     "@rocket.chat/icons": "*"
     "@rocket.chat/prettier-config": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-contexts": 4.0.4
+    "@rocket.chat/ui-contexts": 4.0.5
     "@rocket.chat/ui-kit": 0.33.0
-    "@rocket.chat/ui-video-conf": 4.0.4
+    "@rocket.chat/ui-video-conf": 4.0.5
     "@tanstack/react-query": "*"
     react: "*"
     react-dom: "*"
@@ -9432,14 +9432,14 @@ __metadata:
     ts-jest: ~29.1.1
     typescript: ~5.3.2
   peerDependencies:
-    "@rocket.chat/core-typings": 6.6.4
+    "@rocket.chat/core-typings": 6.6.5
     "@rocket.chat/css-in-js": "*"
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-tokens": "*"
     "@rocket.chat/message-parser": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-client": 4.0.4
-    "@rocket.chat/ui-contexts": 4.0.4
+    "@rocket.chat/ui-client": 4.0.5
+    "@rocket.chat/ui-contexts": 4.0.5
     katex: "*"
     react: "*"
   languageName: unknown
@@ -10621,7 +10621,7 @@ __metadata:
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-contexts": 4.0.4
+    "@rocket.chat/ui-contexts": 4.0.5
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -10796,7 +10796,7 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-contexts": 4.0.4
+    "@rocket.chat/ui-contexts": 4.0.5
     react: ^17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -10885,7 +10885,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.2.1
-    "@rocket.chat/ui-contexts": 4.0.4
+    "@rocket.chat/ui-contexts": 4.0.5
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION


<!-- release-notes-start -->
<!-- This content is automatically generated. Changing this will not reflect on the final release log -->

_You can see below a preview of the release change log:_

# 6.6.6

### Engine versions

- Node: `14.21.3`
- MongoDB: `4.4, 5.0, 6.0`
- Apps-Engine: `^1.41.1`

### Patch Changes

*   Bump @rocket.chat/meteor version.

*   ([#32064](https://github.com/RocketChat/Rocket.Chat/pull/32064)) Fix an issue affecting Rocket.Chat Apps utilizing the OAuth 2 library from Apps Engine, ensuring that apps like Google Drive and Google Calendar are operational once more.

*   ([#32056](https://github.com/RocketChat/Rocket.Chat/pull/32056)) Fix error during migration 304. Throwing `Cannot read property 'finally' of undefined` error.

*   <details><summary>Updated dependencies [ada096901a]:</summary>

    *   @rocket.chat/models@0.0.34
    *   @rocket.chat/omnichannel-services@0.1.10
    *   @rocket.chat/presence@0.1.10
    *   @rocket.chat/core-services@0.3.10
    *   @rocket.chat/cron@0.0.30
    *   @rocket.chat/instance-status@0.0.34
    *   @rocket.chat/core-typings@6.6.6
    *   @rocket.chat/rest-typings@6.6.6
    *   @rocket.chat/api-client@0.1.28
    *   @rocket.chat/license@0.1.10
    *   @rocket.chat/pdf-worker@0.0.34
    *   @rocket.chat/gazzodown@4.0.6
    *   @rocket.chat/model-typings@0.3.6
    *   @rocket.chat/ui-contexts@4.0.6
    *   @rocket.chat/server-cloud-communication@0.0.2
    *   @rocket.chat/fuselage-ui-kit@4.0.6
    *   @rocket.chat/ui-theming@0.1.2
    *   @rocket.chat/ui-client@4.0.6
    *   @rocket.chat/ui-video-conf@4.0.6
    *   @rocket.chat/web-ui-registration@4.0.6

    </details>

<!-- release-notes-end -->