### PR TITLE
fix(utils): prevent `RangeError` in `pad()` when target length is smaller than string

### DIFF
--- a/apps/meteor/lib/utils/stringUtils.ts
+++ b/apps/meteor/lib/utils/stringUtils.ts
@@ -97,13 +97,13 @@ export function pad(_str: unknown, _length: number, padStr?: string, type: 'righ
 
 	switch (type) {
 		case 'right':
-			padlen = length - str.length;
+			padlen = Math.max(0, length - str.length);
 			return str + padStr.repeat(padlen);
 		case 'both':
-			padlen = length - str.length;
+			padlen = Math.max(0, length - str.length);
 			return padStr.repeat(Math.ceil(padlen / 2)) + str + padStr.repeat(Math.floor(padlen / 2));
 		default: // 'left'
-			padlen = length - str.length;
+			padlen = Math.max(0, length - str.length);
 			return padStr.repeat(padlen) + str;
 	}
 }


### PR DESCRIPTION
## Proposed changes
Fixes an edge case in the shared utility `pad()` function (`stringUtils.ts`).

When the target length is smaller than the string length, the function computes a negative padding value and passes it to `String.prototype.repeat()`, which throws:

RangeError: Invalid count value

The fix clamps the padding length to zero before calling `repeat()`:
```
padlen = Math.max(0, length - str.length);
```
This prevents runtime server exceptions and keeps behavior unchanged for valid inputs.

---

## Issue(s)
Fixes #39160

---

## Further comments
This is a defensive fix for a shared utility function used across the codebase.  
It does not change expected behavior for valid inputs and only prevents a runtime exception in edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed string padding utility behavior to handle edge cases where the requested padding length is shorter than the input string length. The utility now safely clamps negative padding values to zero across all padding modes, preventing potential runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->