### PR TITLE
fix(message-parser): parse emojis and inline elements inside headings

### DIFF
--- a/.changeset/fix-heading-emoji-parsing.md
+++ b/.changeset/fix-heading-emoji-parsing.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/message-parser": patch
+---
+
+Fix nested emojis and inline markdown elements failing to parse correctly inside of heading blocks.

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -144,11 +144,12 @@ CodeChunk = text:$(!EndOfLine !"```" .)+ { return plain(text); }
  * #### Heading 4
  *
 */
-Heading = count:HeadingStart [ \t]+ text:HeadingChunk { return heading([text], count); }
+Heading = count:HeadingStart [ \t]+ text:HeadingChunk { return heading(text.map(v => Array.isArray(v) ? v[1] : v), count); }
 
 HeadingStart = value:"#" |1..4| { return value.length; }
 
-HeadingChunk = text:$(!EndOfLine .)+ { return plain(text); }
+HeadingChunk = text:(!EndOfLine Inline)+ { return text; }
+
 
 /**
  *

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -144,11 +144,11 @@ CodeChunk = text:$(!EndOfLine !"```" .)+ { return plain(text); }
  * #### Heading 4
  *
 */
-Heading = count:HeadingStart [ \t]+ text:HeadingChunk { return heading(text.map(v => Array.isArray(v) ? v[1] : v), count); }
+Heading = count:HeadingStart [ \t]+ text:HeadingChunk { return heading(text, count); }
 
 HeadingStart = value:"#" |1..4| { return value.length; }
 
-HeadingChunk = text:(!EndOfLine Inline)+ { return text; }
+HeadingChunk = text:Inline { return text; }
 
 
 /**

--- a/packages/message-parser/tests/heading.test.ts
+++ b/packages/message-parser/tests/heading.test.ts
@@ -1,5 +1,5 @@
 import { parse } from '../src';
-import { heading, lineBreak, mentionChannel, paragraph, plain } from './helpers';
+import { emoji, heading, lineBreak, mentionChannel, paragraph, plain } from './helpers';
 
 test.each([
 	['# h1', [heading([plain('h1')], 1)]],
@@ -44,6 +44,10 @@ test.each([
 	['He####llo', [paragraph([plain('He####llo')])]],
 	['# Hello\n', [heading([plain('Hello')], 1), lineBreak()]],
 	['# # Hello\n', [heading([plain('# Hello')], 1), lineBreak()]],
+	['# :newspaper: Headline', [heading([emoji('newspaper'), plain(' Headline')], 1)]],
+	['## Hello :smile:', [heading([plain('Hello '), emoji('smile')], 2)]],
+	['### :smile: text :newspaper:', [heading([emoji('smile'), plain(' text '), emoji('newspaper')], 3)]],
+
 ])('parses %p', (input, output) => {
 	expect(parse(input)).toMatchObject(output);
 });


### PR DESCRIPTION
## Proposed changes
Fixes #33067. 

The PEG grammar in `message-parser` previously restricted Heading chunks to raw `HeadingString` tokens. This prevented nested inline elements, like Emojis (`# :smile:`) and bold variations, from being parsed correctly into their structural AST node objects. 

This PR updates the parser grammar block to evaluate standard `Inline` rules recursively inside `Heading` components, restoring native markdown formatting behavior without negatively impacting simple text rendering. Verified by expanding testing capabilities for emoji-nested headlines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Headings now correctly parse and render emojis and inline formatting. Emojis placed before, after, or between words in heading text are preserved in order and display as expected.
  * Improves reliability of heading rendering so nested emojis and mixed inline markdown inside headings no longer break or lose content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->