### PR TITLE
chore: Add shebang line, -p flag to mkdir, and clean up unwanted characters in build.sh (#33123)

### DIFF
--- a/apps/meteor/packages/rocketchat-livechat/plugin/build.sh
+++ b/apps/meteor/packages/rocketchat-livechat/plugin/build.sh
@@ -1,4 +1,6 @@
-# set -x
+#!/bin/bash
+set -x
+
 export NODE_ENV="production"
 export LIVECHAT_DIR="./public/livechat"
 export LIVECHAT_ASSETS_DIR="./private/livechat"
@@ -9,7 +11,7 @@ rm -rf $LIVECHAT_DIR
 mkdir -p $LIVECHAT_DIR
 
 rm -rf $LIVECHAT_ASSETS_DIR
-mkdir $LIVECHAT_ASSETS_DIR
+mkdir -p $LIVECHAT_ASSETS_DIR
 
 #NEW LIVECHAT#
 echo "Installing Livechat ${LATEST_LIVECHAT_VERSION}..."


### PR DESCRIPTION
This PR addresses issue #33123 by making the following changes in `Rocket.Chat/apps/meteor/packages/rocketchat-livechat/plugin/build.sh`:

- Added a shebang line (`#!/bin/bash`) at the beginning of the script to specify the shell to use.
- Added the `-p` flag to the `mkdir` command to ensure parent directories are created if they do not exist.
- Removed unwanted characters from the script to clean up the formatting.

### Reproduction Steps:
To test these changes, execute the `build.sh` script from the following path in an environment where parent directories are not present:

`Rocket.Chat/apps/meteor/packages/rocketchat-livechat/plugin/build.sh`

These changes improve the script's portability and reliability, especially in environments where the required parent directories may not exist.
