### PR TITLE
Update RAM requirement and add pre-installation check

### DIFF
--- a/apps/meteor/server/methods/getSetupWizardParameters.ts
+++ b/apps/meteor/server/methods/getSetupWizardParameters.ts
@@ -2,6 +2,7 @@ import type { ISetting } from '@rocket.chat/core-typings';
 import type { ServerMethods } from '@rocket.chat/ddp-client';
 import { Settings } from '@rocket.chat/models';
 import { Meteor } from 'meteor/meteor';
+import { execSync } from 'child_process';
 
 import { settings } from '../../app/settings/server';
 
@@ -17,6 +18,11 @@ declare module '@rocket.chat/ddp-client' {
 
 Meteor.methods<ServerMethods>({
 	async getSetupWizardParameters() {
+		const totalMemory = parseInt(execSync('grep MemTotal /proc/meminfo').toString().split(':')[1].trim().split(' ')[0], 10) / 1024;
+		if (totalMemory < 2560) {
+			throw new Meteor.Error('error-insufficient-ram', 'At least 2.5GB of RAM is required to install Rocket.Chat.');
+		}
+
 		const setupWizardSettings = await Settings.findSetupWizardSettings().toArray();
 		const serverAlreadyRegistered = !!settings.get('Cloud_Workspace_Client_Id') || process.env.DEPLOY_PLATFORM === 'rocket-cloud';
 

--- a/docs/deploy/prepare-for-your-deployment/hardware-requirements.md
+++ b/docs/deploy/prepare-for-your-deployment/hardware-requirements.md
@@ -1,0 +1,20 @@
+# Hardware Requirements
+
+To ensure optimal performance and stability of Rocket.Chat, it is important to meet the following hardware requirements:
+
+## Minimum Requirements
+
+- **CPU**: 1 GHz
+- **RAM**: 2.5 GB
+- **Disk Space**: 10 GB
+
+## Recommended Requirements
+
+- **CPU**: 2 GHz or higher
+- **RAM**: 4 GB or higher
+- **Disk Space**: 20 GB or higher
+
+## Notes
+
+- The setup wizard will check for the minimum RAM requirement of 2.5GB before proceeding with the installation.
+- These requirements are based on a standard installation and may vary depending on the number of users and usage patterns.


### PR DESCRIPTION
Fixes #30093

Add a pre-installation RAM check and update hardware requirements documentation.

* **RAM Check**: Add a check in `apps/meteor/server/methods/getSetupWizardParameters.ts` to verify if the system has at least 2.5GB of RAM before proceeding with the installation. If the system does not meet the requirement, return an error message indicating the need for more RAM.
* **Documentation Update**: Add a new file `docs/deploy/prepare-for-your-deployment/hardware-requirements.md` to update the minimum RAM requirement to 2.5GB for Rocket.Chat 6.3.1 and add a note explaining that the setup wizard will check for this requirement before proceeding with the installation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/RocketChat/Rocket.Chat/issues/30093?shareId=fb535e2e-2d68-4662-bb4b-e457150adfae).