### PR TITLE
fix: add missing padding to Skeleton placeholders in omnichannel

### DIFF
--- a/apps/meteor/client/views/omnichannel/directory/chats/ChatInfo/VisitorClientInfo.tsx
+++ b/apps/meteor/client/views/omnichannel/directory/chats/ChatInfo/VisitorClientInfo.tsx
@@ -29,7 +29,7 @@ const VisitorClientInfo = ({ uid }: VisitorClientInfoProps) => {
 	});
 
 	if (isPending) {
-		return <FormSkeleton />;
+		return <FormSkeleton pi={24} />;
 	}
 
 	if (isError || !visitor.userAgent) {

--- a/apps/meteor/client/views/omnichannel/directory/components/AgentField.tsx
+++ b/apps/meteor/client/views/omnichannel/directory/components/AgentField.tsx
@@ -26,7 +26,7 @@ const AgentField = ({ agent, isSmall = false }: AgentFieldProps) => {
 	});
 
 	if (isLoading) {
-		return <FormSkeleton />;
+		return <FormSkeleton pi={24} />;
 	}
 
 	const {

--- a/apps/meteor/client/views/omnichannel/directory/components/ContactField.tsx
+++ b/apps/meteor/client/views/omnichannel/directory/components/ContactField.tsx
@@ -31,7 +31,7 @@ const ContactField = ({ contact, room }: ContactFieldProps) => {
 	});
 
 	if (isPending) {
-		return <FormSkeleton />;
+		return <FormSkeleton pi={24} />;
 	}
 
 	if (isError || !data?.visitor) {

--- a/apps/meteor/client/views/omnichannel/directory/components/PriorityField.tsx
+++ b/apps/meteor/client/views/omnichannel/directory/components/PriorityField.tsx
@@ -16,7 +16,7 @@ const PriorityField = ({ id }: PriorityFieldProps) => {
 	const { data, isLoading, isError } = usePriorityInfo(id);
 
 	if (isLoading) {
-		return <FormSkeleton />;
+		return <FormSkeleton pi={24} />;
 	}
 
 	if (isError || !data) {

--- a/apps/meteor/client/views/omnichannel/directory/components/SlaField.tsx
+++ b/apps/meteor/client/views/omnichannel/directory/components/SlaField.tsx
@@ -18,7 +18,7 @@ const SlaField = ({ id }: SlaFieldProps) => {
 	const slaFieldId = useId();
 
 	if (isLoading) {
-		return <FormSkeleton />;
+		return <FormSkeleton pi={24} />;
 	}
 
 	if (isError || !data) {


### PR DESCRIPTION


#### Describe the changes you have made in this PR -

Fixed missing padding on Skeleton placeholders in the omnichannel contact centre chat info panel.

Added `pi={24}` (horizontal padding) to the `FormSkeleton` in all 5 affected components so the loading skeleton matches the spacing of the loaded content.

**Files changed:**
- `apps/meteor/client/views/omnichannel/directory/components/ContactField.tsx`
- `apps/meteor/client/views/omnichannel/directory/components/AgentField.tsx`
- `apps/meteor/client/views/omnichannel/directory/components/PriorityField.tsx`
- `apps/meteor/client/views/omnichannel/directory/components/SlaField.tsx`
- `apps/meteor/client/views/omnichannel/directory/chats/ChatInfo/VisitorClientInfo.tsx`

---
## Code Understanding and AI Usage
**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**Explain your implementation approach:**

Looked at how ChatInfo renders its children - everything is inside `ContextualbarScrollableContent` with `p={24}`. When I traced into each child component, their loading states were returning bare `<FormSkeleton />` with no padding props.

The fix was straightforward - `FormSkeleton` already accepts props (it spreads them onto a `Box`), so I just added `pi={24}` to match the parent's horizontal padding. Used `pi` (padding inline/horizontal) instead of `p` because the parent's vertical padding is handled by the scrollable content itself.

---
## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
---
Note: ✓ Allow edits from maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated loading state visual styling across omnichannel directory components for improved consistency during data retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->