### PR TITLE
chore: move afterOmnichannelSaveMessage hook to work with updater

### DIFF
--- a/apps/meteor/app/livechat/server/hooks/afterSaveOmnichannelMessage.ts
+++ b/apps/meteor/app/livechat/server/hooks/afterSaveOmnichannelMessage.ts
@@ -1,15 +1,23 @@
 import { isOmnichannelRoom } from '@rocket.chat/core-typings';
+import { LivechatRooms } from '@rocket.chat/models';
 
 import { callbacks } from '../../../../lib/callbacks';
 
 callbacks.add(
 	'afterSaveMessage',
 	async (message, room) => {
-		// only call webhook if it is a livechat room
 		if (!isOmnichannelRoom(room)) {
 			return message;
 		}
-		return callbacks.run('afterOmnichannelSaveMessage', message, { room });
+
+		const updater = LivechatRooms.getUpdater();
+		await callbacks.run('afterOmnichannelSaveMessage', message, { room, roomUpdater: updater });
+
+		if (updater.hasChanges()) {
+			await updater.persist({ _id: room._id });
+		}
+
+		return message;
 	},
 	callbacks.priority.MEDIUM,
 	'after-omnichannel-save-message',

--- a/apps/meteor/app/livechat/server/hooks/afterSaveOmnichannelMessage.ts
+++ b/apps/meteor/app/livechat/server/hooks/afterSaveOmnichannelMessage.ts
@@ -11,13 +11,13 @@ callbacks.add(
 		}
 
 		const updater = LivechatRooms.getUpdater();
-		await callbacks.run('afterOmnichannelSaveMessage', message, { room, roomUpdater: updater });
+		const result = await callbacks.run('afterOmnichannelSaveMessage', message, { room, roomUpdater: updater });
 
 		if (updater.hasChanges()) {
 			await updater.persist({ _id: room._id });
 		}
 
-		return message;
+		return result;
 	},
 	callbacks.priority.MEDIUM,
 	'after-omnichannel-save-message',

--- a/apps/meteor/app/livechat/server/hooks/saveAnalyticsData.ts
+++ b/apps/meteor/app/livechat/server/hooks/saveAnalyticsData.ts
@@ -61,7 +61,7 @@ const getAnalyticsData = (room: IOmnichannelRoom, now: Date): Record<string, str
 
 callbacks.add(
 	'afterOmnichannelSaveMessage',
-	async (message, { room }) => {
+	async (message, { room, roomUpdater }) => {
 		if (!message || isEditedMessage(message)) {
 			return message;
 		}
@@ -71,13 +71,7 @@ callbacks.add(
 		}
 
 		const analyticsData = getAnalyticsData(room, new Date());
-		const updater = await LivechatRooms.getAnalyticsUpdateQueryByRoomId(room, message, analyticsData);
-
-		if (updater.hasChanges()) {
-			await updater.persist({
-				_id: room._id,
-			});
-		}
+		await LivechatRooms.getAnalyticsUpdateQueryByRoomId(room, message, analyticsData, roomUpdater);
 
 		return message;
 	},

--- a/apps/meteor/lib/callbacks.ts
+++ b/apps/meteor/lib/callbacks.ts
@@ -51,7 +51,7 @@ interface EventLikeCallbackSignatures {
 	'afterFileUpload': (params: { user: IUser; room: IRoom; message: IMessage }) => void;
 	'afterRoomNameChange': (params: { rid: string; name: string; oldName: string }) => void;
 	'afterSaveMessage': (message: IMessage, room: IRoom, uid?: string) => void;
-	'afterOmnichannelSaveMessage': (message: IMessage, constant: { room: IOmnichannelRoom; roomUpdater?: Updater<IOmnichannelRoom> }) => void;
+	'afterOmnichannelSaveMessage': (message: IMessage, constant: { room: IOmnichannelRoom; roomUpdater: Updater<IOmnichannelRoom> }) => void;
 	'livechat.removeAgentDepartment': (params: { departmentId: ILivechatDepartmentRecord['_id']; agentsId: ILivechatAgent['_id'][] }) => void;
 	'livechat.saveAgentDepartment': (params: { departmentId: ILivechatDepartmentRecord['_id']; agentsId: ILivechatAgent['_id'][] }) => void;
 	'livechat.closeRoom': (params: { room: IOmnichannelRoom; options: CloseRoomParams['options'] }) => void;

--- a/apps/meteor/lib/callbacks.ts
+++ b/apps/meteor/lib/callbacks.ts
@@ -23,6 +23,7 @@ import type {
 	MessageMention,
 	OmnichannelSourceType,
 } from '@rocket.chat/core-typings';
+import type { Updater } from '@rocket.chat/models';
 import type { FilterOperators } from 'mongodb';
 
 import type { ILoginAttempt } from '../app/authentication/server/ILoginAttempt';
@@ -50,7 +51,7 @@ interface EventLikeCallbackSignatures {
 	'afterFileUpload': (params: { user: IUser; room: IRoom; message: IMessage }) => void;
 	'afterRoomNameChange': (params: { rid: string; name: string; oldName: string }) => void;
 	'afterSaveMessage': (message: IMessage, room: IRoom, uid?: string) => void;
-	'afterOmnichannelSaveMessage': (message: IMessage, constant: { room: IOmnichannelRoom }) => void;
+	'afterOmnichannelSaveMessage': (message: IMessage, constant: { room: IOmnichannelRoom; roomUpdater?: Updater<IOmnichannelRoom> }) => void;
 	'livechat.removeAgentDepartment': (params: { departmentId: ILivechatDepartmentRecord['_id']; agentsId: ILivechatAgent['_id'][] }) => void;
 	'livechat.saveAgentDepartment': (params: { departmentId: ILivechatDepartmentRecord['_id']; agentsId: ILivechatAgent['_id'][] }) => void;
 	'livechat.closeRoom': (params: { room: IOmnichannelRoom; options: CloseRoomParams['options'] }) => void;

--- a/apps/meteor/server/models/raw/LivechatRooms.ts
+++ b/apps/meteor/server/models/raw/LivechatRooms.ts
@@ -2060,7 +2060,7 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 			return this.getAnalyticsUpdateQuery(analyticsData, updater).set('metrics.servedBy.lr', message.ts);
 		}
 
-		return updater;
+		return this.getAnalyticsUpdateQuery(analyticsData, updater);
 	}
 
 	private getAnalyticsUpdateQueryBySentByVisitor(
@@ -2075,10 +2075,10 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 
 		// update visitor timestamp, only if its new inquiry and not continuing message
 		if (agentLastReply >= visitorLastQuery) {
-			return this.getAnalyticsUpdateQuery(analyticsData).set('metrics.v.lq', message.ts);
+			return this.getAnalyticsUpdateQuery(analyticsData, updater).set('metrics.v.lq', message.ts);
 		}
 
-		return updater;
+		return this.getAnalyticsUpdateQuery(analyticsData, updater);
 	}
 
 	async getAnalyticsUpdateQueryByRoomId(

--- a/apps/meteor/server/models/raw/LivechatRooms.ts
+++ b/apps/meteor/server/models/raw/LivechatRooms.ts
@@ -78,6 +78,10 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 		];
 	}
 
+	getUpdater(): Updater<IOmnichannelRoom> {
+		return super.getUpdater();
+	}
+
 	getQueueMetrics({
 		departmentId,
 		agentId,

--- a/packages/model-typings/src/models/ILivechatRoomsModel.ts
+++ b/packages/model-typings/src/models/ILivechatRoomsModel.ts
@@ -31,6 +31,8 @@ type WithOptions = {
 
 // TODO: Fix types of model
 export interface ILivechatRoomsModel extends IBaseModel<IOmnichannelRoom> {
+	getUpdater(): Updater<IOmnichannelRoom>;
+
 	getQueueMetrics(params: { departmentId: any; agentId: any; includeOfflineAgents: any; options?: any }): any;
 
 	findAllNumberOfAbandonedRooms(params: Period & WithDepartment & WithOnlyCount & WithOptions): Promise<any>;


### PR DESCRIPTION
This pull request addresses the requirements of [OPI-12](https://rocketchat.atlassian.net/browse/OPI-12) by adding updater support to the `afterOmnichannelSaveMessage` hook - that aims to optimize performance by reducing database calls related to omnichannel rooms.

[OPI-12]: https://rocketchat.atlassian.net/browse/OPI-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ