### PR TITLE
fix: fix sorting of usernames in the member-list

### DIFF
--- a/apps/meteor/app/api/server/v1/channels.ts
+++ b/apps/meteor/app/api/server/v1/channels.ts
@@ -1082,6 +1082,8 @@ API.v1.addRoute(
 
 			const [members, total] = await Promise.all([cursor.toArray(), totalCount]);
 
+			members.sort((a, b) => (a.username ?? "").localeCompare(b.username ?? ""));
+
 			return API.v1.success({
 				members,
 				count: members.length,

--- a/apps/meteor/app/api/server/v1/groups.ts
+++ b/apps/meteor/app/api/server/v1/groups.ts
@@ -733,6 +733,7 @@ API.v1.addRoute(
 			});
 
 			const [members, total] = await Promise.all([cursor.toArray(), totalCount]);
+			members.sort((a, b) => (a.username ?? "").localeCompare(b.username ?? ""));
 
 			return API.v1.success({
 				members,

--- a/apps/meteor/app/api/server/v1/im.ts
+++ b/apps/meteor/app/api/server/v1/im.ts
@@ -359,6 +359,7 @@ API.v1.addRoute(
 			const { cursor, totalCount } = Users.findPaginatedByActiveUsersExcept(filter, [], options, searchFields, [extraQuery]);
 
 			const [members, total] = await Promise.all([cursor.toArray(), totalCount]);
+			members.sort((a, b) => (a.username ?? "").localeCompare(b.username ?? ""));
 
 			return API.v1.success({
 				members,


### PR DESCRIPTION
Hey I fixed,
1. the sorting problem of the usernames in the member-list  for all room types \
2. by adding a sorting function at all three endpoint **channels.members, groups.members, im.members** before returning the member list.\
3. 
![241209_12h22m42s_screenshot](https://github.com/user-attachments/assets/bd46dba9-1532-4146-bd77-f12eedc3e09f)

