### PR TITLE
fix: Normalize font weight of Advanced settings Menu Item in Create Channel modal (#37788)

### DIFF
--- a/apps/meteor/client/sidebar/header/CreateChannel/CreateChannelModal.tsx
+++ b/apps/meteor/client/sidebar/header/CreateChannel/CreateChannelModal.tsx
@@ -281,7 +281,7 @@ const CreateChannelModal = ({ teamId = '', mainRoom, onClose, reload }: CreateCh
 					</Field>
 				</FieldGroup>
 				<Accordion>
-					<AccordionItem title={t('Advanced_settings')}>
+					<AccordionItem title={<Box is='span' fontScale='p2' fontWeight='400'>{t('Advanced_settings')}</Box>}>
 						<FieldGroup>
 							<Box is='h5' fontScale='h5' color='titles-labels'>
 								{t('Security_and_permissions')}


### PR DESCRIPTION
## Proposed changes
Normalized the font weight of the “Advanced settings” label in the Create Channel modal so it matches the font weight of other section labels.  
This change improves visual consistency in the channel creation flow without altering any functionality.

### Screenshots

**Before**  
<img width="1260" height="766" alt="image" src="https://github.com/user-attachments/assets/d56c3fc3-cde3-40a6-899c-80c9219dd8ec" />

**After**  
<img width="1733" height="1568" alt="image" src="https://github.com/user-attachments/assets/2141bff0-58c2-4d88-a5af-3b1be1ba257b" />

---

## Issue(s)
Closes #37788

---

## Steps to test or reproduce
1. Open any workspace
2. Click **Create Channel**
3. Observe the “Advanced settings” section
4. Confirm that its font weight matches other labels such as Name, Topic, Members, and Security & permissions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the visual presentation of the Advanced settings section header in the channel creation interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->