### PR TITLE
fix!: Only room creator can set the E2EE room key for the first time

### DIFF
--- a/.changeset/soft-planets-cross.md
+++ b/.changeset/soft-planets-cross.md
@@ -1,5 +1,5 @@
 ---
-"@rocket.chat/meteor": patch
+"@rocket.chat/meteor": major
 ---
 
 Fixes a behavior of E2EE room creation that allowed any user on the room to define room keys before the room creator, causing race conditions.

--- a/.changeset/soft-planets-cross.md
+++ b/.changeset/soft-planets-cross.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixes a behavior of E2EE room creation that allowed any user on the room to define room keys before the room creator, causing race conditions.

--- a/apps/meteor/app/e2e/client/rocketchat.e2e.room.js
+++ b/apps/meteor/app/e2e/client/rocketchat.e2e.room.js
@@ -245,8 +245,8 @@ export class E2ERoom extends Emitter {
 
 		try {
 			const room = ChatRoom.findOne({ _id: this.roomId });
-			if (!room.e2eKeyId) {
-				// TODO CHECK_PERMISSION
+			// Only room creator can set keys for room
+			if (!room.e2eKeyId && room.u._id === this.userId) {
 				this.setState(E2ERoomState.CREATING_KEYS);
 				await this.createGroupKey();
 				this.setState(E2ERoomState.READY);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
- Checks that `room.u._id` is the same as the user requesting. Currently anyone invited to the room can set the roomKeyID (and the E2EE key) before the owner gets the key, which can cause race conditions and leave the room in a bad state.
- 
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/E2EE2-79
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
