### PR TITLE
feat: Add OpenAPI Support to oauth-apps.list API

### DIFF
--- a/.changeset/strange-worms-smoke.md
+++ b/.changeset/strange-worms-smoke.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/meteor": patch
+"@rocket.chat/rest-typings": patch
+---
+
+Add OpenAPI support for the Rocket.Chat oauth-apps.list API endpoints by migrating to a modern chained route definition syntax and utilizing shared AJV schemas for validation to enhance API documentation and ensure type safety through response validation.

--- a/apps/meteor/app/api/server/v1/oauthapps.ts
+++ b/apps/meteor/app/api/server/v1/oauthapps.ts
@@ -33,47 +33,9 @@ const oauthAppsListEndpoints = API.v1.get(
 		}),
 		permissionsRequired: ['manage-oauth-apps'],
 		response: {
-			400: ajv.compile<{
-				error?: string;
-				errorType?: string;
-				stack?: string;
-				details?: object;
-			}>({
-				type: 'object',
-				properties: {
-					success: { type: 'boolean', enum: [false] },
-					stack: { type: 'string' },
-					error: { type: 'string' },
-					errorType: { type: 'string' },
-					details: { type: 'object' },
-				},
-				required: ['success'],
-				additionalProperties: false,
-			}),
-			401: ajv.compile({
-				type: 'object',
-				properties: {
-					success: { type: 'boolean', enum: [false] },
-					status: { type: 'string' },
-					message: { type: 'string' },
-					error: { type: 'string' },
-					errorType: { type: 'string' },
-				},
-				required: ['success'],
-				additionalProperties: false,
-			}),
-			403: ajv.compile({
-				type: 'object',
-				properties: {
-					success: { type: 'boolean', enum: [false] },
-					status: { type: 'string' },
-					message: { type: 'string' },
-					error: { type: 'string' },
-					errorType: { type: 'string' },
-				},
-				required: ['success'],
-				additionalProperties: false,
-			}),
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 			200: ajv.compile<{ oauthApps: IOAuthApps[] }>({
 				type: 'object',
 				properties: {

--- a/apps/meteor/app/api/server/v1/oauthapps.ts
+++ b/apps/meteor/app/api/server/v1/oauthapps.ts
@@ -14,6 +14,15 @@ const oauthAppsListEndpoints = API.v1.get(
 	'oauth-apps.list',
 	{
 		authRequired: true,
+		query: ajv.compile<{ uid?: string }>({
+			type: 'object',
+			properties: {
+				uid: {
+					type: 'string',
+				},
+			},
+			additionalProperties: false,
+		}),
 		permissionsRequired: ['manage-oauth-apps'],
 		response: {
 			400: ajv.compile<{

--- a/apps/meteor/app/api/server/v1/oauthapps.ts
+++ b/apps/meteor/app/api/server/v1/oauthapps.ts
@@ -10,15 +10,77 @@ import { updateOAuthApp } from '../../../oauth2-server-config/server/admin/metho
 import type { ExtractRoutesFromAPI } from '../ApiClass';
 import { API } from '../api';
 
-API.v1.addRoute(
+const oauthAppsListEndpoints = API.v1.get(
 	'oauth-apps.list',
-	{ authRequired: true, permissionsRequired: ['manage-oauth-apps'] },
 	{
-		async get() {
-			return API.v1.success({
-				oauthApps: await OAuthApps.find().toArray(),
-			});
+		authRequired: true,
+		permissionsRequired: ['manage-oauth-apps'],
+		response: {
+			400: ajv.compile<{
+				error?: string;
+				errorType?: string;
+				stack?: string;
+				details?: object;
+			}>({
+				type: 'object',
+				properties: {
+					success: { type: 'boolean', enum: [false] },
+					stack: { type: 'string' },
+					error: { type: 'string' },
+					errorType: { type: 'string' },
+					details: { type: 'object' },
+				},
+				required: ['success'],
+				additionalProperties: false,
+			}),
+			401: ajv.compile({
+				type: 'object',
+				properties: {
+					success: { type: 'boolean', enum: [false] },
+					status: { type: 'string' },
+					message: { type: 'string' },
+					error: { type: 'string' },
+					errorType: { type: 'string' },
+				},
+				required: ['success'],
+				additionalProperties: false,
+			}),
+			403: ajv.compile({
+				type: 'object',
+				properties: {
+					success: { type: 'boolean', enum: [false] },
+					status: { type: 'string' },
+					message: { type: 'string' },
+					error: { type: 'string' },
+					errorType: { type: 'string' },
+				},
+				required: ['success'],
+				additionalProperties: false,
+			}),
+			200: ajv.compile<{ oauthApps: IOAuthApps[] }>({
+				type: 'object',
+				properties: {
+					oauthApps: {
+						type: 'array',
+						items: {
+							$ref: '#/components/schemas/IOAuthApps',
+						},
+					},
+					success: {
+						type: 'boolean',
+						enum: [true],
+					},
+				},
+				required: ['oauthApps', 'success'],
+				additionalProperties: false,
+			}),
 		},
+	},
+
+	async function action() {
+		return API.v1.success({
+			oauthApps: await OAuthApps.find().toArray(),
+		});
 	},
 );
 
@@ -182,9 +244,13 @@ const oauthAppsCreateEndpoints = API.v1.post(
 
 type OauthAppsCreateEndpoints = ExtractRoutesFromAPI<typeof oauthAppsCreateEndpoints>;
 
-export type OAuthAppsEndpoints = OauthAppsCreateEndpoints;
+type OauthAppsListEndpoints = ExtractRoutesFromAPI<typeof oauthAppsListEndpoints>;
+
+export type OAuthAppsEndpoints = OauthAppsCreateEndpoints | OauthAppsListEndpoints;
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	interface Endpoints extends OauthAppsCreateEndpoints {}
+	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
+	interface Endpoints extends OauthAppsListEndpoints {}
 }

--- a/packages/rest-typings/src/v1/oauthapps.ts
+++ b/packages/rest-typings/src/v1/oauthapps.ts
@@ -1,16 +1,10 @@
-import type { IOAuthApps, IUser } from '@rocket.chat/core-typings';
+import type { IOAuthApps } from '@rocket.chat/core-typings';
 
 import type { DeleteOAuthAppParams } from './oauthapps/DeleteOAuthAppParamsDELETE';
 import type { OauthAppsGetParams } from './oauthapps/OAuthAppsGetParamsGET';
 import type { UpdateOAuthAppParams } from './oauthapps/UpdateOAuthAppParamsPOST';
 
 export type OAuthAppsEndpoint = {
-	'/v1/oauth-apps.list': {
-		GET: (params: { uid: IUser['_id'] }) => {
-			oauthApps: IOAuthApps[];
-		};
-	};
-
 	'/v1/oauth-apps.get': {
 		GET: (params: OauthAppsGetParams) => {
 			oauthApp: IOAuthApps;


### PR DESCRIPTION
https://rocketchat.atlassian.net/browse/ARCH-1730
**Description:**  
This PR integrates OpenAPI support into the `Rocket.Chat API`, migrate of `Rocket.Chat API` endpoints to the new OpenAPI pattern. The update includes improved API documentation, enhanced type safety, and response validation using AJV.

**Key Changes:**  
- **Implemented the new pattern** and added AJV-based JSON schema validation for API.  
- **Uses the ExtractRoutesFromAPI utility** from the TypeScript definitions to dynamically derive the routes from the endpoint specifications.
- **Enabled Swagger UI** integration for this API.
- **This does not introduce any breaking changes** to the endpoint logic.

**Issue Reference:**  
Relates to #34983, part of the ongoing OpenAPI integration effort.

**Testing:**
- Verified that the API response schemas are correctly documented in Swagger UI.  
- All tests passed without any breaking changes

  ```shell
  $ yarn testapi -f '[OAuthApps]'        


  [OAuthApps]
    [/oauth-apps.list]
      ✔ should return an error when the user does not have the necessary permission (205ms)
      ✔ should return an array of oauth apps (183ms)
    [/oauth-apps.create]
      ✔ should return an error when the user does not have the necessary permission (382ms)
      ✔ should return an error when the 'name' property is invalid (115ms)
      ✔ should return an error when the 'redirectUri' property is invalid
      ✔ should return an error when the 'active' property is not a boolean
      ✔ should create an oauthApp (151ms)
    [/oauth-apps.get]
      ✔ should return a single oauthApp by client id
      ✔ should return a single oauthApp by _id
      ✔ should return a single oauthApp by appId (deprecated)
      ✔ should return only non sensitive information if user does not have the permission to manage oauth apps when searching by clientId (194ms)
      ✔ should return only non sensitive information if user does not have the permission to manage oauth apps when searching by _id (185ms)
      ✔ should return only non sensitive information if user does not have the permission to manage oauth apps when searching by appId (deprecated) (188ms)
      ✔ should fail returning an oauth app when an invalid id is provided (avoid NoSQL injections)
      ✔ should fail returning an oauth app when an invalid id string is provided (avoid NoSQL injections)
      ✔ should fail returning an oauth app when an invalid clientId is provided (avoid NoSQL injections)
      ✔ should fail returning an oauth app when an invalid clientId string is provided (avoid NoSQL injections)
      ✔ should fail returning an oauth app when an invalid appId is provided (avoid NoSQL injections; deprecated)
      ✔ should fail returning an oauth app when an invalid appId string is provided (avoid NoSQL injections; deprecated)
    [/oauth-apps.update]
      ✔ should update an app's name, its Active and Redirect URI fields correctly by its id
      ✔ should fail updating an app if user does NOT have the manage-oauth-apps permission (243ms)
    [/oauth-apps.delete]
      ✔ should delete an app by its id
      ✔ should fail deleting an app by its id if user does NOT have the manage-oauth-apps permission (176ms)


  23 passing (4s)
  ```

**Endpoints:**
- [x] [Get List of OAuth Apps](https://developer.rocket.chat/apidocs/get-list-of-oauth-apps)
  
  ![Get List of OAuth Apps](https://github.com/user-attachments/assets/3f5d7e78-4ffc-4a43-a107-9d8525b24cec "screenshot's Get List of OAuth Apps")



Looking forward to your feedback! 🚀