### PR TITLE
docs: fix broken local template link in emoji-emojione README

### DIFF
--- a/apps/meteor/app/emoji-emojione/README.md
+++ b/apps/meteor/app/emoji-emojione/README.md
@@ -8,7 +8,7 @@ node --experimental-modules generateEmojiIndex.mjs
 
 ## Generate new percentage sprite
 Clone the repository https://github.com/Ranks/emojione/ and replace the file `assets/sprites/emojione.sprites.mustache` with the content 
-of [emojione.sprites.mustache](emojione.sprites.mustache), then run at `emojione` folder:
+of [emojione.tpl](lib/emojione.tpl), then run at `emojione` folder:
 
 ```
 grunt sprite


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fixes a broken local markdown link in `apps/meteor/app/emoji-emojione/README.md`.

- Replaced:
  - `[emojione.sprites.mustache](emojione.sprites.mustache)`
- With:
  - `[emojione.tpl](lib/emojione.tpl)`

This is a one-line docs-only fix.

## Issue(s)

Closes #39139

## Steps to test or reproduce

1. Open [apps/meteor/app/emoji-emojione/README.md](https://github.com/RocketChat/Rocket.Chat/blob/develop/apps/meteor/app/emoji-emojione/README.md).
2. Click `emojione.tpl`.
3. Confirm it resolves to `apps/meteor/app/emoji-emojione/lib/emojione.tpl`.

## Further comments

No runtime/code behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated emoji sprite generation instructions in the documentation to reflect current file paths and folder structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->