### PR TITLE
regression: API endpoints query parameter validation not working for nested properties

### DIFF
--- a/apps/meteor/app/api/server/router.ts
+++ b/apps/meteor/app/api/server/router.ts
@@ -191,9 +191,12 @@ export class Router<
 		this.innerRouter[method.toLowerCase() as Lowercase<Method>](`/${subpath}`.replace('//', '/'), ...middlewares, async (c) => {
 			const { req, res } = c;
 			req.raw.route = `${c.var.route ?? ''}${subpath}`;
+
+			const queryParams = this.parseQueryParams(req);
+
 			if (options.query) {
 				const validatorFn = options.query;
-				if (typeof options.query === 'function' && !validatorFn(req.query())) {
+				if (typeof options.query === 'function' && !validatorFn(queryParams)) {
 					return c.json(
 						{
 							success: false,
@@ -229,7 +232,7 @@ export class Router<
 				{
 					requestIp: c.get('remoteAddress'),
 					urlParams: req.param(),
-					queryParams: this.parseQueryParams(req),
+					queryParams,
 					bodyParams,
 					request: req.raw.clone(),
 					path: req.path,


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-1135](https://rocketchat.atlassian.net/browse/CORE-1135)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

This pull request addresses an issue in the Rocket.Chat repository where API endpoint query parameter validation was not functioning correctly for nested properties. The changes are made in the `apps/meteor/app/api/server/router.ts` file. The update involves modifying the router class to handle query parameters by parsing them, rather than accessing them directly from the request. This adjustment aims to improve the validation process for nested query parameters. The source branch for this fix is `fix/routerQuery`, and it is targeted to be merged into the `develop` branch.

[CORE-1135]: https://rocketchat.atlassian.net/browse/CORE-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ