### PR TITLE
fix(gazzodown): render timestamp inside strikethrough text

### DIFF
--- a/packages/gazzodown/src/elements/StrikeSpan.tsx
+++ b/packages/gazzodown/src/elements/StrikeSpan.tsx
@@ -5,6 +5,7 @@ import BoldSpan from './BoldSpan';
 import ItalicSpan from './ItalicSpan';
 import LinkSpan from './LinkSpan';
 import PlainSpan from './PlainSpan';
+import Timestamp from './Timestamp';
 import CodeElement from '../code/CodeElement';
 import EmojiElement from '../emoji/EmojiElement';
 import ChannelMentionElement from '../mentions/ChannelMentionElement';
@@ -31,7 +32,8 @@ const StrikeSpan = ({ children }: StrikeSpanProps): ReactElement => (
 				block.type === 'PLAIN_TEXT' ||
 				block.type === 'ITALIC' ||
 				block.type === 'BOLD' ||
-				block.type === 'INLINE_CODE'
+				block.type === 'INLINE_CODE' ||
+				block.type === 'TIMESTAMP'
 			) {
 				return <del key={index}>{renderBlockComponent(block, index)}</del>;
 			}
@@ -65,6 +67,9 @@ const renderBlockComponent = (block: MessageBlock, index: number): ReactElement 
 
 		case 'INLINE_CODE':
 			return <CodeElement key={index} code={block.value.value} />;
+
+		case 'TIMESTAMP':
+			return <Timestamp key={index}>{block}</Timestamp>;
 
 		default:
 			return null;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

Timestamps inside strikethrough text were **not rendering**, they silently vanished. The parser grammar explicitly supports timestamps inside strikethrough (`StrikethroughContent` includes `TimestampRules`), and  `StrikeSpan` type already included `MessageParser.Timestamp`, but the render switch had no case for it.

This PR adds the missing TIMESTAMP case to `StrikeSpan`.

> Note: This fix resolves the vanishing issue, timestamps now render inside strikethrough. However, since timestamps render as formatted badges, the `<del>` strikethrough line is not visually applied to them (similar to how emojis inside strikethrough do not display a line through them)

### Before

https://github.com/user-attachments/assets/0a95c395-d7c4-49b5-b4c8-8341d1ac0467


### After (Fix)


https://github.com/user-attachments/assets/810a6632-4a59-429a-bbfc-5c12c0b62778


## Issue(s)
Fixes #39255 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timestamps now render correctly inside strikethrough text; timestamp elements are treated as inline and display properly when included in struck-through content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->