### PR TITLE
 fix: : Keeping emojiPicker open even after an emoji selection 

### DIFF
--- a/apps/meteor/client/views/composer/EmojiPicker/EmojiPicker.tsx
+++ b/apps/meteor/client/views/composer/EmojiPicker/EmojiPicker.tsx
@@ -125,7 +125,7 @@ const EmojiPicker = ({ reference, onClose, onPickEmoji }: EmojiPickerProps) => {
 
 		onPickEmoji(_emoji + tone);
 		addRecentEmoji(_emoji + tone);
-		onClose();
+		
 	};
 
 	useEffect(() => {

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -162,6 +162,7 @@ const MessageBox = ({
 		const text = chat.composer?.text ?? '';
 		chat.composer?.clear();
 		popup.clear();
+		chat.emojiPicker?.close();
 
 		onSend?.({
 			value: text,


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
The emoji picker should remain open until the user performs one of the following actions:
- Clicks on the message bar,
- Clicks the send button,
- Clicks outside of the emoji picker (i.e., the focus leaves the popup).

https://github.com/user-attachments/assets/e4ffe678-87e1-4713-a47c-e4b152c0f700


## Issue(s)
 #35200

