### PR TITLE
fix: Omnichannel making a request for room data after every message sent

### DIFF
--- a/.changeset/heavy-boats-mix.md
+++ b/.changeset/heavy-boats-mix.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/models': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes an issue when sending a message on an omnichannel room would cause the web client to fetch the room data again.

--- a/apps/meteor/app/livechat/server/lib/RoutingManager.ts
+++ b/apps/meteor/app/livechat/server/lib/RoutingManager.ts
@@ -175,7 +175,7 @@ export const RoutingManager: Routing = {
 		const { servedBy } = room;
 
 		if (shouldQueue) {
-			const queuedInquiry = await LivechatInquiry.queueInquiry(inquiry._id);
+			const queuedInquiry = await LivechatInquiry.queueInquiry(inquiry._id, room.lastMessage);
 			if (queuedInquiry) {
 				inquiry = queuedInquiry;
 				void notifyOnLivechatInquiryChanged(inquiry, 'updated', {

--- a/apps/meteor/app/livechat/server/lib/rooms.ts
+++ b/apps/meteor/app/livechat/server/lib/rooms.ts
@@ -226,6 +226,12 @@ export async function returnRoomAsInquiry(room: IOmnichannelRoom, departmentId?:
 		return false;
 	}
 
+	// update inquiry's last message with room's last message to correctly display in the queue
+	// because we stop updating the inquiry when it's been taken
+	if (room.lastMessage) {
+		await LivechatInquiry.setLastMessageById(inquiry._id, room.lastMessage);
+	}
+
 	const transferredBy = normalizeTransferredByData(user, room);
 	livechatLogger.debug(`Transfering room ${room._id} by user ${transferredBy._id}`);
 	const transferData = { roomId: room._id, scope: 'queue', departmentId, transferredBy, ...overrideTransferData };

--- a/apps/meteor/tests/end-to-end/api/livechat/00-rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/00-rooms.ts
@@ -40,6 +40,7 @@ import {
 	makeAgentUnavailable,
 	sendAgentMessage,
 	fetchInquiry,
+	takeInquiry,
 } from '../../../data/livechat/rooms';
 import { saveTags } from '../../../data/livechat/tags';
 import { createMonitor, createUnit, deleteUnit } from '../../../data/livechat/units';
@@ -1169,6 +1170,67 @@ describe('LIVECHAT - rooms', () => {
 			await deleteDepartment(initialDepartment._id);
 			await deleteDepartment(forwardToOfflineDepartment._id);
 		});
+
+		(IS_EE ? it : it.skip)(
+			'should update inquiry last message when manager forward to offline department and the inquiry returns to queued',
+			async () => {
+				await updateSetting('Livechat_Routing_Method', 'Manual_Selection');
+				const { department: initialDepartment, agent } = await createDepartmentWithAnOnlineAgent();
+				const { department: forwardToOfflineDepartment, agent: offlineAgent } = await createDepartmentWithAnOfflineAgent({
+					allowReceiveForwardOffline: true,
+				});
+
+				const newVisitor = await createVisitor(initialDepartment._id);
+				const newRoom = await createLivechatRoom(newVisitor.token);
+
+				const inq = await fetchInquiry(newRoom._id);
+				await takeInquiry(inq._id, agent.credentials);
+
+				const msgText = `return to queue ${Date.now()}`;
+				await request.post(api('livechat/message')).send({ token: newVisitor.token, rid: newRoom._id, msg: msgText }).expect(200);
+
+				await makeAgentUnavailable(offlineAgent.credentials);
+
+				const manager = await createUser();
+				const managerCredentials = await login(manager.username, password);
+				await createManager(manager.username);
+
+				await request.post(api('livechat/room.forward')).set(managerCredentials).send({
+					roomId: newRoom._id,
+					departmentId: forwardToOfflineDepartment._id,
+					clientAction: true,
+					comment: 'test comment',
+				});
+
+				await request
+					.get(api(`livechat/queue`))
+					.set(credentials)
+					.query({
+						count: 1,
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res: Response) => {
+						expect(res.body).to.have.property('success', true);
+						expect(res.body.queue).to.be.an('array');
+						expect(res.body.queue[0].chats).not.to.undefined;
+						expect(res.body).to.have.property('offset');
+						expect(res.body).to.have.property('total');
+						expect(res.body).to.have.property('count');
+					});
+
+				const inquiry = await fetchInquiry(newRoom._id);
+
+				expect(inquiry).to.have.property('_id', inquiry._id);
+				expect(inquiry).to.have.property('rid', newRoom._id);
+				expect(inquiry).to.have.property('lastMessage');
+				expect(inquiry.lastMessage).to.have.property('msg', '');
+				expect(inquiry.lastMessage).to.have.property('t', 'livechat_transfer_history');
+
+				await deleteDepartment(initialDepartment._id);
+				await deleteDepartment(forwardToOfflineDepartment._id);
+			},
+		);
 
 		let roomId: string;
 		let visitorToken: string;

--- a/packages/model-typings/src/models/ILivechatInquiryModel.ts
+++ b/packages/model-typings/src/models/ILivechatInquiryModel.ts
@@ -32,7 +32,7 @@ export interface ILivechatInquiryModel extends IBaseModel<ILivechatInquiryRecord
 	getQueuedInquiries(options?: FindOptions<ILivechatInquiryRecord>): FindCursor<ILivechatInquiryRecord>;
 	takeInquiry(inquiryId: string): Promise<void>;
 	openInquiry(inquiryId: string): Promise<UpdateResult>;
-	queueInquiry(inquiryId: string): Promise<ILivechatInquiryRecord | null>;
+	queueInquiry(inquiryId: string, lastMessage?: IMessage): Promise<ILivechatInquiryRecord | null>;
 	queueInquiryAndRemoveDefaultAgent(inquiryId: string): Promise<UpdateResult>;
 	readyInquiry(inquiryId: string): Promise<UpdateResult>;
 	changeDepartmentIdByRoomId(rid: string, department: string): Promise<void>;

--- a/packages/model-typings/src/models/ILivechatInquiryModel.ts
+++ b/packages/model-typings/src/models/ILivechatInquiryModel.ts
@@ -16,6 +16,7 @@ export interface ILivechatInquiryModel extends IBaseModel<ILivechatInquiryRecord
 	getDistinctQueuedDepartments(options: AggregateOptions): Promise<{ _id: string | null }[]>;
 	setDepartmentByInquiryId(inquiryId: string, department: string): Promise<ILivechatInquiryRecord | null>;
 	setLastMessageByRoomId(rid: ILivechatInquiryRecord['rid'], message: IMessage): Promise<ILivechatInquiryRecord | null>;
+	setLastMessageById(inquiryId: string, lastMessage: IMessage): Promise<UpdateResult>;
 	findNextAndLock(
 		queueSortBy: FindOptions<ILivechatInquiryRecord>['sort'],
 		department: string | null,

--- a/packages/models/src/models/LivechatInquiry.ts
+++ b/packages/models/src/models/LivechatInquiry.ts
@@ -327,13 +327,17 @@ export class LivechatInquiryRaw extends BaseRaw<ILivechatInquiryRecord> implemen
 		);
 	}
 
-	async queueInquiry(inquiryId: string): Promise<ILivechatInquiryRecord | null> {
+	async queueInquiry(inquiryId: string, lastMessage?: IMessage): Promise<ILivechatInquiryRecord | null> {
 		return this.findOneAndUpdate(
 			{
 				_id: inquiryId,
 			},
 			{
-				$set: { status: LivechatInquiryStatus.QUEUED, queuedAt: new Date() },
+				$set: {
+					status: LivechatInquiryStatus.QUEUED,
+					queuedAt: new Date(),
+					...(lastMessage && { lastMessage }),
+				},
 				$unset: { takenAt: 1 },
 			},
 			{ returnDocument: 'after' },

--- a/packages/models/src/models/LivechatInquiry.ts
+++ b/packages/models/src/models/LivechatInquiry.ts
@@ -153,8 +153,19 @@ export class LivechatInquiryRaw extends BaseRaw<ILivechatInquiryRecord> implemen
 		return this.findOneAndUpdate({ _id: inquiryId }, { $set: { department } }, { returnDocument: 'after' });
 	}
 
+	/**
+	 * Updates the `lastMessage` of inquiries that are not taken yet, after they're taken we only need to update room's `lastMessage`
+	 */
 	async setLastMessageByRoomId(rid: ILivechatInquiryRecord['rid'], message: IMessage): Promise<ILivechatInquiryRecord | null> {
-		return this.findOneAndUpdate({ rid }, { $set: { lastMessage: message } }, { returnDocument: 'after' });
+		return this.findOneAndUpdate(
+			{ rid, status: { $ne: LivechatInquiryStatus.TAKEN } },
+			{ $set: { lastMessage: message } },
+			{ returnDocument: 'after' },
+		);
+	}
+
+	async setLastMessageById(inquiryId: string, lastMessage: IMessage): Promise<UpdateResult> {
+		return this.updateOne({ _id: inquiryId }, { $set: { lastMessage } });
 	}
 
 	async findNextAndLock(


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
This endpoint is called every time a message is sent by an omnichannel agent. On every message we used update the inquiry's `lastMessage`, which caused an invalidation on the frontend so it mistakenly thought it would need to fetch the room data again (since something changed).

The proposal is that we update the inquiry's last message only if it has not been taken yet. Once it is taken we update only the room's last message property. If it happens to the room to be sent back to the queue, then we update the inquiry's last message so it can reflect the latest state. A test was added to cover this exact behavior.

This is chart of a production workspace that uses inquiries, showing how massive the amount of calls to the endpoint is:
![image](https://github.com/user-attachments/assets/3eaa62c3-1f39-4cd5-a498-6e64dad36df9)


## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CTZ-28]

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CTZ-28]: https://rocketchat.atlassian.net/browse/CTZ-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ