### PR TITLE
fix(auth): add defensive guard for missing room context in canAccessRoom

### DIFF
--- a/apps/meteor/server/services/authorization/canAccessRoom.ts
+++ b/apps/meteor/server/services/authorization/canAccessRoom.ts
@@ -95,10 +95,12 @@ const roomAccessValidators: RoomAccessValidator[] = [
 ];
 
 export const canAccessRoom: RoomAccessValidator = async (room, user, extraData): Promise<boolean> => {
-	// TODO livechat can send both as null, so they we need to validate nevertheless
-	// if (!room || !user) {
-	// 	return false;
-	// }
+	// Defensive validation: livechat can send null/undefined room.
+	// If we have neither a room id nor a rid in extraData context, we cannot
+	// identify which room to check access for, so fail fast.
+	if (!room?._id && !extraData?.rid) {
+		return false;
+	}
 
 	for await (const roomAccessValidator of roomAccessValidators) {
 		if (await roomAccessValidator(room, user, extraData)) {
@@ -108,3 +110,4 @@ export const canAccessRoom: RoomAccessValidator = async (room, user, extraData):
 
 	return false;
 };
+


### PR DESCRIPTION
Adds a defensive fail-fast guard to canAccessRoom to ensure it is not
invoked without any room context.

This prevents validators from receiving invalid input when livechat
requests provide neither a room nor a rid, while preserving existing
anonymous-access behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room access authorization with enhanced validation for edge cases, ensuring consistent and secure access control when critical information is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->