### PR TITLE
fix: Run QueryClient.clear() on logout

### DIFF
--- a/.changeset/fuzzy-readers-bake.md
+++ b/.changeset/fuzzy-readers-bake.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixes issues with loading license modules when loading the page while logged out

--- a/apps/meteor/client/providers/UserProvider/UserProvider.tsx
+++ b/apps/meteor/client/providers/UserProvider/UserProvider.tsx
@@ -4,7 +4,7 @@ import type { SubscriptionWithRoom } from '@rocket.chat/ui-contexts';
 import { UserContext, useEndpoint } from '@rocket.chat/ui-contexts';
 import { Meteor } from 'meteor/meteor';
 import type { ContextType, ReactElement, ReactNode } from 'react';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 
 import { Subscriptions, ChatRoom } from '../../../app/models/client';
 import { getUserPreference } from '../../../app/utils/client';
@@ -43,6 +43,7 @@ type UserProviderProps = {
 
 const UserProvider = ({ children }: UserProviderProps): ReactElement => {
 	const userId = useReactiveValue(getUserId);
+	const previousUserId = useRef(userId);
 	const user = useReactiveValue(getUser);
 	const [userLanguage, setUserLanguage] = useLocalStorage('userLanguage', '');
 	const [preferedLanguage, setPreferedLanguage] = useLocalStorage('preferedLanguage', '');
@@ -94,9 +95,11 @@ const UserProvider = ({ children }: UserProviderProps): ReactElement => {
 	}, [preferedLanguage, setPreferedLanguage, setUserLanguage, user?.language, userLanguage, userId, setUserPreferences]);
 
 	useEffect(() => {
-		if (!userId) {
+		if (previousUserId.current && previousUserId.current !== userId) {
 			queryClient.clear();
 		}
+
+		previousUserId.current = userId;
 	}, [userId]);
 
 	return <UserContext.Provider children={children} value={contextValue} />;

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-enterprise-menus-logout.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-enterprise-menus-logout.spec.ts
@@ -1,0 +1,31 @@
+import type { Page } from '@playwright/test';
+
+import { ADMIN_CREDENTIALS, IS_EE } from '../config/constants';
+import injectInitialData from '../fixtures/inject-initial-data';
+import { test, expect } from '../utils/test';
+
+test.describe('OC - Enterprise Menu Items After Relogin', () => {
+	// Create page object and redirect to home
+	test.beforeEach(async ({ page }: { page: Page }) => {
+		await page.goto('/omnichannel/current');
+
+		await page.locator('role=textbox[name=/username/i]').waitFor({ state: 'visible' });
+		await page.locator('role=textbox[name=/username/i]').fill(ADMIN_CREDENTIALS.email);
+		await page.locator('[name=password]').fill(ADMIN_CREDENTIALS.password);
+		await page.locator('role=button[name="Login"]').click();
+
+		await page.locator('.main-content').waitFor();
+	});
+
+	// Delete all data
+	test.afterAll(async () => {
+		await injectInitialData();
+	});
+
+	test('OC - Enterprise Menu Items - Logout & Login', async ({ page }) => {
+		test.skip(!IS_EE);
+		await test.step('expect EE menu items to be visible', async () => {
+			await expect(page.locator('a[href="/omnichannel/tags"]')).toBeVisible();
+		});
+	});
+});


### PR DESCRIPTION
Fixes issues with loading license modules when loading the page while logged out
Fixes `Error getting modules i {revert: undefined, silent: true}` error

[SUP-595]

[SUP-595]: https://rocketchat.atlassian.net/browse/SUP-595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ