### PR TITLE
fix(cron): ensure userDataDownloadsCron is awaited during startup

### DIFF
--- a/apps/meteor/server/startup/cron.ts
+++ b/apps/meteor/server/startup/cron.ts
@@ -11,6 +11,6 @@ import { videoConferencesCron } from '../cron/videoConferences';
 const logger = new Logger('SyncedCron');
 
 export const startCronJobs = async (): Promise<void> => {
-	await Promise.all([startCron(), oembedCron(), usageReportCron(logger), npsCron(), temporaryUploadCleanupCron(), videoConferencesCron()]);
-	userDataDownloadsCron();
+	await Promise.all([startCron(), oembedCron(), usageReportCron(logger), npsCron(), temporaryUploadCleanupCron(), videoConferencesCron(),userDataDownloadsCron()]);
+	
 };


### PR DESCRIPTION
## Proposed changes
During server startup, `userDataDownloadsCron()` was executed outside the awaited initialization flow in `apps/meteor/server/startup/cron.ts`.

All other cron initializers are awaited through `Promise.all`, but this specific job was invoked as a fire-and-forget call. If an exception occurs during its initialization (for example database connection delay or scheduler registration failure), the server continues booting successfully while the cron job may never be registered.

This change moves `userDataDownloadsCron()` into the awaited `Promise.all` block so all scheduled background tasks are initialized consistently and startup failures are properly surfaced.

This does not change behavior for end users, but improves reliability and observability of background job scheduling.

---

## Issue(s)
N/A (reliability fix discovered during code inspection)

---

## Steps to test or reproduce
1. Start the server locally using:
   ```bash
   yarn dev
   ```
2. Verify the server boots normally and reaches SERVER RUNNING.
3. Confirm no startup errors occur.
4. All cron initializers now run within the same awaited initialization path.

(Previously, failures inside userDataDownloadsCron would not affect startup and could silently skip scheduling.)

### Further comments

This is a small safety improvement ensuring that all cron jobs follow the same initialization contract. It prevents silent scheduler initialization failures and makes startup behavior deterministic without introducing any functional or API changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized background task scheduling for improved system startup efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->