### PR TITLE
fix: Duplicate `PermissionStatus` event

### DIFF
--- a/.changeset/neat-dingos-smoke.md
+++ b/.changeset/neat-dingos-smoke.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Reduces web application memory comsumption related to duplicate Media Devices permissions events

--- a/apps/meteor/client/views/room/composer/messageBox/hooks/useMediaPermissions.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/hooks/useMediaPermissions.ts
@@ -1,5 +1,5 @@
 import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
-import { useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 type MediaDevices = 'camera' | 'microphone';
 
@@ -13,39 +13,47 @@ const getDeviceKind = (name: MediaDevices): MediaDeviceKind => {
 };
 
 export const useMediaPermissions = (name: MediaDevices): [isPermissionDenied: boolean, setIsPermissionDenied: (state: boolean) => void] => {
-	const [isPermissionDenied, setIsPermissionDenied] = useState(false);
+	const queryClient = useQueryClient();
 
-	const handleMount = useEffectEvent(async (): Promise<void> => {
-		if (navigator.permissions) {
+	const queryKey = ['media-permissions', name];
+
+	const setIsPermissionDenied = useEffectEvent((isDenied: boolean) => {
+		queryClient.setQueryData(queryKey, isDenied);
+	});
+
+	const { data } = useQuery({
+		queryKey,
+		queryFn: async () => {
+			if (navigator.permissions) {
+				try {
+					const permissionStatus = await navigator.permissions.query({ name: name as PermissionName });
+					permissionStatus.onchange = (): void => {
+						queryClient.setQueryData(queryKey, permissionStatus.state === 'denied');
+					};
+					return permissionStatus.state === 'denied';
+				} catch (error) {
+					console.warn(error);
+				}
+			}
+
+			if (!navigator.mediaDevices?.enumerateDevices) {
+				return true;
+			}
+
 			try {
-				const permissionStatus = await navigator.permissions.query({ name: name as PermissionName });
-				setIsPermissionDenied(permissionStatus.state === 'denied');
-				permissionStatus.onchange = (): void => {
-					setIsPermissionDenied(permissionStatus.state === 'denied');
-				};
-				return;
+				if (!(await navigator.mediaDevices.enumerateDevices()).some(({ kind }) => kind === getDeviceKind(name))) {
+					return true;
+				}
 			} catch (error) {
 				console.warn(error);
 			}
-		}
-
-		if (!navigator.mediaDevices?.enumerateDevices) {
-			setIsPermissionDenied(true);
-			return;
-		}
-
-		try {
-			if (!(await navigator.mediaDevices.enumerateDevices()).some(({ kind }) => kind === getDeviceKind(name))) {
-				setIsPermissionDenied(true);
-			}
-		} catch (error) {
-			console.warn(error);
-		}
+		},
+		refetchOnMount: true,
+		refetchOnWindowFocus: false,
+		refetchOnReconnect: false,
+		staleTime: Infinity,
+		placeholderData: false,
 	});
 
-	useEffect(() => {
-		handleMount();
-	}, [handleMount]);
-
-	return [isPermissionDenied, setIsPermissionDenied];
+	return [Boolean(data), setIsPermissionDenied];
 };


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Each time the hook was called, a new instance of `PermissionStatus` was created with an `onchange` listener that was never cleaned up.

This PR leverages `useQuery` in order to maintain a single listener per permission type during the lifecycle of the application.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
