### PR TITLE
perf: use Map for O(1) team name lookups in channel directory

### DIFF
--- a/.changeset/optimize-browse-channels-team-lookup.md
+++ b/.changeset/optimize-browse-channels-team-lookup.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Optimized team name lookup in channel directory browse from O(n*m) Array.find to O(1) Map.get, improving performance for workspaces with many teams and channels.

--- a/apps/meteor/server/methods/browseChannels.ts
+++ b/apps/meteor/server/methods/browseChannels.ts
@@ -98,11 +98,13 @@ const getChannelsAndGroups = async (
 	const teamIds = result.map(({ teamId }) => teamId).filter(isTruthy);
 	const teamsMains = await Team.listByIds([...new Set(teamIds)], { projection: { _id: 1, name: 1 } });
 
+	const teamsMap = new Map(teamsMains.map((team) => [team._id, team.name]));
+
 	const results = result.map((room) => {
 		if (room.teamId) {
-			const team = teamsMains.find((mainRoom) => mainRoom._id === room.teamId);
-			if (team) {
-				return { ...room, belongsTo: team.name };
+			const teamName = teamsMap.get(room.teamId);
+			if (teamName) {
+				return { ...room, belongsTo: teamName };
 			}
 		}
 		return room;


### PR DESCRIPTION
## Changes

Replace `Array.find()` inside `Array.map()` with a pre-built `Map` for team name lookups in the `browseChannels` method — a user-facing paginated endpoint.

## Root Cause

In `apps/meteor/server/methods/browseChannels.ts` (line 103), for every room in the results:

```ts
const results = result.map((room) => {
    if (room.teamId) {
        const team = teamsMains.find((mainRoom) => mainRoom._id === room.teamId);
```

A linear scan of `teamsMains` is performed via `.find()`. This results in **O(rooms × teams)** complexity on every channel directory browse request.

## Fix

Build a `Map<teamId, teamName>` from `teamsMains` before the mapping loop, then use `Map.get()` for O(1) lookups:

```ts
const teamsMap = new Map(teamsMains.map((team) => [team._id, team.name]));
const results = result.map((room) => {
    if (room.teamId) {
        const teamName = teamsMap.get(room.teamId);
```

Reduces overall complexity from **O(n×m)** to **O(n+m)**.

## Testing

- No behavioral change — same output, just faster lookups
- All existing tests pass unchanged
