### PR TITLE
chore!: make ManagersTable component stop to use fields query param

### DIFF
--- a/apps/meteor/client/views/omnichannel/managers/ManagersTable.tsx
+++ b/apps/meteor/client/views/omnichannel/managers/ManagersTable.tsx
@@ -36,7 +36,6 @@ const ManagersTable = () => {
 		useMemo(
 			() => ({
 				text: debouncedText,
-				fields: JSON.stringify({ name: 1, username: 1, emails: 1, avatarETag: 1 }),
 				sort: `{ "${sortBy}": ${sortDirection === 'asc' ? 1 : -1} }`,
 				count: itemsPerPage,
 				offset: current,


### PR DESCRIPTION
This pull request addresses [CORE-729](https://rocketchat.atlassian.net/browse/CORE-729) and it's parent [CORE-718](https://rocketchat.atlassian.net/browse/CORE-718) by removing the query param `fields` sent to `/v1/livechat/users/manager` endpoint.

[CORE-729]: https://rocketchat.atlassian.net/browse/CORE-729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-718]: https://rocketchat.atlassian.net/browse/CORE-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ