### PR TITLE
 fix: Apps-engine reliability fixes

### DIFF
--- a/.changeset/silent-numbers-love.md
+++ b/.changeset/silent-numbers-love.md
@@ -1,0 +1,38 @@
+---
+'@rocket.chat/omnichannel-services': patch
+'rocketchat-services': patch
+'@rocket.chat/omnichannel-transcript': patch
+'@rocket.chat/authorization-service': patch
+'@rocket.chat/web-ui-registration': patch
+'@rocket.chat/stream-hub-service': patch
+'@rocket.chat/uikit-playground': patch
+'@rocket.chat/presence-service': patch
+'@rocket.chat/fuselage-ui-kit': patch
+'@rocket.chat/instance-status': patch
+'@rocket.chat/account-service': patch
+'@rocket.chat/message-parser': patch
+'@rocket.chat/api-client': patch
+'@rocket.chat/ddp-client': patch
+'@rocket.chat/pdf-worker': patch
+'@rocket.chat/core-services': patch
+'@rocket.chat/model-typings': patch
+'@rocket.chat/ui-video-conf': patch
+'@rocket.chat/core-typings': patch
+'@rocket.chat/peggy-loader': patch
+'@rocket.chat/rest-typings': patch
+'@rocket.chat/ddp-streamer': patch
+'@rocket.chat/queue-worker': patch
+'@rocket.chat/presence': patch
+'@rocket.chat/ui-contexts': patch
+'@rocket.chat/license': patch
+'@rocket.chat/gazzodown': patch
+'@rocket.chat/ui-avatar': patch
+'@rocket.chat/ui-client': patch
+'@rocket.chat/livechat': patch
+'@rocket.chat/models': patch
+'@rocket.chat/apps': patch
+'@rocket.chat/cron': patch
+'@rocket.chat/meteor': patch
+---
+
+Adds simple app subprocess metrics report

--- a/.changeset/silent-numbers-love2.md
+++ b/.changeset/silent-numbers-love2.md
@@ -1,0 +1,38 @@
+---
+'@rocket.chat/omnichannel-services': patch
+'rocketchat-services': patch
+'@rocket.chat/omnichannel-transcript': patch
+'@rocket.chat/authorization-service': patch
+'@rocket.chat/web-ui-registration': patch
+'@rocket.chat/stream-hub-service': patch
+'@rocket.chat/uikit-playground': patch
+'@rocket.chat/presence-service': patch
+'@rocket.chat/fuselage-ui-kit': patch
+'@rocket.chat/instance-status': patch
+'@rocket.chat/account-service': patch
+'@rocket.chat/message-parser': patch
+'@rocket.chat/api-client': patch
+'@rocket.chat/ddp-client': patch
+'@rocket.chat/pdf-worker': patch
+'@rocket.chat/core-services': patch
+'@rocket.chat/model-typings': patch
+'@rocket.chat/ui-video-conf': patch
+'@rocket.chat/core-typings': patch
+'@rocket.chat/peggy-loader': patch
+'@rocket.chat/rest-typings': patch
+'@rocket.chat/ddp-streamer': patch
+'@rocket.chat/queue-worker': patch
+'@rocket.chat/presence': patch
+'@rocket.chat/ui-contexts': patch
+'@rocket.chat/license': patch
+'@rocket.chat/gazzodown': patch
+'@rocket.chat/ui-avatar': patch
+'@rocket.chat/ui-client': patch
+'@rocket.chat/livechat': patch
+'@rocket.chat/models': patch
+'@rocket.chat/apps': patch
+'@rocket.chat/cron': patch
+'@rocket.chat/meteor': patch
+---
+
+Attempts to restart an app subprocess if the spawn command fails

--- a/.changeset/silent-numbers-love3.md
+++ b/.changeset/silent-numbers-love3.md
@@ -1,0 +1,38 @@
+---
+'@rocket.chat/omnichannel-services': patch
+'rocketchat-services': patch
+'@rocket.chat/omnichannel-transcript': patch
+'@rocket.chat/authorization-service': patch
+'@rocket.chat/web-ui-registration': patch
+'@rocket.chat/stream-hub-service': patch
+'@rocket.chat/uikit-playground': patch
+'@rocket.chat/presence-service': patch
+'@rocket.chat/fuselage-ui-kit': patch
+'@rocket.chat/instance-status': patch
+'@rocket.chat/account-service': patch
+'@rocket.chat/message-parser': patch
+'@rocket.chat/api-client': patch
+'@rocket.chat/ddp-client': patch
+'@rocket.chat/pdf-worker': patch
+'@rocket.chat/core-services': patch
+'@rocket.chat/model-typings': patch
+'@rocket.chat/ui-video-conf': patch
+'@rocket.chat/core-typings': patch
+'@rocket.chat/peggy-loader': patch
+'@rocket.chat/rest-typings': patch
+'@rocket.chat/ddp-streamer': patch
+'@rocket.chat/queue-worker': patch
+'@rocket.chat/presence': patch
+'@rocket.chat/ui-contexts': patch
+'@rocket.chat/license': patch
+'@rocket.chat/gazzodown': patch
+'@rocket.chat/ui-avatar': patch
+'@rocket.chat/ui-client': patch
+'@rocket.chat/livechat': patch
+'@rocket.chat/models': patch
+'@rocket.chat/apps': patch
+'@rocket.chat/cron': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes an issue while collecting the error message from a failed restart attempt of an app subprocess

--- a/.changeset/silent-numbers-love4.md
+++ b/.changeset/silent-numbers-love4.md
@@ -1,0 +1,38 @@
+---
+'@rocket.chat/omnichannel-services': patch
+'rocketchat-services': patch
+'@rocket.chat/omnichannel-transcript': patch
+'@rocket.chat/authorization-service': patch
+'@rocket.chat/web-ui-registration': patch
+'@rocket.chat/stream-hub-service': patch
+'@rocket.chat/uikit-playground': patch
+'@rocket.chat/presence-service': patch
+'@rocket.chat/fuselage-ui-kit': patch
+'@rocket.chat/instance-status': patch
+'@rocket.chat/account-service': patch
+'@rocket.chat/message-parser': patch
+'@rocket.chat/api-client': patch
+'@rocket.chat/ddp-client': patch
+'@rocket.chat/pdf-worker': patch
+'@rocket.chat/core-services': patch
+'@rocket.chat/model-typings': patch
+'@rocket.chat/ui-video-conf': patch
+'@rocket.chat/core-typings': patch
+'@rocket.chat/peggy-loader': patch
+'@rocket.chat/rest-typings': patch
+'@rocket.chat/ddp-streamer': patch
+'@rocket.chat/queue-worker': patch
+'@rocket.chat/presence': patch
+'@rocket.chat/ui-contexts': patch
+'@rocket.chat/license': patch
+'@rocket.chat/gazzodown': patch
+'@rocket.chat/ui-avatar': patch
+'@rocket.chat/ui-client': patch
+'@rocket.chat/livechat': patch
+'@rocket.chat/models': patch
+'@rocket.chat/apps': patch
+'@rocket.chat/cron': patch
+'@rocket.chat/meteor': patch
+---
+
+Prevents app:getStatus requests from timing out in some cases

--- a/.changeset/silent-numbers-love5.md
+++ b/.changeset/silent-numbers-love5.md
@@ -1,0 +1,38 @@
+---
+'@rocket.chat/omnichannel-services': patch
+'rocketchat-services': patch
+'@rocket.chat/omnichannel-transcript': patch
+'@rocket.chat/authorization-service': patch
+'@rocket.chat/web-ui-registration': patch
+'@rocket.chat/stream-hub-service': patch
+'@rocket.chat/uikit-playground': patch
+'@rocket.chat/presence-service': patch
+'@rocket.chat/fuselage-ui-kit': patch
+'@rocket.chat/instance-status': patch
+'@rocket.chat/account-service': patch
+'@rocket.chat/message-parser': patch
+'@rocket.chat/api-client': patch
+'@rocket.chat/ddp-client': patch
+'@rocket.chat/pdf-worker': patch
+'@rocket.chat/core-services': patch
+'@rocket.chat/model-typings': patch
+'@rocket.chat/ui-video-conf': patch
+'@rocket.chat/core-typings': patch
+'@rocket.chat/peggy-loader': patch
+'@rocket.chat/rest-typings': patch
+'@rocket.chat/ddp-streamer': patch
+'@rocket.chat/queue-worker': patch
+'@rocket.chat/presence': patch
+'@rocket.chat/ui-contexts': patch
+'@rocket.chat/license': patch
+'@rocket.chat/gazzodown': patch
+'@rocket.chat/ui-avatar': patch
+'@rocket.chat/ui-client': patch
+'@rocket.chat/livechat': patch
+'@rocket.chat/models': patch
+'@rocket.chat/apps': patch
+'@rocket.chat/cron': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes an error where the engine would not retry a subprocess restart if the last attempt failed

--- a/.changeset/silent-numbers-love6.md
+++ b/.changeset/silent-numbers-love6.md
@@ -1,0 +1,38 @@
+---
+'@rocket.chat/omnichannel-services': patch
+'rocketchat-services': patch
+'@rocket.chat/omnichannel-transcript': patch
+'@rocket.chat/authorization-service': patch
+'@rocket.chat/web-ui-registration': patch
+'@rocket.chat/stream-hub-service': patch
+'@rocket.chat/uikit-playground': patch
+'@rocket.chat/presence-service': patch
+'@rocket.chat/fuselage-ui-kit': patch
+'@rocket.chat/instance-status': patch
+'@rocket.chat/account-service': patch
+'@rocket.chat/message-parser': patch
+'@rocket.chat/api-client': patch
+'@rocket.chat/ddp-client': patch
+'@rocket.chat/pdf-worker': patch
+'@rocket.chat/core-services': patch
+'@rocket.chat/model-typings': patch
+'@rocket.chat/ui-video-conf': patch
+'@rocket.chat/core-typings': patch
+'@rocket.chat/peggy-loader': patch
+'@rocket.chat/rest-typings': patch
+'@rocket.chat/ddp-streamer': patch
+'@rocket.chat/queue-worker': patch
+'@rocket.chat/presence': patch
+'@rocket.chat/ui-contexts': patch
+'@rocket.chat/license': patch
+'@rocket.chat/gazzodown': patch
+'@rocket.chat/ui-avatar': patch
+'@rocket.chat/ui-client': patch
+'@rocket.chat/livechat': patch
+'@rocket.chat/models': patch
+'@rocket.chat/apps': patch
+'@rocket.chat/cron': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes error propagation when trying to get the status of apps in some cases

--- a/.changeset/silent-numbers-love7.md
+++ b/.changeset/silent-numbers-love7.md
@@ -1,0 +1,38 @@
+---
+'@rocket.chat/omnichannel-services': patch
+'rocketchat-services': patch
+'@rocket.chat/omnichannel-transcript': patch
+'@rocket.chat/authorization-service': patch
+'@rocket.chat/web-ui-registration': patch
+'@rocket.chat/stream-hub-service': patch
+'@rocket.chat/uikit-playground': patch
+'@rocket.chat/presence-service': patch
+'@rocket.chat/fuselage-ui-kit': patch
+'@rocket.chat/instance-status': patch
+'@rocket.chat/account-service': patch
+'@rocket.chat/message-parser': patch
+'@rocket.chat/api-client': patch
+'@rocket.chat/ddp-client': patch
+'@rocket.chat/pdf-worker': patch
+'@rocket.chat/core-services': patch
+'@rocket.chat/model-typings': patch
+'@rocket.chat/ui-video-conf': patch
+'@rocket.chat/core-typings': patch
+'@rocket.chat/peggy-loader': patch
+'@rocket.chat/rest-typings': patch
+'@rocket.chat/ddp-streamer': patch
+'@rocket.chat/queue-worker': patch
+'@rocket.chat/presence': patch
+'@rocket.chat/ui-contexts': patch
+'@rocket.chat/license': patch
+'@rocket.chat/gazzodown': patch
+'@rocket.chat/ui-avatar': patch
+'@rocket.chat/ui-client': patch
+'@rocket.chat/livechat': patch
+'@rocket.chat/models': patch
+'@rocket.chat/apps': patch
+'@rocket.chat/cron': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes wrong data being reported to total failed apps metrics and statistics

--- a/.changeset/silent-numbers-love8.md
+++ b/.changeset/silent-numbers-love8.md
@@ -1,0 +1,38 @@
+---
+'@rocket.chat/omnichannel-services': patch
+'rocketchat-services': patch
+'@rocket.chat/omnichannel-transcript': patch
+'@rocket.chat/authorization-service': patch
+'@rocket.chat/web-ui-registration': patch
+'@rocket.chat/stream-hub-service': patch
+'@rocket.chat/uikit-playground': patch
+'@rocket.chat/presence-service': patch
+'@rocket.chat/fuselage-ui-kit': patch
+'@rocket.chat/instance-status': patch
+'@rocket.chat/account-service': patch
+'@rocket.chat/message-parser': patch
+'@rocket.chat/api-client': patch
+'@rocket.chat/ddp-client': patch
+'@rocket.chat/pdf-worker': patch
+'@rocket.chat/core-services': patch
+'@rocket.chat/model-typings': patch
+'@rocket.chat/ui-video-conf': patch
+'@rocket.chat/core-typings': patch
+'@rocket.chat/peggy-loader': patch
+'@rocket.chat/rest-typings': patch
+'@rocket.chat/ddp-streamer': patch
+'@rocket.chat/queue-worker': patch
+'@rocket.chat/presence': patch
+'@rocket.chat/ui-contexts': patch
+'@rocket.chat/license': patch
+'@rocket.chat/gazzodown': patch
+'@rocket.chat/ui-avatar': patch
+'@rocket.chat/ui-client': patch
+'@rocket.chat/livechat': patch
+'@rocket.chat/models': patch
+'@rocket.chat/apps': patch
+'@rocket.chat/cron': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes an issue that prevented the apps-engine from reestablishing communications with subprocesses in some cases

--- a/apps/meteor/ee/server/services/package.json
+++ b/apps/meteor/ee/server/services/package.json
@@ -18,7 +18,7 @@
 	"author": "Rocket.Chat",
 	"license": "MIT",
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.43.4",
+		"@rocket.chat/apps-engine": "1.43.5",
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/emitter": "~0.31.25",

--- a/apps/meteor/package.json
+++ b/apps/meteor/package.json
@@ -231,7 +231,7 @@
 		"@rocket.chat/agenda": "workspace:^",
 		"@rocket.chat/api-client": "workspace:^",
 		"@rocket.chat/apps": "workspace:^",
-		"@rocket.chat/apps-engine": "1.43.4",
+		"@rocket.chat/apps-engine": "1.43.5",
 		"@rocket.chat/base64": "workspace:^",
 		"@rocket.chat/cas-validate": "workspace:^",
 		"@rocket.chat/core-services": "workspace:^",

--- a/ee/apps/ddp-streamer/package.json
+++ b/ee/apps/ddp-streamer/package.json
@@ -15,7 +15,7 @@
 	],
 	"author": "Rocket.Chat",
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.43.4",
+		"@rocket.chat/apps-engine": "1.43.5",
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/emitter": "~0.31.25",

--- a/ee/packages/presence/package.json
+++ b/ee/packages/presence/package.json
@@ -6,7 +6,7 @@
 		"@babel/core": "~7.22.20",
 		"@babel/preset-env": "~7.22.20",
 		"@babel/preset-typescript": "~7.22.15",
-		"@rocket.chat/apps-engine": "1.43.4",
+		"@rocket.chat/apps-engine": "1.43.5",
 		"@rocket.chat/eslint-config": "workspace:^",
 		"@rocket.chat/rest-typings": "workspace:^",
 		"@types/node": "^14.18.63",

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -22,7 +22,7 @@
 		"/dist"
 	],
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.43.4",
+		"@rocket.chat/apps-engine": "1.43.5",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/model-typings": "workspace:^"
 	}

--- a/packages/core-services/package.json
+++ b/packages/core-services/package.json
@@ -34,7 +34,7 @@
 		"extends": "../../package.json"
 	},
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.43.4",
+		"@rocket.chat/apps-engine": "1.43.5",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/icons": "^0.36.0",
 		"@rocket.chat/message-parser": "workspace:^",

--- a/packages/core-typings/package.json
+++ b/packages/core-typings/package.json
@@ -22,7 +22,7 @@
 		"/dist"
 	],
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.43.4",
+		"@rocket.chat/apps-engine": "1.43.5",
 		"@rocket.chat/icons": "^0.36.0",
 		"@rocket.chat/message-parser": "workspace:^",
 		"@rocket.chat/ui-kit": "workspace:~",

--- a/packages/fuselage-ui-kit/package.json
+++ b/packages/fuselage-ui-kit/package.json
@@ -63,7 +63,7 @@
     "@babel/preset-env": "~7.22.20",
     "@babel/preset-react": "~7.22.15",
     "@babel/preset-typescript": "~7.22.15",
-    "@rocket.chat/apps-engine": "1.43.4",
+    "@rocket.chat/apps-engine": "1.43.5",
     "@rocket.chat/core-typings": "workspace:^",
     "@rocket.chat/eslint-config": "workspace:^",
     "@rocket.chat/fuselage": "^0.54.3",

--- a/packages/rest-typings/package.json
+++ b/packages/rest-typings/package.json
@@ -24,7 +24,7 @@
 		"/dist"
 	],
 	"dependencies": {
-		"@rocket.chat/apps-engine": "1.43.4",
+		"@rocket.chat/apps-engine": "1.43.5",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/message-parser": "workspace:^",
 		"@rocket.chat/ui-kit": "workspace:~",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8508,9 +8508,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rocket.chat/apps-engine@npm:1.43.4":
-  version: 1.43.4
-  resolution: "@rocket.chat/apps-engine@npm:1.43.4"
+"@rocket.chat/apps-engine@npm:1.43.5":
+  version: 1.43.5
+  resolution: "@rocket.chat/apps-engine@npm:1.43.5"
   dependencies:
     "@msgpack/msgpack": 3.0.0-beta2
     adm-zip: ^0.5.9
@@ -8526,7 +8526,7 @@ __metadata:
     uuid: ~8.3.2
   peerDependencies:
     "@rocket.chat/ui-kit": "*"
-  checksum: 0ee4e8cfb31a5280878fac15231d79d9036bcabb080b6400163bc2ead1f24e72693c99f72153ec6536b7e8abcc56dde6b9e96d193cebe76b528b9d6ea8354cb5
+  checksum: 55d8dcbe526a1e0d62badfdab0119caad921743a8e118bbc27b438e84a52220d12d20eacc978c61c6b633fd9814ebffa2caea252534ec68de2c1d2bda5dd213c
   languageName: node
   linkType: hard
 
@@ -8534,7 +8534,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/apps@workspace:packages/apps"
   dependencies:
-    "@rocket.chat/apps-engine": 1.43.4
+    "@rocket.chat/apps-engine": 1.43.5
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/model-typings": "workspace:^"
     "@types/jest": ~29.5.7
@@ -8613,7 +8613,7 @@ __metadata:
     "@babel/core": ~7.22.20
     "@babel/preset-env": ~7.22.20
     "@babel/preset-typescript": ~7.22.15
-    "@rocket.chat/apps-engine": 1.43.4
+    "@rocket.chat/apps-engine": 1.43.5
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/icons": ^0.36.0
@@ -8639,7 +8639,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/core-typings@workspace:packages/core-typings"
   dependencies:
-    "@rocket.chat/apps-engine": 1.43.4
+    "@rocket.chat/apps-engine": 1.43.5
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/icons": ^0.36.0
     "@rocket.chat/message-parser": "workspace:^"
@@ -8717,7 +8717,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/ddp-streamer@workspace:ee/apps/ddp-streamer"
   dependencies:
-    "@rocket.chat/apps-engine": 1.43.4
+    "@rocket.chat/apps-engine": 1.43.5
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/emitter": ~0.31.25
@@ -8913,7 +8913,7 @@ __metadata:
     "@babel/preset-env": ~7.22.20
     "@babel/preset-react": ~7.22.15
     "@babel/preset-typescript": ~7.22.15
-    "@rocket.chat/apps-engine": 1.43.4
+    "@rocket.chat/apps-engine": 1.43.5
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/fuselage": ^0.54.3
@@ -9359,7 +9359,7 @@ __metadata:
     "@rocket.chat/agenda": "workspace:^"
     "@rocket.chat/api-client": "workspace:^"
     "@rocket.chat/apps": "workspace:^"
-    "@rocket.chat/apps-engine": 1.43.4
+    "@rocket.chat/apps-engine": 1.43.5
     "@rocket.chat/base64": "workspace:^"
     "@rocket.chat/cas-validate": "workspace:^"
     "@rocket.chat/core-services": "workspace:^"
@@ -9997,7 +9997,7 @@ __metadata:
     "@babel/core": ~7.22.20
     "@babel/preset-env": ~7.22.20
     "@babel/preset-typescript": ~7.22.15
-    "@rocket.chat/apps-engine": 1.43.4
+    "@rocket.chat/apps-engine": 1.43.5
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/eslint-config": "workspace:^"
@@ -10112,7 +10112,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/rest-typings@workspace:packages/rest-typings"
   dependencies:
-    "@rocket.chat/apps-engine": 1.43.4
+    "@rocket.chat/apps-engine": 1.43.5
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/eslint-config": "workspace:^"
     "@rocket.chat/message-parser": "workspace:^"
@@ -37166,7 +37166,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "rocketchat-services@workspace:apps/meteor/ee/server/services"
   dependencies:
-    "@rocket.chat/apps-engine": 1.43.4
+    "@rocket.chat/apps-engine": 1.43.5
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/emitter": ~0.31.25


### PR DESCRIPTION
Backport of several fixes in the Apps-Engine.

Fixes published with Apps-Engine patch version 1.43.5 https://github.com/RocketChat/Rocket.Chat.Apps-engine/releases/tag/v1.43.5

The changes as listed on the Apps-Engine release:

- fix: app subprocess restart on error and better reporting https://github.com/RocketChat/Rocket.Chat/pull/34106 [(43393)](https://github.com/RocketChat/Rocket.Chat.Apps-engine/commit/43393eb15c974d92ca82c82b565af52f2f27d046)

- fix: runtime orchestration fixes https://github.com/RocketChat/Rocket.Chat/pull/34205 [(480fb)](https://github.com/RocketChat/Rocket.Chat.Apps-engine/commit/480fb95f21d145dabe7b968d1ade1db6993e3b86)

- fix: decoder error preventing succesfull app subprocess restart https://github.com/RocketChat/Rocket.Chat/pull/34858 [(72717)](https://github.com/RocketChat/Rocket.Chat.Apps-engine/commit/72717c1abaa06f59a96b34723f69fbd72f574d3f)

- fix: interval for metrics kept subprocess alive https://github.com/RocketChat/Rocket.Chat/pull/34894 [(19d74)](https://github.com/RocketChat/Rocket.Chat.Apps-engine/commit/19d74584d7bca833a87a8e063848b0235f7d25f9)
