### PR TITLE
fix: Contact's custom fields are now properly sent to api

### DIFF
--- a/.changeset/warm-steaks-fetch.md
+++ b/.changeset/warm-steaks-fetch.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixes contact's conflict resolution not working due to invalid parameters

--- a/apps/meteor/client/views/omnichannel/contactInfo/ContactInfo/ReviewContactModal.tsx
+++ b/apps/meteor/client/views/omnichannel/contactInfo/ContactInfo/ReviewContactModal.tsx
@@ -47,7 +47,7 @@ const ReviewContactModal = ({ contact, onCancel }: ReviewContactModalProps) => {
 		const payload = {
 			name,
 			contactManager,
-			...(customFields && { ...customFields }),
+			...(customFields && { customFields }),
 			wipeConflicts: true,
 		};
 

--- a/apps/meteor/client/views/omnichannel/contactInfo/ContactInfo/ReviewContactModal.tsx
+++ b/apps/meteor/client/views/omnichannel/contactInfo/ContactInfo/ReviewContactModal.tsx
@@ -86,7 +86,7 @@ const ReviewContactModal = ({ contact, onCancel }: ReviewContactModalProps) => {
 
 					return (
 						<Field key={index}>
-							<FieldLabel>{t(label as TranslationKey)}</FieldLabel>
+							<FieldLabel id={name}>{t(label as TranslationKey)}</FieldLabel>
 							<FieldRow>
 								<Controller
 									name={name}
@@ -94,16 +94,24 @@ const ReviewContactModal = ({ contact, onCancel }: ReviewContactModalProps) => {
 									rules={{
 										required: isContactManagerField ? undefined : t('Required_field', { field: t(label as TranslationKey) }),
 									}}
-									render={({ field: { value, onChange } }) => <Component options={mappedOptions} value={value} onChange={onChange} />}
+									render={({ field: { value, onChange } }) => (
+										<Component
+											aria-labelledby={name}
+											aria-describedby={`${name}-hint ${name}-error`}
+											options={mappedOptions}
+											value={value}
+											onChange={onChange}
+										/>
+									)}
 								/>
 							</FieldRow>
-							<FieldHint>
+							<FieldHint id={`${name}-hint`}>
 								<Box display='flex' alignItems='center'>
 									<Box mie={4}>{t('different_values_found', { number: values.length })}</Box>
 									<Badge variant='primary' small />
 								</Box>
 							</FieldHint>
-							{errors?.[name] && <FieldError>{errors?.[name]?.message}</FieldError>}
+							{errors?.[name] && <FieldError id={`${name}-error`}>{errors?.[name]?.message}</FieldError>}
 						</Field>
 					);
 				})}

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-contact-conflict-review.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-contact-conflict-review.spec.ts
@@ -1,3 +1,5 @@
+import { faker } from '@faker-js/faker';
+
 import { createFakeVisitor } from '../../mocks/data';
 import { IS_EE } from '../config/constants';
 import { Users } from '../fixtures/userStates';
@@ -17,7 +19,7 @@ test.describe.serial('OC - Contact Review', () => {
 	let poRoomInfo: OmnichannelRoomInfo;
 
 	const customFieldName = 'customField';
-	const visitorToken = '<KEY>';
+	const visitorToken = faker.string.uuid();
 
 	test.beforeAll(async ({ api }) => {
 		(
@@ -27,7 +29,22 @@ test.describe.serial('OC - Contact Review', () => {
 				api.post('/method.call/livechat:saveCustomField', {
 					message: JSON.stringify({
 						method: 'livechat:saveCustomField',
-						params: [null, customFieldName, customFieldName],
+						params: [
+							null,
+							{
+								field: customFieldName,
+								label: customFieldName,
+								visibility: 'visible',
+								scope: 'visitor',
+								searchable: false,
+								regexp: '',
+								type: 'input',
+								required: false,
+								defaultValue: '',
+								options: '',
+								public: false,
+							},
+						],
 						id: 'id',
 						msg: 'method',
 					}),
@@ -49,8 +66,21 @@ test.describe.serial('OC - Contact Review', () => {
 	test.beforeEach(async ({ api }) => {
 		await createConversation(api, { visitorName: visitor.name, agentId: `user1`, visitorToken });
 
-		void api.post('livechat/custom.field', { token: visitorToken, key: customFieldName, value: 'custom-field-value', overwrite: true });
-		void api.post('livechat/custom.field', { token: visitorToken, key: customFieldName, value: 'custom-field-value-2', overwrite: false });
+		const resCustomFieldA = await api.post('/livechat/custom.field', {
+			token: visitorToken,
+			key: customFieldName,
+			value: 'custom-field-value',
+			overwrite: true,
+		});
+		expect(resCustomFieldA.status()).toBe(200);
+
+		const resCustomFieldB = await api.post('/livechat/custom.field', {
+			token: visitorToken,
+			key: customFieldName,
+			value: 'custom-field-value-2',
+			overwrite: false,
+		});
+		expect(resCustomFieldB.status()).toBe(200);
 	});
 
 	test.afterAll(async ({ api }) => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-contact-conflict-review.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-contact-conflict-review.spec.ts
@@ -1,0 +1,77 @@
+import { createFakeVisitor } from '../../mocks/data';
+import { IS_EE } from '../config/constants';
+import { Users } from '../fixtures/userStates';
+import { HomeOmnichannel } from '../page-objects';
+import { OmnichannelRoomInfo } from '../page-objects/omnichannel-room-info';
+import { createConversation } from '../utils/omnichannel/rooms';
+import { test, expect } from '../utils/test';
+
+const visitor = createFakeVisitor();
+
+test.skip(!IS_EE, 'Omnichannel Contact Review > Enterprise Only');
+
+test.use({ storageState: Users.user1.state });
+
+test.describe.serial('OC - Contact Review', () => {
+	let poHomeChannel: HomeOmnichannel;
+	let poRoomInfo: OmnichannelRoomInfo;
+
+	const customFieldName = 'customField';
+	const visitorToken = '<KEY>';
+
+	test.beforeAll(async ({ api }) => {
+		(
+			await Promise.all([
+				api.post('/livechat/users/agent', { username: 'user1' }),
+				api.post('/livechat/users/manager', { username: 'user1' }),
+				api.post('/method.call/livechat:saveCustomField', {
+					message: JSON.stringify({
+						method: 'livechat:saveCustomField',
+						params: [null, customFieldName, customFieldName],
+						id: 'id',
+						msg: 'method',
+					}),
+				}),
+			])
+		).every((res) => expect(res.status()).toBe(200));
+	});
+
+	test.beforeEach(async ({ page }) => {
+		poHomeChannel = new HomeOmnichannel(page);
+		poRoomInfo = new OmnichannelRoomInfo(page);
+	});
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page.locator('.main-content').waitFor();
+	});
+
+	test.beforeEach(async ({ api }) => {
+		await createConversation(api, { visitorName: visitor.name, agentId: `user1`, visitorToken });
+
+		void api.post('livechat/custom.field', { token: visitorToken, key: customFieldName, value: 'custom-field-value', overwrite: true });
+		void api.post('livechat/custom.field', { token: visitorToken, key: customFieldName, value: 'custom-field-value-2', overwrite: false });
+	});
+
+	test.afterAll(async ({ api }) => {
+		(await Promise.all([api.delete('/livechat/users/agent/user1'), api.delete('/livechat/users/manager/user1')])).every((res) =>
+			expect(res.status()).toBe(200),
+		);
+	});
+
+	test('OC - Contact Review - Update custom field conflicting', async ({ page }) => {
+		await test.step('expect to resolve custom field conflict', async () => {
+			await poHomeChannel.sidenav.getSidebarItemByName(visitor.name).click();
+			await poHomeChannel.content.btnContactInformation.click();
+
+			await page.getByRole('button', { name: 'See conflicts' }).click();
+
+			await page.getByLabel(customFieldName).click();
+			await page.getByRole('option', { name: 'custom-field-value-2' }).click();
+			await page.getByRole('button', { name: 'Save' }).click();
+
+			const response = await page.waitForResponse('**/api/v1/omnichannel/contacts.update');
+			expect(response.status()).toBe(200);
+		});
+	});
+});

--- a/apps/meteor/tests/e2e/page-objects/fragments/home-omnichannel-content.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/home-omnichannel-content.ts
@@ -3,16 +3,20 @@ import type { Locator, Page } from '@playwright/test';
 import { OmnichannelTransferChatModal } from '../omnichannel-transfer-chat-modal';
 import { HomeContent } from './home-content';
 import { OmnichannelCloseChatModal } from './omnichannel-close-chat-modal';
+import { OmnichannelContactReviewModal } from '../omnichannel-contact-review-modal';
 
 export class HomeOmnichannelContent extends HomeContent {
 	readonly closeChatModal: OmnichannelCloseChatModal;
 
 	readonly forwardChatModal: OmnichannelTransferChatModal;
 
+	readonly contactReviewModal: OmnichannelContactReviewModal;
+
 	constructor(page: Page) {
 		super(page);
 		this.closeChatModal = new OmnichannelCloseChatModal(page);
 		this.forwardChatModal = new OmnichannelTransferChatModal(page);
+		this.contactReviewModal = new OmnichannelContactReviewModal(page);
 	}
 
 	get btnReturnToQueue(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel-contact-review-modal.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel-contact-review-modal.ts
@@ -1,0 +1,25 @@
+import type { Locator, Page } from '@playwright/test';
+
+export class OmnichannelContactReviewModal {
+	private readonly page: Page;
+
+	constructor(page: Page) {
+		this.page = page;
+	}
+
+	get btnSeeConflicts(): Locator {
+		return this.page.getByRole('button', { name: 'See conflicts', exact: true });
+	}
+
+	get btnSave(): Locator {
+		return this.page.getByRole('button', { name: 'Save', exact: true });
+	}
+
+	getFieldByName(name: string): Locator {
+		return this.page.getByLabel(name, { exact: true });
+	}
+
+	findOption(name: string): Locator {
+		return this.page.getByRole('option', { name, exact: true });
+	}
+}

--- a/apps/meteor/tests/e2e/utils/omnichannel/custom-field.ts
+++ b/apps/meteor/tests/e2e/utils/omnichannel/custom-field.ts
@@ -1,0 +1,54 @@
+import type { ILivechatCustomField } from '@rocket.chat/core-typings';
+
+import { parseMeteorResponse } from '../parseMeteorResponse';
+import type { BaseTest } from '../test';
+
+type CustomField = Omit<ILivechatCustomField, '_id' | '_updatedAt'> & { field: string };
+
+export const removeCustomField = (api: BaseTest['api'], id: string) => {
+	return api.post('/method.call/livechat:deleteCustomField', {
+		method: 'livechat:saveCustomField',
+		params: [id],
+		id: 'id',
+		msg: 'method',
+	});
+};
+
+export const createCustomField = async (api: BaseTest['api'], overwrides: Partial<CustomField>) => {
+	const response = await api.post('/method.call/livechat:saveCustomField', {
+		message: JSON.stringify({
+			method: 'livechat:saveCustomField',
+			params: [
+				null,
+				{
+					field: overwrides.field,
+					label: overwrides.label || overwrides.field,
+					visibility: 'visible',
+					scope: 'visitor',
+					searchable: false,
+					regexp: '',
+					type: 'input',
+					required: false,
+					defaultValue: '',
+					options: '',
+					public: false,
+					...overwrides,
+				},
+			],
+			id: 'id',
+			msg: 'method',
+		}),
+	});
+
+	if (!response.ok()) {
+		throw new Error(`Failed to create custom field [http status: ${response.status()}]`);
+	}
+
+	const customField = await parseMeteorResponse<CustomField & { _id: string }>(response);
+
+	return {
+		response,
+		customField,
+		delete: () => removeCustomField(api, customField._id),
+	};
+};


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
This PR fixes a small bug that caused the API to return an error during contact's custom field conflict resolution, the issue was caused  by a payload being incorrectly built and sent to the API.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CTZ-97](https://rocketchat.atlassian.net/browse/CTZ-97)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Create a custom field (visitor scope)
2. Call  setCustomField widget API method with overwrite: false (this.setCustomField('fieldName2', 'A value set just once', false))
3. Go to Contact Info Panel
4. Click See Conflicts
5. Chose an option and click Save
6. Error message is raised right away

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CTZ-97]: https://rocketchat.atlassian.net/browse/CTZ-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

### Pull Request Description

This pull request addresses a bug in the Rocket.Chat repository, specifically in the `ReviewContactModal` component of the Omnichannel contact information view. The issue was related to the improper handling of contact's custom fields when sending data to the API. The changes ensure that custom fields are now correctly nested under a `customFields` object in the payload. This fix is implemented in the `ReviewContactModal.tsx` file. The source branch for this fix is `bugfix/CTZ-97`, and it is targeted to be merged into the `develop` branch.