### PR TITLE
test: changed Send button locator to be more specific

### DIFF
--- a/apps/meteor/tests/e2e/page-objects/fragments/home-content.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/home-content.ts
@@ -85,7 +85,7 @@ export class HomeContent {
 		await this.joinRoomIfNeeded();
 		await this.page.waitForSelector('[name="msg"]:not([disabled])');
 		await this.page.locator('[name="msg"]').fill(text);
-		await this.page.locator('button[aria-label="Send"]').click();
+		await this.page.getByRole('button', { name: 'Send', exact: true }).click();
 	}
 
 	async dispatchSlashCommand(text: string): Promise<void> {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR fixes the locator for the button "Send" not being exact causing tests for fail when other matches were found in the page.

![Screenshot 2024-11-07 at 18 21 31](https://github.com/user-attachments/assets/f00f5a06-e4c8-4302-a744-e6a7b1ab1382)

## Issue(s)
[FLAKY-922](https://rocketchat.atlassian.net/browse/FLAKY-922)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
