### PR TITLE
fix: create-c and create-p not being applied to Team Creation

### DIFF
--- a/apps/meteor/client/NavBarV2/NavBarPagesGroup/hooks/useCreateNewItems.tsx
+++ b/apps/meteor/client/NavBarV2/NavBarPagesGroup/hooks/useCreateNewItems.tsx
@@ -63,6 +63,6 @@ export const useCreateNewItems = (): GenericMenuItemProps[] => {
 		...(canCreateDirectMessages ? [createDirectMessageItem] : []),
 		...(canCreateDiscussion && discussionEnabled ? [createDiscussionItem] : []),
 		...(canCreateChannel ? [createChannelItem] : []),
-		...(canCreateTeam ? [createTeamItem] : []),
+		...(canCreateTeam && canCreateChannel ? [createTeamItem] : []),
 	];
 };

--- a/apps/meteor/client/sidebar/header/actions/hooks/useCreateRoomItems.tsx
+++ b/apps/meteor/client/sidebar/header/actions/hooks/useCreateRoomItems.tsx
@@ -63,6 +63,6 @@ export const useCreateRoomItems = (): GenericMenuItemProps[] => {
 		...(canCreateDirectMessages ? [createDirectMessageItem] : []),
 		...(canCreateDiscussion && discussionEnabled ? [createDiscussionItem] : []),
 		...(canCreateChannel ? [createChannelItem] : []),
-		...(canCreateTeam ? [createTeamItem] : []),
+		...(canCreateTeam && canCreateChannel ? [createTeamItem] : []),
 	];
 };


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

When the "Create Private/Public Channels" permission is turned off, the team creation UI still allows selecting a private team. However, attempting to create such a team results in an API error ("error-team-creation"). This is inconsistent with the channel creation UI, which disables the public/private toggle when the corresponding permission is off.

Since the Team has a main "channel", the user needs both create-team and create-c or create-p to be able to create a team

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

[SUP-747](https://rocketchat.atlassian.net/browse/SUP-747)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

Disable the "Create Private Channels" permission for the user role.

Attempt to create a new team with the payload:

For public team: {"name": "newest_team8", "type": 0} → Succeeds

For private team: {"name": "newest_team9", "type": 1} → Fails with "error-team-creation"
