### PR TITLE
fix(livechat): reset smallScreen state when leaving mobile layout

### DIFF
--- a/apps/meteor/packages/rocketchat-livechat/assets/rocket-livechat.js
+++ b/apps/meteor/packages/rocketchat-livechat/assets/rocket-livechat.js
@@ -728,6 +728,7 @@
 				chatWidget.style.right = '0';
 				chatWidget.style.width = '100%';
 			} else {
+				smallScreen = false;
 				chatWidget.style.left = 'auto';
 				chatWidget.style.right = '50px';
 				chatWidget.style.width = widgetWidth;


### PR DESCRIPTION
## Proposed changes
- reset smallScreen to alse in the desktop branch of mediaqueryresponse
- keep existing layout style updates unchanged

## Issue(s)
Closes #38763

## How to test
1. Load the livechat widget on a page.
2. Resize viewport to mobile so widget enters small-screen mode.
3. Resize back to desktop.
4. Open/close widget and verify mobile-only body scroll-lock behavior does not persist.

## Notes
This is a minimal one-line fix targeting the stale internal state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed responsive layout behavior in livechat to properly adjust when switching between small and large screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->