### PR TITLE
chore: Allow clients to register a session after accepting a call

### DIFF
--- a/ee/packages/media-calls/src/internal/SignalProcessor.ts
+++ b/ee/packages/media-calls/src/internal/SignalProcessor.ts
@@ -137,9 +137,8 @@ export class GlobalSignalProcessor {
 
 		// If this user's side of the call has already been signed
 		if (actor.contractId) {
-			// If it's signed to the same session that is now registering
-			// Or it was signed by a session that the current session is replacing (as in a browser refresh)
-			if (actor.contractId === signal.contractId || actor.contractId === signal.oldContractId) {
+			// If it was signed by a session that the current session is replacing (as in a browser refresh)
+			if (actor.contractId === signal.oldContractId) {
 				logger.info({ msg: 'Server detected a client refresh for a session with an active call.', callId: call._id });
 				await mediaCallDirector.hangupDetachedCall(call, { endedBy: { ...actor, contractId: signal.contractId }, reason: 'unknown' });
 				return;

--- a/packages/media-signaling/src/lib/Session.ts
+++ b/packages/media-signaling/src/lib/Session.ts
@@ -23,6 +23,7 @@ export type MediaSignalingEvents = {
 
 export type MediaSignalingSessionConfig = {
 	userId: string;
+	mobileDeviceId?: string;
 	oldSessionId?: string;
 	logger?: IMediaSignalLogger;
 	processorFactories: IServiceProcessorFactoryList;
@@ -74,7 +75,7 @@ export class MediaSignalingSession extends Emitter<MediaSignalingEvents> {
 	constructor(private config: MediaSignalingSessionConfig) {
 		super();
 		this._userId = config.userId;
-		this._sessionId = config.randomStringFactory();
+		this._sessionId = config.mobileDeviceId || config.randomStringFactory();
 		this.recurringStateReportHandler = null;
 		this.knownCalls = new Map<string, ClientMediaCall>();
 		this.ignoredCalls = new Set<string>();


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Currently if we register a session with an ID that is already linked to a call, the server will end that call assuming that it was happening on a session that was refreshed. With #38646 a session may be linked to a call before actually being registered, so we need to change the registration process to not drop those calls anymore.

The PR also adds the option to register a session with a specific ID instead of generating a random one.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[VMUX-39](https://rocketchat.atlassian.net/browse/VMUX-39)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[VMUX-39]: https://rocketchat.atlassian.net/browse/VMUX-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media call session handling for contract validation in specific scenarios.

* **New Features**
  * Added support for mobile device identification in media signaling sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->