### PR TITLE
regression: Department's unit field missing error state

### DIFF
--- a/apps/meteor/client/omnichannel/additionalForms/AutoCompleteUnit.tsx
+++ b/apps/meteor/client/omnichannel/additionalForms/AutoCompleteUnit.tsx
@@ -10,6 +10,7 @@ import { AsyncStatePhase } from '../../lib/asyncState';
 import type { RecordList } from '../../lib/lists/RecordList';
 
 type AutoCompleteUnitProps = {
+	id?: string;
 	disabled?: boolean;
 	value: string | undefined;
 	error?: string;
@@ -20,6 +21,7 @@ type AutoCompleteUnitProps = {
 };
 
 const AutoCompleteUnit = ({
+	id,
 	value,
 	disabled = false,
 	error,
@@ -46,6 +48,7 @@ const AutoCompleteUnit = ({
 
 	return (
 		<PaginatedSelectFiltered
+			id={id}
 			data-qa='autocomplete-unit'
 			error={error}
 			filter={unitsFilter}

--- a/apps/meteor/client/views/omnichannel/departments/EditDepartment.tsx
+++ b/apps/meteor/client/views/omnichannel/departments/EditDepartment.tsx
@@ -138,6 +138,7 @@ function EditDepartment({ data, id, title, allowedToForwardData }: EditDepartmen
 	const requestTagBeforeClosingChatField = useId();
 	const chatClosingTagsField = useId();
 	const allowReceiveForwardOffline = useId();
+	const unitFieldId = useId();
 
 	return (
 		<Page flexDirection='row'>
@@ -358,16 +359,21 @@ function EditDepartment({ data, id, title, allowedToForwardData }: EditDepartmen
 								</Field>
 
 								<Field>
-									<FieldLabel required={isUnitRequired}>{t('Unit')}</FieldLabel>
+									<FieldLabel htmlFor={unitFieldId} required={isUnitRequired}>
+										{t('Unit')}
+									</FieldLabel>
 									<FieldRow>
 										<Controller
 											name='unit'
 											control={control}
-											rules={{ required: isUnitRequired }}
+											rules={{ required: isUnitRequired ? t('Required_field', { field: t('Unit') }) : false }}
 											render={({ field: { value, onChange } }) => (
 												<AutoCompleteUnit
 													disabled={!!initialValues.unit}
 													haveNone
+													id={unitFieldId}
+													error={errors.unit?.message as string}
+													aria-describedby={`${unitFieldId}-error`}
 													value={value}
 													onChange={onChange}
 													onLoadItems={(list) => {
@@ -378,6 +384,11 @@ function EditDepartment({ data, id, title, allowedToForwardData }: EditDepartmen
 											)}
 										/>
 									</FieldRow>
+									{errors.unit && (
+										<FieldError aria-live='assertive' id={`${unitFieldId}-error`}>
+											{errors.unit?.message}
+										</FieldError>
+									)}
 								</Field>
 							</>
 						)}

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-monitor-department.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-monitor-department.spec.ts
@@ -110,6 +110,16 @@ test.describe.serial('OC - Monitor Role', () => {
 			await poOmnichannelDepartments.findOption(unitB.name).click();
 		});
 
+		await test.step('expect unit field to be required', async () => {
+			await poOmnichannelDepartments.inputUnit.click();
+			await poOmnichannelDepartments.findOption('None').click();
+			await expect(poOmnichannelDepartments.btnSave).toBeDisabled();
+			await expect(poOmnichannelDepartments.errorMessage('Unit required')).toBeVisible();
+			await poOmnichannelDepartments.inputUnit.click();
+			await poOmnichannelDepartments.findOption(unitB.name).click();
+			await expect(poOmnichannelDepartments.btnSave).toBeEnabled();
+		});
+
 		await test.step('expect to save department', async () => {
 			await poOmnichannelDepartments.btnEnabled.click();
 			await poOmnichannelDepartments.btnSave.click();

--- a/apps/meteor/tests/e2e/utils/omnichannel/units.ts
+++ b/apps/meteor/tests/e2e/utils/omnichannel/units.ts
@@ -26,7 +26,7 @@ export const createOrUpdateUnit = async (
 			msg: 'method',
 			id: '34',
 			method: 'livechat:saveUnit',
-			params: [id, { name: name || faker.commerce.department(), visibility: visibility || 'public' }, monitors, departments],
+			params: [id, { name: name || faker.string.uuid(), visibility: visibility || 'public' }, monitors, departments],
 		}),
 	});
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR adds error state to the Unit field within the EditDepartment page.

![Screenshot 2025-03-21 at 12 09 45](https://github.com/user-attachments/assets/b1d4113e-2039-4325-ab85-512579b7089e)

## Issue(s)
[CTZ-23](https://rocketchat.atlassian.net/browse/CTZ-23)

## Steps to test or reproduce
- Access Enterprise workspace
- Go Omnichannel > Department
- New department
- Field "Unit" should be visible
- Select a unit
- Select none as a unit
- Should display error message "Unit required"

## Further comments
Introduced here: #35370


[CTZ-23]: https://rocketchat.atlassian.net/browse/CTZ-23?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ