### PR TITLE
fix: clear pinned state when deleting messages

### DIFF
--- a/apps/meteor/app/lib/server/functions/deleteMessage.ts
+++ b/apps/meteor/app/lib/server/functions/deleteMessage.ts
@@ -30,6 +30,19 @@ export const deleteMessageValidatingPermission = async (message: AtLeast<IMessag
 
 export async function deleteMessage(message: IMessage, user: IUser): Promise<void> {
 	const deletedMsg: IMessage | null = await Messages.findOneById(message._id);
+	if (deletedMsg?.pinned) {
+		await Messages.updateOne(
+			{ _id: deletedMsg._id },
+			{
+				$unset: {
+					pinned: '',
+					pinnedAt: '',
+					pinnedBy: '',
+				},
+			},
+		);
+	}
+
 	const isThread = (deletedMsg?.tcount || 0) > 0;
 	const keepHistory = settings.get('Message_KeepHistory') || isThread;
 	const showDeletedStatus = settings.get('Message_ShowDeletedStatus') || isThread;


### PR DESCRIPTION
## Issue
Pinned messages remain visible after the original message is deleted.

## Steps to Reproduce
1. Create a channel
2. Send a message
3. Pin the message
4. Delete the message
5. Open pinned messages

## Expected Behavior
Deleted messages should not appear in the pinned messages list.

## Actual Behavior
Deleted messages remain listed as pinned.

## Solution
Ensure pinned metadata is removed when a message is deleted so pinned message queries remain consistent.

## Notes
Handled server-side to ensure all delete flows remain consistent and avoid UI-level workarounds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where deleting a pinned message would not clear its pinned status. Pinned messages now properly have their pin metadata removed upon deletion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->