### PR TITLE
fix: correct parameter order in afterSaveMessage to restore outgoing webhooks and related features

### DIFF
--- a/.changeset/rotten-rabbits-brush.md
+++ b/.changeset/rotten-rabbits-brush.md
@@ -2,4 +2,4 @@
 '@rocket.chat/meteor': patch
 ---
 
-Fixes the parameter order in callbackHandler and updates the integration logic, autotranslate, and the EngagementDashboard.afterSaveMessage trigger to correctly pass the room parameter. This resolves the malfunction in outgoing webhooks and other use cases impacted by the format change introduced in version 6.12.0.
+Resolves the issue where outgoing integrations failed to trigger after the version 6.12.0 upgrade by correcting the parameter order from the `afterSaveMessage` callback to listener functions. This ensures the correct room information is passed, restoring the functionality of outgoing webhooks, IRC bridge, Autotranslate, and Engagement Dashboard.

--- a/.changeset/rotten-rabbits-brush.md
+++ b/.changeset/rotten-rabbits-brush.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes the parameter order in callbackHandler and updates the integration logic, autotranslate, and the EngagementDashboard.afterSaveMessage trigger to correctly pass the room parameter. This resolves the malfunction in outgoing webhooks and other use cases impacted by the format change introduced in version 6.12.0.

--- a/apps/meteor/app/autotranslate/server/autotranslate.ts
+++ b/apps/meteor/app/autotranslate/server/autotranslate.ts
@@ -113,7 +113,12 @@ export class TranslationProviderRegistry {
 			return;
 		}
 
-		callbacks.add('afterSaveMessage', provider.translateMessage.bind(provider), callbacks.priority.MEDIUM, 'autotranslate');
+		callbacks.add(
+			'afterSaveMessage',
+			(message, { room }) => provider.translateMessage(message, { room }),
+			callbacks.priority.MEDIUM,
+			'autotranslate',
+		);
 	}
 }
 

--- a/apps/meteor/app/integrations/server/triggers.ts
+++ b/apps/meteor/app/integrations/server/triggers.ts
@@ -8,7 +8,12 @@ const callbackHandler = function _callbackHandler(eventType: string) {
 	};
 };
 
-callbacks.add('afterSaveMessage', callbackHandler('sendMessage'), callbacks.priority.LOW, 'integrations-sendMessage');
+callbacks.add(
+	'afterSaveMessage',
+	(message, { room }) => callbackHandler('sendMessage')(message, room),
+	callbacks.priority.LOW,
+	'integrations-sendMessage',
+);
 callbacks.add('afterCreateChannel', callbackHandler('roomCreated'), callbacks.priority.LOW, 'integrations-roomCreated');
 callbacks.add('afterCreatePrivateGroup', callbackHandler('roomCreated'), callbacks.priority.LOW, 'integrations-roomCreated');
 callbacks.add('afterCreateUser', callbackHandler('userCreated'), callbacks.priority.LOW, 'integrations-userCreated');

--- a/apps/meteor/app/irc/server/irc-bridge/index.js
+++ b/apps/meteor/app/irc/server/irc-bridge/index.js
@@ -209,7 +209,7 @@ class Bridge {
 		// Chatting
 		callbacks.add(
 			'afterSaveMessage',
-			(message, { room }) => this.onMessageReceived.bind(this, 'local', 'onSaveMessage')(message, room),
+			(message, { room }) => this.onMessageReceived('local', 'onSaveMessage', message, room),
 			callbacks.priority.LOW,
 			'irc-on-save-message',
 		);

--- a/apps/meteor/app/irc/server/irc-bridge/index.js
+++ b/apps/meteor/app/irc/server/irc-bridge/index.js
@@ -209,7 +209,7 @@ class Bridge {
 		// Chatting
 		callbacks.add(
 			'afterSaveMessage',
-			this.onMessageReceived.bind(this, 'local', 'onSaveMessage'),
+			(message, { room }) => this.onMessageReceived.bind(this, 'local', 'onSaveMessage')(message, room),
 			callbacks.priority.LOW,
 			'irc-on-save-message',
 		);

--- a/apps/meteor/ee/server/lib/engagementDashboard/startup.ts
+++ b/apps/meteor/ee/server/lib/engagementDashboard/startup.ts
@@ -3,7 +3,12 @@ import { fillFirstDaysOfMessagesIfNeeded, handleMessagesDeleted, handleMessagesS
 import { fillFirstDaysOfUsersIfNeeded, handleUserCreated } from './users';
 
 export const attachCallbacks = (): void => {
-	callbacks.add('afterSaveMessage', handleMessagesSent, callbacks.priority.MEDIUM, 'engagementDashboard.afterSaveMessage');
+	callbacks.add(
+		'afterSaveMessage',
+		(message, { room }) => handleMessagesSent(message, { room }),
+		callbacks.priority.MEDIUM,
+		'engagementDashboard.afterSaveMessage',
+	);
 	callbacks.add('afterDeleteMessage', handleMessagesDeleted, callbacks.priority.MEDIUM, 'engagementDashboard.afterDeleteMessage');
 	callbacks.add('afterCreateUser', handleUserCreated, callbacks.priority.MEDIUM, 'engagementDashboard.afterCreateUser');
 };


### PR DESCRIPTION
After upgrading from Rocket.Chat version 6.9.0 to 6.12.0, outgoing integrations stopped functioning. The root cause was traced to a change in the parameter order passed by the `afterSendMessage` callback to the `sendMessage` event from the integrations app triggers. Specifically, the room parameter was not forwarded correctly, resulting in errors when searching for outgoing webhook triggers.

This issue was introduced by [PR #33034](https://github.com/RocketChat/Rocket.Chat/pull/33034), which modified the `afterSaveMessage` parameter signature but did not update the corresponding integration logic.

As outlined in [SUP-665](https://rocketchat.atlassian.net/browse/SUP-665), this malfunction blocked the propagation of certain actions due to the callback failing to forward the correct parameters.

This PR resolves the issue by correcting the parameter order, ensuring the room parameter is passed correctly, thus restoring the functionality of outgoing webhooks.

Additionally, the same issue affected the following areas, which have now been fixed:
- **IRC Bridge:** Fixed an issue where the service failed to bind Rocket.Chat users with their correct IRC nickname or channel path.
- **Autotranslate:** Resolved an issue preventing messages from being automatically translated.
- **EngagementDashboard:** Corrected the issue where new messages were not being counted in the engagement dashboard.

[SUP-665]: https://rocketchat.atlassian.net/browse/SUP-665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ