### PR TITLE
chore: saveAnalyticsData with accumulator

### DIFF
--- a/apps/meteor/app/livechat/server/hooks/saveAnalyticsData.ts
+++ b/apps/meteor/app/livechat/server/hooks/saveAnalyticsData.ts
@@ -1,23 +1,68 @@
-import { isEditedMessage, isMessageFromVisitor } from '@rocket.chat/core-typings';
+import { isEditedMessage } from '@rocket.chat/core-typings';
+import type { IOmnichannelRoom } from '@rocket.chat/core-typings';
 import { LivechatRooms } from '@rocket.chat/models';
 
 import { callbacks } from '../../../../lib/callbacks';
 import { normalizeMessageFileUpload } from '../../../utils/server/functions/normalizeMessageFileUpload';
 
+const getMetricValue = <T>(metric: T | undefined, defaultValue: T): T => metric ?? defaultValue;
+const calculateTimeDifference = <T extends Date | number>(startTime: T, now: Date): number =>
+	(now.getTime() - new Date(startTime).getTime()) / 1000;
+const calculateAvgResponseTime = (totalResponseTime: number, newResponseTime: number, responseCount: number) =>
+	(totalResponseTime + newResponseTime) / (responseCount + 1);
+
+const getFirstResponseAnalytics = (
+	visitorLastQuery: Date,
+	agentJoinTime: Date,
+	totalResponseTime: number,
+	responseCount: number,
+	now: Date,
+) => {
+	const responseTime = calculateTimeDifference(visitorLastQuery, now);
+	const reactionTime = calculateTimeDifference(agentJoinTime, now);
+	const avgResponseTime = calculateAvgResponseTime(totalResponseTime, responseTime, responseCount);
+
+	return {
+		firstResponseDate: now,
+		firstResponseTime: responseTime,
+		responseTime,
+		avgResponseTime,
+		firstReactionDate: now,
+		firstReactionTime: reactionTime,
+		reactionTime,
+	};
+};
+
+const getSubsequentResponseAnalytics = (visitorLastQuery: Date, totalResponseTime: number, responseCount: number, now: Date) => {
+	const responseTime = calculateTimeDifference(visitorLastQuery, now);
+	const avgResponseTime = calculateAvgResponseTime(totalResponseTime, responseTime, responseCount);
+
+	return {
+		responseTime,
+		avgResponseTime,
+		reactionTime: responseTime,
+	};
+};
+
+const getAnalyticsData = (room: IOmnichannelRoom, now: Date): Record<string, string | number | Date> | undefined => {
+	const visitorLastQuery = getMetricValue(room.metrics?.v?.lq, room.ts);
+	const agentLastReply = getMetricValue(room.metrics?.servedBy?.lr, room.ts);
+	const agentJoinTime = getMetricValue(room.servedBy?.ts, room.ts);
+	const totalResponseTime = getMetricValue(room.metrics?.response?.tt, 0);
+	const responseCount = getMetricValue(room.metrics?.response?.total, 0);
+
+	if (agentLastReply === room.ts) {
+		return getFirstResponseAnalytics(visitorLastQuery, agentJoinTime, totalResponseTime, responseCount, now);
+	}
+	if (visitorLastQuery > agentLastReply) {
+		return getSubsequentResponseAnalytics(visitorLastQuery, totalResponseTime, responseCount, now);
+	}
+};
+
 callbacks.add(
 	'afterOmnichannelSaveMessage',
 	async (message, { room }) => {
-		// skips this callback if the message was edited
 		if (!message || isEditedMessage(message)) {
-			return message;
-		}
-
-		// if the message has a token, it was sent by the visitor
-		if (isMessageFromVisitor(message)) {
-			// When visitor sends a mesage, most metrics wont be calculated/served.
-			// But, v.lq (last query) will be updated to the message time. This has to be done
-			// As not doing it will cause the metrics to be crazy and not have real values.
-			await LivechatRooms.saveAnalyticsDataByRoomId(room, message);
 			return message;
 		}
 
@@ -25,55 +70,9 @@ callbacks.add(
 			message = { ...(await normalizeMessageFileUpload(message)), ...{ _updatedAt: message._updatedAt } };
 		}
 
-		const now = new Date();
-		let analyticsData;
-
-		const visitorLastQuery = room.metrics?.v ? room.metrics.v.lq : room.ts;
-		const agentLastReply = room.metrics?.servedBy ? room.metrics.servedBy.lr : room.ts;
-		const agentJoinTime = room.servedBy?.ts ? room.servedBy.ts : room.ts;
-
-		const isResponseTt = room.metrics?.response?.tt;
-		const isResponseTotal = room.metrics?.response?.total;
-
-		if (agentLastReply === room.ts) {
-			// first response
-			const firstResponseDate = now;
-			const firstResponseTime = (now.getTime() - new Date(visitorLastQuery).getTime()) / 1000;
-			const responseTime = (now.getTime() - new Date(visitorLastQuery).getTime()) / 1000;
-			const avgResponseTime =
-				((isResponseTt ? room.metrics?.response?.tt : 0) || 0 + responseTime) /
-				((isResponseTotal ? room.metrics?.response?.total : 0) || 0 + 1);
-
-			const firstReactionDate = now;
-			const firstReactionTime = (now.getTime() - new Date(agentJoinTime).getTime()) / 1000;
-			const reactionTime = (now.getTime() - new Date(agentJoinTime).getTime()) / 1000;
-
-			analyticsData = {
-				firstResponseDate,
-				firstResponseTime,
-				responseTime,
-				avgResponseTime,
-				firstReactionDate,
-				firstReactionTime,
-				reactionTime,
-			};
-		} else if (visitorLastQuery > agentLastReply) {
-			// response, not first
-			const responseTime = (now.getTime() - new Date(visitorLastQuery).getTime()) / 1000;
-			const avgResponseTime =
-				((isResponseTt ? room.metrics?.response?.tt : 0) || 0 + responseTime) /
-				((isResponseTotal ? room.metrics?.response?.total : 0) || 0 + 1);
-
-			const reactionTime = (now.getTime() - new Date(visitorLastQuery).getTime()) / 1000;
-
-			analyticsData = {
-				responseTime,
-				avgResponseTime,
-				reactionTime,
-			};
-		} // ignore, its continuing response
-
+		const analyticsData = getAnalyticsData(room, new Date());
 		await LivechatRooms.saveAnalyticsDataByRoomId(room, message, analyticsData);
+
 		return message;
 	},
 	callbacks.priority.LOW,

--- a/apps/meteor/app/livechat/server/hooks/saveAnalyticsData.ts
+++ b/apps/meteor/app/livechat/server/hooks/saveAnalyticsData.ts
@@ -71,7 +71,13 @@ callbacks.add(
 		}
 
 		const analyticsData = getAnalyticsData(room, new Date());
-		await LivechatRooms.saveAnalyticsDataByRoomId(room, message, analyticsData);
+		const updater = await LivechatRooms.getAnalyticsUpdateQueryByRoomId(room, message, analyticsData);
+
+		if (updater.hasChanges()) {
+			await updater.persist({
+				_id: room._id,
+			});
+		}
 
 		return message;
 	},

--- a/apps/meteor/server/models/raw/LivechatRooms.ts
+++ b/apps/meteor/server/models/raw/LivechatRooms.ts
@@ -2022,7 +2022,7 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 	}
 
 	private getAnalyticsUpdateQuery(
-		analyticsData: Record<string, string | number | Date>,
+		analyticsData: Record<string, string | number | Date> | undefined,
 		updater: Updater<IOmnichannelRoom> = this.getUpdater(),
 	) {
 		if (analyticsData) {
@@ -2032,7 +2032,7 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 			updater.inc('metrics.reaction.tt', analyticsData.reactionTime as number);
 		}
 
-		if (analyticsData.firstResponseTime) {
+		if (analyticsData?.firstResponseTime) {
 			updater.set('metrics.reaction.fd', analyticsData.firstReactionDate);
 			updater.set('metrics.reaction.ft', analyticsData.firstReactionTime);
 			updater.set('metrics.response.fd', analyticsData.firstResponseDate);
@@ -2045,7 +2045,7 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 	private getAnalyticsUpdateQueryBySentByAgent(
 		room: IOmnichannelRoom,
 		message: IMessage,
-		analyticsData: Record<string, string | number | Date>,
+		analyticsData: Record<string, string | number | Date> | undefined,
 	) {
 		const updater = this.getAnalyticsUpdateQuery(analyticsData);
 
@@ -2063,7 +2063,7 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 	private getAnalyticsUpdateQueryBySentByVisitor(
 		room: IOmnichannelRoom,
 		message: IMessage,
-		analyticsData: Record<string, string | number | Date>,
+		analyticsData: Record<string, string | number | Date> | undefined,
 	) {
 		const updater = this.getAnalyticsUpdateQuery(analyticsData);
 
@@ -2082,7 +2082,7 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 	private getAnalyticsUpdateQueryByRoomId(
 		room: IOmnichannelRoom,
 		message: IMessage,
-		analyticsData: Record<string, string | number | Date>,
+		analyticsData: Record<string, string | number | Date> | undefined,
 	) {
 		return isMessageFromVisitor(message)
 			? this.getAnalyticsUpdateQueryBySentByVisitor(room, message, analyticsData)
@@ -2092,7 +2092,7 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 	async saveAnalyticsDataByRoomId(
 		room: IOmnichannelRoom,
 		message: IMessage,
-		analyticsData: Record<string, string | number | Date>,
+		analyticsData?: Record<string, string | number | Date>,
 	): Promise<void> {
 		const updater = this.getAnalyticsUpdateQueryByRoomId(room, message, analyticsData);
 		return updater.persist({ _id: room._id });

--- a/packages/core-typings/src/IRoom.ts
+++ b/packages/core-typings/src/IRoom.ts
@@ -275,9 +275,11 @@ export interface IOmnichannelRoom extends IOmnichannelGenericRoom {
 			total: number;
 			avg: number;
 			ft: number;
+			fd?: number;
 		};
 		reaction?: {
 			ft: number;
+			fd?: number;
 		};
 	};
 

--- a/packages/core-typings/src/IRoom.ts
+++ b/packages/core-typings/src/IRoom.ts
@@ -278,6 +278,7 @@ export interface IOmnichannelRoom extends IOmnichannelGenericRoom {
 			fd?: number;
 		};
 		reaction?: {
+			tt: number;
 			ft: number;
 			fd?: number;
 		};

--- a/packages/model-typings/src/models/ILivechatRoomsModel.ts
+++ b/packages/model-typings/src/models/ILivechatRoomsModel.ts
@@ -212,7 +212,7 @@ export interface ILivechatRoomsModel extends IBaseModel<IOmnichannelRoom> {
 		room: IOmnichannelRoom,
 		message: IMessage,
 		analyticsData?: Record<string, string | number | Date>,
-	): Promise<UpdateResult>;
+	): Promise<void>; // Promise<UpdateResult>;
 	getTotalConversationsBetweenDate(t: 'l', date: { gte: Date; lt: Date }, data?: { departmentId: string }): Promise<number>;
 	getAnalyticsMetricsBetweenDate(
 		t: 'l',

--- a/packages/model-typings/src/models/ILivechatRoomsModel.ts
+++ b/packages/model-typings/src/models/ILivechatRoomsModel.ts
@@ -9,6 +9,7 @@ import type {
 import type { FindCursor, UpdateResult, AggregationCursor, Document, FindOptions, DeleteResult, Filter } from 'mongodb';
 
 import type { FindPaginated } from '..';
+import type { Updater } from '../updater';
 import type { IBaseModel } from './IBaseModel';
 
 type Period = {
@@ -208,11 +209,12 @@ export interface ILivechatRoomsModel extends IBaseModel<IOmnichannelRoom> {
 	setResponseByRoomId(roomId: string, responseBy: IOmnichannelRoom['responseBy']): Promise<UpdateResult>;
 	setNotResponseByRoomId(roomId: string): Promise<UpdateResult>;
 	setAgentLastMessageTs(roomId: string): Promise<UpdateResult>;
-	saveAnalyticsDataByRoomId(
+	getAnalyticsUpdateQueryByRoomId(
 		room: IOmnichannelRoom,
 		message: IMessage,
-		analyticsData?: Record<string, string | number | Date>,
-	): Promise<void>; // Promise<UpdateResult>;
+		analyticsData: Record<string, string | number | Date> | undefined,
+		updater?: Updater<IOmnichannelRoom>,
+	): Promise<Updater<IOmnichannelRoom>>;
 	getTotalConversationsBetweenDate(t: 'l', date: { gte: Date; lt: Date }, data?: { departmentId: string }): Promise<number>;
 	getAnalyticsMetricsBetweenDate(
 		t: 'l',


### PR DESCRIPTION
As per [OPI-24](https://rocketchat.atlassian.net/browse/OPI-24), this PR modifies `saveAnalyticsData` hook to work with updater accumulator. This marks the initial implementation of the updater in practice. Additionally, this change will facilitate the integration of all `afterOmnichannelSaveMessage` calls into the accumulator in the near future.

Also related with #32948 and #32970.

[OPI-24]: https://rocketchat.atlassian.net/browse/OPI-24?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ