### PR TITLE
fix: Inconsistent button spacing in RTL mode

### DIFF
--- a/.changeset/rtl-button-spacing-fix.md
+++ b/.changeset/rtl-button-spacing-fix.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed inconsistent button spacing in RTL mode on Account Preferences page

--- a/apps/meteor/client/views/account/preferences/AccountPreferencesPage.tsx
+++ b/apps/meteor/client/views/account/preferences/AccountPreferencesPage.tsx
@@ -93,8 +93,10 @@ const AccountPreferencesPage = (): ReactElement => {
 			</PageScrollableContentWithShadow>
 			<PageFooter isDirty={isDirty}>
 				<ButtonGroup>
-					<Button onClick={() => reset(preferencesValues)}>{t('Cancel')}</Button>
-					<Button form={preferencesFormId} primary type='submit'>
+					<Button onClick={() => reset(preferencesValues)} mie='x4'>
+						{t('Cancel')}
+					</Button>
+					<Button form={preferencesFormId} primary type='submit' mis='x4'>
 						{t('Save_changes')}
 					</Button>
 				</ButtonGroup>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

Fixed inconsistent button spacing in RTL (Right-to-Left) mode on the Account Preferences page. 

In Arabic and other RTL languages, the Cancel and Save Changes buttons were appearing too close together or touching, while they had proper spacing in LTR mode. This happened because the ButtonGroup component uses physical CSS properties instead of logical ones.

The fix adds margin-inline props (`mie='x4'` and `mis='x4'`) to the buttons, which automatically adapt to text direction and ensure consistent spacing in both LTR and RTL layouts.


Closes #38276 


## Steps to test or reproduce

1. Login to Rocket.Chat
2. Change language to Arabic
3. Navigate to Account → Preferences
4. Scroll to the bottom and observe the Cancel and Save Changes buttons
5. Verify proper spacing between buttons
6. Switch back to English and verify LTR layout still looks good

## Before fix:

<img width="577" height="153" alt="Screenshot 2026-01-21 001110" src="https://github.com/user-attachments/assets/c3dfa708-3e7e-4fc8-a00e-bc222070abe1" />


## After fix:


<img width="543" height="160" alt="Screenshot 2026-01-20 225507" src="https://github.com/user-attachments/assets/c5b89baa-bc99-42ee-b294-194024d01690" />






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent button spacing in RTL mode on the Account Preferences page so Cancel and Save align consistently.

* **Documentation**
  * Added a release-notes entry documenting this patch.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->