### PR TITLE
fix(search): cap `messageSearch` limit to prevent expensive database queries

### DIFF
--- a/apps/meteor/server/methods/messageSearch.ts
+++ b/apps/meteor/server/methods/messageSearch.ts
@@ -28,7 +28,7 @@ export const messageSearch = async function (
 	check(rid, Match.Maybe(String));
 	check(limit, Match.Optional(Number));
 	check(offset, Match.Optional(Number));
-	limit = Math.min(limit ?? 20, 100);
+	limit = Math.max(0, Math.min(limit ?? 20, 100));
     offset = Math.max(offset ?? 0, 0);
 
 	// Don't process anything else if the user can't access the room


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The DDP method `messageSearch` accepts a user-controlled limit parameter without any upper bound validation.

Currently the method only checks the parameter type:
```
check(limit, Match.Optional(Number));
```
The value is later passed into MongoDB query options via `parseMessageSearchQuery` and used in:
```
Messages.find(query, { ...options }).toArray()
```
Because no maximum value is enforced, an authenticated user can request extremely large result sets:
```
Meteor.call('messageSearch', 'a', null, 200000, 0)
```
This causes a large query execution on the `rocketchat_message` collection (the largest collection in most deployments), resulting in:

- high CPU usage
- slow server responses
- event loop blocking

This patch introduces a safe bound to the query pagination:
```
limit = Math.min(limit ?? 20, 100);
offset = Math.max(offset ?? 0, 0);
```
This behavior is consistent with other paginated endpoints and prevents resource exhaustion while preserving existing functionality.

## Issue(s)

Closes #39163

##After this change

The request completes quickly and returns a limited result set (~100 messages), preventing heavy database operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Message search now enforces sensible defaults and limits for pagination: results default to 20 items, the maximum returned is capped at 100, and the offset defaults to 0. These adjustments ensure consistent and predictable pagination behavior for search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->