### PR TITLE
fix: business hours validation for invalid time ranges

### DIFF
--- a/.changeset/stale-jeans-hide.md
+++ b/.changeset/stale-jeans-hide.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/i18n': patch
+'@rocket.chat/meteor': patch
+---
+
+Fix business hours validation for invalid time ranges

--- a/apps/meteor/client/views/omnichannel/businessHours/BusinessHoursForm.tsx
+++ b/apps/meteor/client/views/omnichannel/businessHours/BusinessHoursForm.tsx
@@ -42,7 +42,7 @@ const BusinessHoursForm = ({ type }: { type?: 'default' | 'custom' }) => {
 	const timeZonesOptions: SelectOption[] = useMemo(() => timeZones.map((name) => [name, t(name as TranslationKey)]), [t, timeZones]);
 	const daysOptions: SelectOption[] = useMemo(() => DAYS_OF_WEEK.map((day) => [day, t(day as TranslationKey)]), [t]);
 
-	const { watch, control } = useFormContext<BusinessHoursFormData>();
+	const { watch, control, trigger } = useFormContext<BusinessHoursFormData>();
 	const { daysTime } = watch();
 	const { fields: daysTimeFields, replace } = useFieldArray({ control, name: 'daysTime' });
 
@@ -105,7 +105,19 @@ const BusinessHoursForm = ({ type }: { type?: 'default' | 'custom' }) => {
 							<FieldLabel htmlFor={`${daysTimeField + index}-start`}>{t('Open')}</FieldLabel>
 							<Controller
 								name={`daysTime.${index}.start.time`}
-								render={({ field }) => <InputBox id={`${daysTimeField + index}-start`} type='time' {...field} />}
+								control={control}
+								render={({ field: { onChange, value, ...field } }) => (
+									<InputBox
+										id={`${daysTimeField + index}-start`}
+										type='time'
+										{...field}
+										value={value}
+										onChange={(e) => {
+											onChange(e);
+											trigger(`daysTime.${index}.finish.time`);
+										}}
+									/>
+								)}
 							/>
 						</Box>
 						<Box display='flex' flexDirection='column' flexGrow={1} mis={2}>

--- a/apps/meteor/client/views/omnichannel/businessHours/BusinessHoursForm.tsx
+++ b/apps/meteor/client/views/omnichannel/businessHours/BusinessHoursForm.tsx
@@ -112,7 +112,21 @@ const BusinessHoursForm = ({ type }: { type?: 'default' | 'custom' }) => {
 							<FieldLabel htmlFor={`${daysTimeField + index}-finish`}>{t('Close')}</FieldLabel>
 							<Controller
 								name={`daysTime.${index}.finish.time`}
-								render={({ field }) => <InputBox id={`${daysTimeField + index}-finish`} type='time' {...field} />}
+								control={control}
+								rules={{
+									validate: (value) => {
+										const startTime = watch(`daysTime.${index}.start.time`);
+										if (value <= startTime) {
+											return t('Business_hours_finish_must_be_greater_than_start');
+										}
+									},
+								}}
+								render={({ field, fieldState: { error } }) => (
+									<>
+										<InputBox id={`${daysTimeField + index}-finish`} type='time' {...field} error={error?.message} />
+										<Field.Error>{error?.message}</Field.Error>
+									</>
+								)}
 							/>
 						</Box>
 					</FieldRow>

--- a/apps/meteor/tests/end-to-end/api/livechat/19-business-hours.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/19-business-hours.ts
@@ -148,6 +148,29 @@ describe('LIVECHAT - business hours', () => {
 			expect(workHours[0].finish.utc.dayOfWeek).to.be.equal('Sunday');
 		});
 
+
+		it('should fail if finish is before start time', async () => {
+			const { _updatedAt, ts, ...cleanedBusinessHour } = defaultBhId;
+			await request.post(api('livechat/business-hour'))
+				.set(credentials)
+				.send({
+					...cleanedBusinessHour,
+					workHours: [
+						{
+							day: 'Monday',
+							open: true,
+							start: '10:00',
+							finish: '08:00',
+						},
+					],
+				})
+				.expect(400)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', false);
+					expect(res.body.error).to.include('error-business-hour-finish-time-before-start-time');
+				});
+		});
+
 		it('should allow agents to be available', async () => {
 			const { body } = await makeAgentAvailable(credentials);
 			expect(body).to.have.property('success', true);

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -963,6 +963,7 @@
   "Business_hours_is_disabled": "Business hours is disabled",
   "Business_hours_is_disabled_description": "Enable business hours at the workspace admin panel to let customers know when you're available and when can they expect a response.",
   "Business_hours_updated": "Business hours updated",
+  "Business_hours_finish_must_be_greater_than_start": "The finish time must be later than the start time.",
   "Business_hours_will_update_automatically": "Business hours will update automatically",
   "Busy": "Busy",
   "Buy": "Buy",


### PR DESCRIPTION
## Proposed changes
Added form validation to Business Hours to prevent saving when the "Close" time is earlier than the "Open" time. 

Previously, you could set an invalid range (like Open: 17:00, Close: 09:00) and it would save without warning. I've added a check in the form controller to catch this and show an error message ("The finish time must be later than the start time").

## Issue(s)
Closes #38301

## Steps to test or reproduce
1. Go to **Omnichannel > Business Hours**.
2. Pick any day and set the **Open** time (e.g., 10:00 PM) to be later than the **Close** time (e.g., 8:00 AM).
3. You should see an error message under the Close time input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Business hours form now enforces that finish times must be later than start times, re-validates when start changes, and displays field-level errors.

* **Localization**
  * Added a translated error message for the business-hours time validation.

* **Tests**
  * Added end-to-end tests to ensure validation rejects finish times earlier than start times.

* **Chores**
  * Added a changeset documenting the validation fix and patch bumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->