### PR TITLE
chore!: remove deprecated appId parameter from oauth-apps.get endpoint

### DIFF
--- a/.changeset/poor-trains-mate.md
+++ b/.changeset/poor-trains-mate.md
@@ -1,5 +1,5 @@
 ---
-'@rocket.chat/meteor': patch
+'@rocket.chat/meteor': major
 ---
 
 Removes deprecated `appId` parameter from the `oauth-apps.get` endpoint.

--- a/.changeset/poor-trains-mate.md
+++ b/.changeset/poor-trains-mate.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Removes deprecated `appId` parameter from the `oauth-apps.get` endpoint.

--- a/apps/meteor/app/api/server/v1/oauthapps.ts
+++ b/apps/meteor/app/api/server/v1/oauthapps.ts
@@ -87,7 +87,7 @@ const UpdateOAuthAppParamsSchema = {
 
 const isUpdateOAuthAppParams = ajv.compile<UpdateOAuthAppParams>(UpdateOAuthAppParamsSchema);
 
-type OauthAppsGetParams = { clientId: string } | { appId: string } | { _id: string };
+type OauthAppsGetParams = { clientId: string } | { _id: string };
 
 const oauthAppsGetParamsSchema = {
 	oneOf: [
@@ -109,16 +109,6 @@ const oauthAppsGetParamsSchema = {
 				},
 			},
 			required: ['clientId'],
-			additionalProperties: false,
-		},
-		{
-			type: 'object',
-			properties: {
-				appId: {
-					type: 'string',
-				},
-			},
-			required: ['appId'],
 			additionalProperties: false,
 		},
 	],

--- a/apps/meteor/app/api/server/v1/oauthapps.ts
+++ b/apps/meteor/app/api/server/v1/oauthapps.ts
@@ -8,7 +8,6 @@ import {
 } from '@rocket.chat/rest-typings';
 
 import { hasPermissionAsync } from '../../../authorization/server/functions/hasPermission';
-import { apiDeprecationLogger } from '../../../lib/server/lib/deprecationWarningLogger';
 import { addOAuthApp } from '../../../oauth2-server-config/server/admin/functions/addOAuthApp';
 import { deleteOAuthApp } from '../../../oauth2-server-config/server/admin/methods/deleteOAuthApp';
 import { updateOAuthApp } from '../../../oauth2-server-config/server/admin/methods/updateOAuthApp';
@@ -290,10 +289,6 @@ const oauthAppsEndpoints = API.v1
 
 			if (!oauthApp) {
 				return API.v1.failure('OAuth app not found.');
-			}
-
-			if ('appId' in this.queryParams) {
-				apiDeprecationLogger.parameter(this.route, 'appId', '7.0.0', this.response);
 			}
 
 			return API.v1.success({

--- a/apps/meteor/tests/end-to-end/api/oauthapps.ts
+++ b/apps/meteor/tests/end-to-end/api/oauthapps.ts
@@ -212,24 +212,6 @@ describe('[OAuthApps]', () => {
 				});
 		});
 
-		it('should return a single oauthApp by appId (deprecated)', () => {
-			return request
-				.get(api('oauth-apps.get'))
-				.query({ appId: _id })
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('oauthApp');
-					expect(res.body.oauthApp._id).to.be.equal(_id);
-					expect(res.body.oauthApp.clientId).to.be.equal(clientId);
-					expect(res.body.oauthApp).to.have.property('clientSecret');
-					if (clientSecret) {
-						expect(res.body.oauthApp.clientSecret).to.be.equal(clientSecret);
-					}
-				});
-		});
-
 		it('should return only non sensitive information if user does not have the permission to manage oauth apps when searching by clientId', async () => {
 			await updatePermission('manage-oauth-apps', []);
 			await request
@@ -251,22 +233,6 @@ describe('[OAuthApps]', () => {
 			await request
 				.get(api('oauth-apps.get'))
 				.query({ _id })
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('oauthApp');
-					expect(res.body.oauthApp._id).to.be.equal(_id);
-					expect(res.body.oauthApp.clientId).to.be.equal(clientId);
-					expect(res.body.oauthApp).to.not.have.property('clientSecret');
-				});
-		});
-
-		it('should return only non sensitive information if user does not have the permission to manage oauth apps when searching by appId (deprecated)', async () => {
-			await updatePermission('manage-oauth-apps', []);
-			await request
-				.get(api('oauth-apps.get'))
-				.query({ appId: _id })
 				.set(credentials)
 				.expect(200)
 				.expect((res) => {
@@ -322,32 +288,6 @@ describe('[OAuthApps]', () => {
 			return request
 				.get(api('oauth-apps.get'))
 				.query({ clientId: '{ "$ne": "" }' })
-				.set(credentials)
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', 'OAuth app not found.');
-				});
-		});
-
-		it('should fail returning an oauth app when an invalid appId is provided (avoid NoSQL injections; deprecated)', () => {
-			return request
-				.get(api('oauth-apps.get'))
-				.query({ appId: { $ne: '' } })
-				.set(credentials)
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'error-invalid-params');
-					expect(res.body).to.have.property('error');
-					expect(res.body.error).to.include('must be string').and.include('must match exactly one schema in oneOf');
-				});
-		});
-
-		it('should fail returning an oauth app when an invalid appId string is provided (avoid NoSQL injections; deprecated)', () => {
-			return request
-				.get(api('oauth-apps.get'))
-				.query({ appId: '{ "$ne": "" }' })
 				.set(credentials)
 				.expect(400)
 				.expect((res) => {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Removes deprecated `appId` parameter from the `oauth-apps.get` endpoint.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[ARCH-1742](https://rocketchat.atlassian.net/browse/ARCH-1742)

[ARCH-1742]: https://rocketchat.atlassian.net/browse/ARCH-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Major version bump.
  * Removed deprecated appId support from the oauth-apps.get endpoint; it now accepts only _id or clientId.
* Tests
  * Removed tests related to appId-based retrieval and associated validation cases.
* Documentation
  * Updated release notes metadata to reflect the removal of appId from oauth-apps.get.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->