### PR TITLE
regression: Broken links in the UI when multiple links are used

### DIFF
--- a/apps/meteor/client/components/MarkdownText.spec.tsx
+++ b/apps/meteor/client/components/MarkdownText.spec.tsx
@@ -1,16 +1,83 @@
 import { mockAppRoot } from '@rocket.chat/mock-providers';
 import { render, screen } from '@testing-library/react';
 
-import MarkdownText from './MarkdownText';
+import MarkdownText, { supportedURISchemes } from './MarkdownText';
 
 import '@testing-library/jest-dom';
+
+const MOCKED_BASE_URI = 'http://localhost/';
 
 // Mock getBaseURI from @rocket.chat/ui-client to ensure consistent behavior in tests
 // This will affect the isExternal function imported above.
 jest.mock('@rocket.chat/ui-client', () => ({
 	...jest.requireActual('@rocket.chat/ui-client'), // Import and retain default behavior for other exports
-	getBaseURI: jest.fn(() => 'http://localhost/'), // Mock getBaseURI for consistent test behavior
+	getBaseURI: jest.fn(() => MOCKED_BASE_URI), // Mock getBaseURI for consistent test behavior
 }));
+
+// List of common URI schemes. This list was taken from https://en.wikipedia.org/wiki/List_of_URI_schemes
+const commonUriSchemes = [
+	'file',
+	'ftp',
+	'http',
+	'https',
+	'mailto',
+	'tel',
+	'imap',
+	'irc',
+	'nntp',
+	'acap',
+	'icap',
+	'mtqp',
+	'wss',
+	'admin',
+	'app',
+	'freeplane',
+	'geo',
+	'javascript',
+	'jdbc',
+	'msteams',
+	'ms-access',
+	'ms-excel',
+	'ms-infopath',
+	'ms-powerpoint',
+	'ms-project',
+	'ms-publisher',
+	'ms-spd',
+	'ms-visio',
+	'ms-word',
+	'odbc',
+	'psns',
+	'rdar',
+	's3',
+	'shortcuts',
+	'slack',
+	'stratum',
+	'trueconf',
+	'viber',
+	'zoommtgzoomus',
+];
+
+const nonSupportedUriSchemes = commonUriSchemes.filter((scheme) => !supportedURISchemes.includes(scheme));
+
+const testUris = [
+	'example.com',
+	'example.com/path',
+	'example.com/path/to/resource',
+	'localhost/home',
+	'localhost/path/to/',
+	'localhost/path/to/resource',
+];
+
+const getTestCases = (schemes: string[], uris: string[]): { scheme: string; links: string[] }[] => {
+	return schemes.map((scheme) => {
+		return {
+			scheme,
+			links: uris.map((uri) => `${scheme}://${uri}`),
+		};
+	});
+};
+
+const isExternal = (link: string): boolean => link.indexOf(MOCKED_BASE_URI) !== 0;
 
 const normalizeHtml = (html: any) => {
 	return html.replace(/\s+/g, ' ').trim();
@@ -266,5 +333,67 @@ describe('links handling', () => {
 
 		if (expectedTitleAttribute !== undefined) expect(anchorElement).toHaveAttribute('title', expectedTitleAttribute);
 		else expect(anchorElement).not.toHaveAttribute('title');
+	});
+
+	describe('multiple links', () => {
+		it.each(getTestCases(supportedURISchemes, testUris))('supported scheme: $scheme', ({ scheme, links }) => {
+			const getTextContent = (link: string) => `Test link - ${link}`;
+			const markdownContent = links.map((link) => `[${getTextContent(link)}](${link})`).join('\n');
+
+			render(<MarkdownText content={markdownContent} variant='document' />, {
+				wrapper: mockAppRoot().withTranslations('en', 'core', { Go_to_href: 'Go to: {{href}}' }).build(),
+			});
+
+			links.forEach((link) => {
+				const text = getTextContent(link);
+				const title = `Go to: ${link.replace(MOCKED_BASE_URI, '')}`;
+				const anchorElement = screen.getByText(text);
+
+				expect(anchorElement).toBeInTheDocument();
+				expect(anchorElement.tagName).toBe('A');
+				expect(anchorElement).toHaveTextContent(text);
+				expect(anchorElement).toHaveAttribute('href', link);
+
+				if (scheme === 'mailto') {
+					expect(anchorElement).toHaveAttribute('rel', 'nofollow noopener noreferrer');
+					expect(anchorElement).toHaveAttribute('target', '_blank');
+					expect(anchorElement).toHaveAttribute('href', link);
+					expect(anchorElement).toHaveAttribute('title', link);
+					return;
+				}
+
+				if (isExternal(link)) {
+					expect(anchorElement).toHaveAttribute('rel', 'nofollow noopener noreferrer');
+					expect(anchorElement).toHaveAttribute('target', '_blank');
+					expect(anchorElement).toHaveAttribute('title', '');
+					return;
+				}
+
+				expect(anchorElement).toHaveAttribute('title', title);
+			});
+		});
+
+		it.each(getTestCases(nonSupportedUriSchemes, testUris))('unsupported scheme: $scheme', ({ links }) => {
+			const getTextContent = (link: string) => `Test link - ${link}`;
+			const markdownContent = links.map((link) => `[${getTextContent(link)}](${link})`).join('\n');
+
+			render(<MarkdownText content={markdownContent} variant='document' />, {
+				wrapper: mockAppRoot().withTranslations('en', 'core', { Go_to_href: 'Go to: {{href}}' }).build(),
+			});
+
+			links.forEach((link) => {
+				const text = getTextContent(link);
+				const anchorElement = screen.getByText(text);
+
+				expect(anchorElement).toBeInTheDocument();
+				expect(anchorElement.tagName).toBe('A');
+				expect(anchorElement).toHaveTextContent(text);
+				expect(anchorElement).not.toHaveAttribute('href');
+
+				expect(anchorElement).toHaveAttribute('rel', 'nofollow noopener noreferrer');
+				expect(anchorElement).toHaveAttribute('target', '_blank');
+				expect(anchorElement).toHaveAttribute('title', '');
+			});
+		});
 	});
 });

--- a/apps/meteor/client/components/MarkdownText.tsx
+++ b/apps/meteor/client/components/MarkdownText.tsx
@@ -80,12 +80,15 @@ const inlineWithoutBreaksOptions = {
 	renderer: inlineWithoutBreaks,
 };
 
-const getRegexp = (schemeSetting: string): RegExp => {
-	const schemes = schemeSetting ? schemeSetting.split(',').join('|') : '';
-	return new RegExp(`^(${schemes}):`, 'gim');
+const getRegexp = (supportedURISchemes: string[]): RegExp => {
+	const schemes = supportedURISchemes.join('|');
+
+	return new RegExp(`^(${schemes}):`, 'im');
 };
 
 type MarkdownTextProps = Partial<MarkdownTextParams>;
+
+export const supportedURISchemes = ['http', 'https', 'notes', 'ftp', 'ftps', 'tel', 'mailto', 'sms', 'cid'];
 
 const MarkdownText = ({
 	content,
@@ -98,8 +101,6 @@ const MarkdownText = ({
 	const sanitizer = dompurify.sanitize;
 	const { t } = useTranslation();
 	let markedOptions: marked.MarkedOptions;
-
-	const schemes = 'http,https,notes,ftp,ftps,tel,mailto,sms,cid';
 
 	switch (variant) {
 		case 'inline':
@@ -165,8 +166,8 @@ const MarkdownText = ({
 			}
 		});
 
-		return preserveHtml ? html : html && sanitizer(html, { ADD_ATTR: ['target'], ALLOWED_URI_REGEXP: getRegexp(schemes) });
-	}, [preserveHtml, sanitizer, content, variant, markedOptions, parseEmoji, t, schemes]);
+		return preserveHtml ? html : html && sanitizer(html, { ADD_ATTR: ['target'], ALLOWED_URI_REGEXP: getRegexp(supportedURISchemes) });
+	}, [preserveHtml, sanitizer, content, variant, markedOptions, parseEmoji, t]);
 
 	return __html ? (
 		<Box


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Implements more test cases to ensure behaviour is correct.

Changes the regex that matches the URI schemes to not have the "global" property.

The issue was introduced here: https://github.com/RocketChat/Rocket.Chat/pull/32917
For some reason, the change to the `inlineMarked` return is what broke the links. I did not find why that was the case, but reading domPurify's documentation and types, the default regex was found to not have the `global` property. Given the whole context, it was inferred that the issue happened due to regexes with the "global" flag set keeping an internal index after matching the text. If the same regex was being used to try to match multiple strings, some of them would not match due to the Regexe's dirty state.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-1160](https://rocketchat.atlassian.net/browse/CORE-1160)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-1160]: https://rocketchat.atlassian.net/browse/CORE-1160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ