### PR TITLE
fix: avoid empty React Query key in RoomOpenerEmbedded

### DIFF
--- a/apps/meteor/client/views/room/RoomOpenerEmbedded.tsx
+++ b/apps/meteor/client/views/room/RoomOpenerEmbedded.tsx
@@ -17,7 +17,6 @@ import { NotAuthorizedError } from '../../lib/errors/NotAuthorizedError';
 import { NotSubscribedToRoomError } from '../../lib/errors/NotSubscribedToRoomError';
 import { OldUrlRoomError } from '../../lib/errors/OldUrlRoomError';
 import { RoomNotFoundError } from '../../lib/errors/RoomNotFoundError';
-import { subscriptionsQueryKeys } from '../../lib/queryKeys';
 import { mapSubscriptionFromApi } from '../../lib/utils/mapSubscriptionFromApi';
 
 const RoomProvider = lazy(() => import('./providers/RoomProvider'));
@@ -41,7 +40,7 @@ const RoomOpenerEmbedded = ({ type, reference }: RoomOpenerProps): ReactElement 
 
 	const rid = data?.rid;
 	const { data: subscriptionData, refetch } = useQuery({
-		queryKey: rid ? subscriptionsQueryKeys.subscription(rid) : [],
+		queryKey: ['subscription', rid],
 		queryFn: () => {
 			if (!rid) {
 				throw new Error('Room not found');


### PR DESCRIPTION
## Proposed changes

This PR improves React Query key stability in:

`apps/meteor/client/views/room/RoomOpenerEmbedded.tsx`

Previously, an empty array (`[]`) could be passed as the `queryKey` when `rid` was falsy. Although the query was disabled, React Query would still register a query with an empty key.

The change ensures a stable and descriptive query key is always used, preventing empty key registration and improving cache correctness.

This does not alter fetching behavior or user-facing functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal query key structure to improve application efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->