### PR TITLE
fix: close active room when hidden from sidebar

### DIFF
--- a/apps/meteor/client/hooks/useHideRoomAction.tsx
+++ b/apps/meteor/client/hooks/useHideRoomAction.tsx
@@ -30,10 +30,10 @@ const CLOSE_ENDPOINTS_BY_ROOM_TYPE: Record<
 	RoomType,
 	'/v1/groups.close' | '/v1/channels.close' | '/v1/im.close'
 > = {
-	p: '/v1/groups.close',   // private room / team
-	c: '/v1/channels.close', // channel
-	d: '/v1/im.close',       // direct message
-	l: '/v1/channels.close', // livechat
+	p: '/v1/groups.close',
+	c: '/v1/channels.close',
+	d: '/v1/im.close',
+	l: '/v1/channels.close',
 };
 
 export const useHideRoomAction = (
@@ -65,13 +65,11 @@ export const useHideRoomAction = (
 		},
 
 		onSuccess: () => {
-			// Default behaviour (used outside the sidebar)
 			if (redirect) {
 				router.navigate('/home');
 				return;
 			}
 
-			// Sidebar usage: close the active room if it was hidden
 			const routeName = router.getRouteName();
 			const routeParams = router.getRouteParameters();
 
@@ -87,7 +85,7 @@ export const useHideRoomAction = (
 					routeParams?.rid === roomId) ||
 				(type === 'l' &&
 					routeName === 'live' &&
-					routeParams?.id === roomId);
+					routeParams?.rid === roomId);
 
 			if (isCurrentRoom) {
 				router.navigate('/home');


### PR DESCRIPTION
## Proposed changes

When a room (channel, private room, or direct message) is hidden from the sidebar while it is currently open, the main chat view remains open. This results in an inconsistent UI state where the room is no longer visible in the sidebar but is still active on the right-hand panel.

This change ensures that when the currently active room is hidden via the sidebar, the user is redirected to `/home`, effectively closing the active room view.  
The existing behaviour remains unchanged for rooms that are hidden while not being actively viewed.

The fix is intentionally scoped to sidebar usage only and does not introduce global redirects.

## Issue(s)

Fixes #35412  
Related to #35413

## Steps to test or reproduce

1. Open any channel, private room, or direct message from the sidebar.
2. Ensure the room is currently active and visible on the main chat panel.
3. Click the three-dot (more options) menu for the same room in the sidebar.
4. Click **Hide**.

**Expected behaviour:**  
The active room closes and the user is redirected to `/home`.

**Previous behaviour:**  
The room was hidden from the sidebar, but the active chat view remained open.

## Further comments

The solution checks whether the hidden room matches the currently active route before triggering navigation.  
This prevents unnecessary redirects when hiding rooms that are not currently open.

The logic explicitly supports:
- Public channels (`type === 'c'`)
- Private rooms / teams (`type === 'p'`)
- Direct messages (`type === 'd'`)

No functional behaviour outside the sidebar context is affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures users are redirected to the home page when hiding a room they're currently viewing (including when a redirect is requested), preventing staying on a hidden room.
  * Preserves rollback and error notifications when hiding fails.

* **Chores**
  * Internal code cleanup and typing improvements with no changes to public behavior or APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->