### PR TITLE
feat: page warning before leave/reload while a call is ongoing

### DIFF
--- a/packages/ui-voip/src/providers/VoipProvider.tsx
+++ b/packages/ui-voip/src/providers/VoipProvider.tsx
@@ -34,22 +34,18 @@ const VoipProvider = ({ children }: { children: ReactNode }) => {
 			return;
 		}
 
+		const onBeforeUnload = (event: BeforeUnloadEvent) => {
+			event.preventDefault();
+			event.returnValue = true;
+		};
+
 		const onCallEstablished = async (): Promise<void> => {
 			voipSounds.stopAll();
+			window.addEventListener('beforeunload', onBeforeUnload);
 
-			if (!voipClient) {
-				return;
+			if (voipClient.isCallee() && remoteAudioMediaRef.current) {
+				voipClient.switchMediaRenderer({ remoteMediaElement: remoteAudioMediaRef.current });
 			}
-
-			if (voipClient.isCallee()) {
-				return;
-			}
-
-			if (!remoteAudioMediaRef.current) {
-				return;
-			}
-
-			voipClient.switchMediaRenderer({ remoteMediaElement: remoteAudioMediaRef.current });
 		};
 
 		const onNetworkDisconnected = (): void => {
@@ -69,6 +65,7 @@ const VoipProvider = ({ children }: { children: ReactNode }) => {
 		const onCallTerminated = (): void => {
 			voipSounds.play('call-ended', false);
 			voipSounds.stopAll();
+			window.removeEventListener('beforeunload', onBeforeUnload);
 		};
 
 		const onRegistrationError = () => {

--- a/packages/ui-voip/src/providers/VoipProvider.tsx
+++ b/packages/ui-voip/src/providers/VoipProvider.tsx
@@ -103,6 +103,7 @@ const VoipProvider = ({ children }: { children: ReactNode }) => {
 			voipClient.networkEmitter.off('disconnected', onNetworkDisconnected);
 			voipClient.networkEmitter.off('connectionerror', onNetworkDisconnected);
 			voipClient.networkEmitter.off('localnetworkoffline', onNetworkDisconnected);
+			window.addEventListener('beforeunload', onBeforeUnload);
 		};
 	}, [dispatchToastMessage, setStorageRegistered, t, voipClient, voipSounds]);
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Users should now be warned when trying to leave or reloading the page during calls.

![Screenshot 2024-10-02 at 10 03 11](https://github.com/user-attachments/assets/5ddca503-cc72-4f04-baea-d8ab9f948688)

![Screenshot 2024-10-02 at 10 03 01](https://github.com/user-attachments/assets/012cb85d-1398-423a-9ea4-c6b0e37ac38d)

## Issue(s)
[VOIP-98](https://rocketchat.atlassian.net/browse/VOIP-98)

## Steps to test or reproduce
- Open the application
- Configure Voip for team collab and user extension
- Start a call
- Try to leave or reload page

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

[VOIP-98]: https://rocketchat.atlassian.net/browse/VOIP-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ