### PR TITLE
fix: resolve react-hooks/exhaustive-deps violations in BlockEditor component

### DIFF
--- a/apps/uikit-playground/src/Components/CodeEditor/BlockEditor.tsx
+++ b/apps/uikit-playground/src/Components/CodeEditor/BlockEditor.tsx
@@ -52,12 +52,14 @@ const BlockEditor = ({ extensions }: CodeMirrorProps) => {
 
   useEffect(() => {
     if (!changedByEditor) {
-      setValue(intendCode(activeScreenData?.payload), {});
+      const payload = { blocks: payloadBlocks, surface: payloadSurface };
+      setValue(intendCode(payload), {});
     }
   }, [payloadBlocks, payloadSurface, changedByEditor, activeScreen, setValue]);
 
   useEffect(() => {
-    setValue(intendCode(activeScreenData?.payload), {});
+    const payload = { blocks: payloadBlocks, surface: payloadSurface };
+    setValue(intendCode(payload), {});
   }, [activeScreen, payloadBlocks, payloadSurface, setValue]);
 
   return (


### PR DESCRIPTION
fixes #38552 Fix react-hooks/exhaustive-deps violations in BlockEditor component

This PR fixes `react-hooks/exhaustive-deps` violations in the `BlockEditor` component by removing the file-level ESLint disable, memoizing a callback passed to a custom hook, and adding all missing hook dependencies using a granular pattern.

---

### What was changed

* Removed file-level `/* eslint-disable react-hooks/exhaustive-deps */`
* Wrapped the callback passed to `useFormatCodeMirrorValue` with `useCallback`
* Added all accessed values to `useEffect` dependency arrays
* Used **granular nested dependencies** instead of depending on entire objects to avoid unnecessary re-renders

---

### File modified

* `apps/uikit-playground/src/Components/CodeEditor/BlockEditor.tsx`

---

### Why this approach

* Fixes the root causes instead of suppressing ESLint warnings
* Allows React to correctly track effect dependencies
* Avoids performance regressions by not depending on large objects like `screens`
* Preserves existing component behavior

---

### Testing

* ESLint reports no `react-hooks/exhaustive-deps` warnings for `BlockEditor`
* TypeScript checks pass

**Manual verification Passed (UIKit Playground):**

* Switching between screens
* Editing code in the CodeMirror editor
* Auto-formatting and prettification
* No infinite re-render loops observed

*No automated tests exist for this component.*

---

### Scope

* Single file only
* No refactors or behavioral changes
* Focused exclusively on fixing exhaustive-deps issues

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved editor formatting integration for more reliable, timely code formatting.
  * Reduced redundant updates by deriving editor state and tightening update triggers, improving responsiveness and performance.
  * Kept public component behavior and APIs unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->