### PR TITLE
chore: remove development log from canAccessRoom function

### DIFF
--- a/apps/meteor/server/services/authorization/canAccessRoom.ts
+++ b/apps/meteor/server/services/authorization/canAccessRoom.ts
@@ -113,10 +113,7 @@ export const canAccessRoom: RoomAccessValidator = async (room, user, extraData):
 		if (!user) {
 			throw new Error('User not found');
 		}
-
-		if (process.env.NODE_ENV === 'development') {
-			console.log('User converted to full IUser object');
-		}
+		
 	}
 
 	for await (const roomAccessValidator of roomAccessValidators) {


### PR DESCRIPTION
This is a minor cleanup to remove a development-only console.log in the canAccessRoom authorization hot-path to reduce log pollution and improve performance in dev environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed debug logging from the authorization service. No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->