### PR TITLE
ci: use node20 for release action

### DIFF
--- a/packages/release-action/action.yml
+++ b/packages/release-action/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 
 branding:


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Uses node20 for release action

## Issue(s)
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/