### PR TITLE
regression: Minimongo queries with operator matching only first found _id

### DIFF
--- a/apps/meteor/packages/meteor-run-as-user/lib/collection.overwrites.js
+++ b/apps/meteor/packages/meteor-run-as-user/lib/collection.overwrites.js
@@ -1,9 +1,25 @@
 // TODO: Remove this after meteor fixes the issue
 // This override fixes a recent issue introduced after the update to Meteor 3.0
 // MinimongoCollection.remove(query) where `query` has `_id: { $in: Array }` removes only the first found record.
-LocalCollection.prototype['_eachPossiblyMatchingDocSync'] = function (selector, fn) {
+LocalCollection.prototype['_eachPossiblyMatchingDocAsync'] =  async function (selector, fn) {
     const specificIds = LocalCollection._idsMatchedBySelector(selector);
-	console.log('here');
+
+    if (specificIds) {
+      for (const id of specificIds) {
+        const doc = this._docs.get(id);
+
+        if (doc && (await fn(doc, id)) === false) { // Changed from `!fn(doc,id)`
+          break
+        }
+      }
+    } else {
+      await this._docs.forEachAsync(fn);
+    }
+  }
+
+  LocalCollection.prototype['_eachPossiblyMatchingDocSync'] = function (selector, fn) {
+    const specificIds = LocalCollection._idsMatchedBySelector(selector);
+
     if (specificIds) {
       for (const id of specificIds) {
         const doc = this._docs.get(id);
@@ -29,7 +45,6 @@ _.each(['insert', 'update', 'remove'], function (method) {
 	var _super = Mongo.Collection.prototype[method];
 
 	Mongo.Collection.prototype[method] = function (/* arguments */) {
-		// console.log(Mongo.Collection.prototype['_eachPossiblyMatchingDocSync']);
 		var self = this;
 		var args = _.toArray(arguments);
 

--- a/apps/meteor/packages/meteor-run-as-user/package.js
+++ b/apps/meteor/packages/meteor-run-as-user/package.js
@@ -14,6 +14,7 @@ Package.onUse(function (api) {
 		'underscore',
 		'mongo',
 		'ddp',
+		'minimongo',
 		// 'ddp-common',
 		// 'ddp-client'
 	]);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
There is an issue in the latest mongo release that broke some minimongo queries. When removing or updating multiple local records with a query that matches using operators ($in, $eq, etc) it would match only the first record and then bailout.

This was noticed because the `bulkMessageDelete` stream would not remove all messages provided in the query.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-786](https://rocketchat.atlassian.net/browse/CORE-786)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-786]: https://rocketchat.atlassian.net/browse/CORE-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ