### PR TITLE
chore!: make tags table component stop to use fields query param

### DIFF
--- a/apps/meteor/client/omnichannel/tags/TagsTable.tsx
+++ b/apps/meteor/client/omnichannel/tags/TagsTable.tsx
@@ -35,7 +35,6 @@ const TagsTable = () => {
 	const query = useMemo(
 		() => ({
 			viewAll: 'true' as const,
-			fields: JSON.stringify({ name: 1 }),
 			text: debouncedFilter,
 			sort: JSON.stringify({ [sortBy]: sortDirection === 'asc' ? 1 : -1 }),
 			...(itemsPerPage && { count: itemsPerPage }),


### PR DESCRIPTION
This pull request addresses [CORE-726](https://rocketchat.atlassian.net/browse/CORE-726) by removing `fields` query parameter sent to `/v1/livechat/tags` endpoint.

Also related to parent task [CORE-718](https://rocketchat.atlassian.net/browse/CORE-718).

[CORE-726]: https://rocketchat.atlassian.net/browse/CORE-726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-718]: https://rocketchat.atlassian.net/browse/CORE-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ