### PR TITLE
chore: remove 'as any' usage by applying required Type safety

### DIFF
--- a/apps/meteor/client/views/marketplace/components/CategoryFilter/CategoryDropDown.tsx
+++ b/apps/meteor/client/views/marketplace/components/CategoryFilter/CategoryDropDown.tsx
@@ -36,7 +36,7 @@ const CategoryDropDown = ({ categories, onSelected, selectedCategories, ...props
 		<>
 			<CategoryDropDownAnchor
 				ref={reference}
-				onClick={toggleCollapsed as any}
+				onClick={() => toggleCollapsed()}
 				selectedCategoriesCount={selectedCategories.length}
 				{...props}
 			/>

--- a/apps/meteor/client/views/marketplace/components/RadioDropDown/RadioDownAnchor.tsx
+++ b/apps/meteor/client/views/marketplace/components/RadioDropDown/RadioDownAnchor.tsx
@@ -1,12 +1,12 @@
 import type { Button } from '@rocket.chat/fuselage';
 import { Box, Icon } from '@rocket.chat/fuselage';
-import type { ComponentProps, SetStateAction } from 'react';
+import type { ComponentProps } from 'react';
 import { forwardRef } from 'react';
 
 import type { RadioDropDownGroup } from '../../definitions/RadioDropDownDefinitions';
 
 type RadioDropdownAnchorProps = {
-	onClick: (forcedValue?: SetStateAction<boolean> | undefined) => void;
+	onClick: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 	group: RadioDropDownGroup;
 } & Omit<ComponentProps<typeof Button>, 'onClick'>;
 
@@ -17,7 +17,7 @@ const RadioDownAnchor = forwardRef<HTMLElement, RadioDropdownAnchorProps>(functi
 		<Box
 			is='button'
 			ref={ref}
-			onClick={onClick as any}
+			onClick={onClick}
 			alignItems='center'
 			bg='light'
 			borderColor='light'

--- a/apps/meteor/client/views/marketplace/components/RadioDropDown/RadioDropDown.tsx
+++ b/apps/meteor/client/views/marketplace/components/RadioDropDown/RadioDropDown.tsx
@@ -30,7 +30,7 @@ const RadioDropDown = ({ group, onSelected, ...props }: RadioDropDownProps & Com
 
 	return (
 		<>
-			<RadioDropDownAnchor ref={reference} group={group} onClick={toggleCollapsed as any} {...props} />
+			<RadioDropDownAnchor ref={reference} group={group} onClick={() => toggleCollapsed()} {...props} />
 			{collapsed && (
 				<DropDownListWrapper ref={reference} onClose={onClose}>
 					<RadioButtonList group={group} onSelected={onSelected} />


### PR DESCRIPTION
### Description
This PR addresses `as any` type casts in Marketplace dropdowns `CategoryDropDown`, `RadioDropDown` and `RadioDownAnchor`  

remove unsafe casts and ensure strict TypeScript safety.

#39060 

### Proposed Changes
- Replaced `onClick={toggleCollapsed as any}` with `onClick={() => toggleCollapsed()}` in both dropdown files  
- Updated `onClick` type in `RadioDownAnchor.tsx` from `SetStateAction<boolean>` to `React.MouseEvent<HTMLElement, MouseEvent>`
- Removed as any from the internal button render in `RadioDownAnchor.tsx`

### Logic Behind the changes
`useToggle` returns `(forcedValue?: boolean) => void`. Direct assignment caused type mismatch with React `MouseEvent` handler. Wrapping in arrow function + correct typing fixes it cleanly with zero runtime change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal event handling mechanisms in dropdown components for better code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2008]
 [COMM-144]

[ARCH-2008]: https://rocketchat.atlassian.net/browse/ARCH-2008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ