### PR TITLE
fix: Slider filled track alignment in RTL mode

### DIFF
--- a/apps/meteor/client/lib/utils/injectSliderRTLFix.ts
+++ b/apps/meteor/client/lib/utils/injectSliderRTLFix.ts
@@ -1,0 +1,21 @@
+export const injectSliderRTLFix = (): void => {
+    const id = 'rcx-slider-rtl-fix';
+    if (document.getElementById(id)) {
+        return;
+    }
+    const styleElement = document.createElement('style');
+    styleElement.id = id;
+    styleElement.innerHTML = `
+		[dir='rtl'] .rcx-slider-track {
+			left: auto !important;
+			right: auto !important;
+			inset-inline-start: 0 !important;
+		}
+
+		[dir='rtl'] .rcx-slider-track::before {
+			transform: scaleX(-1) !important;
+			transform-origin: center !important;
+		}
+	`;
+    document.head.appendChild(styleElement);
+};

--- a/apps/meteor/client/startup/index.ts
+++ b/apps/meteor/client/startup/index.ts
@@ -8,4 +8,5 @@ import './roles';
 import './routes';
 import './slashCommands';
 import './startup';
+import './sliderRTLFix';
 import './streamMessage';

--- a/apps/meteor/client/startup/sliderRTLFix.ts
+++ b/apps/meteor/client/startup/sliderRTLFix.ts
@@ -1,0 +1,7 @@
+import { Meteor } from 'meteor/meteor';
+
+import { injectSliderRTLFix } from '../lib/utils/injectSliderRTLFix';
+
+Meteor.startup(() => {
+    injectSliderRTLFix();
+});


### PR DESCRIPTION
## Proposed changes
This PR implements a global CSS workaround to fix an alignment issue with the `Slider` component when the application is in Right-to-Left (RTL) mode. 

### The Problem
In the current version of `@rocket.chat/fuselage`, the slider track background (the fill) uses a hardcoded `linear-gradient(to right, ...)`, causing the highlighted part of the slider to grow from the left even in RTL mode, where it should grow from the right.

### The Solution
Since the slider logic (powered by `react-aria`) correctly mirrors the thumb position, this PR adds a CSS patch that targets the `Slider` track and applies `transform: scaleX(-1)` when the document is in RTL mode. This effectively flips the gradient direction without affecting the mirrored interaction logic.

## Issue(s)
Fixes #38670

## Steps to test or reproduce
1. Go to **My Account > Preferences > Sound**.
2. Switch language to an RTL language (e.g., Arabic).
3. Observe the Sound Sliders. The blue fill should now correctly start from the right side and align with the thumb position.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved right-to-left (RTL) slider layouts by correcting track positioning and direction.
  - Ensured the fix is applied automatically when the application starts.
  - Prevented duplicate styling from being added during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->