### PR TITLE
regression: voip toggle success/error toasts being displayed in quick succession

### DIFF
--- a/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/UserMenu/hooks/useVoipItemsSection.tsx
+++ b/apps/meteor/client/NavBarV2/NavBarSettingsToolbar/UserMenu/hooks/useVoipItemsSection.tsx
@@ -11,7 +11,7 @@ export const useVoipItemsSection = (): { items: GenericMenuItemProps[] } | undef
 	const dispatchToastMessage = useToastMessageDispatch();
 
 	const { clientError, isEnabled, isReady, isRegistered } = useVoipState();
-	const { register, unregister } = useVoipAPI();
+	const { register, unregister, onRegistered, onUnregistered } = useVoipAPI();
 
 	const toggleVoip = useMutation({
 		mutationFn: async () => {
@@ -24,10 +24,20 @@ export const useVoipItemsSection = (): { items: GenericMenuItemProps[] } | undef
 			return false;
 		},
 		onSuccess: (isEnabled: boolean) => {
-			dispatchToastMessage({
-				type: 'success',
-				message: isEnabled ? t('Voice_calling_enabled') : t('Voice_calling_disabled'),
-			});
+			if (isEnabled) {
+				const offRegistered = onRegistered(() => {
+					dispatchToastMessage({ type: 'success', message: t('Voice_calling_enabled') });
+					offRegistered();
+				});
+			} else {
+				const offUnregistered = onUnregistered(() => {
+					dispatchToastMessage({ type: 'success', message: t('Voice_calling_disabled') });
+					offUnregistered();
+				});
+			}
+		},
+		onError: () => {
+			dispatchToastMessage({ type: 'error', message: t('Voice_calling_registration_failed') });
 		},
 	});
 

--- a/apps/meteor/client/sidebar/header/hooks/useVoipItemsSection.tsx
+++ b/apps/meteor/client/sidebar/header/hooks/useVoipItemsSection.tsx
@@ -11,7 +11,7 @@ export const useVoipItemsSection = (): { items: GenericMenuItemProps[] } | undef
 	const dispatchToastMessage = useToastMessageDispatch();
 
 	const { clientError, isEnabled, isReady, isRegistered } = useVoipState();
-	const { register, unregister } = useVoipAPI();
+	const { register, unregister, onRegistered, onUnregistered } = useVoipAPI();
 
 	const toggleVoip = useMutation({
 		mutationFn: async () => {
@@ -24,10 +24,20 @@ export const useVoipItemsSection = (): { items: GenericMenuItemProps[] } | undef
 			return false;
 		},
 		onSuccess: (isEnabled: boolean) => {
-			dispatchToastMessage({
-				type: 'success',
-				message: isEnabled ? t('Voice_calling_enabled') : t('Voice_calling_disabled'),
-			});
+			if (isEnabled) {
+				const offRegistered = onRegistered(() => {
+					dispatchToastMessage({ type: 'success', message: t('Voice_calling_enabled') });
+					offRegistered();
+				});
+			} else {
+				const offUnregistered = onUnregistered(() => {
+					dispatchToastMessage({ type: 'success', message: t('Voice_calling_disabled') });
+					offUnregistered();
+				});
+			}
+		},
+		onError: () => {
+			dispatchToastMessage({ type: 'error', message: t('Voice_calling_registration_failed') });
 		},
 	});
 

--- a/packages/ui-voip/src/hooks/useVoipAPI.tsx
+++ b/packages/ui-voip/src/hooks/useVoipAPI.tsx
@@ -10,6 +10,8 @@ type VoipAPI = {
 	unregister(): Promise<void>;
 	openDialer(): void;
 	closeDialer(): void;
+	onRegistered(cb: () => void): () => void;
+	onUnregistered(cb: () => void): () => void;
 	transferCall(calleeURL: string): Promise<void>;
 	changeAudioOutputDevice: VoipContextReady['changeAudioOutputDevice'];
 	changeAudioInputDevice: VoipContextReady['changeAudioInputDevice'];
@@ -32,6 +34,8 @@ export const useVoipAPI = (): VoipAPI => {
 				transferCall: NOOP,
 				changeAudioInputDevice: NOOP,
 				changeAudioOutputDevice: NOOP,
+				onRegistered: NOOP,
+				onUnregistered: NOOP,
 			} as VoipAPI;
 		}
 
@@ -47,6 +51,8 @@ export const useVoipAPI = (): VoipAPI => {
 			closeDialer: () => voipClient.notifyDialer({ open: false }),
 			changeAudioInputDevice,
 			changeAudioOutputDevice,
+			onRegistered: (cb: () => void) => voipClient.on('registered', cb),
+			onUnregistered: (cb: () => void) => voipClient.on('unregistered', cb),
 		};
 	}, [context]);
 };


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR fixes a situation where you attempt to "Enable voice calling" but it fails and both the success and erros toasts are displayed in quick succession,

![errors](https://github.com/user-attachments/assets/4df320e5-3c7e-4d59-a3c0-e3cb13f43ddd)


## Issue(s)
[VOIP-112](https://rocketchat.atlassian.net/browse/VOIP-112)

## Steps to test or reproduce
- Access workspace
- Configure and enable voip for team collab
- Attempt to enable voice calling for the same user in two different sessions
- Only the error message should appear
- 
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
