### PR TITLE
fix: add validation for user avatar file format

### DIFF
--- a/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
+++ b/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
@@ -32,15 +32,22 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 
 	const setUploadedPreview = useCallback(
 		async (file: File, avatarObj: AvatarObject) => {
+			if (!file.type.startsWith('image/')) {
+				dispatchToastMessage({ type: 'error', message: t('Avatar_format_invalid') });
+				return;
+			}
+
 			setAvatarObj(avatarObj);
 			try {
 				const dataURL = await readFileAsDataURL(file);
 
 				if (await isValidImageFormat(dataURL)) {
 					setNewAvatarSource(dataURL);
+				} else {
+					dispatchToastMessage({ type: 'error', message: t('Avatar_format_invalid') });
 				}
 			} catch (error) {
-				dispatchToastMessage({ type: 'error', message: t('Avatar_format_invalid') });
+				dispatchToastMessage({ type: 'error', message: t('FileUpload_Error') });
 			}
 		},
 		[setAvatarObj, t, dispatchToastMessage],


### PR DESCRIPTION
## Proposed changes
This PR adds validation to the `UserAvatarEditor` component to ensure that only valid image files can be uploaded as avatars. Previously, selecting a non-image file would fail silently. Now, it triggers a proper error toast notification.

## Fixes
Fixes #37895

## Checklist
- [x] I have verified the fix locally
- [x] I have followed the Conventional Commits standard
- [x] My code is clean and follows project standards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avatar upload now blocks non-image files before processing and surfaces an Avatar_format_invalid error.
  * Data URLs are validated; invalid image formats also produce Avatar_format_invalid.
  * File read failures during avatar upload now surface a FileUpload_Error to improve error clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->