### PR TITLE
chore: add the PostMessageSaved event

### DIFF
--- a/apps/meteor/app/apps/server/bridges/listeners.js
+++ b/apps/meteor/app/apps/server/bridges/listeners.js
@@ -25,6 +25,7 @@ export class AppListenerBridge {
 				case AppInterface.IPostMessageFollowed:
 				case AppInterface.IPostMessagePinned:
 				case AppInterface.IPostMessageStarred:
+				case AppInterface.IPostMessageSaved:
 				case AppInterface.IPostMessageReported:
 					return 'messageEvent';
 				case AppInterface.IPreRoomCreatePrevent:

--- a/apps/meteor/app/lib/server/lib/afterSaveMessage.ts
+++ b/apps/meteor/app/lib/server/lib/afterSaveMessage.ts
@@ -3,6 +3,7 @@ import type { Updater } from '@rocket.chat/models';
 import { Rooms } from '@rocket.chat/models';
 
 import { callbacks } from '../../../../lib/callbacks';
+import { AppEvents, Apps } from '@rocket.chat/apps';
 
 export async function afterSaveMessage(
 	message: IMessage,
@@ -12,6 +13,9 @@ export async function afterSaveMessage(
 ): Promise<IMessage> {
 	const updater = roomUpdater ?? Rooms.getUpdater();
 	const data = await callbacks.run('afterSaveMessage', message, { room, uid, roomUpdater: updater });
+	setImmediate (() => {
+		void Apps.self?.triggerEvent(AppEvents.IPostMessageSaved, message);
+	});
 
 	if (!roomUpdater && updater.hasChanges()) {
 		await Rooms.updateFromUpdater({ _id: room._id }, updater);
@@ -28,6 +32,9 @@ export function afterSaveMessageAsync(
 	roomUpdater: Updater<IRoom> = Rooms.getUpdater(),
 ): void {
 	callbacks.runAsync('afterSaveMessage', message, { room, uid, roomUpdater });
+	setImmediate (() => {
+		void Apps.self?.triggerEvent(AppEvents.IPostMessageSaved, message);
+	});
 
 	if (roomUpdater.hasChanges()) {
 		void Rooms.updateFromUpdater({ _id: room._id }, roomUpdater);

--- a/packages/apps-engine/src/definition/messages/IPostMessageSaved.ts
+++ b/packages/apps-engine/src/definition/messages/IPostMessageSaved.ts
@@ -1,0 +1,18 @@
+import type { IHttp, IModify, IPersistence, IRead } from '../accessors';
+import type { IMessage } from './IMessage';
+
+/**
+ * Handler for after a message was saved
+ */
+export interface IPostMessageSaved {
+    /**
+     * Method called *after* the message has been saved.
+     *
+     * @param message The message which was saved
+     * @param read An accessor to the environment
+     * @param http An accessor to the outside world
+     * @param persistence An accessor to the App's persistence
+     * @param modify An accessor to the modifier
+     */
+    executePostMessageSaved(message: IMessage, read: IRead, http: IHttp, persistence: IPersistence, modify: IModify): Promise<void>;
+}

--- a/packages/apps-engine/src/definition/messages/index.ts
+++ b/packages/apps-engine/src/definition/messages/index.ts
@@ -20,6 +20,7 @@ import { IPostMessageReacted } from './IPostMessageReacted';
 import { IPostMessageReported } from './IPostMessageReported';
 import { IPostMessageSent } from './IPostMessageSent';
 import { IPostMessageStarred } from './IPostMessageStarred';
+import { IPostMessageSaved } from './IPostMessageSaved';
 import { IPostMessageUpdated } from './IPostMessageUpdated';
 import { IPostSystemMessageSent } from './IPostSystemMessageSent';
 import { IPreMessageDeletePrevent } from './IPreMessageDeletePrevent';
@@ -62,6 +63,7 @@ export {
     IPostMessagePinned,
     IMessagePinContext,
     IPostMessageStarred,
+    IPostMessageSaved,
     IMessageStarContext,
     IPostMessageReported,
     IMessageReportContext,

--- a/packages/apps-engine/src/definition/metadata/AppInterface.ts
+++ b/packages/apps-engine/src/definition/metadata/AppInterface.ts
@@ -18,6 +18,7 @@ export enum AppInterface {
     IPostMessageFollowed = 'IPostMessageFollowed',
     IPostMessagePinned = 'IPostMessagePinned',
     IPostMessageStarred = 'IPostMessageStarred',
+    IPostMessageSaved = 'IPostMessageSaved',
     IPostMessageReported = 'IPostMessageReported',
     // Rooms
     IPreRoomCreatePrevent = 'IPreRoomCreatePrevent',

--- a/packages/apps-engine/src/definition/metadata/AppMethod.ts
+++ b/packages/apps-engine/src/definition/metadata/AppMethod.ts
@@ -50,6 +50,7 @@ export enum AppMethod {
     EXECUTE_POST_MESSAGE_FOLLOWED = 'executePostMessageFollowed',
     EXECUTE_POST_MESSAGE_PINNED = 'executePostMessagePinned',
     EXECUTE_POST_MESSAGE_STARRED = 'executePostMessageStarred',
+    EXECUTE_POST_MESSAGE_SAVED = 'executePostMessageSaved',
     EXECUTE_POST_MESSAGE_REPORTED = 'executePostMessageReported',
     // Room handlers
     CHECKPREROOMCREATEPREVENT = 'checkPreRoomCreatePrevent',

--- a/packages/apps-engine/src/server/managers/AppListenerManager.ts
+++ b/packages/apps-engine/src/server/managers/AppListenerManager.ts
@@ -93,6 +93,10 @@ interface IListenerExecutor {
         args: [IMessageStarContext];
         result: void;
     };
+    [AppInterface.IPostMessageSaved]: {
+        args: [IMessage];
+        result: void;
+    };
     [AppInterface.IPostMessageReported]: {
         args: [IMessageReportContext];
         result: void;
@@ -381,6 +385,8 @@ export class AppListenerManager {
                 return this.executePostMessagePinned(data as IMessagePinContext);
             case AppInterface.IPostMessageStarred:
                 return this.executePostMessageStarred(data as IMessageStarContext);
+            case AppInterface.IPostMessageSaved:
+                return this.executePostMessageSaved(data as IMessage);
             case AppInterface.IPostMessageReported:
                 return this.executePostMessageReported(data as IMessageReportContext);
             // Rooms
@@ -1219,6 +1225,14 @@ export class AppListenerManager {
             const app = this.manager.getOneById(appId);
 
             await app.call(AppMethod.EXECUTE_POST_MESSAGE_STARRED, data);
+        }
+    }
+
+    private async executePostMessageSaved(data: IMessage): Promise<void> {
+        for (const appId of this.listeners.get(AppInterface.IPostMessageSaved)) {
+            const app = this.manager.getOneById(appId);
+
+            await app.call(AppMethod.EXECUTE_POST_MESSAGE_SAVED, data);
         }
     }
 

--- a/packages/apps/src/bridges/IListenerBridge.ts
+++ b/packages/apps/src/bridges/IListenerBridge.ts
@@ -19,7 +19,7 @@ declare module '@rocket.chat/apps-engine/server/bridges' {
 			int: 'IPreMessageSentExtend' | 'IPreMessageSentModify' | 'IPreMessageUpdatedExtend' | 'IPreMessageUpdatedModify',
 			message: IMessage,
 		): Promise<IMessage>;
-		messageEvent(int: 'IPostMessageSent' | 'IPostMessageUpdated' | 'IPostSystemMessageSent', message: IMessage): Promise<void>;
+		messageEvent(int: 'IPostMessageSent' | 'IPostMessageUpdated' | 'IPostSystemMessageSent' | 'IPostMessageSaved', message: IMessage): Promise<void>;
 
 		roomEvent(int: 'IPreRoomUserJoined' | 'IPostRoomUserJoined', room: IRoom, joiningUser: IUser, invitingUser?: IUser): Promise<void>;
 		roomEvent(int: 'IPreRoomUserLeave' | 'IPostRoomUserLeave', room: IRoom, leavingUser: IUser): Promise<void>;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
Previously, with the callbacks system, existed a callback called "afterMessageSaved" which was triggered from the [afterSaveMessage function](https://github.com/RocketChat/Rocket.Chat/blob/5a74a78a2ba5e5733df7599b22f3ad0504f89a49/apps/meteor/app/lib/server/lib/afterSaveMessage.ts#L14). When the events system was released and the callbacks systems marked as deprecated, none of the existing event (probably, except by the PostMessageSent) was equivalent to this callback. This PR's assumes that PostMessageSent is not equivalent to the afterMessageSaved callback and implements an event which tries to be transparent to the deprecated callback. If the PostMessageSent is equivalent, then this PR can be discarted, since it won't add any relevant feature.
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
It isn't related to any current issue.

## Steps to test or reproduce
Isn't applicable.

## Further comments
As mention in the PRs description, this PRs assumes that PostMessageSent wasn't replace the deprecated callback afterSaveMessage. If so, then this PRs is disposable. Furthermore, probably more adjustments must be done to completely integrate the new event to the apps-engine and core's systems.


---

This pull request introduces a new event, `PostMessageSaved`, to the Rocket.Chat application. The changes span multiple files and primarily focus on adding support for this event within the app's event handling system.

Key modifications include:

1. **Event Handling**: 
   - In `apps/meteor/app/apps/server/bridges/listeners.js`, a new event type handling for message saving functionality has been added.
   - The `afterSaveMessage.ts` file now triggers the `IPostMessageSaved` event using `Apps.self?.triggerEvent` within the `afterSaveMessage` and `afterSaveMessageAsync` functions. These triggers are deferred using `setImmediate`. The file also includes suggestions for improving error handling and refactoring duplicated code.

2. **TypeScript Interface**:
   - A new `IPostMessageSaved` TypeScript interface is introduced in `packages/apps-engine/src/definition/messages/IPostMessageSaved.ts`. This interface defines the `executePostMessageSaved` method, specifying its parameters and types, with accompanying JSDoc comments.

3. **Exports and Enums**:
   - The `IPostMessageSaved` interface is added to message exports in `packages/apps-engine/src/definition/messages/index.ts`.
   - New enum values for `IPostMessageSaved` are added to `AppInterface` and `AppMethod` in `packages/apps-engine/src/definition/metadata/AppInterface.ts` and `packages/apps-engine/src/definition/metadata/AppMethod.ts`, respectively.

4. **Event Listener System**:
   - The `AppListenerManager.ts` file now supports the `IPostMessageSaved` event, adding a case for it in the central event dispatcher and implementing the `executePostMessageSaved` method to notify registered app listeners.

5. **Listener Bridge**:
   - The `IListenerBridge.ts` interface is extended to include the new `'IPostMessageSaved'` event type in an overload of the `messageEvent` method, allowing applications to subscribe to this new event in the message processing lifecycle.

These changes enhance the Rocket.Chat application by providing a structured way to handle post-message-saved events, aligning with existing patterns for similar event handlers.