### PR TITLE
fix: This endpoint does not provide the extension number, which is necessa…

### DIFF
--- a/apps/meteor/app/api/server/lib/users.ts
+++ b/apps/meteor/app/api/server/lib/users.ts
@@ -7,7 +7,8 @@ import type { Filter, FindOptions, RootFilterOperators } from 'mongodb';
 import { hasPermissionAsync } from '../../../authorization/server/functions/hasPermission';
 import { settings } from '../../../settings/server';
 
-type UserAutoComplete = Required<Pick<IUser, '_id' | 'name' | 'username' | 'nickname' | 'status' | 'avatarETag'>>;
+type UserAutoComplete = Required<Pick<IUser, '_id' | 'name' | 'username' | 'nickname' | 'status' | 'avatarETag'>> &
+	Pick<IUser, 'freeSwitchExtension'>;
 
 export async function findUsersToAutocomplete({
 	uid,

--- a/packages/rest-typings/src/v1/users.ts
+++ b/packages/rest-typings/src/v1/users.ts
@@ -147,7 +147,8 @@ export type UsersEndpoints = {
 
 	'/v1/users.autocomplete': {
 		GET: (params: UsersAutocompleteParamsGET) => {
-			items: Required<Pick<IUser, '_id' | 'name' | 'username' | 'nickname' | 'status' | 'avatarETag'>>[];
+			items: (Required<Pick<IUser, '_id' | 'name' | 'username' | 'nickname' | 'status' | 'avatarETag'>> &
+				Pick<IUser, 'freeSwitchExtension'>)[];
 		};
 	};
 

--- a/packages/ui-voip/src/providers/useGetAutocompleteOptions.ts
+++ b/packages/ui-voip/src/providers/useGetAutocompleteOptions.ts
@@ -40,8 +40,7 @@ export const useGetAutocompleteOptions = (instance: MediaSignalingSession | unde
 			return (
 				items.map((user) => {
 					const label = user.name || user.username;
-					// TODO: This endpoint does not provide the extension number, which is necessary to show in the UI.
-					const identifier = user.username !== label ? user.username : undefined;
+					const identifier = user.freeSwitchExtension || (user.username !== label ? user.username : undefined);
 
 					return {
 						value: user._id,


### PR DESCRIPTION
Now:
user.freeSwitchExtension is available from the endpoint (and properly typed).
The identifier used by PeerAutocomplete prefers freeSwitchExtension (extension number) and only falls back to the username when no extension is present.
This resolves the TODO: the endpoint provides the extension number, and the UI can display/use it.

fixes: #39251


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User autocomplete now includes Free Switch extension information.
  * Improved identifier selection in autocomplete to prioritize Free Switch extensions when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->