### PR TITLE
chore: remove notifyListener call that was causing startup issues

### DIFF
--- a/apps/meteor/server/startup/cloudRegistration.ts
+++ b/apps/meteor/server/startup/cloudRegistration.ts
@@ -1,7 +1,5 @@
 import { Settings } from '@rocket.chat/models';
 
-import { notifyOnSettingChangedById } from '../../app/lib/server/lib/notifyListener';
-
 export async function ensureCloudWorkspaceRegistered(): Promise<void> {
 	const cloudWorkspaceClientId = await Settings.getValueById('Cloud_Workspace_Client_Id');
 	const cloudWorkspaceClientSecret = await Settings.getValueById('Cloud_Workspace_Client_Secret');
@@ -18,6 +16,5 @@ export async function ensureCloudWorkspaceRegistered(): Promise<void> {
 	}
 
 	// otherwise, set the setup wizard to in_progress forcing admins to complete the registration
-	(await Settings.updateValueById('Show_Setup_Wizard', 'in_progress')).modifiedCount &&
-		void notifyOnSettingChangedById('Show_Setup_Wizard');
+	await Settings.updateValueById('Show_Setup_Wizard', 'in_progress');
 }


### PR DESCRIPTION
This PR addresses a specific issue where the `no broker set to broadcast: watch.settings` error would occur for certain users, particularly during the dry run initialization of the development environment.

It's important to note that while this fix resolves this particular error, similar issues could arise in other parts of the code. These will need to be addressed in future updates as they are identified.