### PR TITLE
fix: scope livechat trigger sender promise cache by sender context

### DIFF
--- a/packages/livechat/src/lib/triggerUtils.ts
+++ b/packages/livechat/src/lib/triggerUtils.ts
@@ -8,7 +8,7 @@ import { processUnread } from './main';
 
 type AgentPromise = { username: string } | Serialized<ILivechatAgent> | null;
 
-let agentPromise: Promise<AgentPromise> | null = null;
+const agentPromiseCache = new Map<string, Promise<AgentPromise>>();
 
 const agentCacheExpiry = 3600000;
 
@@ -43,32 +43,36 @@ const getNextAgentFromQueue = async () => {
 };
 
 export const getAgent = async (triggerAction: ILivechatTriggerAction): Promise<AgentPromise> => {
-	if (agentPromise) {
-		return agentPromise;
+	const {
+		iframe: { defaultDepartment, guest: { department } = {} },
+	} = store.state;
+	const sender = triggerAction.params?.sender || 'queue';
+	const cacheKey = sender === 'custom' ? `custom:${triggerAction.params?.name || ''}` : `queue:${department || defaultDepartment || ''}`;
+
+	const cachedAgentPromise = agentPromiseCache.get(cacheKey);
+	if (cachedAgentPromise) {
+		return cachedAgentPromise;
 	}
 
-	agentPromise = new Promise(async (resolve, reject) => {
-		const { sender, name = '' } = triggerAction.params || {};
-
+	const agentPromise = (async (): Promise<AgentPromise> => {
 		if (sender === 'custom') {
-			resolve({ username: name });
+			return { username: triggerAction.params?.name || '' };
 		}
 
-		if (sender === 'queue') {
-			try {
-				const agent = await getNextAgentFromQueue();
-				resolve(agent);
-			} catch (_) {
-				resolve({ username: 'rocket.cat' });
-			}
+		try {
+			return await getNextAgentFromQueue();
+		} catch (_) {
+			return { username: 'rocket.cat' };
 		}
+	})();
 
-		return reject('Unknown sender type.');
-	});
+	agentPromiseCache.set(cacheKey, agentPromise);
 
 	// expire the promise cache as well
 	setTimeout(() => {
-		agentPromise = null;
+		if (agentPromiseCache.get(cacheKey) === agentPromise) {
+			agentPromiseCache.delete(cacheKey);
+		}
 	}, agentCacheExpiry);
 
 	return agentPromise;


### PR DESCRIPTION
## Summary
- replace global `agentPromise` with per-context promise cache in livechat triggers
- key cache by sender context (`custom:<name>` and `queue:<department>`) to prevent cross-trigger sender leakage
- preserve 1-hour cache TTL while expiring entries safely per key

## Problem
`getAgent` cached a single global promise for 1 hour. Different trigger configurations could reuse the same promise path, causing sender resolution from one trigger context to leak into another.

## Validation
- `yarn exec eslint packages/livechat/src/lib/triggerUtils.ts`
- `yarn workspace @rocket.chat/livechat typecheck`
- `yarn workspace @rocket.chat/livechat build`

Fix #39150 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Agent lookup caching has been enhanced with an efficient per-key caching mechanism and automatic cache expiration after one hour. This optimization reduces redundant operations and improves system performance while maintaining data freshness and consistency across all agent assignment methods, with no impact on existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->