### PR TITLE
regression: Department's unit field becomes disabled after selecting a unit

### DIFF
--- a/apps/meteor/client/views/omnichannel/departments/EditDepartment.tsx
+++ b/apps/meteor/client/views/omnichannel/departments/EditDepartment.tsx
@@ -366,7 +366,7 @@ function EditDepartment({ data, id, title, allowedToForwardData }: EditDepartmen
 											rules={{ required: isUnitRequired }}
 											render={({ field: { value, onChange } }) => (
 												<AutoCompleteUnit
-													disabled={!!value}
+													disabled={!!initialValues.unit}
 													haveNone
 													value={value}
 													onChange={onChange}

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-monitor-department.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-monitor-department.spec.ts
@@ -96,10 +96,17 @@ test.describe.serial('OC - Monitor Role', () => {
 		});
 
 		await test.step('expect to only have the units from monitor visible', async () => {
+			await expect(poOmnichannelDepartments.inputUnit).not.toBeDisabled();
 			await poOmnichannelDepartments.inputUnit.click();
 			await expect(poOmnichannelDepartments.findOption(unitA.name)).not.toBeVisible();
 			await expect(poOmnichannelDepartments.findOption(unitB.name)).toBeVisible();
 			await expect(poOmnichannelDepartments.findOption(unitC.name)).toBeVisible();
+		});
+
+		await test.step('expect to be able to switch freely between available units', async () => {
+			await poOmnichannelDepartments.findOption(unitC.name).click();
+			await expect(poOmnichannelDepartments.inputUnit).not.toBeDisabled();
+			await poOmnichannelDepartments.inputUnit.click();
 			await poOmnichannelDepartments.findOption(unitB.name).click();
 		});
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR fixes a bug where the unit field in the EditDepartment page becomes disabled immediately after selecting a unit. The field should only become disabled after a unit has been set **and** saved. 

Now, the field remains editable until the department is saved, ensuring users can freely change the business unit while creating a department.

## Issue(s)
[CTZ-22](https://rocketchat.atlassian.net/browse/CTZ-22)

## Steps to test or reproduce
- Access Enterprise workspace
- Go Omnichannel > Department
- New department
- Field "Unit" should be visible
- Select a unit
- Field should remain enabled
- Save and edit
- Unit field should be disabled

## Further comments
Introduced here: #35370


[CTZ-22]: https://rocketchat.atlassian.net/browse/CTZ-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ