### PR TITLE
fix(video-recorder): invoke pause() instead of referencing it

### DIFF
--- a/apps/meteor/app/ui/client/lib/recorderjs/videoRecorder.ts
+++ b/apps/meteor/app/ui/client/lib/recorderjs/videoRecorder.ts
@@ -109,7 +109,7 @@ class VideoRecorder {
 		}
 
 		if (this.videoel) {
-			this.videoel.pause;
+			this.videoel.pause();
 			this.videoel.src = '';
 		}
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fixes a typo in the video message recorder where the video element’s `pause` method was referenced but never invoked when stopping a recording.

In `apps/meteor/app/ui/client/lib/recorderjs/videoRecorder.ts` (around line 112), the code currently uses:

- `this.videoel.pause;`

This does not execute anything, which can leave the video element playing or in an inconsistent “active” state after pressing stop. The fix is a minimal, behavior-correcting change:

- `this.videoel.pause();`

This ensures the video element is properly paused immediately after stopping a recording, preventing unexpected playback/time updates in the recorder UI.


## Issue(s)

- Closes #38718
- [bug] Video Recorder: pause is not invoked after stop due to missing parentheses #38718

## Steps to test or reproduce

1. Open the video message recorder UI.
2. Start recording a video message.
3. Stop recording.
4. Observe the video element behavior after stopping.

### Expected behavior

- When recording stops, the video element is paused via:
  - `this.videoel.pause();`
- The video stops immediately and remains in a paused state.

### Actual behavior (before this fix)

- The pause method is referenced but not called:
  - `this.videoel.pause;`
- This can cause:
  - Video continuing to play
  - Playback time continuing to update
  - Media element remaining active after stop

## Further comments

This is a minimal fix for what appears to be a simple invocation typo (method reference vs method call). No related server logs were observed, and the browser console shows no errors, but DevTools may show the media element remains in a playing/active state after stopping.

Relevant logs:
- None (no server logs related)
- Browser console: no errors observed, but media element state can remain active after stop


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the video element was not properly pausing when stopping a recording, ensuring correct cleanup of resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->