### PR TITLE
chore: add roomUpdater on notifyUsersOnMessage

### DIFF
--- a/apps/meteor/app/federation/server/endpoints/dispatch.js
+++ b/apps/meteor/app/federation/server/endpoints/dispatch.js
@@ -293,8 +293,12 @@ const eventHandlers = {
 
 					await processThreads(denormalizedMessage, room);
 
-					// Notify users
-					await notifyUsersOnMessage(denormalizedMessage, room);
+					const roomUpdater = Rooms.getUpdater();
+					await notifyUsersOnMessage(denormalizedMessage, room, roomUpdater);
+					if (roomUpdater.hasChanges()) {
+						await roomUpdater.persist({ _id: room._id });
+					}
+
 					sendAllNotifications(denormalizedMessage, room);
 					messageForNotification = denormalizedMessage;
 				} catch (err) {

--- a/apps/meteor/app/lib/server/lib/notifyUsersOnMessage.ts
+++ b/apps/meteor/app/lib/server/lib/notifyUsersOnMessage.ts
@@ -1,5 +1,6 @@
 import type { IMessage, IRoom, IUser, RoomType } from '@rocket.chat/core-typings';
 import { isEditedMessage } from '@rocket.chat/core-typings';
+import type { Updater } from '@rocket.chat/models';
 import { Subscriptions, Rooms } from '@rocket.chat/models';
 import { escapeRegExp } from '@rocket.chat/string-helpers';
 import moment from 'moment';
@@ -141,12 +142,12 @@ export async function updateThreadUsersSubscriptions(message: IMessage, replies:
 	await Subscriptions.setLastReplyForRoomIdAndUserIds(message.rid, repliesPlusSender, new Date());
 }
 
-export async function notifyUsersOnMessage(message: IMessage, room: IRoom): Promise<IMessage> {
+export async function notifyUsersOnMessage(message: IMessage, room: IRoom, roomUpdater: Updater<IRoom>): Promise<IMessage> {
 	// Skips this callback if the message was edited and increments it if the edit was way in the past (aka imported)
 	if (isEditedMessage(message)) {
 		if (Math.abs(moment(message.editedAt).diff(Date.now())) > 60000) {
 			// TODO: Review as I am not sure how else to get around this as the incrementing of the msgs count shouldn't be in this callback
-			await Rooms.incMsgCountById(message.rid, 1);
+			Rooms.getIncMsgCountUpdateQuery(1, roomUpdater);
 			return message;
 		}
 
@@ -156,25 +157,25 @@ export async function notifyUsersOnMessage(message: IMessage, room: IRoom): Prom
 			(!message.tmid || message.tshow) &&
 			(!room.lastMessage || room.lastMessage._id === message._id)
 		) {
-			await Rooms.setLastMessageById(message.rid, message);
+			Rooms.getLastMessageUpdateQuery(message, roomUpdater);
 		}
 
 		return message;
 	}
 
 	if (message.ts && Math.abs(moment(message.ts).diff(Date.now())) > 60000) {
-		await Rooms.incMsgCountById(message.rid, 1);
+		Rooms.getIncMsgCountUpdateQuery(1, roomUpdater);
 		return message;
 	}
 
 	// If message sent ONLY on a thread, skips the rest as it is done on a callback specific to threads
 	if (message.tmid && !message.tshow) {
-		await Rooms.incMsgCountById(message.rid, 1);
+		Rooms.getIncMsgCountUpdateQuery(1, roomUpdater);
 		return message;
 	}
 
 	// Update all the room activity tracker fields
-	await Rooms.incMsgCountAndSetLastMessageById(message.rid, 1, message.ts, settings.get('Store_Last_Message') ? message : undefined);
+	Rooms.setIncMsgCountAndSetLastMessageUpdateQuery(1, message, !!settings.get('Store_Last_Message'), roomUpdater);
 	await updateUsersSubscriptions(message, room);
 
 	return message;
@@ -182,7 +183,16 @@ export async function notifyUsersOnMessage(message: IMessage, room: IRoom): Prom
 
 callbacks.add(
 	'afterSaveMessage',
-	(message, room) => notifyUsersOnMessage(message, room),
+	async (message, room) => {
+		const roomUpdater = Rooms.getUpdater();
+		await notifyUsersOnMessage(message, room, roomUpdater);
+
+		if (roomUpdater.hasChanges()) {
+			await roomUpdater.persist({ _id: room._id });
+		}
+
+		return message;
+	},
 	callbacks.priority.MEDIUM,
 	'notifyUsersOnMessage',
 );

--- a/apps/meteor/server/models/dummy/BaseDummy.ts
+++ b/apps/meteor/server/models/dummy/BaseDummy.ts
@@ -1,6 +1,7 @@
 import type { RocketChatRecordDeleted } from '@rocket.chat/core-typings';
 import type { DefaultFields, FindPaginated, IBaseModel, InsertionModel, ResultFields } from '@rocket.chat/model-typings';
-import { getCollectionName } from '@rocket.chat/models';
+import { getCollectionName, UpdaterImpl } from '@rocket.chat/models';
+import type { Updater } from '@rocket.chat/models';
 import type {
 	BulkWriteOptions,
 	ChangeStream,
@@ -38,6 +39,10 @@ export class BaseDummy<
 
 	public async createIndexes(): Promise<string[] | void> {
 		// nothing to do
+	}
+
+	public getUpdater(): Updater<T> {
+		return new UpdaterImpl<T>(this.col as unknown as IBaseModel<T>);
 	}
 
 	getCollectionName(): string {

--- a/apps/meteor/server/models/raw/BaseRaw.ts
+++ b/apps/meteor/server/models/raw/BaseRaw.ts
@@ -110,7 +110,7 @@ export abstract class BaseRaw<
 		return this.collectionName;
 	}
 
-	protected getUpdater(): Updater<T> {
+	public getUpdater(): Updater<T> {
 		return new UpdaterImpl<T>(this.col as unknown as IBaseModel<T>);
 	}
 

--- a/apps/meteor/server/models/raw/LivechatRooms.ts
+++ b/apps/meteor/server/models/raw/LivechatRooms.ts
@@ -78,10 +78,6 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 		];
 	}
 
-	getUpdater(): Updater<IOmnichannelRoom> {
-		return super.getUpdater();
-	}
-
 	getQueueMetrics({
 		departmentId,
 		agentId,

--- a/packages/model-typings/src/models/IBaseModel.ts
+++ b/packages/model-typings/src/models/IBaseModel.ts
@@ -22,6 +22,8 @@ import type {
 	WithId,
 } from 'mongodb';
 
+import type { Updater } from '../updater';
+
 export type DefaultFields<Base> = Record<keyof Base, 1> | Record<keyof Base, 0> | void;
 export type ResultFields<Base, Defaults> = Defaults extends void
 	? Base
@@ -48,6 +50,7 @@ export interface IBaseModel<
 	createIndexes(): Promise<string[] | void>;
 
 	getCollectionName(): string;
+	getUpdater(): Updater<T>;
 
 	findOneAndUpdate(query: Filter<T>, update: UpdateFilter<T> | T, options?: FindOneAndUpdateOptions): Promise<ModifyResult<T>>;
 

--- a/packages/model-typings/src/models/IRoomsModel.ts
+++ b/packages/model-typings/src/models/IRoomsModel.ts
@@ -1,7 +1,7 @@
 import type { IDirectMessageRoom, IMessage, IOmnichannelGenericRoom, IRoom, IRoomFederated, ITeam, IUser } from '@rocket.chat/core-typings';
-import type { Updater } from '@rocket.chat/models';
 import type { AggregationCursor, DeleteResult, Document, FindCursor, FindOptions, UpdateOptions, UpdateResult } from 'mongodb';
 
+import type { Updater } from '../updater';
 import type { FindPaginated, IBaseModel } from './IBaseModel';
 
 export interface IChannelsWithNumberOfMessagesBetweenDate {

--- a/packages/model-typings/src/models/IRoomsModel.ts
+++ b/packages/model-typings/src/models/IRoomsModel.ts
@@ -1,4 +1,5 @@
 import type { IDirectMessageRoom, IMessage, IOmnichannelGenericRoom, IRoom, IRoomFederated, ITeam, IUser } from '@rocket.chat/core-typings';
+import type { Updater } from '@rocket.chat/models';
 import type { AggregationCursor, DeleteResult, Document, FindCursor, FindOptions, UpdateOptions, UpdateResult } from 'mongodb';
 
 import type { FindPaginated, IBaseModel } from './IBaseModel';
@@ -162,6 +163,7 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 
 	countFederatedRooms(): Promise<number>;
 	incMsgCountById(rid: string, inc: number): Promise<UpdateResult>;
+	getIncMsgCountUpdateQuery(inc: number, roomUpdater: Updater<IRoom>): Updater<IRoom>;
 	decreaseMessageCountById(rid: string, dec: number): Promise<UpdateResult>;
 	findOneByIdOrName(_idOrName: string, options?: FindOptions<IRoom>): Promise<IRoom | null>;
 	setCallStatus(_id: string, callStatus: IRoom['callStatus']): Promise<UpdateResult>;
@@ -234,10 +236,15 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 	archiveById(rid: string): Promise<UpdateResult>;
 	unarchiveById(rid: string): Promise<UpdateResult>;
 	setNameById(rid: string, name: string, fname: string): Promise<UpdateResult>;
-	incMsgCountAndSetLastMessageById(rid: IRoom['_id'], inc: number, lastMessageTs: Date, lastMessage?: IMessage): Promise<UpdateResult>;
+	setIncMsgCountAndSetLastMessageUpdateQuery(
+		inc: number,
+		lastMessage: IMessage,
+		shouldStoreLastMessage: boolean,
+		roomUpdater: Updater<IRoom>,
+	): Updater<IRoom>;
 	incUsersCountById(rid: string, inc: number): Promise<UpdateResult>;
 	incUsersCountNotDMsByIds(rids: string[], inc: number): Promise<Document | UpdateResult>;
-	setLastMessageById(rid: string, lastMessage: IRoom['lastMessage']): Promise<UpdateResult>;
+	getLastMessageUpdateQuery(lastMessage: IRoom['lastMessage'], roomUpdater: Updater<IRoom>): Updater<IRoom>;
 	resetLastMessageById(rid: string, lastMessage: IMessage | null, msgCountDelta?: number): Promise<UpdateResult>;
 	replaceUsername(username: string, newUsername: string): Promise<UpdateResult | Document>;
 	replaceMutedUsername(username: string, newUsername: string): Promise<UpdateResult | Document>;


### PR DESCRIPTION
This pull request addresses the requirements of [OPI-26](https://rocketchat.atlassian.net/browse/OPI-26) by adding updater support to the `afterSaveMessage.notifyUsersOnMessage` hook - that aims to optimize performance by reducing database calls related to omnichannel rooms.

[OPI-26]: https://rocketchat.atlassian.net/browse/OPI-26