### PR TITLE
i18n: add missing translation for workspace registration email footer

### DIFF
--- a/apps/meteor/client/views/admin/workspace/VersionCard/modals/RegisterWorkspaceSetupModal/RegisterWorkspaceSetupStepTwoModal.tsx
+++ b/apps/meteor/client/views/admin/workspace/VersionCard/modals/RegisterWorkspaceSetupModal/RegisterWorkspaceSetupStepTwoModal.tsx
@@ -103,16 +103,17 @@ const RegisterWorkspaceSetupStepTwoModal = ({ email, step, setStep, onClose, int
 				</Box>
 			</ModalContent>
 			<ModalFooter>
-				{/* FIXME: missing translation */}
 				<Box is='div' display='flex' justifyContent='start' fontSize='c1' w='full'>
-					Didn’t receive email?{' '}
-					<Box is='a' pi={4} onClick={handleResendRegistrationEmail}>
-						Resend
-					</Box>{' '}
-					or{' '}
-					<Box is='a' pi={4} onClick={handleBackFromConfirmation}>
-						change email
-					</Box>
+					<Trans i18nKey='RegisterWorkspace_Didnt_Receive_Email'>
+						Didn't receive email?{' '}
+						<Box is='a' pi={4} onClick={handleResendRegistrationEmail}>
+							Resend
+						</Box>{' '}
+						or{' '}
+						<Box is='a' pi={4} onClick={handleBackFromConfirmation}>
+							change email
+						</Box>
+					</Trans>
 				</Box>
 			</ModalFooter>
 		</Modal>

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -4355,6 +4355,7 @@
   "RegisterWorkspace_Setup_No_Account_Title": "Don't have an account?",
   "RegisterWorkspace_Setup_Steps": "Step {{step}} of {{numberOfSteps}}",
   "RegisterWorkspace_Setup_Subtitle": "To register this workspace it needs to be associated it with a Rocket.Chat Cloud account.",
+  "RegisterWorkspace_Didnt_Receive_Email": "Didn't receive email? <1>Resend</1> or <3>change email</3>",
   "RegisterWorkspace_Syncing_Complete": "Sync Complete",
   "RegisterWorkspace_Syncing_Error": "An error occurred syncing your workspace",
   "RegisterWorkspace_Token_Step_Two": "Copy the token and paste it below.",


### PR DESCRIPTION
## Proposed changes

Fixes FIXME comment by adding proper i18n translation for the workspace registration email confirmation footer.

## Issue(s)

Closes #38428

## Changes made

| File | Description |
|------|-------------|
| [RegisterWorkspaceSetupStepTwoModal.tsx](cci:7://file://wsl$/Ubuntu/home/ashwaniyadav/Rocket.Chat/apps/meteor/client/views/admin/workspace/VersionCard/modals/RegisterWorkspaceSetupModal/RegisterWorkspaceSetupStepTwoModal.tsx:0:0-0:0) | Wrapped hardcoded text in `<Trans>` component |
| [en.i18n.json](cci:7://file://wsl$/Ubuntu/home/ashwaniyadav/Rocket.Chat/packages/i18n/src/locales/en.i18n.json:0:0-0:0) | Added `RegisterWorkspace_Didnt_Receive_Email` translation key |

## Problem solved

- Removed FIXME comment indicating missing translation
- Replaced hardcoded English text with proper i18n-compatible markup
- Follows existing pattern used in `onboarding.component.emailCodeFallback`

## Type of change

- [x] Improvement (no API changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Internationalization**
  * Enhanced the workspace registration setup modal with internationalization support.
  * Added translation for "Didn't receive email?" messaging in the email verification step, allowing resend and email change options to be translated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-1947]

[ARCH-1947]: https://rocketchat.atlassian.net/browse/ARCH-1947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ