### PR TITLE
Revert "fix: Inconsistent Markdown Formatting in Custom Status Field"

### DIFF
--- a/.changeset/kind-drinks-joke.md
+++ b/.changeset/kind-drinks-joke.md
@@ -1,5 +1,0 @@
----
-'@rocket.chat/meteor': patch
----
-
-Fixed issue with asterisk-wrapped text not becoming bold when user enters profile custom status.

--- a/apps/meteor/client/components/MarkdownText.tsx
+++ b/apps/meteor/client/components/MarkdownText.tsx
@@ -16,20 +16,15 @@ type MarkdownTextParams = {
 	withTruncatedText: boolean;
 } & ComponentProps<typeof Box>;
 
-const walkTokens = (token: marked.Token) => {
-	const boldPattern = /^\*.*\*$|^\*.*|.*\*$/;
-	const italicPattern = /^__(?=\S)([\s\S]*?\S)__(?!_)|^_(?=\S)([\s\S]*?\S)_(?!_)/;
-	if (boldPattern.test(token.raw)) {
-		token.type = 'strong';
-	} else if (italicPattern.test(token.raw)) {
-		token.type = 'em';
-	}
-};
-
-marked.use({ walkTokens });
 const documentRenderer = new marked.Renderer();
 const inlineRenderer = new marked.Renderer();
 const inlineWithoutBreaks = new marked.Renderer();
+
+marked.Lexer.rules.gfm = {
+	...marked.Lexer.rules.gfm,
+	strong: /^\*\*(?=\S)([\s\S]*?\S)\*\*(?!\*)|^\*(?=\S)([\s\S]*?\S)\*(?!\*)/,
+	em: /^__(?=\S)([\s\S]*?\S)__(?!_)|^_(?=\S)([\s\S]*?\S)_(?!_)/,
+};
 
 const linkMarked = (href: string | null, _title: string | null, text: string): string =>
 	`<a href="${href}" rel="nofollow noopener noreferrer">${text}</a> `;
@@ -117,6 +112,7 @@ const MarkdownText = ({
 				const markedHtml = /inline/.test(variant)
 					? marked.parseInline(new Option(content).innerHTML, markedOptions)
 					: marked.parse(new Option(content).innerHTML, markedOptions);
+
 				if (parseEmoji) {
 					// We are using the old emoji parser here. This could come
 					// with additional processing use, but is the workaround available right now.


### PR DESCRIPTION
Reverts RocketChat/Rocket.Chat#32574 from community since there are some scenarios where it is making channels to break where the MarkdownComponent is used.

Task: [SUP-537](https://rocketchat.atlassian.net/browse/SUP-537) [CORE-651](https://rocketchat.atlassian.net/browse/CORE-651)

[SUP-537]: https://rocketchat.atlassian.net/browse/SUP-537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-651]: https://rocketchat.atlassian.net/browse/CORE-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ