### PR TITLE
fix: (4.1.3) encrypted key icon - very low contrast

### DIFF
--- a/apps/meteor/client/views/room/Header/icons/Encrypted.tsx
+++ b/apps/meteor/client/views/room/Header/icons/Encrypted.tsx
@@ -1,5 +1,4 @@
 import type { IRoom } from '@rocket.chat/core-typings';
-import colors from '@rocket.chat/fuselage-tokens/colors';
 import { useSetting } from '@rocket.chat/ui-contexts';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,7 +8,7 @@ import { HeaderState } from '../../../../components/Header';
 const Encrypted = ({ room }: { room: IRoom }) => {
 	const { t } = useTranslation();
 	const e2eEnabled = useSetting('E2E_Enable');
-	return e2eEnabled && room?.encrypted ? <HeaderState title={t('Encrypted')} icon='key' color={colors.g500} /> : null;
+	return e2eEnabled && room?.encrypted ? <HeaderState title={t('Encrypted')} icon='key' color='status-font-on-success' /> : null;
 };
 
 export default memo(Encrypted);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->


<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

This PR fixes a UI contrast issue for the encrypted key icon in room headers.
The icon previously had very low contrast (as identified using the WAVE accessibility extension).

I used `status-font-on-success` for the icon, which maps to `green/800`. <br>
Before:
![image](https://github.com/user-attachments/assets/49efd878-1397-415e-9228-0921cfa3f8a3)
After:
![image](https://github.com/user-attachments/assets/cffcd84f-89f4-463f-a047-c097fdd62b53)


## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce

Join a room with E2E encryption enabled.
Check the encrypted key icon in the header (should appear green and clearly visible).
Test in both light and dark mode.

## Further comments
