### PR TITLE
fix: replace dead matrix federation URL in shared links constants

### DIFF
--- a/apps/meteor/client/lib/links.ts
+++ b/apps/meteor/client/lib/links.ts
@@ -20,7 +20,7 @@ export const links = {
 		homepage: `${GO_ROCKET_CHAT_PREFIX}/home`,
 		invite: `${GO_ROCKET_CHAT_PREFIX}/invite?host=open.rocket.chat&path=invite%2F5sBs3a`,
 		ldapDocs: `${GO_ROCKET_CHAT_PREFIX}/i/ldap-docs`,
-		matrixFederation: `${GO_ROCKET_CHAT_PREFIX}/i/matrix-federation`,
+		matrixFederation: 'https://docs.rocket.chat/docs/federation-architecture-and-capabilities',
 		mobileAppGoogle: `${GO_ROCKET_CHAT_PREFIX}/i/hp-mobile-app-google`,
 		mobileAppApple: `${GO_ROCKET_CHAT_PREFIX}/i/hp-mobile-app-apple`,
 		omnichannelDocs: `${GO_ROCKET_CHAT_PREFIX}/i/omnichannel-docs`,

--- a/packages/ui-client/src/lib/links.ts
+++ b/packages/ui-client/src/lib/links.ts
@@ -20,7 +20,7 @@ export const links = {
 		homepage: `${GO_ROCKET_CHAT_PREFIX}/home`,
 		invite: `${GO_ROCKET_CHAT_PREFIX}/invite?host=open.rocket.chat&path=invite%2F5sBs3a`,
 		ldapDocs: `${GO_ROCKET_CHAT_PREFIX}/i/ldap-docs`,
-		matrixFederation: `${GO_ROCKET_CHAT_PREFIX}/i/matrix-federation`,
+		matrixFederation: 'https://docs.rocket.chat/docs/federation-architecture-and-capabilities',
 		mobileAppGoogle: `${GO_ROCKET_CHAT_PREFIX}/i/hp-mobile-app-google`,
 		mobileAppApple: `${GO_ROCKET_CHAT_PREFIX}/i/hp-mobile-app-apple`,
 		omnichannelDocs: `${GO_ROCKET_CHAT_PREFIX}/i/omnichannel-docs`,


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Replaces a dead matrix federation shortlink with a live docs URL in shared link constants.

Updated:

- `apps/meteor/client/lib/links.ts`
- `packages/ui-client/src/lib/links.ts`

`links.go.matrixFederation` now points to:
`https://docs.rocket.chat/docs/federation-architecture-and-capabilities`

instead of:
`https://go.rocket.chat/i/matrix-federation`

## Issue(s)

Closes #39167

## Steps to test or reproduce

1. Open:
   - `apps/meteor/client/lib/links.ts`
   - `packages/ui-client/src/lib/links.ts`
2. Confirm `matrixFederation` points to:
   - `https://docs.rocket.chat/docs/federation-architecture-and-capabilities`
3. Open the URL and confirm it resolves successfully.
4. (Optional) open old URL and confirm it is dead.

## Further comments

Scope is intentionally minimal: constant replacement only, no behavior/code-path changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Matrix Federation documentation link to direct users to official Rocket.Chat documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->