### PR TITLE
refactor: standardize TwoFactorRequiredModal using GenericModal

### DIFF
--- a/apps/meteor/client/views/root/MainLayout/TwoFactorRequiredModal.tsx
+++ b/apps/meteor/client/views/root/MainLayout/TwoFactorRequiredModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal, ModalContent, ModalFooter, ModalFooterControllers, ModalHeader, ModalTitle } from '@rocket.chat/fuselage';
+import { GenericModal } from '@rocket.chat/ui-client';
 import { useSetModal } from '@rocket.chat/ui-contexts';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -12,19 +12,14 @@ const TwoFactorRequiredModal = () => {
 	}, [setModal]);
 
 	return (
-		<Modal>
-			<ModalHeader>
-				<ModalTitle>{t('Two-factor_authentication_required')}</ModalTitle>
-			</ModalHeader>
-			<ModalContent>{t('Enable_two-factor_authentication_callout_description')}</ModalContent>
-			<ModalFooter>
-				<ModalFooterControllers>
-					<Button primary onClick={closeModal}>
-						{t('Set_up_2FA')}
-					</Button>
-				</ModalFooterControllers>
-			</ModalFooter>
-		</Modal>
+		<GenericModal
+			title={t('Two-factor_authentication_required')}
+			confirmText={t('Set_up_2FA')}
+			onConfirm={closeModal}
+			onClose={closeModal}
+		>
+			{t('Enable_two-factor_authentication_callout_description')}
+		</GenericModal>
 	);
 };
 


### PR DESCRIPTION
Closes #39146

Replaced raw fuselage [Modal](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/Rocket.Chat/packages/ui-client/src/components/Modal/GenericModal/GenericModal.tsx:79:0-169:2) primitives ([Modal](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/Rocket.Chat/packages/ui-client/src/components/Modal/GenericModal/GenericModal.tsx:79:0-169:2), `ModalHeader`, `ModalTitle`, `ModalContent`, `ModalFooter`, `ModalFooterControllers`, [Button](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/Rocket.Chat/packages/ui-client/src/components/Modal/GenericModal/GenericModal.tsx:49:0-61:2)) with the standardized [GenericModal](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/Rocket.Chat/packages/ui-client/src/components/Modal/GenericModal/GenericModal.tsx:79:0-169:2) component from `@rocket.chat/ui-client` in [TwoFactorRequiredModal](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/Rocket.Chat/apps/meteor/client/views/root/MainLayout/TwoFactorRequiredModal.tsx:5:0-23:2).

This follows the same pattern established in #38334, #38431, and #38433.

### Changes
-   Replaced manual modal composition with [GenericModal](cci:1://file://wsl.localhost/Ubuntu/home/ashwaniyadav/Rocket.Chat/packages/ui-client/src/components/Modal/GenericModal/GenericModal.tsx:79:0-169:2) using its declarative prop API (`title`, `confirmText`, `onConfirm`, `onClose`)
-   Removed unused `@rocket.chat/fuselage` modal imports

### Screenshots
_No UI changes — the modal renders identically using GenericModal's internal layout._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized the two-factor authentication modal component to improve code maintainability and consistency with the design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->