### PR TITLE
fix: Add migration to remove null fields from Slack-imported messages

### DIFF
--- a/apps/meteor/server/startup/migrations/index.ts
+++ b/apps/meteor/server/startup/migrations/index.ts
@@ -38,5 +38,6 @@ import './v329';
 import './v330';
 import './v331';
 import './v332';
+import './v333';
 
 export * from './xrun';

--- a/apps/meteor/server/startup/migrations/v333.ts
+++ b/apps/meteor/server/startup/migrations/v333.ts
@@ -1,0 +1,63 @@
+import { Messages } from '@rocket.chat/models';
+
+import { addMigration } from '../../lib/migrations';
+
+/**
+ * Migration to fix null fields in messages imported from Slack.
+ * 
+ * Issue: https://github.com/RocketChat/Rocket.Chat/issues/37058
+ * 
+ * The Slack importer was creating messages with null values for various fields,
+ * which broke the message loading query. This migration removes those null fields
+ * and converts null arrays to empty arrays.
+ * 
+ * This migration complements PR #37805 which fixes the root cause in MessageConverter.ts.
+ */
+addMigration({
+    version: 333,
+    name: 'Remove null fields from Slack-imported messages',
+    async up() {
+        // Fields to remove if they are null
+        const fieldsToUnset = [
+            't',
+            'groupable',
+            'tmid', // Thread message ID - critical field that breaks message loading
+            'tlm', // Thread last message
+            'tcount', // Thread count
+            'replies',
+            'editedBy',
+            '_importFile',
+            'url',
+            'bot',
+            'alias',
+        ];
+
+        // Remove null values for each field
+        for (const field of fieldsToUnset) {
+            const result = await Messages.updateMany(
+                { [field]: null },
+                { $unset: { [field]: '' } }
+            );
+
+            if (result.modifiedCount > 0) {
+                console.log(`Migration v333: Removed null '${field}' from ${result.modifiedCount} messages`);
+            }
+        }
+
+        // Convert null arrays to empty arrays
+        const arrayFields = ['mentions', 'urls'];
+
+        for (const field of arrayFields) {
+            const result = await Messages.updateMany(
+                { [field]: null },
+                { $set: { [field]: [] } }
+            );
+
+            if (result.modifiedCount > 0) {
+                console.log(`Migration v333: Converted null '${field}' to empty array in ${result.modifiedCount} messages`);
+            }
+        }
+
+        console.log('Migration v333: Completed fixing null fields in Slack-imported messages');
+    },
+});


### PR DESCRIPTION

## Proposed changes

After importing from Slack, imported rooms show "Start of conversation" with no message history loading. The Slack importer was setting fields to `null` instead of leaving them undefined, which breaks the message loading query.

This PR adds migration v333 that cleans up existing Slack imports by:
- Removing fields set to `null` (like `tmid`, `groupable`, `tlm`, `tcount`, `replies`, `editedBy`, `_importFile`, `url`, `bot`, `alias`) using MongoDB `$unset`
- Converting `mentions` and `urls` from `null` to empty arrays `[]` using MongoDB `$set`

The migration processes each field separately and logs the number of affected messages for transparency.

Big thanks to @tlueder who debugged this in #37058 and found the exact database commands that fix it. This PR automates that fix as a migration.

## Issue(s)

Fixes #37058
Complements #37805 (which fixes the importer so future imports don't have this problem)

## Steps to test or reproduce

If you'd like to test this:

1. Set up RocketChat with Docker
2. Perform a Slack import (even a small export works)
3. Open an imported room - you'll see "Start of conversation" with no messages (bug reproduction)
4. Restart RocketChat with this branch - migration v333 runs automatically
5. Check logs to see migration progress
6. Open the same room - message history should now load properly
7. Verify threads still work and search doesn't throw errors

## Further comments

The migration is idempotent (safe to run multiple times) and only modifies messages with null values in the specific fields. It's based on the proven database fix that @tlueder tested manually.

@tlueder @ghuls - I've implemented your database fix as a migration! Would you be willing to test it on your actual Slack import data when you get a chance? Would really appreciate the feedback!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue preventing Slack-imported messages from loading properly. Data inconsistencies from the import process have been cleaned up to ensure messages display correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->