### PR TITLE
feat: Add Timestamp-Based Filtering to RoomBridge getMessages and Improve RoomRead Tests

### DIFF
--- a/.changeset/giant-parents-repeat.md
+++ b/.changeset/giant-parents-repeat.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/apps-engine': minor
+'@rocket.chat/meteor': minor
+---
+
+Adds createdAt and updatedAt filters to the getMessages method to allow filtering messages by date.

--- a/apps/meteor/app/apps/server/bridges/rooms.ts
+++ b/apps/meteor/app/apps/server/bridges/rooms.ts
@@ -135,26 +135,26 @@ export class AppRoomBridge extends RoomBridge {
 
 		// Add timestamp filters if provided
 		if (createdAt) {
-			// createdAt: { $gte, $lte }
-			if (createdAt.$gte || createdAt.$lte) {
+			// createdAt: { start, end }
+			if (createdAt.start || createdAt.end) {
 				query.ts = {};
-				if (createdAt.$gte) {
-					query.ts.$gte = createdAt.$gte;
+				if (createdAt.start) {
+					query.ts.$gte = createdAt.start;
 				}
-				if (createdAt.$lte) {
-					query.ts.$lte = createdAt.$lte;
+				if (createdAt.end) {
+					query.ts.$lte = createdAt.end;
 				}
 			}
 		}
 		if (updatedAt) {
-			// updatedAt: { $gte, $lte }
-			if (updatedAt.$gte || updatedAt.$lte) {
+			// updatedAt: { start, end }
+			if (updatedAt.start || updatedAt.end) {
 				query._updatedAt = {};
-				if (updatedAt.$gte) {
-					query._updatedAt.$gte = updatedAt.$gte;
+				if (updatedAt.start) {
+					query._updatedAt.$gte = updatedAt.start;
 				}
-				if (updatedAt.$lte) {
-					query._updatedAt.$lte = updatedAt.$lte;
+				if (updatedAt.end) {
+					query._updatedAt.$lte = updatedAt.end;
 				}
 			}
 		}

--- a/packages/apps-engine/src/definition/accessors/IRoomRead.ts
+++ b/packages/apps-engine/src/definition/accessors/IRoomRead.ts
@@ -49,6 +49,8 @@ export interface IRoomRead {
 	 *                - skip: The number of messages to skip (for pagination).
 	 *                - sort: An object defining the sorting order of the messages. Each key is a field to sort by, and the value is either "asc" for ascending order or "desc" for descending order.
 	 *                - showThreadMessages: Whether to include thread messages in the results. Defaults to true.
+	 * 			  	  - createdAt: An object with optional start and end properties, both of which should be Date objects, to filter messages by creation time.
+	 * 			      - updatedAt: An object with optional start and end properties, both of which should be Date objects, to filter messages by last update time.
 	 * @returns A Promise that resolves to an array of IMessage objects representing the messages in the room.
 	 */
 	getMessages(roomId: string, options?: Partial<GetMessagesOptions>): Promise<Array<IMessageRaw>>;

--- a/packages/apps-engine/src/server/accessors/RoomRead.ts
+++ b/packages/apps-engine/src/server/accessors/RoomRead.ts
@@ -39,6 +39,14 @@ export class RoomRead implements IRoomRead {
 			this.validateSort(options.sort);
 		}
 
+		// Ensure that date fields are Date objects
+		if (options.createdAt && !(options.createdAt instanceof Date)) {
+			throw new Error('Invalid createdAt: must be a Date object');
+		}
+		if (options.updatedAt && !(options.updatedAt instanceof Date)) {
+			throw new Error('Invalid updatedAt: must be a Date object');
+		}
+
 		return this.roomBridge.doGetMessages(roomId, options as GetMessagesOptions, this.appId);
 	}
 

--- a/packages/apps-engine/src/server/accessors/RoomRead.ts
+++ b/packages/apps-engine/src/server/accessors/RoomRead.ts
@@ -39,12 +39,24 @@ export class RoomRead implements IRoomRead {
 			this.validateSort(options.sort);
 		}
 
-		// Ensure that date fields are Date objects
-		if (options.createdAt && !(options.createdAt instanceof Date)) {
-			throw new Error('Invalid createdAt: must be a Date object');
+		if (options.createdAt) {
+			if (typeof options.createdAt === 'object') {
+				const { start, end } = options.createdAt as any;
+				if (start && !(start instanceof Date)) throw new Error('createdAt.start must be a Date');
+				if (end && !(end instanceof Date)) throw new Error('createdAt.end must be a Date');
+			} else {
+				throw new Error('Invalid createdAt: must be a { start, end }');
+			}
 		}
-		if (options.updatedAt && !(options.updatedAt instanceof Date)) {
-			throw new Error('Invalid updatedAt: must be a Date object');
+
+		if (options.updatedAt) {
+			if (typeof options.updatedAt === 'object') {
+				const { start, end } = options.updatedAt as any;
+				if (start && !(start instanceof Date)) throw new Error('updatedAt.start must be a Date');
+				if (end && !(end instanceof Date)) throw new Error('updatedAt.end must be a Date');
+			} else {
+				throw new Error('Invalid updatedAt: must be a { start, end }');
+			}
 		}
 
 		return this.roomBridge.doGetMessages(roomId, options as GetMessagesOptions, this.appId);

--- a/packages/apps-engine/src/server/accessors/RoomRead.ts
+++ b/packages/apps-engine/src/server/accessors/RoomRead.ts
@@ -45,7 +45,7 @@ export class RoomRead implements IRoomRead {
 				if (start && !(start instanceof Date)) throw new Error('createdAt.start must be a Date');
 				if (end && !(end instanceof Date)) throw new Error('createdAt.end must be a Date');
 			} else {
-				throw new Error('Invalid createdAt: must be a { start, end }');
+				throw new Error('createdAt filter must be an object with optional `start` and `end` Date properties.');
 			}
 		}
 
@@ -55,7 +55,7 @@ export class RoomRead implements IRoomRead {
 				if (start && !(start instanceof Date)) throw new Error('updatedAt.start must be a Date');
 				if (end && !(end instanceof Date)) throw new Error('updatedAt.end must be a Date');
 			} else {
-				throw new Error('Invalid updatedAt: must be a { start, end }');
+				throw new Error('updatedAt filter must be an object with optional `start` and `end` Date properties.');
 			}
 		}
 

--- a/packages/apps-engine/src/server/bridges/RoomBridge.ts
+++ b/packages/apps-engine/src/server/bridges/RoomBridge.ts
@@ -13,6 +13,8 @@ export type GetMessagesOptions = {
 	skip: number;
 	sort: Record<(typeof GetMessagesSortableFields)[number], 'asc' | 'desc'>;
 	showThreadMessages: boolean;
+	createdAt?: Date;
+	updatedAt?: Date;
 };
 
 export abstract class RoomBridge extends BaseBridge {

--- a/packages/apps-engine/src/server/bridges/RoomBridge.ts
+++ b/packages/apps-engine/src/server/bridges/RoomBridge.ts
@@ -13,8 +13,8 @@ export type GetMessagesOptions = {
 	skip: number;
 	sort: Record<(typeof GetMessagesSortableFields)[number], 'asc' | 'desc'>;
 	showThreadMessages: boolean;
-	createdAt?: Date;
-	updatedAt?: Date;
+	createdAt?: { start?: Date; end?: Date };
+	updatedAt?: { start?: Date; end?: Date };
 };
 
 export abstract class RoomBridge extends BaseBridge {

--- a/packages/apps-engine/tests/server/accessors/RoomRead.spec.ts
+++ b/packages/apps-engine/tests/server/accessors/RoomRead.spec.ts
@@ -113,7 +113,7 @@ export class RoomReadAccessorTestFixture {
 	public async getMessages_withCreatedAtFilter() {
 		const rr = new RoomRead(this.mockRoomBridgeWithRoom, 'testing-app');
 		const date = new Date();
-		const messages = await rr.getMessages('testing', { createdAt: date });
+		const messages = await rr.getMessages('testing', { createdAt: { start: date, end: date } });
 		Expect(messages).toBe(this.messages);
 	}
 
@@ -121,7 +121,7 @@ export class RoomReadAccessorTestFixture {
 	public async getMessages_withUpdatedAtFilter() {
 		const rr = new RoomRead(this.mockRoomBridgeWithRoom, 'testing-app');
 		const date = new Date();
-		const messages = await rr.getMessages('testing', { updatedAt: date });
+		const messages = await rr.getMessages('testing', { updatedAt: { start: date, end: date } });
 		Expect(messages).toBe(this.messages);
 	}
 

--- a/packages/apps-engine/tests/server/accessors/RoomRead.spec.ts
+++ b/packages/apps-engine/tests/server/accessors/RoomRead.spec.ts
@@ -101,4 +101,51 @@ export class RoomReadAccessorTestFixture {
 		Expect((await rr.getMembers('testing')) as Array<IUser>).not.toBeEmpty();
 		Expect((await rr.getMembers('testing'))[0]).toBe(this.user);
 	}
+
+	@AsyncTest()
+	public async getMessages_withLimitAndSort() {
+		const rr = new RoomRead(this.mockRoomBridgeWithRoom, 'testing-app');
+		const messages = await rr.getMessages('testing', { limit: 1, sort: { createdAt: 'asc' } });
+		Expect(messages).toBe(this.messages);
+	}
+
+	@AsyncTest()
+	public async getMessages_withCreatedAtFilter() {
+		const rr = new RoomRead(this.mockRoomBridgeWithRoom, 'testing-app');
+		const date = new Date();
+		const messages = await rr.getMessages('testing', { createdAt: date });
+		Expect(messages).toBe(this.messages);
+	}
+
+	@AsyncTest()
+	public async getMessages_withUpdatedAtFilter() {
+		const rr = new RoomRead(this.mockRoomBridgeWithRoom, 'testing-app');
+		const date = new Date();
+		const messages = await rr.getMessages('testing', { updatedAt: date });
+		Expect(messages).toBe(this.messages);
+	}
+
+	@AsyncTest()
+	public async getMessages_invalidLimitThrows() {
+		const rr = new RoomRead(this.mockRoomBridgeWithRoom, 'testing-app');
+		await Expect(async () => rr.getMessages('testing', { limit: 101 })).toThrowAsync();
+	}
+
+	@AsyncTest()
+	public async getMessages_invalidSortThrows() {
+		const rr = new RoomRead(this.mockRoomBridgeWithRoom, 'testing-app');
+		await Expect(async () => rr.getMessages('testing', { sort: { invalidField: 'asc' } as any })).toThrowAsync();
+	}
+
+	@AsyncTest()
+	public async getMessages_invalidCreatedAtThrows() {
+		const rr = new RoomRead(this.mockRoomBridgeWithRoom, 'testing-app');
+		await Expect(async () => rr.getMessages('testing', { createdAt: 'not-a-date' as any })).toThrowAsync();
+	}
+
+	@AsyncTest()
+	public async getMessages_invalidUpdatedAtThrows() {
+		const rr = new RoomRead(this.mockRoomBridgeWithRoom, 'testing-app');
+		await Expect(async () => rr.getMessages('testing', { updatedAt: 'not-a-date' as any })).toThrowAsync();
+	}
 }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
This PR adds support for timestamp-based filtering to the `getMessages` method in the Apps-Engine RoomBridge and related classes. It also improves and extends the test coverage for message retrieval, including validation and error cases.

- **RoomBridge & GetMessagesOptions**
  - Extended `GetMessagesOptions` to include optional `createdAt` and `updatedAt` fields for filtering messages by creation and update timestamps.
  - Updated the abstract and concrete `getMessages` implementations to map these options to the correct message fields (`ts` for `createdAt`, `_updatedAt` for `updatedAt`).

- **RoomRead**
  - Ensured that `createdAt` and `updatedAt` are validated before passing to the bridge.
  - Passed these filters through to the bridge layer for backend filtering.

- **Testing**
  - Added and improved tests in `RoomRead.spec.ts` to cover:
    - Filtering by `createdAt` and `updatedAt`
    - Invalid filter values (non-Date)
    - Invalid sort fields and limits
    - General retrieval and error scenarios

These changes allow app developers to retrieve messages from a room based on creation or update timestamps, improving the flexibility and power of the Apps-Engine API. The changes are backward compatible and covered by comprehensive unit tests.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[RCAI5-9](https://rocketchat.atlassian.net/browse/RCAI5-9)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->


```ts
// Helper function to test getMessages with different parameters
        const testGetMessages = async (params: any, description: string) => {
            try {
                const messages = await read
                    .getRoomReader()
                    .getMessages(roomName, params);
                console.log(
                    `${description}:---------------\n`,
                    messages,
                    `--------------\nTotal Messages: ${messages.length}\n\n\n`
                );
            } catch (error) {
                console.error(
                    `Error fetching messages with ${description}:`,
                    error
                );
            }
        };

const startDate = new Date("2025-06-01T00:00:00Z");
        const endDate = new Date("2025-07-07T11:38:00.000Z");
        await testGetMessages(
            {
                createdAt: {
                    start: startDate,
                    end: endDate,
                },
            },
            "test date for createdAt"
        );
```

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[RCAI5-9]: https://rocketchat.atlassian.net/browse/RCAI5-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ