### PR TITLE
fix(ux): prevent modal from closing when team/channel creation fails

### DIFF
--- a/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateChannelModal.tsx
+++ b/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateChannelModal.tsx
@@ -109,7 +109,6 @@ const CreateChannelModal = ({ teamId = '', mainRoom, onClose, reload }: CreateCh
 		handleSubmit,
 		control,
 		setValue,
-		setError,
 		watch,
 	} = useForm({
 		mode: 'onBlur',
@@ -189,10 +188,7 @@ const CreateChannelModal = ({ teamId = '', mainRoom, onClose, reload }: CreateCh
 			reload?.();
 			onClose();
 		} catch (error) {
-			setError('root.serverError', {
-				type: 'manual',
-				message: error instanceof Error ? error.message : t('Something_went_wrong_try_again_later'),
-			});
+			dispatchToastMessage({ type: 'error', message: error });
 		}
 	};
 
@@ -404,13 +400,6 @@ const CreateChannelModal = ({ teamId = '', mainRoom, onClose, reload }: CreateCh
 						</FieldGroup>
 					</AccordionItem>
 				</Accordion>
-				{errors?.root?.serverError ? (
-					<Field>
-						<FieldError aria-live='assertive'>
-							{errors.root.serverError.message}
-						</FieldError>
-					</Field>
-				) : null}
 			</ModalContent>
 			<ModalFooter>
 				<ModalFooterControllers>

--- a/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateChannelModal.tsx
+++ b/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateChannelModal.tsx
@@ -186,10 +186,9 @@ const CreateChannelModal = ({ teamId = '', mainRoom, onClose, reload }: CreateCh
 
 			dispatchToastMessage({ type: 'success', message: t('Room_has_been_created') });
 			reload?.();
+			onClose();
 		} catch (error) {
 			dispatchToastMessage({ type: 'error', message: error });
-		} finally {
-			onClose();
 		}
 	};
 

--- a/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateChannelModal.tsx
+++ b/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateChannelModal.tsx
@@ -109,6 +109,7 @@ const CreateChannelModal = ({ teamId = '', mainRoom, onClose, reload }: CreateCh
 		handleSubmit,
 		control,
 		setValue,
+		setError,
 		watch,
 	} = useForm({
 		mode: 'onBlur',
@@ -188,7 +189,10 @@ const CreateChannelModal = ({ teamId = '', mainRoom, onClose, reload }: CreateCh
 			reload?.();
 			onClose();
 		} catch (error) {
-			dispatchToastMessage({ type: 'error', message: error });
+			setError('root.serverError', {
+				type: 'manual',
+				message: error instanceof Error ? error.message : t('Something_went_wrong_try_again_later'),
+			});
 		}
 	};
 
@@ -400,6 +404,13 @@ const CreateChannelModal = ({ teamId = '', mainRoom, onClose, reload }: CreateCh
 						</FieldGroup>
 					</AccordionItem>
 				</Accordion>
+				{errors?.root?.serverError ? (
+					<Field>
+						<FieldError aria-live='assertive'>
+							{errors.root.serverError.message}
+						</FieldError>
+					</Field>
+				) : null}
 			</ModalContent>
 			<ModalFooter>
 				<ModalFooterControllers>

--- a/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateTeamModal.tsx
+++ b/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateTeamModal.tsx
@@ -93,6 +93,7 @@ const CreateTeamModal = ({ onClose }: CreateTeamModalProps) => {
 		control,
 		handleSubmit,
 		setValue,
+		setError,
 		watch,
 		formState: { errors, isSubmitting },
 	} = useForm<CreateTeamModalInputs>({
@@ -148,8 +149,11 @@ const CreateTeamModal = ({ onClose }: CreateTeamModalProps) => {
 			goToRoomById(team.roomId);
 			onClose();
 		} catch (error) {
-			dispatchToastMessage({ type: 'error', message: error });
-		} 
+			setError('root.serverError', {
+				type: 'manual',
+				message: error instanceof Error ? error.message : t('Something_went_wrong_try_again_later'),
+			});
+		}
 	};
 
 	const createTeamFormId = useId();
@@ -314,6 +318,13 @@ const CreateTeamModal = ({ onClose }: CreateTeamModalProps) => {
 						</FieldGroup>
 					</AccordionItem>
 				</Accordion>
+				{errors?.root?.serverError ? (
+					<Field>
+						<FieldError aria-live='assertive'>
+							{errors.root.serverError.message}
+						</FieldError>
+					</Field>
+				) : null}
 			</ModalContent>
 			<ModalFooter>
 				<ModalFooterControllers>

--- a/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateTeamModal.tsx
+++ b/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateTeamModal.tsx
@@ -146,11 +146,10 @@ const CreateTeamModal = ({ onClose }: CreateTeamModalProps) => {
 			const { team } = await createTeamAction(params);
 			dispatchToastMessage({ type: 'success', message: t('Team_has_been_created') });
 			goToRoomById(team.roomId);
+			onClose();
 		} catch (error) {
 			dispatchToastMessage({ type: 'error', message: error });
-		} finally {
-			onClose();
-		}
+		} 
 	};
 
 	const createTeamFormId = useId();

--- a/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateTeamModal.tsx
+++ b/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateTeamModal.tsx
@@ -93,7 +93,6 @@ const CreateTeamModal = ({ onClose }: CreateTeamModalProps) => {
 		control,
 		handleSubmit,
 		setValue,
-		setError,
 		watch,
 		formState: { errors, isSubmitting },
 	} = useForm<CreateTeamModalInputs>({
@@ -149,11 +148,8 @@ const CreateTeamModal = ({ onClose }: CreateTeamModalProps) => {
 			goToRoomById(team.roomId);
 			onClose();
 		} catch (error) {
-			setError('root.serverError', {
-				type: 'manual',
-				message: error instanceof Error ? error.message : t('Something_went_wrong_try_again_later'),
-			});
-		}
+			dispatchToastMessage({ type: 'error', message: error });
+		} 
 	};
 
 	const createTeamFormId = useId();
@@ -318,13 +314,6 @@ const CreateTeamModal = ({ onClose }: CreateTeamModalProps) => {
 						</FieldGroup>
 					</AccordionItem>
 				</Accordion>
-				{errors?.root?.serverError ? (
-					<Field>
-						<FieldError aria-live='assertive'>
-							{errors.root.serverError.message}
-						</FieldError>
-					</Field>
-				) : null}
 			</ModalContent>
 			<ModalFooter>
 				<ModalFooterControllers>

--- a/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateTeamModal.tsx
+++ b/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateTeamModal.tsx
@@ -149,7 +149,7 @@ const CreateTeamModal = ({ onClose }: CreateTeamModalProps) => {
 			onClose();
 		} catch (error) {
 			dispatchToastMessage({ type: 'error', message: error });
-		} 
+		}
 	};
 
 	const createTeamFormId = useId();


### PR DESCRIPTION
## About this PR



`onClose()` was being called inside a `finally` block in both `CreateTeamModal.tsx` and `CreateChannelModal.tsx`. Since `finally` always executes regardless of success or failure, the modal was closing even when the API call failed — losing all the user's form data.

This PR moves `onClose()` to the success path only, so the modal stays open on error and users can retry without re-entering their data.

## Affected files
- `apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateTeamModal.tsx`
- `apps/meteor/client/views/navbar/NavBarPagesGroup/actions/CreateChannelModal.tsx`

## Testing

**Error scenario (before fix):** Modal closed on failure, form data lost.  
**Error scenario (after fix):** Modal stays open, error toast shown, form data preserved.  
**Success scenario:** Modal closes and redirects as expected.

**Before fix:**
<img width="1200" height="600" alt="Screenshot 2026-02-11 at 7 44 01 AM" src="https://github.com/user-attachments/assets/f9084aff-37b8-4c7f-8ed9-5c284aedfb91" /> (form Filled)

<img width="1200" height="600" alt="Screenshot 2026-02-11 at 7 44 30 AM" src="https://github.com/user-attachments/assets/3446b0e8-9fae-465d-9ecd-3941c24e5a18" /> (modal closed, data lost)

**After fix:**
<img width="1106" height="572" alt="Screenshot 2026-02-11 at 9 04 43 PM" src="https://github.com/user-attachments/assets/9f8b151e-5410-475c-8042-b1095f838c34" /> (modal stays open, data preserved)


Fixes #38607
Closes #39345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Channel and team creation modals now remain open when creation fails and only close automatically after a successful creation, so users can view and address errors without losing modal state.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-1958]

[ARCH-1958]: https://rocketchat.atlassian.net/browse/ARCH-1958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[COMM-144]