### PR TITLE
[FIX] Dropdown not closing when clicking outside and obstructing 'Create' button in Direct Message modal

### DIFF
--- a/apps/meteor/client/components/UserAutoCompleteMultiple/UserAutoCompleteMultipleFederated.tsx
+++ b/apps/meteor/client/components/UserAutoCompleteMultiple/UserAutoCompleteMultipleFederated.tsx
@@ -5,122 +5,199 @@ import { UserAvatar } from '@rocket.chat/ui-avatar';
 import { useEndpoint } from '@rocket.chat/ui-contexts';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import type { ReactElement, AllHTMLAttributes } from 'react';
-import { memo, useState, useCallback, useMemo } from 'react';
+import React, { memo, useState, useCallback, useMemo, useRef, useEffect } from 'react';
 
 import AutocompleteOptions, { OptionsContext } from './UserAutoCompleteMultipleOptions';
 
 type UserAutoCompleteMultipleFederatedProps = {
-	onChange: (value: Array<string>) => void;
-	value: Array<string>;
-	placeholder?: string;
+  onChange: (value: Array<string>) => void;
+  value: Array<string>;
+  placeholder?: string;
 } & Omit<AllHTMLAttributes<HTMLElement>, 'is' | 'onChange'>;
 
 type UserAutoCompleteOptionType = {
-	name: string;
-	username: string;
-	_federated?: boolean;
+  name: string;
+  username: string;
+  _federated?: boolean;
 };
 
 type UserAutoCompleteOptions = {
-	[k: string]: UserAutoCompleteOptionType;
+  [k: string]: UserAutoCompleteOptionType;
 };
 
 const matrixRegex = new RegExp('@(.*:.*)');
 
 const UserAutoCompleteMultipleFederated = ({
-	onChange,
-	value,
-	placeholder,
-	...props
+  onChange,
+  value,
+  placeholder,
+  ...props
 }: UserAutoCompleteMultipleFederatedProps): ReactElement => {
-	const [filter, setFilter] = useState('');
-	const [selectedCache, setSelectedCache] = useState<UserAutoCompleteOptions>({});
+  const [filter, setFilter] = useState('');
+  const [selectedCache, setSelectedCache] = useState<UserAutoCompleteOptions>({});
+  const [dropUp, setDropUp] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
-	const debouncedFilter = useDebouncedValue(filter, 500);
-	const getUsers = useEndpoint('GET', '/v1/users.autocomplete');
+  const debouncedFilter = useDebouncedValue(filter, 500);
+  const getUsers = useEndpoint('GET', '/v1/users.autocomplete');
 
-	const { data } = useQuery({
-		queryKey: ['users.autocomplete', debouncedFilter],
+  const { data } = useQuery({
+    queryKey: ['users.autocomplete', debouncedFilter],
 
-		queryFn: async () => {
-			const users = await getUsers({ selector: JSON.stringify({ term: debouncedFilter }) });
-			const options = users.items.map((item): [string, UserAutoCompleteOptionType] => [item.username, item]);
+    queryFn: async () => {
+      const users = await getUsers({ selector: JSON.stringify({ term: debouncedFilter }) });
+      const options = users.items.map((item): [string, UserAutoCompleteOptionType] => [item.username, item]);
 
-			// Add extra option if filter text matches `username:server`
-			// Used to add federated users that do not exist yet
-			if (matrixRegex.test(debouncedFilter)) {
-				options.unshift([debouncedFilter, { name: debouncedFilter, username: debouncedFilter, _federated: true }]);
-			}
+      // Add extra option if filter text matches `username:server`
+      // Used to add federated users that do not exist yet
+      if (matrixRegex.test(debouncedFilter)) {
+        options.unshift([debouncedFilter, { name: debouncedFilter, username: debouncedFilter, _federated: true }]);
+      }
 
-			return options;
-		},
+      return options;
+    },
 
-		placeholderData: keepPreviousData,
-	});
+    placeholderData: keepPreviousData,
+  });
 
-	const options = useMemo(() => data || [], [data]);
+  const options = useMemo(() => data || [], [data]);
 
-	const onAddUser = useCallback(
-		(username: string): void => {
-			const user = options.find(([val]) => val === username)?.[1];
-			if (!user) {
-				throw new Error('UserAutoCompleteMultiple - onAddSelected - failed to cache option');
-			}
-			setSelectedCache((selectedCache) => ({ ...selectedCache, [username]: user }));
-		},
-		[setSelectedCache, options],
-	);
+  const onAddUser = useCallback(
+    (username: string): void => {
+      const user = options.find(([val]) => val === username)?.[1];
+      if (!user) {
+        throw new Error('UserAutoCompleteMultiple - onAddSelected - failed to cache option');
+      }
+      setSelectedCache((selectedCache) => ({ ...selectedCache, [username]: user }));
+    },
+    [setSelectedCache, options],
+  );
 
-	const onRemoveUser = useCallback(
-		(username: string): void =>
-			setSelectedCache((selectedCache) => {
-				const users = { ...selectedCache };
-				delete users[username];
-				return users;
-			}),
-		[setSelectedCache],
-	);
+  const onRemoveUser = useCallback(
+    (username: string): void =>
+      setSelectedCache((selectedCache) => {
+        const users = { ...selectedCache };
+        delete users[username];
+        return users;
+      }),
+    [setSelectedCache],
+  );
 
-	const handleOnChange = useCallback(
-		(usernames: string[]) => {
-			onChange(usernames);
-			const newAddedUsername = usernames.filter((username) => !value.includes(username))[0];
-			const removedUsername = value.filter((username) => !usernames.includes(username))[0];
-			setFilter('');
-			newAddedUsername && onAddUser(newAddedUsername);
-			removedUsername && onRemoveUser(removedUsername);
-		},
-		[onChange, setFilter, onAddUser, onRemoveUser, value],
-	);
+  const handleOnChange = useCallback(
+    (usernames: string[]) => {
+      onChange(usernames);
+      const newAddedUsername = usernames.find((username) => !value.includes(username));
+      const removedUsername = value.find((username) => !usernames.includes(username));
+      setFilter('');
+      newAddedUsername && onAddUser(newAddedUsername);
+      removedUsername && onRemoveUser(removedUsername);
+    },
+    [onChange, setFilter, onAddUser, onRemoveUser, value],
+  );
 
-	return (
-		<OptionsContext.Provider value={{ options: options as unknown as OptionType[] }}>
-			<MultiSelectFiltered
-				{...props}
-				data-qa-type='user-auto-complete-input'
-				placeholder={placeholder}
-				value={value}
-				onChange={handleOnChange}
-				filter={filter}
-				setFilter={setFilter}
-				renderSelected={({ value, onMouseDown }: { value: string; onMouseDown: () => void }) => {
-					const currentCachedOption = selectedCache[value] || {};
+  const toggleDropDirection = () => {
+    setDropUp((prev) => !prev);
+  };
 
-					return (
-						<Chip key={value} height='x20' onMouseDown={onMouseDown} mie={4} mb={2}>
-							{currentCachedOption._federated ? <Icon size='x20' name='globe' /> : <UserAvatar size='x20' username={value} />}
-							<Box is='span' margin='none' mis={4}>
-								{currentCachedOption.name || currentCachedOption.username || value}
-							</Box>
-						</Chip>
-					);
-				}}
-				renderOptions={AutocompleteOptions}
-				options={options.concat(Object.entries(selectedCache)).map(([, item]) => [item.username, item.name || item.username])}
-				data-qa='create-channel-users-autocomplete'
-			/>
-		</OptionsContext.Provider>
-	);
+  // Function to adjust dropdown position
+  const adjustDropdownPosition = () => {
+    if (dropdownRef.current) {
+      const rect = dropdownRef.current.getBoundingClientRect();
+      const dropdownHeight = 200; // Approximate height of the dropdown
+      const spaceBelow = window.innerHeight - rect.bottom;
+
+      if (!dropUp && spaceBelow < dropdownHeight) {
+        setDropUp(true);
+      }
+    }
+  };
+
+  // Click-outside detection
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setFilter(''); // Close the dropdown by clearing the filter
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  // Adjust dropdown position
+  useEffect(() => {
+    adjustDropdownPosition();
+
+    if (filter) {
+      window.addEventListener('resize', adjustDropdownPosition);
+    } else {
+      window.removeEventListener('resize', adjustDropdownPosition);
+    }
+
+    return () => {
+      window.removeEventListener('resize', adjustDropdownPosition);
+    };
+  }, [filter, dropUp]);
+
+  return (
+    <div ref={dropdownRef} style={{ width: '100%' }}>
+      <style>
+        {`
+          .dropup .rcx-options {
+            top: auto;
+            bottom: 100%;
+          }
+        `}
+      </style>
+      <OptionsContext.Provider value={{ options: options as unknown as OptionType[] }}>
+        <MultiSelectFiltered
+          {...props}
+          style={{ width: '100%' }}
+          data-qa-type='user-auto-complete-input'
+          placeholder={placeholder}
+          value={value}
+          onChange={handleOnChange}
+          filter={filter}
+          setFilter={setFilter}
+          className={dropUp ? 'dropup' : ''}
+          renderSelected={({ value, onMouseDown }: { value: string; onMouseDown: () => void }) => {
+            const currentCachedOption = selectedCache[value] || {};
+
+            return (
+              <Chip key={value} height='x20' onMouseDown={onMouseDown} mie={4} mb={2}>
+                {currentCachedOption._federated ? (
+                  <Icon size='x20' name='globe' />
+                ) : (
+                  <UserAvatar size='x20' username={value} />
+                )}
+                <Box is='span' margin='none' mis={4}>
+                  {currentCachedOption.name || currentCachedOption.username || value}
+                </Box>
+              </Chip>
+            );
+          }}
+          renderOptions={AutocompleteOptions}
+          options={options.concat(Object.entries(selectedCache)).map(([, item]) => [
+            item.username,
+            item.name || item.username,
+          ])}
+          data-qa='create-channel-users-autocomplete'
+          addon={
+            <Icon
+              name={dropUp ? 'chevron-up' : 'chevron-down'}
+              size='x20'
+              onClick={(e) => {
+                e.stopPropagation();
+                toggleDropDirection();
+              }}
+            />
+          }
+        />
+      </OptionsContext.Provider>
+    </div>
+  );
 };
 
 export default memo(UserAutoCompleteMultipleFederated);


### PR DESCRIPTION
Closes #35375
Type: Bug

### Description

This pull request fixes the issue where the dropdown in the 'Create Direct Message' modal does not close when clicking outside, and when there are many suggested users, it obstructs the 'Create' button.

### Changes Made

- **Implemented click-outside detection**: The dropdown now closes when the user clicks outside of it.
- **Added drop-up functionality**: The dropdown opens upwards when there is insufficient space below, preventing it from covering the 'Create' button.
- **Ensured full-width input box**: The user input field now maintains full width for better usability.

### Testing

- Manually tested the dropdown behavior in the 'Create Direct Message' modal.
- Confirmed that clicking outside the dropdown closes it.
- Verified that the dropdown adjusts its position based on available space (drop-up functionality).
- Ensured that selecting and removing users works as expected.
- Checked that the input box stretches to fill the available space.

<h1>Before</h1>

Watch the video preview: [Google Drive Video](https://drive.google.com/file/d/1eFrNOdthbp8HjB4WzOlgN8-EA2wi_skq/view?usp=sharing)

<h1>After</h1>

Watch the video preview: [Google Drive Video](https://drive.google.com/file/d/1IqdxM6tMc81NFeZOfEnU3tJhw59KPFQ7/view?usp=sharing)
