### PR TITLE
test: adding type-level test for chat.postMessage POST bodyParams returning correct type

### DIFF
--- a/apps/meteor/app/api/server/definition.spec.ts
+++ b/apps/meteor/app/api/server/definition.spec.ts
@@ -12,6 +12,11 @@ type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 interface IChatPostMessageBody {
 	channal: string;
 	text: string;
+	attachments?: Array<{
+		text: string;
+		color?: string;
+		image_url?: string;
+	}>;
 }
 type ChatPostMessageBodyValidator = ValidateFunction<IChatPostMessageBody>;
 
@@ -31,7 +36,7 @@ type ExpectedActionThis = {
 	urlParams: never;
 	readonly response: Response;
 	readonly queryParams: Record<string, string>;
-	readonly bodyParams: IChatPostMessageBody;
+	readonly bodyParams: ChatPostMessageBodyValidator;
 	readonly request: Request;
 	readonly queryOperations: never;
 	parseJsonQuery: () => Promise<{


### PR DESCRIPTION
### Description

This PR adds a **test scenario for the POST method of `/v1/chat.postMessage`**. The purpose is to check whether the `bodyParams` type returns `never` or the expected `bodyParams` type content.

The test uses **type-level assertions** with both `ActionType` and `InnerActionType` to ensure that the return type for `bodyParams` is correct. Essentially, it verifies if `bodyParams` returns its defined type or something else (such as `never` or a generic type).

---

### Context

Previously, when using the GET method, the returned `bodyParams` type was an abstract version like `Record<string, unknown>`, which is expected because GET does not have a body by default. However, when testing with the POST method, the `bodyParams` type was returning `never` instead of its actual defined type. This test is added to validate and prevent such issues in the type inference of our OpenAPI schema definitions.

---

### Issue(s) Addressed

* **Fixes:** Issue #35923
* **Replaces:** PR #36093
* **Related to:** #36090

---

### Steps to Test or Reproduce

1. **Run the type-level tests** included in this PR.
2. **Observe the results:**

   * For the **GET method**, the `bodyParams` type should return an abstract type like `Record<string, unknown>`, as GET does not define a body schema.
   * For the **POST method**, it should return the actual `bodyParams` type instead of `never`.
