### PR TITLE
feat: added eye icon to toggle password visibility on click

### DIFF
--- a/.changeset/lemon-mirrors-battle.md
+++ b/.changeset/lemon-mirrors-battle.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+changed password key to eye with visibility on click


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Removed key icon from the password input box which does nothing replaced with eye icon when clicked it shows the password.
[Screencast from 2025-02-12 00-22-35.webm](https://github.com/user-attachments/assets/e89d04b5-3c66-4a4c-a1bc-901313319cc0)

## Issue(s)
closes #35166


## Steps to test or reproduce
1. select profile 
2. choose security 
3. fill up the password 
4. click on the eye icon

