### PR TITLE
Custom  audioplayer with dropdown playback menu

### DIFF
--- a/apps/meteor/client/components/message/content/attachments/file/AudioAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/AudioAttachment.tsx
@@ -1,31 +1,40 @@
-import type { AudioAttachmentProps } from '@rocket.chat/core-typings';
-import { AudioPlayer } from '@rocket.chat/fuselage';
+import { AudioAttachmentProps } from '@rocket.chat/core-typings';
+import { Box } from '@rocket.chat/fuselage';
 import { useMediaUrl } from '@rocket.chat/ui-contexts';
-
 import MarkdownText from '../../../../MarkdownText';
 import MessageCollapsible from '../../../MessageCollapsible';
 import MessageContentBody from '../../../MessageContentBody';
+import CustomAudioPlayer from './AudioPlayerWithSpeed'; // 
 
 const AudioAttachment = ({
-	title,
-	audio_url: url,
-	audio_type: type,
-	audio_size: size,
-	description,
-	descriptionMd,
-	title_link: link,
-	title_link_download: hasDownload,
-	collapsed,
+  title,
+  audio_url: url,
+  audio_type: type,
+  description,
+  title_link: link,
+  title_link_download: hasDownload,
+  audio_size: size,
+  collapsed,
+  descriptionMd,
 }: AudioAttachmentProps) => {
-	const getURL = useMediaUrl();
-	return (
-		<>
-			{descriptionMd ? <MessageContentBody md={descriptionMd} /> : <MarkdownText parseEmoji content={description} />}
-			<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
-				<AudioPlayer src={getURL(url)} type={type} />
-			</MessageCollapsible>
-		</>
-	);
+  const getURL = useMediaUrl();
+  const audioSrc = getURL(url);
+
+  return (
+    <Box display="flex" flexDirection="column" alignItems="flex-start" p="x8">
+	<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
+
+      {descriptionMd ? (
+        <MessageContentBody md={descriptionMd} />
+      ) : (
+        <MarkdownText parseEmoji content={description} />
+      )}
+
+        <CustomAudioPlayer src={audioSrc} type={type} />
+      </MessageCollapsible>
+
+    </Box>
+  );
 };
 
 export default AudioAttachment;

--- a/apps/meteor/client/components/message/content/attachments/file/AudioPlayerWithSpeed.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/AudioPlayerWithSpeed.tsx
@@ -1,0 +1,150 @@
+import { Box, Button, Icon, Select } from '@rocket.chat/fuselage';
+import { ChangeEvent, FC, Key, useEffect, useRef, useState } from 'react';
+
+const formatTime = (timeInSeconds: number): string => {
+  if (!Number.isFinite(timeInSeconds)) {
+    return '00:00';
+  }
+  const minutes = Math.floor(timeInSeconds / 60);
+  const seconds = Math.floor(timeInSeconds % 60);
+  const mm = String(minutes).padStart(2, '0');
+  const ss = String(seconds).padStart(2, '0');
+  return `${mm}:${ss}`;
+};
+
+interface CustomAudioPlayerProps {
+  src: string;
+  type?: string;
+  downloadUrl?: string;
+  onDownloadClick?: () => void;
+}
+
+const CustomAudioPlayer: FC<CustomAudioPlayerProps> = ({
+  src,
+  type,
+  downloadUrl,
+  onDownloadClick,
+}) => {
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [playbackRate, setPlaybackRate] = useState(1);
+
+  const handlePlayPause = () => {
+    if (!audioRef.current) return;
+    if (isPlaying) {
+      audioRef.current.pause();
+    } else {
+      audioRef.current.play();
+    }
+  };
+
+  const handlePlay = () => setIsPlaying(true);
+  const handlePause = () => setIsPlaying(false);
+
+  const handleLoadedMetadata = () => {
+    if (audioRef.current) {
+      setDuration(audioRef.current.duration);
+    }
+  };
+
+  const handleTimeUpdate = () => {
+    if (audioRef.current) {
+      setCurrentTime(audioRef.current.currentTime);
+    }
+  };
+
+  const handleEnded = () => setIsPlaying(false);
+
+  const handleSeekChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const newTime = Number(e.target.value);
+    if (audioRef.current) {
+      audioRef.current.currentTime = newTime;
+    }
+    setCurrentTime(newTime);
+  };
+
+  const handleSpeedChange = (key: Key) => {
+    const newSpeed = parseFloat(key.toString());
+    if (!isNaN(newSpeed)) {
+      setPlaybackRate(newSpeed);
+      if (audioRef.current) {
+        audioRef.current.playbackRate = newSpeed;
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (audioRef.current) {
+      audioRef.current.playbackRate = playbackRate;
+    }
+  }, [playbackRate]);
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      borderRadius="x4"
+      p="x8"
+      bg="neutral-100"
+      border="none"
+      style={{ gap: '8px', width: '100%', maxWidth: '400px' }}
+    >
+      <audio
+        ref={audioRef}
+        src={src}
+        onPlay={handlePlay}
+        onPause={handlePause}
+        onEnded={handleEnded}
+        onTimeUpdate={handleTimeUpdate}
+        onLoadedMetadata={handleLoadedMetadata}
+      >
+        {type && <source src={src} type={type} />}
+        Your browser does not support the audio element.
+      </audio>
+
+      <Button square small onClick={handlePlayPause}>
+        {isPlaying ? <Icon name="pause" size="x20" /> : <Icon name="play" size="x20" />}
+      </Button>
+
+      <Box fontScale="c1" width="80px" textAlign="center">
+        {formatTime(currentTime)} / {formatTime(duration)}
+      </Box>
+
+      <Box flexGrow={1}>
+        <input
+          type="range"
+          min={0}
+          max={duration}
+          value={currentTime}
+          onChange={handleSeekChange}
+          style={{ width: '100%' }}
+        />
+      </Box>
+
+      <Select
+        options={[
+          ['0.5', '0.5x'],
+          ['0.75', '0.75x'],
+          ['1', '1x'],
+          ['1.25', '1.25x'],
+          ['1.5', '1.5x'],
+          ['2', '2x'],
+        ]}
+        value={playbackRate.toString()}
+        onChange={handleSpeedChange}
+        style={{ width: '70px' }}
+      />
+
+      {downloadUrl && (
+        <Button square small is="a" href={downloadUrl} download onClick={onDownloadClick}>
+          <Icon size="x20" name="download" />
+        </Button>
+      )}
+    </Box>
+  );
+};
+
+export default CustomAudioPlayer;


### PR DESCRIPTION
## Fixes #35337 

 Added a custom audioplayer and created a dropdown Playback menu.
 The main motivation behind this change was to address the limitations of the default player—specifically, its non-removable toggle UI that hindered our ability to achieve a clean, streamlined design.
 
 
![image](https://github.com/user-attachments/assets/123400fc-fdff-4047-be24-07b1d7f6253d)
