### PR TITLE
fix: check if release branch exists before creating it

### DIFF
--- a/packages/release-action/src/gitUtils.ts
+++ b/packages/release-action/src/gitUtils.ts
@@ -50,3 +50,13 @@ export async function pushNewBranch(newBranch: string, force = false) {
 
 	await exec('git', params);
 }
+
+export async function doesBranchExist(branchName: string) {
+	const { exitCode } = await getExecOutput(
+		'git',
+		['ls-remote', '--exit-code', '--heads', 'origin', branchName],
+		{ ignoreReturnCode: true }, // prevents throwing on non-zero exit code
+	);
+
+	return exitCode === 0;
+}

--- a/packages/release-action/src/startPatchRelease.ts
+++ b/packages/release-action/src/startPatchRelease.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 import semver from 'semver';
 
-import { checkoutBranch, commitChanges, createBranch, pushNewBranch } from './gitUtils';
+import { checkoutBranch, commitChanges, createBranch, doesBranchExist, pushNewBranch } from './gitUtils';
 import { setupOctokit } from './setupOctokit';
 import { createBumpFile, readPackageJson } from './utils';
 
@@ -31,7 +31,11 @@ export async function startPatchRelease({
 
 	const newBranch = `release-${newVersion}`;
 
-	// TODO check if branch exists
+	const branchExists = await doesBranchExist(newBranch);
+	if (branchExists) {
+		throw new Error(`Branch ${newBranch} already exists. A release for version ${newVersion} may already be in progress.`);
+	}
+
 	await createBranch(newBranch);
 
 	// by creating a changeset we make sure we'll always bump the version


### PR DESCRIPTION
## Proposed changes

Add branch existence check before creating release branch in startPatchRelease.ts. The doesBranchExist function has been added to gitUtils.ts to check if a release branch already exists on the remote before attempting to create it. This resolves the existing // TODO check if branch exists comment. No runtime behavior changes on the happy path.

The following function has been added:

- `doesBranchExist` in gitUtils.ts

The following call sites have been updated:

- `packages/release-action/src/startPatchRelease.ts`
- `packages/release-action/src/gitUtils.ts`

**Before**
```
tsconst newBranch = release-${newVersion};

// TODO check if branch exists
await createBranch(newBranch);
```


**After**
```
tsconst newBranch = `release-${newVersion}`;

`const branchExists = await doesBranchExist(newBranch);
if (branchExists) {
    throw new Error(`Branch ${newBranch} already exists. A release for version ${newVersion} may already be in progress.`);
}

await createBranch(newBranch);
```

```
export async function doesBranchExist(branchName: string) {
	const { exitCode } = await getExecOutput(
		'git',
		['ls-remote', '--exit-code', '--heads', 'origin', branchName],
		{ ignoreReturnCode: true }, // prevents throwing on non-zero exit code
	);

	return exitCode === 0;
}
```

## Issue(s)
Closes #38961

## Steps to reproduce

See `packages/ci/src/startPatchRelease.ts`

## Testing

No runtime changes on the happy path — only adds an early exit when branch already exists
Resolves the existing // TODO check if branch exists comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent release branch creation errors when a branch already exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->