### PR TITLE
chore: update login label for better clarity

### DIFF
--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -3257,7 +3257,7 @@
   "Logged_In_Via": "Logged in via",
   "Logged_Out_Banner_Text": "Your session was ended on this device, please log in again to continue.",
   "Logged_out_of_other_clients_successfully": "Logged out of other clients successfully",
-  "Login": "Login",
+  "Login": "Sign in to Rocket.Chat",
   "Login_Attempts": "Failed Login Attempts",
   "Login_Detected": "Login detected",
   "Login_Logs": "Login Logs",


### PR DESCRIPTION
Hi team! I noticed the login label could be more descriptive. I've updated it to 'Sign in to Rocket.Chat' to improve the user experience. This is my first contribution!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the login prompt text to "Sign in to Rocket.Chat" — users will see the new wording on authentication screens.
  * Minor formatting adjustment to locale files to ensure proper newline handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->