### PR TITLE
fix: (1.3.1) Added a visually hidden legends in FieldGroup

### DIFF
--- a/apps/meteor/client/views/account/preferences/PreferencesGlobalSection.tsx
+++ b/apps/meteor/client/views/account/preferences/PreferencesGlobalSection.tsx
@@ -1,7 +1,8 @@
 import type { SelectOption } from '@rocket.chat/fuselage';
-import { AccordionItem, Field, FieldGroup, FieldLabel, FieldRow, MultiSelect } from '@rocket.chat/fuselage';
+import { AccordionItem, Box, Field, FieldGroup, FieldLabel, FieldRow, MultiSelect } from '@rocket.chat/fuselage';
 import { useUserPreference } from '@rocket.chat/ui-contexts';
 import { useId } from 'react';
+import { VisuallyHidden } from 'react-aria';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -17,6 +18,11 @@ const PreferencesGlobalSection = () => {
 	return (
 		<AccordionItem title={t('Global')}>
 			<FieldGroup>
+				<VisuallyHidden>
+					<Box is='legend' aria-hidden={true}>
+						{t('Global')}
+					</Box>
+				</VisuallyHidden>
 				<Field>
 					<FieldLabel is='span' htmlFor={dontAskAgainListId}>
 						{t('Dont_ask_me_again_list')}

--- a/apps/meteor/client/views/account/preferences/PreferencesHighlightsSection.tsx
+++ b/apps/meteor/client/views/account/preferences/PreferencesHighlightsSection.tsx
@@ -1,5 +1,6 @@
-import { AccordionItem, Field, FieldGroup, FieldLabel, FieldRow, FieldHint, TextAreaInput } from '@rocket.chat/fuselage';
+import { AccordionItem, Box, Field, FieldGroup, FieldLabel, FieldRow, FieldHint, TextAreaInput } from '@rocket.chat/fuselage';
 import { useId } from 'react';
+import { VisuallyHidden } from 'react-aria';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -12,6 +13,11 @@ const PreferencesHighlightsSection = () => {
 	return (
 		<AccordionItem title={t('Highlights')}>
 			<FieldGroup>
+				<VisuallyHidden>
+					<Box is='legend' aria-hidden={true}>
+						{t('Highlights')}
+					</Box>
+				</VisuallyHidden>
 				<Field>
 					<FieldLabel htmlFor={highlightsId}>{t('Highlights_List')}</FieldLabel>
 					<FieldRow>

--- a/apps/meteor/client/views/account/preferences/PreferencesLocalizationSection.tsx
+++ b/apps/meteor/client/views/account/preferences/PreferencesLocalizationSection.tsx
@@ -1,7 +1,8 @@
 import type { SelectOption } from '@rocket.chat/fuselage';
-import { AccordionItem, Field, FieldGroup, FieldLabel, FieldRow, Select } from '@rocket.chat/fuselage';
+import { AccordionItem, Box, Field, FieldGroup, FieldLabel, FieldRow, Select } from '@rocket.chat/fuselage';
 import { useLanguages } from '@rocket.chat/ui-contexts';
 import { useId, useMemo } from 'react';
+import { VisuallyHidden } from 'react-aria';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -18,6 +19,11 @@ const PreferencesLocalizationSection = () => {
 	return (
 		<AccordionItem title={t('Localization')} defaultExpanded>
 			<FieldGroup>
+				<VisuallyHidden>
+					<Box is='legend' aria-hidden={true}>
+						{t('Localization')}
+					</Box>
+				</VisuallyHidden>
 				<Field>
 					<FieldLabel is='span' id={languageId}>
 						{t('Language')}

--- a/apps/meteor/client/views/account/preferences/PreferencesMessagesSection.tsx
+++ b/apps/meteor/client/views/account/preferences/PreferencesMessagesSection.tsx
@@ -1,6 +1,18 @@
 import type { SelectOption } from '@rocket.chat/fuselage';
-import { AccordionItem, Field, FieldGroup, FieldHint, FieldLabel, FieldLink, FieldRow, Select, ToggleSwitch } from '@rocket.chat/fuselage';
+import {
+	AccordionItem,
+	Box,
+	Field,
+	FieldGroup,
+	FieldHint,
+	FieldLabel,
+	FieldLink,
+	FieldRow,
+	Select,
+	ToggleSwitch,
+} from '@rocket.chat/fuselage';
 import { useId, useMemo } from 'react';
+import { VisuallyHidden } from 'react-aria';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -47,6 +59,11 @@ const PreferencesMessagesSection = () => {
 	return (
 		<AccordionItem title={t('Messages')}>
 			<FieldGroup>
+				<VisuallyHidden>
+					<Box is='legend' aria-hidden={true}>
+						{t('Messages')}
+					</Box>
+				</VisuallyHidden>
 				<Field>
 					<FieldRow>
 						<FieldLabel htmlFor={unreadAlertId}>{t('Unread_Tray_Icon_Alert')}</FieldLabel>

--- a/apps/meteor/client/views/account/preferences/PreferencesNotificationsSection.tsx
+++ b/apps/meteor/client/views/account/preferences/PreferencesNotificationsSection.tsx
@@ -1,9 +1,21 @@
 import type { INotificationDesktop } from '@rocket.chat/core-typings';
 import type { SelectOption } from '@rocket.chat/fuselage';
-import { AccordionItem, Button, Field, FieldGroup, FieldHint, FieldLabel, FieldRow, Select, ToggleSwitch } from '@rocket.chat/fuselage';
+import {
+	AccordionItem,
+	Box,
+	Button,
+	Field,
+	FieldGroup,
+	FieldHint,
+	FieldLabel,
+	FieldRow,
+	Select,
+	ToggleSwitch,
+} from '@rocket.chat/fuselage';
 import type { TranslationKey } from '@rocket.chat/ui-contexts';
 import { useSetting, useUserPreference, useUser } from '@rocket.chat/ui-contexts';
 import { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { VisuallyHidden } from 'react-aria';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -100,6 +112,11 @@ const PreferencesNotificationsSection = () => {
 	return (
 		<AccordionItem title={t('Notifications')}>
 			<FieldGroup>
+				<VisuallyHidden>
+					<Box is='legend' aria-hidden={true}>
+						{t('Notifications')}
+					</Box>
+				</VisuallyHidden>
 				<Field>
 					<FieldLabel is='span' id={desktopNotificationsLabelId}>
 						{t('Desktop_Notifications')}

--- a/apps/meteor/client/views/account/preferences/PreferencesSoundSection.tsx
+++ b/apps/meteor/client/views/account/preferences/PreferencesSoundSection.tsx
@@ -1,8 +1,20 @@
 import type { SelectOption } from '@rocket.chat/fuselage';
-import { AccordionItem, Field, FieldGroup, FieldHint, FieldLabel, FieldRow, Select, Slider, ToggleSwitch } from '@rocket.chat/fuselage';
+import {
+	AccordionItem,
+	Box,
+	Field,
+	FieldGroup,
+	FieldHint,
+	FieldLabel,
+	FieldRow,
+	Select,
+	Slider,
+	ToggleSwitch,
+} from '@rocket.chat/fuselage';
 import type { TranslationKey } from '@rocket.chat/ui-contexts';
 import { useCustomSound, useTranslation } from '@rocket.chat/ui-contexts';
 import { useId } from 'react';
+import { VisuallyHidden } from 'react-aria';
 import { Controller, useFormContext } from 'react-hook-form';
 
 const PreferencesSoundSection = () => {
@@ -23,6 +35,11 @@ const PreferencesSoundSection = () => {
 	return (
 		<AccordionItem title={t('Sound')}>
 			<FieldGroup>
+				<VisuallyHidden>
+					<Box is='legend' aria-hidden={true}>
+						{t('Sound')}
+					</Box>
+				</VisuallyHidden>
 				<Field>
 					<FieldLabel is='span' aria-describedby={`${masterVolumeId}-hint`}>
 						{t('Master_volume')}

--- a/apps/meteor/client/views/account/preferences/PreferencesUserPresenceSection.tsx
+++ b/apps/meteor/client/views/account/preferences/PreferencesUserPresenceSection.tsx
@@ -1,5 +1,6 @@
-import { AccordionItem, Field, FieldGroup, FieldLabel, FieldRow, NumberInput, ToggleSwitch } from '@rocket.chat/fuselage';
+import { AccordionItem, Box, Field, FieldGroup, FieldLabel, FieldRow, NumberInput, ToggleSwitch } from '@rocket.chat/fuselage';
 import { useId } from 'react';
+import { VisuallyHidden } from 'react-aria';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -13,6 +14,11 @@ const PreferencesUserPresenceSection = () => {
 	return (
 		<AccordionItem title={t('User_Presence')}>
 			<FieldGroup>
+				<VisuallyHidden>
+					<Box is='legend' aria-hidden={true}>
+						{t('User_Presence')}
+					</Box>
+				</VisuallyHidden>
 				<Field>
 					<FieldRow>
 						<FieldLabel is='span' id={enableAutoAwayId}>


### PR DESCRIPTION
For WCAG compability, a fieldset must have a legend. The FieldGroup-component used in the profile-page returns a fieldset. To assure WCAG-compability a visually hidden fieldset is added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Accessibility
  - Improved screen reader support across Account Preferences sections (Global, Highlights, Localization, Messages, Notifications, Sound, User Presence).
  - Added non-visual legends to better convey section context and grouping to assistive technologies.
  - Enhances navigation and comprehension for users relying on screen readers without altering visible UI or behavior.
  - No changes to user workflows, settings, or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->