### PR TITLE
feat: Auto-format Authentication Code with Hyphen

### DIFF
--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorEmailModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorEmailModal.tsx
@@ -42,6 +42,10 @@ const TwoFactorEmailModal = ({ onConfirm, onClose, emailOrUsername, invalidAttem
 	};
 
 	const onChange = ({ currentTarget }: ChangeEvent<HTMLInputElement>): void => {
+		const { value } = currentTarget;
+		if (value.length === 3 && !value.includes("-")) {
+			currentTarget.value = `${value}-`;
+		}
 		setCode(currentTarget.value);
 	};
 


### PR DESCRIPTION
### feat: Auto-format Authentication Code with Hyphen

## Proposed changes (including videos or screenshots)
In the current authentication code input process, users can enter the code in two formats: `123456` or `123-456`. This can lead to confusion as users may not always know if they should manually add the hyphen (`-`). 

### Solution:
This feature automatically adds a hyphen (`-`) after every three digits once the user enters the first three characters. The code will appear as `123-456`, and users will be able to continue entering the remaining digits without needing to manually insert the hyphen. This improves the user experience and ensures the correct format is always followed.

**Screenshots/Video:**


https://github.com/user-attachments/assets/6b31c33f-d400-41e5-824e-c3928077d89e



## Issue(s)
Closes #35178


## Steps to test or reproduce
Step 0: Enable Two-factor authentication First (Profile -> Security -> Two-factor authentication via email)
1. Navigate to the authentication input screen where users are prompted to enter an OTP.
2. Start typing the first three digits of the code.
3. The hyphen (`-`) should automatically appear after the third digit (e.g., `123-`).
4. Continue typing the remaining digits, ensuring the hyphen is retained, and the code is formatted correctly (e.g., `123-456`).
5. Verify that both `123456` and `123-456` formats are accepted.

## Further comments
This solution should simplify the process for users and eliminate any confusion regarding whether they need to manually enter the hyphen. It is a small UI improvement that enhances usability without impacting the backend or requiring complex changes.

Let me know if you need any changes or improvements, and I look forward to your feedback.
