### PR TITLE
test(message-parser): expand KaTeX test coverage for dollar syntax and option gating

### DIFF
--- a/packages/message-parser/tests/katex.test.ts
+++ b/packages/message-parser/tests/katex.test.ts
@@ -20,3 +20,23 @@ test.each([
 ])('parses %p', (input, output) => {
 	expect(parse(input, { katex: { parenthesisSyntax: true } })).toMatchObject(output);
 });
+
+test.each([
+	['$$E = mc^2$$', [katex('E = mc^2')]],
+	['$E = mc^2$', [paragraph([inlineKatex('E = mc^2')])]],
+	['Easy as $E = mc^2$, right?', [paragraph([plain('Easy as '), inlineKatex('E = mc^2'), plain(', right?')])]],
+	['$$\n\\sum_{i=1}^{n} x_i\n$$', [katex('\n\\sum_{i=1}^{n} x_i\n')]],
+	['$$\\frac{a}{b} + \\sqrt{c}$$', [katex('\\frac{a}{b} + \\sqrt{c}')]],
+	['$a$ text $b$', [paragraph([inlineKatex('a'), plain(' text '), inlineKatex('b')])]],
+	['$x$ and $y$', [paragraph([inlineKatex('x'), plain(' and '), inlineKatex('y')])]],
+])('parses %p', (input, output) => {
+	expect(parse(input, { katex: { dollarSyntax: true } })).toMatchObject(output);
+});
+
+test.each([
+	['$$E = mc^2$$', [paragraph([plain('$$E = mc^2$$')])]],
+	['$E = mc^2$', [paragraph([plain('$E = mc^2$')])]],
+	['\\(E = mc^2\\)', [paragraph([plain('\\(E = mc^2\\)')])]],
+])('parses KaTeX as plain text when syntax options are disabled: %p', (input, output) => {
+	expect(parse(input)).toMatchObject(output);
+});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
Expands katex.test.ts to cover missing test cases:
- Dollar syntax (`$$...$$`) block Katex
- Dollar syntax (`$...$`) inline Katex
- Multiple inline KaTeX expressions in one message
- Option gating KaTeX delimiters treated as plain text when dollarSyntax or parenthesisSyntax is disabled

## Issue(s)
Fix #39096

## Steps to test or reproduce
`yarn workspace '@rocket.chat/message-parser' test`
All tests pass

## Further comments
The existing test file only had 2 test cases covering parenthesis syntax. this PR adds coverage for dollar syntax and verifies that option flags correctly gate KaTeX parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded KaTeX-related test coverage for dollar-delimited inline and block math, cross-form content, mixed delimiters, and mixed text with math.
  * Added tests verifying KaTeX is treated as plain text when math parsing options are disabled.
  * No runtime or public API changes; only additional test coverage to ensure consistent parsing across syntax settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->