### PR TITLE
fix: `featuresPreview` wrong DB structure

### DIFF
--- a/.changeset/violet-pets-attend.md
+++ b/.changeset/violet-pets-attend.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/ui-client': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixed the data structure of the features preview

--- a/apps/meteor/client/views/account/featurePreview/AccountFeaturePreviewPage.tsx
+++ b/apps/meteor/client/views/account/featurePreview/AccountFeaturePreviewPage.tsx
@@ -56,8 +56,9 @@ const AccountFeaturePreviewPage = () => {
 	const { featuresPreview } = watch();
 
 	const handleSave = async () => {
+		const featuresToBeSaved = featuresPreview.map((feature) => ({ name: feature.name, value: feature.value }));
 		try {
-			await setUserPreferences({ data: { featuresPreview } });
+			await setUserPreferences({ data: { featuresPreview: featuresToBeSaved } });
 			dispatchToastMessage({ type: 'success', message: t('Preferences_saved') });
 		} catch (error) {
 			dispatchToastMessage({ type: 'error', message: error });

--- a/packages/ui-client/src/hooks/useFeaturePreviewList.ts
+++ b/packages/ui-client/src/hooks/useFeaturePreviewList.ts
@@ -97,14 +97,20 @@ export const parseSetting = (setting?: FeaturePreviewProps[] | string) => {
 	return setting;
 };
 
-export const useFeaturePreviewList = (featuresList: Pick<FeaturePreviewProps, 'name' | 'value'>[]) => {
+export const useFeaturePreviewList = (featuresList: FeaturePreviewProps[]) => {
 	const unseenFeatures = enabledDefaultFeatures.filter(
 		(defaultFeature) => !featuresList?.find((feature) => feature.name === defaultFeature.name),
 	).length;
 
 	const mergedFeatures = enabledDefaultFeatures.map((defaultFeature) => {
-		const features = featuresList?.find((feature) => feature.name === defaultFeature.name);
-		return { ...defaultFeature, ...features };
+		const feature = featuresList?.find((feature) => feature.name === defaultFeature.name);
+		// overwrite enableQuery and disabled with default value to avoid a migration to remove this from the DB
+		// payload on save now only have `name` and `value`
+		if (feature) {
+			feature.enableQuery = defaultFeature.enableQuery;
+			feature.disabled = defaultFeature.disabled;
+		}
+		return { ...defaultFeature, ...feature };
 	});
 
 	return { unseenFeatures, features: mergedFeatures };


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

- `AccountFeaturePreviewPage.tsx` was sending the whole feature on save payload - it should be only `name` and `value`
- it's necessary then to overwrite these values from DB with the default values so it can be changed without a migration

This fix is needed to allow changing the rules of `enableQuery` that is currently depending on the value of a feature that is going to be official (Enhanced navigation)

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
