### PR TITLE
feat: show Marketplace in navbar on mobile and tablet screens

### DIFF
--- a/apps/meteor/client/sidebar/Item/Condensed.tsx
+++ b/apps/meteor/client/sidebar/Item/Condensed.tsx
@@ -24,7 +24,7 @@ const Condensed = ({ icon, title, avatar, actions, unread, menu, badges, ...prop
 	const handlePointerEnter = () => setMenuVisibility(true);
 
 	return (
-		<SidebarV2Item {...props} onFocus={handleFocus} onPointerEnter={handlePointerEnter}>
+		<SidebarV2Item title={title} {...props} onFocus={handleFocus} onPointerEnter={handlePointerEnter}>
 			{avatar && <SidebarV2ItemAvatarWrapper>{avatar}</SidebarV2ItemAvatarWrapper>}
 			{icon}
 			<SidebarV2ItemTitle unread={unread}>{title}</SidebarV2ItemTitle>

--- a/apps/meteor/client/sidebar/Item/Extended.tsx
+++ b/apps/meteor/client/sidebar/Item/Extended.tsx
@@ -55,7 +55,7 @@ const Extended = ({
 	const handlePointerEnter = () => setMenuVisibility(true);
 
 	return (
-		<SidebarV2Item href={href} selected={selected} {...props} onFocus={handleFocus} onPointerEnter={handlePointerEnter}>
+		<SidebarV2Item title={title} href={href} selected={selected} {...props} onFocus={handleFocus} onPointerEnter={handlePointerEnter}>
 			{avatar && <SidebarV2ItemAvatarWrapper>{avatar}</SidebarV2ItemAvatarWrapper>}
 			<SidebarV2ItemCol>
 				<SidebarV2ItemRow>

--- a/apps/meteor/client/sidebar/Item/Medium.tsx
+++ b/apps/meteor/client/sidebar/Item/Medium.tsx
@@ -23,7 +23,7 @@ const Medium = ({ icon, title, avatar, actions, badges, unread, menu, ...props }
 	const handlePointerEnter = () => setMenuVisibility(true);
 
 	return (
-		<SidebarV2Item {...props} onFocus={handleFocus} onPointerEnter={handlePointerEnter}>
+		<SidebarV2Item title={title} {...props} onFocus={handleFocus} onPointerEnter={handlePointerEnter}>
 			<SidebarV2ItemAvatarWrapper>{avatar}</SidebarV2ItemAvatarWrapper>
 			{icon}
 			<SidebarV2ItemTitle unread={unread}>{title}</SidebarV2ItemTitle>


### PR DESCRIPTION
## Description

On mobile screens, the Marketplace button was hidden due to a `!isMobile` guard in `NavBarPagesGroup.tsx`. This fix removes that condition so users on mobile and tablet can access Marketplace directly from the top navbar.

## Changes
- Removed `!isMobile` condition from `NavBarItemMarketPlaceMenu` in `NavBarPagesGroup.tsx`

## Screenshots

### Marketplace icon visible in navbar on mobile

<img width="399" height="600" alt="Screenshot 2026-02-28 at 4 20 57 AM" src="https://github.com/user-attachments/assets/068b094a-e3f9-4794-9d69-5f6b9c760598" />


### Marketplace dropdown expanded (Explore, Installed, Requested)

<img width="399" height="600" alt="Screenshot 2026-02-28 at 4 21 09 AM" src="https://github.com/user-attachments/assets/d7cd42e4-130e-42e7-a327-be4fdb686ed1" />


Closes #38676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Marketplace menu is now accessible on mobile and tablet devices.

* **Style**
  * Minor formatting and whitespace adjustments.

* **Chores**
  * Added a patch release note to publish the mobile Marketplace change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->