### PR TITLE
test(message-parser): add skip-flag regression tests to document complexity

### DIFF
--- a/packages/message-parser/tests/skip-flags-regression.spec.ts
+++ b/packages/message-parser/tests/skip-flags-regression.spec.ts
@@ -11,14 +11,13 @@ describe('Skip Flags Regression (Complexity Audit)', () => {
     it('should demonstrate non-linear growth with nested formatting', () => {
         const times: Record<number, number> = {};
         for (let d = 1; d <= 7; d++) {
-            times[d] = measureDepth(d);
+            const samples = Array.from({ length: 5 }, () => measureDepth(d)).sort((a, b) => a - b);
+            times[d] = samples[Math.floor(samples.length / 2)];
         }
 
         console.table(Object.entries(times).map(([depth, time]) => ({ depth, 'time (ms)': time.toFixed(4) })));
 
-        // If d=7 takes significantly longer than linear growth from d=1
-        // we have confirmed the problem.
-        expect(times[7]).toBeDefined();
+        expect(times[7]).toBeGreaterThan(times[1]);
     });
 
     it('should handle pathological unmatched markers without crashing', () => {


### PR DESCRIPTION
# test(message-parser): add skip-flag regression tests to document complexity

This PR adds a specific test suite to `packages/message-parser` designed to document and measure the performance degradation caused by "skip flags" in the current Peggy-based parser.

## Problem Statement

As detailed in High-Parser research, the current parser uses 7 mutable "skip flags" (skipBold, skipItalic, etc.) to handle nested formatting. This approach effectively breaks packrat memoization because the parser's result at a specific position is no longer determined solely by its location, but by a 128-state ($2^7$) combination of global flags.

## Impact

This PR implements `packages/message-parser/tests/skip-flags-regression.spec.ts`, which measures:
1. **Nesting Depth:** Validates parsing time as formatting depth increases.
2. **Pathological Cases:** Measures the overhead of deeply nested, unmatched markers (the "Exponential Attack" vector).

While individual parse times remain low for simple messages, these tests establish a baseline for identifying the "performance cliff" where linear growth turns exponential.

## Why This PR?
- Document the root cause of the parser's performance issues.
- Provide a target for regression testing during the GSoC parser rewrite.
- Ensure the new parser (which will not use global mutable state) remains linear regardless of nesting complexity.

## Verification
- Run `cd packages/message-parser && yarn test tests/skip-flags-regression.spec.ts` (requires Peggy-aware runner).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests
- Added regression tests for the message parser that measure parsing performance across varying nesting depths, generate timing summaries, and verify performance scaling.
- Added a robustness test that exercises pathological inputs with repeated unmatched markers to ensure parsing completes within expected time bounds and remains stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->