### PR TITLE
Release 6.7.2

### DIFF
--- a/.changeset/bump-patch-1714490920088.md
+++ b/.changeset/bump-patch-1714490920088.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Bump @rocket.chat/meteor version.

--- a/.changeset/yellow-lies-judge.md
+++ b/.changeset/yellow-lies-judge.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+fixed Engagement Dashboard and Device Management admin pages loading indefinitely

--- a/apps/meteor/ee/client/views/admin/deviceManagement/DeviceManagementAdminRoute.tsx
+++ b/apps/meteor/ee/client/views/admin/deviceManagement/DeviceManagementAdminRoute.tsx
@@ -14,7 +14,7 @@ const DeviceManagementAdminRoute = (): ReactElement => {
 	const t = useTranslation();
 	const router = useRouter();
 	const setModal = useSetModal();
-	const isModalOpen = useCurrentModal() !== null;
+	const isModalOpen = !!useCurrentModal();
 
 	const hasDeviceManagement = useHasLicenseModule('device-management') as boolean;
 	const canViewDeviceManagement = usePermission('view-device-management');
@@ -25,6 +25,7 @@ const DeviceManagementAdminRoute = (): ReactElement => {
 		if (shouldShowUpsell) {
 			setModal(
 				<GenericUpsellModal
+					aria-label={t('Device_Management')}
 					title={t('Device_Management')}
 					img={getURL('images/device-management.png')}
 					subtitle={t('Ensure_secure_workspace_access')}

--- a/apps/meteor/ee/client/views/admin/engagementDashboard/EngagementDashboardRoute.tsx
+++ b/apps/meteor/ee/client/views/admin/engagementDashboard/EngagementDashboardRoute.tsx
@@ -25,7 +25,7 @@ const EngagementDashboardRoute = (): ReactElement | null => {
 	const t = useTranslation();
 	const canViewEngagementDashboard = usePermission('view-engagement-dashboard');
 	const setModal = useSetModal();
-	const isModalOpen = useCurrentModal() !== null;
+	const isModalOpen = !!useCurrentModal();
 
 	const router = useRouter();
 	const tab = useRouteParameter('tab');
@@ -39,6 +39,7 @@ const EngagementDashboardRoute = (): ReactElement | null => {
 		if (shouldShowUpsell) {
 			setModal(
 				<GenericUpsellModal
+					aria-label={t('Engagement_Dashboard')}
 					title={t('Engagement_Dashboard')}
 					img={getURL('images/engagement.png')}
 					subtitle={t('Analyze_practical_usage')}

--- a/apps/meteor/tests/e2e/administration.spec.ts
+++ b/apps/meteor/tests/e2e/administration.spec.ts
@@ -28,6 +28,38 @@ test.describe.parallel('administration', () => {
 		});
 	});
 
+	test.describe('Engagement dashboard', () => {
+		test('Should show upsell modal', async ({ page }) => {
+			test.skip(IS_EE);
+			await page.goto('/admin/engagement/users');
+
+			await expect(page.locator('role=dialog[name="Engagement dashboard"]')).toBeVisible();
+		});
+
+		test('Should show engagement dashboard', async ({ page }) => {
+			test.skip(!IS_EE);
+			await page.goto('/admin/engagement/users');
+
+			await expect(page.locator('h1 >> text="Engagement"')).toBeVisible();
+		});
+	});
+
+	test.describe('Device management', () => {
+		test('Should show upsell modal', async ({ page }) => {
+			test.skip(IS_EE);
+			await page.goto('/admin/device-management');
+
+			await expect(page.locator('role=dialog[name="Device management"]')).toBeVisible();
+		});
+
+		test('Should show device management page', async ({ page }) => {
+			test.skip(!IS_EE);
+			await page.goto('/admin/device-management');
+
+			await expect(page.locator('h1 >> text="Device management"')).toBeVisible();
+		});
+	});
+
 	test.describe('Users', () => {
 		test.beforeEach(async ({ page }) => {
 			await page.goto('/admin/users');

--- a/yarn.lock
+++ b/yarn.lock
@@ -8791,10 +8791,10 @@ __metadata:
     "@rocket.chat/icons": "*"
     "@rocket.chat/prettier-config": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 1.0.0
-    "@rocket.chat/ui-contexts": 5.0.0
+    "@rocket.chat/ui-avatar": 1.0.1
+    "@rocket.chat/ui-contexts": 5.0.1
     "@rocket.chat/ui-kit": 0.33.0
-    "@rocket.chat/ui-video-conf": 5.0.0
+    "@rocket.chat/ui-video-conf": 5.0.1
     "@tanstack/react-query": "*"
     react: "*"
     react-dom: "*"
@@ -8883,8 +8883,8 @@ __metadata:
     "@rocket.chat/fuselage-tokens": "*"
     "@rocket.chat/message-parser": 0.31.29
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-client": 5.0.0
-    "@rocket.chat/ui-contexts": 5.0.0
+    "@rocket.chat/ui-client": 5.0.1
+    "@rocket.chat/ui-contexts": 5.0.1
     katex: "*"
     react: "*"
   languageName: unknown
@@ -10088,7 +10088,7 @@ __metadata:
     typescript: ~5.3.3
   peerDependencies:
     "@rocket.chat/fuselage": "*"
-    "@rocket.chat/ui-contexts": 5.0.0
+    "@rocket.chat/ui-contexts": 5.0.1
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -10141,7 +10141,7 @@ __metadata:
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-contexts": 5.0.0
+    "@rocket.chat/ui-contexts": 5.0.1
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -10317,8 +10317,8 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 1.0.0
-    "@rocket.chat/ui-contexts": 5.0.0
+    "@rocket.chat/ui-avatar": 1.0.1
+    "@rocket.chat/ui-contexts": 5.0.1
     react: ^17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -10408,7 +10408,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.2.1
-    "@rocket.chat/ui-contexts": 5.0.0
+    "@rocket.chat/ui-contexts": 5.0.1
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION


<!-- release-notes-start -->
<!-- This content is automatically generated. Changing this will not reflect on the final release log -->

_You can see below a preview of the release change log:_

# 6.7.2

### Engine versions

- Node: `14.21.3`
- MongoDB: `4.4, 5.0, 6.0`
- Apps-Engine: `^1.42.1`

### Patch Changes

*   Bump @rocket.chat/meteor version.

*   ([#32315](https://github.com/RocketChat/Rocket.Chat/pull/32315) by [@dionisio-bot](https://github.com/dionisio-bot)) fixed Engagement Dashboard and Device Management admin pages loading indefinitely

*   <details><summary>Updated dependencies []:</summary>

    *   @rocket.chat/core-typings@6.7.2
    *   @rocket.chat/rest-typings@6.7.2
    *   @rocket.chat/api-client@0.1.31
    *   @rocket.chat/license@0.1.13
    *   @rocket.chat/omnichannel-services@0.1.13
    *   @rocket.chat/pdf-worker@0.0.37
    *   @rocket.chat/presence@0.1.13
    *   @rocket.chat/apps@0.0.4
    *   @rocket.chat/core-services@0.3.13
    *   @rocket.chat/cron@0.0.33
    *   @rocket.chat/gazzodown@5.0.2
    *   @rocket.chat/model-typings@0.3.9
    *   @rocket.chat/ui-contexts@5.0.2
    *   @rocket.chat/server-cloud-communication@0.0.2
    *   @rocket.chat/fuselage-ui-kit@5.0.2
    *   @rocket.chat/models@0.0.37
    *   @rocket.chat/ui-theming@0.1.2
    *   @rocket.chat/ui-avatar@1.0.2
    *   @rocket.chat/ui-client@5.0.2
    *   @rocket.chat/ui-video-conf@5.0.2
    *   @rocket.chat/web-ui-registration@5.0.2
    *   @rocket.chat/instance-status@0.0.37

    </details>

<!-- release-notes-end -->