### PR TITLE
chore: Suspend `SettingsProvider`

### DIFF
--- a/apps/meteor/client/omnichannel/securityPrivacy/SecurityPrivacyRoute.tsx
+++ b/apps/meteor/client/omnichannel/securityPrivacy/SecurityPrivacyRoute.tsx
@@ -4,7 +4,7 @@ import EditableSettingsProvider from '../../views/admin/settings/EditableSetting
 
 const SecurityPrivacyRoute = () => {
 	return (
-		<SettingsProvider privileged>
+		<SettingsProvider>
 			<EditableSettingsProvider>
 				<SecurityPrivacyPage />
 			</EditableSettingsProvider>

--- a/apps/meteor/client/providers/SettingsProvider.tsx
+++ b/apps/meteor/client/providers/SettingsProvider.tsx
@@ -12,15 +12,14 @@ import { PublicSettingsCachedCollection } from '../lib/settings/PublicSettingsCa
 
 type SettingsProviderProps = {
 	children?: ReactNode;
-	privileged?: boolean;
 };
 
-const SettingsProvider = ({ children, privileged = false }: SettingsProviderProps) => {
+const SettingsProvider = ({ children }: SettingsProviderProps) => {
 	const hasPrivilegedPermission = useAtLeastOnePermission(
 		useMemo(() => ['view-privileged-setting', 'edit-privileged-setting', 'manage-selected-settings'], []),
 	);
 
-	const hasPrivateAccess = privileged && hasPrivilegedPermission;
+	const hasPrivateAccess = hasPrivilegedPermission;
 
 	const cachedCollection = useMemo(
 		() => (hasPrivateAccess ? PrivateSettingsCachedCollection : PublicSettingsCachedCollection),
@@ -121,6 +120,3 @@ const SettingsProvider = ({ children, privileged = false }: SettingsProviderProp
 };
 
 export default SettingsProvider;
-
-// '[subscribe: (onStoreChange: () => void) => () => void, getSnapshot: () => {}]'
-// '[subscribe: (onStoreChange: () => void) => () => void, getSnapshot: () => ISetting | undefined]'

--- a/apps/meteor/client/sidebar/Sidebar.stories.tsx
+++ b/apps/meteor/client/sidebar/Sidebar.stories.tsx
@@ -31,7 +31,6 @@ const settings: Record<string, ISetting> = {
 
 const settingContextValue: ContextType<typeof SettingsContext> = {
 	hasPrivateAccess: true,
-	isLoading: false,
 	querySetting: (_id) => [() => () => undefined, () => settings[_id]],
 	querySettings: () => [() => () => undefined, () => []],
 	dispatch: async () => undefined,

--- a/apps/meteor/client/sidebarv2/Sidebar.stories.tsx
+++ b/apps/meteor/client/sidebarv2/Sidebar.stories.tsx
@@ -31,7 +31,6 @@ const settings: Record<string, ISetting> = {
 
 const settingContextValue: ContextType<typeof SettingsContext> = {
 	hasPrivateAccess: true,
-	isLoading: false,
 	querySetting: (_id) => [() => () => undefined, () => settings[_id]],
 	querySettings: () => [() => () => undefined, () => []],
 	dispatch: async () => undefined,

--- a/apps/meteor/client/views/account/AccountSidebar.tsx
+++ b/apps/meteor/client/views/account/AccountSidebar.tsx
@@ -16,7 +16,7 @@ const AccountSidebar = () => {
 
 	// TODO: uplift this provider
 	return (
-		<SettingsProvider privileged>
+		<SettingsProvider>
 			<Sidebar>
 				<Sidebar.Header onClose={sidebar.close} title={t('Account')} />
 				<Sidebar.Content>

--- a/apps/meteor/client/views/admin/AdministrationRouter.tsx
+++ b/apps/meteor/client/views/admin/AdministrationRouter.tsx
@@ -49,9 +49,7 @@ const AdministrationRouter = ({ children }: AdministrationRouterProps): ReactEle
 
 	return (
 		<AdministrationLayout>
-			<SettingsProvider privileged>
-				{children ? <Suspense fallback={<PageSkeleton />}>{children}</Suspense> : <PageSkeleton />}
-			</SettingsProvider>
+			<SettingsProvider>{children ? <Suspense fallback={<PageSkeleton />}>{children}</Suspense> : <PageSkeleton />}</SettingsProvider>
 		</AdministrationLayout>
 	);
 };

--- a/apps/meteor/client/views/admin/featurePreview/AdminFeaturePreviewRoute.tsx
+++ b/apps/meteor/client/views/admin/featurePreview/AdminFeaturePreviewRoute.tsx
@@ -15,7 +15,7 @@ const AdminFeaturePreviewRoute = (): ReactElement => {
 	}
 
 	return (
-		<SettingsProvider privileged>
+		<SettingsProvider>
 			<EditableSettingsProvider>
 				<AdminFeaturePreviewPage />
 			</EditableSettingsProvider>

--- a/apps/meteor/client/views/admin/settings/SettingsPage.tsx
+++ b/apps/meteor/client/views/admin/settings/SettingsPage.tsx
@@ -1,7 +1,6 @@
-import { Icon, SearchInput, Skeleton, CardGrid } from '@rocket.chat/fuselage';
+import { Icon, SearchInput, CardGrid } from '@rocket.chat/fuselage';
 import { useDebouncedValue } from '@rocket.chat/fuselage-hooks';
 import type { TranslationKey } from '@rocket.chat/ui-contexts';
-import { useIsSettingsContextLoading } from '@rocket.chat/ui-contexts';
 import type { ChangeEvent, ReactElement } from 'react';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -18,7 +17,6 @@ const SettingsPage = (): ReactElement => {
 	const handleChange = useCallback((e: ChangeEvent<HTMLInputElement>) => setFilter(e.currentTarget.value), []);
 
 	const groups = useSettingsGroups(useDebouncedValue(filter, 400));
-	const isLoadingGroups = useIsSettingsContextLoading();
 
 	return (
 		<Page background='tint'>
@@ -28,7 +26,6 @@ const SettingsPage = (): ReactElement => {
 			</PageBlockWithBorder>
 
 			<PageScrollableContentWithShadow p={0} mi={24} mbe={16}>
-				{isLoadingGroups && <Skeleton />}
 				<CardGrid
 					breakpoints={{
 						xs: 4,
@@ -39,8 +36,7 @@ const SettingsPage = (): ReactElement => {
 						p: 8,
 					}}
 				>
-					{!isLoadingGroups &&
-						!!groups.length &&
+					{!!groups.length &&
 						groups.map((group) => (
 							<SettingsGroupCard
 								key={group._id}
@@ -51,7 +47,7 @@ const SettingsPage = (): ReactElement => {
 						))}
 				</CardGrid>
 
-				{!isLoadingGroups && !groups.length && <GenericNoResults />}
+				{!groups.length && <GenericNoResults />}
 			</PageScrollableContentWithShadow>
 		</Page>
 	);

--- a/apps/meteor/client/views/admin/sidebar/AdminSidebar.tsx
+++ b/apps/meteor/client/views/admin/sidebar/AdminSidebar.tsx
@@ -15,7 +15,7 @@ const AdminSidebar = () => {
 
 	// TODO: uplift this provider
 	return (
-		<SettingsProvider privileged>
+		<SettingsProvider>
 			<Sidebar>
 				<Sidebar.Header
 					onClose={sidebar.close}

--- a/apps/meteor/client/views/marketplace/MarketplaceSidebar.tsx
+++ b/apps/meteor/client/views/marketplace/MarketplaceSidebar.tsx
@@ -16,7 +16,7 @@ const MarketplaceSidebar = (): ReactElement => {
 	const currentPath = useCurrentRoutePath();
 
 	return (
-		<SettingsProvider privileged>
+		<SettingsProvider>
 			<Sidebar>
 				<Sidebar.Header onClose={sidebar.close} title={t('Marketplace')} />
 				<Sidebar.Content>

--- a/apps/meteor/client/views/omnichannel/sidebar/OmnichannelSidebar.tsx
+++ b/apps/meteor/client/views/omnichannel/sidebar/OmnichannelSidebar.tsx
@@ -15,7 +15,7 @@ const OmnichannelSidebar = () => {
 	const currentPath = useCurrentRoutePath();
 
 	return (
-		<SettingsProvider privileged>
+		<SettingsProvider>
 			<Sidebar>
 				<Sidebar.Header onClose={sidebar.close} title={t('Omnichannel')} />
 				<Sidebar.Content>

--- a/packages/mock-providers/src/MockedAppRootBuilder.tsx
+++ b/packages/mock-providers/src/MockedAppRootBuilder.tsx
@@ -92,7 +92,6 @@ export class MockedAppRootBuilder {
 
 	private settings: Mutable<ContextType<typeof SettingsContext>> = {
 		hasPrivateAccess: true,
-		isLoading: false,
 		querySetting: (_id: string) => [() => () => undefined, () => undefined],
 		querySettings: () => [() => () => undefined, () => []],
 		dispatch: async () => undefined,

--- a/packages/mock-providers/src/MockedSettingsContext.tsx
+++ b/packages/mock-providers/src/MockedSettingsContext.tsx
@@ -4,7 +4,6 @@ import type { ContextType, ReactNode } from 'react';
 
 const settingContextValue: ContextType<typeof SettingsContext> = {
 	hasPrivateAccess: true,
-	isLoading: false,
 	querySetting: (_id: string) => [() => () => undefined, () => undefined],
 	querySettings: () => [() => () => undefined, () => []],
 	dispatch: async () => undefined,

--- a/packages/ui-client/src/components/Header/Header.stories.tsx
+++ b/packages/ui-client/src/components/Header/Header.stories.tsx
@@ -40,7 +40,6 @@ export default {
 			<SettingsContext.Provider
 				value={{
 					hasPrivateAccess: true,
-					isLoading: false,
 					querySetting: (_id) => [
 						() => () => undefined,
 						() => ({

--- a/packages/ui-client/src/components/HeaderV2/Header.stories.tsx
+++ b/packages/ui-client/src/components/HeaderV2/Header.stories.tsx
@@ -41,7 +41,6 @@ export default {
 			<SettingsContext.Provider
 				value={{
 					hasPrivateAccess: true,
-					isLoading: false,
 					querySetting: (_id) => [
 						() => () => undefined,
 						() => ({

--- a/packages/ui-contexts/src/SettingsContext.ts
+++ b/packages/ui-contexts/src/SettingsContext.ts
@@ -10,7 +10,6 @@ export type SettingsContextQuery = {
 
 export type SettingsContextValue = {
 	readonly hasPrivateAccess: boolean;
-	readonly isLoading: boolean;
 	readonly querySetting: (
 		_id: ISetting['_id'],
 	) => [subscribe: (onStoreChange: () => void) => () => void, getSnapshot: () => ISetting | undefined];
@@ -22,7 +21,6 @@ export type SettingsContextValue = {
 
 export const SettingsContext = createContext<SettingsContextValue>({
 	hasPrivateAccess: false,
-	isLoading: false,
 	querySetting: () => [(): (() => void) => (): void => undefined, (): undefined => undefined],
 	querySettings: () => [(): (() => void) => (): void => undefined, (): ISetting[] => []],
 	dispatch: async () => undefined,

--- a/packages/ui-contexts/src/hooks/useIsSettingsContextLoading.ts
+++ b/packages/ui-contexts/src/hooks/useIsSettingsContextLoading.ts
@@ -1,5 +1,0 @@
-import { useContext } from 'react';
-
-import { SettingsContext } from '../SettingsContext';
-
-export const useIsSettingsContextLoading = (): boolean => useContext(SettingsContext).isLoading;

--- a/packages/ui-contexts/src/index.ts
+++ b/packages/ui-contexts/src/index.ts
@@ -33,7 +33,6 @@ export { useEndpoint } from './hooks/useEndpoint';
 export { useGoToRoom } from './hooks/useGoToRoom';
 export type { EndpointFunction } from './hooks/useEndpoint';
 export { useIsPrivilegedSettingsContext } from './hooks/useIsPrivilegedSettingsContext';
-export { useIsSettingsContextLoading } from './hooks/useIsSettingsContextLoading';
 export { useLanguage } from './hooks/useLanguage';
 export { useLanguages } from './hooks/useLanguages';
 export { useLayout } from './hooks/useLayout';


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
https://rocketchat.atlassian.net/browse/ARCH-1505
<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
It suspends the rendering of `SettingsProvider` until the settings are loaded.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Might be interesting in the future to make the `SettingsContext` consumers themselves suspend components.