### PR TITLE
chore: create getNotResponseByRoomIdUpdateQuery method

### DIFF
--- a/apps/meteor/app/livechat/server/hooks/markRoomNotResponded.ts
+++ b/apps/meteor/app/livechat/server/hooks/markRoomNotResponded.ts
@@ -5,7 +5,7 @@ import { callbacks } from '../../../../lib/callbacks';
 
 callbacks.add(
 	'afterOmnichannelSaveMessage',
-	async (message, { room }) => {
+	(message, { room, roomUpdater }) => {
 		// skips this callback if the message was edited
 		if (!message || isEditedMessage(message)) {
 			return message;
@@ -21,7 +21,7 @@ callbacks.add(
 			return message;
 		}
 
-		await LivechatRooms.setNotResponseByRoomId(room._id);
+		LivechatRooms.getNotResponseByRoomIdUpdateQuery(roomUpdater);
 
 		return message;
 	},

--- a/apps/meteor/server/models/raw/LivechatRooms.ts
+++ b/apps/meteor/server/models/raw/LivechatRooms.ts
@@ -1983,21 +1983,10 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 		return updater;
 	}
 
-	setNotResponseByRoomId(roomId: string) {
-		return this.updateOne(
-			{
-				_id: roomId,
-				t: 'l',
-			},
-			{
-				$set: {
-					waitingResponse: true,
-				},
-				$unset: {
-					responseBy: 1,
-				},
-			},
-		);
+	getNotResponseByRoomIdUpdateQuery(updater: Updater<IOmnichannelRoom> = this.getUpdater()) {
+		updater.set('waitingResponse', true);
+		updater.unset('responseBy');
+		return updater;
 	}
 
 	getAgentLastMessageTsUpdateQuery(updater: Updater<IOmnichannelRoom> = this.getUpdater()) {

--- a/packages/model-typings/src/models/ILivechatRoomsModel.ts
+++ b/packages/model-typings/src/models/ILivechatRoomsModel.ts
@@ -212,7 +212,7 @@ export interface ILivechatRoomsModel extends IBaseModel<IOmnichannelRoom> {
 		responseBy: IOmnichannelRoom['responseBy'],
 		updater?: Updater<IOmnichannelRoom>,
 	): Updater<IOmnichannelRoom>;
-	getNotResponseByRoomIdUpdateQuery(updater: Updater<IOmnichannelRoom> = this.getUpdater()): Updater<IOmnichannelRoom>;
+	getNotResponseByRoomIdUpdateQuery(updater: Updater<IOmnichannelRoom>): Updater<IOmnichannelRoom>;
 	getAgentLastMessageTsUpdateQuery(updater?: Updater<IOmnichannelRoom>): Updater<IOmnichannelRoom>;
 	getAnalyticsUpdateQueryByRoomId(
 		room: IOmnichannelRoom,

--- a/packages/model-typings/src/models/ILivechatRoomsModel.ts
+++ b/packages/model-typings/src/models/ILivechatRoomsModel.ts
@@ -212,7 +212,7 @@ export interface ILivechatRoomsModel extends IBaseModel<IOmnichannelRoom> {
 		responseBy: IOmnichannelRoom['responseBy'],
 		updater?: Updater<IOmnichannelRoom>,
 	): Updater<IOmnichannelRoom>;
-	setNotResponseByRoomId(roomId: string): Promise<UpdateResult>;
+	getNotResponseByRoomIdUpdateQuery(updater: Updater<IOmnichannelRoom> = this.getUpdater()): Updater<IOmnichannelRoom>;
 	getAgentLastMessageTsUpdateQuery(updater?: Updater<IOmnichannelRoom>): Updater<IOmnichannelRoom>;
 	getAnalyticsUpdateQueryByRoomId(
 		room: IOmnichannelRoom,


### PR DESCRIPTION
This pull request addresses the requirements of [OPI-27](https://rocketchat.atlassian.net/browse/OPI-27) by adding updater support to the `afterOmnichannelSaveMessage.markRoomNotResponded` hook - that aims to optimize performance by reducing database calls related to omnichannel rooms.

[OPI-27]: https://rocketchat.atlassian.net/browse/OPI-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ