### PR TITLE
Release 7.1.1

### DIFF
--- a/.changeset/blue-items-raise.md
+++ b/.changeset/blue-items-raise.md
@@ -1,0 +1,22 @@
+---
+'@rocket.chat/fuselage-ui-kit': patch
+'@rocket.chat/instance-status': patch
+'@rocket.chat/ui-theming': patch
+'@rocket.chat/model-typings': patch
+'@rocket.chat/ui-video-conf': patch
+'@rocket.chat/uikit-playground': patch
+'@rocket.chat/core-typings': patch
+'@rocket.chat/rest-typings': patch
+'@rocket.chat/apps-engine': patch
+'@rocket.chat/ui-composer': patch
+'@rocket.chat/ui-contexts': patch
+'@rocket.chat/gazzodown': patch
+'@rocket.chat/ui-avatar': patch
+'@rocket.chat/ui-client': patch
+'@rocket.chat/livechat': patch
+'@rocket.chat/ui-voip': patch
+'@rocket.chat/i18n': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes an error where the engine would not retry a subprocess restart if the last attempt failed

--- a/.changeset/bump-patch-1733428606813.md
+++ b/.changeset/bump-patch-1733428606813.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Bump @rocket.chat/meteor version.

--- a/.changeset/chilled-seas-refuse.md
+++ b/.changeset/chilled-seas-refuse.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/apps-engine': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes the subprocess restarting routine failing to correctly restart apps in some cases

--- a/.changeset/cold-mangos-impress.md
+++ b/.changeset/cold-mangos-impress.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed an issue that caused clients to not properly receive certain server notifications right after login

--- a/.changeset/cool-planes-protect.md
+++ b/.changeset/cool-planes-protect.md
@@ -1,0 +1,22 @@
+---
+'@rocket.chat/omnichannel-transcript': patch
+'@rocket.chat/authorization-service': patch
+'@rocket.chat/stream-hub-service': patch
+'@rocket.chat/presence-service': patch
+'@rocket.chat/fuselage-ui-kit': patch
+'@rocket.chat/account-service': patch
+'@rocket.chat/mock-providers': patch
+'@rocket.chat/ui-theming': patch
+'@rocket.chat/uikit-playground': patch
+'@rocket.chat/ddp-streamer': patch
+'@rocket.chat/queue-worker': patch
+'@rocket.chat/apps-engine': patch
+'@rocket.chat/ui-composer': patch
+'@rocket.chat/ui-contexts': patch
+'@rocket.chat/ui-client': patch
+'@rocket.chat/models': patch
+'@rocket.chat/sha256': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes an issue that prevented the apps-engine from reestablishing communications with subprocesses in some cases

--- a/.changeset/gold-comics-taste.md
+++ b/.changeset/gold-comics-taste.md
@@ -1,0 +1,22 @@
+---
+'@rocket.chat/fuselage-ui-kit': patch
+'@rocket.chat/instance-status': patch
+'@rocket.chat/ui-theming': patch
+'@rocket.chat/model-typings': patch
+'@rocket.chat/ui-video-conf': patch
+'@rocket.chat/uikit-playground': patch
+'@rocket.chat/core-typings': patch
+'@rocket.chat/rest-typings': patch
+'@rocket.chat/apps-engine': patch
+'@rocket.chat/ui-composer': patch
+'@rocket.chat/ui-contexts': patch
+'@rocket.chat/gazzodown': patch
+'@rocket.chat/ui-avatar': patch
+'@rocket.chat/ui-client': patch
+'@rocket.chat/livechat': patch
+'@rocket.chat/ui-voip': patch
+'@rocket.chat/i18n': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes error propagation when trying to get the status of apps in some cases

--- a/.changeset/popular-cameras-grin.md
+++ b/.changeset/popular-cameras-grin.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/meteor": patch
+"@rocket.chat/model-typings": patch
+---
+
+Fixes livechat conversations not being assigned to the contact manager even when the "Assign new conversations to the contact manager" setting is enabled

--- a/.changeset/proud-planets-applaud.md
+++ b/.changeset/proud-planets-applaud.md
@@ -1,0 +1,22 @@
+---
+'@rocket.chat/fuselage-ui-kit': patch
+'@rocket.chat/instance-status': patch
+'@rocket.chat/ui-theming': patch
+'@rocket.chat/model-typings': patch
+'@rocket.chat/ui-video-conf': patch
+'@rocket.chat/uikit-playground': patch
+'@rocket.chat/core-typings': patch
+'@rocket.chat/rest-typings': patch
+'@rocket.chat/apps-engine': patch
+'@rocket.chat/ui-composer': patch
+'@rocket.chat/ui-contexts': patch
+'@rocket.chat/gazzodown': patch
+'@rocket.chat/ui-avatar': patch
+'@rocket.chat/ui-client': patch
+'@rocket.chat/livechat': patch
+'@rocket.chat/ui-voip': patch
+'@rocket.chat/i18n': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes wrong data being reported to total failed apps metrics and statistics

--- a/.changeset/seven-owls-tell.md
+++ b/.changeset/seven-owls-tell.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixed an issue that added potencially infinite callbacks to the same event, degrading performance over time.

--- a/.changeset/strange-countries-carry.md
+++ b/.changeset/strange-countries-carry.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+fixed an issue that caused the conference call ringer to fail to accept calls if the user logged out and in again

--- a/apps/meteor/app/lib/server/methods/sendMessage.ts
+++ b/apps/meteor/app/lib/server/methods/sendMessage.ts
@@ -132,7 +132,7 @@ Meteor.methods<ServerMethods>({
 			ts: Match.Maybe(Date),
 			t: Match.Maybe(String),
 			otrAck: Match.Maybe(String),
-			bot: Match.Maybe(Boolean),
+			bot: Match.Maybe(Object),
 			content: Match.Maybe(Object),
 			e2e: Match.Maybe(String),
 			e2eMentions: Match.Maybe(Object),

--- a/apps/meteor/app/livechat/server/lib/LivechatTyped.ts
+++ b/apps/meteor/app/livechat/server/lib/LivechatTyped.ts
@@ -357,7 +357,12 @@ class LivechatClass {
 			throw new Error('error-contact-channel-blocked');
 		}
 
-		const defaultAgent = await callbacks.run('livechat.checkDefaultAgentOnNewRoom', agent, visitor);
+		const defaultAgent =
+			agent ??
+			(await callbacks.run('livechat.checkDefaultAgentOnNewRoom', agent, {
+				visitorId: visitor._id,
+				source: roomInfo.source,
+			}));
 		// if no department selected verify if there is at least one active and pick the first
 		if (!defaultAgent && !visitor.department) {
 			const department = await getRequiredDepartment();

--- a/apps/meteor/app/statistics/server/lib/getAppsStatistics.ts
+++ b/apps/meteor/app/statistics/server/lib/getAppsStatistics.ts
@@ -41,7 +41,7 @@ async function _getAppsStatistics(): Promise<AppsStatistics> {
 				totalInstalled++;
 
 				const status = await app.getStatus();
-				const storageItem = await app.getStorageItem();
+				const storageItem = app.getStorageItem();
 
 				if (storageItem.installationSource === AppInstallationSource.PRIVATE) {
 					totalPrivateApps++;
@@ -51,12 +51,10 @@ async function _getAppsStatistics(): Promise<AppsStatistics> {
 					}
 				}
 
-				if (status === AppStatus.MANUALLY_DISABLED) {
-					totalFailed++;
-				}
-
 				if (AppStatusUtils.isEnabled(status)) {
 					totalActive++;
+				} else if (status !== AppStatus.MANUALLY_DISABLED) {
+					totalFailed++;
 				}
 			}),
 		);

--- a/apps/meteor/client/components/message/MessageHeader.tsx
+++ b/apps/meteor/client/components/message/MessageHeader.tsx
@@ -72,7 +72,7 @@ const MessageHeader = ({ message }: MessageHeaderProps): ReactElement => {
 					</>
 				)}
 			</MessageNameContainer>
-			{shouldShowRolesList && <MessageRoles roles={roles} isBot={message.bot} />}
+			{shouldShowRolesList && <MessageRoles roles={roles} isBot={!!message.bot} />}
 			<MessageTimestamp id={`${message._id}-time`} title={formatDateAndTime(message.ts)}>
 				{formatTime(message.ts)}
 			</MessageTimestamp>

--- a/apps/meteor/client/hooks/useNotifyUser.ts
+++ b/apps/meteor/client/hooks/useNotifyUser.ts
@@ -1,6 +1,7 @@
-import type { AtLeast, ISubscription } from '@rocket.chat/core-typings';
+import type { AtLeast, INotificationDesktop, ISubscription } from '@rocket.chat/core-typings';
+import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
 import { useRouter, useStream, useUser, useUserPreference } from '@rocket.chat/ui-contexts';
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { useEmbeddedLayout } from './useEmbeddedLayout';
 import { CachedChatSubscription } from '../../app/models/client';
@@ -15,79 +16,68 @@ export const useNotifyUser = () => {
 	const notifyUserStream = useStream('notify-user');
 	const muteFocusedConversations = useUserPreference('muteFocusedConversations');
 
-	const notifyNewRoom = useCallback(
-		async (sub: AtLeast<ISubscription, 'rid'>): Promise<void> => {
-			if (!user || user.status === 'busy') {
-				return;
-			}
+	const notifyNewRoom = useEffectEvent(async (sub: AtLeast<ISubscription, 'rid'>): Promise<void> => {
+		if (!user || user.status === 'busy') {
+			return;
+		}
 
-			if ((!router.getRouteParameters().name || router.getRouteParameters().name !== sub.name) && !sub.ls && sub.alert === true) {
-				KonchatNotification.newRoom(sub.rid);
-			}
-		},
-		[router, user],
-	);
+		if ((!router.getRouteParameters().name || router.getRouteParameters().name !== sub.name) && !sub.ls && sub.alert === true) {
+			KonchatNotification.newRoom(sub.rid);
+		}
+	});
 
-	const notifyNewMessageAudio = useCallback(
-		(rid?: string) => {
-			const hasFocus = document.hasFocus();
-			const messageIsInOpenedRoom = RoomManager.opened === rid;
+	const notifyNewMessageAudioAndDesktop = useEffectEvent((notification: INotificationDesktop) => {
+		const hasFocus = document.hasFocus();
 
-			if (isLayoutEmbedded) {
-				if (!hasFocus && messageIsInOpenedRoom) {
-					// Play a notification sound
-					void KonchatNotification.newMessage(rid);
-				}
-			} else if (!hasFocus || !messageIsInOpenedRoom || !muteFocusedConversations) {
+		const openedRoomId = ['channel', 'group', 'direct'].includes(router.getRouteName() || '') ? RoomManager.opened : undefined;
+
+		const { rid } = notification.payload;
+		const messageIsInOpenedRoom = openedRoomId === rid;
+
+		fireGlobalEvent('notification', {
+			notification,
+			fromOpenedRoom: messageIsInOpenedRoom,
+			hasFocus,
+		});
+
+		if (isLayoutEmbedded) {
+			if (!hasFocus && messageIsInOpenedRoom) {
 				// Play a notification sound
 				void KonchatNotification.newMessage(rid);
+				void KonchatNotification.showDesktop(notification);
 			}
-		},
-		[isLayoutEmbedded, muteFocusedConversations],
-	);
+		} else if (!hasFocus || !messageIsInOpenedRoom || !muteFocusedConversations) {
+			// Play a notification sound
+			void KonchatNotification.newMessage(rid);
+			void KonchatNotification.showDesktop(notification);
+		}
+	});
 
 	useEffect(() => {
 		if (!user?._id) {
 			return;
 		}
 
-		notifyUserStream(`${user?._id}/notification`, (notification) => {
-			const openedRoomId = ['channel', 'group', 'direct'].includes(router.getRouteName() || '') ? RoomManager.opened : undefined;
+		const unsubNotification = notifyUserStream(`${user._id}/notification`, notifyNewMessageAudioAndDesktop);
 
-			const hasFocus = document.hasFocus();
-			const messageIsInOpenedRoom = openedRoomId === notification.payload.rid;
-
-			fireGlobalEvent('notification', {
-				notification,
-				fromOpenedRoom: messageIsInOpenedRoom,
-				hasFocus,
-			});
-
-			if (isLayoutEmbedded) {
-				if (!hasFocus && messageIsInOpenedRoom) {
-					// Show a notification.
-					KonchatNotification.showDesktop(notification);
-				}
-			} else if (!hasFocus || !messageIsInOpenedRoom) {
-				// Show a notification.
-				KonchatNotification.showDesktop(notification);
-			}
-
-			notifyNewMessageAudio(notification.payload.rid);
-		});
-
-		notifyUserStream(`${user?._id}/subscriptions-changed`, (action, sub) => {
-			if (action === 'removed') {
+		const unsubSubs = notifyUserStream(`${user._id}/subscriptions-changed`, (action, sub) => {
+			if (action !== 'inserted') {
 				return;
 			}
 
 			void notifyNewRoom(sub);
 		});
 
-		CachedChatSubscription.collection.find().observe({
+		const handle = CachedChatSubscription.collection.find().observe({
 			changed: (sub) => {
 				void notifyNewRoom(sub);
 			},
 		});
-	}, [isLayoutEmbedded, notifyNewMessageAudio, notifyNewRoom, notifyUserStream, router, user?._id]);
+
+		return () => {
+			unsubNotification();
+			unsubSubs();
+			handle.stop();
+		};
+	}, [isLayoutEmbedded, notifyNewMessageAudioAndDesktop, notifyNewRoom, notifyUserStream, router, user?._id]);
 };

--- a/apps/meteor/client/lib/VideoConfManager.ts
+++ b/apps/meteor/client/lib/VideoConfManager.ts
@@ -472,6 +472,7 @@ export const VideoConfManager = new (class VideoConfManager extends Emitter<Vide
 				clearTimeout(call.acceptTimeout);
 			}
 		});
+		this.userId = undefined;
 		this.incomingDirectCalls.clear();
 		this.dismissedCalls.clear();
 		this.currentCallData = undefined;

--- a/apps/meteor/client/meteorOverrides/ddpOverREST.ts
+++ b/apps/meteor/client/meteorOverrides/ddpOverREST.ts
@@ -57,13 +57,35 @@ const withDDPOverREST = (_send: (this: Meteor.IMeteorConnection, message: Meteor
 		sdk.rest
 			.post(`/v1/${endpoint}/${method}`, restParams)
 			.then(({ message: _message }) => {
-				processResult(_message);
+				// Calling Meteor.loginWithToken before processing the result of the first login will ensure that the new login request
+				// is added to the top of the list of methodInvokers.
+				// The request itself will only be sent after the first login result is processed, but
+				// the Accounts.onLogin callbacks will be called before this request is effectively sent;
+				// This way, any requests done inside of onLogin callbacks will be added to the list
+				// and processed only after the Meteor.loginWithToken request is done
+				// So, the effective order is:
+				//   1. regular login with password is sent
+				//   2. result of the password login is received
+				//   3. login with token is added to the list of pending requests
+				//   4. result of the password login is processed
+				//   5. Accounts.onLogin callbacks are triggered, Meteor.userId is set
+				//   6. the request for the login with token is effectively sent
+				//   7. login with token result is processed
+				//   8. requests initiated inside of the Accounts.onLogin callback are then finally sent
+				//
+				// Keep in mind that there's a difference in how meteor3 processes the request results, compared to older meteor versions
+				// On meteor3, any collection writes triggered by a request result are done async, which means that the `processResult` call
+				// will not immediatelly trigger the callbacks, like it used to in older versions.
+				// That means that on meteor3+, it doesn't really make a difference if processResult is called before or after the Meteor.loginWithToken here
+				// as the result will be processed async, the loginWithToken call will be initiated before it is effectively processed anyway.
 				if (message.method === 'login') {
 					const parsedMessage = DDPCommon.parseDDP(_message) as { result?: { token?: string } };
 					if (parsedMessage.result?.token) {
 						Meteor.loginWithToken(parsedMessage.result.token);
 					}
 				}
+
+				processResult(_message);
 			})
 			.catch((error) => {
 				console.error(error);

--- a/apps/meteor/ee/app/livechat-enterprise/server/hooks/handleNextAgentPreferredEvents.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/hooks/handleNextAgentPreferredEvents.ts
@@ -1,29 +1,33 @@
 import type { IUser, SelectedAgent } from '@rocket.chat/core-typings';
-import { LivechatVisitors, LivechatInquiry, LivechatRooms, Users } from '@rocket.chat/models';
+import { LivechatVisitors, LivechatContacts, LivechatInquiry, LivechatRooms, Users } from '@rocket.chat/models';
 
 import { notifyOnLivechatInquiryChanged } from '../../../../../app/lib/server/lib/notifyListener';
 import { RoutingManager } from '../../../../../app/livechat/server/lib/RoutingManager';
+import { migrateVisitorIfMissingContact } from '../../../../../app/livechat/server/lib/contacts/migrateVisitorIfMissingContact';
 import { settings } from '../../../../../app/settings/server';
 import { callbacks } from '../../../../../lib/callbacks';
 
 let contactManagerPreferred = false;
 let lastChattedAgentPreferred = false;
 
-const normalizeDefaultAgent = (agent?: Pick<IUser, '_id' | 'username'> | null): SelectedAgent | null => {
+const normalizeDefaultAgent = (agent?: Pick<IUser, '_id' | 'username'> | null): SelectedAgent | undefined => {
 	if (!agent) {
-		return null;
+		return undefined;
 	}
 
 	const { _id: agentId, username } = agent;
 	return { agentId, username };
 };
 
-const getDefaultAgent = async (username?: string): Promise<SelectedAgent | null> => {
-	if (!username) {
-		return null;
+const getDefaultAgent = async ({ username, id }: { username?: string; id?: string }): Promise<SelectedAgent | undefined> => {
+	if (!username && !id) {
+		return undefined;
 	}
 
-	return normalizeDefaultAgent(await Users.findOneOnlineAgentByUserList(username, { projection: { _id: 1, username: 1 } }));
+	if (id) {
+		return normalizeDefaultAgent(await Users.findOneOnlineAgentById(id, undefined, { projection: { _id: 1, username: 1 } }));
+	}
+	return normalizeDefaultAgent(await Users.findOneOnlineAgentByUserList(username || [], { projection: { _id: 1, username: 1 } }));
 };
 
 settings.watch<boolean>('Livechat_last_chatted_agent_routing', (value) => {
@@ -88,30 +92,32 @@ settings.watch<boolean>('Omnichannel_contact_manager_routing', (value) => {
 
 callbacks.add(
 	'livechat.checkDefaultAgentOnNewRoom',
-	async (defaultAgent, defaultGuest) => {
-		if (defaultAgent || !defaultGuest) {
+	async (defaultAgent, { visitorId, source } = {}) => {
+		if (defaultAgent || !visitorId || !source) {
 			return defaultAgent;
 		}
 
-		const { _id: guestId } = defaultGuest;
-		const guest = await LivechatVisitors.findOneEnabledById(guestId, {
+		const guest = await LivechatVisitors.findOneEnabledById(visitorId, {
 			projection: { lastAgent: 1, token: 1, contactManager: 1 },
 		});
 		if (!guest) {
-			return defaultAgent;
+			return undefined;
 		}
 
-		const { lastAgent, token, contactManager } = guest;
-		const guestManager = contactManager?.username && contactManagerPreferred && getDefaultAgent(contactManager?.username);
+		const contactId = await migrateVisitorIfMissingContact(visitorId, source);
+		const contact = contactId ? await LivechatContacts.findOneById(contactId, { projection: { contactManager: 1 } }) : undefined;
+
+		const guestManager = contactManagerPreferred && (await getDefaultAgent({ id: contact?.contactManager }));
 		if (guestManager) {
 			return guestManager;
 		}
 
 		if (!lastChattedAgentPreferred) {
-			return defaultAgent;
+			return undefined;
 		}
 
-		const guestAgent = lastAgent?.username && getDefaultAgent(lastAgent?.username);
+		const { lastAgent, token } = guest;
+		const guestAgent = await getDefaultAgent({ username: lastAgent?.username });
 		if (guestAgent) {
 			return guestAgent;
 		}
@@ -120,19 +126,19 @@ callbacks.add(
 			projection: { servedBy: 1 },
 		});
 		if (!room?.servedBy) {
-			return defaultAgent;
+			return undefined;
 		}
 
 		const {
 			servedBy: { username: usernameByRoom },
 		} = room;
 		if (!usernameByRoom) {
-			return defaultAgent;
+			return undefined;
 		}
 		const lastRoomAgent = normalizeDefaultAgent(
 			await Users.findOneOnlineAgentByUserList(usernameByRoom, { projection: { _id: 1, username: 1 } }),
 		);
-		return lastRoomAgent ?? defaultAgent;
+		return lastRoomAgent;
 	},
 	callbacks.priority.MEDIUM,
 	'livechat-check-default-agent-new-room',

--- a/apps/meteor/lib/callbacks.ts
+++ b/apps/meteor/lib/callbacks.ts
@@ -24,6 +24,7 @@ import type {
 	IOmnichannelRoomInfo,
 	IOmnichannelInquiryExtraData,
 	IOmnichannelRoomExtraData,
+	IOmnichannelSource,
 } from '@rocket.chat/core-typings';
 import type { Updater } from '@rocket.chat/models';
 import type { FilterOperators } from 'mongodb';
@@ -118,7 +119,10 @@ type ChainedCallbackSignatures = {
 	) => Promise<T>;
 
 	'livechat.beforeRouteChat': (inquiry: ILivechatInquiryRecord, agent?: { agentId: string; username: string }) => ILivechatInquiryRecord;
-	'livechat.checkDefaultAgentOnNewRoom': (agent: SelectedAgent, visitor?: ILivechatVisitor) => SelectedAgent | null;
+	'livechat.checkDefaultAgentOnNewRoom': (
+		defaultAgent?: SelectedAgent,
+		params?: { visitorId?: string; source?: IOmnichannelSource },
+	) => SelectedAgent | undefined;
 
 	'livechat.onLoadForwardDepartmentRestrictions': (params: { departmentId: string }) => Record<string, unknown>;
 

--- a/apps/meteor/server/models/raw/Users.js
+++ b/apps/meteor/server/models/raw/Users.js
@@ -1657,11 +1657,11 @@ export class UsersRaw extends BaseRaw {
 		return this.findOne(query);
 	}
 
-	findOneOnlineAgentById(_id, isLivechatEnabledWhenAgentIdle) {
+	findOneOnlineAgentById(_id, isLivechatEnabledWhenAgentIdle, options) {
 		// TODO: Create class Agent
 		const query = queryStatusAgentOnline({ _id }, isLivechatEnabledWhenAgentIdle);
 
-		return this.findOne(query);
+		return this.findOne(query, options);
 	}
 
 	findAgents() {

--- a/apps/meteor/tests/end-to-end/api/livechat/24-routing.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/24-routing.ts
@@ -1,9 +1,11 @@
+import { faker } from '@faker-js/faker';
 import type { Credentials } from '@rocket.chat/api-client';
-import { UserStatus, type ILivechatDepartment, type IUser } from '@rocket.chat/core-typings';
+import { UserStatus } from '@rocket.chat/core-typings';
+import type { ILivechatDepartment, IUser } from '@rocket.chat/core-typings';
 import { expect } from 'chai';
 import { after, before, describe, it } from 'mocha';
 
-import { getCredentials, request, api } from '../../../data/api-data';
+import { getCredentials, request, api, credentials } from '../../../data/api-data';
 import {
 	createAgent,
 	makeAgentAvailable,
@@ -33,7 +35,9 @@ import { IS_EE } from '../../../e2e/config/constants';
 
 		let testUser: { user: IUser; credentials: Credentials };
 		let testUser2: { user: IUser; credentials: Credentials };
+		let testUser3: { user: IUser; credentials: Credentials };
 		let testDepartment: ILivechatDepartment;
+		let visitorEmail: string;
 
 		before(async () => {
 			const user = await createUser();
@@ -60,13 +64,42 @@ import { IS_EE } from '../../../e2e/config/constants';
 		});
 
 		before(async () => {
-			testDepartment = await createDepartment([{ agentId: testUser.user._id }]);
+			const user = await createUser();
+			await createAgent(user.username);
+			const credentials3 = await login(user.username, password);
+			await makeAgentAvailable(credentials3);
+
+			testUser3 = {
+				user,
+				credentials: credentials3,
+			};
 		});
 
-		after(async () => {
-			await deleteUser(testUser.user);
-			await deleteUser(testUser2.user);
+		before(async () => {
+			testDepartment = await createDepartment([{ agentId: testUser.user._id }, { agentId: testUser3.user._id }]);
+			await updateSetting('Livechat_assign_new_conversation_to_bot', true);
+
+			const visitorName = faker.person.fullName();
+			visitorEmail = faker.internet.email().toLowerCase();
+			await request
+				.post(api('omnichannel/contacts'))
+				.set(credentials)
+				.send({
+					name: visitorName,
+					emails: [visitorEmail],
+					phones: [],
+					contactManager: testUser3.user._id,
+				});
 		});
+
+		after(async () =>
+			Promise.all([
+				deleteUser(testUser.user),
+				deleteUser(testUser2.user),
+				deleteUser(testUser3.user),
+				updateSetting('Livechat_assign_new_conversation_to_bot', false),
+			]),
+		);
 
 		it('should route a room to an available agent', async () => {
 			const visitor = await createVisitor(testDepartment._id);
@@ -91,9 +124,24 @@ import { IS_EE } from '../../../e2e/config/constants';
 			expect(roomInfo.servedBy).to.be.an('object');
 			expect(roomInfo.servedBy?._id).to.not.be.equal(testUser2.user._id);
 		});
+		(IS_EE ? it : it.skip)(
+			'should route to contact manager if it is online and Livechat_assign_new_conversation_to_bot is enabled',
+			async () => {
+				const visitor = await createVisitor(testDepartment._id, faker.person.fullName(), visitorEmail);
+				const room = await createLivechatRoom(visitor.token);
+
+				await sleep(5000);
+
+				const roomInfo = await getLivechatRoomInfo(room._id);
+
+				expect(roomInfo.servedBy).to.be.an('object');
+				expect(roomInfo.servedBy?._id).to.be.equal(testUser3.user._id);
+			},
+		);
 		it('should fail to start a conversation if there is noone available and Livechat_accept_chats_with_no_agents is false', async () => {
 			await updateSetting('Livechat_accept_chats_with_no_agents', false);
 			await makeAgentUnavailable(testUser.credentials);
+			await makeAgentUnavailable(testUser3.credentials);
 
 			const visitor = await createVisitor(testDepartment._id);
 			const { body } = await request.get(api('livechat/room')).query({ token: visitor.token }).expect(400);
@@ -147,6 +195,21 @@ import { IS_EE } from '../../../e2e/config/constants';
 			const roomInfo = await getLivechatRoomInfo(room._id);
 			expect(roomInfo.servedBy).to.be.undefined;
 		});
+		(IS_EE ? it : it.skip)(
+			'should route to another available agent if contact manager is unavailable and Livechat_assign_new_conversation_to_bot is enabled',
+			async () => {
+				await makeAgentAvailable(testUser.credentials);
+				const visitor = await createVisitor(testDepartment._id, faker.person.fullName(), visitorEmail);
+				const room = await createLivechatRoom(visitor.token);
+
+				await sleep(5000);
+
+				const roomInfo = await getLivechatRoomInfo(room._id);
+
+				expect(roomInfo.servedBy).to.be.an('object');
+				expect(roomInfo.servedBy?._id).to.be.equal(testUser.user._id);
+			},
+		);
 	});
 	describe('Load Balancing', () => {
 		before(async () => {

--- a/apps/meteor/tests/end-to-end/api/methods.ts
+++ b/apps/meteor/tests/end-to-end/api/methods.ts
@@ -2082,6 +2082,32 @@ describe('Meteor.methods', () => {
 				})
 				.end(done);
 		});
+
+		it('should accept message sent by js.SDK', (done) => {
+			void request
+				.post(methodCall('sendMessage'))
+				.set(credentials)
+				.send({
+					message: JSON.stringify({
+						method: 'sendMessage',
+						params: [{ rid, msg: 'test message', bot: { i: 'js.SDK' } }],
+						id: 1000,
+						msg: 'method',
+					}),
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+
+					const data = JSON.parse(res.body.message);
+
+					expect(data).to.have.a.property('result').that.is.an('object');
+					expect(data.result).to.have.a.property('bot').that.is.an('object');
+					expect(data.result.bot).to.have.a.property('i', 'js.SDK');
+				})
+				.end(done);
+		});
 	});
 
 	describe('[@updateMessage]', () => {

--- a/packages/apps-engine/deno-runtime/deno.lock
+++ b/packages/apps-engine/deno-runtime/deno.lock
@@ -90,18 +90,7 @@
     "https://deno.land/std@0.203.0/testing/bdd.ts": "3f446df5ef8e856a869e8eec54c8482590415741ff0b6358a00c43486cc15769",
     "https://deno.land/std@0.203.0/testing/mock.ts": "6576b4aa55ee20b1990d656a78fff83599e190948c00e9f25a7f3ac5e9d6492d",
     "https://deno.land/std@0.216.0/io/types.ts": "748bbb3ac96abda03594ef5a0db15ce5450dcc6c0d841c8906f8b10ac8d32c96",
-    "https://deno.land/std@0.216.0/io/write_all.ts": "24aac2312bb21096ae3ae0b102b22c26164d3249dff96dbac130958aa736f038"
-  },
-  "workspace": {
-    "dependencies": [
-      "npm:@msgpack/msgpack@3.0.0-beta2",
-      "npm:@rocket.chat/ui-kit@^0.31.22",
-      "npm:acorn-walk@8.2.0",
-      "npm:acorn@8.10.0",
-      "npm:astring@1.8.6",
-      "npm:jsonrpc-lite@2.2.0",
-      "npm:stack-trace@0.0.10",
-      "npm:uuid@8.3.2"
-    ]
+    "https://deno.land/std@0.216.0/io/write_all.ts": "24aac2312bb21096ae3ae0b102b22c26164d3249dff96dbac130958aa736f038",
+    "https://jsr.io/@std/cli/1.0.9/parse_args.ts": "29ac18602d8836d2723cab1d90111ff954acc369f184626a3f9f677e3185caef"
   }
 }

--- a/packages/apps-engine/deno-runtime/lib/metricsCollector.ts
+++ b/packages/apps-engine/deno-runtime/lib/metricsCollector.ts
@@ -1,0 +1,31 @@
+import { writeAll } from "https://deno.land/std@0.216.0/io/write_all.ts";
+import { Queue } from "./messenger.ts";
+
+export function collectMetrics() {
+    return {
+        pid: Deno.pid,
+        queueSize: Queue.getCurrentSize(),
+    }
+};
+
+const encoder = new TextEncoder();
+
+export async function sendMetrics() {
+    const metrics = collectMetrics();
+
+    await writeAll(Deno.stderr, encoder.encode(JSON.stringify(metrics)));
+}
+
+let intervalId: number;
+
+export function startMetricsReport(frequencyInMs = 5000) {
+    if (intervalId) {
+        throw new Error('There is already an active metrics report');
+    }
+
+    intervalId = setInterval(sendMetrics, frequencyInMs);
+}
+
+export function abortMetricsReport() {
+    clearInterval(intervalId);
+}

--- a/packages/apps-engine/deno-runtime/lib/parseArgs.ts
+++ b/packages/apps-engine/deno-runtime/lib/parseArgs.ts
@@ -1,0 +1,11 @@
+import { parseArgs as $parseArgs } from "https://jsr.io/@std/cli/1.0.9/parse_args.ts";
+
+export type ParsedArgs = {
+    subprocess: string;
+    spawnId: number;
+    metricsReportFrequencyInMs?: number;
+}
+
+export function parseArgs(args: string[]): ParsedArgs {
+    return $parseArgs(args);
+}

--- a/packages/apps-engine/deno-runtime/main.ts
+++ b/packages/apps-engine/deno-runtime/main.ts
@@ -22,6 +22,8 @@ import apiHandler from './handlers/api-handler.ts';
 import handleApp from './handlers/app/handler.ts';
 import handleScheduler from './handlers/scheduler-handler.ts';
 import registerErrorListeners from './error-handlers.ts';
+import { startMetricsReport } from "./lib/metricsCollector.ts";
+import { parseArgs } from "./lib/parseArgs.ts";
 
 type Handlers = {
     app: typeof handleApp;
@@ -127,6 +129,10 @@ async function main() {
     }
 }
 
+const mainArgs = parseArgs(Deno.args);
+
 registerErrorListeners();
 
 main();
+
+startMetricsReport(mainArgs.metricsReportFrequencyInMs);

--- a/packages/apps-engine/src/server/AppManager.ts
+++ b/packages/apps-engine/src/server/AppManager.ts
@@ -271,7 +271,7 @@ export class AppManager {
                 const prl = new ProxiedApp(this, item, {
                     // Maybe we should have an "EmptyRuntime" class for this?
                     getStatus() {
-                        return AppStatus.COMPILER_ERROR_DISABLED;
+                        return Promise.resolve(AppStatus.COMPILER_ERROR_DISABLED);
                     },
                 } as unknown as DenoRuntimeSubprocessController);
 

--- a/packages/apps-engine/src/server/AppManager.ts
+++ b/packages/apps-engine/src/server/AppManager.ts
@@ -1033,6 +1033,10 @@ export class AppManager {
             result = false;
 
             await app.setStatus(status, silenceStatus);
+
+            // If some error has happened in initialization, like license or installations invalidation
+            // we need to store this on the DB regardless of what the parameter requests
+            saveToDb = true;
         }
 
         if (saveToDb) {
@@ -1111,6 +1115,10 @@ export class AppManager {
             }
 
             console.error(e);
+
+            // If some error has happened during enabling, like license or installations invalidation
+            // we need to store this on the DB regardless of what the parameter requests
+            saveToDb = true;
         }
 
         if (enable) {

--- a/packages/apps-engine/src/server/ProxiedApp.ts
+++ b/packages/apps-engine/src/server/ProxiedApp.ts
@@ -1,5 +1,5 @@
 import type { AppManager } from './AppManager';
-import type { AppStatus } from '../definition/AppStatus';
+import { AppStatus } from '../definition/AppStatus';
 import { AppsEngineException } from '../definition/exceptions';
 import type { IAppAuthorInfo, IAppInfo } from '../definition/metadata';
 import { AppMethod } from '../definition/metadata';
@@ -79,7 +79,7 @@ export class ProxiedApp {
     }
 
     public async getStatus(): Promise<AppStatus> {
-        return this.appRuntime.getStatus();
+        return this.appRuntime.getStatus().catch(() => AppStatus.UNKNOWN);
     }
 
     public async setStatus(status: AppStatus, silent?: boolean): Promise<void> {

--- a/packages/apps-engine/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/packages/apps-engine/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -9,14 +9,14 @@ import { LivenessManager } from './LivenessManager';
 import { ProcessMessenger } from './ProcessMessenger';
 import { bundleLegacyApp } from './bundler';
 import { decoder } from './codec';
-import { AppStatus } from '../../../definition/AppStatus';
+import { AppStatus, AppStatusUtils } from '../../../definition/AppStatus';
+import type { AppMethod } from '../../../definition/metadata';
 import type { AppManager } from '../../AppManager';
 import type { AppBridges } from '../../bridges';
 import type { IParseAppPackageResult } from '../../compiler';
 import { AppConsole, type ILoggerStorageEntry } from '../../logging';
 import type { AppAccessorManager, AppApiManager } from '../../managers';
 import type { AppLogStorage, IAppStorageItem } from '../../storage';
-import { AppMethod } from '../../../definition/metadata';
 
 const baseDebug = debugFactory('appsEngine:runtime:deno');
 
@@ -286,6 +286,10 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
 
             await this.sendRequest({ method: 'app:initialize' });
             await this.sendRequest({ method: 'app:setStatus', params: [this.storageItem.status] });
+
+            if (AppStatusUtils.isEnabled(this.storageItem.status)) {
+                await this.sendRequest({ method: 'app:onEnable' });
+            }
 
             this.state = 'ready';
 

--- a/packages/apps-engine/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/packages/apps-engine/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -8,7 +8,7 @@ import * as jsonrpc from 'jsonrpc-lite';
 import { LivenessManager } from './LivenessManager';
 import { ProcessMessenger } from './ProcessMessenger';
 import { bundleLegacyApp } from './bundler';
-import { decoder } from './codec';
+import { newDecoder } from './codec';
 import { AppStatus, AppStatusUtils } from '../../../definition/AppStatus';
 import type { AppMethod } from '../../../definition/metadata';
 import type { AppManager } from '../../AppManager';
@@ -383,6 +383,7 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
             console.error(`Failed to startup Deno subprocess for app ${this.getAppId()}`, err);
         });
         this.once('ready', this.onReady.bind(this));
+
         this.parseStdout(this.deno.stdout);
     }
 
@@ -604,47 +605,60 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
     }
 
     private async parseStdout(stream: Readable): Promise<void> {
-        for await (const message of decoder.decodeStream(stream)) {
-            this.debug('Received message from subprocess %o', message);
-            try {
-                // Process PONG resonse first as it is not JSON RPC
-                if (message === COMMAND_PONG) {
-                    this.emit('pong');
-                    continue;
+        try {
+            for await (const message of newDecoder().decodeStream(stream)) {
+                this.debug('Received message from subprocess %o', message);
+                try {
+                    // Process PONG resonse first as it is not JSON RPC
+                    if (message === COMMAND_PONG) {
+                        this.emit('pong');
+                        continue;
+                    }
+
+                    const JSONRPCMessage = jsonrpc.parseObject(message);
+
+                    if (Array.isArray(JSONRPCMessage)) {
+                        throw new Error('Invalid message format');
+                    }
+
+                    if (JSONRPCMessage.type === 'request' || JSONRPCMessage.type === 'notification') {
+                        this.handleIncomingMessage(JSONRPCMessage).catch((reason) =>
+                            console.error(`[${this.getAppId()}] Error executing handler`, reason, message),
+                        );
+                        continue;
+                    }
+
+                    if (JSONRPCMessage.type === 'success' || JSONRPCMessage.type === 'error') {
+                        this.handleResultMessage(JSONRPCMessage).catch((reason) =>
+                            console.error(`[${this.getAppId()}] Error executing handler`, reason, message),
+                        );
+                        continue;
+                    }
+
+                    console.error('Unrecognized message type', JSONRPCMessage);
+                } catch (e) {
+                    // SyntaxError is thrown when the message is not a valid JSON
+                    if (e instanceof SyntaxError) {
+                        console.error(`[${this.getAppId()}] Failed to parse message`);
+                        continue;
+                    }
+
+                    console.error(`[${this.getAppId()}] Error executing handler`, e, message);
                 }
-
-                const JSONRPCMessage = jsonrpc.parseObject(message);
-
-                if (Array.isArray(JSONRPCMessage)) {
-                    throw new Error('Invalid message format');
-                }
-
-                if (JSONRPCMessage.type === 'request' || JSONRPCMessage.type === 'notification') {
-                    this.handleIncomingMessage(JSONRPCMessage).catch((reason) =>
-                        console.error(`[${this.getAppId()}] Error executing handler`, reason, message),
-                    );
-                    continue;
-                }
-
-                if (JSONRPCMessage.type === 'success' || JSONRPCMessage.type === 'error') {
-                    this.handleResultMessage(JSONRPCMessage).catch((reason) => console.error(`[${this.getAppId()}] Error executing handler`, reason, message));
-                    continue;
-                }
-
-                console.error('Unrecognized message type', JSONRPCMessage);
-            } catch (e) {
-                // SyntaxError is thrown when the message is not a valid JSON
-                if (e instanceof SyntaxError) {
-                    console.error(`[${this.getAppId()}] Failed to parse message`);
-                    continue;
-                }
-
-                console.error(`[${this.getAppId()}] Error executing handler`, e, message);
             }
+        } catch (e) {
+            console.error(`[${this.getAppId()}]`, e);
+            this.emit('error', new Error('DECODE_ERROR'));
         }
     }
 
     private async parseError(chunk: Buffer): Promise<void> {
-        console.error('Subprocess stderr', chunk.toString());
+        try {
+            const data = JSON.parse(chunk.toString());
+
+            this.debug('Metrics received from subprocess (via stderr): %o', data);
+        } catch (e) {
+            console.error('Subprocess stderr', chunk.toString());
+        }
     }
 }

--- a/packages/apps-engine/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/packages/apps-engine/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -88,6 +88,11 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
 
     private state: 'uninitialized' | 'ready' | 'invalid' | 'restarting' | 'unknown' | 'stopped';
 
+    /**
+     * Incremental id that keeps track of how many times we've spawned a process for this app
+     */
+    private spawnId = 0;
+
     private readonly debug: debug.Debugger;
 
     private readonly options = {
@@ -149,6 +154,8 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
                 denoWrapperPath,
                 '--subprocess',
                 this.appPackage.info.id,
+                '--spawnId',
+                String(this.spawnId++),
             ];
 
             // If the app doesn't request any permissions, it gets the default set of permissions, which includes "networking"
@@ -295,7 +302,8 @@ export class DenoRuntimeSubprocessController extends EventEmitter {
 
             logger.info('Successfully restarted app subprocess');
         } catch (e) {
-            logger.error("Failed to restart app's subprocess", { error: e });
+            logger.error("Failed to restart app's subprocess", { error: e.message || e });
+            throw e;
         } finally {
             await this.logStorage.storeEntries(AppConsole.toStorageEntry(this.getAppId(), logger));
         }

--- a/packages/apps-engine/src/server/runtime/deno/LivenessManager.ts
+++ b/packages/apps-engine/src/server/runtime/deno/LivenessManager.ts
@@ -7,10 +7,11 @@ import type { ProcessMessenger } from './ProcessMessenger';
 const COMMAND_PING = '_zPING';
 
 const defaultOptions: LivenessManager['options'] = {
-    pingRequestTimeout: 10000,
+    pingRequestTimeout: 1000,
     pingFrequencyInMS: 10000,
     consecutiveTimeoutLimit: 4,
     maxRestarts: Infinity,
+    restartAttemptDelayInMS: 1000,
 };
 
 /**
@@ -36,6 +37,9 @@ export class LivenessManager {
 
         // Limit of times we can try to restart a process
         maxRestarts: number;
+
+        // Time to delay the next restart attempt after a failed one
+        restartAttemptDelayInMS: number;
     };
 
     private subprocess: ChildProcess;
@@ -178,7 +182,7 @@ export class LivenessManager {
         this.restartProcess(reason);
     }
 
-    private restartProcess(reason: string) {
+    private async restartProcess(reason: string) {
         if (this.restartCount >= this.options.maxRestarts) {
             this.debug('Limit of restarts reached (%d). Aborting restart...', this.options.maxRestarts);
             this.controller.stopApp();
@@ -194,6 +198,14 @@ export class LivenessManager {
             pid: this.subprocess.pid,
         });
 
-        this.controller.restartApp();
+        try {
+            await this.controller.restartApp();
+        } catch (e) {
+            this.debug('Restart attempt failed. Retrying in %dms', this.options.restartAttemptDelayInMS);
+            setTimeout(() => this.restartProcess('Failed restart attempt'), this.options.restartAttemptDelayInMS);
+        }
+
+        this.pingTimeoutConsecutiveCount = 0;
+        this.restartCount++;
     }
 }

--- a/packages/apps-engine/src/server/runtime/deno/ProcessMessenger.ts
+++ b/packages/apps-engine/src/server/runtime/deno/ProcessMessenger.ts
@@ -2,10 +2,12 @@ import { ChildProcess } from 'child_process';
 
 import type { JsonRpc } from 'jsonrpc-lite';
 
-import { encoder } from './codec';
+import { type Encoder, newEncoder } from './codec';
 
 export class ProcessMessenger {
-    private deno: ChildProcess;
+    private deno: ChildProcess | undefined;
+
+    private encoder: Encoder | undefined;
 
     private _sendStrategy: (message: JsonRpc) => void;
 
@@ -25,6 +27,7 @@ export class ProcessMessenger {
 
     public clearReceiver() {
         delete this.deno;
+        delete this.encoder;
 
         this.switchStrategy();
     }
@@ -32,6 +35,9 @@ export class ProcessMessenger {
     private switchStrategy() {
         if (this.deno instanceof ChildProcess) {
             this._sendStrategy = this.strategySend.bind(this);
+
+            // Get a clean encoder
+            this.encoder = newEncoder();
         } else {
             this._sendStrategy = this.strategyError.bind(this);
         }
@@ -43,6 +49,6 @@ export class ProcessMessenger {
 
     private strategySend(message: JsonRpc) {
         this.debug('Sending message to subprocess %o', message);
-        this.deno.stdin.write(encoder.encode(message));
+        this.deno.stdin.write(this.encoder.encode(message));
     }
 }

--- a/packages/apps-engine/src/server/runtime/deno/codec.ts
+++ b/packages/apps-engine/src/server/runtime/deno/codec.ts
@@ -1,4 +1,4 @@
-import { Decoder, Encoder, ExtensionCodec } from '@msgpack/msgpack';
+import { Decoder as _Decoder, Encoder as _Encoder, ExtensionCodec } from '@msgpack/msgpack';
 
 const extensionCodec = new ExtensionCodec();
 
@@ -10,6 +10,7 @@ extensionCodec.register({
             return new Uint8Array([0]);
         }
     },
+
     decode: (_data: Uint8Array) => undefined,
 });
 
@@ -21,9 +22,24 @@ extensionCodec.register({
             return new Uint8Array(object.buffer, object.byteOffset, object.byteLength);
         }
     },
+
     // msgpack will reuse the Uint8Array instance, so WE NEED to copy it instead of simply creating a view
     decode: (data: Uint8Array) => Buffer.from(data),
 });
 
-export const encoder = new Encoder({ extensionCodec });
-export const decoder = new Decoder({ extensionCodec });
+/**
+ * The Encoder and Decoder classes perform "stateful" operations, i.e. they read from a
+ * stream, store the data locally and decode it from its buffer.
+ *
+ * In practice, this affects the decoder when there is decode error. After an error, the decoder
+ * keeps the malformed data in its buffer, and even if we try to decode from another source (e.g. different stream)
+ * it will fail again as there's still data in the buffer.
+ *
+ * For that reason, we can't have a singleton instance of Encoder and Decoder, but rather one
+ * instance for each time we create a new subprocess
+ */
+export const newEncoder = () => new _Encoder({ extensionCodec });
+export const newDecoder = () => new _Decoder({ extensionCodec });
+
+export type Encoder = _Encoder;
+export type Decoder = _Decoder;

--- a/packages/core-typings/src/IMessage/IMessage.ts
+++ b/packages/core-typings/src/IMessage/IMessage.ts
@@ -200,7 +200,7 @@ export interface IMessage extends IRocketChatRecord {
 
 	private?: boolean;
 	/* @deprecated */
-	bot?: boolean;
+	bot?: Record<string, any>;
 	sentByEmail?: boolean;
 	webRtcCallEndTs?: Date;
 	role?: string;

--- a/packages/model-typings/src/models/IUsersModel.ts
+++ b/packages/model-typings/src/models/IUsersModel.ts
@@ -263,7 +263,11 @@ export interface IUsersModel extends IBaseModel<IUser> {
 	findOnlineAgents(agentId?: string): FindCursor<ILivechatAgent>;
 	countOnlineAgents(agentId: string): Promise<number>;
 	findOneBotAgent(): Promise<ILivechatAgent | null>;
-	findOneOnlineAgentById(agentId: string, isLivechatEnabledWhenAgentIdle?: boolean): Promise<ILivechatAgent | null>;
+	findOneOnlineAgentById(
+		agentId: string,
+		isLivechatEnabledWhenAgentIdle?: boolean,
+		options?: FindOptions<IUser>,
+	): Promise<ILivechatAgent | null>;
 	findAgents(): FindCursor<ILivechatAgent>;
 	countAgents(): Promise<number>;
 	getNextAgent(ignoreAgentId?: string, extraQuery?: Filter<IUser>): Promise<{ agentId: string; username: string } | null>;

--- a/packages/release-action/src/getMetadata.ts
+++ b/packages/release-action/src/getMetadata.ts
@@ -1,8 +1,6 @@
 import { readFile } from 'fs/promises';
 import path from 'path';
 
-import { getExecOutput } from '@actions/exec';
-
 import { readPackageJson } from './utils';
 
 export async function getMongoVersion(cwd: string) {
@@ -27,14 +25,11 @@ export async function getNodeNpmVersions(cwd: string): Promise<{ node: string; y
 	return packageJson.engines;
 }
 
-export async function getAppsEngineVersion() {
+export async function getAppsEngineVersion(cwd: string) {
 	try {
-		const result = await getExecOutput('yarn why @rocket.chat/apps-engine --json');
+		const result = await readPackageJson(path.join(cwd, 'packages/apps-engine'));
 
-		const match = result.stdout.match(/"@rocket\.chat\/meteor@workspace:apps\/meteor".*"@rocket\.chat\/apps\-engine@[^#]+#npm:([^"]+)"/);
-		if (match) {
-			return match[1];
-		}
+		return result.version ?? 'Not Available';
 	} catch (e) {
 		console.error(e);
 	}

--- a/packages/release-action/src/utils.ts
+++ b/packages/release-action/src/utils.ts
@@ -109,7 +109,7 @@ Bump ${pkgName} version.
 
 export async function getEngineVersionsMd(cwd: string) {
 	const { node } = await getNodeNpmVersions(cwd);
-	const appsEngine = await getAppsEngineVersion();
+	const appsEngine = await getAppsEngineVersion(cwd);
 	const mongo = await getMongoVersion(cwd);
 
 	return `### Engine versions

--- a/yarn.lock
+++ b/yarn.lock
@@ -8757,7 +8757,7 @@ __metadata:
     storybook-dark-mode: "npm:^4.0.2"
     typescript: "npm:~5.6.3"
   peerDependencies:
-    "@rocket.chat/apps-engine": 1.48.0-rc.0
+    "@rocket.chat/apps-engine": 1.48.0
     "@rocket.chat/eslint-config": 0.7.0
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
@@ -8765,10 +8765,10 @@ __metadata:
     "@rocket.chat/icons": "*"
     "@rocket.chat/prettier-config": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 9.0.0-rc.3
-    "@rocket.chat/ui-contexts": 13.0.0-rc.3
+    "@rocket.chat/ui-avatar": 9.0.0
+    "@rocket.chat/ui-contexts": 13.0.0
     "@rocket.chat/ui-kit": 0.37.0
-    "@rocket.chat/ui-video-conf": 13.0.0-rc.3
+    "@rocket.chat/ui-video-conf": 13.0.0
     "@tanstack/react-query": "*"
     react: ~17.0.2
     react-dom: "*"
@@ -8853,8 +8853,8 @@ __metadata:
     "@rocket.chat/fuselage-tokens": "*"
     "@rocket.chat/message-parser": 0.31.31
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-client": 13.0.0-rc.3
-    "@rocket.chat/ui-contexts": 13.0.0-rc.3
+    "@rocket.chat/ui-client": 13.0.0
+    "@rocket.chat/ui-contexts": 13.0.0
     katex: "*"
     react: "*"
   languageName: unknown
@@ -10089,7 +10089,7 @@ __metadata:
     typescript: "npm:~5.6.3"
   peerDependencies:
     "@rocket.chat/fuselage": "*"
-    "@rocket.chat/ui-contexts": 13.0.0-rc.3
+    "@rocket.chat/ui-contexts": 13.0.0
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -10139,8 +10139,8 @@ __metadata:
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-avatar": 9.0.0-rc.3
-    "@rocket.chat/ui-contexts": 13.0.0-rc.3
+    "@rocket.chat/ui-avatar": 9.0.0
+    "@rocket.chat/ui-contexts": 13.0.0
     react: "*"
     react-i18next: "*"
   languageName: unknown
@@ -10310,8 +10310,8 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 9.0.0-rc.3
-    "@rocket.chat/ui-contexts": 13.0.0-rc.3
+    "@rocket.chat/ui-avatar": 9.0.0
+    "@rocket.chat/ui-contexts": 13.0.0
     react: ~17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -10367,9 +10367,9 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 9.0.0-rc.3
-    "@rocket.chat/ui-client": 13.0.0-rc.3
-    "@rocket.chat/ui-contexts": 13.0.0-rc.3
+    "@rocket.chat/ui-avatar": 9.0.0
+    "@rocket.chat/ui-client": 13.0.0
+    "@rocket.chat/ui-contexts": 13.0.0
     react: ~17.0.2
     react-aria: ~3.23.1
     react-dom: ^17.0.2
@@ -10457,7 +10457,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.2.2
-    "@rocket.chat/ui-contexts": 13.0.0-rc.3
+    "@rocket.chat/ui-contexts": 13.0.0
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION


<!-- release-notes-start -->
<!-- This content is automatically generated. Changing this will not reflect on the final release log -->

_You can see below a preview of the release change log:_

# 7.1.1

### Engine versions

- Node: `20.18.0`
- MongoDB: `5.0, 6.0, 7.0`
- Apps-Engine: `1.48.1`

### Patch Changes

*   ([#34876](https://github.com/RocketChat/Rocket.Chat/pull/34876) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixes an error where the engine would not retry a subprocess restart if the last attempt failed

*   Bump @rocket.chat/meteor version.

*   ([#34874](https://github.com/RocketChat/Rocket.Chat/pull/34874) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixes the subprocess restarting routine failing to correctly restart apps in some cases

*   ([#34116](https://github.com/RocketChat/Rocket.Chat/pull/34116) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixed an issue that caused clients to not properly receive certain server notifications right after login

*   ([#34879](https://github.com/RocketChat/Rocket.Chat/pull/34879) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixes an issue that prevented the apps-engine from reestablishing communications with subprocesses in some cases

*   ([#34876](https://github.com/RocketChat/Rocket.Chat/pull/34876) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixes error propagation when trying to get the status of apps in some cases

*   ([#34492](https://github.com/RocketChat/Rocket.Chat/pull/34492) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixes livechat conversations not being assigned to the contact manager even when the "Assign new conversations to the contact manager" setting is enabled

*   ([#34876](https://github.com/RocketChat/Rocket.Chat/pull/34876) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixes wrong data being reported to total failed apps metrics and statistics

*   ([#34219](https://github.com/RocketChat/Rocket.Chat/pull/34219) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixed an issue that added potencially infinite callbacks to the same event, degrading performance over time.

*   ([#34117](https://github.com/RocketChat/Rocket.Chat/pull/34117) by [@dionisio-bot](https://github.com/dionisio-bot)) fixed an issue that caused the conference call ringer to fail to accept calls if the user logged out and in again

*   <details><summary>Updated dependencies [c28e139a25aadc55149e8ee55c8881aa8f87318c, 409e459542e152ec01f730af99ed74965ebd89c9, ce886fce09c435c12a073fa9611d2471d2dbe956, c28e139a25aadc55149e8ee55c8881aa8f87318c, eb4e0f162ce3676ffbd395edeb3c96df245e8707, c28e139a25aadc55149e8ee55c8881aa8f87318c]:</summary>

    *   @rocket.chat/fuselage-ui-kit@13.0.1
    *   @rocket.chat/instance-status@0.1.11
    *   @rocket.chat/ui-theming@0.4.1
    *   @rocket.chat/model-typings@1.1.1
    *   @rocket.chat/ui-video-conf@13.0.1
    *   @rocket.chat/core-typings@7.1.1
    *   @rocket.chat/rest-typings@7.1.1
    *   @rocket.chat/apps-engine@1.48.1
    *   @rocket.chat/ui-composer@0.4.1
    *   @rocket.chat/ui-contexts@13.0.1
    *   @rocket.chat/gazzodown@13.0.1
    *   @rocket.chat/ui-avatar@9.0.1
    *   @rocket.chat/ui-client@13.0.1
    *   @rocket.chat/ui-voip@3.0.1
    *   @rocket.chat/i18n@1.1.1
    *   @rocket.chat/models@1.0.2
    *   @rocket.chat/sha256@1.0.11
    *   @rocket.chat/omnichannel-services@0.3.8
    *   @rocket.chat/apps@0.2.2
    *   @rocket.chat/license@1.0.2
    *   @rocket.chat/pdf-worker@0.2.8
    *   @rocket.chat/presence@0.2.11
    *   @rocket.chat/api-client@0.2.11
    *   @rocket.chat/core-services@0.7.3
    *   @rocket.chat/cron@0.1.11
    *   @rocket.chat/freeswitch@1.0.2
    *   @rocket.chat/web-ui-registration@13.0.1
    *   @rocket.chat/server-cloud-communication@0.0.2
    *   @rocket.chat/network-broker@0.1.3

    </details>

<!-- release-notes-end -->