### PR TITLE
fix(outbound): agent autocomplete displaying incorrect avatar

### DIFF
--- a/apps/meteor/client/components/Omnichannel/OutboundMessage/components/AutoCompleteDepartmentAgent.tsx
+++ b/apps/meteor/client/components/Omnichannel/OutboundMessage/components/AutoCompleteDepartmentAgent.tsx
@@ -50,7 +50,7 @@ const AutoCompleteDepartmentAgent = ({ value, onChange, agents, ...props }: Auto
 			renderItem={({ value, label, ...props }): ReactElement => (
 				<Option key={value} {...props}>
 					<OptionAvatar>
-						<UserAvatar username={value} size='x20' />
+						<UserAvatar username={label} size='x20' />
 					</OptionAvatar>
 					<OptionContent>{label}</OptionContent>
 				</Option>


### PR DESCRIPTION

## Proposed changes (including videos or screenshots)
**Before:**
<img width="1504" height="998" alt="image" src="https://github.com/user-attachments/assets/577a217f-561f-43b3-b356-e1b08af5b3a7" />

**After:**
<img width="625" height="445" alt="Screenshot 2025-09-09 at 11 50 16" src="https://github.com/user-attachments/assets/96f8ba9b-5368-4be8-9189-f145d4175205" />


## Issue(s)
[CTZ-320](https://rocketchat.atlassian.net/browse/CTZ-320)

## Steps to test or reproduce
- Create new > Outbound message
- Fill out Recipient step, then next
- Fill out Message step, then next
- Select a department
- Click agent field
- Agent avatars should be correctly displayed

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CTZ-320]: https://rocketchat.atlassian.net/browse/CTZ-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ