### PR TITLE
chore(custom-sounds): sanitize any usage in AddCustomSound and EditSound

### DIFF
--- a/apps/meteor/client/views/admin/customSounds/AddCustomSound.tsx
+++ b/apps/meteor/client/views/admin/customSounds/AddCustomSound.tsx
@@ -19,7 +19,7 @@ const AddCustomSound = ({ goToNew, close, onChange, ...props }: AddCustomSoundPr
 	const dispatchToastMessage = useToastMessageDispatch();
 
 	const [name, setName] = useState('');
-	const [sound, setSound] = useState<{ name: string }>();
+	const [sound, setSound] = useState<File>();
 
 	const uploadCustomSound = useMethod('uploadCustomSound');
 	const insertOrUpdateSound = useMethod('insertOrUpdateSound');
@@ -31,8 +31,7 @@ const AddCustomSound = ({ goToNew, close, onChange, ...props }: AddCustomSoundPr
 	const [clickUpload] = useSingleFileInput(handleChangeFile, 'audio/mp3');
 
 	const saveAction = useCallback(
-		// FIXME
-		async (name: string, soundFile: any) => {
+		async (name: string, soundFile: File) => {
 			const soundData = createSoundData(soundFile, name);
 			const validation = validate(soundData, soundFile) as Array<Parameters<typeof t>[0]>;
 
@@ -73,6 +72,9 @@ const AddCustomSound = ({ goToNew, close, onChange, ...props }: AddCustomSoundPr
 
 	const handleSave = useCallback(async () => {
 		try {
+			if (!sound) {
+				return;
+			}
 			const result = await saveAction(name, sound);
 			if (result) {
 				dispatchToastMessage({ type: 'success', message: t('Custom_Sound_Saved_Successfully') });

--- a/apps/meteor/client/views/admin/customSounds/EditSound.tsx
+++ b/apps/meteor/client/views/admin/customSounds/EditSound.tsx
@@ -53,7 +53,7 @@ function EditSound({ close, onChange, data, ...props }: EditSoundProps): ReactEl
 
 	const saveAction = useCallback(
 		async (sound: { _id: string; name: string; extension?: string } | File) => {
-			const extension = 'extension' in sound ? sound.extension ?? '' : '';
+			const extension = 'extension' in sound ? (sound.extension ?? '') : '';
 			const soundData = createSoundData(sound, name, { previousName, previousSound, _id, extension });
 			const validation = validate(soundData, sound);
 			if (validation.length === 0) {

--- a/apps/meteor/client/views/admin/customSounds/EditSound.tsx
+++ b/apps/meteor/client/views/admin/customSounds/EditSound.tsx
@@ -52,9 +52,9 @@ function EditSound({ close, onChange, data, ...props }: EditSoundProps): ReactEl
 	const hasUnsavedChanges = useMemo(() => previousName !== name || previousSound !== sound, [name, previousName, previousSound, sound]);
 
 	const saveAction = useCallback(
-		// FIXME
-		async (sound: any) => {
-			const soundData = createSoundData(sound, name, { previousName, previousSound, _id, extension: sound.extension });
+		async (sound: { _id: string; name: string; extension?: string } | File) => {
+			const extension = 'extension' in sound ? sound.extension ?? '' : '';
+			const soundData = createSoundData(sound, name, { previousName, previousSound, _id, extension });
 			const validation = validate(soundData, sound);
 			if (validation.length === 0) {
 				let soundId: string;
@@ -68,7 +68,7 @@ function EditSound({ close, onChange, data, ...props }: EditSoundProps): ReactEl
 				soundData._id = soundId;
 				soundData.random = Math.round(Math.random() * 1000);
 
-				if (sound && sound !== previousSound) {
+				if (sound instanceof File) {
 					dispatchToastMessage({ type: 'success', message: t('Uploading_file') });
 
 					const reader = new FileReader();

--- a/apps/meteor/client/views/admin/customSounds/lib.ts
+++ b/apps/meteor/client/views/admin/customSounds/lib.ts
@@ -2,7 +2,7 @@ import type { ICustomSoundData } from '../../../../app/custom-sounds/server/meth
 
 type ICustomSoundFile = {
 	name: string;
-	type: string;
+	type?: string;
 	extension?: string;
 };
 
@@ -20,7 +20,7 @@ export function validate(soundData: ICustomSoundData, soundFile?: ICustomSoundFi
 
 	if (soundFile) {
 		if (!soundData.previousSound || soundData.previousSound !== soundFile) {
-			if (!/audio\/mp3/.test(soundFile.type) && !/audio\/mpeg/.test(soundFile.type) && !/audio\/x-mpeg/.test(soundFile.type)) {
+			if (soundFile.type && !/audio\/mp3/.test(soundFile.type) && !/audio\/mpeg/.test(soundFile.type) && !/audio\/x-mpeg/.test(soundFile.type)) {
 				errors.push('FileType');
 			}
 		}

--- a/apps/meteor/client/views/admin/customSounds/lib.ts
+++ b/apps/meteor/client/views/admin/customSounds/lib.ts
@@ -20,7 +20,12 @@ export function validate(soundData: ICustomSoundData, soundFile?: ICustomSoundFi
 
 	if (soundFile) {
 		if (!soundData.previousSound || soundData.previousSound !== soundFile) {
-			if ('type' in soundFile && !/audio\/mp3/.test(soundFile.type ?? '') && !/audio\/mpeg/.test(soundFile.type ?? '') && !/audio\/x-mpeg/.test(soundFile.type ?? '')) {
+			if (
+				'type' in soundFile &&
+				!/audio\/mp3/.test(soundFile.type ?? '') &&
+				!/audio\/mpeg/.test(soundFile.type ?? '') &&
+				!/audio\/x-mpeg/.test(soundFile.type ?? '')
+			) {
 				errors.push('FileType');
 			}
 		}

--- a/apps/meteor/client/views/admin/customSounds/lib.ts
+++ b/apps/meteor/client/views/admin/customSounds/lib.ts
@@ -20,7 +20,7 @@ export function validate(soundData: ICustomSoundData, soundFile?: ICustomSoundFi
 
 	if (soundFile) {
 		if (!soundData.previousSound || soundData.previousSound !== soundFile) {
-			if (soundFile.type && !/audio\/mp3/.test(soundFile.type) && !/audio\/mpeg/.test(soundFile.type) && !/audio\/x-mpeg/.test(soundFile.type)) {
+			if ('type' in soundFile && !/audio\/mp3/.test(soundFile.type ?? '') && !/audio\/mpeg/.test(soundFile.type ?? '') && !/audio\/x-mpeg/.test(soundFile.type ?? '')) {
 				errors.push('FileType');
 			}
 		}


### PR DESCRIPTION
Fixes #39043

### What changed
- Replaced `any` in custom-sound save callbacks with strict types
- Removed `// FIXME` markers
- Updated shared custom-sound file typing in `lib.ts` to support both existing data and uploaded files
- Added safe guards for file-specific checks

### Why
This improves type safety in admin custom-sound create/edit flows without changing behavior.

### Impact
- No runtime changes
- Compile-time safety improved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now tolerates missing file-type metadata and avoids runtime errors.
  * Save/upload flow short-circuits when no file is selected; uploads occur only for actual file uploads.

* **Refactor**
  * Tightened handling of sound inputs (files vs. existing sound references), including safer extraction of file extensions.
  * No public component APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
[COMM-164]

[COMM-164]: https://rocketchat.atlassian.net/browse/COMM-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ