### PR TITLE
fix: Fix issue #35402: missing comma in package.json.ejs.t

### DIFF
--- a/_templates/package/new/package.json.ejs.t
+++ b/_templates/package/new/package.json.ejs.t
@@ -18,7 +18,7 @@ to: packages/<%= name %>/package.json
 		"lint:fix": "eslint --ext .js,.jsx,.ts,.tsx . --fix",
 		"test": "jest",
 		"build": "rm -rf dist && tsc -p tsconfig.json",
-		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput"
+		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"build-preview": "mkdir -p ../../.preview && cp -r ./dist ../../.preview/<%= name.toLowerCase() %>"
 	},
 	"main": "./dist/index.js",


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

## **Title**  
fix: Fix issue #35402 - missing comma in `package.json.ejs.t`  

---

## **Proposed changes**  
The `_templates/package/new/package.json.ejs.t` file was missing a comma between `"dev"` and `"build-preview"`, causing a JSON syntax error.  
This issue was breaking package installation and script execution.  

### **Fix:**  
- Added the missing comma to ensure proper JSON syntax.  
- The file now works as expected.  

---

## **Issue(s)**  
Fixes #35402  

---

## **Steps to test or reproduce**  
1. Before the fix, running `npm install` would result in a JSON syntax error.  
2. After the fix, `npm install` and script execution function correctly.  

---

## **Further comments**  
This was a minor syntax issue but had a significant impact on package management. The fix ensures `package.json.ejs.t` remains valid and functional.  

