### PR TITLE
Implement Toggle Behavior for Formatting Buttons and Shortcuts in Message Composer

### DIFF
--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxFormattingToolbar/MessageBoxFormattingToolbar.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxFormattingToolbar/MessageBoxFormattingToolbar.tsx
@@ -14,6 +14,12 @@ type MessageBoxFormattingToolbarProps = {
 	disabled: boolean;
 };
 
+const toggleFormatting = (composer: ComposerAPI, pattern: string) => {
+	const selection = composer.getSelection();
+	const isFormatted = selection.startsWith(pattern) && selection.endsWith(pattern);
+	composer.wrapSelection(isFormatted ? selection.slice(pattern.length, -pattern.length) : pattern + selection + pattern);
+};
+
 const MessageBoxFormattingToolbar = ({ items, variant = 'large', composer, disabled }: MessageBoxFormattingToolbarProps) => {
 	const { t } = useTranslation();
 
@@ -26,7 +32,9 @@ const MessageBoxFormattingToolbar = ({ items, variant = 'large', composer, disab
 				{'icon' in featuredFormatter && (
 					<MessageComposerAction
 						onClick={() =>
-							isPromptButton(featuredFormatter) ? featuredFormatter.prompt(composer) : composer.wrapSelection(featuredFormatter.pattern)
+							isPromptButton(featuredFormatter)
+								? featuredFormatter.prompt(composer)
+								: toggleFormatting(composer, featuredFormatter.pattern)
 						}
 						icon={featuredFormatter.icon}
 						title={t(featuredFormatter.label)}
@@ -48,7 +56,7 @@ const MessageBoxFormattingToolbar = ({ items, variant = 'large', composer, disab
 						key={formatter.label}
 						data-id={formatter.label}
 						title={t(formatter.label)}
-						onClick={(): void => {
+						onClick={() => {
 							if (isPromptButton(formatter)) {
 								formatter.prompt(composer);
 								return;
@@ -57,7 +65,7 @@ const MessageBoxFormattingToolbar = ({ items, variant = 'large', composer, disab
 								window.open(formatter.link, '_blank', 'rel=noreferrer noopener');
 								return;
 							}
-							composer.wrapSelection(formatter.pattern);
+							toggleFormatting(composer, formatter.pattern);
 						}}
 					/>
 				) : (
@@ -66,7 +74,7 @@ const MessageBoxFormattingToolbar = ({ items, variant = 'large', composer, disab
 							{formatter.text()}
 						</a>
 					</span>
-				),
+				)
 			)}
 		</>
 	);


### PR DESCRIPTION
_Description:_
This pull request addresses an issue in Rocket.Chat where formatting buttons (e.g., Bold, Italic, Strikethrough) and keyboard shortcuts (e.g., Ctrl+B, Cmd+B) do not toggle formatting correctly in the message composer. Instead of removing the formatting when pressed again, they repeatedly apply it, resulting in incorrect text styling (e.g., nested asterisks for bold).

_Changes Made:_
Updated the behavior of formatting buttons in the message composer to toggle the applied formatting.
Modified the small screen formatting toolbar dropdown to implement toggle behavior.
Adjusted the keyboard shortcuts for formatting (e.g., Bold) to toggle the corresponding style on selected text.

_Problem:_
Previously, clicking a formatting button (or using the corresponding shortcut) would add formatting repeatedly, even if the text was already formatted. This led to undesired nested or duplicated formatting, which is inconsistent with common behavior seen in other markdown editors like GitHub's.

_Expected Behavior:_
Pressing a formatting button or using the keyboard shortcut should toggle the format:
If the selected text is already formatted (e.g., bold), clicking the button again should remove the formatting.
If the text is not formatted, applying the button should wrap it with the appropriate formatting (e.g., bold).

_Example:_
Select some text.
Click the Bold button or use Ctrl+B (Cmd+B on Mac).
The text becomes bold (text).
Click the Bold button again or use Ctrl+B (Cmd+B) again.
The bold formatting is removed.

_Benefits:_
Consistent user experience with standard markdown editors.
Prevents the issue of text being incorrectly styled with multiple levels of formatting.
Improved usability for users interacting with the message composer.

_Testing:_
Verified the toggle behavior for Bold, Italic, Strikethrough, Code, and other supported formatting options.
Confirmed the same behavior for both the button clicks and the corresponding keyboard shortcuts (Ctrl+B, Ctrl+I, etc.).
Ensured that small screen formatting dropdown behaves as expected with the toggle behavior.