### PR TITLE
chore!: make useQuery hook stop to use fields query param

### DIFF
--- a/apps/meteor/client/views/omnichannel/agents/hooks/useQuery.ts
+++ b/apps/meteor/client/views/omnichannel/agents/hooks/useQuery.ts
@@ -17,7 +17,6 @@ export const useQuery = (
 ): PaginatedRequest<{ text: string }> =>
 	useMemo(
 		() => ({
-			fields: JSON.stringify({ name: 1, username: 1, emails: 1, avatarETag: 1 }),
 			text,
 			sort: JSON.stringify({
 				[column]: sortDir(direction),


### PR DESCRIPTION
This pull request addresses [CORE-730](https://rocketchat.atlassian.net/browse/CORE-730) and it's parent [CORE-718](https://rocketchat.atlassian.net/browse/CORE-718) by removing the query param `fields` from `useQuery` hook.

[CORE-730]: https://rocketchat.atlassian.net/browse/CORE-730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-718]: https://rocketchat.atlassian.net/browse/CORE-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ