### PR TITLE
feat: Improve AutoCompleteDepartment loading state

### DIFF
--- a/apps/meteor/client/components/AutoCompleteDepartment.spec.tsx
+++ b/apps/meteor/client/components/AutoCompleteDepartment.spec.tsx
@@ -1,0 +1,43 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { render, screen } from '@testing-library/react';
+
+import AutoCompleteDepartment from './AutoCompleteDepartment';
+import { useDepartmentsList } from './Omnichannel/hooks/useDepartmentsList';
+
+jest.mock('./Omnichannel/hooks/useDepartmentsList');
+
+const useDepartmentsListMocked = jest.mocked(useDepartmentsList);
+
+const appRoot = mockAppRoot().build();
+
+describe('AutoCompleteDepartment', () => {
+	beforeEach(() => {
+		useDepartmentsListMocked.mockClear();
+	});
+
+	it('should render loading state correctly', () => {
+		useDepartmentsListMocked.mockReturnValue({
+			data: [],
+			isPending: true,
+			fetchNextPage: jest.fn(),
+		} as unknown as ReturnType<typeof useDepartmentsList>);
+
+		const { rerender } = render(<AutoCompleteDepartment value='' onChange={jest.fn()} />, { wrapper: appRoot });
+
+		expect(screen.getByPlaceholderText('Loading...')).toBeInTheDocument();
+		expect(screen.queryByPlaceholderText('Select_an_option')).not.toBeInTheDocument();
+		expect(screen.getByRole('textbox')).toBeDisabled();
+
+		useDepartmentsListMocked.mockReturnValue({
+			data: [],
+			isPending: false,
+			fetchNextPage: jest.fn(),
+		} as unknown as ReturnType<typeof useDepartmentsList>);
+
+		rerender(<AutoCompleteDepartment value='' onChange={jest.fn()} />);
+
+		expect(screen.getByPlaceholderText('Select_an_option')).toBeInTheDocument();
+		expect(screen.queryByPlaceholderText('Loading...')).not.toBeInTheDocument();
+		expect(screen.getByRole('textbox')).toBeEnabled();
+	});
+});

--- a/apps/meteor/client/components/AutoCompleteDepartment.tsx
+++ b/apps/meteor/client/components/AutoCompleteDepartment.tsx
@@ -26,6 +26,7 @@ const AutoCompleteDepartment = ({
 	haveAll,
 	haveNone,
 	showArchived = false,
+	disabled,
 	...props
 }: AutoCompleteDepartmentProps): ReactElement | null => {
 	const { t } = useTranslation();
@@ -33,7 +34,11 @@ const AutoCompleteDepartment = ({
 
 	const debouncedDepartmentsFilter = useDebouncedValue(departmentsFilter, 500);
 
-	const { data: departmentsItems, fetchNextPage } = useDepartmentsList({
+	const {
+		data: departmentsItems,
+		isPending,
+		fetchNextPage,
+	} = useDepartmentsList({
 		filter: debouncedDepartmentsFilter,
 		onlyMyDepartments,
 		haveAll,
@@ -51,9 +56,12 @@ const AutoCompleteDepartment = ({
 			value={value}
 			onChange={onChange}
 			filter={departmentsFilter}
+			disabled={isPending || disabled}
+			aria-busy={isPending}
+			aria-disabled={disabled}
 			setFilter={setDepartmentsFilter as (value?: string | number) => void}
 			options={departmentsItems}
-			placeholder={t('Select_an_option')}
+			placeholder={isPending ? t('Loading...') : t('Select_an_option')}
 			data-qa='autocomplete-department'
 			endReached={() => fetchNextPage()}
 			renderItem={({ label, ...props }) => <Option {...props} label={<span style={{ whiteSpace: 'normal' }}>{label}</span>} />}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR enhances the user experience of the AutoCompleteDepartment component during its loading phase.
- Prevents user interaction: The field is now disabled while fetching data.
- Improves feedback: A "Loading..." placeholder text is shown.
- Improves accessibility: The `aria-busy="true"` attribute is added to inform screen readers that the component is loading.

## Issue(s)
[CTZ-194](https://rocketchat.atlassian.net/browse/CTZ-194)

## Steps to test or reproduce

- Navigate to one of the following pages:
   - Analytics
   - Canned Responses
   - Edit Department
- Open your browser's Developer Tools and go to the "Network" tab.
- Throttle the connection speed (e.g., to "Slow 3G").
- Refresh the page or interact with the AutoCompleteDepartment component.
- The component should appear disabled with a "Loading..." placeholder text.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
