### PR TITLE
add missing radix parameter to parseInt

### DIFF
--- a/apps/meteor/app/api/server/helpers/getPaginationItems.ts
+++ b/apps/meteor/app/api/server/helpers/getPaginationItems.ts
@@ -12,12 +12,12 @@ export async function getPaginationItems(params: { offset?: string | number | nu
 
 	const hardUpperLimit = hardUpperLimitTest && hardUpperLimitTest <= 0 ? 100 : settings.get<number>('API_Upper_Count_Limit');
 	const defaultCount = defaultCountTest && defaultCountTest <= 0 ? 50 : settings.get<number>('API_Default_Count');
-	const offset = params.offset ? parseInt(String(params.offset || 0)) : 0;
+	const offset = params.offset ? parseInt(String(params.offset || 0), 10) : 0;
 	let count = defaultCount;
 
 	// Ensure count is an appropriate amount
 	if (params.count !== undefined && params.count !== null) {
-		count = parseInt(String(params.count || 0));
+		count = parseInt(String(params.count || 0), 10);
 	} else {
 		count = defaultCount;
 	}


### PR DESCRIPTION
Fixed a bug in getPaginationItems() where parseInt() was called without specifying a radix parameter. This helper function is used by all API endpoints that support pagination.

If a user sends offset=08 or count=09 as query parameters, they could receive incorrect pagination results in older environments.
The Fix:
Added explicit radix parameter 10 to both parseInt()

Changed files:
apps/meteor/app/api/server/helpers/getPaginationItems.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of decimal number parsing in pagination handling to ensure consistent behavior across different numeric formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->