### PR TITLE
docs: fix broken federation link in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We support different methods of deployment for different needs. Choose your meth
 
 - Looking for a custom cloud-hosted solution without handling infrastructure? Check out our premium, dedicated [cloud hosting options](https://docs.rocket.chat/docs/rocketchat-cloud-hosting-service-level-agreement-sla) that adapt to your needs.
 
-- Interested in decentralized communication? Enable [federation](https://docs.rocket.chat/docs/rocketchat-native-federation) to securely communicate and share resources across a federated network.
+- Interested in decentralized communication? Enable [federation](https://docs.rocket.chat/docs/decentralized-communication-with-federation-in-rocketchat) to securely communicate and share resources across a federated network.
 
 # 📱 Desktop and mobile apps
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR fixes a broken federation documentation link in the root `README.md`.

- Replaced:
  - `https://docs.rocket.chat/docs/rocketchat-native-federation`
- With:
  - `https://docs.rocket.chat/docs/decentralized-communication-with-federation-in-rocketchat`

Scope is intentionally minimal (one-line docs fix, no runtime/code behavior changes).

## Issue(s)

Closes #39127

## Steps to test or reproduce

1. Open `README.md`.
2. Find the deployment bullet mentioning decentralized communication / federation.
3. Click the federation link.
4. Confirm it opens a valid docs page (HTTP 200), not 404.

Optional CLI verification:

```bash
curl -L -s -o /dev/null -w "%{http_code} %{url_effective}\n" "https://docs.rocket.chat/docs/decentralized-communication-with-federation-in-rocketchat"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated federation URL reference in the Rocket.Chat deployment section to reflect accurate documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->