### PR TITLE
fix: remove redundant index specs in UserDataFile inherited from BaseUpload

### DIFF
--- a/apps/meteor/server/models/raw/Avatars.ts
+++ b/apps/meteor/server/models/raw/Avatars.ts
@@ -1,12 +1,16 @@
 import type { IAvatar, RocketChatRecordDeleted, IUser } from '@rocket.chat/core-typings';
 import type { IAvatarsModel } from '@rocket.chat/model-typings';
-import type { Collection, Db, FindOptions } from 'mongodb';
+import type { Collection, Db, IndexDescription, FindOptions } from 'mongodb';
 
 import { BaseUploadModelRaw } from './BaseUploadModel';
 
 export class AvatarsRaw extends BaseUploadModelRaw implements IAvatarsModel {
 	constructor(db: Db, trash?: Collection<RocketChatRecordDeleted<IAvatar>>) {
 		super(db, 'avatars', trash);
+	}
+
+	protected modelIndexes(): IndexDescription[] {
+		return [...super.modelIndexes(), { key: { userId: 1 }, sparse: true }];
 	}
 
 	findOneByUserId(userId: IUser['_id'], options?: FindOptions<IAvatar>) {

--- a/apps/meteor/server/models/raw/BaseUploadModel.ts
+++ b/apps/meteor/server/models/raw/BaseUploadModel.ts
@@ -19,7 +19,6 @@ type T = IUpload;
 export abstract class BaseUploadModelRaw extends BaseRaw<T> implements IBaseUploadsModel<T> {
 	protected modelIndexes(): IndexDescription[] {
 		return [
-			{ key: { userId: 1 }, sparse: true },
 			{ key: { name: 1 }, sparse: true },
 			{ key: { rid: 1 }, sparse: true },
 			{ key: { expiresAt: 1 }, sparse: true },


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

As per [ARCH-1393](https://rocketchat.atlassian.net/browse/ARCH-1393), this PR resolves the [issue](https://github.com/RocketChat/Rocket.Chat/issues/34132) where a duplicate index key error was triggered on application startup starting with Rocket.Chat 7.1.0.

After investigation, it was identified that the userId index was defined twice on the `rocketchat_user_data_files` collection:
- Initially defined in the `UserDataFiles` model
- Since version 7.1.0 within the `BaseUpload` model, which `UserDataFiles` extends - https://github.com/RocketChat/Rocket.Chat/pull/33214

This duplication caused index creation conflicts when the application started.

To fix that, we removed the `userId` index specification from `BaseUpload`, ensuring that it is only defined in the `UserDataFiles` model.

## Issue(s)

- [ARCH-1393](https://rocketchat.atlassian.net/browse/ARCH-1393)
- #34132 

## Steps to test or reproduce

## Further comments

[ARCH-1393]: https://rocketchat.atlassian.net/browse/ARCH-1393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARCH-1393]: https://rocketchat.atlassian.net/browse/ARCH-1393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ