### PR TITLE
Release 6.9.2

### DIFF
--- a/.changeset/bump-patch-1718743154258.md
+++ b/.changeset/bump-patch-1718743154258.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Bump @rocket.chat/meteor version.

--- a/.changeset/dry-shoes-tap.md
+++ b/.changeset/dry-shoes-tap.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixes the supported versions problem, where in most cases the data chosen was the oldest

--- a/.changeset/nervous-wolves-collect.md
+++ b/.changeset/nervous-wolves-collect.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes the issue not allowing users without edit-room-retention-policy permission try to edit the room with the retention policy enabled

--- a/apps/meteor/app/cloud/server/functions/supportedVersionsToken/supportedVersionsChooseLatest.ts
+++ b/apps/meteor/app/cloud/server/functions/supportedVersionsToken/supportedVersionsChooseLatest.ts
@@ -2,7 +2,7 @@ import type { SignedSupportedVersions } from '@rocket.chat/server-cloud-communic
 
 export const supportedVersionsChooseLatest = async (...tokens: (SignedSupportedVersions | undefined)[]) => {
 	const [token] = (tokens.filter((r) => r?.timestamp != null) as SignedSupportedVersions[]).sort((a, b) => {
-		return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+		return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
 	});
 
 	return token;

--- a/apps/meteor/app/cloud/server/functions/supportedVersionsToken/supportedVersionsToken.ts
+++ b/apps/meteor/app/cloud/server/functions/supportedVersionsToken/supportedVersionsToken.ts
@@ -62,6 +62,7 @@ const cacheValueInSettings = <T extends SettingValue>(
 	reset: () => Promise<T>;
 } => {
 	const reset = async () => {
+		SystemLogger.debug(`Resetting cached value ${key} in settings`);
 		const value = await fn();
 
 		await Settings.updateValueById(key, value);
@@ -133,6 +134,31 @@ const getSupportedVersionsToken = async () => {
 		versionsFromLicense?.supportedVersions,
 		(response.success && response.result) || undefined,
 	);
+
+	SystemLogger.debug({
+		msg: 'Supported versions',
+		supportedVersionsFromBuild: supportedVersionsFromBuild.timestamp,
+		versionsFromLicense: versionsFromLicense?.supportedVersions?.timestamp,
+		response: response.success && response.result?.timestamp,
+	});
+
+	switch (supportedVersions) {
+		case supportedVersionsFromBuild:
+			SystemLogger.info({
+				msg: 'Using supported versions from build',
+			});
+			break;
+		case versionsFromLicense?.supportedVersions:
+			SystemLogger.info({
+				msg: 'Using supported versions from license',
+			});
+			break;
+		case response.success && response.result:
+			SystemLogger.info({
+				msg: 'Using supported versions from cloud',
+			});
+			break;
+	}
 
 	await buildVersionUpdateMessage(supportedVersions?.versions);
 

--- a/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/useEditRoomInitialValues.ts
+++ b/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/useEditRoomInitialValues.ts
@@ -1,4 +1,5 @@
 import type { IRoomWithRetentionPolicy } from '@rocket.chat/core-typings';
+import { usePermission } from '@rocket.chat/ui-contexts';
 import { useMemo } from 'react';
 
 import { roomCoordinator } from '../../../../../lib/rooms/roomCoordinator';
@@ -6,6 +7,8 @@ import { useRetentionPolicy } from '../../../hooks/useRetentionPolicy';
 
 export const useEditRoomInitialValues = (room: IRoomWithRetentionPolicy) => {
 	const retentionPolicy = useRetentionPolicy(room);
+	const canEditRoomRetentionPolicy = usePermission('edit-room-retention-policy', room._id);
+
 	const { t, ro, archived, topic, description, announcement, joinCodeRequired, sysMes, encrypted, retention, reactWhenReadOnly } = room;
 
 	return useMemo(
@@ -24,13 +27,14 @@ export const useEditRoomInitialValues = (room: IRoomWithRetentionPolicy) => {
 			systemMessages: Array.isArray(sysMes) ? sysMes : [],
 			hideSysMes: Array.isArray(sysMes) ? !!sysMes?.length : !!sysMes,
 			encrypted,
-			...(retentionPolicy?.enabled && {
-				retentionEnabled: retention?.enabled ?? retentionPolicy.isActive,
-				retentionOverrideGlobal: !!retention?.overrideGlobal,
-				retentionMaxAge: retention?.maxAge ?? retentionPolicy.maxAge,
-				retentionExcludePinned: retention?.excludePinned ?? retentionPolicy.excludePinned,
-				retentionFilesOnly: retention?.filesOnly ?? retentionPolicy.filesOnly,
-			}),
+			...(canEditRoomRetentionPolicy &&
+				retentionPolicy?.enabled && {
+					retentionEnabled: retention?.enabled ?? retentionPolicy.isActive,
+					retentionOverrideGlobal: !!retention?.overrideGlobal,
+					retentionMaxAge: retention?.maxAge ?? retentionPolicy.maxAge,
+					retentionExcludePinned: retention?.excludePinned ?? retentionPolicy.excludePinned,
+					retentionFilesOnly: retention?.filesOnly ?? retentionPolicy.filesOnly,
+				}),
 		}),
 		[
 			announcement,
@@ -46,6 +50,7 @@ export const useEditRoomInitialValues = (room: IRoomWithRetentionPolicy) => {
 			topic,
 			encrypted,
 			reactWhenReadOnly,
+			canEditRoomRetentionPolicy,
 		],
 	);
 };

--- a/apps/meteor/jest.config.ts
+++ b/apps/meteor/jest.config.ts
@@ -33,6 +33,7 @@ const config: Config = {
 				'<rootDir>/app/livechat/server/business-hour/**/*.spec.ts?(x)',
 				'<rootDir>/app/livechat/server/api/**/*.spec.ts',
 				'<rootDir>/ee/app/authorization/server/validateUserRoles.spec.ts',
+				'<rootDir>/app/cloud/server/functions/supportedVersionsToken/**.spec.ts',
 			],
 			transformIgnorePatterns: ['!/node_modules/jose'],
 			errorOnDeprecated: true,

--- a/apps/meteor/tests/e2e/retention-policy.spec.ts
+++ b/apps/meteor/tests/e2e/retention-policy.spec.ts
@@ -85,16 +85,31 @@ test.describe.serial('retention-policy', () => {
 			await expect(poHomeChannel.tabs.room.pruneAccordion).toBeVisible();
 		});
 
-		test('should not show prune section in edit channel for users without permission', async ({ browser }) => {
-			const { page } = await createAuxContext(browser, Users.user1);
-			const auxContext = { page, poHomeChannel: new HomeChannel(page) };
-			await auxContext.poHomeChannel.sidenav.openChat(targetChannel);
-			await auxContext.poHomeChannel.tabs.btnRoomInfo.click();
-			await auxContext.poHomeChannel.tabs.room.btnEdit.click();
+		test.describe('edit-room-retention-policy permission', async () => {
+			test('should not show prune section in edit channel for users without permission', async ({ browser }) => {
+				const { page } = await createAuxContext(browser, Users.user1);
+				const auxContext = { page, poHomeChannel: new HomeChannel(page) };
+				await auxContext.poHomeChannel.sidenav.openChat(targetChannel);
+				await auxContext.poHomeChannel.tabs.btnRoomInfo.click();
+				await auxContext.poHomeChannel.tabs.room.btnEdit.click();
 
-			await expect(poHomeChannel.tabs.room.pruneAccordion).not.toBeVisible();
-			await auxContext.page.close();
-		})
+				await expect(poHomeChannel.tabs.room.pruneAccordion).not.toBeVisible();
+				await auxContext.page.close();
+			});
+
+			test('users without permission should be able to edit the channel', async ({ browser }) => {
+				const { page } = await createAuxContext(browser, Users.user1);
+				const auxContext = { page, poHomeChannel: new HomeChannel(page) };
+				await auxContext.poHomeChannel.sidenav.openChat(targetChannel);
+				await auxContext.poHomeChannel.tabs.btnRoomInfo.click();
+				await auxContext.poHomeChannel.tabs.room.btnEdit.click();
+				await auxContext.poHomeChannel.tabs.room.checkboxReadOnly.check();
+				await auxContext.poHomeChannel.tabs.room.btnSave.click();
+
+				await expect(auxContext.poHomeChannel.getSystemMessageByText('set room to read only')).toBeVisible();
+				await auxContext.page.close();
+			});
+		});
 
 		test.describe('retention policy applies enabled by default', () => {
 			test.beforeAll(async ({ api }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8795,10 +8795,10 @@ __metadata:
     "@rocket.chat/icons": "*"
     "@rocket.chat/prettier-config": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 3.0.0
-    "@rocket.chat/ui-contexts": 7.0.0
+    "@rocket.chat/ui-avatar": 3.0.1
+    "@rocket.chat/ui-contexts": 7.0.1
     "@rocket.chat/ui-kit": 0.34.0
-    "@rocket.chat/ui-video-conf": 7.0.0
+    "@rocket.chat/ui-video-conf": 7.0.1
     "@tanstack/react-query": "*"
     react: "*"
     react-dom: "*"
@@ -8887,8 +8887,8 @@ __metadata:
     "@rocket.chat/fuselage-tokens": "*"
     "@rocket.chat/message-parser": 0.31.29
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-client": 7.0.0
-    "@rocket.chat/ui-contexts": 7.0.0
+    "@rocket.chat/ui-client": 7.0.1
+    "@rocket.chat/ui-contexts": 7.0.1
     katex: "*"
     react: "*"
   languageName: unknown
@@ -10106,7 +10106,7 @@ __metadata:
     typescript: ~5.3.3
   peerDependencies:
     "@rocket.chat/fuselage": "*"
-    "@rocket.chat/ui-contexts": 7.0.0
+    "@rocket.chat/ui-contexts": 7.0.1
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -10159,7 +10159,7 @@ __metadata:
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-contexts": 7.0.0
+    "@rocket.chat/ui-contexts": 7.0.1
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -10335,8 +10335,8 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 3.0.0
-    "@rocket.chat/ui-contexts": 7.0.0
+    "@rocket.chat/ui-avatar": 3.0.1
+    "@rocket.chat/ui-contexts": 7.0.1
     react: ^17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -10426,7 +10426,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.2.1
-    "@rocket.chat/ui-contexts": 7.0.0
+    "@rocket.chat/ui-contexts": 7.0.1
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION


<!-- release-notes-start -->
<!-- This content is automatically generated. Changing this will not reflect on the final release log -->

_You can see below a preview of the release change log:_

# 6.9.2

### Engine versions

- Node: `14.21.3`
- MongoDB: `4.4, 5.0, 6.0`
- Apps-Engine: `1.42.2`

### Patch Changes

*   Bump @rocket.chat/meteor version.

*   ([#32621](https://github.com/RocketChat/Rocket.Chat/pull/32621) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixes the supported versions problem, where in most cases the data chosen was the oldest

*   ([#32622](https://github.com/RocketChat/Rocket.Chat/pull/32622) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixes the issue not allowing users without edit-room-retention-policy permission try to edit the room with the retention policy enabled

*   <details><summary>Updated dependencies []:</summary>

    *   @rocket.chat/core-typings@6.9.2
    *   @rocket.chat/rest-typings@6.9.2
    *   @rocket.chat/api-client@0.1.35
    *   @rocket.chat/license@0.1.17
    *   @rocket.chat/omnichannel-services@0.1.17
    *   @rocket.chat/pdf-worker@0.0.41
    *   @rocket.chat/presence@0.1.17
    *   @rocket.chat/apps@0.0.8
    *   @rocket.chat/core-services@0.3.17
    *   @rocket.chat/cron@0.0.37
    *   @rocket.chat/fuselage-ui-kit@7.0.2
    *   @rocket.chat/gazzodown@7.0.2
    *   @rocket.chat/model-typings@0.4.3
    *   @rocket.chat/ui-contexts@7.0.2
    *   @rocket.chat/server-cloud-communication@0.0.2
    *   @rocket.chat/models@0.0.41
    *   @rocket.chat/ui-theming@0.1.2
    *   @rocket.chat/ui-avatar@3.0.2
    *   @rocket.chat/ui-client@7.0.2
    *   @rocket.chat/ui-video-conf@7.0.2
    *   @rocket.chat/web-ui-registration@7.0.2
    *   @rocket.chat/instance-status@0.0.41

    </details>

<!-- release-notes-end -->