### PR TITLE
fix: remove duplicate database query in deleteMessage

### DIFF
--- a/apps/meteor/app/lib/server/functions/deleteMessage.ts
+++ b/apps/meteor/app/lib/server/functions/deleteMessage.ts
@@ -29,7 +29,7 @@ export const deleteMessageValidatingPermission = async (message: AtLeast<IMessag
 };
 
 export async function deleteMessage(message: IMessage, user: IUser): Promise<void> {
-	const deletedMsg: IMessage | null = await Messages.findOneById(message._id);
+	const deletedMsg: IMessage = message;
 	const isThread = (deletedMsg?.tcount || 0) > 0;
 	const keepHistory = settings.get('Message_KeepHistory') || isThread;
 	const showDeletedStatus = settings.get('Message_ShowDeletedStatus') || isThread;


### PR DESCRIPTION
## Description

This PR removes an unnecessary duplicate database query in the `deleteMessage` function.

The message is already retrieved in `deleteMessageValidatingPermission` and passed to `deleteMessage`. However, `deleteMessage` performs another `Messages.findOneById` query for the same message.

This change reuses the existing message object instead of querying the database again.

---
## Fix

  closes #39325

## Changes

- Removed redundant `Messages.findOneById` call in `deleteMessage`
- Reused the message object already fetched by `deleteMessageValidatingPermission`

---

## Why This Change?

This eliminates an unnecessary database query during message deletion, improving efficiency and reducing redundant database access.

---
## Impact

- No functional changes
- Removes unnecessary database query
- Slight performance improvement


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized message deletion performance through internal efficiency improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->