### PR TITLE
chore: prevent multiple listener.once `updateSubscription`

### DIFF
--- a/apps/meteor/client/lib/chats/readStateManager.ts
+++ b/apps/meteor/client/lib/chats/readStateManager.ts
@@ -38,6 +38,10 @@ export class ReadStateManager extends Emitter {
 		return this.firstUnreadRecordId;
 	};
 
+	public subscribeToMessages() {
+		return RoomHistoryManager.on('loaded-messages', () => this.updateFirstUnreadRecordId());
+	}
+
 	public updateSubscription(subscription?: ISubscription) {
 		if (!subscription) {
 			return;
@@ -88,8 +92,6 @@ export class ReadStateManager extends Emitter {
 		);
 
 		this.setFirstUnreadRecordId(firstUnreadRecord?._id);
-
-		RoomHistoryManager.once('loaded-messages', () => this.updateFirstUnreadRecordId());
 	}
 
 	private setFirstUnreadRecordId(firstUnreadRecordId: string | undefined) {

--- a/apps/meteor/client/views/room/providers/hooks/useChatMessagesInstance.spec.ts
+++ b/apps/meteor/client/views/room/providers/hooks/useChatMessagesInstance.spec.ts
@@ -35,6 +35,7 @@ jest.mock('../../../../../app/ui/client/lib/ChatMessages', () => {
 				release: jest.fn(),
 				readStateManager: {
 					updateSubscription: updateSubscriptionMock,
+					subscribeToMessages: jest.fn(),
 				},
 			};
 		}),

--- a/apps/meteor/client/views/room/providers/hooks/useChatMessagesInstance.ts
+++ b/apps/meteor/client/views/room/providers/hooks/useChatMessagesInstance.ts
@@ -31,6 +31,12 @@ export function useChatMessagesInstance({
 	}, [rid, tmid, uid, encrypted, e2eRoomState]);
 
 	useEffect(() => {
+		if (subscription?.rid) {
+			return chatMessages?.readStateManager.subscribeToMessages();
+		}
+	}, [subscription?.rid, chatMessages?.readStateManager]);
+
+	useEffect(() => {
 		if (subscription) {
 			chatMessages?.readStateManager.updateSubscription(subscription);
 		}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
https://rocketchat.atlassian.net/browse/ARCH-1585

found during https://github.com/RocketChat/Rocket.Chat/pull/35880
<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

This pull request aims to address an issue in the Rocket.Chat repository by preventing multiple `listener.once` calls to `updateSubscription`. The changes are made in two files:

1. **readStateManager.ts**: A new method has been added to subscribe to message loading events and update the first unread record ID.

2. **useChatMessagesInstance.ts**: A `useEffect` hook is introduced to manage message subscriptions using `chatMessages.readStateManager`. The hook utilizes optional chaining to avoid runtime errors when `subscription` or `chatMessages` are temporarily undefined.

These updates are intended to enhance the management of message subscriptions and improve the stability of the chat application.