### PR TITLE
regression: add OpenTelemetry exporter URL on tracing library initialization

### DIFF
--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -7,12 +7,14 @@ export { initDatabaseTracing } from './traceDatabaseCalls';
 
 let tracer: Tracer | undefined;
 
+const otelExporterUrl = process.env.OTEL_EXPORTER_OTLP_ENDPOINT || 'http://localhost:4317';
+
 export function isTracingEnabled() {
 	return ['yes', 'true'].includes(String(process.env.TRACING_ENABLED).toLowerCase());
 }
 
 export const startTracing = ({ service }: { service: string }) => {
-	const exporter = new OTLPTraceExporter();
+	const exporter = new OTLPTraceExporter({ url: otelExporterUrl });
 
 	const sdk = new NodeSDK({
 		traceExporter: exporter,


### PR DESCRIPTION
As per [OPI-47](https://rocketchat.atlassian.net/browse/OPI-47), it adds the _optional_ OPTL exporter URL on tracing library initialization.

[OPI-47]: https://rocketchat.atlassian.net/browse/OPI-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ