### PR TITLE
docs: fix broken relative link in rocketchat-i18n README

### DIFF
--- a/apps/meteor/packages/rocketchat-i18n/README.md
+++ b/apps/meteor/packages/rocketchat-i18n/README.md
@@ -3,4 +3,4 @@ This package contains internationalization for Rocket.Chat.
 Due to limitations of the i18n-library used, _only_ translations from this very folder will be respected.
 Thus, if you extend Rocket.Chat with custom packages which have got own translation files, you'll have to put them into this package. They should be named `<package>.<language>.i18n.(json|yaml)`.
 
-Alternatively, you can add the i18n-files in your package and then copy it to this folder during build time. In this case, you should add the copied files to the `.gitignore`. See [how livechat did](../package.js) as an example.
+Alternatively, you can add the i18n-files in your package and then copy it to this folder during build time. In this case, you should add the copied files to the `.gitignore`. See [how livechat did](./package.js) as an example.


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fix a broken relative link in `apps/meteor/packages/rocketchat-i18n/README.md`.

- Changed:
  - `../package.js`
- To:
  - `./package.js`

This is a docs-only one-line fix and keeps all existing wording intact.

## Issue(s)

Closes #39137

## Steps to test or reproduce

1. Open [apps/meteor/packages/rocketchat-i18n/README.md](https://github.com/RocketChat/Rocket.Chat/blob/develop/apps/meteor/packages/rocketchat-i18n/README.md).
2. Click `how livechat did`.
3. Confirm it opens `apps/meteor/packages/rocketchat-i18n/package.js`.

## Further comments

No runtime code changes. No behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example path reference in internationalization documentation for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->