### PR TITLE
fix: ensure omnichannel transfer comment text wraps to multiple lines

### DIFF
--- a/apps/meteor/app/theme/client/imports/general/base.css
+++ b/apps/meteor/app/theme/client/imports/general/base.css
@@ -110,3 +110,19 @@ button {
 	max-width: 100%;
 	cursor: pointer;
 }
+
+/* Fix for issue #26723: Omnichannel transfer comment text wrapping */
+.rcx-message-system__block {
+	flex-wrap: wrap;
+}
+
+.rcx-message-system__body {
+	white-space: normal !important;
+	word-wrap: break-word;
+	word-break: break-word;
+	overflow-wrap: break-word;
+	text-overflow: clip !important;
+	overflow: visible !important;
+	flex-shrink: 1;
+	min-width: 0;
+}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The transfer comment in omnichannel system messages was not wrapping when the comment was longer than the available space. This was caused by the Fuselage `MessageSystemBody` component using text truncation styles (`white-space: nowrap`, `text-overflow: ellipsis`) and the parent flex container (`.rcx-message-system__block`) not allowing wrap.

### Changes Made:
- Added `flex-wrap: wrap` to `.rcx-message-system__block` to allow the flex container to wrap content
- Override `white-space`, `text-overflow`, and `overflow` on `.rcx-message-system__body` to allow text wrapping
- Added `flex-shrink` and `min-width` properties to enable proper text wrapping behavior

### Before (Bug):
<img width="1330" height="792" alt="image" src="https://github.com/user-attachments/assets/2fbfd6a0-91ab-4a36-ab9f-e9eccb23324f" />


### After (Fixed):
<img width="1326" height="789" alt="image" src="https://github.com/user-attachments/assets/3d88d22b-9330-4f7a-9819-c6ef038e7643" />

## Issue(s)

Fixes #26723

## Steps to test or reproduce

1. Enable Omnichannel in **Administration → Settings → Omnichannel**
2. Add yourself as an agent and set status to "Available"
3. Create a new livechat conversation (open `/livechat` in incognito browser)
4. Accept the chat as an agent
5. Click **Forward** to transfer the chat
6. Enter a very long comment like:
   "ThisIsAVeryLongCommentThatShouldWrapToMultipleLinesInsteadOfOverflowingHorizontallyWhichWasThePreviousBehaviorBeforeTheFix"
7. Complete the transfer
8. **Expected Result**: The transfer system message should display the comment wrapped across multiple lines instead of being truncated with ellipsis

## Further comments

This is a CSS-only fix that overrides the default Fuselage component styles. The fix is minimal and targeted specifically at the system message body element to avoid unintended side effects on other components.

**Root cause:**
- `.rcx-message-system__block` uses `display: flex` with `flex-direction: row` which keeps all items on one line
- `.rcx-message-system__body` uses Fuselage's truncation mixin which adds `white-space: nowrap` and `text-overflow: ellipsis`

**Solution:**
- Allow the flex container to wrap with `flex-wrap: wrap`
- Override truncation styles to enable normal text wrapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text wrapping and display issues in Omnichannel transfer comments to ensure messages render properly with correct word breaks and no unexpected truncation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->