### PR TITLE
fix(registration): display blocked username validation error in UI

### DIFF
--- a/packages/web-ui-registration/src/RegisterForm.tsx
+++ b/packages/web-ui-registration/src/RegisterForm.tsx
@@ -90,7 +90,7 @@ export const RegisterForm = ({ setLoginRoute }: { setLoginRoute: DispatchLoginRo
 					if ([error.error, error.errorType].includes('error-invalid-email')) {
 						setError('email', { type: 'invalid-email', message: t('registration.component.form.invalidEmail') });
 					}
-					if (error.errorType === 'error-blocked-username') {
+					if ([error.error, error.errorType].includes('error-blocked-username')) {
 						setError('username', {
 							type: 'error-blocked-username',
 							message: t('error-blocked-username', { field: getValues('username') }),


### PR DESCRIPTION
### Summary

This PR ensures that usernames blocked via `Accounts_BlockedUsernameList` are properly displayed as validation errors on the registration form.

Previously, when a blocked username (e.g., `john.doe`, `sahil.dev`) was submitted, the backend correctly returned `error-blocked-username`, but the UI did not render the error message. This resulted in no visible feedback for the user.

### What was changed

- Added explicit handling for `error-blocked-username` in the registration form.
- The error is now displayed under the username field using the existing i18n translation (`error-blocked-username`).
- Maintains consistency with other username validation errors (e.g., already exists, invalid format).
## before :
 UI did not render the Error message , but shown in dev tools Network 
## after changes:
<img width="757" height="131" alt="Screenshot 2026-02-28 144001" src="https://github.com/user-attachments/assets/a7e87877-660c-4809-a7bd-acd43c4e9bb0" />

### Result

- Blocked usernames now show a proper inline validation message.
- No silent failures.
- UI behavior is consistent with other validation cases.

Closes #39182 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Registration now properly handles blocked usernames: the form displays a localized error message that includes the attempted username and stops further redundant error checks, preventing confusing or duplicate validation messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->