### PR TITLE
fix(a11y): TOTP modal validation and error handling

### DIFF
--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorEmailModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorEmailModal.tsx
@@ -86,6 +86,7 @@ const TwoFactorEmailModal = ({ onConfirm, onClose, emailOrUsername }: TwoFactorE
 									autoComplete='one-time-code'
 									inputMode='numeric'
 									disabled={isSubmitting}
+									error={errors.code?.message}
 								/>
 							)}
 						/>

--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorEmailModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorEmailModal.tsx
@@ -1,9 +1,9 @@
-import { Box, FieldGroup, TextInput, Field, FieldLabel, FieldRow, FieldError, Button } from '@rocket.chat/fuselage';
-import { useAutoFocus } from '@rocket.chat/fuselage-hooks';
+import { Box, Button } from '@rocket.chat/fuselage';
+import { FieldGroup, TextInput, Field, FieldLabel, FieldRow, FieldError } from '@rocket.chat/fuselage-forms';
 import { GenericModal } from '@rocket.chat/ui-client';
 import { useToastMessageDispatch, useEndpoint } from '@rocket.chat/ui-contexts';
-import type { ReactElement, ChangeEvent, SyntheticEvent } from 'react';
-import { useId, useState } from 'react';
+import type { ReactElement } from 'react';
+import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import type { OnConfirm } from './TwoFactorModal';
@@ -13,14 +13,25 @@ type TwoFactorEmailModalProps = {
 	onConfirm: OnConfirm;
 	onClose: () => void;
 	emailOrUsername: string;
-	invalidAttempt?: boolean;
 };
 
-const TwoFactorEmailModal = ({ onConfirm, onClose, emailOrUsername, invalidAttempt }: TwoFactorEmailModalProps): ReactElement => {
+type TwoFactorEmailFormData = {
+	code: string;
+};
+
+const TwoFactorEmailModal = ({ onConfirm, onClose, emailOrUsername }: TwoFactorEmailModalProps): ReactElement => {
 	const dispatchToastMessage = useToastMessageDispatch();
 	const { t } = useTranslation();
-	const [code, setCode] = useState<string>('');
-	const ref = useAutoFocus<HTMLInputElement>();
+
+	const {
+		control,
+		handleSubmit,
+		setError,
+		setValue,
+		formState: { errors, isSubmitting },
+	} = useForm<TwoFactorEmailFormData>({
+		defaultValues: { code: '' },
+	});
 
 	const sendEmailCode = useEndpoint('POST', '/v1/users.2fa.sendEmailCode');
 
@@ -36,46 +47,50 @@ const TwoFactorEmailModal = ({ onConfirm, onClose, emailOrUsername, invalidAttem
 		}
 	};
 
-	const onConfirmEmailCode = (e: SyntheticEvent): void => {
-		e.preventDefault();
-		onConfirm(code, Method.EMAIL);
-	};
-
-	const onChange = ({ currentTarget }: ChangeEvent<HTMLInputElement>): void => {
-		setCode(currentTarget.value);
-	};
-
-	const id = useId();
+	const onSubmit = handleSubmit(async ({ code }) => {
+		try {
+			await onConfirm(code, Method.EMAIL);
+		} catch (error) {
+			setError('code', {
+				type: 'manual',
+				message: t('Invalid_two_factor_code'),
+			});
+			setValue('code', '');
+		}
+	});
 
 	return (
 		<GenericModal
-			wrapperFunction={(props) => <Box is='form' onSubmit={onConfirmEmailCode} {...props} />}
+			wrapperFunction={(props) => <Box is='form' onSubmit={onSubmit} {...props} />}
 			onCancel={onClose}
 			confirmText={t('Verify')}
 			title={t('Enter_authentication_code')}
 			onClose={onClose}
 			variant='warning'
-			confirmDisabled={!code}
+			confirmDisabled={isSubmitting}
 			tagline={t('Email_two-factor_authentication')}
 			icon={null}
 		>
 			<FieldGroup>
 				<Field>
-					<FieldLabel alignSelf='stretch' htmlFor={id}>
-						{t('Enter_the_code_we_just_emailed_you')}
-					</FieldLabel>
+					<FieldLabel alignSelf='stretch'>{t('Enter_the_code_we_just_emailed_you')}</FieldLabel>
 					<FieldRow>
-						<TextInput
-							id={id}
-							ref={ref}
-							value={code}
-							onChange={onChange}
-							placeholder={t('Enter_code_here')}
-							autoComplete='one-time-code'
-							inputMode='numeric'
+						<Controller
+							name='code'
+							control={control}
+							rules={{ required: t('Required_field', { field: t('Code') }) }}
+							render={({ field }) => (
+								<TextInput
+									{...field}
+									placeholder={t('Enter_code_here')}
+									autoComplete='one-time-code'
+									inputMode='numeric'
+									disabled={isSubmitting}
+								/>
+							)}
 						/>
 					</FieldRow>
-					{invalidAttempt && <FieldError>{t('Invalid_password')}</FieldError>}
+					{errors.code && <FieldError>{errors.code.message}</FieldError>}
 				</Field>
 			</FieldGroup>
 			<Button display='flex' justifyContent='end' onClick={onClickResendCode} small mbs={24}>

--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorModal.tsx
@@ -10,12 +10,11 @@ export enum Method {
 	PASSWORD = 'password',
 }
 
-export type OnConfirm = (code: string, method: Method) => void;
+export type OnConfirm = (code: string, method: Method) => void | Promise<void>;
 
 type TwoFactorModalProps = {
 	onConfirm: OnConfirm;
 	onClose: () => void;
-	invalidAttempt?: boolean;
 } & (
 	| {
 			method: 'totp' | 'password';
@@ -26,19 +25,19 @@ type TwoFactorModalProps = {
 	  }
 );
 
-const TwoFactorModal = ({ onConfirm, onClose, invalidAttempt, ...props }: TwoFactorModalProps): ReactElement => {
+const TwoFactorModal = ({ onConfirm, onClose, ...props }: TwoFactorModalProps): ReactElement => {
 	if (props.method === Method.TOTP) {
-		return <TwoFactorTotp onConfirm={onConfirm} onClose={onClose} invalidAttempt={invalidAttempt} />;
+		return <TwoFactorTotp onConfirm={onConfirm} onClose={onClose} />;
 	}
 
 	if (props.method === Method.EMAIL) {
 		const { emailOrUsername } = props;
 
-		return <TwoFactorEmail onConfirm={onConfirm} onClose={onClose} emailOrUsername={emailOrUsername} invalidAttempt={invalidAttempt} />;
+		return <TwoFactorEmail onConfirm={onConfirm} onClose={onClose} emailOrUsername={emailOrUsername} />;
 	}
 
 	if (props.method === Method.PASSWORD) {
-		return <TwoFactorPassword onConfirm={onConfirm} onClose={onClose} invalidAttempt={invalidAttempt} />;
+		return <TwoFactorPassword onConfirm={onConfirm} onClose={onClose} />;
 	}
 
 	throw new Error('Invalid Two Factor method');

--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorPasswordModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorPasswordModal.tsx
@@ -1,4 +1,5 @@
-import { Box, PasswordInput, FieldGroup, Field, FieldLabel, FieldRow, FieldError } from '@rocket.chat/fuselage';
+import { Box } from '@rocket.chat/fuselage';
+import { PasswordInput, FieldGroup, Field, FieldLabel, FieldRow, FieldError } from '@rocket.chat/fuselage-forms';
 import { GenericModal } from '@rocket.chat/ui-client';
 import type { ReactElement } from 'react';
 import { useForm, Controller } from 'react-hook-form';

--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorPasswordModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorPasswordModal.tsx
@@ -60,7 +60,9 @@ const TwoFactorPasswordModal = ({ onConfirm, onClose }: TwoFactorPasswordModalPr
 							name='password'
 							control={control}
 							rules={{ required: t('Required_field', { field: t('Password') }) }}
-							render={({ field }) => <PasswordInput {...field} placeholder={t('Password')} disabled={isSubmitting} />}
+							render={({ field }) => (
+								<PasswordInput {...field} placeholder={t('Password')} disabled={isSubmitting} error={errors.password?.message} />
+							)}
 						/>
 					</FieldRow>
 					{errors.password && <FieldError>{errors.password.message}</FieldError>}

--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorPasswordModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorPasswordModal.tsx
@@ -1,8 +1,7 @@
 import { Box, PasswordInput, FieldGroup, Field, FieldLabel, FieldRow, FieldError } from '@rocket.chat/fuselage';
-import { useAutoFocus } from '@rocket.chat/fuselage-hooks';
 import { GenericModal } from '@rocket.chat/ui-client';
-import type { ReactElement, ChangeEvent, Ref, SyntheticEvent } from 'react';
-import { useId, useState } from 'react';
+import type { ReactElement } from 'react';
+import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import type { OnConfirm } from './TwoFactorModal';
@@ -11,51 +10,60 @@ import { Method } from './TwoFactorModal';
 type TwoFactorPasswordModalProps = {
 	onConfirm: OnConfirm;
 	onClose: () => void;
-	invalidAttempt?: boolean;
 };
 
-const TwoFactorPasswordModal = ({ onConfirm, onClose, invalidAttempt }: TwoFactorPasswordModalProps): ReactElement => {
+type TwoFactorPasswordFormData = {
+	password: string;
+};
+
+const TwoFactorPasswordModal = ({ onConfirm, onClose }: TwoFactorPasswordModalProps): ReactElement => {
 	const { t } = useTranslation();
-	const [code, setCode] = useState<string>('');
-	const ref = useAutoFocus();
 
-	const onConfirmTotpCode = (e: SyntheticEvent): void => {
-		e.preventDefault();
-		onConfirm(code, Method.PASSWORD);
-	};
+	const {
+		control,
+		handleSubmit,
+		setError,
+		setValue,
+		formState: { errors, isSubmitting },
+	} = useForm<TwoFactorPasswordFormData>({
+		defaultValues: { password: '' },
+	});
 
-	const onChange = ({ currentTarget }: ChangeEvent<HTMLInputElement>): void => {
-		setCode(currentTarget.value);
-	};
-
-	const id = useId();
+	const onSubmit = handleSubmit(async ({ password }) => {
+		try {
+			await onConfirm(password, Method.PASSWORD);
+		} catch (error) {
+			setError('password', {
+				type: 'manual',
+				message: t('Invalid_password'),
+			});
+			setValue('password', '');
+		}
+	});
 
 	return (
 		<GenericModal
-			wrapperFunction={(props) => <Box is='form' onSubmit={onConfirmTotpCode} {...props} />}
+			wrapperFunction={(props) => <Box is='form' onSubmit={onSubmit} {...props} />}
 			onCancel={onClose}
 			confirmText={t('Verify')}
 			title={t('Please_enter_your_password')}
 			onClose={onClose}
 			variant='warning'
 			icon='info'
-			confirmDisabled={!code}
+			confirmDisabled={isSubmitting}
 		>
 			<FieldGroup>
 				<Field>
-					<FieldLabel alignSelf='stretch' htmlFor={id}>
-						{t('For_your_security_you_must_enter_your_current_password_to_continue')}
-					</FieldLabel>
+					<FieldLabel alignSelf='stretch'>{t('For_your_security_you_must_enter_your_current_password_to_continue')}</FieldLabel>
 					<FieldRow>
-						<PasswordInput
-							id={id}
-							ref={ref as Ref<HTMLInputElement>}
-							value={code}
-							onChange={onChange}
-							placeholder={t('Password')}
-						></PasswordInput>
+						<Controller
+							name='password'
+							control={control}
+							rules={{ required: t('Required_field', { field: t('Password') }) }}
+							render={({ field }) => <PasswordInput {...field} placeholder={t('Password')} disabled={isSubmitting} />}
+						/>
 					</FieldRow>
-					{invalidAttempt && <FieldError>{t('Invalid_password')}</FieldError>}
+					{errors.password && <FieldError>{errors.password.message}</FieldError>}
 				</Field>
 			</FieldGroup>
 		</GenericModal>

--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
@@ -59,7 +59,7 @@ const TwoFactorTotpModal = ({ onConfirm, onClose, onDismiss, invalidAttempt }: T
 							inputMode='numeric'
 						/>
 					</FieldRow>
-					{invalidAttempt && <FieldError>{t('Invalid_password')}</FieldError>}
+					{invalidAttempt && <FieldError>{t('Invalid_two_factor_code')}</FieldError>}
 				</Field>
 			</FieldGroup>
 		</GenericModal>

--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
@@ -1,8 +1,8 @@
-import { Box, TextInput, Field, FieldGroup, FieldLabel, FieldRow, FieldError } from '@rocket.chat/fuselage';
-import { useAutoFocus } from '@rocket.chat/fuselage-hooks';
+import { Box } from '@rocket.chat/fuselage';
+import { FieldGroup, TextInput, Field, FieldLabel, FieldRow, FieldError } from '@rocket.chat/fuselage-forms';
 import { GenericModal } from '@rocket.chat/ui-client';
-import type { ReactElement, ChangeEvent, SyntheticEvent } from 'react';
-import { useId, useState } from 'react';
+import type { ReactElement } from 'react';
+import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import type { OnConfirm } from './TwoFactorModal';
@@ -12,54 +12,70 @@ type TwoFactorTotpModalProps = {
 	onConfirm: OnConfirm;
 	onClose: () => void;
 	onDismiss?: () => void;
-	invalidAttempt?: boolean;
 };
 
-const TwoFactorTotpModal = ({ onConfirm, onClose, onDismiss, invalidAttempt }: TwoFactorTotpModalProps): ReactElement => {
+type TwoFactorTotpFormData = {
+	code: string;
+};
+
+const TwoFactorTotpModal = ({ onConfirm, onClose, onDismiss }: TwoFactorTotpModalProps): ReactElement => {
 	const { t } = useTranslation();
-	const [code, setCode] = useState<string>('');
-	const ref = useAutoFocus<HTMLInputElement>();
 
-	const onConfirmTotpCode = (e: SyntheticEvent): void => {
-		e.preventDefault();
-		onConfirm(code, Method.TOTP);
-	};
+	const {
+		control,
+		handleSubmit,
+		setError,
+		setValue,
+		formState: { errors, isSubmitting },
+	} = useForm<TwoFactorTotpFormData>({
+		defaultValues: { code: '' },
+	});
 
-	const onChange = ({ currentTarget }: ChangeEvent<HTMLInputElement>): void => {
-		setCode(currentTarget.value);
-	};
+	const onSubmit = handleSubmit(async ({ code }) => {
+		try {
+			await onConfirm(code, Method.TOTP);
+		} catch (error) {
+			setError('code', {
+				type: 'manual',
+				message: t('Invalid_two_factor_code'),
+			});
+			setValue('code', '');
+		}
+	});
 
-	const id = useId();
 	return (
 		<GenericModal
-			wrapperFunction={(props) => <Box is='form' onSubmit={onConfirmTotpCode} {...props} />}
+			wrapperFunction={(props) => <Box is='form' onSubmit={onSubmit} {...props} />}
 			onCancel={onClose}
 			confirmText={t('Verify')}
 			title={t('Enter_TOTP_password')}
 			onClose={onClose}
 			onDismiss={onDismiss}
 			variant='warning'
-			confirmDisabled={!code}
+			confirmDisabled={isSubmitting}
 			tagline={t('Two-factor_authentication')}
 			icon={null}
 		>
 			<FieldGroup>
 				<Field>
-					<FieldLabel alignSelf='stretch' htmlFor={id}>
-						{t('Enter_the_code_provided_by_your_authentication_app_to_continue')}
-					</FieldLabel>
+					<FieldLabel alignSelf='stretch'>{t('Enter_the_code_provided_by_your_authentication_app_to_continue')}</FieldLabel>
 					<FieldRow>
-						<TextInput
-							id={id}
-							ref={ref}
-							value={code}
-							onChange={onChange}
-							placeholder={t('Enter_code_here')}
-							autoComplete='one-time-code'
-							inputMode='numeric'
+						<Controller
+							name='code'
+							control={control}
+							rules={{ required: t('Required_field', { field: t('Code') }) }}
+							render={({ field }) => (
+								<TextInput
+									{...field}
+									placeholder={t('Enter_code_here')}
+									autoComplete='one-time-code'
+									inputMode='numeric'
+									disabled={isSubmitting}
+								/>
+							)}
 						/>
 					</FieldRow>
-					{invalidAttempt && <FieldError>{t('Invalid_two_factor_code')}</FieldError>}
+					{errors.code && <FieldError>{errors.code.message}</FieldError>}
 				</Field>
 			</FieldGroup>
 		</GenericModal>

--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
@@ -71,6 +71,7 @@ const TwoFactorTotpModal = ({ onConfirm, onClose, onDismiss }: TwoFactorTotpModa
 									autoComplete='one-time-code'
 									inputMode='numeric'
 									disabled={isSubmitting}
+									error={errors.code?.message}
 								/>
 							)}
 						/>

--- a/apps/meteor/client/lib/2fa/overrideLoginMethod.ts
+++ b/apps/meteor/client/lib/2fa/overrideLoginMethod.ts
@@ -16,7 +16,7 @@ export const overrideLoginMethod = <TArgs extends any[]>(
 	loginMethod(...loginArgs, async (error: LoginError | undefined, result?: unknown) => {
 		if (!isTotpRequiredError(error)) {
 			callback?.(error);
-			return;
+			return error;
 		}
 
 		const { process2faReturn } = await import('./process2faReturn');
@@ -27,32 +27,33 @@ export const overrideLoginMethod = <TArgs extends any[]>(
 			emailOrUsername: typeof loginArgs[0] === 'string' ? loginArgs[0] : undefined,
 			originalCallback: callback,
 			onCode: (code: string) => {
-				loginMethodTOTP(...loginArgs, code, (error: LoginError | undefined, result?: unknown) => {
-					if (!error) {
-						callback?.(undefined, result);
-						return;
-					}
-
-					if (isTotpInvalidError(error)) {
-						callback?.(error);
-						return;
-					}
-
-					Promise.all([import('../../../app/utils/lib/i18n'), import('../toast')]).then(([{ t }, { dispatchToastMessage }]) => {
-						if (isTotpMaxAttemptsError(error)) {
-							dispatchToastMessage({
-								type: 'error',
-								message: t('totp-max-attempts'),
-							});
-							callback?.(undefined);
+				return new Promise<void>((resolve, reject) => {
+					loginMethodTOTP(...loginArgs, code, (error: LoginError | undefined, result?: unknown) => {
+						if (!error) {
+							callback?.(undefined, result);
+							resolve();
 							return;
 						}
 
-						dispatchToastMessage({ type: 'error', message: t('Invalid_two_factor_code') });
-						callback?.(undefined);
+						if (isTotpInvalidError(error)) {
+							reject(error);
+							return;
+						}
+
+						Promise.all([import('../../../app/utils/lib/i18n'), import('../toast')]).then(([{ t }, { dispatchToastMessage }]) => {
+							if (isTotpMaxAttemptsError(error)) {
+								dispatchToastMessage({ type: 'error', message: t('totp-max-attempts') });
+								resolve();
+								return;
+							}
+
+							dispatchToastMessage({ type: 'error', message: t('Invalid_two_factor_code') });
+							reject();
+						});
 					});
 				});
-			},
+			}
+
 		});
 	});
 };

--- a/apps/meteor/client/lib/2fa/overrideLoginMethod.ts
+++ b/apps/meteor/client/lib/2fa/overrideLoginMethod.ts
@@ -21,40 +21,43 @@ export const overrideLoginMethod = <TArgs extends any[]>(
 
 		const { process2faReturn } = await import('./process2faReturn');
 
-		await process2faReturn({
-			error,
-			result,
-			emailOrUsername: typeof loginArgs[0] === 'string' ? loginArgs[0] : undefined,
-			originalCallback: callback,
-			onCode: (code: string) => {
-				return new Promise<void>((resolve, reject) => {
-					loginMethodTOTP(...loginArgs, code, (error: LoginError | undefined, result?: unknown) => {
-						if (!error) {
-							callback?.(undefined, result);
-							resolve();
-							return;
-						}
-
-						if (isTotpInvalidError(error)) {
-							reject(error);
-							return;
-						}
-
-						Promise.all([import('../../../app/utils/lib/i18n'), import('../toast')]).then(([{ t }, { dispatchToastMessage }]) => {
-							if (isTotpMaxAttemptsError(error)) {
-								dispatchToastMessage({ type: 'error', message: t('totp-max-attempts') });
+		try {
+			await process2faReturn({
+				error,
+				result,
+				emailOrUsername: typeof loginArgs[0] === 'string' ? loginArgs[0] : undefined,
+				originalCallback: callback,
+				onCode: (code: string) => {
+					return new Promise<void>((resolve, reject) => {
+						loginMethodTOTP(...loginArgs, code, (error: LoginError | undefined, result?: unknown) => {
+							if (!error) {
+								callback?.(undefined, result);
 								resolve();
 								return;
 							}
 
-							dispatchToastMessage({ type: 'error', message: t('Invalid_two_factor_code') });
-							reject();
+							if (isTotpInvalidError(error)) {
+								reject(error);
+								return;
+							}
+
+							Promise.all([import('../../../app/utils/lib/i18n'), import('../toast')]).then(([{ t }, { dispatchToastMessage }]) => {
+								if (isTotpMaxAttemptsError(error)) {
+									dispatchToastMessage({ type: 'error', message: t('totp-max-attempts') });
+									reject(error);
+									return;
+								}
+
+								dispatchToastMessage({ type: 'error', message: t('Invalid_two_factor_code') });
+								reject(error);
+							});
 						});
 					});
-				});
-			}
-
-		});
+				},
+			});
+		} catch (error) {
+			callback?.(error as LoginError);
+		}
 	});
 };
 

--- a/apps/meteor/client/lib/2fa/process2faReturn.ts
+++ b/apps/meteor/client/lib/2fa/process2faReturn.ts
@@ -81,7 +81,7 @@ export async function process2faReturn({
 	try {
 		const code = await invokeTwoFactorModal(props);
 
-		onCode(code, props.method);
+		await onCode(code, props.method);
 	} catch (error) {
 		process2faReturn({
 			error: error as globalThis.Error | Meteor.Error | Meteor.TypedError | undefined,

--- a/apps/meteor/client/lib/2fa/process2faReturn.ts
+++ b/apps/meteor/client/lib/2fa/process2faReturn.ts
@@ -64,7 +64,7 @@ export async function process2faReturn({
 	error: globalThis.Error | Meteor.Error | Meteor.TypedError | undefined;
 	result: unknown;
 	originalCallback: LoginCallback | undefined;
-	onCode: (code: string, method: string) => void;
+	onCode: (code: string, method: string) => void | Promise<void>;
 	emailOrUsername: { username: string } | { email: string } | { id: string } | string | null | undefined;
 }): Promise<void> {
 	if (!(isTotpRequiredError(error) || isTotpInvalidError(error)) || !hasRequiredTwoFactorMethod(error)) {
@@ -74,23 +74,13 @@ export async function process2faReturn({
 
 	const props = {
 		...getProps(error.details.method, emailOrUsername || error.details.emailOrUsername),
-		// eslint-disable-next-line no-nested-ternary
-		invalidAttempt: isTotpInvalidError(error),
 	};
 
-	try {
-		const code = await invokeTwoFactorModal(props);
+	const validateCode = async (code: string, method: string): Promise<void> => {
+		await onCode(code, method);
+	};
 
-		await onCode(code, props.method);
-	} catch (error) {
-		process2faReturn({
-			error: error as globalThis.Error | Meteor.Error | Meteor.TypedError | undefined,
-			result,
-			originalCallback,
-			onCode,
-			emailOrUsername,
-		});
-	}
+	await invokeTwoFactorModal(props, validateCode);
 }
 
 export async function process2faAsyncReturn<TResult>({
@@ -111,44 +101,60 @@ export async function process2faAsyncReturn<TResult>({
 	const props = {
 		method: error.details.method,
 		emailOrUsername: emailOrUsername || error.details.emailOrUsername || getUser()?.username,
-		// eslint-disable-next-line no-nested-ternary
-		invalidAttempt: isTotpInvalidError(error),
 	};
 
 	assertModalProps(props);
 
-	try {
-		const code = await invokeTwoFactorModal(props);
+	let result: TResult | undefined;
 
-		return onCode(code, props.method);
-	} catch (error) {
-		return process2faAsyncReturn({
-			error,
-			onCode,
-			emailOrUsername,
-		});
+	const validateCode = async (code: string, method: string): Promise<void> => {
+		result = await onCode(code, method);
+	};
+
+	await invokeTwoFactorModal(props, validateCode);
+
+	if (!result) {
+		throw new Error('Unexpected error: result is undefined');
 	}
+
+	return result;
 }
 
-export const invokeTwoFactorModal = async (props: {
-	method: 'totp' | 'email' | 'password';
-	emailOrUsername?: string | undefined;
-	invalidAttempt?: boolean;
-}) => {
+export const invokeTwoFactorModal = async (
+	props: {
+		method: 'totp' | 'email' | 'password';
+		emailOrUsername?: string | undefined;
+	},
+	validateCode?: (code: string, method: string) => Promise<void>,
+) => {
 	assertModalProps(props);
 
 	return new Promise<string>((resolve, reject) => {
+		let isResolved = false;
+
 		imperativeModal.open({
 			component: TwoFactorModal,
 			props: {
 				...props,
-				onConfirm: (code: string, method: string): void => {
+				onConfirm: async (code: string, method: string): Promise<void> => {
+					if (validateCode) {
+						await validateCode(code, method);
+					}
+					isResolved = true;
 					imperativeModal.close();
 					resolve(method === 'password' ? SHA256(code) : code);
 				},
 				onClose: (): void => {
 					imperativeModal.close();
-					reject(new Meteor.Error('totp-canceled'));
+					if (!isResolved) {
+						Promise.all([import('../../../app/utils/lib/i18n'), import('../toast')]).then(([{ t }, { dispatchToastMessage }]) => {
+							dispatchToastMessage({
+								type: 'error',
+								message: t('Two-factor_authentication_cancelled'),
+							});
+						});
+						reject(new Meteor.Error('totp-canceled'));
+					}
 				},
 			},
 		});

--- a/apps/meteor/client/lib/2fa/process2faReturn.ts
+++ b/apps/meteor/client/lib/2fa/process2faReturn.ts
@@ -131,6 +131,7 @@ export const invokeTwoFactorModal = async (
 
 	return new Promise<string>((resolve, reject) => {
 		let isResolved = false;
+		let isClosed = false;
 
 		imperativeModal.open({
 			component: TwoFactorModal,
@@ -145,6 +146,10 @@ export const invokeTwoFactorModal = async (
 					resolve(method === 'password' ? SHA256(code) : code);
 				},
 				onClose: (): void => {
+					if (isClosed) {
+						return;
+					}
+					isClosed = true;
 					imperativeModal.close();
 					if (!isResolved) {
 						Promise.all([import('../../../app/utils/lib/i18n'), import('../toast')]).then(([{ t }, { dispatchToastMessage }]) => {

--- a/apps/meteor/client/lib/2fa/process2faReturn.ts
+++ b/apps/meteor/client/lib/2fa/process2faReturn.ts
@@ -113,7 +113,7 @@ export async function process2faAsyncReturn<TResult>({
 
 	await invokeTwoFactorModal(props, validateCode);
 
-	if (!result) {
+	if (result === undefined) {
 		throw new Error('Unexpected error: result is undefined');
 	}
 

--- a/apps/meteor/client/meteor/login/password.ts
+++ b/apps/meteor/client/meteor/login/password.ts
@@ -14,47 +14,47 @@ declare module 'meteor/meteor' {
 	}
 }
 
-const loginWithPasswordAndTOTP = (
-	userDescriptor: { username: string } | { email: string } | { id: string } | string,
-	password: string,
-	code: string,
-	callback?: LoginCallback,
-) => {
-	if (typeof userDescriptor === 'string') {
-		if (userDescriptor.indexOf('@') === -1) {
-			userDescriptor = { username: userDescriptor };
-		} else {
-			userDescriptor = { email: userDescriptor };
-		}
-	}
+export const loginWithPasswordAndTOTP = (
+  userDescriptor: { username: string } | { email: string } | { id: string } | string,
+  password: string,
+  code: string,
+  callback?: LoginCallback,
+): Promise<void> => {
+  if (typeof userDescriptor === 'string') {
+    if (userDescriptor.indexOf('@') === -1) {
+      userDescriptor = { username: userDescriptor };
+    } else {
+      userDescriptor = { email: userDescriptor };
+    }
+  }
 
-	Accounts.callLoginMethod({
-		methodArguments: [
-			{
-				totp: {
-					login: {
-						user: userDescriptor,
-						password: Accounts._hashPassword(password),
-					},
-					code,
-				},
-			},
-		],
-		userCallback(error) {
-			if (!error) {
-				callback?.(undefined);
-				return;
-			}
+  return new Promise<void>((resolve, reject) => {
+    Accounts.callLoginMethod({
+      methodArguments: [
+        {
+          totp: {
+            login: {
+              user: userDescriptor,
+              password: Accounts._hashPassword(password),
+            },
+            code,
+          },
+        },
+      ],
+      userCallback(error) {
+        if (!error) {
+          callback?.(undefined);
+          resolve();
+          return;
+        }
 
-			if (callback) {
-				callback(error);
-				return;
-			}
-
-			throw error;
-		},
-	});
+        callback?.(error);
+        resolve();
+      },
+    });
+  });
 };
+
 
 const { loginWithPassword } = Meteor;
 

--- a/apps/meteor/client/meteor/login/password.ts
+++ b/apps/meteor/client/meteor/login/password.ts
@@ -15,46 +15,45 @@ declare module 'meteor/meteor' {
 }
 
 export const loginWithPasswordAndTOTP = (
-  userDescriptor: { username: string } | { email: string } | { id: string } | string,
-  password: string,
-  code: string,
-  callback?: LoginCallback,
+	userDescriptor: { username: string } | { email: string } | { id: string } | string,
+	password: string,
+	code: string,
+	callback?: LoginCallback,
 ): Promise<void> => {
-  if (typeof userDescriptor === 'string') {
-    if (userDescriptor.indexOf('@') === -1) {
-      userDescriptor = { username: userDescriptor };
-    } else {
-      userDescriptor = { email: userDescriptor };
-    }
-  }
+	if (typeof userDescriptor === 'string') {
+		if (userDescriptor.indexOf('@') === -1) {
+			userDescriptor = { username: userDescriptor };
+		} else {
+			userDescriptor = { email: userDescriptor };
+		}
+	}
 
-  return new Promise<void>((resolve, reject) => {
-    Accounts.callLoginMethod({
-      methodArguments: [
-        {
-          totp: {
-            login: {
-              user: userDescriptor,
-              password: Accounts._hashPassword(password),
-            },
-            code,
-          },
-        },
-      ],
-      userCallback(error) {
-        if (!error) {
-          callback?.(undefined);
-          resolve();
-          return;
-        }
+	return new Promise<void>((resolve, reject) => {
+		Accounts.callLoginMethod({
+			methodArguments: [
+				{
+					totp: {
+						login: {
+							user: userDescriptor,
+							password: Accounts._hashPassword(password),
+						},
+						code,
+					},
+				},
+			],
+			userCallback(error) {
+				if (!error) {
+					callback?.(undefined);
+					resolve();
+					return;
+				}
 
-        callback?.(error);
-        resolve();
-      },
-    });
-  });
+				callback?.(error);
+				reject(error as Error);
+			},
+		});
+	});
 };
-
 
 const { loginWithPassword } = Meteor;
 

--- a/apps/meteor/client/meteor/overrides/totpOnCall.ts
+++ b/apps/meteor/client/meteor/overrides/totpOnCall.ts
@@ -8,7 +8,7 @@ import { isTotpInvalidError } from '../../lib/2fa/utils';
 const withSyncTOTP = (call: (name: string, ...args: any[]) => any) => {
 	const callWithTotp =
 		(methodName: string, args: unknown[], callback: LoginCallback) =>
-		(twoFactorCode: string, twoFactorMethod: string): unknown =>
+		(twoFactorCode: string, twoFactorMethod: string): void =>
 			call(
 				methodName,
 				...args,

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -5417,6 +5417,7 @@
   "Turn_on_video": "Turn on video",
   "Two Factor Authentication": "Two Factor Authentication",
   "Two-factor_authentication": "Two-factor authentication",
+  "Two-factor_authentication_cancelled": "Two-factor authentication cancelled",
   "Two-factor_authentication_disabled": "Two-factor authentication disabled",
   "Two-factor_authentication_email": "Two-factor authentication via email",
   "Two-factor_authentication_enabled": "Two-factor authentication enabled",


### PR DESCRIPTION
fix modal not closing when entering wrong code. fixed inline error to display correct text

[WA-60](https://rocketchat.atlassian.net/browse/WA-60)
[WA-33](https://rocketchat.atlassian.net/browse/WA-33)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected the error message shown for invalid two-factor codes.
  - Improved handling of invalid 2FA attempts with clearer user feedback.
  - Non-2FA login errors are now surfaced more reliably.

- Refactor
  - Modernized the 2FA and password+TOTP login flows to use async promises, improving stability and responsiveness without changing user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[WA-33]: https://rocketchat.atlassian.net/browse/WA-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WA-60]: https://rocketchat.atlassian.net/browse/WA-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ