### PR TITLE
fix: Updating path `responseBy` would create a conflict on `responseBy`

### DIFF
--- a/apps/meteor/app/livechat/server/hooks/markRoomResponded.ts
+++ b/apps/meteor/app/livechat/server/hooks/markRoomResponded.ts
@@ -33,10 +33,6 @@ export async function markRoomResponded(
 		}
 	}
 
-	if (room.responseBy) {
-		LivechatRooms.getAgentLastMessageTsUpdateQuery(roomUpdater);
-	}
-
 	if (!room.waitingResponse) {
 		// case where agent sends second message or any subsequent message in a room before visitor responds to the first message
 		// in this case, we just need to update the lastMessageTs of the responseBy object
@@ -47,10 +43,13 @@ export async function markRoomResponded(
 		return room.responseBy;
 	}
 
-	const responseBy: IOmnichannelRoom['responseBy'] = room.responseBy || {
-		_id: message.u._id,
-		username: message.u.username,
-		firstResponseTs: new Date(message.ts),
+	// Since we're updating the whole object anyways, we re-use the same values from object (or from message if not present)
+	// And then we update the lastMessageTs, which is the only thing that should be updating here
+	const { responseBy: { _id, username, firstResponseTs } = {} } = room;
+	const responseBy: IOmnichannelRoom['responseBy'] = {
+		_id: _id || message.u._id,
+		username: username || message.u.username,
+		firstResponseTs: firstResponseTs || new Date(message.ts),
 		lastMessageTs: new Date(message.ts),
 	};
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
- Removes unnecessary call to `getAgentLastMessageTsUpdateQuery`
- Changes the logic for applying the update on the `responseBy` object in a way that won't create a conflict.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/CORE-703
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Kinda hard to reproduce. It just happened in candidate with a single whatsapp conversation after having 2 agents + visitor interacting on the same conversation.
- On local, you can force it to happen by sending a message on a conversation, then manually updating the database to set `waitingResponse: true` flag on the room object and send a message again. It should fail.

When these preconditions are met, Mongo will get an update similar to:
```
{
  $set: {
		'responseBy.lastMessageTs': ISODate(),
   		 responseBy: { lastMessageTs: ISODate() }
  },
}
```

Since the same update is modifying the same property on different ways, Mongo issues a "ConflictError" and blocks the update.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
