### PR TITLE
fix: Add cleanup for VideoConfManager listener in VideoConfProvider

### DIFF
--- a/apps/meteor/client/providers/VideoConfProvider.tsx
+++ b/apps/meteor/client/providers/VideoConfProvider.tsx
@@ -35,10 +35,15 @@ const VideoConfContextProvider = ({ children }: { children: ReactNode }): ReactE
 		[dispatchToastMessage, t],
 	);
 
-	useEffect(() => {
-		VideoConfManager.on('direct/stopped', () => setOutgoing(undefined));
-		VideoConfManager.on('calling/ended', () => setOutgoing(undefined));
-	}, []);
+		useEffect(() => {
+			const stopDirect = VideoConfManager.on('direct/stopped', () => setOutgoing(undefined));
+			const stopCalling = VideoConfManager.on('calling/ended', () => setOutgoing(undefined));
+
+			return () => {
+				stopDirect();
+				stopCalling();
+			};
+		}, []);
 
 	const contextValue = useMemo<VideoConfContextValue>(
 		() => ({


### PR DESCRIPTION
Proposed changes 
 This PR addresses a memory leak in the VideoConfProvider component. Previously, event listeners for 
 direct/stopped and calling/ended were registered within a useEffect hook but lacked a cleanup/unsubscribe  
 mechanism.

 I have updated the hook to capture the teardown functions returned by the VideoConfManager.on() method 
 and ensure they are invoked when the component unmounts. This prevents listeners from accumulating in 
 memory during the application lifecycle.

Issue
 Fixed a memory leak identified during code analysis of the Video conference provider.

Steps to test or reproduce
1.Start the Rocket.Chat application.
2.Navigate to a room and initial/join a video call.
3.Navigate away from the room or close the video conference provider.
4.Observe that the event listeners are properly disposed of (logic verified via code review of VideoConfManager subscription patterns)

Further comments 
 The fix follows the exisiting pattern used for the call/join and error listeners in the same file, ensuring
 consistency across the provider's lifecycle management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video conferencing stability by ensuring event handlers are properly unsubscribed when components unmount, preventing lingering listeners and potential memory leaks and improving overall app performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->