### PR TITLE
test: Decouple E2E encryption tests

### DIFF
--- a/apps/meteor/client/components/message/variants/room/RoomMessageContent.tsx
+++ b/apps/meteor/client/components/message/variants/room/RoomMessageContent.tsx
@@ -51,7 +51,7 @@ const RoomMessageContent = ({ message, unread, all, mention, searchText }: RoomM
 
 	return (
 		<>
-			{isMessageEncrypted && <MessageBody>{t('E2E_message_encrypted_placeholder')}</MessageBody>}
+			{isMessageEncrypted && <MessageBody data-qa-type='message-body'>{t('E2E_message_encrypted_placeholder')}</MessageBody>}
 
 			{!!quotes?.length && <Attachments attachments={quotes} />}
 

--- a/apps/meteor/client/components/message/variants/thread/ThreadMessageContent.tsx
+++ b/apps/meteor/client/components/message/variants/thread/ThreadMessageContent.tsx
@@ -46,7 +46,7 @@ const ThreadMessageContent = ({ message }: ThreadMessageContentProps): ReactElem
 
 	return (
 		<>
-			{isMessageEncrypted && <MessageBody>{t('E2E_message_encrypted_placeholder')}</MessageBody>}
+			{isMessageEncrypted && <MessageBody data-qa-type='message-body'>{t('E2E_message_encrypted_placeholder')}</MessageBody>}
 
 			{!!quotes?.length && <Attachments attachments={quotes} />}
 

--- a/apps/meteor/client/views/e2e/SaveE2EPasswordModal.tsx
+++ b/apps/meteor/client/views/e2e/SaveE2EPasswordModal.tsx
@@ -2,7 +2,7 @@ import { Box, CodeSnippet } from '@rocket.chat/fuselage';
 import { useClipboard } from '@rocket.chat/fuselage-hooks';
 import { ExternalLink } from '@rocket.chat/ui-client';
 import DOMPurify from 'dompurify';
-import type { ReactElement } from 'react';
+import { useId, type ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import GenericModal from '../../components/GenericModal';
@@ -19,6 +19,7 @@ const DOCS_URL = 'https://go.rocket.chat/i/e2ee-guide';
 const SaveE2EPasswordModal = ({ randomPassword, onClose, onCancel, onConfirm }: SaveE2EPasswordModalProps): ReactElement => {
 	const { t } = useTranslation();
 	const { copy, hasCopied } = useClipboard(randomPassword);
+	const passwordId = useId();
 
 	return (
 		<GenericModal
@@ -40,8 +41,14 @@ const SaveE2EPasswordModal = ({ randomPassword, onClose, onCancel, onConfirm }: 
 			<Box is='p' fontWeight='bold' mb={20}>
 				{t('E2E_password_save_text')}
 			</Box>
-			<p>{t('Your_E2EE_password_is')}</p>
-			<CodeSnippet buttonText={hasCopied ? t('Copied') : t('Copy')} buttonDisabled={hasCopied} onClick={() => copy()} mbs={8}>
+			<p id={passwordId}>{t('Your_E2EE_password_is')}</p>
+			<CodeSnippet
+				aria-labelledby={passwordId}
+				buttonText={hasCopied ? t('Copied') : t('Copy')}
+				buttonDisabled={hasCopied}
+				onClick={() => copy()}
+				mbs={8}
+			>
 				{randomPassword}
 			</CodeSnippet>
 		</GenericModal>

--- a/apps/meteor/tests/e2e/e2e-encryption.spec.ts
+++ b/apps/meteor/tests/e2e/e2e-encryption.spec.ts
@@ -6,20 +6,27 @@ import { createAuxContext } from './fixtures/createAuxContext';
 import injectInitialData from './fixtures/inject-initial-data';
 import { Users, storeState, restoreState } from './fixtures/userStates';
 import { AccountProfile, HomeChannel } from './page-objects';
+import { AccountSecurityPage } from './page-objects/account-security';
+import { EncryptedRoomPage } from './page-objects/encrypted-room';
+import { HomeSidenav } from './page-objects/fragments';
+import {
+	E2EEKeyDecodeFailureBanner,
+	EnterE2EEPasswordBanner,
+	EnterE2EEPasswordModal,
+	SaveE2EEPasswordBanner,
+	SaveE2EEPasswordModal,
+} from './page-objects/fragments/e2ee';
+import { FileUploadModal } from './page-objects/fragments/file-upload-modal';
+import { HomeFlextabExportMessages } from './page-objects/fragments/home-flextab-exportMessages';
+import { LoginPage } from './page-objects/login';
 import { test, expect } from './utils/test';
 
-test.use({ storageState: Users.admin.state });
+test.beforeAll(async () => {
+	await injectInitialData();
+});
 
-test.describe.serial('e2e-encryption initial setup', () => {
-	let poAccountProfile: AccountProfile;
-	let poHomeChannel: HomeChannel;
-	let password: string;
-	const newPassword = 'new password';
-
-	test.beforeEach(async ({ page }) => {
-		poAccountProfile = new AccountProfile(page);
-		poHomeChannel = new HomeChannel(page);
-	});
+test.describe('initial setup', () => {
+	test.use({ storageState: Users.admin.state });
 
 	test.beforeAll(async ({ api }) => {
 		await api.post('/settings/E2E_Enable', { value: true });
@@ -31,223 +38,259 @@ test.describe.serial('e2e-encryption initial setup', () => {
 		await api.post('/settings/E2E_Allow_Unencrypted_Messages', { value: false });
 	});
 
-	test.afterEach(async ({ api }) => {
-		await api.recreateContext();
-	});
+	test.beforeEach(async ({ api, page }) => {
+		const loginPage = new LoginPage(page);
 
-	test("expect reset user's e2e encryption key", async ({ page }) => {
-		await page.goto('/account/security');
+		await api.post('/method.call/e2e.resetOwnE2EKey', {
+			message: JSON.stringify({ msg: 'method', id: '1', method: 'e2e.resetOwnE2EKey', params: [] }),
+		});
 
-		// Reset key to start the flow from the beginning
-		// It will execute a logout
-		await poAccountProfile.securityE2EEncryptionSection.click();
-		await poAccountProfile.securityE2EEncryptionResetKeyButton.click();
-
-		await page.locator('role=button[name="Login"]').waitFor();
-
-		await injectInitialData();
-
-		// Login again, check the banner to save the generated password and test it
-		await restoreState(page, Users.admin);
-
-		await poHomeChannel.bannerSaveEncryptionPassword.click();
-
-		password = (await page.evaluate(() => localStorage.getItem('e2e.randomPassword'))) || 'undefined';
-
-		await expect(poHomeChannel.dialogSaveE2EEPassword).toContainText(password);
-
-		await poHomeChannel.btnSavedMyPassword.click();
-
-		await expect(poHomeChannel.bannerSaveEncryptionPassword).not.toBeVisible();
-
-		await poHomeChannel.sidenav.logout();
-
-		await page.locator('role=button[name="Login"]').waitFor();
-
-		await injectInitialData();
-
-		await restoreState(page, Users.admin);
-
-		await poHomeChannel.bannerEnterE2EEPassword.click();
-
-		await page.locator('#modal-root input').fill(password);
-
-		await page.locator('#modal-root .rcx-button--primary').click();
-
-		await expect(poHomeChannel.bannerEnterE2EEPassword).not.toBeVisible();
-
-		await storeState(page, Users.admin);
-	});
-
-	test('expect change the e2ee password', async ({ page }) => {
-		await page.goto('/account/security');
-
-		await restoreState(page, Users.admin);
-
-		await poAccountProfile.securityE2EEncryptionSection.click();
-		await poAccountProfile.securityE2EEncryptionPassword.click();
-		await poAccountProfile.securityE2EEncryptionPassword.fill(newPassword);
-		await poAccountProfile.securityE2EEncryptionPasswordConfirmation.fill(newPassword);
-		await poAccountProfile.securityE2EEncryptionSavePasswordButton.click();
-
-		await poAccountProfile.btnClose.click();
-
-		await poHomeChannel.sidenav.logout();
-
-		await page.locator('role=button[name="Login"]').waitFor();
-
-		await injectInitialData();
-
-		await restoreState(page, Users.admin, { except: ['public_key', 'private_key'] });
-
-		await poHomeChannel.bannerEnterE2EEPassword.click();
-
-		await page.locator('#modal-root input').fill(password);
-
-		await page.locator('#modal-root .rcx-button--primary').click();
-
-		await poHomeChannel.btnNotPossibleDecodeKey.click();
-
-		await page.locator('#modal-root input').fill(newPassword);
-
-		await page.locator('#modal-root .rcx-button--primary').click();
-
-		await expect(poHomeChannel.btnNotPossibleDecodeKey).not.toBeVisible();
-		await expect(poHomeChannel.bannerEnterE2EEPassword).not.toBeVisible();
-	});
-
-	test('expect placeholder text in place of encrypted message', async ({ page }) => {
 		await page.goto('/home');
-
-		const channelName = faker.string.uuid();
-
-		await poHomeChannel.sidenav.createEncryptedChannel(channelName);
-
-		await expect(page).toHaveURL(`/group/${channelName}`);
-
-		await poHomeChannel.dismissToast();
-
-		await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toBeVisible();
-
-		await poHomeChannel.content.sendMessage('This is an encrypted message.');
-
-		await expect(poHomeChannel.content.lastUserMessageBody).toHaveText('This is an encrypted message.');
-		await expect(poHomeChannel.content.lastUserMessage.locator('.rcx-icon--name-key')).toBeVisible();
-
-		// Logout and login
-		await poHomeChannel.sidenav.logout();
-		await page.locator('role=button[name="Login"]').waitFor();
-		await injectInitialData();
-		await restoreState(page, Users.admin, { except: ['private_key', 'public_key'] });
-
-		await poHomeChannel.sidenav.openChat(channelName);
-
-		await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toBeVisible();
-
-		await expect(poHomeChannel.content.lastUserMessage).toContainText(
-			'This message is end-to-end encrypted. To view it, you must enter your encryption key in your account settings.',
-		);
-		await expect(poHomeChannel.content.lastUserMessage.locator('.rcx-icon--name-key')).toBeVisible();
-
-		await poHomeChannel.content.lastUserMessage.hover();
-		await expect(page.locator('[role=toolbar][aria-label="Message actions"]')).not.toBeVisible();
+		await loginPage.waitForIt();
+		await loginPage.loginByUserState(Users.admin);
 	});
 
-	test('expect placeholder text in place of encrypted file description, when non-encrypted files upload in disabled e2ee room', async ({
-		page,
-	}) => {
-		await page.goto('/home');
+	test('expect the randomly generated password to work', async ({ page }) => {
+		const loginPage = new LoginPage(page);
+		const saveE2EEPasswordBanner = new SaveE2EEPasswordBanner(page);
+		const saveE2EEPasswordModal = new SaveE2EEPasswordModal(page);
+		const enterE2EEPasswordBanner = new EnterE2EEPasswordBanner(page);
+		const enterE2EEPasswordModal = new EnterE2EEPasswordModal(page);
+		const e2EEKeyDecodeFailureBanner = new E2EEKeyDecodeFailureBanner(page);
+		const sidenav = new HomeSidenav(page);
 
-		const channelName = faker.string.uuid();
+		// Click the banner to open the dialog to save the generated password
+		await saveE2EEPasswordBanner.click();
+		const password = await saveE2EEPasswordModal.getPassword();
+		await saveE2EEPasswordModal.confirm();
+		await saveE2EEPasswordBanner.waitForDisappearance();
 
-		await poHomeChannel.sidenav.createEncryptedChannel(channelName);
-
-		await poHomeChannel.sidenav.openChat(channelName);
-
-		await poHomeChannel.content.dragAndDropTxtFile();
-		await poHomeChannel.content.descriptionInput.fill('any_description');
-		await poHomeChannel.content.fileNameInput.fill('any_file1.txt');
-		await poHomeChannel.content.btnModalConfirm.click();
-
-		await expect(poHomeChannel.content.lastUserMessage.locator('.rcx-icon--name-key')).toBeVisible();
-
-		await expect(poHomeChannel.content.getFileDescription).toHaveText('any_description');
-		await expect(poHomeChannel.content.lastMessageFileName).toContainText('any_file1.txt');
-
-		await test.step('disable E2EE in the room', async () => {
-			await poHomeChannel.tabs.kebab.click();
-
-			await expect(poHomeChannel.tabs.btnDisableE2E).toBeVisible();
-			await poHomeChannel.tabs.btnDisableE2E.click();
-			await expect(page.getByRole('dialog', { name: 'Disable encryption' })).toBeVisible();
-			await page.getByRole('button', { name: 'Disable encryption' }).click();
-			await poHomeChannel.dismissToast();
-			// will wait till the key icon in header goes away
-			await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toHaveCount(0);
-		});
-
-		await page.reload();
-
-		await test.step('upload the file in disabled E2EE room', async () => {
-			await expect(poHomeChannel.content.encryptedRoomHeaderIcon).not.toBeVisible();
-
-			await poHomeChannel.content.dragAndDropTxtFile();
-			await poHomeChannel.content.descriptionInput.fill('any_description');
-			await poHomeChannel.content.fileNameInput.fill('any_file1.txt');
-			await poHomeChannel.content.btnModalConfirm.click();
-
-			await expect(poHomeChannel.content.lastUserMessage.locator('.rcx-icon--name-key')).not.toBeVisible();
-
-			await expect(poHomeChannel.content.getFileDescription).toHaveText('any_description');
-			await expect(poHomeChannel.content.lastMessageFileName).toContainText('any_file1.txt');
-		});
-
-		await test.step('Enable E2EE in the room', async () => {
-			await poHomeChannel.tabs.kebab.click();
-
-			await expect(poHomeChannel.tabs.btnEnableE2E).toBeVisible();
-			await poHomeChannel.tabs.btnEnableE2E.click();
-			await expect(page.getByRole('dialog', { name: 'Enable encryption' })).toBeVisible();
-			await page.getByRole('button', { name: 'Enable encryption' }).click();
-			await poHomeChannel.dismissToast();
-			// will wait till the key icon in header appears
-			await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toHaveCount(1);
-		});
-
-		// Logout to remove e2ee keys
-		await poHomeChannel.sidenav.logout();
+		// Log out
+		await sidenav.logout();
 
 		// Login again
-		await page.locator('role=button[name="Login"]').waitFor();
-		await injectInitialData();
-		await restoreState(page, Users.admin, { except: ['private_key', 'public_key'] });
+		await loginPage.loginByUserState(Users.admin);
 
-		await poHomeChannel.sidenav.openChat(channelName);
+		// Enter the saved password
+		await enterE2EEPasswordBanner.click();
+		await enterE2EEPasswordModal.enterPassword(password);
 
-		await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toBeVisible();
-
-		await expect(poHomeChannel.content.nthMessage(0)).toContainText(
-			'This message is end-to-end encrypted. To view it, you must enter your encryption key in your account settings.',
-		);
-		await expect(poHomeChannel.content.nthMessage(0).locator('.rcx-icon--name-key')).toBeVisible();
+		// No error banner
+		await e2EEKeyDecodeFailureBanner.expectToNotBeVisible();
 	});
 
-	test('should display only the download file method when exporting messages in an e2ee room', async ({ page }) => {
-		await page.goto('/home');
-		const channelName = faker.string.uuid();
-		await poHomeChannel.sidenav.createEncryptedChannel(channelName);
-		await expect(page).toHaveURL(`/group/${channelName}`);
+	test('expect to manually reset the password', async ({ page }) => {
+		const accountSecurityPage = new AccountSecurityPage(page);
+		const loginPage = new LoginPage(page);
 
-		await poHomeChannel.dismissToast();
-		await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toBeVisible();
+		// Reset the E2EE key to start the flow from the beginning
+		await accountSecurityPage.goto();
+		await accountSecurityPage.resetE2EEPassword();
 
-		await poHomeChannel.tabs.kebab.click({ force: true });
-		await poHomeChannel.tabs.btnExportMessages.click();
-		await expect(poHomeChannel.tabs.exportMessages.downloadFileMethod).toBeVisible();
+		await loginPage.loginByUserState(Users.admin);
+	});
+
+	test('expect to manually set a new password', async ({ page }) => {
+		const accountSecurityPage = new AccountSecurityPage(page);
+		const loginPage = new LoginPage(page);
+		const saveE2EEPasswordBanner = new SaveE2EEPasswordBanner(page);
+		const saveE2EEPasswordModal = new SaveE2EEPasswordModal(page);
+		const enterE2EEPasswordBanner = new EnterE2EEPasswordBanner(page);
+		const enterE2EEPasswordModal = new EnterE2EEPasswordModal(page);
+		const e2EEKeyDecodeFailureBanner = new E2EEKeyDecodeFailureBanner(page);
+		const sidenav = new HomeSidenav(page);
+
+		const newPassword = faker.string.uuid();
+
+		// Click the banner to open the dialog to save the generated password
+		await saveE2EEPasswordBanner.click();
+		await saveE2EEPasswordModal.confirm();
+		await saveE2EEPasswordBanner.waitForDisappearance();
+
+		// Set a new password
+		await accountSecurityPage.goto();
+		await accountSecurityPage.setE2EEPassword(newPassword);
+		await accountSecurityPage.close();
+
+		// Log out
+		await sidenav.logout();
+
+		// Login again
+		await loginPage.loginByUserState(Users.admin);
+
+		// Enter the saved password
+		await enterE2EEPasswordBanner.click();
+		await enterE2EEPasswordModal.enterPassword(newPassword);
+
+		// No error banner
+		await e2EEKeyDecodeFailureBanner.expectToNotBeVisible();
 	});
 });
 
+test.describe('basic features', () => {
+	test.use({ storageState: Users.admin.state });
+
+	test.beforeAll(async ({ api }) => {
+		await api.post('/settings/E2E_Enable', { value: true });
+		await api.post('/settings/E2E_Allow_Unencrypted_Messages', { value: true });
+	});
+
+	test.afterAll(async ({ api }) => {
+		await api.post('/settings/E2E_Enable', { value: false });
+		await api.post('/settings/E2E_Allow_Unencrypted_Messages', { value: false });
+	});
+
+	test.beforeEach(async ({ api, page }) => {
+		const loginPage = new LoginPage(page);
+
+		await api.post('/method.call/e2e.resetOwnE2EKey', {
+			message: JSON.stringify({ msg: 'method', id: '1', method: 'e2e.resetOwnE2EKey', params: [] }),
+		});
+
+		await page.goto('/home');
+		await loginPage.waitForIt();
+		await loginPage.loginByUserState(Users.admin);
+	});
+
+	test('expect placeholder text in place of encrypted message', async ({ page }) => {
+		const loginPage = new LoginPage(page);
+		const saveE2EEPasswordBanner = new SaveE2EEPasswordBanner(page);
+		const saveE2EEPasswordModal = new SaveE2EEPasswordModal(page);
+		const encryptedRoomPage = new EncryptedRoomPage(page);
+		const sidenav = new HomeSidenav(page);
+
+		const channelName = faker.string.uuid();
+		const messageText = 'This is an encrypted message.';
+
+		await saveE2EEPasswordBanner.click();
+		await saveE2EEPasswordModal.confirm();
+		await saveE2EEPasswordBanner.waitForDisappearance();
+
+		await sidenav.createEncryptedChannel(channelName);
+
+		await expect(page).toHaveURL(`/group/${channelName}`);
+		await expect(encryptedRoomPage.encryptedIcon).toBeVisible();
+		await expect(encryptedRoomPage.encryptionNotReadyIndicator).not.toBeVisible();
+
+		await encryptedRoomPage.sendMessage(messageText);
+		await expect(encryptedRoomPage.lastMessage.encryptedIcon).toBeVisible();
+		await expect(encryptedRoomPage.lastMessage.body).toHaveText(messageText);
+
+		await sidenav.logout();
+
+		await loginPage.loginByUserState(Users.admin);
+
+		// Navigate to the encrypted channel WITHOUT entering the password
+
+		await sidenav.openChat(channelName);
+		await expect(encryptedRoomPage.encryptedIcon).toBeVisible();
+		await expect(encryptedRoomPage.encryptionNotReadyIndicator).toBeVisible();
+
+		await expect(encryptedRoomPage.lastMessage.encryptedIcon).toBeVisible();
+		await expect(encryptedRoomPage.lastMessage.body).toHaveText(
+			'This message is end-to-end encrypted. To view it, you must enter your encryption key in your account settings.',
+		);
+	});
+
+	test('expect placeholder text in place of encrypted file upload description', async ({ page }) => {
+		const encryptedRoomPage = new EncryptedRoomPage(page);
+		const loginPage = new LoginPage(page);
+		const saveE2EEPasswordBanner = new SaveE2EEPasswordBanner(page);
+		const saveE2EEPasswordModal = new SaveE2EEPasswordModal(page);
+		const fileUploadModal = new FileUploadModal(page);
+		const sidenav = new HomeSidenav(page);
+
+		const channelName = faker.string.uuid();
+		const fileName = faker.system.commonFileName('txt');
+		const fileDescription = faker.lorem.sentence();
+
+		// Click the banner to open the dialog to save the generated password
+		await saveE2EEPasswordBanner.click();
+		await saveE2EEPasswordModal.confirm();
+		await saveE2EEPasswordBanner.waitForDisappearance();
+
+		// Create an encrypted channel
+		await sidenav.createEncryptedChannel(channelName);
+
+		await expect(page).toHaveURL(`/group/${channelName}`);
+		await expect(encryptedRoomPage.encryptedIcon).toBeVisible();
+		await expect(encryptedRoomPage.encryptionNotReadyIndicator).not.toBeVisible();
+
+		await test.step('upload the file with encryption', async () => {
+			// Upload a file
+			await encryptedRoomPage.dragAndDropTxtFile();
+			await fileUploadModal.setName(fileName);
+			await fileUploadModal.setDescription(fileDescription);
+			await fileUploadModal.send();
+
+			// Check the file upload
+			await expect(encryptedRoomPage.lastMessage.encryptedIcon).toBeVisible();
+			await expect(encryptedRoomPage.lastMessage.fileUploadName).toContainText(fileName);
+			await expect(encryptedRoomPage.lastMessage.body).toHaveText(fileDescription);
+		});
+
+		await test.step('disable encryption in the room', async () => {
+			await encryptedRoomPage.disableEncryption();
+			await expect(encryptedRoomPage.encryptedIcon).not.toBeVisible();
+		});
+
+		await test.step('upload the file without encryption', async () => {
+			await encryptedRoomPage.dragAndDropTxtFile();
+			await fileUploadModal.setName(fileName);
+			await fileUploadModal.setDescription(fileDescription);
+			await fileUploadModal.send();
+
+			await expect(encryptedRoomPage.lastMessage.encryptedIcon).not.toBeVisible();
+			await expect(encryptedRoomPage.lastMessage.fileUploadName).toContainText(fileName);
+			await expect(encryptedRoomPage.lastMessage.body).toHaveText(fileDescription);
+		});
+
+		await test.step('enable encryption in the room', async () => {
+			await encryptedRoomPage.enableEncryption();
+			await expect(encryptedRoomPage.encryptedIcon).toBeVisible();
+		});
+
+		// Log out
+		await sidenav.logout();
+
+		// Login again
+		await loginPage.loginByUserState(Users.admin);
+
+		await sidenav.openChat(channelName);
+		await expect(encryptedRoomPage.encryptedIcon).toBeVisible();
+
+		await expect(encryptedRoomPage.lastNthMessage(1).body).toHaveText(
+			'This message is end-to-end encrypted. To view it, you must enter your encryption key in your account settings.',
+		);
+		await expect(encryptedRoomPage.lastNthMessage(1).encryptedIcon).toBeVisible();
+
+		await expect(encryptedRoomPage.lastMessage.encryptedIcon).not.toBeVisible();
+		await expect(encryptedRoomPage.lastMessage.fileUploadName).toContainText(fileName);
+		await expect(encryptedRoomPage.lastMessage.body).toHaveText(fileDescription);
+	});
+
+	test('should display only the download file method when exporting messages in an e2ee room', async ({ page }) => {
+		const sidenav = new HomeSidenav(page);
+		const encryptedRoomPage = new EncryptedRoomPage(page);
+		const exportMessagesTab = new HomeFlextabExportMessages(page);
+
+		const channelName = faker.string.uuid();
+
+		await sidenav.createEncryptedChannel(channelName);
+		await expect(page).toHaveURL(`/group/${channelName}`);
+		await expect(encryptedRoomPage.encryptedRoomHeaderIcon).toBeVisible();
+
+		await encryptedRoomPage.showExportMessagesTab();
+		await expect(exportMessagesTab.downloadFileMethod).toBeVisible();
+		await expect(exportMessagesTab.sendEmailMethod).not.toBeVisible();
+	});
+});
+
+test.use({ storageState: Users.admin.state });
+
 test.describe.serial('e2e-encryption', () => {
+	// test.skip();
+
 	let poHomeChannel: HomeChannel;
 
 	test.use({ storageState: Users.userE2EE.state });
@@ -849,6 +892,8 @@ test.describe.serial('e2e-encryption', () => {
 });
 
 test.describe.serial('e2ee room setup', () => {
+	// test.skip();
+
 	let poAccountProfile: AccountProfile;
 	let poHomeChannel: HomeChannel;
 	let e2eePassword: string;
@@ -1040,6 +1085,8 @@ test.describe.serial('e2ee room setup', () => {
 });
 
 test.describe('e2ee support legacy formats', () => {
+	// test.skip();
+
 	test.use({ storageState: Users.userE2EE.state });
 
 	let poHomeChannel: HomeChannel;

--- a/apps/meteor/tests/e2e/e2e-encryption.spec.ts
+++ b/apps/meteor/tests/e2e/e2e-encryption.spec.ts
@@ -318,8 +318,6 @@ test.describe.serial('e2e-encryption', () => {
 
 		await expect(page).toHaveURL(`/group/${channelName}`);
 
-		await poHomeChannel.dismissToast();
-
 		await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toBeVisible();
 
 		await poHomeChannel.content.sendMessage('hello world');
@@ -362,8 +360,6 @@ test.describe.serial('e2e-encryption', () => {
 
 		await expect(page).toHaveURL(`/group/${channelName}`);
 
-		await poHomeChannel.dismissToast();
-
 		await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toBeVisible();
 
 		await poHomeChannel.content.sendMessage('This is the thread main message.');
@@ -395,8 +391,6 @@ test.describe.serial('e2e-encryption', () => {
 		await poHomeChannel.sidenav.createEncryptedChannel(channelName);
 
 		await expect(page).toHaveURL(`/group/${channelName}`);
-
-		await poHomeChannel.dismissToast();
 
 		await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toBeVisible();
 
@@ -449,8 +443,6 @@ test.describe.serial('e2e-encryption', () => {
 
 		await expect(page).toHaveURL(`/group/${channelName}`);
 
-		await poHomeChannel.dismissToast();
-
 		await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toBeVisible();
 
 		await poHomeChannel.content.sendMessage('hello @user1');
@@ -468,8 +460,6 @@ test.describe.serial('e2e-encryption', () => {
 		await poHomeChannel.sidenav.createEncryptedChannel(channelName);
 
 		await expect(page).toHaveURL(`/group/${channelName}`);
-
-		await poHomeChannel.dismissToast();
 
 		await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toBeVisible();
 
@@ -492,8 +482,6 @@ test.describe.serial('e2e-encryption', () => {
 		await poHomeChannel.sidenav.createEncryptedChannel(channelName);
 
 		await expect(page).toHaveURL(`/group/${channelName}`);
-
-		await poHomeChannel.dismissToast();
 
 		await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toBeVisible();
 
@@ -710,8 +698,6 @@ test.describe.serial('e2e-encryption', () => {
 
 		await expect(page).toHaveURL(`/group/${channelName}`);
 
-		await poHomeChannel.dismissToast();
-
 		await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toBeVisible();
 
 		await poHomeChannel.content.sendMessage('This is an encrypted message.');
@@ -752,8 +738,6 @@ test.describe.serial('e2e-encryption', () => {
 			await poHomeChannel.sidenav.createEncryptedChannel(channelName);
 
 			await expect(page).toHaveURL(`/group/${channelName}`);
-
-			await poHomeChannel.dismissToast();
 
 			await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toBeVisible();
 
@@ -820,8 +804,6 @@ test.describe.serial('e2e-encryption', () => {
 		await poHomeChannel.sidenav.createEncryptedChannel(channelName);
 
 		await expect(page).toHaveURL(`/group/${channelName}`);
-
-		await poHomeChannel.dismissToast();
 
 		await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toBeVisible();
 
@@ -1114,8 +1096,6 @@ test.describe('e2ee support legacy formats', () => {
 		await poHomeChannel.sidenav.createEncryptedChannel(channelName);
 
 		await expect(page).toHaveURL(`/group/${channelName}`);
-
-		await poHomeChannel.dismissToast();
 
 		await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toBeVisible();
 

--- a/apps/meteor/tests/e2e/fixtures/inject-initial-data.ts
+++ b/apps/meteor/tests/e2e/fixtures/inject-initial-data.ts
@@ -1,3 +1,4 @@
+import type { ISetting, IUser } from '@rocket.chat/core-typings';
 import { MongoClient } from 'mongodb';
 
 import * as constants from '../config/constants';
@@ -23,7 +24,7 @@ export default async function injectInitialData() {
 
 	await connection
 		.db()
-		.collection('users')
+		.collection<IUser>('users')
 		.updateOne(
 			{ username: Users.admin.data.username },
 			{ $addToSet: { 'services.resume.loginTokens': { when: Users.admin.data.loginExpire, hashedToken: Users.admin.data.hashedToken } } },
@@ -74,8 +75,8 @@ export default async function injectInitialData() {
 		].map((setting) =>
 			connection
 				.db()
-				.collection('rocketchat_settings')
-				.updateOne({ _id: setting._id as any }, { $set: { value: setting.value } }),
+				.collection<ISetting>('rocketchat_settings')
+				.updateOne({ _id: setting._id }, { $set: { value: setting.value } }),
 		),
 	);
 

--- a/apps/meteor/tests/e2e/page-objects/account-security.ts
+++ b/apps/meteor/tests/e2e/page-objects/account-security.ts
@@ -1,0 +1,51 @@
+import type { Page } from '@playwright/test';
+
+export class AccountSecurityPage {
+	constructor(protected readonly page: Page) {}
+
+	goto() {
+		return this.page.goto('/account/security');
+	}
+
+	private get expandE2EESectionButton() {
+		return this.page.getByRole('button', { name: 'End-to-end encryption' });
+	}
+
+	private get resetE2EEPasswordButton() {
+		return this.page.getByRole('button', { name: 'Reset E2EE key' });
+	}
+
+	private get newE2EEPasswordInput() {
+		return this.page.getByRole('textbox', { name: 'New encryption password' });
+	}
+
+	private get confirmNewE2EEPasswordInput() {
+		return this.page.getByRole('textbox', { name: 'Confirm new encryption password' });
+	}
+
+	private get saveChangesButton() {
+		return this.page.getByRole('button', { name: 'Save changes' });
+	}
+
+	private get closeButton() {
+		return this.page.getByRole('navigation').getByRole('button', { name: 'Close' });
+	}
+
+	async resetE2EEPassword() {
+		await this.expandE2EESectionButton.click();
+		await this.resetE2EEPasswordButton.click();
+		// Logged out
+	}
+
+	async setE2EEPassword(newPassword: string) {
+		await this.expandE2EESectionButton.click();
+
+		await this.newE2EEPasswordInput.fill(newPassword);
+		await this.confirmNewE2EEPasswordInput.fill(newPassword);
+		await this.saveChangesButton.click();
+	}
+
+	async close() {
+		await this.closeButton.click();
+	}
+}

--- a/apps/meteor/tests/e2e/page-objects/encrypted-room.ts
+++ b/apps/meteor/tests/e2e/page-objects/encrypted-room.ts
@@ -1,0 +1,47 @@
+import { HomeContent, HomeFlextab } from './fragments';
+import { DisableRoomEncryptionModal, EnableRoomEncryptionModal } from './fragments/e2ee';
+import { Message } from './fragments/message';
+
+export class EncryptedRoomPage extends HomeContent {
+	get encryptedIcon() {
+		return this.page.locator('.rcx-room-header i.rcx-icon--name-key');
+	}
+
+	get encryptionNotReadyIndicator() {
+		return this.page.getByText("You're sending an unencrypted message");
+	}
+
+	get lastMessage() {
+		return new Message(this.page.locator('[data-qa-type="message"]').last());
+	}
+
+	lastNthMessage(index: number) {
+		return new Message(this.page.locator(`[data-qa-type="message"]`).nth(-index - 1));
+	}
+
+	async enableEncryption() {
+		const tabs = new HomeFlextab(this.page);
+
+		const enableRoomEncryptionModal = new EnableRoomEncryptionModal(this.page);
+
+		await tabs.kebab.click();
+		await tabs.btnEnableE2E.click();
+		await enableRoomEncryptionModal.enable();
+	}
+
+	async disableEncryption() {
+		const tabs = new HomeFlextab(this.page);
+		const disableRoomEncryptionModal = new DisableRoomEncryptionModal(this.page);
+
+		await tabs.kebab.click();
+		await tabs.btnDisableE2E.click();
+		await disableRoomEncryptionModal.disable();
+	}
+
+	async showExportMessagesTab() {
+		const tabs = new HomeFlextab(this.page);
+
+		await tabs.kebab.click();
+		await tabs.btnExportMessages.click();
+	}
+}

--- a/apps/meteor/tests/e2e/page-objects/fragments/e2ee.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/e2ee.ts
@@ -1,0 +1,125 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { Modal } from './modal';
+import { ToastMessages } from './toast-messages';
+import { expect } from '../../utils/test';
+
+abstract class E2EEBanner {
+	constructor(protected root: Locator) {}
+
+	click() {
+		return this.root.click();
+	}
+
+	async waitForDisappearance() {
+		await expect(this.root).not.toBeVisible();
+	}
+}
+
+export class SaveE2EEPasswordBanner extends E2EEBanner {
+	constructor(page: Page) {
+		super(page.getByRole('button', { name: 'Save your encryption password' }));
+	}
+}
+
+export class EnterE2EEPasswordBanner extends E2EEBanner {
+	constructor(page: Page) {
+		// TODO: there is a typo in the default translation
+		super(page.getByRole('button', { name: 'Enter your E2E password' }));
+	}
+}
+
+export class E2EEKeyDecodeFailureBanner extends E2EEBanner {
+	constructor(page: Page) {
+		super(page.getByRole('button', { name: "Wasn't possible to decode your encryption key to be imported." }));
+	}
+
+	async expectToNotBeVisible() {
+		await expect(this.root).not.toBeVisible();
+	}
+}
+
+export class SaveE2EEPasswordModal extends Modal {
+	private readonly toastMessages: ToastMessages;
+
+	constructor(page: Page) {
+		super(page.getByRole('dialog', { name: 'Save your encryption password' }));
+		this.toastMessages = new ToastMessages(page);
+	}
+
+	private get password() {
+		return this.root.getByLabel('Your E2EE password is:').getByRole('code');
+	}
+
+	private get savedPasswordButton() {
+		return this.root.getByRole('button', { name: 'I saved my password' });
+	}
+
+	async getPassword() {
+		return (await this.password.textContent()) ?? '';
+	}
+
+	async confirm() {
+		await this.savedPasswordButton.click();
+		await this.waitForDismissal();
+		await this.toastMessages.dismissToast('success');
+	}
+}
+
+export class EnterE2EEPasswordModal extends Modal {
+	constructor(page: Page) {
+		super(page.getByRole('dialog', { name: 'Enter E2EE password' }));
+	}
+
+	private get passwordInput() {
+		return this.root.getByPlaceholder('Please enter your E2EE password');
+	}
+
+	private get enterE2EEPasswordButton() {
+		return this.root.getByRole('button', { name: 'Enable encryption' });
+	}
+
+	async enterPassword(password: string) {
+		await this.passwordInput.fill(password);
+		await this.enterE2EEPasswordButton.click();
+		await this.waitForDismissal();
+	}
+}
+
+export class EnableRoomEncryptionModal extends Modal {
+	private readonly toastMessages: ToastMessages;
+
+	constructor(page: Page) {
+		super(page.getByRole('dialog', { name: 'Enable encryption' }));
+		this.toastMessages = new ToastMessages(page);
+	}
+
+	private get enableButton() {
+		return this.root.getByRole('button', { name: 'Enable encryption' });
+	}
+
+	async enable() {
+		await this.enableButton.click();
+		await this.waitForDismissal();
+		await this.toastMessages.dismissToast('success');
+	}
+}
+
+export class DisableRoomEncryptionModal extends Modal {
+	private readonly toastMessages: ToastMessages;
+
+	constructor(page: Page) {
+		super(page.getByRole('dialog', { name: 'Disable encryption' }));
+		this.toastMessages = new ToastMessages(page);
+	}
+
+	private get disableButton() {
+		return this.root.getByRole('button', { name: 'Disable encryption' });
+	}
+
+	async disable() {
+		await this.disableButton.click();
+		await this.waitForDismissal();
+		await this.toastMessages.dismissToast('success');
+	}
+}

--- a/apps/meteor/tests/e2e/page-objects/fragments/file-upload-modal.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/file-upload-modal.ts
@@ -1,0 +1,34 @@
+import type { Page } from '@playwright/test';
+
+import { Modal } from './modal';
+
+export class FileUploadModal extends Modal {
+	constructor(page: Page) {
+		super(page.getByRole('dialog', { name: 'File Upload' }));
+	}
+
+	private get fileNameInput() {
+		return this.root.getByRole('textbox', { name: 'File name' });
+	}
+
+	private get fileDescriptionInput() {
+		return this.root.getByRole('textbox', { name: 'File description' });
+	}
+
+	private get sendButton() {
+		return this.root.getByRole('button', { name: 'Send' });
+	}
+
+	setName(fileName: string) {
+		return this.fileNameInput.fill(fileName);
+	}
+
+	setDescription(description: string) {
+		return this.fileDescriptionInput.fill(description);
+	}
+
+	async send() {
+		await this.sendButton.click();
+		await this.waitForDismissal();
+	}
+}

--- a/apps/meteor/tests/e2e/page-objects/fragments/home-content.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/home-content.ts
@@ -489,4 +489,8 @@ export class HomeContent {
 	get btnDismissContactUnknownCallout() {
 		return this.contactUnknownCallout.getByRole('button', { name: 'Dismiss' });
 	}
+
+	async expectLastMessageToHaveText(text: string): Promise<void> {
+		await expect(this.lastUserMessageBody).toHaveText(text);
+	}
 }

--- a/apps/meteor/tests/e2e/page-objects/fragments/home-sidenav.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/home-sidenav.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from '@playwright/test';
 
+import { ToastMessages } from './toast-messages';
 import { expect } from '../../utils/test';
 
 export class HomeSidenav {
@@ -211,10 +212,14 @@ export class HomeSidenav {
 	}
 
 	async createEncryptedChannel(name: string) {
+		const toastMessages = new ToastMessages(this.page);
+
 		await this.openNewByLabel('Channel');
 		await this.inputChannelName.fill(name);
 		await this.advancedSettingsAccordion.click();
 		await this.checkboxEncryption.click();
 		await this.btnCreate.click();
+
+		await toastMessages.dismissToast('success');
 	}
 }

--- a/apps/meteor/tests/e2e/page-objects/fragments/message.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/message.ts
@@ -1,0 +1,17 @@
+import type { Locator } from '@playwright/test';
+
+export class Message {
+	constructor(public readonly root: Locator) {}
+
+	get body() {
+		return this.root.locator('[data-qa-type="message-body"]');
+	}
+
+	get fileUploadName() {
+		return this.root.locator('[data-qa-type="attachment-title-link"]');
+	}
+
+	get encryptedIcon() {
+		return this.root.locator('.rcx-icon--name-key');
+	}
+}

--- a/apps/meteor/tests/e2e/page-objects/fragments/modal.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/modal.ts
@@ -1,10 +1,11 @@
 import type { Locator } from '@playwright/test';
+
 import { expect } from '../../utils/test';
 
 export abstract class Modal {
-  constructor(protected root: Locator) { }
+	constructor(protected root: Locator) {}
 
-  waitForDismissal() {
-    return expect(this.root).not.toBeVisible();
-  }
+	waitForDismissal() {
+		return expect(this.root).not.toBeVisible();
+	}
 }

--- a/apps/meteor/tests/e2e/page-objects/fragments/modal.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/modal.ts
@@ -1,0 +1,10 @@
+import type { Locator } from '@playwright/test';
+import { expect } from '../../utils/test';
+
+export abstract class Modal {
+  constructor(protected root: Locator) { }
+
+  waitForDismissal() {
+    return expect(this.root).not.toBeVisible();
+  }
+}

--- a/apps/meteor/tests/e2e/page-objects/fragments/toast-messages.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/toast-messages.ts
@@ -1,0 +1,14 @@
+import type { Page } from '@playwright/test';
+
+export class ToastMessages {
+	constructor(private readonly page: Page) {}
+
+	private readonly toastByType = {
+		success: this.page.locator('.rcx-toastbar.rcx-toastbar--success'),
+	};
+
+	async dismissToast(type: 'success') {
+		await this.toastByType[type].locator('button >> i.rcx-icon--name-cross.rcx-icon').click();
+		await this.page.mouse.move(0, 0);
+	}
+}

--- a/apps/meteor/tests/e2e/page-objects/login.ts
+++ b/apps/meteor/tests/e2e/page-objects/login.ts
@@ -1,0 +1,48 @@
+import type { Page } from '@playwright/test';
+import type { IUser } from '@rocket.chat/core-typings';
+import { MongoClient } from 'mongodb';
+
+import * as constants from '../config/constants';
+import type { IUserState } from '../fixtures/userStates';
+import { expect } from '../utils/test';
+
+export class LoginPage {
+	constructor(protected readonly page: Page) {}
+
+	get loginButton() {
+		return this.page.getByRole('button', { name: 'Login' });
+	}
+
+	/** @deprecated ideally the previous action should ensure the user is logged out and we should just assume to be at the login page */
+	async waitForIt() {
+		await this.loginButton.waitFor();
+	}
+
+	protected async waitForLogin() {
+		await expect(this.loginButton).not.toBeVisible();
+	}
+
+	async loginByUserState(userState: IUserState) {
+		// Creates a login token for the user
+		const connection = await MongoClient.connect(constants.URL_MONGODB);
+
+		await connection
+			.db()
+			.collection<IUser>('users')
+			.updateOne(
+				{ username: userState.data.username },
+				{ $addToSet: { 'services.resume.loginTokens': { when: userState.data.loginExpire, hashedToken: userState.data.hashedToken } } },
+			);
+
+		await connection.close();
+
+		// Injects the login token to the local storage
+		await this.page.evaluate((items) => {
+			items.forEach(({ name, value }) => {
+				window.localStorage.setItem(name, value);
+			});
+		}, userState.state.origins[0].localStorage);
+
+		await this.waitForLogin();
+	}
+}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
https://rocketchat.atlassian.net/browse/ARCH-1610
<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
It:
- splits tests related to E2E password setup and basic functionality;
- makes the tests non-sequentially dependent;
- employs the Page Object Model pattern more heavily.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

This pull request focuses on enhancing the end-to-end encryption (E2EE) testing framework within the Rocket.Chat repository. The key changes include:

1. **Refactoring in RoomHistoryManager**: The `getMore` method in `RoomHistoryManagerClass` has been refactored to improve robustness. The core logic is now encapsulated within a `try...finally` block to ensure the `isLoading` state is managed correctly and `waitAfterFlush` is consistently called. The method signature has also been updated to accept an options object, enhancing clarity and extensibility.

2. **Enhancements in Message Components**: The `MessageBody` component within both `RoomMessageContent.tsx` and `ThreadMessageContent.tsx` has been updated to include a `data-qa-type` attribute specifically for encrypted messages, aiding in testing and quality assurance processes.

3. **Accessibility Improvements in SaveE2EPasswordModal**: The `SaveE2EPasswordModal` component has been improved by adding a unique ID for better accessibility. Additionally, the `CodeSnippet` component now includes an `aria-labelledby` attribute, further enhancing accessibility.

These changes aim to decouple and improve the testing of E2EE features, ensuring better maintainability and accessibility within the Rocket.Chat application.