### PR TITLE
fix: Quote chaining in E2EE room not limiting quote depth

### DIFF
--- a/apps/meteor/app/ui-message/client/messageBox/createComposerAPI.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/createComposerAPI.ts
@@ -2,6 +2,7 @@ import type { IMessage } from '@rocket.chat/core-typings';
 import { Emitter } from '@rocket.chat/emitter';
 import { Accounts } from 'meteor/accounts-base';
 
+import { limitQuoteChain } from './limitQuoteChain';
 import type { FormattingButton } from './messageBoxFormatting';
 import { formattingButtons } from './messageBoxFormatting';
 import type { ComposerAPI } from '../../../../client/lib/chats/ChatAPI';
@@ -107,8 +108,8 @@ export const createComposerAPI = (input: HTMLTextAreaElement, storageID: string)
 		}
 	};
 
-	const quoteMessage = async (message: IMessage): Promise<void> => {
-		_quotedMessages = [..._quotedMessages.filter((_message) => _message._id !== message._id), message];
+	const quoteMessage = async (message: IMessage, quoteChainLimit = 2): Promise<void> => {
+		_quotedMessages = [..._quotedMessages.filter((_message) => _message._id !== message._id), limitQuoteChain(message, quoteChainLimit)];
 		notifyQuotedMessagesUpdate();
 		input.focus();
 	};

--- a/apps/meteor/app/ui-message/client/messageBox/limitQuoteChain.spec.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/limitQuoteChain.spec.ts
@@ -1,0 +1,89 @@
+import { faker } from '@faker-js/faker/locale/af_ZA';
+import { isQuoteAttachment } from '@rocket.chat/core-typings';
+import type { AtLeast, IMessage, MessageAttachment, MessageQuoteAttachment } from '@rocket.chat/core-typings';
+
+import { limitQuoteChain } from './limitQuoteChain';
+
+class TestAttachment {}
+
+const makeQuote = (): MessageQuoteAttachment => {
+	return {
+		text: `[ ](http://localhost:3000/group/encrypted?msg=${faker.string.uuid()})`,
+		message_link: `http://localhost:3000/group/encrypted?msg=${faker.string.uuid()}`,
+		author_name: faker.internet.userName(),
+		author_icon: `/avatar/${faker.internet.userName()}`,
+		author_link: `http://localhost:3000/group/encrypted?msg=${faker.string.uuid()}`,
+	};
+};
+
+const makeChainedQuote = (chainSize: number): MessageQuoteAttachment => {
+	if (chainSize === 0) {
+		throw new Error('Chain size cannot be 0');
+	}
+
+	if (chainSize === 1) {
+		return makeQuote();
+	}
+
+	return {
+		...makeQuote(),
+		attachments: [
+			makeChainedQuote(chainSize - 1),
+			// add a few extra attachments to ensure they are not messed with
+			new TestAttachment() as MessageAttachment,
+			new TestAttachment() as MessageAttachment,
+		],
+	};
+};
+
+const makeMessage = (chainSize: number): any => {
+	if (chainSize === 0) {
+		return {};
+	}
+
+	return {
+		attachments: [makeChainedQuote(chainSize)],
+	};
+};
+
+const chainSizes = [0, 1, 2, 3, 4, 5, 10, 20, 50, 100];
+
+const limits = [0, 1, 2, 3, 4, 5, 10, 20, 50, 100];
+
+const countQuoteDeepnes = (attachments?: MessageAttachment[], quoteLength = 0): number => {
+	if (!attachments || attachments.length < 1) {
+		return quoteLength + 1;
+	}
+
+	// Ensure sibling attachments didn't change
+	attachments.forEach((attachment) => {
+		if (!isQuoteAttachment(attachment) && !(attachment instanceof TestAttachment)) {
+			throw new Error('PANIC! Non quote attachment changed. This should never happen.');
+		}
+	});
+
+	const quote = attachments.find((attachment) => isQuoteAttachment(attachment));
+	if (!quote?.attachments) {
+		return quoteLength + 1;
+	}
+
+	return countQuoteDeepnes(quote.attachments, quoteLength + 1);
+};
+
+const countMessageQuoteChain = (message: AtLeast<IMessage, 'attachments'>) => {
+	return countQuoteDeepnes(message.attachments);
+};
+
+describe('ChatMessages Composer API - limitQuoteChain', () => {
+	describe.each(chainSizes)('quote chain %i levels deep', (size) => {
+		it.each(limits)('should limit chain to be at max %i level(s) deep', (limit) => {
+			// If the size is less than the limit, it shouldn't filter anything
+			// The main message also counts as a quote, so this will never be less than 1. See implementation for more details.
+			const quoteLimitOrSize = Math.max(1, Math.min(limit, size));
+			const message = makeMessage(size);
+			const limitedMessage = limitQuoteChain(message, limit);
+
+			expect(countMessageQuoteChain(limitedMessage)).toBe(quoteLimitOrSize);
+		});
+	});
+});

--- a/apps/meteor/app/ui-message/client/messageBox/limitQuoteChain.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/limitQuoteChain.ts
@@ -1,0 +1,38 @@
+import { isQuoteAttachment } from '@rocket.chat/core-typings';
+import type { IMessage, MessageAttachment, AtLeast } from '@rocket.chat/core-typings';
+
+// Observation:
+// Currently, if the limit is 0, one quote is still allowed.
+// This behavior is defined in the server side, so to keep things consistent, we'll keep it that way.
+// See @createAttachmentForMessageURLs in @BeforeSaveJumpToMessage.ts
+export const limitQuoteChain = <TMessage extends AtLeast<IMessage, 'attachments'>>(message: TMessage, limit = 2): TMessage => {
+	if (!Array.isArray(message.attachments) || message.attachments.length === 0) {
+		return message;
+	}
+
+	return {
+		...message,
+		attachments: traverseMessageQuoteChain(message.attachments, limit),
+	};
+};
+
+const traverseMessageQuoteChain = (attachments: MessageAttachment[], limit: number, currentLevel = 1): MessageAttachment[] => {
+	// read observation above.
+	if (limit < 2 || currentLevel >= limit) {
+		return attachments.filter((attachment) => !isQuoteAttachment(attachment));
+	}
+
+	return attachments.map((attachment) => {
+		if (isQuoteAttachment(attachment)) {
+			if (!attachment.attachments) {
+				return attachment;
+			}
+			return {
+				...attachment,
+				attachments: traverseMessageQuoteChain(attachment.attachments, limit, currentLevel + 1),
+			};
+		}
+
+		return attachment;
+	});
+};

--- a/apps/meteor/client/components/message/toolbar/items/actions/QuoteMessageAction.tsx
+++ b/apps/meteor/client/components/message/toolbar/items/actions/QuoteMessageAction.tsx
@@ -1,4 +1,5 @@
 import type { ITranslatedMessage, IMessage, ISubscription } from '@rocket.chat/core-typings';
+import { useSetting } from '@rocket.chat/ui-contexts';
 import { useTranslation } from 'react-i18next';
 
 import { useChat } from '../../../../../views/room/contexts/ChatContext';
@@ -13,6 +14,7 @@ type QuoteMessageActionProps = {
 const QuoteMessageAction = ({ message, subscription }: QuoteMessageActionProps) => {
 	const chat = useChat();
 	const autoTranslateOptions = useMessageListAutoTranslate();
+	const quoteChainLimit = Number(useSetting('Message_QuoteChainLimit'));
 	const { t } = useTranslation();
 
 	if (!chat || !subscription) {
@@ -33,7 +35,7 @@ const QuoteMessageAction = ({ message, subscription }: QuoteMessageActionProps) 
 							: message.msg;
 				}
 
-				chat?.composer?.quoteMessage(message);
+				chat?.composer?.quoteMessage(message, quoteChainLimit);
 			}}
 		/>
 	);

--- a/apps/meteor/client/lib/chats/ChatAPI.ts
+++ b/apps/meteor/client/lib/chats/ChatAPI.ts
@@ -39,7 +39,7 @@ export type ComposerAPI = {
 	setCursorToEnd(): void;
 	setCursorToStart(): void;
 	replyWith(text: string): Promise<void>;
-	quoteMessage(message: IMessage): Promise<void>;
+	quoteMessage(message: IMessage, quoteChainLimit?: number): Promise<void>;
 	dismissQuotedMessage(mid: IMessage['_id']): Promise<void>;
 	dismissAllQuotedMessages(): Promise<void>;
 	readonly quotedMessages: Subscribable<IMessage[]>;

--- a/apps/meteor/jest.config.ts
+++ b/apps/meteor/jest.config.ts
@@ -12,6 +12,7 @@ export default {
 			testMatch: [
 				'<rootDir>/client/**/**.spec.[jt]s?(x)',
 				'<rootDir>/ee/client/**/**.spec.[jt]s?(x)',
+				'<rootDir>/app/ui-message/client/**/**.spec.[jt]s?(x)',
 				'<rootDir>/tests/unit/client/views/**/*.spec.{ts,tsx}',
 				'<rootDir>/tests/unit/client/providers/**/*.spec.{ts,tsx}',
 			],


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
This issue occurs because we only enforce the quote chaining limit on the server, but the server cannot evaluate the message or its content due to the message being encrypted.

Due to this constraint, the limit can only be applied client-side before the message is sent, and that is what was done. This also improves UX since previously the quote preview did not evaluate the chain limit, causing a mismatch between what showed in the preview and what was actually experienced once the message was sent.

Caveats:
- as said before there's no way to prevent exceeding the quote chain limit for encrypted messages in the backend, because that would require encryption to be broken, and no longer end-to-end. Due to this it is still possible to send messages through the API that exceed said limit. There's no way around this.
- Since we currently only apply this limit server-side, messages sent before the limit is decreased still display all quotes as they were when the message was sent (change to the setting does not modify messages retroactively). Due to this, no limit to quotes was applied to the message layout, as to not break expected behavior. This means that encrypted messages sent through the APIs can display quote chains bigger thant the limit (see previous caveat).

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[SUP-782](https://rocketchat.atlassian.net/browse/SUP-782)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
It's not clear whether the message layout should also respect the limit, but historically it has not, so no attempt was or will made to change the message layout at this point. If this changes at any point, a new PR is warranted.
