### PR TITLE
fix(ui-client): remove invalid transparent color token from PageHeader

### DIFF
--- a/packages/ui-client/src/components/Page/PageHeader.tsx
+++ b/packages/ui-client/src/components/Page/PageHeader.tsx
@@ -15,8 +15,8 @@ const PageHeader = ({ borderBlockEndColor, ...props }: PageHeaderProps) => {
 
 	return (
 		<PageHeaderNoShadow
-			borderBlockEndWidth='default'
-			borderBlockEndColor={(borderBlockEndColor ?? border) ? 'extra-light' : 'transparent'}
+			borderBlockEndWidth={(borderBlockEndColor ?? border) ? 'default' : 'none'}
+			borderBlockEndColor={(borderBlockEndColor ?? border) ? 'extra-light' : undefined}
 			{...props}
 		/>
 	);

--- a/packages/ui-client/src/components/Page/PageHeaderNoShadow.tsx
+++ b/packages/ui-client/src/components/Page/PageHeaderNoShadow.tsx
@@ -20,7 +20,7 @@ const PageHeaderNoShadow = ({ children = undefined, title, onClickBack, ...props
 	useDocumentTitle(typeof title === 'string' ? title : undefined);
 
 	return (
-		<Box is='header' borderBlockEndWidth='default' pb={8} borderBlockEndColor='transparent' {...props}>
+		<Box is='header' borderBlockEndWidth='default' pb={8} {...props}>
 			<Box
 				height='100%'
 				marginInline={24}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The `PageHeader` component was previously passing the string `'transparent'` to the `borderBlockEndColor` prop. This is not a valid color token in the Fuselage design system and caused an `invalid color: transparent` error in the browser console.

This PR fixes the issue by:
1. Passing `undefined` instead of `'transparent'` when no border color is required.
2. Conditionally setting `borderBlockEndWidth` to `'none'` when the border is hidden. This prevents the browser from rendering a default-colored border (visible as a white line) when a width is present but the color is undefined.

**Screenshots:**
_Before:_
<img width="1904" height="934" alt="Before" src="https://github.com/user-attachments/assets/a0fe0dc8-dbc5-4d70-9891-70a9110366d6" />

After:
<img width="1883" height="956" alt="After" src="https://github.com/user-attachments/assets/7812b7cc-5311-4bcb-b548-91584652f904" />

## Issue(s)
Fixes #38577

## Steps to test or reproduce
1. Log in as any user.
2. Navigate to the **Home** page (`/home`).
3. Open Developer Tools (`F12`) -> **Console**.
4. **Verify:** The `invalid color: transparent` error **does not appear**.
5. **Verify:** There is no unwanted border line visible below the header text.

## Further comments
This change satisfies Fuselage's strict token requirements by ensuring only valid tokens or `undefined` are passed to the `Box` component.