### PR TITLE
fix: correct required validation label for Incoming Webhook 'Post as'

### DIFF
--- a/apps/meteor/client/views/admin/integrations/incoming/IncomingWebhookForm.tsx
+++ b/apps/meteor/client/views/admin/integrations/incoming/IncomingWebhookForm.tsx
@@ -202,7 +202,7 @@ const IncomingWebhookForm = ({ webhookData }: { webhookData?: Serialized<IIncomi
 								<Controller
 									name='username'
 									control={control}
-									rules={{ required: t('Required_field', { field: t('Post_to_Channel') }) }}
+									rules={{ required: t('Required_field', { field: t('Post_as') }) }}
 									render={({ field }) => (
 										<TextInput
 											id={usernameField}


### PR DESCRIPTION
## Issue
Closes #39102

## Summary
- fixes the required validation rule for the **Post as** field in Incoming Webhook form
- error message now correctly references **Post as** instead of **Post to Channel**

## Testing
I could not run lint/tests in this environment because the repository enforces Node.js `22.16.0`, while this host currently has `v25.6.1`.

Attempted command:
`yarn install --immutable`

Result:
`The current Node version v25.6.1 does not satisfy the required version 22.16.0.`

Manual validation path:
1. Go to **Administration → Integrations → New → Incoming Webhook**
2. Fill **Post to Channel**
3. Leave **Post as** empty
4. Trigger validation
5. Confirm message now says **"Post as is required"**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incoming webhook form validation message for the username field to provide clearer, more accurate user guidance when the field is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->