### PR TITLE
feat: Sort room members alphabetically before grouping

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/RoomMembers/RoomMembers.tsx
+++ b/apps/meteor/client/views/room/contextualBar/RoomMembers/RoomMembers.tsx
@@ -90,7 +90,6 @@ const RoomMembers = ({
 	const useRealName = useSetting('UI_Use_Real_Name', false);
 
 	const { counts, titles, flattenedMembers } = useMemo(() => {
-		
 	const membersWithSortName = members.map((member) => ({
 		...member,
 		sortName: (useRealName ? member.name || member.username : member.username) ?? '',
@@ -107,12 +106,12 @@ const RoomMembers = ({
 	);
 
 		const sortGroup = (arr: typeof membersWithSortName) =>
-			[...arr].sort((a,b)=> a.sortName.localeCompare(b.sortName));
+			[...arr].sort((a, b) => a.sortName.localeCompare(b.sortName));
 		
-		const sortedOwners=sortGroup(owners);
-		const sortedLeaders=sortGroup(leaders);
-		const sortedModerators=sortGroup(moderators);
-		const sortedNormal=sortGroup(normalMembers);
+		const sortedOwners = sortGroup(owners);
+		const sortedLeaders = sortGroup(leaders);
+		const sortedModerators = sortGroup(moderators);
+		const sortedNormal = sortGroup(normalMembers);
 		
 		const counts: number[] = [];
 		const titles: ReactElement[] = [];

--- a/apps/meteor/client/views/room/contextualBar/RoomMembers/RoomMembers.tsx
+++ b/apps/meteor/client/views/room/contextualBar/RoomMembers/RoomMembers.tsx
@@ -106,7 +106,7 @@ const RoomMembers = ({
 			!m.roles?.includes('moderator')
 	);
 
-		const sortGroup = (arr: typeof memberWithSortName)=>
+		const sortGroup = (arr: typeof membersWithSortName)=>
 			[...arr].sort((a,b)=> a.sortName.localeCompare(b.sortName));
 		const sortedOwners=sortGroup(owners);
 		const sortedLeaders=sortGroup(leaders);

--- a/apps/meteor/client/views/room/contextualBar/RoomMembers/RoomMembers.tsx
+++ b/apps/meteor/client/views/room/contextualBar/RoomMembers/RoomMembers.tsx
@@ -89,13 +89,22 @@ const RoomMembers = ({
 
 	const useRealName = useSetting('UI_Use_Real_Name', false);
 
+	const sortedMembers = useMemo(() => {
+		return [...members].sort((a, b) => {
+			const nameA = useRealName ? a.name || a.username : a.username;
+			const nameB = useRealName ? b.name || b.username : b.username;
+
+			return nameA.localeCompare(nameB);
+		});
+	}, [members, useRealName]);
+
 	const { counts, titles } = useMemo(() => {
 		const owners: RoomMember[] = [];
 		const leaders: RoomMember[] = [];
 		const moderators: RoomMember[] = [];
 		const normalMembers: RoomMember[] = [];
 
-		members.forEach((member) => {
+		sortedMembers.forEach((member) => {
 			if (member.roles?.includes('owner')) {
 				owners.push(member);
 			} else if (member.roles?.includes('leader')) {
@@ -131,7 +140,7 @@ const RoomMembers = ({
 		}
 
 		return { counts, titles };
-	}, [members]);
+	}, [sortedMembers]);
 
 	return (
 		<ContextualbarDialog>
@@ -165,13 +174,13 @@ const RoomMembers = ({
 					</Box>
 				)}
 
-				{!loading && members.length <= 0 && <ContextualbarEmptyContent title={t('No_members_found')} />}
+				{!loading && sortedMembers.length <= 0 && <ContextualbarEmptyContent title={t('No_members_found')} />}
 
-				{!loading && members.length > 0 && (
+				{!loading && sortedMembers.length > 0 && (
 					<>
 						<Box pi={24} pb={12}>
 							<Box is='span' color='hint' fontScale='p2'>
-								{t('Showing_current_of_total', { current: members.length, total })}
+								{t('Showing_current_of_total', { current: sortedMembers.length, total })}
 							</Box>
 						</Box>
 
@@ -188,7 +197,7 @@ const RoomMembers = ({
 									// eslint-disable-next-line react/no-multi-comp
 									components={{ Footer: () => <InfiniteListAnchor loadMore={loadMoreMembers} /> }}
 									itemContent={(index): ReactElement => (
-										<RowComponent useRealName={useRealName} data={itemData} user={members[index]} index={index} reload={reload} />
+										<RowComponent useRealName={useRealName} data={itemData} user={sortedMembers[index]} index={index} reload={reload} />
 									)}
 								/>
 							</VirtualizedScrollbars>

--- a/apps/meteor/client/views/room/contextualBar/RoomMembers/RoomMembers.tsx
+++ b/apps/meteor/client/views/room/contextualBar/RoomMembers/RoomMembers.tsx
@@ -92,8 +92,8 @@ const RoomMembers = ({
 	const { counts, titles, flattenedMembers } = useMemo(() => {
 		
 	const membersWithSortName = members.map((member) => ({
-	...member,
-	sortName: useRealName ? member.name || member.username : member.username,
+		...member,
+		sortName: (useRealName ? member.name || member.username : member.username) ?? '',
 	}));
 
 	const owners = membersWithSortName.filter((m) => m.roles?.includes('owner'));
@@ -106,15 +106,16 @@ const RoomMembers = ({
 			!m.roles?.includes('moderator')
 	);
 
-		const sortGroup = (arr: typeof membersWithSortName)=>
+		const sortGroup = (arr: typeof membersWithSortName) =>
 			[...arr].sort((a,b)=> a.sortName.localeCompare(b.sortName));
+		
 		const sortedOwners=sortGroup(owners);
 		const sortedLeaders=sortGroup(leaders);
 		const sortedModerators=sortGroup(moderators);
 		const sortedNormal=sortGroup(normalMembers);
 		
 		const counts: number[] = [];
-		const titles:ReactElement[] = [];
+		const titles: ReactElement[] = [];
 
 		if (sortedOwners.length) {
 			counts.push(sortedOwners.length);
@@ -135,7 +136,9 @@ const RoomMembers = ({
 			counts.push(sortedNormal.length);
 			titles.push(<MembersListDivider title={t('Members')} count={sortedNormal.length} />);
 		}
-		const flattenedMembers= [...sortedOwners, ...sortedLeaders, ...sortedModerators, ...sortedNormal];
+		
+		const flattenedMembers = [...sortedOwners, ...sortedLeaders, ...sortedModerators, ...sortedNormal];
+		
 		return { counts, titles, flattenedMembers };
 	}, [members, useRealName, t]);
 

--- a/apps/meteor/client/views/room/contextualBar/RoomMembers/RoomMembers.tsx
+++ b/apps/meteor/client/views/room/contextualBar/RoomMembers/RoomMembers.tsx
@@ -90,57 +90,54 @@ const RoomMembers = ({
 	const useRealName = useSetting('UI_Use_Real_Name', false);
 
 	const { counts, titles, flattenedMembers } = useMemo(() => {
-		const owners: RoomMember[] = [];
-		const leaders: RoomMember[] = [];
-		const moderators: RoomMember[] = [];
-		const normalMembers: RoomMember[] = [];
+		
+	const membersWithSortName = members.map((member) => ({
+	...member,
+	sortName: useRealName ? member.name || member.username : member.username,
+	}));
 
-		members.forEach((member) => {
-			const name = useRealName ? member.name || member.username : member.username;
-			( member as any ).sortName = name;
-			
-			if (member.roles?.includes('owner')) {
-				owners.push(member);
-			} else if (member.roles?.includes('leader')) {
-				leaders.push(member);
-			} else if (member.roles?.includes('moderator')) {
-				moderators.push(member);
-			} else {
-				normalMembers.push(member);
-			}
-		});
+	const owners = membersWithSortName.filter((m) => m.roles?.includes('owner'));
+	const leaders = membersWithSortName.filter((m) => m.roles?.includes('leader'));
+	const moderators = membersWithSortName.filter((m) => m.roles?.includes('moderator'));
+	const normalMembers = membersWithSortName.filter(
+		(m) =>
+			!m.roles?.includes('owner') &&
+			!m.roles?.includes('leader') &&
+			!m.roles?.includes('moderator')
+	);
 
-		const sortGroup = (arr: RoomMember[])=>
-			arr.sort((a,b)=> ((a as any).sortName as string).localeCompare((b as any).sortName));
+		const sortGroup = (arr: typeof memberWithSortName)=>
+			[...arr].sort((a,b)=> a.sortName.localeCompare(b.sortName));
 		const sortedOwners=sortGroup(owners);
 		const sortedLeaders=sortGroup(leaders);
 		const sortedModerators=sortGroup(moderators);
 		const sortedNormal=sortGroup(normalMembers);
+		
 		const counts: number[] = [];
 		const titles:ReactElement[] = [];
 
 		if (sortedOwners.length) {
 			counts.push(sortedOwners.length);
-			titles.push(<MembersListDivider title='Owners' count={sortedOwners.length} />);
+			titles.push(<MembersListDivider title={t('Owners')} count={sortedOwners.length} />);
 		}
 
 		if (sortedLeaders.length) {
 			counts.push(sortedLeaders.length);
-			titles.push(<MembersListDivider title='Leaders' count={sortedLeaders.length} />);
+			titles.push(<MembersListDivider title={t('Leaders')} count={sortedLeaders.length} />);
 		}
 
 		if (sortedModerators.length) {
 			counts.push(sortedModerators.length);
-			titles.push(<MembersListDivider title='Moderators' count={sortedModerators.length} />);
+			titles.push(<MembersListDivider title={t('Moderators')} count={sortedModerators.length} />);
 		}
 
 		if (sortedNormal.length) {
 			counts.push(sortedNormal.length);
-			titles.push(<MembersListDivider title='Members' count={sortedNormal.length} />);
+			titles.push(<MembersListDivider title={t('Members')} count={sortedNormal.length} />);
 		}
 		const flattenedMembers= [...sortedOwners, ...sortedLeaders, ...sortedModerators, ...sortedNormal];
 		return { counts, titles, flattenedMembers };
-	}, [members, useRealName]);
+	}, [members, useRealName, t]);
 
 	return (
 		<ContextualbarDialog>


### PR DESCRIPTION
Ensures members are sorted alphabetically before grouping and rendering.

- Sorts room members alphabetically before grouping by roles
- Ensures consistent ordering when rendering grouped member lists
- Uses UI_Use_Real_Name setting while sorting

## Issue(s)
Closes #22145  

## Steps to test or reproduce
1. Open any channel or group with multiple members.
2. Open the members list (Contextual Bar).
3. Observe that members are now sorted alphabetically before grouping by roles.
4. Check that owners, leaders, moderators, and normal members are correctly grouped.

## Further comments
This change improves consistency in the members list by sorting members before grouping. It respects the UI_Use_Real_Name setting, so display names are used if enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancement**
  * Members list now shows a single grouped view ordered by role (owners, leaders, moderators, members) and alphabetically within each group.
  * Display names respect the real-name preference when enabled.
  * Group headings use localized titles and show accurate counts.
  * Empty state, “Showing X of Y” and list rendering reflect the new flattened, sorted structure.
  * Memoization and rendering now account for name preference and translations for more consistent performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->