### PR TITLE
fix(message-parser): avoid protocol duplication for invalid absolute URLs

### DIFF
--- a/packages/message-parser/src/utils.ts
+++ b/packages/message-parser/src/utils.ts
@@ -75,7 +75,7 @@ const isValidLink = (link: string) => {
 	}
 };
 
-const hasAbsoluteSchemePrefix = (src: string) => /^[A-Za-z0-9+-]{1,32}:\/\//.test(src);
+const hasAbsoluteSchemePrefix = (src: string) => /^[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\//.test(src);
 
 export const link = (src: string, label?: Markup[]): Link => ({
 	type: 'LINK',

--- a/packages/message-parser/src/utils.ts
+++ b/packages/message-parser/src/utils.ts
@@ -75,6 +75,8 @@ const isValidLink = (link: string) => {
 	}
 };
 
+const hasAbsoluteSchemePrefix = (src: string) => /^[A-Za-z0-9+-]{1,32}:\/\//.test(src);
+
 export const link = (src: string, label?: Markup[]): Link => ({
 	type: 'LINK',
 	value: { src: plain(src), label: label ?? [plain(src)] },
@@ -92,7 +94,7 @@ export const autoLink = (src: string, customDomains?: string[]) => {
 		return plain(src);
 	}
 
-	const href = isValidLink(src) || src.startsWith('//') ? src : `//${src}`;
+	const href = isValidLink(src) || src.startsWith('//') || hasAbsoluteSchemePrefix(src) ? src : `//${src}`;
 
 	return link(href, [plain(src)]);
 };

--- a/packages/message-parser/tests/url.test.ts
+++ b/packages/message-parser/tests/url.test.ts
@@ -25,6 +25,8 @@ test.each([
 	['https://test', [paragraph([plain('https://test')])]],
 	['httpsss://rocket.chat/test', [paragraph([link('httpsss://rocket.chat/test')])]],
 	['https://rocket.chat:3000/test', [paragraph([link('https://rocket.chat:3000/test')])]],
+	['https://rocket.chat:99999', [paragraph([link('https://rocket.chat:99999')])]],
+	['https://rocket.chat:99999/test', [paragraph([link('https://rocket.chat:99999/test')])]],
 	['https://rocket.chat/test?search', [paragraph([link('https://rocket.chat/test?search')])]],
 	['https://rocket.chat/test?search=test', [paragraph([link('https://rocket.chat/test?search=test')])]],
 	['https://rocket.chat', [paragraph([link('https://rocket.chat')])]],
@@ -155,6 +157,11 @@ describe('autoLink helper function', () => {
 		expect(autoLink('https://rocket.chat/test')).toMatchObject(link('https://rocket.chat/test'));
 
 		expect(autoLink('http://rocket.chat/test')).toMatchObject(link('http://rocket.chat/test'));
+	});
+
+	it('should preserve the original protocol for invalid absolute URLs', () => {
+		expect(autoLink('https://rocket.chat:99999')).toMatchObject(link('https://rocket.chat:99999'));
+		expect(autoLink('https://rocket.chat:65536')).toMatchObject(link('https://rocket.chat:65536'));
 	});
 
 	it('should preserve the original protocol even if for custom protocols', () => {


### PR DESCRIPTION
## Summary
- Preserve absolute URL sources in `autoLink` even when `URL()` validation fails (for example, invalid ports).
- Avoid adding a leading `//` to already-absolute inputs such as `https://rocket.chat:99999`.
- Add parser-level and helper-level regression tests for invalid absolute port cases.

## Problem
When `autoLink` received an absolute URL that failed `URL()` validation, it prepended `//` and produced malformed href values like `//https://rocket.chat:99999`.

## Testing
- Parser build succeeded locally.
- Verified parse output for:
  - `https://rocket.chat:99999`
  - `https://rocket.chat:99999/test`
  - `https://rocket.chat:3000/test`
  - `rocket.chat/test`
  - `rocket.chattt/url_path`
  
  Fix #39295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved URL handling in message parsing: links with absolute schemes (http, https, custom) are now recognized and preserved as entered.
  * Message links retain original protocol and port information, preventing unintended rewrites for edge-case URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->