### PR TITLE
fix(sidebar): prevent spotlight rpc call for whitespace queries

### DIFF
--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
@@ -56,6 +56,9 @@ export const useSearchItems = (filterText: string): UseQueryResult<SubscriptionW
 			if (localRooms.length === LIMIT) {
 				return localRooms;
 			}
+			if (!name.trim()) {
+				return localRooms;
+			}
 
 			const spotlight = await getSpotlight(name, usernamesFromClient, type);
 


### PR DESCRIPTION
fixed(sidebar): prevent spotlight rpc call for whitespace queries.

## Proposed changes (including videos or screenshots)
This PR fixes an issue where the sidebar search triggers unnecessary `spotlight` RPC calls to the backend when the search input is empty or contains only whitespace. 

By applying a `.trim()` check to the search term within the `useSearchItems` hook (`queryFn`), the function now short-circuits and immediately returns `localRooms`. This prevents broad, useless network requests and reduces backend workload.

## Issue(s)- #38809

## Steps to test or reproduce
1. Open the workspace sidebar search.
2. Keep the query empty or enter only whitespace (e.g., `"   "`).
3. Observe the network/method activity in the browser developer tools.
4. Verify that the `spotlight` method is not invoked.

## Further comments
This is a straightforward frontend validation fix that immediately improves performance during frequent search focus/open interactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search performance by skipping unnecessary lookups when search input is empty or contains only whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->