### PR TITLE
refactor(admin): migrate AdminInviteUsers to react-hook-form

### DIFF
--- a/apps/meteor/client/views/admin/users/AdminInviteUsers.tsx
+++ b/apps/meteor/client/views/admin/users/AdminInviteUsers.tsx
@@ -12,24 +12,27 @@ import {
 import { validateEmail } from '@rocket.chat/tools';
 import { ContextualbarScrollableContent, ContextualbarFooter, ContextualbarContent } from '@rocket.chat/ui-client';
 import { useTranslation, useRoute } from '@rocket.chat/ui-contexts';
-import type { ChangeEvent } from 'react';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
+import { useForm, Controller } from 'react-hook-form';
 
 import { useSendInvitationEmailMutation } from './hooks/useSendInvitationEmailMutation';
 import { useSmtpQuery } from './hooks/useSmtpQuery';
 import { FormSkeleton } from '../../../components/Skeleton';
 
-// TODO: Replace using RHF
 const AdminInviteUsers = () => {
 	const t = useTranslation();
-	const [text, setText] = useState('');
 	const getEmails = useCallback((text: string) => text.split(/[\ ,;]+/i).filter((val: string) => validateEmail(val)), []);
 	const adminRouter = useRoute('admin-settings');
 	const sendInvitationMutation = useSendInvitationEmailMutation();
 	const { data, isLoading } = useSmtpQuery();
 
-	const handleClick = () => {
-		sendInvitationMutation.mutate({ emails: getEmails(text) });
+	const { control, handleSubmit, formState: { isValid } } = useForm({
+		defaultValues: { emails: '' },
+		mode: 'onChange',
+	});
+
+	const onSubmit = ({ emails }: { emails: string }) => {
+		sendInvitationMutation.mutate({ emails: getEmails(emails) });
 	};
 
 	if (isLoading) {
@@ -65,11 +68,16 @@ const AdminInviteUsers = () => {
 				<Box fontScale='p2' mb={8}>
 					{t('Send_invitation_email_info')}
 				</Box>
-				<TextAreaInput rows={5} flexGrow={0} onChange={(e: ChangeEvent<HTMLInputElement>): void => setText(e.currentTarget.value)} />
+				<Controller
+					control={control}
+					name='emails'
+					rules={{ validate: (value) => getEmails(value).length > 0 || t('Send_invitation_email_info') }}
+					render={({ field }) => <TextAreaInput {...field} rows={5} flexGrow={0} />}
+				/>
 			</ContextualbarScrollableContent>
 			<ContextualbarFooter>
 				<ButtonGroup stretch>
-					<Button icon='send' primary onClick={handleClick} disabled={!getEmails(text).length} alignItems='stretch' mb={8}>
+					<Button icon='send' primary onClick={handleSubmit(onSubmit)} disabled={!isValid} alignItems='stretch' mb={8}>
 						{t('Send')}
 					</Button>
 				</ButtonGroup>


### PR DESCRIPTION
## Proposed Changes

Resolves the `// TODO: Replace using RHF` in [AdminInviteUsers.tsx](cci:7://file:///home/ubuntu/Rocket.Chat/apps/meteor/client/views/admin/users/AdminInviteUsers.tsx:0:0-0:0) by migrating the form from manual `useState` to `react-hook-form`.

### What changed

- Replaced `useState('text')` with `useForm` + `Controller` from `react-hook-form`
- Email validation now handled via RHF `rules.validate` instead of manual checking
- Form submission uses `handleSubmit(onSubmit)` instead of a manual `handleClick`
- Send button remains disabled until valid emails are entered, using `formState.isValid` with `mode: 'onChange'`
- Removed the resolved `// TODO: Replace using RHF` comment
- Removed unused `ChangeEvent` type import

### How to verify

1. Admin → Users → click **Invite**
2. Textarea should appear with "Send invitation email" heading
3. Type random text (e.g., `hello`) → Send button stays **greyed out**
4. Type a valid email (e.g., `test@example.com`) → Send button becomes **active**
5. Click Send → invitation is dispatched (requires SMTP configured)

> **Note:** If SMTP is not configured, the component correctly shows the "SMTP Server Not Setup" fallback — this behavior is unchanged.


https://github.com/user-attachments/assets/0a2b65b2-1db9-4c62-a465-aa3139978def



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced form validation and state management for the admin invite users feature, improving input handling and button state control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->