### PR TITLE
fix: replace console.log with console.error for proper error logging

### DIFF
--- a/apps/meteor/client/views/admin/workspace/VersionCard/modals/RegisterWorkspaceSetupModal/RegisterWorkspaceSetupStepTwoModal.tsx
+++ b/apps/meteor/client/views/admin/workspace/VersionCard/modals/RegisterWorkspaceSetupModal/RegisterWorkspaceSetupStepTwoModal.tsx
@@ -61,7 +61,7 @@ const RegisterWorkspaceSetupStepTwoModal = ({ email, step, setStep, onClose, int
 				onSuccess();
 			}
 		} catch (error: any) {
-			console.log(error);
+			console.error('Failed to poll workspace registration confirmation:', error);
 		}
 	}, [cloudConfirmationPoll, intentData.device_code, dispatchToastMessage, t, onSuccess]);
 

--- a/apps/meteor/client/views/composer/AudioMessageRecorder/AudioMessageRecorder.tsx
+++ b/apps/meteor/client/views/composer/AudioMessageRecorder/AudioMessageRecorder.tsx
@@ -72,7 +72,7 @@ const AudioMessageRecorder = ({ rid, chatContext, isMicrophoneDenied }: AudioMes
 			);
 			setRecordingRoomId(rid);
 		} catch (error) {
-			console.log(error);
+			console.error('Failed to start audio recording:', error);
 			chat?.composer?.setRecordingMode(false);
 		}
 	});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fixed improper error handling in multiple components where `console.log(error)` was being used in catch blocks instead of `console.error()`

Using `console.log` for errors makes them harder to spot in production logs 

**Files changed:**
- `RegisterWorkspaceSetupStepTwoModal.tsx` 
- `AudioMessageRecorder.tsx` 

**Changes:**
- Replaced `console.log(error)` with `console.error('descriptive message', error)`
- Added context to error messages for easier debugging

## Issue(s)

No existing issue - found during code review

## Steps to test or reproduce

These errors only appear when:
1. Workspace registration polling fails (network error, etc.)
2. Audio recording fails to start (permissions, device issues, etc.)

Testing would require forcing these error conditions, but the change is safe as it only affects logging.

## Further comments

This is a code quality improvement. Errors will now:
- Appear in red in browser console (console.error)
- Include descriptive context
- Be easier to debug in production



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error logging for workspace registration and audio message recording functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->