### PR TITLE
Revert "fix: Editing encrypted message attachment description"

### DIFF
--- a/.changeset/healthy-colts-notice.md
+++ b/.changeset/healthy-colts-notice.md
@@ -1,6 +1,0 @@
----
-'@rocket.chat/core-typings': patch
-'@rocket.chat/meteor': patch
----
-
-Fixes editing of encrypted message attachment description.

--- a/apps/meteor/client/lib/parseMessageTextToAstMarkdown.ts
+++ b/apps/meteor/client/lib/parseMessageTextToAstMarkdown.ts
@@ -7,7 +7,6 @@ import {
 	isQuoteAttachment,
 	isTranslatedAttachment,
 	isTranslatedMessage,
-	isEncryptedMessageAttachment,
 } from '@rocket.chat/core-typings';
 import type { Options, Root } from '@rocket.chat/message-parser';
 import { parse } from '@rocket.chat/message-parser';
@@ -78,10 +77,9 @@ export const parseMessageAttachment = <T extends MessageAttachment>(
 		'';
 
 	if (isFileAttachment(attachment) && attachment.description) {
-		attachment.descriptionMd =
-			translated || isEncryptedMessageAttachment(attachment)
-				? textToMessageToken(text, parseOptions)
-				: (attachment.descriptionMd ?? textToMessageToken(text, parseOptions));
+		attachment.descriptionMd = translated
+			? textToMessageToken(text, parseOptions)
+			: (attachment.descriptionMd ?? textToMessageToken(text, parseOptions));
 	}
 
 	return {

--- a/apps/meteor/tests/e2e/e2e-encryption/e2ee-file-encryption.spec.ts
+++ b/apps/meteor/tests/e2e/e2e-encryption/e2ee-file-encryption.spec.ts
@@ -38,7 +38,7 @@ test.describe('E2EE File Encryption', () => {
 		await page.goto('/home');
 	});
 
-	test('File and description encryption and editing the description', async ({ page }) => {
+	test('File and description encryption', async ({ page }) => {
 		await test.step('create an encrypted channel', async () => {
 			const channelName = faker.string.uuid();
 
@@ -58,18 +58,6 @@ test.describe('E2EE File Encryption', () => {
 			await expect(poHomeChannel.content.lastUserMessage.locator('.rcx-icon--name-key')).toBeVisible();
 			await expect(poHomeChannel.content.getFileDescription).toHaveText('any_description');
 			await expect(poHomeChannel.content.lastMessageFileName).toContainText('any_file1.txt');
-		});
-
-		await test.step('edit the description', async () => {
-			await poHomeChannel.content.openLastMessageMenu();
-			await poHomeChannel.content.btnOptionEditMessage.click();
-
-			expect(await poHomeChannel.composer.inputValue()).toBe('any_description');
-
-			await poHomeChannel.content.inputMessage.fill('edited any_description');
-			await page.keyboard.press('Enter');
-
-			await expect(poHomeChannel.content.getFileDescription).toHaveText('edited any_description');
 		});
 	});
 

--- a/packages/core-typings/src/IMessage/MessageAttachment/MessageAttachmentBase.ts
+++ b/packages/core-typings/src/IMessage/MessageAttachment/MessageAttachmentBase.ts
@@ -21,11 +21,3 @@ export type MessageAttachmentBase = {
 		sha256: string;
 	};
 };
-
-export type EncryptedMessageAttachment = MessageAttachmentBase & {
-	encryption: Required<MessageAttachmentBase>['encryption'];
-};
-
-export const isEncryptedMessageAttachment = (attachment: MessageAttachmentBase): attachment is EncryptedMessageAttachment => {
-	return attachment?.encryption !== undefined && typeof attachment.encryption === 'object';
-};


### PR DESCRIPTION
Reverts RocketChat/Rocket.Chat#37270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined attachment description parsing by removing encryption-specific branching logic; description handling now uses consistent behavior regardless of encryption status
  * Updated encryption tests accordingly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->