### PR TITLE
fix: Missing error handling in avatar upload components

### DIFF
--- a/apps/meteor/client/components/avatar/RoomAvatarEditor.tsx
+++ b/apps/meteor/client/components/avatar/RoomAvatarEditor.tsx
@@ -33,8 +33,8 @@ const handleChangeAvatar = useEffectEvent(async (file: File) => {
             return;
         }
         dispatchToastMessage({ type: 'error', message: t('Avatar_format_invalid') });
-    } catch (error) {
-        dispatchToastMessage({ type: 'error', message: error });
+   } catch (error) {
+        dispatchToastMessage({ type: 'error', message: String(error) });
     }
 });
 

--- a/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
+++ b/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
@@ -40,9 +40,9 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
                     return;
                 }
                 dispatchToastMessage({ type: 'error', message: t('Avatar_format_invalid') });
-            } catch (error) {
-                dispatchToastMessage({ type: 'error', message: t('Avatar_format_invalid') });
-            }
+   				} catch (error) {
+        		dispatchToastMessage({ type: 'error', message: t('Avatar_upload_failed') });
+    			}
         },
         [setAvatarObj, t, dispatchToastMessage],
     );


### PR DESCRIPTION
### Description
This PR addresses issue #37895. Previously, if an avatar upload failed (due to an invalid file format or a file-reading error), the application would fail silently, leaving the user confused.

### Changes
- **RoomAvatarEditor.tsx**: Refactored to use `readFileAsDataURL` utility and added `try/catch` logic to dispatch a toast message on failure.
- **UserAvatarEditor.tsx**: Updated `setUploadedPreview` to ensure a toast message is dispatched if `isValidImageFormat` returns false or if the file read fails.

### How to test
1. **User Profile**: Open the profile page, use DevTools to allow all file types on the hidden file input, and upload a `.txt` file. You should see a red "Avatar format invalid" toast.
2. **Room Info**: Simulate a `FileReader` failure via the browser console and attempt to upload a valid image. You should see an error toast message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for avatar uploads so actual read failures now surface as specific error toasts.
  * Enhanced avatar image validation to prevent invalid state changes and ensure preview/state update only on valid images.
  * Maintained existing success behavior for valid avatars while providing clearer user feedback when uploads or edits fail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->