### PR TITLE
Prevent DWG attachments from triggering image preview

### DIFF
--- a/apps/meteor/client/components/message/content/attachments/FileAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/FileAttachment.tsx
@@ -5,13 +5,9 @@ import GenericFileAttachment from './file/GenericFileAttachment';
 import ImageAttachment from './file/ImageAttachment';
 import VideoAttachment from './file/VideoAttachment';
 
-/**
- * Detect AutoCAD / DWG files.
- * These must never be previewed as images.
- */
 const isDWGFile = (attachment: FileAttachmentProps) => {
 	const name = attachment.title || attachment.name || '';
-	const type = attachment.type || '';
+	const type = (attachment.type || '').toLowerCase().trim();
 
 	return (
 		name.toLowerCase().endsWith('.dwg') ||
@@ -22,22 +18,18 @@ const isDWGFile = (attachment: FileAttachmentProps) => {
 };
 
 const FileAttachment = (attachment: FileAttachmentProps) => {
-	// 🚨 BLOCK DWG FROM IMAGE PREVIEW
 	if (isDWGFile(attachment)) {
 		return <GenericFileAttachment {...attachment} />;
 	}
 
-	// image
 	if (attachment.image_url) {
 		return <ImageAttachment {...attachment} />;
 	}
 
-	// audio
 	if (attachment.audio_url) {
 		return <AudioAttachment {...attachment} />;
 	}
 
-	// video
 	if (attachment.video_url) {
 		return <VideoAttachment {...attachment} />;
 	}


### PR DESCRIPTION
## Problem
Uploading AutoCAD `.dwg` files caused Rocket.Chat to treat them as image attachments.
This triggered image preview generation and resulted in runtime errors such as:

- `Input buffer contains unsupported image format`
- Retry loop in the UI
- Application GUI crashes

## Solution
DWG files are now explicitly excluded from image preview rendering and are always
displayed using the generic file attachment component.

This prevents unsupported formats from entering the image pipeline while keeping
download functionality intact.

## Notes
- Change is limited to attachment rendering logic
- No server-side or Sharp changes required
- Other attachment types remain unaffected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DWG (AutoCAD) attachments now render as downloadable files instead of attempting image preview.

* **New Features**
  * DWG detection added and prioritized to prevent misclassification as images.
  * Media handling for images, audio, and video preserved; unknown attachments now reliably fall back to a generic downloadable file view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->