### PR TITLE
refactor: remove deps from FederationRoomEvents model

### DIFF
--- a/apps/meteor/server/models/raw/FederationRoomEvents.ts
+++ b/apps/meteor/server/models/raw/FederationRoomEvents.ts
@@ -4,9 +4,6 @@ import type { IFederationRoomEventsModel } from '@rocket.chat/model-typings';
 import type { Db, DeleteResult, IndexDescription } from 'mongodb';
 
 import { FederationEventsModel } from './FederationEvents';
-import { contextDefinitions } from '../../../app/federation/server/lib/context';
-
-const { type, contextQuery } = contextDefinitions.ROOM;
 
 export class FederationRoomEvents extends FederationEventsModel implements IFederationRoomEventsModel {
 	constructor(db: Db) {
@@ -19,11 +16,11 @@ export class FederationRoomEvents extends FederationEventsModel implements IFede
 
 	// @ts-expect-error - TODO: Bad extends
 	async createGenesisEvent(origin: string, room: IRoom): Promise<Omit<IFederationEvent, '_updatedAt'>> {
-		return super.createGenesisEvent(origin, contextQuery(room._id), { contextType: type, room });
+		return super.createGenesisEvent(origin, { roomId: room._id }, { contextType: 'room', room });
 	}
 
 	async createDeleteRoomEvent(origin: string, roomId: string): Promise<Omit<IFederationEvent, '_updatedAt'>> {
-		return super.createEvent(origin, contextQuery(roomId), eventTypes.ROOM_DELETE, { roomId });
+		return super.createEvent(origin, { roomId }, eventTypes.ROOM_DELETE, { roomId });
 	}
 
 	async createAddUserEvent(
@@ -33,7 +30,7 @@ export class FederationRoomEvents extends FederationEventsModel implements IFede
 		subscription: ISubscription,
 		domainsAfterAdd: string[],
 	): Promise<Omit<IFederationEvent, '_updatedAt'>> {
-		return super.createEvent(origin, contextQuery(roomId), eventTypes.ROOM_ADD_USER, {
+		return super.createEvent(origin, { roomId }, eventTypes.ROOM_ADD_USER, {
 			roomId,
 			user,
 			subscription,
@@ -47,7 +44,7 @@ export class FederationRoomEvents extends FederationEventsModel implements IFede
 		user: IUser,
 		domainsAfterRemoval: string[],
 	): Promise<Omit<IFederationEvent, '_updatedAt'>> {
-		return super.createEvent(origin, contextQuery(roomId), eventTypes.ROOM_REMOVE_USER, {
+		return super.createEvent(origin, { roomId }, eventTypes.ROOM_REMOVE_USER, {
 			roomId,
 			user,
 			domainsAfterRemoval,
@@ -60,7 +57,7 @@ export class FederationRoomEvents extends FederationEventsModel implements IFede
 		user: IUser,
 		domainsAfterLeave: string[],
 	): Promise<Omit<IFederationEvent, '_updatedAt'>> {
-		return super.createEvent(origin, contextQuery(roomId), eventTypes.ROOM_USER_LEFT, {
+		return super.createEvent(origin, { roomId }, eventTypes.ROOM_USER_LEFT, {
 			roomId,
 			user,
 			domainsAfterLeave,
@@ -68,7 +65,7 @@ export class FederationRoomEvents extends FederationEventsModel implements IFede
 	}
 
 	async createMessageEvent(origin: string, roomId: string, message: string): Promise<Omit<IFederationEvent, '_updatedAt'>> {
-		return super.createEvent(origin, contextQuery(roomId), eventTypes.ROOM_MESSAGE, { message });
+		return super.createEvent(origin, { roomId }, eventTypes.ROOM_MESSAGE, { message });
 	}
 
 	async createEditMessageEvent(
@@ -82,13 +79,13 @@ export class FederationRoomEvents extends FederationEventsModel implements IFede
 			federation: originalMessage.federation,
 		};
 
-		return super.createEvent(origin, contextQuery(roomId), eventTypes.ROOM_EDIT_MESSAGE, {
+		return super.createEvent(origin, { roomId }, eventTypes.ROOM_EDIT_MESSAGE, {
 			message,
 		});
 	}
 
 	async createDeleteMessageEvent(origin: string, roomId: string, messageId: string): Promise<Omit<IFederationEvent, '_updatedAt'>> {
-		return super.createEvent(origin, contextQuery(roomId), eventTypes.ROOM_DELETE_MESSAGE, {
+		return super.createEvent(origin, { roomId }, eventTypes.ROOM_DELETE_MESSAGE, {
 			roomId,
 			messageId,
 		});
@@ -101,7 +98,7 @@ export class FederationRoomEvents extends FederationEventsModel implements IFede
 		username: string,
 		reaction: string,
 	): Promise<Omit<IFederationEvent, '_updatedAt'>> {
-		return super.createEvent(origin, contextQuery(roomId), eventTypes.ROOM_SET_MESSAGE_REACTION, {
+		return super.createEvent(origin, { roomId }, eventTypes.ROOM_SET_MESSAGE_REACTION, {
 			roomId,
 			messageId,
 			username,
@@ -116,7 +113,7 @@ export class FederationRoomEvents extends FederationEventsModel implements IFede
 		username: string,
 		reaction: string,
 	): Promise<Omit<IFederationEvent, '_updatedAt'>> {
-		return super.createEvent(origin, contextQuery(roomId), eventTypes.ROOM_UNSET_MESSAGE_REACTION, {
+		return super.createEvent(origin, { roomId }, eventTypes.ROOM_UNSET_MESSAGE_REACTION, {
 			roomId,
 			messageId,
 			username,
@@ -125,20 +122,20 @@ export class FederationRoomEvents extends FederationEventsModel implements IFede
 	}
 
 	async createMuteUserEvent(origin: string, roomId: string, user: IUser): Promise<Omit<IFederationEvent, '_updatedAt'>> {
-		return super.createEvent(origin, contextQuery(roomId), eventTypes.ROOM_MUTE_USER, {
+		return super.createEvent(origin, { roomId }, eventTypes.ROOM_MUTE_USER, {
 			roomId,
 			user,
 		});
 	}
 
 	async createUnmuteUserEvent(origin: string, roomId: string, user: IUser): Promise<Omit<IFederationEvent, '_updatedAt'>> {
-		return super.createEvent(origin, contextQuery(roomId), eventTypes.ROOM_UNMUTE_USER, {
+		return super.createEvent(origin, { roomId }, eventTypes.ROOM_UNMUTE_USER, {
 			roomId,
 			user,
 		});
 	}
 
 	async removeRoomEvents(roomId: string): Promise<DeleteResult> {
-		return super.removeContextEvents(contextQuery(roomId));
+		return super.removeContextEvents({ roomId });
 	}
 }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Use hardcoded queries instead of relying on `contextDefinitions` which is an external dependency since they're known from the context of the rooms model. This is also from a deprecated implementation of federation, so this code should be removed anytime soon.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Extracted from https://github.com/RocketChat/Rocket.Chat/pull/34154
[ARCH-1356](https://rocketchat.atlassian.net/browse/ARCH-1356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[ARCH-1356]: https://rocketchat.atlassian.net/browse/ARCH-1356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ