### PR TITLE
Fix: prevent duplicate beforeAddedToRoom callback in addUserToRoom

### DIFF
--- a/apps/meteor/app/lib/server/functions/addUserToRoom.ts
+++ b/apps/meteor/app/lib/server/functions/addUserToRoom.ts
@@ -80,12 +80,9 @@ export const addUserToRoom = async (
 		}
 
 		throw error;
-	}
-	// TODO: are we calling this twice?
-	if (room.t === 'c' || room.t === 'p' || room.t === 'l') {
-		// Add a new event, with an optional inviter
-		await callbacks.run('beforeAddedToRoom', { user: userToBeAdded, inviter }, room);
+	// Ensure single pre-add callback; fire room-scoped events only once
 
+	if (room.t === 'c' || room.t === 'p' || room.t === 'l') {
 		// Keep the current event
 		await callbacks.run('beforeJoinRoom', userToBeAdded, room);
 	}


### PR DESCRIPTION
What was fixed or enhanced:
- Removed a redundant invocation of the `beforeAddedToRoom` callback in `addUserToRoom` that caused the event to fire twice for channel, private, and livechat rooms.

Why the change was necessary:
- The duplicate event invocation could lead to unintended side effects in registered callbacks (for example, license checks or rate limiting being evaluated twice), as hinted by the in-code TODO.

What exact changes were made:
- Updated `apps/meteor/app/lib/server/functions/addUserToRoom.ts` to call `callbacks.run('beforeAddedToRoom', ...)` only once and keep room-scoped `beforeJoinRoom` intact.
- Replaced the TODO with a clarifying comment to avoid regressions.

How it improves the project:
- Ensures predictable, single execution of pre-add callback logic, avoiding duplicate work and potential double application of policies.

Verification steps:
1. Start a dev workspace and create a test room (public/private) with an admin user.
2. Register a test callback for `beforeAddedToRoom` that increments a counter or logs invocations.
3. Add a user to the room via UI or API; confirm the callback runs once.
4. Smoke test joining behavior still triggers `beforeJoinRoom` and subsequent system messages.

Next steps (optional):
- Consider normalizing callback signatures (with/without `room`) across call sites for consistency.

Dependencies / Config changes / Tests:
- No new dependencies.
- No config changes.
- No test added for now; existing integration flows cover user-add paths.

### Modified Files
- apps/meteor/app/lib/server/functions/addUserToRoom.ts 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined room join event handling to eliminate potential duplicate callbacks and ensure consistent parameter passing for room management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->