### PR TITLE
fix: UI not reflecting 2FA TOTP and email status change immediately

### DIFF
--- a/.changeset/clever-shirts-talk.md
+++ b/.changeset/clever-shirts-talk.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Written code to update UI to immediately reflect 2FA status change after enabling/disabling TOTP/email

--- a/apps/meteor/client/views/account/security/TwoFactorEmail.tsx
+++ b/apps/meteor/client/views/account/security/TwoFactorEmail.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Margins } from '@rocket.chat/fuselage';
 import { useUser } from '@rocket.chat/ui-contexts';
 import type { ComponentProps } from 'react';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useEndpointAction } from '../../../hooks/useEndpointAction';
@@ -10,7 +10,7 @@ const TwoFactorEmail = (props: ComponentProps<typeof Box>) => {
 	const { t } = useTranslation();
 	const user = useUser();
 
-	const isEnabled = user?.services?.email2fa?.enabled;
+	const [isEnabled, setIsEnabled] = useState(user?.services?.email2fa?.enabled);
 
 	const enable2faAction = useEndpointAction('POST', '/v1/users.2fa.enableEmail', {
 		successMessage: t('Two-factor_authentication_enabled'),
@@ -21,9 +21,12 @@ const TwoFactorEmail = (props: ComponentProps<typeof Box>) => {
 
 	const handleEnable = useCallback(async () => {
 		await enable2faAction();
+		setIsEnabled(true);
 	}, [enable2faAction]);
+
 	const handleDisable = useCallback(async () => {
 		await disable2faAction();
+		setIsEnabled(false);
 	}, [disable2faAction]);
 
 	return (

--- a/apps/meteor/client/views/account/security/TwoFactorTOTP.tsx
+++ b/apps/meteor/client/views/account/security/TwoFactorTOTP.tsx
@@ -36,20 +36,20 @@ const TwoFactorTOTP = (props: TwoFactorTOTPProps): ReactElement => {
 
 	const { register, handleSubmit } = useForm<TwoFactorTOTPFormData>({ defaultValues: { authCode: '' } });
 
-	const totpEnabled = user?.services?.totp?.enabled;
+	const [isTotpEnabled, setIsTotpEnabled] = useState(user?.services?.totp?.enabled);
 
 	const closeModal = useCallback(() => setModal(null), [setModal]);
 
 	useEffect(() => {
 		const updateCodesRemaining = async (): Promise<void | boolean> => {
-			if (!totpEnabled) {
+			if (!isTotpEnabled) {
 				return false;
 			}
 			const result = await checkCodesRemainingFn();
 			setCodesRemaining(result.remaining);
 		};
 		updateCodesRemaining();
-	}, [checkCodesRemainingFn, setCodesRemaining, totpEnabled]);
+	}, [checkCodesRemainingFn, setCodesRemaining, isTotpEnabled]);
 
 	const handleEnableTotp = useCallback(async () => {
 		try {
@@ -73,6 +73,9 @@ const TwoFactorTOTP = (props: TwoFactorTOTPProps): ReactElement => {
 					return dispatchToastMessage({ type: 'error', message: t('Invalid_two_factor_code') });
 				}
 
+				setIsTotpEnabled(false);
+				setRegisteringTotp(false);
+
 				dispatchToastMessage({ type: 'success', message: t('Two-factor_authentication_disabled') });
 			} catch (error) {
 				dispatchToastMessage({ type: 'error', message: error });
@@ -93,6 +96,7 @@ const TwoFactorTOTP = (props: TwoFactorTOTPProps): ReactElement => {
 				}
 
 				setModal(<BackupCodesModal codes={result.codes} onClose={closeModal} />);
+				setIsTotpEnabled(true);
 			} catch (error) {
 				dispatchToastMessage({ type: 'error', message: error });
 			}
@@ -121,7 +125,7 @@ const TwoFactorTOTP = (props: TwoFactorTOTPProps): ReactElement => {
 		<Box display='flex' flexDirection='column' alignItems='flex-start' {...props}>
 			<Margins blockEnd={8}>
 				<Box fontScale='h4'>{t('Two-factor_authentication_via_TOTP')}</Box>
-				{!totpEnabled && !registeringTotp && (
+				{!isTotpEnabled && !registeringTotp && (
 					<>
 						<Box>{t('Two-factor_authentication_is_currently_disabled')}</Box>
 						<Button primary onClick={handleEnableTotp}>
@@ -129,7 +133,7 @@ const TwoFactorTOTP = (props: TwoFactorTOTPProps): ReactElement => {
 						</Button>
 					</>
 				)}
-				{!totpEnabled && registeringTotp && (
+				{!isTotpEnabled && registeringTotp && (
 					<>
 						<Box>{t('Scan_QR_code')}</Box>
 						<Box>{t('Scan_QR_code_alternative_s')}</Box>
@@ -143,7 +147,7 @@ const TwoFactorTOTP = (props: TwoFactorTOTPProps): ReactElement => {
 						</Box>
 					</>
 				)}
-				{totpEnabled && (
+				{isTotpEnabled && (
 					<>
 						<Button danger onClick={handleDisableTotp}>
 							{t('Disable_two-factor_authentication')}


### PR DESCRIPTION
## Proposed changes (including videos)
This pull request addresses the issue where the UI does not immediately reflect changes in the 2FA status (both TOTP and email) after enabling or disabling them. The state is updated correctly in the backend, but the frontend UI fails to re-render, requiring a page reload to display the updated status. The fix ensures that the UI reflects the new 2FA status immediately after the change is made without requiring a page reload.

## 2FA TOTP Video:

https://github.com/user-attachments/assets/8bfb8fe3-c70e-4d67-87df-fd55a0eba5e8



## 2FA Email Video:

https://github.com/user-attachments/assets/0efc74ef-9ab4-4681-9955-b37aa89296b6



## Issue(s)
Closes #35184


## Steps to test or reproduce

1. Go to the 2FA settings page (Profile -> Security).
2. Enable or disable 2FA for either TOTP or email.
3. Observe that the UI now updates immediately to reflect the new status without requiring a page reload.
4. Verify that the UI correctly reflects the changes after each action, ensuring the status is in sync with the backend.

## Further comments
To resolve the issue, I added a state update and re-render logic to the UI component after enabling or disabling 2FA. This ensures that the UI synchronizes with the backend immediately. No page reload is needed after the action is performed.
