### PR TITLE
regression: remove query field on messages listing

### DIFF
--- a/.changeset/quiet-jokes-add.md
+++ b/.changeset/quiet-jokes-add.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/rest-typings': major
+'@rocket.chat/meteor': major
+---
+
+Changes channels messages listing endpoint by moving query params from the 'query' attribute to standard query parameters.

--- a/apps/meteor/tests/data/chat.helper.ts
+++ b/apps/meteor/tests/data/chat.helper.ts
@@ -22,11 +22,24 @@ export const sendSimpleMessage = ({
 		rid: roomId,
 		text,
 	};
+
 	if (tmid) {
 		message.tmid = tmid;
 	}
 
 	return request.post(api('chat.sendMessage')).set(credentials).send({ message });
+};
+
+export const sendMessage = ({ message }: { message: { rid: IRoom['_id']; msg: string } & Partial<Omit<IMessage, 'rid' | 'msg'>> }) => {
+	return request.post(api('chat.sendMessage')).set(credentials).send({ message });
+};
+
+export const starMessage = ({ messageId }: { messageId: IMessage['_id'] }) => {
+	return request.post(api('chat.starMessage')).set(credentials).send({ messageId });
+};
+
+export const pinMessage = ({ messageId }: { messageId: IMessage['_id'] }) => {
+	return request.post(api('chat.pinMessage')).set(credentials).send({ messageId });
 };
 
 export const deleteMessage = ({ roomId, msgId }: { roomId: IRoom['_id']; msgId: IMessage['_id'] }) => {

--- a/packages/rest-typings/src/v1/channels/ChannelsMessagesProps.ts
+++ b/packages/rest-typings/src/v1/channels/ChannelsMessagesProps.ts
@@ -5,8 +5,16 @@ import type { PaginatedRequest } from '../../helpers/PaginatedRequest';
 
 const ajv = new Ajv({ coerceTypes: true });
 
-// query: { 'mentions._id': { $in: string[] } } | { 'starred._id': { $in: string[] } } | { pinned: boolean };
-export type ChannelsMessagesProps = PaginatedRequest<{ roomId: IRoom['_id'] }, 'ts'>;
+export type ChannelsMessagesProps = PaginatedRequest<
+	{
+		roomId: IRoom['_id'];
+		mentionIds?: string;
+		starredIds?: string;
+		pinned?: boolean;
+		query?: Record<string, any>;
+	},
+	'ts'
+>;
 
 const channelsMessagesPropsSchema = {
 	type: 'object',
@@ -14,9 +22,17 @@ const channelsMessagesPropsSchema = {
 		roomId: {
 			type: 'string',
 		},
+		mentionIds: {
+			type: 'string',
+		},
+		starredIds: {
+			type: 'string',
+		},
+		pinned: {
+			type: 'string',
+		},
 		query: {
 			type: 'string',
-			nullable: true,
 		},
 		count: {
 			type: 'number',


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Per [CORE-767](https://rocketchat.atlassian.net/browse/CORE-767), this update shifts the `mentions._id`, `starred._id`, and `pinned` query parameters directly to the root level in **GET** `/api/v1/channels.messages` and removes the query attribute.

- `mentions._id` should now be passed as `mentionIds` directly at the root level and supports a comma-separated list of setting IDs (e.g., `mentionIds=foo` or `mentionIds=foo,bar`).
- `starred._id` should now be passed as `starredIds` directly at the root level and supports a comma-separated list of setting IDs (e.g., `starredIds=foo` or `starredIds=foo,bar`).
- `pinned` should now be passed directly at the root level as a boolean or string. 
- The query attribute is removed, aligning with the new structure outlined in [CORE-718](https://rocketchat.atlassian.net/browse/CORE-718).
    - For continued query use, set the `ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS` environment variable to `true` when initializing the server.

## Issue(s)
- [CORE-767](https://rocketchat.atlassian.net/browse/CORE-767) and [CORE-764](https://rocketchat.atlassian.net/browse/CORE-764)

## Steps to test or reproduce

## Further comments
**Note to Mobile Team** – Based on [channels.ts#L112](https://github.com/RocketChat/Rocket.Chat.ReactNative/blob/develop/app/definitions/rest/v1/channels.ts#L112), it looks like `mentions._id`, `starred._id`, and `pinned` are the attributes needing support. If any other parameters are required, please reach out.

[CORE-767]: https://rocketchat.atlassian.net/browse/CORE-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-718]: https://rocketchat.atlassian.net/browse/CORE-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-767]: https://rocketchat.atlassian.net/browse/CORE-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ