### PR TITLE
fix: remove colons from emoji names  #35437

### DIFF
--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -43,6 +43,7 @@ import { useEnablePopupPreview } from '../hooks/useEnablePopupPreview';
 import { useMessageComposerMergedRefs } from '../hooks/useMessageComposerMergedRefs';
 import { useMessageBoxAutoFocus } from './hooks/useMessageBoxAutoFocus';
 import { useMessageBoxPlaceholder } from './hooks/useMessageBoxPlaceholder';
+import emojione from 'emojione';
 
 const reducer = (_: unknown, event: FormEvent<HTMLInputElement>): boolean => {
 	const target = event.target as HTMLInputElement;
@@ -155,7 +156,11 @@ const MessageBox = ({
 		}
 
 		const ref = messageComposerRef.current as HTMLElement;
-		chat.emojiPicker.open(ref, (emoji: string) => chat.composer?.insertText(` :${emoji}: `));
+		chat.emojiPicker.open(ref, (emoji: string) => {
+			// chat.composer?.insertText(`:${emoji}:`);
+			const unicodeEmoji = emojione.shortnameToUnicode(`:${emoji}:`);
+			chat.composer?.insertText(`${unicodeEmoji}`);
+		});
 	});
 
 	const handleSendMessage = useEffectEvent(() => {


### PR DESCRIPTION
## Fixes-Improve emoji name display by removing colons #35437
Changes :
1.Send an emoji in a message.
2.Hover over the emoji.
3.Previously, the tooltip displayed names with colons (e.g., :smile:).
Now, it correctly shows names without colons.
4.This is a UI improvement with no breaking changes.

##Solved
<img width="663" alt="EmojiFixed" src="https://github.com/user-attachments/assets/f3b461d8-681d-4997-ac5f-354501602508" />



