### PR TITLE
fix: keyboard shortcuts with alt keys in message composer

### DIFF
--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -217,31 +217,35 @@ const MessageBox = ({
 			}
 
 			case 'ArrowUp': {
-				if (input.selectionEnd === 0) {
+				if (event.altKey) {
 					event.preventDefault();
 					event.stopPropagation();
-
-					onNavigateToPreviousMessage?.();
-
-					if (event.altKey) {
-						input.setSelectionRange(0, 0);
-					}
+					input.setSelectionRange(0, 0);
+					return;
 				}
 
+				if (input.selectionEnd === 0) {
+					event.preventDefault(); 
+					event.stopPropagation();
+					onNavigateToPreviousMessage?.();
+				}
 				return;
 			}
 
 			case 'ArrowDown': {
-				if (input.selectionEnd === input.value.length) {
+				if (event.altKey) {
 					event.preventDefault();
 					event.stopPropagation();
-
-					onNavigateToNextMessage?.();
-
-					if (event.altKey) {
-						input.setSelectionRange(input.value.length, input.value.length);
-					}
+					input.setSelectionRange(input.value.length, input.value.length);
+					return;
 				}
+
+				if (input.selectionEnd === input.value.length) {
+					event.preventDefault();
+					event.stopPropagation(); 
+					onNavigateToNextMessage?.();
+				}
+				return;
 			}
 		}
 


### PR DESCRIPTION

## Proposed changes
Fixed keyboard shortcuts behavior in message composer:
- Alt + Up Arrow now correctly moves cursor to start
- Alt + Down Arrow now correctly moves cursor to end
- Separated navigation logic from Alt key handling

## Issue(s)
Fixes #[issue_number]

## Steps to test or reproduce
1. Open any chat room
2. Click message composer
3. Test following shortcuts:
   - Press Alt + Up Arrow -> Cursor should move to start
   - Press Alt + Down Arrow -> Cursor should move to end
   - Press Up Arrow without Alt at start -> Should navigate to previous message
   - Press Down Arrow without Alt at end -> Should navigate to next message

## Technical Implementation
Changed keyboard event handling in MessageBox.tsx to properly manage event propagation and cursor positioning.
