### PR TITLE
feat: Add Close Button to Formatting Toolbar in Mobile View

### DIFF
--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxFormattingToolbar/FormattingToolbarDropdown.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxFormattingToolbar/FormattingToolbarDropdown.tsx
@@ -1,3 +1,4 @@
+import React, { useRef } from 'react';
 import { GenericMenu } from '@rocket.chat/ui-client';
 import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { useTranslation } from 'react-i18next';
@@ -13,6 +14,7 @@ type FormattingToolbarDropdownProps = {
 
 const FormattingToolbarDropdown = ({ composer, items, disabled }: FormattingToolbarDropdownProps) => {
 	const { t } = useTranslation();
+	const menuRef = useRef<any>(null);
 
 	const formattingItems: GenericMenuItemProps[] = items.map((formatter) => {
 		const handleFormattingAction = () => {
@@ -34,9 +36,30 @@ const FormattingToolbarDropdown = ({ composer, items, disabled }: FormattingTool
 		};
 	});
 
-	const sections = [{ title: t('Message_Formatting_toolbox'), items: formattingItems }];
+	// Add a new "Close" item that will trigger the menu's close method
+	const closeItem: GenericMenuItemProps = {
+		id: 'close',
+		content: t('Close'),
+		icon: 'cross',
+		onClick: () => {
+			if (menuRef.current && typeof menuRef.current.close === 'function') {
+				menuRef.current.close();
+			}
+		},
+	};
 
-	return <GenericMenu title={t('Message_Formatting_toolbox')} disabled={disabled} detached icon='meatballs' sections={sections} />;
+	const sections = [{ title: t('Message_Formatting_toolbox'), items: [...formattingItems, closeItem] }];
+
+	return (
+		<GenericMenu
+			ref={menuRef}
+			title={t('Message_Formatting_toolbox')}
+			disabled={disabled}
+			detached
+			icon='meatballs'
+			sections={sections}
+		/>
+	);
 };
 
 export default FormattingToolbarDropdown;


### PR DESCRIPTION
This pull request implements an enhancement for the mobile view of Rocket.Chat by adding a dedicated close button to the message formatting toolbar. This improvement aims to enhance user experience by providing an explicit method to close the toolbar, which is currently lacking.

#### Changes Introduced:
- Added a close button (`X`) to the formatting toolbar in the mobile view.
- Implemented the close functionality directly within the `onClick` event of the close button.

#### Steps to Test:
1. Access the Rocket.Chat application on a mobile device or use the browser's developer tools to simulate a mobile view.
2. Navigate to a page with the message input bar.
3. Tap on the "..." symbol to open the formatting toolbar.
4. Verify that the close button (`X`) appears on the toolbar.
5. Click on the close button and ensure that the toolbar closes as expected.

#### Related Issue:
This pull request addresses [issue #31541](https://github.com/RocketChat/Rocket.Chat/issues/31541).

#### Additional Context:
This enhancement is aimed at improving the intuitiveness and accessibility of the user interface, particularly for users who expect a more explicit method to close modals.

#### Screenshot:
![close_button_ss](https://github.com/user-attachments/assets/299a962e-d21d-409a-b445-52ccd50402f1)

