### PR TITLE
fix(banner): dismissal not working for UiKit banners

### DIFF
--- a/apps/meteor/client/views/banners/UiKitBanner.tsx
+++ b/apps/meteor/client/views/banners/UiKitBanner.tsx
@@ -6,6 +6,7 @@ import type * as UiKit from '@rocket.chat/ui-kit';
 import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 
+import * as banners from '../../lib/banners';
 import MarkdownText from '../../components/MarkdownText';
 import { useBannerContextValue } from '../../uikit/hooks/useBannerContextValue';
 import { useUiKitActionManager } from '../../uikit/hooks/useUiKitActionManager';
@@ -34,6 +35,7 @@ const UiKitBanner = ({ initialView }: UiKitBannerProps) => {
 
 	const dispatchToastMessage = useToastMessageDispatch();
 	const handleClose = useEffectEvent(() => {
+		banners.closeById(view.viewId);
 		void actionManager
 			.emitInteraction(view.appId, {
 				type: 'viewClosed',


### PR DESCRIPTION
## What this does
Fixes an issue where UiKit notification banners were not dismissed from the UI when clicking the close (X) button.

## Root cause
`UiKitBanner` only emitted a server interaction (`emitInteraction`) on dismissal, but did not update the local banner state.  
This caused the banner to remain visible until a refresh.

`LegacyBanner` already handles this correctly by closing the banner locally.

## Solution
Added a local dismissal call using `banners.closeById(view.viewId)` before emitting the interaction event.  
This ensures the banner is immediately removed from the UI while the server is notified asynchronously.

## Changes
- Import `banners` in `UiKitBanner.tsx`
- Call `banners.closeById(view.viewId)` inside `handleClose`

## How to test
1. Open https://www.rocket.chat/
2. Observe the notification banner at the top
3. Click the dismiss (X) button
4. Confirm the banner disappears immediately

## Issue
Fixes #38588


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where banners were not being properly closed when dismissed by users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->