### PR TITLE
fix: users.update overwrites customFields instead of merging #37993

### DIFF
--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -120,6 +120,7 @@ API.v1.addRoute(
 			await saveUser(this.userId, userData, { auditStore });
 
 			
+			
 			if (this.bodyParams.data.customFields) {
 				validateCustomFields(this.bodyParams.data.customFields);
 
@@ -131,10 +132,14 @@ API.v1.addRoute(
 
 				await Users.update({ _id: this.bodyParams.userId }, { $set: flattenedFields });
 				
-				await Subscriptions.setCustomFieldsDirectMessagesByUserId(this.bodyParams.userId, this.bodyParams.data.customFields);
+				
+				const updatedUser = await Users.findOneById(this.bodyParams.userId, { projection: { customFields: 1 } });
+				if (updatedUser?.customFields) {
+					await Subscriptions.setCustomFieldsDirectMessagesByUserId(this.bodyParams.userId, updatedUser.customFields);
+				}
 			}
 
-			// [THEIR CHANGE] Active Status
+			
 			if (typeof this.bodyParams.data.active !== 'undefined') {
 				const {
 					userId,


### PR DESCRIPTION
### 🚀 Improvements

This PR fixes a data loss issue in the `users.update` endpoint where updating a single custom field would overwrite all existing custom fields.

I have modified the update logic to flatten the `customFields` object before passing it to the database model. This ensures that the update performs a specific `$set` on keys (e.g., `customFields.team`) rather than replacing the entire `customFields` root object.

### 🔗 Related Issues

Closes #37993

### 🧪 How to Test

1. Create two Custom Fields in **Administration > Accounts > Registration** (e.g., `role`, `team`).
2. Set initial values for a user: `{ "role": "Developer", "team": "Red" }`.
3. Send a POST request to `api/v1/users.update` updating *only* the team:
   ```json
   {
       "userId": "TARGET_USER_ID",
       "data": { "customFields": { "team": "Blue" } }
   }





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the users API update endpoint's handling of custom fields for improved performance and database consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->