### PR TITLE
fix: add missing permission check to feature-preview admin sidebar item

### DIFF
--- a/.changeset/funny-houses-peel.md
+++ b/.changeset/funny-houses-peel.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fix missing permission check in feature-preview admin sidebar item

--- a/apps/meteor/app/authorization/server/constant/permissions.ts
+++ b/apps/meteor/app/authorization/server/constant/permissions.ts
@@ -218,6 +218,7 @@ export const permissions = [
 	{ _id: 'set-react-when-readonly', roles: ['admin', 'owner'] },
 	{ _id: 'manage-cloud', roles: ['admin'] },
 	{ _id: 'manage-sounds', roles: ['admin'] },
+	{ _id: 'manage-feature-preview', roles: ['admin'] },
 	{ _id: 'access-mailer', roles: ['admin'] },
 	{ _id: 'pin-message', roles: ['owner', 'moderator', 'admin'] },
 	{ _id: 'mobile-upload-file', roles: ['user', 'federated-external', 'admin'] },

--- a/apps/meteor/client/views/admin/featurePreview/AdminFeaturePreviewRoute.tsx
+++ b/apps/meteor/client/views/admin/featurePreview/AdminFeaturePreviewRoute.tsx
@@ -8,7 +8,7 @@ import NotAuthorizedPage from '../../notAuthorized/NotAuthorizedPage';
 import EditableSettingsProvider from '../settings/EditableSettingsProvider';
 
 const AdminFeaturePreviewRoute = (): ReactElement => {
-	const canViewFeaturesPreview = usePermission('manage-cloud');
+	const canViewFeaturesPreview = usePermission('manage-feature-preview');
 
 	if (!canViewFeaturesPreview) {
 		return <NotAuthorizedPage />;

--- a/apps/meteor/client/views/admin/sidebarItems.ts
+++ b/apps/meteor/client/views/admin/sidebarItems.ts
@@ -135,7 +135,8 @@ export const {
 		href: '/admin/feature-preview',
 		i18nLabel: 'Feature_preview',
 		icon: 'flask',
-		permissionGranted: () => defaultFeaturesPreview?.length > 0,
+		permissionGranted: (): boolean => hasPermission('manage-feature-preview') &&
+			defaultFeaturesPreview?.length > 0,
 	},
 	{
 		href: '/admin/settings',

--- a/apps/meteor/client/views/admin/sidebarItems.ts
+++ b/apps/meteor/client/views/admin/sidebarItems.ts
@@ -135,8 +135,7 @@ export const {
 		href: '/admin/feature-preview',
 		i18nLabel: 'Feature_preview',
 		icon: 'flask',
-		permissionGranted: (): boolean => hasPermission('manage-feature-preview') &&
-			defaultFeaturesPreview?.length > 0,
+		permissionGranted: (): boolean => hasPermission('manage-feature-preview') && defaultFeaturesPreview?.length > 0,
 	},
 	{
 		href: '/admin/settings',

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -6580,6 +6580,8 @@
   "manage-selected-settings_description": "Permission to change settings which are explicitly granted to be changed",
   "manage-sounds": "Manage Sounds",
   "manage-sounds_description": "Permission to manage the server sounds",
+  "manage-feature-preview": "Manage Feature Preview",
+  "manage-feature-preview_description": "Permission to manage feature preview",
   "manage-the-app": "Manage the App",
   "manage-user-status": "Manage User Status",
   "manage-user-status_description": "Permission to manage the server custom user statuses",
@@ -7158,7 +7160,7 @@
   "__count__replies": "{{count}} replies",
   "__count__replies__date__": "{{count}} replies, {{date}}",
   "__count__result_found": {
-     "one": "{{count}} result found",
+    "one": "{{count}} result found",
     "other": "{{count}} results found"
   },
   "__count__tags__and__count__conversations__period__": "{{count}} tags and {{conversations}} conversations, {{period}}",


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes

The `feature-preview` sidebar item in the admin panel was visible to regular users (role: user) because its`permissionGranted` function only checked whether feature previews exist, without verifying if the 
user actually has permission to access them.

Every other admin sidebar item uses `hasPermission()` to control visibility, but `feature-preview` was only doing:
`defaultFeaturesPreview?.length > 0`

This caused the sidebar item to appear for all users as long as any feature previews were configured — regardless of their role or permissions.


**Code Fix:**
// Before

`permissionGranted: () => defaultFeaturesPreview?.length > 0`

// After
```
permissionGranted: (): boolean =>
    hasPermission('manage-feature-preview') &&
    defaultFeaturesPreview?.length > 0

```

**Before Fix**

**url-admin/feature-preview**

<img width="1200" height="600" alt="Screenshot 2026-02-23 at 7 47 05 PM" src="https://github.com/user-attachments/assets/dc255807-cd62-4ff9-b7a9-d41349a1f171" />

**url - admin/subscription or any other sidebar item** 

<img width="1200" height="600" alt="Screenshot 2026-02-23 at 7 47 20 PM" src="https://github.com/user-attachments/assets/0453bced-69aa-4a81-a3bb-efed51e31df7" />

**After Fix**

**url-admin/feature-preview**

<img width="1200" height="600" alt="Screenshot 2026-02-23 at 7 51 22 PM" src="https://github.com/user-attachments/assets/be1d757d-d45c-4ac0-bfb9-dbab09d3deb8" />

**url - admin/subscription or any other sidebar item** 

<img width="1200" height="600" alt="Screenshot 2026-02-23 at 8 18 41 PM" src="https://github.com/user-attachments/assets/997989f4-3528-4f05-9b80-09b32f351316" />

## Steps to test or reproduce

1. Create a regular user with role: user (no admin permissions)
2. Login as that regular user
3. Hit /admin/rooms → sidebar empty 
4. Hit /admin/integrations → sidebar empty 
5. Hit /admin/feature-preview → "Feature preview" visible 
   in sidebar (before fix).
6. After fix → sidebar empty for feature-preview too 

## Further comments
During testing, an inconsistency was discovered in the admin 
sidebar permission model:

- /admin/rooms → sidebar completely empty for regular user -> correct
- /admin/integrations → sidebar completely empty -> correct
- /admin/subscription → sidebar completely empty -> correct
- /admin/feature-preview → "Feature preview" still visible -> wrong

Every other sidebar item uses hasPermission() — feature-preview was the only exception. This also creates a security concern: any user who knows the URL can discover this admin feature exists, even without access. Sidebar items should never leak information about admin features to unauthorized users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Feature Preview admin sidebar item now enforces admin authorization and only appears for users with the required admin permission, preventing unauthorized users from seeing or accessing the Feature Preview area.

* **Chores**
  * Added a dedicated admin permission ("manage-feature-preview") to centrally control access to the Feature Preview area for stricter admin-only visibility and easier future management.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [COMM-157]

[COMM-157]: https://rocketchat.atlassian.net/browse/COMM-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ