### PR TITLE
fix(notifications): Provide fallback for undefined client details in …

### DIFF
--- a/apps/meteor/ee/server/lib/deviceManagement/session.ts
+++ b/apps/meteor/ee/server/lib/deviceManagement/session.ts
@@ -71,8 +71,8 @@ export const listenSessionLogin = () => {
 		const mailData = {
 			name,
 			username,
-			browserInfo: `${browser.name} ${browser.version}`,
-			osInfo: `${os.name}`,
+			browserInfo: `${browser.name || 'Unknown Client'} ${browser.version || ''}`.trim(),
+			osInfo: `${os.name || 'Unknown OS'}`,
 			deviceInfo: `${device.type || t('Device_Management_Device_Unknown')} ${device.vendor || ''} ${device.model || ''} ${
 				cpu.architecture || ''
 			}`,


### PR DESCRIPTION
Proposed changes :
This change fixes a bug where the login notification email would display undefined undefined for the Client and OS fields if the server failed to parse the user-agent string from the login request.

The fix adds a graceful fallback to 'Unknown Client' and 'Unknown OS' within the mailData object. This ensures the email is always user-friendly and makes the notification system more robust by correctly handling cases where device information is incomplete.

Issue(s)
Closes #36409

Further comments
This is my first contribution. I'm looking forward to any feedback!