### PR TITLE
chore: Deduplicate keyboard event in MessageBox

### DIFF
--- a/apps/meteor/client/hooks/useSafeRefCallback.spec.tsx
+++ b/apps/meteor/client/hooks/useSafeRefCallback.spec.tsx
@@ -1,0 +1,123 @@
+import { render } from '@testing-library/react';
+
+import { useSafeRefCallback } from './useSafeRefCallback';
+
+// const TestComponent = (callback: () => () => void) => {
+// 	const cbRef = useSafeRefCallback(callback);
+
+// 	return <div ref={cbRef}></div>;
+// };
+
+const TestComponent = ({ callback, renderSpan }: { callback: any; renderSpan?: boolean }) => {
+	const cbRef = useSafeRefCallback(callback);
+
+	if (renderSpan) {
+		return <span ref={cbRef}></span>;
+	}
+	return <div ref={cbRef}></div>;
+};
+
+describe('useSafeRefCallback', () => {
+	it('should work as a regular callbackRef if cleanup is not provided', () => {
+		const callback = jest.fn();
+
+		const { rerender, unmount } = render(<TestComponent callback={callback} />);
+
+		expect(callback).toHaveBeenCalledTimes(1);
+		expect(callback.mock.lastCall[0]).toBeInstanceOf(HTMLDivElement);
+
+		rerender(<TestComponent callback={callback} renderSpan />);
+
+		expect(callback).toHaveBeenCalledTimes(3);
+		expect(callback.mock.calls[1][0]).toBe(null);
+		expect(callback.mock.calls[2][0]).toBeInstanceOf(HTMLSpanElement);
+
+		unmount();
+
+		expect(callback).toHaveBeenCalledTimes(4);
+		expect(callback.mock.calls[3][0]).toBe(null);
+	});
+
+	it('should run again when callback reference changes', () => {
+		const callback = jest.fn();
+
+		const { rerender, unmount } = render(<TestComponent callback={callback} />);
+
+		expect(callback).toHaveBeenCalledTimes(1);
+		expect(callback.mock.lastCall[0]).toBeInstanceOf(HTMLDivElement);
+
+		const callback2 = jest.fn();
+
+		rerender(<TestComponent callback={callback2} />);
+
+		// Ensure first callback has been properly unmounted
+		expect(callback).toHaveBeenCalledTimes(2);
+		expect(callback.mock.calls[1][0]).toBe(null);
+
+		expect(callback2).toHaveBeenCalledTimes(1);
+		expect(callback2.mock.lastCall[0]).toBeInstanceOf(HTMLDivElement);
+
+		rerender(<TestComponent callback={callback2} renderSpan />);
+
+		expect(callback2).toHaveBeenCalledTimes(3);
+		expect(callback2.mock.calls[1][0]).toBe(null);
+		expect(callback2.mock.calls[2][0]).toBeInstanceOf(HTMLSpanElement);
+
+		unmount();
+
+		expect(callback2).toHaveBeenCalledTimes(4);
+		expect(callback2.mock.calls[3][0]).toBe(null);
+	});
+
+	it('should call cleanup with previous value on rerender', () => {
+		const cleanup = jest.fn();
+		const callback = jest.fn<() => void, any>(() => cleanup);
+
+		const { rerender, unmount } = render(<TestComponent callback={callback} />);
+
+		expect(callback).toHaveBeenCalledTimes(1);
+		expect(callback.mock.lastCall[0]).toBeInstanceOf(HTMLDivElement);
+
+		expect(cleanup).not.toHaveBeenCalled();
+
+		rerender(<TestComponent callback={callback} renderSpan />);
+
+		expect(callback).toHaveBeenCalledTimes(3);
+		expect(callback.mock.calls[1][0]).toBe(null);
+		expect(callback.mock.calls[2][0]).toBeInstanceOf(HTMLSpanElement);
+
+		expect(cleanup).toHaveBeenCalledTimes(2);
+
+		const cleanup2 = jest.fn();
+		const callback2 = jest.fn<() => void, any>(() => cleanup2);
+
+		rerender(<TestComponent callback={callback2} renderSpan />);
+
+		// Ensure first callback has been properly unmounted
+		expect(callback).toHaveBeenCalledTimes(4);
+		expect(callback.mock.calls[3][0]).toBe(null);
+
+		console.log(cleanup.mock.calls);
+		expect(cleanup).toHaveBeenCalledTimes(3);
+
+		expect(callback2).toHaveBeenCalledTimes(1);
+		expect(callback2.mock.lastCall[0]).toBeInstanceOf(HTMLSpanElement);
+
+		expect(cleanup2).not.toHaveBeenCalled();
+
+		rerender(<TestComponent callback={callback2} />);
+
+		expect(callback2).toHaveBeenCalledTimes(3);
+		expect(callback2.mock.calls[1][0]).toBe(null);
+		expect(callback2.mock.calls[2][0]).toBeInstanceOf(HTMLDivElement);
+
+		expect(cleanup2).toHaveBeenCalledTimes(2);
+
+		unmount();
+
+		expect(callback2).toHaveBeenCalledTimes(4);
+		expect(callback2.mock.calls[3][0]).toBe(null);
+
+		expect(cleanup2).toHaveBeenCalledTimes(3);
+	});
+});

--- a/apps/meteor/client/hooks/useSafeRefCallback.ts
+++ b/apps/meteor/client/hooks/useSafeRefCallback.ts
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+
+type CallbackRefWithCleanup<T> = (node: T) => () => void;
+type CallbackRef<T> = (node: T) => void;
+
+type SafeCallbackRef<T> = CallbackRefWithCleanup<T> | CallbackRef<T>;
+
+/**
+ * useSafeRefCallback will call a cleanup function (returned from the passed callback)
+ * if the passed callback is called multiple times (similar to useEffect, but in a callbackRef)
+ *
+ * @example
+ *   const callback = useSafeRefCallback(
+ *       useCallback(
+ *           (node: T) => {
+ *               if (!node) {
+ *                   return;
+ *               }
+ *               node.addEventListener('click', listener);
+ *               return () => {
+ *                   node.removeEventListener('click', listener);
+ *               };
+ *           },
+ *           [listener],
+ *       ),
+ *   );
+ *
+ */
+export const useSafeRefCallback = <T extends HTMLElement | null>(callback: SafeCallbackRef<T>) => {
+	const callbackRef = useMemo(() => {
+		let _cleanup: (() => void) | null;
+
+		return (node: T): void => {
+			if (typeof _cleanup === 'function') {
+				_cleanup();
+			}
+			const cleanup = callback(node);
+
+			_cleanup = cleanup || null;
+		};
+	}, [callback]);
+
+	return callbackRef;
+};

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -43,6 +43,7 @@ import { useEnablePopupPreview } from '../hooks/useEnablePopupPreview';
 import { useMessageComposerMergedRefs } from '../hooks/useMessageComposerMergedRefs';
 import { useMessageBoxAutoFocus } from './hooks/useMessageBoxAutoFocus';
 import { useMessageBoxPlaceholder } from './hooks/useMessageBoxPlaceholder';
+import { useSafeRefCallback } from '../../../../hooks/useSafeRefCallback';
 
 const reducer = (_: unknown, event: FormEvent<HTMLInputElement>): boolean => {
 	const target = event.target as HTMLInputElement;
@@ -184,7 +185,7 @@ const MessageBox = ({
 		}
 	};
 
-	const handler = useEffectEvent((event: KeyboardEvent) => {
+	const keyboardEventHandler = useEffectEvent((event: KeyboardEvent) => {
 		const { which: keyCode } = event;
 
 		const input = event.target as HTMLTextAreaElement;
@@ -330,16 +331,21 @@ const MessageBox = ({
 	const popupOptions = useComposerPopupOptions();
 	const popup = useComposerBoxPopup(popupOptions);
 
-	const keyDownHandlerCallbackRef = useCallback(
-		(node: HTMLTextAreaElement) => {
-			if (node === null) {
-				return;
-			}
-			node.addEventListener('keydown', (e: KeyboardEvent) => {
-				handler(e);
-			});
-		},
-		[handler],
+	const keyDownHandlerCallbackRef = useSafeRefCallback(
+		useCallback(
+			(node: HTMLTextAreaElement) => {
+				if (node === null) {
+					return;
+				}
+				const eventHandler = (e: KeyboardEvent) => keyboardEventHandler(e);
+				node.addEventListener('keydown', eventHandler);
+
+				return () => {
+					node.removeEventListener('keydown', eventHandler);
+				};
+			},
+			[keyboardEventHandler],
+		),
 	);
 
 	const mergedRefs = useMessageComposerMergedRefs(popup.callbackRef, textareaRef, callbackRef, autofocusRef, keyDownHandlerCallbackRef);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Whenever a callbackRef reference (e.g. pointer to the function) changes, the callbackRef runs again.

In the MessageBox component it is expected that the callbackRef's references can change at any given time, but attached event listeners are never removed, thus duplicating events in certain occasions.

In order to solve this issue in an elegant manner, a new hook is being introduced, called `useSafeCallbackRef`. This hook allows a `cleanup` callback to be returned from the callbackRef, and will run such callback whenever the callbackRef is called after the first time. The `cleanup` callback is optional, in case some condition inside the callback is not required.

If a callbackRef never requires a cleanup effect, there's no need to use it.

PS.: This PR is labaled as `chore` because currently there are other safeguards around such duplicated events, so there's no behaviour change, and a changeset should not be added. This issue was noticed during the development of #32703 since those safeguards have changed, and breaks messaging behaviour.

Also, having duplicate events is never a good idea, since it can lead to memory leaks.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
No change in behaviour so far, only way to test is adding logs.

If you want to ensure proper behaviour, go to `apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx` and add a log to `keyboardEventHandler`. Then open an encrypted room, evey keyboard input in the composer will output 2 logs to the console. This should not happen.
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This is a niche issue, since usually callbackRefs do not change. Most of the time you should prefer to use [react events](https://react.dev/learn/responding-to-events#adding-event-handlers).
