### PR TITLE
Release 7.4.2

### DIFF
--- a/.changeset/bump-patch-1743103516484.md
+++ b/.changeset/bump-patch-1743103516484.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Bump @rocket.chat/meteor version.

--- a/.changeset/short-garlics-attack.md
+++ b/.changeset/short-garlics-attack.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/livechat": patch
+"@rocket.chat/meteor": patch
+---
+
+Fixes Livechat's setDepartment api method not updating the visitor's department as expected

--- a/packages/livechat/src/lib/hooks.ts
+++ b/packages/livechat/src/lib/hooks.ts
@@ -48,7 +48,7 @@ export const createOrUpdateGuest = async (guest: StoreState['guest']) => {
 	}
 
 	const { token } = guest;
-	token && (await store.setState({ token }));
+	token && store.setState({ token });
 
 	const {
 		iframe: { defaultDepartment },
@@ -150,6 +150,7 @@ const api = {
 		}
 
 		updateIframeData({ defaultDepartment: department });
+		updateIframeGuestData({ department });
 
 		if (defaultAgent && defaultAgent.department !== department) {
 			store.setState({ defaultAgent: undefined });
@@ -232,13 +233,6 @@ const api = {
 		await evaluateChangesAndLoadConfigByFields(async () => {
 			if (!data.token) {
 				data.token = createToken();
-			}
-			const {
-				iframe: { defaultDepartment },
-			} = store.state;
-
-			if (defaultDepartment && !data.department) {
-				data.department = defaultDepartment;
 			}
 
 			Livechat.unsubscribeAll();

--- a/yarn.lock
+++ b/yarn.lock
@@ -8401,10 +8401,10 @@ __metadata:
     "@rocket.chat/icons": "*"
     "@rocket.chat/prettier-config": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 12.0.0
-    "@rocket.chat/ui-contexts": 16.0.0
+    "@rocket.chat/ui-avatar": 12.0.1
+    "@rocket.chat/ui-contexts": 16.0.1
     "@rocket.chat/ui-kit": 0.37.0
-    "@rocket.chat/ui-video-conf": 16.0.0
+    "@rocket.chat/ui-video-conf": 16.0.1
     "@tanstack/react-query": "*"
     react: "*"
     react-dom: "*"
@@ -8491,8 +8491,8 @@ __metadata:
     "@rocket.chat/fuselage-tokens": "*"
     "@rocket.chat/message-parser": 0.31.31
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-client": 16.0.0
-    "@rocket.chat/ui-contexts": 16.0.0
+    "@rocket.chat/ui-client": 16.0.1
+    "@rocket.chat/ui-contexts": 16.0.1
     katex: "*"
     react: "*"
   languageName: unknown
@@ -9730,7 +9730,7 @@ __metadata:
     typescript: "npm:~5.7.2"
   peerDependencies:
     "@rocket.chat/fuselage": "*"
-    "@rocket.chat/ui-contexts": 16.0.0
+    "@rocket.chat/ui-contexts": 16.0.1
     react: ~17.0.2
   languageName: unknown
   linkType: soft
@@ -9782,8 +9782,8 @@ __metadata:
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-avatar": 12.0.0
-    "@rocket.chat/ui-contexts": 16.0.0
+    "@rocket.chat/ui-avatar": 12.0.1
+    "@rocket.chat/ui-contexts": 16.0.1
     react: "*"
     react-i18next: "*"
   languageName: unknown
@@ -9950,8 +9950,8 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 12.0.0
-    "@rocket.chat/ui-contexts": 16.0.0
+    "@rocket.chat/ui-avatar": 12.0.1
+    "@rocket.chat/ui-contexts": 16.0.1
     react: ~17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -10007,9 +10007,9 @@ __metadata:
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/icons": "*"
     "@rocket.chat/styled": "*"
-    "@rocket.chat/ui-avatar": 12.0.0
-    "@rocket.chat/ui-client": 16.0.0
-    "@rocket.chat/ui-contexts": 16.0.0
+    "@rocket.chat/ui-avatar": 12.0.1
+    "@rocket.chat/ui-client": 16.0.1
+    "@rocket.chat/ui-contexts": 16.0.1
     react: ~17.0.2
     react-aria: ~3.23.1
     react-dom: ^17.0.2
@@ -10100,7 +10100,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.2.2
-    "@rocket.chat/ui-contexts": 16.0.0
+    "@rocket.chat/ui-contexts": 16.0.1
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION


<!-- release-notes-start -->
<!-- This content is automatically generated. Changing this will not reflect on the final release log -->

_You can see below a preview of the release change log:_

# 7.4.2

### Engine versions

- Node: `22.13.1`
- MongoDB: `5.0, 6.0, 7.0`
- Apps-Engine: `1.49.0`

### Patch Changes

*   Bump @rocket.chat/meteor version.

*   <details><summary>Updated dependencies []:</summary>

    *   @rocket.chat/core-typings@7.4.2
    *   @rocket.chat/rest-typings@7.4.2
    *   @rocket.chat/license@1.0.10
    *   @rocket.chat/omnichannel-services@0.3.16
    *   @rocket.chat/pdf-worker@0.2.16
    *   @rocket.chat/presence@0.2.19
    *   @rocket.chat/api-client@0.2.19
    *   @rocket.chat/apps@0.3.2
    *   @rocket.chat/core-services@0.7.11
    *   @rocket.chat/cron@0.1.19
    *   @rocket.chat/freeswitch@1.2.6
    *   @rocket.chat/fuselage-ui-kit@16.0.2
    *   @rocket.chat/gazzodown@16.0.2
    *   @rocket.chat/model-typings@1.4.2
    *   @rocket.chat/ui-contexts@16.0.2
    *   @rocket.chat/models@1.3.2
    *   @rocket.chat/server-cloud-communication@0.0.2
    *   @rocket.chat/network-broker@0.1.11
    *   @rocket.chat/ui-theming@0.4.2
    *   @rocket.chat/ui-avatar@12.0.2
    *   @rocket.chat/ui-client@16.0.2
    *   @rocket.chat/ui-video-conf@16.0.2
    *   @rocket.chat/ui-voip@6.0.2
    *   @rocket.chat/web-ui-registration@16.0.2
    *   @rocket.chat/instance-status@0.1.19

    </details>

<!-- release-notes-end -->