### PR TITLE
feat: adds federation event ACL

### DIFF
--- a/ee/packages/federation-matrix/src/api/_matrix/transactions.ts
+++ b/ee/packages/federation-matrix/src/api/_matrix/transactions.ts
@@ -390,7 +390,7 @@ export const getMatrixTransactionsRoutes = (services: HomeserverServices) => {
 
 					return {
 						body: {
-							origin_server_ts: eventData.origin_server_ts,
+							origin_server_ts: eventData.event.origin_server_ts,
 							origin: eventData.origin,
 							pdus: [eventData.event],
 						},

--- a/ee/packages/federation-matrix/src/api/middlewares.ts
+++ b/ee/packages/federation-matrix/src/api/middlewares.ts
@@ -1,5 +1,6 @@
 import type { EventAuthorizationService } from '@hs/federation-sdk';
 import { errCodes } from '@hs/federation-sdk';
+import type { EventID } from '@hs/room';
 import type { Context, Next } from 'hono';
 
 export const canAccessEvent = (federationAuth: EventAuthorizationService) => async (c: Context, next: Next) => {
@@ -8,7 +9,7 @@ export const canAccessEvent = (federationAuth: EventAuthorizationService) => asy
 		const path = url.search ? `${c.req.path}${url.search}` : c.req.path;
 
 		const verificationResult = await federationAuth.canAccessEventFromAuthorizationHeader(
-			c.req.param('eventId'),
+			c.req.param('eventId') as EventID,
 			c.req.header('Authorization') || '',
 			c.req.method,
 			path,


### PR DESCRIPTION
Works along with https://github.com/RocketChat/homeserver/pull/161.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an endpoint to retrieve a specific event by ID, returning event metadata (timestamp, origin) and the event payload.
  - Enforced request-level access control for event retrieval so only authorized callers can fetch events.
  - GET now returns 404 with the appropriate error code when an event is not found.

- **Bug Fixes**
  - Response origin now reflects the stored event’s origin rather than the configured server name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->