### PR TITLE
fix(a11y): Add inline error for UserAvatarEditor's URL input

### DIFF
--- a/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
+++ b/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import type { UserAvatarSuggestion } from './UserAvatarSuggestion';
 import UserAvatarSuggestions from './UserAvatarSuggestions';
 import { readFileAsDataURL } from './readFileAsDataURL';
+import { isURL } from '../../../../lib/utils/isURL';
 import { useSingleFileInput } from '../../../hooks/useSingleFileInput';
 import { isValidImageFormat } from '../../../lib/utils/isValidImageFormat';
 
@@ -66,8 +67,13 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 	const url = newAvatarSource;
 
 	const handleAvatarFromUrlChange = (event: ChangeEvent<HTMLInputElement>): void => {
-		setAvatarUrlError(undefined);
-		setAvatarFromUrl(event.currentTarget.value);
+		const { value } = event.currentTarget;
+		setAvatarFromUrl(value);
+		if (isURL(value) || !value) {
+			setAvatarUrlError(undefined);
+		} else {
+			setAvatarUrlError(t('error-invalid-image-url'));
+		}
 	};
 
 	const handleSelectSuggestion = useCallback(
@@ -104,7 +110,7 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 						<IconButton
 							icon='permalink'
 							secondary
-							disabled={disabled || !avatarFromUrl}
+							disabled={disabled || !avatarFromUrl || !!avatarUrlError}
 							title={t('Add_URL')}
 							mi={4}
 							onClick={handleAddUrl}

--- a/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
+++ b/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
@@ -3,13 +3,12 @@ import { Box, Button, Avatar, TextInput, IconButton, Label, FieldError } from '@
 import { UserAvatar } from '@rocket.chat/ui-avatar';
 import { useToastMessageDispatch, useSetting } from '@rocket.chat/ui-contexts';
 import type { ReactElement, ChangeEvent } from 'react';
-import { useId, useState, useCallback, useEffect } from 'react';
+import { useId, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { UserAvatarSuggestion } from './UserAvatarSuggestion';
 import UserAvatarSuggestions from './UserAvatarSuggestions';
 import { readFileAsDataURL } from './readFileAsDataURL';
-import { isURL } from '../../../../lib/utils/isURL';
 import { useSingleFileInput } from '../../../hooks/useSingleFileInput';
 import { isValidImageFormat } from '../../../lib/utils/isValidImageFormat';
 
@@ -22,6 +21,15 @@ type UserAvatarEditorProps = {
 	name: IUser['name'];
 };
 
+function isUrl(myUrlString: string) {
+	try {
+		new URL(myUrlString);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disabled, etag }: UserAvatarEditorProps): ReactElement {
 	const { t } = useTranslation();
 	const useFullNameForDefaultAvatar = useSetting('UI_Use_Name_Avatar');
@@ -31,10 +39,6 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 	const imageUrlField = useId();
 	const dispatchToastMessage = useToastMessageDispatch();
 	const [avatarUrlError, setAvatarUrlError] = useState<string | undefined>(undefined);
-
-	useEffect(() => {
-		setAvatarUrlError(undefined);
-	}, []);
 
 	const setUploadedPreview = useCallback(
 		async (file: File, avatarObj: AvatarObject) => {
@@ -55,8 +59,12 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 	const [clickUpload] = useSingleFileInput(setUploadedPreview);
 
 	const handleAddUrl = (): void => {
-		setNewAvatarSource(avatarFromUrl);
-		setAvatarObj({ avatarUrl: avatarFromUrl });
+		if (isUrl(avatarFromUrl)) {
+			setNewAvatarSource(avatarFromUrl);
+			setAvatarObj({ avatarUrl: avatarFromUrl });
+		} else {
+			setAvatarUrlError(t('error-invalid-image-url'));
+		}
 	};
 
 	const clickReset = (): void => {
@@ -67,13 +75,11 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 	const url = newAvatarSource;
 
 	const handleAvatarFromUrlChange = (event: ChangeEvent<HTMLInputElement>): void => {
+		if (avatarUrlError) {
+			setAvatarUrlError(undefined);
+		}
 		const { value } = event.currentTarget;
 		setAvatarFromUrl(value);
-		if (isURL(value) || !value) {
-			setAvatarUrlError(undefined);
-		} else {
-			setAvatarUrlError(t('error-invalid-image-url'));
-		}
 	};
 
 	const handleSelectSuggestion = useCallback(

--- a/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
+++ b/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
@@ -1,9 +1,9 @@
 import type { IUser, AvatarObject } from '@rocket.chat/core-typings';
-import { Box, Button, Avatar, TextInput, IconButton, Label } from '@rocket.chat/fuselage';
+import { Box, Button, Avatar, TextInput, IconButton, Label, FieldError } from '@rocket.chat/fuselage';
 import { UserAvatar } from '@rocket.chat/ui-avatar';
 import { useToastMessageDispatch, useSetting } from '@rocket.chat/ui-contexts';
 import type { ReactElement, ChangeEvent } from 'react';
-import { useId, useState, useCallback } from 'react';
+import { useId, useState, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { UserAvatarSuggestion } from './UserAvatarSuggestion';
@@ -29,6 +29,11 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 	const [newAvatarSource, setNewAvatarSource] = useState<string>();
 	const imageUrlField = useId();
 	const dispatchToastMessage = useToastMessageDispatch();
+	const [avatarUrlError, setAvatarUrlError] = useState<string | undefined>(undefined);
+
+	useEffect(() => {
+		setAvatarUrlError(undefined);
+	}, []);
 
 	const setUploadedPreview = useCallback(
 		async (file: File, avatarObj: AvatarObject) => {
@@ -61,6 +66,7 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 	const url = newAvatarSource;
 
 	const handleAvatarFromUrlChange = (event: ChangeEvent<HTMLInputElement>): void => {
+		setAvatarUrlError(undefined);
 		setAvatarFromUrl(event.currentTarget.value);
 	};
 
@@ -87,7 +93,7 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 						imageOrientation: rotateImages ? 'from-image' : 'none',
 						objectFit: 'contain',
 					}}
-					onError={() => dispatchToastMessage({ type: 'error', message: t('error-invalid-image-url') })}
+					onError={() => setAvatarUrlError(t('error-invalid-image-url'))}
 				/>
 				<Box display='flex' flexDirection='column' flexGrow='1' justifyContent='space-between' mis={4}>
 					<Box display='flex' flexDirection='row' mbs='none'>
@@ -116,6 +122,11 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 						mis={4}
 						onChange={handleAvatarFromUrlChange}
 					/>
+					{avatarUrlError && (
+						<FieldError aria-live='assertive' id={`${imageUrlField}-error`}>
+							{avatarUrlError}
+						</FieldError>
+					)}
 				</Box>
 			</Box>
 		</Box>

--- a/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
+++ b/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
@@ -113,21 +113,25 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 							<Avatar url={`/avatar/%40${useFullNameForDefaultAvatar ? name : username}`} />
 						</Button>
 						<IconButton icon='upload' secondary disabled={disabled} title={t('Upload')} mi={4} onClick={clickUpload} />
-						<IconButton
-							icon='permalink'
-							secondary
-							disabled={disabled || !avatarFromUrl || !!avatarUrlError}
-							title={t('Add_URL')}
-							mi={4}
-							onClick={handleAddUrl}
-						/>
 						<UserAvatarSuggestions disabled={disabled} onSelectOne={handleSelectSuggestion} />
 					</Box>
-					<Field mis={4} mbs={12}>
+					<Field pis={4} mbs={12}>
 						<FieldLabel>{t('Use_url_for_avatar')}</FieldLabel>
 						<FieldRow>
 							<TextInput
 								placeholder={t('Use_url_for_avatar')}
+								addon={
+									<IconButton
+										icon='permalink'
+										secondary
+										small
+										disabled={disabled || !avatarFromUrl || !!avatarUrlError}
+										title={t('Add_URL')}
+										onClick={handleAddUrl}
+										mb={-4}
+										mie={-4}
+									/>
+								}
 								value={avatarFromUrl}
 								onChange={handleAvatarFromUrlChange}
 								error={avatarUrlError}

--- a/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
+++ b/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
@@ -4,7 +4,7 @@ import { Field, FieldLabel, FieldRow, FieldError, TextInput } from '@rocket.chat
 import { UserAvatar } from '@rocket.chat/ui-avatar';
 import { useToastMessageDispatch, useSetting } from '@rocket.chat/ui-contexts';
 import type { ReactElement, ChangeEvent } from 'react';
-import { useId, useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { UserAvatarSuggestion } from './UserAvatarSuggestion';
@@ -29,7 +29,6 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 	const rotateImages = useSetting('FileUpload_RotateImages');
 	const [avatarFromUrl, setAvatarFromUrl] = useState('');
 	const [newAvatarSource, setNewAvatarSource] = useState<string>();
-	const imageUrlField = useId();
 	const dispatchToastMessage = useToastMessageDispatch();
 	const [avatarUrlError, setAvatarUrlError] = useState<string | undefined>(undefined);
 
@@ -56,6 +55,7 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 			setNewAvatarSource(avatarFromUrl);
 			setAvatarObj({ avatarUrl: avatarFromUrl });
 			setAvatarUrlError(undefined);
+			dispatchToastMessage({ type: 'info', message: t('Avatar_preview_updated') });
 		} else {
 			setAvatarUrlError(t('error-invalid-image-url'));
 		}
@@ -117,24 +117,22 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 						/>
 						<UserAvatarSuggestions disabled={disabled} onSelectOne={handleSelectSuggestion} />
 					</Box>
-					<Field mis={4} mbs={16}>
-						<FieldLabel htmlFor={imageUrlField}>{t('Use_url_for_avatar')}</FieldLabel>
+					<Field mis={4} mbs={12}>
+						<FieldLabel>{t('Use_url_for_avatar')}</FieldLabel>
 						<FieldRow>
 							<TextInput
-								id={imageUrlField}
 								placeholder={t('Use_url_for_avatar')}
 								value={avatarFromUrl}
 								onChange={handleAvatarFromUrlChange}
 								error={avatarUrlError}
-								aria-invalid={!!avatarUrlError}
-								aria-describedby={avatarUrlError ? `${imageUrlField}-error` : undefined}
+								onKeyDown={(event): void => {
+									if (event.key === 'Enter') {
+										handleAddUrl();
+									}
+								}}
 							/>
 						</FieldRow>
-						{avatarUrlError && (
-							<FieldError aria-live='assertive' id={`${imageUrlField}-error`}>
-								{avatarUrlError}
-							</FieldError>
-						)}
+						{avatarUrlError && <FieldError>{avatarUrlError}</FieldError>}
 					</Field>
 				</Box>
 			</Box>

--- a/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
+++ b/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
@@ -1,5 +1,6 @@
 import type { IUser, AvatarObject } from '@rocket.chat/core-typings';
-import { Box, Button, Avatar, TextInput, IconButton, Label, FieldError } from '@rocket.chat/fuselage';
+import { Box, Button, Avatar, IconButton } from '@rocket.chat/fuselage';
+import { Field, FieldLabel, FieldRow, FieldError, TextInput } from '@rocket.chat/fuselage-forms';
 import { UserAvatar } from '@rocket.chat/ui-avatar';
 import { useToastMessageDispatch, useSetting } from '@rocket.chat/ui-contexts';
 import type { ReactElement, ChangeEvent } from 'react';
@@ -10,6 +11,7 @@ import type { UserAvatarSuggestion } from './UserAvatarSuggestion';
 import UserAvatarSuggestions from './UserAvatarSuggestions';
 import { readFileAsDataURL } from './readFileAsDataURL';
 import { useSingleFileInput } from '../../../hooks/useSingleFileInput';
+import { isSafeAvatarUrl } from '../../../lib/utils/isSafeAvatarUrl';
 import { isValidImageFormat } from '../../../lib/utils/isValidImageFormat';
 
 type UserAvatarEditorProps = {
@@ -20,15 +22,6 @@ type UserAvatarEditorProps = {
 	etag: IUser['avatarETag'];
 	name: IUser['name'];
 };
-
-function isUrl(myUrlString: string) {
-	try {
-		new URL(myUrlString);
-		return true;
-	} catch {
-		return false;
-	}
-}
 
 function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disabled, etag }: UserAvatarEditorProps): ReactElement {
 	const { t } = useTranslation();
@@ -59,9 +52,10 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 	const [clickUpload] = useSingleFileInput(setUploadedPreview);
 
 	const handleAddUrl = (): void => {
-		if (isUrl(avatarFromUrl)) {
+		if (isSafeAvatarUrl(avatarFromUrl)) {
 			setNewAvatarSource(avatarFromUrl);
 			setAvatarObj({ avatarUrl: avatarFromUrl });
+			setAvatarUrlError(undefined);
 		} else {
 			setAvatarUrlError(t('error-invalid-image-url'));
 		}
@@ -107,7 +101,7 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 					}}
 					onError={() => setAvatarUrlError(t('error-invalid-image-url'))}
 				/>
-				<Box display='flex' flexDirection='column' flexGrow='1' justifyContent='space-between' mis={4}>
+				<Box display='flex' flexDirection='column' flexGrow='1' mis={4}>
 					<Box display='flex' flexDirection='row' mbs='none'>
 						<Button square disabled={disabled} mi={4} title={t('Accounts_SetDefaultAvatar')} onClick={clickReset}>
 							<Avatar url={`/avatar/%40${useFullNameForDefaultAvatar ? name : username}`} />
@@ -123,22 +117,25 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 						/>
 						<UserAvatarSuggestions disabled={disabled} onSelectOne={handleSelectSuggestion} />
 					</Box>
-					<Label htmlFor={imageUrlField} mis={4}>
-						{t('Use_url_for_avatar')}
-					</Label>
-					<TextInput
-						id={imageUrlField}
-						flexGrow={0}
-						placeholder={t('Use_url_for_avatar')}
-						value={avatarFromUrl}
-						mis={4}
-						onChange={handleAvatarFromUrlChange}
-					/>
-					{avatarUrlError && (
-						<FieldError aria-live='assertive' id={`${imageUrlField}-error`}>
-							{avatarUrlError}
-						</FieldError>
-					)}
+					<Field mis={4} mbs={16}>
+						<FieldLabel htmlFor={imageUrlField}>{t('Use_url_for_avatar')}</FieldLabel>
+						<FieldRow>
+							<TextInput
+								id={imageUrlField}
+								placeholder={t('Use_url_for_avatar')}
+								value={avatarFromUrl}
+								onChange={handleAvatarFromUrlChange}
+								error={avatarUrlError}
+								aria-invalid={!!avatarUrlError}
+								aria-describedby={avatarUrlError ? `${imageUrlField}-error` : undefined}
+							/>
+						</FieldRow>
+						{avatarUrlError && (
+							<FieldError aria-live='assertive' id={`${imageUrlField}-error`}>
+								{avatarUrlError}
+							</FieldError>
+						)}
+					</Field>
 				</Box>
 			</Box>
 		</Box>

--- a/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
+++ b/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
@@ -50,15 +50,21 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 
 	const [clickUpload] = useSingleFileInput(setUploadedPreview);
 
-	const handleAddUrl = (): void => {
-		if (isSafeAvatarUrl(avatarFromUrl)) {
-			setNewAvatarSource(avatarFromUrl);
-			setAvatarObj({ avatarUrl: avatarFromUrl });
-			setAvatarUrlError(undefined);
-			dispatchToastMessage({ type: 'info', message: t('Avatar_preview_updated') });
-		} else {
+	const handleAddUrl = async (): Promise<void> => {
+		if (!isSafeAvatarUrl(avatarFromUrl)) {
 			setAvatarUrlError(t('error-invalid-image-url'));
+			return;
 		}
+
+		if (!(await isValidImageFormat(avatarFromUrl))) {
+			setAvatarUrlError(t('error-invalid-image-url'));
+			return;
+		}
+
+		setNewAvatarSource(avatarFromUrl);
+		setAvatarObj({ avatarUrl: avatarFromUrl });
+		setAvatarUrlError(undefined);
+		dispatchToastMessage({ type: 'info', message: t('Avatar_preview_updated') });
 	};
 
 	const clickReset = (): void => {

--- a/apps/meteor/client/lib/utils/isSafeAvatarUrl.spec.ts
+++ b/apps/meteor/client/lib/utils/isSafeAvatarUrl.spec.ts
@@ -1,0 +1,86 @@
+import { isSafeAvatarUrl } from './isSafeAvatarUrl';
+
+describe('isSafeAvatarUrl', () => {
+	describe('valid URLs', () => {
+		it('should accept HTTPS URLs', () => {
+			expect(isSafeAvatarUrl('https://example.com/avatar.png')).toBe(true);
+			expect(isSafeAvatarUrl('https://cdn.example.com/user/123/avatar.jpg')).toBe(true);
+		});
+
+		it('should accept HTTP URLs', () => {
+			expect(isSafeAvatarUrl('http://example.com/avatar.png')).toBe(true);
+			expect(isSafeAvatarUrl('http://localhost:3000/avatar.png')).toBe(true);
+		});
+
+		it('should accept data URLs with image MIME types', () => {
+			expect(isSafeAvatarUrl('data:image/png;base64,iVBORw0KGgoAAAANSUhEUg')).toBe(true);
+			expect(isSafeAvatarUrl('data:image/jpeg;base64,/9j/4AAQSkZJRg')).toBe(true);
+			expect(isSafeAvatarUrl('data:image/gif;base64,R0lGODlh')).toBe(true);
+			expect(isSafeAvatarUrl('data:image/webp;base64,UklGRiQA')).toBe(true);
+			expect(isSafeAvatarUrl('data:image/svg+xml;base64,PHN2Zw')).toBe(true);
+		});
+
+		it('should be case-insensitive for protocols', () => {
+			expect(isSafeAvatarUrl('HTTPS://example.com/avatar.png')).toBe(true);
+			expect(isSafeAvatarUrl('HTTP://example.com/avatar.png')).toBe(true);
+			expect(isSafeAvatarUrl('DATA:IMAGE/PNG;base64,iVBORw0KGgoAAAANSUhEUg')).toBe(true);
+		});
+	});
+
+	describe('invalid URLs', () => {
+		it('should reject javascript: protocol', () => {
+			expect(isSafeAvatarUrl('javascript:alert(1)')).toBe(false);
+			expect(isSafeAvatarUrl('javascript:void(0)')).toBe(false);
+		});
+
+		it('should reject file: protocol', () => {
+			expect(isSafeAvatarUrl('file:///etc/passwd')).toBe(false);
+			expect(isSafeAvatarUrl('file:///C:/Windows/System32')).toBe(false);
+		});
+
+		it('should reject data: URLs with non-image MIME types', () => {
+			expect(isSafeAvatarUrl('data:text/html;base64,PHNjcmlwdD4')).toBe(false);
+			expect(isSafeAvatarUrl('data:text/javascript;base64,YWxlcnQoMSk')).toBe(false);
+			expect(isSafeAvatarUrl('data:application/javascript;base64,YWxlcnQoMSk')).toBe(false);
+			expect(isSafeAvatarUrl('data:text/plain;base64,SGVsbG8=')).toBe(false);
+		});
+
+		it('should reject ftp: protocol', () => {
+			expect(isSafeAvatarUrl('ftp://example.com/avatar.png')).toBe(false);
+		});
+
+		it('should reject malformed URLs', () => {
+			expect(isSafeAvatarUrl('not a url')).toBe(false);
+			expect(isSafeAvatarUrl('htp://missing-t.com')).toBe(false);
+			expect(isSafeAvatarUrl('://example.com')).toBe(false);
+		});
+
+		it('should reject empty strings', () => {
+			expect(isSafeAvatarUrl('')).toBe(false);
+		});
+
+		it('should reject other dangerous protocols', () => {
+			expect(isSafeAvatarUrl('vbscript:msgbox(1)')).toBe(false);
+			expect(isSafeAvatarUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should handle URLs with query parameters', () => {
+			expect(isSafeAvatarUrl('https://example.com/avatar.png?size=large&format=webp')).toBe(true);
+		});
+
+		it('should handle URLs with fragments', () => {
+			expect(isSafeAvatarUrl('https://example.com/avatar.png#profile')).toBe(true);
+		});
+
+		it('should handle URLs with authentication', () => {
+			expect(isSafeAvatarUrl('https://user:pass@example.com/avatar.png')).toBe(true);
+		});
+
+		it('should handle URLs with non-standard ports', () => {
+			expect(isSafeAvatarUrl('http://example.com:8080/avatar.png')).toBe(true);
+			expect(isSafeAvatarUrl('https://example.com:443/avatar.png')).toBe(true);
+		});
+	});
+});

--- a/apps/meteor/client/lib/utils/isSafeAvatarUrl.spec.ts
+++ b/apps/meteor/client/lib/utils/isSafeAvatarUrl.spec.ts
@@ -1,86 +1,84 @@
 import { isSafeAvatarUrl } from './isSafeAvatarUrl';
 
-describe('isSafeAvatarUrl', () => {
-	describe('valid URLs', () => {
-		it('should accept HTTPS URLs', () => {
-			expect(isSafeAvatarUrl('https://example.com/avatar.png')).toBe(true);
-			expect(isSafeAvatarUrl('https://cdn.example.com/user/123/avatar.jpg')).toBe(true);
-		});
-
-		it('should accept HTTP URLs', () => {
-			expect(isSafeAvatarUrl('http://example.com/avatar.png')).toBe(true);
-			expect(isSafeAvatarUrl('http://localhost:3000/avatar.png')).toBe(true);
-		});
-
-		it('should accept data URLs with image MIME types', () => {
-			expect(isSafeAvatarUrl('data:image/png;base64,iVBORw0KGgoAAAANSUhEUg')).toBe(true);
-			expect(isSafeAvatarUrl('data:image/jpeg;base64,/9j/4AAQSkZJRg')).toBe(true);
-			expect(isSafeAvatarUrl('data:image/gif;base64,R0lGODlh')).toBe(true);
-			expect(isSafeAvatarUrl('data:image/webp;base64,UklGRiQA')).toBe(true);
-			expect(isSafeAvatarUrl('data:image/svg+xml;base64,PHN2Zw')).toBe(true);
-		});
-
-		it('should be case-insensitive for protocols', () => {
-			expect(isSafeAvatarUrl('HTTPS://example.com/avatar.png')).toBe(true);
-			expect(isSafeAvatarUrl('HTTP://example.com/avatar.png')).toBe(true);
-			expect(isSafeAvatarUrl('DATA:IMAGE/PNG;base64,iVBORw0KGgoAAAANSUhEUg')).toBe(true);
-		});
+describe('valid URLs', () => {
+	it('should accept HTTPS URLs', () => {
+		expect(isSafeAvatarUrl('https://example.com/avatar.png')).toBe(true);
+		expect(isSafeAvatarUrl('https://cdn.example.com/user/123/avatar.jpg')).toBe(true);
 	});
 
-	describe('invalid URLs', () => {
-		it('should reject javascript: protocol', () => {
-			expect(isSafeAvatarUrl('javascript:alert(1)')).toBe(false);
-			expect(isSafeAvatarUrl('javascript:void(0)')).toBe(false);
-		});
-
-		it('should reject file: protocol', () => {
-			expect(isSafeAvatarUrl('file:///etc/passwd')).toBe(false);
-			expect(isSafeAvatarUrl('file:///C:/Windows/System32')).toBe(false);
-		});
-
-		it('should reject data: URLs with non-image MIME types', () => {
-			expect(isSafeAvatarUrl('data:text/html;base64,PHNjcmlwdD4')).toBe(false);
-			expect(isSafeAvatarUrl('data:text/javascript;base64,YWxlcnQoMSk')).toBe(false);
-			expect(isSafeAvatarUrl('data:application/javascript;base64,YWxlcnQoMSk')).toBe(false);
-			expect(isSafeAvatarUrl('data:text/plain;base64,SGVsbG8=')).toBe(false);
-		});
-
-		it('should reject ftp: protocol', () => {
-			expect(isSafeAvatarUrl('ftp://example.com/avatar.png')).toBe(false);
-		});
-
-		it('should reject malformed URLs', () => {
-			expect(isSafeAvatarUrl('not a url')).toBe(false);
-			expect(isSafeAvatarUrl('htp://missing-t.com')).toBe(false);
-			expect(isSafeAvatarUrl('://example.com')).toBe(false);
-		});
-
-		it('should reject empty strings', () => {
-			expect(isSafeAvatarUrl('')).toBe(false);
-		});
-
-		it('should reject other dangerous protocols', () => {
-			expect(isSafeAvatarUrl('vbscript:msgbox(1)')).toBe(false);
-			expect(isSafeAvatarUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
-		});
+	it('should accept HTTP URLs', () => {
+		expect(isSafeAvatarUrl('http://example.com/avatar.png')).toBe(true);
+		expect(isSafeAvatarUrl('http://localhost:3000/avatar.png')).toBe(true);
 	});
 
-	describe('edge cases', () => {
-		it('should handle URLs with query parameters', () => {
-			expect(isSafeAvatarUrl('https://example.com/avatar.png?size=large&format=webp')).toBe(true);
-		});
+	it('should accept data URLs with image MIME types', () => {
+		expect(isSafeAvatarUrl('data:image/png;base64,iVBORw0KGgoAAAANSUhEUg')).toBe(true);
+		expect(isSafeAvatarUrl('data:image/jpeg;base64,/9j/4AAQSkZJRg')).toBe(true);
+		expect(isSafeAvatarUrl('data:image/gif;base64,R0lGODlh')).toBe(true);
+		expect(isSafeAvatarUrl('data:image/webp;base64,UklGRiQA')).toBe(true);
+		expect(isSafeAvatarUrl('data:image/svg+xml;base64,PHN2Zw')).toBe(true);
+	});
 
-		it('should handle URLs with fragments', () => {
-			expect(isSafeAvatarUrl('https://example.com/avatar.png#profile')).toBe(true);
-		});
+	it('should be case-insensitive for protocols', () => {
+		expect(isSafeAvatarUrl('HTTPS://example.com/avatar.png')).toBe(true);
+		expect(isSafeAvatarUrl('HTTP://example.com/avatar.png')).toBe(true);
+		expect(isSafeAvatarUrl('DATA:IMAGE/PNG;base64,iVBORw0KGgoAAAANSUhEUg')).toBe(true);
+	});
+});
 
-		it('should handle URLs with authentication', () => {
-			expect(isSafeAvatarUrl('https://user:pass@example.com/avatar.png')).toBe(true);
-		});
+describe('invalid URLs', () => {
+	it('should reject javascript: protocol', () => {
+		expect(isSafeAvatarUrl('javascript:alert(1)')).toBe(false);
+		expect(isSafeAvatarUrl('javascript:void(0)')).toBe(false);
+	});
 
-		it('should handle URLs with non-standard ports', () => {
-			expect(isSafeAvatarUrl('http://example.com:8080/avatar.png')).toBe(true);
-			expect(isSafeAvatarUrl('https://example.com:443/avatar.png')).toBe(true);
-		});
+	it('should reject file: protocol', () => {
+		expect(isSafeAvatarUrl('file:///etc/passwd')).toBe(false);
+		expect(isSafeAvatarUrl('file:///C:/Windows/System32')).toBe(false);
+	});
+
+	it('should reject data: URLs with non-image MIME types', () => {
+		expect(isSafeAvatarUrl('data:text/html;base64,PHNjcmlwdD4')).toBe(false);
+		expect(isSafeAvatarUrl('data:text/javascript;base64,YWxlcnQoMSk')).toBe(false);
+		expect(isSafeAvatarUrl('data:application/javascript;base64,YWxlcnQoMSk')).toBe(false);
+		expect(isSafeAvatarUrl('data:text/plain;base64,SGVsbG8=')).toBe(false);
+	});
+
+	it('should reject ftp: protocol', () => {
+		expect(isSafeAvatarUrl('ftp://example.com/avatar.png')).toBe(false);
+	});
+
+	it('should reject malformed URLs', () => {
+		expect(isSafeAvatarUrl('not a url')).toBe(false);
+		expect(isSafeAvatarUrl('htp://missing-t.com')).toBe(false);
+		expect(isSafeAvatarUrl('://example.com')).toBe(false);
+	});
+
+	it('should reject empty strings', () => {
+		expect(isSafeAvatarUrl('')).toBe(false);
+	});
+
+	it('should reject other dangerous protocols', () => {
+		expect(isSafeAvatarUrl('vbscript:msgbox(1)')).toBe(false);
+		expect(isSafeAvatarUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+	});
+});
+
+describe('URL edge cases', () => {
+	it('should handle URLs with query parameters', () => {
+		expect(isSafeAvatarUrl('https://example.com/avatar.png?size=large&format=webp')).toBe(true);
+	});
+
+	it('should handle URLs with fragments', () => {
+		expect(isSafeAvatarUrl('https://example.com/avatar.png#profile')).toBe(true);
+	});
+
+	it('should handle URLs with authentication', () => {
+		expect(isSafeAvatarUrl('https://user:pass@example.com/avatar.png')).toBe(true);
+	});
+
+	it('should handle URLs with non-standard ports', () => {
+		expect(isSafeAvatarUrl('http://example.com:8080/avatar.png')).toBe(true);
+		expect(isSafeAvatarUrl('https://example.com:443/avatar.png')).toBe(true);
 	});
 });

--- a/apps/meteor/client/lib/utils/isSafeAvatarUrl.ts
+++ b/apps/meteor/client/lib/utils/isSafeAvatarUrl.ts
@@ -1,0 +1,17 @@
+export function isSafeAvatarUrl(urlString: string): boolean {
+	try {
+		const url = new URL(urlString);
+		const protocol = url.protocol.toLowerCase();
+
+		if (protocol === 'http:' || protocol === 'https:') {
+			return true;
+		}
+		if (protocol === 'data:') {
+			return urlString.toLowerCase().startsWith('data:image/');
+		}
+
+		return false;
+	} catch {
+		return false;
+	}
+}

--- a/apps/meteor/tests/e2e/account-profile.spec.ts
+++ b/apps/meteor/tests/e2e/account-profile.spec.ts
@@ -58,12 +58,11 @@ test.describe.serial('settings-account-profile', () => {
 				await expect(poAccountProfile.userAvatarEditor).toHaveAttribute('src');
 			});
 
-			test('should display a skeleton if the image url is not valid', async () => {
+			test('should show inline error if the image url is not valid', async () => {
 				await poAccountProfile.inputAvatarLink.fill('https://invalidUrl');
 				await poAccountProfile.btnSetAvatarLink.click();
 
-				await poAccountProfile.btnSubmit.click();
-				await expect(poAccountProfile.userAvatarEditor).not.toHaveAttribute('src');
+				await expect(poAccountProfile.errorInvalidUrl).toBeVisible();
 			});
 		});
 	});

--- a/apps/meteor/tests/e2e/account-profile.spec.ts
+++ b/apps/meteor/tests/e2e/account-profile.spec.ts
@@ -64,6 +64,13 @@ test.describe.serial('settings-account-profile', () => {
 
 				await expect(poAccountProfile.errorInvalidUrl).toBeVisible();
 			});
+
+			test('should show inline error if url does not point to an image', async () => {
+				await poAccountProfile.inputAvatarLink.fill('https://google.com');
+				await poAccountProfile.btnSetAvatarLink.click();
+
+				await expect(poAccountProfile.errorInvalidUrl).toBeVisible();
+			});
 		});
 	});
 

--- a/apps/meteor/tests/e2e/page-objects/account-profile.ts
+++ b/apps/meteor/tests/e2e/page-objects/account-profile.ts
@@ -125,6 +125,6 @@ export class AccountProfile extends Account {
 	}
 
 	get errorInvalidUrl(): Locator {
-		return this.getErrorAlertByText('Please enter a valid URL');
+		return this.getErrorAlertByText('Invalid image URL');
 	}
 }

--- a/apps/meteor/tests/e2e/page-objects/account-profile.ts
+++ b/apps/meteor/tests/e2e/page-objects/account-profile.ts
@@ -119,4 +119,12 @@ export class AccountProfile extends Account {
 	get btnDeleteMyAccount(): Locator {
 		return this.page.getByRole('button', { name: 'Delete my account' });
 	}
+
+	private getErrorAlertByText(text: string): Locator {
+		return this.page.getByRole('alert').filter({ hasText: text });
+	}
+
+	get errorInvalidUrl(): Locator {
+		return this.getErrorAlertByText('Please enter a valid URL');
+	}
 }

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -7159,5 +7159,6 @@
   "message_body": "message body",
   "message_attachment": "message attachment",
   "system_message_body": "system message body",
-  "No_changes_to_save": "No changes to save"
+  "No_changes_to_save": "No changes to save",
+  "Avatar_preview_updated": "Avatar preview updated"
 }


### PR DESCRIPTION
Inline errors on profile page, more information in Figma https://www.figma.com/design/eCqiUBG2zmN7C0HrFxc7ji/Inline-errors-for-web-forms?node-id=50-2235&t=Qc1iBq6EYwRBeec6-0
URL for avatar: Invalid URL
Name: Name required
Username: Username required
Email: Email required

WCAG (3.3.1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced avatar URL validation with real-time inline error messages displayed to users.
  * Invalid URLs are caught and reported before attempting to load them.
  * The Add URL button is automatically disabled when the input is invalid or empty.
  * Improved error handling for image load failures with consistent, localized error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[WA-54]

[WA-54]: https://rocketchat.atlassian.net/browse/WA-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ