### PR TITLE
chore: add batch span processor

### DIFF
--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -2,6 +2,7 @@ import { context, propagation, SpanStatusCode, trace } from '@opentelemetry/api'
 import type { Span, SpanOptions, Tracer } from '@opentelemetry/api';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import { NodeSDK } from '@opentelemetry/sdk-node';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
 
 export { initDatabaseTracing } from './traceDatabaseCalls';
 
@@ -18,6 +19,7 @@ export const startTracing = ({ service }: { service: string }) => {
 		traceExporter: exporter,
 		instrumentations: [],
 		serviceName: service,
+		spanProcessors: [new BatchSpanProcessor(exporter)],
 	});
 	sdk.start();
 


### PR DESCRIPTION
Adds `BatchSpanProcessor` to improve the efficiency of span transportation.

> The batch processor accepts spans, metrics, or logs and places them into batches. Batching helps better compress the data and reduce the number of outgoing connections required to transmit the data. [Source](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md#batch-processor)