### PR TITLE
regression: Twilio failing signature check

### DIFF
--- a/apps/meteor/app/livechat/imports/server/rest/sms.ts
+++ b/apps/meteor/app/livechat/imports/server/rest/sms.ts
@@ -108,7 +108,7 @@ API.v1.addRoute('livechat/sms-incoming/:service', {
 		const smsDepartment = settings.get<string>('SMS_Default_Omnichannel_Department');
 		const SMSService = await OmnichannelIntegration.getSmsService(service);
 
-		if (!(await SMSService.validateRequest(this.request.clone()))) {
+		if (!(await SMSService.validateRequest(this.request.clone(), this.bodyParams))) {
 			return API.v1.failure('Invalid request');
 		}
 

--- a/apps/meteor/server/services/omnichannel-integrations/providers/mobex.ts
+++ b/apps/meteor/server/services/omnichannel-integrations/providers/mobex.ts
@@ -196,7 +196,7 @@ export class Mobex implements ISMSProvider {
 		};
 	}
 
-	async validateRequest(_request: Request): Promise<boolean> {
+	async validateRequest(_request: Request, _requestBody: unknown): Promise<boolean> {
 		return true;
 	}
 

--- a/apps/meteor/server/services/omnichannel-integrations/providers/twilio.ts
+++ b/apps/meteor/server/services/omnichannel-integrations/providers/twilio.ts
@@ -244,7 +244,16 @@ export class Twilio implements ISMSProvider {
 		};
 	}
 
-	async isRequestFromTwilio(signature: string, request: Request): Promise<boolean> {
+	private getUrl(url: string, siteUrl: string): string {
+		const baseUrl = new URL(url);
+		const newUrl = new URL(siteUrl);
+		baseUrl.protocol = newUrl.protocol;
+		baseUrl.host = newUrl.host;
+
+		return baseUrl.toString();
+	}
+
+	async isRequestFromTwilio(signature: string, request: Request, requestBody: unknown): Promise<boolean> {
 		const authToken = settings.get<string>('SMS_Twilio_authToken');
 		let siteUrl = settings.get<string>('Site_Url');
 		if (siteUrl.endsWith('/')) {
@@ -256,25 +265,19 @@ export class Twilio implements ISMSProvider {
 			return false;
 		}
 
-		const twilioUrl = request.url ? `${siteUrl}${request.url}` : `${siteUrl}/api/v1/livechat/sms-incoming/twilio`;
+		const twilioUrl = request.url ? this.getUrl(request.url, siteUrl) : `${siteUrl}/api/v1/livechat/sms-incoming/twilio`;
 
-		let body = {};
-		try {
-			body = await request.json();
-			// eslint-disable-next-line no-empty
-		} catch {}
-
-		return twilio.validateRequest(authToken, signature, twilioUrl, body);
+		return twilio.validateRequest(authToken, signature, twilioUrl, requestBody as Record<string, any>);
 	}
 
-	async validateRequest(request: Request): Promise<boolean> {
+	async validateRequest(request: Request, requestBody: unknown): Promise<boolean> {
 		// We're not getting original twilio requests on CI :p
 		if (process.env.TEST_MODE === 'true') {
 			return true;
 		}
 		const twilioHeader = request.headers.get('x-twilio-signature') || '';
 		const twilioSignature = Array.isArray(twilioHeader) ? twilioHeader[0] : twilioHeader;
-		return this.isRequestFromTwilio(twilioSignature, request);
+		return this.isRequestFromTwilio(twilioSignature, request, requestBody);
 	}
 
 	error(error: Error & { reason?: string }): SMSProviderResponse {

--- a/apps/meteor/server/services/omnichannel-integrations/providers/voxtelesys.ts
+++ b/apps/meteor/server/services/omnichannel-integrations/providers/voxtelesys.ts
@@ -162,7 +162,7 @@ export class Voxtelesys implements ISMSProvider {
 		};
 	}
 
-	async validateRequest(_request: Request): Promise<boolean> {
+	async validateRequest(_request: Request, _requestBody: unknown): Promise<boolean> {
 		return true;
 	}
 

--- a/packages/core-typings/src/omnichannel/sms.ts
+++ b/packages/core-typings/src/omnichannel/sms.ts
@@ -27,7 +27,7 @@ export interface ISMSProviderConstructor {
 
 export interface ISMSProvider {
 	parse(data: unknown): ServiceData;
-	validateRequest(request: Request): Promise<boolean>;
+	validateRequest(request: Request, requestBody: unknown): Promise<boolean>;
 
 	sendBatch?(from: string, to: string[], message: string): Promise<SMSProviderResult>;
 	response(): SMSProviderResponse;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/CTZ-178
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
(Note: 2 issues in one as one fix is not enough for the feature to work)

For some reason, Hono defaults to `localhost` in req.url (or it's using the localhost domain instead of the public site url)

For example, on candidate:
```
{"level":35,"time":"2025-05-26T16:21:11.617Z","pid":1,"hostname":"rocketchat-candidate-55c86cb5c-hnqdb","name":"API","method":"POST","url":"http://localhost/api/v1/livechat/message","userAgent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36 Edg/135.0.0.0","length":"115","host":"candidate.qa.rocket.chat","referer":"https://candidate.qa.rocket.chat/livechat","remoteIP":"122.161.242.36","status":200,"responseTime":93} 
```

Since twilio assumed this property `req.url` was _relative_, it created its own URL based on it. Now, it's absolute, including hostname which caused the signature to mismatch from what twilio was sending.

The other issue was that the body was being re-parsed as `json`, which didn't work, causing an empty body which made the validation fail (as the signature from twilio includes the body)

Since on CI (dum, ik) we skip this twilio validation, the bug wasn't caught. A task will be created to change the CI tests to be more real-world and avoid the diff behavior when TEST_MODE is true.