### PR TITLE
fix(import): restore message visibility after Slack/CSV import

### DIFF
--- a/apps/meteor/app/importer/server/classes/converters/MessageConverter.ts
+++ b/apps/meteor/app/importer/server/classes/converters/MessageConverter.ts
@@ -85,6 +85,7 @@ export class MessageConverter extends RecordConverter<IImportMessageRecord> {
 		const channels = data.channels && (await this.convertMessageChannels(data));
 		const editedBy = data.editedBy ? await this._cache.findImportedUser(data.editedBy) : undefined;
 		const reactions = data.reactions ? await this.convertMessageReactions(data.reactions) : undefined;
+		const replies = data.replies?.length ? await this.convertMessageReplies(data.replies) : undefined;
 
 		return {
 			rid,
@@ -100,7 +101,7 @@ export class MessageConverter extends RecordConverter<IImportMessageRecord> {
 			...(data.tmid ? { tmid: data.tmid } : {}),
 			...(data.tlm ? { tlm: data.tlm } : {}),
 			...(data.tcount !== undefined ? { tcount: data.tcount } : {}),
-			...(data.replies?.length ? { replies: await this.convertMessageReplies(data.replies) } : {}),
+			...(replies?.length ? { replies } : {}),
 			...(data.editedAt ? { editedAt: data.editedAt } : {}),
 			...(editedBy ? { editedBy } : {}),
 			...(mentions?.length ? { mentions } : {}),

--- a/apps/meteor/app/importer/server/classes/converters/RoomConverter.ts
+++ b/apps/meteor/app/importer/server/classes/converters/RoomConverter.ts
@@ -47,8 +47,19 @@ export class RoomConverter extends RecordConverter<IImportChannelRecord> {
 			await this.insertRoom(data, startedByUserId);
 		}
 
+		this.registerImportedRoomIdsInCache(data);
+
 		if (data.archived && data._id) {
 			await this.archiveRoomById(data._id);
+		}
+	}
+
+	private registerImportedRoomIdsInCache(roomData: IImportChannel): void {
+		for (const importId of roomData.importIds) {
+			this._cache.addRoom(importId, roomData._id as string);
+			if (roomData.name) {
+				this._cache.addRoomName(importId, roomData.name);
+			}
 		}
 	}
 
@@ -131,14 +142,6 @@ export class RoomConverter extends RecordConverter<IImportChannelRecord> {
 			this._logger.warn({ msg: 'Failed to create new room', name: roomData.name, members, err: e });
 			throw e;
 		}
-
-		// Register imported room ids in cache (required for message import)
-        for (const importId of roomData.importIds) {
-                this._cache.addRoom(importId, roomData._id as string);
-                if (roomData.name) {
-                        this._cache.addRoomName(importId, roomData.name);
-                }
-        }
 
 		await this.updateRoomId(roomData._id as 'string', roomData);
 	}


### PR DESCRIPTION
## Summary

Fixes an issue where messages imported via Slack or CSV importers were not appearing in channels after import completion.

Although rooms were successfully created, message conversion failed because newly created rooms were not registered in the importer cache used for resolving imported room IDs.

This resulted in message insertion errors (`importer-message-unknown-room`) and missing chat history after import.

## Changes

- Register imported room IDs in `ConverterCache` after successful room creation
- Ensure Optional message metadata fields are omitted to preserve normal messages.

## Result

After this change:
- Slack imports correctly populates channel history
- CSV/slack imports correctly display imported messages
- Imported channels immediately contain their expected messages

## Testing
closes #39257


https://github.com/user-attachments/assets/85ac66d0-aa26-4785-ac9e-bb77e40d71e4



Tested using manufactured Slack-style datasets and CSV imports containing:
- public channels
- historical messages
- other users

Messages are now successfully inserted and visible in imported channels.

## Note/Correction
second commit to be named 

`fix(import): preserve explicit null/boolean fields (e.g., thread-related fields) during message import`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Message import processing now conditionally includes optional fields only when present, reducing unnecessary empty fields in imported messages.
  * Room import caching improved to register import IDs and, when available, room names to better resolve imported room relationships during migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->