### PR TITLE
refactor(omnichannel): spare few Room.find on requestRoom method

### DIFF
--- a/apps/meteor/app/livechat/server/lib/Helper.ts
+++ b/apps/meteor/app/livechat/server/lib/Helper.ts
@@ -335,6 +335,10 @@ export const dispatchAgentDelegated = async (rid: string, agentId?: string) => {
 	});
 };
 
+/**
+ * @deprecated
+ */
+
 export const dispatchInquiryQueued = async (inquiry: ILivechatInquiryRecord, agent?: SelectedAgent | null) => {
 	if (!inquiry?._id) {
 		return;

--- a/apps/meteor/app/livechat/server/lib/Helper.ts
+++ b/apps/meteor/app/livechat/server/lib/Helper.ts
@@ -353,7 +353,7 @@ export const dispatchInquiryQueued = async (inquiry: ILivechatInquiryRecord, age
 		return;
 	}
 
-	if (agent && !(await allowAgentSkipQueue(agent))) {
+	if (agent && (await allowAgentSkipQueue(agent))) {
 		return;
 	}
 

--- a/apps/meteor/app/livechat/server/lib/Helper.ts
+++ b/apps/meteor/app/livechat/server/lib/Helper.ts
@@ -353,9 +353,11 @@ export const dispatchInquiryQueued = async (inquiry: ILivechatInquiryRecord, age
 		return;
 	}
 
-	if (!agent || !(await allowAgentSkipQueue(agent))) {
-		await saveQueueInquiry(inquiry);
+	if (agent && !(await allowAgentSkipQueue(agent))) {
+		return;
 	}
+
+	await saveQueueInquiry(inquiry);
 
 	// Alert only the online agents of the queued request
 	const onlineAgents = await LivechatTyped.getOnlineAgents(department, agent);

--- a/apps/meteor/app/livechat/server/lib/LivechatTyped.ts
+++ b/apps/meteor/app/livechat/server/lib/LivechatTyped.ts
@@ -242,7 +242,7 @@ class LivechatClass {
 				return;
 			}
 
-			return Users.findByIds<ILivechatAgent>(agentIds);
+			return Users.findByIds<ILivechatAgent>([...new Set(agentIds)]);
 		}
 		return Users.findOnlineAgents();
 	}

--- a/apps/meteor/app/livechat/server/lib/QueueManager.ts
+++ b/apps/meteor/app/livechat/server/lib/QueueManager.ts
@@ -222,7 +222,7 @@ export const QueueManager = class {
 				throw new Meteor.Error('no-agent-online', 'Sorry, no online agents');
 			}
 
-			if (guest.department && !department) {
+			if (!defaultAgent && guest.department && !department) {
 				throw new Meteor.Error('no-agent-online', 'Sorry, no online agents');
 			}
 

--- a/apps/meteor/app/livechat/server/lib/QueueManager.ts
+++ b/apps/meteor/app/livechat/server/lib/QueueManager.ts
@@ -22,6 +22,7 @@ import {
 	notifyOnLivechatInquiryChanged,
 	notifyOnSettingChanged,
 } from '../../../lib/server/lib/notifyListener';
+import { settings } from '../../../settings/server';
 import { i18n } from '../../../utils/lib/i18n';
 import { createLivechatRoom, createLivechatInquiry, allowAgentSkipQueue } from './Helper';
 import { Livechat } from './LivechatTyped';
@@ -216,16 +217,16 @@ export const QueueManager = class {
 		 *
 		 */
 
-		if (agent && !defaultAgent) {
-			throw new Meteor.Error('no-agent-online', 'Sorry, no online agents');
-		}
+		if (!settings.get('Livechat_accept_chats_with_no_agents')) {
+			if (agent && !defaultAgent) {
+				throw new Meteor.Error('no-agent-online', 'Sorry, no online agents');
+			}
 
-		if (guest.department && !department) {
-			throw new Meteor.Error('no-agent-online', 'Sorry, no online agents');
-		}
+			if (guest.department && !department) {
+				throw new Meteor.Error('no-agent-online', 'Sorry, no online agents');
+			}
 
-		if (!agent && !guest.department) {
-			if (!(await Livechat.checkOnlineAgents())) {
+			if (!agent && !guest.department && !(await Livechat.checkOnlineAgents())) {
 				throw new Meteor.Error('no-agent-online', 'Sorry, no online agents');
 			}
 		}

--- a/apps/meteor/app/livechat/server/lib/QueueManager.ts
+++ b/apps/meteor/app/livechat/server/lib/QueueManager.ts
@@ -132,8 +132,6 @@ export class QueueManager {
 	}
 
 	static async queueInquiry(inquiry: ILivechatInquiryRecord, room: IOmnichannelRoom, defaultAgent?: SelectedAgent | null) {
-		await callbacks.run('livechat.new-beforeRouteChat', inquiry);
-
 		if (inquiry.status === 'ready') {
 			return RoutingManager.delegateInquiry(inquiry, defaultAgent, undefined, room);
 		}

--- a/apps/meteor/app/livechat/server/lib/QueueManager.ts
+++ b/apps/meteor/app/livechat/server/lib/QueueManager.ts
@@ -256,9 +256,13 @@ export const QueueManager = class {
 			void notifyOnSettingChanged(livechatSetting);
 		}
 
-		const newRoom = await this.queueInquiry(inquiry, defaultAgent);
+		const newRoom = (await this.queueInquiry(inquiry, defaultAgent)) ?? (await LivechatRooms.findOneById(rid));
+		if (!newRoom) {
+			logger.error(`Room with id ${rid} not found`);
+			throw new Error('room-not-found');
+		}
 
-		return newRoom ?? room;
+		return newRoom;
 	}
 
 	static async unarchiveRoom(archivedRoom: IOmnichannelRoom) {

--- a/apps/meteor/app/livechat/server/lib/QueueManager.ts
+++ b/apps/meteor/app/livechat/server/lib/QueueManager.ts
@@ -178,6 +178,24 @@ export const QueueManager = class {
 
 		const department = guest.department && (await getDepartment(guest.department));
 
+		/**
+		 * we have 4 cases here
+		 * 1. agent and no department
+		 * 2. no agent and no department
+		 * 3. no agent and department
+		 * 4. agent and department informed
+		 *
+		 * in case 1, we check if the agent is online
+		 * in case 2, we check if there is at least one online agent in the whole service
+		 * in case 3, we check if there is at least one online agent in the department
+		 *
+		 * the case 4 is weird, but we are not throwing an error, just because the application works in some mysterious way
+		 * we don't have explicitly defined what to do in this case so we just kept the old behavior
+		 * it seems that agent has priority over department
+		 * but some cases department is handled before agent
+		 *
+		 */
+
 		if (agent && !defaultAgent) {
 			throw new Meteor.Error('no-agent-online', 'Sorry, no online agents');
 		}
@@ -187,8 +205,7 @@ export const QueueManager = class {
 		}
 
 		if (!agent && !guest.department) {
-			const serviceStatus = await Livechat.checkOnlineAgents();
-			if (!serviceStatus) {
+			if (!(await Livechat.checkOnlineAgents())) {
 				throw new Meteor.Error('no-agent-online', 'Sorry, no online agents');
 			}
 		}

--- a/apps/meteor/app/livechat/server/lib/QueueManager.ts
+++ b/apps/meteor/app/livechat/server/lib/QueueManager.ts
@@ -176,10 +176,21 @@ export const QueueManager = class {
 				department: guest.department,
 			})) || undefined;
 
-		const serviceStatus = defaultAgent || (guest.department && (await getDepartment(guest.department)));
+		const department = guest.department && (await getDepartment(guest.department));
 
-		if (!serviceStatus) {
+		if (agent && !defaultAgent) {
 			throw new Meteor.Error('no-agent-online', 'Sorry, no online agents');
+		}
+
+		if (guest.department && !department) {
+			throw new Meteor.Error('no-agent-online', 'Sorry, no online agents');
+		}
+
+		if (!agent && !guest.department) {
+			const serviceStatus = await Livechat.checkOnlineAgents();
+			if (!serviceStatus) {
+				throw new Meteor.Error('no-agent-online', 'Sorry, no online agents');
+			}
 		}
 
 		const name = (roomInfo?.fname as string) || guest.name || guest.username;

--- a/apps/meteor/ee/app/livechat-enterprise/server/hooks/beforeRoutingChat.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/hooks/beforeRoutingChat.ts
@@ -20,7 +20,7 @@ QueueManager.patchInquiryStatus(async ({ room, agent }) => {
 		return LivechatInquiryStatus.READY;
 	}
 
-	if (agent && (await allowAgentSkipQueue(agent))) {
+	if (!agent || !(await allowAgentSkipQueue(agent))) {
 		return LivechatInquiryStatus.READY;
 	}
 

--- a/apps/meteor/ee/app/livechat-enterprise/server/hooks/beforeRoutingChat.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/hooks/beforeRoutingChat.ts
@@ -1,31 +1,14 @@
-import { Omnichannel } from '@rocket.chat/core-services';
-import { LivechatInquiryStatus, type ILivechatDepartment } from '@rocket.chat/core-typings';
+import { type ILivechatDepartment } from '@rocket.chat/core-typings';
 import { LivechatDepartment, LivechatInquiry, LivechatRooms } from '@rocket.chat/models';
 
 import { notifyOnLivechatInquiryChanged } from '../../../../../app/lib/server/lib/notifyListener';
 import { online } from '../../../../../app/livechat/server/api/lib/livechat';
 import { allowAgentSkipQueue } from '../../../../../app/livechat/server/lib/Helper';
 import { Livechat } from '../../../../../app/livechat/server/lib/LivechatTyped';
-import { QueueManager, saveQueueInquiry } from '../../../../../app/livechat/server/lib/QueueManager';
+import { saveQueueInquiry } from '../../../../../app/livechat/server/lib/QueueManager';
 import { settings } from '../../../../../app/settings/server';
 import { callbacks } from '../../../../../lib/callbacks';
 import { cbLogger } from '../lib/logger';
-
-QueueManager.patchInquiryStatus(async ({ room, agent }) => {
-	if (!(await Omnichannel.isWithinMACLimit(room))) {
-		return LivechatInquiryStatus.QUEUED;
-	}
-
-	if (!settings.get('Livechat_waiting_queue')) {
-		return LivechatInquiryStatus.READY;
-	}
-
-	if (!agent || !(await allowAgentSkipQueue(agent))) {
-		return LivechatInquiryStatus.QUEUED;
-	}
-
-	return LivechatInquiryStatus.READY;
-});
 
 callbacks.add(
 	'livechat.beforeRouteChat',

--- a/apps/meteor/ee/app/livechat-enterprise/server/hooks/beforeRoutingChat.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/hooks/beforeRoutingChat.ts
@@ -21,10 +21,10 @@ QueueManager.patchInquiryStatus(async ({ room, agent }) => {
 	}
 
 	if (!agent || !(await allowAgentSkipQueue(agent))) {
-		return LivechatInquiryStatus.READY;
+		return LivechatInquiryStatus.QUEUED;
 	}
 
-	return LivechatInquiryStatus.QUEUED;
+	return LivechatInquiryStatus.READY;
 });
 
 callbacks.add(

--- a/apps/meteor/lib/callbacks.ts
+++ b/apps/meteor/lib/callbacks.ts
@@ -115,6 +115,7 @@ type ChainedCallbackSignatures = {
 	) => Promise<T>;
 
 	'livechat.beforeRouteChat': (inquiry: ILivechatInquiryRecord, agent?: { agentId: string; username: string }) => ILivechatInquiryRecord;
+	'livechat.new-beforeRouteChat': (inquiry: ILivechatInquiryRecord) => ILivechatInquiryRecord;
 	'livechat.checkDefaultAgentOnNewRoom': (agent: SelectedAgent, visitor?: ILivechatVisitor) => SelectedAgent | null;
 
 	'livechat.onLoadForwardDepartmentRestrictions': (params: { departmentId: string }) => Record<string, unknown>;
@@ -235,7 +236,6 @@ export type Hook =
 	| 'beforeRemoveFromRoom'
 	| 'beforeValidateLogin'
 	| 'livechat.beforeForwardRoomToDepartment'
-	| 'livechat.beforeRouteChat'
 	| 'livechat.chatQueued'
 	| 'livechat.checkAgentBeforeTakeInquiry'
 	| 'livechat.sendTranscript'

--- a/apps/meteor/lib/callbacks.ts
+++ b/apps/meteor/lib/callbacks.ts
@@ -115,7 +115,6 @@ type ChainedCallbackSignatures = {
 	) => Promise<T>;
 
 	'livechat.beforeRouteChat': (inquiry: ILivechatInquiryRecord, agent?: { agentId: string; username: string }) => ILivechatInquiryRecord;
-	'livechat.new-beforeRouteChat': (inquiry: ILivechatInquiryRecord) => ILivechatInquiryRecord;
 	'livechat.checkDefaultAgentOnNewRoom': (agent: SelectedAgent, visitor?: ILivechatVisitor) => SelectedAgent | null;
 
 	'livechat.onLoadForwardDepartmentRestrictions': (params: { departmentId: string }) => Record<string, unknown>;

--- a/apps/meteor/tests/end-to-end/api/livechat/05-inquiries.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/05-inquiries.ts
@@ -124,7 +124,6 @@ describe('LIVECHAT - inquiries', () => {
 					expect(res.body.inquiry).to.have.property('estimatedWaitingTimeQueue');
 					expect(res.body.inquiry.source).to.have.property('type', 'api');
 					expect(res.body.inquiry).to.have.property('_updatedAt');
-					expect(res.body.inquiry).to.have.property('queuedAt');
 					expect(res.body.inquiry).to.have.property('v').and.be.an('object');
 					expect(res.body.inquiry.v).to.have.property('_id', visitor._id);
 				});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

Changing the order in which things happen can help avoid testing the same things multiple times.

Previously, we would test if the system had an agent online, then find who was online, and then assign once again. These actions end up being repetitive, making the system difficult to understand and consuming CPU.


We also avoid calling the same collection multiple times to update different fields on the same document, thus optimizing messages sent to the database.



Database operations( find/update) `GET http://localhost:3000/api/v1/livechat/room?token=${visitor.token}`
88 versus 76



With that, the order of events has changed a bit, but I believe it's not something problematic.

old:

```
 run livechat.applyRoomRestrictions 
 run livechat.onCheckRoomApiParams 
 run livechat.checkDefaultAgentOnNewRoom 
 run livechat.beforeRoom 
 run livechat.newRoom 
 run afterSaveMessage 
 run beforeGetMentions 
 run beforeGetMentions 
 run beforeSendMessageNotifications 
 run livechat.beforeInquiry 
 run livechat.beforeDelegateAgent 
 run livechat.chatQueued 
 run livechat.afterInquiryQueued 
 run renderNotification 
 run livechat.beforeRouteChat
```

new 
```

 run livechat.applyRoomRestrictions
 run livechat.onCheckRoomApiParams
 run livechat.checkDefaultAgentOnNewRoom
 run livechat.beforeDelegateAgent
 run livechat.beforeRoom
 run livechat.newRoom
 run afterSaveMessage
 run beforeGetMentions
 run beforeGetMentions
 run beforeSendMessageNotifications
 run livechat.beforeInquiry
 run livechat.afterInquiryQueued
 run livechat.chatQueued
 run renderNotification
```

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

```bash

          /\      |‾‾| /‾‾/   /‾‾/
     /\  /  \     |  |/  /   /  /
    /  \/    \    |     (   /   ‾‾\
   /          \   |  |\  \ |  (‾)  |
  / __________ \  |__| \__\ \_____/ .io

     execution: local
        script: create-room-omnichannel.js
        output: Prometheus remote write (http://localhost:9090/api/v1/write)

     scenarios: (100.00%) 1 scenario, 1 max VUs, 1m0s max duration (incl. graceful stop):
              * default: 1 looping VUs for 30s (gracefulStop: 30s)


     █ setup

     data_received..................: 2.1 MB 70 kB/s
     data_sent......................: 243 kB 8.1 kB/s
     http_req_blocked...............: avg=7.13µs  min=1µs    med=2µs     max=5.51ms   p(90)=3µs     p(95)=3µs
     http_req_connecting............: avg=2.68µs  min=0s     med=0s      max=3.22ms   p(90)=0s      p(95)=0s
     http_req_duration..............: avg=24.9ms  min=4.76ms med=31.63ms max=100.54ms p(90)=46.93ms p(95)=49.92ms
       { expected_response:true }...: avg=24.9ms  min=4.76ms med=31.63ms max=100.54ms p(90)=46.93ms p(95)=49.92ms
     http_req_failed................: 0.00%  ✓ 0         ✗ 1200
     http_req_receiving.............: avg=52.31µs min=27µs   med=47µs    max=736µs    p(90)=68µs    p(95)=76µs
     http_req_sending...............: avg=12.8µs  min=7µs    med=12µs    max=86µs     p(90)=16µs    p(95)=19µs
     http_req_tls_handshaking.......: avg=0s      min=0s     med=0s      max=0s       p(90)=0s      p(95)=0s
     http_req_waiting...............: avg=24.83ms min=4.72ms med=31.56ms max=100.48ms p(90)=46.83ms p(95)=49.87ms
     http_reqs......................: 1200   39.979253/s
     iteration_duration.............: avg=49.92ms min=875ns  med=48.9ms  max=107.63ms p(90)=57.58ms p(95)=63.55ms
     iterations.....................: 600    19.989627/s
     vus............................: 1      min=1       max=1
     vus_max........................: 1      min=1       max=1


running (0m30.0s), 0/1 VUs, 600 complete and 0 interrupted iterations
default ✓ [======================================] 1 VUs  30s
```

after: 
```bash

          /\      |‾‾| /‾‾/   /‾‾/
     /\  /  \     |  |/  /   /  /
    /  \/    \    |     (   /   ‾‾\
   /          \   |  |\  \ |  (‾)  |
  / __________ \  |__| \__\ \_____/ .io

     execution: local
        script: create-room-omnichannel.js
        output: Prometheus remote write (http://localhost:9090/api/v1/write)

     scenarios: (100.00%) 1 scenario, 1 max VUs, 1m0s max duration (incl. graceful stop):
              * default: 1 looping VUs for 30s (gracefulStop: 30s)


     █ setup

     data_received..................: 3.2 MB 106 kB/s
     data_sent......................: 365 kB 12 kB/s
     http_req_blocked...............: avg=5µs     min=1µs    med=2µs     max=5.56ms   p(90)=2µs     p(95)=3µs
     http_req_connecting............: avg=2.55µs  min=0s     med=0s      max=4.6ms    p(90)=0s      p(95)=0s
     http_req_duration..............: avg=16.55ms min=4.1ms  med=19.01ms max=109.15ms p(90)=29.89ms p(95)=32.56ms
       { expected_response:true }...: avg=16.55ms min=4.1ms  med=19.01ms max=109.15ms p(90)=29.89ms p(95)=32.56ms
     http_req_failed................: 0.00%  ✓ 0         ✗ 1804
     http_req_receiving.............: avg=46.38µs min=23µs   med=44µs    max=156µs    p(90)=60µs    p(95)=66.84µs
     http_req_sending...............: avg=11.78µs min=5µs    med=11µs    max=302µs    p(90)=15µs    p(95)=16.84µs
     http_req_tls_handshaking.......: avg=0s      min=0s     med=0s      max=0s       p(90)=0s      p(95)=0s
     http_req_waiting...............: avg=16.49ms min=4.05ms med=18.94ms max=109.08ms p(90)=29.84ms p(95)=32.49ms
     http_reqs......................: 1804   60.071478/s
     iteration_duration.............: avg=33.24ms min=584ns  med=31.89ms max=123.58ms p(90)=39.34ms p(95)=43.2ms
     iterations.....................: 902    30.035739/s
     vus............................: 1      min=1       max=1
     vus_max........................: 1      min=1       max=1


running (0m30.0s), 0/1 VUs, 902 complete and 0 interrupted iterations
default ✓ [======================================] 1 VUs  30s
```
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
https://rocketchat.atlassian.net/browse/CORE-440