### PR TITLE
Harsh sharma225/23977

### DIFF
--- a/apps/meteor/app/lib/server/lib/notifyUsersOnMessage.ts
+++ b/apps/meteor/app/lib/server/lib/notifyUsersOnMessage.ts
@@ -127,8 +127,8 @@ async function updateUsersSubscriptions(message: IMessage, room: IRoom): Promise
 	}
 
 	if (!toAll && !toHere && (unreadCount === 'all_messages' || room.t === 'd')) {
-	await Subscriptions.incUnreadForRoomIdExcludingUserIds(room._id, [...userIds, message.u._id], 1);
-}
+		await Subscriptions.incUnreadForRoomIdExcludingUserIds(room._id, [...userIds, message.u._id], 1);
+	}
 
 	// update subscriptions of other members of the room
 	await Promise.all([

--- a/apps/meteor/app/lib/server/lib/notifyUsersOnMessage.ts
+++ b/apps/meteor/app/lib/server/lib/notifyUsersOnMessage.ts
@@ -126,9 +126,9 @@ async function updateUsersSubscriptions(message: IMessage, room: IRoom): Promise
 		await Subscriptions.incGroupMentionsAndUnreadForRoomIdExcludingUserId(room._id, message.u._id, 1, groupMentionInc);
 	}
 
-	if (!toAll && !toHere && unreadCount === 'all_messages') {
-		await Subscriptions.incUnreadForRoomIdExcludingUserIds(room._id, [...userIds, message.u._id], 1);
-	}
+	if (!toAll && !toHere && (unreadCount === 'all_messages' || room.t === 'd')) {
+	await Subscriptions.incUnreadForRoomIdExcludingUserIds(room._id, [...userIds, message.u._id], 1);
+}
 
 	// update subscriptions of other members of the room
 	await Promise.all([


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
Fixes unread count for DMs:
 Ensures that the unread count is always incremented for direct messages (DMs), regardless of the Unread_Count_DM admin setting.
This makes the /api/v1/subscriptions.get API and UI unread badge reflect the correct number of unread DMs for all users.

Technical change:
 In updateUsersSubscriptions, the logic was updated so that for DMs (room.t === 'd'), the unread count is always incremented for all recipients except the sender and mentioned users.

## Issue(s)
Closes #23977 — Private message unread count 0 for normal user

## Steps to test or reproduce
1. Send a direct message (DM) to a user.
2. As the recipient, do not open/read the DM.
3. Call the /api/v1/subscriptions.get endpoint as the recipient.

Expected: The unread field for the DM should increment and reflect the correct number of unread messages.
Before this fix: The unread field would remain 0 unless the admin setting was changed.
After this fix: The unread field increments for every new DM, regardless of settings.

## Further comments
This change is targeted and only affects the unread logic for DMs, making the unread count behavior consistent and user-friendly.
No changes are made to channel or group unread logic.
No breaking changes or new settings are introduced.
