### PR TITLE
fix: properly abort XMLHttpRequest in SaveToWebdavModal

### DIFF
--- a/apps/meteor/client/views/room/webdav/SaveToWebdavModal.tsx
+++ b/apps/meteor/client/views/room/webdav/SaveToWebdavModal.tsx
@@ -57,7 +57,7 @@ const SaveToWebdavModal = ({ onClose, data }: SaveToWebdavModalProps): ReactElem
 		return value?.map(({ _id, ...current }) => [_id, getWebdavServerName(current)]) ?? [];
 	}, [value]);
 
-	useEffect(() => fileRequest.current?.abort, []);
+	useEffect(() => () => fileRequest.current?.abort(), []);
 
 	const handleSaveFile = ({ accountId }: { accountId: IWebdavAccount['_id'] }): void => {
 		setIsLoading(true);


### PR DESCRIPTION
## Proposed changes

This PR fixes a memory leak in the [SaveToWebdavModal](cci:1://file:///c:/Users/tanay/Downloads/Projects%20DEV/Rocket.Chat/apps/meteor/client/views/room/webdav/SaveToWebdavModal.tsx:37:0-136:2) component where XMLHttpRequest instances were not being properly aborted on component unmount.

### The Problem
The current implementation has an incorrect `useEffect` cleanup that doesn't actually call the abort method:

```javascript
useEffect(() => fileRequest.current?.abort, []);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Save to WebDAV modal stability by ensuring file requests are properly cancelled when closing the dialog, preventing potential issues with incomplete cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->