### PR TITLE
feat: add configurable retry with exponential backoff to HTTP requests

### DIFF
--- a/packages/apps-engine/src/definition/accessors/IHttp.ts
+++ b/packages/apps-engine/src/definition/accessors/IHttp.ts
@@ -40,6 +40,10 @@ export interface IHttpRequest {
     };
     timeout?: number;
     /**
+     * Retry configuration for the request
+     */
+    retry?: IHttpRetryConfig;
+    /**
      * The encoding to be used on response data.
      *
      * If null, the body is returned as a Buffer. Anything else (including the default value of undefined)
@@ -199,4 +203,16 @@ export enum HttpStatusCode {
     SERVICE_UNAVAILABLE = 503,
     GATEWAY_TIMEOUT = 504,
     HTTP_VERSION_NOT_SUPPORTED = 505,
+}
+
+/**
+ * Configuration options for HTTP request retry behavior
+ */
+export interface IHttpRetryConfig {
+    /** Whether retry functionality is enabled */
+    enabled?: boolean;
+    /** Maximum number of retry attempts */
+    maxAttempts?: number;
+    /** Initial delay in milliseconds before first retry */
+    initialDelay?: number;
 }

--- a/packages/apps-engine/src/server/accessors/Http.ts
+++ b/packages/apps-engine/src/server/accessors/Http.ts
@@ -1,9 +1,15 @@
-import type { IHttp, IHttpExtend, IHttpRequest, IHttpResponse } from '../../definition/accessors';
+import type { IHttp, IHttpExtend, IHttpRequest, IHttpResponse, IHttpRetryConfig } from '../../definition/accessors';
 import { RequestMethod } from '../../definition/accessors';
 import type { AppBridges } from '../bridges/AppBridges';
 import type { AppAccessorManager } from '../managers/AppAccessorManager';
 
 export class Http implements IHttp {
+    private static readonly DEFAULT_RETRY_CONFIG: IHttpRetryConfig = {
+        enabled: false,
+        maxAttempts: 3,
+        initialDelay: 1000,  // 1 second
+    };
+
     constructor(
         private readonly accessManager: AppAccessorManager,
         private readonly bridges: AppBridges,
@@ -31,47 +37,76 @@ export class Http implements IHttp {
         return this._processHandler(url, RequestMethod.PATCH, options);
     }
 
-    private async _processHandler(url: string, method: RequestMethod, options?: IHttpRequest): Promise<IHttpResponse> {
-        let request = options || {};
+    private async _processHandler(
+        url: string,
+        method: RequestMethod,
+        options?: IHttpRequest
+    ): Promise<IHttpResponse> {
+        const retryConfig = {
+            ...Http.DEFAULT_RETRY_CONFIG,
+            ...options?.retry
+        };
 
-        if (typeof request.headers === 'undefined') {
-            request.headers = {};
-        }
+        let attempt = 0;
+        let lastError: any;
 
-        this.httpExtender.getDefaultHeaders().forEach((value: string, key: string) => {
-            if (typeof request.headers[key] !== 'string') {
-                request.headers[key] = value;
+        while (attempt < (retryConfig.maxAttempts)) {
+            try {
+                let request = options || {};
+
+                if (typeof request.headers === 'undefined') {
+                    request.headers = {};
+                }
+
+                this.httpExtender.getDefaultHeaders().forEach((value: string, key: string) => {
+                    if (typeof request.headers[key] !== 'string') {
+                        request.headers[key] = value;
+                    }
+                });
+
+                if (typeof request.params === 'undefined') {
+                    request.params = {};
+                }
+
+                this.httpExtender.getDefaultParams().forEach((value: string, key: string) => {
+                    if (typeof request.params[key] !== 'string') {
+                        request.params[key] = value;
+                    }
+                });
+
+                const reader = this.accessManager.getReader(this.appId);
+                const persis = this.accessManager.getPersistence(this.appId);
+
+                for (const handler of this.httpExtender.getPreRequestHandlers()) {
+                    request = await handler.executePreHttpRequest(url, request, reader, persis);
+                }
+
+                let response = await this.bridges.getHttpBridge().doCall({
+                    appId: this.appId,
+                    method,
+                    url,
+                    request,
+                });
+
+                for (const handler of this.httpExtender.getPreResponseHandlers()) {
+                    response = await handler.executePreHttpResponse(response, reader, persis);
+                }
+
+                return response;
+
+            } catch (error) {
+                lastError = error;
+                if (!retryConfig.enabled || attempt === (retryConfig.maxAttempts || 3) - 1) {
+                    throw error;
+                }
+
+                // Exponential backoff
+                const delay = retryConfig.initialDelay * Math.pow(2, attempt);
+                await new Promise(resolve => setTimeout(resolve, delay));
+                attempt++;
             }
-        });
-
-        if (typeof request.params === 'undefined') {
-            request.params = {};
         }
 
-        this.httpExtender.getDefaultParams().forEach((value: string, key: string) => {
-            if (typeof request.params[key] !== 'string') {
-                request.params[key] = value;
-            }
-        });
-
-        const reader = this.accessManager.getReader(this.appId);
-        const persis = this.accessManager.getPersistence(this.appId);
-
-        for (const handler of this.httpExtender.getPreRequestHandlers()) {
-            request = await handler.executePreHttpRequest(url, request, reader, persis);
-        }
-
-        let response = await this.bridges.getHttpBridge().doCall({
-            appId: this.appId,
-            method,
-            url,
-            request,
-        });
-
-        for (const handler of this.httpExtender.getPreResponseHandlers()) {
-            response = await handler.executePreHttpResponse(response, reader, persis);
-        }
-
-        return response;
+        throw lastError;
     }
 }


### PR DESCRIPTION
## Proposed changes
### Add HTTP Retry Mechanism

The HTTP accessor in the Apps Engine now supports automatic retries with exponential backoff for failed requests. This feature helps apps handle transient network failures and API rate limits more gracefully.

### Configuration

The retry mechanism is disabled by default and can be enabled per request through the retry configuration option in the HTTP request options.

#### Default Configuration
```typescript
{
  enabled: false,    // Retry mechanism disabled by default
  maxAttempts: 3,    // Maximum number of attempts including the initial request
  initialDelay: 1000 // Initial delay in milliseconds before first retry
}
```

#### Configuration Options

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| enabled | boolean | false | Enables/disables the retry mechanism |
| maxAttempts | number | 3 | Maximum number of attempts including the initial request |
| initialDelay | number | 1000 | Initial delay in milliseconds before first retry |

### Usage Examples

#### Basic Usage with Default Settings
```typescript
import { IHttp } from '@rocket.chat/apps-engine/definition/accessors';

export async function makeRequest({ http }: { http: IHttp }) {
    const response = await http.get('https://api.example.com/data', {
        retry: {
            enabled: true // Uses default maxAttempts and initialDelay
        }
    });
    return response;
}
```

#### Custom Configuration
```typescript
import { IHttp } from '@rocket.chat/apps-engine/definition/accessors';

export async function makeRequest({ http }: { http: IHttp }) {
    const response = await http.get('https://api.example.com/data', {
        retry: {
            enabled: true,
            maxAttempts: 5,     // Try up to 5 times
            initialDelay: 2000  // Start with 2 second delay
        }
    });
    return response;
}
```

### How It Works

When enabled, the retry mechanism will:

1. Attempt the HTTP request
2. If the request fails:
   - If retries are disabled or max attempts reached: throw the error
   - Otherwise: wait for the calculated delay and retry
3. For each retry:
   - The delay increases exponentially: initialDelay * (2 ^ attemptNumber)
   - Example with initialDelay = 1000:
     - First retry: 1000ms delay
     - Second retry: 2000ms delay
     - Third retry: 4000ms delay

### Error Handling

The final error from the last retry attempt will be thrown after all retries are exhausted. This error maintains the original structure and stack trace from the failed request.
```typescript
try {
    await http.get('https://api.example.com/data', {
        retry: {
            enabled: true,
            maxAttempts: 3
        }
    });
} catch (error) {
    // Error from the last failed attempt
    console.error('All retries failed:', error);
}
```

### Best Practices

1. *Selective Usage*: Enable retries only for operations that are safe to retry (idempotent operations)
2. *Timeout Configuration*: Consider setting appropriate request timeouts along with retry configuration
3. *Monitoring*: Monitor retry patterns to identify recurring issues with external services

### Interface Definition
```typescript
interface IHttpRetryConfig {
    enabled?: boolean;      // Enable/disable retries
    maxAttempts?: number;   // Maximum number of attempts
    initialDelay?: number;  // Initial delay in milliseconds
}

interface IHttpRequest {
    // ... existing options ...
    retry?: IHttpRetryConfig;
}
```

### Implementation Details

The retry mechanism is implemented in the Http class of the Apps Engine. It preserves all existing functionality including:
- Pre-request handlers
- Pre-response handlers
- Default headers and parameters
- Error handling

Each retry attempt is treated as a new request, running through all pre-request and pre-response handlers to maintain consistency with the original request behavior.