### PR TITLE
fix(accounts): enforce blocked usernames containing special characters

### DIFF
--- a/apps/meteor/app/lib/server/functions/checkUsernameAvailability.ts
+++ b/apps/meteor/app/lib/server/functions/checkUsernameAvailability.ts
@@ -16,7 +16,7 @@ settings.watch('Accounts_BlockedUsernameList', (value: string) => {
 });
 
 const usernameIsBlocked = (username: string, usernameBlackList: RegExp[]): boolean | number =>
-	usernameBlackList.length && usernameBlackList.some((restrictedUsername) => restrictedUsername.test(escapeRegExp(username).trim()));
+	usernameBlackList.length && usernameBlackList.some((restrictedUsername) => restrictedUsername.test(username.trim()));
 
 export const checkUsernameAvailabilityWithValidation = async function (userId: string, username: string): Promise<boolean> {
 	if (!username) {


### PR DESCRIPTION
Closes #39182 1st part

## Summary

This PR fixes an issue where usernames containing regex special characters (e.g., `.`, `+`, `*`) were not properly enforced when added to `Blocked UsernameList`.

Previously, the username was escaped both when constructing the blacklist regex and again when testing it. This double escaping caused blocked usernames such as `john.doe` to bypass validation.

## Changes

- Removed the unnecessary `escapeRegExp` call when testing usernames against the blocked list.
- Ensured usernames containing special characters are correctly matched and blocked.

## Result

Usernames explicitly added to `BlockedUsernameList` are now consistently enforced, regardless of whether they contain special characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved username validation to accurately check blacklisted patterns, ensuring special characters are properly handled during availability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->