### PR TITLE
Revert "fix: Private apps restrictions are not applied on license removal"

### DIFF
--- a/.changeset/eighty-items-behave.md
+++ b/.changeset/eighty-items-behave.md
@@ -1,5 +1,0 @@
----
-"@rocket.chat/meteor": patch
----
-
-Adds missing readjustment to private apps restrictions on license removal

--- a/apps/meteor/ee/server/startup/apps/trialExpiration.ts
+++ b/apps/meteor/ee/server/startup/apps/trialExpiration.ts
@@ -1,12 +1,9 @@
 import { License } from '@rocket.chat/license';
 import { Meteor } from 'meteor/meteor';
 
-Meteor.startup(async () => {
-	const { Apps } = await import('../../apps');
-	License.onInvalidateLicense(() => {
-		void Apps.disableApps();
-	});
-	License.onRemoveLicense(() => {
+Meteor.startup(() => {
+	License.onInvalidateLicense(async () => {
+		const { Apps } = await import('../../apps');
 		void Apps.disableApps();
 	});
 });


### PR DESCRIPTION
Reverts RocketChat/Rocket.Chat#33400 due to a a business rule change decision