### PR TITLE
chore: Inherit environment variables in deno cache build script

### DIFF
--- a/packages/apps-engine/scripts/deno-cache.js
+++ b/packages/apps-engine/scripts/deno-cache.js
@@ -18,8 +18,8 @@ const DENO_DIR = process.env.DENO_DIR ?? path.join(rootPath, '.deno-cache');
 childProcess.execSync('deno cache main.ts', {
 	cwd: denoRuntimePath,
 	env: {
+		...process.env,
 		DENO_DIR,
-		PATH: process.env.PATH,
 	},
 	stdio: 'inherit',
 });


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
When building Rocket.Chat, this step's `deno cache` will not use env var `HTTP_PROXY` and `HTTPS_PROXY` because they were replaced. 

 Task: [ARCH-2098]

[ARCH-2098]: https://rocketchat.atlassian.net/browse/ARCH-2098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ