### PR TITLE
fix: dynamically calculate unread count in /subscriptions.get for iframe integration

### DIFF
--- a/apps/meteor/app/api/server/v1/subscriptions.ts
+++ b/apps/meteor/app/api/server/v1/subscriptions.ts
@@ -13,35 +13,50 @@ import { unreadMessages } from '../../../message-mark-as-unread/server/unreadMes
 import { API } from '../api';
 
 API.v1.addRoute(
-	'subscriptions.get',
-	{
-		authRequired: true,
-		validateParams: isSubscriptionsGetProps,
-	},
-	{
-		async get() {
-			const { updatedSince } = this.queryParams;
+  'subscriptions.get',
+  {
+    authRequired: true,
+    validateParams: isSubscriptionsGetProps,
+  },
+  {
+    async get() {
+      const { updatedSince } = this.queryParams;
 
-			let updatedSinceDate: Date | undefined;
-			if (updatedSince) {
-				if (isNaN(Date.parse(updatedSince as string))) {
-					throw new Meteor.Error('error-roomId-param-invalid', 'The "lastUpdate" query parameter must be a valid date.');
-				}
-				updatedSinceDate = new Date(updatedSince as string);
-			}
+      let updatedSinceDate: Date | undefined;
+      if (updatedSince) {
+        if (isNaN(Date.parse(updatedSince as string))) {
+          throw new Meteor.Error(
+            'error-roomId-param-invalid',
+            'The "lastUpdate" query parameter must be a valid date.'
+          );
+        }
+        updatedSinceDate = new Date(updatedSince as string);
+      }
 
-			const result = await getSubscriptions(this.userId, updatedSinceDate);
+      const result = await getSubscriptions(this.userId, updatedSinceDate);
 
-			return API.v1.success(
-				Array.isArray(result)
-					? {
-							update: result,
-							remove: [],
-						}
-					: result,
-			);
-		},
-	},
+      const subscriptionsWithUnread = Array.isArray(result)
+        ? await Promise.all(
+            result.map(async (sub) => {
+              const unreadCount = await unreadMessages.countByRoomIdAndUserId(sub.rid, this.userId);
+              return {
+                ...sub,
+                unread: unreadCount,
+              };
+            })
+          )
+        : result;
+
+      return API.v1.success(
+        Array.isArray(result)
+          ? {
+              update: subscriptionsWithUnread,
+              remove: [],
+            }
+          : subscriptionsWithUnread
+      );
+    },
+  }
 );
 
 API.v1.addRoute(


### PR DESCRIPTION
Closes : #23977
Description :
In /api/v1/subscriptions.get, the unread count was always 0 in iframe integrations, even if the channel had unread messages.

Solution : 
- Calculated unread messages dynamically for each subscription using Messages collection.
- Preserved the API response structure: { update: [...], remove: [] }.
- Works for iframe users where Subscriptions.unread was not updated correctly.

How Lumyst helped : 
I used Lumyst to explore the Rocket.Chat codebase, identify the flow of subscription data, and understand how unread counts are calculated. It helped trace the path from API endpoint → getSubscriptions → Subscriptions collection → unreadMessages logic.

Suggestions for Lumyst : 
- Ability to search and navigate code based on file paths, not just functions or keywords. Often, open source issues reference a specific file path, so direct file-based search would speed up understanding.
- Currently, only the first ~20,000 lines of code are inserted for analysis, which works well. In the future, it would be helpful to give users a choice to insert either a whole folder or a specific file. This would make it easier to focus on relevant parts of a codebase without having to load everything.For example, when an issue references a specific file path, the user could just insert that file for quicker analysis.