### PR TITLE
fix: (registration) handle password complexity length validation error

### DIFF
--- a/packages/web-ui-registration/src/RegisterForm.tsx
+++ b/packages/web-ui-registration/src/RegisterForm.tsx
@@ -111,6 +111,12 @@ export const RegisterForm = ({ setLoginRoute }: { setLoginRoute: DispatchLoginRo
 					if (/Name contains invalid characters/.test(error.error)) {
 						setError('name', { type: 'name-contains-invalid-chars', message: t('registration.component.form.nameContainsInvalidChars') });
 					}
+					if (error.error === 'user_password_invalid_complexity_length') {
+						setError('password', {
+							type: 'password-complexity-length',
+							message: t('registration.component.form.passwordTooShort'),
+						});
+					}
 					if (/error-too-many-requests/.test(error.error)) {
 						dispatchToastMessage({ type: 'error', message: error.error });
 					}


### PR DESCRIPTION
## Summary

This PR fixes an issue where the registration form displayed a generic error message when the backend returned the following error:

`user_password_invalid_complexity_length`

Instead of showing a clear validation message to the user, the UI would fall back to an unknown error state.

---

## What Was Happening

When a user entered a password shorter than the required minimum length (e.g., 14 characters), the backend returned:

```json
{
  "status": 400,
  "error": "user_password_invalid_complexity_length"
}
```

However, this error was not handled in the `RegisterForm` error handler, resulting in a generic error message instead of a field-level validation message.

---

## What This PR Changes

- Adds explicit handling for `user_password_invalid_complexity_length`
- Maps the backend error to the `password` field using `setError`
- Displays a proper validation message under the password input
- Preserves existing error handling logic

---

## Result

Now when a password shorter than the required minimum length is submitted:

- The error is displayed directly under the password field
- The user receives a clear and specific validation message
- The generic error is no longer shown

---

## How to Test

1. Set the minimum password length to 14 characters.
2. Open the registration page.
3. Enter a password shorter than 14 characters.
4. Submit the form.
5. Verify that a proper validation message appears under the password field.

---

Fixes: #38891

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password validation error handling during registration. Users now receive a more specific error message when their password fails complexity requirements, particularly regarding length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->