### PR TITLE
fix: Application crashes when opening the Custom Status modal after previously saving an empty status message.

### DIFF
--- a/.changeset/fix-custom-status-modal-crash.md
+++ b/.changeset/fix-custom-status-modal-crash.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixes app crash when reopening Custom Status modal after saving with empty status message

--- a/apps/meteor/client/navbar/NavBarSettingsToolbar/UserMenu/EditStatusModal.tsx
+++ b/apps/meteor/client/navbar/NavBarSettingsToolbar/UserMenu/EditStatusModal.tsx
@@ -32,6 +32,18 @@ type EditStatusModalProps = {
 	userStatusText: IUser['statusText'];
 };
 
+if (typeof window !== 'undefined') {
+	try {
+		const key = 'fuselage-localStorage-Local_Custom_Status';
+		const value = window.localStorage.getItem(key);
+		if (value === 'undefined' || value === 'null') {
+			window.localStorage.removeItem(key);
+		}
+	} catch {
+		// Ignore localStorage access errors
+	}
+}
+
 const EditStatusModal = ({ onClose, userStatus, userStatusText }: EditStatusModalProps): ReactElement => {
 	const allowUserStatusMessageChange = useSetting('Accounts_AllowUserStatusMessageChange');
 	const dispatchToastMessage = useToastMessageDispatch();
@@ -61,7 +73,7 @@ const EditStatusModal = ({ onClose, userStatus, userStatusText }: EditStatusModa
 	const handleSaveStatus = useCallback(async () => {
 		try {
 			await setUserStatus({ message: statusText, status: statusType });
-			setCustomStatus(statusText);
+			setCustomStatus(statusText ?? '');
 			dispatchToastMessage({ type: 'success', message: t('StatusMessage_Changed_Successfully') });
 		} catch (error) {
 			dispatchToastMessage({ type: 'error', message: error });


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR fixes a crash that occurs when users try to reopen the Custom Status modal after saving an empty status message.

**The bug:**

When a user saves an empty custom status, `undefined` gets stored in localStorage as the string `"undefined"`. When the modal is reopened, `JSON.parse("undefined")` throws an error and crashes the app with "Uncaught SyntaxError: 'undefined' is not valid JSON".

**The fix:**
1. Clean up corrupted localStorage data on module load (for already affected users)
2. Add `?? ''` when saving status to prevent storing undefined in the future


## Issue(s)

Closes #38171 

## Steps to test or reproduce

**Before fix:**
1. Click profile icon → Custom Status
2. Clear the status message field (leave it empty)
3. Click Save
4. Try to reopen Custom Status modal
5. App crashes with "Uncaught SyntaxError"

https://github.com/user-attachments/assets/022e102d-5691-4ab5-91ac-1efed57095fe




**After fix:**
1. Same steps as above
2. Modal opens without crashing


https://github.com/user-attachments/assets/5e795c57-a41b-4031-a90a-1765da0eae67



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that occurred when reopening the Custom Status modal after saving with an empty status message.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->