### PR TITLE
fix: add notification on setting changes for Deployment FingerPrint

### DIFF
--- a/apps/meteor/server/services/settings/service.ts
+++ b/apps/meteor/server/services/settings/service.ts
@@ -3,11 +3,18 @@ import { ServiceClassInternal } from '@rocket.chat/core-services';
 import type { SettingValue } from '@rocket.chat/core-typings';
 
 import { settings } from '../../../app/settings/server';
+import { verifyFingerPrint } from '../../settings/misc';
 
 export class SettingsService extends ServiceClassInternal implements ISettingsService {
 	protected name = 'settings';
 
 	async get<T extends SettingValue>(settingId: string): Promise<T> {
 		return settings.get<T>(settingId);
+	}
+
+	async started() {
+		settings.change('Site_Url', () => {
+			void verifyFingerPrint();
+		});
 	}
 }

--- a/apps/meteor/server/settings/misc.ts
+++ b/apps/meteor/server/settings/misc.ts
@@ -5,6 +5,7 @@ import { Settings } from '@rocket.chat/models';
 import { v4 as uuidv4 } from 'uuid';
 
 import { updateAuditedBySystem } from './lib/auditedSettingUpdates';
+import { notifyOnSettingChangedById } from '../../app/lib/server/lib/notifyListener';
 import { settingsRegistry, settings } from '../../app/settings/server';
 
 const logger = new Logger('FingerPrint');
@@ -26,6 +27,9 @@ const updateFingerprint = async function (fingerprint: string, verified: boolean
 		auditedSettingBySystem(Settings.updateValueById, 'Deployment_FingerPrint_Hash', fingerprint),
 		auditedSettingBySystem(Settings.updateValueById, 'Deployment_FingerPrint_Verified', verified),
 	]);
+
+	void notifyOnSettingChangedById('Deployment_FingerPrint_Hash');
+	void notifyOnSettingChangedById('Deployment_FingerPrint_Verified');
 };
 
 const verifyFingerPrint = async function () {

--- a/apps/meteor/server/settings/misc.ts
+++ b/apps/meteor/server/settings/misc.ts
@@ -27,13 +27,14 @@ const updateFingerprint = async function (fingerprint: string, verified: boolean
 		auditedSettingBySystem(Settings.updateValueById, 'Deployment_FingerPrint_Hash', fingerprint),
 		auditedSettingBySystem(Settings.updateValueById, 'Deployment_FingerPrint_Verified', verified),
 	]);
+
 	if (emit) {
 		void notifyOnSettingChangedById('Deployment_FingerPrint_Hash');
 		void notifyOnSettingChangedById('Deployment_FingerPrint_Verified');
 	}
 };
 
-const verifyFingerPrint = async function (emit = true) {
+export const verifyFingerPrint = async function (emit = true) {
 	const DeploymentFingerPrintRecordHash = await Settings.getValueById('Deployment_FingerPrint_Hash');
 
 	const fingerprint = generateFingerprint();
@@ -76,9 +77,6 @@ export const createMiscSettings = async () => {
 	});
 
 	await verifyFingerPrint(false);
-	settings.change('Site_Url', () => {
-		void verifyFingerPrint();
-	});
 
 	await settingsRegistry.add('Initial_Channel_Created', false, {
 		type: 'boolean',

--- a/apps/meteor/server/settings/misc.ts
+++ b/apps/meteor/server/settings/misc.ts
@@ -75,11 +75,10 @@ export const createMiscSettings = async () => {
 		readonly: true,
 	});
 
+	await verifyFingerPrint(false);
 	settings.change('Site_Url', () => {
 		void verifyFingerPrint();
 	});
-
-	void verifyFingerPrint(false);
 
 	await settingsRegistry.add('Initial_Channel_Created', false, {
 		type: 'boolean',


### PR DESCRIPTION
https://rocketchat.atlassian.net/browse/ARCH-1616

Updated the updateFingerprint function to invoke notifyOnSettingChangedById for the Deployment_FingerPrint_Hash and Deployment_FingerPrint_Verified settings, ensuring listeners are notified of changes

Since https://github.com/RocketChat/Rocket.Chat/pull/35981 we no longer use oplog, so in this case ui/backend wont realize the changes
introduced "around" here: https://github.com/RocketChat/Rocket.Chat/issues/31527
