### PR TITLE
Release 7.3.1

### DIFF
--- a/.changeset/bump-patch-1738597514712.md
+++ b/.changeset/bump-patch-1738597514712.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Bump @rocket.chat/meteor version.

--- a/.changeset/old-schools-build.md
+++ b/.changeset/old-schools-build.md
@@ -1,0 +1,11 @@
+---
+"@rocket.chat/meteor": patch
+"@rocket.chat/model-typings": patch
+"@rocket.chat/models": patch
+---
+
+Fixes the queue processing of Omnichannel's waiting queue focusing on 3 main areas:
+- Changes the way we fetch the queue list to not append the public queue by default. This makes the server to not run the public queue always (as it is now) even if there was no work to be done.
+- Changes how the queue executes: previously, it was executed in a kind of chain: We fetched a list of "queues", then we took one, processed it, and after that we scheduled the next run, which could take some time. Now, every TIMEOUT, server will try to process all the queues, 1 by 1, and then schedule the next run for all queues after TIMEOUT. This should speed up chat assignment and reduce waiting time when waiting queue is enabled.
+- Removes the unlockAndRequeue and replcaes it with just unlock. This change shouldn't be noticeable. The original idea of the requeueing was to iterate over the inquiries when 1 wasn't being able to be taken. Idea was to avoid blocking the queue by rotating them instead of fetching the same until it gets routed, however this never worked cause we never modified the global sorting for the inquiries and it kept using the ts as the sorting, which returned always the oldest and ignored the requeing. So we're removing those extra steps as well.
+

--- a/.changeset/silly-emus-remain.md
+++ b/.changeset/silly-emus-remain.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixes a behavior in Omnichannel that was causing bot agents to be waiting in the queue, when they should always skip it.

--- a/apps/meteor/app/livechat/server/lib/QueueManager.ts
+++ b/apps/meteor/app/livechat/server/lib/QueueManager.ts
@@ -132,6 +132,11 @@ export class QueueManager {
 			return LivechatInquiryStatus.QUEUED;
 		}
 
+		// bots should be able to skip the queue and the routing check
+		if (agent && (await allowAgentSkipQueue(agent))) {
+			return LivechatInquiryStatus.READY;
+		}
+
 		if (settings.get('Livechat_waiting_queue')) {
 			return LivechatInquiryStatus.QUEUED;
 		}
@@ -140,7 +145,7 @@ export class QueueManager {
 			return LivechatInquiryStatus.READY;
 		}
 
-		if (!agent || !(await allowAgentSkipQueue(agent))) {
+		if (!agent) {
 			return LivechatInquiryStatus.QUEUED;
 		}
 

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/Helper.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/Helper.ts
@@ -38,7 +38,7 @@ export const getMaxNumberSimultaneousChat = async ({ agentId, departmentId }: { 
 		const department = await LivechatDepartmentRaw.findOneById(departmentId);
 		const { maxNumberSimultaneousChat = 0 } = department || { maxNumberSimultaneousChat: 0 };
 		if (maxNumberSimultaneousChat > 0) {
-			return maxNumberSimultaneousChat;
+			return Number(maxNumberSimultaneousChat);
 		}
 	}
 
@@ -46,7 +46,7 @@ export const getMaxNumberSimultaneousChat = async ({ agentId, departmentId }: { 
 		const user = await Users.getAgentInfo(agentId, settings.get('Livechat_show_agent_info'));
 		const { livechat: { maxNumberSimultaneousChat = 0 } = {} } = user || {};
 		if (maxNumberSimultaneousChat > 0) {
-			return maxNumberSimultaneousChat;
+			return Number(maxNumberSimultaneousChat);
 		}
 	}
 

--- a/apps/meteor/server/services/omnichannel/queue.ts
+++ b/apps/meteor/server/services/omnichannel/queue.ts
@@ -2,6 +2,7 @@ import { ServiceStarter } from '@rocket.chat/core-services';
 import { type InquiryWithAgentInfo, type IOmnichannelQueue } from '@rocket.chat/core-typings';
 import { License } from '@rocket.chat/license';
 import { LivechatInquiry, LivechatRooms } from '@rocket.chat/models';
+import { tracerSpan } from '@rocket.chat/tracing';
 
 import { queueLogger } from './logger';
 import { getOmniChatSortQuery } from '../../../app/livechat/lib/inquiries';
@@ -25,8 +26,6 @@ export class OmnichannelQueue implements IOmnichannelQueue {
 	}
 
 	private running = false;
-
-	private queues: (string | undefined)[] = [];
 
 	private delay() {
 		const timeout = settings.get<number>('Omnichannel_queue_delay_timeout') ?? 5;
@@ -76,17 +75,7 @@ export class OmnichannelQueue implements IOmnichannelQueue {
 	}
 
 	private async getActiveQueues() {
-		// undefined = public queue(without department)
-		return ([undefined] as typeof this.queues).concat(await LivechatInquiry.getDistinctQueuedDepartments({}));
-	}
-
-	private async nextQueue() {
-		if (!this.queues.length) {
-			queueLogger.debug('No more registered queues. Refreshing');
-			this.queues = await this.getActiveQueues();
-		}
-
-		return this.queues.shift();
+		return (await LivechatInquiry.getDistinctQueuedDepartments({})).map(({ _id }) => _id);
 	}
 
 	private async execute() {
@@ -101,16 +90,20 @@ export class OmnichannelQueue implements IOmnichannelQueue {
 			return;
 		}
 
-		const queue = await this.nextQueue();
-		const queueDelayTimeout = this.delay();
-		queueLogger.debug(`Executing queue ${queue || 'Public'} with timeout of ${queueDelayTimeout}`);
-
-		void this.checkQueue(queue).catch((e) => {
-			queueLogger.error(e);
-		});
+		// We still go 1 by 1, but we go with every queue every cycle instead of just 1 queue per cycle
+		// And we get tracing :)
+		const queues = await this.getActiveQueues();
+		for await (const queue of queues) {
+			await tracerSpan(
+				'omnichannel.queue',
+				{ attributes: { workerTime: new Date().toISOString(), queue: queue || 'Public' }, root: true },
+				() => this.checkQueue(queue),
+			);
+		}
+		this.scheduleExecution();
 	}
 
-	private async checkQueue(queue: string | undefined) {
+	private async checkQueue(queue: string | null) {
 		queueLogger.debug(`Processing items for queue ${queue || 'Public'}`);
 		try {
 			const nextInquiry = await LivechatInquiry.findNextAndLock(getOmniChatSortQuery(getInquirySortMechanismSetting()), queue);
@@ -122,12 +115,8 @@ export class OmnichannelQueue implements IOmnichannelQueue {
 			const result = await this.processWaitingQueue(queue, nextInquiry as InquiryWithAgentInfo);
 
 			if (!result) {
-				// Note: this removes the "one-shot" behavior of queue, allowing it to take a conversation again in the future
-				// And sorting them by _updatedAt: -1 will make it so that the oldest inquiries are taken first
-				// preventing us from playing with the same inquiry over and over again
 				queueLogger.debug(`Inquiry ${nextInquiry._id} not taken. Unlocking and re-queueing`);
-				const updatedQueue = await LivechatInquiry.unlockAndQueue(nextInquiry._id);
-				return updatedQueue;
+				return await LivechatInquiry.unlock(nextInquiry._id);
 			}
 
 			queueLogger.debug(`Inquiry ${nextInquiry._id} taken successfully. Unlocking`);
@@ -144,8 +133,6 @@ export class OmnichannelQueue implements IOmnichannelQueue {
 				queue: queue || 'Public',
 				err: e,
 			});
-		} finally {
-			this.scheduleExecution();
 		}
 	}
 
@@ -217,7 +204,7 @@ export class OmnichannelQueue implements IOmnichannelQueue {
 		return true;
 	}
 
-	private async processWaitingQueue(department: string | undefined, inquiry: InquiryWithAgentInfo) {
+	private async processWaitingQueue(department: string | null, inquiry: InquiryWithAgentInfo) {
 		const queue = department || 'Public';
 
 		queueLogger.debug(`Processing inquiry ${inquiry._id} from queue ${queue}`);

--- a/apps/meteor/tests/end-to-end/api/livechat/24-routing.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/24-routing.ts
@@ -28,6 +28,186 @@ import { IS_EE } from '../../../e2e/config/constants';
 		await updateSetting('Livechat_Routing_Method', 'Manual_Selection');
 	});
 
+	// Basically: if there's a bot in the department, it should be assigned to the conversation
+	// No matter what settings workspace has in, as long as the setting to assign new conversations to bots is enabled
+	describe('Bots - Manual selection', () => {
+		let botUser: { user: IUser; credentials: Credentials };
+		let testDepartment: ILivechatDepartment;
+		let testDepartment2: ILivechatDepartment;
+		before(async () => {
+			const bot = await createUser({ roles: ['bot', 'livechat-agent'] });
+			const credentials = await login(bot.username, password);
+
+			botUser = { user: bot, credentials };
+		});
+		before(async () => {
+			testDepartment = await createDepartment([{ agentId: botUser.user._id }]);
+			testDepartment2 = await createDepartment();
+			await updateSetting('Livechat_Routing_Method', 'Manual_Selection');
+			await updateSetting('Livechat_assign_new_conversation_to_bot', true);
+			await updateSetting('Livechat_accept_chats_with_no_agents', true);
+		});
+
+		after(async () => {
+			await deleteUser(botUser.user);
+			await updateSetting('Livechat_Routing_Method', 'Auto_Selection');
+			await updateSetting('Livechat_assign_new_conversation_to_bot', false);
+			await updateSetting('Livechat_accept_chats_with_no_agents', false);
+		});
+
+		it('should assign conversation to bot', async () => {
+			const visitor = await createVisitor(testDepartment._id);
+			const room = await createLivechatRoom(visitor.token);
+
+			const roomInfo = await getLivechatRoomInfo(room._id);
+
+			expect(roomInfo.servedBy?._id).to.be.equal(botUser.user._id);
+		});
+		it('should not assign conversation to bot if department has no bots', async () => {
+			const visitor = await createVisitor(testDepartment2._id);
+			const room = await createLivechatRoom(visitor.token);
+
+			expect(room.servedBy).to.be.undefined;
+		});
+
+		describe('with setting disabled', () => {
+			before(async () => {
+				await updateSetting('Livechat_assign_new_conversation_to_bot', false);
+			});
+			after(async () => {
+				await updateSetting('Livechat_assign_new_conversation_to_bot', true);
+			});
+
+			it('should not assign conversation to bot', async () => {
+				const visitor = await createVisitor(testDepartment._id);
+				const room = await createLivechatRoom(visitor.token);
+
+				expect(room.servedBy).to.be.undefined;
+			});
+		});
+	});
+
+	describe('Bots - Auto selection', () => {
+		let botUser: { user: IUser; credentials: Credentials };
+		let otherUser: { user: IUser; credentials: Credentials };
+		let testDepartment: ILivechatDepartment;
+		let testDepartment2: ILivechatDepartment;
+		before(async () => {
+			const bot = await createUser({ roles: ['bot', 'livechat-agent'] });
+			const credentials = await login(bot.username, password);
+
+			const other = await createUser({ roles: ['livechat-agent'] });
+			const otherCredentials = await login(other.username, password);
+
+			await makeAgentAvailable(otherCredentials);
+
+			botUser = { user: bot, credentials };
+			otherUser = { user: other, credentials: otherCredentials };
+		});
+		before(async () => {
+			testDepartment = await createDepartment([{ agentId: botUser.user._id }, { agentId: otherUser.user._id }]);
+			testDepartment2 = await createDepartment();
+			await updateSetting('Livechat_Routing_Method', 'Auto_Selection');
+			await updateSetting('Livechat_assign_new_conversation_to_bot', true);
+			await updateSetting('Livechat_accept_chats_with_no_agents', true);
+		});
+
+		after(async () => {
+			await deleteUser(botUser.user);
+			await updateSetting('Livechat_assign_new_conversation_to_bot', false);
+			await updateSetting('Livechat_accept_chats_with_no_agents', false);
+		});
+
+		it('should assign conversation to bot', async () => {
+			const visitor = await createVisitor(testDepartment._id);
+			const room = await createLivechatRoom(visitor.token);
+
+			const roomInfo = await getLivechatRoomInfo(room._id);
+
+			expect(roomInfo.servedBy?._id).to.be.equal(botUser.user._id);
+		});
+		it('should not assign conversation to bot if department has no bots', async () => {
+			const visitor = await createVisitor(testDepartment2._id);
+			const room = await createLivechatRoom(visitor.token);
+
+			expect(room.servedBy).to.be.undefined;
+		});
+
+		describe('with setting disabled', () => {
+			before(async () => {
+				await updateSetting('Livechat_assign_new_conversation_to_bot', false);
+			});
+			after(async () => {
+				await updateSetting('Livechat_assign_new_conversation_to_bot', true);
+			});
+
+			it('should not assign conversation to bot', async () => {
+				const visitor = await createVisitor(testDepartment._id);
+				const room = await createLivechatRoom(visitor.token);
+
+				expect(room.servedBy?._id).to.be.equal(otherUser.user._id);
+			});
+		});
+	});
+
+	describe('Bots - Auto selection & Waiting queue', () => {
+		let botUser: { user: IUser; credentials: Credentials };
+		let testDepartment: ILivechatDepartment;
+		let testDepartment2: ILivechatDepartment;
+		before(async () => {
+			const bot = await createUser({ roles: ['bot', 'livechat-agent'] });
+			const credentials = await login(bot.username, password);
+
+			botUser = { user: bot, credentials };
+		});
+		before(async () => {
+			testDepartment = await createDepartment([{ agentId: botUser.user._id }]);
+			testDepartment2 = await createDepartment();
+			await updateSetting('Livechat_Routing_Method', 'Auto_Selection');
+			await updateSetting('Livechat_waiting_queue', true);
+			await updateSetting('Livechat_assign_new_conversation_to_bot', true);
+			await updateSetting('Livechat_accept_chats_with_no_agents', true);
+		});
+
+		after(async () => {
+			await deleteUser(botUser.user);
+			await updateSetting('Livechat_waiting_queue', false);
+			await updateSetting('Livechat_assign_new_conversation_to_bot', false);
+			await updateSetting('Livechat_accept_chats_with_no_agents', false);
+		});
+
+		it('should assign conversation to bot', async () => {
+			const visitor = await createVisitor(testDepartment._id);
+			const room = await createLivechatRoom(visitor.token);
+
+			const roomInfo = await getLivechatRoomInfo(room._id);
+
+			expect(roomInfo.servedBy?._id).to.be.equal(botUser.user._id);
+		});
+		it('should not assign conversation to bot if department has no bots', async () => {
+			const visitor = await createVisitor(testDepartment2._id);
+			const room = await createLivechatRoom(visitor.token);
+
+			expect(room.servedBy).to.be.undefined;
+		});
+
+		describe('with setting disabled', () => {
+			before(async () => {
+				await updateSetting('Livechat_assign_new_conversation_to_bot', false);
+			});
+			after(async () => {
+				await updateSetting('Livechat_assign_new_conversation_to_bot', true);
+			});
+
+			it('should not assign conversation to bot', async () => {
+				const visitor = await createVisitor(testDepartment._id);
+				const room = await createLivechatRoom(visitor.token);
+
+				expect(room.servedBy).to.be.undefined;
+			});
+		});
+	});
+
 	describe('Auto-Selection', () => {
 		before(async () => {
 			await updateSetting('Livechat_Routing_Method', 'Auto_Selection');

--- a/packages/model-typings/src/models/ILivechatInquiryModel.ts
+++ b/packages/model-typings/src/models/ILivechatInquiryModel.ts
@@ -1,5 +1,5 @@
 import type { IMessage, ILivechatInquiryRecord, LivechatInquiryStatus } from '@rocket.chat/core-typings';
-import type { FindOptions, DistinctOptions, Document, UpdateResult, DeleteResult, FindCursor, DeleteOptions } from 'mongodb';
+import type { FindOptions, Document, UpdateResult, DeleteResult, FindCursor, DeleteOptions, AggregateOptions } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
 
@@ -13,12 +13,14 @@ export interface ILivechatInquiryModel extends IBaseModel<ILivechatInquiryRecord
 		rid: string,
 		options?: FindOptions<T extends ILivechatInquiryRecord ? ILivechatInquiryRecord : T>,
 	): Promise<T | null>;
-	getDistinctQueuedDepartments(options: DistinctOptions): Promise<(string | undefined)[]>;
+	getDistinctQueuedDepartments(options: AggregateOptions): Promise<{ _id: string | null }[]>;
 	setDepartmentByInquiryId(inquiryId: string, department: string): Promise<ILivechatInquiryRecord | null>;
 	setLastMessageByRoomId(rid: ILivechatInquiryRecord['rid'], message: IMessage): Promise<ILivechatInquiryRecord | null>;
-	findNextAndLock(queueSortBy: FindOptions<ILivechatInquiryRecord>['sort'], department?: string): Promise<ILivechatInquiryRecord | null>;
+	findNextAndLock(
+		queueSortBy: FindOptions<ILivechatInquiryRecord>['sort'],
+		department: string | null,
+	): Promise<ILivechatInquiryRecord | null>;
 	unlock(inquiryId: string): Promise<UpdateResult>;
-	unlockAndQueue(inquiryId: string): Promise<UpdateResult>;
 	unlockAll(): Promise<UpdateResult | Document>;
 	getCurrentSortedQueueAsync(props: {
 		inquiryId?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7894,7 +7894,7 @@ __metadata:
     storybook-dark-mode: "npm:^4.0.2"
     typescript: "npm:~5.7.2"
   peerDependencies:
-    "@rocket.chat/apps-engine": 1.48.2-rc.0
+    "@rocket.chat/apps-engine": 1.48.2
     "@rocket.chat/eslint-config": 0.7.0
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
@@ -7902,10 +7902,10 @@ __metadata:
     "@rocket.chat/icons": "*"
     "@rocket.chat/prettier-config": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 11.0.0-rc.5
-    "@rocket.chat/ui-contexts": 15.0.0-rc.5
+    "@rocket.chat/ui-avatar": 11.0.0
+    "@rocket.chat/ui-contexts": 15.0.0
     "@rocket.chat/ui-kit": 0.37.0
-    "@rocket.chat/ui-video-conf": 15.0.0-rc.5
+    "@rocket.chat/ui-video-conf": 15.0.0
     "@tanstack/react-query": "*"
     react: ~17.0.2
     react-dom: "*"
@@ -7990,8 +7990,8 @@ __metadata:
     "@rocket.chat/fuselage-tokens": "*"
     "@rocket.chat/message-parser": 0.31.31
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-client": 15.0.0-rc.5
-    "@rocket.chat/ui-contexts": 15.0.0-rc.5
+    "@rocket.chat/ui-client": 15.0.0
+    "@rocket.chat/ui-contexts": 15.0.0
     katex: "*"
     react: "*"
   languageName: unknown
@@ -9234,7 +9234,7 @@ __metadata:
     typescript: "npm:~5.7.2"
   peerDependencies:
     "@rocket.chat/fuselage": "*"
-    "@rocket.chat/ui-contexts": 15.0.0-rc.5
+    "@rocket.chat/ui-contexts": 15.0.0
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -9286,8 +9286,8 @@ __metadata:
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-avatar": 11.0.0-rc.5
-    "@rocket.chat/ui-contexts": 15.0.0-rc.5
+    "@rocket.chat/ui-avatar": 11.0.0
+    "@rocket.chat/ui-contexts": 15.0.0
     react: "*"
     react-i18next: "*"
   languageName: unknown
@@ -9457,8 +9457,8 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 11.0.0-rc.5
-    "@rocket.chat/ui-contexts": 15.0.0-rc.5
+    "@rocket.chat/ui-avatar": 11.0.0
+    "@rocket.chat/ui-contexts": 15.0.0
     react: ~17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -9514,9 +9514,9 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 11.0.0-rc.5
-    "@rocket.chat/ui-client": 15.0.0-rc.5
-    "@rocket.chat/ui-contexts": 15.0.0-rc.5
+    "@rocket.chat/ui-avatar": 11.0.0
+    "@rocket.chat/ui-client": 15.0.0
+    "@rocket.chat/ui-contexts": 15.0.0
     react: ~17.0.2
     react-aria: ~3.23.1
     react-dom: ^17.0.2
@@ -9606,7 +9606,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.2.2
-    "@rocket.chat/ui-contexts": 15.0.0-rc.5
+    "@rocket.chat/ui-contexts": 15.0.0
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION


<!-- release-notes-start -->
<!-- This content is automatically generated. Changing this will not reflect on the final release log -->

_You can see below a preview of the release change log:_

# 7.3.1

### Engine versions

- Node: `22.11.0`
- MongoDB: `5.0, 6.0, 7.0`
- Apps-Engine: `1.48.2`

### Patch Changes

*   Bump @rocket.chat/meteor version.

*   ([#35112](https://github.com/RocketChat/Rocket.Chat/pull/35112) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixes the queue processing of Omnichannel's waiting queue focusing on 3 main areas:
    *   Changes the way we fetch the queue list to not append the public queue by default. This makes the server to not run the public queue always (as it is now) even if there was no work to be done.
    *   Changes how the queue executes: previously, it was executed in a kind of chain: We fetched a list of "queues", then we took one, processed it, and after that we scheduled the next run, which could take some time. Now, every TIMEOUT, server will try to process all the queues, 1 by 1, and then schedule the next run for all queues after TIMEOUT. This should speed up chat assignment and reduce waiting time when waiting queue is enabled.
    *   Removes the unlockAndRequeue and replcaes it with just unlock. This change shouldn't be noticeable. The original idea of the requeueing was to iterate over the inquiries when 1 wasn't being able to be taken. Idea was to avoid blocking the queue by rotating them instead of fetching the same until it gets routed, however this never worked cause we never modified the global sorting for the inquiries and it kept using the ts as the sorting, which returned always the oldest and ignored the requeing. So we're removing those extra steps as well.

*   ([#35096](https://github.com/RocketChat/Rocket.Chat/pull/35096) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixes a behavior in Omnichannel that was causing bot agents to be waiting in the queue, when they should always skip it.

*   <details><summary>Updated dependencies [b7905dfebe48d27d0d774fb23cc579ea9dfd01f4]:</summary>

    *   @rocket.chat/model-typings@1.3.1
    *   @rocket.chat/models@1.2.1
    *   @rocket.chat/omnichannel-services@0.3.11
    *   @rocket.chat/apps@0.2.5
    *   @rocket.chat/presence@0.2.14
    *   @rocket.chat/core-services@0.7.6
    *   @rocket.chat/cron@0.1.14
    *   @rocket.chat/instance-status@0.1.14
    *   @rocket.chat/network-broker@0.1.6
    *   @rocket.chat/core-typings@7.3.1
    *   @rocket.chat/rest-typings@7.3.1
    *   @rocket.chat/license@1.0.5
    *   @rocket.chat/pdf-worker@0.2.11
    *   @rocket.chat/api-client@0.2.14
    *   @rocket.chat/freeswitch@1.2.1
    *   @rocket.chat/fuselage-ui-kit@15.0.1
    *   @rocket.chat/gazzodown@15.0.1
    *   @rocket.chat/ui-contexts@15.0.1
    *   @rocket.chat/server-cloud-communication@0.0.2
    *   @rocket.chat/ui-theming@0.4.2
    *   @rocket.chat/ui-avatar@11.0.1
    *   @rocket.chat/ui-client@15.0.1
    *   @rocket.chat/ui-video-conf@15.0.1
    *   @rocket.chat/ui-voip@5.0.1
    *   @rocket.chat/web-ui-registration@15.0.1

    </details>

<!-- release-notes-end -->