### PR TITLE
fix: Livechat Monitors can't view departments they are not agents of

### DIFF
--- a/apps/meteor/client/views/omnichannel/departments/DepartmentsTable/DepartmentsTable.tsx
+++ b/apps/meteor/client/views/omnichannel/departments/DepartmentsTable/DepartmentsTable.tsx
@@ -40,7 +40,7 @@ const DepartmentsTable = ({ archived }: { archived: boolean }) => {
 
 	const query = useMemo(
 		() => ({
-			onlyMyDepartments: 'true' as const,
+			onlyMyDepartments: 'false' as const,
 			text: debouncedText,
 			sort: JSON.stringify({ [sortBy]: sortDirection === 'asc' ? 1 : -1 }),
 			...(current && { offset: current }),

--- a/apps/meteor/client/views/omnichannel/departments/EditDepartmentWithData.tsx
+++ b/apps/meteor/client/views/omnichannel/departments/EditDepartmentWithData.tsx
@@ -7,7 +7,7 @@ import { FormSkeleton } from '../../../components/Skeleton';
 import EditDepartment from './EditDepartment';
 import EditDepartmentWithAllowedForwardData from './EditDepartmentWithAllowedForwardData';
 
-const params = { onlyMyDepartments: 'true' } as const;
+const params = { onlyMyDepartments: 'false' } as const;
 
 type EditDepartmentWithDataProps = {
 	id?: string;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
 - Send `onlyMyDepartments = false` param to the `livechat/departments` endpoints from the client (which will remove the agents filter that is currently being applied only to livechat-monitors);
 - Add end-to-end tests to make sure livechat-monitors can view and edit departments they are not agents of.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Login as a `livechat-monitor` (role) user;
2. Go to **Omnichannel > Departments** and create a new department (do not add the logged in monitor user as an agent to this department);

**_Current behavior:_** when redirected to the list after c reating the department, the monitor user won't be able to view the department they just created.
**_Expected behavior:_** the monitor should be able to view and edit departments that they are not agents of (as long as they have the `view-livechat-departments` permission) 

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[SUP-601](https://rocketchat.atlassian.net/browse/SUP-601)