### PR TITLE
fix: correct React anti-patterns — index as list key, useMemo for DOM side-effect, parseInt missing radix

### DIFF
--- a/.changeset/fix-react-antipatterns-key-index-usememo-parseint.md
+++ b/.changeset/fix-react-antipatterns-key-index-usememo-parseint.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+fix: correct React anti-patterns — index as list key, useMemo for DOM side-effect, parseInt missing radix

--- a/apps/meteor/client/components/message/content/Attachments.tsx
+++ b/apps/meteor/client/components/message/content/Attachments.tsx
@@ -9,7 +9,7 @@ type AttachmentsProps = {
 };
 
 const Attachments = ({ attachments, id }: AttachmentsProps): ReactElement => {
-	return <>{attachments?.map((attachment, index) => <AttachmentsItem key={index} id={id} attachment={{ ...attachment }} />)}</>;
+	return <>{attachments?.map((attachment, index) => <AttachmentsItem key={attachment.title_link ?? attachment.title ?? index} id={id} attachment={{ ...attachment }} />)}</>;
 };
 
 export default Attachments;

--- a/apps/meteor/client/components/message/content/attachments/default/ActionAttachtment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/default/ActionAttachtment.tsx
@@ -21,13 +21,13 @@ export const ActionAttachment = ({ actions }: ActionAttachmentProps) => {
 						const content = image ? <Box is='img' src={image} maxHeight={200} /> : text;
 						if (url) {
 							return (
-								<Button role='link' onClick={() => handleLinkClick(url)} key={index} small>
+								<Button role='link' onClick={() => handleLinkClick(url)} key={url ?? `action-${index}`} small>
 									{content}
 								</Button>
 							);
 						}
 						return (
-							<ActionAttachmentButton key={index} processingType={processingType} msg={msg} mid={msgId}>
+							<ActionAttachmentButton key={text ?? `action-${index}`} processingType={processingType} msg={msg} mid={msgId}>
 								{content}
 							</ActionAttachmentButton>
 						);

--- a/apps/meteor/client/components/message/content/attachments/default/FieldsAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/default/FieldsAttachment.tsx
@@ -14,7 +14,7 @@ type FieldsAttachmentProps = {
 
 const FieldsAttachment = ({ fields }: FieldsAttachmentProps) => (
 	<Box flexWrap='wrap' display='flex' mb={4} mi={-4}>
-		{fields.map((field, index) => (field.short ? <ShortField key={index} {...field} /> : <Field key={index} {...field} />))}
+		{fields.map((field, index) => (field.short ? <ShortField key={`${index}-${String(field.title)}`} {...field} /> : <Field key={`${index}-${String(field.title)}`} {...field} />))}
 	</Box>
 );
 

--- a/apps/meteor/client/lib/utils/isIE11.ts
+++ b/apps/meteor/client/lib/utils/isIE11.ts
@@ -3,7 +3,7 @@ export const isIE11: boolean = ((): boolean => {
 	const msieIdx = userAgent.indexOf('MSIE');
 
 	if (msieIdx > 0) {
-		return parseInt(userAgent.substring(msieIdx + 5, userAgent.indexOf('.', msieIdx))) === 11;
+		return parseInt(userAgent.substring(msieIdx + 5, userAgent.indexOf('.', msieIdx)), 10) === 11;
 	}
 
 	// If MSIE detection fails, check the Trident engine version

--- a/apps/meteor/client/views/modal/uikit/ModalBlock.tsx
+++ b/apps/meteor/client/views/modal/uikit/ModalBlock.tsx
@@ -14,7 +14,7 @@ import {
 import { UiKitComponent, UiKitModal, modalParser } from '@rocket.chat/fuselage-ui-kit';
 import * as UiKit from '@rocket.chat/ui-kit';
 import type { FormEvent, FormEventHandler, ReactElement } from 'react';
-import { useId, useCallback, useEffect, useMemo, useRef } from 'react';
+import { useId, useCallback, useEffect, useRef } from 'react';
 import { FocusScope } from 'react-aria';
 
 import { getButtonStyle } from './getButtonStyle';
@@ -82,15 +82,15 @@ const ModalBlock = ({ view, errors, onSubmit, onClose, onCancel }: ModalBlockPar
 		}
 	}, [errors]);
 
-	const previousFocus = useMemo(() => document.activeElement, []);
+	const previousFocus = useRef(document.activeElement);
 
 	useEffect(
 		() => () => {
-			if (previousFocus && isFocusable(previousFocus)) {
-				return previousFocus.focus();
+			if (previousFocus.current && isFocusable(previousFocus.current)) {
+				previousFocus.current.focus();
 			}
 		},
-		[previousFocus],
+		[],
 	);
 
 	const formRef = useRef<HTMLFormElement>(null);

--- a/apps/meteor/client/views/root/hooks/useAnalytics.ts
+++ b/apps/meteor/client/views/root/hooks/useAnalytics.ts
@@ -126,7 +126,7 @@ export const useAnalytics = (): void => {
 				console.log('Error while parsing JSON value of "piwikAdditionalTracker": ', e);
 			}
 			window._paq.push(['setTrackerUrl', `${piwikUrl}js/`]);
-			window._paq.push(['setSiteId', Number.parseInt(piwikSiteId)]);
+			window._paq.push(['setSiteId', Number.parseInt(piwikSiteId, 10)]);
 			const d = document;
 			const g = d.createElement('script');
 			g.setAttribute('id', 'piwik-analytics');


### PR DESCRIPTION
## Summary

This PR fixes three categories of React anti-patterns identified across the client codebase.

---

### 1. `useMemo` used to capture a DOM side-effect (`ModalBlock.tsx`)

**File:** `apps/meteor/client/views/modal/uikit/ModalBlock.tsx`

`useMemo` was being used to snapshot `document.activeElement` at mount time so it can be restored when the UiKit modal closes. This is semantically wrong:

> React may choose to "forget" previously memoized values and recalculate them on the next render, e.g. to free memory for offscreen components. — [React docs](https://react.dev/reference/react/useMemo)

In concurrent/strict mode React is free to recompute the memo value at any time, meaning `document.activeElement` would be captured at the wrong moment, breaking focus restoration.

**Fix:** Replace `useMemo` with `useRef`, which is the correct primitive for capturing a mutable value at initialisation. The stable ref identity also lets us remove `previousFocus` from the `useEffect` dependency array.

```tsx
// Before — wrong primitive, dep array had a stable-but-not-ref value
const previousFocus = useMemo(() => document.activeElement, []);
useEffect(() => () => {
  if (previousFocus && isFocusable(previousFocus)) return previousFocus.focus();
}, [previousFocus]);

// After — useRef captures the value once and is always stable
const previousFocus = useRef(document.activeElement);
useEffect(() => () => {
  if (previousFocus.current && isFocusable(previousFocus.current)) {
    previousFocus.current.focus();
  }
}, []);
```

---

### 2. Array index used as React list `key` (3 files)

**Files:**
- `apps/meteor/client/components/message/content/Attachments.tsx`
- `apps/meteor/client/components/message/content/attachments/default/FieldsAttachment.tsx`
- `apps/meteor/client/components/message/content/attachments/default/ActionAttachtment.tsx`

Using the array index as a key causes React to mis-associate component state with the wrong element whenever items are added, removed, or reordered. This can produce visual glitches or stale data in message threads with multiple attachments.

**Fixes** — replaced index with stable keys derived from existing data:

| File | Before | After |
|------|--------|-------|
| `Attachments.tsx` | `key={index}` | `key={attachment.title_link ?? attachment.title ?? index}` |
| `FieldsAttachment.tsx` | `key={index}` | `` key={`${index}-${String(field.title)}`} `` |
| `ActionAttachtment.tsx` | `key={index}` (both branches) | `key={url ?? \`action-${index}\`}` / `key={text ?? \`action-${index}\`}` |

---

### 3. `parseInt` / `Number.parseInt` without explicit radix (2 files)

**Files:**
- `apps/meteor/client/lib/utils/isIE11.ts`
- `apps/meteor/client/views/root/hooks/useAnalytics.ts`

Calling `parseInt` without a radix is flagged by ESLint's `radix` rule. While modern engines default to base-10, the spec historically allowed base-8 inference for strings prefixed with `0`. Added explicit `, 10` to both call sites.

```ts
// Before
parseInt(userAgent.substring(...))        // isIE11.ts
Number.parseInt(piwikSiteId)              // useAnalytics.ts

// After
parseInt(userAgent.substring(...), 10)
Number.parseInt(piwikSiteId, 10)
```

---

## Test plan

- [ ] Open a UiKit modal (e.g. from a slash command or App), close it — confirm focus returns to the previously focused element
- [ ] Send a message with multiple attachments containing fields — confirm correct rendering with no flicker on re-render
- [ ] Run `yarn typecheck` — no new errors
- [ ] Run `yarn lint` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved list rendering stability by using stable identifiers instead of index-based keys for attachments and fields.
  * Fixed DOM focus restoration in modal dialogs.
  * Enhanced numeric parsing precision for version detection and analytics tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->