### PR TITLE
fix: WCAG 3.3.1 inline error in report message modal

### DIFF
--- a/apps/meteor/client/views/room/modals/ReportMessageModal/ReportMessageModal.tsx
+++ b/apps/meteor/client/views/room/modals/ReportMessageModal/ReportMessageModal.tsx
@@ -1,8 +1,9 @@
 import type { IMessage } from '@rocket.chat/core-typings';
 import { css } from '@rocket.chat/css-in-js';
-import { TextAreaInput, FieldGroup, Field, FieldRow, FieldError, Box } from '@rocket.chat/fuselage';
+import { TextAreaInput, FieldGroup, Field, FieldRow, FieldError, FieldLabel, FieldDescription, Box } from '@rocket.chat/fuselage';
 import { useToastMessageDispatch, useTranslation, useEndpoint } from '@rocket.chat/ui-contexts';
-import type { ReactElement } from 'react';
+import type { ReactElement} from 'react';
+import { useId } from 'react';
 import { useForm } from 'react-hook-form';
 
 import GenericModal from '../../../../components/GenericModal';
@@ -24,11 +25,16 @@ const wordBreak = css`
 
 const ReportMessageModal = ({ message, onClose }: ReportMessageModalProps): ReactElement => {
 	const t = useTranslation();
+	const reasonForReportId = useId();
 	const {
 		register,
 		formState: { errors },
 		handleSubmit,
-	} = useForm<ReportMessageModalsFields>();
+	} = useForm<ReportMessageModalsFields>({
+		defaultValues: {
+			description: '',
+		},
+	});
 	const dispatchToastMessage = useToastMessageDispatch();
 	const reportMessage = useEndpoint('POST', '/v1/chat.reportMessage');
 
@@ -49,20 +55,36 @@ const ReportMessageModal = ({ message, onClose }: ReportMessageModalProps): Reac
 		<GenericModal
 			wrapperFunction={(props) => <Box is='form' onSubmit={handleSubmit(handleReportMessage)} {...props} />}
 			variant='danger'
-			title={t('Report_this_message_question_mark')}
+			title={t('Report_Message')}
 			onClose={onClose}
 			onCancel={onClose}
-			confirmText={t('Report_exclamation_mark')}
+			confirmText={t('Report')}
 		>
 			<Box mbe={24} className={wordBreak}>
 				{message.md ? <MessageContentBody md={message.md} /> : <MarkdownText variant='inline' parseEmoji content={message.msg} />}
 			</Box>
 			<FieldGroup>
 				<Field>
+					<FieldLabel htmlFor={reasonForReportId}>{t('Report_reason')}</FieldLabel>
+										<FieldDescription id={`${reasonForReportId}-description`}>{t('Let_moderators_know_what_the_issue_is')}</FieldDescription>
 					<FieldRow>
-						<TextAreaInput {...register('description', { required: true })} placeholder={t('Why_do_you_want_to_report_question_mark')} />
+						<TextAreaInput
+							id={reasonForReportId}
+							rows={3}
+							width='full'
+							mbe={4}
+							aria-required='true'
+							aria-describedby={`${reasonForReportId}-description ${reasonForReportId}-error`}
+							{...register('description', {
+								required: t('Required_field', { field: t('Reason_for_report') }),
+							})}
+						/>
 					</FieldRow>
-					{errors.description && <FieldError>{t('You_need_to_write_something')}</FieldError>}
+					{errors.description && (
+  						<FieldError aria-live='assertive' id={`${reasonForReportId}-error`}>
+    						{errors.description.message}
+  						</FieldError>
+					)}
 				</Field>
 			</FieldGroup>
 		</GenericModal>

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -4243,6 +4243,7 @@
   "Report_Abuse": "Report Abuse",
   "Report_Number": "Report Number",
   "Report_User": "Report user",
+  "Report_Message": "Report message",
   "Report_exclamation_mark": "Report!",
   "Report_has_been_sent": "Report has been sent",
   "Report_reason": "Report reason",


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
This PR improves the accessibility and UX consistency of the **Report Message Modal**

### Changes made:
- Updated inline error to follow i18n and WCAG 3.3.1 (Error Identification)
- Added accessible label–input–error linking via `useId()` and `aria-describedby`
- Added `Report_Message` key to `en.i18n.json`
- Synced text content and structure with the `ReportUserModal`

## Issue(s)
![image](https://github.com/user-attachments/assets/df6ff3b1-d53e-4cf0-a5da-0f6b66068f04)


## Steps to test or reproduce
#### Before:
![image](https://github.com/user-attachments/assets/9d87d22c-1bd6-4fba-8d18-90a879a00690)

#### After:
![Skärmbild 2025-06-26 102820](https://github.com/user-attachments/assets/54896ec7-9602-413f-9873-c812c503a96f)


## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
