### PR TITLE
regression: disabled voip leaves empty section in the user menu

### DIFF
--- a/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/UserMenu/hooks/useUserMenu.tsx
+++ b/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/UserMenu/hooks/useUserMenu.tsx
@@ -7,14 +7,14 @@ import React from 'react';
 import UserMenuHeader from '../UserMenuHeader';
 import { useAccountItems } from './useAccountItems';
 import { useStatusItems } from './useStatusItems';
-import { useVoipItems } from './useVoipItems';
+import { useVoipItemsSection } from './useVoipItemsSection';
 
 export const useUserMenu = (user: IUser) => {
 	const t = useTranslation();
 
 	const statusItems = useStatusItems();
 	const accountItems = useAccountItems();
-	const voipItems = useVoipItems();
+	const voipSection = useVoipItemsSection();
 
 	const logout = useLogout();
 	const handleLogout = useEffectEvent(() => {
@@ -37,9 +37,7 @@ export const useUserMenu = (user: IUser) => {
 			title: t('Status'),
 			items: statusItems,
 		},
-		{
-			items: voipItems,
-		},
+		voipSection,
 		{
 			title: t('Account'),
 			items: accountItems,
@@ -47,5 +45,5 @@ export const useUserMenu = (user: IUser) => {
 		{
 			items: [logoutItem],
 		},
-	];
+	].filter((section) => section !== undefined);
 };

--- a/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/UserMenu/hooks/useVoipItemsSection.tsx
+++ b/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/UserMenu/hooks/useVoipItemsSection.tsx
@@ -6,7 +6,7 @@ import { useMutation } from '@tanstack/react-query';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const useVoipItems = (): GenericMenuItemProps[] => {
+export const useVoipItemsSection = (): { items: GenericMenuItemProps[] } | undefined => {
 	const { t } = useTranslation();
 	const dispatchToastMessage = useToastMessageDispatch();
 
@@ -45,23 +45,25 @@ const useVoipItems = (): GenericMenuItemProps[] => {
 
 	return useMemo(() => {
 		if (!isEnabled) {
-			return [];
+			return;
 		}
 
-		return [
-			{
-				id: 'toggle-voip',
-				icon: isRegistered ? 'phone-disabled' : 'phone',
-				disabled: !isReady || toggleVoip.isLoading,
-				onClick: () => toggleVoip.mutate(),
-				content: (
-					<Box is='span' title={tooltip}>
-						{isRegistered ? t('Disable_voice_calling') : t('Enable_voice_calling')}
-					</Box>
-				),
-			},
-		];
+		return {
+			items: [
+				{
+					id: 'toggle-voip',
+					icon: isRegistered ? 'phone-disabled' : 'phone',
+					disabled: !isReady || toggleVoip.isLoading,
+					onClick: () => toggleVoip.mutate(),
+					content: (
+						<Box is='span' title={tooltip}>
+							{isRegistered ? t('Disable_voice_calling') : t('Enable_voice_calling')}
+						</Box>
+					),
+				},
+			],
+		};
 	}, [isEnabled, isRegistered, isReady, tooltip, t, toggleVoip]);
 };
 
-export default useVoipItems;
+export default useVoipItemsSection;

--- a/apps/meteor/client/sidebar/header/hooks/useUserMenu.tsx
+++ b/apps/meteor/client/sidebar/header/hooks/useUserMenu.tsx
@@ -7,14 +7,14 @@ import React from 'react';
 import UserMenuHeader from '../UserMenuHeader';
 import { useAccountItems } from './useAccountItems';
 import { useStatusItems } from './useStatusItems';
-import useVoipItems from './useVoipItems';
+import { useVoipItemsSection } from './useVoipItemsSection';
 
 export const useUserMenu = (user: IUser) => {
 	const t = useTranslation();
 
 	const statusItems = useStatusItems();
 	const accountItems = useAccountItems();
-	const voipItems = useVoipItems();
+	const voipItemsSection = useVoipItemsSection();
 
 	const logout = useLogout();
 	const handleLogout = useMutableCallback(() => {
@@ -37,9 +37,7 @@ export const useUserMenu = (user: IUser) => {
 			title: t('Status'),
 			items: statusItems,
 		},
-		{
-			items: voipItems,
-		},
+		voipItemsSection,
 		{
 			title: t('Account'),
 			items: accountItems,
@@ -47,5 +45,5 @@ export const useUserMenu = (user: IUser) => {
 		{
 			items: [logoutItem],
 		},
-	];
+	].filter((section) => section !== undefined);
 };

--- a/apps/meteor/client/sidebar/header/hooks/useVoipItemsSection.tsx
+++ b/apps/meteor/client/sidebar/header/hooks/useVoipItemsSection.tsx
@@ -6,7 +6,7 @@ import { useMutation } from '@tanstack/react-query';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-export const useVoipItems = (): GenericMenuItemProps[] => {
+export const useVoipItemsSection = (): { items: GenericMenuItemProps[] } | undefined => {
 	const { t } = useTranslation();
 	const dispatchToastMessage = useToastMessageDispatch();
 
@@ -45,23 +45,23 @@ export const useVoipItems = (): GenericMenuItemProps[] => {
 
 	return useMemo(() => {
 		if (!isEnabled) {
-			return [];
+			return;
 		}
 
-		return [
-			{
-				id: 'toggle-voip',
-				icon: isRegistered ? 'phone-disabled' : 'phone',
-				disabled: !isReady || toggleVoip.isLoading,
-				onClick: () => toggleVoip.mutate(),
-				content: (
-					<Box is='span' title={tooltip}>
-						{isRegistered ? t('Disable_voice_calling') : t('Enable_voice_calling')}
-					</Box>
-				),
-			},
-		];
+		return {
+			items: [
+				{
+					id: 'toggle-voip',
+					icon: isRegistered ? 'phone-disabled' : 'phone',
+					disabled: !isReady || toggleVoip.isLoading,
+					onClick: () => toggleVoip.mutate(),
+					content: (
+						<Box is='span' title={tooltip}>
+							{isRegistered ? t('Disable_voice_calling') : t('Enable_voice_calling')}
+						</Box>
+					),
+				},
+			],
+		};
 	}, [isEnabled, isRegistered, isReady, tooltip, t, toggleVoip]);
 };
-
-export default useVoipItems;


### PR DESCRIPTION


## Proposed changes (including videos or screenshots)
This PR fixes an empty section being displayed in the user menu when voip is disabled.

![Clipboard - October 10, 2024 8_10 AM](https://github.com/user-attachments/assets/abf88573-e705-4c55-9843-f74c1d8f53ec)

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
