### PR TITLE
Fix: File URLs and livechat API query parameters

### DIFF
--- a/apps/meteor/app/livechat/imports/server/rest/rooms.ts
+++ b/apps/meteor/app/livechat/imports/server/rest/rooms.ts
@@ -29,7 +29,7 @@ API.v1.addRoute(
 	{
 		async get() {
 			const { offset, count } = await getPaginationItems(this.queryParams);
-			const { sort, fields } = await this.parseJsonQuery();
+			const { sort, fields, query } = await this.parseJsonQuery();
 			const { agents, departmentId, open, tags, roomName, onhold, queued, units } = this.queryParams;
 			const { createdAt, customFields, closedAt } = this.queryParams;
 
@@ -71,7 +71,7 @@ API.v1.addRoute(
 					onhold,
 					queued,
 					units,
-					options: { offset, count, sort, fields },
+					options: { offset, count, sort, fields, query },
 					callerId: this.userId,
 				}),
 			);

--- a/apps/meteor/app/livechat/server/api/lib/rooms.ts
+++ b/apps/meteor/app/livechat/server/api/lib/rooms.ts
@@ -16,7 +16,7 @@ export async function findRooms({
 	onhold,
 	queued,
 	units,
-	options: { offset, count, fields, sort },
+	options: { offset, count, fields, sort, query },
 	callerId,
 }: {
 	agents?: Array<string>;
@@ -36,8 +36,7 @@ export async function findRooms({
 	onhold?: string | boolean;
 	queued?: string | boolean;
 	units?: Array<string>;
-	options: { offset: number; count: number; fields: Record<string, number>; sort: Record<string, number> };
-	callerId: string;
+	options: { offset: number; count: number; fields: Record<string, number>; sort: Record<string, number>; query?: Record<string, any> };	callerId: string;
 }): Promise<PaginatedResult<{ rooms: Array<IOmnichannelRoom> }>> {
 	const extraQuery = await callbacks.run('livechat.applyRoomRestrictions', {}, { unitsFilter: units, userId: callerId });
 	const { cursor, totalCount } = LivechatRooms.findRoomsWithCriteria({
@@ -56,6 +55,7 @@ export async function findRooms({
 			offset,
 			count,
 			fields,
+			query,
 		},
 		extraQuery,
 	});

--- a/apps/meteor/client/views/room/contextualBar/RoomFiles/components/FileItem.tsx
+++ b/apps/meteor/client/views/room/contextualBar/RoomFiles/components/FileItem.tsx
@@ -6,6 +6,7 @@ import FileItemMenu from './FileItemMenu';
 import ImageItem from './ImageItem';
 import { useDownloadFromServiceWorker } from '../../../../../hooks/useDownloadFromServiceWorker';
 import { useFormatDateAndTime } from '../../../../../hooks/useFormatDateAndTime';
+import { fixFileUrl } from '../utils/fixFileUrl';
 
 type FileItemProps = {
 	fileData: IUploadWithUser;
@@ -15,14 +16,13 @@ type FileItemProps = {
 const FileItem = ({ fileData, onClickDelete }: FileItemProps) => {
 	const format = useFormatDateAndTime();
 	const { _id, path, name, uploadedAt, type, typeGroup, user } = fileData;
-
-	const encryptedAnchorProps = useDownloadFromServiceWorker(path || '', name);
+	const correctedPath = fixFileUrl(path);
+	const encryptedAnchorProps = useDownloadFromServiceWorker(correctedPath || '', name);
 
 	return (
 		<>
 			{typeGroup === 'image' ? (
-				<ImageItem id={_id} url={path} name={name} username={user?.username} timestamp={format(uploadedAt)} />
-			) : (
+				<ImageItem id={_id} url={correctedPath} name={name} username={user?.username} timestamp={format(uploadedAt)} /> ) : (
 				<Box
 					is='a'
 					minWidth={0}
@@ -34,10 +34,10 @@ const FileItem = ({ fileData, onClickDelete }: FileItemProps) => {
 					display='flex'
 					flexGrow={1}
 					flexShrink={1}
-					href={path}
+					href={correctedPath}
 					tabIndex={-1}
 					textDecorationLine='none'
-					{...(path?.includes('/file-decrypt/') ? encryptedAnchorProps : {})}
+					{...(correctedPath?.includes('/file-decrypt/') ? encryptedAnchorProps : {})}
 				>
 					<FileItemIcon type={type} />
 					<Box mis={8} flexShrink={1} overflow='hidden'>

--- a/apps/meteor/client/views/room/contextualBar/RoomFiles/utils/fixFileUrl.ts
+++ b/apps/meteor/client/views/room/contextualBar/RoomFiles/utils/fixFileUrl.ts
@@ -1,0 +1,22 @@
+export const fixFileUrl = (originalPath: string | undefined): string | undefined => {
+	if (!originalPath) {
+		return originalPath;
+	}
+
+	if (!originalPath.startsWith('http://') && !originalPath.startsWith('https://')) {
+		return originalPath;
+	}
+
+	try {
+		const originalUrl = new URL(originalPath);
+		const currentServerUrl = window.location.origin;
+		const fixedUrl = `${currentServerUrl}${originalUrl.pathname}${originalUrl.search}${originalUrl.hash}`;
+		return fixedUrl;
+	} catch (error) {
+		const pathMatch = originalPath.match(/(\/file-upload\/.*|\/ufs\/.*|\/file-decrypt\/.*)$/);
+		if (pathMatch) {
+			return `${window.location.origin}${pathMatch[1]}`;
+		}
+		return originalPath;
+	}
+};


### PR DESCRIPTION
**Issues Fixed**
1. Files Panel URLs Not Updated After Server IP Change
Files panel showed old hardcoded IP addresses while main chat displayed correct URLs after server IP changes.
2. Livechat Rooms API Ignoring Query Parameters
/api/v1/livechat/rooms endpoint ignored query and fields parameters despite being defined in API spec.
🔧 Changes Made
**File URL Fix**
•	**NEW FILE**: apps/meteor/client/views/room/contextualBar/RoomFiles/utils/fixFileUrl.ts 
o	Added utility to replace hardcoded IPs with current server URL
•	**MODIFIED**: apps/meteor/client/views/room/contextualBar/RoomFiles/components/FileItem.tsx 
o	Added import for fixFileUrl utility
o	Added correctedPath variable using fixFileUrl(path)
o	Replaced all path usage with correctedPath in component
**Livechat API Fix**
•	**MODIFIED**: apps/meteor/app/livechat/imports/server/rest/rooms.ts 
o	Added query to parseJsonQuery() destructuring
o	Added query parameter to options object passed to findRooms
•	**MODIFIED**: apps/meteor/app/livechat/server/api/lib/rooms.ts 
o	Added query to function parameter destructuring
o	Added query?: Record<string, any> to TypeScript type definition
o	Added query parameter to database call options
**Testing**
•	File URLs now use current server address dynamically
•	API accepts query/fields parameters without errors
•	Both fixes maintain backward compatibility
•	Tested in localhost environment with authentication

