### PR TITLE
chore(message-parser): align ASTNode union with parser output

### DIFF
--- a/packages/message-parser/src/definitions.ts
+++ b/packages/message-parser/src/definitions.ts
@@ -198,29 +198,13 @@ export type Types = {
 	LIST_ITEM: ListItem;
 	IMAGE: Image;
 	LINE_BREAK: LineBreak;
+	KATEX: KaTeX;
+	INLINE_KATEX: InlineKaTeX;
+	TIMESTAMP: Timestamp;
 	SPOILER_BLOCK: SpoilerBlock;
 };
 
-export type ASTNode =
-	| BigEmoji
-	| Bold
-	| Spoiler
-	| Paragraph
-	| Plain
-	| Italic
-	| Strike
-	| Code
-	| CodeLine
-	| InlineCode
-	| Heading
-	| Quote
-	| SpoilerBlock
-	| Link
-	| UserMention
-	| ChannelMention
-	| Emoji
-	| Color
-	| Tasks;
+export type ASTNode = Types[keyof Types];
 
 export type TypesKeys = keyof Types;
 

--- a/packages/message-parser/src/guards.ts
+++ b/packages/message-parser/src/guards.ts
@@ -1,4 +1,4 @@
 import type { ASTNode } from './definitions';
 
-export const isNodeOfType = <N extends ASTNode>(value: unknown, type: N['type']): value is N =>
+export const isNodeOfType = <T extends ASTNode['type']>(value: unknown, type: T): value is Extract<ASTNode, { type: T }> =>
 	typeof value === 'object' && value !== null && 'type' in value && (value as { type: unknown }).type === type;

--- a/packages/message-parser/tests/guards.test.ts
+++ b/packages/message-parser/tests/guards.test.ts
@@ -1,0 +1,62 @@
+import { isNodeOfType, parse } from '../src';
+import type { Image, OrderedList, Timestamp } from '../src/definitions';
+import { timestamp } from '../src/utils';
+
+describe('isNodeOfType', () => {
+	it('narrows timestamp nodes', () => {
+		const value: unknown = timestamp('1708551317');
+
+		expect(isNodeOfType(value, 'TIMESTAMP')).toBe(true);
+
+		if (!isNodeOfType(value, 'TIMESTAMP')) {
+			throw new Error('expected TIMESTAMP node');
+		}
+
+		const narrowed: Timestamp = value;
+		expect(value.value.timestamp).toBe('1708551317');
+		expect(value.value.format).toBe('t');
+		expect(narrowed.value.format).toBe('t');
+	});
+
+	it('narrows ordered list nodes from parser output', () => {
+		const value: unknown = parse('1. one')[0];
+
+		expect(isNodeOfType(value, 'ORDERED_LIST')).toBe(true);
+
+		if (!isNodeOfType(value, 'ORDERED_LIST')) {
+			throw new Error('expected ORDERED_LIST node');
+		}
+
+		const narrowed: OrderedList = value;
+		expect(value.value[0].number).toBe(1);
+		expect(narrowed.value[0].number).toBe(1);
+	});
+
+	it('narrows image nodes from parser output', () => {
+		const paragraph: unknown = parse('![logo](https://rocket.chat/logo.png)')[0];
+
+		expect(isNodeOfType(paragraph, 'PARAGRAPH')).toBe(true);
+
+		if (!isNodeOfType(paragraph, 'PARAGRAPH')) {
+			throw new Error('expected PARAGRAPH node');
+		}
+
+		const imageNode: unknown = paragraph.value[0];
+
+		expect(isNodeOfType(imageNode, 'IMAGE')).toBe(true);
+
+		if (!isNodeOfType(imageNode, 'IMAGE')) {
+			throw new Error('expected IMAGE node');
+		}
+
+		const narrowed: Image = imageNode;
+		expect(imageNode.value.src.value).toBe('https://rocket.chat/logo.png');
+		expect(narrowed.value.src.value).toBe('https://rocket.chat/logo.png');
+	});
+
+	it('returns false for mismatched types', () => {
+		const value: unknown = timestamp('1708551317');
+
+		expect(isNodeOfType(value, 'ORDERED_LIST')).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- align `ASTNode` with runtime parser output by deriving it from `Types[keyof Types]`
- include missing parser-emitted node types in `Types` (`KATEX`, `INLINE_KATEX`, `TIMESTAMP`)
- improve `isNodeOfType` typing to narrow via `Extract<ASTNode, { type: T }>`
- add coverage tests for narrowing `TIMESTAMP`, `ORDERED_LIST`, and `IMAGE` nodes

## Testing
- `yarn workspace '@rocket.chat/message-parser' exec eslint src/definitions.ts src/guards.ts tests/guards.test.ts`

Fix #39057
Fix #39295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for KaTeX, InlineKaTeX, and Timestamp message types.

* **Refactor**
  * Enhanced type system architecture for improved type safety and precision in message parsing.

* **Tests**
  * Added test coverage for type narrowing across multiple message node kinds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
[COMM-144]

[COMM-144]: https://rocketchat.atlassian.net/browse/COMM-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ