### PR TITLE
chore: correct spelling of 'receive' 

### DIFF
--- a/packages/apps-engine/src/definition/messages/IMessageReactionContext.ts
+++ b/packages/apps-engine/src/definition/messages/IMessageReactionContext.ts
@@ -15,7 +15,7 @@ export interface IMessageReactionContext {
 	 */
 	isReacted: boolean;
 	/**
-	 * The message that recieved the reaction
+	 * The message that received the reaction
 	 */
 	message: IMessage;
 	/**

--- a/packages/core-typings/CHANGELOG.md
+++ b/packages/core-typings/CHANGELOG.md
@@ -819,7 +819,7 @@
 
 ### Minor Changes
 
-- ([#32197](https://github.com/RocketChat/Rocket.Chat/pull/32197)) Async End-to-End Encrypted rooms key distribution process. Users now don't need to be online to get the keys of their subscribed encrypted rooms, the key distribution process is now async and users can recieve keys even when they are not online.
+- ([#32197](https://github.com/RocketChat/Rocket.Chat/pull/32197)) Async End-to-End Encrypted rooms key distribution process. Users now don't need to be online to get the keys of their subscribed encrypted rooms, the key distribution process is now async and users can receive keys even when they are not online.
 
 - ([#31821](https://github.com/RocketChat/Rocket.Chat/pull/31821)) New runtime for apps in the Apps-Engine based on the Deno platform
 
@@ -855,7 +855,7 @@
 
 ### Minor Changes
 
-- ([#32197](https://github.com/RocketChat/Rocket.Chat/pull/32197)) Async End-to-End Encrypted rooms key distribution process. Users now don't need to be online to get the keys of their subscribed encrypted rooms, the key distribution process is now async and users can recieve keys even when they are not online.
+- ([#32197](https://github.com/RocketChat/Rocket.Chat/pull/32197)) Async End-to-End Encrypted rooms key distribution process. Users now don't need to be online to get the keys of their subscribed encrypted rooms, the key distribution process is now async and users can receive keys even when they are not online.
 
 - ([#31821](https://github.com/RocketChat/Rocket.Chat/pull/31821)) New runtime for apps in the Apps-Engine based on the Deno platform
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Found another spelling typo while going through the code - "recieve" should be "receive" (i before e, except after c). Fixed it in a code comment and CHANGELOG entries.



**Files changed:**
- `packages/apps-engine/src/definition/messages/IMessageReactionContext.ts` 
- `packages/core-typings/CHANGELOG.md` 
## Issue(s)

N/A - Found while reviewing codebase

## Steps to test or reproduce

No testing needed - just spelling corrections. Search for "recieve" should return no results in these files.

## Further comments

Small consistency fix. Continuing to help clean up typos in the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed spelling errors in documentation and changelog for improved accuracy and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->