### PR TITLE
i18n: Fix Username Highlighting Issue in Russian Language Mentions

### DIFF
--- a/packages/i18n/src/locales/ru.i18n.json
+++ b/packages/i18n/src/locales/ru.i18n.json
@@ -4656,7 +4656,7 @@
   "Username_doesnt_exist": "Логин `%s` не существует.",
   "Username_ended_the_OTR_session": "{{username}} завершил конфиденциальную беседу",
   "Username_invalid": "<strong>%s</strong> недопустимое имя пользователя, <br/>> используйте только буквы, цифры, точки, дефисы и подчеркивания",
-  "Username_is_already_in_here": "\"@%s\" уже здесь.",
+  "Username_is_already_in_here": "`@%s` уже здесь.",
   "Username_Placeholder": "Пожалуйста, введите логин...",
   "Username_title": "Зарегистрировать логин",
   "Username_wants_to_start_otr_Do_you_want_to_accept": "{{username}} хочет начать конфиденциальную беседу. Принять?",


### PR DESCRIPTION
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
This PR addresses a bug where usernames mentioned with the @ symbol are not highlighted when the user’s language is set to Russian. This issue occurs in system messages, such as those generated by Rocket.Cat, and prevents proper highlighting of the @username mention in Russian.

## Changes:

Adjusted the JSON file of Russian translations to render highlighted username
Tested the fix with both Russian and English language settings to confirm consistency.

## Screenshots:
Before 
![image](https://github.com/user-attachments/assets/a5423678-dc31-4f28-b178-b46889fd0c17)

After
![image](https://github.com/user-attachments/assets/ea1863d9-eee0-4ca5-a4fc-d883bc392aa1)

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Closes #33793 

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This fix ensures that users in Russian-speaking regions experience the same usability as other language settings, where mentions are correctly highlighted. Further testing might be beneficial to confirm no issues with other languages.