### PR TITLE
fix: replace ref any type with proper typed callback ref in MenuProps

### DIFF
--- a/packages/livechat/src/components/Menu/index.tsx
+++ b/packages/livechat/src/components/Menu/index.tsx
@@ -9,10 +9,10 @@ import styles from './styles.scss';
 type MenuProps = {
 	hidden?: boolean;
 	placement?: string;
-	ref?: any; // FIXME: remove this
+	ref?: ((instance: (Component & { base: Element }) | null) => void) | null;
 } & Omit<HTMLAttributes<HTMLDivElement>, 'ref'>;
 
-export const Menu = ({ children, hidden, placement = '', ...props }: MenuProps) => (
+export const Menu = ({ children, hidden, placement = '', ref: _ref, ...props }: MenuProps) => (
 	<div className={createClassName(styles, 'menu', { hidden, placement })} {...props}>
 		{children}
 	</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10437,7 +10437,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.2.4
-    "@rocket.chat/ui-contexts": 27.0.0
+    "@rocket.chat/ui-contexts": 27.0.1
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Replaced `ref?: any` with a properly typed callback ref in `MenuProps`, addressing the existing `FIXME` comment. The `ref` is explicitly destructured as `_ref` to prevent it from spreading into DOM props. The type matches the ref used in `PopoverMenuWrapper` which expects a Preact class component ref `(Component & { base: Element }) | null`.

## Issue(s)

Closes #38952

## Steps to test or reproduce

1. Run `npx tsc --noEmit` in `packages/livechat`
2. Verify no type errors in `packages/livechat/src/components/Menu/index.tsx`

## Further comments

Before:
```ts
type MenuProps = {
	hidden?: boolean;
	placement?: string;
	ref?: any; // FIXME: remove this
} & Omit<HTMLAttributes<HTMLDivElement>, 'ref'>;

export const Menu = ({ children, hidden, placement = '', ...props }: MenuProps) => (
	<div className={createClassName(styles, 'menu', { hidden, placement })} {...props}>
		{children}
	</div>
);
```

After:
```ts
type MenuProps = {
	hidden?: boolean;
	placement?: string;
	ref?: ((instance: (Component & { base: Element }) | null) => void) | null;
} & Omit<HTMLAttributes<HTMLDivElement>, 'ref'>;

export const Menu = ({ children, hidden, placement = '', ref: _ref, ...props }: MenuProps) => (
	<div className={createClassName(styles, 'menu', { hidden, placement })} {...props}>
		{children}
	</div>
);
```

The ref type matches `PopoverMenuWrapper.handleRef` which expects `(Component & { base: Element }) | null`.