### PR TITLE
fix: Pressing esc whilst editing a message closes the contextual bar

### DIFF
--- a/.changeset/large-vans-attack.md
+++ b/.changeset/large-vans-attack.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+fixed the contextual bar closing when editing thread messages instead of cancelling the message edit

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -357,7 +357,20 @@ const MessageBox = ({
 		configurations: composerPopupConfig,
 	});
 
-	const mergedRefs = useMessageComposerMergedRefs(c, textareaRef, callbackRef, autofocusRef);
+	const keyDownHandlerCallbackRef = useCallback(
+		(node: any) => {
+			if (node === null) {
+				return;
+			}
+			node.addEventListener('keydown', (e: KeyboardEvent<HTMLTextAreaElement>) => {
+				handler(e);
+				return;
+			});
+		},
+		[handler],
+	);
+
+	const mergedRefs = useMessageComposerMergedRefs(c, textareaRef, callbackRef, autofocusRef, keyDownHandlerCallbackRef);
 
 	const shouldPopupPreview = useEnablePopupPreview(filter, popup);
 
@@ -411,7 +424,6 @@ const MessageBox = ({
 					onChange={setTyping}
 					style={textAreaStyle}
 					placeholder={composerPlaceholder}
-					onKeyDown={handler}
 					onPaste={handlePaste}
 					aria-activedescendant={ariaActiveDescendant}
 				/>

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -18,8 +18,6 @@ import type {
 	ReactElement,
 	MouseEventHandler,
 	FormEvent,
-	KeyboardEventHandler,
-	KeyboardEvent,
 	ClipboardEventHandler,
 	MouseEvent,
 } from 'react';
@@ -61,7 +59,7 @@ const reducer = (_: unknown, event: FormEvent<HTMLInputElement>): boolean => {
 };
 
 const handleFormattingShortcut = (
-	event: KeyboardEvent<HTMLTextAreaElement>,
+	event: KeyboardEvent,
 	formattingButtons: FormattingButton[],
 	composer: ComposerAPI,
 ) => {
@@ -196,7 +194,7 @@ const MessageBox = ({
 		}
 	};
 
-	const handler: KeyboardEventHandler<HTMLTextAreaElement> = useMutableCallback((event) => {
+	const handler = useMutableCallback((event: KeyboardEvent) => {
 		const { which: keyCode } = event;
 
 		const input = event.target as HTMLTextAreaElement;
@@ -358,11 +356,11 @@ const MessageBox = ({
 	});
 
 	const keyDownHandlerCallbackRef = useCallback(
-		(node: any) => {
+		(node: HTMLTextAreaElement) => {
 			if (node === null) {
 				return;
 			}
-			node.addEventListener('keydown', (e: KeyboardEvent<HTMLTextAreaElement>) => {
+			node.addEventListener('keydown', (e: KeyboardEvent) => {
 				handler(e);
 				return;
 			});

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -14,13 +14,7 @@ import {
 } from '@rocket.chat/ui-composer';
 import { useTranslation, useUserPreference, useLayout, useSetting } from '@rocket.chat/ui-contexts';
 import { useMutation } from '@tanstack/react-query';
-import type {
-	ReactElement,
-	MouseEventHandler,
-	FormEvent,
-	ClipboardEventHandler,
-	MouseEvent,
-} from 'react';
+import type { ReactElement, MouseEventHandler, FormEvent, ClipboardEventHandler, MouseEvent } from 'react';
 import React, { memo, useRef, useReducer, useCallback } from 'react';
 import { Trans } from 'react-i18next';
 import { useSubscription } from 'use-subscription';
@@ -58,11 +52,7 @@ const reducer = (_: unknown, event: FormEvent<HTMLInputElement>): boolean => {
 	return Boolean(target.value.trim());
 };
 
-const handleFormattingShortcut = (
-	event: KeyboardEvent,
-	formattingButtons: FormattingButton[],
-	composer: ComposerAPI,
-) => {
+const handleFormattingShortcut = (event: KeyboardEvent, formattingButtons: FormattingButton[], composer: ComposerAPI) => {
 	const isMacOS = navigator.platform.indexOf('Mac') !== -1;
 	const isCmdOrCtrlPressed = (isMacOS && event.metaKey) || (!isMacOS && event.ctrlKey);
 
@@ -362,7 +352,6 @@ const MessageBox = ({
 			}
 			node.addEventListener('keydown', (e: KeyboardEvent) => {
 				handler(e);
-				return;
 			});
 		},
 		[handler],

--- a/apps/meteor/tests/e2e/threads.spec.ts
+++ b/apps/meteor/tests/e2e/threads.spec.ts
@@ -184,13 +184,13 @@ test.describe.serial('Threads', () => {
 			await expect(page).toHaveURL(/.*thread/);
 			await expect(page.getByRole('dialog').locator('[data-qa-type="message"]')).toBeVisible();
 			await expect(page.locator('[name="msg"]').last()).toBeFocused();
-	
+
 			await page.locator('[name="msg"]').last().fill('message to be edited');
 			await page.keyboard.press('Enter');
-	
+
 			await page.keyboard.press('ArrowUp');
 			await expect(page.locator('[name="msg"]').last()).toHaveValue('message to be edited');
-			
+
 			await page.keyboard.press('Escape');
 			await expect(page.locator('[name="msg"]').last()).toHaveValue('');
 			await expect(page).toHaveURL(/.*thread/);

--- a/apps/meteor/tests/e2e/threads.spec.ts
+++ b/apps/meteor/tests/e2e/threads.spec.ts
@@ -162,5 +162,38 @@ test.describe.serial('Threads', () => {
 			await page.keyboard.press('Escape');
 			await expect(page).not.toHaveURL(/.*thread/);
 		});
+
+		test('expect reset the thread composer to original message if user presses escape', async ({ page }) => {
+			await expect(page).toHaveURL(/.*thread/);
+			await expect(page.getByRole('dialog').locator('[data-qa-type="message"]')).toBeVisible();
+
+			await expect(page.locator('[name="msg"]').last()).toBeFocused();
+			await page.locator('[name="msg"]').last().fill('message to be edited');
+			await page.keyboard.press('Enter');
+			await page.keyboard.press('ArrowUp');
+
+			await expect(page.locator('[name="msg"]').last()).toHaveValue('message to be edited');
+			await page.locator('[name="msg"]').last().fill('this message was edited');
+
+			await page.keyboard.press('Escape');
+			await expect(page.locator('[name="msg"]').last()).toHaveValue('message to be edited');
+			await expect(page).toHaveURL(/.*thread/);
+		});
+
+		test('expect clean composer and keep the thread open if user is editing message and presses escape', async ({ page }) => {
+			await expect(page).toHaveURL(/.*thread/);
+			await expect(page.getByRole('dialog').locator('[data-qa-type="message"]')).toBeVisible();
+			await expect(page.locator('[name="msg"]').last()).toBeFocused();
+	
+			await page.locator('[name="msg"]').last().fill('message to be edited');
+			await page.keyboard.press('Enter');
+	
+			await page.keyboard.press('ArrowUp');
+			await expect(page.locator('[name="msg"]').last()).toHaveValue('message to be edited');
+			
+			await page.keyboard.press('Escape');
+			await expect(page.locator('[name="msg"]').last()).toHaveValue('');
+			await expect(page).toHaveURL(/.*thread/);
+		});
 	});
 });


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
There's 2 ways to attach an event listener to a component, using react props (onClick, onKeyDown, etc) or directly to the node (using a callbackRef or getting the element directly from the dom). Attaching events using both ways changes how event propagation works due to react's synthetic event handlers.

The issue was resolved by adding the composer keydown event using a callbackRef instead of as a prop.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-529]

[CORE-529]: https://rocketchat.atlassian.net/browse/CORE-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ