### PR TITLE
fix: ensure toast notifications appear above modals

### DIFF
--- a/.changeset/hot-doors-wait.md
+++ b/.changeset/hot-doors-wait.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+ensure toast notifications appear above modals

--- a/apps/meteor/app/theme/client/main.css
+++ b/apps/meteor/app/theme/client/main.css
@@ -14,3 +14,9 @@
 @import url('imports/general/theme_old.css');
 @import url('./rocketchat.font.css');
 @import url('../../../node_modules/@rocket.chat/fuselage/dist/fuselage.css');
+
+/* Toast above modals */
+#toastBarRoot {
+	position: fixed;
+	z-index: 10000;
+}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes 

Toast notifications were appearing behind modals when triggered during team/channel creation. This was caused by #toastBarRoot (the toast portal container) having the same z-index as the modal, but appearing earlier in the DOM — causing the modal to visually stack above it.

**before fix:**

<img width="1414" height="603" alt="Screenshot 2026-02-21 at 2 00 25 PM" src="https://github.com/user-attachments/assets/a3940d28-0932-48a5-83d0-b47aa0ccdcd1" />

**After Fix:**
Added a CSS override in main.css to ensure #toastBarRoot always renders above the modal layer.

<img width="1412" height="613" alt="Screenshot 2026-02-21 at 1 49 37 PM" src="https://github.com/user-attachments/assets/632cc57e-2b5d-42ae-9b09-9fabd95606e7" />


## Issue(s)
Related to #38611

## Steps to test or reproduce
1. Open the Create Channel or Create Team modal
2. Fill in the form and click Create
3. Observe that the error toast appears above the modal instead of behind it

## Further comments
I also Investigated DOM reordering as an alternative approach, but both **#modal-root** and **#toastBarRoot** are created dynamically by their respective libraries on mount, making startup ordering unreliable. CSS z-index override on #toastBarRoot is the most reliable solution without modifying third-party library code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated UI styling so toast notifications consistently appear above modal windows, improving visibility and user feedback when multiple overlays are present.
* **Chores**
  * Added a changeset entry to record this visual update for release tracking and versioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->