### PR TITLE
fix: newly created teams displayed as channels in sidebar with DISABLE_DB_WATCHERS enabled

### DIFF
--- a/.changeset/light-terms-ring.md
+++ b/.changeset/light-terms-ring.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes the issue where newly created teams are incorrectly displayed as channels on the sidebar when the DISABLE_DB_WATCHERS environment variable is enabled

--- a/apps/meteor/server/services/team/service.ts
+++ b/apps/meteor/server/services/team/service.ts
@@ -33,7 +33,7 @@ import { addUserToRoom } from '../../../app/lib/server/functions/addUserToRoom';
 import { checkUsernameAvailability } from '../../../app/lib/server/functions/checkUsernameAvailability';
 import { getSubscribedRoomsForUserWithDetails } from '../../../app/lib/server/functions/getRoomsWithSingleOwner';
 import { removeUserFromRoom } from '../../../app/lib/server/functions/removeUserFromRoom';
-import { notifyOnSubscriptionChangedByRoomIdAndUserId } from '../../../app/lib/server/lib/notifyListener';
+import { notifyOnSubscriptionChangedByRoomIdAndUserId, notifyOnRoomChangedById } from '../../../app/lib/server/lib/notifyListener';
 import { settings } from '../../../app/settings/server';
 
 export class TeamService extends ServiceClassInternal implements ITeamService {
@@ -130,6 +130,8 @@ export class TeamService extends ServiceClassInternal implements ITeamService {
 			if (room.id) {
 				await Message.saveSystemMessage('user-converted-to-team', roomId, team.name, createdBy);
 			}
+
+			void notifyOnRoomChangedById(roomId, 'inserted');
 
 			return {
 				_id: teamId,


### PR DESCRIPTION
## Proposed changes

This PR addresses the issue described in [CORE-800](https://rocketchat.atlassian.net/browse/CORE-800) where newly created teams are mistakenly displayed as channels in the sidebar when the DISABLE_DB_WATCHERS environment variable is enabled.

https://github.com/user-attachments/assets/97852c44-846c-493b-ac44-b7805b5dd6fc

## Issue(s)
- [CORE-800](https://rocketchat.atlassian.net/browse/CORE-800)

## Steps to test or reproduce
- Set `DISABLE_DB_WATCHERS` to `true`.
- Create a new team – it will initially appear as a channel.
- Refresh the page – the team should now display correctly as a team.

## Further comments

[CORE-800]: https://rocketchat.atlassian.net/browse/CORE-800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-800]: https://rocketchat.atlassian.net/browse/CORE-800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ