### PR TITLE
fix: move DOMPurify hook to module level to prevent memory leak

### DIFF
--- a/apps/meteor/client/components/MarkdownText.tsx
+++ b/apps/meteor/client/components/MarkdownText.tsx
@@ -1,9 +1,10 @@
 import { Box } from '@rocket.chat/fuselage';
 import { isExternal, getBaseURI } from '@rocket.chat/ui-client';
 import dompurify from 'dompurify';
+import { t } from 'i18next';
 import { marked } from 'marked';
 import type { ComponentProps } from 'react';
-import { useMemo, useEffect } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { renderMessageEmoji } from '../lib/utils/renderMessageEmoji';
@@ -104,10 +105,6 @@ export const supportedURISchemes = ['http', 'https', 'notes', 'ftp', 'ftps', 'te
 const isElement = (node: Node): node is Element => node.nodeType === Node.ELEMENT_NODE;
 const isLinkElement = (node: Node): node is HTMLAnchorElement => isElement(node) && node.tagName.toLowerCase() === 'a';
 
-// Module level translator ref updated by the component via useEffect.
-let _t: (key: string, options?: Record<string, unknown>) => string = (key) => key;
-
-// Add a hook to make all external links open a new window
 dompurify.addHook('afterSanitizeAttributes', (node) => {
 	if (!isLinkElement(node)) {
 		return;
@@ -117,28 +114,17 @@ dompurify.addHook('afterSanitizeAttributes', (node) => {
 	const isExternalLink = isExternal(href);
 	const isMailto = href.startsWith('mailto:');
 
-	// Set appropriate attributes based on link type
 	if (isExternalLink || isMailto) {
 		node.setAttribute('rel', 'nofollow noopener noreferrer');
-		// Enforcing external links to open in new tabs is critical to assure users never navigate away from the chat
-		// This attribute must be preserved to guarantee users maintain their chat context
 		node.setAttribute('target', '_blank');
 	}
 
-	// Set appropriate title based on link type
 	if (isMailto) {
-		// For mailto links, use the email address as the title for better user experience
-		// Example: for href "mailto:user@example.com" the title would be "mailto:user@example.com"
 		node.setAttribute('title', href);
 	} else if (isExternalLink) {
-		// For external links, set an empty title to prevent tooltips
-		// This reduces visual clutter and lets users see the URL in the browser's status bar instead
 		node.setAttribute('title', '');
 	} else {
-		// For internal links, add a translated title with the relative path
-		// Example: for href "https://my-server.rocket.chat/channel/general" the title would be "Go to #general"
-		node.setAttribute('title', `${_t('Go_to_href', { href: href.replace(getBaseURI(), '') })}`);
-		// Note: _t is kept in sync by the MarkdownText component via useEffect
+		node.setAttribute('title', t('Go_to_href', { href: href.replace(getBaseURI(), '') }));
 	}
 });
 
@@ -151,11 +137,7 @@ const MarkdownText = ({
 	...props
 }: MarkdownTextProps) => {
 	const sanitizer = dompurify.sanitize;
-	const { t } = useTranslation();
-
-	useEffect(() => {
-		_t = t;
-	}, [t]);
+	const { i18n } = useTranslation();
 
 	let markedOptions: marked.MarkedOptions;
 
@@ -190,7 +172,7 @@ const MarkdownText = ({
 		})();
 
 		return preserveHtml ? html : html && sanitizer(html, { ADD_ATTR: ['target'], ALLOWED_URI_REGEXP: getRegexp(supportedURISchemes) });
-	}, [preserveHtml, sanitizer, content, variant, markedOptions, parseEmoji]);
+	}, [preserveHtml, sanitizer, content, variant, markedOptions, parseEmoji, i18n.language]);
 
 	return __html ? (
 		<Box


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

The dompurify.addHook('afterSanitizeAttributes', ...) was inside useMemo so every time the component re-rendered it kept adding a new copy of the same hook. DOMPurify does not deduplicate hooks so they just pile up and the hook runs N times per node where N is how many times the component rendered. This causes a memory leak over time.

Moved the hook registration to module level so it only runs once. The translator t was the only reactive thing inside the hook so I pulled that out into a module level variable _t and keep it updated via a useEffect. Also removed t from the useMemo dependency array since it is not needed there anymore.



https://github.com/user-attachments/assets/c85bcf34-5035-4ff8-b6ad-f8c37207b9be

In the video you can see **addHook registered prints only once**  while addHook called goes 40+ showing how many times the old hook would have stacked up per render.


## Issue(s)

fixes #38819 

## Further comments
dompurify.addHook inside a render path like useMemo just appends to an internal array every time with no deduplication. Moved it to module level and sync the dynamic value through a ref instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External links in markdown now open in new tabs with proper security attributes.
  * Mailto links show correct titles and behavior.
  * Internal links display translated titles correctly.

* **Refactor**
  * Link handling and translation logic consolidated at module level to ensure consistent behavior and language-aware titles without changing the public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->