### PR TITLE
regression: remove unnecessary log on notifyUsersOnMessage

### DIFF
--- a/apps/meteor/app/lib/server/lib/notifyUsersOnMessage.ts
+++ b/apps/meteor/app/lib/server/lib/notifyUsersOnMessage.ts
@@ -168,8 +168,6 @@ export async function updateThreadUsersSubscriptions(message: IMessage, replies:
 }
 
 export async function notifyUsersOnMessage(message: IMessage, room: IRoom, roomUpdater: Updater<IRoom>): Promise<IMessage> {
-	console.log('notifyUsersOnMessage function');
-
 	// Skips this callback if the message was edited and increments it if the edit was way in the past (aka imported)
 	if (isEditedMessage(message)) {
 		if (Math.abs(moment(message.editedAt).diff(Date.now())) > 60000) {


### PR DESCRIPTION
This PR removes an unnecessary `console.log` that was displaying on the server every time a message was sent.