### PR TITLE
regression: do not update logged out sessions

### DIFF
--- a/apps/meteor/app/statistics/server/lib/SAUMonitor.ts
+++ b/apps/meteor/app/statistics/server/lib/SAUMonitor.ts
@@ -143,7 +143,8 @@ export class SAUMonitorClass {
 				projection: { loginToken: 1 },
 			});
 			if (!session?.loginToken) {
-				throw new Error('Session not found');
+				logger.error('Session not found during logout', { userId, sessionId });
+				return;
 			}
 
 			await Sessions.logoutBySessionIdAndUserId({ loginToken: session.loginToken, userId });

--- a/apps/meteor/app/statistics/server/lib/SAUMonitor.ts
+++ b/apps/meteor/app/statistics/server/lib/SAUMonitor.ts
@@ -30,6 +30,8 @@ const getUserRoles = mem(
 	{ maxAge: 5000 },
 );
 
+const isProdEnv = process.env.NODE_ENV === 'production';
+
 /**
  * Server Session Monitor for SAU(Simultaneously Active Users) based on Meteor server sessions
  */
@@ -143,6 +145,9 @@ export class SAUMonitorClass {
 				projection: { loginToken: 1 },
 			});
 			if (!session?.loginToken) {
+				if (!isProdEnv) {
+					throw new Error('Session not found during logout');
+				}
 				logger.error('Session not found during logout', { userId, sessionId });
 				return;
 			}

--- a/packages/models/src/models/Sessions.ts
+++ b/packages/models/src/models/Sessions.ts
@@ -1442,8 +1442,10 @@ export class SessionsRaw extends BaseRaw<ISession> implements ISessionsModel {
 
 		const now = new Date();
 
+		const query = { instanceId, sessionId, year, month, day, logoutAt: { $exists: false } };
+
 		return this.updateOne(
-			{ instanceId, sessionId, year, month, day },
+			query,
 			{
 				$set: data,
 				$setOnInsert: {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Regression for https://github.com/RocketChat/Rocket.Chat/pull/35010 which was causing an issue when the same session was logging in and out multiple times.

The problem was that if the new log in was using the same `sessionId` as a previous one, that was probably logged out already, it was not creating a new session, so when the code was trying to to log out the session it couldn't find it, causing the error to be thrown.

I also changed to not throw an error if the session is not found.

```
W20250127-13:22:58.343(-3)? (STDERR) === UnHandledPromiseRejection ===
W20250127-13:22:58.344(-3)? (STDERR) Error: Session not found
W20250127-13:22:58.344(-3)? (STDERR)     at app/statistics/server/lib/SAUMonitor.ts:151:11
W20250127-13:22:58.344(-3)? (STDERR)     at processTicksAndRejections (node:internal/process/task_queues:105:5)
W20250127-13:22:58.344(-3)? (STDERR) ---------------------------------
W20250127-13:22:58.344(-3)? (STDERR) Errors like this can cause oplog processing errors.
W20250127-13:22:58.344(-3)? (STDERR) Setting EXIT_UNHANDLEDPROMISEREJECTION will cause the process to exit allowing your service to automatically restart the process
W20250127-13:22:58.344(-3)? (STDERR) Future node.js versions will automatically exit the process
W20250127-13:22:58.344(-3)? (STDERR) =================================
```

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
