### PR TITLE
fix: Twitter/X oEmbed previews not rendering

### DIFF
--- a/apps/meteor/client/components/message/content/urlPreviews/OEmbedResolver.tsx
+++ b/apps/meteor/client/components/message/content/urlPreviews/OEmbedResolver.tsx
@@ -10,6 +10,18 @@ type OEmbedResolverProps = {
 };
 
 const OEmbedResolver = ({ meta }: OEmbedResolverProps): ReactElement | null => {
+
+   // We force it to render as a standard Link Preview (Image + Text) instead.
+	const isTwitter =
+	   meta.providerName?.toLowerCase() === 'twitter' ||
+	   meta.providerName === 'X' ||
+	   meta.providerUrl?.includes('twitter.com') ||
+	   meta.providerUrl?.includes('x.com');
+
+    if (isTwitter) {
+	   return <OEmbedLinkPreview {...meta} />;
+    }
+
 	switch (meta.type) {
 		case 'rich':
 		case 'video':


### PR DESCRIPTION

## Proposed changes 
Twitter/X oEmbed links were failing to render previews due to missing response handling.  
This PR adds proper fallback logic and ensures consistency with Bluesky and LinkedIn previews.  


## Issue(s)
Closes #37429

## Steps to test or reproduce

## Further comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced rendering of link previews for Twitter and X sources to display with improved consistency and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->