### PR TITLE
regression: Federated room entering an invalid state after accepting invitation

### DIFF
--- a/apps/meteor/client/views/room/RoomInvite.tsx
+++ b/apps/meteor/client/views/room/RoomInvite.tsx
@@ -1,6 +1,8 @@
 import { isRoomFederated } from '@rocket.chat/core-typings';
 import type { IUser, IInviteSubscription } from '@rocket.chat/core-typings';
-import type { ComponentProps } from 'react';
+import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, type ComponentProps } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import Header from './Header';
@@ -10,6 +12,7 @@ import type { IRoomWithFederationOriginalName } from './contexts/RoomContext';
 import { useRoomInvitation } from './hooks/useRoomInvitation';
 import RoomLayout from './layout/RoomLayout';
 import { links } from '../../lib/links';
+import { roomsQueryKeys, subscriptionsQueryKeys } from '../../lib/queryKeys';
 
 type RoomInviteProps = Omit<ComponentProps<typeof RoomLayout>, 'header' | 'body' | 'aside'> & {
 	userId?: IUser['_id'];
@@ -19,11 +22,24 @@ type RoomInviteProps = Omit<ComponentProps<typeof RoomLayout>, 'header' | 'body'
 
 const RoomInvite = ({ room, subscription, userId, ...props }: RoomInviteProps) => {
 	const { t } = useTranslation();
+	const queryClient = useQueryClient();
 	const { acceptInvite, rejectInvite, isPending } = useRoomInvitation(room);
 
 	const infoLink = isRoomFederated(room) ? { label: t('Learn_more_about_Federation'), href: links.go.matrixFederation } : undefined;
 
 	useGoToHomeOnRemoved(room, userId);
+
+	const invalidateQueries = useEffectEvent(() => {
+		const reference = room.federationOriginalName ?? room.name ?? room._id;
+		void queryClient.invalidateQueries({ queryKey: roomsQueryKeys.room(room._id) });
+		void queryClient.invalidateQueries({ queryKey: subscriptionsQueryKeys.subscription(room._id) });
+		void queryClient.invalidateQueries({ queryKey: roomsQueryKeys.roomReference(reference, room.t, userId) });
+	});
+
+	useEffect(() => {
+		// Invalidate room and subscription queries when unmounting (invite accepted or rejected)
+		return () => invalidateQueries();
+	}, [invalidateQueries]);
 
 	return (
 		<RoomLayout

--- a/apps/meteor/client/views/room/hooks/useRoomInvitation.spec.tsx
+++ b/apps/meteor/client/views/room/hooks/useRoomInvitation.spec.tsx
@@ -26,7 +26,7 @@ jest.mock('@rocket.chat/ui-contexts', () => ({
 describe('useRoomInvitation', () => {
 	const mockedRoom = createFakeRoom();
 	const roomId = mockedRoom._id;
-	const appRoot = mockAppRoot().withJohnDoe().withEndpoint('POST', '/v1/rooms.invite', mockInviteEndpoint).build();
+	const appRoot = mockAppRoot().withEndpoint('POST', '/v1/rooms.invite', mockInviteEndpoint).build();
 
 	beforeEach(() => {
 		jest.clearAllMocks();

--- a/apps/meteor/client/views/room/hooks/useRoomInvitation.tsx
+++ b/apps/meteor/client/views/room/hooks/useRoomInvitation.tsx
@@ -1,60 +1,10 @@
-import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
-import { useStream, useUser } from '@rocket.chat/ui-contexts';
-import { useQueryClient } from '@tanstack/react-query';
-import { useEffect } from 'react';
-
 import { useRoomRejectInvitationModal } from './useRoomRejectInvitationModal';
 import { useEndpointMutation } from '../../../hooks/useEndpointMutation';
-import { roomsQueryKeys, subscriptionsQueryKeys } from '../../../lib/queryKeys';
 import type { IRoomWithFederationOriginalName } from '../contexts/RoomContext';
 
 export const useRoomInvitation = (room: IRoomWithFederationOriginalName) => {
-	const user = useUser();
-
-	if (!user) {
-		throw new Error('error-user-not-found');
-	}
-
-	const queryClient = useQueryClient();
-	const subscribeToNotifyUser = useStream('notify-user');
 	const { open: openConfirmationModal } = useRoomRejectInvitationModal(room);
 	const replyInvite = useEndpointMutation('POST', '/v1/rooms.invite');
-
-	const invalidateQueries = useEffectEvent(() => {
-		const reference = room.federationOriginalName ?? room.name ?? room._id;
-		return Promise.all([
-			queryClient.invalidateQueries({ queryKey: roomsQueryKeys.room(room._id) }),
-			queryClient.invalidateQueries({ queryKey: subscriptionsQueryKeys.subscription(room._id) }),
-			queryClient.refetchQueries({
-				queryKey: roomsQueryKeys.roomReference(reference, room.t, user._id, user.username),
-			}),
-		]);
-	});
-
-	useEffect(() => {
-		// Only listen for subscription changes if the mutation has been initiated
-		if (!replyInvite.isPending) {
-			return;
-		}
-
-		/*
-		 * NOTE: We need to listen for subscription changes here because when accepting an invitation
-		 * to a federated room, the server processes the acceptance asynchronously. Therefore,
-		 * we cannot rely solely on the mutation's completion to know when the subscription status
-		 * has changed. By subscribing to the 'notify-user' stream, we can react to changes in the
-		 * subscription status and ensure that our UI reflects the most up-to-date information.
-		 */
-		return subscribeToNotifyUser(`${user._id}/subscriptions-changed`, async (event, data) => {
-			if (data.rid !== room._id) {
-				return;
-			}
-
-			// Only invalidate when subscription is removed OR invite is accepted (status cleared)
-			if (event === 'removed' || data.status === undefined) {
-				await invalidateQueries();
-			}
-		});
-	}, [room._id, user._id, invalidateQueries, replyInvite.isPending, subscribeToNotifyUser]);
 
 	return {
 		...replyInvite,

--- a/packages/ddp-client/src/types/streams.ts
+++ b/packages/ddp-client/src/types/streams.ts
@@ -154,7 +154,6 @@ export interface StreamerEvents {
 							| 'tunread'
 							| 'tunreadGroup'
 							| 'tunreadUser'
-							| 'status'
 
 							// Omnichannel fields
 							| 'department'


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This pull request refactors how query invalidation and navigation are handled after accepting or rejecting a room invite. The logic for invalidating queries is moved out of the `useRoomInvitation` hook and into the `RoomInvite` component, making responsibilities clearer and improving separation of concerns. Additionally, some tests related to navigation on invite actions are removed and will be handled by a general hook for user removal.

This is necessary due to recent changes made to the federation backend streamlining the room acceptance flow. Due to asynchronous nature of the room join events, invalidating the room query right away introduces a race condition where fetched data might still be outdated, causing room stream access to be denied, resulting in the room entering an invalid state.

**Refactoring and Separation of Concerns:**

* Moved query invalidation logic from the `useRoomInvitation` hook to the `RoomInvite` component, now using `useEffect` and a new `invalidateQueries` callback to invalidate relevant queries when the component unmounts (invite accepted or rejected). (`apps/meteor/client/views/room/RoomInvite.tsx`, `apps/meteor/client/views/room/hooks/useRoomInvitation.tsx`) [[1]](diffhunk://#diff-e99f79dea4c406afd77153b6e62e7f16b969b9766ba771cc434519e3f4e2c024L3-R5) [[2]](diffhunk://#diff-e99f79dea4c406afd77153b6e62e7f16b969b9766ba771cc434519e3f4e2c024R15) [[3]](diffhunk://#diff-e99f79dea4c406afd77153b6e62e7f16b969b9766ba771cc434519e3f4e2c024R25-R43) [[4]](diffhunk://#diff-f41336508a414a7c7462bb07812215ea9c69e3e4c4d1969d67e6eca7274362e7L1-R7)

**Testing Updates:**

* Removed tests that checked for navigation to `/home` after invite rejection or acceptance, reflecting the fact that navigation is no longer handled in the `useRoomInvitation` hook. (`apps/meteor/client/views/room/hooks/useRoomInvitation.spec.tsx`)

## Issue(s)
[FB-172](https://rocketchat.atlassian.net/browse/FB-172)

## Steps to test or reproduce
1. Element User: Create a room and invite a Rocket.Chat user.
2. Rocket.Chat User: Navigate to the room and click "Accept".
3. Observation: Room history populates.
4. Observation: The message composer remains in a permanent loading state.
5. Action: Refresh the page.
6. Result: The composer becomes active immediately.

## Further comments
Introduced on #37924

[FB-172]: https://rocketchat.atlassian.net/browse/FB-172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed room invitation data synchronization by ensuring related queries are properly refreshed when leaving the invitation view, preventing stale data from persisting after handling invitations.

* **Refactor**
  * Simplified room invitation flows with improved internal state management and reduced external dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->