### PR TITLE
chore: migrate `e2e.acceptSuggestedGroupKey` endpoint to chained API pattern with AJV validation

### DIFF
--- a/apps/meteor/app/api/server/v1/e2e.ts
+++ b/apps/meteor/app/api/server/v1/e2e.ts
@@ -214,6 +214,29 @@ const e2eEndpoints = API.v1
 
 			return API.v1.success();
 		},
+	)
+	.post(
+		'e2e.acceptSuggestedGroupKey',
+		{
+			authRequired: true,
+			body: ise2eGetUsersOfRoomWithoutKeyParamsGET,
+			response: {
+				200: ajv.compile<void>({
+					type: 'object',
+					properties: {
+						success: { type: 'boolean', enum: [true] },
+					},
+					required: ['success'],
+				}),
+			},
+		},
+		async function action() {
+			const { rid } = this.bodyParams;
+
+			await handleSuggestedGroupKey('accept', rid, this.userId, 'e2e.acceptSuggestedGroupKey');
+
+			return API.v1.success();
+		},
 	);
 
 /**
@@ -271,22 +294,7 @@ API.v1.addRoute(
 	},
 );
 
-API.v1.addRoute(
-	'e2e.acceptSuggestedGroupKey',
-	{
-		authRequired: true,
-		validateParams: ise2eGetUsersOfRoomWithoutKeyParamsGET,
-	},
-	{
-		async post() {
-			const { rid } = this.bodyParams;
 
-			await handleSuggestedGroupKey('accept', rid, this.userId, 'e2e.acceptSuggestedGroupKey');
-
-			return API.v1.success();
-		},
-	},
-);
 
 API.v1.addRoute(
 	'e2e.rejectSuggestedGroupKey',
@@ -385,5 +393,5 @@ export type E2eEndpoints = ExtractRoutesFromAPI<typeof e2eEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends E2eEndpoints {}
+	interface Endpoints extends E2eEndpoints { }
 }

--- a/packages/rest-typings/src/v1/e2e.ts
+++ b/packages/rest-typings/src/v1/e2e.ts
@@ -124,9 +124,6 @@ export type E2eEndpoints = {
 	'/v1/e2e.setUserPublicAndPrivateKeys': {
 		POST: (params: E2eSetUserPublicAndPrivateKeysProps) => void;
 	};
-	'/v1/e2e.acceptSuggestedGroupKey': {
-		POST: (params: E2eGetUsersOfRoomWithoutKeyProps) => void;
-	};
 	'/v1/e2e.rejectSuggestedGroupKey': {
 		POST: (params: E2eGetUsersOfRoomWithoutKeyProps) => void;
 	};


### PR DESCRIPTION
Closes #39201

## Changes

- Migrated `e2e.acceptSuggestedGroupKey` POST endpoint from legacy `API.v1.addRoute` to the new chained `.post()` API pattern
- Replaced `validateParams` with AJV `body` schema validation
- Added AJV response schema validation for the `200` response
- Removed manual `'/v1/e2e.acceptSuggestedGroupKey'` type definition from `rest-typings` (now auto-inferred via [ExtractRoutesFromAPI](cci:2://file://wsl.localhost/Ubuntu/home/ashwaniyadav/Rocket.Chat/apps/meteor/app/api/server/ApiClass.ts:73:0-77:2))

## Files Changed

- [apps/meteor/app/api/server/v1/e2e.ts](cci:7://file://wsl.localhost/Ubuntu/home/ashwaniyadav/Rocket.Chat/apps/meteor/app/api/server/v1/e2e.ts:0:0-0:0) — endpoint migration
- [packages/rest-typings/src/v1/e2e.ts](cci:7://file://wsl.localhost/Ubuntu/home/ashwaniyadav/Rocket.Chat/packages/rest-typings/src/v1/e2e.ts:0:0-0:0) — removed manual type definition

## No behavioral changes

The endpoint logic remains identical — only the registration pattern has been updated.

### Related project

This continues the REST API migration effort described in the [GSoC 2026 project: Replace old REST API definitions over the new API](https://github.com/RocketChat/google-summer-of-code/blob/main/google-summer-of-code-2026.md).

cc @diego-sampaio @ggazzo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated an end-to-end encryption endpoint into the existing chained flow for a cleaner request path.
  * Removed a duplicate standalone registration and adjusted the public API declaration; visible behavior and responses remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->