### PR TITLE
feat: apps-engine timeout config

### DIFF
--- a/packages/apps-engine/src/server/ProxiedApp.ts
+++ b/packages/apps-engine/src/server/ProxiedApp.ts
@@ -53,11 +53,6 @@ export class ProxiedApp {
     public async call(method: `${AppMethod}`, ...args: Array<any>): Promise<any> {
         let options;
 
-        // Pre events need to be fast as they block the user
-        if (method.startsWith('checkPre') || method.startsWith('executePre')) {
-            options = { timeout: 1000 };
-        }
-
         try {
             return await this.appRuntime.sendRequest({ method: `app:${method}`, params: args }, options);
         } catch (e) {

--- a/packages/apps-engine/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/packages/apps-engine/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -52,6 +52,17 @@ const COMMAND_PONG = '_zPONG';
 
 export const JSONRPC_METHOD_NOT_FOUND = -32601;
 
+export function getDefaultRuntimeTimeout() {
+    const envValue = isFinite(process.env.APPS_ENGINE_RUNTIME_TIMEOUT as any) ? Number(process.env.APPS_ENGINE_RUNTIME_TIMEOUT) : 10000;
+
+    if (envValue < 0) {
+        console.log('Environment variable APPS_ENGINE_RUNTIME_TIMEOUT has a negative value, ignoring...');
+        return 10000;
+    }
+
+    return envValue;
+}
+
 export function isValidOrigin(accessor: string): accessor is (typeof ALLOWED_ACCESSOR_METHODS)[number] {
     return ALLOWED_ACCESSOR_METHODS.includes(accessor as any);
 }
@@ -78,7 +89,7 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
     private readonly debug: debug.Debugger;
 
     private readonly options = {
-        timeout: 10000,
+        timeout: getDefaultRuntimeTimeout(),
     };
 
     private readonly accessors: AppAccessorManager;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request
-->
Make the Apps-Engine runtime accept the `APPS_ENGINE_RUNTIME_TIMEOUT` environment variable to configure the time limit for requests to the Deno subprocess.
Also, makes calls to `Pre` app event methods follow the same "global" timeout, instead of the shorter 1 second.

We've had reports of some environments having timeouts where the request was actually expected to take a longer time to resolve.

Default timeout continues being 10 seconds.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
