### PR TITLE
fix: enforce room membership check when sending messages

### DIFF
--- a/apps/meteor/app/authorization/server/functions/canSendMessage.ts
+++ b/apps/meteor/app/authorization/server/functions/canSendMessage.ts
@@ -13,6 +13,7 @@ const subscriptionOptions = {
 	},
 };
 
+
 export async function validateRoomMessagePermissionsAsync(
 	room: IRoom | null,
 	{ uid, username, type }: { uid: IUser['_id']; username: IUser['username']; type: IUser['type'] },
@@ -28,6 +29,13 @@ export async function validateRoomMessagePermissionsAsync(
 
 	if (type !== 'app' && !(await canAccessRoomAsync(room, { _id: uid }, extraData))) {
 		throw new Error('error-not-allowed');
+	}
+
+	if (room.t !== 'd') {
+		const membership = await Subscriptions.findOneByRoomIdAndUserId(room._id, uid);
+		if (!membership) {
+			throw new Error('error-not-allowed');
+		}
 	}
 
 	if (await roomCoordinator.getRoomDirectives(room.t).allowMemberAction(room, RoomMemberActions.BLOCK, uid)) {


### PR DESCRIPTION
## Proposed changes

This PR adds a subscription (room membership) validation to the message sending authorization logic.

Previously, `canAccessRoomAsync` only verified room visibility and permissions, which allowed users who were not members of a room to send messages.  
This change ensures that only users with an active subscription to the room can send messages.

---

## Issue(s)

Fixes #38869

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message permission validation in rooms to ensure proper membership verification before allowing messages in non-direct rooms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->