### PR TITLE
refactor(omnichannel): migrate DepartmentItemMenu from GenericMenu to MenuV2

### DIFF
--- a/apps/meteor/client/views/omnichannel/departments/DepartmentsTable/DepartmentItemMenu.tsx
+++ b/apps/meteor/client/views/omnichannel/departments/DepartmentsTable/DepartmentItemMenu.tsx
@@ -95,7 +95,7 @@ const DepartmentItemMenu = ({ department, archived }: DepartmentItemMenuProps): 
 	const disabledKeys = useMemo(() => items.filter((item) => item.disabled).map((item) => item.id), [items]);
 
 	return (
-		<MenuV2 title={t('Options')} onAction={onAction} disabledKeys={disabledKeys} detached>
+		<MenuV2 title={t('Options')} onAction={onAction} disabledKeys={disabledKeys}>
 			{items.map((item) => (
 				<MenuItem key={item.id}>
 					{item.icon && <MenuItemIcon name={item.icon} />}


### PR DESCRIPTION
Fixes #38815 Migrate DepartmentItemMenu from GenericMenu to MenuV2

Migrates `DepartmentItemMenu` from the legacy `GenericMenu` wrapper to direct `MenuV2` usage from `@rocket.chat/fuselage`.

## Changes

* Removed `GenericMenu` import from `@rocket.chat/ui-client`
* Replaced it with `MenuV2`, `MenuItem`, `MenuItemIcon`, and `MenuItemContent`
* Added `useHandleMenuAction` for action handling
* Computed `disabledKeys` from the existing `items` array
* Removed the resolved TODO comment

## Details

The `items` structure remains unchanged.
Actions are now handled via `useHandleMenuAction`, and disabled states are derived using `disabledKeys`. Tooltips and icons are rendered explicitly using `MenuItemContent` and `MenuItemIcon`.

This aligns the component with the current `MenuV2` usage pattern already adopted in other parts of the codebase (e.g., `AppMenu.tsx`).

## Verification

* TypeScript: No new type errors
* ESLint: No new lint violations
* Manual test: Verified Edit / Archive / Delete actions work correctly in Administration → Omnichannel → Departments

No behavioral changes introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release includes internal infrastructure improvements to the Omnichannel Departments menu component. No changes to user-facing functionality. The department menu actions (edit, archive/unarchive, delete) continue to operate as previously.

* **Refactor**
  * Updated internal menu component architecture

<!-- end of auto-generated comment: release notes by coderabbit.ai -->