### PR TITLE
fix:user avatar now updates everywhere in the UI with simple refresh

### DIFF
--- a/apps/meteor/client/components/message/variants/RoomMessage.tsx
+++ b/apps/meteor/client/components/message/variants/RoomMessage.tsx
@@ -22,6 +22,7 @@ import MessageHeader from '../MessageHeader';
 import MessageToolbarHolder from '../MessageToolbarHolder';
 import StatusIndicators from '../StatusIndicators';
 import RoomMessageContent from './room/RoomMessageContent';
+import { Users } from '../../../stores/Users';
 
 type RoomMessageProps = {
 	message: IMessage & { ignored?: boolean };
@@ -89,16 +90,23 @@ const RoomMessage = ({
 		>
 			<MessageLeftContainer>
 				{!sequential && message.u.username && !selecting && showUserAvatar && (
-					<MessageAvatar
-						emoji={message.emoji ? <Emoji emojiHandle={message.emoji} fillContainer /> : undefined}
-						avatarUrl={message.avatar}
-						username={message.u.username}
-						size='x36'
-						onClick={(e) => openUserCard(e, message.u.username)}
-						style={{ cursor: 'pointer' }}
-						role='button'
-						{...triggerProps}
-					/>
+					(() => {
+						const user = Users.state.find((u) => u.username === message.u.username);
+						const etag = user?.avatarETag;
+						const avatarUrl = etag ? `/avatar/${message.u.username}?etag=${etag}` : message.avatar;
+						return (
+							<MessageAvatar
+								emoji={message.emoji ? <Emoji emojiHandle={message.emoji} fillContainer /> : undefined}
+								avatarUrl={avatarUrl}
+								username={message.u.username}
+								size='x36'
+								onClick={(e) => openUserCard(e, message.u.username)}
+								style={{ cursor: 'pointer' }}
+								role='button'
+								{...triggerProps}
+							/>
+						);
+					})()
 				)}
 				{selecting && <CheckBox disabled={isOTRMsg} checked={selected} onChange={toggleSelected} />}
 				{sequential && <StatusIndicators message={message} />}

--- a/apps/meteor/client/components/message/variants/SystemMessage.tsx
+++ b/apps/meteor/client/components/message/variants/SystemMessage.tsx
@@ -36,6 +36,7 @@ import {
 	useMessageListFormatDateAndTime,
 	useMessageListFormatTime,
 } from '../list/MessageListContext';
+import { Users } from '../../../stores/Users';
 
 type SystemMessageProps = {
 	message: IMessage;
@@ -75,7 +76,11 @@ const SystemMessage = ({ message, showUserAvatar, ...props }: SystemMessageProps
 			{...props}
 		>
 			<MessageSystemLeftContainer>
-				{!isSelecting && showUserAvatar && <UserAvatar username={message.u.username} size='x18' />}
+				{!isSelecting && showUserAvatar && (() => {
+					const user = Users.state.find((u) => u.username === message.u.username);
+					const etag = user?.avatarETag;
+					return <UserAvatar username={message.u.username} etag={etag} size='x18' />;
+				})()}
 				{isSelecting && <CheckBox checked={isSelected} onChange={toggleSelected} />}
 			</MessageSystemLeftContainer>
 			<MessageSystemContainer>

--- a/apps/meteor/client/components/message/variants/ThreadMessage.tsx
+++ b/apps/meteor/client/components/message/variants/ThreadMessage.tsx
@@ -5,6 +5,7 @@ import { MessageAvatar } from '@rocket.chat/ui-avatar';
 import { useTranslation, useUserId } from '@rocket.chat/ui-contexts';
 import type { ReactElement } from 'react';
 import { memo } from 'react';
+import { Users } from '../../../stores/Users';
 
 import type { MessageActionContext } from '../../../../app/ui-utils/client/lib/MessageAction';
 import { useIsMessageHighlight } from '../../../views/room/MessageList/contexts/MessageHighlightContext';
@@ -56,16 +57,23 @@ const ThreadMessage = ({ message, sequential, unread, showUserAvatar }: ThreadMe
 		>
 			<MessageLeftContainer>
 				{!sequential && message.u.username && showUserAvatar && (
-					<MessageAvatar
-						emoji={message.emoji ? <Emoji emojiHandle={message.emoji} fillContainer /> : undefined}
-						avatarUrl={message.avatar}
-						username={message.u.username}
-						size='x36'
-						onClick={(e) => openUserCard(e, message.u.username)}
-						style={{ cursor: 'pointer' }}
-						role='button'
-						{...triggerProps}
-					/>
+					(() => {
+						const user = Users.state.find((u) => u.username === message.u.username);
+						const etag = user?.avatarETag;
+						const avatarUrl = etag ? `/avatar/${message.u.username}?etag=${etag}` : message.avatar;
+						return (
+							<MessageAvatar
+								emoji={message.emoji ? <Emoji emojiHandle={message.emoji} fillContainer /> : undefined}
+								avatarUrl={avatarUrl}
+								username={message.u.username}
+								size='x36'
+								onClick={(e) => openUserCard(e, message.u.username)}
+								style={{ cursor: 'pointer' }}
+								role='button'
+								{...triggerProps}
+							/>
+						);
+					})()
 				)}
 				{sequential && <StatusIndicators message={message} />}
 			</MessageLeftContainer>


### PR DESCRIPTION
## Fix: user avatar now updates everywhere in the UI with simple refresh

## Proposed changes (including videos or screenshots)

Fixes avatar caching issue where user avatars don't update consistently across the UI after profile picture changes. Previously, old messages and some UI elements would continue showing stale avatars until a hard refresh.

### Root Cause
- Avatar URLs lacked cache-busting parameters (`/avatar/username` vs `/avatar/username?etag=avatarETag`)
- Message components weren't using latest `avatarETag` from user data
- Browser caching prevented new avatar images from loading

### Solution
- Enhanced message components to lookup latest `avatarETag` from `Users` collection
- Construct cache-busting URLs: `/avatar/username?etag=avatarETag`
- Leverage existing real-time `user.avatarUpdate` events

### Files Modified
- `apps/meteor/client/components/message/variants/RoomMessage.tsx`
- `apps/meteor/client/components/message/variants/ThreadMessage.tsx`
- `apps/meteor/client/components/message/variants/SystemMessage.tsx`

## Issue(s)
User avatar doesn't update in real-time #36560

## Before fix

https://github.com/user-attachments/assets/7fa9528e-dfc3-47e2-b3a2-129f6d70b491

## After Fix


https://github.com/user-attachments/assets/bae95e21-13a9-4526-b691-2c75aa2ee3c3




## Further comments

Minimal fix that ensures all avatar URLs include cache-busting `etag` parameter, forcing browsers to load fresh images. Maintains existing functionality and performance.