### PR TITLE
docs: fix apps-engine README customer stories link

### DIFF
--- a/packages/apps-engine/README.md
+++ b/packages/apps-engine/README.md
@@ -119,7 +119,7 @@ To update or generate the documentation, please commit your changes first and th
 
 # Engage with us
 ## Share your story
-We’d love to hear about [your experience](https://survey.zohopublic.com/zs/e4BUFG) and potentially feature it on our [Blog](https://rocket.chat/case-studies/?utm_source=github&utm_medium=readme&utm_campaign=community).
+We’d love to hear about [your experience](https://survey.zohopublic.com/zs/e4BUFG) and potentially feature it in our [Customer stories](https://www.rocket.chat/customers?utm_source=github&utm_medium=readme&utm_campaign=community).
 
 ## Subscribe for Updates
 Once a month our marketing team releases an email update with news about product releases, company related topics, events and use cases. [Sign Up!](https://rocket.chat/newsletter/?utm_source=github&utm_medium=readme&utm_campaign=community)


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fixes a broken link in `packages/apps-engine/README.md` under "Share your story".

- Replaced dead URL:
  - `https://rocket.chat/case-studies/?utm_source=github&utm_medium=readme&utm_campaign=community`
- With live URL aligned to case-study/customer-story intent:
  - `https://www.rocket.chat/customers?utm_source=github&utm_medium=readme&utm_campaign=community`
- Updated anchor text from `Blog` to `Customer stories` for semantic accuracy.

Scope is minimal: one-line docs change only.

## Issue(s)

Closes #39132

## Steps to test or reproduce

1. Open [packages/apps-engine/README.md](https://github.com/RocketChat/Rocket.Chat/blob/develop/packages/apps-engine/README.md).
2. Locate "Share your story".
3. Click `Customer stories`.
4. Confirm the destination is reachable (HTTP 200).

Optional CLI check:

```bash
curl -L -s -o /dev/null -w "%{http_code} %{url_effective}\n" "https://www.rocket.chat/customers?utm_source=github&utm_medium=readme&utm_campaign=community"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Share your story" section to direct users to the customer stories page instead of the blog for potential feature opportunities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->