### PR TITLE
fix(rooms): Update lastMessage to previous valid message on user deletion

### DIFF
--- a/.changeset/stupid-keys-double.md
+++ b/.changeset/stupid-keys-double.md
@@ -1,0 +1,7 @@
+---
+'@rocket.chat/model-typings': patch
+'@rocket.chat/models': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes user deletion not removing thumbnails of images sent by the deleted user

--- a/packages/model-typings/src/models/IMessagesModel.ts
+++ b/packages/model-typings/src/models/IMessagesModel.ts
@@ -151,7 +151,7 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 	findByMention(username: string, options?: FindOptions<IMessage>): FindCursor<IMessage>;
 	findVisibleThreadByThreadId(tmid: string, options?: FindOptions<IMessage>): FindCursor<IMessage>;
 
-	findFilesByUserId(userId: string, options?: FindOptions<IMessage>): FindCursor<Pick<IMessage, 'file'>>;
+	findFilesByUserId(userId: string, options?: FindOptions<IMessage>): FindCursor<Pick<IMessage, 'file' | 'files'>>;
 	findVisibleByIds(ids: string[], options?: FindOptions<IMessage>): FindCursor<IMessage>;
 	findVisibleByRoomIdNotContainingTypes(
 		roomId: string,

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -768,12 +768,12 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 		return this.find(query, options);
 	}
 
-	findFilesByUserId(userId: string, options: FindOptions<IMessage> = {}): FindCursor<Pick<IMessage, 'file'>> {
+	findFilesByUserId(userId: string, options: FindOptions<IMessage> = {}): FindCursor<Pick<IMessage, 'file' | 'files'>> {
 		const query = {
 			'u._id': userId,
-			'file._id': { $exists: true },
+			'$or': [{ 'file._id': { $exists: true } }, { 'files._id': { $exists: true } }],
 		};
-		return this.find(query, { projection: { 'file._id': 1 }, ...options });
+		return this.find(query, { projection: { 'file._id': 1, 'files._id': 1 }, ...options });
 	}
 
 	findFilesByRoomIdPinnedTimestampAndUsers(


### PR DESCRIPTION
Closes #36885

## Proposed changes

This pull request fixes the "ghost last message" bug (#36885).

Instead of just unsetting the `lastMessage` field, this fix implements the more robust solution suggested by the mentor.

When a user is deleted, this code now:
1.  Finds all rooms where the deleted user sent the last message.
2.  For each of those rooms, it searches for the *new* latest valid message.
3.  If a new last message is found, it updates the `rocketchat_room.lastMessage` field to this new message.
4.  If no new message is found (i.e., the room is now empty), it completely removes (`$unset`) the `lastMessage` field.

This ensures that room previews always show the correct, most-recent valid message, or nothing at all, preventing any ghost messages.

## Steps to test or reproduce

1.  Log in as **User A** and post a message in `#general` (e.g., "This is an old message").
2.  Log in as **User B** and post a new message in `#general` (e.g., "This message will be a ghost").
3.  Log in as an **Admin** and delete **User B**.
4.  **Expected behavior:** The chat preview for `#general` should now correctly show User A's message ("This is an old message") as the last message, not the deleted ghost message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rooms referencing a deleted user's message now recompute and update to the next valid last message or clear it when none remain.
  * Room-change notifications now include all rooms affected by deletions and unlink flows so clients stay in sync.

* **Chores**
  * Added a patch release entry documenting the fix.
  * Added a sparse index to improve lookup for rooms that reference message authors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->