### PR TITLE
refactor: InstanceStatus out of DB Watcher

### DIFF
--- a/apps/meteor/app/lib/server/lib/notifyListener.ts
+++ b/apps/meteor/app/lib/server/lib/notifyListener.ts
@@ -1,6 +1,6 @@
 import { api, dbWatchersDisabled } from '@rocket.chat/core-services';
-import type { IPermission, IRocketChatRecord, IRoom, ISetting, IPbxEvent, IRole } from '@rocket.chat/core-typings';
-import { Rooms, Permissions, Settings, PbxEvents, Roles } from '@rocket.chat/models';
+import type { IPermission, IRocketChatRecord, IRoom, ISetting, IPbxEvent, IRole, IInstanceStatus } from '@rocket.chat/core-typings';
+import { Rooms, Permissions, Settings, PbxEvents, Roles, InstanceStatus } from '@rocket.chat/models';
 
 type ClientAction = 'inserted' | 'updated' | 'removed';
 
@@ -63,6 +63,23 @@ export async function notifyOnRoomChangedByUserDM<T extends IRoom>(
 
 	for await (const item of items) {
 		void api.broadcast('watch.rooms', { clientAction, room: item });
+	}
+}
+
+export async function notifyOnInstanceStatusChangedById<T extends IInstanceStatus>(
+	id: T['_id'],
+	clientAction: 'inserted' | 'updated' | 'removed',
+	data?: Record<string, unknown>,
+	diff?: Record<string, unknown>,
+) {
+	if (!dbWatchersDisabled) {
+		return;
+	}
+
+	const instanceStatus = await InstanceStatus.findOneById(id);
+
+	if (instanceStatus) {
+		void api.broadcast('watch.instanceStatus', { id, clientAction, data, diff });
 	}
 }
 

--- a/apps/meteor/app/lib/server/lib/notifyListener.ts
+++ b/apps/meteor/app/lib/server/lib/notifyListener.ts
@@ -69,7 +69,6 @@ export async function notifyOnRoomChangedByUserDM<T extends IRoom>(
 export async function notifyOnInstanceStatusChangedById<T extends IInstanceStatus>(
 	id: T['_id'],
 	clientAction: 'inserted' | 'updated' | 'removed',
-	data?: Record<string, unknown>,
 	diff?: Record<string, unknown>,
 ) {
 	if (!dbWatchersDisabled) {
@@ -77,10 +76,11 @@ export async function notifyOnInstanceStatusChangedById<T extends IInstanceStatu
 	}
 
 	const instanceStatus = await InstanceStatus.findOneById(id);
-
-	if (instanceStatus) {
-		void api.broadcast('watch.instanceStatus', { id, clientAction, data, diff });
+	if (!instanceStatus) {
+		return;
 	}
+
+	void api.broadcast('watch.instanceStatus', { id, clientAction, data: instanceStatus, diff });
 }
 
 export async function notifyOnSettingChanged(setting: ISetting, clientAction: ClientAction = 'updated'): Promise<void> {

--- a/apps/meteor/ee/server/local-services/instance/service.ts
+++ b/apps/meteor/ee/server/local-services/instance/service.ts
@@ -7,6 +7,7 @@ import EJSON from 'ejson';
 import type { BrokerNode } from 'moleculer';
 import { ServiceBroker, Transporters, Serializers } from 'moleculer';
 
+import { notifyOnInstanceStatusChangedById } from '../../../../app/lib/server/lib/notifyListener';
 import { StreamerCentral } from '../../../../server/modules/streamer/streamer.module';
 import type { IInstanceService } from '../../sdk/types/IInstanceService';
 import { getLogger } from './getLogger';
@@ -155,6 +156,10 @@ export class InstanceService extends ServiceClassInternal implements IInstanceSe
 		};
 
 		await InstanceStatus.registerInstance('rocket.chat', instance);
+		void notifyOnInstanceStatusChangedById(InstanceStatus.id(), 'inserted');
+		process.on('exit', async () => {
+			void notifyOnInstanceStatusChangedById(InstanceStatus.id(), 'removed');
+		});
 
 		try {
 			const hasLicense = await License.hasModule('scalability');

--- a/apps/meteor/ee/server/local-services/instance/service.ts
+++ b/apps/meteor/ee/server/local-services/instance/service.ts
@@ -156,7 +156,7 @@ export class InstanceService extends ServiceClassInternal implements IInstanceSe
 		};
 
 		await InstanceStatus.registerInstance('rocket.chat', instance);
-		void notifyOnInstanceStatusChangedById(InstanceStatus.id(), 'inserted');
+
 		process.on('exit', async () => {
 			void notifyOnInstanceStatusChangedById(InstanceStatus.id(), 'removed');
 		});

--- a/apps/meteor/server/database/DatabaseWatcher.ts
+++ b/apps/meteor/server/database/DatabaseWatcher.ts
@@ -1,5 +1,6 @@
 import EventEmitter from 'events';
 
+import { dbWatchersDisabled } from '@rocket.chat/core-services';
 import type { IRocketChatRecord } from '@rocket.chat/core-typings';
 import type { Logger } from '@rocket.chat/logger';
 import { escapeRegExp } from '@rocket.chat/string-helpers';
@@ -241,6 +242,9 @@ export class DatabaseWatcher extends EventEmitter {
 	 * @returns Indicates if the last document received is older than it should be. If that happens, it means that the oplog is not working properly
 	 */
 	isLastDocDelayed(): boolean {
+		if (dbWatchersDisabled) {
+			return false;
+		}
 		return this.getLastDocDelta() > maxDocMs;
 	}
 }

--- a/apps/meteor/server/database/watchCollections.ts
+++ b/apps/meteor/server/database/watchCollections.ts
@@ -34,7 +34,6 @@ export function getWatchCollections(): string[] {
 		LivechatInquiry.getCollectionName(),
 		LivechatDepartmentAgents.getCollectionName(),
 		LoginServiceConfiguration.getCollectionName(),
-		InstanceStatus.getCollectionName(),
 		IntegrationHistory.getCollectionName(),
 		Integrations.getCollectionName(),
 		EmailInbox.getCollectionName(),
@@ -48,6 +47,7 @@ export function getWatchCollections(): string[] {
 		collections.push(Messages.getCollectionName());
 		collections.push(Roles.getCollectionName());
 		collections.push(Rooms.getCollectionName());
+		collections.push(InstanceStatus.getCollectionName());
 		collections.push(PbxEvents.getCollectionName());
 		collections.push(Permissions.getCollectionName());
 	}

--- a/ee/apps/ddp-streamer/src/DDPStreamer.ts
+++ b/ee/apps/ddp-streamer/src/DDPStreamer.ts
@@ -6,10 +6,10 @@ import polka from 'polka';
 import { throttle } from 'underscore';
 import WebSocket from 'ws';
 
+import { notifyOnInstanceStatusChangedById } from '../../../../apps/meteor/app/lib/server/lib/notifyListener';
 import { ListenersModule } from '../../../../apps/meteor/server/modules/listeners/listeners.module';
 import type { NotificationsModule } from '../../../../apps/meteor/server/modules/notifications/notifications.module';
 import { StreamerCentral } from '../../../../apps/meteor/server/modules/streamer/streamer.module';
-import { notifyOnInstanceStatusChangedById } from '../../../../apps/meteor/app/lib/server/lib/notifyListener';
 import { Client, clientMap } from './Client';
 import { events, server } from './configureServer';
 import { DDP_EVENTS } from './constants';

--- a/packages/instance-status/src/index.ts
+++ b/packages/instance-status/src/index.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from 'events';
 
 import { InstanceStatus as InstanceStatusModel } from '@rocket.chat/models';
-import { v4 as uuidv4 } from 'uuid';
 import type { UpdateResult } from 'mongodb';
+import { v4 as uuidv4 } from 'uuid';
 
 const events = new EventEmitter();
 


### PR DESCRIPTION
As per the updates mentioned in [PROJ-7](https://rocketchat.atlassian.net/browse/PROJ-7) [SCA-9] and [ADR #74](https://adr.rocket.chat/0074), **this pull request focuses on relocating InstanceStatus entity out of DB Watcher service.**

### Quick context to public readers

In essence, this modification empowers RocketChat's app to directly call listeners through the `api.broadcast` global function, eliminating the reliance on MongoDB Change Stream data propagation

Why is this beneficial? It provides better control over notifying users by enabling more precise use-case management. Unlike Change Streams, which notify every action on Mongo's documents and sometimes might result in unnecessary duplicate notifications. Moreover, it contributes to the future removal of the DB Watcher deployment, thereby optimizing resource utilization.

## Proposed changes

Key changes include:

- Conditionally incorporating InstanceStatus entity import within DB watchers on application startup based on the `dbWatchersDisabled` flag.
- Enabling support for the following use cases to directly trigger `watch.instanceStatus` listener event, subject to the `dbWatchersDisabled` flag.

Changes were made within the instance-status package to cater to its use case, thereby avoiding the addition of a new package containing broadcast helpers (located at app/lib/server/lib/notifyListener.ts) - similar to the approach taken with other entities recently moved out of the database watcher.

<details>
<summary>Updated use cases.</summary>

| Use Case | Route/Trigger | Notes |
|--|--|--|
| registerService | When setting up a new service | |
| unregisterService | When a specific service shuts down | |
| updateConnections | Triggered every 30 seconds or upon receiving an event | Updates the number of connections |

</details>

## Steps to test or reproduce

1. Start RocketChat's application with the `DISABLE_DB_WATCHERS` flag set to true.
2. Initiate RocketChat Community Edition or perform new services setup on Enterprise Edition to witness the registration of one service.

## Further comments

To maintain consistency and avoid potential regressions, event names and signatures have been kept unchanged on both the client and app sides. This decision streamlines efforts and mitigates the risk of unintended consequences.

[PROJ-7]: https://rocketchat.atlassian.net/browse/PROJ-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SCA-9]: https://rocketchat.atlassian.net/browse/SCA-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ