### PR TITLE
fix: Improve User Dropdown Menu – Clicking Username, Status, or Avatar Should Open Profile #35224

### DIFF
--- a/apps/meteor/client/sidebar/header/hooks/useUserMenu.tsx
+++ b/apps/meteor/client/sidebar/header/hooks/useUserMenu.tsx
@@ -1,7 +1,7 @@
 import type { IUser } from '@rocket.chat/core-typings';
 import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
 import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
-import { useLogout } from '@rocket.chat/ui-contexts';
+import { useLogout, useRouter } from '@rocket.chat/ui-contexts';
 import { useTranslation } from 'react-i18next';
 
 import UserMenuHeader from '../UserMenuHeader';
@@ -11,6 +11,7 @@ import { useVoipItemsSection } from './useVoipItemsSection';
 
 export const useUserMenu = (user: IUser) => {
 	const { t } = useTranslation();
+	const router = useRouter();
 
 	const statusItems = useStatusItems();
 	const accountItems = useAccountItems();
@@ -21,6 +22,10 @@ export const useUserMenu = (user: IUser) => {
 		logout();
 	});
 
+	const handleProfileClick = () => {
+		router.navigate('/account/profile');
+	};
+
 	const logoutItem: GenericMenuItemProps = {
 		id: 'logout',
 		icon: 'sign-out',
@@ -30,7 +35,7 @@ export const useUserMenu = (user: IUser) => {
 
 	return [
 		{
-			title: <UserMenuHeader user={user} />,
+			title: <div onClick={handleProfileClick} style={{ cursor: 'pointer' }}><UserMenuHeader user={user} /></div>,
 			items: [],
 		},
 		{


### PR DESCRIPTION
PR for this issue: #35224 

## Problem
Currently, clicking on the **username, status, or avatar** in the **User Dropdown Menu** does nothing.  
However, users expect this action to navigate to their **Profile Settings**, as it is a common UX pattern.  

## Solution
- Implemented an `onClick` event on the **username, status, and avatar** section.
- Clicking any of these now redirects users to `/account/profile`.

## Screenshots (if applicable)

https://github.com/user-attachments/assets/12e21028-daef-40e7-8cd9-6b73fe3d9099



## Testing
- Manually tested the behavior in the UI.
- Ensured navigation works correctly without breaking existing functionality.

## Related Issue
Closes #35224
