### PR TITLE
feat: added beta disclaimer to voip settings

### DIFF
--- a/apps/meteor/ee/server/settings/voip.ts
+++ b/apps/meteor/ee/server/settings/voip.ts
@@ -12,6 +12,7 @@ export function addSettings(): Promise<void> {
 					type: 'boolean',
 					public: true,
 					invalidValue: false,
+					alert: 'VoIP_TeamCollab_Beta_Alert',
 				});
 
 				await this.add('VoIP_TeamCollab_FreeSwitch_Host', '', {

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -6010,6 +6010,7 @@
   "VoIP_TeamCollab_FreeSwitch_Password": "FreeSwitch Password",
   "VoIP_TeamCollab_FreeSwitch_Timeout": "FreeSwitch Request Timeout",
   "VoIP_TeamCollab_FreeSwitch_WebSocket_Path": "WebSocket Path",
+  "VoIP_TeamCollab_Beta_Alert": "This feature is currently in Beta, please report any issues to Rocket.Chat support",
   "VoIP_Toggle": "Enable/Disable VoIP",
   "Chat_opened_by_visitor": "Chat opened by the visitor",
   "Wait_activation_warning": "Before you can login, your account must be manually activated by an administrator.",

--- a/packages/i18n/src/locales/pt-BR.i18n.json
+++ b/packages/i18n/src/locales/pt-BR.i18n.json
@@ -4800,6 +4800,7 @@
   "VoIP_JWT_Secret_description": "Isso permite que você defina uma chave secreta para compartilhar detalhes da extensão do servidor para o cliente como JWT, em vez de texto simples. Se você não configurar isso, os detalhes do registro da extensão serão enviados como texto simples.",
   "Voip_is_disabled": "VoIP está desabilitado",
   "Voip_is_disabled_description": "Para ver a lista de extensões é necessário ativar o VoIP, faça isso na aba Configurações.",
+  "VoIP_TeamCollab_Beta_Alert": "Este recurso está atualmente em Beta, por favor, reporte quaisquer problemas ao suporte da Rocket.Chat.",
   "VoIP_Toggle": "Habilitar/Desabilitar VoIP",
   "Chat_opened_by_visitor": "Conversa aberta pelo visitante",
   "Wait_activation_warning": "Antes que você possa fazer o login, sua conta deve ser manualmente ativada por um administrador.",


### PR DESCRIPTION

## Proposed changes (including videos or screenshots)
Added a beta disclaimer to the 'Team voice calls (VoIP)' settings page.

![Screenshot 2024-10-04 at 12 21 29](https://github.com/user-attachments/assets/aba49665-93c8-497f-8423-eeb54670e516)


## Issue(s)
N/A

## Steps to test or reproduce
- Access the workspace
- Go to workspace > settings > Team voice calls (VoIP)
- Disclaimer should be visible


## Further comments
[VOIP-110](https://rocketchat.atlassian.net/browse/VOIP-110)


[VOIP-110]: https://rocketchat.atlassian.net/browse/VOIP-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ