### PR TITLE
refactor: Remove global references to `Meteor`

### DIFF
--- a/apps/meteor/app/2fa/server/code/PasswordCheckFallback.ts
+++ b/apps/meteor/app/2fa/server/code/PasswordCheckFallback.ts
@@ -1,5 +1,6 @@
 import type { IUser } from '@rocket.chat/core-typings';
 import { Accounts } from 'meteor/accounts-base';
+import type { Meteor } from 'meteor/meteor';
 
 import type { ICodeCheck, IProcessInvalidCodeResult } from './ICodeCheck';
 import { settings } from '../../../settings/server';

--- a/apps/meteor/app/lib/server/functions/joinDefaultChannels.ts
+++ b/apps/meteor/app/lib/server/functions/joinDefaultChannels.ts
@@ -1,4 +1,5 @@
 import { Users } from '@rocket.chat/models';
+import { Meteor } from 'meteor/meteor';
 
 import { addUserToDefaultChannels } from './addUserToDefaultChannels';
 

--- a/apps/meteor/app/livechat/imports/server/rest/inquiries.ts
+++ b/apps/meteor/app/livechat/imports/server/rest/inquiries.ts
@@ -18,6 +18,7 @@ import { getPaginationItems } from '../../../../api/server/helpers/getPagination
 import { findInquiries, findOneInquiryByRoomId } from '../../../server/api/lib/inquiries';
 import { returnRoomAsInquiry } from '../../../server/lib/rooms';
 import { takeInquiry } from '../../../server/lib/takeInquiry';
+import { Meteor } from 'meteor/meteor';
 
 API.v1.addRoute(
 	'livechat/inquiries.list',

--- a/apps/meteor/app/livechat/server/api/v1/room.ts
+++ b/apps/meteor/app/livechat/server/api/v1/room.ts
@@ -28,6 +28,7 @@ import {
 } from '@rocket.chat/rest-typings';
 import { isPOSTLivechatVisitorDepartmentTransferParams } from '@rocket.chat/rest-typings/src/v1/omnichannel';
 import { check } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
 
 import { callbacks } from '../../../../../server/lib/callbacks';
 import { i18n } from '../../../../../server/lib/i18n';
@@ -67,7 +68,7 @@ API.v1.addRoute(
 				agentId: Match.Maybe(String),
 			});
 
-			check(this.queryParams, extraCheckParams as any);
+			check(this.queryParams, extraCheckParams);
 
 			const { token, rid, agentId, ...extraParams } = this.queryParams;
 
@@ -291,7 +292,7 @@ API.v1.addRoute(
 			};
 
 			const room = await LivechatRooms.findOneById(this.bodyParams.roomId);
-			if (!room || room.t !== 'l') {
+			if (room?.t !== 'l') {
 				throw new Error('error-invalid-room');
 			}
 
@@ -358,7 +359,7 @@ const livechatVisitorDepartmentTransfer = API.v1.post(
 		}
 		const room = await LivechatRooms.findOneById(rid);
 
-		if (!room || room.t !== 'l') {
+		if (room?.t !== 'l') {
 			return API.v1.failure('error-invalid-room');
 		}
 
@@ -463,7 +464,7 @@ API.v1.addRoute(
 
 			const firstError = result.find((item) => item.status === 'rejected');
 			if (firstError) {
-				throw new Error((firstError as PromiseRejectedResult).reason.error);
+				throw new Error(firstError.reason.error);
 			}
 
 			await callbacks.run('livechat.saveInfo', await LivechatRooms.findOneById(roomData._id), {

--- a/apps/meteor/app/livechat/server/lib/rooms.ts
+++ b/apps/meteor/app/livechat/server/lib/rooms.ts
@@ -21,6 +21,7 @@ import {
 	Users,
 	ReadReceipts,
 } from '@rocket.chat/models';
+import { Meteor } from 'meteor/meteor';
 
 import { normalizeTransferredByData } from './Helper';
 import { QueueManager } from './QueueManager';

--- a/apps/meteor/app/livechat/server/lib/sendTranscript.ts
+++ b/apps/meteor/app/livechat/server/lib/sendTranscript.ts
@@ -15,6 +15,7 @@ import { MessageTypes } from '@rocket.chat/message-types';
 import { LivechatRooms, Messages, Uploads, Users } from '@rocket.chat/models';
 import createDOMPurify from 'dompurify';
 import { JSDOM } from 'jsdom';
+import { Meteor } from 'meteor/meteor';
 import moment from 'moment-timezone';
 
 import { callbacks } from '../../../../server/lib/callbacks';

--- a/apps/meteor/app/slashcommands-leave/server/leave.ts
+++ b/apps/meteor/app/slashcommands-leave/server/leave.ts
@@ -1,6 +1,7 @@
 import { api } from '@rocket.chat/core-services';
 import type { SlashCommandCallbackParams } from '@rocket.chat/core-typings';
 import { Users } from '@rocket.chat/models';
+import { Meteor } from 'meteor/meteor';
 
 import { i18n } from '../../../server/lib/i18n';
 import { leaveRoomMethod } from '../../lib/server/methods/leaveRoom';

--- a/apps/meteor/client/lib/2fa/overrideLoginMethod.ts
+++ b/apps/meteor/client/lib/2fa/overrideLoginMethod.ts
@@ -1,4 +1,5 @@
 import { Accounts } from 'meteor/accounts-base';
+import type { Meteor } from 'meteor/meteor';
 
 import { isTotpInvalidError, isTotpMaxAttemptsError, isTotpRequiredError } from './utils';
 

--- a/apps/meteor/client/lib/2fa/utils.ts
+++ b/apps/meteor/client/lib/2fa/utils.ts
@@ -1,3 +1,5 @@
+import type { Meteor } from 'meteor/meteor';
+
 export const isTotpRequiredError = (
 	error: unknown,
 ): error is Meteor.Error & ({ error: 'totp-required' } | { errorType: 'totp-required' }) =>

--- a/apps/meteor/client/meteor/minimongo/DiffSequence.ts
+++ b/apps/meteor/client/meteor/minimongo/DiffSequence.ts
@@ -1,3 +1,5 @@
+import { Meteor } from 'meteor/meteor';
+
 import type { IdMap } from './IdMap';
 import { clone, hasOwn, equals } from './common';
 import type { Observer, OrderedObserver, UnorderedObserver } from './observers';

--- a/apps/meteor/client/views/root/hooks/useIframe.ts
+++ b/apps/meteor/client/views/root/hooks/useIframe.ts
@@ -1,5 +1,6 @@
 import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
 import { useLoginWithIframe, useLoginWithToken, useSetting } from '@rocket.chat/ui-contexts';
+import type { Meteor } from 'meteor/meteor';
 import { useCallback, useEffect, useState } from 'react';
 
 export const useIframe = () => {

--- a/apps/meteor/definition/externals/meteor/accounts-base.d.ts
+++ b/apps/meteor/definition/externals/meteor/accounts-base.d.ts
@@ -1,4 +1,6 @@
 declare module 'meteor/accounts-base' {
+	import type { Meteor } from 'meteor/meteor';
+
 	namespace Accounts {
 		const storageLocation: Window['localStorage'];
 		function createUser(
@@ -65,7 +67,6 @@ declare module 'meteor/accounts-base' {
 
 		export const _options: AccountsServerOptions;
 
-		// eslint-disable-next-line @typescript-eslint/no-namespace
 		namespace oauth {
 			function credentialRequestCompleteHandler(
 				callback?: (error?: globalThis.Error | Meteor.Error | Meteor.TypedError) => void,

--- a/apps/meteor/definition/externals/meteor/http.d.ts
+++ b/apps/meteor/definition/externals/meteor/http.d.ts
@@ -1,4 +1,5 @@
 import 'meteor/http';
+import type { Meteor } from 'meteor/meteor';
 
 declare module 'meteor/http' {
 	namespace HTTP {

--- a/apps/meteor/definition/externals/meteor/oauth.d.ts
+++ b/apps/meteor/definition/externals/meteor/oauth.d.ts
@@ -1,5 +1,6 @@
 declare module 'meteor/oauth' {
 	import type { IRocketChatRecord } from '@rocket.chat/core-typings';
+	import type { Meteor } from 'meteor/meteor';
 	import type { Mongo } from 'meteor/mongo';
 
 	// These functions may only be used on the client's Mongo.Collection

--- a/apps/meteor/ee/app/livechat-enterprise/server/api/monitors.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/api/monitors.ts
@@ -8,6 +8,7 @@ import {
 	validateForbiddenErrorResponse,
 	validateUnauthorizedErrorResponse,
 } from '@rocket.chat/rest-typings';
+import { Meteor } from 'meteor/meteor';
 
 import { findMonitors, findMonitorByUsername } from './lib/monitors';
 import { API } from '../../../../../app/api/server';

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/unit.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/unit.ts
@@ -1,5 +1,6 @@
 import { LivechatUnit } from '@rocket.chat/models';
 import { getUnitsFromUser } from '@rocket.chat/omni-core-ee';
+import { Meteor } from 'meteor/meteor';
 
 import type { CheckUnitsFromUser } from '../../../../../app/livechat/server/api/lib/livechat';
 import { checkUnitsFromUser } from '../../../../../app/livechat/server/api/lib/livechat';

--- a/apps/meteor/ee/server/api/roles.ts
+++ b/apps/meteor/ee/server/api/roles.ts
@@ -2,6 +2,7 @@ import type { IRole } from '@rocket.chat/core-typings';
 import { License } from '@rocket.chat/license';
 import { Roles } from '@rocket.chat/models';
 import { ajv } from '@rocket.chat/rest-typings';
+import { Meteor } from 'meteor/meteor';
 
 import { API } from '../../../app/api/server/api';
 import { hasPermissionAsync } from '../../../app/authorization/server/functions/hasPermission';

--- a/apps/meteor/ee/server/configuration/abac.ts
+++ b/apps/meteor/ee/server/configuration/abac.ts
@@ -1,5 +1,6 @@
 import { License } from '@rocket.chat/license';
 import { Users } from '@rocket.chat/models';
+import { Meteor } from 'meteor/meteor';
 
 import { settings } from '../../../app/settings/server';
 import { LDAPEE } from '../sdk';

--- a/apps/meteor/ee/server/configuration/contact-verification.ts
+++ b/apps/meteor/ee/server/configuration/contact-verification.ts
@@ -1,3 +1,5 @@
+import { Meteor } from 'meteor/meteor';
+
 import { addSettings } from '../settings/contact-verification';
 
 Meteor.startup(async () => {

--- a/apps/meteor/packages/autoupdate/autoupdate_client.js
+++ b/apps/meteor/packages/autoupdate/autoupdate_client.js
@@ -25,6 +25,7 @@
 // The client version of the client code currently running in the
 // browser.
 
+import { Meteor } from 'meteor/meteor';
 import { ClientVersions } from './client_versions.js';
 
 const clientArch = Meteor.isCordova ? 'web.cordova' : Meteor.isModern ? 'web.browser' : 'web.browser.legacy';

--- a/apps/meteor/packages/autoupdate/autoupdate_server.js
+++ b/apps/meteor/packages/autoupdate/autoupdate_server.js
@@ -25,6 +25,7 @@
 // The ID of each document is the client architecture, and the fields of
 // the document are the versions described above.
 
+import { Meteor } from 'meteor/meteor';
 import { ClientVersions } from './client_versions.js';
 
 export const Autoupdate = (__meteor_runtime_config__.autoupdate = {

--- a/apps/meteor/server/lib/cas/loginHandler.ts
+++ b/apps/meteor/server/lib/cas/loginHandler.ts
@@ -1,6 +1,7 @@
 import { CredentialTokens, Users } from '@rocket.chat/models';
 import { getObjectKeys, wrapExceptions } from '@rocket.chat/tools';
 import { Accounts } from 'meteor/accounts-base';
+import { Meteor } from 'meteor/meteor';
 
 import { createNewUser } from './createNewUser';
 import { findExistingCASUser } from './findExistingCASUser';

--- a/apps/meteor/server/lib/cas/middleware.ts
+++ b/apps/meteor/server/lib/cas/middleware.ts
@@ -4,6 +4,7 @@ import url from 'url';
 import { validate } from '@rocket.chat/cas-validate';
 import type { ICredentialToken, RequiredField } from '@rocket.chat/core-typings';
 import { CredentialTokens } from '@rocket.chat/models';
+import { Meteor } from 'meteor/meteor';
 import _ from 'underscore';
 
 import { logger } from './logger';

--- a/apps/meteor/server/lib/compareUserPassword.ts
+++ b/apps/meteor/server/lib/compareUserPassword.ts
@@ -1,5 +1,6 @@
 import type { IUser, IPassword } from '@rocket.chat/core-typings';
 import { Accounts } from 'meteor/accounts-base';
+import type { Meteor } from 'meteor/meteor';
 
 /**
  * Check if a given password is the one user by given user or if the user doesn't have a password

--- a/apps/meteor/server/lib/compareUserPasswordHistory.ts
+++ b/apps/meteor/server/lib/compareUserPasswordHistory.ts
@@ -1,5 +1,6 @@
 import type { IUser, IPassword } from '@rocket.chat/core-typings';
 import { Accounts } from 'meteor/accounts-base';
+import type { Meteor } from 'meteor/meteor';
 
 import { settings } from '../../app/settings/server';
 

--- a/apps/meteor/server/services/video-conference/service.ts
+++ b/apps/meteor/server/services/video-conference/service.ts
@@ -37,6 +37,7 @@ import { Random } from '@rocket.chat/random';
 import type { PaginatedResult } from '@rocket.chat/rest-typings';
 import { wrapExceptions } from '@rocket.chat/tools';
 import type * as UiKit from '@rocket.chat/ui-kit';
+import { Meteor } from 'meteor/meteor';
 import { MongoInternals } from 'meteor/mongo';
 
 import { RocketChatAssets } from '../../../app/assets/server';

--- a/apps/meteor/tests/unit/app/livechat/server/lib/sendTranscript.spec.ts
+++ b/apps/meteor/tests/unit/app/livechat/server/lib/sendTranscript.spec.ts
@@ -54,6 +54,11 @@ const tStub = sinon.stub();
 const { sendTranscript } = p.noCallThru().load('../../../../../../app/livechat/server/lib/sendTranscript', {
 	'@rocket.chat/models': modelsMock,
 	'@rocket.chat/logger': { Logger: mockLogger },
+	'meteor/meteor': {
+		Meteor: {
+			Error: globalThis.Error,
+		},
+	},
 	'meteor/check': { check: checkMock },
 	'../../../../server/lib/callbacks': {
 		callbacks: {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
It imports `Meteor` from `meteor/meteor` instead of referencing the global-scoped variable. 

 Task: [ARCH-2037]

[ARCH-2037]: https://rocketchat.atlassian.net/browse/ARCH-2037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added missing and type-only imports for consistent typing across the codebase.
* **Bug Fixes**
  * Improved null-safety in room handling, tightened parameter validation, and fixed error propagation in API paths.
* **Chores**
  * Startup now performs an asynchronous settings addition during initialization.
* **Tests**
  * Adjusted test setup to provide compatible error handling in unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->