### PR TITLE
fix: update error type for invalid parameters in Router class

### DIFF
--- a/.changeset/silly-laws-act.md
+++ b/.changeset/silly-laws-act.md
@@ -1,5 +1,4 @@
 ---
-"@rocket.chat/meteor": patch
 "@rocket.chat/http-router": patch
 ---
 

--- a/.changeset/silly-laws-act.md
+++ b/.changeset/silly-laws-act.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/meteor": patch
+"@rocket.chat/http-router": patch
+---
+
+This change fixes the HTTP route validation to return the correct error message 'invalid-params' instead of 'error-invalid-params', ensuring consistency with our API error codes. The body validation should now return 'invalid-params' instead of 'error-invalid-params'.'

--- a/packages/http-router/src/Router.spec.ts
+++ b/packages/http-router/src/Router.spec.ts
@@ -167,7 +167,7 @@ describe('Router', () => {
 			const invalidResponse = await request(app).get('/api/validate-query');
 
 			expect(invalidResponse.status).toBe(400);
-			expect(invalidResponse.body).toHaveProperty('errorType', 'invalid-params');
+			expect(invalidResponse.body).toHaveProperty('errorType', 'error-invalid-params');
 		});
 
 		it('should validate request body', async () => {

--- a/packages/http-router/src/Router.spec.ts
+++ b/packages/http-router/src/Router.spec.ts
@@ -167,7 +167,7 @@ describe('Router', () => {
 			const invalidResponse = await request(app).get('/api/validate-query');
 
 			expect(invalidResponse.status).toBe(400);
-			expect(invalidResponse.body).toHaveProperty('errorType', 'error-invalid-params');
+			expect(invalidResponse.body).toHaveProperty('errorType', 'invalid-params');
 		});
 
 		it('should validate request body', async () => {
@@ -207,12 +207,12 @@ describe('Router', () => {
 			const invalidResponse = await request(app).post('/api/validate-body').send({ name: 'John' });
 
 			expect(invalidResponse.status).toBe(400);
-			expect(invalidResponse.body).toHaveProperty('errorType', 'error-invalid-params');
+			expect(invalidResponse.body).toHaveProperty('errorType', 'invalid-params');
 
 			const invalidTypeResponse = await request(app).post('/api/validate-body').send({ name: 'John', age: 'thirty' });
 
 			expect(invalidTypeResponse.status).toBe(400);
-			expect(invalidTypeResponse.body).toHaveProperty('errorType', 'error-invalid-params');
+			expect(invalidTypeResponse.body).toHaveProperty('errorType', 'invalid-params');
 		});
 
 		it('should validate response body in test mode', async () => {

--- a/packages/http-router/src/Router.ts
+++ b/packages/http-router/src/Router.ts
@@ -218,7 +218,7 @@ export class Router<
 					return c.json(
 						{
 							success: false,
-							errorType: 'error-invalid-params',
+							errorType: 'invalid-params',
 							error: validatorFn.errors?.map((error: any) => error.message).join('\n '),
 						},
 						400,


### PR DESCRIPTION
**Description**

This PR fixes a bug in the HTTP route validation method where it was returning the wrong error message. Previously, it returned `'error-invalid-params'` instead of the expected `'invalid-params'`.

**Changes**

- Updated the HTTP route validation method to return `'invalid-params'` as intended.

**Motivation**

Returning the correct error message ensures consistency with our error handling standards and prevents potential issues in clients relying on specific error codes.

**Run OAuthApps Tests**

```bash
yarn testapi -f '[OAuthApps]'


  [OAuthApps]
    [/oauth-apps.list]
      ✔ should return an error when the user does not have the necessary permission (254ms)
      ✔ should return an array of oauth apps (201ms)
    [/oauth-apps.create]
      ✔ should return an error when the user does not have the necessary permission (380ms)
      ✔ should return an error when the 'name' property is invalid (47ms)
      ✔ should return an error when the 'redirectUri' property is invalid (50ms)
      ✔ should return an error when the 'active' property is not a boolean
      ✔ should create an oauthApp
    [/oauth-apps.get]
      ✔ should return a single oauthApp by client id
      ✔ should return a single oauthApp by _id
      ✔ should return a single oauthApp by appId (deprecated)
      ✔ should return only non sensitive information if user does not have the permission to manage oauth apps when searching by clientId (199ms)
      ✔ should return only non sensitive information if user does not have the permission to manage oauth apps when searching by _id (211ms)
      ✔ should return only non sensitive information if user does not have the permission to manage oauth apps when searching by appId (deprecated) (201ms)
      ✔ should fail returning an oauth app when an invalid id is provided (avoid NoSQL injections)
      ✔ should fail returning an oauth app when an invalid id string is provided (avoid NoSQL injections)
      ✔ should fail returning an oauth app when an invalid clientId is provided (avoid NoSQL injections)
      ✔ should fail returning an oauth app when an invalid clientId string is provided (avoid NoSQL injections)
      ✔ should fail returning an oauth app when an invalid appId is provided (avoid NoSQL injections; deprecated)
      ✔ should fail returning an oauth app when an invalid appId string is provided (avoid NoSQL injections; deprecated)
    [/oauth-apps.update]
      ✔ should update an app's name, its Active and Redirect URI fields correctly by its id
      ✔ should fail updating an app if user does NOT have the manage-oauth-apps permission (188ms)
    [/oauth-apps.delete]
      ✔ should delete an app by its id
      ✔ should fail deleting an app by its id if user does NOT have the manage-oauth-apps permission (181ms)


  23 passing (4s)
  ```

