### PR TITLE
fix(sidebar): update room avatar in real-time

### DIFF
--- a/apps/meteor/client/components/RoomIcon/RoomIcon.tsx
+++ b/apps/meteor/client/components/RoomIcon/RoomIcon.tsx
@@ -7,68 +7,34 @@ import { isValidElement } from 'react';
 import { OmnichannelRoomIcon } from './OmnichannelRoomIcon';
 import { useRoomIcon } from '../../hooks/useRoomIcon';
 
-// export const RoomIcon = ({
-// 	room,
-// 	size = 'x16',
-// 	isIncomingCall,
-// 	placement = 'default',
-// }: {
-//     room: Pick<IRoom, 't' | 'prid' | 'teamMain' | 'uids' | 'u' | 'avatarETag'>;
-// 	size?: ComponentProps<typeof Icon>['size'];
-// 	isIncomingCall?: boolean;
-// 	placement?: 'sidebar' | 'default';
-// }): ReactElement | null => {
-// 	const iconPropsOrReactNode = useRoomIcon(room);
-
-// 	if (isIncomingCall) {
-// 		return <Icon name='phone' size={size} />;
-// 	}
-
-// 	if (isOmnichannelRoom(room)) {
-// 		return <OmnichannelRoomIcon placement={placement} source={room.source} status={room.v?.status} size={size} />;
-// 	}
-
-// 	if (isValidElement<any>(iconPropsOrReactNode)) {
-// 		return iconPropsOrReactNode;
-// 	}
-
-// 	if (!iconPropsOrReactNode) {
-// 		return null;
-// 	}
-
-// 	return <Icon {...iconPropsOrReactNode} size={size} />;
-// };
-
 export const RoomIcon = ({
-    room,
-    size = 'x16',
-    isIncomingCall,
-    placement = 'default',
+	room,
+	size = 'x16',
+	isIncomingCall,
+	placement = 'default',
 }: {
-    // Add avatarETag here so the component tracks it
-    room: Pick<IRoom, 't' | 'prid' | 'teamMain' | 'uids' | 'u' | 'avatarETag'>; 
-    size?: ComponentProps<typeof Icon>['size'];
-    isIncomingCall?: boolean;
-    placement?: 'sidebar' | 'default';
+	room: Pick<IRoom, 't' | 'prid' | 'teamMain' | 'uids' | 'u' | 'avatarETag'>;
+	size?: ComponentProps<typeof Icon>['size'];
+	isIncomingCall?: boolean;
+	placement?: 'sidebar' | 'default';
 }): ReactElement | null => {
-    // Passing the room with the avatarETag into the hook
-    const iconPropsOrReactNode = useRoomIcon(room); 
+	const iconPropsOrReactNode = useRoomIcon(room);
 
-    if (isIncomingCall) {
-        return <Icon name='phone' size={size} />;
-    }
+	if (isIncomingCall) {
+		return <Icon name='phone' size={size} />;
+	}
 
-    if (isOmnichannelRoom(room)) {
-        return <OmnichannelRoomIcon placement={placement} source={room.source} status={room.v?.status} size={size} />;
-    }
+	if (isOmnichannelRoom(room)) {
+		return <OmnichannelRoomIcon placement={placement} source={room.source} status={room.v?.status} size={size} />;
+	}
 
-    if (isValidElement<any>(iconPropsOrReactNode)) {
-        return iconPropsOrReactNode;
-    }
+	if (isValidElement<any>(iconPropsOrReactNode)) {
+		return iconPropsOrReactNode;
+	}
 
-    if (!iconPropsOrReactNode) {
-        return null;
-    }
+	if (!iconPropsOrReactNode) {
+		return null;
+	}
 
-    return <Icon {...iconPropsOrReactNode} size={size} />;
+	return <Icon {...iconPropsOrReactNode} size={size} />;
 };

--- a/apps/meteor/client/sidebar/RoomList/SidebarItemWithData.tsx
+++ b/apps/meteor/client/sidebar/RoomList/SidebarItemWithData.tsx
@@ -159,54 +159,53 @@ const keys: (keyof RoomListRowProps)[] = ['id', 'style', 't', 'videoConfActions'
 // });
 
 
+const keys: (keyof RoomListRowProps)[] = ['id', 'style', 't', 'videoConfActions'];
+
 // eslint-disable-next-line react/no-multi-comp
 export default memo(SidebarItemWithData, (prevProps, nextProps) => {
-    if (keys.some((key) => prevProps[key] !== nextProps[key])) {
-        return false;
-    }
+	if (keys.some((key) => prevProps[key] !== nextProps[key])) {
+		return false;
+	}
 
-    if (prevProps.room === nextProps.room) {
-        return true;
-    }
+	if (prevProps.room === nextProps.room) {
+		return true;
+	}
 
-    if (prevProps.room._id !== nextProps.room._id) {
-        return false;
-    }
-
-    
-    // This ensures the sidebar re-renders when the avatar is updated
-    if (prevProps.room.avatarETag !== nextProps.room.avatarETag) {
-        return false;
-    }
-    
+	if (prevProps.room._id !== nextProps.room._id) {
+		return false;
+	}
 
 	if (prevProps.room.avatarETag !== nextProps.room.avatarETag) {
-        return false; // Tells React to re-render the sidebar item
-    }
+		return false;
+	}
 
-    if (prevProps.room._updatedAt?.toISOString() !== nextProps.room._updatedAt?.toISOString()) {
-        return false;
-    }
-    if (safeDateNotEqualCheck(prevProps.room.lastMessage?._updatedAt, nextProps.room.lastMessage?._updatedAt)) {
-        return false;
-    }
-    if (prevProps.room.alert !== nextProps.room.alert) {
-        return false;
-    }
-    if (isOmnichannelRoom(prevProps.room) && isOmnichannelRoom(nextProps.room) && prevProps.room?.v?.status !== nextProps.room?.v?.status) {
-        return false;
-    }
-    if (prevProps.room.teamMain !== nextProps.room.teamMain) {
-        return false;
-    }
+	if (prevProps.room._updatedAt?.toISOString() !== nextProps.room._updatedAt?.toISOString()) {
+		return false;
+	}
 
-    if (
-        isOmnichannelRoom(prevProps.room) &&
-        isOmnichannelRoom(nextProps.room) &&
-        prevProps.room.priorityWeight !== nextProps.room.priorityWeight
-    ) {
-        return false;
-    }
+	if (safeDateNotEqualCheck(prevProps.room.lastMessage?._updatedAt, nextProps.room.lastMessage?._updatedAt)) {
+		return false;
+	}
 
-    return true;
+	if (prevProps.room.alert !== nextProps.room.alert) {
+		return false;
+	}
+
+	if (isOmnichannelRoom(prevProps.room) && isOmnichannelRoom(nextProps.room) && prevProps.room?.v?.status !== nextProps.room?.v?.status) {
+		return false;
+	}
+
+	if (prevProps.room.teamMain !== nextProps.room.teamMain) {
+		return false;
+	}
+
+	if (
+		isOmnichannelRoom(prevProps.room) &&
+		isOmnichannelRoom(nextProps.room) &&
+		prevProps.room.priorityWeight !== nextProps.room.priorityWeight
+	) {
+		return false;
+	}
+
+	return true;
 });


### PR DESCRIPTION
## Proposed changes
This PR fixes an issue where updating a room/channel avatar would reflect in the Room Header and Room Info panel, but not in the Sidebar until a manual refresh.

The issue was caused by:
1. `SidebarItemWithData.tsx` using a `memo` comparison that ignored `avatarETag` changes, preventing re-renders.
2. `RoomIcon.tsx` prop types excluding `avatarETag`, which prevented the component from tracking avatar version updates.

## Checklist
- I have reproduced the issue locally.
- I have verified that the sidebar now updates immediately after an avatar change.
- The `avatarETag` is correctly used to bust the browser cache for the new image.

## Steps to test
1. Open any channel.
2. Go to Room Info -> Edit -> Upload Avatar.
3. Save the new avatar.
4. Observe the sidebar item icon updating immediately without page refresh.

closes #37913 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar items now update immediately when a room avatar changes, ensuring the latest avatar is shown.
  * Room icons consistently reflect recent avatar updates across the app so users see avatar changes in real time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->