### PR TITLE
fix: change site url  breaks `meteor_runtime_config`

### DIFF
--- a/.changeset/curly-teachers-sort.md
+++ b/.changeset/curly-teachers-sort.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixes a bug where changing site url  breaks `meteor_runtime_config` path until we reset the server

--- a/apps/meteor/app/cors/server/cors.ts
+++ b/apps/meteor/app/cors/server/cors.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'crypto';
 import type http from 'http';
 import type { UrlWithParsedQuery } from 'url';
 import url from 'url';
@@ -9,6 +8,7 @@ import { Meteor } from 'meteor/meteor';
 import type { StaticFiles } from 'meteor/webapp';
 import { WebApp, WebAppInternals } from 'meteor/webapp';
 
+import { getWebAppHash } from '../../../server/configuration/configureBoilerplate';
 import { settings } from '../../settings/server';
 
 // Taken from 'connect' types
@@ -128,20 +128,7 @@ WebAppInternals.staticFilesMiddleware = function (
 	// a cache of the file for the wrong hash and start a client loop due to the mismatch
 	// of the hashes of ui versions which would be checked against a websocket response
 	if (path === '/meteor_runtime_config.js') {
-		const program = WebApp.clientPrograms[arch] as (typeof WebApp.clientPrograms)[string] & {
-			meteorRuntimeConfigHash?: string;
-			meteorRuntimeConfig: string;
-		};
-
-		const [siteUrl] = program?.meteorRuntimeConfigHash?.split(' ') ?? [];
-
-		if (siteUrl !== __meteor_runtime_config__.ROOT_URL) {
-			program.meteorRuntimeConfigHash = `${__meteor_runtime_config__.ROOT_URL} ${createHash('sha1')
-				.update(JSON.stringify(encodeURIComponent(program.meteorRuntimeConfig)))
-				.digest('hex')}`;
-		}
-
-		const [, hash] = program?.meteorRuntimeConfigHash?.split(' ') ?? [];
+		const hash = getWebAppHash(arch);
 
 		if (!hash || hash !== url.query.hash) {
 			res.writeHead(404);

--- a/apps/meteor/app/cors/server/cors.ts
+++ b/apps/meteor/app/cors/server/cors.ts
@@ -133,13 +133,20 @@ WebAppInternals.staticFilesMiddleware = function (
 			meteorRuntimeConfig: string;
 		};
 
-		if (!program?.meteorRuntimeConfigHash) {
-			program.meteorRuntimeConfigHash = createHash('sha1')
-				.update(JSON.stringify(encodeURIComponent(program.meteorRuntimeConfig)))
-				.digest('hex');
+		const [siteUrl] = program?.meteorRuntimeConfigHash?.split(' ') ?? [];
+
+		if (siteUrl !== __meteor_runtime_config__.ROOT_URL) {
+			program.meteorRuntimeConfigHash =
+				__meteor_runtime_config__.ROOT_URL +
+				' ' +
+				createHash('sha1')
+					.update(JSON.stringify(encodeURIComponent(program.meteorRuntimeConfig)))
+					.digest('hex');
 		}
 
-		if (program.meteorRuntimeConfigHash !== url.query.hash) {
+		const [, hash] = program?.meteorRuntimeConfigHash?.split(' ') ?? [];
+
+		if (!hash || hash !== url.query.hash) {
 			res.writeHead(404);
 			return res.end();
 		}

--- a/apps/meteor/app/cors/server/cors.ts
+++ b/apps/meteor/app/cors/server/cors.ts
@@ -136,12 +136,9 @@ WebAppInternals.staticFilesMiddleware = function (
 		const [siteUrl] = program?.meteorRuntimeConfigHash?.split(' ') ?? [];
 
 		if (siteUrl !== __meteor_runtime_config__.ROOT_URL) {
-			program.meteorRuntimeConfigHash =
-				__meteor_runtime_config__.ROOT_URL +
-				' ' +
-				createHash('sha1')
-					.update(JSON.stringify(encodeURIComponent(program.meteorRuntimeConfig)))
-					.digest('hex');
+			program.meteorRuntimeConfigHash = `${__meteor_runtime_config__.ROOT_URL} ${createHash('sha1')
+				.update(JSON.stringify(encodeURIComponent(program.meteorRuntimeConfig)))
+				.digest('hex')}`;
 		}
 
 		const [, hash] = program?.meteorRuntimeConfigHash?.split(' ') ?? [];

--- a/apps/meteor/tests/end-to-end/api/cors.ts
+++ b/apps/meteor/tests/end-to-end/api/cors.ts
@@ -8,7 +8,7 @@ const getHash = () =>
 	request
 		.get('/')
 		.expect(200)
-		.expect('Content-Type', 'text/html')
+		.expect('Content-Type', 'text/html; charset=utf-8')
 		.then((res) => {
 			const hashMatch = res.text.match(/meteor_runtime_config\.js\?hash=([^"']+)/);
 			expect(hashMatch).to.not.be.null;
@@ -36,7 +36,15 @@ describe('[CORS]', () => {
 			const hash = await getHash();
 
 			// Now request with the extracted hash
-			await request.get('/meteor_runtime_config.js').query({ hash }).expect(200).expect('Content-Type', 'application/javascript');
+			await request
+				.get('/meteor_runtime_config.js')
+				.query({ hash })
+				.expect(200)
+				.expect('Content-Type', 'application/javascript; charset=UTF-8')
+				.expect((res) => {
+					expect(res.text).to.include('__meteor_runtime_config__');
+					expect(res.text).to.include('http://localhost:3000');
+				});
 		});
 
 		it('should return 404 when hash does not match', (done) => {
@@ -50,7 +58,15 @@ describe('[CORS]', () => {
 			const newHash = await getHash();
 			expect(newHash).to.not.equal(originalHash);
 			// it should return if the new hash is valid
-			await request.get('/meteor_runtime_config.js').query({ hash: newHash }).expect(200).expect('Content-Type', 'application/javascript');
+			await request
+				.get('/meteor_runtime_config.js')
+				.query({ hash: newHash })
+				.expect(200)
+				.expect('Content-Type', 'application/javascript; charset=UTF-8')
+				.expect((res) => {
+					expect(res.text).to.include('__meteor_runtime_config__');
+					expect(res.text).to.include('http://new-url:3000');
+				});
 		});
 	});
 });

--- a/apps/meteor/tests/end-to-end/api/cors.ts
+++ b/apps/meteor/tests/end-to-end/api/cors.ts
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+import { after, before, describe, it } from 'mocha';
+
+import { getCredentials, request } from '../../data/api-data';
+import { updateSetting } from '../../data/permissions.helper';
+
+const getHash = () =>
+	request
+		.get('/')
+		.expect(200)
+		.expect('Content-Type', 'text/html')
+		.then((res) => {
+			const hashMatch = res.text.match(/meteor_runtime_config\.js\?hash=([^"']+)/);
+			expect(hashMatch).to.not.be.null;
+			const hash = hashMatch![1];
+			return hash;
+		});
+
+describe('[CORS]', () => {
+	before((done) => getCredentials(done));
+	after(async () => {
+		await updateSetting('Site_Url', 'http://localhost:3000');
+	});
+
+	describe('[/meteor_runtime_config.js]', () => {
+		it('should return 404 when hash is missing', (done) => {
+			void request.get('/meteor_runtime_config.js').expect(404).end(done);
+		});
+
+		it('should return 404 when hash is invalid', (done) => {
+			void request.get('/meteor_runtime_config.js').query({ hash: 'invalid_hash' }).expect(404).end(done);
+		});
+
+		it('should return runtime config when hash matches', async () => {
+			// First get the root page to extract the hash
+			const hash = await getHash();
+
+			// Now request with the extracted hash
+			await request.get('/meteor_runtime_config.js').query({ hash }).expect(200).expect('Content-Type', 'application/javascript');
+		});
+
+		it('should return 404 when hash does not match', (done) => {
+			// First get the root page to extract the hash
+			void request.get('/meteor_runtime_config.js').query({ hash: 'invalidHash' }).expect(404).end(done);
+		});
+
+		it('should update hash when ROOT_URL changes', async () => {
+			const originalHash = getHash();
+			await updateSetting('Site_Url', 'http://new-url:3000');
+			const newHash = await getHash();
+			expect(newHash).to.not.equal(originalHash);
+			// it should return if the new hash is valid
+			await request.get('/meteor_runtime_config.js').query({ hash: newHash }).expect(200).expect('Content-Type', 'application/javascript');
+		});
+	});
+});


### PR DESCRIPTION
https://rocketchat.atlassian.net/browse/ARCH-1601

After we saved the `meteorRuntimeConfigHash` value once, this value was persisted forever.

It works fine between redeploys, but if we change settings (like Site_url) we will end up in a state where the API always returns 404
### Improvements to runtime configuration hash handling:

* Updated the logic in `WebAppInternals.staticFilesMiddleware` to include the `ROOT_URL` in the runtime configuration hash. This ensures that the hash changes when the `ROOT_URL` changes, improving the consistency and accuracy of the runtime configuration validation.

### Addition of end-to-end tests:

* Added a new test suite in `apps/meteor/tests/end-to-end/api/cors.ts` to validate the behavior of `/meteor_runtime_config.js`. The tests include scenarios for missing, invalid, and matching hashes, as well as ensuring the hash updates correctly when the `ROOT_URL` changes.<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

This pull request addresses an issue in the Rocket.Chat repository where changing the site URL breaks the `meteor_runtime_config`. The changes are made in the `fix/root_url_meteor_config` branch and are targeted to be merged into the `develop` branch. Specifically, the modifications are in the `apps/meteor/app/cors/server/cors.ts` file, where the CORS middleware has been updated to improve the handling of meteor runtime config hash validation and security headers.