### PR TITLE
fix(navbar): add missing tooltip to search icon

### DIFF
--- a/apps/meteor/client/navbar/NavBarSearch/NavBarSearch.tsx
+++ b/apps/meteor/client/navbar/NavBarSearch/NavBarSearch.tsx
@@ -92,6 +92,7 @@ const NavBarSearch = () => {
 							size='x20'
 							onClick={handleClearText}
 							title={isDirty ? t('Clear_search') : t('Search_rooms')}
+							aria-label={isDirty ? t('Clear_search') : t('Search_rooms')}
 						/>
 					}
 				/>


### PR DESCRIPTION
## Description
Tooltip was missing on navbar search magnifier icon.
Added title attribute to display tooltip on hover.

## Issue
Fixes #38480

## Before

https://github.com/user-attachments/assets/aad76f30-7c68-4b7b-86c3-d7ae1c555a4d



## After

https://github.com/user-attachments/assets/4557b5fa-6b08-42ee-a48f-bf624d7ae373



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for the navigation bar search icon by adding a descriptive tooltip and aria-label that update depending on whether the search is active or not (e.g., "Clear search" when dirty, "Search rooms" otherwise).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->