### PR TITLE
regression: Broken translation in `UrlChangeModal` at setup wizard

### DIFF
--- a/apps/meteor/client/components/UrlChangeModal.tsx
+++ b/apps/meteor/client/components/UrlChangeModal.tsx
@@ -13,7 +13,8 @@ type UrlChangeModalProps = {
 };
 
 const UrlChangeModal = ({ onConfirm, siteUrl, currentUrl, onClose }: UrlChangeModalProps): ReactElement => {
-	const { t } = useTranslation();
+	const { t } = useTranslation('core');
+
 	return (
 		<GenericModal variant='warning' title={t('Warning')} onConfirm={onConfirm} onClose={onClose} onCancel={onClose} confirmText={t('Yes')}>
 			<Box
@@ -26,7 +27,14 @@ const UrlChangeModal = ({ onConfirm, siteUrl, currentUrl, onClose }: UrlChangeMo
 					}),
 				}}
 			/>
-			<p dangerouslySetInnerHTML={{ __html: t('Do_you_want_to_change_to_s_question', currentUrl) }} />
+			<p
+				dangerouslySetInnerHTML={{
+					__html: t('Do_you_want_to_change_to_s_question', {
+						postProcess: 'sprintf',
+						sprintf: [currentUrl],
+					}),
+				}}
+			/>
 		</GenericModal>
 	);
 };

--- a/apps/meteor/client/views/setupWizard/SetupWizardRoute.tsx
+++ b/apps/meteor/client/views/setupWizard/SetupWizardRoute.tsx
@@ -23,6 +23,7 @@ export const SetupWizardRoute = (): ReactElement | null => {
 	}
 
 	return (
+		// FIXME: setting the defaultNS here is problematic for components/hooks expecting it to be 'core'
 		<I18nextProvider i18n={i18n} defaultNS='onboarding'>
 			<SetupWizardProvider>
 				<DarkModeProvider.default>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
It fixes two distinct issues:
- the translation keys are not correctly referenced if the `<ModalRegion />` is under `<SetupWizardProvider />` i.e. at the Setup Wizard pages;
- the `Do_you_want_to_change_to_s_question` translation's positional parameters were not handled by i18next.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
