### PR TITLE
feat: added onConfirm loading state to generic modal

### DIFF
--- a/apps/meteor/client/components/GenericModal/GenericModal.spec.tsx
+++ b/apps/meteor/client/components/GenericModal/GenericModal.spec.tsx
@@ -1,22 +1,25 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
 import { useSetModal } from '@rocket.chat/ui-contexts';
 import { act, screen, renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactElement } from 'react';
 import React, { Suspense } from 'react';
 
-import ModalProviderWithRegion from '../../providers/ModalProvider/ModalProviderWithRegion';
 import GenericModal from './GenericModal';
+import ModalProviderWithRegion from '../../providers/ModalProvider/ModalProviderWithRegion';
 
 const renderModal = (modalElement: ReactElement) => {
 	const {
 		result: { current: setModal },
 	} = renderHook(() => useSetModal(), {
 		legacyRoot: true,
-		wrapper: ({ children }) => (
-			<Suspense fallback={null}>
-				<ModalProviderWithRegion>{children}</ModalProviderWithRegion>
-			</Suspense>
-		),
+		wrapper: mockAppRoot()
+			.wrap((children) => (
+				<Suspense fallback={null}>
+					<ModalProviderWithRegion>{children}</ModalProviderWithRegion>
+				</Suspense>
+			))
+			.build(),
 	});
 
 	act(() => {

--- a/apps/meteor/client/components/GenericModal/GenericModal.tsx
+++ b/apps/meteor/client/components/GenericModal/GenericModal.tsx
@@ -1,6 +1,7 @@
 import { Button, Modal } from '@rocket.chat/fuselage';
 import { useEffectEvent, useUniqueId } from '@rocket.chat/fuselage-hooks';
 import type { Keys as IconName } from '@rocket.chat/icons';
+import { useMutation } from '@tanstack/react-query';
 import type { ComponentProps, ReactElement, ReactNode, ComponentPropsWithoutRef } from 'react';
 import React, { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -82,9 +83,11 @@ const GenericModal = ({
 
 	const dismissedRef = useRef(true);
 
-	const handleConfirm = useEffectEvent(() => {
-		dismissedRef.current = false;
-		onConfirm?.();
+	const handleConfirm = useMutation({
+		mutationFn: async () => {
+			dismissedRef.current = false;
+			await onConfirm?.();
+		},
 	});
 
 	const handleCancel = useEffectEvent(() => {
@@ -131,7 +134,12 @@ const GenericModal = ({
 						</Button>
 					)}
 					{!wrapperFunction && onConfirm && (
-						<Button {...getButtonProps(variant)} onClick={handleConfirm} disabled={confirmDisabled}>
+						<Button
+							{...getButtonProps(variant)}
+							loading={handleConfirm.isLoading}
+							onClick={() => handleConfirm.mutate()}
+							disabled={confirmDisabled}
+						>
 							{confirmText ?? t('Ok')}
 						</Button>
 					)}

--- a/apps/meteor/client/providers/ModalProvider/ModalProvider.spec.tsx
+++ b/apps/meteor/client/providers/ModalProvider/ModalProvider.spec.tsx
@@ -1,18 +1,21 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
 import { useSetModal } from '@rocket.chat/ui-contexts';
 import { act, render, screen } from '@testing-library/react';
 import type { ForwardedRef, ReactElement } from 'react';
 import React, { Suspense, createContext, createRef, forwardRef, useContext, useImperativeHandle } from 'react';
 
+import ModalProvider from './ModalProvider';
+import ModalProviderWithRegion from './ModalProviderWithRegion';
 import GenericModal from '../../components/GenericModal';
 import { imperativeModal } from '../../lib/imperativeModal';
 import ModalRegion from '../../views/modal/ModalRegion';
-import ModalProvider from './ModalProvider';
-import ModalProviderWithRegion from './ModalProviderWithRegion';
 
 const renderWithSuspense = (ui: ReactElement) =>
 	render(ui, {
 		legacyRoot: true,
-		wrapper: ({ children }) => <Suspense fallback={null}>{children}</Suspense>,
+		wrapper: mockAppRoot()
+			.wrap((children) => <Suspense fallback={null}>{children}</Suspense>)
+			.build(),
 	});
 
 describe('via useSetModal', () => {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR is exploring the idea of adding a loading state to the GenericModal button based on the promise returned by the `onConfirm` callback. 

❗ At the moment there's no plan of merging this PR. ❗ 

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
