### PR TITLE
fix: inconsistent method metadata in `removeUserFromRole` error

### DIFF
--- a/apps/meteor/app/authorization/server/methods/removeUserFromRole.ts
+++ b/apps/meteor/app/authorization/server/methods/removeUserFromRole.ts
@@ -52,7 +52,7 @@ export const removeUserFromRole = async (userId: string, roleId: string, usernam
 		const userIsAdmin = user.roles?.indexOf('admin') > -1;
 		if (adminCount === 1 && userIsAdmin) {
 			throw new Meteor.Error('error-action-not-allowed', 'Leaving the app without admins is not allowed', {
-				method: 'removeUserFromRole',
+				method: 'authorization:removeUserFromRole',
 				action: 'Remove_last_admin',
 			});
 		}


### PR DESCRIPTION
## Summary

Ensures consistent `method` metadata in `removeUserFromRole` errors.

The "last admin removal" error used `method: 'removeUserFromRole'`
while other errors in the same function use
`method: 'authorization:removeUserFromRole'`.

This change aligns the metadata for consistency in logging and observability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message formatting when attempting to remove the last admin from a role, now using the correct error identifier for better clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->