### PR TITLE
regression: Handle live setting forget user session on window close update

### DIFF
--- a/apps/meteor/client/startup/accounts.ts
+++ b/apps/meteor/client/startup/accounts.ts
@@ -27,12 +27,14 @@ Accounts.onEmailVerificationLink((token: string) => {
 });
 
 Meteor.startup(() => {
-	Tracker.autorun(() => {
+	Tracker.autorun((computation) => {
 		const forgetUserSessionOnWindowClose = settings.get('Accounts_ForgetUserSessionOnWindowClose');
 
 		if (forgetUserSessionOnWindowClose === undefined) {
 			return;
 		}
+
+		computation.stop();
 
 		Accounts.config({ clientStorage: forgetUserSessionOnWindowClose ? 'session' : 'local' });
 	});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Meteor recently developed a way to choose the client storage location between local storage and session storage.

We recently started configuring meteor to choose between both location options based on our setting `Accounts_ForgetUserSessionOnWindowClose`.

There was a small issue, we are handling these updates in a `Tracker.autorun` which runs everytime any dependency changes. In this case, it wasn't handling this setting change on a live user session.

We shouldn't change the client storage location in the middle of an active session, so this PR fixes it by stopping the autorun and which stops the listening of live setting update, essentially just configuring the client storage location just once in a session.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-653](https://rocketchat.atlassian.net/browse/CORE-653)

[CORE-653]: https://rocketchat.atlassian.net/browse/CORE-653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ