### PR TITLE
fix: messages redaction echo

### DIFF
--- a/apps/meteor/ee/server/hooks/federation/index.ts
+++ b/apps/meteor/ee/server/hooks/federation/index.ts
@@ -1,6 +1,6 @@
 import { api, FederationMatrix } from '@rocket.chat/core-services';
 import type { IMessage, IRoom, IUser } from '@rocket.chat/core-typings';
-import { Messages, Rooms } from '@rocket.chat/models';
+import { Rooms } from '@rocket.chat/models';
 
 import notifications from '../../../../app/notifications/server/lib/Notifications';
 import { callbacks } from '../../../../lib/callbacks';
@@ -13,10 +13,12 @@ callbacks.add(
 		if (!message.federation?.eventId) {
 			return;
 		}
-		const isEchoMessage = !(await Messages.findOneByFederationId(message.federation?.eventId));
-		if (isEchoMessage) {
+
+		const isFromExternalUser = message.u?.username?.includes(':');
+		if (isFromExternalUser) {
 			return;
 		}
+
 		await FederationMatrix.deleteMessage(message);
 	},
 	callbacks.priority.MEDIUM,


### PR DESCRIPTION
this PR fixes a bug in the redaction flow from Rocket.Chat to Matrix, where `isEchoMessage` was mistakenly dropping redaction events before they were processed.

with this fix, redactions now work correctly in both directions (Rocket.Chat ↔ Matrix), including for thread messages.