### PR TITLE
refactor: Integration entity out of db watcher

### DIFF
--- a/apps/meteor/app/channel-settings/server/functions/saveRoomName.ts
+++ b/apps/meteor/app/channel-settings/server/functions/saveRoomName.ts
@@ -8,6 +8,7 @@ import type { Document, UpdateResult } from 'mongodb';
 import { callbacks } from '../../../../lib/callbacks';
 import { roomCoordinator } from '../../../../server/lib/rooms/roomCoordinator';
 import { checkUsernameAvailability } from '../../../lib/server/functions/checkUsernameAvailability';
+import { notifyOnIntegrationChangedByChannels } from '../../../lib/server/lib/notifyListener';
 import { getValidRoomName } from '../../../utils/server/lib/getValidRoomName';
 
 const updateFName = async (rid: string, displayName: string): Promise<(UpdateResult | Document)[]> => {
@@ -73,6 +74,7 @@ export async function saveRoomName(
 
 	if (room.name && !isDiscussion) {
 		await Integrations.updateRoomName(room.name, slugifiedRoomName);
+		void notifyOnIntegrationChangedByChannels([room.name, slugifiedRoomName]);
 	}
 	if (sendMessage) {
 		await Message.saveSystemMessage('r', rid, displayName, user);

--- a/apps/meteor/app/channel-settings/server/functions/saveRoomName.ts
+++ b/apps/meteor/app/channel-settings/server/functions/saveRoomName.ts
@@ -74,11 +74,13 @@ export async function saveRoomName(
 
 	if (room.name && !isDiscussion) {
 		await Integrations.updateRoomName(room.name, slugifiedRoomName);
-		void notifyOnIntegrationChangedByChannels([room.name, slugifiedRoomName]);
+		void notifyOnIntegrationChangedByChannels([slugifiedRoomName]);
 	}
+
 	if (sendMessage) {
 		await Message.saveSystemMessage('r', rid, displayName, user);
 	}
+
 	await callbacks.run('afterRoomNameChange', { rid, name: displayName, oldName: room.name });
 	return displayName;
 }

--- a/apps/meteor/app/integrations/server/lib/triggerHandler.js
+++ b/apps/meteor/app/integrations/server/lib/triggerHandler.js
@@ -6,6 +6,7 @@ import _ from 'underscore';
 
 import { getRoomByNameOrIdWithOptionToJoin } from '../../../lib/server/functions/getRoomByNameOrIdWithOptionToJoin';
 import { processWebhookMessage } from '../../../lib/server/functions/processWebhookMessage';
+import { notifyOnIntegrationChangedById } from '../../../lib/server/lib/notifyListener';
 import { settings } from '../../../settings/server';
 import { outgoingEvents } from '../../lib/outgoingEvents';
 import { outgoingLogger } from '../logger';
@@ -579,6 +580,7 @@ class RocketChatIntegrationHandler {
 							await updateHistory({ historyId, step: 'after-process-http-status-410', error: true });
 							outgoingLogger.error(`Disabling the Integration "${trigger.name}" because the status code was 401 (Gone).`);
 							await Integrations.updateOne({ _id: trigger._id }, { $set: { enabled: false } });
+							void notifyOnIntegrationChangedById(trigger._id);
 							return;
 						}
 

--- a/apps/meteor/app/integrations/server/methods/incoming/deleteIncomingIntegration.ts
+++ b/apps/meteor/app/integrations/server/methods/incoming/deleteIncomingIntegration.ts
@@ -3,6 +3,7 @@ import type { ServerMethods } from '@rocket.chat/ui-contexts';
 import { Meteor } from 'meteor/meteor';
 
 import { hasPermissionAsync } from '../../../../authorization/server/functions/hasPermission';
+import { notifyOnIntegrationChangedById } from '../../../../lib/server/lib/notifyListener';
 
 declare module '@rocket.chat/ui-contexts' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -34,6 +35,7 @@ export const deleteIncomingIntegration = async (integrationId: string, userId: s
 	}
 
 	await Integrations.removeById(integrationId);
+	void notifyOnIntegrationChangedById(integrationId, 'removed');
 };
 
 Meteor.methods<ServerMethods>({

--- a/apps/meteor/app/integrations/server/methods/outgoing/deleteOutgoingIntegration.ts
+++ b/apps/meteor/app/integrations/server/methods/outgoing/deleteOutgoingIntegration.ts
@@ -3,6 +3,7 @@ import type { ServerMethods } from '@rocket.chat/ui-contexts';
 import { Meteor } from 'meteor/meteor';
 
 import { hasPermissionAsync } from '../../../../authorization/server/functions/hasPermission';
+import { notifyOnIntegrationChangedById } from '../../../../lib/server/lib/notifyListener';
 
 declare module '@rocket.chat/ui-contexts' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -41,6 +42,7 @@ export const deleteOutgoingIntegration = async (integrationId: string, userId: s
 
 	await Integrations.removeById(integrationId);
 	await IntegrationHistory.removeByIntegrationId(integrationId);
+	void notifyOnIntegrationChangedById(integrationId, 'removed');
 };
 
 Meteor.methods<ServerMethods>({

--- a/apps/meteor/app/integrations/server/methods/outgoing/updateOutgoingIntegration.ts
+++ b/apps/meteor/app/integrations/server/methods/outgoing/updateOutgoingIntegration.ts
@@ -5,6 +5,7 @@ import type { ServerMethods } from '@rocket.chat/ui-contexts';
 import { Meteor } from 'meteor/meteor';
 
 import { hasPermissionAsync } from '../../../../authorization/server/functions/hasPermission';
+import { notifyOnIntegrationChanged } from '../../../../lib/server/lib/notifyListener';
 import { validateOutgoingIntegration } from '../../lib/validateOutgoingIntegration';
 import { isScriptEngineFrozen, validateScriptEngine } from '../../lib/validateScriptEngine';
 
@@ -66,7 +67,7 @@ Meteor.methods<ServerMethods>({
 
 		const isFrozen = isScriptEngineFrozen(scriptEngine);
 
-		await Integrations.updateOne(
+		const updatedIntegration = await Integrations.findOneAndUpdate(
 			{ _id: integrationId },
 			{
 				$set: {
@@ -110,6 +111,10 @@ Meteor.methods<ServerMethods>({
 			},
 		);
 
-		return Integrations.findOneById(integrationId);
+		if (updatedIntegration.value) {
+			await notifyOnIntegrationChanged(updatedIntegration.value);
+		}
+
+		return updatedIntegration.value;
 	},
 });

--- a/apps/meteor/app/lib/server/functions/deleteUser.ts
+++ b/apps/meteor/app/lib/server/functions/deleteUser.ts
@@ -19,7 +19,7 @@ import { callbacks } from '../../../../lib/callbacks';
 import { i18n } from '../../../../server/lib/i18n';
 import { FileUpload } from '../../../file-upload/server';
 import { settings } from '../../../settings/server';
-import { notifyOnRoomChangedById } from '../lib/notifyListener';
+import { notifyOnRoomChangedById, notifyOnIntegrationChangedByUserId } from '../lib/notifyListener';
 import { getSubscribedRoomsForUserWithDetails, shouldRemoveOrChangeOwner } from './getRoomsWithSingleOwner';
 import { getUserSingleOwnedRooms } from './getUserSingleOwnedRooms';
 import { relinquishRoomOwnerships } from './relinquishRoomOwnerships';
@@ -114,7 +114,9 @@ export async function deleteUser(userId: string, confirmRelinquish = false, dele
 			await FileUpload.getStore('Avatars').deleteByName(user.username);
 		}
 
-		await Integrations.disableByUserId(userId); // Disables all the integrations which rely on the user being deleted.
+		// Disables all the integrations which rely on the user being deleted.
+		await Integrations.disableByUserId(userId);
+		void notifyOnIntegrationChangedByUserId(userId);
 
 		// Don't broadcast user.deleted for Erasure Type of 'Keep' so that messages don't disappear from logged in sessions
 		if (messageErasureType === 'Delete') {

--- a/apps/meteor/app/lib/server/lib/notifyListener.ts
+++ b/apps/meteor/app/lib/server/lib/notifyListener.ts
@@ -1,6 +1,6 @@
 import { api, dbWatchersDisabled } from '@rocket.chat/core-services';
-import type { IPermission, IRocketChatRecord, IRoom, ISetting, IPbxEvent, IRole } from '@rocket.chat/core-typings';
-import { Rooms, Permissions, Settings, PbxEvents, Roles } from '@rocket.chat/models';
+import type { IPermission, IRocketChatRecord, IRoom, ISetting, IPbxEvent, IRole, IIntegration } from '@rocket.chat/core-typings';
+import { Rooms, Permissions, Settings, PbxEvents, Roles, Integrations } from '@rocket.chat/models';
 
 type ClientAction = 'inserted' | 'updated' | 'removed';
 
@@ -140,4 +140,54 @@ export async function notifyOnRoleChangedById<T extends IRole>(
 	}
 
 	void notifyOnRoleChanged(role, clientAction);
+}
+
+export async function notifyOnIntegrationChanged<T extends IIntegration>(data: T, clientAction: ClientAction = 'updated'): Promise<void> {
+	if (!dbWatchersDisabled) {
+		return;
+	}
+
+	void api.broadcast('watch.integrations', { clientAction, id: data._id, data });
+}
+
+export async function notifyOnIntegrationChangedById<T extends IIntegration>(
+	id: T['_id'],
+	clientAction: ClientAction = 'updated',
+): Promise<void> {
+	if (!dbWatchersDisabled) {
+		return;
+	}
+
+	const item = await Integrations.findOneById(id);
+
+	if (item) {
+		void api.broadcast('watch.integrations', { clientAction, id: item._id, data: item });
+	}
+}
+
+export async function notifyOnIntegrationChangedByUserId<T extends IIntegration>(
+	id: T['userId'],
+	clientAction: ClientAction = 'updated',
+): Promise<void> {
+	if (!dbWatchersDisabled) {
+		return;
+	}
+
+	const items = Integrations.findByUserId(id);
+
+	for await (const item of items) {
+		void api.broadcast('watch.integrations', { clientAction, id: item._id, data: item });
+	}
+}
+
+export async function notifyOnIntegrationChangedByChannels(channels: string[], clientAction: ClientAction = 'updated'): Promise<void> {
+	if (!dbWatchersDisabled) {
+		return;
+	}
+
+	const items = Integrations.findByChannels(channels);
+
+	for await (const item of items) {
+		void api.broadcast('watch.integrations', { clientAction, id: item._id, data: item });
+	}
 }

--- a/apps/meteor/app/lib/server/lib/notifyListener.ts
+++ b/apps/meteor/app/lib/server/lib/notifyListener.ts
@@ -180,7 +180,10 @@ export async function notifyOnIntegrationChangedByUserId<T extends IIntegration>
 	}
 }
 
-export async function notifyOnIntegrationChangedByChannels(channels: string[], clientAction: ClientAction = 'updated'): Promise<void> {
+export async function notifyOnIntegrationChangedByChannels<T extends IIntegration>(
+	channels: T['channel'],
+	clientAction: ClientAction = 'updated',
+): Promise<void> {
 	if (!dbWatchersDisabled) {
 		return;
 	}

--- a/apps/meteor/server/database/watchCollections.ts
+++ b/apps/meteor/server/database/watchCollections.ts
@@ -36,7 +36,6 @@ export function getWatchCollections(): string[] {
 		LoginServiceConfiguration.getCollectionName(),
 		InstanceStatus.getCollectionName(),
 		IntegrationHistory.getCollectionName(),
-		Integrations.getCollectionName(),
 		EmailInbox.getCollectionName(),
 		Settings.getCollectionName(),
 		LivechatPriority.getCollectionName(),
@@ -49,6 +48,7 @@ export function getWatchCollections(): string[] {
 		collections.push(Roles.getCollectionName());
 		collections.push(Rooms.getCollectionName());
 		collections.push(PbxEvents.getCollectionName());
+		collections.push(Integrations.getCollectionName());
 		collections.push(Permissions.getCollectionName());
 	}
 

--- a/apps/meteor/server/models/raw/Integrations.ts
+++ b/apps/meteor/server/models/raw/Integrations.ts
@@ -50,7 +50,7 @@ export class IntegrationsRaw extends BaseRaw<IIntegration> implements IIntegrati
 		return this.updateMany({ userId }, { $set: { enabled: false } });
 	}
 
-	findByUserId(userId: IIntegration['userId']): FindCursor<IIntegration> {
+	findByUserId(userId: IIntegration['userId']): FindCursor<Pick<IIntegration, '_id'>> {
 		return this.find({ userId }, { projection: { _id: 1 } });
 	}
 

--- a/apps/meteor/server/models/raw/Integrations.ts
+++ b/apps/meteor/server/models/raw/Integrations.ts
@@ -46,11 +46,11 @@ export class IntegrationsRaw extends BaseRaw<IIntegration> implements IIntegrati
 		});
 	}
 
-	disableByUserId(userId: IIntegration['_id']): ReturnType<IBaseModel<IIntegration>['updateMany']> {
+	disableByUserId(userId: IIntegration['userId']): ReturnType<IBaseModel<IIntegration>['updateMany']> {
 		return this.updateMany({ userId }, { $set: { enabled: false } });
 	}
 
-	findByUserId(userId: IIntegration['_id']): FindCursor<IIntegration> {
+	findByUserId(userId: IIntegration['userId']): FindCursor<IIntegration> {
 		return this.find({ userId }, { projection: { _id: 1 } });
 	}
 

--- a/apps/meteor/server/models/raw/Integrations.ts
+++ b/apps/meteor/server/models/raw/Integrations.ts
@@ -1,6 +1,6 @@
 import type { IIntegration, IUser, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
 import type { IBaseModel, IIntegrationsModel } from '@rocket.chat/model-typings';
-import type { Collection, Db, IndexDescription } from 'mongodb';
+import type { Collection, Db, FindCursor, IndexDescription } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -46,7 +46,15 @@ export class IntegrationsRaw extends BaseRaw<IIntegration> implements IIntegrati
 		});
 	}
 
-	disableByUserId(userId: string): ReturnType<IBaseModel<IIntegration>['updateMany']> {
+	disableByUserId(userId: IIntegration['_id']): ReturnType<IBaseModel<IIntegration>['updateMany']> {
 		return this.updateMany({ userId }, { $set: { enabled: false } });
+	}
+
+	findByUserId(userId: IIntegration['_id']): FindCursor<IIntegration> {
+		return this.find({ userId }, { projection: { _id: 1 } });
+	}
+
+	findByChannels(channels: IIntegration['channel']): FindCursor<IIntegration> {
+		return this.find({ channel: { $in: channels } });
 	}
 }

--- a/packages/model-typings/src/models/IIntegrationsModel.ts
+++ b/packages/model-typings/src/models/IIntegrationsModel.ts
@@ -1,10 +1,13 @@
 import type { IIntegration, IUser } from '@rocket.chat/core-typings';
+import type { FindCursor } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
 
 export interface IIntegrationsModel extends IBaseModel<IIntegration> {
+	disableByUserId(userId: IIntegration['_id']): ReturnType<IBaseModel<IIntegration>['updateMany']>;
+	findByChannels(channels: IIntegration['channel']): FindCursor<IIntegration>;
+	findByUserId(userId: IIntegration['_id']): FindCursor<IIntegration>;
+	findOneByIdAndCreatedByIfExists(params: { _id: IIntegration['_id']; createdBy?: IUser['_id'] }): Promise<IIntegration | null>;
 	findOneByUrl(url: string): Promise<IIntegration | null>;
 	updateRoomName(oldRoomName: string, newRoomName: string): ReturnType<IBaseModel<IIntegration>['updateMany']>;
-	findOneByIdAndCreatedByIfExists(params: { _id: IIntegration['_id']; createdBy?: IUser['_id'] }): Promise<IIntegration | null>;
-	disableByUserId(userId: string): ReturnType<IBaseModel<IIntegration>['updateMany']>;
 }

--- a/packages/model-typings/src/models/IIntegrationsModel.ts
+++ b/packages/model-typings/src/models/IIntegrationsModel.ts
@@ -6,7 +6,7 @@ import type { IBaseModel } from './IBaseModel';
 export interface IIntegrationsModel extends IBaseModel<IIntegration> {
 	disableByUserId(userId: IIntegration['userId']): ReturnType<IBaseModel<IIntegration>['updateMany']>;
 	findByChannels(channels: IIntegration['channel']): FindCursor<IIntegration>;
-	findByUserId(userId: IIntegration['userId']): FindCursor<IIntegration>;
+	findByUserId(userId: IIntegration['userId']): FindCursor<Pick<IIntegration, '_id'>>;
 	findOneByIdAndCreatedByIfExists(params: { _id: IIntegration['_id']; createdBy?: IUser['_id'] }): Promise<IIntegration | null>;
 	findOneByUrl(url: string): Promise<IIntegration | null>;
 	updateRoomName(oldRoomName: string, newRoomName: string): ReturnType<IBaseModel<IIntegration>['updateMany']>;

--- a/packages/model-typings/src/models/IIntegrationsModel.ts
+++ b/packages/model-typings/src/models/IIntegrationsModel.ts
@@ -4,9 +4,9 @@ import type { FindCursor } from 'mongodb';
 import type { IBaseModel } from './IBaseModel';
 
 export interface IIntegrationsModel extends IBaseModel<IIntegration> {
-	disableByUserId(userId: IIntegration['_id']): ReturnType<IBaseModel<IIntegration>['updateMany']>;
+	disableByUserId(userId: IIntegration['userId']): ReturnType<IBaseModel<IIntegration>['updateMany']>;
 	findByChannels(channels: IIntegration['channel']): FindCursor<IIntegration>;
-	findByUserId(userId: IIntegration['_id']): FindCursor<IIntegration>;
+	findByUserId(userId: IIntegration['userId']): FindCursor<IIntegration>;
 	findOneByIdAndCreatedByIfExists(params: { _id: IIntegration['_id']; createdBy?: IUser['_id'] }): Promise<IIntegration | null>;
 	findOneByUrl(url: string): Promise<IIntegration | null>;
 	updateRoomName(oldRoomName: string, newRoomName: string): ReturnType<IBaseModel<IIntegration>['updateMany']>;


### PR DESCRIPTION
As per the updates mentioned in [PROJ-7](https://rocketchat.atlassian.net/browse/PROJ-7) [SCA-4] and [ADR #74](https://adr.rocket.chat/0074), **this pull request focuses on relocating Integration entity out of DB Watcher service.**

### Quick context to public readers

In essence, this modification empowers RocketChat's app to directly call listeners through the `api.broadcast` global function, eliminating the reliance on MongoDB Change Stream data propagation

Why is this beneficial? It provides better control over notifying users by enabling more precise use-case management. Unlike Change Streams, which notify every action on Mongo's documents and sometimes might result in unnecessary duplicate notifications. Moreover, it contributes to the future removal of the DB Watcher deployment, thereby optimizing resource utilization.

## Proposed changes

Key changes include:

- Conditionally incorporating Permissions entity import within DB watchers on application startup based on the `dbWatchersDisabled` flag.
- Enabling support for the following use cases to directly trigger `watch.integrations` listener event, subject to the `dbWatchersDisabled` flag.

<details>
<summary>Updated use cases.</summary>

| Use Case | Route/Trigger | Notes |
|--|--|--|
| deleteUser | Route POST `users.delete` | |
| updateRoomName | Function existing within `saveRoomName` on channel-settings package | |
| deleteOutgoingIntegration <br> deleteIncomingIntegration | Route POST `integrations.remove` | |
| updateOutgoingIntegration <br> updateIncomingIntegration | Route PUT `integrations.update` | |
| addIncomingIntegration | Route POST `integrations.create` | |
| executeTriggerUrl | Function `executeTriggerUrl` on `RocketChatIntegrationHandler` file | |

</details>

## Steps to test or reproduce

1. Start RocketChat's application with the `DISABLE_DB_WATCHERS` flag set to true.
2. Perform a `POST` request to above given endpoints available on updated use cases.

## Further comments

To maintain consistency and avoid potential regressions, event names and signatures have been kept unchanged on both the client and app sides. This decision streamlines efforts and mitigates the risk of unintended consequences.

<details>
<summary>Integration model WBS. Used to guide changes discovery.</summary>

<br>
:arrows_counterclockwise: Work in progress <br>
:white_check_mark: Done <br>
:heavy_minus_sign: Not applicable <br>
<br>

|Function|Status|
|---|---|
| findOneByUrl | :heavy_minus_sign: |
| updateRoomName | :white_check_mark: |
| findOneByIdAndCreatedByIfExists | :heavy_minus_sign: |
| disableByUserId | :white_check_mark: |

</details>


[PROJ-7]: https://rocketchat.atlassian.net/browse/PROJ-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SCA-4]: https://rocketchat.atlassian.net/browse/SCA-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ