### PR TITLE
chore: change 'Accounts_AvatarBlockUnauthenticatedAccess' default value from false to true

### DIFF
--- a/apps/meteor/server/routes/avatar/middlewares/auth.js
+++ b/apps/meteor/server/routes/avatar/middlewares/auth.js
@@ -1,11 +1,20 @@
-import { userCanAccessAvatar } from '../utils';
+import { userCanAccessAvatar, renderSVGLetters } from '../utils';
 
 // protect all avatar endpoints
 export const protectAvatars = async (req, res, next) => {
 	if (!(await userCanAccessAvatar(req))) {
-		res.writeHead(403);
-		res.write('Forbidden');
+		let roomOrUsername;
+
+		if (req.url.startsWith('/room')) {
+			roomOrUsername = req.url.split('/')[2] || 'Room';
+		} else {
+			roomOrUsername = req.url.split('/')[1] || 'Anonymous';
+		}
+
+		res.writeHead(200, { 'Content-Type': 'image/svg+xml' });
+		res.write(renderSVGLetters(roomOrUsername, 200));
 		res.end();
+
 		return;
 	}
 

--- a/apps/meteor/server/settings/accounts.ts
+++ b/apps/meteor/server/settings/accounts.ts
@@ -760,7 +760,7 @@ export const createAccountSettings = () =>
 				i18nDescription: 'Accounts_AvatarCacheTime_description',
 			});
 
-			await this.add('Accounts_AvatarBlockUnauthenticatedAccess', false, {
+			await this.add('Accounts_AvatarBlockUnauthenticatedAccess', true, {
 				type: 'boolean',
 				public: true,
 			});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
As part of a security by default approach, we should deny unauthenticated access to avatars by default. This PR changes the default value from `false` to `true`.

EDIT: in order to properly handle anonymous access, instead of returning `403` and `Forbidden`, this PR alters the logic to return an avatar with the user / room initials.

## Issue(s)
N/A

## Steps to test or reproduce
N/A

## Further comments
N/A