### PR TITLE
chore: deprecates dbWatchers  and set default value to false

### DIFF
--- a/.changeset/cuddly-feet-clap.md
+++ b/.changeset/cuddly-feet-clap.md
@@ -3,7 +3,7 @@
 "@rocket.chat/models": patch
 ---
 
-Deprecates the use of `oplog/change streams`.
+Deprecates the use of MongoDB oplog or Change Streams to receive real time data updates.
 
 The previous behavior can still be enabled using the environment flag `DISABLE_DB_WATCHERS=false`.
 

--- a/.changeset/cuddly-feet-clap.md
+++ b/.changeset/cuddly-feet-clap.md
@@ -1,0 +1,10 @@
+---
+"@rocket.chat/meteor": patch
+"@rocket.chat/models": patch
+---
+
+Deprecates the use of `oplog/change streams`.
+
+The previous behavior can still be enabled using the environment flag `DISABLE_DB_WATCHERS=false`.
+
+⚠️ In future major versions, this flag will be completely removed, and the `@rocket.chat/stream-hub-service` package and the `stream-hub-service` Docker image will no longer be published.

--- a/.github/workflows/ci-test-e2e.yml
+++ b/.github/workflows/ci-test-e2e.yml
@@ -86,7 +86,7 @@ jobs:
         mongodb-version: ${{ fromJSON(inputs.mongodb-version) }}
         shard: ${{ fromJSON(inputs.shard) }}
 
-    name: MongoDB ${{ matrix.mongodb-version }}${{ inputs.db-watcher-disabled == 'true' && ' [no watchers]' || '' }} (${{ matrix.shard }}/${{ inputs.total-shard }}) - ${{ (matrix.mongodb-version == '7.0' && 'Debian' && false) || 'Alpine (Official)' }}
+    name: MongoDB ${{ matrix.mongodb-version }}${{ inputs.db-watcher-disabled == 'false' && ' [legacy watchers]' || '' }} (${{ matrix.shard }}/${{ inputs.total-shard }}) - ${{ (matrix.mongodb-version == '7.0' && 'Debian' && false) || 'Alpine (Official)' }}
 
     steps:
       - name: Collect Workflow Telemetry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -593,7 +593,7 @@ jobs:
             exit 1
           fi
 
-          if [[ '${{ needs.test-ui-ee-no-watcher.result }}' != 'success' ]]; then
+          if [[ '${{ needs.test-ui-ee-watcher.result }}' != 'success' ]]; then
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,7 +531,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       REPORTER_JIRA_ROCKETCHAT_API_KEY: ${{ secrets.REPORTER_JIRA_ROCKETCHAT_API_KEY }}
 
-  test-ui-ee-no-watcher:
+  test-ui-ee-watcher:
     name: 🔨 Test UI (EE)
     needs: [checks, build-gh-docker-coverage, release-versions]
 
@@ -551,7 +551,7 @@ jobs:
       rc-docker-tag: ${{ needs.release-versions.outputs.rc-docker-tag }}
       gh-docker-tag: ${{ needs.release-versions.outputs.gh-docker-tag }}
       retries: ${{ (github.event_name == 'release' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master') && 2 || 0 }}
-      db-watcher-disabled: 'true'
+      db-watcher-disabled: 'false'
     secrets:
       CR_USER: ${{ secrets.CR_USER }}
       CR_PAT: ${{ secrets.CR_PAT }}
@@ -564,7 +564,7 @@ jobs:
   tests-done:
     name: ✅ Tests Done
     runs-on: ubuntu-24.04
-    needs: [checks, test-unit, test-api, test-ui, test-api-ee, test-ui-ee, test-ui-ee-no-watcher]
+    needs: [checks, test-unit, test-api, test-ui, test-api-ee, test-ui-ee, test-ui-ee-watcher]
     if: always()
     steps:
       - name: Test finish aggregation

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -125,9 +125,7 @@ export function getCollectionName(name: string): string {
 
 const disabledEnvVar = String(process.env.DISABLE_DB_WATCHERS).toLowerCase();
 
-export const dbWatchersDisabled =
-	(process.env.NODE_ENV === 'production' && ['yes', 'true'].includes(disabledEnvVar)) ||
-	(process.env.NODE_ENV !== 'production' && !['no', 'false'].includes(disabledEnvVar));
+export const dbWatchersDisabled = !['no', 'false'].includes(disabledEnvVar);
 
 export * from './modelClasses';
 export * from './DatabaseWatcher';
@@ -256,4 +254,10 @@ export function registerServiceModels(db: Db, trash?: Collection<RocketChatRecor
 	registerModel('ILivechatRoomsModel', () => new LivechatRoomsRaw(db));
 	registerModel('IUploadsModel', () => new UploadsRaw(db));
 	registerModel('ILivechatVisitorsModel', () => new LivechatVisitorsRaw(db));
+}
+
+if (!dbWatchersDisabled) {
+	console.warn(
+		`Database watchers is enabled and this is not the default option.\nRocket.Chat deprecated the usage of \`oplog/change streams\` and are going to remove it the next major version (8.0.0).`,
+	);
 }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
https://rocketchat.atlassian.net/browse/ARCH-1602
<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

This pull request updates the Rocket.Chat repository by modifying the default behavior of database watchers. The changes are made in the `packages/models/src/index.ts` file. The logic is adjusted so that database watchers are now disabled by default in more scenarios, particularly in production environments where the `DISABLE_DB_WATCHERS` environment variable is not set or is not explicitly set to 'no' or 'false'. Additionally, a console warning is introduced to alert users when watchers are active, highlighting their deprecation. The source branch for this change is `chore/deprecate-streamhub-oplog-changestreams`, and it targets the `develop` branch.