### PR TITLE
fix(apps-engine): use typeof check for undefined in areRequiredSettingsSet

### DIFF
--- a/.changeset/fix-apps-engine-required-settings-check.md
+++ b/.changeset/fix-apps-engine-required-settings-check.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/apps-engine": patch
+---
+
+Fixed `areRequiredSettingsSet` comparing setting values against the string literal `"undefined"` instead of using `typeof` to check for actual `undefined` values, which caused required app settings to never be properly validated.

--- a/.changeset/fix-apps-engine-required-settings-check.md
+++ b/.changeset/fix-apps-engine-required-settings-check.md
@@ -2,4 +2,4 @@
 "@rocket.chat/apps-engine": patch
 ---
 
-Fixed `areRequiredSettingsSet` comparing setting values against the string literal `"undefined"` instead of using `typeof` to check for actual `undefined` values, which caused required app settings to never be properly validated.
+Fixed `areRequiredSettingsSet` to correctly identify unset required app settings. Previously, the check compared values against the string literal `"undefined"` instead of using `typeof`, and also incorrectly treated `null` and empty string (`""`) as valid configured values. The method now uses a strict `isValueSet` guard so that `null`, `""`, and `undefined` are all treated as unset, preventing apps with empty required settings from being enabled.

--- a/packages/apps-engine/src/server/AppManager.ts
+++ b/packages/apps-engine/src/server/AppManager.ts
@@ -1108,6 +1108,8 @@ export class AppManager {
 	 * Should a packageValue be provided and not empty, then it's considered set.
 	 */
 	private areRequiredSettingsSet(storageItem: IAppStorageItem): boolean {
+		const isValueSet = (v: unknown): boolean => v !== undefined && v !== null && v !== '';
+
 		let result = true;
 
 		for (const setk of Object.keys(storageItem.settings)) {
@@ -1117,7 +1119,7 @@ export class AppManager {
 				continue;
 			}
 
-			if (typeof sett.value !== 'undefined' || typeof sett.packageValue !== 'undefined') {
+			if (isValueSet(sett.value) || isValueSet(sett.packageValue)) {
 				continue;
 			}
 

--- a/packages/apps-engine/src/server/AppManager.ts
+++ b/packages/apps-engine/src/server/AppManager.ts
@@ -1117,7 +1117,7 @@ export class AppManager {
 				continue;
 			}
 
-			if (sett.value !== 'undefined' || sett.packageValue !== 'undefined') {
+			if (typeof sett.value !== 'undefined' || typeof sett.packageValue !== 'undefined') {
 				continue;
 			}
 

--- a/packages/apps-engine/tests/server/AppManager.spec.ts
+++ b/packages/apps-engine/tests/server/AppManager.spec.ts
@@ -259,4 +259,131 @@ export class AppManagerTestFixture {
 		Expect(expectedStorageItem.signature).toBe('signed-app-data');
 		Expect(updatePartialAndReturnDocumentSpy).toHaveBeenCalled().exactly(1).times;
 	}
+
+	@Test('areRequiredSettingsSet - returns true when there are no required settings')
+	public areRequiredSettingsSetNoRequiredSettings() {
+		const manager = new AppManager({
+			metadataStorage: this.testingInfastructure.getAppStorage(),
+			logStorage: this.testingInfastructure.getLogStorage(),
+			bridges: this.testingInfastructure.getAppBridges(),
+			sourceStorage: this.testingInfastructure.getSourceStorage(),
+		});
+
+		const storageItem = TestData.getAppStorageItem({
+			settings: {
+				optionalSetting: { id: 'optionalSetting', type: 0, required: false, packageValue: undefined, value: undefined } as any,
+			},
+		});
+
+		Expect((manager as any).areRequiredSettingsSet(storageItem)).toBe(true);
+	}
+
+	@Test('areRequiredSettingsSet - returns false when a required setting has no value and no packageValue')
+	public areRequiredSettingsSetMissingBothValues() {
+		const manager = new AppManager({
+			metadataStorage: this.testingInfastructure.getAppStorage(),
+			logStorage: this.testingInfastructure.getLogStorage(),
+			bridges: this.testingInfastructure.getAppBridges(),
+			sourceStorage: this.testingInfastructure.getSourceStorage(),
+		});
+
+		const storageItem = TestData.getAppStorageItem({
+			settings: {
+				requiredSetting: { id: 'requiredSetting', type: 0, required: true, packageValue: undefined, value: undefined } as any,
+			},
+		});
+
+		Expect((manager as any).areRequiredSettingsSet(storageItem)).toBe(false);
+	}
+
+	@Test('areRequiredSettingsSet - returns true when a required setting has a real value')
+	public areRequiredSettingsSetWithValue() {
+		const manager = new AppManager({
+			metadataStorage: this.testingInfastructure.getAppStorage(),
+			logStorage: this.testingInfastructure.getLogStorage(),
+			bridges: this.testingInfastructure.getAppBridges(),
+			sourceStorage: this.testingInfastructure.getSourceStorage(),
+		});
+
+		const storageItem = TestData.getAppStorageItem({
+			settings: {
+				requiredSetting: { id: 'requiredSetting', type: 0, required: true, packageValue: undefined, value: 'configured' } as any,
+			},
+		});
+
+		Expect((manager as any).areRequiredSettingsSet(storageItem)).toBe(true);
+	}
+
+	@Test('areRequiredSettingsSet - returns true when a required setting has a real packageValue but no value')
+	public areRequiredSettingsSetWithPackageValue() {
+		const manager = new AppManager({
+			metadataStorage: this.testingInfastructure.getAppStorage(),
+			logStorage: this.testingInfastructure.getLogStorage(),
+			bridges: this.testingInfastructure.getAppBridges(),
+			sourceStorage: this.testingInfastructure.getSourceStorage(),
+		});
+
+		const storageItem = TestData.getAppStorageItem({
+			settings: {
+				requiredSetting: { id: 'requiredSetting', type: 0, required: true, packageValue: 'default', value: undefined } as any,
+			},
+		});
+
+		Expect((manager as any).areRequiredSettingsSet(storageItem)).toBe(true);
+	}
+
+	@Test('areRequiredSettingsSet - returns false when a required setting has null value and null packageValue')
+	public areRequiredSettingsSetNullValues() {
+		const manager = new AppManager({
+			metadataStorage: this.testingInfastructure.getAppStorage(),
+			logStorage: this.testingInfastructure.getLogStorage(),
+			bridges: this.testingInfastructure.getAppBridges(),
+			sourceStorage: this.testingInfastructure.getSourceStorage(),
+		});
+
+		const storageItem = TestData.getAppStorageItem({
+			settings: {
+				requiredSetting: { id: 'requiredSetting', type: 0, required: true, packageValue: null, value: null } as any,
+			},
+		});
+
+		Expect((manager as any).areRequiredSettingsSet(storageItem)).toBe(false);
+	}
+
+	@Test('areRequiredSettingsSet - returns false when a required setting has empty string value and empty string packageValue')
+	public areRequiredSettingsSetEmptyStringValues() {
+		const manager = new AppManager({
+			metadataStorage: this.testingInfastructure.getAppStorage(),
+			logStorage: this.testingInfastructure.getLogStorage(),
+			bridges: this.testingInfastructure.getAppBridges(),
+			sourceStorage: this.testingInfastructure.getSourceStorage(),
+		});
+
+		const storageItem = TestData.getAppStorageItem({
+			settings: {
+				requiredSetting: { id: 'requiredSetting', type: 0, required: true, packageValue: '', value: '' } as any,
+			},
+		});
+
+		Expect((manager as any).areRequiredSettingsSet(storageItem)).toBe(false);
+	}
+
+	@Test('areRequiredSettingsSet - returns true when a required setting has null value but a valid packageValue is present')
+	public areRequiredSettingsSetNullValueWithValidPackageValue() {
+		const manager = new AppManager({
+			metadataStorage: this.testingInfastructure.getAppStorage(),
+			logStorage: this.testingInfastructure.getLogStorage(),
+			bridges: this.testingInfastructure.getAppBridges(),
+			sourceStorage: this.testingInfastructure.getSourceStorage(),
+		});
+
+		const storageItem = TestData.getAppStorageItem({
+			settings: {
+				requiredSetting: { id: 'requiredSetting', type: 0, required: true, packageValue: 'default', value: null } as any,
+			},
+		});
+
+		// packageValue is 'default' (valid), so the setting is considered set
+		Expect((manager as any).areRequiredSettingsSet(storageItem)).toBe(true);
+	}
 }


### PR DESCRIPTION
## Changes

Fix a logic bug in `AppManager.areRequiredSettingsSet()` where required app settings were never properly validated.

## Root Cause

In `packages/apps-engine/src/server/AppManager.ts` (line 1121), the comparison checks against the **string literal** `"undefined"` instead of checking for the actual `undefined` JavaScript primitive.

When `sett.value` is `undefined` (the JS primitive), the expression evaluates incorrectly, causing the code to skip the setting — treating it as "already configured" when it is not.

This means **required app settings are never enforced**, allowing apps to be enabled with missing required configuration.

## Fix

Changed from direct string comparison to `typeof` check, which correctly detects when values are actually unset.

## Testing

- The fix is a straightforward type-check correction
- No existing tests cover this function
- The fix ensures apps with missing required settings are properly blocked from enabling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected required app settings validation so undefined, null, and empty values are treated as unset, preventing apps with missing required settings from being enabled.

* **Tests**
  * Added unit tests covering various required-setting scenarios (present, missing, null, empty, package-provided).

* **Documentation**
  * Added a changelog entry describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->