### PR TITLE
fix: prevent duplicate warning toasts on file upload validation

### DIFF
--- a/apps/meteor/client/views/room/modals/FileUploadModal/FileUploadModal.tsx
+++ b/apps/meteor/client/views/room/modals/FileUploadModal/FileUploadModal.tsx
@@ -53,8 +53,6 @@ const FileUploadModal = ({
 	const dispatchToastMessage = useToastMessageDispatch();
 	const maxMsgSize = useSetting('Message_MaxAllowedSize', 5000);
 	const maxFileSize = useSetting('FileUpload_MaxFileSize', 104857600);
-
-	
 	const hasShownErrorRef = useRef(false);
 
 	const isDescriptionValid = (description: string) =>
@@ -78,8 +76,9 @@ const FileUploadModal = ({
 		if (hasShownErrorRef.current) {
 			return;
 		}
+
 		hasShownErrorRef.current = true;
-		
+
 		if (invalidContentType) {
 			dispatchToastMessage({
 				type: 'error',

--- a/apps/meteor/client/views/room/modals/FileUploadModal/FileUploadModal.tsx
+++ b/apps/meteor/client/views/room/modals/FileUploadModal/FileUploadModal.tsx
@@ -72,14 +72,12 @@ const FileUploadModal = ({
 	};
 
 	useEffect(() => {
-		
 		if (hasShownErrorRef.current) {
 			return;
 		}
 
-		hasShownErrorRef.current = true;
-
 		if (invalidContentType) {
+			hasShownErrorRef.current = true;
 			dispatchToastMessage({
 				type: 'error',
 				message: t('FileUpload_MediaType_NotAccepted__type__', { type: file.type }),
@@ -89,6 +87,7 @@ const FileUploadModal = ({
 		}
 
 		if (file.size === 0) {
+			hasShownErrorRef.current = true;
 			dispatchToastMessage({
 				type: 'error',
 				message: t('FileUpload_File_Empty'),

--- a/apps/meteor/client/views/room/modals/FileUploadModal/FileUploadModal.tsx
+++ b/apps/meteor/client/views/room/modals/FileUploadModal/FileUploadModal.tsx
@@ -19,7 +19,7 @@ import { useAutoFocus, useMergedRefs } from '@rocket.chat/fuselage-hooks';
 import { useToastMessageDispatch, useTranslation, useSetting } from '@rocket.chat/ui-contexts';
 import fileSize from 'filesize';
 import type { ReactElement, ComponentProps } from 'react';
-import { memo, useEffect, useId } from 'react';
+import { memo, useEffect, useId, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 
 import FilePreview from './FilePreview';
@@ -54,6 +54,9 @@ const FileUploadModal = ({
 	const maxMsgSize = useSetting('Message_MaxAllowedSize', 5000);
 	const maxFileSize = useSetting('FileUpload_MaxFileSize', 104857600);
 
+	
+	const hasShownErrorRef = useRef(false);
+
 	const isDescriptionValid = (description: string) =>
 		description.length >= maxMsgSize ? t('Cannot_upload_file_character_limit', { count: maxMsgSize }) : true;
 
@@ -71,6 +74,12 @@ const FileUploadModal = ({
 	};
 
 	useEffect(() => {
+		
+		if (hasShownErrorRef.current) {
+			return;
+		}
+		hasShownErrorRef.current = true;
+		
 		if (invalidContentType) {
 			dispatchToastMessage({
 				type: 'error',


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

**This PR fixes the duplicate warning toast issue that occurs when uploading invalid files.**

https://github.com/user-attachments/assets/9e8d1a8f-beea-460f-99d4-2a40a413a248



### Problem
When dragging and dropping a 0 KB file or a file with an invalid content type, the error toast message ("File empty" or "Media type not accepted") was displayed **twice**.

### Solution
Added a `useRef` hook (`hasShownErrorRef`) to track if the validation effect has already executed, preventing duplicate toast messages.


## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Fixes #35499

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Open a team, channel, or direct message from the left pane.
2. Now drag and drop and SVG (image) or a file with size 0 KB.
3. analyze the warning.

## Further comments

While investigating this issue, I also found
https://github.com/RocketChat/Rocket.Chat/issues/35499#issuecomment-3711619214

happy to work more on this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate error messages during file uploads — errors for invalid content type or zero-length files are now shown only once.
  * Improved upload error handling to reduce repeated alerts and provide a cleaner, less noisy user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->