### PR TITLE
None and default wasn't producing sound

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/NotificationPreferences/NotificationPreferencesWithData.tsx
+++ b/apps/meteor/client/views/room/contextualBar/NotificationPreferences/NotificationPreferencesWithData.tsx
@@ -30,7 +30,6 @@ const NotificationPreferencesWithData = (): ReactElement => {
 	];
 
 	const defaultSoundOption: SelectOption[] = [
-		['none', t('None')],
 		['default', t('Default')],
 	];
 


### PR DESCRIPTION


## Proposed changes (including videos or screenshots)
 Since both the option wasn't producing sound so I removed "none" to maintain the consistency with other dropdown menus. 

*Before*
![image](https://github.com/user-attachments/assets/67a81e39-79d2-4724-9cb7-48bb11665224)

  

*After*
![Screenshot 2025-02-08 132820](https://github.com/user-attachments/assets/05fd08e8-1713-4153-b3ab-9d1bb6179fce)



## Steps to test or reproduce
1. choose any channel. 
2. click on three dots
3. navigate to "Notification preference". 
4. click on desktop and then sound. 
 


