### PR TITLE
regression: allow specific routes to receive query attr

### DIFF
--- a/apps/meteor/app/api/server/helpers/parseJsonQuery.ts
+++ b/apps/meteor/app/api/server/helpers/parseJsonQuery.ts
@@ -107,8 +107,16 @@ export async function parseJsonQuery(api: PartialThis): Promise<{
 		}
 	}
 
+	const allowedRoutes = [
+		'/api/v1/settings.public',
+		'/api/v1/directory',
+		'/api/v1/channels.messages',
+		'/api/v1/groups.messages',
+		'/api/v1/dm.messages',
+		'/api/v1/im.messages',
+	];
 	let query: Record<string, any> = {};
-	if (params.query && isUnsafeQueryParamsAllowed) {
+	if (params.query && (isUnsafeQueryParamsAllowed || allowedRoutes.includes(route))) {
 		apiDeprecationLogger.parameter(route, 'query', '8.0.0', response, messageGenerator);
 		try {
 			query = ejson.parse(params.query);


### PR DESCRIPTION
As per  [CORE-748](https://rocketchat.atlassian.net/browse/CORE-748), due to the removal of the query parameters, the mobile app is not able to retrieve settings from the workspace. This prevents users to log into the app. 

The three endpoints below were adapted so they can deliver the information required by the mobile app (with 'query' param attribute):
- settings.public
- directory
- channels.messages | groups.messages | dm.messages | im.messages

[CORE-748]: https://rocketchat.atlassian.net/browse/CORE-748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ