### PR TITLE
chore: apps-engine livechat's createRoom function with optional agent

### DIFF
--- a/apps/meteor/app/apps/server/bridges/livechat.ts
+++ b/apps/meteor/app/apps/server/bridges/livechat.ts
@@ -99,8 +99,8 @@ export class AppLivechatBridge extends LivechatBridge {
 
 	protected async createRoom(
 		visitor: IVisitor,
-		agent: IUser,
 		appId: string,
+		agent?: IUser,
 		{ source, customFields }: IExtraRoomParams = {},
 	): Promise<ILivechatRoom> {
 		this.orch.debugLog(`The App ${appId} is creating a livechat room.`);

--- a/packages/apps-engine/src/definition/accessors/ILivechatCreator.ts
+++ b/packages/apps-engine/src/definition/accessors/ILivechatCreator.ts
@@ -18,7 +18,7 @@ export interface ILivechatCreator {
      * @param visitor The Livechat Visitor that started the conversation
      * @param agent The agent responsible for the room
      */
-    createRoom(visitor: IVisitor, agent: IUser, extraParams?: IExtraRoomParams): Promise<ILivechatRoom>;
+    createRoom(visitor: IVisitor, agent?: IUser, extraParams?: IExtraRoomParams): Promise<ILivechatRoom>;
 
     /**
      * @deprecated Use `createAndReturnVisitor` instead.

--- a/packages/apps-engine/src/server/accessors/LivechatCreator.ts
+++ b/packages/apps-engine/src/server/accessors/LivechatCreator.ts
@@ -13,8 +13,8 @@ export class LivechatCreator implements ILivechatCreator {
         private readonly appId: string,
     ) {}
 
-    public createRoom(visitor: IVisitor, agent: IUser, extraParams?: IExtraRoomParams): Promise<ILivechatRoom> {
-        return this.bridges.getLivechatBridge().doCreateRoom(visitor, agent, this.appId, extraParams);
+    public createRoom(visitor: IVisitor, agent?: IUser, extraParams?: IExtraRoomParams): Promise<ILivechatRoom> {
+        return this.bridges.getLivechatBridge().doCreateRoom(visitor, this.appId, agent, extraParams);
     }
 
     /**

--- a/packages/apps-engine/src/server/bridges/LivechatBridge.ts
+++ b/packages/apps-engine/src/server/bridges/LivechatBridge.ts
@@ -101,9 +101,9 @@ export abstract class LivechatBridge extends BaseBridge {
         }
     }
 
-    public async doCreateRoom(visitor: IVisitor, agent: IUser, appId: string, extraParams?: IExtraRoomParams): Promise<ILivechatRoom> {
+    public async doCreateRoom(visitor: IVisitor, appId: string, agent?: IUser, extraParams?: IExtraRoomParams): Promise<ILivechatRoom> {
         if (this.hasWritePermission(appId, 'livechat-room')) {
-            return this.createRoom(visitor, agent, appId, extraParams);
+            return this.createRoom(visitor, appId, agent, extraParams);
         }
     }
 
@@ -194,7 +194,7 @@ export abstract class LivechatBridge extends BaseBridge {
 
     protected abstract transferVisitor(visitor: IVisitor, transferData: ILivechatTransferData, appId: string): Promise<boolean>;
 
-    protected abstract createRoom(visitor: IVisitor, agent: IUser, appId: string, extraParams?: IExtraRoomParams): Promise<ILivechatRoom>;
+    protected abstract createRoom(visitor: IVisitor, appId: string, agent?: IUser, extraParams?: IExtraRoomParams): Promise<ILivechatRoom>;
 
     protected abstract closeRoom(room: ILivechatRoom, comment: string, closer: IUser | undefined, appId: string): Promise<boolean>;
 

--- a/packages/apps-engine/tests/test-data/bridges/livechatBridge.ts
+++ b/packages/apps-engine/tests/test-data/bridges/livechatBridge.ts
@@ -62,7 +62,7 @@ export class TestLivechatBridge extends LivechatBridge {
         throw new Error('Method not implemented');
     }
 
-    public createRoom(visitor: IVisitor, agent: IUser, appId: string, extraParams?: IExtraRoomParams): Promise<ILivechatRoom> {
+    public createRoom(visitor: IVisitor, appId: string, agent?: IUser,  extraParams?: IExtraRoomParams): Promise<ILivechatRoom> {
         throw new Error('Method not implemented');
     }
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
Today exists an apps-engine function to [create rooms](https://github.com/RocketChat/Rocket.Chat/blob/df489462155c04edfdc414403ce713b0e80f1b6b/packages/apps-engine/src/server/accessors/LivechatCreator.ts#L16C1-L16C96). However, this function, establish that is mandatory to pass an agent responsible for the room, but, at the same time, the [function](https://github.com/RocketChat/Rocket.Chat/blob/df489462155c04edfdc414403ce713b0e80f1b6b/apps/meteor/app/apps/server/bridges/livechat.ts#L117) that performs this action doesn't apply this obligation. The same behavior can be seen on the [livechat's API](https://developer.rocket.chat/apidocs/get-or-create-livechat-rooms). So, this PR accommodates this behavior to the apps-engine too. The behavior stills the same in the situations where the agent is passed as argument, however, now it's possible to create rooms without agents too. I do think this probably opens an opportunity to implement some functions related to manage inquires and the chat's queues with apps, enhancing the apps-engine feature. 
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
Doesn't relate to any issue.
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
Isn't applicable.
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
No comments.
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

This pull request updates the `createRoom` function within the Rocket.Chat repository to enhance its flexibility by making the agent parameter optional. The changes affect several files, including `apps/meteor/app/apps/server/bridges/livechat.ts`, `packages/apps-engine/src/definition/accessors/ILivechatCreator.ts`, `packages/apps-engine/src/server/accessors/LivechatCreator.ts`, and `packages/apps-engine/src/server/bridges/LivechatBridge.ts`. These modifications adjust the method signature and, in some cases, the parameter order, allowing for more versatile room creation scenarios in the live chat application.