### PR TITLE
fix(omnichannel): allow multiline wrapping for transfer system messages

### DIFF
--- a/apps/meteor/client/components/message/variants/SystemMessage.tsx
+++ b/apps/meteor/client/components/message/variants/SystemMessage.tsx
@@ -9,6 +9,7 @@ import {
 	MessageSystemBlock,
 	CheckBox,
 	MessageUsername,
+	
 	MessageNameContainer,
 } from '@rocket.chat/fuselage';
 import { useButtonPattern } from '@rocket.chat/fuselage-hooks';
@@ -80,7 +81,7 @@ const SystemMessage = ({ message, showUserAvatar, ...props }: SystemMessageProps
 			<MessageSystemContainer>
 				<MessageSystemBlock>
 					<MessageNameContainer style={{ cursor: 'pointer' }} {...buttonProps} {...triggerProps}>
-						<MessageSystemName>{displayName}</MessageSystemName>
+						<MessageSystemName style={{ whiteSpace:'pre-wrap'}} >{displayName}</MessageSystemName>
 						{showUsername && (
 							<>
 								{' '}
@@ -88,7 +89,7 @@ const SystemMessage = ({ message, showUserAvatar, ...props }: SystemMessageProps
 							</>
 						)}
 					</MessageNameContainer>
-					{messageType && <MessageSystemBody data-qa-type='system-message-body'>{messageType.text(t, message)}</MessageSystemBody>}
+					{messageType && <MessageSystemBody style={{whiteSpace:'normal', overflowWrap: 'break-word'}} data-qa-type='system-message-body'>{messageType.text(t, message)}</MessageSystemBody>}
 					<MessageSystemTimestamp title={formatDateAndTime(message.ts)}>{formatTime(message.ts)}</MessageSystemTimestamp>
 				</MessageSystemBlock>
 				{message.attachments && (


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
This PR fixes an issue where omnichannel transfer system messages with long
comments were rendered as a single line .

The system message body now allows multiline wrapping so transfer comments
remain fully readable, while keeping the change scoped to the SystemMessage
component without altering global layout or design-system styles.


Before:
<img width="1506" height="147" alt="image" src="https://github.com/user-attachments/assets/1e6242b4-fcee-4599-8524-b23e7f9bdce6" />


After:
<img width="1497" height="209" alt="Screenshot 2025-12-17 120815" src="https://github.com/user-attachments/assets/d5843c10-9865-4e3e-aa95-bcc5d07a2a57" />

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
related to : #26723 
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This fix avoids modifying global Fuselage or layout styles and applies a localized text-wrapping adjustment within system messages to prevent truncation.

A global CSS change may still be required to fully address system message layout consistency.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced text wrapping behavior in system messages to better preserve line breaks in names and prevent text overflow in message bodies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->