### PR TITLE
chore: remove debug console.log in API authentication handler

### DIFF
--- a/apps/meteor/app/api/server/ApiClass.ts
+++ b/apps/meteor/app/api/server/ApiClass.ts
@@ -835,7 +835,6 @@ export class APIClass<TBasePath extends string = '', TOperations extends Record<
 						const shouldPreventUserRead = !this.user && options.authRequired;
 
 						if (shouldPreventAnonymousRead || shouldPreventUserRead) {
-							console.log('shouldPreventAnonymousRead', shouldPreventAnonymousRead);
 							const result = api.unauthorized('You must be logged in to do this.');
 							// compatibility with the old API
 							// TODO: MAJOR


### PR DESCRIPTION
Remove stale `console.log('shouldPreventAnonymousRead', ...)` statement that runs on every unauthenticated API request in production, adding unnecessary noise to logs and bypassing the structured logging system.

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

A debug `console.log` statement was left in the REST API authentication handler (`apps/meteor/app/api/server/ApiClass.ts`, line 838). This line:

```js
console.log('shouldPreventAnonymousRead', shouldPreventAnonymousRead);
```

runs inside the `_internalRouteActionHandler` function on **every unauthenticated API request**, causing:

1. **Log noise in production** — prints to stdout on every anonymous/unauthenticated call
2. **Bypasses structured logging** — the project uses `@rocket.chat/logger` for all logging, but this uses raw `console.log`
3. **Minor performance overhead** — unnecessary I/O on a hot authentication path

This PR simply removes the single `console.log` line. No functional behavior is changed — the authentication logic (`shouldPreventAnonymousRead`, `shouldPreventUserRead`, and the `api.unauthorized()` response) remains exactly the same.

## Issue(s)


Fixes #39231

## Steps to test or reproduce

**To reproduce the debug log:**
1. Start a Rocket.Chat server
2. Make any unauthenticated API request, e.g.: `curl http://localhost:3000/api/v1/channels.list`
3. Observe `shouldPreventAnonymousRead true` printed to the server's stdout

**To verify the fix:**
1. Apply this PR
2. Repeat the same unauthenticated API request
3. Confirm the `shouldPreventAnonymousRead` message no longer appears in stdout
4. Confirm the API still correctly returns a 401 Unauthorized response

## Further comments

This is a minimal, zero-risk change — 1 file changed, 1 line deleted. No functional logic is altered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal debug logging to improve code cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2073]

[ARCH-2073]: https://rocketchat.atlassian.net/browse/ARCH-2073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ