### PR TITLE
fix: webdav mime is optional

### DIFF
--- a/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/lib/getNodeIconType.ts
+++ b/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/lib/getNodeIconType.ts
@@ -13,31 +13,29 @@ export const getNodeIconType = (
 		extension = '';
 	}
 
-	if (!mime) {
-		throw new Error('mime is required');
-	}
-
 	if (fileType === 'directory') {
 		icon = 'folder';
 		type = 'directory';
-	} else if (mime.match(/application\/pdf/)) {
-		icon = 'file-pdf';
-		type = 'pdf';
-	} else if (['application/vnd.oasis.opendocument.text', 'application/vnd.oasis.opendocument.presentation'].includes(mime)) {
-		icon = 'file-document';
-		type = 'document';
-	} else if (
-		[
-			'application/vnd.ms-excel',
-			'application/vnd.oasis.opendocument.spreadsheet',
-			'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-		].includes(mime)
-	) {
-		icon = 'file-sheets';
-		type = 'sheets';
-	} else if (['application/vnd.ms-powerpoint', 'application/vnd.oasis.opendocument.presentation'].includes(mime)) {
-		icon = 'file-sheets';
-		type = 'ppt';
+	} else if (mime) {
+		if (mime.match(/application\/pdf/)) {
+			icon = 'file-pdf';
+			type = 'pdf';
+		} else if (['application/vnd.oasis.opendocument.text', 'application/vnd.oasis.opendocument.presentation'].includes(mime)) {
+			icon = 'file-document';
+			type = 'document';
+		} else if (
+			[
+				'application/vnd.ms-excel',
+				'application/vnd.oasis.opendocument.spreadsheet',
+				'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+			].includes(mime)
+		) {
+			icon = 'file-sheets';
+			type = 'sheets';
+		} else if (['application/vnd.ms-powerpoint', 'application/vnd.oasis.opendocument.presentation'].includes(mime)) {
+			icon = 'file-sheets';
+			type = 'ppt';
+		}
 	}
 	return { icon, type, extension };
 };


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

## Issue(s)
https://github.com/RocketChat/Rocket.Chat/issues/31183

## Steps to test or reproduce
- Enable webdav
- add nextcloud server (see https://docs.rocket.chat/docs/nextcloud-and-webdav-integrations)
- it works!

## Further comments
`mime` is not defined for folder and the if condition does not use it for folder, so I make it truly optional.

I tested the change again my Nextcloud and now it works great
