### PR TITLE
chore!: make custom sounds page stop to use query param

### DIFF
--- a/apps/meteor/app/api/server/helpers/parseJsonQuery.ts
+++ b/apps/meteor/app/api/server/helpers/parseJsonQuery.ts
@@ -59,6 +59,7 @@ export async function parseJsonQuery(api: PartialThis): Promise<{
 		'/api/v1/channels.files',
 		'/api/v1/integrations.list',
 		'/api/v1/custom-user-status.list',
+		'/api/v1/custom-sounds.list',
 	].includes(route);
 
 	const isUnsafeQueryParamsAllowed = process.env.ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS?.toUpperCase() === 'TRUE';

--- a/apps/meteor/app/api/server/helpers/parseJsonQuery.ts
+++ b/apps/meteor/app/api/server/helpers/parseJsonQuery.ts
@@ -70,7 +70,6 @@ export async function parseJsonQuery(api: PartialThis): Promise<{
 		try {
 			apiDeprecationLogger.parameter(route, 'fields', '8.0.0', response, messageGenerator);
 			fields = JSON.parse(params.fields) as Record<string, 0 | 1>;
-
 			Object.entries(fields).forEach(([key, value]) => {
 				if (value !== 1 && value !== 0) {
 					throw new Meteor.Error('error-invalid-sort-parameter', `Invalid fields parameter: ${key}`, {

--- a/apps/meteor/app/api/server/v1/custom-sounds.ts
+++ b/apps/meteor/app/api/server/v1/custom-sounds.ts
@@ -1,16 +1,20 @@
 import { CustomSounds } from '@rocket.chat/models';
+import { isCustomSoundsListProps } from '@rocket.chat/rest-typings';
+import { escapeRegExp } from '@rocket.chat/string-helpers';
 
 import { API } from '../api';
 import { getPaginationItems } from '../helpers/getPaginationItems';
 
 API.v1.addRoute(
 	'custom-sounds.list',
-	{ authRequired: true },
+	{ authRequired: true, validateParams: isCustomSoundsListProps },
 	{
 		async get() {
 			const { offset, count } = await getPaginationItems(this.queryParams);
-			const { sort, query } = await this.parseJsonQuery();
-			const { cursor, totalCount } = CustomSounds.findPaginated(query, {
+			const { sort } = await this.parseJsonQuery();
+			const { name } = this.queryParams;
+			const filter = name ? { name: { $regex: escapeRegExp(name), $options: 'i' } } : {};
+			const { cursor, totalCount } = CustomSounds.findPaginated(filter, {
 				sort: sort || { name: 1 },
 				skip: offset,
 				limit: count,

--- a/apps/meteor/app/api/server/v1/custom-sounds.ts
+++ b/apps/meteor/app/api/server/v1/custom-sounds.ts
@@ -11,9 +11,15 @@ API.v1.addRoute(
 	{
 		async get() {
 			const { offset, count } = await getPaginationItems(this.queryParams);
-			const { sort } = await this.parseJsonQuery();
+			const { sort, query } = await this.parseJsonQuery();
+
 			const { name } = this.queryParams;
-			const filter = name ? { name: { $regex: escapeRegExp(name), $options: 'i' } } : {};
+
+			const filter = {
+				...query,
+				...(name ? { name: { $regex: escapeRegExp(name as string), $options: 'i' } } : {}),
+			};
+
 			const { cursor, totalCount } = CustomSounds.findPaginated(filter, {
 				sort: sort || { name: 1 },
 				skip: offset,

--- a/apps/meteor/app/api/server/v1/custom-sounds.ts
+++ b/apps/meteor/app/api/server/v1/custom-sounds.ts
@@ -10,7 +10,7 @@ API.v1.addRoute(
 	{ authRequired: true, validateParams: isCustomSoundsListProps },
 	{
 		async get() {
-			const { offset, count } = await getPaginationItems(this.queryParams);
+			const { offset, count } = await getPaginationItems(this.queryParams as Record<string, string | number | null | undefined>);
 			const { sort, query } = await this.parseJsonQuery();
 
 			const { name } = this.queryParams;

--- a/apps/meteor/client/views/admin/customSounds/CustomSoundsTable/CustomSoundsTable.tsx
+++ b/apps/meteor/client/views/admin/customSounds/CustomSoundsTable/CustomSoundsTable.tsx
@@ -1,6 +1,5 @@
 import { Pagination, States, StatesIcon, StatesActions, StatesAction, StatesTitle } from '@rocket.chat/fuselage';
 import { useDebouncedValue } from '@rocket.chat/fuselage-hooks';
-import { escapeRegExp } from '@rocket.chat/string-helpers';
 import { useTranslation, useEndpoint } from '@rocket.chat/ui-contexts';
 import { useQuery } from '@tanstack/react-query';
 import type { MutableRefObject } from 'react';
@@ -34,7 +33,7 @@ const CustomSoundsTable = ({ reload, onClick }: CustomSoundsTableProps) => {
 	const query = useDebouncedValue(
 		useMemo(
 			() => ({
-				query: JSON.stringify({ name: { $regex: escapeRegExp(text), $options: 'i' } }),
+				name: text,
 				sort: `{ "${sortBy}": ${sortDirection === 'asc' ? 1 : -1} }`,
 				...(itemsPerPage && { count: itemsPerPage }),
 				...(current && { offset: current }),

--- a/apps/meteor/tests/end-to-end/api/custom-sounds.ts
+++ b/apps/meteor/tests/end-to-end/api/custom-sounds.ts
@@ -8,7 +8,57 @@ import { before, describe, it, after } from 'mocha';
 import { getCredentials, api, request, credentials } from '../../data/api-data';
 
 describe('[CustomSounds]', () => {
+	const fileName = `test-file-${randomUUID()}`;
+	let fileId: string;
+	let uploadDate: unknown;
+
 	before((done) => getCredentials(done));
+
+	before(async () => {
+		const data = readFileSync(path.resolve(__dirname, '../../mocks/files/audio_mock.wav'));
+		const binary = data.toString('binary');
+		await request
+			.post(api('method.call/insertOrUpdateSound'))
+			.set(credentials)
+			.send({
+				message: JSON.stringify({
+					msg: 'method',
+					id: '1',
+					method: 'insertOrUpdateSound',
+					params: [{ name: fileName, extension: 'mp3', newFile: true }],
+				}),
+			})
+			.expect(200)
+			.expect((res) => {
+				fileId = JSON.parse(res.body.message).result;
+			});
+		await request
+			.post(api('method.call/uploadCustomSound'))
+			.set(credentials)
+			.send({
+				message: JSON.stringify({
+					msg: 'method',
+					id: '2',
+					method: 'uploadCustomSound',
+					params: [binary, 'audio/wav', { name: fileName, extension: 'wav', newFile: true, _id: fileId }],
+				}),
+			})
+			.expect(200);
+	});
+
+	after(() =>
+		request
+			.post(api('method.call/deleteCustomSound'))
+			.set(credentials)
+			.send({
+				message: JSON.stringify({
+					msg: 'method',
+					id: '33',
+					method: 'deleteCustomSound',
+					params: [fileId],
+				}),
+			}),
+	);
 
 	describe('[/custom-sounds.list]', () => {
 		it('should return custom sounds', (done) => {
@@ -41,59 +91,28 @@ describe('[CustomSounds]', () => {
 				})
 				.end(done);
 		});
+		it('should return custom sounds filtering it using the `name` parameter', (done) => {
+			void request
+				.get(api('custom-sounds.list'))
+				.set(credentials)
+				.expect(200)
+				.query({
+					name: fileName,
+					count: 5,
+					offset: 0,
+				})
+				.expect((res) => {
+					expect(res.body).to.have.property('sounds').and.to.be.an('array');
+					expect(res.body).to.have.property('total');
+					expect(res.body).to.have.property('offset');
+					expect(res.body).to.have.property('count');
+					expect(res.body.sounds[0]._id).to.be.equal(fileId);
+				})
+				.end(done);
+		});
 	});
 
 	describe('Accessing custom sounds', () => {
-		let fileId: string;
-		const fileName = `test-file-${randomUUID()}`;
-		let uploadDate: unknown;
-
-		before(async () => {
-			const data = readFileSync(path.resolve(__dirname, '../../mocks/files/audio_mock.wav'));
-			const binary = data.toString('binary');
-			await request
-				.post(api('method.call/insertOrUpdateSound'))
-				.set(credentials)
-				.send({
-					message: JSON.stringify({
-						msg: 'method',
-						id: '1',
-						method: 'insertOrUpdateSound',
-						params: [{ name: fileName, extension: 'mp3', newFile: true }],
-					}),
-				})
-				.expect(200)
-				.expect((res) => {
-					fileId = JSON.parse(res.body.message).result;
-				});
-			await request
-				.post(api('method.call/uploadCustomSound'))
-				.set(credentials)
-				.send({
-					message: JSON.stringify({
-						msg: 'method',
-						id: '2',
-						method: 'uploadCustomSound',
-						params: [binary, 'audio/wav', { name: fileName, extension: 'wav', newFile: true, _id: fileId }],
-					}),
-				})
-				.expect(200);
-		});
-
-		after(() =>
-			request
-				.post(api('method.call/deleteCustomSound'))
-				.set(credentials)
-				.send({
-					message: JSON.stringify({
-						msg: 'method',
-						id: '33',
-						method: 'deleteCustomSound',
-						params: [fileId],
-					}),
-				}),
-		);
-
 		it('should return forbidden if the there is no fileId on the url', (done) => {
 			void request
 				.get('/custom-sounds/')

--- a/packages/rest-typings/src/index.ts
+++ b/packages/rest-typings/src/index.ts
@@ -222,6 +222,7 @@ export * from './v1/videoConference';
 export * from './v1/assets';
 export * from './v1/channels';
 export * from './v1/customUserStatus';
+export * from './v1/customSounds';
 export * from './v1/subscriptionsEndpoints';
 export * from './v1/mailer';
 export * from './v1/mailer/MailerParamsPOST';

--- a/packages/rest-typings/src/v1/customSounds.ts
+++ b/packages/rest-typings/src/v1/customSounds.ts
@@ -29,6 +29,10 @@ const CustomSoundsListSchema = {
 			type: 'string',
 			nullable: true,
 		},
+		query: {
+			type: 'string',
+			nullable: true,
+		},
 	},
 	required: [],
 	additionalProperties: false,

--- a/packages/rest-typings/src/v1/customSounds.ts
+++ b/packages/rest-typings/src/v1/customSounds.ts
@@ -8,7 +8,7 @@ const ajv = new Ajv({
 	coerceTypes: true,
 });
 
-type CustomSoundsList = PaginatedRequest<{ query: string }>;
+type CustomSoundsList = PaginatedRequest<{ name?: string }>;
 
 const CustomSoundsListSchema = {
 	type: 'object',
@@ -25,11 +25,12 @@ const CustomSoundsListSchema = {
 			type: 'string',
 			nullable: true,
 		},
-		query: {
+		name: {
 			type: 'string',
+			nullable: true,
 		},
 	},
-	required: ['query'],
+	required: [],
 	additionalProperties: false,
 };
 

--- a/packages/rest-typings/src/v1/voip.ts
+++ b/packages/rest-typings/src/v1/voip.ts
@@ -21,35 +21,6 @@ const ajv = new Ajv({
 	coerceTypes: true,
 });
 
-/** *************************************************/
-type CustomSoundsList = PaginatedRequest<{ query: string }>;
-
-const CustomSoundsListSchema = {
-	type: 'object',
-	properties: {
-		count: {
-			type: 'number',
-			nullable: true,
-		},
-		offset: {
-			type: 'number',
-			nullable: true,
-		},
-		sort: {
-			type: 'string',
-			nullable: true,
-		},
-		query: {
-			type: 'string',
-			nullable: true,
-		},
-	},
-	required: [],
-	additionalProperties: false,
-};
-
-export const isCustomSoundsListProps = ajv.compile<CustomSoundsList>(CustomSoundsListSchema);
-
 type ConnectorExtensionGetRegistrationInfoByUserId = { id: string };
 
 const ConnectorExtensionGetRegistrationInfoByUserIdSchema: JSONSchemaType<ConnectorExtensionGetRegistrationInfoByUserId> = {


### PR DESCRIPTION
This pull request addresses [CORE-719](https://rocketchat.atlassian.net/browse/CORE-719) by updating the `/api/v1/custom-sounds.list` endpoint.
- The `name` attribute has been moved out of the query parameter and is now placed directly at the root of the query parameters.
- For backward compatibility, the query parameter will still be supported when the environment variable `ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS` is set, but this should be reserved for exceptional cases, not standard usage.

[CORE-718]: https://rocketchat.atlassian.net/browse/CORE-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CORE-719]: https://rocketchat.atlassian.net/browse/CORE-719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ