### PR TITLE
docs(ui-kit): fix typos and minor grammar in README

### DIFF
--- a/packages/ui-kit/README.md
+++ b/packages/ui-kit/README.md
@@ -45,7 +45,7 @@ Feel free to check the [issues](https://github.com/RocketChat/Rocket.Chat/issues
 
 ### Building
 
-As this package dependends on others in this monorepo, before anything run the following at the root directory:
+As this package depends on others in this monorepo, before anything, run the following at the root directory:
 
 <!--yarn(build)-->
 
@@ -57,8 +57,8 @@ yarn build
 
 ### Linting
 
-To ensure the source is matching our coding style, we perform [linting](<https://en.wikipedia.org/wiki/Lint_(software)>).
-Before commiting, check if your code fits our style by running:
+To ensure the source matches our coding style, we perform [linting](<https://en.wikipedia.org/wiki/Lint_(software)>).
+Before committing, check if your code fits our style by running:
 
 <!--yarn(lint)-->
 
@@ -80,7 +80,7 @@ yarn lint-and-fix
 
 ### Running tests
 
-Whenever possible, add tests to describe exactly what your code do. You can run them by yourself:
+Whenever possible, add tests to describe exactly what your code does. You can run them locally:
 
 <!--yarn(test)-->
 


### PR DESCRIPTION
Proposed changes: This PR fixes typos and minor grammar issues in the @rocket.chat/ui-kit README to improve clarity and professionalism. Changes include:

- Fixed "dependends" → "depends"
- Added comma for clarity: "before anything, run"
- Corrected "is matching" → "matches"
- Fixed "commiting" → "committing"
- Improved "what your code do" → "what your code does"
- Enhanced readability: "run them locally" instead of "run them by yourself"
This is a documentation-only change with no functional impact.

Issue(s): Closes #[issue-number]

Steps to test or reproduce:

1. Open packages/ui-kit/README.md
2. Verify the corrected phrases appear in the Building, Linting, and Running tests sections
3. Confirm no other content has been modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README documentation with corrections to spelling, grammar, and phrasing for improved clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->