### PR TITLE
fix(omnichannel): remove hardcoded global moment locale from DateRangePicker

### DIFF
--- a/apps/meteor/client/views/omnichannel/analytics/DateRangePicker.tsx
+++ b/apps/meteor/client/views/omnichannel/analytics/DateRangePicker.tsx
@@ -13,7 +13,8 @@ type DateRangePickerProps = Omit<ComponentProps<typeof Box>, 'onChange'> & {
 	onChange(range: { start: string; end: string }): void;
 };
 
-const formatToDateInput = (date: Moment) => date.format('YYYY-MM-DD');
+const formatToDateInput = (date: Moment) =>
+	date.clone().locale('en').format('YYYY-MM-DD');
 
 const todayDate = formatToDateInput(moment());
 


### PR DESCRIPTION

## Proposed changes (including videos or screenshots)

This PR removes the module-level `moment.locale('en')` call from:

`apps/meteor/client/views/omnichannel/analytics/DateRangePicker.tsx`

Moment's locale is global, and forcing English at module scope overrides Rocket.Chat’s centralized locale handling via `TranslationProvider`. This can cause inconsistent localization behavior in non-English environments.

The DateRangePicker component formats dates explicitly using `YYYY-MM-DD`, which does not require forcing the locale. Removing this override prevents unintended global side effects and aligns the component with the application's localization architecture.

No UI behavior changes are introduced.

## Issue(s)

Fixes #38652

## Steps to test or reproduce

1. Change the Rocket.Chat UI language to a non-English language (e.g., Arabic or Persian).
2. Navigate to **Omnichannel → Analytics**.
3. Open browser DevTools.
4. Run: `moment.locale()`.
5. Confirm that the locale reflects the selected UI language instead of being forced to `"en"`.

## Further comments

This is a small and isolated fix that removes a global side-effect. No changeset is included, as this does not introduce a user-facing change or require a version bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Revert**
  * Removed the hardcoded global English locale. The app now respects the system/inferred locale across the UI while date range picker input fields continue to display dates in English formatting for consistent inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->