### PR TITLE
fix(omnichannel): allow transfer comment to wrap into multiple lines

### DIFF
--- a/apps/meteor/client/views/omnichannel/contactHistory/MessageList/ContactHistoryMessage.tsx
+++ b/apps/meteor/client/views/omnichannel/contactHistory/MessageList/ContactHistoryMessage.tsx
@@ -71,7 +71,13 @@ const ContactHistoryMessage = ({ message, sequential, isNewDay, showUserAvatar }
 						<MessageSystemName data-username={message.u.username} data-qa-type='username'>
 							@{message.u.username}
 						</MessageSystemName>
-						<MessageSystemBody title={message.msg}>{t('Conversation_closed', { comment: message.msg })}</MessageSystemBody>
+						<MessageSystemBody
+							title={message.msg}
+							style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+						>
+							{t('Conversation_closed', { comment: message.msg })}
+						</MessageSystemBody>
+					
 						<MessageSystemTimestamp title={formatTime(message.ts)}>{formatTime(message.ts)}</MessageSystemTimestamp>
 					</MessageSystemBlock>
 				</MessageSystemContainer>


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where omnichannel transfer/close comments were rendered in a single line and did not wrap properly.

### Why is this needed?

Long comments overflowed the message container, making them hard to read.

### How is this fixed?

Allows multi-line wrapping on `MessageSystemBody` by enabling whitespace wrapping and word breaking.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced formatting and display of closed conversation messages with improved text wrapping and word break handling for better readability.
  * Added contextual information to closed conversation messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->