### PR TITLE
regression: add tracing instrumentation on LocalBroker

### DIFF
--- a/packages/core-services/src/LocalBroker.ts
+++ b/packages/core-services/src/LocalBroker.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 
 import { InstanceStatus } from '@rocket.chat/models';
+import { injectCurrentContext, tracerActiveSpan } from '@rocket.chat/tracing';
 
 import { asyncLocalStorage } from '.';
 import type { EventSignatures } from './events/Events';
@@ -17,17 +18,22 @@ export class LocalBroker implements IBroker {
 	private services = new Set<IServiceClass>();
 
 	async call(method: string, data: any): Promise<any> {
-		const result = await asyncLocalStorage.run(
-			{
-				id: 'ctx.id',
-				nodeID: 'ctx.nodeID',
-				requestID: 'ctx.requestID',
-				broker: this,
+		return tracerActiveSpan(
+			`action ${method}`,
+			{},
+			() => {
+				return asyncLocalStorage.run(
+					{
+						id: 'ctx.id',
+						nodeID: 'ctx.nodeID',
+						requestID: 'ctx.requestID',
+						broker: this,
+					},
+					(): any => this.methods.get(method)?.(...data),
+				);
 			},
-			(): any => this.methods.get(method)?.(...data),
+			injectCurrentContext(),
 		);
-
-		return result;
 	}
 
 	async waitAndCall(method: string, data: any): Promise<any> {


### PR DESCRIPTION
Adds OPTL instrumentation on LocalBroker as per [OPI-48](https://rocketchat.atlassian.net/browse/OPI-48).

[OPI-48]: https://rocketchat.atlassian.net/browse/OPI-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ