### PR TITLE
refactor(webdav): simplify getNodeIconType return type

### DIFF
--- a/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/WebdavFilePickerGrid/WebdavFilePickerGrid.tsx
+++ b/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/WebdavFilePickerGrid/WebdavFilePickerGrid.tsx
@@ -33,7 +33,7 @@ const WebdavFilePickerGrid = ({ webdavNodes, onNodeClick, isLoading }: WebdavFil
 					))}
 			{!isLoading &&
 				webdavNodes.map((webdavNode, index) => {
-					const { icon } = getNodeIconType(webdavNode.basename, webdavNode.type, webdavNode.mime);
+					const icon = getNodeIconType(webdavNode.basename, webdavNode.type, webdavNode.mime);
 
 					return (
 						<WebdavFilePickerGridItem key={index} className={hoverStyle} onClick={(): void => onNodeClick(webdavNode)}>

--- a/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/WebdavFilePickerTable.tsx
+++ b/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/WebdavFilePickerTable.tsx
@@ -72,7 +72,7 @@ const WebdavFilePickerTable = ({
 								.map((_, index) => <GenericTableLoadingRow key={index} cols={3} />)}
 						{!isLoading &&
 							webdavNodes?.map((webdavNode, index) => {
-								const { icon } = getNodeIconType(webdavNode.basename, webdavNode.type, webdavNode.mime);
+								const icon = getNodeIconType(webdavNode.basename, webdavNode.type, webdavNode.mime);
 
 								return (
 									<GenericTableRow key={index} onClick={(): void => onNodeClick(webdavNode)} tabIndex={index} role='link' action>

--- a/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/lib/getNodeIconType.spec.ts
+++ b/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/lib/getNodeIconType.spec.ts
@@ -4,10 +4,10 @@ import { getNodeIconType } from './getNodeIconType';
 
 it('should return clip icon if file does not have mime type', () => {
 	const result = getNodeIconType(faker.system.fileName(), faker.system.fileType(), undefined);
-	expect(result.icon).toBe('clip');
+	expect(result).toBe('clip');
 });
 
 it('should return folder icon if file type is directory', () => {
 	const result = getNodeIconType(faker.system.fileName(), 'directory', undefined);
-	expect(result.icon).toBe('folder');
+	expect(result).toBe('folder');
 });

--- a/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/lib/getNodeIconType.ts
+++ b/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/lib/getNodeIconType.ts
@@ -1,29 +1,19 @@
 import type { Keys as IconName } from '@rocket.chat/icons';
 
-// TODO: This function should be simplified, it only needs to return the icon name
-export const getNodeIconType = (
-	basename: string,
-	fileType: string,
-	mime?: string,
-): { icon: IconName; type: string; extension?: string } => {
-	let icon: IconName = 'clip';
-	let type = '';
-
-	let extension = basename?.split('.').pop();
-	if (extension === basename) {
-		extension = '';
+export const getNodeIconType = (_basename: string, fileType: string, mime?: string): IconName => {
+	if (fileType === 'directory') {
+		return 'folder';
 	}
 
-	if (fileType === 'directory') {
-		icon = 'folder';
-		type = 'directory';
-	} else if (mime?.match(/application\/pdf/)) {
-		icon = 'file-pdf';
-		type = 'pdf';
-	} else if (mime && ['application/vnd.oasis.opendocument.text', 'application/vnd.oasis.opendocument.presentation'].includes(mime)) {
-		icon = 'file-document';
-		type = 'document';
-	} else if (
+	if (mime?.match(/application\/pdf/)) {
+		return 'file-pdf';
+	}
+
+	if (mime && ['application/vnd.oasis.opendocument.text', 'application/vnd.oasis.opendocument.presentation'].includes(mime)) {
+		return 'file-document';
+	}
+
+	if (
 		mime &&
 		[
 			'application/vnd.ms-excel',
@@ -31,11 +21,12 @@ export const getNodeIconType = (
 			'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 		].includes(mime)
 	) {
-		icon = 'file-sheets';
-		type = 'sheets';
-	} else if (mime && ['application/vnd.ms-powerpoint', 'application/vnd.oasis.opendocument.presentation'].includes(mime)) {
-		icon = 'file-sheets';
-		type = 'ppt';
+		return 'file-sheets';
 	}
-	return { icon, type, extension };
+
+	if (mime && ['application/vnd.ms-powerpoint', 'application/vnd.oasis.opendocument.presentation'].includes(mime)) {
+		return 'file-sheets';
+	}
+
+	return 'clip';
 };


### PR DESCRIPTION
## Proposed changes

Simplifies `getNodeIconType` to return `IconName` directly instead of `{ icon, type, extension }`, as noted in the existing TODO comment.

The `type` and `extension` fields were unused and both callers only destructured `{ icon }`.

### Changes

- **getNodeIconType.ts** — return `IconName` directly, remove unused `type`/`extension` variables and TODO comment  
- **WebdavFilePickerGrid.tsx** — change `const { icon } =` → `const icon =`  
- **WebdavFilePickerTable.tsx** — same destructuring update  
- **getNodeIconType.spec.ts** — updated assertions for new return type  

## Issue(s)

Resolves TODO in:

`apps/meteor/client/views/room/webdav/WebdavFilePickerModal/lib/getNodeIconType.ts`

```ts
// TODO: This function should be simplified, it only needs to return the icon name
```

## Steps to test or reproduce

1. Run unit tests:

```bash
npx jest --config apps/meteor/jest.config.ts apps/meteor/client/views/room/webdav/WebdavFilePickerModal/lib/getNodeIconType.spec.ts
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the WebDAV file picker's icon handling by streamlining how file icons are determined based on file type and metadata, improving code efficiency while maintaining consistent file representation and visual display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->