### PR TITLE
refactor: Remove meteor functions from VideoConfManager

### DIFF
--- a/apps/meteor/client/lib/VideoConfManager.ts
+++ b/apps/meteor/client/lib/VideoConfManager.ts
@@ -1,7 +1,6 @@
 import type { CallPreferences, DirectCallData, DirectCallParams, IRoom, IUser, ProviderCapabilities } from '@rocket.chat/core-typings';
 import { Emitter } from '@rocket.chat/emitter';
 import { Meteor } from 'meteor/meteor';
-import { Tracker } from 'meteor/tracker';
 
 import { getConfig } from './utils/getConfig';
 import { sdk } from '../../app/utils/client/lib/SDKClient';
@@ -315,6 +314,7 @@ export const VideoConfManager = new (class VideoConfManager extends Emitter<Vide
 			this.debugLog(`[VideoConf] Connection lost or login process still pending, skipping user change.`);
 			return;
 		}
+
 		if (userId) {
 			this.connectUser(userId);
 		}
@@ -788,5 +788,3 @@ export const VideoConfManager = new (class VideoConfManager extends Emitter<Vide
 		return this.dismissedCalls.has(callId);
 	}
 })();
-
-Meteor.startup(() => Tracker.autorun(() => VideoConfManager.updateUser()));

--- a/apps/meteor/client/lib/VideoConfManager.ts
+++ b/apps/meteor/client/lib/VideoConfManager.ts
@@ -1,6 +1,5 @@
 import type { CallPreferences, DirectCallData, DirectCallParams, IRoom, IUser, ProviderCapabilities } from '@rocket.chat/core-typings';
 import { Emitter } from '@rocket.chat/emitter';
-import { Meteor } from 'meteor/meteor';
 
 import { getConfig } from './utils/getConfig';
 import { sdk } from '../../app/utils/client/lib/SDKClient';
@@ -301,16 +300,14 @@ export const VideoConfManager = new (class VideoConfManager extends Emitter<Vide
 		return false;
 	}
 
-	public updateUser(): void {
-		const userId = Meteor.userId();
-
+	public updateUser(userId: string | null, isLoggingIn: boolean, isConnected: boolean): void {
 		this.debugLog(`[VideoConf] Logged user or connection status has changed.`);
 
 		if (this.userId) {
 			this.disconnect(this.userId !== userId);
 		}
 
-		if (!Meteor.status().connected || (userId && Meteor.loggingIn())) {
+		if (!isConnected || (userId && isLoggingIn)) {
 			this.debugLog(`[VideoConf] Connection lost or login process still pending, skipping user change.`);
 			return;
 		}

--- a/apps/meteor/client/views/root/AppLayout.tsx
+++ b/apps/meteor/client/views/root/AppLayout.tsx
@@ -7,6 +7,7 @@ import { useGoogleTagManager } from './hooks/useGoogleTagManager';
 import { useMessageLinkClicks } from './hooks/useMessageLinkClicks';
 import { useOTRMessaging } from './hooks/useOTRMessaging';
 import { useSettingsOnLoadSiteUrl } from './hooks/useSettingsOnLoadSiteUrl';
+import { useUpdateVideoConfUser } from './hooks/useUpdateVideoConfUser';
 import { useAnalytics } from '../../../app/analytics/client/loadScript';
 import { useCorsSSLConfig } from '../../../app/cors/client/useCorsSSLConfig';
 import { useDolphin } from '../../../app/dolphin/client/hooks/useDolphin';
@@ -52,8 +53,8 @@ const AppLayout = () => {
 	useTokenPassAuth();
 	useCustomOAuth();
 	useCorsSSLConfig();
-
 	useOTRMessaging();
+	useUpdateVideoConfUser();
 
 	const layout = useSyncExternalStore(appLayout.subscribe, appLayout.getSnapshot);
 

--- a/apps/meteor/client/views/root/hooks/useUpdateVideoConfUser.ts
+++ b/apps/meteor/client/views/root/hooks/useUpdateVideoConfUser.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+import { VideoConfManager } from '../../../lib/VideoConfManager';
+
+export const useUpdateVideoConfUser = () => {
+	const userId = Meteor.userId();
+	const isLoggingIn = Meteor.loggingIn();
+	const isConnected = Meteor.status().connected;
+
+	useEffect(() => {
+		VideoConfManager.updateUser();
+	}, [userId, isLoggingIn, isConnected]);
+};

--- a/apps/meteor/client/views/root/hooks/useUpdateVideoConfUser.ts
+++ b/apps/meteor/client/views/root/hooks/useUpdateVideoConfUser.ts
@@ -1,17 +1,13 @@
+import { useConnectionStatus, useUserId } from '@rocket.chat/ui-contexts';
 import { useEffect } from 'react';
 
 import { VideoConfManager } from '../../../lib/VideoConfManager';
 
 export const useUpdateVideoConfUser = () => {
-	const [userId, isLoggingIn, isConnected] = [Meteor.userId(), Meteor.loggingIn(), Meteor.status().connected];
+	const userId = useUserId();
+	const { connected, isLoggingIn } = useConnectionStatus();
 
 	useEffect(() => {
-		console.log('[VideoConf] useUpdateVideoConfUser hook called with:', {
-			userId,
-			isLoggingIn,
-			isConnected,
-		});
-
-		VideoConfManager.updateUser(userId, isLoggingIn, isConnected);
-	}, [userId, isLoggingIn, isConnected]);
+		VideoConfManager.updateUser(userId, isLoggingIn, connected);
+	}, [userId, isLoggingIn, connected]);
 };

--- a/apps/meteor/client/views/root/hooks/useUpdateVideoConfUser.ts
+++ b/apps/meteor/client/views/root/hooks/useUpdateVideoConfUser.ts
@@ -3,11 +3,15 @@ import { useEffect } from 'react';
 import { VideoConfManager } from '../../../lib/VideoConfManager';
 
 export const useUpdateVideoConfUser = () => {
-	const userId = Meteor.userId();
-	const isLoggingIn = Meteor.loggingIn();
-	const isConnected = Meteor.status().connected;
+	const [userId, isLoggingIn, isConnected] = [Meteor.userId(), Meteor.loggingIn(), Meteor.status().connected];
 
 	useEffect(() => {
-		VideoConfManager.updateUser();
+		console.log('[VideoConf] useUpdateVideoConfUser hook called with:', {
+			userId,
+			isLoggingIn,
+			isConnected,
+		});
+
+		VideoConfManager.updateUser(userId, isLoggingIn, isConnected);
 	}, [userId, isLoggingIn, isConnected]);
 };


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Removed Meteor.startup and Tracker.autorun from the VideoConfManager updateUser flow and implemented a startup useEffect that runs the function.

Demo gif:
![remove_meteor_videoConf](https://github.com/user-attachments/assets/57e00ec0-40ed-48a9-8e5f-c93d0f32f9fa)

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Open the `useUpdateVideoConfUser.ts` hook and add some console logs to it;
  - My recommendation:
  ```
  export const useUpdateVideoConfUser = () => {
	const [ userId , isLoggingIn , isConnected ] = [ Meteor.userId(), Meteor.loggingIn(), Meteor.status().connected ];

	console.log('[useUpdateVideoConfUser] Initial values:', {
		userId,
		isLoggingIn,
		isConnected,
	});

	useEffect(() => {
		console.log('[useUpdateVideoConfUser] Effect triggered with:', {
			userId,
			isLoggingIn,
			isConnected,
		});

		VideoConfManager.updateUser(userId , isLoggingIn , isConnected);
	}, [userId, isLoggingIn, isConnected]);
  };
  ```
3. Login as the first user (admin user);
4. Install a conference call provider app (E.G.: Jitsi);
5. Go to `Administration > Workspace > Settings > Conference Call > Default provider` and select your provider app;
6. Create and login as a second user on a separate session;
7. Open the second user DM chat and start a video conf call from the kebab in the top right of the screen;
8. Have a look at your devtools console;

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Jira task: [ARCH-1479](https://rocketchat.atlassian.net/browse/ARCH-1479)

[ARCH-1479]: https://rocketchat.atlassian.net/browse/ARCH-1479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ