### PR TITLE
fix(utils): prevent query string truncation in `_getURL` when multiple '?' are present

### DIFF
--- a/apps/meteor/app/utils/lib/getURL.ts
+++ b/apps/meteor/app/utils/lib/getURL.ts
@@ -45,7 +45,9 @@ export const _getURL = (
 		return path;
 	}
 
-	const [_path, _query] = path.split('?');
+	const qIndex = path.indexOf('?');
+	const _path = qIndex === -1 ? path : path.slice(0, qIndex);
+	const _query = qIndex === -1 ? '' : path.slice(qIndex + 1);
 	path = _path;
 	const query = _query ? `?${_query}` : '';
 


### PR DESCRIPTION
## Problem
_getURL splits the path using `path.split('?')`.  
If the URL contains more than one `?` (e.g. URLs embedded inside query parameters such as OAuth redirects or S3 signed URLs), the query string is truncated and the generated URL becomes invalid.

Example:
Input: /file?name=a?b.png
Before: /file?name=a
After: /file?name=a?b.png

## Solution
Split only at the first occurrence of `?` using index lookup instead of `split`.

## Impact
Fixes broken links for:
- OAuth callback URLs
- S3 signed URLs
- External integrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal URL query parsing logic for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->