### PR TITLE
chore!: remove `hideRoomsWithNoActivity` param

### DIFF
--- a/.changeset/shaggy-otters-think.md
+++ b/.changeset/shaggy-otters-think.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': major
+---
+
+Removes the deprecated param `hideRoomsWithNoActivity` and adjust the api tests accordingly. Endpoint always returns rooms that are not empty.

--- a/apps/meteor/client/views/admin/engagementDashboard/channels/useChannelsList.ts
+++ b/apps/meteor/client/views/admin/engagementDashboard/channels/useChannelsList.ts
@@ -25,7 +25,6 @@ export const useChannelsList = ({ period, offset, count }: UseChannelsListOption
 				end: end.toISOString(),
 				offset,
 				count,
-				hideRoomsWithNoActivity: true,
 			});
 
 			return response

--- a/apps/meteor/ee/server/api/engagementDashboard/channels.ts
+++ b/apps/meteor/ee/server/api/engagementDashboard/channels.ts
@@ -3,7 +3,6 @@ import { check, Match } from 'meteor/check';
 
 import { API } from '../../../../app/api/server';
 import { getPaginationItems } from '../../../../app/api/server/helpers/getPaginationItems';
-import { apiDeprecationLogger } from '../../../../app/lib/server/lib/deprecationWarningLogger';
 import { findChannelsWithNumberOfMessages } from '../../lib/engagementDashboard/channels';
 import { isDateISOString, mapDateForAPI } from '../../lib/engagementDashboard/date';
 
@@ -11,7 +10,7 @@ declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	interface Endpoints {
 		'/v1/engagement-dashboard/channels/list': {
-			GET: (params: { start: string; end: string; offset?: number; count?: number; hideRoomsWithNoActivity?: boolean }) => {
+			GET: (params: { start: string; end: string; offset?: number; count?: number }) => {
 				channels: {
 					room: {
 						_id: IRoom['_id'];
@@ -47,30 +46,17 @@ API.v1.addRoute(
 				Match.ObjectIncluding({
 					start: Match.Where(isDateISOString),
 					end: Match.Where(isDateISOString),
-					hideRoomsWithNoActivity: Match.Maybe(String),
 					offset: Match.Maybe(String),
 					count: Match.Maybe(String),
 				}),
 			);
 
-			const { start, end, hideRoomsWithNoActivity } = this.queryParams;
+			const { start, end } = this.queryParams;
 			const { offset, count } = await getPaginationItems(this.queryParams);
-
-			if (hideRoomsWithNoActivity === undefined) {
-				apiDeprecationLogger.deprecatedParameterUsage(
-					this.route,
-					'hideRoomsWithNoActivity',
-					'7.0.0',
-					this.response,
-					({ parameter, endpoint, version }) =>
-						`Returning rooms that had no activity in ${endpoint} is deprecated and will be removed on version ${version} along with the \`${parameter}\` param. Set \`${parameter}\` as \`true\` to check how the endpoint will behave starting on ${version}`,
-				);
-			}
 
 			const { channels, total } = await findChannelsWithNumberOfMessages({
 				start: mapDateForAPI(start),
 				end: mapDateForAPI(end),
-				hideRoomsWithNoActivity: hideRoomsWithNoActivity === 'true',
 				options: { offset, count },
 			});
 

--- a/apps/meteor/ee/server/lib/engagementDashboard/channels.ts
+++ b/apps/meteor/ee/server/lib/engagementDashboard/channels.ts
@@ -1,5 +1,5 @@
 import type { IDirectMessageRoom, IRoom } from '@rocket.chat/core-typings';
-import { Analytics, Rooms } from '@rocket.chat/models';
+import { Analytics } from '@rocket.chat/models';
 import moment from 'moment';
 
 import { convertDateToInt, diffBetweenDaysInclusive } from './date';
@@ -8,12 +8,10 @@ import { roomCoordinator } from '../../../../server/lib/rooms/roomCoordinator';
 export const findChannelsWithNumberOfMessages = async ({
 	start,
 	end,
-	hideRoomsWithNoActivity,
 	options = {},
 }: {
 	start: Date;
 	end: Date;
-	hideRoomsWithNoActivity: boolean;
 	options: {
 		offset?: number;
 		count?: number;
@@ -34,10 +32,6 @@ export const findChannelsWithNumberOfMessages = async ({
 	}[];
 	total: number;
 }> => {
-	if (!hideRoomsWithNoActivity) {
-		return findAllChannelsWithNumberOfMessages({ start, end, options });
-	}
-
 	const daysBetweenDates = diffBetweenDaysInclusive(end, start);
 	const endOfLastWeek = moment(start).subtract(1, 'days').toDate();
 	const startOfLastWeek = moment(endOfLastWeek).subtract(daysBetweenDates, 'days').toDate();
@@ -58,55 +52,6 @@ export const findChannelsWithNumberOfMessages = async ({
 	}
 
 	const [{ channels, total }] = aggregationResult;
-	return {
-		channels,
-		total,
-	};
-};
-
-export const findAllChannelsWithNumberOfMessages = async ({
-	start,
-	end,
-	options = {},
-}: {
-	start: Date;
-	end: Date;
-	options: {
-		offset?: number;
-		count?: number;
-	};
-}): Promise<{
-	channels: {
-		room: {
-			_id: IRoom['_id'];
-			name: IRoom['name'] | IRoom['fname'];
-			ts: IRoom['ts'];
-			t: IRoom['t'];
-			_updatedAt: IRoom['_updatedAt'];
-			usernames?: IDirectMessageRoom['usernames'];
-		};
-		messages: number;
-		lastWeekMessages: number;
-		diffFromLastWeek: number;
-	}[];
-	total: number;
-}> => {
-	const daysBetweenDates = diffBetweenDaysInclusive(end, start);
-	const endOfLastWeek = moment(start).subtract(1, 'days').toDate();
-	const startOfLastWeek = moment(endOfLastWeek).subtract(daysBetweenDates, 'days').toDate();
-	const roomTypes = roomCoordinator.getTypesToShowOnDashboard() as Array<IRoom['t']>;
-
-	const channels = await Rooms.findChannelsByTypesWithNumberOfMessagesBetweenDate({
-		types: roomTypes,
-		start: convertDateToInt(start),
-		end: convertDateToInt(end),
-		startOfLastWeek: convertDateToInt(startOfLastWeek),
-		endOfLastWeek: convertDateToInt(endOfLastWeek),
-		options,
-	}).toArray();
-
-	const total = await Rooms.countDocuments({ t: { $in: roomTypes } });
-
 	return {
 		channels,
 		total,

--- a/apps/meteor/tests/end-to-end/api/34-engagement-dashboard.ts
+++ b/apps/meteor/tests/end-to-end/api/34-engagement-dashboard.ts
@@ -21,13 +21,16 @@ describe('[Engagement Dashboard]', function () {
 
 	(isEnterprise ? describe : describe.skip)('[/engagement-dashboard/channels/list]', () => {
 		let testRoom: IRoom;
+		let emptyRoom: IRoom;
 
 		before(async () => {
 			testRoom = (await createRoom({ type: 'c', name: `channel.test.engagement.${Date.now()}-${Math.random()}` })).body.channel;
+			emptyRoom = (await createRoom({ type: 'c', name: `channel.test.engagement.empty.${Date.now()}-${Math.random()}` })).body.channel;
 		});
 
 		after(async () => {
 			await deleteRoom({ type: 'c', roomId: testRoom._id });
+			await deleteRoom({ type: 'c', roomId: emptyRoom._id });
 		});
 
 		it('should fail if user does not have the view-engagement-dashboard permission', async () => {
@@ -117,6 +120,8 @@ describe('[Engagement Dashboard]', function () {
 		});
 
 		it('should succesfuly return results', async () => {
+			await sendSimpleMessage({ roomId: testRoom._id });
+
 			await request
 				.get(api('engagement-dashboard/channels/list'))
 				.set(credentials)
@@ -164,13 +169,12 @@ describe('[Engagement Dashboard]', function () {
 					expect(res.body).to.have.property('count');
 					expect(res.body).to.have.property('total');
 					expect(res.body).to.have.property('channels');
-					const channelRecord = res.body.channels.find(({ room }: { room: { _id: string } }) => room._id === testRoom._id);
+					const channelRecord = res.body.channels.find(({ room }: { room: { _id: string } }) => room._id === emptyRoom._id);
 					expect(channelRecord).to.be.undefined;
 				});
 		});
 
 		it('should correctly count messages diff compared to last week when there are messages in a room', async () => {
-			await sendSimpleMessage({ roomId: testRoom._id });
 			await request
 				.get(api('engagement-dashboard/channels/list'))
 				.set(credentials)

--- a/apps/meteor/tests/end-to-end/api/34-engagement-dashboard.ts
+++ b/apps/meteor/tests/end-to-end/api/34-engagement-dashboard.ts
@@ -148,14 +148,13 @@ describe('[Engagement Dashboard]', function () {
 				});
 		});
 
-		it('should not return empty rooms when the hideRoomsWithNoActivity param is provided', async () => {
+		it('should not return empty rooms', async () => {
 			await request
 				.get(api('engagement-dashboard/channels/list'))
 				.set(credentials)
 				.query({
 					end: new Date().toISOString(),
 					start: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
-					hideRoomsWithNoActivity: true,
 				})
 				.expect('Content-Type', 'application/json')
 				.expect(200)
@@ -170,42 +169,7 @@ describe('[Engagement Dashboard]', function () {
 				});
 		});
 
-		it('should correctly count messages in an empty room', async () => {
-			await request
-				.get(api('engagement-dashboard/channels/list'))
-				.set(credentials)
-				.query({
-					end: new Date().toISOString(),
-					start: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
-				})
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res: Response) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('offset', 0);
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('channels');
-					expect(res.body.channels).to.be.an('array').that.is.not.empty;
-
-					const channelRecord = res.body.channels.find(({ room }: { room: { _id: string } }) => room._id === testRoom._id);
-					expect(channelRecord).not.to.be.undefined;
-
-					expect(channelRecord).to.be.an('object').that.is.not.empty;
-					expect(channelRecord).to.have.property('messages', 0);
-					expect(channelRecord).to.have.property('lastWeekMessages', 0);
-					expect(channelRecord).to.have.property('diffFromLastWeek', 0);
-					expect(channelRecord.room).to.be.an('object').that.is.not.empty;
-
-					expect(channelRecord.room).to.have.property('_id', testRoom._id);
-					expect(channelRecord.room).to.have.property('name', testRoom.name);
-					expect(channelRecord.room).to.have.property('ts', testRoom.ts);
-					expect(channelRecord.room).to.have.property('t', testRoom.t);
-					expect(channelRecord.room).to.have.property('_updatedAt', testRoom._updatedAt);
-				});
-		});
-
-		it('should correctly count messages diff compared to last week when the hideRoomsWithNoActivity param is provided and there are messages in a room', async () => {
+		it('should correctly count messages diff compared to last week when there are messages in a room', async () => {
 			await sendSimpleMessage({ roomId: testRoom._id });
 			await request
 				.get(api('engagement-dashboard/channels/list'))
@@ -213,7 +177,6 @@ describe('[Engagement Dashboard]', function () {
 				.query({
 					end: new Date().toISOString(),
 					start: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
-					hideRoomsWithNoActivity: true,
 				})
 				.expect('Content-Type', 'application/json')
 				.expect(200)
@@ -275,14 +238,13 @@ describe('[Engagement Dashboard]', function () {
 				});
 		});
 
-		it('should correctly count messages from last week and diff when moving to the next week and providing the hideRoomsWithNoActivity param', async () => {
+		it('should correctly count messages from last week and diff when moving to the next week', async () => {
 			await request
 				.get(api('engagement-dashboard/channels/list'))
 				.set(credentials)
 				.query({
 					end: new Date(Date.now() + 8 * 24 * 60 * 60 * 1000).toISOString(),
 					start: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-					hideRoomsWithNoActivity: true,
 				})
 				.expect('Content-Type', 'application/json')
 				.expect(200)


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
[ARCH-1757](https://rocketchat.atlassian.net/browse/ARCH-1757)
<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Default behavior from endpoint `engagement-dashboard/channels/list` is to only return rooms that are **not empty**:
- remove `hideRoomsWithNoActivity` param from `engagement-dashboard/channels/list` enpoint
- remove `hideRoomsWithNoActivity` param usage
- adjust tests

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[ARCH-1757]: https://rocketchat.atlassian.net/browse/ARCH-1757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Breaking Changes
  - Engagement Dashboard API no longer accepts hideRoomsWithNoActivity; the channels list now always excludes rooms with no messages. Update clients to stop sending this parameter.

- Improvements
  - More consistent channel analytics: empty rooms are no longer included in results by default.

- Tests
  - Updated end-to-end tests to validate the absence of empty rooms and behavior without the deprecated parameter.

- Chores
  - Bumped @rocket.chat/meteor to a new major version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->