### PR TITLE
fix: Remove cursor reposition bug when typing emoji shortcodes

### DIFF
--- a/apps/meteor/app/ui-message/client/messageBox/createComposerAPI.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/createComposerAPI.ts
@@ -278,8 +278,9 @@ export const createComposerAPI = (input: HTMLTextAreaElement, storageID: string)
 			input.value = textAreaTxt.substring(0, selection.start) + text + textAreaTxt.substring(selection.end);
 		}
 
-		input.selectionStart = selectionStart + text.length;
-		input.selectionEnd = selectionStart + text.length;
+		input.selectionStart = selection.start + text.length;
+		input.selectionEnd = selection.start + text.length;
+
 		if (selectionStart !== selectionEnd) {
 			input.selectionStart = selectionStart;
 		}

--- a/apps/meteor/app/ui-message/client/messageBox/createRichTextComposerAPI.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/createRichTextComposerAPI.ts
@@ -310,8 +310,23 @@ export const createRichTextComposerAPI = (input: HTMLDivElement, storageID: stri
 
 		focus();
 
-		const newStart = selectionStart + text.length;
-		const newEnd = selectionStart + text.length;
+		// Check if the text starts and ends with a colon symbol (:) - Used for emoji detection
+		const emoji = /^:.*:$/.test(text.trim());
+
+		let newStart;
+		let newEnd;
+
+		// selectionStart is the current cursor position whereas
+		// selection.start is cursor starting position from where replaceText takes into consideration
+		// if emoji is true then increment cursor position by 1
+		// else increment by the length of the text
+		if (emoji) {
+			newStart = selection.start + 1;
+			newEnd = selection.start + 1;
+		} else {
+			newStart = selectionStart + text.length;
+			newEnd = selectionStart + text.length;
+		}
 
 		if (selectionStart !== selectionEnd) {
 			setSelectionRange(input, selectionStart, selectionStart);


### PR DESCRIPTION
## Issue
This PR closes #37256, documenting a bugfix issue that emerged from `createComposerAPI` from which `createRichTextComposerAPI` is based.

## Video
The video demonstrates the cursor properly shifting to the right of the rendered emoji. In the PR, the cursor would move further to the right due to incorrect handling of text replacement, not accounting for emoji shortcodes.

https://github.com/user-attachments/assets/ca0551c4-34b2-47ed-b246-da8b260e2a4f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rich text message composer with formatting, emoji, and media recording support (available as a feature preview)

* **Bug Fixes**
  * Improved cursor positioning when inserting text in the message composer
  * Enhanced focus management in text input areas

<!-- end of auto-generated comment: release notes by coderabbit.ai -->