### PR TITLE
feat: Added annotation to WizardActions component

### DIFF
--- a/packages/ui-client/src/components/Wizard/WizardActions.spec.tsx
+++ b/packages/ui-client/src/components/Wizard/WizardActions.spec.tsx
@@ -1,0 +1,20 @@
+import { composeStories } from '@storybook/react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import * as stories from './WizardActions.stories';
+
+const testCases = Object.values(composeStories(stories)).map((Story) => [Story.storyName || 'Story', Story]);
+
+test.each(testCases)(`renders %s without crashing`, async (_storyname, Story) => {
+	const tree = render(<Story />);
+	expect(tree.baseElement).toMatchSnapshot();
+});
+
+test.each(testCases)('%s should have no a11y violations', async (_storyname, Story) => {
+	const { container } = render(<Story />);
+
+	const results = await axe(container);
+	expect(results).toHaveNoViolations();
+});
+

--- a/packages/ui-client/src/components/Wizard/WizardActions.stories.tsx
+++ b/packages/ui-client/src/components/Wizard/WizardActions.stories.tsx
@@ -1,0 +1,49 @@
+import { Box } from '@rocket.chat/fuselage';
+import type { Meta, StoryFn } from '@storybook/react';
+import { ComponentProps } from 'react';
+
+import Wizard from './Wizard';
+import WizardActions from './WizardActions';
+import WizardBackButton from './WizardBackButton';
+import WizardNextButton from './WizardNextButton';
+import { useWizard } from './useWizard';
+
+export default {
+	title: 'Components/Wizard/WizardActions',
+	component: WizardActions,
+	decorators: (Story) => {
+		const wizardApi = useWizard({
+			steps: [
+				{ id: 'first-step', title: 'First step' },
+				{ id: 'second-step', title: 'Second step' },
+				{ id: 'third-step', title: 'Third step' },
+			],
+		});
+
+		return (
+			<Box width={600}>
+				<Wizard api={wizardApi}>
+					<Story />
+				</Wizard>
+			</Box>
+		);
+	},
+	parameters: {
+		layout: 'centered',
+	},
+} satisfies Meta<typeof WizardActions>;
+
+const Template: StoryFn<ComponentProps<typeof WizardActions>> = (args) => (
+	<WizardActions {...args}>
+		<WizardBackButton />
+		<WizardNextButton />
+	</WizardActions>
+);
+
+export const Default = Template.bind({});
+Default.args = {};
+
+export const WithAnnotation = Template.bind({});
+WithAnnotation.args = {
+	annotation: 'This is a sample annotation',
+};

--- a/packages/ui-client/src/components/Wizard/WizardActions.tsx
+++ b/packages/ui-client/src/components/Wizard/WizardActions.tsx
@@ -2,11 +2,18 @@ import { Box, ButtonGroup } from '@rocket.chat/fuselage';
 import type { ReactNode } from 'react';
 
 type WizardActionsProps = {
+	annotation?: string;
 	children: ReactNode;
 };
 
-const WizardActions = ({ children }: WizardActionsProps) => (
-	<Box className='steps-wizard-footer' pbs={24} display='flex' justifyContent='end'>
+const WizardActions = ({ annotation, children }: WizardActionsProps) => (
+	<Box className='steps-wizard-footer' pbs={24} display='flex' alignItems='center' justifyContent='end'>
+		{annotation ? (
+			<Box mie='auto' fontScale='c1' color='annotation'>
+				{annotation}
+			</Box>
+		) : null}
+
 		<ButtonGroup>{children}</ButtonGroup>
 	</Box>
 );

--- a/packages/ui-client/src/components/Wizard/__snapshots__/WizardActions.spec.tsx.snap
+++ b/packages/ui-client/src/components/Wizard/__snapshots__/WizardActions.spec.tsx.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`renders Default without crashing 1`] = `
+<body>
+  <div>
+    <div
+      class="rcx-box rcx-box--full rcx-css-1lvbc7v"
+    >
+      <div
+        class="steps-wizard"
+      >
+        <div
+          class="rcx-box rcx-box--full steps-wizard-footer rcx-css-7vikfg"
+        >
+          <div
+            class="rcx-button-group rcx-button-group--align-start"
+            role="group"
+          >
+            <button
+              class="rcx-box rcx-box--full rcx-button rcx-button-group__item"
+              disabled=""
+              type="button"
+            >
+              <span
+                class="rcx-button--content"
+              >
+                Back
+              </span>
+            </button>
+            <button
+              class="rcx-box rcx-box--full rcx-button--primary rcx-button rcx-button-group__item"
+              type="button"
+            >
+              <span
+                class="rcx-button--content"
+              >
+                Next
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`renders WithAnnotation without crashing 1`] = `
+<body>
+  <div>
+    <div
+      class="rcx-box rcx-box--full rcx-css-1lvbc7v"
+    >
+      <div
+        class="steps-wizard"
+      >
+        <div
+          class="rcx-box rcx-box--full steps-wizard-footer rcx-css-7vikfg"
+        >
+          <div
+            class="rcx-box rcx-box--full rcx-css-kqd92f"
+          >
+            This is a sample annotation
+          </div>
+          <div
+            class="rcx-button-group rcx-button-group--align-start"
+            role="group"
+          >
+            <button
+              class="rcx-box rcx-box--full rcx-button rcx-button-group__item"
+              disabled=""
+              type="button"
+            >
+              <span
+                class="rcx-button--content"
+              >
+                Back
+              </span>
+            </button>
+            <button
+              class="rcx-box rcx-box--full rcx-button--primary rcx-button rcx-button-group__item"
+              type="button"
+            >
+              <span
+                class="rcx-button--content"
+              >
+                Next
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR adds a new property `annotation` to `WizardActions` component that adds a small description besides the actions.

<img width="1002" height="118" alt="Screenshot 2025-07-30 at 14 09 24" src="https://github.com/user-attachments/assets/199ed9d8-92ab-4eed-80f1-fabf6f8d7fb3" />

## Issue(s)
[CTZ-188](https://rocketchat.atlassian.net/browse/CTZ-188)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
