### PR TITLE
refactor: IntegrationHistory out of DB Watcher

### DIFF
--- a/apps/meteor/app/integrations/server/methods/clearIntegrationHistory.ts
+++ b/apps/meteor/app/integrations/server/methods/clearIntegrationHistory.ts
@@ -41,6 +41,7 @@ Meteor.methods<ServerMethods>({
 			});
 		}
 
+		// Don't sending to IntegrationHistory listener since it don't waits for 'removed' events.
 		await IntegrationHistory.removeByIntegrationId(integrationId);
 
 		notifications.streamIntegrationHistory.emit(integrationId, { type: 'removed', id: integrationId });

--- a/apps/meteor/app/integrations/server/methods/outgoing/deleteOutgoingIntegration.ts
+++ b/apps/meteor/app/integrations/server/methods/outgoing/deleteOutgoingIntegration.ts
@@ -41,6 +41,7 @@ export const deleteOutgoingIntegration = async (integrationId: string, userId: s
 	}
 
 	await Integrations.removeById(integrationId);
+	// Don't sending to IntegrationHistory listener since it don't waits for 'removed' events.
 	await IntegrationHistory.removeByIntegrationId(integrationId);
 	void notifyOnIntegrationChangedById(integrationId, 'removed');
 };

--- a/apps/meteor/app/lib/server/lib/notifyListener.ts
+++ b/apps/meteor/app/lib/server/lib/notifyListener.ts
@@ -10,8 +10,19 @@ import type {
 	IPbxEvent,
 	LoginServiceConfiguration as LoginServiceConfigurationData,
 	ILivechatPriority,
+	IIntegrationHistory,
+	AtLeast,
 } from '@rocket.chat/core-typings';
-import { Rooms, Permissions, Settings, PbxEvents, Roles, Integrations, LoginServiceConfiguration } from '@rocket.chat/models';
+import {
+	Rooms,
+	Permissions,
+	Settings,
+	PbxEvents,
+	Roles,
+	Integrations,
+	LoginServiceConfiguration,
+	IntegrationHistory,
+} from '@rocket.chat/models';
 
 type ClientAction = 'inserted' | 'updated' | 'removed';
 
@@ -253,4 +264,34 @@ export async function notifyOnIntegrationChangedByChannels<T extends IIntegratio
 	for await (const item of items) {
 		void api.broadcast('watch.integrations', { clientAction, id: item._id, data: item });
 	}
+}
+
+export async function notifyOnIntegrationHistoryChanged<T extends IIntegrationHistory>(
+	data: AtLeast<T, '_id'>,
+	clientAction: ClientAction = 'updated',
+	diff: Partial<T> = {},
+): Promise<void> {
+	if (!dbWatchersDisabled) {
+		return;
+	}
+
+	void api.broadcast('watch.integrationHistory', { clientAction, id: data._id, data, diff });
+}
+
+export async function notifyOnIntegrationHistoryChangedById<T extends IIntegrationHistory>(
+	id: T['_id'],
+	clientAction: ClientAction = 'updated',
+	diff: Partial<T> = {},
+): Promise<void> {
+	if (!dbWatchersDisabled) {
+		return;
+	}
+
+	const item = await IntegrationHistory.findOneById(id);
+
+	if (!item) {
+		return;
+	}
+
+	void api.broadcast('watch.integrationHistory', { clientAction, id: item._id, data: item, diff });
 }

--- a/apps/meteor/server/database/watchCollections.ts
+++ b/apps/meteor/server/database/watchCollections.ts
@@ -34,7 +34,6 @@ export function getWatchCollections(): string[] {
 		LivechatInquiry.getCollectionName(),
 		LivechatDepartmentAgents.getCollectionName(),
 		InstanceStatus.getCollectionName(),
-		IntegrationHistory.getCollectionName(),
 		EmailInbox.getCollectionName(),
 		Settings.getCollectionName(),
 		Subscriptions.getCollectionName(),
@@ -50,6 +49,7 @@ export function getWatchCollections(): string[] {
 		collections.push(Permissions.getCollectionName());
 		collections.push(LivechatPriority.getCollectionName());
 		collections.push(LoginServiceConfiguration.getCollectionName());
+		collections.push(IntegrationHistory.getCollectionName());
 	}
 
 	if (onlyCollections.length > 0) {

--- a/apps/meteor/server/models/raw/IntegrationHistory.ts
+++ b/apps/meteor/server/models/raw/IntegrationHistory.ts
@@ -25,7 +25,7 @@ export class IntegrationHistoryRaw extends BaseRaw<IIntegrationHistory> implemen
 	}
 
 	async create(integrationHistory: IIntegrationHistory): Promise<InsertOneResult<IIntegrationHistory>> {
-		return this.insertOne(integrationHistory);
+		return this.insertOne({ ...integrationHistory, _createdAt: new Date() });
 	}
 
 	async updateById(

--- a/apps/meteor/server/models/raw/IntegrationHistory.ts
+++ b/apps/meteor/server/models/raw/IntegrationHistory.ts
@@ -1,6 +1,6 @@
 import type { IIntegrationHistory } from '@rocket.chat/core-typings';
 import type { IIntegrationHistoryModel } from '@rocket.chat/model-typings';
-import type { Db, IndexDescription } from 'mongodb';
+import type { Db, IndexDescription, InsertOneResult, FindOneAndUpdateOptions } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -22,5 +22,18 @@ export class IntegrationHistoryRaw extends BaseRaw<IIntegrationHistory> implemen
 
 	findOneByIntegrationIdAndHistoryId(integrationId: string, historyId: string): Promise<IIntegrationHistory | null> {
 		return this.findOne({ 'integration._id': integrationId, '_id': historyId });
+	}
+
+	async create(integrationHistory: IIntegrationHistory): Promise<InsertOneResult<IIntegrationHistory>> {
+		return this.insertOne(integrationHistory);
+	}
+
+	async updateById(
+		_id: IIntegrationHistory['_id'],
+		data: Partial<IIntegrationHistory>,
+		options?: FindOneAndUpdateOptions,
+	): Promise<IIntegrationHistory | null> {
+		const response = await this.findOneAndUpdate({ _id }, { $set: data }, { returnDocument: 'after', ...options });
+		return response.value;
 	}
 }

--- a/packages/model-typings/src/models/IIntegrationHistoryModel.ts
+++ b/packages/model-typings/src/models/IIntegrationHistoryModel.ts
@@ -1,9 +1,15 @@
 import type { IIntegrationHistory } from '@rocket.chat/core-typings';
+import type { FindOneAndUpdateOptions, InsertOneResult } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
 
 export interface IIntegrationHistoryModel extends IBaseModel<IIntegrationHistory> {
 	removeByIntegrationId(integrationId: string): ReturnType<IBaseModel<IIntegrationHistory>['deleteMany']>;
-
 	findOneByIntegrationIdAndHistoryId(integrationId: string, historyId: string): Promise<IIntegrationHistory | null>;
+	create(integrationHistory: IIntegrationHistory): Promise<InsertOneResult<IIntegrationHistory>>;
+	updateById(
+		_id: IIntegrationHistory['_id'],
+		data: Partial<IIntegrationHistory>,
+		options?: FindOneAndUpdateOptions,
+	): Promise<IIntegrationHistory | null>;
 }


### PR DESCRIPTION
As per the updates mentioned in [PROJ-7], [SCA-10] and [ADR #74], **this pull request focuses on relocating `IntegrationHistory` model out of DB Watcher service.**

### Context

This modification enhances RocketChat's app by allowing it to directly call listeners through the `api.broadcast` global function, bypassing the need for MongoDB Change Stream data propagation.

This change offers better control over user notifications via Web Sockets, enabling more precise management of use-cases. Instead of notifying every database change, we can now send an `api.broadcast` call only when necessary, reducing overall network messages. Additionally, this contributes to the future removal of the DB Watcher deployment, optimizing resource utilization.

## Proposed changes

Key changes include:

- Conditionally incorporating **IntegrationHistory** entity import within DB watchers on application startup based on the `dbWatchersDisabled` flag.
- Enabling support for the following use cases to directly trigger `watch.integrationHistory` listener event, subject to the `dbWatchersDisabled` flag.

<summary>Updated Use Cases</summary>

| Use Case | Route/Trigger | Notes |
|----------|---------------|-------|
| Clear integration history | POST Meteor method `clearIntegrationHistory` |  |
| Update history | Calls to updateHistory from ScriptEngine |  |

## Steps to test or reproduce

1. Start RocketChat's application with the `DISABLE_DB_WATCHERS` environment variable set to `true`.
2. Perform HTTP requests or simulate use cases listed in the above table.

## Further comments

To maintain consistency and avoid potential regressions, event names and signatures have been kept unchanged on both the client and app sides. This decision streamlines efforts and mitigates the risk of unintended consequences.

Additionally, some new model functions have been created to accommodate specific needs when dealing with database operations, such as `IntegrationHistory.create` and `IntegrationHistory.updateById`.

[PROJ-7]: https://rocketchat.atlassian.net/browse/PROJ-7

[SCA-10]: https://rocketchat.atlassian.net/browse/SCA-10

[ADR #74]: https://adr.rocket.chat/0074