### PR TITLE
fix(streamer): replace forEach(async) with Promise.allSettled to handle rejections

### DIFF
--- a/.changeset/fix-streamer-foreach-async.md
+++ b/.changeset/fix-streamer-foreach-async.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Replaces `forEach(async ...)` with `await Promise.allSettled([...subscriptions].map(async ...))` in `Streamer.sendToManySubscriptions` to prevent unhandled promise rejections when permission checks or socket sends fail for individual subscriptions.

--- a/apps/meteor/server/modules/streamer/streamer.module.ts
+++ b/apps/meteor/server/modules/streamer/streamer.module.ts
@@ -290,19 +290,21 @@ export abstract class Streamer<N extends keyof StreamerEvents> extends EventEmit
 		args: any[],
 		getMsg: string | TransformMessage,
 	): Promise<void> {
-		subscriptions.forEach(async (subscription) => {
-			if (this.retransmitToSelf === false && origin && origin === subscription.subscription.connection) {
-				return;
-			}
-
-			const allowed = await this.isEmitAllowed(subscription.subscription, eventName, ...args);
-			if (allowed) {
-				const msg = typeof getMsg === 'string' ? getMsg : getMsg(this, subscription, eventName, args, allowed);
-				if (msg) {
-					subscription.subscription._session.socket?.send(msg);
+		await Promise.allSettled(
+			[...subscriptions].map(async (subscription) => {
+				if (this.retransmitToSelf === false && origin && origin === subscription.subscription.connection) {
+					return;
 				}
-			}
-		});
+
+				const allowed = await this.isEmitAllowed(subscription.subscription, eventName, ...args);
+				if (allowed) {
+					const msg = typeof getMsg === 'string' ? getMsg : getMsg(this, subscription, eventName, args, allowed);
+					if (msg) {
+						subscription.subscription._session.socket?.send(msg);
+					}
+				}
+			}),
+		);
 	}
 
 	override emit(eventName: string | symbol, ...args: any[]): boolean {


### PR DESCRIPTION
## Description

Replaces `forEach(async ...)` with `await Promise.allSettled(...)` in `Streamer.sendToManySubscriptions` to prevent unhandled promise rejections.

### Root Cause

```typescript
// BEFORE
subscriptions.forEach(async (subscription) => {
    const allowed = await this.isEmitAllowed(subscription.subscription, eventName, ...args);
    if (allowed) {
        const msg = typeof getMsg === "string" ? getMsg : getMsg(this, subscription, eventName, args, allowed);
        if (msg) {
            subscription.subscription._session.socket?.send(msg);
        }
    }
});
```

`Set.prototype.forEach()` does **not** await the returned promises from async callbacks. Each iteration kicks off an unmonitored microtask.

### Impact

1. **Unhandled rejections**: If `isEmitAllowed()` throws for any subscription, there is no `.catch()` — the error becomes an unhandled rejection that can crash the Node process (depending on runtime config)
2. **Non-deterministic ordering**: Concurrent permission checks and socket sends have unpredictable ordering

### Fix

```typescript
// AFTER
await Promise.allSettled(
    [...subscriptions].map(async (subscription) => {
        // ... same logic
    }),
);
```

Using `Promise.allSettled` (not `Promise.all`) ensures:
- One failing subscription does not abort message sends to others
- All rejections are properly settled, not unhandled
- The method's promise resolves only after all subscription processing completes

Note: The callers use `void this.sendToManySubscriptions(...)` intentionally (fire-and-forget for the broadcast path), so the `await` inside the method is about internal error handling, not blocking the caller.

### Testing

- No TypeScript errors
- Single-responsibility fix: only changes `sendToManySubscriptions` in `streamer.module.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error isolation in subscription message delivery. Individual subscription errors—such as permission checks or socket communication failures—are now properly captured separately, preventing them from triggering unhandled promise rejections or affecting other active subscriptions and causing cascading failures. This enhancement significantly improves overall system stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->