### PR TITLE
fix :Change Password Validation Bug

### DIFF
--- a/apps/meteor/client/views/account/security/ChangePassword.tsx
+++ b/apps/meteor/client/views/account/security/ChangePassword.tsx
@@ -3,7 +3,7 @@ import { useUniqueId } from '@rocket.chat/fuselage-hooks';
 import { PasswordVerifier, useValidatePassword } from '@rocket.chat/ui-client';
 import { useMethod, useToastMessageDispatch, useTranslation } from '@rocket.chat/ui-contexts';
 import type { AllHTMLAttributes } from 'react';
-import React from 'react';
+import React,{useEffect} from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import { useAllowPasswordChange } from './useAllowPasswordChange';
@@ -22,11 +22,14 @@ const ChangePassword = (props: AllHTMLAttributes<HTMLFormElement>) => {
 		watch,
 		formState: { errors },
 		handleSubmit,
+		setError,
+		clearErrors,
 		reset,
 		control,
 	} = useFormContext<PasswordFieldValues>();
 
 	const password = watch('password');
+	const confirmationPassword=watch('confirmationPassword')
 	const passwordIsValid = useValidatePassword(password);
 	const { allowPasswordChange } = useAllowPasswordChange();
 
@@ -42,7 +45,14 @@ const ChangePassword = (props: AllHTMLAttributes<HTMLFormElement>) => {
 			dispatchToastMessage({ type: 'error', message: error });
 		}
 	};
-
+	useEffect(() => {
+		if (confirmationPassword && password !== confirmationPassword) {
+			setError('confirmationPassword', { type: 'validate', message: t('Passwords_do_not_match') });
+		} else {
+			clearErrors('confirmationPassword');
+		}
+	}, [password, confirmationPassword, setError, clearErrors, t]);
+	
 	return (
 		<Box {...props} is='form' autoComplete='off' onSubmit={handleSubmit(handleSave)}>
 			<FieldGroup>


### PR DESCRIPTION

fix #32740

Now behavior is that a warning should appear while writing in the confirm password input if it does not match the new password, rather than only discovering this after submitting the form.
https://github.com/user-attachments/assets/2d747e21-6fdc-4d1f-a41b-71dac03a81cc


