### PR TITLE
fix: Prevent Firefox password autofill in channel search bar

### DIFF
--- a/apps/meteor/client/sidebar/search/SearchList.tsx
+++ b/apps/meteor/client/sidebar/search/SearchList.tsx
@@ -345,6 +345,7 @@ const SearchList = forwardRef(function SearchList({ onClose }: SearchListProps, 
 						{...filter}
 						placeholder={placeholder}
 						role='searchbox'
+						autoComplete='off'
 						addon={<Icon name='cross' size='x20' onClick={onClose} />}
 					/>
 				</Box>


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR fixes an issue where Firefox browser incorrectly shows password autofill suggestions when users click on the channel search bar in the sidebar.

**Problem:**
Firefox's aggressive autofill detection was misidentifying the search input field as a password field, causing it to display saved password suggestions instead of allowing users to search for channels normally.

**Solution:**
Added `autoComplete='off'` attribute to the `TextInput` component in the SearchList component. This explicitly tells Firefox (and other browsers) not to offer autocomplete/autofill suggestions for this field.

<img width="730" height="278" alt="Screenshot from 2025-10-06 13-18-06" src="https://github.com/user-attachments/assets/7d3b439c-0f88-48f6-a318-c278839fcd81" />


**Technical Details:**
- Modified: `apps/meteor/client/sidebar/search/SearchList.tsx` (line 348)
- Added the `autoComplete='off'` prop to the search TextInput
- This matches the existing implementation in the NavBarSearch component which already has this attribute for the same purpose

**Impact:**
- Prevents Firefox from showing password suggestions in the search bar
- Does not affect functionality for other browsers
- Improves user experience when searching for channels
- Minimal, non-breaking change

## Issue(s)

Fixes #37113

## Steps to test or reproduce

### Prerequisites:
- Firefox browser (latest version)
- Some passwords saved in Firefox

### Reproducing the bug:
1. Open Rocket.Chat in Firefox browser
2. Have some saved passwords in Firefox
3. Click on the channel search bar in the sidebar (or press Ctrl+K / Cmd+K)
4. **Bug**: Firefox shows a dropdown with saved passwords instead of search functionality

### Verifying the fix:
1. Apply this PR
2. Open Rocket.Chat in Firefox
3. Click on the channel search bar (or press Ctrl+K / Cmd+K)
4. **Expected**: No password suggestions appear
5. **Expected**: Only channel and user search results are displayed
6. **Expected**: Search functionality works normally

### Tested:
- ✅ Tested locally in Firefox (latest version)
- ✅ Search functionality works correctly
- ✅ No password autofill suggestions appear
- ✅ Other browsers (Chrome, Edge) unaffected
- ✅ Keyboard shortcut (Ctrl+K) works correctly

## Further comments

This is a simple, one-line fix that addresses a long-standing UX issue reported in #37113. 

The solution is consistent with the existing codebase - the `NavBarSearch` component already uses `autoComplete='off'` for the same purpose (see `apps/meteor/client/NavBarV2/NavBarSearch/NavBarSearch.tsx` line 84).

The `autoComplete='off'` attribute is a standard HTML5 attribute supported by all modern browsers and is the recommended way to disable browser autofill/autocomplete on form fields.

**Why this works:**
Firefox uses heuristics to detect password fields and automatically suggests saved passwords. By explicitly setting `autoComplete='off'`, we tell the browser that this field should not use autocomplete, preventing the unwanted password suggestions.

**Checklist:**
- [x] I have read the [Contributing Guide](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat)
- [x] I have signed the CLA (will sign when prompted by the bot)
- [x] Lint and unit tests pass locally with my changes
- [x] Code follows project conventions and style guide
- [x] Changes tested in Firefox browser
- [ ] Tests added (N/A - this is a UI behavior fix with no logic changes)
- [ ] Documentation updated (N/A - internal implementation detail, no user-facing documentation needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled browser autocomplete in the search field to prevent conflicting suggestions with in-app results.
  * Eliminates UI overlap and jitter caused by native dropdowns, improving clarity while typing.
  * Enhances privacy by not exposing past queries and ensures consistent behavior across browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->