### PR TITLE
fix(settings): remove exhaustive-deps suppressions in `Setting.tsx`

### DIFF
--- a/apps/meteor/client/views/admin/settings/Setting/Setting.tsx
+++ b/apps/meteor/client/views/admin/settings/Setting/Setting.tsx
@@ -1,4 +1,4 @@
-import type { ISettingColor, SettingEditor, SettingValue } from '@rocket.chat/core-typings';
+import type { SettingEditor, SettingValue } from '@rocket.chat/core-typings';
 import { isSettingColor, isSetting } from '@rocket.chat/core-typings';
 import { Box, Button, Tag } from '@rocket.chat/fuselage';
 import { useDebouncedCallback } from '@rocket.chat/fuselage-hooks';
@@ -62,16 +62,16 @@ function Setting({ className = undefined, settingId, sectionChanged }: SettingPr
 	const { t, i18n } = useTranslation();
 
 	const [value, setValue] = useState(setting.value);
-	const [editor, setEditor] = useState(isSettingColor(setting) ? setting.editor : undefined);
+	const settingColorEditor = isSettingColor(setting) ? setting.editor : undefined;
+	const [editor, setEditor] = useState(settingColorEditor);
 
 	useEffect(() => {
 		setValue(setting.value);
 	}, [setting.value]);
 
 	useEffect(() => {
-		setEditor(isSettingColor(setting) ? setting.editor : undefined);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [(setting as ISettingColor).editor]);
+		setEditor(settingColorEditor);
+	}, [settingColorEditor]);
 
 	const onChangeValue = useCallback(
 		(value: SettingValue) => {
@@ -91,13 +91,12 @@ function Setting({ className = undefined, settingId, sectionChanged }: SettingPr
 
 	const onResetButtonClick = useCallback(() => {
 		setValue(setting.value);
-		setEditor(isSettingColor(setting) ? setting.editor : undefined);
+		setEditor(settingColorEditor);
 		update({
 			value: persistedSetting.packageValue,
 			...(isSettingColor(persistedSetting) && { editor: persistedSetting.packageEditor }),
 		});
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [setting.value, (setting as ISettingColor).editor, update, persistedSetting]);
+	}, [setting.value, settingColorEditor, update, persistedSetting]);
 
 	const { _id, readonly, type, packageValue, i18nLabel, i18nDescription, alert } = setting;
 


### PR DESCRIPTION
fix: #39112 Fix exhaustive-deps Suppressions in `Setting.tsx`

This PR removes two `react-hooks/exhaustive-deps` suppressions in `apps/meteor/client/views/admin/settings/Setting/Setting.tsx` by extracting `(setting as ISettingColor).editor` into a stable variable and properly declaring it in hook dependency arrays.

No runtime behavior has been changed.

---

## What Changed

* Extracted `isSettingColor(setting) ? setting.editor : undefined` into a top-level variable (`settingColorEditor`).
* Updated the `useEffect` that syncs editor state to depend on `settingColorEditor`.
* Updated `onResetButtonClick` `useCallback` to depend on `settingColorEditor` instead of a cast expression.
* Removed both `eslint-disable-next-line react-hooks/exhaustive-deps` comments.
* Removed the unused `ISettingColor` type import.

---

## Why

ESLint cannot safely analyze cast expressions like `(setting as ISettingColor).editor` inside hook dependency arrays, which required suppressing `react-hooks/exhaustive-deps`.

By extracting the value into a stable variable:

* Hook dependencies are explicit and correct.
* ESLint suppressions are no longer necessary.
* An unsafe type cast is removed.
* Type safety is improved without altering behavior.

---

## Behavior

Behavior remains identical for both color and non-color settings:

* For color settings, `editor` is synced from `setting.editor`.
* For non-color settings, `editor` remains `undefined`.
* Reset functionality works exactly as before.

---

## Verification

* ESLint passes with no new warnings or errors in `Setting.tsx`.
* No additional lint suppressions introduced.
* No changes outside this file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization in the settings component by consolidating repeated color editor logic into a reusable constant. This change enhances maintainability and ensures consistent state management without altering user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->