### PR TITLE
regression: voip action button using default variant instead of secondary variant

### DIFF
--- a/packages/ui-voip/src/components/VoipActionButton/VoipActionButton.tsx
+++ b/packages/ui-voip/src/components/VoipActionButton/VoipActionButton.tsx
@@ -11,9 +11,9 @@ type ActionButtonProps = Pick<ComponentPropsWithoutRef<typeof IconButton>, 'clas
 const VoipActionButton = ({ disabled, label, pressed, icon, danger, success, className, onClick }: ActionButtonProps) => (
 	<IconButton
 		medium
+		secondary
 		danger={danger}
 		success={success}
-		secondary={success || danger}
 		className={className}
 		icon={<Icon name={icon} />}
 		title={label}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR fixes the voip popup buttons using the default variant instead of the secondary variant.

**Before:**
![old-voip-buttons](https://github.com/user-attachments/assets/ebce44b6-9e2e-41d0-95c0-25256e3f3f59)

**After:**
![new-voip-buttons](https://github.com/user-attachments/assets/64c172b7-c04f-4be3-8b95-7b64f2824ab9)

## Issue(s)
[VOIP-117](https://rocketchat.atlassian.net/browse/VOIP-117)

## Steps to test or reproduce
- Access workspace 
- Configure VoIP for team collaboration
- Start a voice call
- Buttons should be visible within the popup

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
