### PR TITLE
Bug fix

### DIFF
--- a/apps/meteor/app/importer-slack-users/server/SlackUsersImporter.ts
+++ b/apps/meteor/app/importer-slack-users/server/SlackUsersImporter.ts
@@ -44,17 +44,10 @@ export class SlackUsersImporter extends Importer {
 		await super.updateProgress(ProgressStep.PREPARING_USERS);
 		const uriResult = RocketChatFile.dataURIParse(dataURI);
 		const buf = Buffer.from(uriResult.image, 'base64');
-
-		// Validate file content before parsing
 		const fileContent = buf.toString('utf8');
-		
-		// Check if file starts with PDF magic bytes or contains binary data
-		const isPDF = buf[0] === 0x25 && buf[1] === 0x50 && buf[2] === 0x44 && buf[3] === 0x46; // %PDF
-		
-		// Check if the content appears to be binary (contains null bytes or high proportion of non-printable characters)
+		const isPDF = buf[0] === 0x25 && buf[1] === 0x50 && buf[2] === 0x44 && buf[3] === 0x46;
 		const nullByteIndex = fileContent.indexOf('\0');
-		const hasBinaryContent = nullByteIndex !== -1 && nullByteIndex < 1000; // Check first 1000 chars for null bytes
-		
+		const hasBinaryContent = nullByteIndex !== -1 && nullByteIndex < 1000;
 		if (isPDF || hasBinaryContent) {
 			this.logger.error('Invalid file type uploaded. Expected CSV file.');
 			await super.updateProgress(ProgressStep.ERROR);
@@ -72,7 +65,7 @@ export class SlackUsersImporter extends Importer {
 
 		let userCount = 0;
 		for await (const [index, user] of parsed.entries()) {
-			// Ignore the first column
+
 			if (index === 0) {
 				continue;
 			}


### PR DESCRIPTION
Fix: Invalid file type error handling in Slack Users CSV import
Problem
Uploading non-CSV files (e.g., PDFs) during Slack Users CSV import displays raw binary content in error messages instead of user-friendly text.

Solution
Added file validation to detect PDF and binary files before parsing, throwing clear error messages:

Validates file format by checking for PDF magic bytes and null bytes
Wraps CSV parser in try-catch for better error handling
Returns actionable error: "Invalid file type. Please upload a valid CSV file."
Changes
Modified 
SlackUsersImporter.ts
 
prepare()
 method
Added pre-parse validation for file type
Improved error messages for better UX
Type: Bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for Slack Users CSV imports to detect and reject invalid file uploads (e.g., PDFs or binary-like files) before processing.
  * CSV parsing now has stronger error handling with clearer user-facing messages and progress reporting when malformed files are encountered.
  * Added pre-import checks to ensure only compatible, UTF-8 text CSV content is parsed, preventing downstream failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->