### PR TITLE
Release 6.12.2

### DIFF
--- a/.changeset/brave-brooms-invent.md
+++ b/.changeset/brave-brooms-invent.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixes a problem that caused visitor creation to fail when GDPR setting was enabled and visitor was created via Apps Engine or the deprecated `livechat:registerGuest` method.

--- a/.changeset/bump-patch-1726584054495.md
+++ b/.changeset/bump-patch-1726584054495.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Bump @rocket.chat/meteor version.

--- a/.changeset/dry-taxis-cry.md
+++ b/.changeset/dry-taxis-cry.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes a race condition that causes livechat conversations to get stuck in the agent's sidebar panel after being forwarded.

--- a/.changeset/rotten-rabbits-brush.md
+++ b/.changeset/rotten-rabbits-brush.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Resolves the issue where outgoing integrations failed to trigger after the version 6.12.0 upgrade by correcting the parameter order from the `afterSaveMessage` callback to listener functions. This ensures the correct room information is passed, restoring the functionality of outgoing webhooks, IRC bridge, Autotranslate, and Engagement Dashboard.

--- a/.changeset/strong-grapes-brake.md
+++ b/.changeset/strong-grapes-brake.md
@@ -1,0 +1,9 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed remaining direct references to external user avatar URLs
+
+Fixed local avatars having priority over external provider
+
+It mainly corrects the behavior of E2E encryption messages and desktop notifications.

--- a/apps/meteor/app/autotranslate/server/autotranslate.ts
+++ b/apps/meteor/app/autotranslate/server/autotranslate.ts
@@ -113,7 +113,12 @@ export class TranslationProviderRegistry {
 			return;
 		}
 
-		callbacks.add('afterSaveMessage', provider.translateMessage.bind(provider), callbacks.priority.MEDIUM, 'autotranslate');
+		callbacks.add(
+			'afterSaveMessage',
+			(message, { room }) => provider.translateMessage(message, { room }),
+			callbacks.priority.MEDIUM,
+			'autotranslate',
+		);
 	}
 }
 

--- a/apps/meteor/app/integrations/server/triggers.ts
+++ b/apps/meteor/app/integrations/server/triggers.ts
@@ -8,7 +8,12 @@ const callbackHandler = function _callbackHandler(eventType: string) {
 	};
 };
 
-callbacks.add('afterSaveMessage', callbackHandler('sendMessage'), callbacks.priority.LOW, 'integrations-sendMessage');
+callbacks.add(
+	'afterSaveMessage',
+	(message, { room }) => callbackHandler('sendMessage')(message, room),
+	callbacks.priority.LOW,
+	'integrations-sendMessage',
+);
 callbacks.add('afterCreateChannel', callbackHandler('roomCreated'), callbacks.priority.LOW, 'integrations-roomCreated');
 callbacks.add('afterCreatePrivateGroup', callbackHandler('roomCreated'), callbacks.priority.LOW, 'integrations-roomCreated');
 callbacks.add('afterCreateUser', callbackHandler('userCreated'), callbacks.priority.LOW, 'integrations-userCreated');

--- a/apps/meteor/app/irc/server/irc-bridge/index.js
+++ b/apps/meteor/app/irc/server/irc-bridge/index.js
@@ -209,7 +209,7 @@ class Bridge {
 		// Chatting
 		callbacks.add(
 			'afterSaveMessage',
-			this.onMessageReceived.bind(this, 'local', 'onSaveMessage'),
+			(message, { room }) => this.onMessageReceived('local', 'onSaveMessage', message, room),
 			callbacks.priority.LOW,
 			'irc-on-save-message',
 		);

--- a/apps/meteor/app/livechat/server/lib/LivechatTyped.ts
+++ b/apps/meteor/app/livechat/server/lib/LivechatTyped.ts
@@ -588,6 +588,10 @@ class LivechatClass {
 		}
 	}
 
+	isValidObject(obj: unknown): obj is Record<string, any> {
+		return typeof obj === 'object' && obj !== null;
+	}
+
 	async registerGuest({
 		id,
 		token,
@@ -653,10 +657,10 @@ class LivechatClass {
 			visitorDataToUpdate.status = status;
 			visitorDataToUpdate.ts = new Date();
 
-			if (settings.get('Livechat_Allow_collect_and_store_HTTP_header_informations')) {
+			if (settings.get('Livechat_Allow_collect_and_store_HTTP_header_informations') && Livechat.isValidObject(connectionData)) {
 				Livechat.logger.debug(`Saving connection data for visitor ${token}`);
 				const { httpHeaders, clientAddress } = connectionData;
-				if (httpHeaders) {
+				if (Livechat.isValidObject(httpHeaders)) {
 					visitorDataToUpdate.userAgent = httpHeaders['user-agent'];
 					visitorDataToUpdate.ip = httpHeaders['x-real-ip'] || httpHeaders['x-forwarded-for'] || clientAddress;
 					visitorDataToUpdate.host = httpHeaders?.host;

--- a/apps/meteor/app/utils/client/getUserAvatarURL.ts
+++ b/apps/meteor/app/utils/client/getUserAvatarURL.ts
@@ -1,11 +1,6 @@
-import { settings } from '../../settings/client';
 import { getAvatarURL } from './getAvatarURL';
 
 export const getUserAvatarURL = function (username: string, cache = ''): string | undefined {
-	const externalSource = (settings.get<string>('Accounts_AvatarExternalProviderUrl') || '').trim().replace(/\/$/, '');
-	if (externalSource !== '') {
-		return externalSource.replace('{username}', username);
-	}
 	if (username == null) {
 		return;
 	}

--- a/apps/meteor/app/utils/server/getUserAvatarURL.ts
+++ b/apps/meteor/app/utils/server/getUserAvatarURL.ts
@@ -1,11 +1,6 @@
-import { settings } from '../../settings/server';
 import { getAvatarURL } from './getAvatarURL';
 
 export const getUserAvatarURL = function (username: string, cache = ''): string | undefined {
-	const externalSource = (settings.get<string>('Accounts_AvatarExternalProviderUrl') || '').trim().replace(/\/$/, '');
-	if (externalSource !== '') {
-		return externalSource.replace('{username}', username);
-	}
 	if (username == null) {
 		return;
 	}

--- a/apps/meteor/client/providers/AvatarUrlProvider.tsx
+++ b/apps/meteor/client/providers/AvatarUrlProvider.tsx
@@ -1,4 +1,4 @@
-import { AvatarUrlContext, useSetting } from '@rocket.chat/ui-contexts';
+import { AvatarUrlContext } from '@rocket.chat/ui-contexts';
 import type { ReactNode } from 'react';
 import React, { useMemo } from 'react';
 
@@ -10,19 +10,15 @@ type AvatarUrlProviderProps = {
 };
 
 const AvatarUrlProvider = ({ children }: AvatarUrlProviderProps) => {
-	const cdnAvatarUrl = String(useSetting('CDN_PREFIX') || '');
 	const contextValue = useMemo(
 		() => ({
 			getUserPathAvatar: ((): ((uid: string, etag?: string) => string) => {
-				if (cdnAvatarUrl) {
-					return (uid: string, etag?: string): string => `${cdnAvatarUrl}/avatar/${uid}${etag ? `?etag=${etag}` : ''}`;
-				}
 				return (uid: string, etag?: string): string => getURL(`/avatar/${uid}${etag ? `?etag=${etag}` : ''}`);
 			})(),
 			getRoomPathAvatar: ({ type, ...room }: any): string =>
 				roomCoordinator.getRoomDirectives(type || room.t).getAvatarPath({ username: room._id, ...room }) || '',
 		}),
-		[cdnAvatarUrl],
+		[],
 	);
 
 	return <AvatarUrlContext.Provider children={children} value={contextValue} />;

--- a/apps/meteor/ee/server/lib/engagementDashboard/startup.ts
+++ b/apps/meteor/ee/server/lib/engagementDashboard/startup.ts
@@ -3,7 +3,12 @@ import { fillFirstDaysOfMessagesIfNeeded, handleMessagesDeleted, handleMessagesS
 import { fillFirstDaysOfUsersIfNeeded, handleUserCreated } from './users';
 
 export const attachCallbacks = (): void => {
-	callbacks.add('afterSaveMessage', handleMessagesSent, callbacks.priority.MEDIUM, 'engagementDashboard.afterSaveMessage');
+	callbacks.add(
+		'afterSaveMessage',
+		(message, { room }) => handleMessagesSent(message, { room }),
+		callbacks.priority.MEDIUM,
+		'engagementDashboard.afterSaveMessage',
+	);
 	callbacks.add('afterDeleteMessage', handleMessagesDeleted, callbacks.priority.MEDIUM, 'engagementDashboard.afterDeleteMessage');
 	callbacks.add('afterCreateUser', handleUserCreated, callbacks.priority.MEDIUM, 'engagementDashboard.afterCreateUser');
 };

--- a/apps/meteor/server/models/raw/BaseRaw.ts
+++ b/apps/meteor/server/models/raw/BaseRaw.ts
@@ -318,33 +318,33 @@ export abstract class BaseRaw<
 
 	async findOneAndDelete(filter: Filter<T>, options?: FindOneAndDeleteOptions): Promise<ModifyResult<T>> {
 		if (!this.trash) {
-			if (options) {
-				return this.col.findOneAndDelete(filter, options);
-			}
-			return this.col.findOneAndDelete(filter);
+			return this.col.findOneAndDelete(filter, options || {});
 		}
 
-		const result = await this.col.findOneAndDelete(filter);
-
-		const { value: doc } = result;
+		const doc = await this.col.findOne(filter);
 		if (!doc) {
-			return result;
+			return { ok: 1, value: null };
 		}
 
 		const { _id, ...record } = doc;
-
 		const trash: TDeleted = {
 			...record,
 			_deletedAt: new Date(),
 			__collection__: this.name,
 		} as unknown as TDeleted;
 
-		// since the operation is not atomic, we need to make sure that the record is not already deleted/inserted
 		await this.trash?.updateOne({ _id } as Filter<TDeleted>, { $set: trash } as UpdateFilter<TDeleted>, {
 			upsert: true,
 		});
 
-		return result;
+		try {
+			await this.col.deleteOne({ _id } as Filter<T>);
+		} catch (e) {
+			await this.trash?.deleteOne({ _id } as Filter<TDeleted>);
+			throw e;
+		}
+
+		return { ok: 1, value: doc };
 	}
 
 	async deleteMany(filter: Filter<T>, options?: DeleteOptions & { onTrash?: (record: ResultFields<T, C>) => void }): Promise<DeleteResult> {

--- a/apps/meteor/server/routes/avatar/user.js
+++ b/apps/meteor/server/routes/avatar/user.js
@@ -32,6 +32,13 @@ export const userAvatar = async function (req, res) {
 		return;
 	}
 
+	if (settings.get('Accounts_AvatarExternalProviderUrl')) {
+		const response = await fetch(settings.get('Accounts_AvatarExternalProviderUrl').replace('{username}', requestUsername));
+		response.headers.forEach((value, key) => res.setHeader(key, value));
+		response.body.pipe(res);
+		return;
+	}
+
 	const reqModifiedHeader = req.headers['if-modified-since'];
 
 	const file = await Avatars.findOneByName(requestUsername);
@@ -50,13 +57,6 @@ export const userAvatar = async function (req, res) {
 		res.setHeader('Content-Length', file.size);
 
 		return FileUpload.get(file, req, res);
-	}
-
-	if (settings.get('Accounts_AvatarExternalProviderUrl')) {
-		const response = await fetch(settings.get('Accounts_AvatarExternalProviderUrl').replace('{username}', requestUsername));
-		response.headers.forEach((value, key) => res.setHeader(key, value));
-		response.body.pipe(res);
-		return;
 	}
 
 	// if still using "letters fallback"

--- a/apps/meteor/tests/end-to-end/api/livechat/09-visitors.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/09-visitors.ts
@@ -1,11 +1,11 @@
 import { faker } from '@faker-js/faker';
 import type { ILivechatVisitor } from '@rocket.chat/core-typings';
 import { expect } from 'chai';
-import { before, describe, it } from 'mocha';
+import { before, describe, it, after } from 'mocha';
 import moment from 'moment';
 import { type Response } from 'supertest';
 
-import { getCredentials, api, request, credentials } from '../../../data/api-data';
+import { getCredentials, api, request, credentials, methodCallAnon } from '../../../data/api-data';
 import { createCustomField, deleteCustomField } from '../../../data/livechat/custom-fields';
 import {
 	makeAgentAvailable,
@@ -215,6 +215,30 @@ describe('LIVECHAT - visitors', () => {
 			expect(body.visitor).to.have.property('token', token);
 			expect(body.visitor).to.have.property('livechatData');
 			expect(body.visitor.livechatData).to.have.property(customFieldName, 'Not a real address :)');
+		});
+
+		describe('special cases', () => {
+			before(async () => {
+				await updateSetting('Livechat_Allow_collect_and_store_HTTP_header_informations', true);
+			});
+			after(async () => {
+				await updateSetting('Livechat_Allow_collect_and_store_HTTP_header_informations', false);
+			});
+
+			// Note: this had to use the meteor method because the endpoint used `req.headers` which we cannot send as empty
+			// method doesn't pass them to the func allowing us to create a test for it
+			it('should allow to create a visitor without passing connectionData when GDPR setting is enabled', async () => {
+				const token = `${new Date().getTime()}-test`;
+				const response = await request
+					.post(methodCallAnon('livechat:registerGuest'))
+					.send({ message: `{"msg":"method","id":"23","method":"livechat:registerGuest","params":[{ "token": "${token}"}]}` });
+
+				expect(response.body).to.have.property('success', true);
+				const r = JSON.parse(response.body.message);
+
+				expect(r.result).to.have.property('visitor');
+				expect(r.result.visitor).to.have.property('token', token);
+			});
 		});
 	});
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8934,10 +8934,10 @@ __metadata:
     "@rocket.chat/icons": "*"
     "@rocket.chat/prettier-config": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 6.0.0
-    "@rocket.chat/ui-contexts": 10.0.0
+    "@rocket.chat/ui-avatar": 6.0.1
+    "@rocket.chat/ui-contexts": 10.0.1
     "@rocket.chat/ui-kit": 0.36.1
-    "@rocket.chat/ui-video-conf": 10.0.0
+    "@rocket.chat/ui-video-conf": 10.0.1
     "@tanstack/react-query": "*"
     react: "*"
     react-dom: "*"
@@ -9021,10 +9021,10 @@ __metadata:
     "@rocket.chat/css-in-js": "*"
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-tokens": "*"
-    "@rocket.chat/message-parser": 0.31.29
+    "@rocket.chat/message-parser": 0.31.30
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-client": 10.0.0
-    "@rocket.chat/ui-contexts": 10.0.0
+    "@rocket.chat/ui-client": 10.0.1
+    "@rocket.chat/ui-contexts": 10.0.1
     katex: "*"
     react: "*"
   languageName: unknown
@@ -10230,7 +10230,7 @@ __metadata:
     typescript: ~5.3.3
   peerDependencies:
     "@rocket.chat/fuselage": "*"
-    "@rocket.chat/ui-contexts": 10.0.0
+    "@rocket.chat/ui-contexts": 10.0.1
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -10280,7 +10280,7 @@ __metadata:
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-contexts": 10.0.0
+    "@rocket.chat/ui-contexts": 10.0.1
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -10450,8 +10450,8 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 6.0.0
-    "@rocket.chat/ui-contexts": 10.0.0
+    "@rocket.chat/ui-avatar": 6.0.1
+    "@rocket.chat/ui-contexts": 10.0.1
     react: ^17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -10538,7 +10538,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.2.2
-    "@rocket.chat/ui-contexts": 10.0.0
+    "@rocket.chat/ui-contexts": 10.0.1
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION


<!-- release-notes-start -->
<!-- This content is automatically generated. Changing this will not reflect on the final release log -->

_You can see below a preview of the release change log:_

# 6.12.2

### Engine versions

- Node: `14.21.3`
- MongoDB: `4.4, 5.0, 6.0`
- Apps-Engine: `1.45.0-alpha.866`

### Patch Changes

*   ([#33348](https://github.com/RocketChat/Rocket.Chat/pull/33348) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixes a problem that caused visitor creation to fail when GDPR setting was enabled and visitor was created via Apps Engine or the deprecated `livechat:registerGuest` method.

*   Bump @rocket.chat/meteor version.

*   ([#33389](https://github.com/RocketChat/Rocket.Chat/pull/33389) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixes a race condition that causes livechat conversations to get stuck in the agent's sidebar panel after being forwarded.

*   ([#33304](https://github.com/RocketChat/Rocket.Chat/pull/33304) by [@dionisio-bot](https://github.com/dionisio-bot)) Resolves the issue where outgoing integrations failed to trigger after the version 6.12.0 upgrade by correcting the parameter order from the `afterSaveMessage` callback to listener functions. This ensures the correct room information is passed, restoring the functionality of outgoing webhooks, IRC bridge, Autotranslate, and Engagement Dashboard.

*   ([#33314](https://github.com/RocketChat/Rocket.Chat/pull/33314) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixed remaining direct references to external user avatar URLs

    Fixed local avatars having priority over external provider

    It mainly corrects the behavior of E2E encryption messages and desktop notifications.

*   <details><summary>Updated dependencies []:</summary>

    *   @rocket.chat/core-typings@6.12.2
    *   @rocket.chat/rest-typings@6.12.2
    *   @rocket.chat/license@0.2.8
    *   @rocket.chat/omnichannel-services@0.3.5
    *   @rocket.chat/pdf-worker@0.2.5
    *   @rocket.chat/presence@0.2.8
    *   @rocket.chat/api-client@0.2.8
    *   @rocket.chat/apps@0.1.8
    *   @rocket.chat/core-services@0.6.2
    *   @rocket.chat/cron@0.1.8
    *   @rocket.chat/fuselage-ui-kit@10.0.2
    *   @rocket.chat/gazzodown@10.0.2
    *   @rocket.chat/model-typings@0.7.2
    *   @rocket.chat/ui-contexts@10.0.2
    *   @rocket.chat/server-cloud-communication@0.0.2
    *   @rocket.chat/models@0.2.5
    *   @rocket.chat/ui-theming@0.2.1
    *   @rocket.chat/ui-avatar@6.0.2
    *   @rocket.chat/ui-client@10.0.2
    *   @rocket.chat/ui-video-conf@10.0.2
    *   @rocket.chat/web-ui-registration@10.0.2
    *   @rocket.chat/instance-status@0.1.8

    </details>

<!-- release-notes-end -->