### PR TITLE
fix(agenda): off-by-one and crash in returnNextConcurrencyFreeJob

### DIFF
--- a/.changeset/fix-agenda-job-queue-off-by-one.md
+++ b/.changeset/fix-agenda-job-queue-off-by-one.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/agenda": patch
+---
+
+Fixed off-by-one error in `returnNextConcurrencyFreeJob` that skipped concurrency checks for the first job in the queue, and fixed potential crash when the queue is empty or all jobs are blocked by concurrency limits.

--- a/packages/agenda/src/Agenda.ts
+++ b/packages/agenda/src/Agenda.ts
@@ -906,7 +906,7 @@ export class Agenda extends EventEmitter {
 		// Get the next job that is not blocked by concurrency
 		const job = this._jobQueue.returnNextConcurrencyFreeJob(this._definitions);
 
-		if (!job.attrs.nextRunAt) {
+		if (!job || !job.attrs.nextRunAt) {
 			return;
 		}
 

--- a/packages/agenda/src/JobProcessingQueue.ts
+++ b/packages/agenda/src/JobProcessingQueue.ts
@@ -58,15 +58,14 @@ export class JobProcessingQueue {
 	 * Returns (does not pop, element remains in queue) first element (always from the right)
 	 * that can be processed (not blocked by concurrency execution)
 	 */
-	returnNextConcurrencyFreeJob(agendaDefinitions: Record<string, JobDefinition>): Job {
-		let next;
-		for (next = this._queue.length - 1; next > 0; next -= 1) {
+	returnNextConcurrencyFreeJob(agendaDefinitions: Record<string, JobDefinition>): Job | undefined {
+		for (let next = this._queue.length - 1; next >= 0; next -= 1) {
 			const def = agendaDefinitions[this._queue[next].attrs.name];
-			if (def.concurrency > def.running) {
-				break;
+			if (def && def.concurrency > def.running) {
+				return this._queue[next];
 			}
 		}
 
-		return this._queue[next];
+		return undefined;
 	}
 }


### PR DESCRIPTION
## Changes

Fix two bugs in `JobProcessingQueue.returnNextConcurrencyFreeJob()` in the Agenda package.

## Bug 1: Off-by-one error skips concurrency check for first job

The loop condition was `next > 0` instead of `next >= 0`:

```ts
for (next = this._queue.length - 1; next > 0; next -= 1) {
```

This means index 0 is **never checked** for concurrency limits. The first job in the queue is always returned as a fallback regardless of whether it has exceeded its concurrency limit.

## Bug 2: Crash when queue is empty or all jobs are blocked

When the queue is empty, `next` becomes `-1` after the loop, and `this._queue[-1]` returns `undefined`. The caller in `_jobProcessing()` then accesses `.attrs.nextRunAt` on `undefined`:

```ts
const job = this._jobQueue.returnNextConcurrencyFreeJob(this._definitions);
if (!job.attrs.nextRunAt) {  // TypeError: Cannot read properties of undefined
```

The same crash occurs when all jobs in the queue are blocked by concurrency limits.

## Fix

1. Changed loop condition from `next > 0` to `next >= 0` so all jobs are checked
2. Added a guard for missing `def` to avoid crashes when job definition doesn't exist
3. Changed return type from `Job` to `Job | undefined`
4. Added null check in the caller `_jobProcessing()`: `if (!job || !job.attrs.nextRunAt)`

## Testing

- The fix is a defensive correction to loop bounds and null safety
- Existing Agenda tests continue to pass
