### PR TITLE
fix(outbound): Clear placeholder once an agent is selected

### DIFF
--- a/apps/meteor/client/components/Omnichannel/OutboundMessage/components/AutoCompleteDepartmentAgent.spec.tsx
+++ b/apps/meteor/client/components/Omnichannel/OutboundMessage/components/AutoCompleteDepartmentAgent.spec.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+
+import AutoCompleteDepartmentAgent from './AutoCompleteDepartmentAgent';
+
+it('should not display the placeholder when there is a value', () => {
+	const { rerender } = render(<AutoCompleteDepartmentAgent value='' onChange={jest.fn()} placeholder='Select an agent' agents={[]} />);
+
+	expect(screen.getByPlaceholderText('Select an agent')).toBeInTheDocument();
+
+	rerender(<AutoCompleteDepartmentAgent value='agent1' onChange={jest.fn()} placeholder='Select an agent' agents={[]} />);
+
+	expect(screen.queryByPlaceholderText('Select an agent')).not.toBeInTheDocument();
+});

--- a/apps/meteor/client/components/Omnichannel/OutboundMessage/components/AutoCompleteDepartmentAgent.tsx
+++ b/apps/meteor/client/components/Omnichannel/OutboundMessage/components/AutoCompleteDepartmentAgent.tsx
@@ -12,7 +12,7 @@ type AutoCompleteDepartmentAgentProps = Omit<AllHTMLAttributes<HTMLInputElement>
 	agents?: Serialized<ILivechatDepartmentAgents>[];
 };
 
-const AutoCompleteDepartmentAgent = ({ value, onChange, agents, ...props }: AutoCompleteDepartmentAgentProps) => {
+const AutoCompleteDepartmentAgent = ({ value, onChange, agents, placeholder, ...props }: AutoCompleteDepartmentAgentProps) => {
 	const [filter, setFilter] = useState('');
 	const debouncedFilter = useDebouncedValue(filter, 1000);
 
@@ -33,6 +33,7 @@ const AutoCompleteDepartmentAgent = ({ value, onChange, agents, ...props }: Auto
 	return (
 		<AutoComplete
 			{...props}
+			placeholder={!value ? placeholder : undefined}
 			filter={filter}
 			setFilter={setFilter}
 			value={value}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR changes the logic to clear the placeholder in the Agent field auto complete once an agent is selected.

## Issue(s)
[CTZ-337](https://rocketchat.atlassian.net/browse/CTZ-337)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
