### PR TITLE
fix(ux): Inline-Errors in LoginForm

### DIFF
--- a/packages/web-ui-registration/src/LoginForm.tsx
+++ b/packages/web-ui-registration/src/LoginForm.tsx
@@ -185,7 +185,7 @@ export const LoginForm = ({ setLoginRoute }: { setLoginRoute: DispatchLoginRoute
 											required: t('Required_field', { field: t('registration.component.form.emailOrUsername') }),
 										})}
 										placeholder={usernameOrEmailPlaceholder || t('registration.component.form.emailPlaceholder')}
-										error={errors.usernameOrEmail?.message || hasAuthError ? errors.password?.message : undefined}
+										error={errors.usernameOrEmail?.message || (hasAuthError ? errors.password?.message : undefined)}
 										aria-invalid={errors.usernameOrEmail || hasAuthError || errorOnSubmit ? 'true' : 'false'}
 										aria-describedby={`${usernameId}-error`}
 										id={usernameId}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
Replaced the existing Callout notification for wrong credentials on the login page with inline <FieldError> messages under the corresponding input fields (email/username and password).

**Before:**
<img width="720" height="546" alt="image" src="https://github.com/user-attachments/assets/7bbf993e-6a55-4f60-8d6a-1b62ce827a09" />

**After:**
<img width="722" height="508" alt="image" src="https://github.com/user-attachments/assets/8548503d-6f2c-4269-b35f-bcf3cd193a33" />

## Issue(s)
Helping the design team implement inline error messages based on the Figma mockup:

<img width="2880" height="1600" alt="image" src="https://github.com/user-attachments/assets/456d62e3-0492-4b00-b9cd-b1d2acaa933f" />


## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
Note: The password mask characters (***) and the eye toggle icon currently inherit the error color and turn red,this is a fuselage styling issue and will be fixed by others.

[COMM-144]
[WA-55]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Form validation errors now automatically clear when you modify the username/email or password fields
  * Login error messages now provide more specific feedback for different error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[WA-55]: https://rocketchat.atlassian.net/browse/WA-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[COMM-144]: https://rocketchat.atlassian.net/browse/COMM-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ