### PR TITLE
fix: Duplicate Toast Notification on Invite-Link

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/RoomMembers/InviteUsers/InviteUsersWithData.tsx
+++ b/apps/meteor/client/views/room/contextualBar/RoomMembers/InviteUsers/InviteUsersWithData.tsx
@@ -2,7 +2,7 @@ import type { IRoom } from '@rocket.chat/core-typings';
 import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
 import { useEndpoint, useTranslation, useToastMessageDispatch } from '@rocket.chat/ui-contexts';
 import type { ReactElement } from 'react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 import InviteUsers from './InviteUsers';
 import { useFormatDateAndTime } from '../../../../../hooks/useFormatDateAndTime';
@@ -36,6 +36,7 @@ const InviteUsersWithData = ({ rid, onClickBack }: InviteUsersWithDataProps): Re
 	const { closeTab } = useRoomToolbox();
 	const format = useFormatDateAndTime();
 	const findOrCreateInvite = useEndpoint('POST', '/v1/findOrCreateInvite');
+	const requestSent = useRef<boolean>(false);
 
 	const handleEdit = useEffectEvent(() => setInviteState((prevState) => ({ ...prevState, isEditing: true })));
 	const handleBackToLink = useEffectEvent(() => setInviteState((prevState) => ({ ...prevState, isEditing: false })));
@@ -80,6 +81,9 @@ const InviteUsersWithData = ({ rid, onClickBack }: InviteUsersWithDataProps): Re
 	);
 
 	useEffect(() => {
+		if (requestSent.current) return;
+		requestSent.current = true;
+
 		(async (): Promise<void> => {
 			try {
 				const data = await findOrCreateInvite({ rid, days: Number(days), maxUses: Number(maxUses) });


### PR DESCRIPTION
## What does this PR do?
This PR fixes the issue where notifications were sent twice instead of once, ensuring proper notification behavior.

## Video

https://github.com/user-attachments/assets/11825f13-21a7-44dc-9214-d41c6807309d

## Issue(s)
#35335 

## Steps to test or reproduce
1. Go to Home.
2. Create a new channel.
3. Inside the channel, click on the member icon at the top.
4. Click on "Invite Link."
