### PR TITLE
regression: Fix meteor dynamic storage for E2EE client

### DIFF
--- a/apps/meteor/client/views/account/security/EndToEnd.tsx
+++ b/apps/meteor/client/views/account/security/EndToEnd.tsx
@@ -4,6 +4,7 @@ import { useToastMessageDispatch, useMethod, useTranslation, useLogout } from '@
 import type { ComponentProps, ReactElement } from 'react';
 import React, { useCallback, useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
+import { Accounts } from 'meteor/accounts-base';
 
 import { e2e } from '../../../../app/e2e/client/rocketchat.e2e';
 
@@ -12,8 +13,8 @@ const EndToEnd = (props: ComponentProps<typeof Box>): ReactElement => {
 	const dispatchToastMessage = useToastMessageDispatch();
 	const logout = useLogout();
 
-	const publicKey = localStorage.getItem('public_key');
-	const privateKey = localStorage.getItem('private_key');
+	const publicKey = Accounts.storageLocation.getItem('public_key');
+	const privateKey = Accounts.storageLocation.getItem('private_key');
 
 	const resetE2eKey = useMethod('e2e.resetOwnE2EKey');
 

--- a/apps/meteor/client/views/account/security/EndToEnd.tsx
+++ b/apps/meteor/client/views/account/security/EndToEnd.tsx
@@ -1,10 +1,10 @@
 import { Box, PasswordInput, Field, FieldGroup, FieldLabel, FieldRow, FieldError, FieldHint, Button, Divider } from '@rocket.chat/fuselage';
 import { useUniqueId } from '@rocket.chat/fuselage-hooks';
 import { useToastMessageDispatch, useMethod, useTranslation, useLogout } from '@rocket.chat/ui-contexts';
+import { Accounts } from 'meteor/accounts-base';
 import type { ComponentProps, ReactElement } from 'react';
 import React, { useCallback, useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { Accounts } from 'meteor/accounts-base';
 
 import { e2e } from '../../../../app/e2e/client/rocketchat.e2e';
 

--- a/apps/meteor/client/views/room/E2EESetup/RoomE2EESetup.tsx
+++ b/apps/meteor/client/views/room/E2EESetup/RoomE2EESetup.tsx
@@ -1,6 +1,7 @@
 import { FeaturePreview, FeaturePreviewOff, FeaturePreviewOn } from '@rocket.chat/ui-client';
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Accounts } from 'meteor/accounts-base';
 
 import { e2e } from '../../../../app/e2e/client';
 import { E2EEState } from '../../../../app/e2e/client/E2EEState';
@@ -19,7 +20,7 @@ const RoomE2EESetup = () => {
 	const e2eRoomState = useE2EERoomState(room._id);
 
 	const { t } = useTranslation();
-	const randomPassword = window.localStorage.getItem('e2e.randomPassword');
+	const randomPassword = Accounts.storageLocation.getItem('e2e.randomPassword');
 
 	const onSavePassword = useCallback(() => {
 		if (!randomPassword) {

--- a/apps/meteor/client/views/room/E2EESetup/RoomE2EESetup.tsx
+++ b/apps/meteor/client/views/room/E2EESetup/RoomE2EESetup.tsx
@@ -1,7 +1,7 @@
 import { FeaturePreview, FeaturePreviewOff, FeaturePreviewOn } from '@rocket.chat/ui-client';
+import { Accounts } from 'meteor/accounts-base';
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Accounts } from 'meteor/accounts-base';
 
 import { e2e } from '../../../../app/e2e/client';
 import { E2EEState } from '../../../../app/e2e/client/E2EEState';


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

Due to Meteor recently added [Account session storage](https://docs.meteor.com/api/accounts.html#accounts-session-storage) and the setting `Accounts_ForgetUserSessionOnWindowClose`, when enabled Meteor uses the session storage instead of local storage.

This was added in: https://github.com/RocketChat/Rocket.Chat/pull/33356

The solution is to use the method `Accounts.storageLocation` to get the storage location

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

https://rocketchat.atlassian.net/browse/E2EE2-90
