### PR TITLE
regression: voip beforeunload listener being added instead of removed

### DIFF
--- a/packages/ui-voip/src/providers/VoipProvider.tsx
+++ b/packages/ui-voip/src/providers/VoipProvider.tsx
@@ -103,7 +103,7 @@ const VoipProvider = ({ children }: { children: ReactNode }) => {
 			voipClient.networkEmitter.off('disconnected', onNetworkDisconnected);
 			voipClient.networkEmitter.off('connectionerror', onNetworkDisconnected);
 			voipClient.networkEmitter.off('localnetworkoffline', onNetworkDisconnected);
-			window.addEventListener('beforeunload', onBeforeUnload);
+			window.removeEventListener('beforeunload', onBeforeUnload);
 		};
 	}, [dispatchToastMessage, setStorageRegistered, t, voipClient, voipSounds]);
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Fixes a mistake causing the `beforeunload` event listener to be added on useEffect clean up instead of being removed as intended.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
