### PR TITLE
refactor(omnichannel): replace Select with SelectFiltered in BusinessHoursForm

### DIFF
--- a/apps/meteor/client/views/omnichannel/businessHours/BusinessHoursForm.tsx
+++ b/apps/meteor/client/views/omnichannel/businessHours/BusinessHoursForm.tsx
@@ -1,5 +1,5 @@
 import type { SelectOption } from '@rocket.chat/fuselage';
-import { InputBox, Field, MultiSelect, FieldGroup, Box, Select, FieldLabel, FieldRow, Callout } from '@rocket.chat/fuselage';
+import { InputBox, Field, MultiSelect, FieldGroup, Box, SelectFiltered, FieldLabel, FieldRow, Callout } from '@rocket.chat/fuselage';
 import type { TranslationKey } from '@rocket.chat/ui-contexts';
 import { useId, useMemo } from 'react';
 import { useFormContext, Controller, useFieldArray } from 'react-hook-form';
@@ -33,7 +33,7 @@ export type BusinessHoursFormData = {
 	}[];
 };
 
-// TODO: replace `Select` in favor `SelectFiltered`
+
 // TODO: add time validation for start and finish not be equal on UI
 // TODO: add time validation for start not be higher than finish on UI
 const BusinessHoursForm = ({ type }: { type?: 'default' | 'custom' }) => {
@@ -66,7 +66,7 @@ const BusinessHoursForm = ({ type }: { type?: 'default' | 'custom' }) => {
 					<Controller
 						name='timezoneName'
 						control={control}
-						render={({ field }) => <Select id={timezoneField} {...field} options={timeZonesOptions} />}
+						render={({ field }) => <SelectFiltered id={timezoneField} {...field} options={timeZonesOptions} />}
 					/>
 				</FieldRow>
 				<Callout title={t('Daylight_savings_time')} type='info' mbs='x8'>


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The timezone dropdown in the Business Hours form contains ~400 timezone options but uses the basic [Select](cci:1://file:///home/ubuntu/Rocket.Chat/apps/meteor/client/views/omnichannel/components/outboundMessage/components/TemplateSelect.tsx:13:0-47:2) component, which only supports type-ahead (jump-to-first-match). This makes it difficult for admins to find a specific timezone like `Africa/Bamako` — typing the full name only jumps to the first `Africa/` entry.

This PR replaces [Select](cci:1://file:///home/ubuntu/Rocket.Chat/apps/meteor/client/views/omnichannel/components/outboundMessage/components/TemplateSelect.tsx:13:0-47:2) with `SelectFiltered`, which adds a text input at the top of the dropdown that **filters the list** as the admin types. This is the same component already used elsewhere in the omnichannel codebase (e.g., [TemplateSelect](cci:1://file:///home/ubuntu/Rocket.Chat/apps/meteor/client/views/omnichannel/components/outboundMessage/components/TemplateSelect.tsx:13:0-47:2), `AutoCompleteDepartment`).

### Changes
- Replaced [Select](cci:1://file:///home/ubuntu/Rocket.Chat/apps/meteor/client/views/omnichannel/components/outboundMessage/components/TemplateSelect.tsx:13:0-47:2) → `SelectFiltered` for the timezone field (drop-in replacement, same props API)
- Removed the resolved `// TODO: replace Select in favor SelectFiltered` comment

## Issue(s)

Resolves an in-code TODO at `apps/meteor/client/views/omnichannel/businessHours/BusinessHoursForm.tsx:36`

## Demo


https://github.com/user-attachments/assets/14813e8a-cb51-4db9-ab4c-e0a2b4dd750e




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved timezone selector in the Business Hours form with enhanced functionality and usability for better user experience when managing business hours settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->