### PR TITLE
feat: integrating rc.guided.tours gsoc 2024

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ yarn-error.log*
 *.sublime-workspace
 
 **/.vim/
+
+# tours
+.tours
+RC.Guided.Tours
+tours.sh

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ After initialized, you can access the server at http://localhost:3000
 More details at: [Developer Docs](https://developer.rocket.chat/v1/docs/server-environment-setup)
 PS: For Windows you MUST use WSL2 and have +12Gb RAM
 
+To learn more about our codebase in an interactive way, you can use our project [RC.Guided.Tours](https://github.com/RocketChat/RC.Guided.Tours)
+
 
 # Gitpod Setup
 


### PR DESCRIPTION
**.gitignore** -> it prevents the tracking of the folders ".tours", "RC.Guided.Tours" and tours.sh file

**.tours** -> the codetours extension uses the .tours folder to display the tours but since the tours are dynamically generated, i.e. the ,tours folder is dynamically generated, we dont need to save it 

**RC.Guided.Tours** -> It contains the main script to generate the .tours files. It can be cloned directly from Rocket.Chat or can be forked, so we dont save it

**tours.sh** -> It is the shell script which is mainly responsible to clone the RC.Guided.Tours Repository and the execute the required scripts.
