### PR TITLE
test: add end-to-end tests for rejecting an invitation from Synapse

### DIFF
--- a/ee/packages/federation-matrix/tests/end-to-end/room.spec.ts
+++ b/ee/packages/federation-matrix/tests/end-to-end/room.spec.ts
@@ -1652,7 +1652,7 @@ import { SynapseClient } from '../helper/synapse-client';
 				expect(rejectResponse.success).toBe(true);
 			});
 
-			it.failing('It should remove the subscription after rejection', async () => {
+			it('It should remove the subscription after rejection', async () => {
 				const subscriptions = await getSubscriptions(rc1AdminRequestConfig);
 
 				const invitedSub = subscriptions.update.find((sub) => sub.fname?.includes(channelName));


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
#### Adds end-to-end tests covering the scenario where a Rocket.Chat user rejects a federated room invitation originating from a Synapse homeserver.
What this PR does: 
- Adds a new test suite Rejecting an invitation from Synapse that verifies:
- A Synapse homeserver can create a room and invite an RC user
- The RC user receives the invitation (subscription with status: 'INVITED')
- The RC user can successfully reject the invite via rejectRoomInvite
- The subscription is removed after rejection (marked as it.failing - since the subscription was still present)

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/QA-108

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tightened selection logic in end-to-end invitation tests to target specific pending invites.
  * Added a new test group for rejecting Synapse-originated invitations and mirroring RC-originated rejection flows.
  * Extended verification that rejecting an invitation removes the corresponding subscription and updates membership state.
  * Kept room state, member lists, and federation metadata consistency checks; minor test formatting clarifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->