### PR TITLE
feat: Add OpenAPI Support to push.test API

### DIFF
--- a/apps/meteor/app/api/server/v1/push.ts
+++ b/apps/meteor/app/api/server/v1/push.ts
@@ -1,6 +1,7 @@
 import type { IAppsTokens } from '@rocket.chat/core-typings';
 import { Messages, AppsTokens, Users, Rooms, Settings } from '@rocket.chat/models';
 import { Random } from '@rocket.chat/random';
+import { ajv, validateBadRequestErrorResponse, validateUnauthorizedErrorResponse } from '@rocket.chat/rest-typings';
 import { Match, check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
@@ -9,6 +10,7 @@ import { canAccessRoomAsync } from '../../../authorization/server/functions/canA
 import { pushUpdate } from '../../../push/server/methods';
 import PushNotification from '../../../push-notifications/server/lib/PushNotification';
 import { settings } from '../../../settings/server';
+import type { ExtractRoutesFromAPI } from '../ApiClass';
 import { API } from '../api';
 
 API.v1.addRoute(
@@ -135,7 +137,7 @@ API.v1.addRoute(
 	},
 );
 
-API.v1.addRoute(
+const pushEndpoints = API.v1.post(
 	'push.test',
 	{
 		authRequired: true,
@@ -144,17 +146,40 @@ API.v1.addRoute(
 			intervalTimeInMS: 1000,
 		},
 		permissionsRequired: ['test-push-notifications'],
-	},
-	{
-		async post() {
-			if (settings.get('Push_enable') !== true) {
-				throw new Meteor.Error('error-push-disabled', 'Push is disabled', {
-					method: 'push_test',
-				});
-			}
-
-			const tokensCount = await executePushTest(this.userId, this.user.username);
-			return API.v1.success({ tokensCount });
+		body: ajv.compile<undefined>({}),
+		response: {
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+			200: ajv.compile<{ tokensCount: number }>({
+				type: 'object',
+				properties: {
+					tokensCount: { type: 'integer' },
+					success: {
+						type: 'boolean',
+						enum: [true],
+					},
+				},
+				required: ['tokensCount', 'success'],
+				additionalProperties: false,
+			}),
 		},
 	},
+
+	async function action() {
+		if (settings.get('Push_enable') !== true) {
+			throw new Meteor.Error('error-push-disabled', 'Push is disabled', {
+				method: 'push_test',
+			});
+		}
+
+		const tokensCount = await executePushTest(this.userId, this.user.username);
+		return API.v1.success({ tokensCount });
+	},
 );
+
+export type PushEndpoints = ExtractRoutesFromAPI<typeof pushEndpoints>;
+
+declare module '@rocket.chat/rest-typings' {
+	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
+	interface Endpoints extends PushEndpoints {}
+}

--- a/packages/rest-typings/src/v1/push.ts
+++ b/packages/rest-typings/src/v1/push.ts
@@ -71,9 +71,4 @@ export type PushEndpoints = {
 			defaultPushGateway: boolean;
 		};
 	};
-	'/v1/push.test': {
-		POST: () => {
-			tokensCount: boolean;
-		};
-	};
 };


### PR DESCRIPTION
**Description:**  
This PR integrates OpenAPI support into the `Rocket.Chat API`, migrate of `Rocket.Chat API` endpoints to the new OpenAPI pattern. The update includes improved API documentation, enhanced type safety, and response validation using AJV.

**Key Changes:**  
- **Implemented the new pattern** and added AJV-based JSON schema validation for API.  
- **Uses the ExtractRoutesFromAPI utility** from the TypeScript definitions to dynamically derive the routes from the endpoint specifications.
- **Enabled Swagger UI** integration for this API.
- **Route Methods Chaining** for the endpoints.
- **This does not introduce any breaking changes** to the endpoint logic.


**Issue Reference:**  
Relates to #34983, part of the ongoing OpenAPI integration effort.

**Testing:**
- Verified that the API response schemas are correctly documented in Swagger UI.  
- All tests passed without any breaking changes

**Endpoints:**

- [x] Test Push Token
  

Looking forward to your feedback! 🚀