### PR TITLE
chore: move GenericMenu to ui-client package

### DIFF
--- a/apps/meteor/client/NavBarV2/NavBarPagesToolbar/NavBarItemAuditMenu.tsx
+++ b/apps/meteor/client/NavBarV2/NavBarPagesToolbar/NavBarItemAuditMenu.tsx
@@ -1,9 +1,9 @@
 import { NavBarItem } from '@rocket.chat/fuselage';
+import { GenericMenu } from '@rocket.chat/ui-client';
 import { useCurrentRoutePath, useTranslation } from '@rocket.chat/ui-contexts';
 import type { HTMLAttributes } from 'react';
 import React from 'react';
 
-import GenericMenu from '../../components/GenericMenu/GenericMenu';
 import { useAuditMenu } from './hooks/useAuditMenu';
 
 type NavBarItemAuditMenuProps = Omit<HTMLAttributes<HTMLElement>, 'is'>;

--- a/apps/meteor/client/NavBarV2/NavBarPagesToolbar/NavBarItemMarketPlaceMenu.tsx
+++ b/apps/meteor/client/NavBarV2/NavBarPagesToolbar/NavBarItemMarketPlaceMenu.tsx
@@ -1,9 +1,9 @@
 import { NavBarItem } from '@rocket.chat/fuselage';
+import { GenericMenu } from '@rocket.chat/ui-client';
 import { useCurrentRoutePath, useTranslation } from '@rocket.chat/ui-contexts';
 import type { HTMLAttributes } from 'react';
 import React from 'react';
 
-import GenericMenu from '../../components/GenericMenu/GenericMenu';
 import { useMarketPlaceMenu } from './hooks/useMarketPlaceMenu';
 
 type NavBarItemMarketPlaceMenuProps = Omit<HTMLAttributes<HTMLElement>, 'is'>;

--- a/apps/meteor/client/NavBarV2/NavBarPagesToolbar/hooks/useAuditMenu.tsx
+++ b/apps/meteor/client/NavBarV2/NavBarPagesToolbar/hooks/useAuditMenu.tsx
@@ -1,6 +1,6 @@
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { usePermission, useRouter, useTranslation } from '@rocket.chat/ui-contexts';
 
-import type { GenericMenuItemProps } from '../../../components/GenericMenu/GenericMenuItem';
 import { useHasLicenseModule } from '../../../hooks/useHasLicenseModule';
 
 export const useAuditMenu = () => {

--- a/apps/meteor/client/NavBarV2/NavBarPagesToolbar/hooks/useMarketPlaceMenu.tsx
+++ b/apps/meteor/client/NavBarV2/NavBarPagesToolbar/hooks/useMarketPlaceMenu.tsx
@@ -1,8 +1,8 @@
 import { Badge, Skeleton } from '@rocket.chat/fuselage';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useTranslation, usePermission, useRouter } from '@rocket.chat/ui-contexts';
 import React from 'react';
 
-import type { GenericMenuItemProps } from '../../../components/GenericMenu/GenericMenuItem';
 import { useUserDropdownAppsActionButtons } from '../../../hooks/useAppActionButtons';
 import { useAppRequestStats } from '../../../views/marketplace/hooks/useAppRequestStats';
 

--- a/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/NavBarItemAdministrationMenu.tsx
+++ b/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/NavBarItemAdministrationMenu.tsx
@@ -1,9 +1,9 @@
 import { NavBarItem } from '@rocket.chat/fuselage';
+import { GenericMenu } from '@rocket.chat/ui-client';
 import { useCurrentRoutePath, useTranslation } from '@rocket.chat/ui-contexts';
 import type { HTMLAttributes } from 'react';
 import React from 'react';
 
-import GenericMenu from '../../components/GenericMenu/GenericMenu';
 import { useAdministrationMenu } from './hooks/useAdministrationMenu';
 
 type NavBarItemAdministrationMenuProps = Omit<HTMLAttributes<HTMLElement>, 'is'>;

--- a/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/UserMenu/UserMenu.tsx
+++ b/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/UserMenu/UserMenu.tsx
@@ -1,11 +1,10 @@
 import type { IUser } from '@rocket.chat/core-typings';
+import { GenericMenu, useHandleMenuAction } from '@rocket.chat/ui-client';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import type { ComponentProps } from 'react';
 import React, { memo, useState } from 'react';
 
-import GenericMenu from '../../../components/GenericMenu/GenericMenu';
-import type { GenericMenuItemProps } from '../../../components/GenericMenu/GenericMenuItem';
-import { useHandleMenuAction } from '../../../components/GenericMenu/hooks/useHandleMenuAction';
 import UserMenuButton from './UserMenuButton';
 import { useUserMenu } from './hooks/useUserMenu';
 

--- a/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/UserMenu/hooks/useAccountItems.tsx
+++ b/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/UserMenu/hooks/useAccountItems.tsx
@@ -1,10 +1,9 @@
 import { Badge } from '@rocket.chat/fuselage';
 import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
 import { defaultFeaturesPreview, useFeaturePreviewList } from '@rocket.chat/ui-client';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useRouter, useTranslation } from '@rocket.chat/ui-contexts';
 import React from 'react';
-
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 
 export const useAccountItems = (): GenericMenuItemProps[] => {
 	const t = useTranslation();

--- a/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/UserMenu/hooks/useStatusItems.tsx
+++ b/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/UserMenu/hooks/useStatusItems.tsx
@@ -1,11 +1,11 @@
 import { Box } from '@rocket.chat/fuselage';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useEndpoint, useSetting } from '@rocket.chat/ui-contexts';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { callbacks } from '../../../../../lib/callbacks';
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import MarkdownText from '../../../../components/MarkdownText';
 import { UserStatus } from '../../../../components/UserStatus';
 import { userStatuses } from '../../../../lib/userStatuses';

--- a/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/UserMenu/hooks/useUserMenu.tsx
+++ b/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/UserMenu/hooks/useUserMenu.tsx
@@ -1,9 +1,9 @@
 import type { IUser } from '@rocket.chat/core-typings';
 import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useLogout, useTranslation } from '@rocket.chat/ui-contexts';
 import React from 'react';
 
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import UserMenuHeader from '../UserMenuHeader';
 import { useAccountItems } from './useAccountItems';
 import { useStatusItems } from './useStatusItems';

--- a/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/hooks/useAdministrationMenu.tsx
+++ b/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/hooks/useAdministrationMenu.tsx
@@ -1,6 +1,5 @@
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useAtLeastOnePermission, usePermission, useRouter, useTranslation } from '@rocket.chat/ui-contexts';
-
-import type { GenericMenuItemProps } from '../../../components/GenericMenu/GenericMenuItem';
 
 const ADMIN_PERMISSIONS = [
 	'view-statistics',

--- a/apps/meteor/client/components/message/toolbar/MessageActionMenu.tsx
+++ b/apps/meteor/client/components/message/toolbar/MessageActionMenu.tsx
@@ -1,11 +1,10 @@
 import { useUniqueId } from '@rocket.chat/fuselage-hooks';
+import { GenericMenu, type GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import type { MouseEvent, ReactElement } from 'react';
 import React from 'react';
 
 import type { MessageActionConditionProps, MessageActionConfig } from '../../../../app/ui-utils/client/lib/MessageAction';
-import GenericMenu from '../../GenericMenu/GenericMenu';
-import type { GenericMenuItemProps } from '../../GenericMenu/GenericMenuItem';
 
 type MessageActionConfigOption = Omit<MessageActionConfig, 'condition' | 'context' | 'order' | 'action'> & {
 	action: (e?: MouseEvent<HTMLElement>) => void;

--- a/apps/meteor/client/hooks/useAppActionButtons.ts
+++ b/apps/meteor/client/hooks/useAppActionButtons.ts
@@ -1,5 +1,6 @@
 import type { IUIActionButton, UIActionButtonContext } from '@rocket.chat/apps-engine/definition/ui';
 import { useDebouncedCallback } from '@rocket.chat/fuselage-hooks';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useEndpoint, useStream, useToastMessageDispatch, useUserId } from '@rocket.chat/ui-contexts';
 import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -10,7 +11,6 @@ import { UiKitTriggerTimeoutError } from '../../app/ui-message/client/UiKitTrigg
 import type { MessageActionConfig, MessageActionContext } from '../../app/ui-utils/client/lib/MessageAction';
 import type { MessageBoxAction } from '../../app/ui-utils/client/lib/messageBox';
 import { Utilities } from '../../ee/lib/misc/Utilities';
-import type { GenericMenuItemProps } from '../components/GenericMenu/GenericMenuItem';
 import { useUiKitActionManager } from '../uikit/hooks/useUiKitActionManager';
 import { useApplyButtonFilters, useApplyButtonAuthFilter } from './useApplyButtonFilters';
 

--- a/apps/meteor/client/navbar/actions/NavbarAdministrationAction.tsx
+++ b/apps/meteor/client/navbar/actions/NavbarAdministrationAction.tsx
@@ -1,9 +1,8 @@
+import { GenericMenu, useHandleMenuAction } from '@rocket.chat/ui-client';
 import { useTranslation, useRouter } from '@rocket.chat/ui-contexts';
 import type { AllHTMLAttributes } from 'react';
 import React from 'react';
 
-import GenericMenu from '../../components/GenericMenu/GenericMenu';
-import { useHandleMenuAction } from '../../components/GenericMenu/hooks/useHandleMenuAction';
 import { NavbarAction } from '../../components/Navbar';
 import { useAdministrationItems } from '../../sidebar/header/actions/hooks/useAdministrationItems';
 

--- a/apps/meteor/client/navbar/actions/NavbarAuditAction.tsx
+++ b/apps/meteor/client/navbar/actions/NavbarAuditAction.tsx
@@ -1,9 +1,8 @@
+import { GenericMenu, useHandleMenuAction } from '@rocket.chat/ui-client';
 import { useTranslation, useRouter } from '@rocket.chat/ui-contexts';
 import type { AllHTMLAttributes } from 'react';
 import React from 'react';
 
-import GenericMenu from '../../components/GenericMenu/GenericMenu';
-import { useHandleMenuAction } from '../../components/GenericMenu/hooks/useHandleMenuAction';
 import { NavbarAction } from '../../components/Navbar';
 import { useAuditItems } from '../../sidebar/header/actions/hooks/useAuditItems';
 

--- a/apps/meteor/client/navbar/actions/NavbarMarketplaceAction.tsx
+++ b/apps/meteor/client/navbar/actions/NavbarMarketplaceAction.tsx
@@ -1,10 +1,9 @@
 import { IconButton } from '@rocket.chat/fuselage';
+import { GenericMenu, useHandleMenuAction } from '@rocket.chat/ui-client';
 import { useTranslation, useRouter } from '@rocket.chat/ui-contexts';
 import type { AllHTMLAttributes } from 'react';
 import React from 'react';
 
-import GenericMenu from '../../components/GenericMenu/GenericMenu';
-import { useHandleMenuAction } from '../../components/GenericMenu/hooks/useHandleMenuAction';
 import { NavbarAction } from '../../components/Navbar';
 import { useAppsItems } from '../../sidebar/header/actions/hooks/useAppsItems';
 

--- a/apps/meteor/client/sidebar/header/UserMenu.tsx
+++ b/apps/meteor/client/sidebar/header/UserMenu.tsx
@@ -1,11 +1,15 @@
 import type { IUser } from '@rocket.chat/core-typings';
-import { FeaturePreview, FeaturePreviewOn, FeaturePreviewOff } from '@rocket.chat/ui-client';
+import {
+	FeaturePreview,
+	FeaturePreviewOn,
+	FeaturePreviewOff,
+	GenericMenu,
+	useHandleMenuAction,
+	type GenericMenuItemProps,
+} from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import React, { useState, memo } from 'react';
 
-import GenericMenu from '../../components/GenericMenu/GenericMenu';
-import type { GenericMenuItemProps } from '../../components/GenericMenu/GenericMenuItem';
-import { useHandleMenuAction } from '../../components/GenericMenu/hooks/useHandleMenuAction';
 import UserAvatarWithStatus from './UserAvatarWithStatus';
 import UserAvatarWithStatusUnstable from './UserAvatarWithStatusUnstable';
 import { useUserMenu } from './hooks/useUserMenu';

--- a/apps/meteor/client/sidebar/header/actions/Administration.tsx
+++ b/apps/meteor/client/sidebar/header/actions/Administration.tsx
@@ -1,9 +1,9 @@
 import { Sidebar } from '@rocket.chat/fuselage';
+import { GenericMenu } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import type { HTMLAttributes } from 'react';
 import React from 'react';
 
-import GenericMenu from '../../../components/GenericMenu/GenericMenu';
 import { useAdministrationMenu } from './hooks/useAdministrationMenu';
 
 type AdministrationProps = Omit<HTMLAttributes<HTMLElement>, 'is'>;

--- a/apps/meteor/client/sidebar/header/actions/CreateRoom.tsx
+++ b/apps/meteor/client/sidebar/header/actions/CreateRoom.tsx
@@ -1,9 +1,9 @@
 import { Sidebar } from '@rocket.chat/fuselage';
+import { GenericMenu } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import type { HTMLAttributes } from 'react';
 import React from 'react';
 
-import GenericMenu from '../../../components/GenericMenu/GenericMenu';
 import { useCreateRoom } from './hooks/useCreateRoomMenu';
 
 type CreateRoomProps = Omit<HTMLAttributes<HTMLElement>, 'is'>;

--- a/apps/meteor/client/sidebar/header/actions/Sort.tsx
+++ b/apps/meteor/client/sidebar/header/actions/Sort.tsx
@@ -1,9 +1,9 @@
 import { Sidebar } from '@rocket.chat/fuselage';
+import { GenericMenu } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import type { HTMLAttributes } from 'react';
 import React from 'react';
 
-import GenericMenu from '../../../components/GenericMenu/GenericMenu';
 import { useSortMenu } from './hooks/useSortMenu';
 
 type SortProps = Omit<HTMLAttributes<HTMLElement>, 'is'>;

--- a/apps/meteor/client/sidebar/header/actions/hooks/useAdministrationItems.tsx
+++ b/apps/meteor/client/sidebar/header/actions/hooks/useAdministrationItems.tsx
@@ -1,6 +1,5 @@
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useTranslation, useRoute, useRouter, useAtLeastOnePermission, usePermission } from '@rocket.chat/ui-contexts';
-
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 
 const ADMIN_PERMISSIONS = [
 	'view-statistics',

--- a/apps/meteor/client/sidebar/header/actions/hooks/useAdministrationMenu.tsx
+++ b/apps/meteor/client/sidebar/header/actions/hooks/useAdministrationMenu.tsx
@@ -1,6 +1,6 @@
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import { useAdministrationItems } from './useAdministrationItems';
 import { useAppsItems } from './useAppsItems';
 import { useAuditItems } from './useAuditItems';

--- a/apps/meteor/client/sidebar/header/actions/hooks/useAppsItems.tsx
+++ b/apps/meteor/client/sidebar/header/actions/hooks/useAppsItems.tsx
@@ -1,8 +1,8 @@
 import { Badge, Skeleton } from '@rocket.chat/fuselage';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useTranslation, useRoute, usePermission } from '@rocket.chat/ui-contexts';
 import React from 'react';
 
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import { useUserDropdownAppsActionButtons } from '../../../../hooks/useAppActionButtons';
 import { useAppRequestStats } from '../../../../views/marketplace/hooks/useAppRequestStats';
 

--- a/apps/meteor/client/sidebar/header/actions/hooks/useAuditItems.tsx
+++ b/apps/meteor/client/sidebar/header/actions/hooks/useAuditItems.tsx
@@ -1,6 +1,6 @@
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useTranslation, useRoute, usePermission } from '@rocket.chat/ui-contexts';
 
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import { useHasLicenseModule } from '../../../../hooks/useHasLicenseModule';
 
 /**

--- a/apps/meteor/client/sidebar/header/actions/hooks/useCreateRoomItems.tsx
+++ b/apps/meteor/client/sidebar/header/actions/hooks/useCreateRoomItems.tsx
@@ -1,7 +1,7 @@
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useTranslation, useSetting, useAtLeastOnePermission } from '@rocket.chat/ui-contexts';
 
 import CreateDiscussion from '../../../../components/CreateDiscussion';
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import CreateChannelWithData from '../../CreateChannel';
 import CreateDirectMessage from '../../CreateDirectMessage';
 import CreateTeam from '../../CreateTeam';

--- a/apps/meteor/client/sidebar/header/actions/hooks/useGroupingListItems.tsx
+++ b/apps/meteor/client/sidebar/header/actions/hooks/useGroupingListItems.tsx
@@ -1,8 +1,7 @@
 import { CheckBox } from '@rocket.chat/fuselage';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useEndpoint, useUserPreference, useTranslation } from '@rocket.chat/ui-contexts';
 import React, { useCallback } from 'react';
-
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 
 export const useGroupingListItems = (): GenericMenuItemProps[] => {
 	const t = useTranslation();

--- a/apps/meteor/client/sidebar/header/actions/hooks/useMatrixFederationItems.tsx.tsx
+++ b/apps/meteor/client/sidebar/header/actions/hooks/useMatrixFederationItems.tsx.tsx
@@ -1,6 +1,6 @@
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import MatrixFederationSearch from '../../MatrixFederationSearch';
 import { useCreateRoomModal } from '../../hooks/useCreateRoomModal';
 

--- a/apps/meteor/client/sidebar/header/actions/hooks/useSortModeItems.tsx
+++ b/apps/meteor/client/sidebar/header/actions/hooks/useSortModeItems.tsx
@@ -1,8 +1,8 @@
 import { RadioButton } from '@rocket.chat/fuselage';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useEndpoint, useUserPreference, useTranslation } from '@rocket.chat/ui-contexts';
 import React, { useCallback } from 'react';
 
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import {
 	OmnichannelSortingDisclaimer,
 	useOmnichannelSortingDisclaimer,

--- a/apps/meteor/client/sidebar/header/actions/hooks/useViewModeItems.tsx
+++ b/apps/meteor/client/sidebar/header/actions/hooks/useViewModeItems.tsx
@@ -1,8 +1,7 @@
 import { RadioButton, ToggleSwitch } from '@rocket.chat/fuselage';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useEndpoint, useUserPreference, useTranslation } from '@rocket.chat/ui-contexts';
 import React, { useCallback } from 'react';
-
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 
 export const useViewModeItems = (): GenericMenuItemProps[] => {
 	const t = useTranslation();

--- a/apps/meteor/client/sidebar/header/hooks/useAccountItems.tsx
+++ b/apps/meteor/client/sidebar/header/hooks/useAccountItems.tsx
@@ -1,10 +1,9 @@
 import { Badge } from '@rocket.chat/fuselage';
 import { useMutableCallback } from '@rocket.chat/fuselage-hooks';
 import { defaultFeaturesPreview, useFeaturePreviewList } from '@rocket.chat/ui-client';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useRouter, useTranslation } from '@rocket.chat/ui-contexts';
 import React from 'react';
-
-import type { GenericMenuItemProps } from '../../../components/GenericMenu/GenericMenuItem';
 
 export const useAccountItems = (): GenericMenuItemProps[] => {
 	const t = useTranslation();

--- a/apps/meteor/client/sidebar/header/hooks/useStatusItems.tsx
+++ b/apps/meteor/client/sidebar/header/hooks/useStatusItems.tsx
@@ -1,11 +1,11 @@
 import { Box } from '@rocket.chat/fuselage';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useEndpoint, useSetting } from '@rocket.chat/ui-contexts';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { callbacks } from '../../../../lib/callbacks';
-import type { GenericMenuItemProps } from '../../../components/GenericMenu/GenericMenuItem';
 import MarkdownText from '../../../components/MarkdownText';
 import { UserStatus } from '../../../components/UserStatus';
 import { userStatuses } from '../../../lib/userStatuses';

--- a/apps/meteor/client/sidebar/header/hooks/useUserMenu.tsx
+++ b/apps/meteor/client/sidebar/header/hooks/useUserMenu.tsx
@@ -1,9 +1,9 @@
 import type { IUser } from '@rocket.chat/core-typings';
 import { useMutableCallback } from '@rocket.chat/fuselage-hooks';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useLogout, useTranslation } from '@rocket.chat/ui-contexts';
 import React from 'react';
 
-import type { GenericMenuItemProps } from '../../../components/GenericMenu/GenericMenuItem';
 import UserMenuHeader from '../UserMenuHeader';
 import { useAccountItems } from './useAccountItems';
 import { useStatusItems } from './useStatusItems';

--- a/apps/meteor/client/sidebarv2/header/actions/CreateRoom.tsx
+++ b/apps/meteor/client/sidebarv2/header/actions/CreateRoom.tsx
@@ -1,9 +1,9 @@
 import { SidebarV2Action } from '@rocket.chat/fuselage';
+import { GenericMenu } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import type { HTMLAttributes } from 'react';
 import React from 'react';
 
-import GenericMenu from '../../../components/GenericMenu/GenericMenu';
 import { useCreateRoom } from './hooks/useCreateRoomMenu';
 
 type CreateRoomProps = Omit<HTMLAttributes<HTMLElement>, 'is'>;

--- a/apps/meteor/client/sidebarv2/header/actions/Sort.tsx
+++ b/apps/meteor/client/sidebarv2/header/actions/Sort.tsx
@@ -1,9 +1,9 @@
 import { SidebarV2Action } from '@rocket.chat/fuselage';
+import { GenericMenu } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import type { HTMLAttributes } from 'react';
 import React from 'react';
 
-import GenericMenu from '../../../components/GenericMenu/GenericMenu';
 import { useSortMenu } from './hooks/useSortMenu';
 
 type SortProps = Omit<HTMLAttributes<HTMLElement>, 'is'>;

--- a/apps/meteor/client/sidebarv2/header/actions/hooks/useCreateRoomItems.tsx
+++ b/apps/meteor/client/sidebarv2/header/actions/hooks/useCreateRoomItems.tsx
@@ -1,7 +1,7 @@
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useTranslation, useSetting, useAtLeastOnePermission } from '@rocket.chat/ui-contexts';
 
 import CreateDiscussion from '../../../../components/CreateDiscussion';
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import CreateChannelModal from '../../CreateChannelModal';
 import CreateDirectMessage from '../../CreateDirectMessage';
 import CreateTeamModal from '../../CreateTeamModal';

--- a/apps/meteor/client/sidebarv2/header/actions/hooks/useGroupingListItems.tsx
+++ b/apps/meteor/client/sidebarv2/header/actions/hooks/useGroupingListItems.tsx
@@ -1,8 +1,7 @@
 import { CheckBox } from '@rocket.chat/fuselage';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useEndpoint, useUserPreference, useTranslation } from '@rocket.chat/ui-contexts';
 import React, { useCallback } from 'react';
-
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 
 export const useGroupingListItems = (): GenericMenuItemProps[] => {
 	const t = useTranslation();

--- a/apps/meteor/client/sidebarv2/header/actions/hooks/useMatrixFederationItems.ts
+++ b/apps/meteor/client/sidebarv2/header/actions/hooks/useMatrixFederationItems.ts
@@ -1,6 +1,6 @@
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import MatrixFederationSearch from '../../MatrixFederationSearch';
 import { useCreateRoomModal } from '../../hooks/useCreateRoomModal';
 

--- a/apps/meteor/client/sidebarv2/header/actions/hooks/useSortModeItems.tsx
+++ b/apps/meteor/client/sidebarv2/header/actions/hooks/useSortModeItems.tsx
@@ -1,8 +1,8 @@
 import { RadioButton } from '@rocket.chat/fuselage';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useEndpoint, useUserPreference, useTranslation } from '@rocket.chat/ui-contexts';
 import React, { useCallback } from 'react';
 
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import {
 	OmnichannelSortingDisclaimer,
 	useOmnichannelSortingDisclaimer,

--- a/apps/meteor/client/sidebarv2/header/actions/hooks/useViewModeItems.tsx
+++ b/apps/meteor/client/sidebarv2/header/actions/hooks/useViewModeItems.tsx
@@ -1,8 +1,7 @@
 import { RadioButton, ToggleSwitch } from '@rocket.chat/fuselage';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useEndpoint, useUserPreference, useTranslation } from '@rocket.chat/ui-contexts';
 import React, { useCallback } from 'react';
-
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 
 export const useViewModeItems = (): GenericMenuItemProps[] => {
 	const t = useTranslation();

--- a/apps/meteor/client/views/admin/moderation/MessageContextFooter.tsx
+++ b/apps/meteor/client/views/admin/moderation/MessageContextFooter.tsx
@@ -1,8 +1,8 @@
 import { Button, ButtonGroup, Box } from '@rocket.chat/fuselage';
+import { GenericMenu } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import React from 'react';
 
-import GenericMenu from '../../../components/GenericMenu/GenericMenu';
 import useDeactivateUserAction from './hooks/useDeactivateUserAction';
 import useDeleteMessagesAction from './hooks/useDeleteMessagesAction';
 import useDismissUserAction from './hooks/useDismissUserAction';

--- a/apps/meteor/client/views/admin/moderation/ModerationConsoleActions.tsx
+++ b/apps/meteor/client/views/admin/moderation/ModerationConsoleActions.tsx
@@ -1,8 +1,8 @@
 // import { Menu, Option } from '@rocket.chat/fuselage';
+import { GenericMenu } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import React from 'react';
 
-import GenericMenu from '../../../components/GenericMenu/GenericMenu';
 import type { ModerationConsoleRowProps } from './ModerationConsoleTableRow';
 import useDeactivateUserAction from './hooks/useDeactivateUserAction';
 import useDeleteMessagesAction from './hooks/useDeleteMessagesAction';

--- a/apps/meteor/client/views/admin/moderation/UserReports/ModConsoleUserActions.tsx
+++ b/apps/meteor/client/views/admin/moderation/UserReports/ModConsoleUserActions.tsx
@@ -1,7 +1,7 @@
+import { GenericMenu } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import React from 'react';
 
-import GenericMenu from '../../../../components/GenericMenu/GenericMenu';
 import useDeactivateUserAction from '../hooks/useDeactivateUserAction';
 import useDismissUserAction from '../hooks/useDismissUserAction';
 import useResetAvatarAction from '../hooks/useResetAvatarAction';

--- a/apps/meteor/client/views/admin/moderation/UserReports/UserContextFooter.tsx
+++ b/apps/meteor/client/views/admin/moderation/UserReports/UserContextFooter.tsx
@@ -1,8 +1,8 @@
 import { Button, ButtonGroup, Box } from '@rocket.chat/fuselage';
+import { GenericMenu } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import React from 'react';
 
-import GenericMenu from '../../../../components/GenericMenu/GenericMenu';
 import useDeactivateUserAction from '../hooks/useDeactivateUserAction';
 import useDismissUserAction from '../hooks/useDismissUserAction';
 import useResetAvatarAction from '../hooks/useResetAvatarAction';

--- a/apps/meteor/client/views/admin/moderation/hooks/useDeactivateUserAction.tsx
+++ b/apps/meteor/client/views/admin/moderation/hooks/useDeactivateUserAction.tsx
@@ -1,9 +1,9 @@
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useEndpoint, useRouteParameter, useRouter, useSetModal, useToastMessageDispatch } from '@rocket.chat/ui-contexts';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import GenericModal from '../../../../components/GenericModal';
 
 const useDeactivateUserAction = (userId: string, isUserReport?: boolean): GenericMenuItemProps => {

--- a/apps/meteor/client/views/admin/moderation/hooks/useDeleteMessagesAction.tsx
+++ b/apps/meteor/client/views/admin/moderation/hooks/useDeleteMessagesAction.tsx
@@ -1,8 +1,8 @@
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useEndpoint, useRouteParameter, useRouter, useSetModal, useToastMessageDispatch, useTranslation } from '@rocket.chat/ui-contexts';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import React from 'react';
 
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import GenericModal from '../../../../components/GenericModal';
 
 const useDeleteMessagesAction = (userId: string): GenericMenuItemProps => {

--- a/apps/meteor/client/views/admin/moderation/hooks/useDismissUserAction.tsx
+++ b/apps/meteor/client/views/admin/moderation/hooks/useDismissUserAction.tsx
@@ -1,9 +1,9 @@
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useEndpoint, useRouter, useSetModal, useToastMessageDispatch, useRouteParameter } from '@rocket.chat/ui-contexts';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import GenericModal from '../../../../components/GenericModal';
 
 const useDismissUserAction = (userId: string, isUserReport?: boolean): GenericMenuItemProps => {

--- a/apps/meteor/client/views/admin/moderation/hooks/useResetAvatarAction.tsx
+++ b/apps/meteor/client/views/admin/moderation/hooks/useResetAvatarAction.tsx
@@ -1,8 +1,8 @@
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useEndpoint, useSetModal, useToastMessageDispatch, useTranslation } from '@rocket.chat/ui-contexts';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import React from 'react';
 
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import GenericModal from '../../../../components/GenericModal';
 
 const useResetAvatarAction = (userId: string): GenericMenuItemProps => {

--- a/apps/meteor/client/views/marketplace/AppMenu.tsx
+++ b/apps/meteor/client/views/marketplace/AppMenu.tsx
@@ -1,9 +1,9 @@
 import type { App } from '@rocket.chat/core-typings';
 import { MenuItem, MenuItemContent, MenuSection, MenuV2, Skeleton } from '@rocket.chat/fuselage';
+import { useHandleMenuAction } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import React, { memo } from 'react';
 
-import { useHandleMenuAction } from '../../components/GenericMenu/hooks/useHandleMenuAction';
 import type { AppMenuOption } from './hooks/useAppMenu';
 import { useAppMenu } from './hooks/useAppMenu';
 

--- a/apps/meteor/client/views/room/Header/RoomToolbox/RoomToolbox.tsx
+++ b/apps/meteor/client/views/room/Header/RoomToolbox/RoomToolbox.tsx
@@ -1,11 +1,11 @@
 import type { Box } from '@rocket.chat/fuselage';
 import { useMutableCallback } from '@rocket.chat/fuselage-hooks';
+import { GenericMenu } from '@rocket.chat/ui-client';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useLayout, useTranslation } from '@rocket.chat/ui-contexts';
 import type { ComponentProps } from 'react';
 import React, { memo } from 'react';
 
-import GenericMenu from '../../../../components/GenericMenu/GenericMenu';
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import { HeaderToolbarAction, HeaderToolbarDivider } from '../../../../components/Header';
 import { useRoomToolbox } from '../../contexts/RoomToolboxContext';
 import type { RoomToolboxActionConfig } from '../../contexts/RoomToolboxContext';

--- a/apps/meteor/client/views/room/HeaderV2/RoomToolbox/RoomToolbox.tsx
+++ b/apps/meteor/client/views/room/HeaderV2/RoomToolbox/RoomToolbox.tsx
@@ -1,11 +1,11 @@
 import type { Box } from '@rocket.chat/fuselage';
 import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
+import { GenericMenu } from '@rocket.chat/ui-client';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useLayout, useTranslation } from '@rocket.chat/ui-contexts';
 import type { ComponentProps } from 'react';
 import React, { memo } from 'react';
 
-import GenericMenu from '../../../../components/GenericMenu/GenericMenu';
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import { HeaderToolbarAction, HeaderToolbarDivider } from '../../../../components/Header';
 import { useRoomToolbox } from '../../contexts/RoomToolboxContext';
 import type { RoomToolboxActionConfig } from '../../contexts/RoomToolboxContext';

--- a/apps/meteor/client/views/room/UserCard/UserCardWithData.tsx
+++ b/apps/meteor/client/views/room/UserCard/UserCardWithData.tsx
@@ -1,11 +1,11 @@
 import type { IRoom } from '@rocket.chat/core-typings';
 import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
+import { GenericMenu } from '@rocket.chat/ui-client';
 import { useSetting, useRolesDescription, useTranslation } from '@rocket.chat/ui-contexts';
 import type { ReactElement } from 'react';
 import React, { useMemo } from 'react';
 
 import { getUserDisplayName } from '../../../../lib/getUserDisplayName';
-import GenericMenu from '../../../components/GenericMenu/GenericMenu';
 import LocalTime from '../../../components/LocalTime';
 import { UserCard, UserCardAction, UserCardRole, UserCardSkeleton } from '../../../components/UserCard';
 import { ReactiveUserStatus } from '../../../components/UserStatus';

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/MessageBoxActionsToolbar.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/MessageBoxActionsToolbar.tsx
@@ -1,5 +1,7 @@
 import type { IRoom, IMessage } from '@rocket.chat/core-typings';
 import type { Icon } from '@rocket.chat/fuselage';
+import { GenericMenu } from '@rocket.chat/ui-client';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { MessageComposerAction, MessageComposerActionsDivider } from '@rocket.chat/ui-composer';
 import type { TranslationKey } from '@rocket.chat/ui-contexts';
 import { useTranslation, useLayoutHiddenActions } from '@rocket.chat/ui-contexts';
@@ -8,8 +10,6 @@ import React, { memo } from 'react';
 
 import { messageBox } from '../../../../../../app/ui-utils/client';
 import { isTruthy } from '../../../../../../lib/isTruthy';
-import GenericMenu from '../../../../../components/GenericMenu/GenericMenu';
-import type { GenericMenuItemProps } from '../../../../../components/GenericMenu/GenericMenuItem';
 import { useMessageboxAppsActionButtons } from '../../../../../hooks/useAppActionButtons';
 import { useChat } from '../../../contexts/ChatContext';
 import { useRoom } from '../../../contexts/RoomContext';

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useAudioMessageAction.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useAudioMessageAction.ts
@@ -1,9 +1,9 @@
 import { useMutableCallback } from '@rocket.chat/fuselage-hooks';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useSetting } from '@rocket.chat/ui-contexts';
 import { useEffect, useMemo } from 'react';
 
 import { AudioRecorder } from '../../../../../../../app/ui/client/lib/recorderjs/AudioRecorder';
-import type { GenericMenuItemProps } from '../../../../../../components/GenericMenu/GenericMenuItem';
 import { useChat } from '../../../../contexts/ChatContext';
 import { useMediaActionTitle } from '../../hooks/useMediaActionTitle';
 import { useMediaPermissions } from '../../hooks/useMediaPermissions';

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useCreateDiscussionAction.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useCreateDiscussionAction.tsx
@@ -1,10 +1,10 @@
 import type { IRoom } from '@rocket.chat/core-typings';
 import { isRoomFederated } from '@rocket.chat/core-typings';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useTranslation, useSetting, usePermission, useSetModal } from '@rocket.chat/ui-contexts';
 import React from 'react';
 
 import CreateDiscussion from '../../../../../../components/CreateDiscussion';
-import type { GenericMenuItemProps } from '../../../../../../components/GenericMenu/GenericMenuItem';
 
 export const useCreateDiscussionAction = (room?: IRoom): GenericMenuItemProps => {
 	const t = useTranslation();

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useFileUploadAction.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useFileUploadAction.ts
@@ -1,7 +1,7 @@
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useTranslation, useSetting } from '@rocket.chat/ui-contexts';
 import { useEffect } from 'react';
 
-import type { GenericMenuItemProps } from '../../../../../../components/GenericMenu/GenericMenuItem';
 import { useFileInput } from '../../../../../../hooks/useFileInput';
 import { useChat } from '../../../../contexts/ChatContext';
 

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useShareLocationAction.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useShareLocationAction.tsx
@@ -1,9 +1,9 @@
 import type { IMessage, IRoom } from '@rocket.chat/core-typings';
 import { isRoomFederated } from '@rocket.chat/core-typings';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useSetting, useSetModal, useTranslation } from '@rocket.chat/ui-contexts';
 import React from 'react';
 
-import type { GenericMenuItemProps } from '../../../../../../components/GenericMenu/GenericMenuItem';
 import ShareLocationModal from '../../../../ShareLocation/ShareLocationModal';
 
 export const useShareLocationAction = (room?: IRoom, tmid?: IMessage['tmid']): GenericMenuItemProps => {

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useVideoMessageAction.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useVideoMessageAction.ts
@@ -1,9 +1,9 @@
 import { useMutableCallback } from '@rocket.chat/fuselage-hooks';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useSetting } from '@rocket.chat/ui-contexts';
 import { useEffect, useMemo } from 'react';
 
 import { VideoRecorder } from '../../../../../../../app/ui/client/lib/recorderjs/videoRecorder';
-import type { GenericMenuItemProps } from '../../../../../../components/GenericMenu/GenericMenuItem';
 import { useChat } from '../../../../contexts/ChatContext';
 import { useMediaActionTitle } from '../../hooks/useMediaActionTitle';
 import { useMediaPermissions } from '../../hooks/useMediaPermissions';

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useWebdavActions.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useWebdavActions.tsx
@@ -1,9 +1,9 @@
 import type { IWebdavAccountIntegration } from '@rocket.chat/core-typings';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useSetModal, useSetting } from '@rocket.chat/ui-contexts';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import type { GenericMenuItemProps } from '../../../../../../components/GenericMenu/GenericMenuItem';
 import { useWebDAVAccountIntegrationsQuery } from '../../../../../../hooks/webdav/useWebDAVAccountIntegrationsQuery';
 import { useChat } from '../../../../contexts/ChatContext';
 import AddWebdavAccountModal from '../../../../webdav/AddWebdavAccountModal';

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxFormattingToolbar/FormattingToolbarDropdown.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxFormattingToolbar/FormattingToolbarDropdown.tsx
@@ -1,9 +1,9 @@
+import { GenericMenu } from '@rocket.chat/ui-client';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import React from 'react';
 
 import { isPromptButton, type FormattingButton } from '../../../../../../app/ui-message/client/messageBox/messageBoxFormatting';
-import GenericMenu from '../../../../../components/GenericMenu/GenericMenu';
-import type { GenericMenuItemProps } from '../../../../../components/GenericMenu/GenericMenuItem';
 import type { ComposerAPI } from '../../../../../lib/chats/ChatAPI';
 
 type FormattingToolbarDropdownProps = {

--- a/apps/meteor/client/views/room/contextualBar/Info/RoomInfo/RoomInfo.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Info/RoomInfo/RoomInfo.tsx
@@ -1,6 +1,7 @@
 import type { IRoom } from '@rocket.chat/core-typings';
 import { Box, Callout, IconButton } from '@rocket.chat/fuselage';
 import { RoomAvatar } from '@rocket.chat/ui-avatar';
+import { GenericMenu } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import React from 'react';
 
@@ -12,7 +13,6 @@ import {
 	ContextualbarClose,
 	ContextualbarTitle,
 } from '../../../../../components/Contextualbar';
-import GenericMenu from '../../../../../components/GenericMenu/GenericMenu';
 import {
 	InfoPanel,
 	InfoPanelActionGroup,

--- a/apps/meteor/client/views/room/contextualBar/RoomMembers/RoomMembersActions.tsx
+++ b/apps/meteor/client/views/room/contextualBar/RoomMembers/RoomMembersActions.tsx
@@ -1,9 +1,9 @@
 import type { IUser, IRoom } from '@rocket.chat/core-typings';
+import { GenericMenu } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import type { ReactElement } from 'react';
 import React from 'react';
 
-import GenericMenu from '../../../../components/GenericMenu/GenericMenu';
 import { useUserInfoActions } from '../../hooks/useUserInfoActions';
 
 type RoomMembersActionsProps = {

--- a/apps/meteor/client/views/room/contextualBar/UserInfo/UserInfoActions.tsx
+++ b/apps/meteor/client/views/room/contextualBar/UserInfo/UserInfoActions.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable react/display-name, react/no-multi-comp */
 import type { IRoom, IUser } from '@rocket.chat/core-typings';
 import { ButtonGroup, IconButton, Skeleton } from '@rocket.chat/fuselage';
+import { GenericMenu } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import type { ReactElement } from 'react';
 import React, { useMemo } from 'react';
 
-import GenericMenu from '../../../../components/GenericMenu/GenericMenu';
 import { UserInfoAction } from '../../../../components/UserInfo';
 import { useMemberExists } from '../../../hooks/useMemberExists';
 import { useUserInfoActions } from '../../hooks/useUserInfoActions';

--- a/apps/meteor/client/views/room/hooks/useUserInfoActions/useUserInfoActions.ts
+++ b/apps/meteor/client/views/room/hooks/useUserInfoActions/useUserInfoActions.ts
@@ -1,10 +1,10 @@
 import type { IRoom, IUser } from '@rocket.chat/core-typings';
 import type { Icon } from '@rocket.chat/fuselage';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useLayoutHiddenActions } from '@rocket.chat/ui-contexts';
 import type { ComponentProps } from 'react';
 import { useMemo } from 'react';
 
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import { useEmbeddedLayout } from '../../../../hooks/useEmbeddedLayout';
 import { useAddUserAction } from './actions/useAddUserAction';
 import { useBlockUserAction } from './actions/useBlockUserAction';

--- a/apps/meteor/client/views/teams/contextualBar/channels/TeamsChannelItemMenu.tsx
+++ b/apps/meteor/client/views/teams/contextualBar/channels/TeamsChannelItemMenu.tsx
@@ -1,10 +1,10 @@
 import type { IRoom } from '@rocket.chat/core-typings';
 import { CheckBox } from '@rocket.chat/fuselage';
+import { GenericMenu } from '@rocket.chat/ui-client';
+import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import React from 'react';
 
-import GenericMenu from '../../../../components/GenericMenu/GenericMenu';
-import type { GenericMenuItemProps } from '../../../../components/GenericMenu/GenericMenuItem';
 import { useDeleteRoom } from '../../../hooks/roomActions/useDeleteRoom';
 import { useRemoveRoomFromTeam } from './hooks/useRemoveRoomFromTeam';
 import { useToggleAutoJoin } from './hooks/useToggleAutoJoin';

--- a/packages/ui-client/src/components/GenericMenu/GenericMenu.spec.tsx
+++ b/packages/ui-client/src/components/GenericMenu/GenericMenu.spec.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 
 import GenericMenu from './GenericMenu';
 

--- a/packages/ui-client/src/components/GenericMenu/GenericMenu.tsx
+++ b/packages/ui-client/src/components/GenericMenu/GenericMenu.tsx
@@ -12,6 +12,7 @@ type GenericMenuCommonProps = {
 	disabled?: boolean;
 	callbackAction?: () => void;
 };
+
 type GenericMenuConditionalProps =
 	| {
 			sections?: {
@@ -28,7 +29,7 @@ type GenericMenuConditionalProps =
 
 type GenericMenuProps = GenericMenuCommonProps & GenericMenuConditionalProps & Omit<ComponentProps<typeof MenuV2>, 'children'>;
 
-export const GenericMenu = ({ title, icon = 'menu', disabled, onAction, callbackAction, ...props }: GenericMenuProps) => {
+const GenericMenu = ({ title, icon = 'menu', disabled, onAction, callbackAction, ...props }: GenericMenuProps) => {
 	const t = useTranslation();
 
 	const sections = 'sections' in props && props.sections;

--- a/packages/ui-client/src/components/GenericMenu/GenericMenu.tsx
+++ b/packages/ui-client/src/components/GenericMenu/GenericMenu.tsx
@@ -1,7 +1,6 @@
 import { IconButton, MenuItem, MenuSection, MenuV2 } from '@rocket.chat/fuselage';
 import { useTranslation } from '@rocket.chat/ui-contexts';
 import type { ComponentProps, ReactNode } from 'react';
-import React from 'react';
 
 import type { GenericMenuItemProps } from './GenericMenuItem';
 import GenericMenuItem from './GenericMenuItem';
@@ -29,7 +28,7 @@ type GenericMenuConditionalProps =
 
 type GenericMenuProps = GenericMenuCommonProps & GenericMenuConditionalProps & Omit<ComponentProps<typeof MenuV2>, 'children'>;
 
-const GenericMenu = ({ title, icon = 'menu', disabled, onAction, callbackAction, ...props }: GenericMenuProps) => {
+export const GenericMenu = ({ title, icon = 'menu', disabled, onAction, callbackAction, ...props }: GenericMenuProps) => {
 	const t = useTranslation();
 
 	const sections = 'sections' in props && props.sections;

--- a/packages/ui-client/src/components/GenericMenu/GenericMenuItem.tsx
+++ b/packages/ui-client/src/components/GenericMenu/GenericMenuItem.tsx
@@ -1,6 +1,5 @@
 import { MenuItemColumn, MenuItemContent, MenuItemIcon, MenuItemInput } from '@rocket.chat/fuselage';
 import type { ComponentProps, MouseEvent, ReactNode } from 'react';
-import React from 'react';
 
 export type GenericMenuItemProps = {
 	id: string;
@@ -16,7 +15,7 @@ export type GenericMenuItemProps = {
 	variant?: string;
 };
 
-const GenericMenuItem = ({ icon, content, addon, status, gap, tooltip }: GenericMenuItemProps) => (
+export const GenericMenuItem = ({ icon, content, addon, status, gap, tooltip }: GenericMenuItemProps) => (
 	<>
 		{gap && <MenuItemColumn />}
 		{icon && <MenuItemIcon name={icon} />}

--- a/packages/ui-client/src/components/GenericMenu/GenericMenuItem.tsx
+++ b/packages/ui-client/src/components/GenericMenu/GenericMenuItem.tsx
@@ -15,7 +15,7 @@ export type GenericMenuItemProps = {
 	variant?: string;
 };
 
-export const GenericMenuItem = ({ icon, content, addon, status, gap, tooltip }: GenericMenuItemProps) => (
+const GenericMenuItem = ({ icon, content, addon, status, gap, tooltip }: GenericMenuItemProps) => (
 	<>
 		{gap && <MenuItemColumn />}
 		{icon && <MenuItemIcon name={icon} />}

--- a/packages/ui-client/src/components/GenericMenu/hooks/useHandleMenuAction.tsx
+++ b/packages/ui-client/src/components/GenericMenu/hooks/useHandleMenuAction.tsx
@@ -2,12 +2,11 @@ import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
 
 import type { GenericMenuItemProps } from '../GenericMenuItem';
 
-export const useHandleMenuAction = (items: GenericMenuItemProps[], callbackAction?: () => void) => {
-	return useEffectEvent((id) => {
+export const useHandleMenuAction = (items: GenericMenuItemProps[], callbackAction?: () => void) =>
+	useEffectEvent((id) => {
 		const item = items.find((item) => item.id === id && !!item.onClick);
 		if (item) {
 			item.onClick?.();
 			callbackAction?.();
 		}
 	});
-};

--- a/packages/ui-client/src/components/GenericMenu/index.ts
+++ b/packages/ui-client/src/components/GenericMenu/index.ts
@@ -1,4 +1,3 @@
-export { default } from './GenericMenu';
-export * from './GenericMenu';
-export * from './GenericMenuItem';
-export * from './hooks/useHandleMenuAction';
+export { default as GenericMenu } from './GenericMenu';
+export { default as GenericMenuItem, GenericMenuItemProps } from './GenericMenuItem';
+export { useHandleMenuAction } from './hooks/useHandleMenuAction';

--- a/packages/ui-client/src/components/GenericMenu/index.ts
+++ b/packages/ui-client/src/components/GenericMenu/index.ts
@@ -1,0 +1,4 @@
+export { default } from './GenericMenu';
+export * from './GenericMenu';
+export * from './GenericMenuItem';
+export * from './hooks/useHandleMenuAction';

--- a/packages/ui-client/src/components/index.ts
+++ b/packages/ui-client/src/components/index.ts
@@ -14,3 +14,4 @@ export * from './MultiSelectCustom/MultiSelectCustom';
 export * from './FeaturePreview/FeaturePreview';
 export * from './RoomBanner';
 export { default as UserAutoComplete } from './UserAutoComplete';
+export * from './GenericMenu';


### PR DESCRIPTION

## Proposed changes (including videos or screenshots)
Moved the component `GenericMenu` to the `@rocket.chat/ui-client` package and adjusted imports accordingly. This change will allow this component to be used by packages outside `apps/meteor`.
