### PR TITLE
fix: enable text wrapping for omnichannel transfer comments

### DIFF
--- a/.changeset/fix-omnichannel-transfer-comment-wrap.md
+++ b/.changeset/fix-omnichannel-transfer-comment-wrap.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fix: enable text wrapping for omnichannel transfer comments by setting appropriate word-break and white-space styles on transfer history messages.

--- a/apps/meteor/client/components/message/variants/SystemMessage.tsx
+++ b/apps/meteor/client/components/message/variants/SystemMessage.tsx
@@ -55,6 +55,12 @@ const SystemMessage = ({ message, showUserAvatar, ...props }: SystemMessageProps
 
 	const messageType = MessageTypes.getType(message);
 
+	const shouldWrapSystemBody =
+		message.t === 'livechat_transfer_history' || message.t === 'livechat_transfer_history_fallback';
+	const systemBodyStyle = shouldWrapSystemBody
+		? ({ whiteSpace: 'normal', overflowWrap: 'anywhere', wordBreak: 'break-word' } as const)
+		: undefined;
+
 	const isSelecting = useIsSelecting();
 	const toggleSelected = useToggleSelect(message._id);
 	const isSelected = useIsSelectedMessage(message._id);
@@ -87,7 +93,7 @@ const SystemMessage = ({ message, showUserAvatar, ...props }: SystemMessageProps
 						)}
 					</MessageNameContainer>
 					{messageType && (
-						<MessageSystemBody role='document' aria-roledescription={t('system_message_body')}>
+						<MessageSystemBody role='document' aria-roledescription={t('system_message_body')} style={systemBodyStyle}>
 							{messageType.text(t, message)}
 						</MessageSystemBody>
 					)}


### PR DESCRIPTION
## Summary

This PR fixes issue #26723 where omnichannel transfer comments with long text were being truncated instead of wrapping properly.

## Problem

When transferring an omnichannel conversation with a long comment, the transfer history system message would display the text in a single line with text-overflow ellipsis, making long comments unreadable.

**Before:** Long transfer comments are truncated with ellipsis  
**After:** Long transfer comments wrap onto multiple lines

## Solution

Added conditional styling to the `MessageSystemBody` component in `SystemMessage.tsx` that enables text wrapping specifically for livechat transfer history messages:

- `whiteSpace: 'normal'` - Allows text to wrap
- `overflowWrap: 'anywhere'` - Enables breaking at any point if needed
- `wordBreak: 'break-word'` - Ensures long words break properly

This approach is scoped only to `livechat_transfer_history` and `livechat_transfer_history_fallback` message types to avoid affecting other system messages.

## Changes Made

**File:** `apps/meteor/client/components/message/variants/SystemMessage.tsx`

- Added `shouldWrapSystemBody` check for transfer history messages
- Added `systemBodyStyle` with CSS properties for proper text wrapping
- Applied conditional style to `MessageSystemBody` component

## Testing

- [ ] Manual testing: Transfer a chat with a long comment and verify wrapping
- [ ] Existing test suite should pass without regressions

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md)
- [x] I have signed the CLA
- [x] My code follows the project's coding standards
- [x] My changes generate no new warnings

Closes #26723

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text wrapping for omnichannel transfer/system messages (transfer history comments). Long or unbroken content now properly wraps and breaks to prevent overflow, ensuring consistent layout and improved readability across message displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->