### PR TITLE
chore: add --skip and --only CLI flags to benchmark suite

### DIFF
--- a/packages/message-parser/benchmarks/parser.bench.ts
+++ b/packages/message-parser/benchmarks/parser.bench.ts
@@ -5,6 +5,14 @@
  * Measures parsing performance (ops/sec) across various message categories.
  * Run with: `yarn bench` from packages/message-parser/
  *
+ * Flags:
+ *   --skip <category1,category2,...>   Skip specific categories (comma-separated, case-insensitive)
+ *   --only <category1,category2,...>   Run only specific categories (comma-separated, case-insensitive)
+ *
+ * Examples:
+ *   yarn bench --skip "KaTeX (Math),Adversarial / Stress"
+ *   yarn bench --only "Plain Text,Emoji"
+ *
  * Uses a custom loader (pegjs-register.js) to compile .pegjs at runtime — no build needed.
  */
 
@@ -166,6 +174,64 @@ const categories: BenchCategory[] = [
 	},
 ];
 
+// ── CLI argument parsing ───────────────────────────────────────────────────
+
+function parseCLIFlags(): { skip: Set<string>; only: Set<string> } {
+	const args = process.argv.slice(2);
+	const result: { skip: Set<string>; only: Set<string> } = {
+		skip: new Set(),
+		only: new Set(),
+	};
+
+	for (let i = 0; i < args.length; i++) {
+		const flag = args[i];
+		const value = args[i + 1];
+
+		if ((flag === '--skip' || flag === '--only') && value && !value.startsWith('--')) {
+			const names = value
+				.split(',')
+				.map((s) => s.trim().toLowerCase())
+				.filter(Boolean);
+
+			names.forEach((n) => result[flag === '--skip' ? 'skip' : 'only'].add(n));
+			i++; // consume the value token
+		}
+	}
+
+	return result;
+}
+
+function filterCategories(all: BenchCategory[]): BenchCategory[] {
+	const { skip, only } = parseCLIFlags();
+	const allNames = all.map((c) => c.name.toLowerCase());
+
+	if (only.size > 0 && skip.size > 0) {
+		console.warn('⚠  Both --only and --skip were provided. --skip will be ignored.\n');
+	}
+
+	// Warn about unrecognised names
+	const checkUnknown = (flags: Set<string>, flagName: string) => {
+		flags.forEach((f) => {
+			if (!allNames.includes(f)) {
+				console.warn(`⚠  Unknown category in ${flagName}: "${f}"`);
+				console.warn(`   Available categories: ${all.map((c) => `"${c.name}"`).join(', ')}\n`);
+			}
+		});
+	};
+
+	if (only.size > 0) {
+		checkUnknown(only, '--only');
+		return all.filter((c) => only.has(c.name.toLowerCase()));
+	}
+
+	if (skip.size > 0) {
+		checkUnknown(skip, '--skip');
+		return all.filter((c) => !skip.has(c.name.toLowerCase()));
+	}
+
+	return all;
+}
+
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 function formatResults(tasks: Task[]) {
@@ -183,14 +249,28 @@ function formatResults(tasks: Task[]) {
 // ── Runner ─────────────────────────────────────────────────────────────────
 
 async function run() {
+	const selected = filterCategories(categories);
+
+	if (selected.length === 0) {
+		console.error('No categories matched the provided flags. Nothing to run.');
+		process.exit(1);
+	}
+
+	const skipped = categories.length - selected.length;
+
 	console.log('='.repeat(72));
 	console.log('  @rocket.chat/message-parser — Performance Benchmark Suite');
 	console.log('='.repeat(72));
+
+	if (skipped > 0) {
+		console.log(`  Running ${selected.length} of ${categories.length} categories (${skipped} skipped)`);
+	}
+
 	console.log();
 
 	// Benchmarks must run sequentially to avoid interference
 	// eslint-disable-next-line no-restricted-syntax
-	for (const category of categories) {
+	for (const category of selected) {
 		const bench = new Bench({
 			time: category.time ?? 1000,
 			warmupTime: category.warmupTime ?? 200,


### PR DESCRIPTION
## Proposed Changes
Replace the hardcoded full-category benchmark run with a filtered approach using --skip and --only CLI flags exposed through `parseCLIFlags()` and `filterCategories()` helpers.

Right now `yarn bench` always runs all 11 categories which takes 20-25 seconds  every time. If a developer is only working on emoji parsing or URL parsing they still have to sit through everything else. This adds --only and --skip flags so you can run just what you need and get results in 3-4 seconds.

The following functions are added to `parser.bench.ts`:
`parseCLIFlags`
`filterCategories`

**Before**
```
async function run() {
    for (const category of categories) {
        // runs all 11 categories, no way to filter
    }
}
```

**After**
```
function filterCategories(all: BenchCategory[]): BenchCategory[] {
	const { skip, only } = parseCLIFlags();
	const allNames = all.map((c) => c.name.toLowerCase());

	if (only.size > 0 && skip.size > 0) {
		console.warn('⚠  Both --only and --skip were provided. --skip will be ignored.\n');
	}

	// Warn about unrecognised names
	const checkUnknown = (flags: Set<string>, flagName: string) => {
		flags.forEach((f) => {
			if (!allNames.includes(f)) {
				console.warn(`⚠  Unknown category in ${flagName}: "${f}"`);
				console.warn(`   Available categories: ${all.map((c) => `"${c.name}"`).join(', ')}\n`);
			}
		});
	};

	if (only.size > 0) {
		checkUnknown(only, '--only');
		return all.filter((c) => only.has(c.name.toLowerCase()));
	}

	if (skip.size > 0) {
		checkUnknown(skip, '--skip');
		return all.filter((c) => !skip.has(c.name.toLowerCase()));
	}

	return all;
}
```

```
async function run() {
    const selected = filterCategories(categories);
    // runs only matched categories based on --skip or --only flags
    for (const category of selected) { ... }
}
```

## Issue(s)
Closes #39076

## Steps to Reproduce
See `packages/message-parser/benchmarks/parser.bench.ts`
Run `yarn bench` in `packages/message-parser`

## Screenshots

<img width="875" height="452" alt="Screenshot 2026-02-26 at 9 50 34 AM" src="https://github.com/user-attachments/assets/944f014a-baa1-4f71-8c32-e1486b32c989" />

<br/>
<br/>

<img width="857" height="826" alt="Screenshot 2026-02-26 at 9 49 45 AM" src="https://github.com/user-attachments/assets/fd725c4d-0cf6-4290-9261-fc1bc6056585" />


## Testing
- Verify `yarn bench` with no flags runs all categories as before
- Verify `yarn bench --only "Emoji"` runs only the Emoji category
- Verify `yarn bench --only "Emoji,Plain Text"` runs only those two categories
- Verify `yarn bench --skip "Adversarial / Stress"` skips that category
- Verify `yarn bench --skip "Adversarial / Stress,KaTeX (Math)"` skips both categories
- Verify names are case-insensitive and whitespace-tolerant
- Verify unknown category names print a warning with valid options
- Verify if no categories match, exits with a non-zero code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--skip` and `--only` CLI flags to filter benchmark categories to run
  * Added validation with user warnings for unknown category names and mixed flag usage
  * Updated progress output to display filtered benchmark subset and skip counts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->