### PR TITLE
Fix: prevent redundant Set Default Avatar action when avatar is already default

### DIFF
--- a/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
+++ b/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
@@ -19,9 +19,10 @@ type UserAvatarEditorProps = {
 	disabled?: boolean;
 	etag: IUser['avatarETag'];
 	name: IUser['name'];
+	isDefaultAvatar?: boolean;
 };
 
-function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disabled, etag }: UserAvatarEditorProps): ReactElement {
+function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disabled, etag, isDefaultAvatar }: UserAvatarEditorProps): ReactElement {
 	const { t } = useTranslation();
 	const useFullNameForDefaultAvatar = useSetting('UI_Use_Name_Avatar');
 	const rotateImages = useSetting('FileUpload_RotateImages');
@@ -91,7 +92,7 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 				/>
 				<Box display='flex' flexDirection='column' flexGrow='1' justifyContent='space-between' mis={4}>
 					<Box display='flex' flexDirection='row' mbs='none'>
-						<Button square disabled={disabled} mi={4} title={t('Accounts_SetDefaultAvatar')} onClick={clickReset}>
+						<Button square disabled={disabled || isDefaultAvatar} mi={4} title={t('Accounts_SetDefaultAvatar')} onClick={clickReset}>
 							<Avatar url={`/avatar/%40${useFullNameForDefaultAvatar ? name : username}`} />
 						</Button>
 						<IconButton icon='upload' secondary disabled={disabled} title={t('Upload')} mi={4} onClick={clickUpload} />

--- a/apps/meteor/client/views/account/profile/AccountProfileForm.tsx
+++ b/apps/meteor/client/views/account/profile/AccountProfileForm.tsx
@@ -71,6 +71,8 @@ const AccountProfileForm = (props: AllHTMLAttributes<HTMLFormElement>): ReactEle
 	const previousEmail = user ? getUserEmailAddress(user) : '';
 	const previousUsername = user?.username || '';
 	const isUserVerified = user?.emails?.[0]?.verified ?? false;
+	const hasCustomAvatarOrigin = !!user?.avatarOrigin && ['upload', 'url', 'rest'].includes(user.avatarOrigin);
+	const isDefaultAvatar = avatar === 'reset' || (avatar === '' && !hasCustomAvatarOrigin);
 
 	const mutateConfirmationEmail = useMutation({
 		mutationFn: sendConfirmationEmail,
@@ -124,12 +126,14 @@ const AccountProfileForm = (props: AllHTMLAttributes<HTMLFormElement>): ReactEle
 				customFields,
 			});
 
-			await updateAvatar();
+			if (avatar !== '') {
+				await updateAvatar();
+			}
 			dispatchToastMessage({ type: 'success', message: t('Profile_saved_successfully') });
 		} catch (error) {
 			dispatchToastMessage({ type: 'error', message: error });
 		} finally {
-			reset({ email, name, username, statusType, statusText, nickname, bio, customFields });
+			reset({ email, name, username, statusType, statusText, nickname, bio, customFields, avatar: '' });
 		}
 	};
 
@@ -157,6 +161,7 @@ const AccountProfileForm = (props: AllHTMLAttributes<HTMLFormElement>): ReactEle
 								name={userFullName}
 								username={username}
 								setAvatarObj={onChange}
+								isDefaultAvatar={isDefaultAvatar}
 								disabled={!allowUserAvatarChange}
 							/>
 						)}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR fixes an issue where the **Set Default Avatar** button remained clickable even when the user's avatar was already set to the default.

### Problem
- The button stayed enabled after setting the avatar to default.
- Users could click it repeatedly (even after intervals).
- Each click triggered an unnecessary API request despite no state change.
- This resulted in redundant server calls and confusing UX.

### Solution
- Added a check to detect when the current avatar is already the default.
- Disabled the **Set Default Avatar** button in that state.
- Ensured the action is only enabled when a non-default avatar is selected.

### Result
- Prevents redundant API calls.
- Improves UX by clearly indicating when no action is required.
- Keeps behaviour consistent with user expectations.

### Files changed
- `apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx`
- `apps/meteor/client/views/account/profile/AccountProfileForm.tsx`

## Issue(s)
- Fixes #38495


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Set Default Avatar" button is now disabled when you're already using the default avatar, preventing unnecessary resets and providing clearer feedback on your current avatar status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->