### PR TITLE
regression: show message asking for updating workspace when unsupported version

### DIFF
--- a/apps/meteor/client/views/marketplace/AppsPage/AppsPageContent.tsx
+++ b/apps/meteor/client/views/marketplace/AppsPage/AppsPageContent.tsx
@@ -140,7 +140,10 @@ const AppsPageContent = (): ReactElement => {
 
 	const noInstalledApps = appsResult.phase === AsyncStatePhase.RESOLVED && !isMarketplace && appsResult.value?.totalAppsLength === 0;
 
-	const unsupportedVersion = appsResult.phase === AsyncStatePhase.REJECTED && appsResult.error.message === 'unsupported version';
+	// TODO: Introduce error codes, so we can avoid using error message strings for this kind of logic
+	//       whenever we change the error message, this code ends up breaking.
+	const unsupportedVersion =
+		appsResult.phase === AsyncStatePhase.REJECTED && appsResult.error.message === 'Marketplace_Unsupported_Version';
 
 	const noMarketplaceOrInstalledAppMatches =
 		appsResult.phase === AsyncStatePhase.RESOLVED && (isMarketplace || isPremium) && appsResult.value?.count === 0;

--- a/apps/meteor/ee/server/apps/communication/rest.ts
+++ b/apps/meteor/ee/server/apps/communication/rest.ts
@@ -28,7 +28,7 @@ import { formatAppInstanceForRest } from '../../../lib/misc/formatAppInstanceFor
 import { notifyAppInstall } from '../marketplace/appInstall';
 import { fetchMarketplaceApps } from '../marketplace/fetchMarketplaceApps';
 import { fetchMarketplaceCategories } from '../marketplace/fetchMarketplaceCategories';
-import { MarketplaceConnectionError, MarketplaceAppsError } from '../marketplace/marketplaceErrors';
+import { MarketplaceConnectionError, MarketplaceAppsError, MarketplaceUnsupportedVersionError } from '../marketplace/marketplaceErrors';
 import type { AppServerOrchestrator } from '../orchestrator';
 import { Apps } from '../orchestrator';
 
@@ -122,7 +122,7 @@ export class AppsRestApi {
 							return handleError('Unable to access Marketplace. Does the server has access to the internet?', err);
 						}
 
-						if (err instanceof MarketplaceAppsError) {
+						if (err instanceof MarketplaceAppsError || err instanceof MarketplaceUnsupportedVersionError) {
 							return API.v1.failure({ error: err.message });
 						}
 
@@ -151,7 +151,7 @@ export class AppsRestApi {
 							return handleError('Unable to access Marketplace. Does the server has access to the internet?', err);
 						}
 
-						if (err instanceof MarketplaceAppsError) {
+						if (err instanceof MarketplaceAppsError || err instanceof MarketplaceUnsupportedVersionError) {
 							return API.v1.failure({ error: err.message });
 						}
 
@@ -229,7 +229,7 @@ export class AppsRestApi {
 								return handleError('Unable to access Marketplace. Does the server has access to the internet?', e);
 							}
 
-							if (e instanceof MarketplaceAppsError) {
+							if (e instanceof MarketplaceAppsError || e instanceof MarketplaceUnsupportedVersionError) {
 								return API.v1.failure({ error: e.message });
 							}
 
@@ -253,7 +253,7 @@ export class AppsRestApi {
 								return handleError('Unable to access Marketplace. Does the server has access to the internet?', err);
 							}
 
-							if (err instanceof MarketplaceAppsError) {
+							if (err instanceof MarketplaceAppsError || err instanceof MarketplaceUnsupportedVersionError) {
 								return API.v1.failure({ error: err.message });
 							}
 

--- a/apps/meteor/ee/server/apps/marketplace/fetchMarketplaceApps.ts
+++ b/apps/meteor/ee/server/apps/marketplace/fetchMarketplaceApps.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { getMarketplaceHeaders } from './getMarketplaceHeaders';
 import { getWorkspaceAccessToken } from '../../../../app/cloud/server';
 import { Apps } from '../orchestrator';
-import { MarketplaceAppsError, MarketplaceConnectionError } from './marketplaceErrors';
+import { MarketplaceAppsError, MarketplaceConnectionError, MarketplaceUnsupportedVersionError } from './marketplaceErrors';
 
 type FetchMarketplaceAppsParams = {
 	endUserID?: string;
@@ -159,6 +159,11 @@ export async function fetchMarketplaceApps({ endUserID }: FetchMarketplaceAppsPa
 	const response = await request.json();
 
 	Apps.getRocketChatLogger().error('Failed to fetch marketplace apps', response);
+
+	// TODO: Refactor cloud to return a proper error code on unsupported version
+	if (request.status === 426 && 'errorMsg' in response && response.errorMsg === 'unsupported version') {
+		throw new MarketplaceUnsupportedVersionError();
+	}
 
 	if (request.status === 400 && response.code === 200) {
 		throw new MarketplaceAppsError('Marketplace_Invalid_Apps_Engine_Version');

--- a/apps/meteor/ee/server/apps/marketplace/fetchMarketplaceCategories.ts
+++ b/apps/meteor/ee/server/apps/marketplace/fetchMarketplaceCategories.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { getMarketplaceHeaders } from './getMarketplaceHeaders';
 import { getWorkspaceAccessToken } from '../../../../app/cloud/server';
 import { Apps } from '../orchestrator';
-import { MarketplaceAppsError, MarketplaceConnectionError } from './marketplaceErrors';
+import { MarketplaceAppsError, MarketplaceConnectionError, MarketplaceUnsupportedVersionError } from './marketplaceErrors';
 
 const fetchMarketplaceCategoriesSchema = z.array(
 	z.object({
@@ -40,6 +40,14 @@ export async function fetchMarketplaceCategories(): Promise<AppCategory[]> {
 	}
 
 	const response = await request.json();
+
+	Apps.getRocketChatLogger().error('Failed to fetch marketplace categories', response);
+
+	// TODO: Refactor cloud to return a proper error code on unsupported version
+	if (request.status === 426 && 'errorMsg' in response && response.errorMsg === 'unsupported version') {
+		throw new MarketplaceUnsupportedVersionError();
+	}
+
 	const INTERNAL_MARKETPLACE_ERROR_CODES = [189, 266];
 
 	if (request.status === 500 && INTERNAL_MARKETPLACE_ERROR_CODES.includes(response.code)) {

--- a/apps/meteor/ee/server/apps/marketplace/marketplaceErrors.ts
+++ b/apps/meteor/ee/server/apps/marketplace/marketplaceErrors.ts
@@ -1,13 +1,17 @@
 export class MarketplaceAppsError extends Error {
 	constructor(message: string) {
 		super(message);
-		this.name = 'MarketplaceAppsError';
 	}
 }
 
 export class MarketplaceConnectionError extends Error {
 	constructor(message: string) {
 		super(message);
-		this.name = 'MarketplaceConnectionError';
+	}
+}
+
+export class MarketplaceUnsupportedVersionError extends Error {
+	constructor() {
+		super('Marketplace_Unsupported_Version');
 	}
 }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Since the changes introduced in: https://github.com/RocketChat/Rocket.Chat/pull/35059 we changed how the errors are returned to the client, abstracting away marketplace errors with our own errors. But, since we used to match on the string value of the error (returned by marketplace) we broken this screen.
The fix is really simple since it is a regression and I don't think we should do major refactorings, but as the backend goes through a more standardized version of throwing marketplace errors, we should look into handling it in the marketplace more gracefully.

![Captura de Tela 2025-02-27 às 10 20 36](https://github.com/user-attachments/assets/552a19cf-b409-4f0f-96d5-f828e6abe60c)


## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CONN-550](https://rocketchat.atlassian.net/browse/CONN-550)

[CONN-550]: https://rocketchat.atlassian.net/browse/CONN-550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

This pull request addresses a regression issue in the Rocket.Chat repository by updating the error message handling for unsupported marketplace versions. Specifically, it modifies the `AppsPageContent.tsx` file to improve the check for unsupported versions and includes a TODO comment suggesting the future implementation of error codes instead of relying on string matching. The changes are intended for the `release-7.4.0` branch, originating from the `regression/not-showing-unsupported-version` branch.