### PR TITLE
fix: Prevent the creation of grouped dm's mixing external and internal users

### DIFF
--- a/apps/meteor/client/lib/federation/Federation.spec.ts
+++ b/apps/meteor/client/lib/federation/Federation.spec.ts
@@ -537,3 +537,21 @@ describe('#isRoomSettingAllowed()', () => {
 		});
 	});
 });
+
+describe('#isMatrixUsername', () => {
+	it('should return true for a valid matrix username', () => {
+		expect(Federation.isMatrixUsername('@user:server.com')).toBe(true);
+	});
+
+	it('should return false for an invalid matrix username (missing @)', () => {
+		expect(Federation.isMatrixUsername('user:server.com')).toBe(false);
+	});
+
+	it('should return false for an invalid matrix username (missing :)', () => {
+		expect(Federation.isMatrixUsername('@userserver.com')).toBe(false);
+	});
+
+	it('should return false for a regular rocketchat username', () => {
+		expect(Federation.isMatrixUsername('user')).toBe(false);
+	});
+});

--- a/apps/meteor/client/lib/federation/Federation.ts
+++ b/apps/meteor/client/lib/federation/Federation.ts
@@ -109,3 +109,7 @@ export const isRoomSettingAllowed = (room: Partial<IRoom>, setting: ValueOf<type
 	}
 	return allowedRoomSettingsChangesInFederatedRooms.includes(setting);
 };
+
+export const isMatrixUsername = (username: string) => {
+	return /@(.*:.*)/.test(username);
+};

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -6159,6 +6159,7 @@
   "error-department-removal-disabled": "Department removal is disabled by administration, please contact your administrator",
   "error-direct-message-file-upload-not-allowed": "File sharing not allowed in direct messages",
   "error-direct-message-max-user-exceeded": "You cannot add more than {{maxUsers}} users, including yourself to a direct message",
+  "error-direct-message-internal-external-user-mix-not-allowed": "Cannot pick multiple people if one is outside of the workspace", 
   "error-duplicate-channel-name": "A channel with name '{{channel_name}}' exists",
   "error-duplicate-priority-name": "A priority with the same name already exists",
   "error-duplicated-sla": "An SLA with the same name or due time already exists",


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

## Issue(s)
[FB-62](https://rocketchat.atlassian.net/browse/FB-62)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[FB-62]: https://rocketchat.atlassian.net/browse/FB-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ