### PR TITLE
fix: AutoCompleteDepartmentMultiple `withCheckbox` property not working

### DIFF
--- a/.changeset/rotten-pianos-serve.md
+++ b/.changeset/rotten-pianos-serve.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixes issue where department autocomplete did not render options with checkboxes when configured

--- a/apps/meteor/client/components/AutoCompleteDepartmentMultiple.spec.tsx
+++ b/apps/meteor/client/components/AutoCompleteDepartmentMultiple.spec.tsx
@@ -1,0 +1,50 @@
+import { MockedAppRootBuilder } from '@rocket.chat/mock-providers/dist/MockedAppRootBuilder';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { VirtuosoMockContext } from 'react-virtuoso';
+
+import AutoCompleteDepartmentMultiple from './AutoCompleteDepartmentMultiple';
+import { createFakeDepartment } from '../../tests/mocks/data';
+
+const mockGetDepartments = jest.fn();
+const appRoot = new MockedAppRootBuilder()
+	.withEndpoint('GET', '/v1/livechat/department', mockGetDepartments)
+	.wrap((children) => (
+		<VirtuosoMockContext.Provider value={{ viewportHeight: 300, itemHeight: 100 }}>{children}</VirtuosoMockContext.Provider>
+	));
+
+it('should render autocomplete with checkbox', async () => {
+	mockGetDepartments.mockResolvedValueOnce({
+		departments: [createFakeDepartment({ name: 'Test Department' })],
+		count: 1,
+		offset: 0,
+		total: 1,
+	});
+
+	render(<AutoCompleteDepartmentMultiple value={undefined} onChange={jest.fn()} />, { wrapper: appRoot.build() });
+
+	await userEvent.click(screen.getByRole('listbox'));
+
+	await waitFor(() => {
+		const checkbox = within(screen.getByRole('option', { name: 'Test Department' })).getByRole('checkbox');
+		expect(checkbox).toBeInTheDocument();
+	});
+});
+
+it('should render autocomplete without checkbox', async () => {
+	mockGetDepartments.mockResolvedValueOnce({
+		departments: [createFakeDepartment({ name: 'Test Department' })],
+		count: 1,
+		offset: 0,
+		total: 1,
+	});
+
+	render(<AutoCompleteDepartmentMultiple value={undefined} onChange={jest.fn()} withCheckbox={false} />, { wrapper: appRoot.build() });
+
+	await userEvent.click(screen.getByRole('listbox'));
+
+	await waitFor(() => {
+		const checkbox = within(screen.getByRole('option', { name: 'Test Department' })).queryByRole('checkbox');
+		expect(checkbox).not.toBeInTheDocument();
+	});
+});

--- a/apps/meteor/client/components/AutoCompleteDepartmentMultiple.spec.tsx
+++ b/apps/meteor/client/components/AutoCompleteDepartmentMultiple.spec.tsx
@@ -21,7 +21,7 @@ it('should render autocomplete with checkbox', async () => {
 		total: 1,
 	});
 
-	render(<AutoCompleteDepartmentMultiple value={undefined} onChange={jest.fn()} />, { wrapper: appRoot.build() });
+	render(<AutoCompleteDepartmentMultiple withCheckbox value={undefined} onChange={jest.fn()} />, { wrapper: appRoot.build() });
 
 	await userEvent.click(screen.getByRole('listbox'));
 
@@ -39,7 +39,7 @@ it('should render autocomplete without checkbox', async () => {
 		total: 1,
 	});
 
-	render(<AutoCompleteDepartmentMultiple value={undefined} onChange={jest.fn()} withCheckbox={false} />, { wrapper: appRoot.build() });
+	render(<AutoCompleteDepartmentMultiple value={undefined} onChange={jest.fn()} />, { wrapper: appRoot.build() });
 
 	await userEvent.click(screen.getByRole('listbox'));
 

--- a/apps/meteor/client/components/AutoCompleteDepartmentMultiple.spec.tsx
+++ b/apps/meteor/client/components/AutoCompleteDepartmentMultiple.spec.tsx
@@ -10,7 +10,7 @@ const mockGetDepartments = jest.fn();
 const appRoot = new MockedAppRootBuilder()
 	.withEndpoint('GET', '/v1/livechat/department', mockGetDepartments)
 	.wrap((children) => (
-		<VirtuosoMockContext.Provider value={{ viewportHeight: 300, itemHeight: 100 }}>{children}</VirtuosoMockContext.Provider>
+		<VirtuosoMockContext.Provider value={{ viewportHeight: 300, itemHeight: 28 }}>{children}</VirtuosoMockContext.Provider>
 	));
 
 it('should render autocomplete with checkbox', async () => {

--- a/apps/meteor/client/components/AutoCompleteDepartmentMultiple.tsx
+++ b/apps/meteor/client/components/AutoCompleteDepartmentMultiple.tsx
@@ -26,7 +26,7 @@ const AutoCompleteDepartmentMultiple = ({
 	onlyMyDepartments = false,
 	showArchived = false,
 	enabled = false,
-	withCheckbox = true,
+	withCheckbox = false,
 	excludeId,
 	unitId,
 	onChange = () => undefined,

--- a/apps/meteor/client/components/AutoCompleteDepartmentMultiple.tsx
+++ b/apps/meteor/client/components/AutoCompleteDepartmentMultiple.tsx
@@ -55,11 +55,13 @@ const AutoCompleteDepartmentMultiple = ({
 
 	const renderItem = ({ label, value, ...props }: ComponentProps<typeof Option>): ReactElement => {
 		if (withCheckbox) {
-			<CheckOption
-				{...props}
-				label={<span style={{ whiteSpace: 'normal' }}>{label}</span>}
-				selected={value ? selectedValues.has(value) : false}
-			/>;
+			return (
+				<CheckOption
+					{...props}
+					label={<span style={{ whiteSpace: 'normal' }}>{label}</span>}
+					selected={value ? selectedValues.has(value) : false}
+				/>
+			);
 		}
 
 		return <Option {...props} label={label} />;

--- a/apps/meteor/client/omnichannel/additionalForms/BusinessHoursMultiple.tsx
+++ b/apps/meteor/client/omnichannel/additionalForms/BusinessHoursMultiple.tsx
@@ -62,6 +62,7 @@ const BusinessHoursMultiple = ({ className }: { className?: ComponentProps<typeo
 						control={control}
 						render={({ field: { value, onChange, name, onBlur } }) => (
 							<AutoCompleteDepartmentMultiple
+								withCheckbox
 								value={value}
 								onChange={onChange}
 								name={name}

--- a/apps/meteor/client/omnichannel/tags/TagEdit.tsx
+++ b/apps/meteor/client/omnichannel/tags/TagEdit.tsx
@@ -113,7 +113,7 @@ const TagEdit = ({ tagData, currentDepartments }: TagEditProps) => {
 								<Controller
 									name='departments'
 									control={control}
-									render={({ field }) => <AutoCompleteDepartmentMultiple id={departmentsField} showArchived {...field} />}
+									render={({ field }) => <AutoCompleteDepartmentMultiple withCheckbox id={departmentsField} showArchived {...field} />}
 								/>
 							</FieldRow>
 						</Field>

--- a/apps/meteor/client/views/omnichannel/directory/chats/ChatsFiltersContextualBar.tsx
+++ b/apps/meteor/client/views/omnichannel/directory/chats/ChatsFiltersContextualBar.tsx
@@ -114,7 +114,7 @@ const ChatsFiltersContextualBar = ({ onClose }: ChatsFiltersContextualBarProps) 
 							name='department'
 							control={control}
 							render={({ field: { value, onChange } }) => (
-								<AutoCompleteDepartmentMultiple showArchived value={value} onChange={onChange} onlyMyDepartments withCheckbox={false} />
+								<AutoCompleteDepartmentMultiple showArchived value={value} onChange={onChange} onlyMyDepartments />
 							)}
 						/>
 					</FieldRow>


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR fixes the property `withCheckbox` not working on the `AutoCompleteDepartmentMultiple` component. A checkbox should be rendered for each option when `withCheckbox` is `true`. This was not happening due to a missing `return`.
 
## Issue(s)
[CTZ-157](https://rocketchat.atlassian.net/browse/CTZ-157)

## Steps to test or reproduce
Can be found in:
- Business Hours page
- Create/edit tags page
- Create/edit unit page
- Create/edit department page

## Further comments
Introduced here #35282


[CTZ-157]: https://rocketchat.atlassian.net/browse/CTZ-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ