### PR TITLE
regression: invalid call states when call initialization signal is missed

### DIFF
--- a/packages/media-signaling/src/lib/Call.ts
+++ b/packages/media-signaling/src/lib/Call.ts
@@ -89,7 +89,15 @@ export class ClientMediaCall implements IClientMediaCall {
 	}
 
 	public get hidden(): boolean {
-		return this.ignored || this.contractState === 'ignored';
+		/**
+		 * A call is hidden if:
+		 * 1. It was flagged as ignored by the Session
+		 * 2. It is happening in a different session
+		 * 3. The call was started in some other session and we have not received its data yet
+		 *    Since the Call instance is only created when we receive "something" from the server, this would mean we received signals out of order, or missed one.
+		 */
+
+		return this.ignored || this.contractState === 'ignored' || !this.initialized;
 	}
 
 	public get muted(): boolean {
@@ -266,6 +274,11 @@ export class ClientMediaCall implements IClientMediaCall {
 			}
 		}
 
+		// If the call is already flagged as over before the initialization, do not process anything other than filling in the basic information
+		if (this.isOver()) {
+			return;
+		}
+
 		// If it's flagged as ignored even before the initialization, tell the server we're unavailable
 		if (this.ignored) {
 			return this.rejectAsUnavailable();
@@ -419,6 +432,12 @@ export class ClientMediaCall implements IClientMediaCall {
 		}
 
 		if (!this.hasRemoteData) {
+			// if the call is over, we no longer need to wait for its data
+			if (signal.type === 'notification' && signal.notification === 'hangup') {
+				this.changeState('hangup');
+				return;
+			}
+
 			this.config.logger?.debug('Remote data missing, adding signal to queue');
 			this.earlySignals.add(signal);
 			return;


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
If a client misses a call initialization signal but receives some other signal about it, then that call is being added to the internal list of calls but never initialized and also never cleared. It doesn't trigger any events so it doesn't cause any problems in the UI, but if a different call happens, then this second call will trigger the session events and once it is over, it'll roll back to the first call even though it is not initialized.
This PR makes two fixes:
1. It ensures that a call is flagged as ended when its over, even if it was not initialized.
2. It ensures that calls that have not been initialized will always be treated as hidden, so they do not show up on the UI.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[VAI-149](https://rocketchat.atlassian.net/browse/VAI-149)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Start a call from user1 to user2
2. As user2, refresh the browser page
3. After the refresh, the call will no longer appear for user2 (separate bug, fixed on another PR)
4. As user1, stop this first call and start a new one
5. The second call will show up for user2 as usual.
6. As user1, stop the second call.
7. The first call that was already over will now show up for user2, with no contact information or anything on the widget.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents processing of already-ended calls to avoid unexpected behavior after hangup.
  * Handles early hangup signals immediately during setup, reducing lingering or stuck ringing states.
  * Improves call visibility: calls remain hidden until fully initialized or when ignored.
  * Enhances handling of signals before remote data is available, reducing race conditions and stuck states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[VAI-149]: https://rocketchat.atlassian.net/browse/VAI-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ