### PR TITLE
fix(customSounds): type sound file parameters instead of using any

### DIFF
--- a/apps/meteor/client/views/admin/customSounds/AddCustomSound.tsx
+++ b/apps/meteor/client/views/admin/customSounds/AddCustomSound.tsx
@@ -31,8 +31,7 @@ const AddCustomSound = ({ goToNew, close, onChange, ...props }: AddCustomSoundPr
 	const [clickUpload] = useSingleFileInput(handleChangeFile, 'audio/mp3');
 
 	const saveAction = useCallback(
-		// FIXME
-		async (name: string, soundFile: any) => {
+		async (name: string, soundFile: File) => {
 			const soundData = createSoundData(soundFile, name);
 			const validation = validate(soundData, soundFile) as Array<Parameters<typeof t>[0]>;
 

--- a/apps/meteor/client/views/admin/customSounds/AddCustomSound.tsx
+++ b/apps/meteor/client/views/admin/customSounds/AddCustomSound.tsx
@@ -19,7 +19,7 @@ const AddCustomSound = ({ goToNew, close, onChange, ...props }: AddCustomSoundPr
 	const dispatchToastMessage = useToastMessageDispatch();
 
 	const [name, setName] = useState('');
-	const [sound, setSound] = useState<{ name: string }>();
+	const [sound, setSound] = useState<File>();
 
 	const uploadCustomSound = useMethod('uploadCustomSound');
 	const insertOrUpdateSound = useMethod('insertOrUpdateSound');
@@ -73,6 +73,10 @@ const AddCustomSound = ({ goToNew, close, onChange, ...props }: AddCustomSoundPr
 
 	const handleSave = useCallback(async () => {
 		try {
+			if (!sound) {
+				dispatchToastMessage({ type: 'error', message: t('Required_field', { field: t('Sound File') }) });
+				return;
+			}
 			const result = await saveAction(name, sound);
 			if (result) {
 				dispatchToastMessage({ type: 'success', message: t('Custom_Sound_Saved_Successfully') });

--- a/apps/meteor/client/views/admin/customSounds/EditSound.tsx
+++ b/apps/meteor/client/views/admin/customSounds/EditSound.tsx
@@ -33,7 +33,7 @@ function EditSound({ close, onChange, data, ...props }: EditSoundProps): ReactEl
 
 	useEffect(() => {
 		setName(previousName || '');
-		setSound(previousSound || '');
+		setSound(previousSound);
 	}, [previousName, previousSound, _id]);
 
 	const deleteCustomSound = useMethod('deleteCustomSound');
@@ -47,10 +47,10 @@ function EditSound({ close, onChange, data, ...props }: EditSoundProps): ReactEl
 	const hasUnsavedChanges = useMemo(() => previousName !== name || previousSound !== sound, [name, previousName, previousSound, sound]);
 
 	const saveAction = useCallback(
-		async (sound: SoundData | File) => {
-			const isFile = sound instanceof File;
-			const extension = isFile ? undefined : sound.extension;
-			const soundFile = isFile ? sound : undefined;
+		async (currentSound: SoundData | File) => {
+			const isFile = currentSound instanceof File;
+			const extension = isFile ? undefined : currentSound.extension;
+			const soundFile = isFile ? currentSound : undefined;
 			const soundData = createSoundData(soundFile, name, { previousName, previousSound, _id, extension });
 			const validation = validate(soundData, soundFile);
 			if (validation.length === 0) {
@@ -65,7 +65,7 @@ function EditSound({ close, onChange, data, ...props }: EditSoundProps): ReactEl
 				soundData._id = soundId;
 				soundData.random = Math.round(Math.random() * 1000);
 
-				if (soundFile && sound !== previousSound) {
+				if (soundFile) {
 					dispatchToastMessage({ type: 'success', message: t('Uploading_file') });
 
 					const reader = new FileReader();

--- a/apps/meteor/client/views/admin/customSounds/EditSound.tsx
+++ b/apps/meteor/client/views/admin/customSounds/EditSound.tsx
@@ -48,9 +48,11 @@ function EditSound({ close, onChange, data, ...props }: EditSoundProps): ReactEl
 
 	const saveAction = useCallback(
 		async (sound: SoundData | File) => {
-			const extension = sound instanceof File ? undefined : sound.extension;
-			const soundData = createSoundData(sound, name, { previousName, previousSound, _id, extension });
-			const validation = validate(soundData, sound);
+			const isFile = sound instanceof File;
+			const extension = isFile ? undefined : sound.extension;
+			const soundFile = isFile ? sound : undefined;
+			const soundData = createSoundData(soundFile, name, { previousName, previousSound, _id, extension });
+			const validation = validate(soundData, soundFile);
 			if (validation.length === 0) {
 				let soundId: string;
 				try {
@@ -63,14 +65,14 @@ function EditSound({ close, onChange, data, ...props }: EditSoundProps): ReactEl
 				soundData._id = soundId;
 				soundData.random = Math.round(Math.random() * 1000);
 
-				if (sound && sound !== previousSound) {
+				if (soundFile && sound !== previousSound) {
 					dispatchToastMessage({ type: 'success', message: t('Uploading_file') });
 
 					const reader = new FileReader();
-					reader.readAsBinaryString(sound);
+					reader.readAsBinaryString(soundFile);
 					reader.onloadend = (): void => {
 						try {
-							uploadCustomSound(reader.result as string, sound.type, { ...soundData, _id: soundId });
+							uploadCustomSound(reader.result as string, soundFile.type, { ...soundData, _id: soundId });
 							return dispatchToastMessage({ type: 'success', message: t('File_uploaded') });
 						} catch (error) {
 							dispatchToastMessage({ type: 'error', message: error });
@@ -87,7 +89,7 @@ function EditSound({ close, onChange, data, ...props }: EditSoundProps): ReactEl
 				}),
 			);
 		},
-		[_id, dispatchToastMessage, insertOrUpdateSound, name, previousName, previousSound, t, uploadCustomSound],
+		[_id, close, dispatchToastMessage, insertOrUpdateSound, name, previousName, previousSound, t, uploadCustomSound],
 	);
 
 	const handleSave = useCallback(async () => {

--- a/apps/meteor/client/views/admin/customSounds/EditSound.tsx
+++ b/apps/meteor/client/views/admin/customSounds/EditSound.tsx
@@ -8,14 +8,16 @@ import { useTranslation } from 'react-i18next';
 import { validate, createSoundData } from './lib';
 import { useSingleFileInput } from '../../../hooks/useSingleFileInput';
 
+type SoundData = {
+	_id: string;
+	name: string;
+	extension?: string;
+};
+
 type EditSoundProps = {
 	close: () => void;
 	onChange: () => void;
-	data: {
-		_id: string;
-		name: string;
-		extension?: string;
-	};
+	data: SoundData;
 };
 
 function EditSound({ close, onChange, data, ...props }: EditSoundProps): ReactElement {
@@ -27,14 +29,7 @@ function EditSound({ close, onChange, data, ...props }: EditSoundProps): ReactEl
 	const previousSound = useMemo(() => data || {}, [data]);
 
 	const [name, setName] = useState(() => data?.name ?? '');
-	const [sound, setSound] = useState<
-		| {
-				_id: string;
-				name: string;
-				extension?: string;
-		  }
-		| File
-	>(() => data);
+	const [sound, setSound] = useState<SoundData | File>(() => data);
 
 	useEffect(() => {
 		setName(previousName || '');
@@ -52,9 +47,9 @@ function EditSound({ close, onChange, data, ...props }: EditSoundProps): ReactEl
 	const hasUnsavedChanges = useMemo(() => previousName !== name || previousSound !== sound, [name, previousName, previousSound, sound]);
 
 	const saveAction = useCallback(
-		// FIXME
-		async (sound: any) => {
-			const soundData = createSoundData(sound, name, { previousName, previousSound, _id, extension: sound.extension });
+		async (sound: SoundData | File) => {
+			const extension = sound instanceof File ? undefined : sound.extension;
+			const soundData = createSoundData(sound, name, { previousName, previousSound, _id, extension });
 			const validation = validate(soundData, sound);
 			if (validation.length === 0) {
 				let soundId: string;

--- a/apps/meteor/client/views/admin/customSounds/lib.ts
+++ b/apps/meteor/client/views/admin/customSounds/lib.ts
@@ -30,11 +30,11 @@ export function validate(soundData: ICustomSoundData, soundFile?: ICustomSoundFi
 }
 
 export const createSoundData = (
-	soundFile: ICustomSoundFile,
+	soundFile: ICustomSoundFile | undefined,
 	name: string,
 	previousData?: {
 		_id: string;
-		extension: string;
+		extension?: string;
 		previousName: string;
 		previousSound: {
 			extension?: string;
@@ -52,10 +52,10 @@ export const createSoundData = (
 	return {
 		_id: previousData._id,
 		name,
-		extension: soundFile?.name.split('.').pop() || '',
+		extension: soundFile?.name.split('.').pop() || previousData.extension || '',
 		previousName: previousData.previousName,
 		previousExtension: previousData.previousSound?.extension,
 		previousSound: previousData.previousSound,
-		newFile: false,
+		newFile: !!soundFile,
 	};
 };


### PR DESCRIPTION
## Summary
Improve type safety in AddCustomSound and EditSound components by replacing `any` types with proper TypeScript types.

## Changes

### AddCustomSound.tsx
- Type `soundFile` parameter as `File` in `saveAction`

### EditSound.tsx
- Extract `SoundData` type for reuse
- Type `sound` parameter as `SoundData | File` union in `saveAction`
- Handle `extension` property access with `instanceof File` check to satisfy TypeScript

## Why
The components were using `any` types with FIXME comments. Since the `soundFile` is always a File object from the file input, and `sound` in EditSound can be either the existing data or a newly selected File, these types accurately represent the runtime values.

Resolves FIXME comments in both components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type safety and state synchronization for custom sound creation and editing, unifying how sound data is handled between create and edit flows.

* **Bug Fixes**
  * Added a runtime check that shows an error if saving without a selected sound file.
  * Made save/upload behavior more reliable when keeping, replacing, or updating existing sound files (better handling of file presence and extensions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->