### PR TITLE
fix: disable send until video is recorded

### DIFF
--- a/apps/meteor/client/views/composer/VideoMessageRecorder/VideoMessageRecorder.tsx
+++ b/apps/meteor/client/views/composer/VideoMessageRecorder/VideoMessageRecorder.tsx
@@ -47,7 +47,7 @@ const VideoMessageRecorder = ({ rid, tmid, chatContext, reference }: VideoMessag
 	const [recordingState, setRecordingState] = useState<'idle' | 'loading' | 'recording'>('idle');
 	const [recordingInterval, setRecordingInterval] = useState<ReturnType<typeof setInterval> | null>(null);
 	const isRecording = recordingState === 'recording';
-	const sendButtonDisabled = !(VideoRecorder.cameraStarted.get() && !(recordingState === 'recording'));
+	const sendButtonDisabled = !VideoRecorder.cameraStarted.get() || recordingState !== 'idle' || !time;
 
 	const chat = useChat() ?? chatContext;
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

This PR fixes a UX and data integrity issue in the video message recorder where the **Send** button is enabled even when no recording has been made. Clicking **Send** immediately can result in an upload attempt of a 0-byte blob or unexpected message behavior.

File:
`apps/meteor/client/views/composer/VideoMessageRecorder/VideoMessageRecorder.tsx`

Previously, the disabled state of the Send button only checked whether the camera was started and whether the user was not currently recording. This allowed the initial idle state (before any recording) to still enable Send.

This PR updates the disabled condition to ensure that:

- The camera is started
- The recording state is idle
- A recording has actually occurred (using `time` as the signal)

### Code change


```diff
- const sendButtonDisabled = !(VideoRecorder.cameraStarted.get() && !(recordingState === 'recording'));
+ const sendButtonDisabled = !VideoRecorder.cameraStarted.get() || recordingState !== 'idle' || !time;
````

### 📸 Screenshots:

(Will be added) Recorder UI showing Send enabled before recording
<img width="1518" height="750" alt="image" src="https://github.com/user-attachments/assets/f81accf6-a8e7-49d9-9931-cff237d04d5b" />


(Will be added) Recorder UI showing Send disabled until recording exists
<img width="1567" height="766" alt="Screenshot from 2026-02-16 20-45-37" src="https://github.com/user-attachments/assets/8af9e22c-b3a8-416b-b307-46f298bc39de" />


This is a minimal, safe change that prevents empty uploads and improves UX consistency.

### Issue

Fixes #38729

Steps to test or reproduce

Open the video message recorder in the message composer.

Do not record anything.

Observe the Send button state.

### Before fix:

Send can be enabled even if no recording has been made.

Clicking Send may trigger an empty upload attempt.

### After fix:

Send remains disabled until a recording has occurred (time is set).

No empty uploads are possible.

### Further comments

This fix prevents unintended empty video uploads and ensures that the Send button reflects actual recording state. It does not introduce new UI behavior and does not require a changeset, as it only corrects incorrect button state logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Send button behavior in the video message recorder to better handle edge cases during recording. The button now correctly disables when the camera hasn't started, recording is still in progress, or no content has been recorded yet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->