### PR TITLE
feat: Smooth transition in Forward Message Modal & replay in the thread section

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/Threads/Thread.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Threads/Thread.tsx
@@ -84,14 +84,22 @@ const Thread = ({ tmid }: ThreadProps) => {
 					rcx-thread-view
 					className={
 						canExpand && expanded
-							? css`
-									max-width: 855px !important;
-									@media (min-width: 780px) and (max-width: 1135px) {
+							 ? css`
+								  max-width: 855px !important;
+								  transform: scale(1);  
+								  opacity: 1;
+								  transition: max-width 0.3s ease-in-out, transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+								  @media (min-width: 780px) and (max-width: 1135px) {
 										max-width: calc(100% - var(--sidebar-width)) !important;
-									}
+								  }
 								`
-							: undefined
-					}
+							 : css`
+								  max-width: 400px;  /* Collapsed state */
+								  transform: scale(0.98);  /* Slight shrink effect */
+								  opacity: 0.9;
+								  transition: max-width 0.3s ease-in-out, transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+								`
+				  }				  
 					position={expanded ? 'fixed' : 'absolute'}
 					display='flex'
 					flexDirection='column'

--- a/apps/meteor/client/views/room/modals/ForwardMessageModal/ForwardMessageModal.tsx
+++ b/apps/meteor/client/views/room/modals/ForwardMessageModal/ForwardMessageModal.tsx
@@ -5,7 +5,7 @@ import { useUserDisplayName } from '@rocket.chat/ui-client';
 import { useTranslation, useEndpoint, useToastMessageDispatch, useUserAvatarPath } from '@rocket.chat/ui-contexts';
 import { useMutation } from '@tanstack/react-query';
 import type { ReactElement } from 'react';
-import { memo, useId } from 'react';
+import { memo, useId, useState, useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 
 import UserAndRoomAutoCompleteMultiple from '../../../../components/UserAndRoomAutoCompleteMultiple';
@@ -57,7 +57,6 @@ const ForwardMessageModal = ({ onClose, permalink, message }: ForwardMessageProp
 	});
 
 	const avatarUrl = getUserAvatarPath(message.u.username);
-
 	const displayName = useUserDisplayName(message.u);
 
 	const attachment = {
@@ -76,11 +75,30 @@ const ForwardMessageModal = ({ onClose, permalink, message }: ForwardMessageProp
 		}
 	};
 
+	// Animation State
+	const [isVisible, setIsVisible] = useState(false);
+
+	useEffect(() => {
+		// Smoothly show modal
+		setTimeout(() => setIsVisible(true), 10);
+	}, []);
+
+	const handleClose = () => {
+		setIsVisible(false);
+		setTimeout(onClose, 200); // Close after transition
+	};
+
 	return (
-		<Modal>
+		<Modal
+			style={{
+				opacity: isVisible ? 1 : 0,
+				transform: isVisible ? 'scale(1)' : 'scale(0.95)',
+				transition: 'opacity 200ms ease-out, transform 200ms ease-out',
+			}}
+		>
 			<Modal.Header>
 				<Modal.Title>{t('Forward_message')}</Modal.Title>
-				<Modal.Close onClick={onClose} title={t('Close')} />
+				<Modal.Close onClick={handleClose} title={t('Close')} />
 			</Modal.Header>
 			<Modal.Content>
 				<FieldGroup>
@@ -102,7 +120,9 @@ const ForwardMessageModal = ({ onClose, permalink, message }: ForwardMessageProp
 							/>
 						</FieldRow>
 						{!rooms.length && (
-							<FieldHint id={`${usersAndRoomsField}-hint`}>{t('Select_atleast_one_channel_to_forward_the_messsage_to')}</FieldHint>
+							<FieldHint id={`${usersAndRoomsField}-hint`}>
+								{t('Select_atleast_one_channel_to_forward_the_messsage_to')}
+							</FieldHint>
 						)}
 					</Field>
 					<Field>


### PR DESCRIPTION
Description
1.in a replay in the thread section transitioning from a collapsed window to an expand one looks older
2.This PR introduces a smooth transition effect when forwarding messages in Rocket.Chat. Previously, the transition felt abrupt, affecting user experience. With this update, the animation ensures a more fluid interaction while forwarding messages.

Changes Made:

✅ Implemented a smooth transition effect when opening the Forward Message Modal.
 ✅ Smooth Transition in Thread Message Collapse to Full

How to Test
1.Open any chat in Rocket.Chat.
2.Select a message and click on Forward Message.
3.Observe the transition effect when the modal appears.

before:
replay in the thread

https://github.com/user-attachments/assets/ef913a4f-4899-493e-bf7e-f7685aaed17e

forwarding message

https://github.com/user-attachments/assets/ecde7a2b-ec52-41c0-afda-62bc8e2c48e6

after:
replay in the thread

https://github.com/user-attachments/assets/903470c5-b15f-4ebf-adce-3ed722a3f1bc

forwarding message

https://github.com/user-attachments/assets/2dd57b59-e535-4bbf-9f12-53ffba40007d


issue #35525 & #35517