### PR TITLE
chore: reorganize grammar 

### DIFF
--- a/packages/message-parser/src/compact.ts
+++ b/packages/message-parser/src/compact.ts
@@ -1,0 +1,609 @@
+/**
+ * Bidirectional converter between the verbose (current) and compact (span-based)
+ * message-parser AST formats.
+ *
+ *   compactify(oldMd, msg) → compact AST with spans referencing msg
+ *   expand(compactMd, msg) → verbose AST with self-contained strings
+ *   validateRoundtrip(oldMd, msg) → test both directions
+ */
+
+import type {
+	BigEmoji,
+	Blockquote,
+	Bold,
+	ChannelMention,
+	Code,
+	CodeLine,
+	Color,
+	Emoji,
+	Heading,
+	Image,
+	InlineCode,
+	InlineKaTeX,
+	Inlines,
+	Italic,
+	KaTeX,
+	LineBreak,
+	Link,
+	ListItem,
+	Markup,
+	OrderedList,
+	Paragraph,
+	Plain,
+	Quote,
+	Root,
+	Spoiler,
+	SpoilerBlock,
+	Strike,
+	Task,
+	Tasks,
+	Timestamp,
+	UnorderedList,
+	UserMention,
+} from './definitions';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Compact Format Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export type Span = [start: number, end: number];
+
+export type CInline = Span | CInlineNode;
+
+export type CInlineNode =
+	| { t: 'b'; c: CInline[] }
+	| { t: 'i'; c: CInline[] }
+	| { t: 's'; c: CInline[] }
+	| { t: '||'; c: CInline[] }
+	| { t: '`'; r: Span }
+	| { t: '@'; r: Span }
+	| { t: '#'; r: Span }
+	| { t: '$'; r: Span }
+	| { t: 'a'; r: Span; s?: string }
+	| { t: 'a'; c: CInline[]; s: string }
+	| { t: 'img'; r: Span; s: string }
+	| { t: ':'; r: Span; u?: true; s?: string }
+	| { t: 'ts'; r: Span; f: string }
+	| { t: 'c'; v: [number, number, number, number] };
+
+export type CBlock =
+	| { t: 'p'; c: CInline[] }
+	| { t: 'h'; l: 1 | 2 | 3 | 4; r: Span }
+	| { t: '```'; l?: string; r: Span }
+	| { t: '>'; c: CBlock[] }
+	| { t: 'q'; c: CBlock[] }
+	| { t: '|||'; c: CBlock[] }
+	| { t: 'ol'; c: CLI[] }
+	| { t: 'ul'; c: CLI[] }
+	| { t: 'tl'; c: CTK[] }
+	| { t: '$$'; r: Span }
+	| { t: 'br' };
+
+export type CLI = { t: 'li'; n?: number; c: CInline[] };
+export type CTK = { t: 'tk'; s: boolean; c: CInline[] };
+export type CBigEmoji = { t: 'E'; c: CInlineNode[] };
+export type CRoot = CBlock[] | [CBigEmoji];
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// expand(compactMd, msg) → verbose Root
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function isSpan(v: CInline): v is Span {
+	return Array.isArray(v) && v.length === 2 && typeof v[0] === 'number' && typeof v[1] === 'number';
+}
+
+function makePlain(msg: string, r: Span): Plain {
+	return { type: 'PLAIN_TEXT', value: msg.slice(r[0], r[1]) };
+}
+
+function expandInline(msg: string, node: CInline): Inlines {
+	if (isSpan(node)) {
+		return makePlain(msg, node);
+	}
+
+	switch (node.t) {
+		case 'b':
+			return { type: 'BOLD', value: node.c.map((c) => expandInline(msg, c)) } as Bold;
+		case 'i':
+			return { type: 'ITALIC', value: node.c.map((c) => expandInline(msg, c)) } as Italic;
+		case 's':
+			return { type: 'STRIKE', value: node.c.map((c) => expandInline(msg, c)) } as Strike;
+		case '||':
+			return { type: 'SPOILER', value: node.c.map((c) => expandInline(msg, c)) } as Spoiler;
+		case '`':
+			return { type: 'INLINE_CODE', value: makePlain(msg, node.r) } as InlineCode;
+		case '@':
+			return { type: 'MENTION_USER', value: makePlain(msg, node.r) } as UserMention;
+		case '#':
+			return { type: 'MENTION_CHANNEL', value: makePlain(msg, node.r) } as ChannelMention;
+		case '$':
+			return { type: 'INLINE_KATEX', value: msg.slice(node.r[0], node.r[1]) } as InlineKaTeX;
+		case 'a': {
+			if ('c' in node && Array.isArray((node as any).c)) {
+				const rich = node as { t: 'a'; c: CInline[]; s: string };
+				return {
+					type: 'LINK',
+					value: {
+						src: { type: 'PLAIN_TEXT', value: rich.s } as Plain,
+						label: rich.c.map((c) => expandInline(msg, c)) as Markup[],
+					},
+				} as Link;
+			}
+			const span = node as { t: 'a'; r: Span; s?: string };
+			const text = msg.slice(span.r[0], span.r[1]);
+			const href = span.s ?? text;
+			return {
+				type: 'LINK',
+				value: {
+					src: { type: 'PLAIN_TEXT', value: href } as Plain,
+					label: [{ type: 'PLAIN_TEXT', value: text } as Plain],
+				},
+			} as Link;
+		}
+		case 'img':
+			return {
+				type: 'IMAGE',
+				value: {
+					src: { type: 'PLAIN_TEXT', value: node.s } as Plain,
+					label: makePlain(msg, node.r),
+				},
+			} as Image;
+		case ':': {
+			if (node.u) {
+				return { type: 'EMOJI', value: undefined, unicode: msg.slice(node.r[0], node.r[1]) } as Emoji;
+			}
+			const raw = msg.slice(node.r[0], node.r[1]);
+			const sc = node.s ?? raw;
+			if (node.s && node.s !== raw) {
+				return { type: 'EMOJI', value: { type: 'PLAIN_TEXT', value: raw } as Plain, shortCode: sc } as Emoji;
+			}
+			return { type: 'EMOJI', value: { type: 'PLAIN_TEXT', value: sc } as Plain, shortCode: sc } as Emoji;
+		}
+		case 'ts': {
+			const v = msg.slice(node.r[0], node.r[1]);
+			return {
+				type: 'TIMESTAMP',
+				value: { timestamp: v, format: node.f as Timestamp['value']['format'] },
+				fallback: { type: 'PLAIN_TEXT', value: `<t:${v}:${node.f}>` } as Plain,
+			} as Timestamp;
+		}
+		case 'c':
+			return { type: 'COLOR', value: { r: node.v[0], g: node.v[1], b: node.v[2], a: node.v[3] } } as Color;
+		default:
+			throw new Error(`Unknown compact inline type: ${(node as any).t}`);
+	}
+}
+
+function expandBlock(msg: string, block: CBlock): Paragraph | Heading | Code | Blockquote | Quote | SpoilerBlock | OrderedList | UnorderedList | Tasks | KaTeX | LineBreak {
+	switch (block.t) {
+		case 'p':
+			return { type: 'PARAGRAPH', value: block.c.map((c) => expandInline(msg, c)) } as Paragraph;
+		case 'h':
+			return { type: 'HEADING', level: block.l, value: [makePlain(msg, block.r)] } as Heading;
+		case '```': {
+			const content = msg.slice(block.r[0], block.r[1]);
+			const lines: CodeLine[] = content.split('\n').map((line) => ({
+				type: 'CODE_LINE' as const,
+				value: { type: 'PLAIN_TEXT' as const, value: line },
+			}));
+			return { type: 'CODE', language: block.l || 'none', value: lines } as Code;
+		}
+		case '>':
+			return { type: 'BLOCKQUOTE', value: block.c.map((c) => expandBlock(msg, c)) } as Blockquote;
+		case 'q':
+			return { type: 'QUOTE', value: block.c.map((c) => expandBlock(msg, c)) } as Quote;
+		case '|||':
+			return { type: 'SPOILER_BLOCK', value: block.c.map((c) => expandBlock(msg, c)) } as SpoilerBlock;
+		case 'ol':
+			return {
+				type: 'ORDERED_LIST',
+				value: block.c.map(
+					(li): ListItem => ({
+						type: 'LIST_ITEM',
+						value: li.c.map((c) => expandInline(msg, c)),
+						...(li.n != null && { number: li.n }),
+					}),
+				),
+			} as OrderedList;
+		case 'ul':
+			return {
+				type: 'UNORDERED_LIST',
+				value: block.c.map(
+					(li): ListItem => ({
+						type: 'LIST_ITEM',
+						value: li.c.map((c) => expandInline(msg, c)),
+					}),
+				),
+			} as UnorderedList;
+		case 'tl':
+			return {
+				type: 'TASKS',
+				value: block.c.map(
+					(tk): Task => ({
+						type: 'TASK',
+						status: tk.s,
+						value: tk.c.map((c) => expandInline(msg, c)),
+					}),
+				),
+			} as Tasks;
+		case '$$':
+			return { type: 'KATEX', value: msg.slice(block.r[0], block.r[1]) } as KaTeX;
+		case 'br':
+			return { type: 'LINE_BREAK', value: undefined } as LineBreak;
+		default:
+			throw new Error(`Unknown compact block type: ${(block as any).t}`);
+	}
+}
+
+export function expand(root: CRoot, msg: string): Root {
+	if (root.length === 1 && 't' in root[0] && root[0].t === 'E') {
+		const bigE = root[0] as CBigEmoji;
+		return [{ type: 'BIG_EMOJI', value: bigE.c.map((c) => expandInline(msg, c)) } as BigEmoji] as Root;
+	}
+	return (root as CBlock[]).map((b) => expandBlock(msg, b)) as Root;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// compactify(oldMd, msg) → compact CRoot
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface Ctx {
+	msg: string;
+	pos: number;
+}
+
+function peek(ctx: Ctx, len = 1): string {
+	return ctx.msg.slice(ctx.pos, ctx.pos + len);
+}
+
+function advance(ctx: Ctx, n: number) {
+	ctx.pos += n;
+}
+
+function advancePast(ctx: Ctx, str: string) {
+	const i = ctx.msg.indexOf(str, ctx.pos);
+	if (i >= 0) ctx.pos = i + str.length;
+}
+
+function skipNewlines(ctx: Ctx) {
+	while (ctx.pos < ctx.msg.length && ctx.msg[ctx.pos] === '\n') ctx.pos++;
+}
+
+function skipWhitespace(ctx: Ctx) {
+	while (ctx.pos < ctx.msg.length && /\s/.test(ctx.msg[ctx.pos])) ctx.pos++;
+}
+
+function spanFor(ctx: Ctx, text: string): Span {
+	const i = ctx.msg.indexOf(text, ctx.pos);
+	if (i === -1) {
+		throw new Error(`Cannot find "${text.slice(0, 40)}" at pos ${ctx.pos} in msg`);
+	}
+	ctx.pos = i + text.length;
+	return [i, i + text.length];
+}
+
+function textOf(node: Plain | Markup | Inlines): string {
+	if ((node as Plain).type === 'PLAIN_TEXT') return (node as Plain).value;
+	if ((node as any).value?.type === 'PLAIN_TEXT') return (node as any).value.value;
+	return '';
+}
+
+function flatLabel(label: Markup | Markup[]): Array<Markup> {
+	return Array.isArray(label) ? label : [label];
+}
+
+// ── Inline ───────────────────────────────────────────────────────────────────
+
+function compactInline(ctx: Ctx, node: Inlines): CInline {
+	switch (node.type) {
+		case 'PLAIN_TEXT':
+			return spanFor(ctx, node.value);
+
+		case 'BOLD': {
+			const d = peek(ctx, 2) === '**' ? '**' : '__';
+			advance(ctx, d.length);
+			const c = node.value.map((ch) => compactInline(ctx, ch as Inlines));
+			advance(ctx, d.length);
+			return { t: 'b', c };
+		}
+		case 'ITALIC': {
+			const d = peek(ctx) === '*' ? '*' : '_';
+			advance(ctx, d.length);
+			const c = node.value.map((ch) => compactInline(ctx, ch as Inlines));
+			advance(ctx, d.length);
+			return { t: 'i', c };
+		}
+		case 'STRIKE': {
+			advance(ctx, 2);
+			const c = node.value.map((ch) => compactInline(ctx, ch as Inlines));
+			advance(ctx, 2);
+			return { t: 's', c };
+		}
+		case 'SPOILER': {
+			advance(ctx, 2);
+			const c = node.value.map((ch) => compactInline(ctx, ch as Inlines));
+			advance(ctx, 2);
+			return { t: '||', c };
+		}
+
+		case 'INLINE_CODE': {
+			advance(ctx, 1);
+			const r = spanFor(ctx, node.value.value);
+			advance(ctx, 1);
+			return { t: '`', r };
+		}
+
+		case 'MENTION_USER': {
+			advance(ctx, 1);
+			const r = spanFor(ctx, node.value.value);
+			return { t: '@', r };
+		}
+		case 'MENTION_CHANNEL': {
+			advance(ctx, 1);
+			const r = spanFor(ctx, node.value.value);
+			return { t: '#', r };
+		}
+
+		case 'EMOJI': {
+			if ('unicode' in node && node.unicode) {
+				const r = spanFor(ctx, node.unicode);
+				return { t: ':', r, u: true };
+			}
+			const emoji = node as Emoji & { value: Plain; shortCode: string };
+			const raw = emoji.value.value;
+			const isEmoticon = emoji.shortCode !== raw;
+
+			if (isEmoticon) {
+				const r = spanFor(ctx, raw);
+				return { t: ':', r, s: emoji.shortCode };
+			}
+
+			advance(ctx, 1); // opening :
+			const r = spanFor(ctx, emoji.shortCode);
+			advance(ctx, 1); // closing :
+			return { t: ':', r };
+		}
+
+		case 'LINK': {
+			const src = node.value.src.value;
+			const labels = flatLabel(node.value.label);
+			const labelTexts = labels.map(textOf);
+			const labelJoined = labelTexts.join('');
+
+			if (peek(ctx) === '[') {
+				advance(ctx, 1); // [
+
+				const isSimpleLabel = labels.length === 1 && labels[0].type === 'PLAIN_TEXT';
+
+				if (isSimpleLabel) {
+					const r = spanFor(ctx, labelJoined);
+					advance(ctx, 2); // ](
+					advancePast(ctx, ')');
+					return src === labelJoined ? { t: 'a', r } : { t: 'a', r, s: src };
+				}
+
+				const c = labels.map((l) => compactInline(ctx, l as Inlines));
+				advance(ctx, 2); // ](
+				advancePast(ctx, ')');
+				return { t: 'a', c, s: src };
+			}
+
+			const r = spanFor(ctx, labelJoined);
+			return src === labelJoined ? { t: 'a', r } : { t: 'a', r, s: src };
+		}
+
+		case 'IMAGE': {
+			advance(ctx, 2); // ![
+			const altText = textOf(node.value.label);
+			const r = spanFor(ctx, altText);
+			advance(ctx, 2); // ](
+			advancePast(ctx, ')');
+			return { t: 'img', r, s: node.value.src.value };
+		}
+
+		case 'INLINE_KATEX': {
+			advance(ctx, 1); // $
+			const r = spanFor(ctx, node.value);
+			advance(ctx, 1); // $
+			return { t: '$', r };
+		}
+
+		case 'TIMESTAMP': {
+			advance(ctx, 3); // <t:
+			const r = spanFor(ctx, node.value.timestamp);
+			advance(ctx, 1); // :
+			advance(ctx, node.value.format.length);
+			advance(ctx, 1); // >
+			return { t: 'ts', r, f: node.value.format };
+		}
+
+		case 'COLOR':
+			return { t: 'c', v: [node.value.r, node.value.g, node.value.b, node.value.a] };
+
+		default:
+			throw new Error(`Unknown inline type: ${(node as any).type}`);
+	}
+}
+
+// ── Block ────────────────────────────────────────────────────────────────────
+
+function compactBlock(ctx: Ctx, node: Paragraph | Root[number]): CBlock {
+	const n = node as any;
+	switch (n.type) {
+		case 'PARAGRAPH': {
+			const para = node as Paragraph;
+			const c = para.value.map((ch) => compactInline(ctx, ch));
+			return { t: 'p', c };
+		}
+
+		case 'HEADING': {
+			const heading = node as Heading;
+			advance(ctx, heading.level); // #, ##, ###, ####
+			advance(ctx, 1); // space
+			const text = heading.value.map(textOf).join('');
+			const r = spanFor(ctx, text);
+			return { t: 'h', l: heading.level, r };
+		}
+
+		case 'CODE': {
+			const code = node as Code;
+			advance(ctx, 3); // ```
+			const lang = code.language && code.language !== 'none' ? code.language : undefined;
+			if (lang) advance(ctx, lang.length);
+			advance(ctx, 1); // \n after lang line
+
+			const lines = code.value.map((cl: CodeLine) => cl.value.value);
+			const content = lines.join('\n');
+			const r = spanFor(ctx, content);
+
+			advance(ctx, 1); // \n before closing ```
+			advance(ctx, 3); // ```
+			return lang ? { t: '```', l: lang, r } : { t: '```', r };
+		}
+
+		case 'BLOCKQUOTE': {
+			const bq = node as unknown as Blockquote;
+			const c: CBlock[] = bq.value.map((para, i) => {
+				if (i > 0) skipNewlines(ctx);
+				advancePast(ctx, '> ');
+				return compactBlock(ctx, para);
+			});
+			return { t: '>', c };
+		}
+
+		case 'QUOTE': {
+			const q = node as Quote;
+			const c: CBlock[] = q.value.map((para, i) => {
+				if (i > 0) skipNewlines(ctx);
+				advancePast(ctx, '> ');
+				return compactBlock(ctx, para);
+			});
+			return { t: 'q', c };
+		}
+
+		case 'SPOILER_BLOCK': {
+			const sb = node as SpoilerBlock;
+			advance(ctx, 2); // ||
+			const c: CBlock[] = sb.value.map((para) => compactBlock(ctx, para));
+			advance(ctx, 2); // ||
+			return { t: '|||', c };
+		}
+
+		case 'ORDERED_LIST': {
+			const ol = node as OrderedList;
+			const c: CLI[] = ol.value.map((item, i) => {
+				if (i > 0) advance(ctx, 1); // \n
+				const num = item.number ?? i + 1;
+				advancePast(ctx, `${num}. `);
+				const children = item.value.map((ch) => compactInline(ctx, ch));
+				return { t: 'li' as const, n: num, c: children };
+			});
+			return { t: 'ol', c };
+		}
+
+		case 'UNORDERED_LIST': {
+			const ul = node as UnorderedList;
+			const c: CLI[] = ul.value.map((item, i) => {
+				if (i > 0) advance(ctx, 1); // \n
+				advancePast(ctx, '- ');
+				const children = item.value.map((ch) => compactInline(ctx, ch));
+				return { t: 'li' as const, c: children };
+			});
+			return { t: 'ul', c };
+		}
+
+		case 'TASKS': {
+			const tasks = node as Tasks;
+			const c: CTK[] = tasks.value.map((task, i) => {
+				if (i > 0) advance(ctx, 1); // \n
+				advancePast(ctx, task.status ? '- [x] ' : '- [ ] ');
+				const children = task.value.map((ch) => compactInline(ctx, ch));
+				return { t: 'tk' as const, s: task.status, c: children };
+			});
+			return { t: 'tl', c };
+		}
+
+		case 'KATEX': {
+			const katex = node as KaTeX;
+			advance(ctx, 2); // $$
+			const r = spanFor(ctx, katex.value);
+			advance(ctx, 2); // $$
+			return { t: '$$', r };
+		}
+
+		case 'LINE_BREAK':
+			advance(ctx, 1); // \n
+			return { t: 'br' };
+
+		default:
+			throw new Error(`Unknown block type: ${n.type}`);
+	}
+}
+
+export function compactify(root: Root, msg: string): CRoot {
+	const ctx: Ctx = { msg, pos: 0 };
+
+	if (root.length === 1 && root[0].type === 'BIG_EMOJI') {
+		skipWhitespace(ctx);
+		const emojis = root[0].value.map((e) => {
+			skipWhitespace(ctx);
+			return compactInline(ctx, e) as CInlineNode;
+		});
+		return [{ t: 'E', c: emojis }];
+	}
+
+	const blocks: CBlock[] = [];
+	for (let i = 0; i < root.length; i++) {
+		if (i > 0 && root[i].type !== 'LINE_BREAK') {
+			skipNewlines(ctx);
+		}
+		blocks.push(compactBlock(ctx, root[i]));
+	}
+	return blocks;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Validation
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function deepEqual(a: unknown, b: unknown): boolean {
+	if (a === b) return true;
+	if (a == null || b == null) return a === b;
+	if (typeof a !== typeof b) return false;
+	if (typeof a !== 'object') return false;
+
+	if (Array.isArray(a) !== Array.isArray(b)) return false;
+	if (Array.isArray(a)) {
+		if (a.length !== (b as unknown[]).length) return false;
+		return a.every((v, i) => deepEqual(v, (b as unknown[])[i]));
+	}
+
+	const objA = a as Record<string, unknown>;
+	const objB = b as Record<string, unknown>;
+	const keysA = Object.keys(objA).sort();
+	const keysB = Object.keys(objB).sort();
+	if (!deepEqual(keysA, keysB)) return false;
+	return keysA.every((k) => deepEqual(objA[k], objB[k]));
+}
+
+export function validateRoundtrip(
+	oldMd: Root,
+	msg: string,
+): {
+	ok: boolean;
+	compact: CRoot;
+	expanded: Root;
+	sizeOld: number;
+	sizeNew: number;
+	reduction: string;
+} {
+	const compact = compactify(oldMd, msg);
+	const expanded = expand(compact, msg);
+	const ok = deepEqual(oldMd, expanded);
+
+	const sizeOld = JSON.stringify(oldMd).length;
+	const sizeNew = JSON.stringify(compact).length;
+	const reduction = `${((1 - sizeNew / sizeOld) * 100).toFixed(1)}%`;
+
+	return { ok, compact, expanded, sizeOld, sizeNew, reduction };
+}

--- a/packages/message-parser/src/compact.ts
+++ b/packages/message-parser/src/compact.ts
@@ -174,7 +174,10 @@ function expandInline(msg: string, node: CInline): Inlines {
 	}
 }
 
-function expandBlock(msg: string, block: CBlock): Paragraph | Heading | Code | Blockquote | Quote | SpoilerBlock | OrderedList | UnorderedList | Tasks | KaTeX | LineBreak {
+function expandBlock(
+	msg: string,
+	block: CBlock,
+): Paragraph | Heading | Code | Blockquote | Quote | SpoilerBlock | OrderedList | UnorderedList | Tasks | KaTeX | LineBreak {
 	switch (block.t) {
 		case 'p':
 			return { type: 'PARAGRAPH', value: block.c.map((c) => expandInline(msg, c)) } as Paragraph;
@@ -237,8 +240,9 @@ function expandBlock(msg: string, block: CBlock): Paragraph | Heading | Code | B
 
 export function expand(root: CRoot, msg: string): Root {
 	if (root.length === 1 && 't' in root[0] && root[0].t === 'E') {
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- narrow CRoot[0] to CBigEmoji
 		const bigE = root[0] as CBigEmoji;
-		return [{ type: 'BIG_EMOJI', value: bigE.c.map((c) => expandInline(msg, c)) } as BigEmoji] as Root;
+		return [{ type: 'BIG_EMOJI', value: bigE.c.map((c) => expandInline(msg, c)) } as BigEmoji];
 	}
 	return (root as CBlock[]).map((b) => expandBlock(msg, b)) as Root;
 }
@@ -247,6 +251,7 @@ export function expand(root: CRoot, msg: string): Root {
 // compactify(oldMd, msg) → compact CRoot
 // ═══════════════════════════════════════════════════════════════════════════════
 
+// eslint-disable-next-line @typescript-eslint/naming-convention -- Ctx is a local context type, not a public API
 interface Ctx {
 	msg: string;
 	pos: number;
@@ -284,7 +289,8 @@ function spanFor(ctx: Ctx, text: string): Span {
 
 function textOf(node: Plain | Markup | Inlines): string {
 	if ((node as Plain).type === 'PLAIN_TEXT') return (node as Plain).value;
-	if ((node as any).value?.type === 'PLAIN_TEXT') return (node as any).value.value;
+	const { value } = node as { value?: Plain };
+	if (value?.type === 'PLAIN_TEXT') return value.value;
 	return '';
 }
 

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -257,8 +257,6 @@ InlinePattern = InlineItem / InlineItemFallback
 
 InlineItem = item:InlineItemPattern { skipInlineEmoji = false; return item; }
 
-InlineItemFallback = item:Any { skipInlineEmoji = true; return item; }
-
 InlineEmoji = & { return !skipInlineEmoji; } emo:Emoji { return emo; }
 
 InlineEmoticon = & { return !skipInlineEmoji; } emo:Emoticon & (EmoticonNeighbor / InlineItemPattern) { skipInlineEmoji = false; return emo; }
@@ -281,6 +279,8 @@ InlineItemPattern = Whitespace
   / Color
   / KatexInline
   / Escaped
+
+InlineItemFallback = item:Any { skipInlineEmoji = true; return item; }
 
 /**
  *
@@ -540,7 +540,7 @@ ItalicContentPreferentialItemPattern = Whitespace
 
 ItalicContentFallbackItem = item:ItalicContentFallbackItemPattern { skipItalicEmoji = true; return item; }
 
-ItalicContentFallbackItemPattern = AnyItalic / Line
+ItalicContentFallbackItemPattern = ItalicPlainRun / AnyItalic / Line
 
 ItalicEmoji = & { return !skipItalicEmoji; } emo:Emoji { return emo; }
 
@@ -557,7 +557,7 @@ BoldContentPreferentialItemPattern = Whitespace / InlineCode / MaybeReferences /
 
 BoldContentFallbackItem = item:BoldContentFallbackItemPattern { skipBoldEmoji = true; return item; }
 
-BoldContentFallbackItemPattern = AnyBold / Line
+BoldContentFallbackItemPattern = BoldPlainRun / AnyBold / Line
 
 BoldContentItem = BoldContentPreferentialItem / BoldContentFallbackItem
 
@@ -568,15 +568,21 @@ BoldEmoticon = & { return !skipBoldEmoji; } emo:Emoticon & (EmoticonNeighbor / B
 /* Strike */
 Strikethrough = [\x7E] [\x7E] @StrikethroughContent [\x7E] [\x7E] / [\x7E] @StrikethroughContent [\x7E]
 
-StrikethroughContent = text:(TimestampRules / Whitespace / InlineCode / MaybeReferences / UserMention / ChannelMention / MaybeItalic / MaybeBold / Emoji / Emoticon / AnyStrike / Line)+ {
+StrikethroughContent = text:(TimestampRules / Whitespace / InlineCode / MaybeReferences / UserMention / ChannelMention / MaybeItalic / MaybeBold / Emoji / Emoticon / StrikePlainRun / AnyStrike / Line)+ {
       return strike(reducePlainTexts(text));
     }
 
+// Exclude _ and ~ so nested italic/strike can be parsed
+BoldPlainRun = run:[^\x0a\* _~ ]+ { return plain(run.join('')); }
 AnyBold = t:[^\x0a\* ] { return plain(t); }
 
-AnyStrike = t:[^\x0a\~ ] { return plain(t); }
-
+// Exclude * and ~ so nested bold/strike can be parsed
+ItalicPlainRun = run:[^\x0a\_ *~]+ { return plain(run.join('')); }
 AnyItalic = t:[^\x0a\_ ] { return plain(t); }
+
+// Exclude * and _ so nested bold/italic can be parsed
+StrikePlainRun = run:[^\x0a\~ *_]+ { return plain(run.join('')); }
+AnyStrike = t:[^\x0a\~ ] { return plain(t); }
 
 /**
  * Emphasis with only whitespaces return plain text

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -273,6 +273,7 @@ InlineItemPattern = Whitespace
   / ChannelMention
   / AutolinkedEmail
   / AutolinkedPhone
+  / PlainUnderscoreThenDomain
   / AutolinkedURL
   / EmphasisWithWhitespace
   / Emphasis
@@ -435,6 +436,9 @@ AutolinkedEmail = e:Email { return autoEmail(e); }
  * with customDomains options as intranet: protocol://internaltool.intranet
  *
  */
+// _example.com (underscore + domain without closing _) → plain
+PlainUnderscoreThenDomain = "_" d:DomainName &(EndOfLine / !. / [^\x5F]) { return plain('_' + d); }
+
 AutolinkedURL = u:AutoLinkURL { return autoLink(u, options.customDomains); }
 
 AutoLinkURL

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -94,20 +94,20 @@ BlockSpoiler = "||" EndOfLine first:(&(! "||") @Paragraph) rest:(&(! "||") @Para
 
 TimestampType = "t" / "T" / "d" / "D" / "f" / "F" / "R"
 
-Unixtime = d:Digit |10| { return d.join(''); }
+Unixtime = $(Digit |10|)
 
-TimestampHoursMinutesSeconds = hours:Digit |2| ":" minutes:Digit|2| ":" seconds:Digit |2| tz:Timezone? { return timestampFromHours(hours.join(''), minutes.join(''), seconds.join(''), tz); }
+TimestampHoursMinutesSeconds = hours:$(Digit |2|) ":" minutes:$(Digit |2|) ":" seconds:$(Digit |2|) tz:Timezone? { return timestampFromHours(hours, minutes, seconds, tz); }
 
-TimestampHoursMinutes = hours:Digit |2| ":" minutes:Digit|2| tz:Timezone? { return timestampFromHours(hours.join(''), minutes.join(''),undefined,  tz); }
+TimestampHoursMinutes = hours:$(Digit |2|) ":" minutes:$(Digit |2|) tz:Timezone? { return timestampFromHours(hours, minutes, undefined, tz); }
 
 
 Timestamp = TimestampHoursMinutesSeconds / TimestampHoursMinutes
 
-Timezone = offset:('+'/'-') tzHour: Digit |2| ':' tzMinute: Digit |2| { return `${offset}${tzHour.join('')}:${tzMinute.join('')}`  }
+Timezone = offset:('+'/'-') tzHour:$(Digit |2|) ":" tzMinute:$(Digit |2|) { return offset + tzHour + ':' + tzMinute; }
 
-ISO8601Date = year:Digit |4| "-" month:Digit |2| "-" day:Digit |2| "T" hours:Digit |2| ":" minutes:Digit|2| ":" seconds:Digit |2| "." milliseconds:Digit |3| tz:Timezone? { return timestampFromIsoTime({year: year.join(''), month: month.join(''), day: day.join(''), hours: hours.join(''), minutes: minutes.join(''), seconds: seconds.join(''), milliseconds: milliseconds.join(''), timezone: tz}) }
+ISO8601Date = year:$(Digit |4|) "-" month:$(Digit |2|) "-" day:$(Digit |2|) "T" hours:$(Digit |2|) ":" minutes:$(Digit |2|) ":" seconds:$(Digit |2|) "." milliseconds:$(Digit |3|) tz:Timezone? { return timestampFromIsoTime({ year, month, day, hours, minutes, seconds, milliseconds, timezone: tz }); }
 
-ISO8601DateWithoutMilliseconds = year:Digit |4| "-" month:Digit |2| "-" day:Digit |2| "T" hours:Digit |2| ":" minutes:Digit|2| ":" seconds:Digit |2| tz:Timezone? { return timestampFromIsoTime({year: year.join(''), month: month.join(''), day: day.join(''), hours: hours.join(''), minutes: minutes.join(''), seconds: seconds.join(''), timezone: tz}) }
+ISO8601DateWithoutMilliseconds = year:$(Digit |4|) "-" month:$(Digit |2|) "-" day:$(Digit |2|) "T" hours:$(Digit |2|) ":" minutes:$(Digit |2|) ":" seconds:$(Digit |2|) tz:Timezone? { return timestampFromIsoTime({ year, month, day, hours, minutes, seconds, timezone: tz }); }
 
 
 TimestampRules = "<t:" date:(Unixtime / ISO8601Date / ISO8601DateWithoutMilliseconds / Timestamp) ":" format:TimestampType ">" { return timestamp(date, format); } / "<t:" date:(Unixtime / ISO8601Date / ISO8601DateWithoutMilliseconds / Timestamp) ">" { return timestamp(date); }
@@ -129,7 +129,9 @@ CodeLine
   / "\n" chunk:CodeChunk { return codeLine(chunk); }
   / "\n" !"```" { return codeLine(plain('')); }
 
-CodeChunk = text:$(!EndOfLine !"```" .)+ { return plain(text); }
+// Charclass avoids per-char lookahead; never consume start of "```"
+CodeChunkChar = [^\r\n`] / "`" [^`\r\n] / "`" "`" [^`\r\n]
+CodeChunk = text:$(CodeChunkChar)+ { return plain(text); }
 
 /**
  *
@@ -315,6 +317,7 @@ References
   = "[" title:LinkTitle* "](" href:MarkdownLinkRef ")" { return title.length ? link(href, reducePlainTexts(title)) : link(href); }
   / "<" href:LinkRef "|" title:LinkTitle2 ">" { return link(href, [plain(title)]); }
 
+// Hot path: complex negative lookahead for ]( and ] [ ... ](
 LinkTitle = (Whitespace / Emphasis) / anyTitle:$(!("](" .) !("] [" [^\]]* "](") .) { return plain(anyTitle) }
 
 LinkTitle2 = $([\x20-\x3B\x3D\x3F-\x60\x61-\x7B\x7D-\xFF] / NonASCII)+
@@ -330,8 +333,7 @@ MarkdownLinkFilePath = $(URLScheme MarkdownLinkURLBody+)
 
 // MarkdownLinkURL allows parentheses in URLs when inside markdown link syntax [title](url)
 MarkdownLinkURL
-  = $(URLScheme URLAuthority MarkdownLinkURLBody*)
-  / $(URLAuthorityHost MarkdownLinkURLBody*)
+  = head:($(URLScheme URLAuthority) / $(URLAuthorityHost)) tail:$(MarkdownLinkURLBody*) { return head + tail; }
 
 MarkdownLinkURLBody
   = (
@@ -381,6 +383,7 @@ DomainName
 
 DomainNameLabel = $(DomainChar+ ("-" DomainChar+)*)
 
+// Hot path: multiple negative lookaheads per character; consider post-validate if profiling shows cost
 DomainChar = !Extra ([\__-] / !Safe) !EndOfLine !Space ![\\/|><%`\[\]] .
 
 /**
@@ -435,8 +438,7 @@ AutolinkedEmail = e:Email { return autoEmail(e); }
 AutolinkedURL = u:AutoLinkURL { return autoLink(u, options.customDomains); }
 
 AutoLinkURL
-  = $(URLScheme URLAuthority AutoLinkURLBody*)
-  / $(URLAuthorityHost AutoLinkURLBody*)
+  = head:($(URLScheme URLAuthority) / $(URLAuthorityHost)) tail:$(AutoLinkURLBody*) { return head + tail; }
 
 AutoLinkURLBody =  !(Extra* (Whitespace / EndOfLine / !.)) .
 

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -43,9 +43,6 @@ let skipBold = false;
 let skipItalic = false;
 let skipStrikethrough = false;
 let skipReferences = false;
-let skipBoldEmoji = false;
-let skipItalicEmoji = false;
-let skipInlineEmoji = false;
 }}
 
 Start
@@ -148,7 +145,7 @@ Heading = count:HeadingStart [ \t]+ text:HeadingChunk { return heading([text], c
 
 HeadingStart = value:"#" |1..4| { return value.length; }
 
-HeadingChunk = text:$(!EndOfLine .)+ { return plain(text); }
+HeadingChunk = text:$([^\r\n]+) { return plain(text); }
 
 /**
  *
@@ -196,7 +193,7 @@ UnorderedListAsteriskItem = "*" [ \t]+ text:UnorderedListItemContent { return li
 
 UnorderedListItemContent = value:UnorderedListItemContentItem+ !"*" EndOfLine? { return reducePlainTexts(value); }
 
-UnorderedListItemContentItem = & {skipInlineEmoji = false; return true} item:(InlineItemPattern / !"*" @Any) { skipInlineEmoji = false; return item }
+UnorderedListItemContentItem = item:(InlineItemPattern / !"*" @Any) { return item }
 
 /**
  *
@@ -251,36 +248,43 @@ Paragraph = value:Inline { return paragraph(value); }
  * Inline
  *
 */
-Inline = & {skipInlineEmoji = false; return true; } value:InlinePattern+ EndOfLine? { skipInlineEmoji = false; return reducePlainTexts(value); }
+Inline = value:InlinePattern+ EndOfLine? { return reducePlainTexts(value); }
 
 InlinePattern = InlineItem / InlineItemFallback
 
-InlineItem = item:InlineItemPattern { skipInlineEmoji = false; return item; }
+InlineItem = item:InlineItemPattern { return item; }
 
-InlineEmoji = & { return !skipInlineEmoji; } emo:Emoji { return emo; }
+InlineEmoji = emo:Emoji { return emo; }
 
-InlineEmoticon = & { return !skipInlineEmoji; } emo:Emoticon & (EmoticonNeighbor / InlineItemPattern) { skipInlineEmoji = false; return emo; }
+InlineEmoticon = emo:Emoticon & (EmoticonNeighbor / InlineItemPattern) { return emo; }
+
+// Match "-" only when "-_-" is followed by more (so "-_-italic" → plain+italic); don't match when "-_-" is the full emoticon
+PlainRunBeforeEmoticon = "-" &("_" "-" .) { return plain('-'); }
+
+PlainRun = run:[^*_~`:\n<\[\]! \t()\\|]+ { return plain(run.join('')); }
 
 InlineItemPattern = Whitespace
-  / TimestampRules
-  / MaybeReferences
-  / AutolinkedPhone
-  / AutolinkedEmail
-  / AutolinkedURL
-  / Spoiler
-  / EmphasisWithWhitespace
-  / Emphasis
+  / Escaped
+  / InlineCode
+  / InlineEmoji
   / UserMention
   / ChannelMention
-  / InlineEmoji
-  / InlineCode
-  / Image
+  / AutolinkedEmail
+  / AutolinkedPhone
+  / AutolinkedURL
+  / EmphasisWithWhitespace
+  / Emphasis
+  / PlainRunBeforeEmoticon
   / InlineEmoticon
+  / MaybeReferences
+  / TimestampRules
+  / Image
   / Color
   / KatexInline
-  / Escaped
+  / Spoiler
+  / PlainRun
 
-InlineItemFallback = item:Any { skipInlineEmoji = true; return item; }
+InlineItemFallback = item:Any { return item; }
 
 /**
  *
@@ -288,16 +292,16 @@ InlineItemFallback = item:Any { skipInlineEmoji = true; return item; }
  * e.g: ||spoiler||, ||spoiler **bold**||
  *
  */
-Spoiler = "||" &{ skipInlineEmoji = false; return true; } text:SpoilerContentItems "||" { return spoiler(text); }
+Spoiler = "||" text:SpoilerContentItems "||" { return spoiler(text); }
 
 SpoilerContentItems = text:SpoilerContentItem+ { return reducePlainTexts(text); }
 
 // Ensure we consume at least one character and do not accidentally match the closing "||"
 SpoilerContentItem = !"||" item:SpoilerInlineItem { return item; } / !"||" item:SpoilerInlineItemFallback { return item; }
 
-SpoilerInlineItem = &{ skipInlineEmoji = false; return true; } item:InlineItemPattern { return item; }
+SpoilerInlineItem = item:InlineItemPattern { return item; }
 
-SpoilerInlineItemFallback = &{ skipInlineEmoji = true; return true; } item:Any { return item; }
+SpoilerInlineItemFallback = item:Any { return item; }
 
 /**
  *
@@ -344,8 +348,7 @@ MarkdownLinkExtra = [.,!%*\"':;=]
 Image = "![" title:Line? "](" href:MarkdownLinkRef ")" { return title ? image(href, title) : image(href); }
 
 URL
-  = $(URLScheme URLAuthority URLBody*)
-  / $(URLAuthorityHost URLBody*)
+  = head:($(URLScheme URLAuthority) / $(URLAuthorityHost)) tail:$(URLBody*) { return head + tail; }
 
 URLScheme = $([A-Za-z0-9+-] |1..32| ":")
 
@@ -451,9 +454,7 @@ Emphasis = MaybeBold / MaybeItalic / MaybeStrikethrough
  *
  */
 
-// This rule is used inside expressions that have a JS code ensuring they always fail,
-// Without any pattern to match, peggy will think the rule may end up succedding without consuming any input, which could cause infinite loops
-// So this unreachable rule is added to them to satisfy peggy's requirement.
+// Prevent re-entrant emphasis (infinite recursion); reset on backtrack via second branch
 BlockedByJavascript = 'unreachable'
 
 MaybeBold
@@ -520,13 +521,13 @@ Italic
   / [\x5F] [\x5F] @ItalicContent [\x5F] [\x5F]
   / [\x5F] @ItalicContent [\x5F]
 
-ItalicContent = & { skipItalicEmoji = false; return true; } text:ItalicContentItems { skipItalicEmoji = false; return italic(text); }
+ItalicContent = text:ItalicContentItems { return italic(text); }
 
 ItalicContentItems = text:ItalicContentItem+ { return reducePlainTexts(text); }
 
 ItalicContentItem = ItalicContentPreferentialItem / ItalicContentFallbackItem
 
-ItalicContentPreferentialItem = item:ItalicContentPreferentialItemPattern { skipItalicEmoji = false; return item; }
+ItalicContentPreferentialItem = item:ItalicContentPreferentialItemPattern { return item; }
 
 ItalicContentPreferentialItemPattern = Whitespace
   / InlineCode
@@ -538,32 +539,32 @@ ItalicContentPreferentialItemPattern = Whitespace
   / ItalicEmoji
   / ItalicEmoticon
 
-ItalicContentFallbackItem = item:ItalicContentFallbackItemPattern { skipItalicEmoji = true; return item; }
+ItalicContentFallbackItem = item:ItalicContentFallbackItemPattern { return item; }
 
 ItalicContentFallbackItemPattern = ItalicPlainRun / AnyItalic / Line
 
-ItalicEmoji = & { return !skipItalicEmoji; } emo:Emoji { return emo; }
+ItalicEmoji = emo:Emoji { return emo; }
 
-ItalicEmoticon = & { return !skipItalicEmoji; } emo:Emoticon & (EmoticonNeighbor / ItalicContentPreferentialItem / [\x5F]) { skipItalicEmoji = false; return emo; }
+ItalicEmoticon = emo:Emoticon & (EmoticonNeighbor / ItalicContentPreferentialItem / [\x5F]) { return emo; }
 
 /* Bold */
 Bold = [\x2A] [\x2A] @BoldContent [\x2A] [\x2A] / [\x2A] @BoldContent [\x2A]
 
-BoldContent = & { skipBoldEmoji = false; return true; } text:BoldContentItem+ { skipBoldEmoji = false; return bold(reducePlainTexts(text)); }
+BoldContent = text:BoldContentItem+ { return bold(reducePlainTexts(text)); }
 
-BoldContentPreferentialItem = item:BoldContentPreferentialItemPattern { skipBoldEmoji = false; return item; }
+BoldContentPreferentialItem = item:BoldContentPreferentialItemPattern { return item; }
 
 BoldContentPreferentialItemPattern = Whitespace / InlineCode / MaybeReferences / UserMention / ChannelMention / MaybeItalic / MaybeStrikethrough / BoldEmoji / BoldEmoticon
 
-BoldContentFallbackItem = item:BoldContentFallbackItemPattern { skipBoldEmoji = true; return item; }
+BoldContentFallbackItem = item:BoldContentFallbackItemPattern { return item; }
 
 BoldContentFallbackItemPattern = BoldPlainRun / AnyBold / Line
 
 BoldContentItem = BoldContentPreferentialItem / BoldContentFallbackItem
 
-BoldEmoji = & { return !skipBoldEmoji; } emo:Emoji { return emo; }
+BoldEmoji = emo:Emoji { return emo; }
 
-BoldEmoticon = & { return !skipBoldEmoji; } emo:Emoticon & (EmoticonNeighbor / BoldContentPreferentialItem) { skipBoldEmoji = false; return emo; }
+BoldEmoticon = emo:Emoticon & (EmoticonNeighbor / BoldContentPreferentialItem) { return emo; }
 
 /* Strike */
 Strikethrough = [\x7E] [\x7E] @StrikethroughContent [\x7E] [\x7E] / [\x7E] @StrikethroughContent [\x7E]
@@ -619,7 +620,7 @@ UserMention
   = t:Text "@"+ user:AlphaNumericChar {
       return reducePlainTexts([t, plain('@' + user)])[0];
     }
-  / "@"+ user:$(UTF8NamesValidation ([:@] UTF8NamesValidation)?) {
+  / "@"+ user:$(UTF8NamesValidation ([:@] UTF8NamesValidation)?) & { return !user.endsWith('__'); } {
       return mentionUser(user);
     }
 
@@ -771,9 +772,7 @@ UnicodeEmojiFlags = $([\uD83C] [\uDD00-\uDDFF] [\uD83C] [\uDD00-\uDDFF])
  * e.g: `console.log('hello world')`
  *
  */
-InlineCode = "`" text:$InlineCode__+ "`" { return inlineCode(plain(text)); }
-
-InlineCode__ = $(!"`" !"\n" .)
+InlineCode = "`" text:$([^`\n]+) "`" { return inlineCode(plain(text)); }
 
 /**
  *
@@ -800,7 +799,7 @@ Space = " " / "\t"
 
 Escaped = "\\" t:[*_~`#.] { return plain(t); }
 
-Any = !EndOfLine t:. p:$AutolinkedPhone? u:$URL? { return plain(t + p + u); }
+Any = !EndOfLine t:. { return plain(t); }
 
 AnyText = [\x20-\x27\x2B-\x40\x41-\x5A\x61-\x7A] / NonASCII
 

--- a/packages/message-parser/tests/compact.test.ts
+++ b/packages/message-parser/tests/compact.test.ts
@@ -1,0 +1,340 @@
+import { parse } from '../src';
+import type { Root } from '../src';
+import { compactify, expand, validateRoundtrip } from '../src/compact';
+import type { CRoot } from '../src/compact';
+
+const fullOptions = {
+	colors: true,
+	emoticons: true,
+	katex: { dollarSyntax: true, parenthesisSyntax: true },
+};
+
+// ── roundtrip helper ─────────────────────────────────────────────────────────
+
+function expectRoundtrip(msg: string, options?: Parameters<typeof parse>[1]) {
+	const oldMd = parse(msg, options);
+	const result = validateRoundtrip(oldMd, msg);
+
+	if (!result.ok) {
+		console.log('Old:', JSON.stringify(oldMd, null, 2));
+		console.log('Compact:', JSON.stringify(result.compact, null, 2));
+		console.log('Expanded:', JSON.stringify(result.expanded, null, 2));
+	}
+
+	expect(result.ok).toBe(true);
+	expect(result.sizeNew).toBeLessThan(result.sizeOld);
+}
+
+// ── expand helper (compact → verbose must produce same AST) ──────────────────
+
+function expectExpand(msg: string, compact: CRoot, expectedOld: Root) {
+	const expanded = expand(compact, msg);
+	expect(expanded).toEqual(expectedOld);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Test suites
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('expand (compact → verbose)', () => {
+	it('plain text', () => {
+		expectExpand('Hello world', [{ t: 'p', c: [[0, 11]] }], [{ type: 'PARAGRAPH', value: [{ type: 'PLAIN_TEXT', value: 'Hello world' }] }]);
+	});
+
+	it('user mention', () => {
+		expectExpand(
+			'@admin',
+			[{ t: 'p', c: [{ t: '@', r: [1, 6] }] }],
+			[{ type: 'PARAGRAPH', value: [{ type: 'MENTION_USER', value: { type: 'PLAIN_TEXT', value: 'admin' } }] }],
+		);
+	});
+
+	it('channel mention', () => {
+		expectExpand(
+			'#general',
+			[{ t: 'p', c: [{ t: '#', r: [1, 8] }] }],
+			[{ type: 'PARAGRAPH', value: [{ type: 'MENTION_CHANNEL', value: { type: 'PLAIN_TEXT', value: 'general' } }] }],
+		);
+	});
+
+	it('inline code', () => {
+		expectExpand(
+			'use `code` here',
+			[{ t: 'p', c: [[0, 4], { t: '`', r: [5, 9] }, [10, 15]] }],
+			[
+				{
+					type: 'PARAGRAPH',
+					value: [
+						{ type: 'PLAIN_TEXT', value: 'use ' },
+						{ type: 'INLINE_CODE', value: { type: 'PLAIN_TEXT', value: 'code' } },
+						{ type: 'PLAIN_TEXT', value: ' here' },
+					],
+				},
+			],
+		);
+	});
+
+	it('autolink (no s = href equals text)', () => {
+		expectExpand(
+			'https://rocket.chat',
+			[{ t: 'p', c: [{ t: 'a', r: [0, 19] }] }],
+			[
+				{
+					type: 'PARAGRAPH',
+					value: [
+						{
+							type: 'LINK',
+							value: {
+								src: { type: 'PLAIN_TEXT', value: 'https://rocket.chat' },
+								label: [{ type: 'PLAIN_TEXT', value: 'https://rocket.chat' }],
+							},
+						},
+					],
+				},
+			],
+		);
+	});
+
+	it('link with different href', () => {
+		expectExpand(
+			'[RC](https://rocket.chat)',
+			[{ t: 'p', c: [{ t: 'a', r: [1, 3], s: 'https://rocket.chat' }] }],
+			[
+				{
+					type: 'PARAGRAPH',
+					value: [
+						{
+							type: 'LINK',
+							value: {
+								src: { type: 'PLAIN_TEXT', value: 'https://rocket.chat' },
+								label: [{ type: 'PLAIN_TEXT', value: 'RC' }],
+							},
+						},
+					],
+				},
+			],
+		);
+	});
+
+	it('shortcode emoji', () => {
+		expectExpand(':smile:', [{ t: 'E', c: [{ t: ':', r: [1, 6] }] }], [
+			{ type: 'BIG_EMOJI', value: [{ type: 'EMOJI', value: { type: 'PLAIN_TEXT', value: 'smile' }, shortCode: 'smile' }] },
+		] as unknown as Root);
+	});
+
+	it('unicode emoji', () => {
+		expectExpand('😀', [{ t: 'E', c: [{ t: ':', r: [0, 2], u: true }] }], [
+			{ type: 'BIG_EMOJI', value: [{ type: 'EMOJI', value: undefined, unicode: '😀' }] },
+		] as unknown as Root);
+	});
+
+	it('heading', () => {
+		expectExpand('## Title', [{ t: 'h', l: 2, r: [3, 8] }], [
+			{ type: 'HEADING', level: 2, value: [{ type: 'PLAIN_TEXT', value: 'Title' }] },
+		] as unknown as Root);
+	});
+
+	it('code block', () => {
+		expectExpand('```js\nlet x = 1;\n```', [{ t: '```', l: 'js', r: [6, 16] }], [
+			{
+				type: 'CODE',
+				language: 'js',
+				value: [{ type: 'CODE_LINE', value: { type: 'PLAIN_TEXT', value: 'let x = 1;' } }],
+			},
+		] as unknown as Root);
+	});
+
+	it('line break', () => {
+		expectExpand('\n', [{ t: 'br' }], [{ type: 'LINE_BREAK', value: undefined }] as unknown as Root);
+	});
+});
+
+describe('compactify (verbose → compact)', () => {
+	it('plain text', () => {
+		const msg = 'Hello world';
+		const oldMd = parse(msg);
+		const compact = compactify(oldMd, msg);
+		expect(compact).toEqual([{ t: 'p', c: [[0, 11]] }]);
+	});
+
+	it('user mention', () => {
+		const msg = '@admin';
+		const compact = compactify(parse(msg), msg);
+		expect(compact).toEqual([{ t: 'p', c: [{ t: '@', r: [1, 6] }] }]);
+	});
+
+	it('bold text', () => {
+		const msg = '**hello**';
+		const compact = compactify(parse(msg), msg);
+		expect(compact).toEqual([{ t: 'p', c: [{ t: 'b', c: [[2, 7]] }] }]);
+	});
+
+	it('italic text', () => {
+		const msg = '_hello_';
+		const compact = compactify(parse(msg), msg);
+		expect(compact).toEqual([{ t: 'p', c: [{ t: 'i', c: [[1, 6]] }] }]);
+	});
+
+	it('strike text', () => {
+		const msg = '~~hello~~';
+		const compact = compactify(parse(msg), msg);
+		expect(compact).toEqual([{ t: 'p', c: [{ t: 's', c: [[2, 7]] }] }]);
+	});
+
+	it('inline code', () => {
+		const msg = 'use `code` here';
+		const compact = compactify(parse(msg), msg);
+		expect(compact).toEqual([{ t: 'p', c: [[0, 4], { t: '`', r: [5, 9] }, [10, 15]] }]);
+	});
+
+	it('shortcode emoji', () => {
+		const msg = ':smile:';
+		const compact = compactify(parse(msg), msg);
+		expect(compact).toEqual([{ t: 'E', c: [{ t: ':', r: [1, 6] }] }]);
+	});
+
+	it('unicode emoji', () => {
+		const msg = '😀';
+		const compact = compactify(parse(msg), msg);
+		expect(compact).toEqual([{ t: 'E', c: [{ t: ':', r: [0, 2], u: true }] }]);
+	});
+
+	it('heading', () => {
+		const msg = '## Title';
+		const compact = compactify(parse(msg), msg);
+		expect(compact).toEqual([{ t: 'h', l: 2, r: [3, 8] }]);
+	});
+});
+
+describe('roundtrip (verbose → compact → verbose)', () => {
+	describe('plain text', () => {
+		it.each(['Hello world', 'The quick brown fox jumps over the lazy dog.', 'free text, with comma'])('%s', (msg) => expectRoundtrip(msg));
+	});
+
+	describe('emphasis / formatting', () => {
+		it.each(['**Hello world**', '_Hello world_', '~~Hello world~~', '**bold _italic_ and ~~strike~~**'])('%s', (msg) =>
+			expectRoundtrip(msg),
+		);
+	});
+
+	describe('mentions', () => {
+		it.each(['@admin', '@admin @user1 @moderator', '#general', 'Hey @admin check #general and @user1'])('%s', (msg) =>
+			expectRoundtrip(msg),
+		);
+	});
+
+	describe('code', () => {
+		it.each(['Use `console.log()` for debugging', 'Use `Array.map()` and `Array.filter()` and `Array.reduce()`'])('%s', (msg) =>
+			expectRoundtrip(msg),
+		);
+
+		it('code block', () => {
+			expectRoundtrip('```javascript\nconst x = 1;\nconsole.log(x);\n```');
+		});
+	});
+
+	describe('emoji', () => {
+		it.each([':smile:', '😀', '😀🚀🌈', ':smile::heart::rocket:'])('%s', (msg) => expectRoundtrip(msg));
+	});
+
+	describe('links', () => {
+		it.each(['Check out https://rocket.chat for more info', '[Rocket.Chat](https://rocket.chat)'])('%s', (msg) => expectRoundtrip(msg));
+	});
+
+	describe('structured blocks', () => {
+		it('ordered list', () => expectRoundtrip('1. First item\n2. Second item\n3. Third item'));
+		it('unordered list', () => expectRoundtrip('- First item\n- Second item\n- Third item'));
+		it('task list', () => expectRoundtrip('- [x] Done task\n- [ ] Pending task\n- [x] Another done'));
+		it('heading', () => expectRoundtrip('# Hello World'));
+		it('heading multi-level', () => expectRoundtrip('# H1\n## H2\n### H3\n#### H4'));
+	});
+
+	describe('katex', () => {
+		it('inline', () => expectRoundtrip('The formula is $E = mc^2$ in physics', fullOptions));
+		it('block', () => expectRoundtrip('$$\\sum_{i=1}^{n} x_i$$', fullOptions));
+	});
+
+	describe('timestamp', () => {
+		it('unix format', () => expectRoundtrip('<t:1630360800:f>'));
+	});
+
+	describe('emoticons', () => {
+		it.each([':)', 'Hi :)', 'D:'])('%s', (msg) => expectRoundtrip(msg, { emoticons: true }));
+	});
+
+	describe('real-world messages', () => {
+		it('simple', () => expectRoundtrip('Hey team, the deploy is done ✅'));
+
+		it('medium', () =>
+			expectRoundtrip(
+				'@admin I pushed the fix to `develop` branch. Check https://github.com/RocketChat/Rocket.Chat/pull/12345 for details. :thumbsup:',
+			));
+	});
+});
+
+describe('roundtrip – benchmark fixtures', () => {
+	describe('plain text', () => {
+		it('long', () => expectRoundtrip('Lorem ipsum dolor sit amet, consectetur adipiscing elit. '.repeat(20).trim()));
+	});
+
+	describe('emphasis / formatting', () => {
+		it('nested', () => expectRoundtrip('**bold _italic_ and ~~strike~~**'));
+		it('deep nesting', () => expectRoundtrip('**bold _italic ~~strike _deep italic_~~_**'));
+		it('multiple', () => expectRoundtrip('**bold** normal _italic_ normal ~~strike~~ **more bold** _more italic_'));
+	});
+
+	describe('urls & links', () => {
+		it('multiple', () =>
+			expectRoundtrip('Visit https://rocket.chat or https://github.com/RocketChat/Rocket.Chat or https://open.rocket.chat'));
+		it('with path', () =>
+			expectRoundtrip('See https://github.com/RocketChat/Rocket.Chat/tree/develop/packages/message-parser for details'));
+	});
+
+	describe('emoji', () => {
+		it('in text', () => expectRoundtrip('Hello :smile: world :heart: test :rocket: done'));
+		it('mixed', () => expectRoundtrip('Great job :thumbsup: 🎉 keep going :rocket:'));
+	});
+
+	describe('code', () => {
+		it('multi inline', () => expectRoundtrip('Use `Array.map()` and `Array.filter()` and `Array.reduce()`'));
+	});
+
+	describe('structured blocks', () => {
+		it('blockquote', () => expectRoundtrip('> This is a quoted message\n> with multiple lines'));
+		it('spoiler', () => expectRoundtrip('||This is a spoiler||'));
+		it('spoiler with formatting', () => expectRoundtrip('||**bold** and _italic_ spoiler||'));
+	});
+
+	describe('real-world complex', () => {
+		it('complex', () =>
+			expectRoundtrip(
+				'**Release Notes v7.0**\n- [x] Fix #12345\n- [ ] Update docs\n\n> Important: check https://docs.rocket.chat\n\ncc @admin @devlead #releases :rocket:',
+				fullOptions,
+			));
+	});
+
+	describe('adversarial', () => {
+		it('long with formatting', () =>
+			expectRoundtrip('**bold** _italic_ ~~strike~~ `code` @user #channel :smile: https://example.com '.repeat(10).trim()));
+	});
+});
+
+describe('size reduction', () => {
+	it.each([
+		['plain short', 'Hello world'],
+		['plain medium', 'The quick brown fox jumps over the lazy dog. This is a typical message.'],
+		['with URL', 'Check https://github.com/RocketChat/Rocket.Chat/pull/12345 for details.'],
+		['with mention', '@admin I pushed the fix to `develop` branch.'],
+		[
+			'real-world medium',
+			'@admin I pushed the fix to `develop` branch. Check https://github.com/RocketChat/Rocket.Chat/pull/12345 for details. :thumbsup:',
+		],
+	])('%s: compact < verbose', (_label, msg) => {
+		const oldMd = parse(msg);
+		const result = validateRoundtrip(oldMd, msg);
+		expect(result.ok).toBe(true);
+		expect(result.sizeNew).toBeLessThan(result.sizeOld);
+
+		console.log(`  ${_label}: ${result.sizeOld}B → ${result.sizeNew}B (${result.reduction})`);
+	});
+});


### PR DESCRIPTION
This pull request refactors the `packages/message-parser/src/grammar.pegjs` file to simplify and optimize the parsing rules for inline formatting, links, and code blocks. The changes remove unnecessary state variables, streamline rule definitions, and improve performance by reducing per-character lookaheads and simplifying fallback logic. The parser is now more maintainable and efficient, with clearer separation between plain text and formatting elements.

**Inline formatting and emphasis simplification:**
* Removed `skipBoldEmoji`, `skipItalicEmoji`, and `skipInlineEmoji` state variables, and refactored emphasis (`Bold`, `Italic`, `Strikethrough`) and inline item rules to eliminate reliance on these flags, simplifying the parsing logic for emojis and emoticons within formatting. [[1]](diffhunk://#diff-cb631744e425986c173e3319d93be6b9fe93f7049fd9fb48c9925873a0a75a86L46-L48) [[2]](diffhunk://#diff-cb631744e425986c173e3319d93be6b9fe93f7049fd9fb48c9925873a0a75a86L523-R532) [[3]](diffhunk://#diff-cb631744e425986c173e3319d93be6b9fe93f7049fd9fb48c9925873a0a75a86L541-R589)
* Added specialized "PlainRun" rules for bold, italic, and strikethrough to improve handling of nested formatting and plain text, and updated fallback patterns to use these.

**Link and URL parsing improvements:**
* Refactored `URL`, `MarkdownLinkURL`, and `AutoLinkURL` rules to concatenate head and tail components, reducing per-character lookahead and improving performance. [[1]](diffhunk://#diff-cb631744e425986c173e3319d93be6b9fe93f7049fd9fb48c9925873a0a75a86L347-R353) [[2]](diffhunk://#diff-cb631744e425986c173e3319d93be6b9fe93f7049fd9fb48c9925873a0a75a86L329-R336) [[3]](diffhunk://#diff-cb631744e425986c173e3319d93be6b9fe93f7049fd9fb48c9925873a0a75a86L435-R441)
* Enhanced `LinkTitle` rule with complex negative lookahead to prevent accidental matching of link end patterns, making link parsing more robust.

**Code block and inline code parsing:**
* Improved `CodeChunk` and `InlineCode` rules to use character classes and direct matches, avoiding inefficient per-character lookahead and ensuring correct handling of backticks and newlines. [[1]](diffhunk://#diff-cb631744e425986c173e3319d93be6b9fe93f7049fd9fb48c9925873a0a75a86L135-R134) [[2]](diffhunk://#diff-cb631744e425986c173e3319d93be6b9fe93f7049fd9fb48c9925873a0a75a86L768-R777)

**General parser optimizations and cleanup:**
* Simplified fallback rules for inline items, spoilers, and list items by removing unnecessary state logic and resetting flags, making the grammar easier to maintain. [[1]](diffhunk://#diff-cb631744e425986c173e3319d93be6b9fe93f7049fd9fb48c9925873a0a75a86L199-R198) [[2]](diffhunk://#diff-cb631744e425986c173e3319d93be6b9fe93f7049fd9fb48c9925873a0a75a86L254-R306)
* Updated domain and heading parsing rules to clarify intent and reduce unnecessary complexity. [[1]](diffhunk://#diff-cb631744e425986c173e3319d93be6b9fe93f7049fd9fb48c9925873a0a75a86R386) [[2]](diffhunk://#diff-cb631744e425986c173e3319d93be6b9fe93f7049fd9fb48c9925873a0a75a86L151-R150)

**User mention parsing enhancement:**
* Modified `UserMention` rule to exclude usernames ending with double underscores, preventing invalid mentions.<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->



# before
```
message-parser git:(develop) yarn bench
========================================================================
  @rocket.chat/message-parser — Performance Benchmark Suite
========================================================================

── Plain Text ──────────────────────────────────────────────
┌─────────┬──────────┬──────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────┐
│ (index) │ Task     │ ops/sec  │ Avg (ms)    │ Min (ms)    │ Max (ms)    │ P99 (ms)    │ Samples │
├─────────┼──────────┼──────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────┤
│ 0       │ 'short'  │ '15.111' │ '68.4304'   │ '62.3750'   │ '568.7080'  │ '176.5622'  │ 14614   │
│ 1       │ 'medium' │ '3.804'  │ '265.9862'  │ '245.9170'  │ '612.2500'  │ '500.4495'  │ 3760    │
│ 2       │ 'long'   │ '348'    │ '2901.2264' │ '2709.5000' │ '8395.7920' │ '3601.0385' │ 345     │
└─────────┴──────────┴──────────┴─────────────┴─────────────┴─────────────┴─────────────┴─────────┘

── Emphasis / Formatting ───────────────────────────────────
┌─────────┬────────────────┬──────────┬────────────┬────────────┬─────────────┬────────────┬─────────┐
│ (index) │ Task           │ ops/sec  │ Avg (ms)   │ Min (ms)   │ Max (ms)    │ P99 (ms)   │ Samples │
├─────────┼────────────────┼──────────┼────────────┼────────────┼─────────────┼────────────┼─────────┤
│ 0       │ 'bold'         │ '18.585' │ '57.6378'  │ '45.9160'  │ '1728.3340' │ '178.1672' │ 17350   │
│ 1       │ 'italic'       │ '18.931' │ '54.7093'  │ '50.0000'  │ '461.1670'  │ '105.3050' │ 18279   │
│ 2       │ 'strike'       │ '19.477' │ '52.6037'  │ '48.6670'  │ '588.7920'  │ '93.9045'  │ 19011   │
│ 3       │ 'nested'       │ '16.526' │ '61.9808'  │ '57.7080'  │ '532.1250'  │ '113.6866' │ 16135   │
│ 4       │ 'deep nesting' │ '12.889' │ '83.1256'  │ '72.6670'  │ '5613.4590' │ '256.6172' │ 12030   │
│ 5       │ 'multiple'     │ '8.870'  │ '114.3897' │ '107.1660' │ '425.1660'  │ '252.9589' │ 8743    │
└─────────┴────────────────┴──────────┴────────────┴────────────┴─────────────┴────────────┴─────────┘

── URLs & Links ────────────────────────────────────────────
┌─────────┬─────────────────────┬──────────┬───────────┬───────────┬────────────┬────────────┬─────────┐
│ (index) │ Task                │ ops/sec  │ Avg (ms)  │ Min (ms)  │ Max (ms)   │ P99 (ms)   │ Samples │
├─────────┼─────────────────────┼──────────┼───────────┼───────────┼────────────┼────────────┼─────────┤
│ 0       │ 'single'            │ '10.979' │ '92.5930' │ '86.9580' │ '451.5420' │ '220.7155' │ 10800   │
│ 1       │ 'multiple'          │ '12.911' │ '78.3832' │ '74.2910' │ '371.3330' │ '167.7325' │ 12758   │
│ 2       │ 'markdown link'     │ '20.657' │ '49.3569' │ '46.2500' │ '311.9170' │ '66.9246'  │ 20261   │
│ 3       │ 'autolinked domain' │ '11.223' │ '89.9522' │ '86.0000' │ '285.8330' │ '183.3756' │ 11119   │
│ 4       │ 'with path'         │ '11.984' │ '84.8961' │ '79.8340' │ '357.5000' │ '233.0368' │ 11780   │
└─────────┴─────────────────────┴──────────┴───────────┴───────────┴────────────┴────────────┴─────────┘

── Emoji ───────────────────────────────────────────────────
┌─────────┬───────────────────────────────┬──────────┬───────────┬───────────┬────────────┬────────────┬─────────┐
│ (index) │ Task                          │ ops/sec  │ Avg (ms)  │ Min (ms)  │ Max (ms)   │ P99 (ms)   │ Samples │
├─────────┼───────────────────────────────┼──────────┼───────────┼───────────┼────────────┼────────────┼─────────┤
│ 0       │ 'single shortcode'            │ '28.983' │ '35.5232' │ '32.7920' │ '681.5000' │ '55.4790'  │ 28151   │
│ 1       │ 'triple shortcode (BigEmoji)' │ '29.240' │ '35.0089' │ '32.2920' │ '324.3750' │ '48.6398'  │ 28565   │
│ 2       │ 'single unicode'              │ '29.082' │ '35.2530' │ '32.5830' │ '291.6250' │ '47.9849'  │ 28369   │
│ 3       │ 'triple unicode (BigEmoji)'   │ '28.667' │ '35.6136' │ '33.0840' │ '258.2500' │ '47.3603'  │ 28080   │
│ 4       │ 'in text'                     │ '11.346' │ '89.0623' │ '85.0000' │ '307.9590' │ '184.5805' │ 11229   │
│ 5       │ 'mixed'                       │ '11.443' │ '88.4342' │ '84.0000' │ '344.0410' │ '188.8266' │ 11308   │
└─────────┴───────────────────────────────┴──────────┴───────────┴───────────┴────────────┴────────────┴─────────┘

── Mentions ────────────────────────────────────────────────
┌─────────┬──────────────────┬──────────┬───────────┬───────────┬─────────────┬───────────┬─────────┐
│ (index) │ Task             │ ops/sec  │ Avg (ms)  │ Min (ms)  │ Max (ms)    │ P99 (ms)  │ Samples │
├─────────┼──────────────────┼──────────┼───────────┼───────────┼─────────────┼───────────┼─────────┤
│ 0       │ 'single user'    │ '24.472' │ '41.5981' │ '38.9590' │ '307.0830'  │ '55.8840' │ 24040   │
│ 1       │ 'multiple users' │ '22.803' │ '44.8320' │ '41.8330' │ '518.0420'  │ '65.4580' │ 22306   │
│ 2       │ 'channel'        │ '24.329' │ '42.6889' │ '39.0420' │ '5187.2500' │ '60.9477' │ 23426   │
│ 3       │ 'mixed'          │ '14.142' │ '71.8212' │ '67.5830' │ '534.3750'  │ '98.6864' │ 13924   │
└─────────┴──────────────────┴──────────┴───────────┴───────────┴─────────────┴───────────┴─────────┘

── Code ────────────────────────────────────────────────────
┌─────────┬────────────────┬──────────┬───────────┬───────────┬────────────┬────────────┬─────────┐
│ (index) │ Task           │ ops/sec  │ Avg (ms)  │ Min (ms)  │ Max (ms)   │ P99 (ms)   │ Samples │
├─────────┼────────────────┼──────────┼───────────┼───────────┼────────────┼────────────┼─────────┤
│ 0       │ 'inline'       │ '11.758' │ '86.0120' │ '81.6660' │ '392.6670' │ '185.3100' │ 11627   │
│ 1       │ 'block'        │ '25.397' │ '40.1935' │ '37.4170' │ '274.0830' │ '54.8836'  │ 24880   │
│ 2       │ 'multi inline' │ '15.207' │ '66.7020' │ '63.2500' │ '378.3330' │ '162.3373' │ 14993   │
└─────────┴────────────────┴──────────┴───────────┴───────────┴────────────┴────────────┴─────────┘

── Structured Blocks ───────────────────────────────────────
┌─────────┬───────────────────────────┬──────────┬────────────┬────────────┬─────────────┬────────────┬─────────┐
│ (index) │ Task                      │ ops/sec  │ Avg (ms)   │ Min (ms)   │ Max (ms)    │ P99 (ms)   │ Samples │
├─────────┼───────────────────────────┼──────────┼────────────┼────────────┼─────────────┼────────────┼─────────┤
│ 0       │ 'ordered list'            │ '8.777'  │ '115.2011' │ '109.5410' │ '402.7080'  │ '225.4168' │ 8681    │
│ 1       │ 'unordered list'          │ '8.774'  │ '115.1760' │ '108.5000' │ '336.6250'  │ '228.9276' │ 8683    │
│ 2       │ 'task list'               │ '8.224'  │ '122.8483' │ '116.1250' │ '420.7090'  │ '235.5084' │ 8141    │
│ 3       │ 'blockquote'              │ '7.094'  │ '142.7896' │ '132.9590' │ '428.7920'  │ '314.9443' │ 7004    │
│ 4       │ 'heading'                 │ '26.246' │ '39.1366'  │ '36.2080'  │ '1160.9170' │ '55.4563'  │ 25552   │
│ 5       │ 'heading multi-level'     │ '25.056' │ '40.9797'  │ '38.0000'  │ '1739.0830' │ '67.9967'  │ 24403   │
│ 6       │ 'spoiler'                 │ '12.339' │ '82.5214'  │ '77.1670'  │ '475.4590'  │ '218.6225' │ 12119   │
│ 7       │ 'spoiler with formatting' │ '11.796' │ '86.3155'  │ '80.7500'  │ '375.9170'  │ '234.6875' │ 11586   │
└─────────┴───────────────────────────┴──────────┴────────────┴────────────┴─────────────┴────────────┴─────────┘

── KaTeX (Math) ────────────────────────────────────────────
┌─────────┬──────────┬──────────┬────────────┬────────────┬─────────────┬────────────┬─────────┐
│ (index) │ Task     │ ops/sec  │ Avg (ms)   │ Min (ms)   │ Max (ms)    │ P99 (ms)   │ Samples │
├─────────┼──────────┼──────────┼────────────┼────────────┼─────────────┼────────────┼─────────┤
│ 0       │ 'inline' │ '8.913'  │ '113.5582' │ '105.5000' │ '1274.1670' │ '220.1219' │ 8807    │
│ 1       │ 'block'  │ '22.913' │ '44.7187'  │ '41.4170'  │ '356.2080'  │ '61.8395'  │ 22363   │
└─────────┴──────────┴──────────┴────────────┴────────────┴─────────────┴────────────┴─────────┘

── Adversarial / Stress ────────────────────────────────────
┌─────────┬────────────────────────┬─────────┬────────────┬────────────┬─────────────┬────────────┬─────────┐
│ (index) │ Task                   │ ops/sec │ Avg (ms)   │ Min (ms)   │ Max (ms)    │ P99 (ms)   │ Samples │
├─────────┼────────────────────────┼─────────┼────────────┼────────────┼─────────────┼────────────┼─────────┤
│ 0       │ 'adversarial emphasis' │ '6.379' │ '157.9280' │ '151.5000' │ '400.7920'  │ '279.7595' │ 12664   │
│ 1       │ 'adversarial mixed'    │ '1.539' │ '653.4250' │ '625.6670' │ '1171.2500' │ '904.8582' │ 3061    │
│ 2       │ 'repeated specials'    │ '1.543' │ '650.5730' │ '627.5830' │ '1017.4170' │ '910.2189' │ 3075    │
│ 3       │ 'long with formatting' │ '2.806' │ '358.5738' │ '344.6250' │ '732.8340'  │ '547.4978' │ 5578    │
└─────────┴────────────────────────┴─────────┴────────────┴────────────┴─────────────┴────────────┴─────────┘

── Real-World Messages ─────────────────────────────────────
┌─────────┬───────────┬──────────┬────────────┬────────────┬────────────┬────────────┬─────────┐
│ (index) │ Task      │ ops/sec  │ Avg (ms)   │ Min (ms)   │ Max (ms)   │ P99 (ms)   │ Samples │
├─────────┼───────────┼──────────┼────────────┼────────────┼────────────┼────────────┼─────────┤
│ 0       │ 'simple'  │ '10.240' │ '99.1179'  │ '93.9170'  │ '362.0830' │ '224.9019' │ 10090   │
│ 1       │ 'medium'  │ '6.714'  │ '151.2868' │ '143.3750' │ '477.0420' │ '355.5912' │ 6610    │
│ 2       │ 'complex' │ '5.345'  │ '190.7712' │ '175.3340' │ '685.8330' │ '416.4897' │ 5242    │
└─────────┴───────────┴──────────┴────────────┴────────────┴────────────┴────────────┴─────────┘

── Timestamps ──────────────────────────────────────────────
┌─────────┬───────────────┬──────────┬───────────┬───────────┬────────────┬───────────┬─────────┐
│ (index) │ Task          │ ops/sec  │ Avg (ms)  │ Min (ms)  │ Max (ms)   │ P99 (ms)  │ Samples │
├─────────┼───────────────┼──────────┼───────────┼───────────┼────────────┼───────────┼─────────┤
│ 0       │ 'unix format' │ '24.237' │ '42.7208' │ '39.0000' │ '596.7500' │ '82.0323' │ 23408   │
└─────────┴───────────────┴──────────┴───────────┴───────────┴────────────┴───────────┴─────────┘

========================================================================
  Done.
========================================================================
```
# after
```
➜  message-parser git:(chore/grammar) yarn bench
========================================================================
  @rocket.chat/message-parser — Performance Benchmark Suite
========================================================================

── Plain Text ──────────────────────────────────────────────
┌─────────┬──────────┬──────────┬────────────┬────────────┬────────────┬────────────┬─────────┐
│ (index) │ Task     │ ops/sec  │ Avg (ms)   │ Min (ms)   │ Max (ms)   │ P99 (ms)   │ Samples │
├─────────┼──────────┼──────────┼────────────┼────────────┼────────────┼────────────┼─────────┤
│ 0       │ 'short'  │ '31.328' │ '32.5552'  │ '27.7080'  │ '189.7910' │ '43.9929'  │ 30718   │
│ 1       │ 'medium' │ '14.798' │ '68.6805'  │ '57.4580'  │ '341.2090' │ '141.2334' │ 14561   │
│ 2       │ 'long'   │ '2.671'  │ '377.5606' │ '327.5840' │ '799.7910' │ '588.4722' │ 2649    │
└─────────┴──────────┴──────────┴────────────┴────────────┴────────────┴────────────┴─────────┘

── Emphasis / Formatting ───────────────────────────────────
┌─────────┬────────────────┬──────────┬───────────┬───────────┬────────────┬────────────┬─────────┐
│ (index) │ Task           │ ops/sec  │ Avg (ms)  │ Min (ms)  │ Max (ms)   │ P99 (ms)   │ Samples │
├─────────┼────────────────┼──────────┼───────────┼───────────┼────────────┼────────────┼─────────┤
│ 0       │ 'bold'         │ '32.169' │ '31.6814' │ '27.0410' │ '207.8750' │ '46.2914'  │ 31565   │
│ 1       │ 'italic'       │ '30.592' │ '33.2980' │ '28.5420' │ '283.5420' │ '47.4873'  │ 30032   │
│ 2       │ 'strike'       │ '31.625' │ '32.2927' │ '27.2910' │ '246.9170' │ '48.3207'  │ 30967   │
│ 3       │ 'nested'       │ '27.691' │ '36.7411' │ '31.4170' │ '250.6660' │ '56.8269'  │ 27218   │
│ 4       │ 'deep nesting' │ '24.281' │ '42.4788' │ '35.2910' │ '930.7500' │ '106.2500' │ 23542   │
│ 5       │ 'multiple'     │ '20.359' │ '49.7510' │ '42.9160' │ '211.7080' │ '85.1670'  │ 20101   │
└─────────┴────────────────┴──────────┴───────────┴───────────┴────────────┴────────────┴─────────┘

── URLs & Links ────────────────────────────────────────────
┌─────────┬─────────────────────┬──────────┬───────────┬───────────┬────────────┬────────────┬─────────┐
│ (index) │ Task                │ ops/sec  │ Avg (ms)  │ Min (ms)  │ Max (ms)   │ P99 (ms)   │ Samples │
├─────────┼─────────────────────┼──────────┼───────────┼───────────┼────────────┼────────────┼─────────┤
│ 0       │ 'single'            │ '24.926' │ '41.2133' │ '35.5410' │ '268.3330' │ '62.0267'  │ 24264   │
│ 1       │ 'multiple'          │ '21.999' │ '46.0478' │ '39.3330' │ '259.0830' │ '106.3750' │ 21717   │
│ 2       │ 'markdown link'     │ '29.555' │ '34.5999' │ '29.8330' │ '410.6250' │ '47.8322'  │ 28902   │
│ 3       │ 'autolinked domain' │ '23.351' │ '43.3978' │ '37.1660' │ '218.8340' │ '61.2426'  │ 23043   │
│ 4       │ 'with path'         │ '24.283' │ '41.7284' │ '35.9580' │ '231.2920' │ '59.9031'  │ 23965   │
└─────────┴─────────────────────┴──────────┴───────────┴───────────┴────────────┴────────────┴─────────┘

── Emoji ───────────────────────────────────────────────────
┌─────────┬───────────────────────────────┬──────────┬───────────┬───────────┬────────────┬────────────┬─────────┐
│ (index) │ Task                          │ ops/sec  │ Avg (ms)  │ Min (ms)  │ Max (ms)   │ P99 (ms)   │ Samples │
├─────────┼───────────────────────────────┼──────────┼───────────┼───────────┼────────────┼────────────┼─────────┤
│ 0       │ 'single shortcode'            │ '39.535' │ '25.8905' │ '22.0830' │ '248.2090' │ '33.1468'  │ 38625   │
│ 1       │ 'triple shortcode (BigEmoji)' │ '41.803' │ '24.4768' │ '20.9580' │ '196.6250' │ '30.7914'  │ 40856   │
│ 2       │ 'single unicode'              │ '39.383' │ '25.9376' │ '22.1660' │ '209.8330' │ '32.6029'  │ 38555   │
│ 3       │ 'triple unicode (BigEmoji)'   │ '39.296' │ '26.2804' │ '21.3340' │ '635.0000' │ '34.5415'  │ 38052   │
│ 4       │ 'in text'                     │ '22.390' │ '45.6065' │ '39.5420' │ '248.7090' │ '112.5311' │ 21927   │
│ 5       │ 'mixed'                       │ '21.707' │ '46.8180' │ '40.1670' │ '326.3750' │ '110.5006' │ 21360   │
└─────────┴───────────────────────────────┴──────────┴───────────┴───────────┴────────────┴────────────┴─────────┘

── Mentions ────────────────────────────────────────────────
┌─────────┬──────────────────┬──────────┬───────────┬───────────┬─────────────┬───────────┬─────────┐
│ (index) │ Task             │ ops/sec  │ Avg (ms)  │ Min (ms)  │ Max (ms)    │ P99 (ms)  │ Samples │
├─────────┼──────────────────┼──────────┼───────────┼───────────┼─────────────┼───────────┼─────────┤
│ 0       │ 'single user'    │ '35.712' │ '28.9189' │ '24.7500' │ '1785.3750' │ '42.7256' │ 34580   │
│ 1       │ 'multiple users' │ '33.485' │ '30.4172' │ '25.8330' │ '242.5000'  │ '38.4568' │ 32877   │
│ 2       │ 'channel'        │ '35.992' │ '28.4930' │ '24.6670' │ '326.8750'  │ '36.9177' │ 35097   │
│ 3       │ 'mixed'          │ '28.076' │ '36.2055' │ '30.9160' │ '247.0830'  │ '50.5668' │ 27621   │
└─────────┴──────────────────┴──────────┴───────────┴───────────┴─────────────┴───────────┴─────────┘

── Code ────────────────────────────────────────────────────
┌─────────┬────────────────┬──────────┬───────────┬───────────┬────────────┬───────────┬─────────┐
│ (index) │ Task           │ ops/sec  │ Avg (ms)  │ Min (ms)  │ Max (ms)   │ P99 (ms)  │ Samples │
├─────────┼────────────────┼──────────┼───────────┼───────────┼────────────┼───────────┼─────────┤
│ 0       │ 'inline'       │ '28.307' │ '36.4314' │ '30.0410' │ '352.7910' │ '74.7315' │ 27449   │
│ 1       │ 'block'        │ '36.003' │ '28.5580' │ '23.9170' │ '270.4580' │ '42.9933' │ 35017   │
│ 2       │ 'multi inline' │ '29.104' │ '35.2041' │ '29.7910' │ '303.5410' │ '64.8289' │ 28406   │
└─────────┴────────────────┴──────────┴───────────┴───────────┴────────────┴───────────┴─────────┘

── Structured Blocks ───────────────────────────────────────
┌─────────┬───────────────────────────┬──────────┬───────────┬───────────┬─────────────┬────────────┬─────────┐
│ (index) │ Task                      │ ops/sec  │ Avg (ms)  │ Min (ms)  │ Max (ms)    │ P99 (ms)   │ Samples │
├─────────┼───────────────────────────┼──────────┼───────────┼───────────┼─────────────┼────────────┼─────────┤
│ 0       │ 'ordered list'            │ '22.497' │ '45.7348' │ '37.9160' │ '307.8330'  │ '122.1193' │ 21866   │
│ 1       │ 'unordered list'          │ '23.240' │ '44.2787' │ '37.5830' │ '359.1250'  │ '90.6716'  │ 22585   │
│ 2       │ 'task list'               │ '22.752' │ '44.9961' │ '37.8750' │ '296.3750'  │ '106.8570' │ 22225   │
│ 3       │ 'blockquote'              │ '21.405' │ '48.9327' │ '40.0410' │ '1177.7920' │ '154.5201' │ 20437   │
│ 4       │ 'heading'                 │ '35.555' │ '30.3965' │ '23.4170' │ '1407.0000' │ '96.4672'  │ 32899   │
│ 5       │ 'heading multi-level'     │ '34.379' │ '30.7523' │ '24.4170' │ '1013.2500' │ '89.6990'  │ 32518   │
│ 6       │ 'spoiler'                 │ '26.286' │ '39.7276' │ '32.0830' │ '441.1250'  │ '118.0998' │ 25181   │
│ 7       │ 'spoiler with formatting' │ '23.752' │ '45.0810' │ '35.1250' │ '482.3330'  │ '148.4937' │ 22183   │
└─────────┴───────────────────────────┴──────────┴───────────┴───────────┴─────────────┴────────────┴─────────┘

── KaTeX (Math) ────────────────────────────────────────────
┌─────────┬──────────┬──────────┬───────────┬───────────┬─────────────┬────────────┬─────────┐
│ (index) │ Task     │ ops/sec  │ Avg (ms)  │ Min (ms)  │ Max (ms)    │ P99 (ms)   │ Samples │
├─────────┼──────────┼──────────┼───────────┼───────────┼─────────────┼────────────┼─────────┤
│ 0       │ 'inline' │ '18.953' │ '57.2044' │ '43.7080' │ '4187.1250' │ '244.7578' │ 17482   │
│ 1       │ 'block'  │ '30.855' │ '35.1737' │ '26.8330' │ '2978.5000' │ '158.5626' │ 28431   │
└─────────┴──────────┴──────────┴───────────┴───────────┴─────────────┴────────────┴─────────┘

── Adversarial / Stress ────────────────────────────────────
┌─────────┬────────────────────────┬─────────┬────────────┬────────────┬─────────────┬────────────┬─────────┐
│ (index) │ Task                   │ ops/sec │ Avg (ms)   │ Min (ms)   │ Max (ms)    │ P99 (ms)   │ Samples │
├─────────┼────────────────────────┼─────────┼────────────┼────────────┼─────────────┼────────────┼─────────┤
│ 0       │ 'adversarial emphasis' │ '7.785' │ '132.4414' │ '108.3750' │ '904.4170'  │ '367.8625' │ 15102   │
│ 1       │ 'adversarial mixed'    │ '5.328' │ '193.2182' │ '157.9580' │ '3082.6250' │ '475.0625' │ 10351   │
│ 2       │ 'repeated specials'    │ '4.613' │ '220.2706' │ '183.7090' │ '631.5420'  │ '442.0701' │ 9080    │
│ 3       │ 'long with formatting' │ '5.550' │ '183.9862' │ '152.0420' │ '576.6670'  │ '404.4875' │ 10871   │
└─────────┴────────────────────────┴─────────┴────────────┴────────────┴─────────────┴────────────┴─────────┘

── Real-World Messages ─────────────────────────────────────
┌─────────┬───────────┬──────────┬───────────┬───────────┬────────────┬────────────┬─────────┐
│ (index) │ Task      │ ops/sec  │ Avg (ms)  │ Min (ms)  │ Max (ms)   │ P99 (ms)   │ Samples │
├─────────┼───────────┼──────────┼───────────┼───────────┼────────────┼────────────┼─────────┤
│ 0       │ 'simple'  │ '23.891' │ '43.6171' │ '35.0830' │ '385.1670' │ '107.5617' │ 22927   │
│ 1       │ 'medium'  │ '18.046' │ '57.4665' │ '46.8750' │ '648.1250' │ '169.7442' │ 17402   │
│ 2       │ 'complex' │ '11.471' │ '90.2881' │ '72.8750' │ '542.2080' │ '259.7923' │ 11076   │
└─────────┴───────────┴──────────┴───────────┴───────────┴────────────┴────────────┴─────────┘

── Timestamps ──────────────────────────────────────────────
┌─────────┬───────────────┬──────────┬───────────┬───────────┬────────────┬───────────┬─────────┐
│ (index) │ Task          │ ops/sec  │ Avg (ms)  │ Min (ms)  │ Max (ms)   │ P99 (ms)  │ Samples │
├─────────┼───────────────┼──────────┼───────────┼───────────┼────────────┼───────────┼─────────┤
│ 0       │ 'unix format' │ '31.239' │ '33.4720' │ '26.7920' │ '385.3340' │ '67.0935' │ 29876   │
└─────────┴───────────────┴──────────┴───────────┴───────────┴────────────┴───────────┴─────────┘

========================================================================
  Done.
========================================================================
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced optimized message format with bidirectional conversion capabilities for efficient storage and display.
  * Added validation and testing tools to measure compression efficiency and verify round-trip format integrity.
  * Enhanced message parsing with streamlined grammar rules and improved handling of inline formatting elements.

* **Tests**
  * Added comprehensive test suite covering format conversion, expansion, and round-trip validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->