### PR TITLE
i18n: Notification "@user is already in here" translation (#26521)

### DIFF
--- a/apps/meteor/app/lib/server/methods/addUsersToRoom.ts
+++ b/apps/meteor/app/lib/server/methods/addUsersToRoom.ts
@@ -103,8 +103,8 @@ export const addUsersToRoomMethod = async (userId: string, data: { rid: string; 
 						{
 							postProcess: 'sprintf',
 							sprintf: [newUser.username],
+							lng: user?.language || 'en',	
 						},
-						user?.language,
 					),
 				});
 			}

--- a/packages/i18n/src/locales/ru.i18n.json
+++ b/packages/i18n/src/locales/ru.i18n.json
@@ -4668,7 +4668,7 @@
   "Username_doesnt_exist": "Логин `%s` не существует.",
   "Username_ended_the_OTR_session": "{{username}} завершил конфиденциальную беседу",
   "Username_invalid": "<strong>%s</strong> недопустимое имя пользователя, <br/>> используйте только буквы, цифры, точки, дефисы и подчеркивания",
-  "Username_is_already_in_here": "\"@%s\" уже здесь.",
+  "Username_is_already_in_here": "`@%s` уже здесь.",
   "Username_Placeholder": "Пожалуйста, введите логин...",
   "Username_title": "Зарегистрировать логин",
   "Username_wants_to_start_otr_Do_you_want_to_accept": "{{username}} хочет начать конфиденциальную беседу. Принять?",


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
After implementing the necessary fixes, I’ve ensured that notifications are now based on the user's selected language preferences. Previously, notifications would default to English when the user's language was "russian", but now they adapt correctly when a user changes their language settings.

![Screenshot 2024-10-12 161642](https://github.com/user-attachments/assets/f648894a-3065-4777-9a33-b54c621db8f2)
![Screenshot 2024-10-07 224008](https://github.com/user-attachments/assets/b72eec81-7181-485e-88a8-1783b2607958)

This resolves the issue where notifications would ignore the user's language preference and revert to English by default.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
#26521 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
