### PR TITLE
fix(ui): improve avatar URL placeholder clarity

### DIFF
--- a/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
+++ b/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
@@ -111,7 +111,7 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 					<TextInput
 						id={imageUrlField}
 						flexGrow={0}
-						placeholder={t('Use_url_for_avatar')}
+						placeholder='https://example.com/avatar.png'
 						value={avatarFromUrl}
 						mis={4}
 						onChange={handleAvatarFromUrlChange}


### PR DESCRIPTION
### What this does
Updates the placeholder text for the “Use URL for avatar” input to show an example image URL instead of repeating the label text.

### Why
Using the same text for both label and placeholder does not add clarity. An example URL makes the expected format immediately clear, especially for new or less technical users.

### Changes
- Kept the label text unchanged
- Updated the placeholder to `https://example.com/avatar.png`

### Impact
- Improves UX clarity
- No functional or accessibility impact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the avatar URL input field placeholder text to display an example URL for clearer user guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->