### PR TITLE
fix: alter the regex in the isValidDomain function to accept hyphens

### DIFF
--- a/.changeset/modern-trees-draw.md
+++ b/.changeset/modern-trees-draw.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed the regex for domains in the isValidDomain function

--- a/apps/meteor/app/lib/server/functions/checkUrlForSsrf.ts
+++ b/apps/meteor/app/lib/server/functions/checkUrlForSsrf.ts
@@ -57,7 +57,7 @@ export const isValidIPv4 = (ip: string): boolean => {
 };
 
 export const isValidDomain = (domain: string): boolean => {
-	const domainPattern = /^(?!-)(?!.*--)[A-Za-z0-9-]{1,63}(?<!-)\.?([A-Za-z]{2,63}\.?)*[A-Za-z]{2,63}$/;
+	const domainPattern = /^(?!-)(?!.*--)[A-Za-z0-9-]{1,63}(?<!-)\.?([A-Za-z0-9-]{2,63}\.?)*[A-Za-z]{2,63}$/;
 	if (!domainPattern.test(domain)) {
 		return false;
 	}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
The regex in the `isValidDomain` function doesn't take hyphens into consideration. This PR changes the regex in order to fix it and accept them.

## Issue(s)
https://github.com/RocketChat/Rocket.Chat/issues/33584

## Steps to test or reproduce
N/A

## Further comments
N/A
