### PR TITLE
fix: Loading Stays Active When Clicking Outside Iframe Popup.

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/UserInfo/UserInfoActions.tsx
+++ b/apps/meteor/client/views/room/contextualBar/UserInfo/UserInfoActions.tsx
@@ -70,7 +70,7 @@ const UserInfoActions = ({ user, rid, backToList }: UserInfoActionsProps): React
 	if (isPending) {
 		return <Skeleton w='full' />;
 	}
-	return <ButtonGroup align='center'>{actions}</ButtonGroup>;
+	return <ButtonGroup align='start' wrap>{actions}</ButtonGroup>;
 };
 
 export default UserInfoActions;


### PR DESCRIPTION
##Proposed Changes: 
added responsiveness to the buttons under avatar so they get aligned perfectly and does looks like chaos. 

## Issue(s)
#35541

### **Steps to Reproduce**
1. Click on the three dots in the left pane.
2. Select **"Marketplace"**.
3. Choose an app and install it then move back to /home page. 
4.press ctrl+k (to search for the name ), type name of the installed app and click on it. 
5. Now click on the "User Info" in top right corner. 
6. analyze the chaos in buttons. 
