### PR TITLE
fix: Add Apps log TTL index

### DIFF
--- a/.changeset/fifty-moles-boil.md
+++ b/.changeset/fifty-moles-boil.md
@@ -4,4 +4,4 @@
 "@rocket.chat/models": patch
 ---
 
-Fixes an issue where the app log ttl were being ignored, also set to be always 30 days 
+Fixes an issue where the app's logs index was not being created by default sometimes, also set to be always 30 days 

--- a/.changeset/fifty-moles-boil.md
+++ b/.changeset/fifty-moles-boil.md
@@ -1,0 +1,7 @@
+---
+"@rocket.chat/meteor": patch
+"@rocket.chat/model-typings": patch
+"@rocket.chat/models": patch
+---
+
+Fixes an issue where the app log ttl were being ignored, also set to be always 30 days 

--- a/apps/meteor/ee/server/apps/startup.ts
+++ b/apps/meteor/ee/server/apps/startup.ts
@@ -24,7 +24,7 @@ export const startupApp = async function startupApp() {
 					},
 				],
 				public: true,
-				hidden: false,
+				hidden: true,
 				alert: 'Apps_Logs_TTL_Alert',
 			});
 
@@ -68,33 +68,6 @@ export const startupApp = async function startupApp() {
 
 	// Disable apps that depend on add-ons (external modules) if they are invalidated
 	License.onModule(disableAppsWithAddonsCallback);
-
-	settings.watch('Apps_Logs_TTL', async (value) => {
-		// TODO: remove this feature, initialized is always false first time
-		if (!Apps.isInitialized()) {
-			return;
-		}
-		let expireAfterSeconds = 0;
-
-		switch (value) {
-			case '7_days':
-				expireAfterSeconds = 604800;
-				break;
-			case '14_days':
-				expireAfterSeconds = 1209600;
-				break;
-			case '30_days':
-				expireAfterSeconds = 2592000;
-				break;
-		}
-
-		if (!expireAfterSeconds) {
-			return;
-		}
-
-		const model = Apps._logModel;
-		await model?.resetTTLIndex(expireAfterSeconds);
-	});
 
 	Apps.initialize();
 

--- a/packages/model-typings/src/models/IAppLogsModel.ts
+++ b/packages/model-typings/src/models/IAppLogsModel.ts
@@ -4,6 +4,5 @@ import type { IBaseModel } from './IBaseModel';
 
 // TODO: type for AppLogs
 export interface IAppLogsModel extends IBaseModel<any> {
-	resetTTLIndex(expireAfterSeconds: number): Promise<void>;
 	remove(query: Filter<any>): Promise<DeleteResult>;
 }

--- a/packages/models/src/models/AppLogsModel.ts
+++ b/packages/models/src/models/AppLogsModel.ts
@@ -4,8 +4,22 @@ import type { Db, DeleteResult, Filter } from 'mongodb';
 import { BaseRaw } from './BaseRaw';
 
 export class AppsLogsModel extends BaseRaw<any> implements IAppLogsModel {
-	constructor(db: Db) {
-		super(db, 'apps_logs', undefined, { _updatedAtIndexOptions: { expireAfterSeconds: 60 * 60 * 24 * 30 } });
+	constructor(
+		db: Db,
+		private readonly expireAfterSeconds: number = 60 * 60 * 24 * 30,
+	) {
+		super(db, 'apps_logs', undefined);
+	}
+
+	protected modelIndexes() {
+		return [
+			{
+				key: {
+					_updatedAt: 1,
+				},
+				expireAfterSeconds: this.expireAfterSeconds,
+			},
+		];
 	}
 
 	remove(query: Filter<any>): Promise<DeleteResult> {

--- a/packages/models/src/models/AppLogsModel.ts
+++ b/packages/models/src/models/AppLogsModel.ts
@@ -25,11 +25,4 @@ export class AppsLogsModel extends BaseRaw<any> implements IAppLogsModel {
 	remove(query: Filter<any>): Promise<DeleteResult> {
 		return this.col.deleteMany(query);
 	}
-
-	async resetTTLIndex(expireAfterSeconds: number): Promise<void> {
-		if (await this.col.indexExists('_updatedAt_1')) {
-			await this.col.dropIndex('_updatedAt_1');
-		}
-		await this.col.createIndex({ _updatedAt: 1 }, { expireAfterSeconds });
-	}
 }

--- a/packages/models/src/models/BaseRaw.ts
+++ b/packages/models/src/models/BaseRaw.ts
@@ -73,7 +73,7 @@ export abstract class BaseRaw<
 		private db: Db,
 		protected name: string,
 		protected trash?: Collection<TDeleted>,
-		private options?: ModelOptions,
+		options?: ModelOptions,
 	) {
 		this.collectionName = options?.collectionNameResolver ? options.collectionNameResolver(name) : getCollectionName(name);
 

--- a/packages/models/src/models/BaseRaw.ts
+++ b/packages/models/src/models/BaseRaw.ts
@@ -44,7 +44,6 @@ type ModelOptions = {
 	preventSetUpdatedAt?: boolean;
 	collectionNameResolver?: (name: string) => string;
 	collection?: CollectionOptions;
-	_updatedAtIndexOptions?: Omit<IndexDescription, 'key'>;
 };
 
 export abstract class BaseRaw<
@@ -91,9 +90,6 @@ export abstract class BaseRaw<
 
 	public async createIndexes() {
 		const indexes = this.modelIndexes();
-		if (this.options?._updatedAtIndexOptions) {
-			indexes?.push({ ...this.options._updatedAtIndexOptions, key: { _updatedAt: 1 } });
-		}
 
 		if (indexes?.length) {
 			if (this.pendingIndexes) {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
**Refactor AppsLogsModel to remove `_updatedAtIndexOptions` and use `modelIndexes`**

This change removes the `_updatedAtIndexOptions` parameter and instead uses the `modelIndexes` method to determine the updated index options.

Without overwriting `modelIndexes` to return a value, `_updatedAtIndexOptions` is never added.


The current implementation check on `Apps.isInitialized()` which is `false` during the first attempt, but you can seethe problem  when the TTL setting is changed.