### PR TITLE
fix: Vertically align App icons in Message Action Menu

### DIFF
--- a/packages/ui-client/src/components/GenericMenu/GenericMenuItem.tsx
+++ b/packages/ui-client/src/components/GenericMenu/GenericMenuItem.tsx
@@ -1,4 +1,4 @@
-import { MenuItemColumn, MenuItemContent, MenuItemIcon, MenuItemInput } from '@rocket.chat/fuselage';
+import { Box, MenuItemColumn, MenuItemContent, MenuItemIcon, MenuItemInput } from '@rocket.chat/fuselage'; // 1. Added Box import
 import type { ComponentProps, MouseEvent, ReactNode } from 'react';
 
 export type GenericMenuItemProps = {
@@ -17,13 +17,18 @@ export type GenericMenuItemProps = {
 };
 
 const GenericMenuItem = ({ icon, iconColor, content, addon, status, gap, tooltip }: GenericMenuItemProps) => (
-	<>
-		{gap && <MenuItemColumn />}
-		{icon && <MenuItemIcon name={icon} color={iconColor} />}
-		{status && <MenuItemColumn>{status}</MenuItemColumn>}
-		{content && <MenuItemContent title={tooltip}>{content}</MenuItemContent>}
-		{addon && <MenuItemInput>{addon}</MenuItemInput>}
-	</>
+    <>
+        {gap && <MenuItemColumn />}
+        {/* 2. Wrap the icon in a flexbox container */}
+        {icon && (
+            <Box display='flex' alignItems='center' justifyContent='center' width='x20'>
+                <MenuItemIcon name={icon} color={iconColor} />
+            </Box>
+        )}
+        {status && <MenuItemColumn>{status}</MenuItemColumn>}
+        {content && <MenuItemContent title={tooltip}>{content}</MenuItemContent>}
+        {addon && <MenuItemInput>{addon}</MenuItemInput>}
+    </>
 );
 
 export default GenericMenuItem;


### PR DESCRIPTION
This PR fixes a vertical alignment issue in the message "More actions" menu where icons provided by the Apps-Engine (such as the Reminder app) appeared offset compared to native icons.

The root cause was that the GenericMenuItem component rendered icons without a flexbox centering wrapper. While native font-icons often have built-in vertical metrics, external SVGs/images from apps align to the text baseline by default, causing them to appear "sunk" or "floating."

Technical Details:

Modified packages/ui-client/src/components/GenericMenu/GenericMenuItem.tsx.

Wrapped the MenuItemIcon in a Box utilizing display='flex', alignItems='center', and justifyContent='center'.

Standardized the icon gutter to width='x20' to maintain consistency with the Rocket.Chat design system.

This architectural fix ensures all current and future app-injected icons are perfectly centered.

Issue(s)
Fixes vertical misalignment of app-engine icons in message toolbox.

Steps to test or reproduce
Install an app from the Marketplace that adds a message action (e.g., the Reminder app).

Open any channel and click the "More actions" (three dots) menu on a message.

Observe the Apps section of the menu.

Actual Behavior: The Reminder icon is slightly misaligned vertically compared to the text.

Expected Behavior: The icon should be perfectly centered with the menu item content.

Further comments
Implementing this fix in the ui-client package rather than the Meteor app ensures that the fix scales across the entire platform. By using Fuselage's Box component, we maintain a small footprint and ensure the fix is compatible with Rocket.Chat's existing styling engine.

Closes #38375 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved icon alignment and centering in menu items for enhanced visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->