### PR TITLE
chore!: make get directory stop to use query param

### DIFF
--- a/apps/meteor/app/api/server/helpers/parseJsonQuery.ts
+++ b/apps/meteor/app/api/server/helpers/parseJsonQuery.ts
@@ -54,7 +54,12 @@ export async function parseJsonQuery(api: PartialThis): Promise<{
 	}
 
 	// TODO: Remove this once we have all routes migrated to the new API params
-	const hasSupportedRoutes = ['/api/v1/channels.files', '/api/v1/integrations.list', '/api/v1/custom-user-status.list'].includes(route);
+	const hasSupportedRoutes = [
+		'/api/v1/directory',
+		'/api/v1/channels.files',
+		'/api/v1/integrations.list',
+		'/api/v1/custom-user-status.list',
+	].includes(route);
 
 	const isUnsafeQueryParamsAllowed = process.env.ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS?.toUpperCase() === 'TRUE';
 	const messageGenerator = ({ endpoint, version, parameter }: { endpoint: string; version: string; parameter: string }): string =>

--- a/apps/meteor/app/api/server/v1/misc.ts
+++ b/apps/meteor/app/api/server/v1/misc.ts
@@ -11,7 +11,7 @@ import {
 	isFingerprintProps,
 	isMeteorCall,
 } from '@rocket.chat/rest-typings';
-import { escapeHTML, escapeRegExp } from '@rocket.chat/string-helpers';
+import { escapeHTML } from '@rocket.chat/string-helpers';
 import EJSON from 'ejson';
 import { check } from 'meteor/check';
 import { DDPRateLimiter } from 'meteor/ddp-rate-limiter';

--- a/apps/meteor/client/views/directory/hooks/useDirectoryQuery.ts
+++ b/apps/meteor/client/views/directory/hooks/useDirectoryQuery.ts
@@ -5,14 +5,12 @@ export function useDirectoryQuery(
 	[column, direction]: [string, 'asc' | 'desc'],
 	type: string,
 	workspace = 'local',
-): { offset?: number | undefined; count?: number; query: string; sort: string } {
+): { sort: string; offset?: number | undefined; count?: number; query?: string; text?: string; type?: string; workspace?: string } {
 	return useMemo(
 		() => ({
-			query: JSON.stringify({
-				type,
-				text,
-				workspace,
-			}),
+			text,
+			type,
+			workspace,
 			sort: JSON.stringify({ [column]: direction === 'asc' ? 1 : -1 }),
 			...(itemsPerPage && { count: itemsPerPage }),
 			...(current && { offset: current }),

--- a/apps/meteor/tests/end-to-end/api/miscellaneous.ts
+++ b/apps/meteor/tests/end-to-end/api/miscellaneous.ts
@@ -233,10 +233,8 @@ describe('miscellaneous', () => {
 				.get(api('directory'))
 				.set(credentials)
 				.query({
-					query: JSON.stringify({
-						text: user.username,
-						type: 'users',
-					}),
+					text: user.username,
+					type: 'users',
 				})
 				.expect('Content-Type', 'application/json')
 				.expect(200)
@@ -260,10 +258,8 @@ describe('miscellaneous', () => {
 				.get(api('directory'))
 				.set(normalUserCredentials)
 				.query({
-					query: JSON.stringify({
-						text: user.username,
-						type: 'users',
-					}),
+					text: user.username,
+					type: 'users',
 				})
 				.expect('Content-Type', 'application/json')
 				.expect(200)
@@ -286,10 +282,8 @@ describe('miscellaneous', () => {
 				.get(api('directory'))
 				.set(credentials)
 				.query({
-					query: JSON.stringify({
-						text: testChannel.name,
-						type: 'channels',
-					}),
+					text: testChannel.name,
+					type: 'channels',
 				})
 				.expect('Content-Type', 'application/json')
 				.expect(200)
@@ -311,10 +305,8 @@ describe('miscellaneous', () => {
 				.get(api('directory'))
 				.set(credentials)
 				.query({
-					query: JSON.stringify({
-						text: testChannel.name,
-						type: 'channels',
-					}),
+					text: testChannel.name,
+					type: 'channels',
 					sort: JSON.stringify({
 						name: 1,
 					}),
@@ -339,10 +331,8 @@ describe('miscellaneous', () => {
 				.get(api('directory'))
 				.set(credentials)
 				.query({
-					query: JSON.stringify({
-						text: 'invalid channel',
-						type: 'invalid',
-					}),
+					text: 'invalid channel',
+					type: 'invalid',
 				})
 				.expect('Content-Type', 'application/json')
 				.expect(400)
@@ -356,10 +346,8 @@ describe('miscellaneous', () => {
 				.get(api('directory'))
 				.set(credentials)
 				.query({
-					query: JSON.stringify({
-						text: testChannel.name,
-						type: 'channels',
-					}),
+					text: testChannel.name,
+					type: 'channels',
 					sort: JSON.stringify({
 						name: 1,
 						test: 1,
@@ -378,10 +366,8 @@ describe('miscellaneous', () => {
 				.get(api('directory'))
 				.set(normalUserCredentials)
 				.query({
-					query: JSON.stringify({
-						text: '',
-						type: 'teams',
-					}),
+					text: '',
+					type: 'teams',
 					sort: JSON.stringify({
 						name: 1,
 					}),

--- a/packages/rest-typings/src/v1/directory.ts
+++ b/packages/rest-typings/src/v1/directory.ts
@@ -8,15 +8,11 @@ const ajv = new Ajv({
 	coerceTypes: true,
 });
 
-type DirectoryProps = PaginatedRequest;
+type DirectoryProps = PaginatedRequest<{ text?: string; type?: string; workspace?: string; query?: string }>;
 
 const DirectorySchema = {
 	type: 'object',
 	properties: {
-		query: {
-			type: 'string',
-			nullable: true,
-		},
 		count: {
 			type: 'number',
 			nullable: true,
@@ -29,7 +25,24 @@ const DirectorySchema = {
 			type: 'string',
 			nullable: true,
 		},
+		text: {
+			type: 'string',
+			nullable: true,
+		},
+		type: {
+			type: 'string',
+			nullable: true,
+		},
+		workspace: {
+			type: 'string',
+			nullable: true,
+		},
+		query: {
+			type: 'string',
+			nullable: true,
+		},
 	},
+	required: [],
 	additionalProperties: false,
 };
 


### PR DESCRIPTION
This pull request addresses [CORE-724](https://rocketchat.atlassian.net/browse/CORE-724) by updating the `/api/v1/directory` endpoint.
- The `text`, `type`, and `workspace` attributes have been moved out of the query parameter and are now placed directly at the root of the query parameters.
- For backward compatibility, the query parameter will still be supported when the environment variable `ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS` is set, but this should only be used for exceptional cases and not as part of the standard usage.

[CORE-724]: https://rocketchat.atlassian.net/browse/CORE-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ