### PR TITLE
fix: Webhook script compilation failure

### DIFF
--- a/apps/meteor/app/integrations/server/methods/incoming/updateIncomingIntegration.ts
+++ b/apps/meteor/app/integrations/server/methods/incoming/updateIncomingIntegration.ts
@@ -84,7 +84,6 @@ export const updateIncomingIntegration = async (
 	}
 
 	let scriptCompiled: string | undefined;
-	let scriptError: Pick<Error, 'name' | 'message' | 'stack'> | undefined;
 	const isFrozen = isScriptEngineFrozen(scriptEngine);
 
 	if (!isFrozen && integration.scriptEnabled === true && integration.script && integration.script.trim() !== '') {
@@ -93,21 +92,14 @@ export const updateIncomingIntegration = async (
 			babelOptions = _.extend(babelOptions, { compact: true, minified: true, comments: false });
 
 			scriptCompiled = Babel.compile(integration.script, babelOptions).code;
-			scriptError = undefined;
 		} catch (e) {
-			scriptCompiled = undefined;
-			if (e instanceof Error) {
-				const { name, message, stack } = e;
-				scriptError = { name, message, stack };
-			}
-			
-			// We throw the error to notify the UI. Because we are using findOneAndUpdate 
-			// later, the error state is NOT persisted if we throw here, keeping the DB clean.
+			// Throwing immediately notifies the UI. Since we exit before findOneAndUpdate,
+			// no broken state is persisted to the database.
 			throw new Meteor.Error('error-invalid-script', `Compilation Error: ${e instanceof Error ? e.message : 'Unknown error'}`);
 		}
 	}
 
-	for await (let channel of channels) {
+	for await (const channel of channels) {
 		const channelType = channel[0];
 		const channelName = channel.slice(1);
 		let record;
@@ -170,7 +162,6 @@ export const updateIncomingIntegration = async (
 							scriptEnabled: integration.scriptEnabled,
 							scriptEngine,
 							...(scriptCompiled && { scriptCompiled }),
-							...(scriptError && { scriptError }),
 						}),
 				...(typeof integration.overrideDestinationChannelEnabled !== 'undefined' && {
 					overrideDestinationChannelEnabled: integration.overrideDestinationChannelEnabled,
@@ -179,8 +170,8 @@ export const updateIncomingIntegration = async (
 				_updatedBy: await Users.findOne({ _id: userId }, { projection: { username: 1 } }),
 			},
 			$unset: {
+				// Only unset scriptError on success. If compilation fails, we never reach this point.
 				...(scriptCompiled ? { scriptError: 1 as const } : {}),
-				...(scriptError ? { scriptCompiled: 1 as const } : {}),
 			},
 		},
 		{ returnDocument: 'after' },
@@ -197,7 +188,7 @@ Meteor.methods<ServerMethods>({
 	async updateIncomingIntegration(integrationId, integration) {
 		if (!this.userId) {
 			throw new Meteor.Error('error-invalid-user', 'Invalid user', {
-				method: 'updateOutgoingIntegration',
+				method: 'updateIncomingIntegration',
 			});
 		}
 


### PR DESCRIPTION
## Proposed changes
This PR fixes issue #37800 where incoming webhooks failed to process scripts using modern JS syntax (like nullish coalescing `??`).

1. **Dependency Fix**: Added `@babel/plugin-syntax-nullish-coalescing-operator` to the server bundle.
2. **UX Improvement**: Updated `addIncomingIntegration` and `updateIncomingIntegration` to throw a `Meteor.Error` upon compilation failure. This prevents silent failures and notifies the admin via the UI.

## Checklist
-  I have tested these changes locally.
-  I have verified that scripts with `??` now compile and execute.
-  I have verified that invalid scripts now show an error toast in the Admin UI.

## Steps to test
1. Go to Administration -> Integrations -> New Incoming Webhook.
2. Enable script and use: `const x = request.content ?? {};`.
3. Save and verify the integration saves successfully.

closes #37800 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent saving broken incoming integrations by failing immediately on script compilation with clearer error messages.
  * Fix channel parsing and resolution so channel identifiers are handled consistently and reliably during integration add/update.

* **Improvements**
  * Correct error-context labels to reference the appropriate integration operation (add vs. update).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->