### PR TITLE
fix: wrap long text in forward chat comment textarea

### DIFF
--- a/apps/meteor/client/views/omnichannel/modals/ForwardChatModal.tsx
+++ b/apps/meteor/client/views/omnichannel/modals/ForwardChatModal.tsx
@@ -138,6 +138,7 @@ const ForwardChatModal = ({ onForward, onCancel, room, ...props }: ForwardChatMo
 							</Box>
 						</FieldLabel>
 						<FieldRow>
+							{/* Fix for issue #26723 - wrap long text */}
 							<TextAreaInput 
 									data-qa-id='ForwardChatModalTextAreaInputComment' 
 									{...register('comment')} 


### PR DESCRIPTION
## Proposed changes

This PR fixes the text overflow issue in the Forward Chat modal's comment textarea. Previously, long text without spaces would overflow horizontally outside the textarea. Now it wraps properly to multiple lines.

**Changes made:**
- Added `style` prop with `wordBreak: 'break-word'` and `whiteSpace: 'pre-wrap'` to the TextAreaInput component in ForwardChatModal.tsx

## Issue(s)

Fixes #26723

## Steps to test or reproduce

1. Go to Omnichannel → Accept a chat
2. Click the Forward button
3. In the "Leave a comment" textarea, type a very long text without spaces (e.g., `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`)
4. Verify the text wraps to multiple lines instead of overflowing horizontally

**Expected behavior:** Text wraps properly across multiple lines
**Screen affected:** Forward Chat Modal in Omnichannel


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text wrapping in the forward chat dialog to properly display long text without layout issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->