### PR TITLE
refactor: set tshow to true for the first thread message in federated rooms

### DIFF
--- a/apps/meteor/server/services/messages/service.ts
+++ b/apps/meteor/server/services/messages/service.ts
@@ -90,19 +90,18 @@ export class MessageService extends ServiceClassInternal implements IMessageServ
 		rid,
 		msg,
 		federation_event_id,
-		tmid,
+		thread,
 	}: {
 		fromId: string;
 		rid: string;
 		msg: string;
 		federation_event_id: string;
-		tmid?: string;
+		thread?: { tmid: string; tshow: boolean };
 	}): Promise<IMessage> {
-		const threadParams = tmid ? { tmid, tshow: false } : {};
 		return executeSendMessage(fromId, {
 			rid,
 			msg,
-			...threadParams,
+			...(thread || {}),
 			federation: { eventId: federation_event_id },
 		});
 	}

--- a/apps/meteor/server/services/messages/service.ts
+++ b/apps/meteor/server/services/messages/service.ts
@@ -101,7 +101,7 @@ export class MessageService extends ServiceClassInternal implements IMessageServ
 		return executeSendMessage(fromId, {
 			rid,
 			msg,
-			...(thread || {}),
+			...thread,
 			federation: { eventId: federation_event_id },
 		});
 	}

--- a/apps/meteor/server/services/messages/service.ts
+++ b/apps/meteor/server/services/messages/service.ts
@@ -98,7 +98,7 @@ export class MessageService extends ServiceClassInternal implements IMessageServ
 		federation_event_id: string;
 		tmid?: string;
 	}): Promise<IMessage> {
-		const threadParams = tmid ? { tmid, tshow: true } : {};
+		const threadParams = tmid ? { tmid, tshow: false } : {};
 		return executeSendMessage(fromId, {
 			rid,
 			msg,

--- a/ee/packages/federation-matrix/src/events/message.ts
+++ b/ee/packages/federation-matrix/src/events/message.ts
@@ -114,15 +114,16 @@ export function message(emitter: Emitter<HomeserverEventSignatures>, serverName:
 				}
 			}
 
-			let tmid: string | undefined;
+			let thread: { tmid: string; tshow: boolean } | undefined;
 			if (isThreadMessage && threadRootEventId) {
 				const threadRootMessage = await Messages.findOneByFederationId(threadRootEventId);
-				if (threadRootMessage) {
-					tmid = threadRootMessage._id;
-					logger.debug('Found thread root message:', { tmid, threadRootEventId });
-				} else {
+				if (!threadRootMessage) {
 					logger.warn('Thread root message not found for event:', threadRootEventId);
+					return;
 				}
+
+				const shouldSetTshow = !threadRootMessage?.tcount;
+				thread = { tmid: threadRootMessage._id, tshow: shouldSetTshow };
 			}
 
 			const isEditedMessage = data.content['m.relates_to']?.rel_type === 'm.replace';
@@ -201,7 +202,7 @@ export function message(emitter: Emitter<HomeserverEventSignatures>, serverName:
 					rid: internalRoomId,
 					msg: formatted,
 					federation_event_id: data.event_id,
-					tmid,
+					...(thread ? { thread } : {}),
 				});
 				return;
 			}
@@ -217,7 +218,7 @@ export function message(emitter: Emitter<HomeserverEventSignatures>, serverName:
 				rid: internalRoomId,
 				msg: formatted,
 				federation_event_id: data.event_id,
-				tmid,
+				...(thread ? { thread } : {}),
 			});
 		} catch (error) {
 			logger.error('Error processing Matrix message:', error);

--- a/ee/packages/federation-matrix/src/events/message.ts
+++ b/ee/packages/federation-matrix/src/events/message.ts
@@ -202,7 +202,7 @@ export function message(emitter: Emitter<HomeserverEventSignatures>, serverName:
 					rid: internalRoomId,
 					msg: formatted,
 					federation_event_id: data.event_id,
-					...(thread ? { thread } : {}),
+					thread,
 				});
 				return;
 			}
@@ -218,7 +218,7 @@ export function message(emitter: Emitter<HomeserverEventSignatures>, serverName:
 				rid: internalRoomId,
 				msg: formatted,
 				federation_event_id: data.event_id,
-				...(thread ? { thread } : {}),
+				thread,
 			});
 		} catch (error) {
 			logger.error('Error processing Matrix message:', error);


### PR DESCRIPTION
As per [FDR-126](https://rocketchat.atlassian.net/browse/FDR-126), added a check on the `threadRootMessage.tcount` to identify the first message of a thread. If `tcount` is missing, the message is treated as the first in the thread and `tshow` is set to `true`, ensuring it is also sent to the main room. Otherwise, will set `tshow` to `false`.

This mirrors the Rocket.Chat behavior, where federated rooms don’t provide a checkbox to choose whether to send a thread message to the main room, but the first message of a thread is always posted there automatically.

[FDR-126]: https://rocketchat.atlassian.net/browse/FDR-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents orphaned threaded replies from federated sources by skipping processing when the thread root is missing.
  - Fixes incorrect initial thread visibility by removing an implicit default so visibility is now accurate.

- Improvements
  - Standardizes and explicitly carries thread metadata (including visibility) for incoming federated messages.
  - Adds a warning when a thread root cannot be found to improve reliability and diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->