### PR TITLE
fix: improve retention policy UI clarity with placeholder and hint text

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/EditRoomInfo.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/EditRoomInfo.tsx
@@ -535,11 +535,14 @@ const EditRoomInfo = ({ room, onClickClose, onClickBack }: EditRoomInfoProps) =>
 																<NumberInput
 																	id={retentionMaxAgeField}
 																	{...field}
+																	placeholder='7'
+																	min={1}
 																	onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(Number(e.currentTarget.value))}
 																/>
 															)}
 														/>
 													</FieldRow>
+													<FieldHint>Enter the number of days (e.g., 7 for one week, 30 for one month)</FieldHint>
 												</Field>
 												<Field>
 													<FieldRow>


### PR DESCRIPTION
## Description
Fixes #37309

Improves the retention policy UI to make it clearer that users should enter the number of days, not a specific date.

## Changes
- Added `placeholder='7'` to show an example value
- Added `min={1}` validation to prevent invalid inputs (0 or negative)
- Added `FieldHint` text explaining users should enter number of days with examples

## Before
The retention policy input field had no guidance, causing confusion about whether to enter a date or number of days.

## After
The input field now has:
- A placeholder showing "7" as an example
- A helpful hint: "Enter the number of days (e.g., 7 for one week, 30 for one month)"
- Minimum value validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved message retention configuration with helpful input guidance. Users now see a placeholder example and minimum value validation when setting retention days for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->