### PR TITLE
fix: correct method name in `getRoomById` error metadata

### DIFF
--- a/apps/meteor/server/methods/getRoomById.ts
+++ b/apps/meteor/server/methods/getRoomById.ts
@@ -20,14 +20,14 @@ Meteor.methods<ServerMethods>({
 		const userId = Meteor.userId();
 		if (!userId) {
 			throw new Meteor.Error('error-invalid-user', 'Invalid user', {
-				method: 'getRoomNameById',
+				method: 'getRoomById',
 			});
 		}
 
 		const room = await Rooms.findOneById(rid);
 		if (room == null) {
 			throw new Meteor.Error('error-not-allowed', 'Not allowed', {
-				method: 'getRoomNameById',
+				method: 'getRoomById',
 			});
 		}
 		if (!(await canAccessRoomAsync(room, (await Meteor.userAsync()) as IUser))) {


### PR DESCRIPTION
### Summary

This PR fixes an inconsistency in the `getRoomById` Meteor method.

The `Meteor.Error` metadata was using `getRoomNameById` as the method name, 
which does not match the actual registered method (`getRoomById`).

### Changes

- Replaced `getRoomNameById` with `getRoomById` in error metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an internal API method naming inconsistency to ensure consistency between declared and actual implementation names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->