### PR TITLE
fix: Prevent adding duplicate omnichannel agents with client-side validation

### DIFF
--- a/.changeset/chilly-wasps-love.md
+++ b/.changeset/chilly-wasps-love.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Prevent adding duplicate omnichannel agents by adding client-side validation.

--- a/apps/meteor/client/views/omnichannel/agents/AgentsTable/AddAgent.tsx
+++ b/apps/meteor/client/views/omnichannel/agents/AgentsTable/AddAgent.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { useEndpointMutation } from '../../../../hooks/useEndpointMutation';
 import { omnichannelQueryKeys } from '../../../../lib/queryKeys';
 
-const AddAgent = () => {
+const AddAgent = ({ agents }: { agents?: { username?: string }[] }) => {
 	const { t } = useTranslation();
 	const [username, setUsername] = useState('');
 	const dispatchToastMessage = useToastMessageDispatch();
@@ -25,8 +25,18 @@ const AddAgent = () => {
 		},
 	});
 
-	const handleSave = useEffectEvent(async () => {
-		await saveAction({ username });
+	const handleSave = useEffectEvent(async () => { 
+		const isAlreadyAgent = agents?.some((agent) => agent.username?.toLowerCase() === username.toLowerCase());
+    
+		if (isAlreadyAgent) {
+			return dispatchToastMessage({ type: 'error', message: t('User_is_already_an_agent') });
+		}
+		try {
+			await saveAction({ username });
+			setUsername(''); 
+		} catch (error: any) {
+			dispatchToastMessage({ type: 'error', message: error });
+		}
 	});
 
 	const handleChange = (value: unknown): void => {

--- a/apps/meteor/client/views/omnichannel/agents/AgentsTable/AgentsTable.tsx
+++ b/apps/meteor/client/views/omnichannel/agents/AgentsTable/AgentsTable.tsx
@@ -72,7 +72,7 @@ const AgentsTable = () => {
 
 	return (
 		<>
-			<AddAgent />
+			<AddAgent agents={data?.users} />
 			{((isSuccess && data?.users.length > 0) || queryHasChanged) && (
 				<FilterByText value={text} onChange={(event) => setText(event.target.value)} />
 			)}

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -37,6 +37,7 @@
   "ABAC_Attribute_created": "{{attributeName}} attribute created",
   "ABAC_Attribute_updated": "{{attributeName}} attribute updated",
   "ABAC_Attribute_deleted": "{{attributeName}} attribute deleted",
+  "User_is_already_an_agent": "User is already an agent",
   "ABAC_New_attribute": "New attribute",
   "ABAC_Edit_attribute": "Edit attribute",
   "ABAC_Edit_attribute_description": "Attribute values cannot be edited, but can be added or deleted.",


### PR DESCRIPTION
Summary
Currently, attempting to add a user as an Omnichannel agent when they are already an agent results in a misleading "Agent added" success toast, even though no change occurred on the server. This PR introduces client-side validation to check the existing agents list before the API call is made.

Changes
AgentsTable.tsx: Now passes the agents data list to the AddAgent component.

AddAgent.tsx:

Added a check using .some() to verify if the selected username already exists in the current agents list.

Prevents the API request if a duplicate is found.

Displays an error toast: "User is already an agent."

Changeset: Added a patch changeset for @rocket.chat/meteor.

Fixes
Closes #38684 ---

How to test
Navigate to Omnichannel > Agents.

Add a user as an agent.

Immediately try to add that same user again.

Expected Result: An error toast should appear, and no network request should be sent to the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents adding duplicate omnichannel agents by validating the entered username before saving; shows an error notification and blocks the operation if a duplicate is detected.
  * Improves save flow to reliably reset the input on success and display appropriate success or error notifications on failure.

* **Localization**
  * Added a localized message for the duplicate-agent error ("User is already an agent").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->