### PR TITLE
feat: Add mute/unmute option to user dropdown

### DIFF
--- a/apps/meteor/client/sidebar/RoomMenu.spec.tsx
+++ b/apps/meteor/client/sidebar/RoomMenu.spec.tsx
@@ -31,10 +31,11 @@ const defaultProps = {
 const renderOptions = {
 	wrapper: mockAppRoot()
 		.withTranslations('en', 'core', {
-			Hide: 'Hide',
-			Mark_unread: 'Mark Unread',
-			Favorite: 'Favorite',
-			Leave_room: 'Leave',
+			'Hide': 'Hide',
+			'Mark_unread': 'Mark Unread',
+			'Favorite': 'Favorite',
+			'Leave_room': 'Leave',
+			'Mute room': 'Mute room',
 		})
 		.withSetting('Favorite_Rooms', true)
 		.withPermission('leave-c')
@@ -53,15 +54,19 @@ it('should display all the menu options for regular rooms', async () => {
 	expect(await screen.findByRole('option', { name: 'Favorite' })).toBeInTheDocument();
 	expect(await screen.findByRole('option', { name: 'Mark Unread' })).toBeInTheDocument();
 	expect(await screen.findByRole('option', { name: 'Leave' })).toBeInTheDocument();
+	expect(await screen.findByRole('option', { name: 'Mute room' })).toBeInTheDocument();
 });
 
-it('should display only mark unread and favorite for omnichannel rooms', async () => {
+it('should display only mark unread, favorite, and mute for omnichannel rooms', async () => {
 	render(<RoomMenu {...defaultProps} type='l' />, renderOptions);
 
 	const menu = screen.queryByRole('button');
 	await userEvent.click(menu as HTMLElement);
 
-	expect(await screen.findAllByRole('option')).toHaveLength(2);
+	expect(await screen.findAllByRole('option')).toHaveLength(3);
+	expect(screen.getByRole('option', { name: 'Mark Unread' })).toBeInTheDocument();
+	expect(screen.getByRole('option', { name: 'Favorite' })).toBeInTheDocument();
+	expect(screen.getByRole('option', { name: 'Mute room' })).toBeInTheDocument();
 	expect(screen.queryByRole('option', { name: 'Hide' })).not.toBeInTheDocument();
 	expect(screen.queryByRole('option', { name: 'Leave' })).not.toBeInTheDocument();
 });


### PR DESCRIPTION
## feat: add new feature Mute unmute feature added to RoomMenu Dropdown

## Proposed changes (including videos or screenshots)

I have implemented a mute/unmute feature in the dropdown of the `RoomMenu.tsx` file, addressing the issue where users could not mute or unmute other users directly from the room menu. A new button for muting and unmuting users has been added to the dropdown menu for every channel.

**Video demonstration:**  
[[Loom Video]](https://www.loom.com/share/8d590f4655054081b8b95a5b5325be90?sid=4c6c27a8-55a7-4306-a36e-7373a754f77f)

**Screenshot:**  
 
![mute](https://github.com/user-attachments/assets/716effbd-c1a1-4de9-9628-78d18480d825)

## Issue(s)

Closes #11954

## Steps to test or reproduce

1. Go to any channel in the application.
2. Open the dropdown menu in the `RoomMenu.tsx` file.
3. You should now see the new mute/unmute button.
4. Use the button to mute or unmute users in the channel.

## Further comments

This feature allows users to mute or unmute others directly from the dropdown menu within the channel. The solution was chosen to enhance user control within chat rooms, making it more intuitive. No significant alternatives were considered as this directly resolves the identified issue efficiently.
