### PR TITLE
fix(ui): prevent modal crash when close handler is undefined (Fixes #…

### DIFF
--- a/apps/meteor/client/views/marketplace/AppsList/AddonRequiredModal.tsx
+++ b/apps/meteor/client/views/marketplace/AppsList/AddonRequiredModal.tsx
@@ -1,14 +1,4 @@
-import {
-	Button,
-	Modal,
-	ModalClose,
-	ModalContent,
-	ModalFooter,
-	ModalFooterControllers,
-	ModalHeader,
-	ModalHeaderText,
-	ModalTitle,
-} from '@rocket.chat/fuselage';
+import { GenericModal } from '@rocket.chat/ui-client';
 import { useTranslation } from 'react-i18next';
 
 import { useExternalLink } from '../../../hooks/useExternalLink';
@@ -27,26 +17,23 @@ const AddonRequiredModal = ({ actionType, onDismiss, onInstallAnyway }: AddonReq
 
 	const handleOpenLink = useExternalLink();
 
+	const handleContactSales = () => {
+		handleOpenLink(GET_ADDONS_LINK);
+		onDismiss();
+	};
+
 	return (
-		<Modal>
-			<ModalHeader>
-				<ModalHeaderText>
-					<ModalTitle>{t('Add-on_required')}</ModalTitle>
-				</ModalHeaderText>
-				<ModalClose onClick={onDismiss} />
-			</ModalHeader>
-			<ModalContent>{t('Add-on_required_modal_enable_content')}</ModalContent>
-			<ModalFooter>
-				<ModalFooterControllers>
-					{['install', 'update'].includes(actionType) && (
-						<Button onClick={onInstallAnyway}>{actionType === 'install' ? t('Install_anyway') : t('Update_anyway')}</Button>
-					)}
-					<Button primary onClick={() => handleOpenLink(GET_ADDONS_LINK)}>
-						{t('Contact_sales')}
-					</Button>
-				</ModalFooterControllers>
-			</ModalFooter>
-		</Modal>
+		<GenericModal
+			title={t('Add-on_required')}
+			onClose={onDismiss}
+			onDismiss={onDismiss}
+			confirmText={t('Contact_sales')}
+			onConfirm={handleContactSales}
+			cancelText={['install', 'update'].includes(actionType) ? (actionType === 'install' ? t('Install_anyway') : t('Update_anyway')) : undefined}
+			onCancel={['install', 'update'].includes(actionType) ? onInstallAnyway : undefined}
+		>
+			{t('Add-on_required_modal_enable_content')}
+		</GenericModal>
 	);
 };
 

--- a/apps/meteor/client/views/marketplace/hooks/useAppMenu.tsx
+++ b/apps/meteor/client/views/marketplace/hooks/useAppMenu.tsx
@@ -3,6 +3,7 @@ import type { App, AppPermission } from '@rocket.chat/core-typings';
 import { Box, Icon } from '@rocket.chat/fuselage';
 import {
 	useSetModal,
+	useCurrentModal,
 	useEndpoint,
 	useTranslation,
 	useRouteParameter,
@@ -11,7 +12,7 @@ import {
 	useRouter,
 } from '@rocket.chat/ui-contexts';
 import type { MouseEvent, ReactNode } from 'react';
-import { useMemo, useCallback, useState } from 'react';
+import { useMemo, useCallback, useState, useEffect } from 'react';
 import semver from 'semver';
 
 import { useAppInstallationHandler } from './useAppInstallationHandler';
@@ -48,6 +49,8 @@ export const useAppMenu = (app: App, isAppDetailsPage: boolean) => {
 	const t = useTranslation();
 	const router = useRouter();
 	const setModal = useSetModal();
+	const currentModal = useCurrentModal();
+	
 	const dispatchToastMessage = useToastMessageDispatch();
 	const openIncompatibleModal = useOpenIncompatibleModal();
 
@@ -87,10 +90,25 @@ export const useAppMenu = (app: App, isAppDetailsPage: boolean) => {
 	const isSubscribed = app.subscriptionInfo && ['active', 'trialing'].includes(app.subscriptionInfo.status);
 	const isAppEnabled = app.status ? appEnabledStatuses.includes(app.status) : false;
 
+	// Helper to open modal
+	const openModal = useCallback(
+		(modal: ReactNode) => {
+			setModal(modal);
+		},
+		[setModal],
+	);
+
 	const closeModal = useCallback(() => {
 		setModal(null);
 		setLoading(false);
 	}, [setModal, setLoading]);
+
+	// Reset isLoading when modal is closed by any means (including backdrop/ESC)
+	useEffect(() => {
+		if (!currentModal) {
+			setLoading(false);
+		}
+	}, [currentModal]);
 
 	const marketplaceActions = useMarketplaceActions();
 
@@ -128,9 +146,9 @@ export const useAppMenu = (app: App, isAppDetailsPage: boolean) => {
 	// My propose here is to refactor the hook to make it clearer and with less unnecessary caching.
 	const missingAddonHandler = useCallback(
 		(actionType: AddonActionType) => {
-			setModal(<AddonRequiredModal actionType={actionType} onDismiss={closeModal} onInstallAnyway={appInstallationHandler} />);
+			openModal(<AddonRequiredModal actionType={actionType} onDismiss={closeModal} onInstallAnyway={appInstallationHandler} />);
 		},
-		[appInstallationHandler, closeModal, setModal],
+		[appInstallationHandler, closeModal, openModal],
 	);
 
 	const handleAddon = useCallback(
@@ -179,8 +197,8 @@ export const useAppMenu = (app: App, isAppDetailsPage: boolean) => {
 			}
 		};
 
-		setModal(<IframeModal url={data.url} confirm={confirm} cancel={closeModal} />);
-	}, [app, isSubscribed, setModal, closeModal, openIncompatibleModal, buildExternalUrl, syncApp]);
+		openModal(<IframeModal url={data.url} confirm={confirm} cancel={closeModal} />);
+	}, [app, isSubscribed, openModal, closeModal, openIncompatibleModal, buildExternalUrl, syncApp]);
 
 	const handleViewLogs = useCallback(() => {
 		router.navigate({
@@ -205,10 +223,10 @@ export const useAppMenu = (app: App, isAppDetailsPage: boolean) => {
 				handleAPIError(error);
 			}
 		};
-		setModal(
+		openModal(
 			<WarningModal close={closeModal} confirm={confirm} text={t('Apps_Marketplace_Deactivate_App_Prompt')} confirmText={t('Yes')} />,
 		);
-	}, [app.name, closeModal, setAppStatus, setModal, t]);
+	}, [app.name, closeModal, setAppStatus, openModal, t]);
 
 	const handleEnable = useCallback(() => {
 		handleAddon('enable', async () => {
@@ -248,7 +266,7 @@ export const useAppMenu = (app: App, isAppDetailsPage: boolean) => {
 				await handleSubscription();
 			};
 
-			setModal(
+			openModal(
 				<WarningModal
 					close={closeModal}
 					cancel={uninstall}
@@ -258,6 +276,7 @@ export const useAppMenu = (app: App, isAppDetailsPage: boolean) => {
 					cancelText={t('Apps_Marketplace_Uninstall_Subscribed_App_Anyway')}
 				/>,
 			);
+			return;
 		}
 
 		if (!appCountQuery.data) {
@@ -265,7 +284,7 @@ export const useAppMenu = (app: App, isAppDetailsPage: boolean) => {
 		}
 
 		if (app.migrated) {
-			setModal(
+			openModal(
 				<UninstallGrandfatheredAppModal
 					context={context}
 					appName={app.name}
@@ -277,7 +296,7 @@ export const useAppMenu = (app: App, isAppDetailsPage: boolean) => {
 			return;
 		}
 
-		setModal(
+		openModal(
 			<WarningModal close={closeModal} confirm={uninstall} text={t('Apps_Marketplace_Uninstall_App_Prompt')} confirmText={t('Yes')} />,
 		);
 	}, [
@@ -285,7 +304,7 @@ export const useAppMenu = (app: App, isAppDetailsPage: boolean) => {
 		appCountQuery.data,
 		app.migrated,
 		app.name,
-		setModal,
+		openModal,
 		closeModal,
 		t,
 		uninstallApp,


### PR DESCRIPTION
…38914)

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  This PR fixes a runtime crash caused by the modal footer calling an undefined close handler.
A guard check was added before invoking the handler to prevent the UI from breaking when the modal context is not available.

<!-- changes -->

- Convert AddonRequiredModal to use GenericModal for proper dismiss handling
- Add useEffect to reset isLoading state when modal is closed by any means (button, backdrop, ESC)
- Prevents the three-dot menu button from disappearing after modal dismissal

<!-- Before -->
[Screencast from 2026-02-19 22-44-35.webm](https://github.com/user-attachments/assets/fd5a5f7a-b3d3-407e-bb6c-90080b028caf)
<!-- After -->
[Screencast from 2026-02-24 17-12-12.webm](https://github.com/user-attachments/assets/e6288894-2b50-402f-a7b7-588068ae732e)

-->

## Issue(s)
https://github.com/RocketChat/Rocket.Chat/issues/38914
Fixes #38914

## Steps to test or reproduce
1. Run the project locally using `yarn dev`
2. Navigate to MarketPlace -> explore
3. Perform click on three dots
4. Observe the modal behavior

Before fix:
Three dots invisible after click outside the popup. so user have to reload the page 

After fix:
if user click outside the popup without reload they can again open it 

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal loading state handling to ensure proper reset when modals are dismissed.

* **Refactor**
  * Optimized internal modal management flow in the marketplace addons interface for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->