### PR TITLE
Release 6.11.2

### DIFF
--- a/.changeset/bump-patch-1724077277110.md
+++ b/.changeset/bump-patch-1724077277110.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Bump @rocket.chat/meteor version.

--- a/.changeset/gentle-bugs-think.md
+++ b/.changeset/gentle-bugs-think.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Prevent `processRoomAbandonment` callback from erroring out when a room was inactive during a day Business Hours was not configured for.

--- a/.changeset/orange-clocks-wait.md
+++ b/.changeset/orange-clocks-wait.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Security Hotfix (https://docs.rocket.chat/docs/security-fixes-and-updates)

--- a/.changeset/strong-rings-rush.md
+++ b/.changeset/strong-rings-rush.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Restored tooltips to the unit edit department field selected options

--- a/.changeset/two-bikes-crash.md
+++ b/.changeset/two-bikes-crash.md
@@ -1,0 +1,7 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed an issue related to setting Accounts_ForgetUserSessionOnWindowClose, this setting was not working as expected.
+
+The new meteor 2.16 release introduced a new option to configure the Accounts package and choose between the local storage or session storage. They also changed how Meteor.\_localstorage works internally. Due to these changes in Meteor, our setting to use session storage wasn't working as expected. This PR fixes this issue and configures the Accounts package according to the workspace settings.

--- a/.changeset/wise-avocados-taste.md
+++ b/.changeset/wise-avocados-taste.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes an issue where multi-step modals were closing unexpectedly

--- a/apps/meteor/app/lib/server/functions/getModifiedHttpHeaders.ts
+++ b/apps/meteor/app/lib/server/functions/getModifiedHttpHeaders.ts
@@ -1,0 +1,20 @@
+export const getModifiedHttpHeaders = (httpHeaders: Record<string, any>) => {
+	const modifiedHttpHeaders = { ...httpHeaders };
+
+	if ('x-auth-token' in modifiedHttpHeaders) {
+		modifiedHttpHeaders['x-auth-token'] = '[redacted]';
+	}
+
+	if (modifiedHttpHeaders.cookie) {
+		const cookies = modifiedHttpHeaders.cookie.split('; ');
+		const modifiedCookies = cookies.map((cookie: string) => {
+			if (cookie.startsWith('rc_token=')) {
+				return 'rc_token=[redacted]';
+			}
+			return cookie;
+		});
+		modifiedHttpHeaders.cookie = modifiedCookies.join('; ');
+	}
+
+	return modifiedHttpHeaders;
+};

--- a/apps/meteor/app/lib/server/lib/debug.js
+++ b/apps/meteor/app/lib/server/lib/debug.js
@@ -7,6 +7,7 @@ import _ from 'underscore';
 import { getMethodArgs } from '../../../../server/lib/logger/logPayloads';
 import { metrics } from '../../../metrics/server';
 import { settings } from '../../../settings/server';
+import { getModifiedHttpHeaders } from '../functions/getModifiedHttpHeaders';
 
 const logger = new Logger('Meteor');
 
@@ -41,7 +42,7 @@ const traceConnection = (enable, filter, prefix, name, connection, userId) => {
 		console.log(name, {
 			id: connection.id,
 			clientAddress: connection.clientAddress,
-			httpHeaders: connection.httpHeaders,
+			httpHeaders: getModifiedHttpHeaders(connection.httpHeaders),
 			userId,
 		});
 	} else {

--- a/apps/meteor/app/livechat/server/api/v1/room.ts
+++ b/apps/meteor/app/livechat/server/api/v1/room.ts
@@ -31,63 +31,72 @@ import { findVisitorInfo } from '../lib/visitors';
 
 const isAgentWithInfo = (agentObj: ILivechatAgent | { hiddenInfo: boolean }): agentObj is ILivechatAgent => !('hiddenInfo' in agentObj);
 
-API.v1.addRoute('livechat/room', {
-	async get() {
-		// I'll temporary use check for validation, as validateParams doesnt support what's being done here
-		const extraCheckParams = await onCheckRoomParams({
-			token: String,
-			rid: Match.Maybe(String),
-			agentId: Match.Maybe(String),
-		});
-
-		check(this.queryParams, extraCheckParams as any);
-
-		const { token, rid, agentId, ...extraParams } = this.queryParams;
-
-		const guest = token && (await findGuest(token));
-		if (!guest) {
-			throw new Error('invalid-token');
-		}
-
-		if (!rid) {
-			const room = await LivechatRooms.findOneOpenByVisitorToken(token, {});
-			if (room) {
-				return API.v1.success({ room, newRoom: false });
-			}
-
-			let agent: SelectedAgent | undefined;
-			const agentObj = agentId && (await findAgent(agentId));
-			if (agentObj) {
-				if (isAgentWithInfo(agentObj)) {
-					const { username = undefined } = agentObj;
-					agent = { agentId, username };
-				} else {
-					agent = { agentId };
-				}
-			}
-
-			const roomInfo = {
-				source: {
-					type: isWidget(this.request.headers) ? OmnichannelSourceType.WIDGET : OmnichannelSourceType.API,
-				},
-			};
-
-			const newRoom = await LivechatTyped.createRoom({ visitor: guest, roomInfo, agent, extraData: extraParams });
-
-			return API.v1.success({
-				room: newRoom,
-				newRoom: true,
-			});
-		}
-
-		const froom = await LivechatRooms.findOneOpenByRoomIdAndVisitorToken(rid, token, {});
-		if (!froom) {
-			throw new Error('invalid-room');
-		}
-
-		return API.v1.success({ room: froom, newRoom: false });
+API.v1.addRoute(
+	'livechat/room',
+	{
+		rateLimiterOptions: {
+			numRequestsAllowed: 5,
+			intervalTimeInMS: 60000,
+		},
 	},
-});
+	{
+		async get() {
+			// I'll temporary use check for validation, as validateParams doesnt support what's being done here
+			const extraCheckParams = await onCheckRoomParams({
+				token: String,
+				rid: Match.Maybe(String),
+				agentId: Match.Maybe(String),
+			});
+
+			check(this.queryParams, extraCheckParams as any);
+
+			const { token, rid, agentId, ...extraParams } = this.queryParams;
+
+			const guest = token && (await findGuest(token));
+			if (!guest) {
+				throw new Error('invalid-token');
+			}
+
+			if (!rid) {
+				const room = await LivechatRooms.findOneOpenByVisitorToken(token, {});
+				if (room) {
+					return API.v1.success({ room, newRoom: false });
+				}
+
+				let agent: SelectedAgent | undefined;
+				const agentObj = agentId && (await findAgent(agentId));
+				if (agentObj) {
+					if (isAgentWithInfo(agentObj)) {
+						const { username = undefined } = agentObj;
+						agent = { agentId, username };
+					} else {
+						agent = { agentId };
+					}
+				}
+
+				const roomInfo = {
+					source: {
+						type: isWidget(this.request.headers) ? OmnichannelSourceType.WIDGET : OmnichannelSourceType.API,
+					},
+				};
+
+				const newRoom = await LivechatTyped.createRoom({ visitor: guest, roomInfo, agent, extraData: extraParams });
+
+				return API.v1.success({
+					room: newRoom,
+					newRoom: true,
+				});
+			}
+
+			const froom = await LivechatRooms.findOneOpenByRoomIdAndVisitorToken(rid, token, {});
+			if (!froom) {
+				throw new Error('invalid-room');
+			}
+
+			return API.v1.success({ room: froom, newRoom: false });
+		},
+	},
+);
 
 // Note: use this route if a visitor is closing a room
 // If a RC user(like eg agent) is closing a room, use the `livechat/room.closeByUser` route

--- a/apps/meteor/app/livechat/server/api/v1/visitor.ts
+++ b/apps/meteor/app/livechat/server/api/v1/visitor.ts
@@ -9,119 +9,128 @@ import { settings } from '../../../../settings/server';
 import { Livechat as LivechatTyped } from '../../lib/LivechatTyped';
 import { findGuest, normalizeHttpHeaderData } from '../lib/livechat';
 
-API.v1.addRoute('livechat/visitor', {
-	async post() {
-		check(this.bodyParams, {
-			visitor: Match.ObjectIncluding({
-				token: String,
-				name: Match.Maybe(String),
-				email: Match.Maybe(String),
-				department: Match.Maybe(String),
-				phone: Match.Maybe(String),
-				username: Match.Maybe(String),
-				customFields: Match.Maybe([
-					Match.ObjectIncluding({
-						key: String,
-						value: String,
-						overwrite: Boolean,
-					}),
-				]),
-			}),
-		});
-
-		const { customFields, id, token, name, email, department, phone, username, connectionData } = this.bodyParams.visitor;
-
-		if (!token?.trim()) {
-			throw new Meteor.Error('error-invalid-token', 'Token cannot be empty', { method: 'livechat/visitor' });
-		}
-
-		const guest = {
-			token,
-			...(id && { id }),
-			...(name && { name }),
-			...(email && { email }),
-			...(department && { department }),
-			...(username && { username }),
-			...(connectionData && { connectionData }),
-			...(phone && typeof phone === 'string' && { phone: { number: phone as string } }),
-			connectionData: normalizeHttpHeaderData(this.request.headers),
-		};
-
-		const visitor = await LivechatTyped.registerGuest(guest);
-		if (!visitor) {
-			throw new Meteor.Error('error-livechat-visitor-registration', 'Error registering visitor', {
-				method: 'livechat/visitor',
+API.v1.addRoute(
+	'livechat/visitor',
+	{
+		rateLimiterOptions: {
+			numRequestsAllowed: 5,
+			intervalTimeInMS: 60000,
+		},
+	},
+	{
+		async post() {
+			check(this.bodyParams, {
+				visitor: Match.ObjectIncluding({
+					token: String,
+					name: Match.Maybe(String),
+					email: Match.Maybe(String),
+					department: Match.Maybe(String),
+					phone: Match.Maybe(String),
+					username: Match.Maybe(String),
+					customFields: Match.Maybe([
+						Match.ObjectIncluding({
+							key: String,
+							value: String,
+							overwrite: Boolean,
+						}),
+					]),
+				}),
 			});
-		}
 
-		const extraQuery = await callbacks.run('livechat.applyRoomRestrictions', {});
-		// If it's updating an existing visitor, it must also update the roomInfo
-		const rooms = await LivechatRooms.findOpenByVisitorToken(visitor?.token, {}, extraQuery).toArray();
-		await Promise.all(
-			rooms.map(
-				(room: IRoom) =>
-					visitor &&
-					LivechatTyped.saveRoomInfo(room, {
-						_id: visitor._id,
-						name: visitor.name,
-						phone: visitor.phone?.[0]?.phoneNumber,
-						livechatData: visitor.livechatData as { [k: string]: string },
-					}),
-			),
-		);
+			const { customFields, id, token, name, email, department, phone, username, connectionData } = this.bodyParams.visitor;
 
-		if (customFields && Array.isArray(customFields) && customFields.length > 0) {
-			const keys = customFields.map((field) => field.key);
-			const errors: string[] = [];
+			if (!token?.trim()) {
+				throw new Meteor.Error('error-invalid-token', 'Token cannot be empty', { method: 'livechat/visitor' });
+			}
 
-			const processedKeys = await Promise.all(
-				await LivechatCustomField.findByIdsAndScope<Pick<ILivechatCustomField, '_id'>>(keys, 'visitor', {
-					projection: { _id: 1 },
-				})
-					.map(async (field) => {
-						const customField = customFields.find((f) => f.key === field._id);
-						if (!customField) {
-							return;
-						}
+			const guest = {
+				token,
+				...(id && { id }),
+				...(name && { name }),
+				...(email && { email }),
+				...(department && { department }),
+				...(username && { username }),
+				...(connectionData && { connectionData }),
+				...(phone && typeof phone === 'string' && { phone: { number: phone as string } }),
+				connectionData: normalizeHttpHeaderData(this.request.headers),
+			};
 
-						const { key, value, overwrite } = customField;
-						// TODO: Change this to Bulk update
-						if (!(await VisitorsRaw.updateLivechatDataByToken(token, key, value, overwrite))) {
-							errors.push(key);
-						}
+			const visitor = await LivechatTyped.registerGuest(guest);
+			if (!visitor) {
+				throw new Meteor.Error('error-livechat-visitor-registration', 'Error registering visitor', {
+					method: 'livechat/visitor',
+				});
+			}
 
-						return key;
-					})
-					.toArray(),
+			const extraQuery = await callbacks.run('livechat.applyRoomRestrictions', {});
+			// If it's updating an existing visitor, it must also update the roomInfo
+			const rooms = await LivechatRooms.findOpenByVisitorToken(visitor?.token, {}, extraQuery).toArray();
+			await Promise.all(
+				rooms.map(
+					(room: IRoom) =>
+						visitor &&
+						LivechatTyped.saveRoomInfo(room, {
+							_id: visitor._id,
+							name: visitor.name,
+							phone: visitor.phone?.[0]?.phoneNumber,
+							livechatData: visitor.livechatData as { [k: string]: string },
+						}),
+				),
 			);
 
-			if (processedKeys.length !== keys.length) {
-				LivechatTyped.logger.warn({
-					msg: 'Some custom fields were not processed',
-					visitorId: visitor._id,
-					missingKeys: keys.filter((key) => !processedKeys.includes(key)),
-				});
+			if (customFields && Array.isArray(customFields) && customFields.length > 0) {
+				const keys = customFields.map((field) => field.key);
+				const errors: string[] = [];
+
+				const processedKeys = await Promise.all(
+					await LivechatCustomField.findByIdsAndScope<Pick<ILivechatCustomField, '_id'>>(keys, 'visitor', {
+						projection: { _id: 1 },
+					})
+						.map(async (field) => {
+							const customField = customFields.find((f) => f.key === field._id);
+							if (!customField) {
+								return;
+							}
+
+							const { key, value, overwrite } = customField;
+							// TODO: Change this to Bulk update
+							if (!(await VisitorsRaw.updateLivechatDataByToken(token, key, value, overwrite))) {
+								errors.push(key);
+							}
+
+							return key;
+						})
+						.toArray(),
+				);
+
+				if (processedKeys.length !== keys.length) {
+					LivechatTyped.logger.warn({
+						msg: 'Some custom fields were not processed',
+						visitorId: visitor._id,
+						missingKeys: keys.filter((key) => !processedKeys.includes(key)),
+					});
+				}
+
+				if (errors.length > 0) {
+					LivechatTyped.logger.error({
+						msg: 'Error updating custom fields',
+						visitorId: visitor._id,
+						errors,
+					});
+					throw new Error('error-updating-custom-fields');
+				}
+
+				return API.v1.success({ visitor: await VisitorsRaw.findOneEnabledById(visitor._id) });
 			}
 
-			if (errors.length > 0) {
-				LivechatTyped.logger.error({
-					msg: 'Error updating custom fields',
-					visitorId: visitor._id,
-					errors,
-				});
-				throw new Error('error-updating-custom-fields');
+			if (!visitor) {
+				throw new Meteor.Error('error-saving-visitor', 'An error ocurred while saving visitor');
 			}
 
-			return API.v1.success({ visitor: await VisitorsRaw.findOneEnabledById(visitor._id) });
-		}
-
-		if (!visitor) {
-			throw new Meteor.Error('error-saving-visitor', 'An error ocurred while saving visitor');
-		}
-
-		return API.v1.success({ visitor });
+			return API.v1.success({ visitor });
+		},
 	},
-});
+);
 
 API.v1.addRoute('livechat/visitor/:token', {
 	async get() {

--- a/apps/meteor/app/livechat/server/hooks/processRoomAbandonment.ts
+++ b/apps/meteor/app/livechat/server/hooks/processRoomAbandonment.ts
@@ -43,7 +43,8 @@ const getSecondsSinceLastAgentResponse = async (room: IOmnichannelRoom, agentLas
 		officeDays = (await businessHourManager.getBusinessHour())?.workHours.reduce(parseDays, {});
 	}
 
-	if (!officeDays) {
+	// Empty object we assume invalid config
+	if (!officeDays || !Object.keys(officeDays).length) {
 		return getSecondsWhenOfficeHoursIsDisabled(room, agentLastMessage);
 	}
 
@@ -55,6 +56,11 @@ const getSecondsSinceLastAgentResponse = async (room: IOmnichannelRoom, agentLas
 	for (let index = 0; index <= daysOfInactivity; index++) {
 		const today = inactivityDay.clone().format('dddd');
 		const officeDay = officeDays[today];
+		// Config doesnt have data for this day, we skip day
+		if (!officeDay) {
+			inactivityDay.add(1, 'days');
+			continue;
+		}
 		const startTodaysOfficeHour = moment(`${officeDay.start.day}:${officeDay.start.time}`, 'dddd:HH:mm').add(index, 'days');
 		const endTodaysOfficeHour = moment(`${officeDay.finish.day}:${officeDay.finish.time}`, 'dddd:HH:mm').add(index, 'days');
 		if (officeDays[today].open) {

--- a/apps/meteor/client/components/GenericModal/GenericModal.tsx
+++ b/apps/meteor/client/components/GenericModal/GenericModal.tsx
@@ -111,7 +111,7 @@ const GenericModal = ({
 					{tagline && <Modal.Tagline>{tagline}</Modal.Tagline>}
 					<Modal.Title id={`${genericModalId}-title`}>{title ?? t('Are_you_sure')}</Modal.Title>
 				</Modal.HeaderText>
-				<Modal.Close aria-label={t('Close')} onClick={handleCloseButtonClick} />
+				{onClose && <Modal.Close aria-label={t('Close')} onClick={handleCloseButtonClick} />}
 			</Modal.Header>
 			<Modal.Content fontScale='p2'>{children}</Modal.Content>
 			<Modal.Footer justifyContent={dontAskAgain ? 'space-between' : 'end'}>

--- a/apps/meteor/client/components/GenericModal/GenericModalSkeleton.tsx
+++ b/apps/meteor/client/components/GenericModal/GenericModalSkeleton.tsx
@@ -1,25 +1,13 @@
 import { Skeleton } from '@rocket.chat/fuselage';
-import { useTranslation } from '@rocket.chat/ui-contexts';
 import type { ComponentProps } from 'react';
 import React from 'react';
 
 import GenericModal from './GenericModal';
 
-const GenericModalSkeleton = ({ onClose, ...props }: ComponentProps<typeof GenericModal>) => {
-	const t = useTranslation();
-
-	return (
-		<GenericModal
-			{...props}
-			variant='warning'
-			onClose={onClose}
-			title={<Skeleton width='50%' />}
-			confirmText={t('Cancel')}
-			onConfirm={onClose}
-		>
-			<Skeleton width='full' />
-		</GenericModal>
-	);
-};
+const GenericModalSkeleton = (props: ComponentProps<typeof GenericModal>) => (
+	<GenericModal {...props} icon={null} title={<Skeleton width='50%' />}>
+		<Skeleton width='full' />
+	</GenericModal>
+);
 
 export default GenericModalSkeleton;

--- a/apps/meteor/client/omnichannel/units/UnitEdit.tsx
+++ b/apps/meteor/client/omnichannel/units/UnitEdit.tsx
@@ -228,7 +228,7 @@ const UnitEdit = ({ unitData, unitMonitors, unitDepartments }: UnitEditProps) =>
 											value={value}
 											onChange={onChange}
 											onBlur={onBlur}
-											withTitle={false}
+											withTitle
 											filter={departmentsFilter}
 											setFilter={setDepartmentsFilter}
 											options={departmentsOptions}

--- a/apps/meteor/client/startup/accounts.ts
+++ b/apps/meteor/client/startup/accounts.ts
@@ -2,6 +2,7 @@ import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
 import { Tracker } from 'meteor/tracker';
 
+import { settings } from '../../app/settings/client';
 import { mainReady } from '../../app/ui-utils/client';
 import { sdk } from '../../app/utils/client/lib/SDKClient';
 import { t } from '../../app/utils/lib/i18n';
@@ -22,5 +23,17 @@ Accounts.onEmailVerificationLink((token: string) => {
 				}
 			}
 		});
+	});
+});
+
+Meteor.startup(() => {
+	Tracker.autorun(() => {
+		const forgetUserSessionOnWindowClose = settings.get('Accounts_ForgetUserSessionOnWindowClose');
+
+		if (forgetUserSessionOnWindowClose === undefined) {
+			return;
+		}
+
+		Accounts.config({ clientStorage: forgetUserSessionOnWindowClose ? 'session' : 'local' });
 	});
 });

--- a/apps/meteor/client/startup/accounts.ts
+++ b/apps/meteor/client/startup/accounts.ts
@@ -27,12 +27,14 @@ Accounts.onEmailVerificationLink((token: string) => {
 });
 
 Meteor.startup(() => {
-	Tracker.autorun(() => {
+	Tracker.autorun((computation) => {
 		const forgetUserSessionOnWindowClose = settings.get('Accounts_ForgetUserSessionOnWindowClose');
 
 		if (forgetUserSessionOnWindowClose === undefined) {
 			return;
 		}
+
+		computation.stop();
 
 		Accounts.config({ clientStorage: forgetUserSessionOnWindowClose ? 'session' : 'local' });
 	});

--- a/apps/meteor/client/views/omnichannel/realTimeMonitoring/RealTimeMonitoringPage.js
+++ b/apps/meteor/client/views/omnichannel/realTimeMonitoring/RealTimeMonitoringPage.js
@@ -18,10 +18,18 @@ import ChatsOverview from './overviews/ChatsOverview';
 import ConversationOverview from './overviews/ConversationOverview';
 import ProductivityOverview from './overviews/ProductivityOverview';
 
+const randomizeKeys = (keys) => {
+	keys.current = keys.current.map((_key, i) => {
+		return `${i}_${new Date().getTime()}`;
+	});
+};
+
 const dateRange = getDateRange();
 
 const RealTimeMonitoringPage = () => {
 	const t = useTranslation();
+
+	const keys = useRef([...Array(10).keys()]);
 
 	const [reloadFrequency, setReloadFrequency] = useState(5);
 	const [departmentId, setDepartment] = useState('');
@@ -43,6 +51,10 @@ const RealTimeMonitoringPage = () => {
 		[departmentParams],
 	);
 
+	useEffect(() => {
+		randomizeKeys(keys);
+	}, [allParams]);
+
 	const reloadCharts = useMutableCallback(() => {
 		Object.values(reloadRef.current).forEach((reload) => {
 			reload();
@@ -53,6 +65,7 @@ const RealTimeMonitoringPage = () => {
 		const interval = setInterval(reloadCharts, reloadFrequency * 1000);
 		return () => {
 			clearInterval(interval);
+			randomizeKeys(keys);
 		};
 	}, [reloadCharts, reloadFrequency]);
 
@@ -90,30 +103,54 @@ const RealTimeMonitoringPage = () => {
 						</Box>
 					</Box>
 					<Box display='flex' flexDirection='row' w='full' alignItems='stretch' flexShrink={1}>
-						<ConversationOverview flexGrow={1} flexShrink={1} width='50%' reloadRef={reloadRef} params={allParams} />
+						<ConversationOverview key={keys?.current[0]} flexGrow={1} flexShrink={1} width='50%' reloadRef={reloadRef} params={allParams} />
 					</Box>
 					<Box display='flex' flexDirection='row' w='full' alignItems='stretch' flexShrink={1}>
-						<ChatsChart flexGrow={1} flexShrink={1} width='50%' mie={2} reloadRef={reloadRef} params={allParams} />
-						<ChatsPerAgentChart flexGrow={1} flexShrink={1} width='50%' mis={2} reloadRef={reloadRef} params={allParams} />
+						<ChatsChart key={keys?.current[1]} flexGrow={1} flexShrink={1} width='50%' mie={2} reloadRef={reloadRef} params={allParams} />
+						<ChatsPerAgentChart
+							key={keys?.current[2]}
+							flexGrow={1}
+							flexShrink={1}
+							width='50%'
+							mis={2}
+							reloadRef={reloadRef}
+							params={allParams}
+						/>
 					</Box>
 					<Box display='flex' flexDirection='row' w='full' alignItems='stretch' flexShrink={1}>
-						<ChatsOverview flexGrow={1} flexShrink={1} width='50%' reloadRef={reloadRef} params={allParams} />
+						<ChatsOverview key={keys?.current[3]} flexGrow={1} flexShrink={1} width='50%' reloadRef={reloadRef} params={allParams} />
 					</Box>
 					<Box display='flex' flexDirection='row' w='full' alignItems='stretch' flexShrink={1}>
-						<AgentStatusChart flexGrow={1} flexShrink={1} width='50%' mie={2} reloadRef={reloadRef} params={allParams} />
-						<ChatsPerDepartmentChart flexGrow={1} flexShrink={1} width='50%' mis={2} reloadRef={reloadRef} params={allParams} />
+						<AgentStatusChart
+							key={keys?.current[4]}
+							flexGrow={1}
+							flexShrink={1}
+							width='50%'
+							mie={2}
+							reloadRef={reloadRef}
+							params={allParams}
+						/>
+						<ChatsPerDepartmentChart
+							key={keys?.current[5]}
+							flexGrow={1}
+							flexShrink={1}
+							width='50%'
+							mis={2}
+							reloadRef={reloadRef}
+							params={allParams}
+						/>
 					</Box>
 					<Box display='flex' flexDirection='row' w='full' alignItems='stretch' flexShrink={1}>
-						<AgentsOverview flexGrow={1} flexShrink={1} reloadRef={reloadRef} params={allParams} />
+						<AgentsOverview key={keys?.current[6]} flexGrow={1} flexShrink={1} reloadRef={reloadRef} params={allParams} />
 					</Box>
 					<Box display='flex' w='full' flexShrink={1}>
-						<ChatDurationChart flexGrow={1} flexShrink={1} w='100%' reloadRef={reloadRef} params={allParams} />
+						<ChatDurationChart key={keys?.current[7]} flexGrow={1} flexShrink={1} w='100%' reloadRef={reloadRef} params={allParams} />
 					</Box>
 					<Box display='flex' flexDirection='row' w='full' alignItems='stretch' flexShrink={1}>
-						<ProductivityOverview flexGrow={1} flexShrink={1} reloadRef={reloadRef} params={allParams} />
+						<ProductivityOverview key={keys?.current[8]} flexGrow={1} flexShrink={1} reloadRef={reloadRef} params={allParams} />
 					</Box>
 					<Box display='flex' w='full' flexShrink={1}>
-						<ResponseTimesChart flexGrow={1} flexShrink={1} w='100%' reloadRef={reloadRef} params={allParams} />
+						<ResponseTimesChart key={keys?.current[9]} flexGrow={1} flexShrink={1} w='100%' reloadRef={reloadRef} params={allParams} />
 					</Box>
 				</Margins>
 			</PageScrollableContentWithShadow>

--- a/apps/meteor/client/views/room/modals/ReadReceiptsModal/ReadReceiptsModal.tsx
+++ b/apps/meteor/client/views/room/modals/ReadReceiptsModal/ReadReceiptsModal.tsx
@@ -1,11 +1,11 @@
 import type { IMessage, ReadReceipt } from '@rocket.chat/core-typings';
-import { Skeleton } from '@rocket.chat/fuselage';
 import { useMethod, useToastMessageDispatch, useTranslation } from '@rocket.chat/ui-contexts';
 import { useQuery } from '@tanstack/react-query';
 import type { ReactElement } from 'react';
 import React, { useEffect } from 'react';
 
 import GenericModal from '../../../../components/GenericModal';
+import GenericModalSkeleton from '../../../../components/GenericModal/GenericModalSkeleton';
 import ReadReceiptRow from './ReadReceiptRow';
 
 type ReadReceiptsModalProps = {
@@ -29,11 +29,7 @@ const ReadReceiptsModal = ({ messageId, onClose }: ReadReceiptsModalProps): Reac
 	}, [dispatchToastMessage, t, onClose, readReceiptsResult.isError, readReceiptsResult.error]);
 
 	if (readReceiptsResult.isLoading || readReceiptsResult.isError) {
-		return (
-			<GenericModal title={t('Read_by')} onConfirm={onClose} onClose={onClose}>
-				<Skeleton type='rect' w='full' h='x120' />
-			</GenericModal>
-		);
+		return <GenericModalSkeleton />;
 	}
 
 	const readReceipts = readReceiptsResult.data;

--- a/apps/meteor/client/views/teams/ConvertToChannelModal/ConvertToChannelModal.tsx
+++ b/apps/meteor/client/views/teams/ConvertToChannelModal/ConvertToChannelModal.tsx
@@ -20,7 +20,7 @@ const ConvertToChannelModal = ({ onClose, onCancel, onConfirm, teamId, userId }:
 	});
 
 	if (phase === AsyncStatePhase.LOADING) {
-		return <GenericModalSkeleton onClose={onClose} />;
+		return <GenericModalSkeleton />;
 	}
 
 	return <BaseConvertToChannelModal onClose={onClose} onCancel={onCancel} onConfirm={onConfirm} rooms={value?.rooms} />;

--- a/apps/meteor/client/views/teams/contextualBar/info/DeleteTeam/DeleteTeamModalWithRooms.tsx
+++ b/apps/meteor/client/views/teams/contextualBar/info/DeleteTeam/DeleteTeamModalWithRooms.tsx
@@ -1,11 +1,10 @@
 import type { IRoom } from '@rocket.chat/core-typings';
-import { Skeleton } from '@rocket.chat/fuselage';
-import { useTranslation, useEndpoint } from '@rocket.chat/ui-contexts';
+import { useEndpoint } from '@rocket.chat/ui-contexts';
 import { useQuery } from '@tanstack/react-query';
 import type { ReactElement } from 'react';
 import React, { useMemo } from 'react';
 
-import GenericModal from '../../../../../components/GenericModal';
+import GenericModalSkeleton from '../../../../../components/GenericModal/GenericModalSkeleton';
 import DeleteTeamModal from './DeleteTeamModal';
 
 type DeleteTeamModalWithRoomsProps = {
@@ -15,17 +14,12 @@ type DeleteTeamModalWithRoomsProps = {
 };
 
 const DeleteTeamModalWithRooms = ({ teamId, onConfirm, onCancel }: DeleteTeamModalWithRoomsProps): ReactElement => {
-	const t = useTranslation();
 	const query = useMemo(() => ({ teamId }), [teamId]);
 	const getTeamsListRooms = useEndpoint('GET', '/v1/teams.listRooms');
 	const { data, isLoading } = useQuery(['getTeamsListRooms', query], async () => getTeamsListRooms(query));
 
 	if (isLoading) {
-		return (
-			<GenericModal variant='warning' onClose={onCancel} onConfirm={onCancel} title={<Skeleton width='50%' />} confirmText={t('Cancel')}>
-				<Skeleton width='full' />
-			</GenericModal>
-		);
+		return <GenericModalSkeleton />;
 	}
 	return <DeleteTeamModal onCancel={onCancel} onConfirm={onConfirm} rooms={data?.rooms || []} />;
 };

--- a/apps/meteor/client/views/teams/contextualBar/info/LeaveTeam/LeaveTeamWithData.tsx
+++ b/apps/meteor/client/views/teams/contextualBar/info/LeaveTeam/LeaveTeamWithData.tsx
@@ -1,11 +1,10 @@
 import type { ITeam } from '@rocket.chat/core-typings';
-import { Skeleton } from '@rocket.chat/fuselage';
-import { useUserId, useEndpoint, useTranslation } from '@rocket.chat/ui-contexts';
+import { useUserId, useEndpoint } from '@rocket.chat/ui-contexts';
 import { useQuery } from '@tanstack/react-query';
 import type { ReactElement } from 'react';
 import React from 'react';
 
-import GenericModal from '../../../../../components/GenericModal';
+import GenericModalSkeleton from '../../../../../components/GenericModal/GenericModalSkeleton';
 import LeaveTeamModal from './LeaveTeamModal/LeaveTeamModal';
 
 type LeaveTeamWithDataProps = {
@@ -15,7 +14,6 @@ type LeaveTeamWithDataProps = {
 };
 
 const LeaveTeamWithData = ({ teamId, onCancel, onConfirm }: LeaveTeamWithDataProps): ReactElement => {
-	const t = useTranslation();
 	const userId = useUserId();
 
 	if (!userId) {
@@ -26,11 +24,7 @@ const LeaveTeamWithData = ({ teamId, onCancel, onConfirm }: LeaveTeamWithDataPro
 	const { data, isLoading } = useQuery(['teams.listRoomsOfUser'], () => getRoomsOfUser({ teamId, userId }));
 
 	if (isLoading) {
-		return (
-			<GenericModal variant='warning' onClose={onCancel} onConfirm={onCancel} title={<Skeleton width='50%' />} confirmText={t('Cancel')}>
-				<Skeleton width='full' />
-			</GenericModal>
-		);
+		return <GenericModalSkeleton />;
 	}
 
 	return <LeaveTeamModal onCancel={onCancel} onConfirm={onConfirm} rooms={data?.rooms || []} />;

--- a/apps/meteor/client/views/teams/contextualBar/members/RemoveUsersModal/RemoveUsersModal.js
+++ b/apps/meteor/client/views/teams/contextualBar/members/RemoveUsersModal/RemoveUsersModal.js
@@ -1,8 +1,6 @@
-import { Skeleton } from '@rocket.chat/fuselage';
-import { useTranslation } from '@rocket.chat/ui-contexts';
 import React, { useMemo } from 'react';
 
-import GenericModal from '../../../../../components/GenericModal';
+import GenericModalSkeleton from '../../../../../components/GenericModal/GenericModalSkeleton';
 import { useEndpointData } from '../../../../../hooks/useEndpointData';
 import { AsyncStatePhase } from '../../../../../lib/asyncState';
 import BaseRemoveUsersModal from './BaseRemoveUsersModal';
@@ -10,7 +8,6 @@ import BaseRemoveUsersModal from './BaseRemoveUsersModal';
 const initialData = { user: { username: '' } };
 
 const RemoveUsersModal = ({ teamId, userId, onClose, onCancel, onConfirm }) => {
-	const t = useTranslation();
 	const { value, phase } = useEndpointData('/v1/teams.listRoomsOfUser', { params: useMemo(() => ({ teamId, userId }), [teamId, userId]) });
 	const userDataFetch = useEndpointData('/v1/users.info', { params: useMemo(() => ({ userId }), [userId]), initialValue: initialData });
 	const {
@@ -18,11 +15,7 @@ const RemoveUsersModal = ({ teamId, userId, onClose, onCancel, onConfirm }) => {
 	} = userDataFetch?.value;
 
 	if (phase === AsyncStatePhase.LOADING) {
-		return (
-			<GenericModal variant='warning' onClose={onClose} title={<Skeleton width='50%' />} confirmText={t('Cancel')} onConfirm={onClose}>
-				<Skeleton width='full' />
-			</GenericModal>
-		);
+		return <GenericModalSkeleton />;
 	}
 
 	return <BaseRemoveUsersModal onClose={onClose} username={username} onCancel={onCancel} onConfirm={onConfirm} rooms={value?.rooms} />;

--- a/apps/meteor/definition/externals/meteor/accounts-base.d.ts
+++ b/apps/meteor/definition/externals/meteor/accounts-base.d.ts
@@ -42,6 +42,8 @@ declare module 'meteor/accounts-base' {
 
 		function _clearAllLoginTokens(userId: string | null): void;
 
+		function config(options: { clientStorage: 'session' | 'local' }): void;
+
 		class ConfigError extends Error {}
 
 		class LoginCancelledError extends Error {

--- a/apps/meteor/tests/e2e/account-forgetSessionOnWindowClose.spec.ts
+++ b/apps/meteor/tests/e2e/account-forgetSessionOnWindowClose.spec.ts
@@ -1,0 +1,55 @@
+import { DEFAULT_USER_CREDENTIALS } from './config/constants';
+import { Registration } from './page-objects';
+import { test, expect } from './utils/test';
+
+test.describe.serial('Forget session on window close setting', () => {
+	let poRegistration: Registration;
+
+	test.beforeEach(async ({ page }) => {
+		poRegistration = new Registration(page);
+
+		await page.goto('/home');
+	});
+
+	test.describe('Setting off', async () => {
+		test.beforeAll(async ({ api }) => {
+			await api.post('/settings/Accounts_ForgetUserSessionOnWindowClose', { value: false });
+		});
+
+		test('Login using credentials and reload to stay logged in', async ({ page, context }) => {
+			await poRegistration.username.type('user1');
+			await poRegistration.inputPassword.type(DEFAULT_USER_CREDENTIALS.password);
+			await poRegistration.btnLogin.click();
+
+			await expect(page.locator('role=heading[name="Welcome to Rocket.Chat"]')).toBeVisible();
+
+			const newPage = await context.newPage();
+			await newPage.goto('/home');
+
+			await expect(newPage.locator('role=heading[name="Welcome to Rocket.Chat"]')).toBeVisible();
+		});
+	});
+
+	test.describe('Setting on', async () => {
+		test.beforeAll(async ({ api }) => {
+			await api.post('/settings/Accounts_ForgetUserSessionOnWindowClose', { value: true });
+		});
+
+		test.afterAll(async ({ api }) => {
+			await api.post('/settings/Accounts_ForgetUserSessionOnWindowClose', { value: false });
+		});
+
+		test('Login using credentials and reload to get logged out', async ({ page, context }) => {
+			await poRegistration.username.type('user1');
+			await poRegistration.inputPassword.type(DEFAULT_USER_CREDENTIALS.password);
+			await poRegistration.btnLogin.click();
+
+			await expect(page.locator('role=heading[name="Welcome to Rocket.Chat"]')).toBeVisible();
+
+			const newPage = await context.newPage();
+			await newPage.goto('/home');
+
+			await expect(newPage.locator('role=button[name="Login"]')).toBeVisible();
+		});
+	});
+});

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-units.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-units.spec.ts
@@ -185,11 +185,14 @@ test.describe('OC - Manage Units', () => {
 			await poOmnichannelUnits.btnSave.click();
 		});
 
-		await test.step('expect department to be in the chosen departments list', async () => {
+		await test.step('expect department to be in the chosen departments list and have title', async () => {
 			await poOmnichannelUnits.search(unit.name);
 			await poOmnichannelUnits.findRowByName(unit.name).click();
 			await expect(poOmnichannelUnits.contextualBar).toBeVisible();
-			await expect(page.getByRole('option', { name: department2.data.name })).toBeVisible();
+			await expect(poOmnichannelUnits.selectOptionChip(department2.data.name)).toBeVisible();
+			await poOmnichannelUnits.selectOptionChip(department2.data.name).hover();
+
+			await expect(page.getByRole('tooltip', { name: department2.data.name })).toBeVisible();
 			await poOmnichannelUnits.btnContextualbarClose.click();
 		});
 

--- a/apps/meteor/tests/e2e/page-objects/omnichannel-units.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel-units.ts
@@ -43,6 +43,10 @@ export class OmnichannelUnits extends OmnichannelAdministration {
 		return this.page.locator(`[role=option][value="${name}"]`);
 	}
 
+	public selectOptionChip(name: string) {
+		return this.page.getByRole('option', { name });
+	}
+
 	async selectDepartment({ name, _id }: { name: string; _id: string }) {
 		await this.inputDepartments.click();
 		await this.inputDepartments.fill(name);

--- a/apps/meteor/tests/unit/app/lib/server/functions/getModifiedHttpHeaders.tests.ts
+++ b/apps/meteor/tests/unit/app/lib/server/functions/getModifiedHttpHeaders.tests.ts
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+
+import { getModifiedHttpHeaders } from '../../../../../../app/lib/server/functions/getModifiedHttpHeaders';
+
+describe('getModifiedHttpHeaders', () => {
+	it('should redact x-auth-token if present', () => {
+		const inputHeaders = {
+			'x-auth-token': '12345',
+			'some-other-header': 'value',
+		};
+		const result = getModifiedHttpHeaders(inputHeaders);
+		expect(result['x-auth-token']).to.equal('[redacted]');
+		expect(result['some-other-header']).to.equal('value');
+	});
+
+	it('should not modify headers if x-auth-token is not present', () => {
+		const inputHeaders = {
+			'some-other-header': 'value',
+		};
+		const result = getModifiedHttpHeaders(inputHeaders);
+		expect(result).to.deep.equal(inputHeaders);
+	});
+
+	it('should redact rc_token in cookies if present', () => {
+		const inputHeaders = {
+			cookie: 'session_id=abc123; rc_token=98765; other_cookie=value',
+		};
+		const expectedCookies = 'session_id=abc123; rc_token=[redacted]; other_cookie=value';
+		const result = getModifiedHttpHeaders(inputHeaders);
+		expect(result.cookie).to.equal(expectedCookies);
+	});
+
+	it('should not modify cookies if rc_token is not present', () => {
+		const inputHeaders = {
+			cookie: 'session_id=abc123; other_cookie=value',
+		};
+		const result = getModifiedHttpHeaders(inputHeaders);
+		expect(result.cookie).to.equal(inputHeaders.cookie);
+	});
+
+	it('should return headers unchanged if neither x-auth-token nor cookie are present', () => {
+		const inputHeaders = {
+			'some-other-header': 'value',
+		};
+		const result = getModifiedHttpHeaders(inputHeaders);
+		expect(result).to.deep.equal(inputHeaders);
+	});
+
+	it('should handle cases with both x-auth-token and rc_token in cookie', () => {
+		const inputHeaders = {
+			'x-auth-token': '12345',
+			'cookie': 'session_id=abc123; rc_token=98765; other_cookie=value',
+		};
+		const expectedCookies = 'session_id=abc123; rc_token=[redacted]; other_cookie=value';
+		const result = getModifiedHttpHeaders(inputHeaders);
+		expect(result['x-auth-token']).to.equal('[redacted]');
+		expect(result.cookie).to.equal(expectedCookies);
+	});
+});

--- a/packages/ui-client/src/components/TooltipComponent.tsx
+++ b/packages/ui-client/src/components/TooltipComponent.tsx
@@ -12,7 +12,7 @@ export const TooltipComponent = ({ title, anchor }: TooltipComponentProps): Reac
 
 	return (
 		<PositionAnimated anchor={ref} placement='top-middle' margin={8} visible={AnimatedVisibility.UNHIDING}>
-			<Tooltip>{title}</Tooltip>
+			<Tooltip role='tooltip'>{title}</Tooltip>
 		</PositionAnimated>
 	);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8969,10 +8969,10 @@ __metadata:
     "@rocket.chat/icons": "*"
     "@rocket.chat/prettier-config": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 5.0.0
-    "@rocket.chat/ui-contexts": 9.0.0
+    "@rocket.chat/ui-avatar": 5.0.1
+    "@rocket.chat/ui-contexts": 9.0.1
     "@rocket.chat/ui-kit": 0.36.0
-    "@rocket.chat/ui-video-conf": 9.0.0
+    "@rocket.chat/ui-video-conf": 9.0.1
     "@tanstack/react-query": "*"
     react: "*"
     react-dom: "*"
@@ -9061,8 +9061,8 @@ __metadata:
     "@rocket.chat/fuselage-tokens": "*"
     "@rocket.chat/message-parser": 0.31.29
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-client": 9.0.0
-    "@rocket.chat/ui-contexts": 9.0.0
+    "@rocket.chat/ui-client": 9.0.1
+    "@rocket.chat/ui-contexts": 9.0.1
     katex: "*"
     react: "*"
   languageName: unknown
@@ -10282,7 +10282,7 @@ __metadata:
     typescript: ~5.3.3
   peerDependencies:
     "@rocket.chat/fuselage": "*"
-    "@rocket.chat/ui-contexts": 9.0.0
+    "@rocket.chat/ui-contexts": 9.0.1
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -10335,7 +10335,7 @@ __metadata:
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-contexts": 9.0.0
+    "@rocket.chat/ui-contexts": 9.0.1
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -10511,8 +10511,8 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 5.0.0
-    "@rocket.chat/ui-contexts": 9.0.0
+    "@rocket.chat/ui-avatar": 5.0.1
+    "@rocket.chat/ui-contexts": 9.0.1
     react: ^17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -10602,7 +10602,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.2.2
-    "@rocket.chat/ui-contexts": 9.0.0
+    "@rocket.chat/ui-contexts": 9.0.1
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION


<!-- release-notes-start -->
<!-- This content is automatically generated. Changing this will not reflect on the final release log -->

_You can see below a preview of the release change log:_

# 6.11.2

### Engine versions

- Node: `14.21.3`
- MongoDB: `4.4, 5.0, 6.0`
- Apps-Engine: `1.44.0`

### Patch Changes

*   Bump @rocket.chat/meteor version.

*   ([#33084](https://github.com/RocketChat/Rocket.Chat/pull/33084) by [@dionisio-bot](https://github.com/dionisio-bot)) Prevent `processRoomAbandonment` callback from erroring out when a room was inactive during a day Business Hours was not configured for.

*   ([#33153](https://github.com/RocketChat/Rocket.Chat/pull/33153) by [@dionisio-bot](https://github.com/dionisio-bot)) Security Hotfix (https://docs.rocket.chat/docs/security-fixes-and-updates)

*   ([#33185](https://github.com/RocketChat/Rocket.Chat/pull/33185) by [@dionisio-bot](https://github.com/dionisio-bot)) Restored tooltips to the unit edit department field selected options

*   ([#33129](https://github.com/RocketChat/Rocket.Chat/pull/33129) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixed an issue related to setting Accounts_ForgetUserSessionOnWindowClose, this setting was not working as expected.

    The new meteor 2.16 release introduced a new option to configure the Accounts package and choose between the local storage or session storage. They also changed how Meteor.\_localstorage works internally. Due to these changes in Meteor, our setting to use session storage wasn't working as expected. This PR fixes this issue and configures the Accounts package according to the workspace settings.

*   ([#33178](https://github.com/RocketChat/Rocket.Chat/pull/33178) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixes an issue where multi-step modals were closing unexpectedly

*   <details><summary>Updated dependencies []:</summary>

    *   @rocket.chat/core-typings@6.11.2
    *   @rocket.chat/rest-typings@6.11.2
    *   @rocket.chat/api-client@0.2.5
    *   @rocket.chat/license@0.2.5
    *   @rocket.chat/omnichannel-services@0.3.2
    *   @rocket.chat/pdf-worker@0.2.2
    *   @rocket.chat/presence@0.2.5
    *   @rocket.chat/apps@0.1.5
    *   @rocket.chat/core-services@0.5.2
    *   @rocket.chat/cron@0.1.5
    *   @rocket.chat/fuselage-ui-kit@9.0.2
    *   @rocket.chat/gazzodown@9.0.2
    *   @rocket.chat/model-typings@0.6.2
    *   @rocket.chat/ui-contexts@9.0.2
    *   @rocket.chat/server-cloud-communication@0.0.2
    *   @rocket.chat/models@0.2.2
    *   @rocket.chat/ui-theming@0.2.0
    *   @rocket.chat/ui-avatar@5.0.2
    *   @rocket.chat/ui-client@9.0.2
    *   @rocket.chat/ui-video-conf@9.0.2
    *   @rocket.chat/web-ui-registration@9.0.2
    *   @rocket.chat/instance-status@0.1.5

    </details>

<!-- release-notes-end -->