### PR TITLE
fix: login service configuration notifier event

### DIFF
--- a/apps/meteor/app/lib/server/lib/notifyListener.ts
+++ b/apps/meteor/app/lib/server/lib/notifyListener.ts
@@ -162,6 +162,19 @@ export const notifyOnLoginServiceConfigurationChanged = withDbWatcherCheck(
 	},
 );
 
+export const notifyOnLoginServiceConfigurationChangedById = withDbWatcherCheck(
+	async <T extends ILoginServiceConfiguration>(_id: T['_id'], clientAction: ClientAction = 'updated'): Promise<void> => {
+		const item = await LoginServiceConfiguration.findOneById<Omit<LoginServiceConfigurationData, 'secret'>>(_id, {
+			projection: { secret: 0 },
+		});
+		if (!item) {
+			return;
+		}
+
+		void notifyOnLoginServiceConfigurationChanged(item, clientAction);
+	},
+);
+
 export const notifyOnLoginServiceConfigurationChangedByService = withDbWatcherCheck(
 	async <T extends ILoginServiceConfiguration>(service: T['service'], clientAction: ClientAction = 'updated'): Promise<void> => {
 		const item = await LoginServiceConfiguration.findOneByService<Omit<LoginServiceConfigurationData, 'secret'>>(service, {

--- a/apps/meteor/server/lib/oauth/updateOAuthServices.ts
+++ b/apps/meteor/server/lib/oauth/updateOAuthServices.ts
@@ -8,10 +8,6 @@ import type {
 import { LoginServiceConfiguration } from '@rocket.chat/models';
 
 import { CustomOAuth } from '../../../app/custom-oauth/server/custom_oauth_server';
-import {
-	notifyOnLoginServiceConfigurationChanged,
-	notifyOnLoginServiceConfigurationChangedByService,
-} from '../../../app/lib/server/lib/notifyListener';
 import { settings } from '../../../app/settings/server/cached';
 import { logger } from './logger';
 
@@ -117,14 +113,10 @@ export async function updateOAuthServices(): Promise<void> {
 			}
 
 			await LoginServiceConfiguration.createOrUpdateService(serviceKey, data);
-			void notifyOnLoginServiceConfigurationChangedByService(serviceKey);
 		} else {
 			const service = await LoginServiceConfiguration.findOneByService(serviceName, { projection: { _id: 1 } });
 			if (service?._id) {
-				const { deletedCount } = await LoginServiceConfiguration.removeService(service._id);
-				if (deletedCount > 0) {
-					void notifyOnLoginServiceConfigurationChanged({ _id: service._id }, 'removed');
-				}
+				await LoginServiceConfiguration.removeService(service._id);
 			}
 		}
 	}

--- a/apps/meteor/server/lib/refreshLoginServices.ts
+++ b/apps/meteor/server/lib/refreshLoginServices.ts
@@ -1,5 +1,6 @@
 import { ServiceConfiguration } from 'meteor/service-configuration';
 
+import { notifyOnLoginServiceConfigurationChangedById } from '../../app/lib/server/lib/notifyListener';
 import { loadSamlServiceProviders } from '../../app/meteor-accounts-saml/server/lib/settings';
 import { updateCasServices } from './cas/updateCasService';
 import { updateOAuthServices } from './oauth/updateOAuthServices';
@@ -7,5 +8,13 @@ import { updateOAuthServices } from './oauth/updateOAuthServices';
 export async function refreshLoginServices(): Promise<void> {
 	await ServiceConfiguration.configurations.removeAsync({});
 
-	await Promise.allSettled([updateOAuthServices(), loadSamlServiceProviders(), updateCasServices()]);
+	const [oAuthServices] = await Promise.allSettled([updateOAuthServices(), loadSamlServiceProviders(), updateCasServices()]);
+
+	if (oAuthServices.status === 'fulfilled') {
+		await Promise.all(
+			oAuthServices.value.map((service) =>
+				notifyOnLoginServiceConfigurationChangedById(service._id, service.deleted ? 'removed' : 'inserted'),
+			),
+		);
+	}
 }


### PR DESCRIPTION
As per [OPI-39](https://rocketchat.atlassian.net/browse/OPI-39), we've identified scenarios where a "no broker set to broadcast" message appears, particularly in the "watch.loginServiceConfiguration" event. After reviewing the root cause, we've determined that it's unnecessary to stream changes in real-time through the socket when the server checks for updates to OAuth provider configurations.

[OPI-39]: https://rocketchat.atlassian.net/browse/OPI-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ