### PR TITLE
fix(ui): add autocomplete attribute to 2FA input fields

### DIFF
--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorEmailModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorEmailModal.tsx
@@ -65,7 +65,7 @@ const TwoFactorEmailModal = ({ onConfirm, onClose, emailOrUsername, invalidAttem
 						{t('Enter_the_code_we_just_emailed_you')}
 					</FieldLabel>
 					<FieldRow>
-						<TextInput id={id} ref={ref} value={code} onChange={onChange} placeholder={t('Enter_code_here')} />
+						<TextInput autoComplete='one-time-code' id={id} ref={ref} value={code} onChange={onChange} placeholder={t('Enter_code_here')} />
 					</FieldRow>
 					{invalidAttempt && <FieldError>{t('Invalid_password')}</FieldError>}
 				</Field>

--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
@@ -49,7 +49,14 @@ const TwoFactorTotpModal = ({ onConfirm, onClose, onDismiss, invalidAttempt }: T
 						{t('Enter_the_code_provided_by_your_authentication_app_to_continue')}
 					</FieldLabel>
 					<FieldRow>
-						<TextInput id={id} ref={ref} value={code} onChange={onChange} placeholder={t('Enter_code_here')}></TextInput>
+						<TextInput
+							autoComplete='one-time-code'
+							id={id}
+							ref={ref}
+							value={code}
+							onChange={onChange}
+							placeholder={t('Enter_code_here')}
+						></TextInput>
 					</FieldRow>
 					{invalidAttempt && <FieldError>{t('Invalid_password')}</FieldError>}
 				</Field>


### PR DESCRIPTION
### Description
This PR addresses **Issue #30025** where password managers (like KeePassXC, 1Password, Bitwarden) were unable to automatically detect and fill the 2FA code input fields on the authentication modals. 

By adding the standard HTML attribute `autoComplete="one-time-code"` to the underlying `<TextInput>` components, password managers and browser autofill features can now successfully identify and populate the TOTP and Email 2FA fields, significantly improving the UX and accessibility during login.

I applied this fix to both the TOTP Modal and the Email 2FA Modal to ensure consistency across the application's security flows.

### Related Issues
Fixes #30025 

### Areas of Code Affected
- Frontend React Components:
  - TwoFactorTotpModal.tsx
  - TwoFactorEmailModal.tsx
   
### Testing Done
* Automated UI/CI checks pass locally via Eslint (`yarn eslint`).
* Confirmed the `<input>` element renders with the correct DOM attributes.
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled browser autofill support for one-time code inputs in two-factor authentication modals (email and TOTP), improving the user experience when entering authentication codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->