### PR TITLE
fix: bold formatting breaks when using *text:*

### DIFF
--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -162,9 +162,9 @@ const MessageBox = ({
 		const text = chat.composer?.text ?? '';
 		chat.composer?.clear();
 		popup.clear();
-
+		const correctText = text.replace(/(\S):/g, "$1: ");
 		onSend?.({
-			value: text,
+			value: correctText,
 			tshow,
 			previewUrls,
 			isSlashCommandAllowed,


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

https://github.com/user-attachments/assets/081512fa-6752-4e41-9f2c-0ce672c3f02d


## Issue(s)
 #35292

## Steps to test or reproduce
1. Open any **group, channel, or direct message**.  
2. Send the following messages to yourself:  
   - `*yourMessage:*`  
   - `*yourMessage: *`  
3. Observe the difference in formatting.  
