### PR TITLE
chore: Disable message read receipts in federated rooms

### DIFF
--- a/apps/meteor/client/components/message/toolbar/useReadReceiptsDetailsAction.spec.tsx
+++ b/apps/meteor/client/components/message/toolbar/useReadReceiptsDetailsAction.spec.tsx
@@ -34,15 +34,6 @@ describe('useReadReceiptsDetailsAction', () => {
 		expect(result.current).toBeNull();
 	});
 
-	it('should return null for a federation message', () => {
-		useMessageListReadReceiptsMocked.mockReturnValue({ enabled: true, storeUsers: true });
-		const federatedMessage = { ...message, federation: { eventId: '' } };
-
-		const { result } = renderHook(() => useReadReceiptsDetailsAction(federatedMessage), { wrapper: mockAppRoot().build() });
-
-		expect(result.current).toBeNull();
-	});
-
 	it('should return a message action config', () => {
 		useMessageListReadReceiptsMocked.mockReturnValue({ enabled: true, storeUsers: true });
 

--- a/apps/meteor/client/components/message/toolbar/useReadReceiptsDetailsAction.tsx
+++ b/apps/meteor/client/components/message/toolbar/useReadReceiptsDetailsAction.tsx
@@ -9,9 +9,8 @@ export const useReadReceiptsDetailsAction = (message: IMessage): MessageActionCo
 	const setModal = useSetModal();
 
 	const { enabled: readReceiptsEnabled, storeUsers: readReceiptsStoreUsers } = useMessageListReadReceipts();
-	const isFederationMessage = Boolean(message?.federation);
 
-	if (!readReceiptsEnabled || !readReceiptsStoreUsers || isFederationMessage) {
+	if (!readReceiptsEnabled || !readReceiptsStoreUsers) {
 		return null;
 	}
 

--- a/apps/meteor/client/components/message/variants/RoomMessage.spec.tsx
+++ b/apps/meteor/client/components/message/variants/RoomMessage.spec.tsx
@@ -3,7 +3,6 @@ import { mockAppRoot } from '@rocket.chat/mock-providers';
 import { render, screen } from '@testing-library/react';
 
 import RoomMessage from './RoomMessage';
-import type { MessageListContextValue } from '../list/MessageListContext';
 import { MessageListContext, messageListContextDefaultValue } from '../list/MessageListContext';
 
 const message: IMessage = {
@@ -122,11 +121,8 @@ it('should show read receipt', () => {
 		/>,
 		{
 			wrapper: mockAppRoot()
-				.withSetting('Message_Read_Receipt_Enabled', true)
 				.wrap((children) => (
-					<MessageListContext.Provider
-						value={{ ...messageListContextDefaultValue, readReceipts: { enabled: true, storeUsers: false } } as MessageListContextValue}
-					>
+					<MessageListContext.Provider value={{ ...messageListContextDefaultValue, readReceipts: { enabled: true, storeUsers: false } }}>
 						{children}
 					</MessageListContext.Provider>
 				))
@@ -137,10 +133,10 @@ it('should show read receipt', () => {
 	expect(screen.getByRole('status', { name: 'Message_viewed' })).toBeInTheDocument();
 });
 
-it('should not show read receipt for federation message', () => {
+it('should not show read receipt if receipt is disabled', () => {
 	render(
 		<RoomMessage
-			message={{ ...message, federation: { version: 1, eventId: '' } }}
+			message={message}
 			sequential={false}
 			all={false}
 			mention={false}
@@ -150,11 +146,8 @@ it('should not show read receipt for federation message', () => {
 		/>,
 		{
 			wrapper: mockAppRoot()
-				.withSetting('Message_Read_Receipt_Enabled', true)
 				.wrap((children) => (
-					<MessageListContext.Provider
-						value={{ ...messageListContextDefaultValue, readReceipts: { enabled: true, storeUsers: false } } as MessageListContextValue}
-					>
+					<MessageListContext.Provider value={{ ...messageListContextDefaultValue, readReceipts: { enabled: false, storeUsers: false } }}>
 						{children}
 					</MessageListContext.Provider>
 				))

--- a/apps/meteor/client/components/message/variants/room/RoomMessageContent.tsx
+++ b/apps/meteor/client/components/message/variants/room/RoomMessageContent.tsx
@@ -38,7 +38,6 @@ const RoomMessageContent = ({ message, unread, all, mention, searchText }: RoomM
 	const broadcast = subscription?.broadcast ?? false;
 	const uid = useUserId();
 	const { enabled: readReceiptEnabled } = useMessageListReadReceipts();
-	const isFederationMessage = Boolean(message?.federation);
 	const messageUser = { ...message.u, roles: [], ...useUserPresence(message.u._id) };
 	const chat = useChat();
 	const t = useTranslation();
@@ -120,7 +119,7 @@ const RoomMessageContent = ({ message, unread, all, mention, searchText }: RoomM
 				<BroadcastMetrics username={messageUser.username} message={normalizedMessage} />
 			)}
 
-			{!isFederationMessage && readReceiptEnabled && <ReadReceiptIndicator mid={normalizedMessage._id} unread={normalizedMessage.unread} />}
+			{readReceiptEnabled && <ReadReceiptIndicator mid={normalizedMessage._id} unread={normalizedMessage.unread} />}
 		</>
 	);
 };

--- a/apps/meteor/client/components/message/variants/thread/ThreadMessageContent.tsx
+++ b/apps/meteor/client/components/message/variants/thread/ThreadMessageContent.tsx
@@ -33,7 +33,6 @@ const ThreadMessageContent = ({ message }: ThreadMessageContentProps): ReactElem
 	const uid = useUserId();
 	const { enabled: readReceiptEnabled } = useMessageListReadReceipts();
 	const messageUser = { ...message.u, roles: [], ...useUserPresence(message.u._id) };
-	const isFederationMessage = Boolean(message?.federation);
 
 	const { t } = useTranslation();
 
@@ -86,7 +85,7 @@ const ThreadMessageContent = ({ message }: ThreadMessageContentProps): ReactElem
 				<BroadcastMetrics username={messageUser.username} message={normalizedMessage} />
 			)}
 
-			{!isFederationMessage && readReceiptEnabled && <ReadReceiptIndicator mid={normalizedMessage._id} unread={normalizedMessage.unread} />}
+			{readReceiptEnabled && <ReadReceiptIndicator mid={normalizedMessage._id} unread={normalizedMessage.unread} />}
 		</>
 	);
 };

--- a/apps/meteor/client/views/room/MessageList/providers/MessageListProvider.tsx
+++ b/apps/meteor/client/views/room/MessageList/providers/MessageListProvider.tsx
@@ -1,4 +1,4 @@
-import { isThreadMainMessage } from '@rocket.chat/core-typings';
+import { isRoomFederated, isThreadMainMessage } from '@rocket.chat/core-typings';
 import { useLayout, useUser, useUserPreference, useSetting, useEndpoint, useSearchParameter } from '@rocket.chat/ui-contexts';
 import type { ReactNode, RefCallback } from 'react';
 import { useMemo, memo } from 'react';
@@ -40,7 +40,7 @@ const MessageListProvider = ({ children, messageListRef, attachmentDimension }: 
 	const { isMobile } = useLayout();
 
 	const autoLinkDomains = useSetting('Message_CustomDomain_AutoLink', '');
-	const readReceiptsEnabled = useSetting('Message_Read_Receipt_Enabled', false) && !room.federated;
+	const readReceiptsEnabled = useSetting('Message_Read_Receipt_Enabled', false) && !isRoomFederated(room);
 	const readReceiptsStoreUsers = useSetting('Message_Read_Receipt_Store_Users', false);
 	const apiEmbedEnabled = useSetting('API_Embed', false);
 	const showRealName = useSetting('UI_Use_Real_Name', false);


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR's disables read receipts for federated rooms. This feature will be re-introduced to federated rooms when the capability becomes fully compatible with Federation. 

## Issue(s)
[FB-45](https://rocketchat.atlassian.net/browse/FB-45)
[FB-75](https://rocketchat.atlassian.net/browse/FB-75)

## Steps to test or reproduce

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[FB-45]: https://rocketchat.atlassian.net/browse/FB-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FB-75]: https://rocketchat.atlassian.net/browse/FB-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Read receipts indicators are disabled in federated rooms to prevent misleading displays.

* **Tests**
  * Added unit and component tests covering read receipts behavior across feature-flag and room states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->