### PR TITLE
fix(omnichannel): wrap transfer comment to multiple lines (#26723)

### DIFF
--- a/apps/meteor/client/components/message/variants/SystemMessage.tsx
+++ b/apps/meteor/client/components/message/variants/SystemMessage.tsx
@@ -87,7 +87,14 @@ const SystemMessage = ({ message, showUserAvatar, ...props }: SystemMessageProps
 						)}
 					</MessageNameContainer>
 					{messageType && (
-						<MessageSystemBody role='document' aria-roledescription={t('system_message_body')}>
+						<MessageSystemBody
+							role='document'
+							aria-roledescription={t('system_message_body')}
+							{...(message.t === 'livechat_transfer_history' && {
+								wordBreak: 'break-word',
+								style: { whiteSpace: 'pre-wrap' },
+							})}
+						>
 							{messageType.text(t, message)}
 						</MessageSystemBody>
 					)}

--- a/apps/meteor/client/views/omnichannel/contactHistory/MessageList/ContactHistoryMessage.tsx
+++ b/apps/meteor/client/views/omnichannel/contactHistory/MessageList/ContactHistoryMessage.tsx
@@ -71,7 +71,7 @@ const ContactHistoryMessage = ({ message, sequential, isNewDay, showUserAvatar }
 						<MessageSystemName data-username={message.u.username} data-qa-type='username'>
 							@{message.u.username}
 						</MessageSystemName>
-						<MessageSystemBody title={message.msg}>{t('Conversation_closed', { comment: message.msg })}</MessageSystemBody>
+						<MessageSystemBody title={message.msg} wordBreak='break-word' style={{ whiteSpace: 'pre-wrap' }}>{t('Conversation_closed', { comment: message.msg })}</MessageSystemBody>
 						<MessageSystemTimestamp title={formatTime(message.ts)}>{formatTime(message.ts)}</MessageSystemTimestamp>
 					</MessageSystemBlock>
 				</MessageSystemContainer>


### PR DESCRIPTION
## Proposed changes
This PR fixes an issue where long omnichannel transfer comments are not properly wrapped to multiple lines, resulting in text bleeding out of the boundaries or being hidden behind ellipsis in the chat history.

I modified the [SystemMessage](cci:1://file:///c:/Users/Shreya/Desktop/GSOC/Rocket.Chat/apps/meteor/client/components/message/variants/SystemMessage.tsx:43:0-120:2) component for `livechat_transfer_history` and [ContactHistoryMessage](cci:1://file:///c:/Users/Shreya/Desktop/GSOC/Rocket.Chat/apps/meteor/client/views/omnichannel/contactHistory/MessageList/ContactHistoryMessage.tsx:40:0-130:2) for `livechat-close` to include `word-break: break-word` and `white-space: pre-wrap`, ensuring that comments explicitly wrap within the message constraints.

## Issue(s)
Fixes #26723

## Steps to test or reproduce
1. Start an omnichannel conversation.
2. Transfer it to another agent, leaving a very long text comment.
3. Observe the transferred message in the chat history. The text should now wrap to multiple lines correctly.
4. Also close the conversation with a long comment and observe that the close comment also neatly wraps to multiple lines.

## Further comments
Tested locally by inspecting the updated components with React Fuselage components.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text rendering and word wrapping for system messages related to livechat transfer history and conversation closures. Messages now display properly with appropriate line breaks and whitespace handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->