### PR TITLE
fix(ui): close Create Channel modal immediately after successful channel creation

### DIFF
--- a/.changeset/fix-create-channel-modal-close.md
+++ b/.changeset/fix-create-channel-modal-close.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+fix(ui): close Create Channel modal immediately after successful channel creation and keep it open on error to show feedback.

--- a/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateChannelModal.spec.tsx
+++ b/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateChannelModal.spec.tsx
@@ -266,4 +266,51 @@ describe('CreateChannelModal', () => {
 			expect(federated).toHaveAccessibleDescription('Federation_Matrix_Federated_Description');
 		});
 	});
+
+	describe('Creation', () => {
+		it('should close the modal and navigate to the room on success', async () => {
+			const onClose = jest.fn();
+			render(<CreateChannelModal onClose={onClose} />, {
+				wrapper: mockAppRoot()
+					.withJohnDoe()
+					.withSetting('UTF8_Channel_Names_Validation', '[a-zA-Z0-9-]+')
+					.withSetting('UI_Allow_room_names_with_special_chars', true)
+					.withEndpoint('GET', '/v1/rooms.nameExists', () => ({ exists: false }))
+					.withEndpoint('POST', '/v1/channels.create', () => ({
+						success: true,
+						channel: { _id: 'channelId', name: 'newchannel', t: 'c' as any } as any,
+					}))
+					.withEndpoint('POST', '/v1/groups.create', () => ({
+						success: true,
+						group: { _id: 'groupId', name: 'newgroup', t: 'p' as any } as any,
+					}))
+					.build(),
+			});
+
+			await userEvent.type(screen.getByLabelText(/Name/i), 'newchannel');
+			await userEvent.click(screen.getByRole('button', { name: /Create/i }));
+			expect(onClose).toHaveBeenCalled();
+		});
+
+		it('should not close the modal on failure', async () => {
+			const onClose = jest.fn();
+			render(<CreateChannelModal onClose={onClose} />, {
+				wrapper: mockAppRoot()
+					.withJohnDoe()
+					.withEndpoint('GET', '/v1/rooms.nameExists', () => ({ exists: false }))
+					.withEndpoint('POST', '/v1/channels.create', () => {
+						throw new Error('Creation failed');
+					})
+					.withEndpoint('POST', '/v1/groups.create', () => {
+						throw new Error('Creation failed');
+					})
+					.build(),
+			});
+
+			await userEvent.type(screen.getByLabelText(/Name/i), 'failedchannel');
+			await userEvent.click(screen.getByRole('button', { name: /Create/i }));
+
+			expect(onClose).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateChannelModal.spec.tsx
+++ b/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateChannelModal.spec.tsx
@@ -1,5 +1,5 @@
 import { mockAppRoot } from '@rocket.chat/mock-providers';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import CreateChannelModal from './CreateChannelModal';
@@ -289,7 +289,7 @@ describe('CreateChannelModal', () => {
 
 			await userEvent.type(screen.getByLabelText(/Name/i), 'newchannel');
 			await userEvent.click(screen.getByRole('button', { name: /Create/i }));
-			expect(onClose).toHaveBeenCalled();
+			await waitFor(() => expect(onClose).toHaveBeenCalled());
 		});
 
 		it('should not close the modal on failure', async () => {
@@ -310,7 +310,7 @@ describe('CreateChannelModal', () => {
 			await userEvent.type(screen.getByLabelText(/Name/i), 'failedchannel');
 			await userEvent.click(screen.getByRole('button', { name: /Create/i }));
 
-			expect(onClose).not.toHaveBeenCalled();
+			await waitFor(() => expect(onClose).not.toHaveBeenCalled());
 		});
 	});
 });

--- a/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateChannelModal.spec.tsx
+++ b/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateChannelModal.spec.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import CreateChannelModal from './CreateChannelModal';
+import { goToRoomById } from '../../../lib/utils/goToRoomById';
 import { createFakeLicenseInfo } from '../../../../tests/mocks/data';
 
 jest.mock('../../../lib/utils/goToRoomById', () => ({
@@ -290,6 +291,7 @@ describe('CreateChannelModal', () => {
 			await userEvent.type(screen.getByLabelText(/Name/i), 'newchannel');
 			await userEvent.click(screen.getByRole('button', { name: /Create/i }));
 			await waitFor(() => expect(onClose).toHaveBeenCalled());
+			await waitFor(() => expect(goToRoomById).toHaveBeenCalled());
 		});
 
 		it('should not close the modal on failure', async () => {

--- a/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateChannelModal.tsx
+++ b/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateChannelModal.tsx
@@ -178,9 +178,11 @@ const CreateChannelModal = ({ teamId = '', mainRoom, onClose, reload }: CreateCh
 		try {
 			if (isPrivate) {
 				roomData = await createPrivateChannel(params);
+				onClose();
 				!teamId && goToRoomById(roomData.group._id);
 			} else {
 				roomData = await createChannel(params);
+				onClose();
 				!teamId && goToRoomById(roomData.channel._id);
 			}
 
@@ -188,8 +190,6 @@ const CreateChannelModal = ({ teamId = '', mainRoom, onClose, reload }: CreateCh
 			reload?.();
 		} catch (error) {
 			dispatchToastMessage({ type: 'error', message: error });
-		} finally {
-			onClose();
 		}
 	};
 


### PR DESCRIPTION
## Proposed changes

This PR fixes a UX issue in the **Create Channel** flow where the modal could remain visible briefly after a channel was successfully created.

Previously, after clicking **Create**, the new channel could appear in the sidebar while the modal was still visible, which made it unclear whether the action had completed successfully.

This change ensures the modal closes immediately after successful channel creation before navigating to the newly created room.

### Result

* Modal closes immediately after successful channel creation
* Navigation to the new channel happens smoothly
* Modal remains open if channel creation fails

## Issue

Fixes #39345

## Steps to test

1. Navigate to any existing channel
2. Click the **"+"** icon to create a new channel
3. Enter a channel name
4. Click **Create**

Expected result:

* Modal closes immediately
* App navigates to the new channel
* Success toast appears

## Further comments

All existing tests pass locally.


https://github.com/user-attachments/assets/be477557-26bd-408d-86a4-5381215b0426





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Modal now closes only after a channel is successfully created; it remains open if creation fails so users can see error feedback.

* **Tests**
  * Added creation tests: confirm modal closes and navigation occurs on success, and confirm modal remains open when creation fails.

* **Chores**
  * Added a changeset entry documenting the UI fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->