### PR TITLE
refactor(message-parser): simplify Any fallback to reduce URL/phone parse attempts

### DIFF
--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -794,7 +794,20 @@ Space = " " / "\t"
 
 Escaped = "\\" t:[*_~`#.] { return plain(t); }
 
-Any = !EndOfLine t:. p:$AutolinkedPhone? u:$URL? { return plain(t + p + u); }
+Any = !EndOfLine t:. p:$AnyPhone? u:$AnyURL? { return plain(t + p + u); }
+
+AnyPhone = &"+" AutolinkedPhone
+
+AnyURL = &AnyURLPrefix URL
+
+AnyURLPrefix = AnyURLSchemePrefix / AnyURLHostPrefix
+
+AnyURLSchemePrefix = [A-Za-z0-9+-] |1..32| "://"
+
+AnyURLHostPrefix
+  = "localhost"
+  / Digits |1..3| "." Digits |1..3| "."
+  / DomainNameLabel "."
 
 AnyText = [\x20-\x27\x2B-\x40\x41-\x5A\x61-\x7A] / NonASCII
 


### PR DESCRIPTION
## Summary
- Optimize `Any` fallback in grammar by gating URL/phone attempts with cheap prefix checks.
- Only try fallback phone parsing when the next character is `+`.
- Only try fallback URL parsing when scheme/host prefixes are present.

## Problem
`Any` fallback attempted optional phone/URL parsing on fallback characters, which can add unnecessary parsing work on plain-text-heavy inputs.

## Changes
- Replaced `Any` optional calls to `AutolinkedPhone`/`URL` with guarded `AnyPhone`/`AnyURL`.
- Added `AnyURLPrefix` rules for scheme/host hints before invoking full `URL`.

## Verification
- Parser build succeeded locally.
- Spot-checked parser outputs on representative URL/plain-text inputs to confirm behavior is unchanged.
- Local micro-benchmark on plain-text-heavy input showed reduced parse time.

Fix #39295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced URL and phone number detection in messages, now supporting a broader range of formats and patterns for improved automatic linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->