### PR TITLE
Revert "fix: Regular members listed as owners in channel members list"

### DIFF
--- a/.changeset/roles-display-fix.md
+++ b/.changeset/roles-display-fix.md
@@ -1,5 +1,0 @@
----
-'@rocket.chat/meteor': patch
----
-
-fix: Regular members were listed as owners in the channel members list due to a mismatch between role sectioning and display order. Now, members are shown in the correct role sections.

--- a/apps/meteor/client/views/room/contextualBar/RoomMembers/RoomMembers.tsx
+++ b/apps/meteor/client/views/room/contextualBar/RoomMembers/RoomMembers.tsx
@@ -89,11 +89,11 @@ const RoomMembers = ({
 
 	const useRealName = useSetting('UI_Use_Real_Name', false);
 
-	const { counts, titles, sortedMembers } = useMemo(() => {
-		const owners: RoomMemberUser[] = [];
-		const leaders: RoomMemberUser[] = [];
-		const moderators: RoomMemberUser[] = [];
-		const normalMembers: RoomMemberUser[] = [];
+	const { counts, titles } = useMemo(() => {
+		const owners: RoomMember[] = [];
+		const leaders: RoomMember[] = [];
+		const moderators: RoomMember[] = [];
+		const normalMembers: RoomMember[] = [];
 
 		members.forEach((member) => {
 			if (member.roles?.includes('owner')) {
@@ -130,9 +130,7 @@ const RoomMembers = ({
 			titles.push(<MembersListDivider title='Members' count={normalMembers.length} />);
 		}
 
-		const sortedMembers = [...owners, ...leaders, ...moderators, ...normalMembers];
-
-		return { counts, titles, sortedMembers };
+		return { counts, titles };
 	}, [members]);
 
 	return (
@@ -190,7 +188,7 @@ const RoomMembers = ({
 									// eslint-disable-next-line react/no-multi-comp
 									components={{ Footer: () => <InfiniteListAnchor loadMore={loadMoreMembers} /> }}
 									itemContent={(index): ReactElement => (
-										<RowComponent useRealName={useRealName} data={itemData} user={sortedMembers[index]} index={index} reload={reload} />
+										<RowComponent useRealName={useRealName} data={itemData} user={members[index]} index={index} reload={reload} />
 									)}
 								/>
 							</VirtualizedScrollbars>


### PR DESCRIPTION
Reverts RocketChat/Rocket.Chat#37373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where members were incorrectly displayed in wrong role sections in the channel members list. Members now appear in their correct role categories (Owners, Leaders, Moderators, Members).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->