### PR TITLE
fix: multi paths is present inside the APIClass

### DIFF
--- a/apps/meteor/app/api/server/ApiClass.spec.ts
+++ b/apps/meteor/app/api/server/ApiClass.spec.ts
@@ -59,3 +59,25 @@ describe('ExtractRoutesFromAPI', () => {
 		true as ExpectedFunctionSignature;
 	});
 });
+
+it('Should extract correct function signature when multi paths is present', () => {
+	type APIWithMultiPath = APIClass<
+		'/v1',
+		{
+			method: 'POST';
+			path: ['/v1/endpoint.foo', '/v1/endpoint.bar'];
+			body: ValidateFunction<{
+				foo: string;
+			}>;
+			response: {
+				200: ValidateFunction<{
+					bar: string;
+				}>;
+			};
+			authRequired: true;
+		}
+	>;
+	type APIEndpoints = ExtractRoutesFromAPI<APIWithMultiPath>['/v1/endpoint.test']['POST'];
+	type ExpectedFunctionSignature = Expect<ShallowEqual<APIEndpoints, (params: { foo: string }) => { bar: string }>>;
+	true satisfies ExpectedFunctionSignature;
+});


### PR DESCRIPTION
**Description**

While working on the dm.delete API PR #36677, I discovered an issue where the endpoint definition used an array in the base path:

```ts
['dm.delete', 'im.delete']
```

The current APIClass implementation expects a single path string, not an array. As a result, several parts of the codebase; such as ExtractRoutesFromAPI - were failing, causing unexpected behavior.