### PR TITLE
chore(federation): rely on MongoDB client to parse db name instead of manual URL parsing

### DIFF
--- a/ee/packages/federation-matrix/src/setup.ts
+++ b/ee/packages/federation-matrix/src/setup.ts
@@ -101,17 +101,12 @@ export function configureFederationMatrixSettings(settings: {
 }
 
 export async function setupFederationMatrix() {
-	// TODO are these required?
-	const mongoUri = process.env.MONGO_URL || 'mongodb://localhost:3001/meteor';
-	const dbName = process.env.DATABASE_NAME || new URL(mongoUri).pathname.slice(1);
-
 	const eventHandler = new Emitter<HomeserverEventSignatures>();
 
 	await init({
 		emitter: eventHandler,
 		dbConfig: {
-			uri: mongoUri,
-			name: dbName,
+			uri: process.env.MONGO_URL || 'mongodb://localhost:3001/meteor',
 			poolSize: Number.parseInt(process.env.DATABASE_POOL_SIZE || '10', 10),
 		},
 	});


### PR DESCRIPTION
As per [FB-72](https://rocketchat.atlassian.net/browse/FB-72), when using MongoDB replica-set URLs (multiple hosts), the federation-matrix setup attempts to extract the database name by instantiating a URL object. Even though these MongoDB URLs are valid, the URL constructor does not support this format and throws `ERR_INVALID_URL`, preventing federation from starting.

This PR removes the manual URL parsing and dbName handling. We now read the database name directly from the MongoDB connection string using the MongoDB client parser. If the connection string does not contain a database name, we explicitly throw a clear error.

Works along with https://github.com/RocketChat/homeserver/pull/303.

[FB-72]: https://rocketchat.atlassian.net/browse/FB-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined database connection initialization to make URI resolution more consistent, improving reliability of federation matrix setup.

* **Chores**
  * Simplified internal configuration handling for connection parameters to improve maintainability and reduce potential initialization issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->