### PR TITLE
regression: remove query field on settings public listing

### DIFF
--- a/.changeset/shaggy-timers-warn.md
+++ b/.changeset/shaggy-timers-warn.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/rest-typings': major
+'@rocket.chat/meteor': major
+---
+
+Changes settings public listing endpoint by moving query params from the 'query' attribute to standard query parameters.

--- a/apps/meteor/tests/end-to-end/api/settings.ts
+++ b/apps/meteor/tests/end-to-end/api/settings.ts
@@ -31,9 +31,56 @@ describe('[Settings]', () => {
 				.expect('Content-Type', 'application/json')
 				.expect(200)
 				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('settings');
-					expect(res.body).to.have.property('count');
+					expect(res.body).to.have.property('success').and.to.be.true;
+					expect(res.body).to.have.property('settings').and.to.be.an('array').and.to.have.lengthOf(5);
+					expect(res.body).to.have.property('count').and.to.be.a('number').and.to.equal(5);
+				})
+				.end(done);
+		});
+		it('should return public settings even requested with _id param', (done) => {
+			void request
+				.get(api('settings.public'))
+				.query({
+					_id: 'Site_Url',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success').and.to.be.true;
+					expect(res.body).to.have.property('settings').and.to.be.an('array').and.to.have.lengthOf(1);
+					expect(res.body).to.have.property('count').and.to.be.a('number').and.to.equal(1);
+				})
+				.end(done);
+		});
+		it('should return public settings even requested with _id param as an array', (done) => {
+			void request
+				.get(api('settings.public'))
+				.query({
+					_id: 'Site_Url,LDAP_Enable',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success').and.to.be.true;
+					expect(res.body).to.have.property('settings').and.to.be.an('array').and.to.have.lengthOf(2);
+					expect(res.body).to.have.property('count').and.to.be.a('number').and.to.equal(2);
+				})
+				.end(done);
+		});
+		it('should return an empty response when requesting public settings with a broken _id param', (done) => {
+			void request
+				.get(api('settings.public'))
+				.query({
+					_id: 10,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success').and.to.be.true;
+					expect(res.body).to.have.property('settings').and.to.be.an('array').and.to.be.empty;
+					expect(res.body).to.have.property('count').and.to.be.a('number').and.to.equal(0);
+					expect(res.body).to.have.property('offset').and.to.be.a('number').and.to.equal(0);
+					expect(res.body).to.have.property('total').and.to.be.a('number').and.to.equal(0);
 				})
 				.end(done);
 		});

--- a/packages/rest-typings/src/v1/settings.ts
+++ b/packages/rest-typings/src/v1/settings.ts
@@ -1,6 +1,8 @@
 import type { ISetting, ISettingColor, LoginServiceConfiguration } from '@rocket.chat/core-typings';
 
+import type { PaginatedRequest } from '../helpers/PaginatedRequest';
 import type { PaginatedResult } from '../helpers/PaginatedResult';
+import { ajv } from './Ajv';
 
 type SettingsUpdateProps = SettingsUpdatePropDefault | SettingsUpdatePropsActions | SettingsUpdatePropsColor;
 
@@ -25,9 +27,39 @@ type SettingsUpdatePropDefault = {
 
 export const isSettingsUpdatePropDefault = (props: Partial<SettingsUpdateProps>): props is SettingsUpdatePropDefault => 'value' in props;
 
+type SettingsPublicWithPaginationProps = PaginatedRequest<{ _id?: string; query?: string }>;
+
+const SettingsPublicWithPaginationSchema = {
+	type: 'object',
+	properties: {
+		count: {
+			type: 'number',
+			nullable: true,
+		},
+		offset: {
+			type: 'number',
+			nullable: true,
+		},
+		sort: {
+			type: 'string',
+			nullable: true,
+		},
+		_id: {
+			type: 'string',
+		},
+		query: {
+			type: 'string',
+		},
+	},
+	required: [],
+	additionalProperties: false,
+};
+
+export const isSettingsPublicWithPaginationProps = ajv.compile<SettingsPublicWithPaginationProps>(SettingsPublicWithPaginationSchema);
+
 export type SettingsEndpoints = {
 	'/v1/settings.public': {
-		GET: () => PaginatedResult & {
+		GET: (params: SettingsPublicWithPaginationProps) => PaginatedResult & {
 			settings: Array<ISetting>;
 		};
 	};


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Per [CORE-765](https://rocketchat.atlassian.net/browse/CORE-765), this update shifts the `_id` query parameter directly to the root level in **GET** `/api/v1/settings.public` and removes the query attribute.

- `_id` can now be passed directly at the root level and supports a comma-separated list of setting IDs (e.g., `_id=Site_Url` or `_id=Site_Url,LDAP_Enable`).
- The query attribute is removed, aligning with the new structure outlined in [CORE-718](https://rocketchat.atlassian.net/browse/CORE-718).
    - For continued query use, set the `ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS` environment variable to `true` when initializing the server.

## Issue(s)
- [CORE-765](https://rocketchat.atlassian.net/browse/CORE-765) and [CORE-764](https://rocketchat.atlassian.net/browse/CORE-764)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
**Note to Mobile Team** – Based on [getServerInfo.ts#L124](https://github.com/RocketChat/Rocket.Chat.ReactNative/blob/develop/app/lib/methods/getServerInfo.ts#L124) and [getSettings.ts#L114](https://github.com/RocketChat/Rocket.Chat.ReactNative/blob/develop/app/lib/methods/getSettings.ts#L114), it looks like `_id` is the only attribute needing support. If any other parameters are required, please reach out.


[CORE-765]: https://rocketchat.atlassian.net/browse/CORE-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-718]: https://rocketchat.atlassian.net/browse/CORE-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-765]: https://rocketchat.atlassian.net/browse/CORE-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-764]: https://rocketchat.atlassian.net/browse/CORE-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ