### PR TITLE
Fix: Allow admins to delete private groups they are not part of

### DIFF
--- a/apps/meteor/app/api/server/v1/groups.ts
+++ b/apps/meteor/app/api/server/v1/groups.ts
@@ -68,12 +68,12 @@ async function findPrivateGroupByIdOrName({
 	userId,
 }: {
 	params:
-		| {
-				roomId?: string;
-		  }
-		| {
-				roomName?: string;
-		  };
+	| {
+		roomId?: string;
+	}
+	| {
+		roomName?: string;
+	};
 	userId: string;
 	checkedArchived?: boolean;
 }): Promise<{
@@ -88,9 +88,20 @@ async function findPrivateGroupByIdOrName({
 
 	const user = await Users.findOneById(userId, { projections: { username: 1 } });
 
-	if (!room || !user || !(await canAccessRoomAsync(room, user))) {
+	if (!user) {
+		throw new Meteor.Error('error-user-not-found', 'User not found');
+	}
+
+	if (user.roles?.includes('admin') || (room && await canAccessRoomAsync(room, user))) {
+		// Continue if the user is an admin or has access to the room
+	} else {
 		throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
 	}
+
+
+	// if (!room || !user || !(await canAccessRoomAsync(room, user))) {
+	// 	throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
+	// }
 
 	// discussions have their names saved on `fname` property
 	const roomName = room.prid ? room.fname : room.name;


### PR DESCRIPTION

# API Enhancement: Improve groups.delete Permission Handling and Error Messages

## Proposed changes
This pull request modifies the behavior of the API call for deleting a group in Rocket.Chat to handle cases where the user is not found or does not have access to the room or user is a admin and is not part of the group. Specifically, we updated the following:
- **Role Check Improvement**: The logic for checking if the user has sufficient permissions (either admin or room access) has been refined.
- **Error Handling**: We now explicitly throw a `user-not-found` error if the user is not found and `room-not-found` if the user does not have the required permissions for the room.
This change should improve the reliability of the `groups.delete` API by providing clearer error messages when an operation is not permitted.

## Issue(s)
Fixes #16954 - Groups deletion API fails for admin users when they're not members of the private group, even with proper admin permissions.

## Steps to Reproduce Original Issue
1. **Setup Prerequisites**
   - Have a Rocket.Chat instance running (tested on version 3.0.4 and above)
   - Create an admin user with appropriate permissions:
     - Delete Private Channels
     - View Private Room

2. **Create Test Environment**
   - Create a private group/channel through the UI
   - Ensure the admin user is NOT a member of this private group
   - Note down the room ID of the created group

3. **API Testing Steps**
   ```bash
   # 1. First authenticate as admin
   POST /api/v1/login
   {
     "username": "admin_user",
     "password": "password"
   }
   # Save the authToken and userId from response

   # 2. Verify group exists using groups.listAll
   GET /api/v1/groups.listAll
   Headers:
     X-Auth-Token: your_auth_token
     X-User-Id: your_user_id

   # 3. Attempt to delete the group
   POST /api/v1/groups.delete
   Headers:
     X-Auth-Token: your_auth_token
     X-User-Id: your_user_id
   Body:
     {
       "roomId": "your_room_id"
     }
   ```

4. **Expected vs Actual Behavior**
   - Expected: Group should be deleted successfully since user has admin permissions
   - Actual: Receives error:
   ```json
   {
     "success": false,
     "error": "The required \"roomId\" or \"roomName\" param provided does not match any group [error-room-not-found]",
     "errorType": "error-room-not-found"
   }
   ```

## Steps to Test Fix
1. Ensure you are logged in as a user with the correct permissions.
2. Call the `groups.listAll` API to retrieve a list of groups.
3. Attempt to delete a group using the `groups.delete` API, passing in the group ID.
4. Verify that:
   - If the user is not found, a `user-not-found` error is thrown.
   - If the user is not an admin or does not have the correct access to the room, a `room-not-found` error is thrown.

## Implementation Details
### Code Changes:
- **Before:**
```js
if (!room || !user || !(await canAccessRoomAsync(room, user))) {
  throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
}
```
- **After:**
```js
if (!user) {
  throw new Meteor.Error('error-user-not-found', 'User not found');
}
if (user.roles?.includes('admin') || (room && await canAccessRoomAsync(room, user))) {
  // Continue if the user is an admin or has access to the room
} else {
  throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
}
```

## Further comments
The key change in this PR is the role check condition, ensuring that the user is either an admin or has specific access to the room. This should prevent unnecessary errors and provide more explicit feedback to the user when attempting to delete a group.

## Testing Checklist
- [ ] Tested with admin user not in private group
- [ ] Tested with admin user in private group
- [ ] Tested with non-admin user
- [ ] Tested with invalid user ID
- [ ] Tested with invalid room ID
- [ ] Tested with user lacking permissions
