### PR TITLE
test: fake timers to prevent voip unit tests failing sporadically

### DIFF
--- a/packages/ui-voip/src/components/VoipPopup/views/VoipOngoingView.spec.tsx
+++ b/packages/ui-voip/src/components/VoipPopup/views/VoipOngoingView.spec.tsx
@@ -8,55 +8,65 @@ const wrapper = mockAppRoot().withEndpoint('GET', '/v1/voip-freeswitch.extension
 
 const ongoingSession = createMockVoipOngoingSession();
 
-it('should properly render ongoing view', async () => {
-	render(<VoipOngoingView session={ongoingSession} />, { wrapper: wrapper.build(), legacyRoot: true });
+describe('VoipOngoingView', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
 
-	expect(screen.getByText('00:00')).toBeInTheDocument();
-	expect(screen.getByRole('button', { name: /Device_settings/ })).toBeInTheDocument();
-	expect(await screen.findByText('Administrator')).toBeInTheDocument();
-	expect(screen.queryByText('On_Hold')).not.toBeInTheDocument();
-	expect(screen.queryByText('Muted')).not.toBeInTheDocument();
-});
+	afterEach(() => {
+		jest.clearAllTimers();
+	});
 
-it('should display on hold and muted', () => {
-	ongoingSession.isMuted = true;
-	ongoingSession.isHeld = true;
+	it('should properly render ongoing view', async () => {
+		render(<VoipOngoingView session={ongoingSession} />, { wrapper: wrapper.build(), legacyRoot: true });
 
-	render(<VoipOngoingView session={ongoingSession} />, { wrapper: wrapper.build(), legacyRoot: true });
+		expect(screen.getByText('00:00')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /Device_settings/ })).toBeInTheDocument();
+		expect(await screen.findByText('Administrator')).toBeInTheDocument();
+		expect(screen.queryByText('On_Hold')).not.toBeInTheDocument();
+		expect(screen.queryByText('Muted')).not.toBeInTheDocument();
+	});
 
-	expect(screen.getByText('On_Hold')).toBeInTheDocument();
-	expect(screen.getByText('Muted')).toBeInTheDocument();
+	it('should display on hold and muted', () => {
+		ongoingSession.isMuted = true;
+		ongoingSession.isHeld = true;
 
-	ongoingSession.isMuted = false;
-	ongoingSession.isHeld = false;
-});
+		render(<VoipOngoingView session={ongoingSession} />, { wrapper: wrapper.build(), legacyRoot: true });
 
-it('should only enable ongoing call actions', () => {
-	render(<VoipOngoingView session={ongoingSession} />, { wrapper: wrapper.build(), legacyRoot: true });
+		expect(screen.getByText('On_Hold')).toBeInTheDocument();
+		expect(screen.getByText('Muted')).toBeInTheDocument();
 
-	expect(within(screen.getByTestId('vc-popup-footer')).queryAllByRole('button')).toHaveLength(5);
-	expect(screen.getByRole('button', { name: 'Turn_off_microphone' })).toBeEnabled();
-	expect(screen.getByRole('button', { name: 'Hold' })).toBeEnabled();
-	expect(screen.getByRole('button', { name: 'Open_Dialpad' })).toBeEnabled();
-	expect(screen.getByRole('button', { name: 'Transfer_call' })).toBeEnabled();
-	expect(screen.getByRole('button', { name: 'End_call' })).toBeEnabled();
-});
+		ongoingSession.isMuted = false;
+		ongoingSession.isHeld = false;
+	});
 
-it('should properly interact with the voice call session', () => {
-	render(<VoipOngoingView session={ongoingSession} />, { wrapper: wrapper.build(), legacyRoot: true });
+	it('should only enable ongoing call actions', () => {
+		render(<VoipOngoingView session={ongoingSession} />, { wrapper: wrapper.build(), legacyRoot: true });
 
-	screen.getByRole('button', { name: 'Turn_off_microphone' }).click();
-	expect(ongoingSession.mute).toHaveBeenCalled();
+		expect(within(screen.getByTestId('vc-popup-footer')).queryAllByRole('button')).toHaveLength(5);
+		expect(screen.getByRole('button', { name: 'Turn_off_microphone' })).toBeEnabled();
+		expect(screen.getByRole('button', { name: 'Hold' })).toBeEnabled();
+		expect(screen.getByRole('button', { name: 'Open_Dialpad' })).toBeEnabled();
+		expect(screen.getByRole('button', { name: 'Transfer_call' })).toBeEnabled();
+		expect(screen.getByRole('button', { name: 'End_call' })).toBeEnabled();
+	});
 
-	screen.getByRole('button', { name: 'Hold' }).click();
-	expect(ongoingSession.hold).toHaveBeenCalled();
+	it('should properly interact with the voice call session', () => {
+		render(<VoipOngoingView session={ongoingSession} />, { wrapper: wrapper.build(), legacyRoot: true });
 
-	screen.getByRole('button', { name: 'Open_Dialpad' }).click();
-	screen.getByTestId('dial-pad-button-1').click();
-	expect(screen.getByRole('textbox', { name: 'Phone_number' })).toHaveValue('1');
-	expect(ongoingSession.dtmf).toHaveBeenCalledWith('1');
+		screen.getByRole('button', { name: 'Turn_off_microphone' }).click();
+		expect(ongoingSession.mute).toHaveBeenCalled();
 
-	expect(screen.getByRole('button', { name: 'End_call' })).toBeEnabled();
-	screen.getByRole('button', { name: 'End_call' }).click();
-	expect(ongoingSession.end).toHaveBeenCalled();
+		screen.getByRole('button', { name: 'Hold' }).click();
+		expect(ongoingSession.hold).toHaveBeenCalled();
+
+		screen.getByRole('button', { name: 'Open_Dialpad' }).click();
+		screen.getByTestId('dial-pad-button-1').click();
+		expect(screen.getByRole('textbox', { name: 'Phone_number' })).toHaveValue('1');
+		expect(ongoingSession.dtmf).toHaveBeenCalledWith('1');
+
+		expect(screen.getByRole('button', { name: 'End_call' })).toBeEnabled();
+		screen.getByRole('button', { name: 'End_call' }).click();
+		expect(ongoingSession.end).toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`Jest.useFakeTimers()` was added to guarantee the UI information for `VoipOngoingPopup` is consistent. This change prevents the test from failing sporadically if the call timer changes while the test is running. 

![Screenshot 2024-10-02 at 10 46 10](https://github.com/user-attachments/assets/bb890645-4193-47e5-b94b-0b1d4c3de9e6)

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
