### PR TITLE
fix: (auth) prevent duplicate failed-login notifications and ensure consistent block telemetry

### DIFF
--- a/apps/meteor/app/authentication/server/hooks/login.ts
+++ b/apps/meteor/app/authentication/server/hooks/login.ts
@@ -6,10 +6,14 @@ import type { ILoginAttempt } from '../ILoginAttempt';
 import { logFailedLoginAttempts } from '../lib/logLoginAttempts';
 import { saveFailedLoginAttempts, saveSuccessfulLogin } from '../lib/restrictLoginAttempts';
 
-const ignoredErrorTypes = ['totp-required', 'error-login-blocked-for-user'];
+// Only ignore TOTP-required failures.
+// Both error-login-blocked-for-user and error-login-blocked-for-ip are intentionally
+// NOT ignored here so that all block-type failures are stored consistently in ServerEvents
+// for accurate security telemetry.
+const ignoredErrorTypes = ['totp-required'];
 
 Accounts.onLoginFailure(async (login: ILoginAttempt) => {
-	// do not save specific failed login attempts
+	// Save failed login attempts consistently for both user and IP blocks
 	if (
 		settings.get('Block_Multiple_Failed_Logins_Enabled') &&
 		login.error?.error &&

--- a/apps/meteor/app/authentication/server/lib/restrictLoginAttempts.ts
+++ b/apps/meteor/app/authentication/server/lib/restrictLoginAttempts.ts
@@ -87,9 +87,14 @@ export const isValidLoginAttemptByIp = async (ip: string): Promise<boolean> => {
 	}
 
 	if (settings.get('Block_Multiple_Failed_Logins_Notify_Failed')) {
-		const willBeBlockedUntil = addMinutesToADate(new Date(lastFailedAttemptAt), minutesUntilUnblock);
-
-		await notifyFailedLogin(ip, willBeBlockedUntil, failedAttemptsSinceLastLogin);
+		// Only notify exactly when the threshold is first crossed (===).
+		// Using > would re-notify on every subsequent blocked attempt within the same
+		// block window, flooding the admin channel. Once the window expires and attempts
+		// accumulate again, the === check will fire once more as intended.
+		if (failedAttemptsSinceLastLogin === attemptsUntilBlock) {
+			const willBeBlockedUntil = addMinutesToADate(new Date(lastFailedAttemptAt), minutesUntilUnblock);
+			await notifyFailedLogin(ip, willBeBlockedUntil, failedAttemptsSinceLastLogin);
+		}
 	}
 
 	return false;
@@ -136,9 +141,14 @@ export const isValidAttemptByUser = async (login: ILoginAttempt): Promise<boolea
 	}
 
 	if (settings.get('Block_Multiple_Failed_Logins_Notify_Failed')) {
-		const willBeBlockedUntil = addMinutesToADate(new Date(lastFailedAttemptAt), minutesUntilUnblock);
-
-		await notifyFailedLogin(loginUsername, willBeBlockedUntil, failedAttemptsSinceLastLogin);
+		// Only notify exactly when the threshold is first crossed (===).
+		// Using > would re-notify on every subsequent blocked attempt within the same
+		// block window, flooding the admin channel. Once the window expires and attempts
+		// accumulate again, the === check will fire once more as intended.
+		if (failedAttemptsSinceLastLogin === attemptsUntilBlock) {
+			const willBeBlockedUntil = addMinutesToADate(new Date(lastFailedAttemptAt), minutesUntilUnblock);
+			await notifyFailedLogin(loginUsername, willBeBlockedUntil, failedAttemptsSinceLastLogin);
+		}
 	}
 
 	return false;


### PR DESCRIPTION
## 🐛 Issue

When `Block_Multiple_Failed_Logins` is enabled, two related issues occur in the failed-login protection flow:

1. **Duplicate Notifications**
   - Once the failed login threshold is exceeded, notifications are sent repeatedly for each blocked retry during the same block window.

2. **Asymmetric Telemetry**
   - `error-login-blocked-for-user` was ignored from failed-attempt persistence.
   - `error-login-blocked-for-ip` was not ignored.
   - This caused inconsistent `server_events` telemetry.

---
fixes: #39037
## 🎯 Root Cause

### 1️⃣ Duplicate Notifications

In `restrictLoginAttempts.ts`, notifications were triggered whenever:

```ts
failedAttemptsSinceLastLogin >= attemptsUntilBlock



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Login blocking notifications now appear only once per block window, eliminating redundant alerts and reducing notification fatigue.
  * Enhanced tracking of failed login attempts to improve security event monitoring and incident investigation across user and IP-based blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->