### PR TITLE
refactor: standardize ReturnChatQueueModal using GenericModal

### DIFF
--- a/apps/meteor/client/views/omnichannel/modals/ReturnChatQueueModal.spec.tsx
+++ b/apps/meteor/client/views/omnichannel/modals/ReturnChatQueueModal.spec.tsx
@@ -1,0 +1,21 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { composeStories } from '@storybook/react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import * as stories from './ReturnChatQueueModal.stories';
+
+const testCases = Object.values(composeStories(stories)).map((Story) => [Story.storyName || 'Story', Story]);
+
+const appRoot = mockAppRoot().build();
+
+test.each(testCases)(`renders %s without crashing`, async (_storyname, Story) => {
+	const { baseElement } = render(<Story />, { wrapper: appRoot });
+	expect(baseElement).toMatchSnapshot();
+});
+
+test.each(testCases)('%s should have no a11y violations', async (_storyname, Story) => {
+	const { container } = render(<Story />, { wrapper: appRoot });
+	const results = await axe(container);
+	expect(results).toHaveNoViolations();
+});

--- a/apps/meteor/client/views/omnichannel/modals/ReturnChatQueueModal.stories.tsx
+++ b/apps/meteor/client/views/omnichannel/modals/ReturnChatQueueModal.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryFn } from '@storybook/react';
+
+import ReturnChatQueueModal from './ReturnChatQueueModal';
+
+export default {
+	component: ReturnChatQueueModal,
+	parameters: {
+		layout: 'fullscreen',
+		actions: { argTypesRegex: '^on.*' },
+	},
+	args: {
+		onMoveChat: () => undefined,
+		onCancel: () => undefined,
+	},
+} satisfies Meta<typeof ReturnChatQueueModal>;
+
+export const Default: StoryFn<typeof ReturnChatQueueModal> = (args) => <ReturnChatQueueModal {...args} />;

--- a/apps/meteor/client/views/omnichannel/modals/ReturnChatQueueModal.tsx
+++ b/apps/meteor/client/views/omnichannel/modals/ReturnChatQueueModal.tsx
@@ -1,14 +1,4 @@
-import {
-	Button,
-	Modal,
-	ModalClose,
-	ModalContent,
-	ModalFooter,
-	ModalFooterControllers,
-	ModalHeader,
-	ModalIcon,
-	ModalTitle,
-} from '@rocket.chat/fuselage';
+import { GenericModal } from '@rocket.chat/ui-client';
 import { useTranslation } from 'react-i18next';
 
 type ReturnChatQueueModalProps = {
@@ -16,27 +6,20 @@ type ReturnChatQueueModalProps = {
 	onCancel: () => void;
 };
 
-// TODO: use `GenericModal` instead of creating a new modal from scratch
-const ReturnChatQueueModal = ({ onCancel, onMoveChat, ...props }: ReturnChatQueueModalProps) => {
+const ReturnChatQueueModal = ({ onCancel, onMoveChat }: ReturnChatQueueModalProps) => {
 	const { t } = useTranslation();
 
 	return (
-		<Modal aria-label={t('Return_to_the_queue')} {...props}>
-			<ModalHeader>
-				<ModalIcon name='burger-arrow-left' />
-				<ModalTitle>{t('Return_to_the_queue')}</ModalTitle>
-				<ModalClose onClick={onCancel} />
-			</ModalHeader>
-			<ModalContent fontScale='p2'>{t('Would_you_like_to_return_the_queue')}</ModalContent>
-			<ModalFooter>
-				<ModalFooterControllers>
-					<Button onClick={onCancel}>{t('Cancel')}</Button>
-					<Button primary onClick={onMoveChat}>
-						{t('Confirm')}
-					</Button>
-				</ModalFooterControllers>
-			</ModalFooter>
-		</Modal>
+		<GenericModal
+			variant='warning'
+			icon='burger-arrow-left'
+			title={t('Return_to_the_queue')}
+			onConfirm={onMoveChat}
+			onCancel={onCancel}
+			confirmText={t('Confirm')}
+		>
+			{t('Would_you_like_to_return_the_queue')}
+		</GenericModal>
 	);
 };
 

--- a/apps/meteor/client/views/omnichannel/modals/__snapshots__/ReturnChatQueueModal.spec.tsx.snap
+++ b/apps/meteor/client/views/omnichannel/modals/__snapshots__/ReturnChatQueueModal.spec.tsx.snap
@@ -1,0 +1,98 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`renders Default without crashing 1`] = `
+<body>
+  <div>
+    <dialog
+      aria-labelledby=":r0:-title"
+      aria-modal="true"
+      class="rcx-box rcx-box--full rcx-modal"
+      open=""
+    >
+      <div
+        class="rcx-box rcx-box--full rcx-modal__inner rcx-css-1euli2f"
+      >
+        <header
+          class="rcx-box rcx-box--full rcx-modal__header"
+        >
+          <div
+            class="rcx-box rcx-box--full rcx-modal__header-inner"
+          >
+            <div
+              class="rcx-box rcx-box--full rcx-css-trljwa rcx-css-1xb12qx"
+            >
+              <i
+                aria-hidden="true"
+                class="rcx-box rcx-box--full rcx-icon--name-burger-arrow-left rcx-icon rcx-css-zozvgz"
+              >
+                
+              </i>
+            </div>
+            <div
+              class="rcx-box rcx-box--full rcx-modal__header-text rcx-css-trljwa rcx-css-lma364"
+            >
+              <h2
+                class="rcx-box rcx-box--full rcx-modal__title"
+                id=":r0:-title"
+              >
+                Return_to_the_queue
+              </h2>
+            </div>
+            <button
+              aria-label="Close"
+              class="rcx-box rcx-box--full rcx-button--small-square rcx-button--square rcx-button--icon rcx-button rcx-css-trljwa rcx-css-lma364"
+              tabindex="-1"
+              type="button"
+            >
+              <i
+                aria-hidden="true"
+                class="rcx-box rcx-box--full rcx-icon--name-cross rcx-icon rcx-css-4pvxx3"
+              >
+                
+              </i>
+            </button>
+          </div>
+        </header>
+        <div
+          class="rcx-box rcx-box--full rcx-modal__content rcx-css-1vw7itl"
+        >
+          <div
+            class="rcx-box rcx-box--full rcx-modal__content-wrapper rcx-css-r1bpeb"
+          >
+            Would_you_like_to_return_the_queue
+          </div>
+        </div>
+        <div
+          class="rcx-box rcx-box--full rcx-modal__footer rcx-css-17mu816"
+        >
+          <div
+            class="rcx-button-group rcx-button-group--align-end"
+            role="group"
+          >
+            <button
+              class="rcx-box rcx-box--full rcx-button--secondary rcx-button"
+              type="button"
+            >
+              <span
+                class="rcx-button--content"
+              >
+                Cancel
+              </span>
+            </button>
+            <button
+              class="rcx-box rcx-box--full rcx-button--primary rcx-button"
+              type="button"
+            >
+              <span
+                class="rcx-button--content"
+              >
+                Confirm
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </dialog>
+  </div>
+</body>
+`;


### PR DESCRIPTION
## Proposed changes

Refactors [ReturnChatQueueModal](cci:1://file://wsl$/Ubuntu/home/ashwaniyadav/Rocket.Chat/apps/meteor/client/views/omnichannel/modals/ReturnChatQueueModal.tsx:8:0-23:2) to use the standardized `GenericModal` component from `@rocket.chat/ui-client`, replacing manual implementations built with raw Modal primitives.

## Related issue

Closes #38383

## Changes made

| File | Changes |
|------|---------|
| [ReturnChatQueueModal.tsx](cci:7://file://wsl$/Ubuntu/home/ashwaniyadav/Rocket.Chat/apps/meteor/client/views/omnichannel/modals/ReturnChatQueueModal.tsx:0:0-0:0) | Replaced raw [Modal](cci:1://file://wsl$/Ubuntu/home/ashwaniyadav/Rocket.Chat/apps/meteor/client/views/omnichannel/modals/CloseChatModal.tsx:51:0-262:2) usage with `GenericModal` using the `warning` variant |
| [ReturnChatQueueModal.spec.tsx](cci:7://file://wsl$/Ubuntu/home/ashwaniyadav/Rocket.Chat/apps/meteor/client/views/omnichannel/modals/ReturnChatQueueModal.spec.tsx:0:0-0:0) | **[NEW]** Added unit tests with snapshot and accessibility checks |
| [ReturnChatQueueModal.stories.tsx](cci:7://file://wsl$/Ubuntu/home/ashwaniyadav/Rocket.Chat/apps/meteor/client/views/omnichannel/modals/ReturnChatQueueModal.stories.tsx:0:0-0:0) | **[NEW]** Added Storybook story for visual testing |

## Improvements

- Removed duplicated boilerplate (headers, footers, close buttons)
- Enforces consistent UI patterns with other Omnichannel modals
- Eliminated explicit `// TODO` comment requesting migration to GenericModal
- Reduced code from 44 lines → 27 lines (~40% reduction)

## Verification

- ✅ Refactor only — no visual or behavioral changes expected
- ✅ Unit tests with accessibility checks added
- ✅ Storybook story added for visual verification

## Note

This PR was split from the original #38384 as requested by @dougfabris. The other modals (CloseChatModal, EnterpriseDepartmentsModal) will be submitted as separate PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added snapshot and accessibility tests for the return-chat modal; updated multiple end-to-end tests to tighten type assumptions (non-null assertions).

* **Refactor**
  * Reworked modal to use a unified generic dialog for a simpler, consistent structure.

* **Storybook**
  * Added a Storybook story for the return-chat modal to preview and validate its appearance and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [COMM-143]

[COMM-143]: https://rocketchat.atlassian.net/browse/COMM-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[COMM-144]