### PR TITLE
feat: add origin to room name to prevent cross-server conflicts

### DIFF
--- a/ee/packages/federation-matrix/src/api/_matrix/invite.ts
+++ b/ee/packages/federation-matrix/src/api/_matrix/invite.ts
@@ -238,13 +238,6 @@ async function joinRoom({
 	const internalMappedRoomId = await MatrixBridgedRoom.getLocalRoomId(inviteEvent.roomId);
 
 	if (!internalMappedRoomId) {
-		let roomName: string;
-		try {
-			roomName = matrixRoom.name || '';
-		} catch (error) {
-			roomName = inviteEvent.roomId.split(':')[0].replace('!', '') || 'Unnamed Room';
-		}
-
 		let roomType: 'c' | 'p' | 'd';
 
 		if (isDM) {
@@ -272,6 +265,10 @@ async function joinRoom({
 				throw new Error('inviteeUser user not found');
 			}
 
+			// TODO: Rethink room name on DMs
+			// get the other user than ourself
+			const roomName = matrixRoom.name === senderUser.username ? inviteeUser.username : senderUser.username;
+
 			ourRoom = await Room.create(senderUserId, {
 				type: roomType,
 				name: roomName,
@@ -285,6 +282,9 @@ async function joinRoom({
 				},
 			});
 		} else {
+			const roomFname = `${matrixRoom.name}:${matrixRoom.origin}`;
+			const roomName = inviteEvent.roomId.replace('!', '').replace(':', '_');
+
 			ourRoom = await Room.create(senderUserId, {
 				type: roomType,
 				name: roomName,
@@ -294,6 +294,7 @@ async function joinRoom({
 				},
 				extraData: {
 					federated: true,
+					fname: roomFname,
 				},
 			});
 		}


### PR DESCRIPTION
- [FDR-113](https://rocketchat.atlassian.net/browse/FDR-113)

[FDR-113]: https://rocketchat.atlassian.net/browse/FDR-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Direct message rooms now display the other participant’s username to avoid self-named DMs.
  * Federated non-DM rooms use consistent display names including origin info for reliable cross-server recognition.
  * Removed unreliable fallback naming that could produce blank or incorrect room names.
  * Improved room creation when no existing mapping exists to ensure consistent names and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->