### PR TITLE
chore: add getLivechatRoomById function

### DIFF
--- a/apps/meteor/app/apps/server/bridges/livechat.ts
+++ b/apps/meteor/app/apps/server/bridges/livechat.ts
@@ -198,6 +198,15 @@ export class AppLivechatBridge extends LivechatBridge {
 		return Promise.all(result.map((room) => this.orch.getConverters()?.get('rooms').convertRoom(room) as Promise<ILivechatRoom>));
 	}
 
+	protected async findRoomById(roomId: string, appId: string): Promise<ILivechatRoom | undefined> {
+		this.orch.debugLog(`The App ${appId} is looking for livechat room with id ${roomId}.`);
+
+		return this.orch
+			.getConverters()
+			?.get('rooms')
+			.convertRoom(await LivechatRooms.findOneById(roomId)) as Promise<ILivechatRoom | undefined>;
+	}
+
 	protected async createVisitor(visitor: IVisitor, appId: string): Promise<string> {
 		this.orch.debugLog(`The App ${appId} is creating a livechat visitor.`);
 

--- a/packages/apps-engine/src/definition/accessors/ILivechatRead.ts
+++ b/packages/apps-engine/src/definition/accessors/ILivechatRead.ts
@@ -17,6 +17,7 @@ export interface ILivechatRead {
     isOnlineAsync(departmentId?: string): Promise<boolean>;
     getDepartmentsEnabledWithAgents(): Promise<Array<IDepartment>>;
     getLivechatRooms(visitor: IVisitor, departmentId?: string): Promise<Array<ILivechatRoom>>;
+    getLivechatRoomById(roomId: string): Promise<ILivechatRoom | undefined>;
     getLivechatOpenRoomsByAgentId(agentId: string): Promise<Array<ILivechatRoom>>;
     getLivechatTotalOpenRoomsByAgentId(agentId: string): Promise<number>;
     /**

--- a/packages/apps-engine/src/server/accessors/LivechatRead.ts
+++ b/packages/apps-engine/src/server/accessors/LivechatRead.ts
@@ -33,6 +33,10 @@ export class LivechatRead implements ILivechatRead {
         return this.livechatBridge.doFindRooms(visitor, departmentId, this.appId);
     }
 
+    public getLivechatRoomById(roomId: string): Promise<ILivechatRoom | undefined> {
+        return this.livechatBridge.doFindRoomById(roomId, this.appId);
+    }
+
     public getLivechatTotalOpenRoomsByAgentId(agentId: string): Promise<number> {
         return this.livechatBridge.doCountOpenRoomsByAgentId(agentId, this.appId);
     }

--- a/packages/apps-engine/src/server/bridges/LivechatBridge.ts
+++ b/packages/apps-engine/src/server/bridges/LivechatBridge.ts
@@ -131,6 +131,12 @@ export abstract class LivechatBridge extends BaseBridge {
         }
     }
 
+    public async doFindRoomById(roomId: string, appId: string): Promise<ILivechatRoom | undefined> {
+        if (this.hasReadPermission(appId, 'livechat-room')) {
+            return this.findRoomById(roomId, appId);
+        }
+    }
+
     public async doFindDepartmentByIdOrName(value: string, appId: string): Promise<IDepartment | undefined> {
         if (this.hasReadPermission(appId, 'livechat-department') || this.hasMultiplePermission(appId, 'livechat-department')) {
             return this.findDepartmentByIdOrName(value, appId);
@@ -203,6 +209,8 @@ export abstract class LivechatBridge extends BaseBridge {
     protected abstract findOpenRoomsByAgentId(agentId: string, appId: string): Promise<Array<ILivechatRoom>>;
 
     protected abstract findRooms(visitor: IVisitor, departmentId: string | null, appId: string): Promise<Array<ILivechatRoom>>;
+
+    protected abstract findRoomById(roomId: string, appId: string): Promise<ILivechatRoom | undefined>;
 
     protected abstract findDepartmentByIdOrName(value: string, appId: string): Promise<IDepartment | undefined>;
 

--- a/packages/apps-engine/tests/test-data/bridges/livechatBridge.ts
+++ b/packages/apps-engine/tests/test-data/bridges/livechatBridge.ts
@@ -74,6 +74,10 @@ export class TestLivechatBridge extends LivechatBridge {
         throw new Error('Method not implemented');
     }
 
+    public findRoomById(roomId: string, appId: string): Promise<ILivechatRoom | undefined> {
+        throw new Error('Method not implemented');
+    }
+
     public findOpenRoomsByAgentId(agentId: string, appId: string): Promise<ILivechatRoom[]> {
         throw new Error('Method not implemented');
     }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
This PR just implements a new ILivechatRead function: getLivechatRoomById. Today there's only one method which we can use to return livechat rooms which is getLivechatRooms function. However, this function only permits to fetch rooms by a specific visitor and, if desired, with a department Id. Adding the new function getLivechatRoomById will benefit users who want to search, in their apps, for specific rooms which the id is already known. A scenario which can be benefited is when the room's queue is manually managed by an external service and an app is responsible to make some updates in the room or other contents based on room's id.
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
Does not relate to any open issue.
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
Isn't applicable.
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
No comments.
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

This pull request introduces a new function, `getLivechatRoomById`, to the Rocket.Chat codebase. The changes span multiple files to support this functionality:

1. In `apps/meteor/app/apps/server/bridges/livechat.ts`, a new method `findRoomById` is added to the `AppLivechatBridge` class. This method allows apps to retrieve a specific livechat room by its ID and convert it for app consumption.

2. The `ILivechatRead` interface in `packages/apps-engine/src/definition/accessors/ILivechatRead.ts` is updated with the new method `getLivechatRoomById`.

3. The `LivechatRead` class in `packages/apps-engine/src/server/accessors/LivechatRead.ts` now includes the `getLivechatRoomById` method to fetch a livechat room by its ID.

4. In `packages/apps-engine/src/server/bridges/LivechatBridge.ts`, a new method `doFindRoomById` is added to the `LivechatBridge` class. This method, along with its abstract counterpart `findRoomById`, is responsible for fetching a livechat room by its ID, incorporating permission checks before execution.

These changes collectively enhance the ability to access livechat rooms by their IDs within the Rocket.Chat application.