### PR TITLE
fix(search): ensure DefaultProvider callback is always executed (#32966)

### DIFF
--- a/apps/meteor/app/search/server/provider/DefaultProvider.ts
+++ b/apps/meteor/app/search/server/provider/DefaultProvider.ts
@@ -42,7 +42,6 @@ export class DefaultProvider extends SearchProvider<{ searchAll?: boolean; limit
 ): Promise<void> {
 	try {
 		const _rid = payload.searchAll ? undefined : context.rid;
-		
 		const _limit = payload.limit || this._settings.get<number>('PageSize');
 
 		const result = await messageSearch(userId, text, _rid, _limit);
@@ -57,7 +56,6 @@ export class DefaultProvider extends SearchProvider<{ searchAll?: boolean; limit
 			return callback(null, safeResult);
 		}
 
-		// If SearchProvider expects promise-based handling
 		return;
 	} catch (error) {
 		if (callback) {

--- a/apps/meteor/app/search/server/provider/DefaultProvider.ts
+++ b/apps/meteor/app/search/server/provider/DefaultProvider.ts
@@ -34,19 +34,37 @@ export class DefaultProvider extends SearchProvider<{ searchAll?: boolean; limit
 	 * Uses Meteor function 'messageSearch'
 	 */
 	async search(
-		userId: string,
-		text: string,
-		context: { uid?: IUser['_id']; rid: IRoom['_id'] },
-		payload: { searchAll?: boolean; limit?: number } = {},
-		callback?: (error: Error | null, result: IRawSearchResult) => void,
-	): Promise<void> {
-		const _rid = payload.searchAll ? undefined : context.rid;
+    userId: string,
+    text: string,
+    context: { uid?: IUser['_id']; rid: IRoom['_id'] },
+    payload: { searchAll?: boolean; limit?: number } = {},
+    callback?: (error: Error | null, result: IRawSearchResult) => void,
+): Promise<void> {
+    try {
+        const _rid = payload.searchAll ? undefined : context.rid;
+		
+        const _limit = payload.limit || this._settings.get<number>('PageSize');
 
-		const _limit = payload.limit || this._settings.get<number>('PageSize');
+        const result = await messageSearch(userId, text, _rid, _limit);
 
-		const result = await messageSearch(userId, text, _rid, _limit);
-		if (callback && result !== false) {
-			return callback(null, result);
-		}
-	}
+        if (callback) {
+            if (!result || result === false) {
+                return callback(null, {
+                    messages: [],
+                    users: [],
+                    rooms: [],
+                } as IRawSearchResult);
+            }
+
+            return callback(null, result);
+        }
+    } catch (error) {
+        if (callback) {
+            return callback(error as Error, {
+                messages: [],
+                users: [],
+                rooms: [],
+            } as IRawSearchResult);
+        }
+    }
 }

--- a/apps/meteor/app/search/server/provider/DefaultProvider.ts
+++ b/apps/meteor/app/search/server/provider/DefaultProvider.ts
@@ -34,37 +34,40 @@ export class DefaultProvider extends SearchProvider<{ searchAll?: boolean; limit
 	 * Uses Meteor function 'messageSearch'
 	 */
 	async search(
-    userId: string,
-    text: string,
-    context: { uid?: IUser['_id']; rid: IRoom['_id'] },
-    payload: { searchAll?: boolean; limit?: number } = {},
-    callback?: (error: Error | null, result: IRawSearchResult) => void,
+	userId: string,
+	text: string,
+	context: { uid?: IUser['_id']; rid: IRoom['_id'] },
+	payload: { searchAll?: boolean; limit?: number } = {},
+	callback?: (error: Error | null, result: IRawSearchResult) => void,
 ): Promise<void> {
-    try {
-        const _rid = payload.searchAll ? undefined : context.rid;
+	try {
+		const _rid = payload.searchAll ? undefined : context.rid;
 		
-        const _limit = payload.limit || this._settings.get<number>('PageSize');
+		const _limit = payload.limit || this._settings.get<number>('PageSize');
 
-        const result = await messageSearch(userId, text, _rid, _limit);
+		const result = await messageSearch(userId, text, _rid, _limit);
 
-        if (callback) {
-            if (!result || result === false) {
-                return callback(null, {
-                    messages: [],
-                    users: [],
-                    rooms: [],
-                } as IRawSearchResult);
-            }
+		const safeResult: IRawSearchResult = result || {
+			messages: [],
+			users: [],
+			rooms: [],
+		};
 
-            return callback(null, result);
-        }
-    } catch (error) {
-        if (callback) {
-            return callback(error as Error, {
-                messages: [],
-                users: [],
-                rooms: [],
-            } as IRawSearchResult);
-        }
-    }
+		if (callback) {
+			return callback(null, safeResult);
+		}
+
+		// If SearchProvider expects promise-based handling
+		return;
+	} catch (error) {
+		if (callback) {
+			return callback(error as Error, {
+				messages: [],
+				users: [],
+				rooms: [],
+			});
+		}
+
+		throw error;
+	}
 }


### PR DESCRIPTION
**Proposed changes**
Fixes an issue where DefaultProvider.search did not execute the callback when messageSearch returned a falsy value.

**The update ensures:**
Callback is always executed when provided.
Empty results are returned safely.
Errors are properly handled.
Search flow remains consistent and predictable.

**Issue(s)**
Closes #32966

**Steps to test**

> Perform a room search with valid input.
> Perform a search that returns no results.
> Enable global search and repeat tests.
> Verify that search responses are returned consistently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search reliability through enhanced error handling, ensuring graceful handling of edge cases and consistent result formatting across all scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->