### PR TITLE
added one styling to wrap text

### DIFF
--- a/apps/meteor/client/components/message/variants/SystemMessage.tsx
+++ b/apps/meteor/client/components/message/variants/SystemMessage.tsx
@@ -90,7 +90,7 @@ const SystemMessage = ({ message, showUserAvatar, ...props }: SystemMessageProps
 					</MessageNameContainer>
 					{messageType && <MessageSystemBody 
 					data-qa-type='system-message-body'
-					style={{ whiteSpace: 'normal'}}
+					style={{ whiteSpace: 'normal', wordBreak: 'break-word' }}
 					>{messageType.text(t, message)}</MessageSystemBody>}
 					<MessageSystemTimestamp title={formatDateAndTime(message.ts)}>{formatTime(message.ts)}</MessageSystemTimestamp>
 				</MessageSystemBlock>


### PR DESCRIPTION
This PR fixes an issue where omnichannel transfer comments were rendered as a single truncated line
The system message body now allows normal text wrapping prevent content from being hidden and keep on extending.

Fixes #<26723>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed system message rendering so multi-line content and long words wrap and break properly, preventing overflow and improving readability across message displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->