### PR TITLE
docs(calendar): clarify cancelUpcomingStatusChanges delegation

### DIFF
--- a/apps/meteor/server/services/calendar/service.ts
+++ b/apps/meteor/server/services/calendar/service.ts
@@ -171,11 +171,7 @@ export class CalendarService extends ServiceClassInternal implements ICalendarSe
 		return this.doSetupNextStatusChange();
 	}
 
-	/**
-        * Public wrapper for upcoming status cancellation logic.
-        * Delegates the actual implementation to the statusEvents module.
-        * This method exists to keep the CalendarService API consistent.
-    */
+	
 	public async cancelUpcomingStatusChanges(uid: IUser['_id'], endTime = new Date()): Promise<void> {
 		return cancelUpcomingStatusChanges(uid, endTime);
 	}


### PR DESCRIPTION
Fixes #38926 

This PR adds a small JSDoc comment to clarify that 
cancelUpcomingStatusChanges is a wrapper method delegating logic 
to the statusEvents module.

No functional changes.
Only documentation improvement.

BEFORE:-

<img width="986" height="384" alt="Screenshot 2026-02-23 162628" src="https://github.com/user-attachments/assets/395c778f-26ee-427e-83fd-580156c8adc4" />

AFTER:-

<img width="1030" height="314" alt="Screenshot 2026-02-23 163450" src="https://github.com/user-attachments/assets/c4caca2e-2a11-438b-872e-5d2ed63b722c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to cancel upcoming status changes for users.
  * Exposed as a publicly accessible calendar operation to provide a consistent way to request cancellation before a specified end time.
  * Improves handling of scheduled status events and offers clearer control when managing future status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->