### PR TITLE
fix: add autocomplete attributes to 2FA TOTP input fields

### DIFF
--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
@@ -49,7 +49,7 @@ const TwoFactorTotpModal = ({ onConfirm, onClose, onDismiss, invalidAttempt }: T
 						{t('Enter_the_code_provided_by_your_authentication_app_to_continue')}
 					</FieldLabel>
 					<FieldRow>
-						<TextInput id={id} ref={ref} value={code} onChange={onChange} placeholder={t('Enter_code_here')}></TextInput>
+						<TextInput id={id} ref={ref} value={code} onChange={onChange} placeholder={t('Enter_code_here')} name="totp" autoComplete="one-time-code" />
 					</FieldRow>
 					{invalidAttempt && <FieldError>{t('Invalid_password')}</FieldError>}
 				</Field>

--- a/apps/meteor/client/views/account/security/TwoFactorTOTP.tsx
+++ b/apps/meteor/client/views/account/security/TwoFactorTOTP.tsx
@@ -158,7 +158,7 @@ const TwoFactorTOTP = (props: TwoFactorTOTPProps): ReactElement => {
 						<Field>
 							<FieldLabel htmlFor={totpCodeId}>{t('Enter_code_provided_by_authentication_app')}</FieldLabel>
 							<FieldRow>
-								<TextInput id={totpCodeId} mie='8px' {...register('authCode')} />
+								<TextInput id={totpCodeId} mie='8px' {...register('authCode')} autoComplete="one-time-code" />
 								<Button primary onClick={handleSubmit(handleVerifyCode)}>
 									{t('Verify')}
 								</Button>

--- a/packages/models/src/models/BaseRaw.ts
+++ b/packages/models/src/models/BaseRaw.ts
@@ -29,16 +29,15 @@ import type {
 	ClientSession,
 } from 'mongodb';
 
-import { UpdaterImpl } from '../updater';
-const getCollectionName = (name: string): string => `rocketchat_${name}`;
+import { getCollectionName, UpdaterImpl } from '..';
 import type { Updater } from '../updater';
 import { setUpdatedAt } from './setUpdatedAt';
 
 const warnFields =
 	process.env.NODE_ENV !== 'production' || process.env.SHOW_WARNINGS === 'true'
 		? (...rest: any): void => {
-			console.warn(...rest, new Error().stack);
-		}
+				console.warn(...rest, new Error().stack);
+			}
 		: new Function();
 
 type ModelOptions = {
@@ -51,7 +50,8 @@ export abstract class BaseRaw<
 	T extends { _id: string },
 	C extends DefaultFields<T> = undefined,
 	TDeleted extends RocketChatRecordDeleted<T> = RocketChatRecordDeleted<T>,
-> implements IBaseModel<T, C, TDeleted> {
+> implements IBaseModel<T, C, TDeleted>
+{
 	protected defaultFields: C | undefined;
 
 	public readonly col: Collection<T>;
@@ -324,14 +324,9 @@ export abstract class BaseRaw<
 			} as unknown as TDeleted;
 
 			// since the operation is not atomic, we need to make sure that the record is not already deleted/inserted
-			await this.trash?.updateOne(
-				{ _id } as Filter<TDeleted>,
-				{ $set: trash } as UpdateFilter<TDeleted>,
-				{
-					upsert: true,
-					session: options?.session,
-				},
-			);
+			await this.trash?.updateOne({ _id } as Filter<TDeleted>, { $set: trash } as UpdateFilter<TDeleted>, {
+				upsert: true,
+			});
 		}
 
 		if (options) {
@@ -345,7 +340,7 @@ export abstract class BaseRaw<
 			return this.col.findOneAndDelete(filter, options || {});
 		}
 
-		const doc = await this.col.findOne(filter, { session: options?.session });
+		const doc = await this.col.findOne(filter);
 		if (!doc) {
 			return null;
 		}
@@ -357,19 +352,14 @@ export abstract class BaseRaw<
 			__collection__: this.name,
 		} as unknown as TDeleted;
 
-		await this.trash?.updateOne(
-			{ _id } as Filter<TDeleted>,
-			{ $set: trash } as UpdateFilter<TDeleted>,
-			{
-				upsert: true,
-				session: options?.session,
-			},
-		);
+		await this.trash?.updateOne({ _id } as Filter<TDeleted>, { $set: trash } as UpdateFilter<TDeleted>, {
+			upsert: true,
+		});
 
 		try {
-			await this.col.deleteOne({ _id } as Filter<T>, { session: options?.session });
+			await this.col.deleteOne({ _id } as Filter<T>);
 		} catch (e) {
-			await this.trash?.deleteOne({ _id } as Filter<TDeleted>, { session: options?.session });
+			await this.trash?.deleteOne({ _id } as Filter<TDeleted>);
 			throw e;
 		}
 
@@ -399,14 +389,10 @@ export abstract class BaseRaw<
 			ids.push(_id as T['_id']);
 
 			// since the operation is not atomic, we need to make sure that the record is not already deleted/inserted
-			await this.trash?.updateOne(
-				{ _id } as Filter<TDeleted>,
-				{ $set: trash } as UpdateFilter<TDeleted>,
-				{
-					upsert: true,
-					session: options?.session,
-				},
-			);
+			await this.trash?.updateOne({ _id } as Filter<TDeleted>, { $set: trash } as UpdateFilter<TDeleted>, {
+				upsert: true,
+				session: options?.session,
+			});
 
 			void options?.onTrash?.(doc);
 		}

--- a/packages/models/src/models/BaseRaw.ts
+++ b/packages/models/src/models/BaseRaw.ts
@@ -29,15 +29,16 @@ import type {
 	ClientSession,
 } from 'mongodb';
 
-import { getCollectionName, UpdaterImpl } from '..';
+import { UpdaterImpl } from '../updater';
+const getCollectionName = (name: string): string => `rocketchat_${name}`;
 import type { Updater } from '../updater';
 import { setUpdatedAt } from './setUpdatedAt';
 
 const warnFields =
 	process.env.NODE_ENV !== 'production' || process.env.SHOW_WARNINGS === 'true'
 		? (...rest: any): void => {
-				console.warn(...rest, new Error().stack);
-			}
+			console.warn(...rest, new Error().stack);
+		}
 		: new Function();
 
 type ModelOptions = {
@@ -50,8 +51,7 @@ export abstract class BaseRaw<
 	T extends { _id: string },
 	C extends DefaultFields<T> = undefined,
 	TDeleted extends RocketChatRecordDeleted<T> = RocketChatRecordDeleted<T>,
-> implements IBaseModel<T, C, TDeleted>
-{
+> implements IBaseModel<T, C, TDeleted> {
 	protected defaultFields: C | undefined;
 
 	public readonly col: Collection<T>;
@@ -324,9 +324,14 @@ export abstract class BaseRaw<
 			} as unknown as TDeleted;
 
 			// since the operation is not atomic, we need to make sure that the record is not already deleted/inserted
-			await this.trash?.updateOne({ _id } as Filter<TDeleted>, { $set: trash } as UpdateFilter<TDeleted>, {
-				upsert: true,
-			});
+			await this.trash?.updateOne(
+				{ _id } as Filter<TDeleted>,
+				{ $set: trash } as UpdateFilter<TDeleted>,
+				{
+					upsert: true,
+					session: options?.session,
+				},
+			);
 		}
 
 		if (options) {
@@ -340,7 +345,7 @@ export abstract class BaseRaw<
 			return this.col.findOneAndDelete(filter, options || {});
 		}
 
-		const doc = await this.col.findOne(filter);
+		const doc = await this.col.findOne(filter, { session: options?.session });
 		if (!doc) {
 			return null;
 		}
@@ -352,14 +357,19 @@ export abstract class BaseRaw<
 			__collection__: this.name,
 		} as unknown as TDeleted;
 
-		await this.trash?.updateOne({ _id } as Filter<TDeleted>, { $set: trash } as UpdateFilter<TDeleted>, {
-			upsert: true,
-		});
+		await this.trash?.updateOne(
+			{ _id } as Filter<TDeleted>,
+			{ $set: trash } as UpdateFilter<TDeleted>,
+			{
+				upsert: true,
+				session: options?.session,
+			},
+		);
 
 		try {
-			await this.col.deleteOne({ _id } as Filter<T>);
+			await this.col.deleteOne({ _id } as Filter<T>, { session: options?.session });
 		} catch (e) {
-			await this.trash?.deleteOne({ _id } as Filter<TDeleted>);
+			await this.trash?.deleteOne({ _id } as Filter<TDeleted>, { session: options?.session });
 			throw e;
 		}
 
@@ -389,10 +399,14 @@ export abstract class BaseRaw<
 			ids.push(_id as T['_id']);
 
 			// since the operation is not atomic, we need to make sure that the record is not already deleted/inserted
-			await this.trash?.updateOne({ _id } as Filter<TDeleted>, { $set: trash } as UpdateFilter<TDeleted>, {
-				upsert: true,
-				session: options?.session,
-			});
+			await this.trash?.updateOne(
+				{ _id } as Filter<TDeleted>,
+				{ $set: trash } as UpdateFilter<TDeleted>,
+				{
+					upsert: true,
+					session: options?.session,
+				},
+			);
 
 			void options?.onTrash?.(doc);
 		}


### PR DESCRIPTION
### Description
This PR addresses issue #30025 by adding standard proper attributes to the 2FA (TOTP) input fields.

### Changes
*   Added `autoComplete="one-time-code"` to the TOTP input in `TwoFactorTotpModal.tsx`
*   Added `name="totp"` to the TOTP input in `TwoFactorTotpModal.tsx`
*   Added `autoComplete="one-time-code"` to the TOTP setup input in `TwoFactorTOTP.tsx`

Closes #30025

### Impact
Password managers (e.g., 1Password, KeePassXC, iCloud Keychain) will now be able to automatically identify and fill the 2FA code field, improving usability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced two-factor authentication (TOTP) input fields with improved browser autofill support and accessibility attributes for smoother authentication verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->