### PR TITLE
regression: prevent unhandled exception from apps statistics

### DIFF
--- a/apps/meteor/app/statistics/server/lib/getAppsStatistics.ts
+++ b/apps/meteor/app/statistics/server/lib/getAppsStatistics.ts
@@ -1,6 +1,8 @@
 import { Apps } from '@rocket.chat/apps';
 import { AppStatus, AppStatusUtils } from '@rocket.chat/apps-engine/definition/AppStatus';
+import mem from 'mem';
 
+import { SystemLogger } from '../../../../server/lib/logger/system';
 import { Info } from '../../../utils/rocketchat.info';
 
 export type AppsStatistics = {
@@ -10,7 +12,7 @@ export type AppsStatistics = {
 	totalFailed: number | false;
 };
 
-export async function getAppsStatistics(): Promise<AppsStatistics> {
+async function _getAppsStatistics(): Promise<AppsStatistics> {
 	if (!Apps.self?.isInitialized()) {
 		return {
 			engineVersion: Info.marketplaceApiVersion,
@@ -20,32 +22,45 @@ export async function getAppsStatistics(): Promise<AppsStatistics> {
 		};
 	}
 
-	const apps = await Apps.getManager().get();
+	try {
+		const apps = await Apps.getManager().get();
 
-	let totalInstalled = 0;
-	let totalActive = 0;
-	let totalFailed = 0;
+		let totalInstalled = 0;
+		let totalActive = 0;
+		let totalFailed = 0;
 
-	await Promise.all(
-		apps.map(async (app) => {
-			totalInstalled++;
+		await Promise.all(
+			apps.map(async (app) => {
+				totalInstalled++;
 
-			const status = await app.getStatus();
+				const status = await app.getStatus();
 
-			if (status === AppStatus.MANUALLY_DISABLED) {
-				totalFailed++;
-			}
+				if (status === AppStatus.MANUALLY_DISABLED) {
+					totalFailed++;
+				}
 
-			if (AppStatusUtils.isEnabled(status)) {
-				totalActive++;
-			}
-		}),
-	);
+				if (AppStatusUtils.isEnabled(status)) {
+					totalActive++;
+				}
+			}),
+		);
 
-	return {
-		engineVersion: Info.marketplaceApiVersion,
-		totalInstalled,
-		totalActive,
-		totalFailed,
-	};
+		return {
+			engineVersion: Info.marketplaceApiVersion,
+			totalInstalled,
+			totalActive,
+			totalFailed,
+		};
+	} catch (err: unknown) {
+		SystemLogger.error({ msg: 'Exception while getting Apps statistics', err });
+		return {
+			engineVersion: Info.marketplaceApiVersion,
+			totalInstalled: false,
+			totalActive: false,
+			totalFailed: false,
+		};
+	}
 }
+
+// since this function is called every 5s by `setPrometheusData` we're memoizing the result since the result won't change that often
+export const getAppsStatistics = mem(_getAppsStatistics, { maxAge: 60000 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8509,8 +8509,8 @@ __metadata:
   linkType: soft
 
 "@rocket.chat/apps-engine@npm:alpha":
-  version: 1.43.0-alpha.783
-  resolution: "@rocket.chat/apps-engine@npm:1.43.0-alpha.783"
+  version: 1.43.0-alpha.784
+  resolution: "@rocket.chat/apps-engine@npm:1.43.0-alpha.784"
   dependencies:
     "@msgpack/msgpack": 3.0.0-beta2
     adm-zip: ^0.5.9
@@ -8526,7 +8526,7 @@ __metadata:
     uuid: ~8.3.2
   peerDependencies:
     "@rocket.chat/ui-kit": "*"
-  checksum: f580ff051914e1c7866fcf42c46844641cd4ab8d09b35a2df8c6a1369d535d060d9b7450eb64e6c8c5c2ac716faf5bf8082b52c9856496b4a41a29d96a781575
+  checksum: b86ec5cf809dc06658be0ae24b72b746f373bf83e7ee381e4fe83d7a5f4754359004cdf4d0f89723861bf4a3c7841d5f78bbe280ee863e2c833e64f73f16b124
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Added a try/catch to prevent errors and also memoized the function result since it should not change that often.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

```
=== UnHandledPromiseRejection ===
Error: Request "jdqmnf7icud" for method "app:getStatus" timed out
    at Timeout._onTimeout (/app/bundle/programs/server/npm/node_modules/@rocket.chat/apps-engine/server/runtime/deno/AppsEngineDenoRuntime.js:241:24)
    at listOnTimeout (internal/timers.js:557:17)
    at processTimers (internal/timers.js:500:7)
 => awaited here:
    at Function.Promise.await (/app/bundle/programs/server/npm/node_modules/meteor/promise/node_modules/meteor-promise/promise_server.js:56:12)
    at app/statistics/server/lib/getAppsStatistics.ts:33:16
    at /app/bundle/programs/server/npm/node_modules/meteor/promise/node_modules/meteor-promise/fiber_pool.js:43:40
 => awaited here:
    at Function.Promise.await (/app/bundle/programs/server/npm/node_modules/meteor/promise/node_modules/meteor-promise/promise_server.js:56:12)
    at app/statistics/server/lib/getAppsStatistics.ts:29:2
    at /app/bundle/programs/server/npm/node_modules/meteor/promise/node_modules/meteor-promise/fiber_pool.js:43:40
 => awaited here:
    at Function.Promise.await (/app/bundle/programs/server/npm/node_modules/meteor/promise/node_modules/meteor-promise/promise_server.js:56:12)
    at app/metrics/server/lib/collectMetrics.ts:42:52
    at /app/bundle/programs/server/npm/node_modules/meteor/promise/node_modules/meteor-promise/fiber_pool.js:43:40
---------------------------------
Errors like this can cause oplog processing errors.
Setting EXIT_UNHANDLEDPROMISEREJECTION will cause the process to exit allowing your service to automatically restart the process
Future node.js versions will automatically exit the process
=================================
```
