### PR TITLE
test: remove test.fail from livechat fileupload

### DIFF
--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-fileupload.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-fileupload.spec.ts
@@ -97,8 +97,6 @@ test.describe('OC - Livechat - OC - File Upload - Disabled', () => {
 		const testName = endpoints.map((endpoint) => endpoint.url.split('/').pop()?.concat(`=${endpoint.value}`)).join(' ');
 
 		test(`OC - Livechat - txt Drag & Drop - ${testName}`, async ({ page, api }) => {
-			test.fail();
-
 			poLiveChat = new OmnichannelLiveChat(page, api);
 
 			await Promise.all(endpoints.map(async (endpoint: { url: string, value: boolean }) => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-fileupload.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-fileupload.spec.ts
@@ -115,7 +115,7 @@ test.describe('OC - Livechat - OC - File Upload - Disabled', () => {
 			await test.step('expect to upload a txt file', async () => {
 				await poLiveChat.dragAndDropTxtFile();
 
-				await expect(poLiveChat.alertMessage('file_upload_disabled')).toBeVisible();
+				await expect(poLiveChat.alertMessage('File upload is disabled')).toBeVisible();
 			});
 		});
 	});


### PR DESCRIPTION
This was supposed to be a part of  [CORE-216] but maybe it got missing on a rebase

Removes test.fail from fileupload test and fix a small issue with a string assertion

[CORE-216]: https://rocketchat.atlassian.net/browse/CORE-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ