### PR TITLE
regression: unable to disable voip client query

### DIFF
--- a/packages/ui-voip/src/hooks/useVoipClient.tsx
+++ b/packages/ui-voip/src/hooks/useVoipClient.tsx
@@ -75,7 +75,7 @@ export const useVoipClient = ({ autoRegister = true }: VoipClientParams): VoipCl
 		},
 		{
 			initialData: null,
-			enabled: !!userId,
+			enabled: isVoipEnabled,
 		},
 	);
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Fixes voip endpoints being called even when the voip feature was disabled in the workspace settings.

![Clipboard - October 9, 2024 8_36 AM](https://github.com/user-attachments/assets/134ac938-9758-4745-ac8d-29163bdcf33e)


## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
