### PR TITLE
fix: allow OAuth users to set their first password

### DIFF
--- a/.changeset/fix-oauth-password-save.md
+++ b/.changeset/fix-oauth-password-save.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes OAuth users being unable to set their first password when `Accounts_AllowPasswordChangeForOAuthUsers` is enabled. The password change condition now correctly allows OAuth users without an existing password to set one for the first time.


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Fixes the issue where OAuth users (e.g., Google signup) cannot set their first password.

The bug was in [saveUserProfile.ts](cci:7://file:///Users/ankitsinghsisodya/Rocket.Chat/apps/meteor/server/methods/saveUserProfile.ts:0:0-0:0) - the condition `user?.services?.password?.bcrypt` 
blocked OAuth users from setting a password because they don't have an existing one.

**Changes:**
- Added `hasExistingPassword` and `isOAuthUserSettingFirstPassword` variables
- Modified condition to allow first-time password setting for OAuth users
- Skip "same password" and "password history" checks for first-time setters

## Issue(s)
Closes #37751

## Steps to test or reproduce
1. Create a Rocket.Chat account using Google OAuth
2. Go to Account Settings → Security
3. Try to set a new password
4. Should now save successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth user password setting to allow users without an existing password to set one for the first time when Accounts_AllowPasswordChangeForOAuthUsers is enabled.
  * Corrected password change validation logic to properly check password history only when an existing password is present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->