### PR TITLE
regression: Prevent room infinite loop when invitation is revoked during invite view

### DIFF
--- a/apps/meteor/client/views/room/Room.tsx
+++ b/apps/meteor/client/views/room/Room.tsx
@@ -1,6 +1,6 @@
 import { isInviteSubscription } from '@rocket.chat/core-typings';
 import { ContextualbarSkeleton } from '@rocket.chat/ui-client';
-import { useSetting, useRoomToolbox } from '@rocket.chat/ui-contexts';
+import { useSetting, useRoomToolbox, useUserId } from '@rocket.chat/ui-contexts';
 import type { ReactElement } from 'react';
 import { createElement, lazy, memo, Suspense } from 'react';
 import { FocusScope } from 'react-aria';
@@ -23,6 +23,7 @@ const UiKitContextualBar = lazy(() => import('./contextualBar/uikit/UiKitContext
 
 const Room = (): ReactElement => {
 	const { t } = useTranslation();
+	const userId = useUserId();
 	const room = useRoom();
 	const subscription = useRoomSubscription();
 	const toolbox = useRoomToolbox();
@@ -36,7 +37,7 @@ const Room = (): ReactElement => {
 	if (subscription && isInviteSubscription(subscription)) {
 		return (
 			<FocusScope>
-				<RoomInvite room={room} subscription={subscription} data-qa-rc-room={room._id} aria-label={roomLabel} />
+				<RoomInvite userId={userId} room={room} subscription={subscription} data-qa-rc-room={room._id} aria-label={roomLabel} />
 			</FocusScope>
 		);
 	}

--- a/apps/meteor/client/views/room/RoomInvite.tsx
+++ b/apps/meteor/client/views/room/RoomInvite.tsx
@@ -1,24 +1,29 @@
-import { isRoomFederated, type IInviteSubscription } from '@rocket.chat/core-typings';
+import { isRoomFederated } from '@rocket.chat/core-typings';
+import type { IUser, IInviteSubscription } from '@rocket.chat/core-typings';
 import type { ComponentProps } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import Header from './Header';
 import RoomInviteBody from './body/RoomInviteBody';
+import { useGoToHomeOnRemoved } from './body/hooks/useGoToHomeOnRemoved';
 import type { IRoomWithFederationOriginalName } from './contexts/RoomContext';
 import { useRoomInvitation } from './hooks/useRoomInvitation';
 import RoomLayout from './layout/RoomLayout';
 import { links } from '../../lib/links';
 
 type RoomInviteProps = Omit<ComponentProps<typeof RoomLayout>, 'header' | 'body' | 'aside'> & {
+	userId?: IUser['_id'];
 	room: IRoomWithFederationOriginalName;
 	subscription: IInviteSubscription;
 };
 
-const RoomInvite = ({ room, subscription, ...props }: RoomInviteProps) => {
+const RoomInvite = ({ room, subscription, userId, ...props }: RoomInviteProps) => {
 	const { t } = useTranslation();
 	const { acceptInvite, rejectInvite, isPending } = useRoomInvitation(room);
 
 	const infoLink = isRoomFederated(room) ? { label: t('Learn_more_about_Federation'), href: links.go.matrixFederation } : undefined;
+
+	useGoToHomeOnRemoved(room, userId);
 
 	return (
 		<RoomLayout


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR fixes a bug happening when a user had it's invitation to a room revoked while still in the invite view. Due to missing logic necessary to redirect the user to the home screen the room entered an invalid state, infinately trying  and failing to fetch the room messages. 

This issue was fixed by properly calling the hook `useGoToHomeOnRemoved` within the `InviteRoom`. 

## Issue(s)
[FB-168](https://rocketchat.atlassian.net/browse/FB-168)

## Steps to test or reproduce
- Access a federation enabled workspace
- Create a federated room
- Invite a userB from the same workspace to the room (userA)
- Access room invite (userB)
- Revoke userB's invitation (members list > userB > actions menu > revoke invitation) (userA)
- userB should be redirected to the home page (previously entered an infinite loop) (userB)

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[FB-168]: https://rocketchat.atlassian.net/browse/FB-168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of user removal within room invite flows to ensure proper navigation and state management.

* **Refactor**
  * Enhanced room invite component architecture to better track user context during invitation processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->