### PR TITLE
fix: Seats pie chart overlaps the text below in Subscription page

### DIFF
--- a/apps/meteor/client/views/admin/subscription/components/UsagePieGraph.tsx
+++ b/apps/meteor/client/views/admin/subscription/components/UsagePieGraph.tsx
@@ -62,7 +62,7 @@ const UsagePieGraph = ({ used = 0, total = 0, label, color, size = 140 }: UsageP
 
 	return (
 		<Box display='flex' flexDirection='column' alignItems='center'>
-			<Box size={`x${size}`}>
+			<Box size={`x${size}`} mbe={8}>
 				<Box position='relative'>
 					<Pie
 						data={parsedData}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR fixes a visual alignment issue on the Subscription page where the Seats donut chart was overlapping the text below it.

**The Problem:**

The bottom arc of the donut chart was touching/overlapping the seat count (e.g., "1 / 50") and the label ("49 Seats Available"), making the UI look cluttered and hard to read.

**The Fix:**

Added `mbe={8}` (margin-bottom of 8px) to the chart container in `UsagePieGraph.tsx`. This creates proper spacing between the donut chart and the text elements below it.


**Before:** Chart touches/overlaps the text below  

<img width="3014" height="1812" alt="image" src="https://github.com/user-attachments/assets/c30dfee3-bdf8-4441-974e-b980dc4dc6fc" />


**After:** Clean 8px gap between chart and text

<img width="1918" height="1017" alt="Screenshot 2025-12-14 144801" src="https://github.com/user-attachments/assets/db8ef1d2-830a-4f9d-98f4-b86a9aa1259b" />


## Issue(s)
Closes #37786 

## Steps to test or reproduce

1. Log in as an admin
2. Navigate to **Administration → Workspace → Subscription**
3. Scroll to the **Seats** widget (requires a license with seat limits to see the donut chart)
4. Observe that the donut chart now has proper spacing and does not overlap the seat count or "Seats Available" text


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual spacing on the subscription usage pie chart for enhanced readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->