### PR TITLE
regression: Old stored query conflicting with new filters applied

### DIFF
--- a/apps/meteor/client/views/omnichannel/directory/providers/ChatsProvider.tsx
+++ b/apps/meteor/client/views/omnichannel/directory/providers/ChatsProvider.tsx
@@ -11,7 +11,7 @@ type ChatsProviderProps = {
 
 const ChatsProvider = ({ children }: ChatsProviderProps) => {
 	const textInputRef = useRef<HTMLInputElement>(null);
-	const [filtersQuery, setFiltersQuery] = useLocalStorage('conversationsQuery', initialValues);
+	const [filtersQuery, setFiltersQuery] = useLocalStorage('newConversationsQuery', initialValues);
 	const displayFilters = useDisplayFilters(filtersQuery);
 
 	const contextValue = useMemo(


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
The problem is: since we store the current query on the local storage, old installations will have some data that's no longer compatible with the new version. For example, fields that have been converted to be an array instead of an string will fail to be processed.
The work to support both, or to make the old compatible with the new is greater than what we get from them (after the first use, the code to support old stored value would become legacy as a new payload will be stored, rendering the code useless from that point). So, quickest solution: change the key where we store, allowing new installations to set new data, and old installations to not fail :)

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
Introduced here: #35147
