### PR TITLE
chore: remove collections when db watcher is disabled

### DIFF
--- a/apps/meteor/server/database/watchCollections.ts
+++ b/apps/meteor/server/database/watchCollections.ts
@@ -1,3 +1,4 @@
+import { dbWatchersDisabled } from '@rocket.chat/core-services';
 import {
 	Messages,
 	Users,
@@ -29,7 +30,6 @@ const onlyCollections = DBWATCHER_ONLY_COLLECTIONS.split(',')
 
 export function getWatchCollections(): string[] {
 	const collections = [
-		Messages.getCollectionName(),
 		Users.getCollectionName(),
 		Subscriptions.getCollectionName(),
 		LivechatInquiry.getCollectionName(),
@@ -46,6 +46,11 @@ export function getWatchCollections(): string[] {
 		Settings.getCollectionName(),
 		LivechatPriority.getCollectionName(),
 	];
+
+	// add back to the list of collections in case db watchers are enabled
+	if (!dbWatchersDisabled) {
+		collections.push(Messages.getCollectionName());
+	}
 
 	if (onlyCollections.length > 0) {
 		return collections.filter((collection) => onlyCollections.includes(collection));


### PR DESCRIPTION
When using `DISABLE_DB_WATCHERS=true` to ignore changes from change streams, we were still receiving all the data from MongoDB and then ignoring them by just not broadcasting.. With this change we'll not even ask MongoDB to send those changes.