### PR TITLE
regression: contact info now updates without overwriting attributes

### DIFF
--- a/apps/meteor/app/livechat/server/lib/contacts/updateContact.ts
+++ b/apps/meteor/app/livechat/server/lib/contacts/updateContact.ts
@@ -61,7 +61,6 @@ export async function updateContact(params: UpdateContactParams): Promise<ILivec
 		validateCustomFields(workspaceAllowedCustomFields, receivedCustomFields, {
 			ignoreAdditionalFields: !!notRegisteredCustomFields.length,
 		});
-
 	if (receivedCustomFields && customFieldsToUpdate && notRegisteredCustomFields.length) {
 		const allowedCustomFields = [...workspaceAllowedCustomFields, ...notRegisteredCustomFields];
 		validateCustomFields(allowedCustomFields, receivedCustomFields);
@@ -72,12 +71,12 @@ export async function updateContact(params: UpdateContactParams): Promise<ILivec
 	}
 
 	const updatedContact = await LivechatContacts.updateContact(contactId, {
-		name,
+		...(name && { name }),
 		...(emails && { emails: emails?.map((address) => ({ address })) }),
 		...(phones && { phones: phones?.map((phoneNumber) => ({ phoneNumber })) }),
 		...(contactManager && { contactManager }),
 		...(channels && { channels }),
-		...(customFieldsToUpdate && { customFields: customFieldsToUpdate }),
+		...(customFieldsToUpdate && { customFields: { ...contact.customFields, ...customFieldsToUpdate } }),
 		...(wipeConflicts && { conflictingFields: [] }),
 	});
 

--- a/apps/meteor/app/livechat/server/lib/contacts/updateContact.ts
+++ b/apps/meteor/app/livechat/server/lib/contacts/updateContact.ts
@@ -56,14 +56,17 @@ export async function updateContact(params: UpdateContactParams): Promise<ILivec
 		.filter((customFieldId) => !workspaceAllowedCustomFieldsIds.includes(customFieldId))
 		.map((customFieldId) => ({ _id: customFieldId }));
 
+	const isResolvingConflicts = !!(wipeConflicts && contact.conflictingFields?.length);
+
 	const customFieldsToUpdate =
 		receivedCustomFields &&
 		validateCustomFields(workspaceAllowedCustomFields, receivedCustomFields, {
 			ignoreAdditionalFields: !!notRegisteredCustomFields.length,
+			ignoreValidationErrors: isResolvingConflicts,
 		});
 	if (receivedCustomFields && customFieldsToUpdate && notRegisteredCustomFields.length) {
 		const allowedCustomFields = [...workspaceAllowedCustomFields, ...notRegisteredCustomFields];
-		validateCustomFields(allowedCustomFields, receivedCustomFields);
+		validateCustomFields(allowedCustomFields, receivedCustomFields, { ignoreValidationErrors: isResolvingConflicts });
 
 		notRegisteredCustomFields.forEach((notRegisteredCustomField) => {
 			customFieldsToUpdate[notRegisteredCustomField._id] = contact.customFields?.[notRegisteredCustomField._id] as string;

--- a/apps/meteor/tests/end-to-end/api/livechat/contacts.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/contacts.ts
@@ -288,24 +288,24 @@ describe('LIVECHAT - contacts', () => {
 				expect(updateRes.body.contact.customFields).to.have.property('cf2', '456');
 			});
 
-			it('should keep a legacy custom field, but remove an optional registered custom field if it is not specified on update', async () => {
-				const updateRes = await request
-					.post(api('omnichannel/contacts.update'))
-					.set(credentials)
-					.send({
-						contactId,
-						customFields: {
-							cf1: '789',
-						},
-					});
-				expect(updateRes.body).to.have.property('success', true);
-				expect(updateRes.body).to.have.property('contact').that.is.an('object');
-				expect(updateRes.body.contact).to.have.property('_id', contactId);
-				expect(updateRes.body.contact).to.have.property('customFields').that.is.an('object');
-				expect(updateRes.body.contact.customFields).to.have.property('cf1', '789');
-				expect(updateRes.body.contact.customFields).to.have.property('cf2', '456');
-				expect(updateRes.body.contact.customFields).to.not.have.property('cfOptional');
-			});
+			// it('should keep a legacy custom field, but remove an optional registered custom field if it is not specified on update', async () => {
+			// 	const updateRes = await request
+			// 		.post(api('omnichannel/contacts.update'))
+			// 		.set(credentials)
+			// 		.send({
+			// 			contactId,
+			// 			customFields: {
+			// 				cf1: '789',
+			// 			},
+			// 		});
+			// 	expect(updateRes.body).to.have.property('success', true);
+			// 	expect(updateRes.body).to.have.property('contact').that.is.an('object');
+			// 	expect(updateRes.body.contact).to.have.property('_id', contactId);
+			// 	expect(updateRes.body.contact).to.have.property('customFields').that.is.an('object');
+			// 	expect(updateRes.body.contact.customFields).to.have.property('cf1', '789');
+			// 	expect(updateRes.body.contact.customFields).to.have.property('cf2', '456');
+			// 	expect(updateRes.body.contact.customFields).to.not.have.property('cfOptional');
+			// });
 
 			it('should throw an error if trying to update a custom field that is not registered in the workspace and does not exist in the contact', async () => {
 				const updateRes = await request


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
This PR aims to fix an issue where `customFields` and other attributes were being overwritten when calling `omnichannel/contacts.update` after resolving conflicts.

**Example:**
Calling the endpoint to update only 
```typescript
{ customFields: { customField: 'value' } }
```
 while the current document has:
```typescript
  customFields: {
    customField: "custom-field-value",
    serviceId: "TAATI"
  }
```
would result in the object being updated as:
```typescript
  customFields: {
    customField: "custom-field-value"
  }
```

Additionally, if `name` is not present in the payload, it would be saved as `null`.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CTZ-112](https://rocketchat.atlassian.net/browse/CTZ-112)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Have at least 2 custom fields with visitor scope
2. Call setCustomField widget api method with overwrite === false
3. Go to Contact Info Panel
4.  Resolve Conflict

Step 2 can be streamlined by updating a contact directly in the database with the information below, or similar:
```json
  "customFields": {
    "customField": "custom-field-value",
    "anotherCustomField": "another-custom-field-value"
  },
  "conflictingFields": [
    {
      "field": "customFields.customField",
      "value": "custom-field-value-2"
    }
  ]
```
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

[CTZ-112]: https://rocketchat.atlassian.net/browse/CTZ-112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ