### PR TITLE
regression: GUI crashing when editing a OC room

### DIFF
--- a/apps/meteor/client/views/omnichannel/directory/chats/ChatInfo/RoomEdit/RoomEdit.tsx
+++ b/apps/meteor/client/views/omnichannel/directory/chats/ChatInfo/RoomEdit/RoomEdit.tsx
@@ -3,7 +3,7 @@ import { Field, FieldLabel, FieldRow, TextInput, ButtonGroup, Button } from '@ro
 import { CustomFieldsForm } from '@rocket.chat/ui-client';
 import { useToastMessageDispatch, useTranslation, useEndpoint } from '@rocket.chat/ui-contexts';
 import { useQueryClient } from '@tanstack/react-query';
-import { useCallback } from 'react';
+import { useCallback, useId } from 'react';
 import { useController, useForm } from 'react-hook-form';
 
 import { hasAtLeastOnePermission } from '../../../../../../../app/authorization/client';
@@ -117,6 +117,8 @@ function RoomEdit({ room, visitor, reload, reloadInfo, onClose }: RoomEditProps)
 		[dispatchToastMessage, isFormValid, onClose, queryClient, reload, reloadInfo, room._id, saveRoom, t, visitor._id],
 	);
 
+	const topicField = useId();
+
 	// TODO: this loading should be checked in the `RoomEditWithData`
 	// This component should not have logical data
 	if (isCustomFieldsLoading || isSlaPoliciesLoading || isPrioritiesLoading) {
@@ -135,9 +137,9 @@ function RoomEdit({ room, visitor, reload, reloadInfo, onClose }: RoomEditProps)
 				)}
 
 				<Field>
-					<FieldLabel>{t('Topic')}</FieldLabel>
+					<FieldLabel htmlFor={topicField}>{t('Topic')}</FieldLabel>
 					<FieldRow>
-						<TextInput {...register('topic')} flexGrow={1} />
+						<TextInput {...register('topic')} id={topicField} flexGrow={1} />
 					</FieldRow>
 				</Field>
 

--- a/apps/meteor/client/views/omnichannel/directory/chats/ChatInfo/RoomEdit/RoomEdit.tsx
+++ b/apps/meteor/client/views/omnichannel/directory/chats/ChatInfo/RoomEdit/RoomEdit.tsx
@@ -7,7 +7,7 @@ import { useCallback } from 'react';
 import { useController, useForm } from 'react-hook-form';
 
 import { hasAtLeastOnePermission } from '../../../../../../../app/authorization/client';
-import { ContextualbarFooter, ContextualbarScrollableContent } from '../../../../../../components/Contextualbar';
+import { ContextualbarContent, ContextualbarFooter, ContextualbarScrollableContent } from '../../../../../../components/Contextualbar';
 import Tags from '../../../../../../components/Omnichannel/Tags';
 import { useOmnichannelPriorities } from '../../../../../../omnichannel/hooks/useOmnichannelPriorities';
 import { SlaPoliciesSelect, PrioritiesSelect } from '../../../../additionalForms';
@@ -117,11 +117,13 @@ function RoomEdit({ room, visitor, reload, reloadInfo, onClose }: RoomEditProps)
 		[dispatchToastMessage, isFormValid, onClose, queryClient, reload, reloadInfo, room._id, saveRoom, t, visitor._id],
 	);
 
+	// TODO: this loading should be checked in the `RoomEditWithData`
+	// This component should not have logical data
 	if (isCustomFieldsLoading || isSlaPoliciesLoading || isPrioritiesLoading) {
 		return (
-			<ContextualbarScrollableContent>
+			<ContextualbarContent>
 				<FormSkeleton />
-			</ContextualbarScrollableContent>
+			</ContextualbarContent>
 		);
 	}
 

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-chat-history.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-chat-history.spec.ts
@@ -48,6 +48,14 @@ test.describe('Omnichannel chat history', () => {
 			await agent.poHomeOmnichannel.sidenav.openChat(newVisitor.name);
 		});
 
+		await test.step('expect to be able to edit room info', async () => {
+			await agent.poHomeOmnichannel.roomInfo.btnEditRoomInfo.click();
+			await agent.poHomeOmnichannel.roomInfo.inputTopic.fill('any_topic');
+			await agent.poHomeOmnichannel.roomInfo.btnSaveEditRoom.click();
+
+			await expect(agent.poHomeOmnichannel.roomInfo.dialogRoomInfo).toContainText('any_topic');
+		});
+
 		await test.step('Expect to be able to close an omnichannel to conversation', async () => {
 			await agent.poHomeOmnichannel.content.btnCloseChat.click();
 			await agent.poHomeOmnichannel.content.inputModalClosingComment.type('any_comment');

--- a/apps/meteor/tests/e2e/page-objects/fragments/home-omnichannel-content.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/home-omnichannel-content.ts
@@ -55,10 +55,6 @@ export class HomeOmnichannelContent extends HomeContent {
 		return this.page.getByRole('dialog').locator('p[data-type="email"]');
 	}
 
-	get infoContactName(): Locator {
-		return this.page.locator('[data-qa-id="contactInfo-name"]');
-	}
-
 	get btnReturn(): Locator {
 		return this.page.locator('[data-qa-id="ToolBoxAction-back"]');
 	}
@@ -69,10 +65,6 @@ export class HomeOmnichannelContent extends HomeContent {
 
 	get modalOnHold(): Locator {
 		return this.page.locator('[data-qa-id="on-hold-modal"]');
-	}
-
-	get btnEditRoomInfo(): Locator {
-		return this.page.locator('button[data-qa-id="room-info-edit"]');
 	}
 
 	get btnOnHoldConfirm(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/home-omnichannel.ts
+++ b/apps/meteor/tests/e2e/page-objects/home-omnichannel.ts
@@ -7,6 +7,7 @@ import { OmnichannelContacts } from './omnichannel-contacts-list';
 import { OmnichannelCurrentChats } from './omnichannel-current-chats';
 import { OmnichannelManager } from './omnichannel-manager';
 import { OmnichannelMonitors } from './omnichannel-monitors';
+import { OmnichannelRoomInfo } from './omnichannel-room-info';
 import { OmnichannelTranscript } from './omnichannel-transcript';
 import { OmnichannelTriggers } from './omnichannel-triggers';
 
@@ -37,6 +38,8 @@ export class HomeOmnichannel {
 
 	readonly contacts: OmnichannelContacts;
 
+	readonly roomInfo: OmnichannelRoomInfo;
+
 	constructor(page: Page) {
 		this.page = page;
 		this.content = new HomeOmnichannelContent(page);
@@ -51,6 +54,7 @@ export class HomeOmnichannel {
 		this.managers = new OmnichannelManager(page);
 		this.monitors = new OmnichannelMonitors(page);
 		this.contacts = new OmnichannelContacts(page);
+		this.roomInfo = new OmnichannelRoomInfo(page);
 	}
 
 	get toastSuccess(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel-room-info.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel-room-info.ts
@@ -7,6 +7,26 @@ export class OmnichannelRoomInfo {
 		this.page = page;
 	}
 
+	get dialogRoomInfo(): Locator {
+		return this.page.getByRole('dialog', { name: 'Room Information' });
+	}
+
+	get btnEditRoomInfo(): Locator {
+		return this.dialogRoomInfo.getByRole('button', { name: 'Edit' });
+	}
+
+	get dialogEditRoom(): Locator {
+		return this.page.getByRole('dialog', { name: 'Edit Room' });
+	}
+
+	get inputTopic(): Locator {
+		return this.dialogEditRoom.getByRole('textbox', { name: 'Topic' });
+	}
+
+	get btnSaveEditRoom(): Locator {
+		return this.dialogEditRoom.getByRole('button', { name: 'Save' });
+	}
+
 	getInfo(value: string): Locator {
 		return this.page.locator(`span >> text="${value}"`);
 	}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Introduced here: #33796

Theres a `ContextualbarScrollabeContent` being used incorrectly in a loading state when editing a omnichannel room. As we recently changed how we handle our scrollbars, the GUI is crashing when accessing it.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Open a Omnichannel Room
- Try to edit the room information
- The GUI should not crash

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-1049]

[CORE-1049]: https://rocketchat.atlassian.net/browse/CORE-1049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ