### PR TITLE
fix: add runtime guard for undefined username in prepareMessageObject

### DIFF
--- a/apps/meteor/app/lib/server/functions/sendMessage.ts
+++ b/apps/meteor/app/lib/server/functions/sendMessage.ts
@@ -201,9 +201,14 @@ export function prepareMessageObject(
 	}
 
 	const { _id, username, name } = user;
+	const resolvedUsername = username ?? name ?? _id;
+	if (!username) {
+		// Log a warning so operators can spot users / visitors with missing usernames
+		console.warn(`[sendMessage] user ${_id} has no username – falling back to "${resolvedUsername}"`);
+	}
 	message.u = {
 		_id,
-		username: username as string, // FIXME: this is wrong but I don't want to change it now
+		username: resolvedUsername,
 		name,
 	};
 	message.rid = rid;


### PR DESCRIPTION
fixes #38799 

The [prepareMessageObject] function in [sendMessage.ts] uses an unsafe type assertion `username as string` even though `username` is typed as `string | undefined`. This silently allows `undefined` to be assigned to `IMessage.u.username`, violating the `IMessage` contract.

This PR replaces the assertion with a runtime guard that throws a descriptive error if `username` is undefined, informing the user, preventing invalid data from being persisted.

**Before:**
```
message.u = {
    _id,
    username: username as string, // FIXME: this is wrong but I don't want to change it now
    name,
};
```
**After:** 

```
if (!username) {
    throw new Error(`Cannot send message: user ${_id} has no username`);
}
message.u = {
    _id,
    username,
    name,
};
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Messaging now uses a fallback display name when a sender's username is missing and logs a warning instead of throwing an error, reducing failed message delivery due to missing username information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->