### PR TITLE
chore!: make custom user status pages stop to use query param

### DIFF
--- a/apps/meteor/app/api/server/helpers/parseJsonQuery.ts
+++ b/apps/meteor/app/api/server/helpers/parseJsonQuery.ts
@@ -54,7 +54,7 @@ export async function parseJsonQuery(api: PartialThis): Promise<{
 	}
 
 	// TODO: Remove this once we have all routes migrated to the new API params
-	const hasSupportedRoutes = ([] as string[]).includes(route);
+	const hasSupportedRoutes = ['/api/v1/custom-user-status.list'].includes(route);
 	const isUnsafeQueryParamsAllowed = process.env.ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS?.toUpperCase() === 'TRUE';
 	const messageGenerator = ({ endpoint, version, parameter }: { endpoint: string; version: string; parameter: string }): string =>
 		`The usage of the "${parameter}" parameter in endpoint "${endpoint}" breaks the security of the API and can lead to data exposure. It has been deprecated and will be removed in the version ${version}.`;

--- a/apps/meteor/client/views/admin/customUserStatus/CustomUserStatusFormWithData.tsx
+++ b/apps/meteor/client/views/admin/customUserStatus/CustomUserStatusFormWithData.tsx
@@ -16,7 +16,7 @@ type CustomUserStatusFormWithDataProps = {
 
 const CustomUserStatusFormWithData = ({ _id, onReload, onClose }: CustomUserStatusFormWithDataProps): ReactElement => {
 	const t = useTranslation();
-	const query = useMemo(() => ({ query: JSON.stringify({ _id }) }), [_id]);
+	const query = useMemo(() => ({ _id }), [_id]);
 
 	const getCustomUserStatus = useEndpoint('GET', '/v1/custom-user-status.list');
 

--- a/apps/meteor/client/views/admin/customUserStatus/CustomUserStatusTable/CustomUserStatusTable.tsx
+++ b/apps/meteor/client/views/admin/customUserStatus/CustomUserStatusTable/CustomUserStatusTable.tsx
@@ -34,7 +34,7 @@ const CustomUserStatus = ({ reload, onClick }: CustomUserStatusProps): ReactElem
 	const query = useDebouncedValue(
 		useMemo(
 			() => ({
-				query: JSON.stringify({ name: { $regex: escapeRegExp(text), $options: 'i' } }),
+				name: escapeRegExp(text),
 				sort: `{ "${sortBy}": ${sortDirection === 'asc' ? 1 : -1} }`,
 				count: itemsPerPage,
 				offset: current,

--- a/apps/meteor/tests/end-to-end/api/custom-user-status.ts
+++ b/apps/meteor/tests/end-to-end/api/custom-user-status.ts
@@ -3,10 +3,25 @@ import { before, describe, it } from 'mocha';
 
 import { getCredentials, api, request, credentials } from '../../data/api-data';
 
+async function createCustomUserStatus(name: string): Promise<string> {
+	const res = await request.post(api('custom-user-status.create')).set(credentials).send({ name }).expect(200);
+	return res.body.customUserStatus._id;
+}
+
 describe('[CustomUserStatus]', () => {
-	before((done) => getCredentials(done));
+	before((done) => {
+		getCredentials(done);
+	});
 
 	describe('[/custom-user-status.list]', () => {
+		let customUserStatusId: string;
+		let customUserStatusName: string;
+
+		before(async () => {
+			customUserStatusName = `test-${Date.now()}`;
+			customUserStatusId = await createCustomUserStatus(customUserStatusName);
+		});
+
 		it('should return custom user status', (done) => {
 			void request
 				.get(api('custom-user-status.list'))
@@ -20,6 +35,7 @@ describe('[CustomUserStatus]', () => {
 				})
 				.end(done);
 		});
+
 		it('should return custom user status even requested with count and offset params', (done) => {
 			void request
 				.get(api('custom-user-status.list'))
@@ -34,6 +50,57 @@ describe('[CustomUserStatus]', () => {
 					expect(res.body).to.have.property('total');
 					expect(res.body).to.have.property('offset');
 					expect(res.body).to.have.property('count');
+				})
+				.end(done);
+		});
+
+		it('should return one custom user status when requested with id param', (done) => {
+			void request
+				.get(api('custom-user-status.list'))
+				.set(credentials)
+				.expect(200)
+				.query({
+					_id: customUserStatusId,
+				})
+				.expect((res) => {
+					expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(1);
+					expect(res.body).to.have.property('total').and.to.equal(1);
+					expect(res.body).to.have.property('offset').and.to.equal(0);
+					expect(res.body).to.have.property('count').and.to.equal(1);
+				})
+				.end(done);
+		});
+
+		it('should return empty array when requested with an existing name param', (done) => {
+			void request
+				.get(api('custom-user-status.list'))
+				.set(credentials)
+				.expect(200)
+				.query({
+					name: customUserStatusName,
+				})
+				.expect((res) => {
+					expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(1);
+					expect(res.body).to.have.property('total').and.to.equal(1);
+					expect(res.body).to.have.property('offset').and.to.equal(0);
+					expect(res.body).to.have.property('count').and.to.equal(1);
+				})
+				.end(done);
+		});
+
+		it('should return empty array when requested with unknown name param', (done) => {
+			void request
+				.get(api('custom-user-status.list'))
+				.set(credentials)
+				.expect(200)
+				.query({
+					name: 'testxxx',
+				})
+				.expect((res) => {
+					expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(0);
+					expect(res.body).to.have.property('total').and.to.equal(0);
+					expect(res.body).to.have.property('offset').and.to.equal(0);
+					expect(res.body).to.have.property('count').and.to.equal(0);
 				})
 				.end(done);
 		});

--- a/apps/meteor/tests/end-to-end/api/custom-user-status.ts
+++ b/apps/meteor/tests/end-to-end/api/custom-user-status.ts
@@ -1,11 +1,15 @@
 import { expect } from 'chai';
-import { before, describe, it } from 'mocha';
+import { before, after, describe, it } from 'mocha';
 
 import { getCredentials, api, request, credentials } from '../../data/api-data';
 
 async function createCustomUserStatus(name: string): Promise<string> {
 	const res = await request.post(api('custom-user-status.create')).set(credentials).send({ name }).expect(200);
 	return res.body.customUserStatus._id;
+}
+
+async function deleteCustomUserStatus(id: string): Promise<void> {
+	await request.post(api('custom-user-status.delete')).set(credentials).send({ customUserStatusId: id }).expect(200);
 }
 
 describe('[CustomUserStatus]', () => {
@@ -20,6 +24,10 @@ describe('[CustomUserStatus]', () => {
 		before(async () => {
 			customUserStatusName = `test-${Date.now()}`;
 			customUserStatusId = await createCustomUserStatus(customUserStatusName);
+		});
+
+		after(async () => {
+			await deleteCustomUserStatus(customUserStatusId);
 		});
 
 		it('should return custom user status', (done) => {

--- a/apps/meteor/tests/end-to-end/api/custom-user-status.ts
+++ b/apps/meteor/tests/end-to-end/api/custom-user-status.ts
@@ -1,16 +1,16 @@
 import { expect } from 'chai';
-import { before, after, describe, it } from 'mocha';
+import { before, describe, it } from 'mocha'; // after
 
 import { getCredentials, api, request, credentials } from '../../data/api-data';
 
-async function createCustomUserStatus(name: string): Promise<string> {
-	const res = await request.post(api('custom-user-status.create')).set(credentials).send({ name }).expect(200);
-	return res.body.customUserStatus._id;
-}
+// async function createCustomUserStatus(name: string): Promise<string> {
+// 	const res = await request.post(api('custom-user-status.create')).set(credentials).send({ name }).expect(200);
+// 	return res.body.customUserStatus._id;
+// }
 
-async function deleteCustomUserStatus(id: string): Promise<void> {
-	await request.post(api('custom-user-status.delete')).set(credentials).send({ customUserStatusId: id }).expect(200);
-}
+// async function deleteCustomUserStatus(id: string): Promise<void> {
+// 	await request.post(api('custom-user-status.delete')).set(credentials).send({ customUserStatusId: id }).expect(200);
+// }
 
 describe('[CustomUserStatus]', () => {
 	before((done) => {
@@ -18,17 +18,17 @@ describe('[CustomUserStatus]', () => {
 	});
 
 	describe('[/custom-user-status.list]', () => {
-		let customUserStatusId: string;
-		let customUserStatusName: string;
+		// let customUserStatusId: string;
+		// let customUserStatusName: string;
 
-		before(async () => {
-			customUserStatusName = `test-${Date.now()}`;
-			customUserStatusId = await createCustomUserStatus(customUserStatusName);
-		});
+		// before(async () => {
+		// 	customUserStatusName = `test-${Date.now()}`;
+		// 	customUserStatusId = await createCustomUserStatus(customUserStatusName);
+		// });
 
-		after(async () => {
-			await deleteCustomUserStatus(customUserStatusId);
-		});
+		// after(async () => {
+		// 	await deleteCustomUserStatus(customUserStatusId);
+		// });
 
 		it('should return custom user status', (done) => {
 			void request
@@ -62,39 +62,39 @@ describe('[CustomUserStatus]', () => {
 				.end(done);
 		});
 
-		it('should return one custom user status when requested with id param', (done) => {
-			void request
-				.get(api('custom-user-status.list'))
-				.set(credentials)
-				.expect(200)
-				.query({
-					_id: customUserStatusId,
-				})
-				.expect((res) => {
-					expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(1);
-					expect(res.body).to.have.property('total').and.to.equal(1);
-					expect(res.body).to.have.property('offset').and.to.equal(0);
-					expect(res.body).to.have.property('count').and.to.equal(1);
-				})
-				.end(done);
-		});
+		// it('should return one custom user status when requested with id param', (done) => {
+		// 	void request
+		// 		.get(api('custom-user-status.list'))
+		// 		.set(credentials)
+		// 		.expect(200)
+		// 		.query({
+		// 			_id: customUserStatusId,
+		// 		})
+		// 		.expect((res) => {
+		// 			expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(1);
+		// 			expect(res.body).to.have.property('total').and.to.equal(1);
+		// 			expect(res.body).to.have.property('offset').and.to.equal(0);
+		// 			expect(res.body).to.have.property('count').and.to.equal(1);
+		// 		})
+		// 		.end(done);
+		// });
 
-		it('should return empty array when requested with an existing name param', (done) => {
-			void request
-				.get(api('custom-user-status.list'))
-				.set(credentials)
-				.expect(200)
-				.query({
-					name: customUserStatusName,
-				})
-				.expect((res) => {
-					expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(1);
-					expect(res.body).to.have.property('total').and.to.equal(1);
-					expect(res.body).to.have.property('offset').and.to.equal(0);
-					expect(res.body).to.have.property('count').and.to.equal(1);
-				})
-				.end(done);
-		});
+		// it('should return empty array when requested with an existing name param', (done) => {
+		// 	void request
+		// 		.get(api('custom-user-status.list'))
+		// 		.set(credentials)
+		// 		.expect(200)
+		// 		.query({
+		// 			name: customUserStatusName,
+		// 		})
+		// 		.expect((res) => {
+		// 			expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(1);
+		// 			expect(res.body).to.have.property('total').and.to.equal(1);
+		// 			expect(res.body).to.have.property('offset').and.to.equal(0);
+		// 			expect(res.body).to.have.property('count').and.to.equal(1);
+		// 		})
+		// 		.end(done);
+		// });
 
 		it('should return empty array when requested with unknown name param', (done) => {
 			void request

--- a/apps/meteor/tests/end-to-end/api/custom-user-status.ts
+++ b/apps/meteor/tests/end-to-end/api/custom-user-status.ts
@@ -1,16 +1,16 @@
 import { expect } from 'chai';
-import { before, describe, it } from 'mocha'; // after
+import { after, before, describe, it } from 'mocha';
 
 import { getCredentials, api, request, credentials } from '../../data/api-data';
 
-// async function createCustomUserStatus(name: string): Promise<string> {
-// 	const res = await request.post(api('custom-user-status.create')).set(credentials).send({ name }).expect(200);
-// 	return res.body.customUserStatus._id;
-// }
+async function createCustomUserStatus(name: string): Promise<string> {
+	const res = await request.post(api('custom-user-status.create')).set(credentials).send({ name }).expect(200);
+	return res.body.customUserStatus._id;
+}
 
-// async function deleteCustomUserStatus(id: string): Promise<void> {
-// 	await request.post(api('custom-user-status.delete')).set(credentials).send({ customUserStatusId: id }).expect(200);
-// }
+async function deleteCustomUserStatus(id: string): Promise<void> {
+	await request.post(api('custom-user-status.delete')).set(credentials).send({ customUserStatusId: id }).expect(200);
+}
 
 describe('[CustomUserStatus]', () => {
 	before((done) => {
@@ -18,17 +18,17 @@ describe('[CustomUserStatus]', () => {
 	});
 
 	describe('[/custom-user-status.list]', () => {
-		// let customUserStatusId: string;
-		// let customUserStatusName: string;
+		let customUserStatusId: string;
+		let customUserStatusName: string;
 
-		// before(async () => {
-		// 	customUserStatusName = `test-${Date.now()}`;
-		// 	customUserStatusId = await createCustomUserStatus(customUserStatusName);
-		// });
+		before(async () => {
+			customUserStatusName = `test-${Date.now()}`;
+			customUserStatusId = await createCustomUserStatus(customUserStatusName);
+		});
 
-		// after(async () => {
-		// 	await deleteCustomUserStatus(customUserStatusId);
-		// });
+		after(async () => {
+			await deleteCustomUserStatus(customUserStatusId);
+		});
 
 		it('should return custom user status', (done) => {
 			void request
@@ -62,39 +62,39 @@ describe('[CustomUserStatus]', () => {
 				.end(done);
 		});
 
-		// it('should return one custom user status when requested with id param', (done) => {
-		// 	void request
-		// 		.get(api('custom-user-status.list'))
-		// 		.set(credentials)
-		// 		.expect(200)
-		// 		.query({
-		// 			_id: customUserStatusId,
-		// 		})
-		// 		.expect((res) => {
-		// 			expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(1);
-		// 			expect(res.body).to.have.property('total').and.to.equal(1);
-		// 			expect(res.body).to.have.property('offset').and.to.equal(0);
-		// 			expect(res.body).to.have.property('count').and.to.equal(1);
-		// 		})
-		// 		.end(done);
-		// });
+		it('should return one custom user status when requested with id param', (done) => {
+			void request
+				.get(api('custom-user-status.list'))
+				.set(credentials)
+				.expect(200)
+				.query({
+					_id: customUserStatusId,
+				})
+				.expect((res) => {
+					expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(1);
+					expect(res.body).to.have.property('total').and.to.equal(1);
+					expect(res.body).to.have.property('offset').and.to.equal(0);
+					expect(res.body).to.have.property('count').and.to.equal(1);
+				})
+				.end(done);
+		});
 
-		// it('should return empty array when requested with an existing name param', (done) => {
-		// 	void request
-		// 		.get(api('custom-user-status.list'))
-		// 		.set(credentials)
-		// 		.expect(200)
-		// 		.query({
-		// 			name: customUserStatusName,
-		// 		})
-		// 		.expect((res) => {
-		// 			expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(1);
-		// 			expect(res.body).to.have.property('total').and.to.equal(1);
-		// 			expect(res.body).to.have.property('offset').and.to.equal(0);
-		// 			expect(res.body).to.have.property('count').and.to.equal(1);
-		// 		})
-		// 		.end(done);
-		// });
+		it('should return empty array when requested with an existing name param', (done) => {
+			void request
+				.get(api('custom-user-status.list'))
+				.set(credentials)
+				.expect(200)
+				.query({
+					name: customUserStatusName,
+				})
+				.expect((res) => {
+					expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(1);
+					expect(res.body).to.have.property('total').and.to.equal(1);
+					expect(res.body).to.have.property('offset').and.to.equal(0);
+					expect(res.body).to.have.property('count').and.to.equal(1);
+				})
+				.end(done);
+		});
 
 		it('should return empty array when requested with unknown name param', (done) => {
 			void request

--- a/packages/rest-typings/src/index.ts
+++ b/packages/rest-typings/src/index.ts
@@ -221,6 +221,7 @@ export * from './v1/teams';
 export * from './v1/videoConference';
 export * from './v1/assets';
 export * from './v1/channels';
+export * from './v1/customUserStatus';
 export * from './v1/subscriptionsEndpoints';
 export * from './v1/mailer';
 export * from './v1/mailer/MailerParamsPOST';

--- a/packages/rest-typings/src/v1/customUserStatus.ts
+++ b/packages/rest-typings/src/v1/customUserStatus.ts
@@ -8,7 +8,7 @@ const ajv = new Ajv({
 	coerceTypes: true,
 });
 
-type CustomUserStatusListProps = PaginatedRequest<{ query: string }>;
+type CustomUserStatusListProps = PaginatedRequest<{ name?: string; _id?: string; query?: string }>;
 
 const CustomUserStatusListSchema = {
 	type: 'object',
@@ -25,11 +25,20 @@ const CustomUserStatusListSchema = {
 			type: 'string',
 			nullable: true,
 		},
+		name: {
+			type: 'string',
+			nullable: true,
+		},
+		_id: {
+			type: 'string',
+			nullable: true,
+		},
 		query: {
 			type: 'string',
+			nullable: true,
 		},
 	},
-	required: ['query'],
+	required: [],
 	additionalProperties: false,
 };
 


### PR DESCRIPTION
This pull request addresses [CORE-721](https://rocketchat.atlassian.net/browse/CORE-721) by updating the `/api/v1/custom-user-status.list` endpoint.
- The `name` and `_id` attributes have been moved out of the query parameter and are now placed directly at the root of the query parameters.
- For backward compatibility, the query parameter will still be supported when the environment variable `ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS` is set, but this should only be used in exceptional cases, not as part of the standard usage.

[CORE-721]: https://rocketchat.atlassian.net/browse/CORE-721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ