### PR TITLE
regression: unread banner appears for thread messages after channel creation

### DIFF
--- a/apps/meteor/tests/e2e/threads.spec.ts
+++ b/apps/meteor/tests/e2e/threads.spec.ts
@@ -15,6 +15,19 @@ test.describe.serial('Threads', () => {
 		await page.goto('/home');
 		await poHomeChannel.sidenav.openChat(targetChannel);
 	});
+
+	test('expect no unread banner when replying to a thread in a fresh channel', async ({ page }) => {
+		await poHomeChannel.content.sendMessage('parent for unread-banner test');
+		await page.locator('[data-qa-type="message"]').last().hover();
+		await page.getByRole('button', { name: 'Reply in thread' }).click();
+		const threadDialog = page.getByRole('dialog');
+		await threadDialog.locator('[name="msg"]').last().fill('first thread reply');
+		await page.keyboard.press('Enter');
+
+		await page.waitForTimeout(200);
+		await expect(page.getByTitle('Mark as read')).not.toBeVisible();
+	});
+
 	test('expect thread message preview if alsoSendToChannel checkbox is checked', async ({ page }) => {
 		await poHomeChannel.content.sendMessage('this is a message for reply');
 		await page.locator('[data-qa-type="message"]').last().hover();

--- a/apps/meteor/tests/e2e/threads.spec.ts
+++ b/apps/meteor/tests/e2e/threads.spec.ts
@@ -1,6 +1,6 @@
 import { Users } from './fixtures/userStates';
 import { HomeChannel } from './page-objects';
-import { createTargetChannel } from './utils';
+import { createTargetChannel, deleteChannel } from './utils';
 import { expect, test } from './utils/test';
 
 test.use({ storageState: Users.admin.state });
@@ -16,13 +16,12 @@ test.describe.serial('Threads', () => {
 		await poHomeChannel.sidenav.openChat(targetChannel);
 	});
 
+	test.afterAll(async ({ api }) => deleteChannel(api, targetChannel));
+
 	test('expect no unread banner when replying to a thread in a fresh channel', async ({ page }) => {
 		await poHomeChannel.content.sendMessage('parent for unread-banner test');
-		await page.locator('[data-qa-type="message"]').last().hover();
-		await page.getByRole('button', { name: 'Reply in thread' }).click();
-		const threadDialog = page.getByRole('dialog');
-		await threadDialog.locator('[name="msg"]').last().fill('first thread reply');
-		await page.keyboard.press('Enter');
+		await poHomeChannel.content.openReplyInThread();
+		await poHomeChannel.content.sendMessageInThread('first thread reply');
 
 		await page.waitForTimeout(200);
 		await expect(page.getByTitle('Mark as read')).not.toBeVisible();


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
When you create a brand-new channel and immediately reply to your own message in a thread, the unread-messages banner was showing up even though you hadn’t missed anything. This happened because the baseline timestamp (lastMessageDate) stayed undefined until an off-screen message was detected, so every reply looked like “new” content. Now, on first load—when the message count goes from zero to some number—we set lastMessageDate to the newest message’s timestamp, giving the unread-count logic a proper anchor and preventing self-sent thread replies from ever triggering the banner.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-1214](https://rocketchat.atlassian.net/browse/CORE-1214)

[CORE-1214]: https://rocketchat.atlassian.net/browse/CORE-1214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ