### PR TITLE
fix: Mark messages as read for deactivated users to fix read receipts

### DIFF
--- a/apps/meteor/ee/app/message-read-receipt/server/hooks/afterSaveMessage.ts
+++ b/apps/meteor/ee/app/message-read-receipt/server/hooks/afterSaveMessage.ts
@@ -14,6 +14,9 @@ callbacks.add(
 		// mark message as read as well
 		await ReadReceipt.markMessageAsReadBySender(message, room, message.u._id);
 
+		// mark message as read by deactivated users
+		void ReadReceipt.markMessageAsReadByDeactivatedMembers(message, room);
+
 		return message;
 	},
 	callbacks.priority.MEDIUM,

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -593,26 +593,26 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 
 		const departmentFilter = department
 			? [
-					{
-						$lookup: {
-							from: 'rocketchat_livechat_department_agents',
-							let: { userId: '$_id' },
-							pipeline: [
-								{
-									$match: {
-										$expr: {
-											$and: [{ $eq: ['$$userId', '$agentId'] }, { $eq: ['$departmentId', department] }],
-										},
+				{
+					$lookup: {
+						from: 'rocketchat_livechat_department_agents',
+						let: { userId: '$_id' },
+						pipeline: [
+							{
+								$match: {
+									$expr: {
+										$and: [{ $eq: ['$$userId', '$agentId'] }, { $eq: ['$departmentId', department] }],
 									},
 								},
-							],
-							as: 'department',
-						},
+							},
+						],
+						as: 'department',
 					},
-					{
-						$match: { department: { $size: 1 } },
-					},
-				]
+				},
+				{
+					$match: { department: { $size: 1 } },
+				},
+			]
 			: [];
 
 		const aggregate: Document[] = [
@@ -673,26 +673,26 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		);
 		const departmentFilter = department
 			? [
-					{
-						$lookup: {
-							from: 'rocketchat_livechat_department_agents',
-							let: { userId: '$_id' },
-							pipeline: [
-								{
-									$match: {
-										$expr: {
-											$and: [{ $eq: ['$$userId', '$agentId'] }, { $eq: ['$departmentId', department] }],
-										},
+				{
+					$lookup: {
+						from: 'rocketchat_livechat_department_agents',
+						let: { userId: '$_id' },
+						pipeline: [
+							{
+								$match: {
+									$expr: {
+										$and: [{ $eq: ['$$userId', '$agentId'] }, { $eq: ['$departmentId', department] }],
 									},
 								},
-							],
-							as: 'department',
-						},
+							},
+						],
+						as: 'department',
 					},
-					{
-						$match: { department: { $size: 1 } },
-					},
-				]
+				},
+				{
+					$match: { department: { $size: 1 } },
+				},
+			]
 			: [];
 
 		const aggregate: Document[] = [
@@ -792,23 +792,23 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 					},
 					...(departmentId
 						? {
-								'queueInfo.chatsForDepartment': {
-									$size: {
-										$filter: {
-											input: '$subs',
-											as: 'sub',
-											cond: {
-												$and: [
-													{ $eq: ['$$sub.t', 'l'] },
-													{ $eq: ['$$sub.open', true] },
-													{ $ne: ['$$sub.onHold', true] },
-													{ $eq: ['$$sub.department', departmentId] },
-												],
-											},
+							'queueInfo.chatsForDepartment': {
+								$size: {
+									$filter: {
+										input: '$subs',
+										as: 'sub',
+										cond: {
+											$and: [
+												{ $eq: ['$$sub.t', 'l'] },
+												{ $eq: ['$$sub.open', true] },
+												{ $ne: ['$$sub.onHold', true] },
+												{ $eq: ['$$sub.department', departmentId] },
+											],
 										},
 									},
 								},
-							}
+							},
+						}
 						: {}),
 				},
 			},
@@ -2469,6 +2469,28 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.find(query, options);
 	}
 
+	async findInactive(users: string[], options?: FindOptions<IUser>) {
+		const query = {
+			_id: {
+				$in: users,
+			},
+			active: false,
+		};
+
+		return this.find(query, options);
+	}
+
+	async findInactiveUsersByRoomId(rid: IRoom['_id'], options?: FindOptions<IUser>) {
+		const usersQuery = await this.findByRoomId(rid, {
+			projection: { u: { _id: 1 } },
+		});
+
+		const users = await usersQuery.toArray();
+		const userIds = users.map((user) => user._id);
+
+		return this.findInactive(userIds, options);
+	}
+
 	findByUsername(username: string, options?: FindOptions<IUser>) {
 		const query = { username };
 
@@ -2973,15 +2995,15 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		const update: UpdateFilter<IUser> = {
 			...(bio.trim()
 				? {
-						$set: {
-							bio,
-						},
-					}
+					$set: {
+						bio,
+					},
+				}
 				: {
-						$unset: {
-							bio: 1,
-						},
-					}),
+					$unset: {
+						bio: 1,
+					},
+				}),
 		};
 		return this.updateOne({ _id }, update);
 	}
@@ -2990,15 +3012,15 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		const update: UpdateFilter<IUser> = {
 			...(nickname.trim()
 				? {
-						$set: {
-							nickname,
-						},
-					}
+					$set: {
+						nickname,
+					},
+				}
 				: {
-						$unset: {
-							nickname: 1,
-						},
-					}),
+					$unset: {
+						nickname: 1,
+					},
+				}),
 		};
 		return this.updateOne({ _id }, update);
 	}


### PR DESCRIPTION
fix: Mark messages as read for deactivated users to fix read receipts

## Proposed changes (including videos or screenshots)

When users are deactivated in a room (like former employees), read receipts stay gray even when all active members have read the message. This happens because deactivated users can't read new messages, so the system never reaches the "all read" state.

This PR fixes that by automatically marking messages as read for deactivated users when a message is saved. This way, read receipts will turn blue once all *active* users have read the message.

**Changes made:**
- Added helper methods to the Users model to find inactive users in a room
- Created a new method in ReadReceipt class that marks messages as read for deactivated members
- Updated the message save hook to call this new method
- Improved the existing read receipt logic to filter only unread messages

The fix runs in the background (fire-and-forget) to avoid impacting message sending performance.

This is based on the work by @salihudickson in #36248, rebased onto the latest develop branch with merge conflicts resolved from the JavaScript to TypeScript migration.

## Issue(s)

Fixes #36132
Based on #36248

## Steps to test or reproduce

1. Create a test room with a few users
2. Deactivate one or more users in that room (Admin → Users → Deactivate)
3. Send a message to the room
4. Have all the *active* users read the message
5. Verify that the read receipt turns blue (double checkmarks)

Before this fix, the receipt would stay gray because deactivated users couldn't read it. Now it turns blue once active users have read it.

## Further comments

This PR continues the work from #36248 which had merge conflicts after the codebase migrated from JavaScript to TypeScript. The core logic and approach remain the same as the original implementation.

Thanks to @salihudickson for figuring out the solution originally!