### PR TITLE
fix: call button misaligned in the contact information contextual bar

### DIFF
--- a/.changeset/late-files-type.md
+++ b/.changeset/late-files-type.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixes call button being misaligned in the contact information contextual bar.

--- a/apps/meteor/client/views/omnichannel/directory/contacts/contextualBar/ContactInfo.tsx
+++ b/apps/meteor/client/views/omnichannel/directory/contacts/contextualBar/ContactInfo.tsx
@@ -172,9 +172,9 @@ const ContactInfo = ({ id: contactId, rid: roomId = '', route }: ContactInfoProp
 			</ContextualbarScrollableContent>
 			<ContextualbarFooter>
 				{isCallReady && (
-					<ButtonGroup stretch>
+					<ButtonGroup stretch wrap>
 						<>
-							<VoipInfoCallButton phoneNumber={phoneNumber} />
+							<VoipInfoCallButton phoneNumber={phoneNumber} mi={0} />
 							{showContactHistory && <Divider width='100%' />}
 						</>
 					</ButtonGroup>


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR fixes the call button being misaligned in the contact information contextual bar. The issue seem to have been introduced with the `ButtonGroup` normalization #31499

#### Before:
![Screenshot 2024-11-07 at 17 40 16](https://github.com/user-attachments/assets/fec6dd38-1fff-48d5-bfbf-b7f5ed2326b1)

#### After:
![Screenshot 2024-11-07 at 17 43 18](https://github.com/user-attachments/assets/09b076a2-202a-445b-b370-bda33141ac24)


## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
- Acess workspace
- Enabled Omnichannel VoIP in `Workspace > Settings > Omnichannel voice channel (VoIP)`
- Open a livechat room
- Open contact information contextual bar
- Call button should be visible

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
