### PR TITLE
feat:  Save button not getting disabled

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/NotificationPreferences/NotificationPreferences.tsx
+++ b/apps/meteor/client/views/room/contextualBar/NotificationPreferences/NotificationPreferences.tsx
@@ -32,7 +32,14 @@ const NotificationPreferences = ({
 	const { t } = useTranslation();
 	const {
 		formState: { isDirty, isSubmitting },
+		reset, 
+		getValues, 
 	} = useFormContext();
+
+	function handleSaveHandler() {
+		handleSave();
+		reset(getValues()); 
+	}
 
 	return (
 		<>
@@ -47,7 +54,7 @@ const NotificationPreferences = ({
 			<ContextualbarFooter>
 				<ButtonGroup stretch>
 					{handleClose && <Button onClick={handleClose}>{t('Cancel')}</Button>}
-					<Button primary disabled={!isDirty} loading={isSubmitting} onClick={handleSave}>
+					<Button primary disabled={!isDirty} loading={isSubmitting} onClick={handleSaveHandler}>
 						{t('Save')}
 					</Button>
 				</ButtonGroup>

--- a/apps/meteor/client/views/room/contextualBar/NotificationPreferences/NotificationPreferencesWithData.tsx
+++ b/apps/meteor/client/views/room/contextualBar/NotificationPreferences/NotificationPreferencesWithData.tsx
@@ -30,7 +30,6 @@ const NotificationPreferencesWithData = (): ReactElement => {
 	];
 
 	const defaultSoundOption: SelectOption[] = [
-		['none', t('None')],
 		['default', t('Default')],
 	];
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
When the Save button in Notification Preferences is clicked without making any changes, it remains enabled. With this update, the Save button will be disabled immediately after clicking and will only be re-enabled once new values or changes are made. 


https://github.com/user-attachments/assets/cf58258c-327a-4a1f-bd01-975ec502c7de



## Issue(s)
#35160


## Steps to test or reproduce
1. Choose any group.
2. Click on the three dots.
3. Click on Notification Preferences.
4. Click on the Save button.
5. Observe that the Save button becomes disabled until new changes are made.
