### PR TITLE
feat: adds Federation GET /events/{eventId} endpoint

### DIFF
--- a/ee/packages/federation-matrix/src/api/_matrix/transactions.ts
+++ b/ee/packages/federation-matrix/src/api/_matrix/transactions.ts
@@ -278,7 +278,7 @@ export const getMatrixTransactionsRoutes = (services: HomeserverServices) => {
 
 					return {
 						body: {
-							origin_server_ts: eventData.event.origin_server_ts,
+							origin_server_ts: new Date().getTime(),
 							origin: config.serverName,
 							pdus: [eventData.event],
 						},


### PR DESCRIPTION
Previously tied to [RocketChat/homeserver#161](https://github.com/RocketChat/homeserver/pull/161). We’ve decided to move forward by pushing only the route implementation, leaving out the ACL for now. This helps us isolate domain concerns and speed up the overall work.

<details> <summary>Response example for <code>GET /_matrix/federation/v1/event/$KMoGnWYWjaoKlZ0FrmYJjWcc8LGLGz-JoOuvM14gqKU</code></summary>

```json
{
  "origin_server_ts": 1757538253737,
  "origin": "rc1",
  "pdus": [
    {
      "auth_events": [
        "$f9msK-kfJrGKleYgsqpLqSP-MchU4-7I_RIdIIA2J5Y",
        "$SWbOYtZ_1fdwE5V8rKQxx76oQgCEz_YnIfvIYDlwt-g",
        "$yWP9I1nqioBqgdeD6-lxPqh1j2qoUYf5Sxw7qY6syeI"
      ],
      "prev_events": [
        "$io6obrsV6Gnc9czkyEamVejsDWvUOEvRFHIhomai0KM"
      ],
      "type": "m.reaction",
      "room_id": "!CawYSGPh:rc1",
      "sender": "@admin:hs1",
      "content": {
        "m.relates_to": {
          "rel_type": "m.annotation",
          "event_id": "$1Na9fJixdb5fm6tr8moV1OIogFQyPKwJP19ZDIi0BIE",
          "key": "😍"
        }
      },
      "depth": 2,
      "origin": "hs1",
      "origin_server_ts": 1753919202258,
      "hashes": {
        "sha256": "LRr1OOmNP7K6w28uUtyeNhpa2uZSPE40G2WlszdElvo"
      },
      "signatures": {
        "hs1": {
          "ed25519:a_HDhg": "aKVRZDFfHmNY6Q1wvXKJ6pFpKr7BB/jwEs6dXyEpLIQrb+YZElD45Y66oqlw5H5mTfVLIlkxE9pgkhQG/dH8BA"
        }
      },
      "unsigned": {
        "age": 6848
      }
    }
  ]
}
```

</details>