### PR TITLE
fix: respect sessionId when terminating connections on logout

### DIFF
--- a/ee/apps/ddp-streamer/src/DDPStreamer.ts
+++ b/ee/apps/ddp-streamer/src/DDPStreamer.ts
@@ -50,10 +50,10 @@ export class DDPStreamer extends ServiceClass {
 			}
 		});
 
-		this.onEvent('user.forceLogout', (uid: string) => {
+		this.onEvent('user.forceLogout', (uid: string, sessionId?: string) => {
 			this.wss?.clients.forEach((ws) => {
 				const client = clientMap.get(ws);
-				if (client?.userId === uid) {
+				if (client?.userId === uid && (!sessionId || client.session === sessionId)) {
 					ws.terminate();
 				}
 			});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

When logging out a specific session via Device Management, DDPStreamer was terminating all WebSocket connections for that user instead of only the targeted session.

The `user.forceLogout` event handler was ignoring the `sessionId` parameter:

```typescript
// Before
this.onEvent('user.forceLogout', (uid: string) => { ... }

// After
this.onEvent('user.forceLogout', (uid: string, sessionId?: string) => { ... }
```

Now it only terminates the specific session when sessionId is provided, or all sessions when it's not (e.g., E2E key reset).

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
1. Run Rocket.Chat in microservices mode (with ddp-streamer)
2. Login with the same user in two different browser sessions
3. Go to Device Management and logout ONE specific session
4. Before fix: Both sessions disconnect briefly (other reconnects automatically)
5. After fix: Only the targeted session disconnects

## Further comments
The other sessions could recover because only the targeted session's login token is invalidated - the others re-authenticate on reconnect. However, this caused unnecessary disconnections.
