### PR TITLE
FIX : Sidebar RoomMenuaction remains visible after sidebar collapse

### DIFF
--- a/.changeset/strong-foxes-lie.md
+++ b/.changeset/strong-foxes-lie.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes an issue where the RoomMenuaction inside the sidebar remains visible after the sidebar is collapse.

--- a/apps/meteor/client/sidebar/RoomMenu.tsx
+++ b/apps/meteor/client/sidebar/RoomMenu.tsx
@@ -1,6 +1,6 @@
 import type { RoomType } from '@rocket.chat/core-typings';
 import { GenericMenu } from '@rocket.chat/ui-client';
-import { useTranslation } from '@rocket.chat/ui-contexts';
+import { useLayout, useTranslation } from '@rocket.chat/ui-contexts';
 import type { ReactElement } from 'react';
 import { memo } from 'react';
 
@@ -30,11 +30,21 @@ const RoomMenu = ({
 	hideDefaultOptions = false,
 }: RoomMenuProps): ReactElement | null => {
 	const t = useTranslation();
-
+	const { sidebar } = useLayout();
 	const isUnread = alert || unread || threadUnread;
 	const sections = useRoomMenuActions({ rid, type, name, isUnread, cl, roomOpen, hideDefaultOptions });
 
-	return <GenericMenu detached className='rcx-sidebar-item__menu' title={t('Options')} mini aria-keyshortcuts='alt' sections={sections} />;
+	return (
+		<GenericMenu
+			detached
+			className='rcx-sidebar-item__menu'
+			title={t('Options')}
+			mini
+			aria-keyshortcuts='alt'
+			disabled={sidebar.isCollapsed}
+			sections={sections}
+		/>
+	);
 };
 
 export default memo(RoomMenu);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
#35385 
## Steps to test or reproduce
1. Open the sidebar using the three horizontal lines.
2. Click on the RoomMenuaction icon to open the panel.
3. With the RoomMenuaction panel open, collapse the sidebar.
4. Observe that the RoomMenuaction panel remains visible.

Before : 

https://github.com/user-attachments/assets/396ac421-a40b-43ff-9c1e-b49c828e7987



After : 

https://github.com/user-attachments/assets/127fe3d5-4444-44e5-98a1-e9cadb0d65fe


## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
