### PR TITLE
chore: Add OpenAPI support for the Rocket.Chat e2e endpoints

### DIFF
--- a/.changeset/swift-badgers-try.md
+++ b/.changeset/swift-badgers-try.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/rest-typings': minor
+'@rocket.chat/meteor': minor
+---
+
+Add OpenAPI support for the Rocket.Chat e2e endpoints by migrating to a modern chained route definition syntax and utilizing shared AJV schemas for validation to enhance API documentation and ensure type safety through response validation.

--- a/apps/meteor/app/api/server/v1/e2e.ts
+++ b/apps/meteor/app/api/server/v1/e2e.ts
@@ -1,13 +1,11 @@
-import type { IUser } from '@rocket.chat/core-typings';
+import type { IRoom, ISubscription, IUser } from '@rocket.chat/core-typings';
 import { Subscriptions, Users } from '@rocket.chat/models';
 import {
 	ajv,
 	validateUnauthorizedErrorResponse,
 	validateBadRequestErrorResponse,
+	validateForbiddenErrorResponse,
 	ise2eSetUserPublicAndPrivateKeysParamsPOST,
-	isE2EProvideUsersGroupKeyProps,
-	isE2EFetchUsersWaitingForGroupKeyProps,
-	isE2EResetRoomKeyProps,
 } from '@rocket.chat/rest-typings';
 import ExpiryMap from 'expiry-map';
 
@@ -41,6 +39,18 @@ type e2eUpdateGroupKeyParamsPOST = {
 	uid: string;
 	rid: string;
 	key: string;
+};
+
+type E2EFetchUsersWaitingForGroupKeyProps = { roomIds: string[] };
+
+type E2EProvideUsersGroupKeyProps = {
+	usersSuggestedGroupKeys: Record<IRoom['_id'], { _id: IUser['_id']; key: string; oldKeys: ISubscription['suggestedOldRoomKeys'] }[]>;
+};
+
+type E2EResetRoomKeyProps = {
+	rid: string;
+	e2eKey: string;
+	e2eKeyId: string;
 };
 
 const E2eSetRoomKeyIdSchema = {
@@ -85,6 +95,67 @@ const e2eUpdateGroupKeyParamsPOSTSchema = {
 	required: ['uid', 'rid', 'key'],
 };
 
+const E2EFetchUsersWaitingForGroupKeySchema = {
+	type: 'object',
+	properties: {
+		roomIds: {
+			type: 'array',
+			items: {
+				type: 'string',
+			},
+		},
+	},
+	required: ['roomIds'],
+	additionalProperties: false,
+};
+
+const E2EProvideUsersGroupKeySchema = {
+	type: 'object',
+	properties: {
+		usersSuggestedGroupKeys: {
+			type: 'object',
+			additionalProperties: {
+				type: 'array',
+				items: {
+					type: 'object',
+					properties: {
+						_id: { type: 'string' },
+						key: { type: 'string' },
+						oldKeys: {
+							type: 'array',
+							items: {
+								type: 'object',
+								properties: { e2eKeyId: { type: 'string' }, ts: { type: 'string' }, E2EKey: { type: 'string' } },
+							},
+						},
+					},
+					required: ['_id', 'key'],
+					additionalProperties: false,
+				},
+			},
+		},
+	},
+	required: ['usersSuggestedGroupKeys'],
+	additionalProperties: false,
+};
+
+const E2EResetRoomKeySchema = {
+	type: 'object',
+	properties: {
+		rid: {
+			type: 'string',
+		},
+		e2eKey: {
+			type: 'string',
+		},
+		e2eKeyId: {
+			type: 'string',
+		},
+	},
+	required: ['rid', 'e2eKey', 'e2eKeyId'],
+	additionalProperties: false,
+};
+
 const isE2eSetRoomKeyIdProps = ajv.compile<E2eSetRoomKeyIdProps>(E2eSetRoomKeyIdSchema);
 
 const ise2eGetUsersOfRoomWithoutKeyParamsGET = ajv.compile<e2eGetUsersOfRoomWithoutKeyParamsGET>(
@@ -92,6 +163,12 @@ const ise2eGetUsersOfRoomWithoutKeyParamsGET = ajv.compile<e2eGetUsersOfRoomWith
 );
 
 const ise2eUpdateGroupKeyParamsPOST = ajv.compile<e2eUpdateGroupKeyParamsPOST>(e2eUpdateGroupKeyParamsPOSTSchema);
+
+const isE2EFetchUsersWaitingForGroupKeyProps = ajv.compile<E2EFetchUsersWaitingForGroupKeyProps>(E2EFetchUsersWaitingForGroupKeySchema);
+
+const isE2EProvideUsersGroupKeyProps = ajv.compile<E2EProvideUsersGroupKeyProps>(E2EProvideUsersGroupKeySchema);
+
+const isE2EResetRoomKeyProps = ajv.compile<E2EResetRoomKeyProps>(E2EResetRoomKeySchema);
 
 const e2eEndpoints = API.v1
 	.post(
@@ -191,6 +268,108 @@ const e2eEndpoints = API.v1
 		},
 	)
 	.post(
+		'e2e.rejectSuggestedGroupKey',
+		{
+			authRequired: true,
+			body: ise2eGetUsersOfRoomWithoutKeyParamsGET,
+			response: {
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				200: ajv.compile<void>({
+					type: 'object',
+					properties: {
+						success: { type: 'boolean', enum: [true] },
+					},
+					required: ['success'],
+				}),
+			},
+		},
+
+		async function action() {
+			const { rid } = this.bodyParams;
+
+			await handleSuggestedGroupKey('reject', rid, this.userId, 'e2e.rejectSuggestedGroupKey');
+
+			return API.v1.success();
+		},
+	)
+	.post(
+		'e2e.acceptSuggestedGroupKey',
+		{
+			authRequired: true,
+			body: ise2eGetUsersOfRoomWithoutKeyParamsGET,
+			response: {
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				200: ajv.compile<void>({
+					type: 'object',
+					properties: {
+						success: { type: 'boolean', enum: [true] },
+					},
+					required: ['success'],
+				}),
+			},
+		},
+
+		async function action() {
+			const { rid } = this.bodyParams;
+
+			await handleSuggestedGroupKey('accept', rid, this.userId, 'e2e.acceptSuggestedGroupKey');
+
+			return API.v1.success();
+		},
+	)
+	.get(
+		'e2e.fetchUsersWaitingForGroupKey',
+		{
+			authRequired: true,
+			query: isE2EFetchUsersWaitingForGroupKeyProps,
+			response: {
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				200: ajv.compile<{
+					usersWaitingForE2EKeys: Record<IRoom['_id'], { _id: IUser['_id']; public_key: string }[]>;
+				}>({
+					type: 'object',
+					properties: {
+						usersWaitingForE2EKeys: {
+							type: 'object',
+							additionalProperties: {
+								type: 'array',
+								items: {
+									type: 'object',
+									properties: {
+										_id: { type: 'string' },
+										public_key: { type: 'string' },
+									},
+									required: ['_id', 'public_key'],
+								},
+							},
+						},
+						success: { type: 'boolean', enum: [true] },
+					},
+					required: ['usersWaitingForE2EKeys', 'success'],
+				}),
+			},
+		},
+
+		async function action() {
+			if (!settings.get('E2E_Enable')) {
+				return API.v1.success({ usersWaitingForE2EKeys: {} });
+			}
+
+			const { roomIds = [] } = this.queryParams;
+			const usersWaitingForE2EKeys = (await Subscriptions.findUsersWithPublicE2EKeyByRids(roomIds, this.userId).toArray()).reduce<
+				Record<string, { _id: string; public_key: string }[]>
+			>((acc, { rid, users }) => ({ [rid]: users, ...acc }), {});
+
+			return API.v1.success({
+				usersWaitingForE2EKeys,
+			});
+		},
+	)
+
+	.post(
 		'e2e.updateGroupKey',
 		{
 			authRequired: true,
@@ -213,6 +392,80 @@ const e2eEndpoints = API.v1
 			await updateGroupKey(rid, uid, key, this.userId);
 
 			return API.v1.success();
+		},
+	)
+	.post(
+		'e2e.provideUsersSuggestedGroupKeys',
+		{
+			authRequired: true,
+			body: isE2EProvideUsersGroupKeyProps,
+			response: {
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				200: ajv.compile<void>({
+					type: 'object',
+					properties: {
+						success: { type: 'boolean', enum: [true] },
+					},
+					required: ['success'],
+				}),
+			},
+		},
+
+		async function action() {
+			if (!settings.get('E2E_Enable')) {
+				return API.v1.success();
+			}
+
+			await provideUsersSuggestedGroupKeys(this.userId, this.bodyParams.usersSuggestedGroupKeys);
+
+			return API.v1.success();
+		},
+	)
+	// This should have permissions
+	.post(
+		'e2e.resetRoomKey',
+		{
+			authRequired: true,
+			body: isE2EResetRoomKeyProps,
+			response: {
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
+				200: ajv.compile<void>({
+					type: 'object',
+					properties: {
+						success: { type: 'boolean', enum: [true] },
+					},
+					required: ['success'],
+				}),
+			},
+		},
+
+		async function action() {
+			const { rid, e2eKey, e2eKeyId } = this.bodyParams;
+			if (!(await hasPermissionAsync(this.userId, 'toggle-room-e2e-encryption', rid))) {
+				return API.v1.forbidden('error-not-allowed');
+			}
+			if (LockMap.has(rid)) {
+				throw new Error('error-e2e-key-reset-in-progress');
+			}
+
+			LockMap.set(rid, true);
+
+			if (!(await canAccessRoomIdAsync(rid, this.userId))) {
+				throw new Error('error-not-allowed');
+			}
+
+			try {
+				await resetRoomKey(rid, this.userId, e2eKey, e2eKeyId);
+				return API.v1.success();
+			} catch (e) {
+				console.error(e);
+				return API.v1.failure('error-e2e-key-reset-failed');
+			} finally {
+				LockMap.delete(rid);
+			}
 		},
 	);
 
@@ -271,117 +524,7 @@ API.v1.addRoute(
 	},
 );
 
-API.v1.addRoute(
-	'e2e.acceptSuggestedGroupKey',
-	{
-		authRequired: true,
-		validateParams: ise2eGetUsersOfRoomWithoutKeyParamsGET,
-	},
-	{
-		async post() {
-			const { rid } = this.bodyParams;
-
-			await handleSuggestedGroupKey('accept', rid, this.userId, 'e2e.acceptSuggestedGroupKey');
-
-			return API.v1.success();
-		},
-	},
-);
-
-API.v1.addRoute(
-	'e2e.rejectSuggestedGroupKey',
-	{
-		authRequired: true,
-		validateParams: ise2eGetUsersOfRoomWithoutKeyParamsGET,
-	},
-	{
-		async post() {
-			const { rid } = this.bodyParams;
-
-			await handleSuggestedGroupKey('reject', rid, this.userId, 'e2e.rejectSuggestedGroupKey');
-
-			return API.v1.success();
-		},
-	},
-);
-
-API.v1.addRoute(
-	'e2e.fetchUsersWaitingForGroupKey',
-	{
-		authRequired: true,
-		validateParams: isE2EFetchUsersWaitingForGroupKeyProps,
-	},
-	{
-		async get() {
-			if (!settings.get('E2E_Enable')) {
-				return API.v1.success({ usersWaitingForE2EKeys: {} });
-			}
-
-			const { roomIds = [] } = this.queryParams;
-			const usersWaitingForE2EKeys = (await Subscriptions.findUsersWithPublicE2EKeyByRids(roomIds, this.userId).toArray()).reduce<
-				Record<string, { _id: string; public_key: string }[]>
-			>((acc, { rid, users }) => ({ [rid]: users, ...acc }), {});
-
-			return API.v1.success({
-				usersWaitingForE2EKeys,
-			});
-		},
-	},
-);
-
-API.v1.addRoute(
-	'e2e.provideUsersSuggestedGroupKeys',
-	{
-		authRequired: true,
-		validateParams: isE2EProvideUsersGroupKeyProps,
-	},
-	{
-		async post() {
-			if (!settings.get('E2E_Enable')) {
-				return API.v1.success();
-			}
-
-			await provideUsersSuggestedGroupKeys(this.userId, this.bodyParams.usersSuggestedGroupKeys);
-
-			return API.v1.success();
-		},
-	},
-);
-
-// This should have permissions
-API.v1.addRoute(
-	'e2e.resetRoomKey',
-	{ authRequired: true, validateParams: isE2EResetRoomKeyProps },
-	{
-		async post() {
-			const { rid, e2eKey, e2eKeyId } = this.bodyParams;
-			if (!(await hasPermissionAsync(this.userId, 'toggle-room-e2e-encryption', rid))) {
-				return API.v1.forbidden();
-			}
-			if (LockMap.has(rid)) {
-				throw new Error('error-e2e-key-reset-in-progress');
-			}
-
-			LockMap.set(rid, true);
-
-			if (!(await canAccessRoomIdAsync(rid, this.userId))) {
-				throw new Error('error-not-allowed');
-			}
-
-			try {
-				await resetRoomKey(rid, this.userId, e2eKey, e2eKeyId);
-				return API.v1.success();
-			} catch (e) {
-				console.error(e);
-				return API.v1.failure('error-e2e-key-reset-failed');
-			} finally {
-				LockMap.delete(rid);
-			}
-		},
-	},
-);
-
-export type E2eEndpoints = ExtractRoutesFromAPI<typeof e2eEndpoints>;
+type E2eEndpoints = ExtractRoutesFromAPI<typeof e2eEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface

--- a/packages/rest-typings/src/v1/e2e.ts
+++ b/packages/rest-typings/src/v1/e2e.ts
@@ -1,5 +1,3 @@
-import type { IRoom, IUser, ISubscription } from '@rocket.chat/core-typings';
-
 import { ajv } from './Ajv';
 
 type E2eSetUserPublicAndPrivateKeysProps = {
@@ -24,121 +22,8 @@ const E2eSetUserPublicAndPrivateKeysSchema = {
 
 export const isE2eSetUserPublicAndPrivateKeysProps = ajv.compile<E2eSetUserPublicAndPrivateKeysProps>(E2eSetUserPublicAndPrivateKeysSchema);
 
-type E2eGetUsersOfRoomWithoutKeyProps = { rid: string };
-
-const E2eGetUsersOfRoomWithoutKeySchema = {
-	type: 'object',
-	properties: {
-		rid: {
-			type: 'string',
-		},
-	},
-	required: ['rid'],
-	additionalProperties: false,
-};
-
-export const isE2eGetUsersOfRoomWithoutKeyProps = ajv.compile<E2eGetUsersOfRoomWithoutKeyProps>(E2eGetUsersOfRoomWithoutKeySchema);
-
-type E2EProvideUsersGroupKeyProps = {
-	usersSuggestedGroupKeys: Record<IRoom['_id'], { _id: IUser['_id']; key: string; oldKeys: ISubscription['suggestedOldRoomKeys'] }[]>;
-};
-
-const E2EProvideUsersGroupKeySchema = {
-	type: 'object',
-	properties: {
-		usersSuggestedGroupKeys: {
-			type: 'object',
-			additionalProperties: {
-				type: 'array',
-				items: {
-					type: 'object',
-					properties: {
-						_id: { type: 'string' },
-						key: { type: 'string' },
-						oldKeys: {
-							type: 'array',
-							items: {
-								type: 'object',
-								properties: { e2eKeyId: { type: 'string' }, ts: { type: 'string' }, E2EKey: { type: 'string' } },
-							},
-						},
-					},
-					required: ['_id', 'key'],
-					additionalProperties: false,
-				},
-			},
-		},
-	},
-	required: ['usersSuggestedGroupKeys'],
-	additionalProperties: false,
-};
-
-export const isE2EProvideUsersGroupKeyProps = ajv.compile<E2EProvideUsersGroupKeyProps>(E2EProvideUsersGroupKeySchema);
-
-type E2EFetchUsersWaitingForGroupKeyProps = { roomIds: string[] };
-
-const E2EFetchUsersWaitingForGroupKeySchema = {
-	type: 'object',
-	properties: {
-		roomIds: {
-			type: 'array',
-			items: {
-				type: 'string',
-			},
-		},
-	},
-	required: ['roomIds'],
-	additionalProperties: false,
-};
-
-export const isE2EFetchUsersWaitingForGroupKeyProps = ajv.compile<E2EFetchUsersWaitingForGroupKeyProps>(
-	E2EFetchUsersWaitingForGroupKeySchema,
-);
-
-type E2EResetRoomKeyProps = {
-	rid: string;
-	e2eKey: string;
-	e2eKeyId: string;
-};
-
-const E2EResetRoomKeySchema = {
-	type: 'object',
-	properties: {
-		rid: {
-			type: 'string',
-		},
-		e2eKey: {
-			type: 'string',
-		},
-		e2eKeyId: {
-			type: 'string',
-		},
-	},
-	required: ['rid', 'e2eKey', 'e2eKeyId'],
-	additionalProperties: false,
-};
-
-export const isE2EResetRoomKeyProps = ajv.compile<E2EResetRoomKeyProps>(E2EResetRoomKeySchema);
-
 export type E2eEndpoints = {
 	'/v1/e2e.setUserPublicAndPrivateKeys': {
 		POST: (params: E2eSetUserPublicAndPrivateKeysProps) => void;
-	};
-	'/v1/e2e.acceptSuggestedGroupKey': {
-		POST: (params: E2eGetUsersOfRoomWithoutKeyProps) => void;
-	};
-	'/v1/e2e.rejectSuggestedGroupKey': {
-		POST: (params: E2eGetUsersOfRoomWithoutKeyProps) => void;
-	};
-	'/v1/e2e.fetchUsersWaitingForGroupKey': {
-		GET: (params: E2EFetchUsersWaitingForGroupKeyProps) => {
-			usersWaitingForE2EKeys: Record<IRoom['_id'], { _id: IUser['_id']; public_key: string }[]>;
-		};
-	};
-	'/v1/e2e.provideUsersSuggestedGroupKeys': {
-		POST: (params: E2EProvideUsersGroupKeyProps) => void;
-	};
-	'/v1/e2e.resetRoomKey': {
-		POST: (params: E2EResetRoomKeyProps) => void;
 	};
 };


### PR DESCRIPTION
**Description:**  
This PR integrates OpenAPI support into the `Rocket.Chat API`, migrate of `Rocket.Chat API` endpoints to the new OpenAPI pattern. The update includes improved API documentation, enhanced type safety, and response validation using AJV.

**Key Changes:**  
- **Implemented the new pattern** and added AJV-based JSON schema validation for API.  
- **Uses the ExtractRoutesFromAPI utility** from the TypeScript definitions to dynamically derive the routes from the endpoint specifications.
- **Enabled Swagger UI** integration for this API.
- **Route Methods Chaining** for the endpoints.
- **This does not introduce any breaking changes** to the endpoint logic.


**Issue Reference:**  
[COMM-144]
Relates to #34983, part of the ongoing OpenAPI integration effort.

**Testing:**
- Verified that the API response schemas are correctly documented in Swagger UI.  
- All tests passed without any breaking changes

**Endpoints:**
* [x] e2e.rejectSuggestedGroupKey 
* [x] e2e.acceptSuggestedGroupKey 
* [x] e2e.fetchUsersWaitingForGroupKey
* [x] e2e.provideUsersSuggestedGroupKeys
* [x] e2e.resetRoomKey
  
Looking forward to your feedback! 🚀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled OpenAPI support for end-to-end encryption endpoints with improved type validation.
  * Added new E2E endpoints for group key management: accepting/rejecting group key suggestions, fetching users awaiting keys, providing suggested group keys, and resetting room keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2016]

[ARCH-2016]: https://rocketchat.atlassian.net/browse/ARCH-2016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[COMM-144]: https://rocketchat.atlassian.net/browse/COMM-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ