### PR TITLE
test: fix flaky e2e test omnichannel-takeChat

### DIFF
--- a/apps/meteor/tests/e2e/page-objects/fragments/home-sidenav.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/home-sidenav.ts
@@ -61,7 +61,7 @@ export class HomeSidenav {
 
 	// Note: this is different from openChat because queued chats are not searchable
 	getQueuedChat(name: string): Locator {
-		return this.page.locator('[data-qa="sidebar-item-title"]', { hasText: name }).first();
+		return this.page.locator('[data-qa="sidebar-item-title"]', { hasText: new RegExp(`^${name}$`) }).first();
 	}
 
 	get accountProfileOption(): Locator {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR changes the `getQueuedChat` selector to be exact. This prevents tests failing by selecting the incorrect room with similar name.

![Screenshot 2024-10-31 at 16 06 34](https://github.com/user-attachments/assets/35e1ba07-c318-4182-810b-1ff1c0601a69)

## Issue(s)
[FLAKY-515](https://rocketchat.atlassian.net/browse/FLAKY-515)

## Steps to test or reproduce
- Create a conversation for `user1` with a visitor named "Connie Willians" _(example name)_
- Run the test with a visitor named "Connie"
- Playwright will find "Connie Willians" instead of "Connie"
- Test will fail

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[FLAKY-515]: https://rocketchat.atlassian.net/browse/FLAKY-515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ