### PR TITLE
regression: Restore accept logic in federation matrix

### DIFF
--- a/ee/packages/federation-matrix/src/FederationMatrix.ts
+++ b/ee/packages/federation-matrix/src/FederationMatrix.ts
@@ -779,6 +779,8 @@ export class FederationMatrix extends ServiceClass implements IFederationMatrixS
 
 		if (action === 'accept') {
 			await federationSDK.acceptInvite(room.federation.mrid, matrixUserId);
+
+			await Room.performAcceptRoomInvite(room, subscription, user);
 		}
 
 		if (action === 'reject') {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This pull request introduces a small but important change to the `FederationMatrix` service: after accepting a Matrix room invite via the federation SDK, the code now also calls `Room.performAcceptRoomInvite` to handle additional logic related to accepting the room invite in the application's domain.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
