### PR TITLE
test: added e2e tests for Livechat's hide watermark setting

### DIFF
--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-watermark.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-watermark.spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-// import { Page } from '@playwright/test';
 
 import { IS_EE } from '../config/constants';
 import { createAuxContext } from '../fixtures/createAuxContext';

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-watermark.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-watermark.spec.ts
@@ -1,0 +1,74 @@
+import { faker } from '@faker-js/faker';
+// import { Page } from '@playwright/test';
+
+import { IS_EE } from '../config/constants';
+import { createAuxContext } from '../fixtures/createAuxContext';
+import { Users } from '../fixtures/userStates';
+import { OmnichannelLiveChat, OmnichannelSettings } from '../page-objects';
+import { createAgent, makeAgentAvailable } from '../utils/omnichannel/agents';
+import { test, expect } from '../utils/test';
+
+const visitor = {
+	name: `${faker.person.firstName()} ${faker.string.uuid()}}`,
+	email: faker.internet.email(),
+};
+
+test.skip(!IS_EE, 'Enterprise Only');
+
+test.use({ storageState: Users.admin.state });
+
+test.describe('OC - Livechat - Hide watermark', async () => {
+	let agent: Awaited<ReturnType<typeof createAgent>>;
+	let poLiveChat: OmnichannelLiveChat;
+	let poOmnichannelSettings: OmnichannelSettings;
+
+	test.beforeAll(async ({ api }) => {
+		agent = await createAgent(api, 'user1');
+
+		const res = await makeAgentAvailable(api, agent.data._id);
+
+		await expect(res.status()).toBe(200);
+	});
+
+	test.beforeEach(async ({ browser, api }) => {
+		const { page: livechatPage } = await createAuxContext(browser, Users.user1, '/livechat', false);
+
+		poLiveChat = new OmnichannelLiveChat(livechatPage, api);
+	});
+
+	test.beforeEach(async ({ page }) => {
+		poOmnichannelSettings = new OmnichannelSettings(page);
+
+		await page.goto('/admin/settings/Omnichannel');
+	});
+
+	test.afterAll(async ({ api }) => {
+		const res = await api.post('/settings/Livechat_hide_watermark', { value: false });
+		await expect(res.status()).toBe(200);
+	});
+
+	test('OC - Livechat - Hide watermark', async () => {
+		await test.step('expect to open Livechat', async () => {
+			await poLiveChat.openLiveChat();
+			await poLiveChat.sendMessage(visitor, false);
+		});
+
+		await test.step('expect watermark to start visible (default)', async () => {
+			await expect(poLiveChat.onlineAgentMessage).toBeVisible();
+			await expect(poLiveChat.txtWatermark).toBeVisible();
+		});
+
+		await test.step('expect to change setting', async () => {
+			await poOmnichannelSettings.group('Livechat').click();
+			await poOmnichannelSettings.labelHideWatermark.click();
+			await poOmnichannelSettings.btnSave.click();
+		});
+
+		await test.step('expect watermark to be hidden', async () => {
+			await poLiveChat.page.reload();
+			await poLiveChat.openLiveChat();
+			await expect(poLiveChat.onlineAgentMessage).toBeVisible();
+			await expect(poLiveChat.txtWatermark).toBeHidden();
+		});
+	});
+});

--- a/apps/meteor/tests/e2e/page-objects/index.ts
+++ b/apps/meteor/tests/e2e/page-objects/index.ts
@@ -15,4 +15,5 @@ export * from './omnichannel-custom-fields';
 export * from './omnichannel-units';
 export * from './home-omnichannel';
 export * from './omnichannel-monitors';
+export * from './omnichannel-settings';
 export * from './utils';

--- a/apps/meteor/tests/e2e/page-objects/omnichannel-livechat.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel-livechat.ts
@@ -46,9 +46,13 @@ export class OmnichannelLiveChat {
 	get btnChatNow(): Locator {
 		return this.page.locator('[type="button"] >> text="Chat now"');
 	}
-	
+
 	get headerTitle(): Locator {
 		return this.page.locator('[data-qa="header-title"]');
+	}
+
+	get txtWatermark(): Locator {
+		return this.page.locator('[data-qa="livechat-watermark"]');
 	}
 
 	alertMessage(message: string): Locator {
@@ -134,7 +138,7 @@ export class OmnichannelLiveChat {
 		return this.page.locator('#files-drop-target');
 	}
 
-	findUploadedFileLink (fileName: string): Locator {
+	findUploadedFileLink(fileName: string): Locator {
 		return this.page.getByRole('link', { name: fileName });
 	}
 

--- a/apps/meteor/tests/e2e/page-objects/omnichannel-settings.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel-settings.ts
@@ -8,7 +8,7 @@ export class OmnichannelSettings {
 	}
 
 	group(sectionName: string): Locator {
-		return this.page.locator(`h2 >> text="${sectionName}"`);
+		return this.page.locator(`[data-qa-section="${sectionName}"] h2 >> text="${sectionName}"`);
 	}
 
 	get labelHideWatermark(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel-settings.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel-settings.ts
@@ -1,0 +1,21 @@
+import type { Locator, Page } from '@playwright/test';
+
+export class OmnichannelSettings {
+	protected readonly page: Page;
+
+	constructor(page: Page) {
+		this.page = page;
+	}
+
+	group(sectionName: string): Locator {
+		return this.page.locator(`h2 >> text="${sectionName}"`);
+	}
+
+	get labelHideWatermark(): Locator {
+		return this.page.locator('label', { has: this.page.locator('[data-qa-setting-id="Livechat_hide_watermark"]') });
+	}
+
+	get btnSave(): Locator {
+		return this.page.locator('role=button[name="Save changes"]');
+	}
+}

--- a/packages/livechat/src/components/Footer/index.tsx
+++ b/packages/livechat/src/components/Footer/index.tsx
@@ -20,7 +20,7 @@ export const FooterContent = ({ children, className, ...props }: { children: Com
 );
 
 export const PoweredBy = withTranslation()(({ className, t, ...props }: { className?: string; t: (translationKey: string) => string }) => (
-	<h3 className={createClassName(styles, 'powered-by', {}, [className])} {...props}>
+	<h3 data-qa='livechat-watermark' className={createClassName(styles, 'powered-by', {}, [className])} {...props}>
 		{t('powered_by_rocket_chat').split('Rocket.Chat')[0]}
 		<a className={createClassName(styles, 'powered-by__logo')} href='https://rocket.chat' target='_blank' rel='noopener noreferrer'>
 			<RocketChatLogo />


### PR DESCRIPTION

## Proposed changes (including videos or screenshots)
This PR adds integration tests for the newly created setting `Hide "powered by Rocket.Chat"` (`Livechat_hide_watermark`). 

It covers checking the correct default state, changing the setting in the workspace and confirming the watermark was hidden.

**Setting:** 
![Screen Shot 2024-04-04 at 13 04 50](https://github.com/RocketChat/Rocket.Chat/assets/6494543/37c4774c-6591-4a66-8ee5-50b78da5eb60)

**Watermark:**
![Screen Shot 2024-04-04 at 13 05 41](https://github.com/RocketChat/Rocket.Chat/assets/6494543/1b2e052f-a4ff-45e0-9a8b-c2dd8959ccc5)

<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[PROSVC-80](https://rocketchat.atlassian.net/browse/PROSVC-80)



[PROSVC-80]: https://rocketchat.atlassian.net/browse/PROSVC-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ