### PR TITLE
fix: Login token creation not respecting number of token limits

### DIFF
--- a/.changeset/chilly-walls-knock.md
+++ b/.changeset/chilly-walls-knock.md
@@ -3,3 +3,11 @@
 ---
 
 Fixed an issue while creating tokens via the special `users.createToken` API was not respecting the maximum login tokens allowed for a user.
+
+The following endpoint was deprecated and will be removed on version `8.0.0`:
+
+- `/api/v1/users.createToken`
+
+The following Meteor method (realtime API) was deprecated and will be removed on version `8.0.0`:
+
+- `createToken`

--- a/.changeset/chilly-walls-knock.md
+++ b/.changeset/chilly-walls-knock.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed an issue while creating tokens via the special `users.createToken` API was not respecting the maximum login tokens allowed for a user.

--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -40,6 +40,7 @@ import { setStatusText } from '../../../lib/server/functions/setStatusText';
 import { setUserAvatar } from '../../../lib/server/functions/setUserAvatar';
 import { setUsernameWithValidation } from '../../../lib/server/functions/setUsername';
 import { validateCustomFields } from '../../../lib/server/functions/validateCustomFields';
+import { generateAccessToken } from '../../../lib/server/methods/createToken';
 import { settings } from '../../../settings/server';
 import { getURL } from '../../../utils/server/getURL';
 import { API } from '../api';
@@ -636,11 +637,13 @@ API.v1.addRoute(
 
 API.v1.addRoute(
 	'users.createToken',
-	{ authRequired: true },
+	{ authRequired: true, deprecationVersion: '8.0.0' },
 	{
 		async post() {
 			const user = await getUserFromParams(this.bodyParams);
-			const data = await Meteor.callAsync('createToken', user._id);
+
+			const data = await generateAccessToken(this.userId, user._id);
+
 			return data ? API.v1.success({ data }) : API.v1.unauthorized();
 		},
 	},

--- a/apps/meteor/app/authentication/server/startup/index.js
+++ b/apps/meteor/app/authentication/server/startup/index.js
@@ -1,4 +1,5 @@
 import { Apps, AppEvents } from '@rocket.chat/apps';
+import { User } from '@rocket.chat/core-services';
 import { Roles, Settings, Users } from '@rocket.chat/models';
 import { escapeRegExp, escapeHTML } from '@rocket.chat/string-helpers';
 import { Accounts } from 'meteor/accounts-base';
@@ -11,6 +12,7 @@ import { beforeCreateUserCallback } from '../../../../lib/callbacks/beforeCreate
 import { parseCSV } from '../../../../lib/utils/parseCSV';
 import { safeHtmlDots } from '../../../../lib/utils/safeHtmlDots';
 import { getClientAddress } from '../../../../server/lib/getClientAddress';
+import { getMaxLoginTokens } from '../../../../server/lib/getMaxLoginTokens';
 import { i18n } from '../../../../server/lib/i18n';
 import { addUserRolesAsync } from '../../../../server/lib/roles/addUserRoles';
 import { getNewUserRoles } from '../../../../server/services/user/lib/getNewUserRoles';
@@ -475,20 +477,14 @@ Accounts.validateNewUser((user) => {
 	return true;
 });
 
-export const MAX_RESUME_LOGIN_TOKENS = parseInt(process.env.MAX_RESUME_LOGIN_TOKENS) || 50;
-
 Accounts.onLogin(async ({ user }) => {
 	if (!user || !user.services || !user.services.resume || !user.services.resume.loginTokens || !user._id) {
 		return;
 	}
 
-	if (user.services.resume.loginTokens.length < MAX_RESUME_LOGIN_TOKENS) {
+	if (user.services.resume.loginTokens.length < getMaxLoginTokens()) {
 		return;
 	}
 
-	const { tokens } = (await Users.findAllResumeTokensByUserId(user._id))[0];
-	if (tokens.length >= MAX_RESUME_LOGIN_TOKENS) {
-		const oldestDate = tokens.reverse()[MAX_RESUME_LOGIN_TOKENS - 1];
-		await Users.removeOlderResumeTokensByUserId(user._id, oldestDate.when);
-	}
+	await User.ensureLoginTokensLimit(user._id);
 });

--- a/apps/meteor/server/lib/getMaxLoginTokens.ts
+++ b/apps/meteor/server/lib/getMaxLoginTokens.ts
@@ -1,0 +1,5 @@
+export const maxLoginTokens = parseInt(String(process.env.MAX_RESUME_LOGIN_TOKENS)) || 50;
+
+export function getMaxLoginTokens(): number {
+	return maxLoginTokens;
+}

--- a/apps/meteor/server/services/startup.ts
+++ b/apps/meteor/server/services/startup.ts
@@ -28,6 +28,7 @@ import { TeamService } from './team/service';
 import { TranslationService } from './translation/service';
 import { UiKitCoreAppService } from './uikit-core-app/service';
 import { UploadService } from './upload/service';
+import { UserService } from './user/service';
 import { VideoConfService } from './video-conference/service';
 import { VoipService } from './voip/service';
 
@@ -60,6 +61,7 @@ export const registerServices = async (): Promise<void> => {
 	api.registerService(new OmnichannelIntegrationService());
 	api.registerService(new ImportService());
 	api.registerService(new OmnichannelAnalyticsService());
+	api.registerService(new UserService());
 
 	// if the process is running in micro services mode we don't need to register services that will run separately
 	if (!isRunningMs()) {

--- a/apps/meteor/server/services/user/service.ts
+++ b/apps/meteor/server/services/user/service.ts
@@ -1,0 +1,19 @@
+import { ServiceClassInternal } from '@rocket.chat/core-services';
+import type { IUserService } from '@rocket.chat/core-services';
+import { Users } from '@rocket.chat/models';
+
+import { getMaxLoginTokens } from '../../lib/getMaxLoginTokens';
+
+export class UserService extends ServiceClassInternal implements IUserService {
+	protected name = 'user';
+
+	async ensureLoginTokensLimit(uid: string): Promise<void> {
+		const [{ tokens }] = await Users.findAllResumeTokensByUserId(uid);
+		if (tokens.length < getMaxLoginTokens()) {
+			return;
+		}
+
+		const oldestDate = tokens.reverse()[getMaxLoginTokens() - 1];
+		await Users.removeOlderResumeTokensByUserId(uid, oldestDate.when);
+	}
+}

--- a/packages/core-services/src/index.ts
+++ b/packages/core-services/src/index.ts
@@ -45,6 +45,7 @@ import type { ITelemetryEvent, TelemetryMap, TelemetryEvents } from './types/ITe
 import type { ITranslationService } from './types/ITranslationService';
 import type { UiKitCoreAppPayload, IUiKitCoreApp, IUiKitCoreAppService } from './types/IUiKitCoreApp';
 import type { ISendFileLivechatMessageParams, ISendFileMessageParams, IUploadFileParams, IUploadService } from './types/IUploadService';
+import type { IUserService } from './types/IUserService';
 import type { IVideoConfService, VideoConferenceJoinOptions } from './types/IVideoConfService';
 import type { IVoipService } from './types/IVoipService';
 
@@ -134,6 +135,7 @@ export {
 	IOmnichannelIntegrationService,
 	IImportService,
 	IOmnichannelAnalyticsService,
+	IUserService,
 };
 
 export const dbWatchersDisabled = ['yes', 'true'].includes(String(process.env.DISABLE_DB_WATCHERS).toLowerCase());
@@ -173,6 +175,7 @@ export const Omnichannel = proxifyWithWait<IOmnichannelService>('omnichannel');
 export const OmnichannelEEService = proxifyWithWait<IOmnichannelEEService>('omnichannel-ee');
 export const Import = proxifyWithWait<IImportService>('import');
 export const OmnichannelAnalytics = proxifyWithWait<IOmnichannelAnalyticsService>('omnichannel-analytics');
+export const User = proxifyWithWait<IUserService>('user');
 
 // Calls without wait. Means that the service is optional and the result may be an error
 // of service/method not available

--- a/packages/core-services/src/types/IUserService.ts
+++ b/packages/core-services/src/types/IUserService.ts
@@ -1,0 +1,3 @@
+export interface IUserService {
+	ensureLoginTokensLimit(uid: string): Promise<void>;
+}


### PR DESCRIPTION
The maximum login tokens limit for users has a huge impact on both Rocket.Chat and MongoDB performance, but since this endpoint doesn't trigger a real "login", it wasn't being applied at there.. but since it is indeed creating new login tokens, it should be treated like so, that's why this can be considered a fix.

I'm also deprecating the mentioned endpoint since this was a feature already under a environment variable for many reasons. Rocket.Chat has now evolved enough where this approach is not required anymore.

I've also tested the performance impact of a user with too many login tokens, you can see the results below:

## Performance impact

### User starting with 50 tokens in DB

This is prior the fix:

```bash
k6 run --duration 30s -e "USER_ID=..." -e "AUTH_TOKEN=..." -e "USERNAME=..." ./create-token.js

          /\      |‾‾| /‾‾/   /‾‾/   
     /\  /  \     |  |/  /   /  /    
    /  \/    \    |     (   /   ‾‾\  
   /          \   |  |\  \ |  (‾)  | 
  / __________ \  |__| \__\ \_____/ .io

  execution: local
     script: ./create-token.js
     output: -

  scenarios: (100.00%) 1 scenario, 1 max VUs, 1m0s max duration (incl. graceful stop):
           * default: 1 looping VUs for 30s (gracefulStop: 30s)


     data_received..................: 2.4 MB 78 kB/s
     data_sent......................: 664 kB 22 kB/s
     http_req_blocked...............: avg=10.49µs  min=1µs    med=5µs    max=10.76ms  p(90)=7µs     p(95)=8µs    
     http_req_connecting............: avg=380ns    min=0s     med=0s     max=930µs    p(90)=0s      p(95)=0s     
     http_req_duration..............: avg=12.02ms  min=3.55ms med=8.5ms  max=279.74ms p(90)=22.74ms p(95)=38.48ms
       { expected_response:true }...: avg=12.02ms  min=3.55ms med=8.5ms  max=279.74ms p(90)=22.74ms p(95)=38.48ms
     http_req_failed................: 0.00%  ✓ 0         ✗ 2441
     http_req_receiving.............: avg=161.97µs min=35µs   med=112µs  max=6.54ms   p(90)=203µs   p(95)=290µs  
     http_req_sending...............: avg=37.55µs  min=6µs    med=29µs   max=7.31ms   p(90)=46µs    p(95)=54µs   
     http_req_tls_handshaking.......: avg=0s       min=0s     med=0s     max=0s       p(90)=0s      p(95)=0s     
     http_req_waiting...............: avg=11.82ms  min=3.5ms  med=8.29ms max=279.48ms p(90)=22.26ms p(95)=38.25ms
     http_reqs......................: 2441   81.265407/s
     iteration_duration.............: avg=12.27ms  min=3.62ms med=8.73ms max=279.91ms p(90)=23.07ms p(95)=38.6ms 
     iterations.....................: 2441   81.265407/s
     vus............................: 1      min=1       max=1 
     vus_max........................: 1      min=1       max=1 


running (0m30.0s), 0/1 VUs, 2441 complete and 0 interrupted iterations
default ✓ [======================================] 1 VUs  30s
```

### User starting with 10k token in DB

This is also prior the fix, hence a user was allowed to have that many login tokes:

```bash
k6 run --duration 30s -e "USER_ID=..." -e "AUTH_TOKEN=..." -e "USERNAME=..." ./create-token.js

          /\      |‾‾| /‾‾/   /‾‾/   
     /\  /  \     |  |/  /   /  /    
    /  \/    \    |     (   /   ‾‾\  
   /          \   |  |\  \ |  (‾)  | 
  / __________ \  |__| \__\ \_____/ .io

  execution: local
     script: ./create-token.js
     output: -

  scenarios: (100.00%) 1 scenario, 1 max VUs, 1m0s max duration (incl. graceful stop):
           * default: 1 looping VUs for 30s (gracefulStop: 30s)


     data_received..................: 513 kB 17 kB/s
     data_sent......................: 145 kB 4.8 kB/s
     http_req_blocked...............: avg=11.07µs  min=2µs     med=6µs     max=2.15ms   p(90)=9µs     p(95)=9µs     
     http_req_connecting............: avg=1.09µs   min=0s      med=0s      max=583µs    p(90)=0s      p(95)=0s      
     http_req_duration..............: avg=56.17ms  min=29.29ms med=37.26ms max=336.22ms p(90)=99.24ms p(95)=112.77ms
       { expected_response:true }...: avg=56.17ms  min=29.29ms med=37.26ms max=336.22ms p(90)=99.24ms p(95)=112.77ms
     http_req_failed................: 0.00%  ✓ 0         ✗ 532
     http_req_receiving.............: avg=196.16µs min=50µs    med=150µs   max=5.34ms   p(90)=254µs   p(95)=402.59µs
     http_req_sending...............: avg=45.17µs  min=13µs    med=37.5µs  max=1.1ms    p(90)=57µs    p(95)=60µs    
     http_req_tls_handshaking.......: avg=0s       min=0s      med=0s      max=0s       p(90)=0s      p(95)=0s      
     http_req_waiting...............: avg=55.92ms  min=29.22ms med=37.08ms max=335.94ms p(90)=99.11ms p(95)=111.97ms
     http_reqs......................: 532    17.694357/s
     iteration_duration.............: avg=56.48ms  min=29.4ms  med=37.51ms max=336.77ms p(90)=99.61ms p(95)=113ms   
     iterations.....................: 532    17.694357/s
     vus............................: 1      min=1       max=1
     vus_max........................: 1      min=1       max=1


running (0m30.1s), 0/1 VUs, 532 complete and 0 interrupted iterations
default ✓ [======================================] 1 VUs  30s
```

As you can see, the extra load added was so massive that only 532 new login tokens were created during the same period.


### Ensuring 50 tokens (after the change)

```bash
k6 run --duration 30s -e "USER_ID=..." -e "AUTH_TOKEN=..." -e "USERNAME=..." ./create-token.js

          /\      |‾‾| /‾‾/   /‾‾/   
     /\  /  \     |  |/  /   /  /    
    /  \/    \    |     (   /   ‾‾\  
   /          \   |  |\  \ |  (‾)  | 
  / __________ \  |__| \__\ \_____/ .io

  execution: local
     script: ./create-token.js
     output: -

  scenarios: (100.00%) 1 scenario, 1 max VUs, 1m0s max duration (incl. graceful stop):
           * default: 1 looping VUs for 30s (gracefulStop: 30s)


     data_received..................: 4.2 MB 139 kB/s
     data_sent......................: 1.2 MB 39 kB/s
     http_req_blocked...............: avg=5.76µs   min=1µs    med=4µs    max=2.12ms   p(90)=6µs     p(95)=7µs    
     http_req_connecting............: avg=148ns    min=0s     med=0s     max=644µs    p(90)=0s      p(95)=0s     
     http_req_duration..............: avg=6.68ms   min=4.01ms med=5.21ms max=267.42ms p(90)=10.65ms p(95)=13.13ms
       { expected_response:true }...: avg=6.68ms   min=4.01ms med=5.21ms max=267.42ms p(90)=10.65ms p(95)=13.13ms
     http_req_failed................: 0.00%  ✓ 0          ✗ 4334
     http_req_receiving.............: avg=138.36µs min=18µs   med=94.5µs max=8.42ms   p(90)=183µs   p(95)=249µs  
     http_req_sending...............: avg=34.45µs  min=4µs    med=26µs   max=4.13ms   p(90)=42µs    p(95)=48µs   
     http_req_tls_handshaking.......: avg=0s       min=0s     med=0s     max=0s       p(90)=0s      p(95)=0s     
     http_req_waiting...............: avg=6.51ms   min=3.9ms  med=5.06ms max=267.33ms p(90)=10.33ms p(95)=12.9ms 
     http_reqs......................: 4334   144.440576/s
     iteration_duration.............: avg=6.89ms   min=4.11ms med=5.41ms max=267.55ms p(90)=10.93ms p(95)=13.41ms
     iterations.....................: 4334   144.440576/s
     vus............................: 1      min=1        max=1 
     vus_max........................: 1      min=1        max=1 


running (0m30.0s), 0/1 VUs, 4334 complete and 0 interrupted iterations
default ✓ [======================================] 1 VUs  30s
```

After the change, even with an additional operations to make sure the limits are being respected, since the number of login tokens is not increasing anymore, it was able to generate almost the double amount of login tokens comparing to prior the fix.