### PR TITLE
fix: media playback failing due to expired urls

### DIFF
--- a/apps/meteor/app/file-upload/server/lib/FileUpload.ts
+++ b/apps/meteor/app/file-upload/server/lib/FileUpload.ts
@@ -589,6 +589,27 @@ export const FileUpload = {
 		res.end();
 	},
 
+	respondWithRedirectUrlInfo(
+		redirectUrl: string | false,
+		file: IUpload,
+		_req: http.IncomingMessage,
+		res: http.ServerResponse,
+		expiresInSeconds?: number | null,
+	) {
+		res.setHeader('Content-Type', 'application/json');
+		res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+		res.writeHead(200);
+		res.end(
+			JSON.stringify({
+				redirectUrl,
+				name: file.name,
+				type: file.type,
+				size: file.size,
+				...(expiresInSeconds && { expires: Date.now() / 1000 + expiresInSeconds }),
+			}),
+		);
+	},
+
 	proxyFile(
 		fileName: string,
 		fileUrl: string,

--- a/apps/meteor/app/file-upload/server/lib/requests.ts
+++ b/apps/meteor/app/file-upload/server/lib/requests.ts
@@ -1,7 +1,21 @@
+import type { IncomingMessage } from 'http';
+
 import { Uploads } from '@rocket.chat/models';
 import { WebApp } from 'meteor/webapp';
 
 import { FileUpload } from './FileUpload';
+
+const hasInfoParam = (req: IncomingMessage) => {
+	if (!req.url) {
+		return false;
+	}
+	const [, params] = req.url.split('?');
+	if (!params) {
+		return false;
+	}
+	const searchParams = new URLSearchParams(params);
+	return searchParams.has('info');
+};
 
 WebApp.connectHandlers.use(FileUpload.getPath(), async (req, res, next) => {
 	const match = /^\/([^\/]+)\/(.*)/.exec(req.url || '');
@@ -14,6 +28,23 @@ WebApp.connectHandlers.use(FileUpload.getPath(), async (req, res, next) => {
 				res.writeHead(403);
 				res.end();
 				return;
+			}
+
+			if (hasInfoParam(req)) {
+				if (!file.store) {
+					res.writeHead(404);
+					res.end();
+					return;
+				}
+				const store = FileUpload.getStoreByName(file.store);
+				let url: string | false;
+				try {
+					url = await store.getStore().getRedirectURL(file, false);
+				} catch {
+					url = false;
+				}
+				const expiryTimespan = await store.getStore().getUrlExpiryTimeSpan();
+				return FileUpload.respondWithRedirectUrlInfo(url, file, req, res, expiryTimespan);
 			}
 
 			res.setHeader('Content-Security-Policy', "default-src 'none'");

--- a/apps/meteor/app/file-upload/server/lib/requests.ts
+++ b/apps/meteor/app/file-upload/server/lib/requests.ts
@@ -14,7 +14,8 @@ const hasInfoParam = (req: IncomingMessage) => {
 		return false;
 	}
 	const searchParams = new URLSearchParams(params);
-	return searchParams.has('info');
+	const infoParam = searchParams.get('info');
+	return infoParam === 'true' || infoParam === '1';
 };
 
 WebApp.connectHandlers.use(FileUpload.getPath(), async (req, res, next) => {

--- a/apps/meteor/app/file-upload/ufs/AmazonS3/server.ts
+++ b/apps/meteor/app/file-upload/ufs/AmazonS3/server.ts
@@ -190,6 +190,10 @@ class AmazonS3Store extends UploadFS.Store {
 
 			return writeStream;
 		};
+
+		this.getUrlExpiryTimeSpan = async () => {
+			return options.URLExpiryTimeSpan || null;
+		};
 	}
 }
 

--- a/apps/meteor/client/components/message/content/attachments/file/AudioAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/AudioAttachment.tsx
@@ -1,7 +1,9 @@
 import type { AudioAttachmentProps } from '@rocket.chat/core-typings';
 import { AudioPlayer } from '@rocket.chat/fuselage';
 import { useMediaUrl } from '@rocket.chat/ui-contexts';
+import { useMemo } from 'react';
 
+import { useReloadOnError } from './hooks/useReloadOnError';
 import MarkdownText from '../../../../MarkdownText';
 import MessageCollapsible from '../../../MessageCollapsible';
 import MessageContentBody from '../../../MessageContentBody';
@@ -18,11 +20,14 @@ const AudioAttachment = ({
 	collapsed,
 }: AudioAttachmentProps) => {
 	const getURL = useMediaUrl();
+	const src = useMemo(() => getURL(url), [getURL, url]);
+	const { mediaRef } = useReloadOnError(src, 'audio');
+
 	return (
 		<>
 			{descriptionMd ? <MessageContentBody md={descriptionMd} /> : <MarkdownText parseEmoji content={description} />}
 			<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
-				<AudioPlayer src={getURL(url)} type={type} />
+				<AudioPlayer src={src} type={type} ref={mediaRef} />
 			</MessageCollapsible>
 		</>
 	);

--- a/apps/meteor/client/components/message/content/attachments/file/VideoAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/VideoAttachment.tsx
@@ -1,7 +1,9 @@
 import type { VideoAttachmentProps } from '@rocket.chat/core-typings';
 import { Box, MessageGenericPreview } from '@rocket.chat/fuselage';
 import { useMediaUrl } from '@rocket.chat/ui-contexts';
+import { useMemo } from 'react';
 
+import { useReloadOnError } from './hooks/useReloadOnError';
 import { userAgentMIMETypeFallback } from '../../../../../lib/utils/userAgentMIMETypeFallback';
 import MarkdownText from '../../../../MarkdownText';
 import MessageCollapsible from '../../../MessageCollapsible';
@@ -19,13 +21,15 @@ const VideoAttachment = ({
 	collapsed,
 }: VideoAttachmentProps) => {
 	const getURL = useMediaUrl();
+	const src = useMemo(() => getURL(url), [getURL, url]);
+	const { mediaRef } = useReloadOnError(src, 'video');
 
 	return (
 		<>
 			{descriptionMd ? <MessageContentBody md={descriptionMd} /> : <MarkdownText parseEmoji content={description} />}
 			<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
 				<MessageGenericPreview style={{ maxWidth: 368, width: '100%' }}>
-					<Box is='video' controls preload='metadata'>
+					<Box is='video' controls preload='metadata' ref={mediaRef}>
 						<source src={getURL(url)} type={userAgentMIMETypeFallback(type)} />
 					</Box>
 				</MessageGenericPreview>

--- a/apps/meteor/client/components/message/content/attachments/file/hooks/useReloadOnError.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/hooks/useReloadOnError.tsx
@@ -1,0 +1,144 @@
+import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
+import { useSafeRefCallback } from '@rocket.chat/ui-client';
+import { useCallback, useRef, useState } from 'react';
+
+const events = ['error', 'stalled', 'play'];
+export const useReloadOnError = (url: string, type: 'video' | 'audio') => {
+	const [expiresAt, setExpiresAt] = useState<number | null>(null);
+	const isRecovering = useRef(false);
+	const firstRecoveryAttempted = useRef(false);
+
+	const getURLInfo = useCallback(async (url: string): Promise<{ redirectUrl: string | false; expires: number | null }> => {
+		const [path, query] = url.split('?');
+		const params = new URLSearchParams(query);
+		params.set('info', 'true');
+		const response = await fetch(`${path}?${params.toString()}`, {
+			credentials: 'same-origin',
+		});
+
+		if (!response.ok) {
+			throw new Error(`Failed to fetch URL info: ${response.statusText}`);
+		}
+
+		const data = await response.json();
+
+		return {
+			redirectUrl: data.redirectUrl,
+			expires: data.expires ? new Date(data.expires * 1000).getTime() : null,
+		};
+	}, []);
+
+	const renderBufferingUIFallback = useCallback((vidEl: HTMLVideoElement) => {
+		const computed = getComputedStyle(vidEl);
+
+		const videoTempStyles = {
+			width: vidEl.style.width,
+			height: vidEl.style.height,
+		};
+		Object.assign(vidEl.style, {
+			width: computed.width,
+			height: computed.height,
+		});
+
+		return () => {
+			Object.assign(vidEl.style, videoTempStyles);
+		};
+	}, []);
+
+	const handleMediaURLRecovery = useEffectEvent(async (event: Event) => {
+		if (isRecovering.current) {
+			console.debug(`Media URL recovery already in progress, skipping ${event.type} event`);
+			return;
+		}
+		isRecovering.current = true;
+
+		const node = event.target as HTMLMediaElement | null;
+		if (!node) {
+			isRecovering.current = false;
+			return;
+		}
+
+		if (firstRecoveryAttempted.current && !expiresAt) {
+			console.debug('No expiration time set, skipping recovery');
+			isRecovering.current = false;
+			return;
+		}
+		firstRecoveryAttempted.current = true;
+
+		if (expiresAt && Date.now() < expiresAt) {
+			console.debug('Media URL is still valid, skipping recovery');
+			isRecovering.current = false;
+			return;
+		}
+
+		console.debug('Handling media URL recovery for event:', event.type);
+
+		let cleanup: (() => void) | undefined;
+		if (type === 'video') {
+			cleanup = renderBufferingUIFallback(node as HTMLVideoElement);
+		}
+
+		const wasPlaying = !node.paused;
+		const { currentTime } = node;
+
+		try {
+			const { redirectUrl: newUrl, expires: newExpiresAt } = await getURLInfo(url);
+			setExpiresAt(newExpiresAt);
+			node.src = newUrl || url;
+
+			const onCanPlay = async () => {
+				node.removeEventListener('canplay', onCanPlay);
+
+				node.currentTime = currentTime;
+				if (wasPlaying) {
+					try {
+						await node.play();
+					} catch (playError) {
+						console.warn('Failed to resume playback after URL recovery:', playError);
+					} finally {
+						isRecovering.current = false;
+					}
+				}
+			};
+
+			const onMetaDataLoaded = () => {
+				node.removeEventListener('loadedmetadata', onMetaDataLoaded);
+				isRecovering.current = false;
+				cleanup?.();
+			};
+
+			node.addEventListener('canplay', onCanPlay, { once: true });
+			node.addEventListener('loadedmetadata', onMetaDataLoaded, { once: true });
+			node.load();
+		} catch (err) {
+			console.error('Error during URL recovery:', err);
+			isRecovering.current = false;
+			cleanup?.();
+		}
+	});
+
+	const mediaRefCallback = useSafeRefCallback(
+		useCallback(
+			(node: HTMLAudioElement | null) => {
+				if (!node) {
+					return;
+				}
+
+				events.forEach((event) => {
+					node.addEventListener(event, handleMediaURLRecovery);
+				});
+				return () => {
+					if (!node) {
+						return;
+					}
+					events.forEach((event) => {
+						node.removeEventListener(event, handleMediaURLRecovery);
+					});
+				};
+			},
+			[handleMediaURLRecovery],
+		),
+	);
+
+	return { mediaRef: mediaRefCallback };
+};

--- a/apps/meteor/server/ufs/ufs-store.ts
+++ b/apps/meteor/server/ufs/ufs-store.ts
@@ -368,4 +368,8 @@ export class Store {
 			await this.onValidate(file, options);
 		}
 	}
+
+	async getUrlExpiryTimeSpan(): Promise<number | null> {
+		return null;
+	}
 }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
### Background
Audio/video files served from S3 use presigned URLs that expire after a configurable timespan. When a user leaves a room open past that window, the media element’s subsequent `Range` requests hit a stale URL, leading to silent playback failures.

---

### Changes
1. **`useReloadOnError` hook**  
   - Listens to `play`, `stalled`, and `error` events on media elements.  
   - Tracks `expiresAt` timestamp returned by the uploads endpoint.  
   - On trigger, checks if the URL has expired before attempting recovery.  
   - If expired, fetches fresh `redirectUrl` and `expires` via an `?info=true` query to the existing `/uploads/:fileId` endpoint.  
   - Swaps the media’s `src`, calls `.load()`, seeks to last known `currentTime`, and resumes playback.

2. **Uploads endpoint enhancement**  
   - Supports an `info=true` query param.  
   - When present, returns JSON `{ redirectUrl, expires }` instead of streaming or redirecting.  
   - No changes to existing redirect or proxy behavior.

3. **UI fallback styling**  
   - On recovery for video, preserves the video dimensions by copying element dimensions to have minimal UI lag.

4. **These were the solutions considered.**  

   | Strategy                 | Chosen | Rationale                                                              |
   |--------------------------|:------:|------------------------------------------------------------------------|
   | Reactive error events    |   ❌    | Too delayed; Safari compatibility issues.                              |
   | Watchdog timer to detect stalls         |   ❌    | False positives on slow networks.                                      |
   | HEAD validation  on src url on stalls       |   ❌    | Fails without CORS headers.                                            |
   | Media Source Extensions  |   ❌    | Overly complex; CORS/storage overhead.                                 |
   | Service Worker proxy     |   ❌    | HTTPS/PWA constraints; added complexity.                               |
   | **Expiry-aware recovery**| **✅** | Minimal complexity; leverages existing metadata; no CORS constraints.      |

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Set the upload provider to amazon s3 bucket and configure it. 
2. Set the url expiry time to a lower value (10s) under the s3 configuration.
3. Send an audio/video message to a channel and wait for more than 10 seconds.
4. Play the media and check if the playback recovers after stalling due to url expiry.
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[SUP-771](https://rocketchat.atlassian.net/browse/SUP-771)