### PR TITLE
fix: avoid async promise executor in makeZipFile

### DIFF
--- a/apps/meteor/server/lib/dataExport/makeZipFile.ts
+++ b/apps/meteor/server/lib/dataExport/makeZipFile.ts
@@ -3,17 +3,19 @@ import { createWriteStream } from 'fs';
 import archiver from 'archiver';
 
 export const makeZipFile = (folderToZip: string, targetFile: string): Promise<void> => {
-	return new Promise(async (resolve, reject) => {
+	return new Promise((resolve, reject) => {
 		const output = createWriteStream(targetFile);
 
 		const archive = archiver('zip');
 
 		output.on('close', () => resolve());
+		output.on('error', (error) => reject(error));
 
 		archive.on('error', (error) => reject(error));
 
 		archive.pipe(output);
 		archive.directory(folderToZip, false);
-		await archive.finalize();
+
+		void archive.finalize().catch((error) => reject(error));
 	});
 };


### PR DESCRIPTION
## Summary
- remove async Promise executor from `makeZipFile`
- ensure output stream errors reject the returned Promise
- ensure `archive.finalize()` rejections are propagated to callers

## Problem
Using `new Promise(async ...)` can hide rejections from awaited work inside the executor and leave the outer Promise unresolved in failure scenarios.

## Fix #39118 
Refactored `makeZipFile` to use a synchronous executor and explicit rejection wiring for all async/stream failure points.

## Validation
- file-scoped lint passed:
  - `yarn workspace @rocket.chat/meteor exec eslint server/lib/dataExport/makeZipFile.ts`

## Risk
Low. This change does not alter business logic; it only hardens error propagation in zip generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for data export operations to catch and report write stream failures in addition to archive errors, making the export process more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->