### PR TITLE
chore: More steps towards isolating client code from Meteor APIs

### DIFF
--- a/apps/meteor/client/meteor/startup/accounts.ts
+++ b/apps/meteor/client/meteor/startup/accounts.ts
@@ -5,12 +5,12 @@ import { sdk } from '../../../app/utils/client/lib/SDKClient';
 import { t } from '../../../app/utils/lib/i18n';
 import { PublicSettingsCachedStore, SubscriptionsCachedStore } from '../../cachedStores';
 import { dispatchToastMessage } from '../../lib/toast';
-import { userIdStore } from '../../lib/user';
+import { getUserId, userIdStore } from '../../lib/user';
 import { useUserDataSyncReady } from '../../lib/userData';
 
 const whenMainReady = (): Promise<void> => {
 	const isMainReady = (): boolean => {
-		const uid = userIdStore.getState();
+		const uid = getUserId();
 		if (!uid) return true;
 
 		const subscriptionsReady = SubscriptionsCachedStore.useReady.getState();

--- a/apps/meteor/client/providers/UserProvider/UserProvider.tsx
+++ b/apps/meteor/client/providers/UserProvider/UserProvider.tsx
@@ -24,7 +24,7 @@ import { useIdleConnection } from '../../hooks/useIdleConnection';
 import type { IDocumentMapStore } from '../../lib/cachedStores/DocumentMapStore';
 import { applyQueryOptions } from '../../lib/cachedStores/applyQueryOptions';
 import { createReactiveSubscriptionFactory } from '../../lib/createReactiveSubscriptionFactory';
-import { userIdStore } from '../../lib/user';
+import { getUser, userIdStore } from '../../lib/user';
 import { Users, Rooms, Subscriptions } from '../../stores';
 import { useSamlInviteToken } from '../../views/invite/hooks/useSamlInviteToken';
 
@@ -36,9 +36,7 @@ const ee = new Emitter();
 Accounts.onLogout(() => ee.emit('logout'));
 
 ee.on('logout', async () => {
-	const userId = userIdStore.getState();
-	if (!userId) return;
-	const user = Users.state.get(userId);
+	const user = getUser();
 	if (!user) return;
 
 	await afterLogoutCleanUpCallback.run(user);

--- a/apps/meteor/client/startup/startup.ts
+++ b/apps/meteor/client/startup/startup.ts
@@ -3,11 +3,11 @@ import { Meteor } from 'meteor/meteor';
 import { Tracker } from 'meteor/tracker';
 import moment from 'moment';
 
-import 'highlight.js/styles/github.css';
 import { sdk } from '../../app/utils/client/lib/SDKClient';
 import { synchronizeUserData, removeLocalUserData } from '../lib/userData';
 import { fireGlobalEvent } from '../lib/utils/fireGlobalEvent';
 import { watchUserId } from '../meteor/user';
+import 'highlight.js/styles/github.css';
 
 Meteor.startup(() => {
 	fireGlobalEvent('startup', true);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
It performs a series of changes in client code codebase to isolate it from Meteor APIs.

- It colocates code related to Meteor APIs under `client/meteor`.
- It introduces `getUserId()` as a non-reactive replacement for `Meteor.userId()`.
- It moves startup code tied to the framework under `client/meteor/startup`.
- It merges `client/omnichannel` and `client/views/omnichannel`.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[ARCH-1795](https://rocketchat.atlassian.net/browse/ARCH-1795)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This PR is part of our “demeteorization” initiative.

Theoretically, the changes presented here aim to make the code to act like a facade for Meteor, isolating events and providing structures to be injected. For instance, it's delivered a Zustand store for _the framework_ to inform the current user ID instead of watching changes on `Meteor.userId()` to mutate the state of `UserProvider` i.e. the code acts like a server for the framework rather than a dependent consumer built on top of it.


[ARCH-1795]: https://rocketchat.atlassian.net/browse/ARCH-1795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ