### PR TITLE
regression: Dragging the VoIP popup handle with right click keeps moving the element after release

### DIFF
--- a/packages/ui-voip/src/components/VoipPopupDraggable/DraggableCore.ts
+++ b/packages/ui-voip/src/components/VoipPopupDraggable/DraggableCore.ts
@@ -341,6 +341,9 @@ interface IHandleElement {
 	onGrab(cb: (event: [mousePosition: PointCoordinates, elementRect: IGenericRect]) => void): OffCallbackHandler;
 }
 
+const isLeftClick = (event: PointerEvent) => event.button === 0;
+const isMousePointer = (event: PointerEvent) => event.pointerType === 'mouse';
+
 class HandleDomElement
 	extends Emitter<{
 		grab: [PointCoordinates, IGenericRect];
@@ -350,7 +353,7 @@ class HandleDomElement
 	public setElement(element: HTMLElement) {
 		const onGrab = (event: PointerEvent) => {
 			const element = event.currentTarget as HTMLElement;
-			if (!element) {
+			if (!element || (isMousePointer(event) && !isLeftClick(event))) {
 				return;
 			}
 

--- a/packages/ui-voip/src/components/VoipPopupDraggable/useDraggable.stories.tsx
+++ b/packages/ui-voip/src/components/VoipPopupDraggable/useDraggable.stories.tsx
@@ -166,6 +166,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
+// TODO: test other pointer types (pen, touch, etc)
 const moveHelper = async (handle: HTMLElement, offset: { x: number; y: number }) => {
 	const handleRect = handle.getBoundingClientRect();
 	// Grab the middle of the handle
@@ -214,6 +215,36 @@ export const DraggingBehavior: Story = {
 			const initialRect = draggable.getBoundingClientRect();
 
 			await moveHelper(draggable, { x: 100, y: 100 });
+
+			await waitFor(() => {
+				const finalRect = draggable.getBoundingClientRect();
+				expect(finalRect.x).toBeCloseTo(initialRect.x, 0);
+				expect(finalRect.y).toBeCloseTo(initialRect.y, 0);
+			});
+		});
+
+		await step('should not allow dragging with right click', async () => {
+			const draggable = await canvas.findByTestId('draggable-box');
+			const handle = await canvas.findByTestId('drag-handle');
+
+			const initialRect = draggable.getBoundingClientRect();
+
+			// for some reason `fireEvent` and `userEvent` do not change the `button` property of the event
+			// so we need to create a new event manually
+			await fireEvent(
+				handle,
+				new PointerEvent('pointerdown', {
+					button: 2,
+					pointerType: 'mouse',
+				}),
+			);
+
+			await fireEvent.pointerMove(document.documentElement, {
+				clientX: 50,
+				clientY: 50,
+			});
+
+			await fireEvent.pointerUp(document.documentElement);
 
 			await waitFor(() => {
 				const finalRect = draggable.getBoundingClientRect();


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
There was no limit to which buttons were allowed to drag the element, and right clicking a page opens the context menu. This makes the mechanism unable to identify that the click was released, so the element would still move around with the mouse even if no button is pressed.

Since we expect the right click to always open the context menu, the popup should now ignore right clicks.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-1170]
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Right click the popup then close the context menu. The popup will follow the cursor despite no buttons being held.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-1170]: https://rocketchat.atlassian.net/browse/CORE-1170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ