### PR TITLE
chore: use lastTokenPart as stable key for personal access tokens list

### DIFF
--- a/apps/meteor/client/views/account/tokens/AccountTokensTable/AccountTokensTable.tsx
+++ b/apps/meteor/client/views/account/tokens/AccountTokensTable/AccountTokensTable.tsx
@@ -169,7 +169,7 @@ const AccountTokensTable = (): ReactElement => {
 								filteredTokens &&
 								filteredTokens.map((filteredToken) => (
 									<AccountTokensRow
-										key={filteredToken.createdAt}
+										key={filteredToken.lastTokenPart}
 										onRegenerate={handleRegenerate}
 										onRemove={handleRemove}
 										isMedium={isMedium}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR replaces `createdAt` with `lastTokenPart` as the React `key` for rows in the Personal Access Tokens list.

Using `createdAt` as a key is not guaranteed to be unique or stable, especially if tokens are regenerated or reordered. `lastTokenPart` provides a stable and unique identifier, making it more appropriate for use as a React key and aligning the implementation with React best practices.

This change does not introduce user-facing behavior changes and is categorized as a small internal improvement (`chore`).

---

## Issue(s)

Closes #38563

---

## Steps to test or reproduce

1. Navigate to **Account → Personal Access Tokens** (`/account/tokens`).
2. Create multiple personal access tokens.
3. Open the browser DevTools and inspect the rendered `AccountTokensRow` components.
4. Confirm that each row now uses `lastTokenPart` as the React key instead of `createdAt`.

There should be no visible UI changes, but the internal rendering now uses a stable key.

---

## Further comments

This is a small, isolated code quality improvement to ensure stable and predictable list rendering in accordance with React best practices. No changeset is included, as this does not introduce a user-facing change or require a version bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token list rendering to ensure proper display updates when managing account tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-1948]

[ARCH-1948]: https://rocketchat.atlassian.net/browse/ARCH-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ