### PR TITLE
feat: Add experimental contenteditable message composer

### DIFF
--- a/apps/meteor/app/ui-message/client/messageBox/newCreateComposerAPI.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/newCreateComposerAPI.ts
@@ -58,7 +58,6 @@ export const newCreateComposerAPI = (input: HTMLDivElement, storageID: string): 
 		sel?.addRange(range);
 	};
 
-
 	let _quotedMessages: IMessage[] = [];
 
 	const persist = withDebouncing({ wait: 300 })(() => {

--- a/apps/meteor/app/ui-message/client/messageBox/newCreateComposerAPI.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/newCreateComposerAPI.ts
@@ -1,0 +1,412 @@
+import type { IMessage } from '@rocket.chat/core-typings';
+import { Emitter } from '@rocket.chat/emitter';
+import { Accounts } from 'meteor/accounts-base';
+
+import type { FormattingButton } from './messageBoxFormatting';
+import { formattingButtons } from './messageBoxFormatting';
+import type { ComposerAPI } from '../../../../client/lib/chats/ChatAPI';
+import { withDebouncing } from '../../../../lib/utils/highOrderFunctions';
+
+export const newCreateComposerAPI = (input: HTMLDivElement, storageID: string): ComposerAPI => {
+	const triggerEvent = (input: HTMLDivElement, evt: string): void => {
+		const event = new Event(evt, { bubbles: true });
+		// TODO: Remove this hack for react to trigger onChange
+		const tracker = (input as any)._valueTracker;
+		if (tracker) {
+			tracker.setValue(new Date().toString());
+		}
+		input.dispatchEvent(event);
+	};
+
+	const emitter = new Emitter<{
+		quotedMessagesUpdate: void;
+		editing: void;
+		recording: void;
+		recordingVideo: void;
+		formatting: void;
+		mircophoneDenied: void;
+	}>();
+
+	/* Use Selection API to get the selectionStart and selectionEnd from contenteditable div */
+	const getSelectionRange = (input: HTMLDivElement): { selectionStart: number; selectionEnd: number } => {
+		const selection = window.getSelection();
+		if (!selection || selection.rangeCount === 0) {
+			return { selectionStart: 0, selectionEnd: input.innerText.length };
+		}
+
+		const range = selection.getRangeAt(0);
+		const preCaretRange = range.cloneRange();
+		preCaretRange.selectNodeContents(input);
+		preCaretRange.setEnd(range.startContainer, range.startOffset);
+		const selectionStart = preCaretRange.toString().length;
+		const selectionEnd = selectionStart + range.toString().length;
+
+		return { selectionStart, selectionEnd };
+	};
+
+	/* Use Selection API to set a selection range in contenteditable div */
+	const setSelectionRange = (input: HTMLDivElement, start: number, end: number): void => {
+		const range = document.createRange();
+		const sel = window.getSelection();
+
+		if (input.firstChild) {
+			range.setStart(input.firstChild, start);
+			range.setEnd(input.firstChild, end);
+		}
+
+		sel?.removeAllRanges();
+		sel?.addRange(range);
+	};
+
+
+	let _quotedMessages: IMessage[] = [];
+
+	const persist = withDebouncing({ wait: 300 })(() => {
+		if (input.innerText) {
+			Accounts.storageLocation.setItem(storageID, input.innerText);
+			return;
+		}
+
+		Accounts.storageLocation.removeItem(storageID);
+	});
+
+	const notifyQuotedMessagesUpdate = (): void => {
+		emitter.emit('quotedMessagesUpdate');
+	};
+
+	input.addEventListener('input', persist);
+
+	const setText = (
+		text: string,
+		{
+			selection,
+			skipFocus,
+		}: {
+			selection?:
+				| { readonly start?: number; readonly end?: number }
+				| ((previous: { readonly start: number; readonly end: number }) => { readonly start?: number; readonly end?: number });
+			skipFocus?: boolean;
+		} = {},
+	): void => {
+		!skipFocus && focus();
+
+		const { selectionStart, selectionEnd } = getSelectionRange(input);
+		const textAreaTxt = input.innerText;
+
+		if (typeof selection === 'function') {
+			selection = selection({ start: selectionStart, end: selectionEnd });
+		}
+
+		if (selection) {
+			if (!document.execCommand?.('insertText', false, text)) {
+				input.innerText = textAreaTxt.substring(0, selectionStart) + text + textAreaTxt.substring(selectionStart);
+				!skipFocus && focus();
+			}
+			setSelectionRange(input, selection.start ?? 0, selection.end ?? text.length);
+		}
+
+		if (!selection) {
+			input.innerText = text;
+		}
+
+		triggerEvent(input, 'input');
+		triggerEvent(input, 'change');
+
+		!skipFocus && focus();
+	};
+
+	const insertText = (text: string): void => {
+		setText(text, {
+			selection: ({ start, end }) => ({
+				start: start + text.length,
+				end: end + text.length,
+			}),
+		});
+	};
+
+	const clear = (): void => {
+		setText('');
+	};
+
+	const focus = (): void => {
+		input.focus();
+	};
+
+	const replyWith = async (text: string): Promise<void> => {
+		if (input) {
+			input.innerText = text;
+			input.focus();
+		}
+	};
+
+	const quoteMessage = async (message: IMessage): Promise<void> => {
+		_quotedMessages = [..._quotedMessages.filter((_message) => _message._id !== message._id), message];
+		notifyQuotedMessagesUpdate();
+		input.focus();
+	};
+
+	const dismissQuotedMessage = async (mid: IMessage['_id']): Promise<void> => {
+		_quotedMessages = _quotedMessages.filter((message) => message._id !== mid);
+		notifyQuotedMessagesUpdate();
+	};
+
+	const dismissAllQuotedMessages = async (): Promise<void> => {
+		_quotedMessages = [];
+		notifyQuotedMessagesUpdate();
+	};
+
+	const quotedMessages = {
+		get: () => _quotedMessages,
+		subscribe: (callback: () => void) => emitter.on('quotedMessagesUpdate', callback),
+	};
+
+	const [editing, setEditing] = (() => {
+		let editing = false;
+
+		return [
+			{
+				get: () => editing,
+				subscribe: (callback: () => void) => emitter.on('editing', callback),
+			},
+			(value: boolean) => {
+				editing = value;
+				emitter.emit('editing');
+			},
+		];
+	})();
+
+	const [recording, setRecordingMode] = (() => {
+		let recording = false;
+
+		return [
+			{
+				get: () => recording,
+				subscribe: (callback: () => void) => emitter.on('recording', callback),
+			},
+			(value: boolean) => {
+				recording = value;
+				emitter.emit('recording');
+			},
+		];
+	})();
+
+	const [recordingVideo, setRecordingVideo] = (() => {
+		let recordingVideo = false;
+
+		return [
+			{
+				get: () => recordingVideo,
+				subscribe: (callback: () => void) => emitter.on('recordingVideo', callback),
+			},
+			(value: boolean) => {
+				recordingVideo = value;
+				emitter.emit('recordingVideo');
+			},
+		];
+	})();
+
+	const [isMicrophoneDenied, setIsMicrophoneDenied] = (() => {
+		let isMicrophoneDenied = false;
+
+		return [
+			{
+				get: () => isMicrophoneDenied,
+				subscribe: (callback: () => void) => emitter.on('mircophoneDenied', callback),
+			},
+			(value: boolean) => {
+				isMicrophoneDenied = value;
+				emitter.emit('mircophoneDenied');
+			},
+		];
+	})();
+
+	const setEditingMode = (editing: boolean): void => {
+		setEditing(editing);
+	};
+
+	const [formatters, stopFormatterTracker] = (() => {
+		let actions: FormattingButton[] = [];
+
+		const c = Tracker.autorun(() => {
+			actions = formattingButtons.filter(({ condition }) => !condition || condition());
+			emitter.emit('formatting');
+		});
+
+		return [
+			{
+				get: () => actions,
+				subscribe: (callback: () => void) => emitter.on('formatting', callback),
+			},
+			c,
+		];
+	})();
+
+	const release = (): void => {
+		input.removeEventListener('input', persist);
+		stopFormatterTracker.stop();
+	};
+
+	const wrapSelection = (pattern: string): void => {
+		const { selectionStart, selectionEnd } = getSelectionRange(input);
+		const initText = input.innerText.slice(0, selectionStart);
+		const selectedText = input.innerText.slice(selectionStart, selectionEnd);
+		const finalText = input.innerText.slice(selectionEnd, input.innerText.length);
+
+		focus();
+
+		const startPattern = pattern.slice(0, pattern.indexOf('{{text}}'));
+		const startPatternFound = [...startPattern]
+			.reverse()
+			.every((char, index) => input.innerText.slice(selectionStart - index - 1, 1) === char);
+
+		if (startPatternFound) {
+			const endPattern = pattern.slice(pattern.indexOf('{{text}}') + '{{text}}'.length);
+			const endPatternFound = [...endPattern].every((char, index) => input.innerText.slice(selectionEnd + index, 1) === char);
+
+			if (endPatternFound) {
+				insertText(selectedText);
+
+				/* Get current selection range */
+				const { selectionStart } = getSelectionRange(input);
+
+				/* This code is redundant! Probably ... */
+				/* input.selectionStart = selectionStart - startPattern.length;
+				input.selectionEnd = selectionEnd + endPattern.length; */
+
+				if (!document.execCommand?.('insertText', false, selectedText)) {
+					input.innerText = initText.slice(0, initText.length - startPattern.length) + selectedText + finalText.slice(endPattern.length);
+				}
+
+				/* input.selectionStart = selectionStart - startPattern.length;
+				input.selectionEnd = input.selectionStart + selectedText.length; */
+
+				focus();
+
+				const newStart = selectionStart - startPattern.length;
+				const newEnd = newStart + selectedText.length;
+
+				setSelectionRange(input, newStart, newEnd);
+
+				triggerEvent(input, 'input');
+				triggerEvent(input, 'change');
+
+				return;
+			}
+		}
+
+		if (!document.execCommand?.('insertText', false, pattern.replace('{{text}}', selectedText))) {
+			input.innerText = initText + pattern.replace('{{text}}', selectedText) + finalText;
+		}
+
+		focus();
+
+		const newStart = selectionStart + pattern.indexOf('{{text}}');
+		const newEnd = newStart + selectedText.length;
+
+		setSelectionRange(input, newStart, newEnd);
+
+		triggerEvent(input, 'input');
+		triggerEvent(input, 'change');
+	};
+
+	const insertNewLine = (): void => insertText('\n');
+
+	setText(Accounts.storageLocation.getItem(storageID) ?? '', {
+		skipFocus: true,
+	});
+
+	// Gets the text that is connected to the cursor and replaces it with the given text
+	const replaceText = (text: string, selection: { readonly start: number; readonly end: number }): void => {
+		const { selectionStart, selectionEnd } = getSelectionRange(input);
+
+		// Selects the text that is connected to the cursor
+		setSelectionRange(input, selection.start ?? 0, selection.end ?? text.length);
+		const textAreaTxt = input.innerText;
+
+		if (!document.execCommand?.('insertText', false, text)) {
+			input.innerText = textAreaTxt.substring(0, selection.start) + text + textAreaTxt.substring(selection.end);
+		}
+
+		// focus();
+
+		// const newStart = selectionStart + pattern.indexOf('{{text}}');
+		// const newEnd = newStart + selectedText.length;
+
+		// const range = document.createRange();
+		// const selection = window.getSelection();
+
+		// range.setStart(input.firstChild || input, newStart);
+		// range.setEnd(input.firstChild || input, newEnd);
+
+		// selection?.removeAllRanges();
+		// selection?.addRange(range);
+
+		focus();
+
+		const newStart = selectionStart + text.length;
+		const newEnd = selectionStart + text.length;
+
+		if (selectionStart !== selectionEnd) {
+			setSelectionRange(input, selectionStart, selectionStart);
+		} else {
+			setSelectionRange(input, newStart, newEnd);
+		}
+
+		triggerEvent(input, 'input');
+		triggerEvent(input, 'change');
+	};
+
+	return {
+		replaceText,
+		insertNewLine,
+		blur: () => input.blur(),
+
+		substring: (start: number, end?: number) => {
+			return input.innerText.substring(start, end);
+		},
+
+		getCursorPosition: () => {
+			return getSelectionRange(input).selectionStart;
+		},
+		setCursorToEnd: () => {
+			const end = input.innerText.length;
+			focus();
+			setSelectionRange(input, end, end);
+		},
+		setCursorToStart: () => {
+			focus();
+			setSelectionRange(input, 0, 0);
+		},
+		release,
+		wrapSelection,
+		get text(): string {
+			return input.innerText;
+		},
+		get selection(): { start: number; end: number } {
+			const { selectionStart, selectionEnd } = getSelectionRange(input);
+			return {
+				start: selectionStart,
+				end: selectionEnd,
+			};
+		},
+
+		editing,
+		setEditingMode,
+		recording,
+		setRecordingMode,
+		recordingVideo,
+		setRecordingVideo,
+		insertText,
+		setText,
+		clear,
+		focus,
+		replyWith,
+		quoteMessage,
+		dismissQuotedMessage,
+		dismissAllQuotedMessages,
+		quotedMessages,
+		formatters,
+		isMicrophoneDenied,
+		setIsMicrophoneDenied,
+	};
+};

--- a/apps/meteor/client/views/room/composer/ComposerMessage.tsx
+++ b/apps/meteor/client/views/room/composer/ComposerMessage.tsx
@@ -27,6 +27,9 @@ export type ComposerMessageProps = {
 };
 
 const ComposerMessage = ({ tmid, onSend, ...props }: ComposerMessageProps): ReactElement => {
+	// true: enables contenteditable <div>; false: uses classic <textarea> composer
+	const featurePreviewComposer = true;
+
 	const chat = useChat();
 	const room = useRoom();
 	const dispatchToastMessage = useToastMessageDispatch();
@@ -90,7 +93,11 @@ const ComposerMessage = ({ tmid, onSend, ...props }: ComposerMessageProps): Reac
 		return <ComposerSkeleton />;
 	}
 
-	return <MessageBoxNew key={room._id} tmid={tmid} {...composerProps} showFormattingTips={true} {...props} />;
+	return featurePreviewComposer ? (
+		<MessageBoxNew key={room._id} tmid={tmid} {...composerProps} showFormattingTips={true} {...props} />
+	) : (
+		<MessageBox key={room._id} tmid={tmid} {...composerProps} showFormattingTips={true} {...props} />
+	);
 };
 
 export default memo(ComposerMessage);

--- a/apps/meteor/client/views/room/composer/ComposerMessage.tsx
+++ b/apps/meteor/client/views/room/composer/ComposerMessage.tsx
@@ -9,6 +9,7 @@ import { useReactiveValue } from '../../../hooks/useReactiveValue';
 import { useChat } from '../contexts/ChatContext';
 import { useRoom } from '../contexts/RoomContext';
 import MessageBox from './messageBox/MessageBox';
+import MessageBoxNew from './messageBox/MessageBoxNew';
 
 export type ComposerMessageProps = {
 	tmid?: IMessage['_id'];
@@ -89,7 +90,7 @@ const ComposerMessage = ({ tmid, onSend, ...props }: ComposerMessageProps): Reac
 		return <ComposerSkeleton />;
 	}
 
-	return <MessageBox key={room._id} tmid={tmid} {...composerProps} showFormattingTips={true} {...props} />;
+	return <MessageBoxNew key={room._id} tmid={tmid} {...composerProps} showFormattingTips={true} {...props} />;
 };
 
 export default memo(ComposerMessage);

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxNew.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxNew.tsx
@@ -12,6 +12,7 @@ import {
 	MessageComposerActionsDivider,
 	MessageComposerToolbarSubmit,
 	MessageComposerButton,
+	MessageComposerHint,
 } from '@rocket.chat/ui-composer';
 import { useTranslation, useUserPreference, useLayout, useSetting } from '@rocket.chat/ui-contexts';
 import { useMutation } from '@tanstack/react-query';
@@ -400,6 +401,9 @@ const MessageBoxNew = ({
 					suspended={popup.suspended}
 				/>
 			)}
+			<MessageComposerHint icon='flask' helperText=''>
+				Experiment: Real Time Composer
+			</MessageComposerHint>
 			<MessageBoxHint
 				isEditing={isEditing}
 				e2eEnabled={e2eEnabled}

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxNew.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxNew.tsx
@@ -22,9 +22,10 @@ import MessageBoxActionsToolbar from './MessageBoxActionsToolbar';
 import MessageBoxFormattingToolbar from './MessageBoxFormattingToolbar';
 import MessageBoxHint from './MessageBoxHint';
 import MessageBoxReplies from './MessageBoxReplies';
-import { createComposerAPI } from '../../../../../app/ui-message/client/messageBox/createComposerAPI';
+// import { createComposerAPI } from '../../../../../app/ui-message/client/messageBox/createComposerAPI';
 import type { FormattingButton } from '../../../../../app/ui-message/client/messageBox/messageBoxFormatting';
 import { formattingButtons } from '../../../../../app/ui-message/client/messageBox/messageBoxFormatting';
+import { newCreateComposerAPI } from '../../../../../app/ui-message/client/messageBox/newCreateComposerAPI';
 import { getImageExtensionFromMime } from '../../../../../lib/getImageExtensionFromMime';
 import { useFormatDateAndTime } from '../../../../hooks/useFormatDateAndTime';
 import { useReactiveValue } from '../../../../hooks/useReactiveValue';
@@ -135,7 +136,7 @@ const MessageBoxNew = ({
 	const storageID = `messagebox_${room._id}${tmid ? `-${tmid}` : ''}`;
 
 	const callbackRef = useCallback(
-		(node: HTMLTextAreaElement) => {
+		(node: HTMLDivElement) => {
 			if (node === null && chat.composer) {
 				return chat.setComposerAPI();
 			}
@@ -143,7 +144,7 @@ const MessageBoxNew = ({
 			if (chat.composer) {
 				return;
 			}
-			chat.setComposerAPI(createComposerAPI(node, storageID));
+			chat.setComposerAPI(newCreateComposerAPI(node, storageID));
 		},
 		[chat, storageID],
 	);

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxNew.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxNew.tsx
@@ -1,0 +1,477 @@
+/* eslint-disable complexity */
+import type { IMessage, ISubscription } from '@rocket.chat/core-typings';
+import { useContentBoxSize, useEffectEvent } from '@rocket.chat/fuselage-hooks';
+import { useSafeRefCallback } from '@rocket.chat/ui-client';
+import {
+	MessageComposerAction,
+	MessageComposerToolbarActions,
+	MessageComposer,
+	/* MessageComposerInput, */
+	MessageComposerInputNew,
+	MessageComposerToolbar,
+	MessageComposerActionsDivider,
+	MessageComposerToolbarSubmit,
+	MessageComposerButton,
+} from '@rocket.chat/ui-composer';
+import { useTranslation, useUserPreference, useLayout, useSetting } from '@rocket.chat/ui-contexts';
+import { useMutation } from '@tanstack/react-query';
+import type { ReactElement, FormEvent, MouseEvent, ClipboardEvent } from 'react';
+import { memo, useRef, useReducer, useCallback, useSyncExternalStore } from 'react';
+
+import MessageBoxActionsToolbar from './MessageBoxActionsToolbar';
+import MessageBoxFormattingToolbar from './MessageBoxFormattingToolbar';
+import MessageBoxHint from './MessageBoxHint';
+import MessageBoxReplies from './MessageBoxReplies';
+import { createComposerAPI } from '../../../../../app/ui-message/client/messageBox/createComposerAPI';
+import type { FormattingButton } from '../../../../../app/ui-message/client/messageBox/messageBoxFormatting';
+import { formattingButtons } from '../../../../../app/ui-message/client/messageBox/messageBoxFormatting';
+import { getImageExtensionFromMime } from '../../../../../lib/getImageExtensionFromMime';
+import { useFormatDateAndTime } from '../../../../hooks/useFormatDateAndTime';
+import { useReactiveValue } from '../../../../hooks/useReactiveValue';
+import type { ComposerAPI } from '../../../../lib/chats/ChatAPI';
+import { roomCoordinator } from '../../../../lib/rooms/roomCoordinator';
+import { keyCodes } from '../../../../lib/utils/keyCodes';
+import AudioMessageRecorder from '../../../composer/AudioMessageRecorder';
+import VideoMessageRecorder from '../../../composer/VideoMessageRecorder';
+import { useChat } from '../../contexts/ChatContext';
+import { useComposerPopupOptions } from '../../contexts/ComposerPopupContext';
+import { useRoom } from '../../contexts/RoomContext';
+import ComposerBoxPopup from '../ComposerBoxPopup';
+import ComposerBoxPopupPreview from '../ComposerBoxPopupPreview';
+import ComposerUserActionIndicator from '../ComposerUserActionIndicator';
+/* import { useAutoGrow } from '../RoomComposer/hooks/useAutoGrow'; */
+import { useComposerBoxPopup } from '../hooks/useComposerBoxPopup';
+import { useEnablePopupPreview } from '../hooks/useEnablePopupPreview';
+import { useMessageComposerMergedRefs } from '../hooks/useMessageComposerMergedRefs';
+import { useMessageBoxAutoFocus } from './hooks/useMessageBoxAutoFocus';
+import { useMessageBoxPlaceholder } from './hooks/useMessageBoxPlaceholder';
+
+const reducer = (_: unknown, event: FormEvent<HTMLInputElement>): boolean => {
+	const target = event.target as HTMLInputElement;
+
+	return Boolean(target.value.trim());
+};
+
+const handleFormattingShortcut = (event: KeyboardEvent, formattingButtons: FormattingButton[], composer: ComposerAPI) => {
+	const isMacOS = navigator.platform.indexOf('Mac') !== -1;
+	const isCmdOrCtrlPressed = (isMacOS && event.metaKey) || (!isMacOS && event.ctrlKey);
+
+	if (!isCmdOrCtrlPressed) {
+		return false;
+	}
+
+	const key = event.key.toLowerCase();
+
+	const formatter = formattingButtons.find((formatter) => 'command' in formatter && formatter.command === key);
+
+	if (!formatter || !('pattern' in formatter)) {
+		return false;
+	}
+
+	composer.wrapSelection(formatter.pattern);
+	return true;
+};
+
+const emptySubscribe = () => () => undefined;
+const getEmptyFalse = () => false;
+const a: any[] = [];
+const getEmptyArray = () => a;
+
+type MessageBoxProps = {
+	tmid?: IMessage['_id'];
+	onSend?: (params: { value: string; tshow?: boolean; previewUrls?: string[]; isSlashCommandAllowed?: boolean }) => Promise<void>;
+	onJoin?: () => Promise<void>;
+	onResize?: () => void;
+	onTyping?: () => void;
+	onEscape?: () => void;
+	onNavigateToPreviousMessage?: () => void;
+	onNavigateToNextMessage?: () => void;
+	onUploadFiles?: (files: readonly File[]) => void;
+	tshow?: IMessage['tshow'];
+	previewUrls?: string[];
+	subscription?: ISubscription;
+	showFormattingTips: boolean;
+	isEmbedded?: boolean;
+};
+
+const MessageBoxNew = ({
+	tmid,
+	onSend,
+	onJoin,
+	onNavigateToNextMessage,
+	onNavigateToPreviousMessage,
+	onUploadFiles,
+	onEscape,
+	onTyping,
+	tshow,
+	previewUrls,
+}: MessageBoxProps): ReactElement => {
+	const chat = useChat();
+	const room = useRoom();
+	const t = useTranslation();
+	const e2eEnabled = useSetting('E2E_Enable', false);
+	const unencryptedMessagesAllowed = useSetting('E2E_Allow_Unencrypted_Messages', false);
+	const isSlashCommandAllowed = !e2eEnabled || !room.encrypted || unencryptedMessagesAllowed;
+	const composerPlaceholder = useMessageBoxPlaceholder(t('Message'), room);
+
+	const [typing, setTyping] = useReducer(reducer, false);
+
+	const { isMobile } = useLayout();
+	const sendOnEnterBehavior = useUserPreference<'normal' | 'alternative' | 'desktop'>('sendOnEnter') || isMobile;
+	const sendOnEnter = sendOnEnterBehavior == null || sendOnEnterBehavior === 'normal' || (sendOnEnterBehavior === 'desktop' && !isMobile);
+
+	if (!chat) {
+		throw new Error('Chat context not found');
+	}
+
+	/* const textareaRef = useRef<HTMLTextAreaElement>(null); */
+
+	/* NEW: contenteditableRef */
+	const contentEditableRef = useRef<HTMLDivElement>(null);
+
+	const messageComposerRef = useRef<HTMLElement>(null);
+	const shadowRef = useRef<HTMLDivElement>(null);
+
+	const storageID = `messagebox_${room._id}${tmid ? `-${tmid}` : ''}`;
+
+	const callbackRef = useCallback(
+		(node: HTMLTextAreaElement) => {
+			if (node === null && chat.composer) {
+				return chat.setComposerAPI();
+			}
+
+			if (chat.composer) {
+				return;
+			}
+			chat.setComposerAPI(createComposerAPI(node, storageID));
+		},
+		[chat, storageID],
+	);
+
+	const autofocusRef = useMessageBoxAutoFocus(!isMobile);
+
+	const useEmojis = useUserPreference<boolean>('useEmojis');
+
+	const handleOpenEmojiPicker = useEffectEvent((e: MouseEvent<HTMLElement>) => {
+		e.stopPropagation();
+		e.preventDefault();
+
+		if (!useEmojis) {
+			return;
+		}
+
+		const ref = messageComposerRef.current as HTMLElement;
+		chat.emojiPicker.open(ref, (emoji: string) => chat.composer?.insertText(` :${emoji}: `));
+	});
+
+	const handleSendMessage = useEffectEvent(() => {
+		const text = chat.composer?.text ?? '';
+		chat.composer?.clear();
+		popup.clear();
+
+		onSend?.({
+			value: text,
+			tshow,
+			previewUrls,
+			isSlashCommandAllowed,
+		});
+	});
+
+	const closeEditing = (event: KeyboardEvent | MouseEvent<HTMLElement>) => {
+		if (chat.currentEditing) {
+			event.preventDefault();
+			event.stopPropagation();
+
+			chat.currentEditing.reset().then((reset) => {
+				if (!reset) {
+					chat.currentEditing?.cancel();
+				}
+			});
+		}
+	};
+
+	const keyboardEventHandler = useEffectEvent((event: KeyboardEvent) => {
+		const { which: keyCode } = event;
+
+		const input = event.target as HTMLTextAreaElement;
+
+		const isSubmitKey = keyCode === keyCodes.CARRIAGE_RETURN || keyCode === keyCodes.NEW_LINE;
+
+		if (isSubmitKey) {
+			const withModifier = event.shiftKey || event.ctrlKey || event.altKey || event.metaKey;
+			const isSending = (sendOnEnter && !withModifier) || (!sendOnEnter && withModifier);
+
+			event.preventDefault();
+			if (!isSending) {
+				chat.composer?.insertNewLine();
+				return false;
+			}
+			handleSendMessage();
+			return false;
+		}
+
+		if (chat.composer && handleFormattingShortcut(event, [...formattingButtons], chat.composer)) {
+			return;
+		}
+
+		if (event.shiftKey || event.ctrlKey || event.metaKey) {
+			return;
+		}
+
+		switch (event.key) {
+			case 'Escape': {
+				closeEditing(event);
+				if (!input.value.trim()) onEscape?.();
+				return;
+			}
+
+			case 'ArrowUp': {
+				if (input.selectionEnd === 0) {
+					event.preventDefault();
+					event.stopPropagation();
+
+					onNavigateToPreviousMessage?.();
+
+					if (event.altKey) {
+						input.setSelectionRange(0, 0);
+					}
+				}
+
+				return;
+			}
+
+			case 'ArrowDown': {
+				if (input.selectionEnd === input.value.length) {
+					event.preventDefault();
+					event.stopPropagation();
+
+					onNavigateToNextMessage?.();
+
+					if (event.altKey) {
+						input.setSelectionRange(input.value.length, input.value.length);
+					}
+				}
+			}
+		}
+
+		onTyping?.();
+	});
+
+	const isEditing = useSyncExternalStore(chat.composer?.editing.subscribe ?? emptySubscribe, chat.composer?.editing.get ?? getEmptyFalse);
+
+	const isRecordingAudio = useSyncExternalStore(
+		chat.composer?.recording.subscribe ?? emptySubscribe,
+		chat.composer?.recording.get ?? getEmptyFalse,
+	);
+
+	const isMicrophoneDenied = useSyncExternalStore(
+		chat.composer?.isMicrophoneDenied.subscribe ?? emptySubscribe,
+		chat.composer?.isMicrophoneDenied.get ?? getEmptyFalse,
+	);
+
+	const isRecordingVideo = useSyncExternalStore(
+		chat.composer?.recordingVideo.subscribe ?? emptySubscribe,
+		chat.composer?.recordingVideo.get ?? getEmptyFalse,
+	);
+
+	const formatters = useSyncExternalStore(
+		chat.composer?.formatters.subscribe ?? emptySubscribe,
+		chat.composer?.formatters.get ?? getEmptyArray,
+	);
+
+	const isRecording = isRecordingAudio || isRecordingVideo;
+
+	/* const { textAreaStyle, shadowStyle } = useAutoGrow(textareaRef, shadowRef, isRecordingAudio); */
+
+	const canSend = useReactiveValue(useCallback(() => roomCoordinator.verifyCanSendMessage(room._id), [room._id]));
+
+	/* const sizes = useContentBoxSize(textareaRef); */
+
+	const newSizes = useContentBoxSize(contentEditableRef);
+
+	const format = useFormatDateAndTime();
+
+	const joinMutation = useMutation({
+		mutationFn: async () => onJoin?.(),
+	});
+
+	const handlePaste = useEffectEvent((event: ClipboardEvent<HTMLTextAreaElement>) => {
+		const { clipboardData } = event;
+
+		if (!clipboardData) {
+			return;
+		}
+
+		const items = Array.from(clipboardData.items);
+
+		if (items.some(({ kind, type }) => kind === 'string' && type === 'text/plain')) {
+			return;
+		}
+
+		const files = items
+			.filter((item) => item.kind === 'file' && item.type.indexOf('image/') !== -1)
+			.map((item) => {
+				const fileItem = item.getAsFile();
+
+				if (!fileItem) {
+					return;
+				}
+
+				const imageExtension = fileItem ? getImageExtensionFromMime(fileItem.type) : undefined;
+
+				const extension = imageExtension ? `.${imageExtension}` : '';
+
+				Object.defineProperty(fileItem, 'name', {
+					writable: true,
+					value: `Clipboard - ${format(new Date())}${extension}`,
+				});
+				return fileItem;
+			})
+			.filter((file): file is File => !!file);
+
+		if (files.length) {
+			event.preventDefault();
+			onUploadFiles?.(files);
+		}
+	});
+
+	const popupOptions = useComposerPopupOptions();
+	const popup = useComposerBoxPopup(popupOptions);
+
+	const keyDownHandlerCallbackRef = useSafeRefCallback(
+		useCallback(
+			(node: HTMLTextAreaElement) => {
+				if (node === null) {
+					return;
+				}
+				const eventHandler = (e: KeyboardEvent) => keyboardEventHandler(e);
+				node.addEventListener('keydown', eventHandler);
+
+				return () => {
+					node.removeEventListener('keydown', eventHandler);
+				};
+			},
+			[keyboardEventHandler],
+		),
+	);
+
+	/* const mergedRefs = useMessageComposerMergedRefs(popup.callbackRef, textareaRef, callbackRef, autofocusRef, keyDownHandlerCallbackRef); */
+
+	/* New mergedRefs */
+	const newMergedRefs = useMessageComposerMergedRefs(
+		popup.callbackRef,
+		contentEditableRef,
+		callbackRef,
+		autofocusRef,
+		keyDownHandlerCallbackRef,
+	);
+
+	const shouldPopupPreview = useEnablePopupPreview(popup.filter, popup.option);
+
+	return (
+		<>
+			{chat.composer?.quotedMessages && <MessageBoxReplies />}
+			{shouldPopupPreview && popup.option && (
+				<ComposerBoxPopup
+					select={popup.select}
+					items={popup.items}
+					focused={popup.focused}
+					title={popup.option.title}
+					renderItem={popup.option.renderItem}
+				/>
+			)}
+			{/*
+				SlashCommand Preview popup works in a weird way
+				There is only one trigger for all the commands: "/"
+				After that we need to the slashcommand list and check if the command exists and provide the preview
+				if not the query is `suspend` which means the slashcommand is not found or doesn't have a preview
+			*/}
+			{popup.option?.preview && (
+				<ComposerBoxPopupPreview
+					select={popup.select}
+					items={popup.items as any}
+					focused={popup.focused as any}
+					title={popup.option.title}
+					renderItem={popup.option.renderItem}
+					ref={popup.commandsRef}
+					rid={room._id}
+					tmid={tmid}
+					suspended={popup.suspended}
+				/>
+			)}
+			<MessageBoxHint
+				isEditing={isEditing}
+				e2eEnabled={e2eEnabled}
+				unencryptedMessagesAllowed={unencryptedMessagesAllowed}
+				isMobile={isMobile}
+			/>
+			{isRecordingVideo && <VideoMessageRecorder reference={messageComposerRef} rid={room._id} tmid={tmid} />}
+			<MessageComposer ref={messageComposerRef} variant={isEditing ? 'editing' : undefined}>
+				{isRecordingAudio && <AudioMessageRecorder rid={room._id} isMicrophoneDenied={isMicrophoneDenied} />}
+				<MessageComposerInputNew
+					ref={newMergedRefs}
+					aria-label={composerPlaceholder}
+					name='msg'
+					disabled={isRecording || !canSend}
+					onChange={setTyping}
+					/* style={textAreaStyle} */
+					placeholder={composerPlaceholder}
+					onPaste={handlePaste}
+					aria-activedescendant={popup.focused ? `popup-item-${popup.focused._id}` : undefined}
+				/>
+				<div ref={shadowRef} /* style={shadowStyle} */ />
+				<MessageComposerToolbar>
+					<MessageComposerToolbarActions aria-label={t('Message_composer_toolbox_primary_actions')}>
+						<MessageComposerAction
+							icon='emoji'
+							disabled={!useEmojis || isRecording || !canSend}
+							onClick={handleOpenEmojiPicker}
+							title={t('Emoji')}
+						/>
+						<MessageComposerActionsDivider />
+						{chat.composer && formatters.length > 0 && (
+							<MessageBoxFormattingToolbar
+								composer={chat.composer}
+								variant={newSizes.inlineSize < 480 ? 'small' : 'large'}
+								items={formatters}
+								disabled={isRecording || !canSend}
+							/>
+						)}
+						<MessageBoxActionsToolbar
+							canSend={canSend}
+							typing={typing}
+							isMicrophoneDenied={isMicrophoneDenied}
+							rid={room._id}
+							tmid={tmid}
+							isRecording={isRecording}
+							variant={newSizes.inlineSize < 480 ? 'small' : 'large'}
+						/>
+					</MessageComposerToolbarActions>
+					<MessageComposerToolbarSubmit>
+						{!canSend && (
+							<MessageComposerButton primary onClick={onJoin} loading={joinMutation.isPending}>
+								{t('Join')}
+							</MessageComposerButton>
+						)}
+						{canSend && (
+							<>
+								{isEditing && <MessageComposerButton onClick={closeEditing}>{t('Cancel')}</MessageComposerButton>}
+								<MessageComposerAction
+									aria-label={t('Send')}
+									icon='send'
+									disabled={!canSend || (!typing && !isEditing)}
+									onClick={handleSendMessage}
+									secondary={typing || isEditing}
+									info={typing || isEditing}
+								/>
+							</>
+						)}
+					</MessageComposerToolbarSubmit>
+				</MessageComposerToolbar>
+			</MessageComposer>
+			<ComposerUserActionIndicator rid={room._id} tmid={tmid} />
+		</>
+	);
+};
+
+export default memo(MessageBoxNew);

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxNew.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxNew.tsx
@@ -47,10 +47,10 @@ import { useMessageComposerMergedRefs } from '../hooks/useMessageComposerMergedR
 import { useMessageBoxAutoFocus } from './hooks/useMessageBoxAutoFocus';
 import { useMessageBoxPlaceholder } from './hooks/useMessageBoxPlaceholder';
 
-const reducer = (_: unknown, event: FormEvent<HTMLInputElement>): boolean => {
+const reducer = (_: unknown, event: FormEvent<HTMLDivElement>): boolean => {
 	const target = event.target as HTMLInputElement;
 
-	return Boolean(target.value.trim());
+	return Boolean(target.innerText.trim());
 };
 
 const handleFormattingShortcut = (event: KeyboardEvent, formattingButtons: FormattingButton[], composer: ComposerAPI) => {
@@ -414,7 +414,7 @@ const MessageBoxNew = ({
 					aria-label={composerPlaceholder}
 					name='msg'
 					disabled={isRecording || !canSend}
-					onChange={setTyping}
+					onInput={setTyping}
 					/* style={textAreaStyle} */
 					placeholder={composerPlaceholder}
 					onPaste={handlePaste}

--- a/packages/ui-composer/src/MessageComposer/MessageComposer.stories.tsx
+++ b/packages/ui-composer/src/MessageComposer/MessageComposer.stories.tsx
@@ -7,6 +7,7 @@ import {
 	MessageComposerAction,
 	MessageComposerToolbarActions,
 	MessageComposerInput,
+	MessageComposerInputNew,
 	MessageComposerToolbar,
 	MessageComposerActionsDivider,
 	MessageComposerToolbarSubmit,
@@ -21,25 +22,28 @@ export default {
 
 const MessageToolbarActions = () => (
 	<MessageComposerToolbarActions>
-		<MessageComposerAction title='emoji' icon='emoji' />
+		<MessageComposerAction icon='emoji' />
 		<MessageComposerActionsDivider />
-		<MessageComposerAction title='bold' icon='bold' />
-		<MessageComposerAction title='italic' icon='italic' />
-		<MessageComposerAction title='underline' icon='underline' />
-		<MessageComposerAction title='strike' icon='strike' />
-		<MessageComposerAction title='code' icon='code' />
-		<MessageComposerAction title='multiline' icon='multiline' />
-		<MessageComposerAction title='link' icon='link' />
-		<MessageComposerAction title='katex' icon='katex' />
+		<MessageComposerAction icon='bold' />
+		<MessageComposerAction icon='italic' />
+		<MessageComposerAction icon='underline' />
+		<MessageComposerAction icon='strike' />
+		<MessageComposerAction icon='code' />
+		<MessageComposerAction icon='multiline' />
+		<MessageComposerAction icon='link' />
+		<MessageComposerAction icon='katex' />
+		<MessageComposerAction icon='arrow-return' />
 		<MessageComposerActionsDivider />
-		<MessageComposerAction title='mic' icon='mic' />
-		<MessageComposerAction title='video' icon='video' />
-		<MessageComposerAction title='attachment' icon='clip' />
-		<MessageComposerAction title='more' icon='plus' />
+		<MessageComposerAction icon='mic' />
+		<MessageComposerAction icon='video' />
+		<MessageComposerAction icon='clip' />
+		<MessageComposerAction icon='plus' />
 	</MessageComposerToolbarActions>
 );
 
-export const Default: StoryFn<typeof MessageComposer> = () => (
+export const MessageToolberActions: StoryFn<typeof MessageComposerToolbarActions> = () => <MessageToolbarActions />;
+
+export const _MessageComposer: StoryFn<typeof MessageComposer> = () => (
 	<MessageComposer>
 		<MessageComposerInput placeholder='Text' />
 		<MessageComposerToolbar>
@@ -48,9 +52,25 @@ export const Default: StoryFn<typeof MessageComposer> = () => (
 	</MessageComposer>
 );
 
-export const ToolbarActions: StoryFn<typeof MessageComposerToolbarActions> = () => <MessageToolbarActions />;
+export const _MessageComposerNew: StoryFn<typeof MessageComposer> = (args) => (
+	<MessageComposer>
+		<MessageComposerInput placeholder={args.placeholder || 'Placeholder text'} />
+		<MessageComposerInputNew placeholder='RealTimeEditor' />
+		<MessageComposerToolbar>
+			<MessageToolbarActions />
+			<MessageComposerToolbarSubmit>
+				<MessageComposerAction aria-label='Send' icon='send' disabled={false} secondary={true} info={true} />
+			</MessageComposerToolbarSubmit>
+		</MessageComposerToolbar>
+	</MessageComposer>
+);
 
-export const WithHints: StoryFn<typeof MessageComposer> = () => (
+_MessageComposerNew.args = {
+	// Define the props (args) you want to control
+	placeholder: 'Type a message...',
+};
+
+export const MessageComposerWithHints: StoryFn<typeof MessageComposer> = () => (
 	<>
 		<MessageComposerHint
 			icon='pencil'
@@ -63,7 +83,7 @@ export const WithHints: StoryFn<typeof MessageComposer> = () => (
 			Editing message
 		</MessageComposerHint>
 		<MessageComposer>
-			<MessageComposerInput placeholder='Text' />
+			<MessageComposerInput placeholder='Text' value='Lorem ipsum dolor' />
 			<MessageComposerToolbar>
 				<MessageToolbarActions />
 				<MessageComposerToolbarSubmit>
@@ -74,7 +94,7 @@ export const WithHints: StoryFn<typeof MessageComposer> = () => (
 	</>
 );
 
-export const WithSubmit: StoryFn<typeof MessageComposer> = () => (
+export const MessageComposerWithSubmitActions: StoryFn<typeof MessageComposer> = () => (
 	<MessageComposer>
 		<MessageComposerInput placeholder='Text' />
 		<MessageComposerToolbar>
@@ -89,4 +109,4 @@ export const WithSubmit: StoryFn<typeof MessageComposer> = () => (
 	</MessageComposer>
 );
 
-export const Loading: StoryFn<typeof MessageComposer> = () => <MessageComposerSkeleton />;
+export const MessageComposerLoading: StoryFn<typeof MessageComposer> = () => <MessageComposerSkeleton />;

--- a/packages/ui-composer/src/MessageComposer/MessageComposerInputNew.tsx
+++ b/packages/ui-composer/src/MessageComposer/MessageComposerInputNew.tsx
@@ -1,0 +1,41 @@
+import { css } from '@rocket.chat/css-in-js';
+import { Box, Palette } from '@rocket.chat/fuselage';
+import type { ComponentProps } from 'react';
+import { forwardRef } from 'react';
+
+const messageComposerInputNewStyle = css`
+	resize: none;
+
+	&::placeholder {
+		color: ${Palette.text['font-annotation']};
+	}
+`;
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface MessageComposerInputNewProps extends ComponentProps<typeof Box> {}
+
+const MessageComposerInputNew = forwardRef<HTMLTextAreaElement, MessageComposerInputNewProps>(function MessageComposerInputNew(props, ref) {
+	return (
+		<Box is='label' width='full' fontSize={0}>
+			<Box
+				className={[messageComposerInputNewStyle, 'rc-message-box__textarea js-input-message']}
+				color='default'
+				width='full'
+				minHeight='20px'
+				maxHeight='155px'
+				rows={1}
+				fontScale='p2'
+				ref={ref}
+				pi={12}
+				mb={16}
+				borderWidth={0}
+				is='div'
+				contentEditable
+				suppressContentEditableWarning
+				{...props}
+			/>
+		</Box>
+	);
+});
+
+export default MessageComposerInputNew;

--- a/packages/ui-composer/src/MessageComposer/index.ts
+++ b/packages/ui-composer/src/MessageComposer/index.ts
@@ -5,6 +5,7 @@ import MessageComposerButton from './MessageComposerButton';
 import MessageComposerHint from './MessageComposerHint';
 import MessageComposerIcon from './MessageComposerIcon';
 import MessageComposerInput from './MessageComposerInput';
+import MessageComposerInputNew from './MessageComposerInputNew';
 import MessageComposerSkeleton from './MessageComposerSkeleton';
 import MessageComposerToolbar from './MessageComposerToolbar';
 import MessageComposerToolbarActions from './MessageComposerToolbarActions';
@@ -22,4 +23,5 @@ export {
 	MessageComposerIcon,
 	MessageComposerHint,
 	MessageComposerButton,
+	MessageComposerInputNew,
 };


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
This PR introduces an **experimental real-time message composer** powered by a `<div contenteditable>` instead of the classic `<textarea>`. The goal is to enable richer in-place text formatting and interaction using modern DOM APIs, while maintaining compatibility with the current composer functionality.

**Key changes include:**
- Replaced the classic `<textarea>` input with a `<div contenteditable>` in `MessageComposerInputNew`.
- Implemented selection and cursor management using the *Selection API* to support real-time formatting features.
- Fixed the Enter key behavior to send messages as expected.
- Adapted input handling logic (e.g., `onInput`, `innerText.trim()`) to support correct state management (e.g., Send button enable/disable).
- Restored basic formatting actions (bold, italic, strikethrough).
- Added a feature flag `featurePreviewComposer` to toggle between the new input and the current one safely.
- Added an in-UI experimental label (`MessageComposerHint`) to indicate this is a preview feature.

![image](https://github.com/user-attachments/assets/be5acb20-e487-4985-a162-dcf5de554f7c)
![image](https://github.com/user-attachments/assets/a806f0d6-f0c8-40c4-9371-ebf34d35aa5f)

## Steps to test 
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Set the `featurePreviewComposer` flag to `true` (or `false`) in `apps/meteor/client/views/room/composer/ComposerMessage.tsx`

## Known Issues & Next Steps
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
- Slash commands `/` and emoji autocomplete open as expected, but *pressing Enter inserts the selection and also sends the message*, which is unintended.
- Placeholder text is not yet implemented for `<div contenteditable>`.

Additional work is needed to:
- Prevent sending when the slash command menu or emoji popups are active.
- Implement placeholder text and fix component UI breakage when the message is over 6 lines tall.
