### PR TITLE
refactor: Replaced agent fetch with department agents and added permission checks to Replies form

### DIFF
--- a/apps/meteor/client/components/Omnichannel/OutboundMessage/components/AutoCompleteDepartmentAgent.tsx
+++ b/apps/meteor/client/components/Omnichannel/OutboundMessage/components/AutoCompleteDepartmentAgent.tsx
@@ -37,14 +37,16 @@ const AutoCompleteDepartmentAgent = ({ value, onChange, agents, ...props }: Auto
 			value={value}
 			onChange={onChange as (value: string | string[]) => void}
 			options={options}
-			renderSelected={({ selected: { value, label }, onRemove, ...props }): ReactElement => (
-				<Chip {...props} height='x20' value={value} onClick={onRemove} mie={4}>
-					<UserAvatar size='x20' username={value} />
-					<Box is='span' margin='none' mis={4}>
-						{label}
-					</Box>
-				</Chip>
-			)}
+			renderSelected={({ selected: { value, label }, ...props }): ReactElement => {
+				return (
+					<Chip {...props} height='x20' value={value} onClick={() => onChange('')} mie={4}>
+						<UserAvatar size='x20' username={value} />
+						<Box is='span' margin='none' mis={4}>
+							{label}
+						</Box>
+					</Chip>
+				);
+			}}
 			renderItem={({ value, label, ...props }): ReactElement => (
 				<Option key={value} {...props}>
 					<OptionAvatar>

--- a/apps/meteor/client/components/Omnichannel/OutboundMessage/components/OutboundMessagePreview/OutboundMessagePreview.tsx
+++ b/apps/meteor/client/components/Omnichannel/OutboundMessage/components/OutboundMessagePreview/OutboundMessagePreview.tsx
@@ -57,7 +57,11 @@ const OutboundMessagePreview = ({
 	const sender = useMemo(() => formatContact(rawSender, providerType), [providerType, rawSender]);
 	const replies = useMemo(() => {
 		if (agentName) {
-			return `${agentName || agentUsername} ${agentUsername ? `(${agentUsername})` : ''} ${departmentName ? `at ${departmentName}` : ''}`;
+			return `${agentName} ${agentUsername ? `(${agentUsername})` : ''} ${departmentName ? `at ${departmentName}` : ''}`;
+		}
+
+		if (agentUsername) {
+			return `@${agentUsername} ${departmentName ? `at ${departmentName}` : ''}`;
 		}
 
 		return departmentName;

--- a/apps/meteor/client/components/Omnichannel/OutboundMessage/components/OutboundMessageWizard/OutboundMessageWizard.tsx
+++ b/apps/meteor/client/components/Omnichannel/OutboundMessage/components/OutboundMessageWizard/OutboundMessageWizard.tsx
@@ -47,7 +47,7 @@ const OutboundMessageWizard = ({ defaultValues = {} }: OutboundMessageWizardProp
 	});
 
 	useEffect(() => {
-		if (!isLoadingProviders && !isLoadingModule && !hasModule && !hasProviders) {
+		if (!isLoadingProviders && !isLoadingModule && (!hasModule || !hasProviders)) {
 			upsellModal.open();
 		}
 	}, [hasModule, hasProviders, isLoadingModule, isLoadingProviders, upsellModal]);
@@ -103,7 +103,6 @@ const OutboundMessageWizard = ({ defaultValues = {} }: OutboundMessageWizardProp
 							departmentName={department?.name}
 							providerType={provider?.providerType}
 							providerName={provider?.providerName}
-							agentName={agent?.name}
 							agentUsername={agent?.username}
 							template={template}
 							templateParameters={templateParameters}


### PR DESCRIPTION

## Proposed changes (including videos or screenshots)
- Removes agent fetch from the replies form and changes structure to rely only on department agent
- Updates unit tests to better cover submit validations
- Added permission checks for `onlyMyDepartment`

## Issue(s)
[CTZ-194](https://rocketchat.atlassian.net/browse/CTZ-194)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CTZ-194]: https://rocketchat.atlassian.net/browse/CTZ-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ