### PR TITLE
regression(federation): restore quoted messages reception

### DIFF
--- a/apps/meteor/server/services/meteor/service.ts
+++ b/apps/meteor/server/services/meteor/service.ts
@@ -294,7 +294,7 @@ export class MeteorService extends ServiceClassInternal implements IMeteor {
 		return getURL(path, params, cloudDeepLinkUrl);
 	}
 
-	async getMessageURLToReplyTo(roomType: string, roomId: string, roomName: string, messageIdToReplyTo: string): Promise<string> {
-		return getURL(`${roomCoordinator.getRouteLink(roomType, { rid: roomId, name: roomName })}?msg=${messageIdToReplyTo}`, { full: true });
+	async getMessageURLToReplyTo(roomType: string, roomId: string, messageIdToReplyTo: string): Promise<string> {
+		return getURL(`${roomCoordinator.getRouteLink(roomType, { rid: roomId })}?msg=${messageIdToReplyTo}`, { full: true });
 	}
 }

--- a/ee/packages/federation-matrix/src/events/message.ts
+++ b/ee/packages/federation-matrix/src/events/message.ts
@@ -167,13 +167,8 @@ export function message(emitter: Emitter<HomeserverEventSignatures>, serverName:
 					return;
 				}
 
-				if (quoteMessageEventId && room.name) {
-					const messageToReplyToUrl = await MeteorService.getMessageURLToReplyTo(
-						room.t as string,
-						room._id,
-						room.name,
-						originalMessage._id,
-					);
+				if (quoteMessageEventId) {
+					const messageToReplyToUrl = await MeteorService.getMessageURLToReplyTo(room.t as string, room._id, originalMessage._id);
 					const formatted = await toInternalQuoteMessageFormat({
 						messageToReplyToUrl,
 						formattedMessage: data.content.formatted_body || '',
@@ -209,13 +204,13 @@ export function message(emitter: Emitter<HomeserverEventSignatures>, serverName:
 				return;
 			}
 
-			if (quoteMessageEventId && room.name) {
+			if (quoteMessageEventId) {
 				const originalMessage = await Messages.findOneByFederationId(quoteMessageEventId);
 				if (!originalMessage) {
 					logger.error('Original message not found for quote:', quoteMessageEventId);
 					return;
 				}
-				const messageToReplyToUrl = await MeteorService.getMessageURLToReplyTo(room.t as string, room._id, room.name, originalMessage._id);
+				const messageToReplyToUrl = await MeteorService.getMessageURLToReplyTo(room.t as string, room._id, originalMessage._id);
 				const formatted = await toInternalQuoteMessageFormat({
 					messageToReplyToUrl,
 					formattedMessage: data.content.formatted_body || '',

--- a/packages/core-services/src/types/IMeteor.ts
+++ b/packages/core-services/src/types/IMeteor.ts
@@ -27,5 +27,5 @@ export interface IMeteor extends IServiceClass {
 	}>;
 	notifyGuestStatusChanged(token: string, status: string): Promise<void>;
 	getURL(path: string, params?: Record<string, any>, cloudDeepLinkUrl?: string): Promise<string>;
-	getMessageURLToReplyTo(roomType: string, roomId: string, roomName: string, messageIdToReplyTo: string): Promise<string>;
+	getMessageURLToReplyTo(roomType: string, roomId: string, messageIdToReplyTo: string): Promise<string>;
 }


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
As per [FDR-182](https://rocketchat.atlassian.net/browse/FDR-182), quoted messages were not working for direct messages. The issue occurred because DMs have neither a `name` nor an `fname`, resulting in a null parameter being passed to the `getMessageURLToReplyTo`. Upon further analysis, there’s no need to pass `roomName` to the function, since only the `rid` is used to generate the quote messages links. Based on that, instead of adding a specific handler to check for DMs and pass an empty room name, I decided to remove the `roomName` parameter from the `getMessageURLToReplyTo` function altogether.

## Issue(s)
- [FDR-182](https://rocketchat.atlassian.net/browse/FDR-182)

## Steps to test or reproduce
1. Open a federated direct message (RC <-> RC or RC → Element).
2. Quote a previous message.
3. Send the quoted message.

Quoted messages should display correctly to the recipient, maintaining the original message content and formatting.

## Further comments

[FDR-182]: https://rocketchat.atlassian.net/browse/FDR-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Quoting and replying work reliably even when a room lacks a display name; links no longer break when room names are missing.
  * Improved robustness for federated or older rooms with incomplete metadata, reducing failures when replying to specific messages.

* **Improvements**
  * Quote payloads now include richer original-message context to help preserve sender and server details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->