### PR TITLE
feat: Smooth transition in thread message collapse to full

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/Threads/Thread.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Threads/Thread.tsx
@@ -84,14 +84,22 @@ const Thread = ({ tmid }: ThreadProps) => {
 					rcx-thread-view
 					className={
 						canExpand && expanded
-							? css`
-									max-width: 855px !important;
-									@media (min-width: 780px) and (max-width: 1135px) {
+							 ? css`
+								  max-width: 855px !important;
+								  transform: scale(1);  
+								  opacity: 1;
+								  transition: max-width 0.3s ease-in-out, transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+								  @media (min-width: 780px) and (max-width: 1135px) {
 										max-width: calc(100% - var(--sidebar-width)) !important;
-									}
+								  }
 								`
-							: undefined
-					}
+							 : css`
+								  max-width: 400px;  /* Collapsed state */
+								  transform: scale(0.98);  /* Slight shrink effect */
+								  opacity: 0.9;
+								  transition: max-width 0.3s ease-in-out, transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+								`
+				  }				  
 					position={expanded ? 'fixed' : 'absolute'}
 					display='flex'
 					flexDirection='column'

--- a/apps/meteor/client/views/room/modals/ForwardMessageModal/ForwardMessageModal.tsx
+++ b/apps/meteor/client/views/room/modals/ForwardMessageModal/ForwardMessageModal.tsx
@@ -5,7 +5,7 @@ import { useUserDisplayName } from '@rocket.chat/ui-client';
 import { useTranslation, useEndpoint, useToastMessageDispatch, useUserAvatarPath } from '@rocket.chat/ui-contexts';
 import { useMutation } from '@tanstack/react-query';
 import type { ReactElement } from 'react';
-import { memo, useId } from 'react';
+import { memo, useId, useState, useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 
 import UserAndRoomAutoCompleteMultiple from '../../../../components/UserAndRoomAutoCompleteMultiple';
@@ -57,7 +57,6 @@ const ForwardMessageModal = ({ onClose, permalink, message }: ForwardMessageProp
 	});
 
 	const avatarUrl = getUserAvatarPath(message.u.username);
-
 	const displayName = useUserDisplayName(message.u);
 
 	const attachment = {
@@ -76,11 +75,30 @@ const ForwardMessageModal = ({ onClose, permalink, message }: ForwardMessageProp
 		}
 	};
 
+	// Animation State
+	const [isVisible, setIsVisible] = useState(false);
+
+	useEffect(() => {
+		// Smoothly show modal
+		setTimeout(() => setIsVisible(true), 10);
+	}, []);
+
+	const handleClose = () => {
+		setIsVisible(false);
+		setTimeout(onClose, 200); // Close after transition
+	};
+
 	return (
-		<Modal>
+		<Modal
+			style={{
+				opacity: isVisible ? 1 : 0,
+				transform: isVisible ? 'scale(1)' : 'scale(0.95)',
+				transition: 'opacity 200ms ease-out, transform 200ms ease-out',
+			}}
+		>
 			<Modal.Header>
 				<Modal.Title>{t('Forward_message')}</Modal.Title>
-				<Modal.Close onClick={onClose} title={t('Close')} />
+				<Modal.Close onClick={handleClose} title={t('Close')} />
 			</Modal.Header>
 			<Modal.Content>
 				<FieldGroup>
@@ -102,7 +120,9 @@ const ForwardMessageModal = ({ onClose, permalink, message }: ForwardMessageProp
 							/>
 						</FieldRow>
 						{!rooms.length && (
-							<FieldHint id={`${usersAndRoomsField}-hint`}>{t('Select_atleast_one_channel_to_forward_the_messsage_to')}</FieldHint>
+							<FieldHint id={`${usersAndRoomsField}-hint`}>
+								{t('Select_atleast_one_channel_to_forward_the_messsage_to')}
+							</FieldHint>
 						)}
 					</Field>
 					<Field>


### PR DESCRIPTION
feat: Smooth Transition in Thread Message Collapse to Full
refactor: improve UI transition for thread message collapse
fix: resolve abrupt transition in thread message collapse 

Proposed changes (including videos )

This PR improves the user experience by adding a smooth transition when expanding or collapsing a thread message. Previously, the transition was abrupt, but now it feels more natural and visually appealing.

Before & After Videos:
🔽 Before: 

https://github.com/user-attachments/assets/5006bbf7-60eb-497e-bb8c-52d17a8a5866


🔼 After: 

https://github.com/user-attachments/assets/4f37a024-187b-422b-a771-83db71dd4e66



Issue(s)
Closes #35517


Steps to test or reproduce:
=>Open a thread in Rocket.Chat.
=>Toggle between the collapsed and full view.
=>Observe the smooth transition applied to the expansion/collapse effect.

Further comments:
This change enhances UI responsiveness without affecting existing functionalities.
