### PR TITLE
Release 7.3.3

### DIFF
--- a/.changeset/green-panthers-poke.md
+++ b/.changeset/green-panthers-poke.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Add a retry mechanism to get supported versions from Cloud

--- a/.changeset/popular-boats-poke.md
+++ b/.changeset/popular-boats-poke.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/omnichannel-services": patch
+"@rocket.chat/pdf-worker": patch
+---
+
+Fixes omnichannel transcript filename breaking download links

--- a/.changeset/popular-boats-poke.md
+++ b/.changeset/popular-boats-poke.md
@@ -1,6 +1,7 @@
 ---
 "@rocket.chat/omnichannel-services": patch
 "@rocket.chat/pdf-worker": patch
+"@rocket.chat/meteor": patch
 ---
 
 Fixes omnichannel transcript filename breaking download links

--- a/ee/packages/omnichannel-services/src/OmnichannelTranscript.ts
+++ b/ee/packages/omnichannel-services/src/OmnichannelTranscript.ts
@@ -519,7 +519,7 @@ export class OmnichannelTranscript extends ServiceClass implements IOmnichannelT
 					buffer,
 					details: {
 						// transcript_{company-name}_{date}_{hour}.pdf
-						name: `${transcriptText}_${data.siteName}_${new Intl.DateTimeFormat('en-US').format(new Date())}_${
+						name: `${transcriptText}_${data.siteName}_${new Intl.DateTimeFormat('en-US').format(new Date()).replace(/\//g, '-')}_${
 							data.visitor?.name || data.visitor?.username || 'Visitor'
 						}.pdf`,
 						type: 'application/pdf',

--- a/ee/packages/pdf-worker/src/worker.fixtures.ts
+++ b/ee/packages/pdf-worker/src/worker.fixtures.ts
@@ -424,7 +424,7 @@ export const bigConversationData = {
 			},
 			files: [
 				{
-					name: 'Transcript_Another test_4/24/2024_Alayna.pdf',
+					name: 'Transcript_Another test_4-24-2024_Alayna.pdf',
 					buffer: null,
 				},
 			],
@@ -454,7 +454,7 @@ export const bigConversationData = {
 			},
 			files: [
 				{
-					name: 'Transcript_Another test_4/24/2024_Alayna.pdf',
+					name: 'Transcript_Another test_4-24-2024_Alayna.pdf',
 					buffer: null,
 				},
 			],

--- a/yarn.lock
+++ b/yarn.lock
@@ -7902,10 +7902,10 @@ __metadata:
     "@rocket.chat/icons": "*"
     "@rocket.chat/prettier-config": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 11.0.1
-    "@rocket.chat/ui-contexts": 15.0.1
+    "@rocket.chat/ui-avatar": 11.0.2
+    "@rocket.chat/ui-contexts": 15.0.2
     "@rocket.chat/ui-kit": 0.37.0
-    "@rocket.chat/ui-video-conf": 15.0.1
+    "@rocket.chat/ui-video-conf": 15.0.2
     "@tanstack/react-query": "*"
     react: ~17.0.2
     react-dom: "*"
@@ -7990,8 +7990,8 @@ __metadata:
     "@rocket.chat/fuselage-tokens": "*"
     "@rocket.chat/message-parser": 0.31.31
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-client": 15.0.1
-    "@rocket.chat/ui-contexts": 15.0.1
+    "@rocket.chat/ui-client": 15.0.2
+    "@rocket.chat/ui-contexts": 15.0.2
     katex: "*"
     react: "*"
   languageName: unknown
@@ -9234,7 +9234,7 @@ __metadata:
     typescript: "npm:~5.7.2"
   peerDependencies:
     "@rocket.chat/fuselage": "*"
-    "@rocket.chat/ui-contexts": 15.0.1
+    "@rocket.chat/ui-contexts": 15.0.2
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -9286,8 +9286,8 @@ __metadata:
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-avatar": 11.0.1
-    "@rocket.chat/ui-contexts": 15.0.1
+    "@rocket.chat/ui-avatar": 11.0.2
+    "@rocket.chat/ui-contexts": 15.0.2
     react: "*"
     react-i18next: "*"
   languageName: unknown
@@ -9457,8 +9457,8 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 11.0.1
-    "@rocket.chat/ui-contexts": 15.0.1
+    "@rocket.chat/ui-avatar": 11.0.2
+    "@rocket.chat/ui-contexts": 15.0.2
     react: ~17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -9514,9 +9514,9 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 11.0.1
-    "@rocket.chat/ui-client": 15.0.1
-    "@rocket.chat/ui-contexts": 15.0.1
+    "@rocket.chat/ui-avatar": 11.0.2
+    "@rocket.chat/ui-client": 15.0.2
+    "@rocket.chat/ui-contexts": 15.0.2
     react: ~17.0.2
     react-aria: ~3.23.1
     react-dom: ^17.0.2
@@ -9606,7 +9606,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.2.2
-    "@rocket.chat/ui-contexts": 15.0.1
+    "@rocket.chat/ui-contexts": 15.0.2
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION
<!-- release-notes-start -->
<!-- This content is automatically generated. Changing this will not reflect on the final release log -->

_You can see below a preview of the release change log:_

# 7.3.3

### Engine versions

- Node: `22.11.0`
- MongoDB: `5.0, 6.0, 7.0`
- Apps-Engine: `1.48.2`

### Patch Changes

*   Add a retry mechanism to get supported versions from Cloud

*   ([#35353](https://github.com/RocketChat/Rocket.Chat/pull/35353) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixes omnichannel transcript filename breaking download links

*   <details><summary>Updated dependencies [b2d71461a6a73157024e4594cc1228419a34673e]:</summary>

    *   @rocket.chat/omnichannel-services@0.3.13
    *   @rocket.chat/pdf-worker@0.2.13
    *   @rocket.chat/core-typings@7.3.3
    *   @rocket.chat/rest-typings@7.3.3
    *   @rocket.chat/license@1.0.7
    *   @rocket.chat/presence@0.2.16
    *   @rocket.chat/api-client@0.2.16
    *   @rocket.chat/apps@0.2.7
    *   @rocket.chat/core-services@0.7.8
    *   @rocket.chat/cron@0.1.16
    *   @rocket.chat/freeswitch@1.2.3
    *   @rocket.chat/fuselage-ui-kit@15.0.3
    *   @rocket.chat/gazzodown@15.0.3
    *   @rocket.chat/model-typings@1.3.3
    *   @rocket.chat/ui-contexts@15.0.3
    *   @rocket.chat/models@1.2.3
    *   @rocket.chat/server-cloud-communication@0.0.2
    *   @rocket.chat/network-broker@0.1.8
    *   @rocket.chat/ui-theming@0.4.2
    *   @rocket.chat/ui-avatar@11.0.3
    *   @rocket.chat/ui-client@15.0.3
    *   @rocket.chat/ui-video-conf@15.0.3
    *   @rocket.chat/ui-voip@5.0.3
    *   @rocket.chat/web-ui-registration@15.0.3
    *   @rocket.chat/instance-status@0.1.16

    </details>

<!-- release-notes-end -->