### PR TITLE
feat: Add 'setOrGetRoomKeyID' endpoint to avoid room key creation race

### DIFF
--- a/apps/meteor/app/api/server/v1/e2e.ts
+++ b/apps/meteor/app/api/server/v1/e2e.ts
@@ -19,6 +19,7 @@ import { provideUsersSuggestedGroupKeys } from '../../../e2e/server/functions/pr
 import { resetRoomKey } from '../../../e2e/server/functions/resetRoomKey';
 import { getUsersOfRoomWithoutKeyMethod } from '../../../e2e/server/methods/getUsersOfRoomWithoutKey';
 import { setRoomKeyIDMethod } from '../../../e2e/server/methods/setRoomKeyID';
+import { setOrGetRoomKeyIDMethod } from '../../../e2e/server/methods/setOrGetRoomKeyID';
 import { setUserPublicAndPrivateKeysMethod } from '../../../e2e/server/methods/setUserPublicAndPrivateKeys';
 import { updateGroupKey } from '../../../e2e/server/methods/updateGroupKey';
 import { settings } from '../../../settings/server';
@@ -74,6 +75,23 @@ const e2eEndpoints = API.v1.post(
 		await setRoomKeyIDMethod(this.userId, rid, keyID);
 
 		return API.v1.success();
+	},
+);
+
+API.v1.addRoute(
+	'e2e.setOrGetRoomKeyID',
+	{
+		authRequired: true,
+		validateParams: ise2eSetRoomKeyIDParamsPOST,
+	},
+	{
+		async post() {
+			const { rid, keyID } = this.bodyParams;
+
+			const result = await setOrGetRoomKeyIDMethod(this.userId, rid, keyID);
+
+			return API.v1.success(result);
+		},
 	},
 );
 

--- a/apps/meteor/app/e2e/server/index.ts
+++ b/apps/meteor/app/e2e/server/index.ts
@@ -7,6 +7,7 @@ import './methods/setUserPublicAndPrivateKeys';
 import './methods/getUsersOfRoomWithoutKey';
 import './methods/updateGroupKey';
 import './methods/setRoomKeyID';
+import './methods/setOrGetRoomKeyID';
 import './methods/fetchMyKeys';
 import './methods/resetOwnE2EKey';
 import './methods/requestSubscriptionKeys';

--- a/apps/meteor/app/e2e/server/methods/setOrGetRoomKeyID.ts
+++ b/apps/meteor/app/e2e/server/methods/setOrGetRoomKeyID.ts
@@ -1,0 +1,66 @@
+import type { IRoom } from '@rocket.chat/core-typings';
+import type { ServerMethods } from '@rocket.chat/ddp-client';
+import { Rooms, Subscriptions } from '@rocket.chat/models';
+import { check } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
+
+import { canAccessRoomIdAsync } from '../../../authorization/server/functions/canAccessRoom';
+import { notifyOnRoomChangedById } from '../../../lib/server/lib/notifyListener';
+
+declare module '@rocket.chat/ddp-client' {
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	interface ServerMethods {
+		'e2e.setOrGetRoomKeyID'(rid: IRoom['_id'], keyID: string): {
+			keyID: string;
+			suggestedKey: string;
+		};
+	}
+}
+
+export const setOrGetRoomKeyIDMethod = async (userId: string, rid: IRoom['_id'], keyID: string): Promise<{ keyID: string; suggestedKey?: string }> => {
+	if (!(await canAccessRoomIdAsync(rid, userId))) {
+		throw new Meteor.Error('error-invalid-room', 'Invalid room', { method: 'e2e.setOrGetRoomKeyID' });
+	}
+
+	const room = await Rooms.findOneById<Pick<IRoom, '_id' | 'e2eKeyId'>>(rid, { projection: { e2eKeyId: 1 } });
+
+	if (!room) {
+		throw new Meteor.Error('error-invalid-room', 'Invalid room', { method: 'e2e.setOrGetRoomKeyID' });
+	}
+
+	const subscription = await Subscriptions.findOneByRoomIdAndUserId(rid, userId, { projection: { E2ESuggestedKey: 1 } })
+
+	if (room.e2eKeyId) {
+		return {
+			keyID: room.e2eKeyId; // Return existing keyID if it already exists
+			suggestedKey: subscription?.E2ESuggestedKey;
+		}
+	}
+
+	await Rooms.setE2eKeyId(room._id, keyID);
+
+	void notifyOnRoomChangedById(room._id);
+
+	return {
+		keyID
+	}; // Return the newly set keyID
+};
+
+Meteor.methods<ServerMethods>({
+	async 'e2e.setOrGetRoomKeyID'(rid, keyID) {
+		check(rid, String);
+		check(keyID, String);
+
+		const userId = Meteor.userId();
+		if (!userId) {
+			throw new Meteor.Error('error-invalid-user', 'Invalid user', { method: 'e2e.setOrGetRoomKeyID' });
+		}
+
+		if (!rid) {
+			throw new Meteor.Error('error-invalid-room', 'Invalid room', { method: 'e2e.setOrGetRoomKeyID' });
+		}
+
+		console.log('apps/meteor/app/e2e/server/methods/setOrGetRoomKeyID.ts e2e.setOrGetRoomKeyID');
+		return await setOrGetRoomKeyIDMethod(userId, rid, keyID);
+	},
+});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

When creating a room on a mobile device there is a race between invitees to create the room key. If an invitee that is currently logged on on the web server wins the race, the state of the mobile app will likely break.

This change adds a safe "set-or-get" method to be used by the mobile code to see if it lost the race and handle it properly.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

This is required to resolve issue in the react native repo: https://github.com/RocketChat/Rocket.Chat.ReactNative/issues/6566

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
