### PR TITLE
chore: Replace `substr()` with `slice()` across the codebase (cont. from issue #340007)

### DIFF
--- a/apps/meteor/app/autotranslate/server/deeplTranslate.ts
+++ b/apps/meteor/app/autotranslate/server/deeplTranslate.ts
@@ -213,7 +213,7 @@ class DeeplAutoTranslate extends AutoTranslate {
 		const supportedLanguages = await this.getSupportedLanguages('en');
 		for await (let language of targetLanguages) {
 			if (language.indexOf('-') !== -1 && !_.findWhere(supportedLanguages, { language })) {
-				language = language.substr(0, 2);
+				language = language.slice(0, 2);
 			}
 			try {
 				const result = await fetch(this.apiEndPointUrl, {
@@ -259,7 +259,7 @@ class DeeplAutoTranslate extends AutoTranslate {
 		const supportedLanguages = await this.getSupportedLanguages('en');
 		for await (let language of targetLanguages) {
 			if (language.indexOf('-') !== -1 && !_.findWhere(supportedLanguages, { language })) {
-				language = language.substr(0, 2);
+				language = language.slice(0, 2);
 			}
 			try {
 				const result = await fetch(this.apiEndPointUrl, {

--- a/apps/meteor/app/autotranslate/server/googleTranslate.ts
+++ b/apps/meteor/app/autotranslate/server/googleTranslate.ts
@@ -131,7 +131,7 @@ class GoogleAutoTranslate extends AutoTranslate {
 
 		for await (let language of targetLanguages) {
 			if (language.indexOf('-') !== -1 && !_.findWhere(supportedLanguages, { language })) {
-				language = language.substr(0, 2);
+				language = language.slice(0, 2);
 			}
 
 			try {
@@ -178,7 +178,7 @@ class GoogleAutoTranslate extends AutoTranslate {
 
 		for await (let language of targetLanguages) {
 			if (language.indexOf('-') !== -1 && !_.findWhere(supportedLanguages, { language })) {
-				language = language.substr(0, 2);
+				language = language.slice(0, 2);
 			}
 
 			try {

--- a/apps/meteor/app/autotranslate/server/msTranslate.ts
+++ b/apps/meteor/app/autotranslate/server/msTranslate.ts
@@ -117,7 +117,7 @@ class MsAutoTranslate extends AutoTranslate {
 		const supportedLanguages = await this.getSupportedLanguages('en');
 		targetLanguages = targetLanguages.map((language) => {
 			if (language.indexOf('-') !== -1 && !_.findWhere(supportedLanguages, { language })) {
-				language = language.substr(0, 2);
+				language = language.slice(0, 2);
 			}
 			return language;
 		});

--- a/apps/meteor/app/emoji-emojione/lib/generateEmojiIndex.mjs
+++ b/apps/meteor/app/emoji-emojione/lib/generateEmojiIndex.mjs
@@ -30,7 +30,7 @@ function generateEmojiPicker(data) {
 		if (emoji && emoji.shortname) {
 			const toneIndex = emoji.shortname.indexOf('_tone');
 			if (toneIndex !== -1) {
-				const tone = emoji.shortname.substr(1, toneIndex - 1);
+				const tone = emoji.shortname.slice(1, toneIndex);
 				if (!toneList.includes(tone)) {
 					toneList.push(tone);
 				}

--- a/apps/meteor/app/file-upload/server/lib/proxy.ts
+++ b/apps/meteor/app/file-upload/server/lib/proxy.ts
@@ -27,7 +27,7 @@ async function handle(req: createServer.IncomingMessage, res: http.ServerRespons
 
 	// Remove store path
 	const parsedUrl = URL.parse(req.url);
-	const path = parsedUrl.pathname?.substr(UploadFS.config.storesPath.length + 1) || '';
+	const path = parsedUrl.pathname?.slice(UploadFS.config.storesPath.length + 1) || '';
 
 	// Get store
 	const regExp = new RegExp('^/([^/?]+)/([^/?]+)$');

--- a/apps/meteor/app/integrations/server/lib/validateOutgoingIntegration.ts
+++ b/apps/meteor/app/integrations/server/lib/validateOutgoingIntegration.ts
@@ -65,7 +65,7 @@ async function _verifyUserHasPermissionForChannels(userId: IUser['_id'], channel
 		} else {
 			let record;
 			const channelType = channel[0];
-			channel = channel.substr(1);
+			channel = channel.slice(1);
 
 			switch (channelType) {
 				case '#':

--- a/apps/meteor/app/integrations/server/methods/incoming/addIncomingIntegration.ts
+++ b/apps/meteor/app/integrations/server/methods/incoming/addIncomingIntegration.ts
@@ -123,7 +123,7 @@ export const addIncomingIntegration = async (userId: string, integration: INewIn
 	for await (let channel of channels) {
 		let record;
 		const channelType = channel[0];
-		channel = channel.substr(1);
+		channel = channel.slice(1);
 
 		switch (channelType) {
 			case '#':

--- a/apps/meteor/app/lib/server/functions/processWebhookMessage.ts
+++ b/apps/meteor/app/lib/server/functions/processWebhookMessage.ts
@@ -47,7 +47,7 @@ export const processWebhookMessage = async function (
 	for await (const channel of channels) {
 		const channelType = channel[0];
 
-		let channelValue = channel.substr(1);
+		let channelValue = channel.slice(1);
 		let room;
 
 		switch (channelType) {

--- a/apps/meteor/app/lib/server/functions/setStatusText.ts
+++ b/apps/meteor/app/lib/server/functions/setStatusText.ts
@@ -11,7 +11,7 @@ async function _setStatusTextPromise(userId: string, statusText: string): Promis
 		return false;
 	}
 
-	statusText = statusText.trim().substr(0, 120);
+	statusText = statusText.trim().slice(0, 120);
 
 	const user = await Users.findOneById<Pick<IUser, '_id' | 'username' | 'name' | 'status' | 'roles' | 'statusText'>>(userId, {
 		projection: { username: 1, name: 1, status: 1, roles: 1, statusText: 1 },

--- a/apps/meteor/app/lib/server/lib/validateEmailDomain.js
+++ b/apps/meteor/app/lib/server/lib/validateEmailDomain.js
@@ -43,7 +43,7 @@ export const validateEmailDomain = async function (email) {
 		});
 	}
 
-	const emailDomain = email.substr(email.lastIndexOf('@') + 1);
+	const emailDomain = email.slice(email.lastIndexOf('@') + 1);
 
 	if (emailDomainWhiteList.length && !emailDomainWhiteList.includes(emailDomain)) {
 		throw new Meteor.Error('error-invalid-domain', 'The email domain is not in whitelist', {

--- a/apps/meteor/app/livechat/server/lib/messages.ts
+++ b/apps/meteor/app/livechat/server/lib/messages.ts
@@ -49,7 +49,7 @@ export async function sendOfflineMessage(data: OfflineMessageData) {
 	}
 
 	if (settings.get('Livechat_validate_offline_email')) {
-		const emailDomain = email.substr(email.lastIndexOf('@') + 1);
+		const emailDomain = email.slice(email.lastIndexOf('@') + 1);
 
 		try {
 			await dnsResolveMx(emailDomain);

--- a/apps/meteor/app/markdown/lib/parser/filtered/filtered.js
+++ b/apps/meteor/app/markdown/lib/parser/filtered/filtered.js
@@ -15,7 +15,7 @@ export const filtered = (
 	message = message.replace(/```/g, '');
 
 	// Remove inline code backticks
-	message = message.replace(new RegExp(/`([^`\r\n]+)\`/gm), (match) => match.substr(1, match.length - 2));
+	message = message.replace(new RegExp(/`([^`\r\n]+)\`/gm), (match) => match.slice(1, match.length - 1));
 
 	// Filter [text](url), ![alt_text](image_url)
 	message = message.replace(new RegExp(`!?\\[([^\\]]+)\\]\\((?:${schemes}):\\/\\/[^\\)]+\\)`, 'gm'), (match, title) => title);

--- a/apps/meteor/app/mentions/server/Mentions.ts
+++ b/apps/meteor/app/mentions/server/Mentions.ts
@@ -54,7 +54,7 @@ export class MentionsServer extends MentionsParser {
 		const userMentions = [];
 
 		for await (const m of mentions) {
-			const mention = m.trim().substr(1);
+			const mention = m.trim().slice(1);
 			if (mention !== 'all' && mention !== 'here') {
 				userMentions.push(mention);
 				continue;
@@ -79,7 +79,7 @@ export class MentionsServer extends MentionsParser {
 			isE2EEMessage(message) && e2eMentions?.e2eChannelMentions && e2eMentions?.e2eChannelMentions.length > 0
 				? e2eMentions?.e2eChannelMentions
 				: this.getChannelMentions(msg);
-		return this.getChannels(channels.map((c) => c.trim().substr(1)));
+		return this.getChannels(channels.map((c) => c.trim().slice(1)));
 	}
 
 	async execute(message: IMessage) {

--- a/apps/meteor/app/meteor-accounts-saml/server/lib/Utils.ts
+++ b/apps/meteor/app/meteor-accounts-saml/server/lib/Utils.ts
@@ -95,7 +95,8 @@ export class SAMLUtils {
 		const chars = 'abcdef0123456789';
 		let uniqueID = 'id-';
 		for (let i = 0; i < 20; i++) {
-			uniqueID += chars.substr(Math.floor(Math.random() * 15), 1);
+			let randomNumber = Math.floor(Math.random() * 15);
+			uniqueID += chars.slice(randomNumber, randomNumber + 1);
 		}
 		return uniqueID;
 	}

--- a/apps/meteor/app/slackbridge/server/SlackAdapter.js
+++ b/apps/meteor/app/slackbridge/server/SlackAdapter.js
@@ -660,9 +660,9 @@ export default class SlackAdapter {
 		let index = rocketMsg._id.indexOf('slack-');
 		if (index === 0) {
 			// This is a msg that originated from Slack
-			slackTS = rocketMsg._id.substr(6, rocketMsg._id.length);
+			slackTS = rocketMsg._id.slice(6, rocketMsg._id.length + 6);
 			index = slackTS.indexOf('-');
-			slackTS = slackTS.substr(index + 1, slackTS.length);
+			slackTS = slackTS.slice(index + 1, slackTS.length + index + 1);
 			slackTS = slackTS.replace('-', '.');
 		} else {
 			// This probably originated as a Rocket msg, but has been sent to Slack

--- a/apps/meteor/client/components/message/toolbar/useNewDiscussionMessageAction.tsx
+++ b/apps/meteor/client/components/message/toolbar/useNewDiscussionMessageAction.tsx
@@ -27,7 +27,7 @@ export const useNewDiscussionMessageAction = () => {
 						defaultParentRoom={room?.prid || room?._id}
 						onClose={() => setModal(undefined)}
 						parentMessageId={message._id}
-						nameSuggestion={message?.msg?.substr(0, 140)}
+						nameSuggestion={message?.msg?.slice(0, 140)}
 					/>,
 				);
 			},

--- a/apps/meteor/client/sidebar/search/SearchList.tsx
+++ b/apps/meteor/client/sidebar/search/SearchList.tsx
@@ -27,7 +27,7 @@ const mobileCheck = function () {
 				a,
 			) ||
 			/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(
-				a.substr(0, 4),
+				a.slice(0, 4),
 			)
 		)
 			check = true;

--- a/apps/meteor/client/sidebarv2/header/SearchSection.tsx
+++ b/apps/meteor/client/sidebarv2/header/SearchSection.tsx
@@ -32,7 +32,7 @@ const mobileCheck = function () {
 				a,
 			) ||
 			/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(
-				a.substr(0, 4),
+				a.slice(0, 4),
 			)
 		)
 			check = true;

--- a/apps/meteor/client/views/meet/OngoingCallDuration.tsx
+++ b/apps/meteor/client/views/meet/OngoingCallDuration.tsx
@@ -13,7 +13,7 @@ const OngoingCallDuration = ({ counter: defaultCounter = 0 }: OngoingCallDuratio
 
 	return (
 		<Box color='white' textAlign='center'>
-			{new Date(counter * 1000).toISOString().substr(11, 8)}
+			{new Date(counter * 1000).toISOString().slice(11, 19)}
 		</Box>
 	);
 };

--- a/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/WebdavFilePickerModal.tsx
+++ b/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/WebdavFilePickerModal.tsx
@@ -115,7 +115,7 @@ const WebdavFilePickerModal = ({ onUpload, onClose, account }: WebdavFilePickerM
 			if (newCurrentFolder[newCurrentFolder.length - 1] === '/') {
 				newCurrentFolder = newCurrentFolder.slice(0, -1);
 			}
-			parentFolder = newCurrentFolder.substr(0, newCurrentFolder.lastIndexOf('/') + 1);
+			parentFolder = newCurrentFolder.slice(0, newCurrentFolder.lastIndexOf('/') + 1);
 		}
 		setCurrentFolder(parentFolder);
 	};

--- a/apps/meteor/packages/meteor-cookies/cookies.js
+++ b/apps/meteor/packages/meteor-cookies/cookies.js
@@ -9,7 +9,7 @@ if (Meteor.isServer) {
 	fetch = require('meteor/fetch').fetch;
 }
 
-const NoOp = () => {};
+const NoOp = () => { };
 const urlRE = /\/___cookie___\/set/;
 const rootUrl = Meteor.isServer
 	? process.env.ROOT_URL
@@ -122,9 +122,9 @@ const parse = (str, options) => {
 		if (eqIndx < 0) {
 			return;
 		}
-		key = pair.substr(0, eqIndx).trim();
+		key = pair.slice(0, eqIndx).trim();
 		key = tryDecode(unescape(key), opt.decode || decode);
-		val = pair.substr(++eqIndx, pair.length).trim();
+		val = pair.substr(++eqIndx, pair.length).trim(); // Unsure how to change to slice()
 		if (val[0] === '"') {
 			val = val.slice(1, -1);
 		}
@@ -448,9 +448,8 @@ class __cookies {
 		}
 
 		if (this.runOnServer) {
-			let path = `${
-				window.__meteor_runtime_config__.ROOT_URL_PATH_PREFIX || window.__meteor_runtime_config__.meteorEnv.ROOT_URL_PATH_PREFIX || ''
-			}/___cookie___/set`;
+			let path = `${window.__meteor_runtime_config__.ROOT_URL_PATH_PREFIX || window.__meteor_runtime_config__.meteorEnv.ROOT_URL_PATH_PREFIX || ''
+				}/___cookie___/set`;
 			let query = '';
 
 			if (Meteor.isCordova && this.allowQueryStringCookies) {

--- a/apps/meteor/server/lib/ldap/Connection.ts
+++ b/apps/meteor/server/lib/ldap/Connection.ts
@@ -314,7 +314,7 @@ export class LDAPConnection {
 					key,
 					type: dataType,
 					length: values[key].length,
-					value: `${values[key].substr(0, 100)}...`,
+					value: `${values[key].slice(0, 100)}...`,
 				});
 				return;
 			}

--- a/apps/meteor/server/lib/oauth/initCustomOAuthServices.ts
+++ b/apps/meteor/server/lib/oauth/initCustomOAuthServices.ts
@@ -10,7 +10,7 @@ export async function initCustomOAuthServices(): Promise<void> {
 			let name = key.replace('Accounts_OAuth_Custom_', '');
 
 			if (name.indexOf('_') > -1) {
-				name = name.replace(name.substr(name.indexOf('_')), '');
+				name = name.replace(name.slice(name.indexOf('_')), '');
 			}
 
 			const serviceKey = `Accounts_OAuth_Custom_${name}`;

--- a/apps/meteor/server/models/raw/Users.js
+++ b/apps/meteor/server/models/raw/Users.js
@@ -931,7 +931,7 @@ export class UsersRaw extends BaseRaw {
 				statusConnection,
 				...(statusDefault && { statusDefault }),
 				...(statusText && {
-					statusText: String(statusText).trim().substr(0, 120),
+					statusText: String(statusText).trim().slice(0, 120),
 				}),
 			},
 		};
@@ -2753,15 +2753,15 @@ export class UsersRaw extends BaseRaw {
 		const update = {
 			...(bio.trim()
 				? {
-						$set: {
-							bio,
-						},
-					}
+					$set: {
+						bio,
+					},
+				}
 				: {
-						$unset: {
-							bio: 1,
-						},
-					}),
+					$unset: {
+						bio: 1,
+					},
+				}),
 		};
 		return this.updateOne({ _id }, update);
 	}
@@ -2770,15 +2770,15 @@ export class UsersRaw extends BaseRaw {
 		const update = {
 			...(nickname.trim()
 				? {
-						$set: {
-							nickname,
-						},
-					}
+					$set: {
+						nickname,
+					},
+				}
 				: {
-						$unset: {
-							nickname: 1,
-						},
-					}),
+					$unset: {
+						nickname: 1,
+					},
+				}),
 		};
 		return this.updateOne({ _id }, update);
 	}

--- a/apps/meteor/server/routes/avatar/utils.ts
+++ b/apps/meteor/server/routes/avatar/utils.ts
@@ -122,7 +122,7 @@ export async function userCanAccessAvatar({ headers = {}, query = {} }: IIncomin
 const getFirstLetter = (name: string) =>
 	name
 		.replace(/[^A-Za-z0-9]/g, '')
-		.substr(0, 1)
+		.slice(0, 1)
 		.toUpperCase();
 
 export const renderSVGLetters = (username: string, viewSize = 200) => {

--- a/apps/meteor/server/startup/serverRunning.js
+++ b/apps/meteor/server/startup/serverRunning.js
@@ -45,7 +45,7 @@ Meteor.startup(async () => {
 		];
 
 		if (Info.commit && Info.commit.hash) {
-			msg.push(`        Commit Hash: ${Info.commit.hash.substr(0, 10)}`);
+			msg.push(`        Commit Hash: ${Info.commit.hash.slice(0, 10)}`);
 		}
 
 		if (Info.commit && Info.commit.branch) {

--- a/apps/meteor/server/ufs/ufs-server.ts
+++ b/apps/meteor/server/ufs/ufs-server.ts
@@ -51,7 +51,7 @@ WebApp.connectHandlers.use(async (req, res, next) => {
 
 	// Remove store path
 	const parsedUrl = URL.parse(req.url, true);
-	const path = parsedUrl.pathname?.substr(UploadFS.config.storesPath.length + 1);
+	const path = parsedUrl.pathname?.slice(UploadFS.config.storesPath.length + 1);
 
 	if (!path) {
 		next();
@@ -122,7 +122,7 @@ WebApp.connectHandlers.use(async (req, res, next) => {
 
 		// Remove file extension from file Id
 		const index = match[2].indexOf('.');
-		const fileId = index !== -1 ? match[2].substr(0, index) : match[2];
+		const fileId = index !== -1 ? match[2].slice(0, index) : match[2];
 
 		// Get file from database
 		const file = await store.getCollection().findOne({ _id: fileId });
@@ -197,7 +197,7 @@ WebApp.connectHandlers.use(async (req, res, next) => {
 						}
 
 						const total = file.size || 0;
-						const unit = range.substr(0, range.indexOf('='));
+						const unit = range.slice(0, range.indexOf('='));
 
 						if (unit !== 'bytes') {
 							res.writeHead(416);
@@ -206,7 +206,7 @@ WebApp.connectHandlers.use(async (req, res, next) => {
 						}
 
 						const ranges = range
-							.substr(unit.length)
+							.slice(unit.length)
 							.replace(/[^0-9\-,]/, '')
 							.split(',');
 

--- a/packages/apps-engine/src/server/oauth2/OAuth2Client.ts
+++ b/packages/apps-engine/src/server/oauth2/OAuth2Client.ts
@@ -33,7 +33,7 @@ export class OAuth2Client implements IOAuth2Client {
     constructor(
         private readonly app: App,
         private readonly config: IOAuth2ClientOptions,
-    ) {}
+    ) { }
 
     public async setup(configuration: IConfigurationExtend): Promise<void> {
         configuration.api.provideApi({
@@ -203,7 +203,7 @@ export class OAuth2Client implements IOAuth2Client {
         const url = await this.app.getAccessors().environmentReader.getServerSettings().getValueById(SITE_URL);
 
         if (url.endsWith('/')) {
-            return url.substr(0, url.length - 1);
+            return url.slice(0, url.length - 1);
         }
         return url;
     }

--- a/packages/node-poplib/src/index.js
+++ b/packages/node-poplib/src/index.js
@@ -54,7 +54,7 @@ function POP3Client(port, host, options) {
 	var callback = function (resp, data) {
 		if (resp === false) {
 			locked = false;
-			callback = function () {};
+			callback = function () { };
 			self.emit('connect', false, data);
 		} else {
 			// Checking for APOP support
@@ -198,10 +198,10 @@ function POP3Client(port, host, options) {
 		if (debug) console.log('Server: ' + util.inspect(data));
 
 		if (checkResp === true) {
-			if (bufferedData.substr(0, 3) === '+OK') {
+			if (bufferedData.slice(0, 3) === '+OK') {
 				checkResp = false;
 				response = true;
-			} else if (bufferedData.substr(0, 4) === '-ERR') {
+			} else if (bufferedData.slice(0, 4) === '-ERR') {
 				checkResp = false;
 				response = false;
 
@@ -213,7 +213,7 @@ function POP3Client(port, host, options) {
 		}
 
 		if (checkResp === false) {
-			if (multiline === true && (response === false || bufferedData.substr(bufferedData.length - 5) === '\r\n.\r\n')) {
+			if (multiline === true && (response === false || bufferedData.slice(bufferedData.length - 5) === '\r\n.\r\n')) {
 				// Make a copy to avoid race conditions
 				var responseCopy = response;
 				var bufferedDataCopy = bufferedData;
@@ -292,12 +292,12 @@ POP3Client.prototype.login = function (username, password) {
 		self.setCallback(function (resp, data) {
 			if (resp === false) {
 				self.setLocked(false);
-				self.setCallback(function () {});
+				self.setCallback(function () { });
 				self.emit('login', false, data);
 			} else {
 				self.setCallback(function (resp, data) {
 					self.setLocked(false);
-					self.setCallback(function () {});
+					self.setCallback(function () { });
 
 					if (resp !== false) self.setState(2);
 					self.emit('login', resp, data);
@@ -340,7 +340,7 @@ POP3Client.prototype.auth = function (type, username, password) {
 			self.setCallback(function (resp, data) {
 				if (resp === false) self.emit('auth', resp, 'Server responded -ERR to AUTH CRAM-MD5', data);
 				else {
-					var challenge = new Buffer(data.trim().substr(2), 'base64').toString();
+					var challenge = new Buffer(data.trim().slice(2), 'base64').toString();
 					var hmac = crypto.createHmac('md5', password);
 					var response = new Buffer(username + ' ' + hmac.update(challenge).digest('hex')).toString('base64');
 
@@ -388,7 +388,7 @@ POP3Client.prototype.apop = function (username, password) {
 		self.setLocked(true);
 		self.setCallback(function (resp, data) {
 			self.setLocked(false);
-			self.setCallback(function () {});
+			self.setCallback(function () { });
 
 			if (resp === true) self.setState(2);
 			self.emit('apop', resp, data);
@@ -398,11 +398,11 @@ POP3Client.prototype.apop = function (username, password) {
 		self.write(
 			'APOP',
 			username +
-				' ' +
-				crypto
-					.createHash('md5')
-					.update(self.data['apop-timestamp'] + password)
-					.digest('hex'),
+			' ' +
+			crypto
+				.createHash('md5')
+				.update(self.data['apop-timestamp'] + password)
+				.digest('hex'),
 		);
 	}
 };
@@ -417,7 +417,7 @@ POP3Client.prototype.stls = function () {
 		self.setLocked(true);
 		self.setCallback(function (resp, data) {
 			self.setLocked(false);
-			self.setCallback(function () {});
+			self.setCallback(function () { });
 
 			if (resp === true) {
 				self.setCallback(function (resp, data) {
@@ -445,14 +445,14 @@ POP3Client.prototype.top = function (msgnumber, lines) {
 		self.setCallback(function (resp, data) {
 			var returnValue = null;
 			self.setLocked(false);
-			self.setCallback(function () {});
+			self.setCallback(function () { });
 
 			if (resp !== false) {
 				returnValue = '';
 				var startOffset = data.indexOf('\r\n', 0) + 2;
 				var endOffset = data.indexOf('\r\n.\r\n', 0) + 2;
 
-				if (endOffset > startOffset) returnValue = data.substr(startOffset, endOffset - startOffset);
+				if (endOffset > startOffset) returnValue = data.slice(startOffset, endOffset);
 			}
 
 			self.emit('top', resp, msgnumber, returnValue, data);
@@ -474,7 +474,7 @@ POP3Client.prototype.list = function (msgnumber) {
 			var returnValue = null;
 			var msgcount = 0;
 			self.setLocked(false);
-			self.setCallback(function () {});
+			self.setCallback(function () { });
 
 			if (resp !== false) {
 				returnValue = [];
@@ -492,7 +492,7 @@ POP3Client.prototype.list = function (msgnumber) {
 					var endOffset = data.indexOf('\r\n.\r\n', 0) + 2;
 
 					if (endOffset > startOffset) {
-						data = data.substr(startOffset, endOffset - startOffset);
+						data = data.slice(startOffset, endOffset);
 
 						while (true) {
 							if (offset > endOffset) break;
@@ -502,7 +502,7 @@ POP3Client.prototype.list = function (msgnumber) {
 							if (newoffset < 0) break;
 
 							msgcount++;
-							listitem = data.substr(offset, newoffset - offset);
+							listitem = data.slice(offset, newoffset);
 							listitem = listitem.split(' ');
 							returnValue[listitem[0]] = listitem[1];
 							offset = newoffset + 2;
@@ -531,7 +531,7 @@ POP3Client.prototype.stat = function () {
 		self.setCallback(function (resp, data) {
 			var returnValue = null;
 			self.setLocked(false);
-			self.setCallback(function () {});
+			self.setCallback(function () { });
 
 			if (resp !== false) {
 				listitem = data.split(' ');
@@ -559,7 +559,7 @@ POP3Client.prototype.uidl = function (msgnumber) {
 		self.setCallback(function (resp, data) {
 			var returnValue = null;
 			self.setLocked(false);
-			self.setCallback(function () {});
+			self.setCallback(function () { });
 
 			if (resp !== false) {
 				returnValue = [];
@@ -576,12 +576,12 @@ POP3Client.prototype.uidl = function (msgnumber) {
 					var endOffset = data.indexOf('\r\n.\r\n', 0) + 2;
 
 					if (endOffset > startOffset) {
-						data = data.substr(startOffset, endOffset - startOffset);
+						data = data.slice(startOffset, endOffset);
 						endOffset -= startOffset;
 
 						while (offset < endOffset) {
 							newoffset = data.indexOf('\r\n', offset);
-							listitem = data.substr(offset, newoffset - offset);
+							listitem = data.slice(offset, newo);
 							listitem = listitem.split(' ');
 							returnValue[listitem[0]] = listitem[1];
 							offset = newoffset + 2;
@@ -610,12 +610,12 @@ POP3Client.prototype.retr = function (msgnumber) {
 		self.setCallback(function (resp, data) {
 			var returnValue = null;
 			self.setLocked(false);
-			self.setCallback(function () {});
+			self.setCallback(function () { });
 
 			if (resp !== false) {
 				var startOffset = data.indexOf('\r\n', 0) + 2;
 				var endOffset = data.indexOf('\r\n.\r\n', 0);
-				returnValue = data.substr(startOffset, endOffset - startOffset);
+				returnValue = data.slice(startOffset, endOffset);
 			}
 
 			self.emit('retr', resp, msgnumber, returnValue, data);
@@ -635,7 +635,7 @@ POP3Client.prototype.dele = function (msgnumber) {
 		self.setLocked(true);
 		self.setCallback(function (resp, data) {
 			self.setLocked(false);
-			self.setCallback(function () {});
+			self.setCallback(function () { });
 			self.emit('dele', resp, msgnumber, data);
 		});
 
@@ -653,7 +653,7 @@ POP3Client.prototype.noop = function () {
 		self.setLocked(true);
 		self.setCallback(function (resp, data) {
 			self.setLocked(false);
-			self.setCallback(function () {});
+			self.setCallback(function () { });
 			self.emit('noop', resp, data);
 		});
 
@@ -671,7 +671,7 @@ POP3Client.prototype.rset = function () {
 		self.setLocked(true);
 		self.setCallback(function (resp, data) {
 			self.setLocked(false);
-			self.setCallback(function () {});
+			self.setCallback(function () { });
 			self.emit('rset', resp, data);
 		});
 
@@ -690,12 +690,12 @@ POP3Client.prototype.capa = function () {
 		self.setCallback(function (resp, data) {
 			var returnValue = null;
 			self.setLocked(false);
-			self.setCallback(function () {});
+			self.setCallback(function () { });
 
 			if (resp === true) {
 				var startOffset = data.indexOf('\r\n', 0) + 2;
 				var endOffset = data.indexOf('\r\n.\r\n', 0);
-				returnValue = data.substr(startOffset, endOffset - startOffset);
+				returnValue = data.slice(startOffset, endOffset);
 				returnValue = returnValue.split('\r\n');
 			}
 
@@ -716,7 +716,7 @@ POP3Client.prototype.quit = function () {
 		self.setLocked(true);
 		self.setCallback(function (resp, data) {
 			self.setLocked(false);
-			self.setCallback(function () {});
+			self.setCallback(function () { });
 
 			self.end();
 			self.emit('quit', resp, data);

--- a/packages/random/src/RandomGenerator.ts
+++ b/packages/random/src/RandomGenerator.ts
@@ -99,7 +99,7 @@ export abstract class RandomGenerator {
 	choice<TArrayLike extends unknown[] | string>(arrayOrString: TArrayLike) {
 		const index = Math.floor(this.fraction() * arrayOrString.length);
 		if (typeof arrayOrString === 'string') {
-			return arrayOrString.substr(index, 1);
+			return arrayOrString.slice(index, index + 1);
 		}
 
 		return arrayOrString[index];


### PR DESCRIPTION
 - [x] I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc

- [x]  I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- [x]  Lint and unit tests pass locally with my changes

This pull request replaces all instances of the deprecated `substr()` method with the modern and recommended `slice()` method throughout the Rocket.Chat codebase.  

### Rationale  
- The `substr()` method is considered a legacy feature and may not be supported in future JavaScript implementations.  
- The `slice()` method offers equivalent functionality for most use cases, aligning with modern JavaScript best practices.  

### Changes Made  
- Replaced all occurrences of `substr()` with `slice()`.  
- Verified functional equivalence to ensure no regressions were introduced.  

### Steps to Test  
1. Run the application locally and navigate through all major features to confirm they work as expected.  
2. Execute the unit and integration tests to validate functionality.  


This change does not introduce new functionality or fix bugs; it is strictly a refactor to improve maintainability and align with current standards.  