### PR TITLE
fix: federated users overwriting local display name with their usernames

### DIFF
--- a/apps/meteor/server/services/federation/domain/FederatedUser.ts
+++ b/apps/meteor/server/services/federation/domain/FederatedUser.ts
@@ -111,7 +111,23 @@ export class FederatedUser {
 	}
 
 	public shouldUpdateDisplayName(displayName: string): boolean {
-		return this.internalReference.name !== displayName;
+		// If there is no change, then we don't need to update
+		if (this.internalReference.name === displayName) {
+			return false;
+		}
+
+		// If we don't have a name yet, then use whatever we're receiving
+		if (!this.internalReference.name) {
+			return true;
+		}
+
+		// If the displayName received is based on the username, then ignore it and keep the existing name instead
+		if (this.internalReference.username?.includes(displayName) || this.externalId.includes(displayName)) {
+			return false;
+		}
+
+		// It's a new value and an actual display name
+		return true;
 	}
 
 	public getInternalId(): string {

--- a/apps/meteor/tests/unit/server/federation/application/user/sender/UserServiceSender.spec.ts
+++ b/apps/meteor/tests/unit/server/federation/application/user/sender/UserServiceSender.spec.ts
@@ -238,7 +238,7 @@ describe('Federation - Application - FederationUserServiceSender', () => {
 					existsOnlyOnProxyServer: false,
 				}),
 			);
-			bridge.getUserProfileInformation.resolves({ displayname: 'normalizedInviterId' });
+			bridge.getUserProfileInformation.resolves({ displayName: 'normalizedInviterId' });
 			await service.afterUserRealNameChanged('id', 'name');
 
 			expect(bridge.setUserDisplayName.called).to.be.false;
@@ -252,7 +252,7 @@ describe('Federation - Application - FederationUserServiceSender', () => {
 					_id: '_id',
 				}),
 			);
-			bridge.getUserProfileInformation.resolves({ displayname: 'different' });
+			bridge.getUserProfileInformation.resolves({ displayName: 'different' });
 			await service.afterUserRealNameChanged('id', 'name');
 
 			expect(bridge.setUserDisplayName.calledWith('externalInviterId', 'name')).to.be.true;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
When we invite an user from a federated workspace, we only have their username available, not the display name. In this situation, synaptic tries to get the user's profile from the remote synaptic, who will not have the data ready if that user had never federated before. In this case synaptic falls back to using the username as display name and passes that information to us as if it were the target user's real display name.

When we pre-create the federated users on all sides, we'll already have their display name properly assigned, but this username coming from synaptic ends up overwriting it.

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This is a hacky, temporary solution for the issue. The proper fix would be to implement responses to user queries from synaptic.
