### PR TITLE
fix(user-profile): enable saving empty bio to clear user profile field

### DIFF
--- a/apps/meteor/server/methods/saveUserProfile.ts
+++ b/apps/meteor/server/methods/saveUserProfile.ts
@@ -79,7 +79,7 @@ async function saveUserProfile(
 		await setUserStatusMethod(this.userId, settings.statusType as UserStatus, undefined);
 	}
 
-	if (user && settings.bio) {
+	if (user && settings.bio !== undefined) {
 		if (typeof settings.bio !== 'string') {
 			throw new Meteor.Error('error-invalid-field', 'bio', {
 				method: 'saveUserProfile',


### PR DESCRIPTION
### Proposed changes
This pull request enables the ability to save an empty bio in the user profile to clear out the bio field, which was previously uneditable if left empty.

- This fix addresses an issue where users could not save changes if they attempted to clear their bio.
- Implements validation adjustments to allow empty strings in the bio field.

### Issue(s)
- Fixes #33783

### Steps to test or reproduce
1. Navigate to the user profile section in the Rocket.Chat application.
2. Attempt to clear the bio field and save changes.
3. Confirm that the profile successfully updates with an empty bio field.

### Checklist
- [x] I have read the [Contributing Guide](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat).
- [x] I have signed the CLA.
- [x] Lint and unit tests pass locally.
- [x] Added tests to verify this fix.
- [x] Updated documentation as needed.