### PR TITLE
chore(omnichannel): remove moment dependency from ChatInfo

### DIFF
--- a/apps/meteor/client/views/omnichannel/directory/chats/ChatInfo/ChatInfo.tsx
+++ b/apps/meteor/client/views/omnichannel/directory/chats/ChatInfo/ChatInfo.tsx
@@ -4,7 +4,7 @@ import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
 import { ContextualbarScrollableContent, ContextualbarFooter, InfoPanelField, InfoPanelLabel, InfoPanelText } from '@rocket.chat/ui-client';
 import type { IRouterPaths } from '@rocket.chat/ui-contexts';
 import { useToastMessageDispatch, useRoute, useUserSubscription, useTranslation, usePermission, useUserId } from '@rocket.chat/ui-contexts';
-import moment from 'moment';
+
 import { useMemo } from 'react';
 
 import DepartmentField from './DepartmentField';
@@ -24,7 +24,7 @@ type ChatInfoProps = {
 	route: keyof IRouterPaths;
 };
 
-// TODO: Remove moment we are mixing moment and our own formatters :sadface:
+
 function ChatInfo({ id, route }: ChatInfoProps) {
 	const t = useTranslation();
 	const dispatchToastMessage = useToastMessageDispatch();
@@ -124,10 +124,10 @@ function ChatInfo({ id, route }: ChatInfoProps) {
 							<InfoPanelText>{queueTime}</InfoPanelText>
 						</InfoPanelField>
 					)}
-					{closedAt && (
+					{closedAt && ts && (
 						<InfoPanelField>
 							<InfoPanelLabel>{t('Chat_Duration')}</InfoPanelLabel>
-							<InfoPanelText>{moment(closedAt).from(moment(ts), true)}</InfoPanelText>
+							<InfoPanelText>{formatDuration((new Date(closedAt).getTime() - new Date(ts).getTime()) / 1000)}</InfoPanelText>
 						</InfoPanelField>
 					)}
 					{ts && (
@@ -157,7 +157,7 @@ function ChatInfo({ id, route }: ChatInfoProps) {
 					{!waitingResponse && responseBy?.lastMessageTs && (
 						<InfoPanelField>
 							<InfoPanelLabel>{t('Inactivity_Time')}</InfoPanelLabel>
-							<InfoPanelText>{moment(responseBy.lastMessageTs).fromNow(true)}</InfoPanelText>
+							<InfoPanelText>{formatDuration((Date.now() - new Date(responseBy.lastMessageTs).getTime()) / 1000)}</InfoPanelText>
 						</InfoPanelField>
 					)}
 					{customFieldEntries?.length > 0 &&


### PR DESCRIPTION
## Description

Removes `moment` from `ChatInfo.tsx` in favor of the existing `formatDuration` hook and native `Date` arithmetic, keeping the codebase consistent with the project's own formatting utilities.

## Changes

- Removed `import moment from 'moment'`
- Removed the associated TODO comment
- Replaced `moment(closedAt).from(moment(ts), true)` with `formatDuration` + native `Date` for Chat Duration
- Replaced `moment(responseBy.lastMessageTs).fromNow(true)` with `formatDuration` + native `Date` for Inactivity Time
- Added missing `ts` nullability guard on the Chat Duration conditional


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated date and time formatting logic in chat information display to use consistent project-specific formatting utilities, improving code maintainability while preserving the same user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->