### PR TITLE
fix: Calling registerGuest multiple times causes loss of communication

### DIFF
--- a/.changeset/selfish-toes-lay.md
+++ b/.changeset/selfish-toes-lay.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/meteor": patch
+"@rocket.chat/livechat": patch
+---
+
+Fixes an issue causing Livechat to disconnect from the websocket when registerGuest is called multiple times with the same token

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-api.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-api.spec.ts
@@ -565,28 +565,24 @@ test.describe('OC - Livechat API', () => {
 
 				await expect(page.frameLocator('#rocketchat-iframe').getByText('Start Chat')).not.toBeVisible();
 
-				await poLiveChat.onlineAgentMessage.type('this_a_test_message_from_visitor');
+				await poLiveChat.onlineAgentMessage.fill('this_a_test_message_from_visitor');
 				await poLiveChat.btnSendMessageToOnlineAgent.click();
 
 				await expect(poLiveChat.txtChatMessage('this_a_test_message_from_visitor')).toBeVisible();
 
-				await poLiveChat.page.evaluate(
-					(registerGuestVisitor) => window.RocketChat.livechat.registerGuest(registerGuestVisitor),
-					registerGuestVisitor,
-				);
+				await poLiveChat.page.evaluate((registerGuestVisitor) => {
+					window.RocketChat.livechat.registerGuest(registerGuestVisitor);
+					window.RocketChat.livechat.registerGuest(registerGuestVisitor);
+				}, registerGuestVisitor);
 
 				await page.waitForResponse('**/api/v1/livechat/visitor');
+				await page.waitForTimeout(500); // NOTE: timeout is necessary to allow websocket unsubscribes to happen
+
+				await poLiveChat.onlineAgentMessage.fill('this_a_new_test_message_from_visitor');
+				await poLiveChat.btnSendMessageToOnlineAgent.click();
 
 				await expect(poLiveChat.txtChatMessage('this_a_test_message_from_visitor')).toBeVisible();
-
-				await poLiveChat.page.evaluate(
-					(registerGuestVisitor) => window.RocketChat.livechat.registerGuest(registerGuestVisitor),
-					registerGuestVisitor,
-				);
-
-				await page.waitForResponse('**/api/v1/livechat/visitor');
-
-				await expect(poLiveChat.txtChatMessage('this_a_test_message_from_visitor')).toBeVisible();
+				await expect(poLiveChat.txtChatMessage('this_a_new_test_message_from_visitor')).toBeVisible();
 			});
 		});
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR resolves an issue where Livechat would lose connection when `registerGuest` was called multiple times with the same token via the Livechat API.

The problem occurred because `Livechat.unsubscribeAll` was being called on every `registerGuest` call, regardless of whether the guest token had actually changed.

- Moved unsubscribeAll to a more appropriate place within createOrUpdateGuest.
- Added validation to ensure the guest token has changed before unsubscribing.

## Issue(s)
[CTZ-7](https://rocketchat.atlassian.net/browse/CTZ-7)
## Steps to test or reproduce
- Embed the livechat widget to a page
- Via Livechat API call the method registerGuest providing a token, name and email
- Start a conversation
- Call registerGuest again with the same token
- Try to send a message
- Connection should have been severed

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CTZ-7]: https://rocketchat.atlassian.net/browse/CTZ-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ