### PR TITLE
fix: Disable Send button when Composer is empty

### DIFF
--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -191,8 +191,9 @@ const MessageBox = ({
 		const input = event.target as HTMLTextAreaElement;
 
 		const isSubmitKey = keyCode === keyCodes.CARRIAGE_RETURN || keyCode === keyCodes.NEW_LINE;
+		const disabled = !canSend || !typing;
 
-		if (isSubmitKey) {
+		if (!disabled && isSubmitKey) {
 			const withModifier = event.shiftKey || event.ctrlKey || event.altKey || event.metaKey;
 			const isSending = (sendOnEnter && !withModifier) || (!sendOnEnter && withModifier);
 
@@ -443,7 +444,7 @@ const MessageBox = ({
 								<MessageComposerAction
 									aria-label={t('Send')}
 									icon='send'
-									disabled={!canSend || (!typing && !isEditing)}
+									disabled={!canSend || !typing}
 									onClick={handleSendMessage}
 									secondary={typing || isEditing}
 									info={typing || isEditing}


### PR DESCRIPTION
### Description  
This PR updates the logic for disabling the Send button in the message composer. Previously, the button was disabled based on both `typing` and `isEditing`, but `isEditing` is irrelevant to whether a message can be sent.  

### Changes  
- Updated the `disabled` condition to `!canSend || !typing`, ensuring the button is only enabled when text is entered.  
- Adjusted the message submission logic to prevent sending messages when the button is disabled.  
- Removed unnecessary dependency on `isEditing` for button state.  

### Why this is needed  
- The previous logic incorrectly considered `isEditing`, leading to cases where the button was enabled even when no text was present.  
- This fix ensures that a message can only be sent when the user has permission (`canSend`) **and** has entered text (`typing`).  

### Testing  
- Verified that the button remains disabled when the input is empty.  
- Confirmed that the button enables when text is typed.  
- Ensured that editing a message does not affect the button's disabled state.  
- Updated the `disabled` condition to `!canSend || !typing`, removing `isEditing` from the logic.
- Prevented message submission when the button is disabled.
- Ensured the button is only enabled when text is being typed, regardless of editing state.

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
2cd9c592b6ac72a87fcc9cb51b473e1368f2a856
- Updated the `disabled` condition to `!canSend || !typing`, removing `isEditing` from the logic.
- Prevented message submission when the button is disabled.
- Ensured the button is only enabled when text is being typed, regardless of editing state.


https://github.com/user-attachments/assets/425de991-084c-4fe0-9f09-43583d55762e



## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
#35650 



## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[35655](https://github.com/RocketChat/Rocket.Chat/pull/35653) and [35653](https://github.com/RocketChat/Rocket.Chat/pull/35655) are PRs that add two workflows such that a warning modal shows up if the edited text is empty.
This PR properly patches this by implementing correct condition checking without altering any chat flows.