### PR TITLE
chore(core-typings): replace as any with type-safe cast in isFileAttachment

### DIFF
--- a/packages/core-typings/src/IMessage/MessageAttachment/Files/FileAttachmentProps.ts
+++ b/packages/core-typings/src/IMessage/MessageAttachment/Files/FileAttachmentProps.ts
@@ -16,4 +16,4 @@ export type FileAttachmentProps =
 	| (CommonFileProps & MessageAttachmentBase);
 
 export const isFileAttachment = (attachment: MessageAttachmentBase): attachment is FileAttachmentProps =>
-	'type' in attachment && (attachment as any).type === 'file';
+	'type' in attachment && (attachment as Record<string, unknown>).type === 'file';


### PR DESCRIPTION
## Proposed changes

In `FileAttachmentProps.ts` — replaced as any with Record<string, unknown> in the isFileAttachment type guard.

**Before**

```typescript
export const isFileAttachment = (attachment: MessageAttachmentBase): attachment is FileAttachmentProps =>
	'type' in attachment && (attachment as any).type === 'file';
```
**After**
```typescript
export const isFileAttachment = (attachment: MessageAttachmentBase): attachment is FileAttachmentProps =>
	'type' in attachment && (attachment as Record<string, unknown>).type === 'file';
```



## Steps to reproduce

See `packages/core-typings/src/IMessage/MessageAttachment/Files/FilesAttachmentProps.ts`

## Why?

- `as any` disables all TypeScript type checking — unsafe
- `Record<string, unknown>` is the correct safe cast here — it tells TypeScript "this object has string keys with unknown values"
- After the `'type' in attachment check`, accessing `.type` via `Record<string, unknown>` is safe and still type-checked
- `unknown` forces proper type checking on comparisons, unlike `any`which silences the compiler entirely


## Testing

- Ran `npx tsc --noEmit` in `packages/core-typings`— no errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for internal file attachment handling by updating type assertions to use stricter type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->