### PR TITLE
fix(server): return 500 error when user data store is unconfigured

### DIFF
--- a/apps/meteor/server/routes/userDataDownload.ts
+++ b/apps/meteor/server/routes/userDataDownload.ts
@@ -47,7 +47,8 @@ const isRequestFromOwner = async (req: IIncomingMessage, ownerUID: IUser['_id'])
 const sendUserDataFile = (file: IUserDataFile) => (req: IncomingMessage, res: ServerResponse, next: () => void) => {
 	const userDataStore = FileUpload.getStore('UserDataFiles');
 	if (!userDataStore?.get) {
-		res.writeHead(403).end(); // @todo: maybe we should return a better error?
+		res.writeHead(500);
+		res.end('User Data Store not configured');
 		return;
 	}
 


### PR DESCRIPTION
### Proposed Changes
Updated the error response in  
`apps/meteor/server/routes/userDataDownload.ts`  
from **403 Forbidden** to **500 Internal Server Error** when the `UserDataFiles` store is not configured.

### Reasoning
A missing `UserDataFiles` store is a **server-side configuration issue**, not a permissions problem.  
Returning a `500` status with a clear message (`User Data Store not configured`) more accurately reflects the failure mode and helps administrators diagnose misconfiguration.

### Issue(s)
N/A

### Steps to Test / Reproduce
1. Run Rocket.Chat.
2. Configure the server such that the `UserDataFiles` store is not available or unconfigured.
3. Request a user data download.

**Before:**  
- Response status: `403 Forbidden`

**After:**  
- Response status: `500 Internal Server Error`  
- Response body: `User Data Store not configured`

### Additional Notes
This is a small, targeted fix to improve error correctness and debuggability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for user data downloads by providing a clearer error message when the system configuration is incomplete, enhancing troubleshooting experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->