### PR TITLE
chore(federation): update typings to match EventEmitter property pruning

### DIFF
--- a/ee/packages/federation-matrix/src/events/room.ts
+++ b/ee/packages/federation-matrix/src/events/room.ts
@@ -6,8 +6,12 @@ import { Rooms, Users } from '@rocket.chat/models';
 import { getUsernameServername } from '../FederationMatrix';
 
 export function room(emitter: Emitter<HomeserverEventSignatures>) {
-	emitter.on('homeserver.matrix.room.name', async (data) => {
-		const { room_id: roomId, name, user_id: userId } = data;
+	emitter.on('homeserver.matrix.room.name', async ({ event }) => {
+		const {
+			room_id: roomId,
+			content: { name },
+			sender: userId,
+		} = event;
 
 		const localRoomId = await Rooms.findOne({ 'federation.mrid': roomId }, { projection: { _id: 1 } });
 		if (!localRoomId) {

--- a/ee/packages/federation-matrix/src/helpers/message.parsers.ts
+++ b/ee/packages/federation-matrix/src/helpers/message.parsers.ts
@@ -2,7 +2,7 @@ import type { EventID, HomeserverEventSignatures } from '@rocket.chat/federation
 import { marked } from 'marked';
 import sanitizeHtml from 'sanitize-html';
 
-type MatrixMessageContent = HomeserverEventSignatures['homeserver.matrix.message']['content'] & { format?: string };
+type MatrixMessageContent = HomeserverEventSignatures['homeserver.matrix.message']['event']['content'] & { format?: string };
 
 type MatrixEvent = {
 	content?: { body?: string; formatted_body?: string };


### PR DESCRIPTION
Fixes the two leftover typing mismatches from https://github.com/RocketChat/homeserver/pull/299 to fully align with pruned event payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated event handling and type structures for improved consistency and maintainability in federation matrix integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->