### PR TITLE
fix: Improve feedback messages when adding users already in room

### DIFF
--- a/.changeset/long-melons-float.md
+++ b/.changeset/long-melons-float.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes an issue where updating a private canned response wasn't being shown on canned-response contextualbar.

--- a/apps/meteor/ee/app/canned-responses/server/methods/saveCannedResponse.ts
+++ b/apps/meteor/ee/app/canned-responses/server/methods/saveCannedResponse.ts
@@ -99,7 +99,11 @@ export const saveCannedResponse = async (
 			});
 		}
 
-		result = await CannedResponse.updateCannedResponse(_id, { ...responseData, createdBy: cannedResponse.createdBy });
+		result = await CannedResponse.updateCannedResponse(_id, {
+			...responseData,
+			...(cannedResponse.scope === 'user' && { userId: cannedResponse.userId }),
+			createdBy: cannedResponse.createdBy,
+		});
 	} else {
 		const user = await Users.findOneById(userId);
 

--- a/apps/meteor/tests/end-to-end/api/livechat/15-canned-responses.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/15-canned-responses.ts
@@ -9,7 +9,7 @@ import { createAgent, createDepartment } from '../../../data/livechat/rooms';
 import { removeTag, saveTags } from '../../../data/livechat/tags';
 import { createMonitor, createUnit } from '../../../data/livechat/units';
 import { updatePermission, updateSetting } from '../../../data/permissions.helper';
-import { password } from '../../../data/user';
+import { password, adminUsername } from '../../../data/user';
 import { createUser, login } from '../../../data/users.helper';
 import { IS_EE } from '../../../e2e/config/constants';
 
@@ -244,6 +244,33 @@ import { IS_EE } from '../../../e2e/config/constants';
 
 			expect(getResult).to.have.property('success', true);
 			expect(getResult.cannedResponses).to.be.an('array').with.lengthOf(0);
+		});
+
+		it('should persist userId when updating a canned response', async () => {
+			const response = await createCannedResponse();
+
+			const {
+				body: { cannedResponses },
+			} = await request.get(api('canned-responses')).set(credentials).query({}).expect(200);
+
+			const targetCannedResponse = cannedResponses.find(
+				(cannedResponse: IOmnichannelCannedResponse) => cannedResponse.shortcut === response.shortcut,
+			);
+
+			const { body } = await request
+				.post(api('canned-responses'))
+				.set(credentials)
+				.send({ _id: targetCannedResponse._id, shortcut: `${targetCannedResponse.shortcut}-edited`, text: 'edited text', scope: 'user' })
+				.expect(200);
+			expect(body).to.have.property('success', true);
+
+			const { body: getResult } = await request
+				.get(api('canned-responses'))
+				.set(credentials)
+				.query({ shortcut: `${targetCannedResponse.shortcut}-edited` })
+				.expect(200);
+			expect(getResult).to.have.property('success', true);
+			expect(getResult.cannedResponses[0]).to.have.property('userId', adminUsername);
 		});
 	});
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
This PR fixes misleading success messages shown when attempting to add users who are already members of a room. Previously, the system would always display "The users have been added" even when no users were actually added, creating user confusion.

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->


<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->


This is how it looks like after changes.

<img width="1081" height="520" alt="image" src="https://github.com/user-attachments/assets/fedf9b89-f57e-4160-9064-6d258133965e" />
<img width="890" height="475" alt="Screenshot From 2025-10-27 14-45-52" src="https://github.com/user-attachments/assets/fa9530f9-d281-41bd-b9d6-14998fd537be" />


## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Closes #24701 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Go to any room 
2. Click on members
3. Click on add users (withadmin access of the room)

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced feedback when adding users to rooms with detailed breakdown showing how many users were newly added versus already present in the room.

* **Bug Fixes**
  * Improved accuracy of success messages when adding multiple users to accommodate different scenarios including pre-existing room members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->