### PR TITLE
fix: resolve memory leak in useReconnectCountdown hook

### DIFF
--- a/apps/meteor/client/components/connectionStatus/useReconnectCountdown.ts
+++ b/apps/meteor/client/components/connectionStatus/useReconnectCountdown.ts
@@ -21,7 +21,10 @@ export const useReconnectCountdown = (
 			reconnectionTimerRef.current = setInterval(() => {
 				retryTime && setReconnectCountdown(getReconnectCountdown(retryTime));
 			}, 500);
-			return;
+			return () => {
+				reconnectionTimerRef.current && clearInterval(reconnectionTimerRef.current);
+				reconnectionTimerRef.current = undefined;
+			}
 		}
 
 		reconnectionTimerRef.current && clearInterval(reconnectionTimerRef.current);


### PR DESCRIPTION
## Proposed changes
This PR resolves a memory leak in `apps/meteor/client/components/connectionStatus/useReconnectCountdown.ts`.

## The Issue:
The `setInterval` used to manage the reconnect countdown timer was not being properly cleared when the component unmounted. Because the interval ID was stored in a `useRef` (`reconnectionTimerRef.current`), if the component unmounted while the status was `'waiting'`, the timer would continue running orphaned in the background.

## The Fix:
* Added a proper return cleanup function to the `useEffect` hook.
* Cleared the interval explicitly using `reconnectionTimerRef.current`.
* Defensively reset the ref to `undefined` to ensure a clean state initialization on subsequent renders.

## Issue(s)
Found via static analysis auditing for unhandled subscription/listener cleanups. (No existing issue number).

## Steps to test or reproduce
1. Force the Rocket.Chat client into a disconnected/reconnecting state so the `useReconnectCountdown` component mounts and status becomes `'waiting'`.
2. Trigger an unmount of the component while the countdown is actively running.
3. Observe via React DevTools or memory profiling that the interval no longer continues executing in the background.

## Further comments
The fix defensively checks for the existence of `reconnectionTimerRef.current` before calling `clearInterval` and resets the reference, ensuring no stale closures or ghost intervals persist. 

 Task: [ARCH-1978]

[ARCH-1978]: https://rocketchat.atlassian.net/browse/ARCH-1978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ