### PR TITLE
fix(message-parser): dynamic ASTNode type from Types schema

### DIFF
--- a/.changeset/fix-astnode-completeness.md
+++ b/.changeset/fix-astnode-completeness.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/message-parser": patch
+---
+
+Fix incomplete `ASTNode` union type and missing entries in the `Types` dictionary, restoring correctly-typed AST guards like `isNodeOfType` for timestamps, images, lists, katex, and blockquotes.

--- a/packages/message-parser/src/definitions.ts
+++ b/packages/message-parser/src/definitions.ts
@@ -51,15 +51,15 @@ export type BigEmoji = {
 
 export type Emoji =
 	| {
-			type: 'EMOJI';
-			value: Plain;
-			shortCode: string;
-	  }
+		type: 'EMOJI';
+		value: Plain;
+		shortCode: string;
+	}
 	| {
-			type: 'EMOJI';
-			value: undefined;
-			unicode: string;
-	  };
+		type: 'EMOJI';
+		value: undefined;
+		unicode: string;
+	};
 
 export type Code = {
 	type: 'CODE';
@@ -199,28 +199,13 @@ export type Types = {
 	IMAGE: Image;
 	LINE_BREAK: LineBreak;
 	SPOILER_BLOCK: SpoilerBlock;
+	TIMESTAMP: Timestamp;
+	BLOCKQUOTE: Blockquote;
+	KATEX: KaTeX;
+	INLINE_KATEX: InlineKaTeX;
 };
 
-export type ASTNode =
-	| BigEmoji
-	| Bold
-	| Spoiler
-	| Paragraph
-	| Plain
-	| Italic
-	| Strike
-	| Code
-	| CodeLine
-	| InlineCode
-	| Heading
-	| Quote
-	| SpoilerBlock
-	| Link
-	| UserMention
-	| ChannelMention
-	| Emoji
-	| Color
-	| Tasks;
+export type ASTNode = Types[keyof Types];
 
 export type TypesKeys = keyof Types;
 


### PR DESCRIPTION
Closes #39057 and Fixes #39057 by deriving the ASTNode union strictly from the Types dictionary interface. Also populates the missing Types mappings for Timestamp, Blockquote, KaTeX, and InlineKaTeX.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type safety for AST node guards, restoring correct type checking for timestamps, images, lists, KaTeX, and blockquotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->