### PR TITLE
fix: Modal ocasionally not focusing properly making input unusable

### DIFF
--- a/.changeset/moody-foxes-sleep.md
+++ b/.changeset/moody-foxes-sleep.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+fixes an issue where opening a modal for the first times renders it's inputs unusable

--- a/apps/meteor/client/views/root/MainLayout/LayoutWithSidebar.tsx
+++ b/apps/meteor/client/views/root/MainLayout/LayoutWithSidebar.tsx
@@ -1,11 +1,19 @@
 import { Box } from '@rocket.chat/fuselage';
 import { useLayout, useSetting, useCurrentModal, useRoute, useCurrentRoutePath } from '@rocket.chat/ui-contexts';
 import type { ReactElement, ReactNode } from 'react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, version } from 'react';
 
 import AccessibilityShortcut from './AccessibilityShortcut';
 import { MainLayoutStyleTags } from './MainLayoutStyleTags';
 import Sidebar from '../../../sidebar';
+
+const inertBooleanSupported = Number(version.split('.')[0]) >= 19;
+
+/**
+ * Before version 19, react JSX treats empty string "" as truthy for inert prop.
+ * @see {@link https://stackoverflow.com/questions/72720469}
+ * */
+const isInert = inertBooleanSupported ? (x: boolean) => x : (x: boolean) => (x ? '' : undefined);
 
 const LayoutWithSidebar = ({ children }: { children: ReactNode }): ReactElement => {
 	const { isEmbedded: embeddedLayout } = useLayout();
@@ -44,7 +52,10 @@ const LayoutWithSidebar = ({ children }: { children: ReactNode }): ReactElement 
 			bg='surface-light'
 			id='rocket-chat'
 			className={[embeddedLayout ? 'embedded-view' : undefined, 'menu-nav'].filter(Boolean).join(' ')}
-			aria-hidden={Boolean(modal)}
+			// @types/react does not recognize the "inert" prop as of now
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			inert={isInert(Boolean(modal))}
 		>
 			<AccessibilityShortcut />
 			<MainLayoutStyleTags />


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Use `inert` prop instead of `aria-hidden` for disabling focus on document when a modal is open.

I was only able to notice this issue when trying to save an edited user in the admin page with TOTP enabled. The TOTP modal opens but the input is unaccessible with mouse clicks nor with keyboard navigation
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-908](https://rocketchat.atlassian.net/browse/CORE-908)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
*Make sure TOTP is enable and `Enforce password fallback` is enabled aswell* (usually both come enabled by default in new workspaces)
- Go to `Admin -> Users`
- Refresh the page (*1)
- Select an user
- Click edit and change any property
- Click save
- TOTP modal will open but unusable (only cancel or close buttons are clickable, but not accessible through keyboard)

Observations:
*1: By clicking "cancel" and trying again the issue goes away, so refreshing the page is necessary to reproduce the issue multiple times.
You can set `Remember Two Factor for (seconds)` to `0` in `Admin -> Accounts -> Two Factor Authentication` to ensure the TOTP modal appears every time, even if you successfully inputed the code/password.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
I do not know how this change affects screen readers, so some support here would be nice.

Edit: apparently `inert` should have the same effect as `aria-hidden` , and is supported in every major browser *BESIDES IE11*. See: https://caniuse.com/?search=inert


[CORE-908]: https://rocketchat.atlassian.net/browse/CORE-908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ