### PR TITLE
fix: livechat room desync on different windows

### DIFF
--- a/.changeset/wild-keys-obey.md
+++ b/.changeset/wild-keys-obey.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/livechat": patch
+---
+
+Fixes issue causing a desync in different browser windows when a chat is closed and started again

--- a/packages/livechat/src/lib/room.js
+++ b/packages/livechat/src/lib/room.js
@@ -348,7 +348,7 @@ export const defaultRoomParams = () => {
 store.on('change', ([state, prevState]) => {
 	// Cross-tab communication
 	// Detects when a room is created and then route to the correct container
-	if (!prevState.room && state.room) {
+	if (prevState.room?._id !== state.room?._id) {
 		route('/');
 	}
 });


### PR DESCRIPTION
Part of [SUP-485]

This stops a situation that could open two different rooms on the same Livechat session

[SUP-485]: https://rocketchat.atlassian.net/browse/SUP-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

https://github.com/RocketChat/Rocket.Chat/assets/20868078/fc4926c4-bf76-4264-947d-81c6a953ffa2