### PR TITLE
fix: LDAP Sync sending repeated deactivation emails to inactive users

### DIFF
--- a/.changeset/violet-donuts-warn.md
+++ b/.changeset/violet-donuts-warn.md
@@ -1,0 +1,7 @@
+---
+'@rocket.chat/model-typings': patch
+'@rocket.chat/models': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes the issue of deactivation emails being sent to users that were removed from AD even if they were not active in the workspace

--- a/apps/meteor/ee/server/lib/ldap/Manager.ts
+++ b/apps/meteor/ee/server/lib/ldap/Manager.ts
@@ -620,14 +620,14 @@ export class LDAPEEManager extends LDAPManager {
 			if (ldapUser) {
 				const userData = this.mapUserData(ldapUser, user.username);
 				converter.addObjectToMemory(userData, { dn: ldapUser.dn, username: this.getLdapUsername(ldapUser) });
-			} else if (disableMissingUsers) {
+			} else if (disableMissingUsers && user.active) {
 				await setUserActiveStatus(user._id, false, true);
 			}
 		}
 	}
 
 	private static async disableMissingUsers(foundUsers: IUser['_id'][]): Promise<void> {
-		const userIds = (await Users.findLDAPUsersExceptIds(foundUsers, { projection: { _id: 1 } }).toArray()).map(({ _id }) => _id);
+		const userIds = (await Users.findActiveLDAPUsersExceptIds(foundUsers, { projection: { _id: 1 } }).toArray()).map(({ _id }) => _id);
 
 		await Promise.allSettled(userIds.map((id) => setUserActiveStatus(id, false, true)));
 	}

--- a/packages/model-typings/src/models/IUsersModel.ts
+++ b/packages/model-typings/src/models/IUsersModel.ts
@@ -89,7 +89,7 @@ export interface IUsersModel extends IBaseModel<IUser> {
 
 	findLDAPUsers<T extends Document = IUser>(options?: FindOptions<IUser>): FindCursor<T>;
 
-	findLDAPUsersExceptIds<T extends Document = IUser>(userIds: IUser['_id'][], options?: FindOptions<IUser>): FindCursor<T>;
+	findActiveLDAPUsersExceptIds<T extends Document = IUser>(userIds: IUser['_id'][], options?: FindOptions<IUser>): FindCursor<T>;
 
 	findConnectedLDAPUsers<T extends Document = IUser>(options?: FindOptions<IUser>): FindCursor<T>;
 

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -504,9 +504,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.find<T>(query, options);
 	}
 
-	findLDAPUsersExceptIds<T extends Document = IUser>(userIds: IUser['_id'][], options: FindOptions<IUser> = {}) {
+	findActiveLDAPUsersExceptIds<T extends Document = IUser>(userIds: IUser['_id'][], options: FindOptions<IUser> = {}) {
 		const query = {
 			ldap: true,
+			active: true,
 			_id: {
 				$nin: userIds,
 			},


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
When the LDAP sync process tries to deactivate an user that is no longer found on LDAP, it does so even if the user was already inactive on Rocket.Chat. This was causing Rocket.Chat to send repeated Deactivation Emails to those users, whenever the sync process ran.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[SUP-805](https://rocketchat.atlassian.net/browse/SUP-805)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
