### PR TITLE
fix: Disable "Create" button until mandatory fields are filled

### DIFF
--- a/apps/meteor/client/components/CreateDiscussion/CreateDiscussion.tsx
+++ b/apps/meteor/client/components/CreateDiscussion/CreateDiscussion.tsx
@@ -62,7 +62,8 @@ const CreateDiscussion = ({ onClose, defaultParentRoom, parentMessageId, nameSug
 	});
 
 	const { encrypted } = watch();
-
+	const parentRoom = watch('parentRoom'); 
+    const name = watch('name');
 	const createDiscussion = useEndpoint('POST', '/v1/rooms.createDiscussion');
 
 	const createDiscussionMutation = useMutation({
@@ -245,7 +246,7 @@ const CreateDiscussion = ({ onClose, defaultParentRoom, parentMessageId, nameSug
 			<Modal.Footer>
 				<Modal.FooterControllers>
 					<Button onClick={onClose}>{t('Cancel')}</Button>
-					<Button type='submit' primary loading={createDiscussionMutation.isPending}>
+					<Button type='submit' disabled={!parentRoom || !name} primary loading={createDiscussionMutation.isPending}>
 						{t('Create')}
 					</Button>
 				</Modal.FooterControllers>

--- a/apps/meteor/client/sidebar/header/CreateChannel/CreateChannelModal.tsx
+++ b/apps/meteor/client/sidebar/header/CreateChannel/CreateChannelModal.tsx
@@ -118,7 +118,7 @@ const CreateChannelModal = ({ teamId = '', mainRoom, onClose, reload }: CreateCh
 			federated: false,
 		},
 	});
-
+	const name = watch('name');
 	const { isPrivate, broadcast, readOnly, federated, encrypted } = watch();
 
 	useEffect(() => {
@@ -379,7 +379,7 @@ const CreateChannelModal = ({ teamId = '', mainRoom, onClose, reload }: CreateCh
 			<Modal.Footer>
 				<Modal.FooterControllers>
 					<Button onClick={onClose}>{t('Cancel')}</Button>
-					<Button type='submit' primary data-qa-type='create-channel-confirm-button'>
+					<Button type='submit' disabled={!name} primary data-qa-type='create-channel-confirm-button'>
 						{t('Create')}
 					</Button>
 				</Modal.FooterControllers>

--- a/apps/meteor/client/sidebar/header/CreateDirectMessage.tsx
+++ b/apps/meteor/client/sidebar/header/CreateDirectMessage.tsx
@@ -20,8 +20,9 @@ const CreateDirectMessage = ({ onClose }: { onClose: () => void }) => {
 		control,
 		handleSubmit,
 		formState: { isSubmitting, isValidating, errors },
+		watch,
 	} = useForm({ mode: 'onBlur', defaultValues: { users: [] } });
-
+	const users= watch('users');
 	const mutateDirectMessage = useMutation({
 		mutationFn: createDirectAction,
 		onSuccess: ({ room: { rid } }) => {
@@ -86,7 +87,7 @@ const CreateDirectMessage = ({ onClose }: { onClose: () => void }) => {
 			<Modal.Footer>
 				<Modal.FooterControllers>
 					<Button onClick={onClose}>{t('Cancel')}</Button>
-					<Button loading={isSubmitting || isValidating} type='submit' primary>
+					<Button loading={isSubmitting || isValidating} disabled={!users.length} type='submit' primary>
 						{t('Create')}
 					</Button>
 				</Modal.FooterControllers>

--- a/apps/meteor/client/sidebar/header/CreateTeam/CreateTeamModal.tsx
+++ b/apps/meteor/client/sidebar/header/CreateTeam/CreateTeamModal.tsx
@@ -93,7 +93,7 @@ const CreateTeamModal = ({ onClose }: { onClose: () => void }): ReactElement => 
 			members: [],
 		},
 	});
-
+	const name = watch('name');
 	const { isPrivate, broadcast, readOnly, encrypted } = watch();
 
 	useEffect(() => {
@@ -305,7 +305,7 @@ const CreateTeamModal = ({ onClose }: { onClose: () => void }): ReactElement => 
 			<Modal.Footer>
 				<Modal.FooterControllers>
 					<Button onClick={onClose}>{t('Cancel')}</Button>
-					<Button disabled={!canCreateTeam} loading={isSubmitting} type='submit' primary>
+					<Button disabled={!(canCreateTeam && name)} loading={isSubmitting} type='submit' primary>
 						{t('Create')}
 					</Button>
 				</Modal.FooterControllers>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->



## Proposed changes (including videos or screenshots)
this code going to disable the "Create" button until all the mandatory fields in direct message, teams, discussion , channel aren't filled. 

https://github.com/user-attachments/assets/bbb28026-cbb7-452a-9ce3-4770e10a2817




## Steps to test or reproduce
1. click on "create new " in top left bar. 
2. choose any from the following (teams, channel, direct message, discussion ) 
3. observe if u didn't fil the fields marked by star you can't click on create. 


### Server/Client Information

1. **Server:**
   1. **Operating System:** Windows 11 (using WSL Terminal)
   2. **Version of Rocket.Chat Server:** 7.5.0‑develop
   3. **NodeJS Version:** 22.13.1
   4. **Yarn Version:** 4.6.0

2. **Client:**
   1. **Client Type:** Browser (Microsoft Edge)
   2. **Access URL:** [http://localhost:3000](http://localhost:3000)

3. **Additional:**
   1. **WSL Terminal:** Used to install dependencies

##Additional
improving UI. 
