### PR TITLE
fix: Long katex strings breaking overflow in x axis

### DIFF
--- a/packages/gazzodown/src/katex/KatexBlock.tsx
+++ b/packages/gazzodown/src/katex/KatexBlock.tsx
@@ -19,7 +19,7 @@ const KatexBlock = ({ code }: KatexBlockProps): ReactElement => {
 		[code],
 	);
 
-	return <div role='math' aria-label={code} dangerouslySetInnerHTML={{ __html: html }} />;
+	return <div role='math' style={{ overflowX: 'auto' }} aria-label={code} dangerouslySetInnerHTML={{ __html: html }} />;
 };
 
 export default KatexBlock;


### PR DESCRIPTION
[SUP-515]

![Screenshot 2024-06-14 at 09 16 43](https://github.com/RocketChat/Rocket.Chat/assets/20868078/889700a8-9cff-4dc5-a2bf-ded7e304d2fc)

I've added a simple overflow-x since katex has it's own rules to break lines (see https://github.com/KaTeX/KaTeX/pull/1287)