### PR TITLE
chore: Update JoyPixels emoji icons

### DIFF
--- a/.changeset/long-mirrors-prove.md
+++ b/.changeset/long-mirrors-prove.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Updates emoji-toolkit dependency to version 9.0.0 for newer emoji support

--- a/apps/meteor/package.json
+++ b/apps/meteor/package.json
@@ -193,7 +193,7 @@
 		"drachtio-srf": "patch:drachtio-srf@npm%3A5.0.12#~/.yarn/patches/drachtio-srf-npm-5.0.12-b0b1afaad6.patch",
 		"ejson": "^2.2.3",
 		"emailreplyparser": "^0.0.5",
-		"emoji-toolkit": "^7.0.1",
+		"emoji-toolkit": "^9.0.0",
 		"emojione": "^4.5.0",
 		"esl": "^11.2.1",
 		"eventemitter3": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9530,7 +9530,7 @@ __metadata:
     drachtio-srf: "patch:drachtio-srf@npm%3A5.0.12#~/.yarn/patches/drachtio-srf-npm-5.0.12-b0b1afaad6.patch"
     ejson: "npm:^2.2.3"
     emailreplyparser: "npm:^0.0.5"
-    emoji-toolkit: "npm:^7.0.1"
+    emoji-toolkit: "npm:^9.0.0"
     emojione: "npm:^4.5.0"
     emojione-assets: "npm:^4.5.0"
     esl: "npm:^11.2.1"
@@ -20426,6 +20426,13 @@ __metadata:
   version: 7.0.1
   resolution: "emoji-toolkit@npm:7.0.1"
   checksum: 10/5b8c84718d0efa4b00a877ac5c6cf3844a9e33f52d5d50b6d02563be781df311390b524a9989289f8a0e80104054dae4517a5e26ee1b40dc901051f80aa7f1af
+  languageName: node
+  linkType: hard
+
+"emoji-toolkit@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "emoji-toolkit@npm:9.0.1"
+  checksum: 10/e2dd3edda04f3b6c0850512438cca8952a2750f04d884b9939850e08a77c296c36b824a298eca42cdce6cd6027df52684e4753cf3d1856a0e5a24560f084d5ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed changes

Updates the `emoji-toolkit` dependency from v7.0.1 to v9.0.0, which includes support for newer Unicode 15.1 emojis.

### Note:
After investigating the codebase, I found that a complete emoji update would require more extensive changes:
- The codebase currently imports from the legacy `emojione` package
- CSS class names use `emojione-*` prefix (would need to change to `joypixels-*`)
- Multiple files in `apps/meteor/app/emoji-emojione/` would need refactoring

This PR updates the `emoji-toolkit` package version as a first step. Full migration may require additional work.

## Issue(s)

Closes #31069

## Steps to test

1. Run `yarn` to install dependencies
2. Start the development server
3. Open emoji picker and verify it still works

## Checklist

- [x] I have read the Contributing Guide
- [x] I have signed the CLA
- [x] Includes changeset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated emoji library to provide access to the latest emoji options and expanded emoji support for enhanced messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->