### PR TITLE
fix(team): await Promise.all in addMembersToDefaultRooms to prevent silent failures

### DIFF
--- a/.changeset/fix-team-service-await-add-members.md
+++ b/.changeset/fix-team-service-await-add-members.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes fire-and-forget async `.map()` in `TeamService.addMembersToDefaultRooms` where promises were never awaited, causing silent failures when adding users to default team rooms. Also replaces unnecessary `for await` over a plain array with `for...of`.

--- a/apps/meteor/server/services/team/service.ts
+++ b/apps/meteor/server/services/team/service.ts
@@ -998,13 +998,15 @@ export class TeamService extends ServiceClassInternal implements ITeamService {
 		const defaultRooms = await Rooms.findDefaultRoomsForTeam(teamId).toArray();
 		const users = await Users.findActiveByIds(members.map((member) => member.userId)).toArray();
 
-		defaultRooms.map(async (room) => {
-			// at this point, users are already part of the team so we won't check for membership
-			for await (const user of users) {
-				// add each user to the default room
-				await addUserToRoom(room._id, user, inviter, { skipSystemMessage: false });
-			}
-		});
+		await Promise.all(
+			defaultRooms.map(async (room) => {
+				// at this point, users are already part of the team so we won't check for membership
+				for (const user of users) {
+					// add each user to the default room
+					await addUserToRoom(room._id, user, inviter, { skipSystemMessage: false });
+				}
+			}),
+		);
 	}
 
 	async deleteById(teamId: string): Promise<boolean> {


### PR DESCRIPTION
## Description

Fixes a fire-and-forget async bug in `TeamService.addMembersToDefaultRooms` where user additions to default team rooms were never properly awaited.

### Root Cause

```typescript
// BEFORE (broken)
defaultRooms.map(async (room) => {
    for await (const user of users) {
        await addUserToRoom(room._id, user, inviter, { skipSystemMessage: false });
    }
});
```

`.map(async ...)` creates an array of Promises that is **immediately discarded** — never wrapped in `Promise.all()` or otherwise awaited.

### Impact

1. **Silent failures**: If `addUserToRoom` throws (e.g., room deleted mid-operation, permission error), the rejection is unhandled
2. **False completion**: The calling code (the "add members to team" API endpoint) returns success to the user before any users are actually added to the default rooms
3. **Inconsistent state**: Team members appear in the team but may not be in the default rooms

### Fix

```typescript
// AFTER (fixed)
await Promise.all(
    defaultRooms.map(async (room) => {
        for (const user of users) {
            await addUserToRoom(room._id, user, inviter, { skipSystemMessage: false });
        }
    }),
);
```

Also replaced unnecessary `for await` over a plain in-memory array (`users`) with a standard `for...of` loop. `for await` is designed for async iterables, not synchronous arrays.

### Testing

- No TypeScript errors
- Single-responsibility fix: only touches `addMembersToDefaultRooms` in `service.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where adding users to default team rooms could fail silently. Improved async handling ensures all operations are properly awaited and completed before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->