### PR TITLE
Fix: Remove HTML tags from username already in use toast message (#35452)

### DIFF
--- a/apps/meteor/app/lib/server/functions/saveUser/validateUserData.ts
+++ b/apps/meteor/app/lib/server/functions/saveUser/validateUserData.ts
@@ -92,14 +92,14 @@ export const validateUserData = makeFunction(async (userId: IUser['_id'], userDa
 
 	if (!isUpdateUserData(userData)) {
 		if (userData.username && !(await checkUsernameAvailability(userData.username))) {
-			throw new MeteorError('error-field-unavailable', `${escape(userData.username)} is already in use :(`, {
+			throw new MeteorError('error-field-unavailable', `${escape(userData.username)} is already in use 😞`, {
 				method: 'insertOrUpdateUser',
 				field: userData.username,
 			});
 		}
 
 		if (userData.email && !(await checkEmailAvailability(userData.email))) {
-			throw new MeteorError('error-field-unavailable', `${escape(userData.email)} is already in use :(`, {
+			throw new MeteorError('error-field-unavailable', `${escape(userData.email)} is already in use 😞`, {
 				method: 'insertOrUpdateUser',
 				field: userData.email,
 			});

--- a/apps/meteor/app/lib/server/functions/setUsername.ts
+++ b/apps/meteor/app/lib/server/functions/setUsername.ts
@@ -47,7 +47,7 @@ export const setUsernameWithValidation = async (userId: string, username: string
 	}
 
 	if (!(await checkUsernameAvailability(username))) {
-		throw new Meteor.Error('error-field-unavailable', `<strong>${_.escape(username)}</strong> is already in use :(`, {
+		throw new Meteor.Error('error-field-unavailable', `**${_.escape(username)}** is already in use 😞`, {
 			method: 'setUsername',
 			field: username,
 		});

--- a/apps/meteor/client/views/root/MainLayout/RegisterUsername.tsx
+++ b/apps/meteor/client/views/root/MainLayout/RegisterUsername.tsx
@@ -81,7 +81,10 @@ const RegisterUsername = () => {
 			}
 
 			if ([error.errorType].includes('error-field-unavailable')) {
-				return setError('username', { type: 'error-field-unavailable', message: t('error-field-unavailable', { field: username }) });
+				return setError('username', {
+					type: 'error-field-unavailable',
+					message: t('error-field-unavailable', { field: `**${username}**` }),
+				});
 			}
 
 			if ([error.errorType].includes('')) {

--- a/packages/i18n/src/locales/af.i18n.json
+++ b/packages/i18n/src/locales/af.i18n.json
@@ -997,7 +997,7 @@
   "error-edit-permissions-not-allowed": "Redigeer toestemmings word nie toegelaat nie",
   "error-email-domain-blacklisted": "Die e-pos domein is swartlys",
   "error-email-send-failed": "Kon nie e-pos stuur nie: {{message}}",
-  "error-field-unavailable": "<strong>{{field}}</strong> is reeds in gebruik :(",
+  "error-field-unavailable": "**{{field}}** is reeds in gebruik :(",
   "error-file-too-large": "Lêer is te groot",
   "error-importer-not-defined": "Die invoerder is nie korrek gedefinieer nie, maar die Invoer-klas ontbreek.",
   "error-input-is-not-a-valid-field": "{{input}} is nie 'n geldige {{field}} nie",


### PR DESCRIPTION
This PR fixes issue #35452 , where the toast message for an already taken username incorrectly includes HTML tags, making it less user friendly.

### Changes Made:

- Removed the <strong> tag and used  a markdown formatted template literal, `**${username}**` to show the toast message in bold.
- Changes made inside 4 files 
1. RegisterUsername.tsx
2. setUsername.ts
3. validateUserData.ts
4. af.i18n.json

### Fixes
Closes #35452 

Let me know if you want to tweak anything!😊