### PR TITLE
refactor: create middleware to handle dbWatchersDisabled check

### DIFF
--- a/apps/meteor/app/lib/server/lib/notifyListener.ts
+++ b/apps/meteor/app/lib/server/lib/notifyListener.ts
@@ -34,87 +34,58 @@ import {
 
 type ClientAction = 'inserted' | 'updated' | 'removed';
 
-export async function notifyOnLivechatPriorityChanged(
-	data: Pick<ILivechatPriority, 'name' | '_id'>,
-	clientAction: ClientAction = 'updated',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
-	const { _id, ...rest } = data;
-
-	void api.broadcast('watch.priorities', { clientAction, id: _id, diff: { ...rest } });
+function withDbWatcherCheck<T extends (...args: any[]) => Promise<void>>(fn: T): T {
+	return dbWatchersDisabled ? fn : ((() => Promise.resolve()) as T);
 }
 
-export async function notifyOnRoomChanged<T extends IRocketChatRecord>(
-	data: T | T[],
+const _notifyOnLivechatPriorityChanged = async (
+	data: Pick<ILivechatPriority, 'name' | '_id'>,
 	clientAction: ClientAction = 'updated',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
+): Promise<void> => {
+	const { _id, ...rest } = data;
+	void api.broadcast('watch.priorities', { clientAction, id: _id, diff: { ...rest } });
+};
 
+const _notifyOnRoomChanged = async <T extends IRocketChatRecord>(data: T | T[], clientAction: ClientAction = 'updated'): Promise<void> => {
 	const items = Array.isArray(data) ? data : [data];
-
 	for (const item of items) {
 		void api.broadcast('watch.rooms', { clientAction, room: item });
 	}
-}
+};
 
-export async function notifyOnRoomChangedById<T extends IRocketChatRecord>(
+const _notifyOnRoomChangedById = async <T extends IRocketChatRecord>(
 	ids: T['_id'] | T['_id'][],
 	clientAction: ClientAction = 'updated',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	const eligibleIds = Array.isArray(ids) ? ids : [ids];
-
 	const items = Rooms.findByIds(eligibleIds);
-
 	for await (const item of items) {
 		void api.broadcast('watch.rooms', { clientAction, room: item });
 	}
-}
+};
 
-export async function notifyOnRoomChangedByUsernamesOrUids<T extends IRoom>(
+const _notifyOnRoomChangedByUsernamesOrUids = async <T extends IRoom>(
 	uids: T['u']['_id'][],
 	usernames: T['u']['username'][],
 	clientAction: ClientAction = 'updated',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	const items = Rooms.findByUsernamesOrUids(uids, usernames);
-
 	for await (const item of items) {
 		void api.broadcast('watch.rooms', { clientAction, room: item });
 	}
-}
+};
 
-export async function notifyOnRoomChangedByUserDM<T extends IRoom>(
+const _notifyOnRoomChangedByUserDM = async <T extends IRoom>(
 	userId: T['u']['_id'],
 	clientAction: ClientAction = 'updated',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	const items = Rooms.findDMsByUids([userId]);
-
 	for await (const item of items) {
 		void api.broadcast('watch.rooms', { clientAction, room: item });
 	}
-}
+};
 
-export async function notifyOnPermissionChanged(permission: IPermission, clientAction: ClientAction = 'updated'): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+const _notifyOnPermissionChanged = async (permission: IPermission, clientAction: ClientAction = 'updated'): Promise<void> => {
 	void api.broadcast('permission.changed', { clientAction, data: permission });
 
 	if (permission.level === 'settings' && permission.settingId) {
@@ -122,86 +93,56 @@ export async function notifyOnPermissionChanged(permission: IPermission, clientA
 		if (!setting) {
 			return;
 		}
-		void notifyOnSettingChanged(setting, 'updated');
+		void _notifyOnSettingChanged(setting, 'updated');
 	}
-}
+};
 
-export async function notifyOnPermissionChangedById(pid: IPermission['_id'], clientAction: ClientAction = 'updated'): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+const _notifyOnPermissionChangedById = async (pid: IPermission['_id'], clientAction: ClientAction = 'updated'): Promise<void> => {
 	const permission = await Permissions.findOneById(pid);
 	if (!permission) {
 		return;
 	}
 
-	return notifyOnPermissionChanged(permission, clientAction);
-}
+	return _notifyOnPermissionChanged(permission, clientAction);
+};
 
-export async function notifyOnPbxEventChangedById<T extends IPbxEvent>(
-	id: T['_id'],
-	clientAction: ClientAction = 'updated',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+const _notifyOnPbxEventChangedById = async <T extends IPbxEvent>(id: T['_id'], clientAction: ClientAction = 'updated'): Promise<void> => {
 	const item = await PbxEvents.findOneById(id);
 	if (!item) {
 		return;
 	}
 
 	void api.broadcast('watch.pbxevents', { clientAction, id, data: item });
-}
+};
 
-export async function notifyOnRoleChanged<T extends IRole>(role: T, clientAction: 'removed' | 'changed' = 'changed'): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+const _notifyOnRoleChanged = async <T extends IRole>(role: T, clientAction: 'removed' | 'changed' = 'changed'): Promise<void> => {
 	void api.broadcast('watch.roles', { clientAction, role });
-}
+};
 
-export async function notifyOnRoleChangedById<T extends IRole>(
-	id: T['_id'],
-	clientAction: 'removed' | 'changed' = 'changed',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+const _notifyOnRoleChangedById = async <T extends IRole>(id: T['_id'], clientAction: 'removed' | 'changed' = 'changed'): Promise<void> => {
 	const role = await Roles.findOneById(id);
 	if (!role) {
 		return;
 	}
 
-	void notifyOnRoleChanged(role, clientAction);
-}
+	void _notifyOnRoleChanged(role, clientAction);
+};
 
-export async function notifyOnLoginServiceConfigurationChanged<T extends ILoginServiceConfiguration>(
+const _notifyOnLoginServiceConfigurationChanged = async <T extends ILoginServiceConfiguration>(
 	service: Partial<T> & Pick<T, '_id'>,
 	clientAction: ClientAction = 'updated',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	void api.broadcast('watch.loginServiceConfiguration', {
 		clientAction,
 		id: service._id,
 		data: service,
 	});
-}
+};
 
-export async function notifyOnLoginServiceConfigurationChangedByService<T extends ILoginServiceConfiguration>(
+const _notifyOnLoginServiceConfigurationChangedByService = async <T extends ILoginServiceConfiguration>(
 	service: T['service'],
 	clientAction: ClientAction = 'updated',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	const item = await LoginServiceConfiguration.findOneByService<Omit<LoginServiceConfigurationData, 'secret'>>(service, {
 		projection: { secret: 0 },
 	});
@@ -209,99 +150,71 @@ export async function notifyOnLoginServiceConfigurationChangedByService<T extend
 		return;
 	}
 
-	void notifyOnLoginServiceConfigurationChanged(item, clientAction);
-}
+	void _notifyOnLoginServiceConfigurationChanged(item, clientAction);
+};
 
-export async function notifyOnIntegrationChanged<T extends IIntegration>(data: T, clientAction: ClientAction = 'updated'): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+const _notifyOnIntegrationChanged = async <T extends IIntegration>(data: T, clientAction: ClientAction = 'updated'): Promise<void> => {
 	void api.broadcast('watch.integrations', { clientAction, id: data._id, data });
-}
+};
 
-export async function notifyOnIntegrationChangedById<T extends IIntegration>(
+const _notifyOnIntegrationChangedById = async <T extends IIntegration>(
 	id: T['_id'],
 	clientAction: ClientAction = 'updated',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	const item = await Integrations.findOneById(id);
 	if (!item) {
 		return;
 	}
 
 	void api.broadcast('watch.integrations', { clientAction, id: item._id, data: item });
-}
+};
 
-export async function notifyOnIntegrationChangedByUserId<T extends IIntegration>(
+const _notifyOnIntegrationChangedByUserId = async <T extends IIntegration>(
 	id: T['userId'],
 	clientAction: ClientAction = 'updated',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	const items = Integrations.findByUserId(id);
 
 	for await (const item of items) {
 		void api.broadcast('watch.integrations', { clientAction, id: item._id, data: item });
 	}
-}
+};
 
-export async function notifyOnIntegrationChangedByChannels<T extends IIntegration>(
+const _notifyOnIntegrationChangedByChannels = async <T extends IIntegration>(
 	channels: T['channel'],
 	clientAction: ClientAction = 'updated',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	const items = Integrations.findByChannels(channels);
 
 	for await (const item of items) {
 		void api.broadcast('watch.integrations', { clientAction, id: item._id, data: item });
 	}
-}
+};
 
-export async function notifyOnEmailInboxChanged<T extends IEmailInbox>(
+const _notifyOnEmailInboxChanged = async <T extends IEmailInbox>(
 	data: Pick<T, '_id'> | T, // TODO: improve typing
 	clientAction: ClientAction = 'updated',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	void api.broadcast('watch.emailInbox', { clientAction, id: data._id, data });
-}
+};
 
-export async function notifyOnLivechatInquiryChanged(
+const _notifyOnLivechatInquiryChanged = async (
 	data: ILivechatInquiryRecord | ILivechatInquiryRecord[],
 	clientAction: ClientAction = 'updated',
 	diff?: Partial<Record<keyof ILivechatInquiryRecord, unknown> & { queuedAt: unknown; takenAt: unknown }>,
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	const items = Array.isArray(data) ? data : [data];
 
 	for (const item of items) {
 		void api.broadcast('watch.inquiries', { clientAction, inquiry: item, diff });
 	}
-}
+};
 
-export async function notifyOnLivechatInquiryChangedById(
+const _notifyOnLivechatInquiryChangedById = async (
 	id: ILivechatInquiryRecord['_id'],
 	clientAction: ClientAction = 'updated',
 	diff?: Partial<Record<keyof ILivechatInquiryRecord, unknown> & { queuedAt: unknown; takenAt: unknown }>,
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	const inquiry = clientAction === 'removed' ? await LivechatInquiry.trashFindOneById(id) : await LivechatInquiry.findOneById(id);
 
 	if (!inquiry) {
@@ -309,17 +222,13 @@ export async function notifyOnLivechatInquiryChangedById(
 	}
 
 	void api.broadcast('watch.inquiries', { clientAction, inquiry, diff });
-}
+};
 
-export async function notifyOnLivechatInquiryChangedByRoom(
+const _notifyOnLivechatInquiryChangedByRoom = async (
 	rid: ILivechatInquiryRecord['rid'],
 	clientAction: ClientAction = 'updated',
 	diff?: Partial<Record<keyof ILivechatInquiryRecord, unknown> & { queuedAt: unknown; takenAt: unknown }>,
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	const inquiry = await LivechatInquiry.findOneByRoomId(rid, {});
 
 	if (!inquiry) {
@@ -327,17 +236,13 @@ export async function notifyOnLivechatInquiryChangedByRoom(
 	}
 
 	void api.broadcast('watch.inquiries', { clientAction, inquiry, diff });
-}
+};
 
-export async function notifyOnLivechatInquiryChangedByToken(
+const _notifyOnLivechatInquiryChangedByToken = async (
 	token: ILivechatInquiryRecord['v']['token'],
 	clientAction: ClientAction = 'updated',
 	diff?: Partial<Record<keyof ILivechatInquiryRecord, unknown> & { queuedAt: unknown; takenAt: unknown }>,
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	const inquiry = await LivechatInquiry.findOneByToken(token);
 
 	if (!inquiry) {
@@ -345,29 +250,21 @@ export async function notifyOnLivechatInquiryChangedByToken(
 	}
 
 	void api.broadcast('watch.inquiries', { clientAction, inquiry, diff });
-}
+};
 
-export async function notifyOnIntegrationHistoryChanged<T extends IIntegrationHistory>(
+const _notifyOnIntegrationHistoryChanged = async <T extends IIntegrationHistory>(
 	data: AtLeast<T, '_id'>,
 	clientAction: ClientAction = 'updated',
 	diff: Partial<T> = {},
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	void api.broadcast('watch.integrationHistory', { clientAction, id: data._id, data, diff });
-}
+};
 
-export async function notifyOnIntegrationHistoryChangedById<T extends IIntegrationHistory>(
+const _notifyOnIntegrationHistoryChangedById = async <T extends IIntegrationHistory>(
 	id: T['_id'],
 	clientAction: ClientAction = 'updated',
 	diff: Partial<T> = {},
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	const item = await IntegrationHistory.findOneById(id);
 
 	if (!item) {
@@ -375,43 +272,31 @@ export async function notifyOnIntegrationHistoryChangedById<T extends IIntegrati
 	}
 
 	void api.broadcast('watch.integrationHistory', { clientAction, id: item._id, data: item, diff });
-}
+};
 
-export async function notifyOnLivechatDepartmentAgentChanged<T extends ILivechatDepartmentAgents>(
+const _notifyOnLivechatDepartmentAgentChanged = async <T extends ILivechatDepartmentAgents>(
 	data: Partial<T> & Pick<T, '_id' | 'agentId' | 'departmentId'>,
 	clientAction: ClientAction = 'updated',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	void api.broadcast('watch.livechatDepartmentAgents', { clientAction, id: data._id, data });
-}
+};
 
-export async function notifyOnLivechatDepartmentAgentChangedByDepartmentId<T extends ILivechatDepartmentAgents>(
+const _notifyOnLivechatDepartmentAgentChangedByDepartmentId = async <T extends ILivechatDepartmentAgents>(
 	departmentId: T['departmentId'],
 	clientAction: 'inserted' | 'updated' = 'updated',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	const items = LivechatDepartmentAgents.findByDepartmentId(departmentId, { projection: { _id: 1, agentId: 1, departmentId: 1 } });
 
 	for await (const item of items) {
 		void api.broadcast('watch.livechatDepartmentAgents', { clientAction, id: item._id, data: item });
 	}
-}
+};
 
-export async function notifyOnLivechatDepartmentAgentChangedByAgentsAndDepartmentId<T extends ILivechatDepartmentAgents>(
+const _notifyOnLivechatDepartmentAgentChangedByAgentsAndDepartmentId = async <T extends ILivechatDepartmentAgents>(
 	agentsIds: T['agentId'][],
 	departmentId: T['departmentId'],
 	clientAction: 'inserted' | 'updated' = 'updated',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+): Promise<void> => {
 	const items = LivechatDepartmentAgents.findByAgentsAndDepartmentId(agentsIds, departmentId, {
 		projection: { _id: 1, agentId: 1, departmentId: 1 },
 	});
@@ -419,22 +304,16 @@ export async function notifyOnLivechatDepartmentAgentChangedByAgentsAndDepartmen
 	for await (const item of items) {
 		void api.broadcast('watch.livechatDepartmentAgents', { clientAction, id: item._id, data: item });
 	}
-}
+};
 
-export async function notifyOnSettingChanged(
+const _notifyOnSettingChanged = async (
 	setting: ISetting & { editor?: ISettingColor['editor'] },
 	clientAction: ClientAction = 'updated',
-): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
+): Promise<void> => {
 	void api.broadcast('watch.settings', { clientAction, setting });
-}
+};
 
-export async function notifyOnSettingChangedById(id: ISetting['_id'], clientAction: ClientAction = 'updated'): Promise<void> {
-	if (!dbWatchersDisabled) {
-		return;
-	}
+const _notifyOnSettingChangedById = async (id: ISetting['_id'], clientAction: ClientAction = 'updated'): Promise<void> => {
 	const item = clientAction === 'removed' ? await Settings.trashFindOneById(id) : await Settings.findOneById(id);
 
 	if (!item) {
@@ -442,7 +321,7 @@ export async function notifyOnSettingChangedById(id: ISetting['_id'], clientActi
 	}
 
 	void api.broadcast('watch.settings', { clientAction, setting: item });
-}
+};
 
 type NotifyUserChange = {
 	id: IUser['_id'];
@@ -452,52 +331,79 @@ type NotifyUserChange = {
 	unset?: Record<string, number>;
 };
 
-export async function notifyOnUserChange({ clientAction, id, data, diff, unset }: NotifyUserChange) {
-	if (!dbWatchersDisabled) {
-		return;
-	}
+const _notifyOnUserChange = async ({ clientAction, id, data, diff, unset }: NotifyUserChange) => {
 	if (clientAction === 'removed') {
 		void api.broadcast('watch.users', { clientAction, id });
 		return;
 	}
+
 	if (clientAction === 'inserted') {
 		void api.broadcast('watch.users', { clientAction, id, data: data! });
 		return;
 	}
 
 	void api.broadcast('watch.users', { clientAction, diff: diff!, unset: unset || {}, id });
-}
+};
 
 /**
  * Calls the callback only if DB Watchers are disabled
  */
-export async function notifyOnUserChangeAsync(cb: () => Promise<NotifyUserChange | NotifyUserChange[] | void>) {
-	if (!dbWatchersDisabled) {
-		return;
-	}
-
+const _notifyOnUserChangeAsync = async (cb: () => Promise<NotifyUserChange | NotifyUserChange[] | void>) => {
 	const result = await cb();
 	if (!result) {
 		return;
 	}
 
 	if (Array.isArray(result)) {
-		result.forEach((n) => notifyOnUserChange(n));
+		result.forEach((n) => _notifyOnUserChange(n));
 		return;
 	}
 
-	return notifyOnUserChange(result);
-}
+	return _notifyOnUserChange(result);
+};
 
 // TODO this may be only useful on 'inserted'
-export async function notifyOnUserChangeById({ clientAction, id }: { id: IUser['_id']; clientAction: 'inserted' | 'removed' | 'updated' }) {
-	if (!dbWatchersDisabled) {
-		return;
-	}
+const _notifyOnUserChangeById = async ({ clientAction, id }: { id: IUser['_id']; clientAction: 'inserted' | 'removed' | 'updated' }) => {
 	const user = await Users.findOneById(id);
 	if (!user) {
 		return;
 	}
 
-	void notifyOnUserChange({ id, clientAction, data: user });
-}
+	void _notifyOnUserChange({ id, clientAction, data: user });
+};
+
+export const notifyOnLivechatPriorityChanged = withDbWatcherCheck(_notifyOnLivechatPriorityChanged);
+export const notifyOnRoomChanged = withDbWatcherCheck(_notifyOnRoomChanged);
+export const notifyOnRoomChangedById = withDbWatcherCheck(_notifyOnRoomChangedById);
+export const notifyOnRoomChangedByUsernamesOrUids = withDbWatcherCheck(_notifyOnRoomChangedByUsernamesOrUids);
+export const notifyOnRoomChangedByUserDM = withDbWatcherCheck(_notifyOnRoomChangedByUserDM);
+export const notifyOnPermissionChanged = withDbWatcherCheck(_notifyOnPermissionChanged);
+export const notifyOnPermissionChangedById = withDbWatcherCheck(_notifyOnPermissionChangedById);
+export const notifyOnPbxEventChangedById = withDbWatcherCheck(_notifyOnPbxEventChangedById);
+export const notifyOnRoleChanged = withDbWatcherCheck(_notifyOnRoleChanged);
+export const notifyOnRoleChangedById = withDbWatcherCheck(_notifyOnRoleChangedById);
+export const notifyOnLoginServiceConfigurationChanged = withDbWatcherCheck(_notifyOnLoginServiceConfigurationChanged);
+export const notifyOnLoginServiceConfigurationChangedByService = withDbWatcherCheck(_notifyOnLoginServiceConfigurationChangedByService);
+export const notifyOnIntegrationChanged = withDbWatcherCheck(_notifyOnIntegrationChanged);
+export const notifyOnIntegrationChangedById = withDbWatcherCheck(_notifyOnIntegrationChangedById);
+export const notifyOnIntegrationChangedByUserId = withDbWatcherCheck(_notifyOnIntegrationChangedByUserId);
+export const notifyOnIntegrationChangedByChannels = withDbWatcherCheck(_notifyOnIntegrationChangedByChannels);
+export const notifyOnEmailInboxChanged = withDbWatcherCheck(_notifyOnEmailInboxChanged);
+export const notifyOnLivechatInquiryChanged = withDbWatcherCheck(_notifyOnLivechatInquiryChanged);
+export const notifyOnLivechatInquiryChangedById = withDbWatcherCheck(_notifyOnLivechatInquiryChangedById);
+export const notifyOnLivechatInquiryChangedByRoom = withDbWatcherCheck(_notifyOnLivechatInquiryChangedByRoom);
+export const notifyOnLivechatInquiryChangedByToken = withDbWatcherCheck(_notifyOnLivechatInquiryChangedByToken);
+export const notifyOnIntegrationHistoryChanged = withDbWatcherCheck(_notifyOnIntegrationHistoryChanged);
+export const notifyOnIntegrationHistoryChangedById = withDbWatcherCheck(_notifyOnIntegrationHistoryChangedById);
+export const notifyOnLivechatDepartmentAgentChanged = withDbWatcherCheck(_notifyOnLivechatDepartmentAgentChanged);
+export const notifyOnLivechatDepartmentAgentChangedByDepartmentId = withDbWatcherCheck(
+	_notifyOnLivechatDepartmentAgentChangedByDepartmentId,
+);
+export const notifyOnLivechatDepartmentAgentChangedByAgentsAndDepartmentId = withDbWatcherCheck(
+	_notifyOnLivechatDepartmentAgentChangedByAgentsAndDepartmentId,
+);
+export const notifyOnSettingChanged = withDbWatcherCheck(_notifyOnSettingChanged);
+export const notifyOnSettingChangedById = withDbWatcherCheck(_notifyOnSettingChangedById);
+export const notifyOnUserChange = withDbWatcherCheck(_notifyOnUserChange);
+export const notifyOnUserChangeAsync = withDbWatcherCheck(_notifyOnUserChangeAsync);
+export const notifyOnUserChangeById = withDbWatcherCheck(_notifyOnUserChangeById);

--- a/apps/meteor/app/lib/server/lib/notifyListener.ts
+++ b/apps/meteor/app/lib/server/lib/notifyListener.ts
@@ -38,290 +38,318 @@ function withDbWatcherCheck<T extends (...args: any[]) => Promise<void>>(fn: T):
 	return dbWatchersDisabled ? fn : ((() => Promise.resolve()) as T);
 }
 
-const _notifyOnLivechatPriorityChanged = async (
-	data: Pick<ILivechatPriority, 'name' | '_id'>,
-	clientAction: ClientAction = 'updated',
-): Promise<void> => {
-	const { _id, ...rest } = data;
-	void api.broadcast('watch.priorities', { clientAction, id: _id, diff: { ...rest } });
-};
+export const notifyOnLivechatPriorityChanged = withDbWatcherCheck(
+	async (data: Pick<ILivechatPriority, 'name' | '_id'>, clientAction: ClientAction = 'updated'): Promise<void> => {
+		const { _id, ...rest } = data;
+		void api.broadcast('watch.priorities', { clientAction, id: _id, diff: { ...rest } });
+	},
+);
 
-const _notifyOnRoomChanged = async <T extends IRocketChatRecord>(data: T | T[], clientAction: ClientAction = 'updated'): Promise<void> => {
-	const items = Array.isArray(data) ? data : [data];
-	for (const item of items) {
-		void api.broadcast('watch.rooms', { clientAction, room: item });
-	}
-};
+export const notifyOnRoomChanged = withDbWatcherCheck(
+	async <T extends IRocketChatRecord>(data: T | T[], clientAction: ClientAction = 'updated'): Promise<void> => {
+		const items = Array.isArray(data) ? data : [data];
+		for (const item of items) {
+			void api.broadcast('watch.rooms', { clientAction, room: item });
+		}
+	},
+);
 
-const _notifyOnRoomChangedById = async <T extends IRocketChatRecord>(
-	ids: T['_id'] | T['_id'][],
-	clientAction: ClientAction = 'updated',
-): Promise<void> => {
-	const eligibleIds = Array.isArray(ids) ? ids : [ids];
-	const items = Rooms.findByIds(eligibleIds);
-	for await (const item of items) {
-		void api.broadcast('watch.rooms', { clientAction, room: item });
-	}
-};
+export const notifyOnRoomChangedById = withDbWatcherCheck(
+	async <T extends IRocketChatRecord>(ids: T['_id'] | T['_id'][], clientAction: ClientAction = 'updated'): Promise<void> => {
+		const eligibleIds = Array.isArray(ids) ? ids : [ids];
+		const items = Rooms.findByIds(eligibleIds);
+		for await (const item of items) {
+			void api.broadcast('watch.rooms', { clientAction, room: item });
+		}
+	},
+);
 
-const _notifyOnRoomChangedByUsernamesOrUids = async <T extends IRoom>(
-	uids: T['u']['_id'][],
-	usernames: T['u']['username'][],
-	clientAction: ClientAction = 'updated',
-): Promise<void> => {
-	const items = Rooms.findByUsernamesOrUids(uids, usernames);
-	for await (const item of items) {
-		void api.broadcast('watch.rooms', { clientAction, room: item });
-	}
-};
+export const notifyOnRoomChangedByUsernamesOrUids = withDbWatcherCheck(
+	async <T extends IRoom>(
+		uids: T['u']['_id'][],
+		usernames: T['u']['username'][],
+		clientAction: ClientAction = 'updated',
+	): Promise<void> => {
+		const items = Rooms.findByUsernamesOrUids(uids, usernames);
+		for await (const item of items) {
+			void api.broadcast('watch.rooms', { clientAction, room: item });
+		}
+	},
+);
 
-const _notifyOnRoomChangedByUserDM = async <T extends IRoom>(
-	userId: T['u']['_id'],
-	clientAction: ClientAction = 'updated',
-): Promise<void> => {
-	const items = Rooms.findDMsByUids([userId]);
-	for await (const item of items) {
-		void api.broadcast('watch.rooms', { clientAction, room: item });
-	}
-};
+export const notifyOnRoomChangedByUserDM = withDbWatcherCheck(
+	async <T extends IRoom>(userId: T['u']['_id'], clientAction: ClientAction = 'updated'): Promise<void> => {
+		const items = Rooms.findDMsByUids([userId]);
+		for await (const item of items) {
+			void api.broadcast('watch.rooms', { clientAction, room: item });
+		}
+	},
+);
 
-const _notifyOnPermissionChanged = async (permission: IPermission, clientAction: ClientAction = 'updated'): Promise<void> => {
-	void api.broadcast('permission.changed', { clientAction, data: permission });
+export const notifyOnPermissionChanged = withDbWatcherCheck(
+	async (permission: IPermission, clientAction: ClientAction = 'updated'): Promise<void> => {
+		void api.broadcast('permission.changed', { clientAction, data: permission });
 
-	if (permission.level === 'settings' && permission.settingId) {
-		const setting = await Settings.findOneNotHiddenById(permission.settingId);
-		if (!setting) {
+		if (permission.level === 'settings' && permission.settingId) {
+			const setting = await Settings.findOneNotHiddenById(permission.settingId);
+			if (!setting) {
+				return;
+			}
+			void notifyOnSettingChanged(setting, 'updated');
+		}
+	},
+);
+
+export const notifyOnPermissionChangedById = withDbWatcherCheck(
+	async (pid: IPermission['_id'], clientAction: ClientAction = 'updated'): Promise<void> => {
+		const permission = await Permissions.findOneById(pid);
+		if (!permission) {
 			return;
 		}
-		void _notifyOnSettingChanged(setting, 'updated');
-	}
-};
 
-const _notifyOnPermissionChangedById = async (pid: IPermission['_id'], clientAction: ClientAction = 'updated'): Promise<void> => {
-	const permission = await Permissions.findOneById(pid);
-	if (!permission) {
-		return;
-	}
+		return notifyOnPermissionChanged(permission, clientAction);
+	},
+);
 
-	return _notifyOnPermissionChanged(permission, clientAction);
-};
+export const notifyOnPbxEventChangedById = withDbWatcherCheck(
+	async <T extends IPbxEvent>(id: T['_id'], clientAction: ClientAction = 'updated'): Promise<void> => {
+		const item = await PbxEvents.findOneById(id);
+		if (!item) {
+			return;
+		}
 
-const _notifyOnPbxEventChangedById = async <T extends IPbxEvent>(id: T['_id'], clientAction: ClientAction = 'updated'): Promise<void> => {
-	const item = await PbxEvents.findOneById(id);
-	if (!item) {
-		return;
-	}
+		void api.broadcast('watch.pbxevents', { clientAction, id, data: item });
+	},
+);
 
-	void api.broadcast('watch.pbxevents', { clientAction, id, data: item });
-};
+export const notifyOnRoleChanged = withDbWatcherCheck(
+	async <T extends IRole>(role: T, clientAction: 'removed' | 'changed' = 'changed'): Promise<void> => {
+		void api.broadcast('watch.roles', { clientAction, role });
+	},
+);
 
-const _notifyOnRoleChanged = async <T extends IRole>(role: T, clientAction: 'removed' | 'changed' = 'changed'): Promise<void> => {
-	void api.broadcast('watch.roles', { clientAction, role });
-};
+export const notifyOnRoleChangedById = withDbWatcherCheck(
+	async <T extends IRole>(id: T['_id'], clientAction: 'removed' | 'changed' = 'changed'): Promise<void> => {
+		const role = await Roles.findOneById(id);
+		if (!role) {
+			return;
+		}
 
-const _notifyOnRoleChangedById = async <T extends IRole>(id: T['_id'], clientAction: 'removed' | 'changed' = 'changed'): Promise<void> => {
-	const role = await Roles.findOneById(id);
-	if (!role) {
-		return;
-	}
+		void notifyOnRoleChanged(role, clientAction);
+	},
+);
 
-	void _notifyOnRoleChanged(role, clientAction);
-};
+export const notifyOnLoginServiceConfigurationChanged = withDbWatcherCheck(
+	async <T extends ILoginServiceConfiguration>(
+		service: Partial<T> & Pick<T, '_id'>,
+		clientAction: ClientAction = 'updated',
+	): Promise<void> => {
+		void api.broadcast('watch.loginServiceConfiguration', {
+			clientAction,
+			id: service._id,
+			data: service,
+		});
+	},
+);
 
-const _notifyOnLoginServiceConfigurationChanged = async <T extends ILoginServiceConfiguration>(
-	service: Partial<T> & Pick<T, '_id'>,
-	clientAction: ClientAction = 'updated',
-): Promise<void> => {
-	void api.broadcast('watch.loginServiceConfiguration', {
-		clientAction,
-		id: service._id,
-		data: service,
-	});
-};
+export const notifyOnLoginServiceConfigurationChangedByService = withDbWatcherCheck(
+	async <T extends ILoginServiceConfiguration>(service: T['service'], clientAction: ClientAction = 'updated'): Promise<void> => {
+		const item = await LoginServiceConfiguration.findOneByService<Omit<LoginServiceConfigurationData, 'secret'>>(service, {
+			projection: { secret: 0 },
+		});
+		if (!item) {
+			return;
+		}
 
-const _notifyOnLoginServiceConfigurationChangedByService = async <T extends ILoginServiceConfiguration>(
-	service: T['service'],
-	clientAction: ClientAction = 'updated',
-): Promise<void> => {
-	const item = await LoginServiceConfiguration.findOneByService<Omit<LoginServiceConfigurationData, 'secret'>>(service, {
-		projection: { secret: 0 },
-	});
-	if (!item) {
-		return;
-	}
+		void notifyOnLoginServiceConfigurationChanged(item, clientAction);
+	},
+);
 
-	void _notifyOnLoginServiceConfigurationChanged(item, clientAction);
-};
+export const notifyOnIntegrationChanged = withDbWatcherCheck(
+	async <T extends IIntegration>(data: T, clientAction: ClientAction = 'updated'): Promise<void> => {
+		void api.broadcast('watch.integrations', { clientAction, id: data._id, data });
+	},
+);
 
-const _notifyOnIntegrationChanged = async <T extends IIntegration>(data: T, clientAction: ClientAction = 'updated'): Promise<void> => {
-	void api.broadcast('watch.integrations', { clientAction, id: data._id, data });
-};
+export const notifyOnIntegrationChangedById = withDbWatcherCheck(
+	async <T extends IIntegration>(id: T['_id'], clientAction: ClientAction = 'updated'): Promise<void> => {
+		const item = await Integrations.findOneById(id);
+		if (!item) {
+			return;
+		}
 
-const _notifyOnIntegrationChangedById = async <T extends IIntegration>(
-	id: T['_id'],
-	clientAction: ClientAction = 'updated',
-): Promise<void> => {
-	const item = await Integrations.findOneById(id);
-	if (!item) {
-		return;
-	}
-
-	void api.broadcast('watch.integrations', { clientAction, id: item._id, data: item });
-};
-
-const _notifyOnIntegrationChangedByUserId = async <T extends IIntegration>(
-	id: T['userId'],
-	clientAction: ClientAction = 'updated',
-): Promise<void> => {
-	const items = Integrations.findByUserId(id);
-
-	for await (const item of items) {
 		void api.broadcast('watch.integrations', { clientAction, id: item._id, data: item });
-	}
-};
+	},
+);
 
-const _notifyOnIntegrationChangedByChannels = async <T extends IIntegration>(
-	channels: T['channel'],
-	clientAction: ClientAction = 'updated',
-): Promise<void> => {
-	const items = Integrations.findByChannels(channels);
+export const notifyOnIntegrationChangedByUserId = withDbWatcherCheck(
+	async <T extends IIntegration>(id: T['userId'], clientAction: ClientAction = 'updated'): Promise<void> => {
+		const items = Integrations.findByUserId(id);
 
-	for await (const item of items) {
-		void api.broadcast('watch.integrations', { clientAction, id: item._id, data: item });
-	}
-};
+		for await (const item of items) {
+			void api.broadcast('watch.integrations', { clientAction, id: item._id, data: item });
+		}
+	},
+);
 
-const _notifyOnEmailInboxChanged = async <T extends IEmailInbox>(
-	data: Pick<T, '_id'> | T, // TODO: improve typing
-	clientAction: ClientAction = 'updated',
-): Promise<void> => {
-	void api.broadcast('watch.emailInbox', { clientAction, id: data._id, data });
-};
+export const notifyOnIntegrationChangedByChannels = withDbWatcherCheck(
+	async <T extends IIntegration>(channels: T['channel'], clientAction: ClientAction = 'updated'): Promise<void> => {
+		const items = Integrations.findByChannels(channels);
 
-const _notifyOnLivechatInquiryChanged = async (
-	data: ILivechatInquiryRecord | ILivechatInquiryRecord[],
-	clientAction: ClientAction = 'updated',
-	diff?: Partial<Record<keyof ILivechatInquiryRecord, unknown> & { queuedAt: unknown; takenAt: unknown }>,
-): Promise<void> => {
-	const items = Array.isArray(data) ? data : [data];
+		for await (const item of items) {
+			void api.broadcast('watch.integrations', { clientAction, id: item._id, data: item });
+		}
+	},
+);
 
-	for (const item of items) {
-		void api.broadcast('watch.inquiries', { clientAction, inquiry: item, diff });
-	}
-};
+export const notifyOnEmailInboxChanged = withDbWatcherCheck(
+	async <T extends IEmailInbox>(
+		data: Pick<T, '_id'> | T, // TODO: improve typing
+		clientAction: ClientAction = 'updated',
+	): Promise<void> => {
+		void api.broadcast('watch.emailInbox', { clientAction, id: data._id, data });
+	},
+);
 
-const _notifyOnLivechatInquiryChangedById = async (
-	id: ILivechatInquiryRecord['_id'],
-	clientAction: ClientAction = 'updated',
-	diff?: Partial<Record<keyof ILivechatInquiryRecord, unknown> & { queuedAt: unknown; takenAt: unknown }>,
-): Promise<void> => {
-	const inquiry = clientAction === 'removed' ? await LivechatInquiry.trashFindOneById(id) : await LivechatInquiry.findOneById(id);
+export const notifyOnLivechatInquiryChanged = withDbWatcherCheck(
+	async (
+		data: ILivechatInquiryRecord | ILivechatInquiryRecord[],
+		clientAction: ClientAction = 'updated',
+		diff?: Partial<Record<keyof ILivechatInquiryRecord, unknown> & { queuedAt: unknown; takenAt: unknown }>,
+	): Promise<void> => {
+		const items = Array.isArray(data) ? data : [data];
 
-	if (!inquiry) {
-		return;
-	}
+		for (const item of items) {
+			void api.broadcast('watch.inquiries', { clientAction, inquiry: item, diff });
+		}
+	},
+);
 
-	void api.broadcast('watch.inquiries', { clientAction, inquiry, diff });
-};
+export const notifyOnLivechatInquiryChangedById = withDbWatcherCheck(
+	async (
+		id: ILivechatInquiryRecord['_id'],
+		clientAction: ClientAction = 'updated',
+		diff?: Partial<Record<keyof ILivechatInquiryRecord, unknown> & { queuedAt: unknown; takenAt: unknown }>,
+	): Promise<void> => {
+		const inquiry = clientAction === 'removed' ? await LivechatInquiry.trashFindOneById(id) : await LivechatInquiry.findOneById(id);
 
-const _notifyOnLivechatInquiryChangedByRoom = async (
-	rid: ILivechatInquiryRecord['rid'],
-	clientAction: ClientAction = 'updated',
-	diff?: Partial<Record<keyof ILivechatInquiryRecord, unknown> & { queuedAt: unknown; takenAt: unknown }>,
-): Promise<void> => {
-	const inquiry = await LivechatInquiry.findOneByRoomId(rid, {});
+		if (!inquiry) {
+			return;
+		}
 
-	if (!inquiry) {
-		return;
-	}
+		void api.broadcast('watch.inquiries', { clientAction, inquiry, diff });
+	},
+);
 
-	void api.broadcast('watch.inquiries', { clientAction, inquiry, diff });
-};
+export const notifyOnLivechatInquiryChangedByRoom = withDbWatcherCheck(
+	async (
+		rid: ILivechatInquiryRecord['rid'],
+		clientAction: ClientAction = 'updated',
+		diff?: Partial<Record<keyof ILivechatInquiryRecord, unknown> & { queuedAt: unknown; takenAt: unknown }>,
+	): Promise<void> => {
+		const inquiry = await LivechatInquiry.findOneByRoomId(rid, {});
 
-const _notifyOnLivechatInquiryChangedByToken = async (
-	token: ILivechatInquiryRecord['v']['token'],
-	clientAction: ClientAction = 'updated',
-	diff?: Partial<Record<keyof ILivechatInquiryRecord, unknown> & { queuedAt: unknown; takenAt: unknown }>,
-): Promise<void> => {
-	const inquiry = await LivechatInquiry.findOneByToken(token);
+		if (!inquiry) {
+			return;
+		}
 
-	if (!inquiry) {
-		return;
-	}
+		void api.broadcast('watch.inquiries', { clientAction, inquiry, diff });
+	},
+);
 
-	void api.broadcast('watch.inquiries', { clientAction, inquiry, diff });
-};
+export const notifyOnLivechatInquiryChangedByToken = withDbWatcherCheck(
+	async (
+		token: ILivechatInquiryRecord['v']['token'],
+		clientAction: ClientAction = 'updated',
+		diff?: Partial<Record<keyof ILivechatInquiryRecord, unknown> & { queuedAt: unknown; takenAt: unknown }>,
+	): Promise<void> => {
+		const inquiry = await LivechatInquiry.findOneByToken(token);
 
-const _notifyOnIntegrationHistoryChanged = async <T extends IIntegrationHistory>(
-	data: AtLeast<T, '_id'>,
-	clientAction: ClientAction = 'updated',
-	diff: Partial<T> = {},
-): Promise<void> => {
-	void api.broadcast('watch.integrationHistory', { clientAction, id: data._id, data, diff });
-};
+		if (!inquiry) {
+			return;
+		}
 
-const _notifyOnIntegrationHistoryChangedById = async <T extends IIntegrationHistory>(
-	id: T['_id'],
-	clientAction: ClientAction = 'updated',
-	diff: Partial<T> = {},
-): Promise<void> => {
-	const item = await IntegrationHistory.findOneById(id);
+		void api.broadcast('watch.inquiries', { clientAction, inquiry, diff });
+	},
+);
 
-	if (!item) {
-		return;
-	}
+export const notifyOnIntegrationHistoryChanged = withDbWatcherCheck(
+	async <T extends IIntegrationHistory>(
+		data: AtLeast<T, '_id'>,
+		clientAction: ClientAction = 'updated',
+		diff: Partial<T> = {},
+	): Promise<void> => {
+		void api.broadcast('watch.integrationHistory', { clientAction, id: data._id, data, diff });
+	},
+);
 
-	void api.broadcast('watch.integrationHistory', { clientAction, id: item._id, data: item, diff });
-};
+export const notifyOnIntegrationHistoryChangedById = withDbWatcherCheck(
+	async <T extends IIntegrationHistory>(id: T['_id'], clientAction: ClientAction = 'updated', diff: Partial<T> = {}): Promise<void> => {
+		const item = await IntegrationHistory.findOneById(id);
 
-const _notifyOnLivechatDepartmentAgentChanged = async <T extends ILivechatDepartmentAgents>(
-	data: Partial<T> & Pick<T, '_id' | 'agentId' | 'departmentId'>,
-	clientAction: ClientAction = 'updated',
-): Promise<void> => {
-	void api.broadcast('watch.livechatDepartmentAgents', { clientAction, id: data._id, data });
-};
+		if (!item) {
+			return;
+		}
 
-const _notifyOnLivechatDepartmentAgentChangedByDepartmentId = async <T extends ILivechatDepartmentAgents>(
-	departmentId: T['departmentId'],
-	clientAction: 'inserted' | 'updated' = 'updated',
-): Promise<void> => {
-	const items = LivechatDepartmentAgents.findByDepartmentId(departmentId, { projection: { _id: 1, agentId: 1, departmentId: 1 } });
+		void api.broadcast('watch.integrationHistory', { clientAction, id: item._id, data: item, diff });
+	},
+);
 
-	for await (const item of items) {
-		void api.broadcast('watch.livechatDepartmentAgents', { clientAction, id: item._id, data: item });
-	}
-};
+export const notifyOnLivechatDepartmentAgentChanged = withDbWatcherCheck(
+	async <T extends ILivechatDepartmentAgents>(
+		data: Partial<T> & Pick<T, '_id' | 'agentId' | 'departmentId'>,
+		clientAction: ClientAction = 'updated',
+	): Promise<void> => {
+		void api.broadcast('watch.livechatDepartmentAgents', { clientAction, id: data._id, data });
+	},
+);
 
-const _notifyOnLivechatDepartmentAgentChangedByAgentsAndDepartmentId = async <T extends ILivechatDepartmentAgents>(
-	agentsIds: T['agentId'][],
-	departmentId: T['departmentId'],
-	clientAction: 'inserted' | 'updated' = 'updated',
-): Promise<void> => {
-	const items = LivechatDepartmentAgents.findByAgentsAndDepartmentId(agentsIds, departmentId, {
-		projection: { _id: 1, agentId: 1, departmentId: 1 },
-	});
+export const notifyOnLivechatDepartmentAgentChangedByDepartmentId = withDbWatcherCheck(
+	async <T extends ILivechatDepartmentAgents>(
+		departmentId: T['departmentId'],
+		clientAction: 'inserted' | 'updated' = 'updated',
+	): Promise<void> => {
+		const items = LivechatDepartmentAgents.findByDepartmentId(departmentId, { projection: { _id: 1, agentId: 1, departmentId: 1 } });
 
-	for await (const item of items) {
-		void api.broadcast('watch.livechatDepartmentAgents', { clientAction, id: item._id, data: item });
-	}
-};
+		for await (const item of items) {
+			void api.broadcast('watch.livechatDepartmentAgents', { clientAction, id: item._id, data: item });
+		}
+	},
+);
 
-const _notifyOnSettingChanged = async (
-	setting: ISetting & { editor?: ISettingColor['editor'] },
-	clientAction: ClientAction = 'updated',
-): Promise<void> => {
-	void api.broadcast('watch.settings', { clientAction, setting });
-};
+export const notifyOnLivechatDepartmentAgentChangedByAgentsAndDepartmentId = withDbWatcherCheck(
+	async <T extends ILivechatDepartmentAgents>(
+		agentsIds: T['agentId'][],
+		departmentId: T['departmentId'],
+		clientAction: 'inserted' | 'updated' = 'updated',
+	): Promise<void> => {
+		const items = LivechatDepartmentAgents.findByAgentsAndDepartmentId(agentsIds, departmentId, {
+			projection: { _id: 1, agentId: 1, departmentId: 1 },
+		});
 
-const _notifyOnSettingChangedById = async (id: ISetting['_id'], clientAction: ClientAction = 'updated'): Promise<void> => {
-	const item = clientAction === 'removed' ? await Settings.trashFindOneById(id) : await Settings.findOneById(id);
+		for await (const item of items) {
+			void api.broadcast('watch.livechatDepartmentAgents', { clientAction, id: item._id, data: item });
+		}
+	},
+);
 
-	if (!item) {
-		return;
-	}
+export const notifyOnSettingChanged = withDbWatcherCheck(
+	async (setting: ISetting & { editor?: ISettingColor['editor'] }, clientAction: ClientAction = 'updated'): Promise<void> => {
+		void api.broadcast('watch.settings', { clientAction, setting });
+	},
+);
 
-	void api.broadcast('watch.settings', { clientAction, setting: item });
-};
+export const notifyOnSettingChangedById = withDbWatcherCheck(
+	async (id: ISetting['_id'], clientAction: ClientAction = 'updated'): Promise<void> => {
+		const item = clientAction === 'removed' ? await Settings.trashFindOneById(id) : await Settings.findOneById(id);
+
+		if (!item) {
+			return;
+		}
+
+		void api.broadcast('watch.settings', { clientAction, setting: item });
+	},
+);
 
 type NotifyUserChange = {
 	id: IUser['_id'];
@@ -331,7 +359,7 @@ type NotifyUserChange = {
 	unset?: Record<string, number>;
 };
 
-const _notifyOnUserChange = async ({ clientAction, id, data, diff, unset }: NotifyUserChange) => {
+export const notifyOnUserChange = withDbWatcherCheck(async ({ clientAction, id, data, diff, unset }: NotifyUserChange) => {
 	if (clientAction === 'removed') {
 		void api.broadcast('watch.users', { clientAction, id });
 		return;
@@ -343,67 +371,33 @@ const _notifyOnUserChange = async ({ clientAction, id, data, diff, unset }: Noti
 	}
 
 	void api.broadcast('watch.users', { clientAction, diff: diff!, unset: unset || {}, id });
-};
+});
 
 /**
  * Calls the callback only if DB Watchers are disabled
  */
-const _notifyOnUserChangeAsync = async (cb: () => Promise<NotifyUserChange | NotifyUserChange[] | void>) => {
+export const notifyOnUserChangeAsync = withDbWatcherCheck(async (cb: () => Promise<NotifyUserChange | NotifyUserChange[] | void>) => {
 	const result = await cb();
 	if (!result) {
 		return;
 	}
 
 	if (Array.isArray(result)) {
-		result.forEach((n) => _notifyOnUserChange(n));
+		result.forEach((n) => notifyOnUserChange(n));
 		return;
 	}
 
-	return _notifyOnUserChange(result);
-};
+	return notifyOnUserChange(result);
+});
 
 // TODO this may be only useful on 'inserted'
-const _notifyOnUserChangeById = async ({ clientAction, id }: { id: IUser['_id']; clientAction: 'inserted' | 'removed' | 'updated' }) => {
-	const user = await Users.findOneById(id);
-	if (!user) {
-		return;
-	}
+export const notifyOnUserChangeById = withDbWatcherCheck(
+	async ({ clientAction, id }: { id: IUser['_id']; clientAction: 'inserted' | 'removed' | 'updated' }) => {
+		const user = await Users.findOneById(id);
+		if (!user) {
+			return;
+		}
 
-	void _notifyOnUserChange({ id, clientAction, data: user });
-};
-
-export const notifyOnLivechatPriorityChanged = withDbWatcherCheck(_notifyOnLivechatPriorityChanged);
-export const notifyOnRoomChanged = withDbWatcherCheck(_notifyOnRoomChanged);
-export const notifyOnRoomChangedById = withDbWatcherCheck(_notifyOnRoomChangedById);
-export const notifyOnRoomChangedByUsernamesOrUids = withDbWatcherCheck(_notifyOnRoomChangedByUsernamesOrUids);
-export const notifyOnRoomChangedByUserDM = withDbWatcherCheck(_notifyOnRoomChangedByUserDM);
-export const notifyOnPermissionChanged = withDbWatcherCheck(_notifyOnPermissionChanged);
-export const notifyOnPermissionChangedById = withDbWatcherCheck(_notifyOnPermissionChangedById);
-export const notifyOnPbxEventChangedById = withDbWatcherCheck(_notifyOnPbxEventChangedById);
-export const notifyOnRoleChanged = withDbWatcherCheck(_notifyOnRoleChanged);
-export const notifyOnRoleChangedById = withDbWatcherCheck(_notifyOnRoleChangedById);
-export const notifyOnLoginServiceConfigurationChanged = withDbWatcherCheck(_notifyOnLoginServiceConfigurationChanged);
-export const notifyOnLoginServiceConfigurationChangedByService = withDbWatcherCheck(_notifyOnLoginServiceConfigurationChangedByService);
-export const notifyOnIntegrationChanged = withDbWatcherCheck(_notifyOnIntegrationChanged);
-export const notifyOnIntegrationChangedById = withDbWatcherCheck(_notifyOnIntegrationChangedById);
-export const notifyOnIntegrationChangedByUserId = withDbWatcherCheck(_notifyOnIntegrationChangedByUserId);
-export const notifyOnIntegrationChangedByChannels = withDbWatcherCheck(_notifyOnIntegrationChangedByChannels);
-export const notifyOnEmailInboxChanged = withDbWatcherCheck(_notifyOnEmailInboxChanged);
-export const notifyOnLivechatInquiryChanged = withDbWatcherCheck(_notifyOnLivechatInquiryChanged);
-export const notifyOnLivechatInquiryChangedById = withDbWatcherCheck(_notifyOnLivechatInquiryChangedById);
-export const notifyOnLivechatInquiryChangedByRoom = withDbWatcherCheck(_notifyOnLivechatInquiryChangedByRoom);
-export const notifyOnLivechatInquiryChangedByToken = withDbWatcherCheck(_notifyOnLivechatInquiryChangedByToken);
-export const notifyOnIntegrationHistoryChanged = withDbWatcherCheck(_notifyOnIntegrationHistoryChanged);
-export const notifyOnIntegrationHistoryChangedById = withDbWatcherCheck(_notifyOnIntegrationHistoryChangedById);
-export const notifyOnLivechatDepartmentAgentChanged = withDbWatcherCheck(_notifyOnLivechatDepartmentAgentChanged);
-export const notifyOnLivechatDepartmentAgentChangedByDepartmentId = withDbWatcherCheck(
-	_notifyOnLivechatDepartmentAgentChangedByDepartmentId,
+		void notifyOnUserChange({ id, clientAction, data: user });
+	},
 );
-export const notifyOnLivechatDepartmentAgentChangedByAgentsAndDepartmentId = withDbWatcherCheck(
-	_notifyOnLivechatDepartmentAgentChangedByAgentsAndDepartmentId,
-);
-export const notifyOnSettingChanged = withDbWatcherCheck(_notifyOnSettingChanged);
-export const notifyOnSettingChangedById = withDbWatcherCheck(_notifyOnSettingChangedById);
-export const notifyOnUserChange = withDbWatcherCheck(_notifyOnUserChange);
-export const notifyOnUserChangeAsync = withDbWatcherCheck(_notifyOnUserChangeAsync);
-export const notifyOnUserChangeById = withDbWatcherCheck(_notifyOnUserChangeById);


### PR DESCRIPTION
This refactor introduces a middleware function, `withDbWatcherCheck`, to handle the `dbWatchersDisabled` check uniformly across various notification functions. By applying this middleware, we ensure that the flag checks are consistently managed, reducing redundancy and potential errors.

The primary changes involve:
- Creation of the `withDbWatcherCheck` middleware to wrap notification functions.
- Direct export of each notification function with the `withDbWatcherCheck` wrapper applied.