### PR TITLE
chore: update AddLinkComposerActionModal variant to primary

### DIFF
--- a/apps/meteor/app/ui-message/client/messageBox/AddLinkComposerActionModal.tsx
+++ b/apps/meteor/app/ui-message/client/messageBox/AddLinkComposerActionModal.tsx
@@ -37,7 +37,7 @@ const AddLinkComposerActionModal = ({ selectedText, onClose, onConfirm }: AddLin
 
 	return (
 		<GenericModal
-			variant='warning'
+			variant='primary'
 			icon={null}
 			confirmText={t('Add')}
 			onCancel={onClose}


### PR DESCRIPTION
This PR performs a minor UI refinement to the message composer's link addition modal.

Changes: Updated the GenericModal variant from warning to primary on line 42 of AddLinkComposerActionModal.tsx.

Impact: The "Add" button and modal header will now display in the primary brand color (blue) instead of the warning color (orange).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of the add link composer modal to use the primary design variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->