### PR TITLE
fix(oauth): preserve custom show_button false and env default visibility

### DIFF
--- a/apps/meteor/server/lib/oauth/addOAuthService.ts
+++ b/apps/meteor/server/lib/oauth/addOAuthService.ts
@@ -244,7 +244,7 @@ export async function addOAuthService(name: string, values: { [k: string]: strin
 		},
 		persistent: true,
 	});
-	await settingsRegistry.add(`Accounts_OAuth_Custom-${name}-show_button`, values.showButton || true, {
+	await settingsRegistry.add(`Accounts_OAuth_Custom-${name}-show_button`, values.showButton ?? true, {
 		type: 'boolean',
 		group: 'OAuth',
 		section: `Custom OAuth: ${name}`,

--- a/apps/meteor/server/lib/oauth/initCustomOAuthServices.ts
+++ b/apps/meteor/server/lib/oauth/initCustomOAuthServices.ts
@@ -3,7 +3,7 @@ import { addOAuthService } from './addOAuthService';
 export async function initCustomOAuthServices(): Promise<void> {
 	// Add settings for custom OAuth providers to the settings so they get
 	// automatically added when they are defined in ENV variables
-	for await (const key of Object.keys(process.env)) {
+	for (const key of Object.keys(process.env)) {
 		if (/Accounts_OAuth_Custom_[a-zA-Z0-9_-]+$/.test(key)) {
 			// Most all shells actually prohibit the usage of - in environment variables
 			// So this will allow replacing - with _ and translate it back to the setting name
@@ -16,6 +16,8 @@ export async function initCustomOAuthServices(): Promise<void> {
 			const serviceKey = `Accounts_OAuth_Custom_${name}`;
 
 			if (key === serviceKey) {
+				const showButtonEnv = process.env[`${serviceKey}_show_button`];
+
 				const values = {
 					enabled: process.env[`${serviceKey}`] === 'true',
 					clientId: process.env[`${serviceKey}_id`],
@@ -45,7 +47,7 @@ export async function initCustomOAuthServices(): Promise<void> {
 					mapChannels: process.env[`${serviceKey}_map_channels`],
 					mergeRoles: process.env[`${serviceKey}_merge_roles`] === 'true',
 					rolesToSync: process.env[`${serviceKey}_roles_to_sync`],
-					showButton: process.env[`${serviceKey}_show_button`] === 'true',
+					showButton: showButtonEnv === undefined ? undefined : showButtonEnv === 'true',
 					avatarField: process.env[`${serviceKey}_avatar_field`],
 				};
 

--- a/apps/meteor/tests/unit/server/lib/oauth/addOAuthService.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/oauth/addOAuthService.spec.ts
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+const stubs = {
+	settingsRegistryAdd: sinon.stub(),
+};
+
+const { addOAuthService } = proxyquire.noCallThru().load('../../../../../server/lib/oauth/addOAuthService', {
+	'../../../app/settings/server': {
+		settingsRegistry: {
+			add: stubs.settingsRegistryAdd,
+		},
+	},
+});
+
+const getShowButtonValue = (): unknown => {
+	const call = stubs.settingsRegistryAdd
+		.getCalls()
+		.find((currentCall) => currentCall.args[0] === 'Accounts_OAuth_Custom-Github-show_button');
+
+	return call?.args[1];
+};
+
+describe('addOAuthService', () => {
+	beforeEach(() => {
+		stubs.settingsRegistryAdd.reset();
+		stubs.settingsRegistryAdd.resolves();
+	});
+
+	it('should preserve show_button as false when explicitly provided', async () => {
+		await addOAuthService('github', { showButton: false });
+
+		expect(getShowButtonValue()).to.equal(false);
+	});
+
+	it('should default show_button to true when not provided', async () => {
+		await addOAuthService('github');
+
+		expect(getShowButtonValue()).to.equal(true);
+	});
+});

--- a/apps/meteor/tests/unit/server/lib/oauth/initCustomOAuthServices.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/oauth/initCustomOAuthServices.spec.ts
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+const stubs = {
+	addOAuthService: sinon.stub(),
+};
+
+const { initCustomOAuthServices } = proxyquire.noCallThru().load('../../../../../server/lib/oauth/initCustomOAuthServices', {
+	'./addOAuthService': {
+		addOAuthService: stubs.addOAuthService,
+	},
+});
+
+const getServiceCall = (serviceName: string) => stubs.addOAuthService.getCalls().find((call) => call.args[0] === serviceName);
+
+describe('initCustomOAuthServices', () => {
+	const serviceName = 'CodexShowButtonService';
+	const serviceKey = `Accounts_OAuth_Custom_${serviceName}`;
+
+	beforeEach(() => {
+		stubs.addOAuthService.reset();
+		stubs.addOAuthService.resolves();
+	});
+
+	afterEach(() => {
+		delete process.env[serviceKey];
+		delete process.env[`${serviceKey}_show_button`];
+	});
+
+	it('should pass undefined showButton when _show_button env is omitted', async () => {
+		process.env[serviceKey] = 'true';
+
+		await initCustomOAuthServices();
+
+		const call = getServiceCall(serviceName);
+		expect(call).to.not.equal(undefined);
+		expect(call?.args[1].showButton).to.equal(undefined);
+	});
+
+	it('should pass false showButton when _show_button env is false', async () => {
+		process.env[serviceKey] = 'true';
+		process.env[`${serviceKey}_show_button`] = 'false';
+
+		await initCustomOAuthServices();
+
+		const call = getServiceCall(serviceName);
+		expect(call).to.not.equal(undefined);
+		expect(call?.args[1].showButton).to.equal(false);
+	});
+
+	it('should pass true showButton when _show_button env is true', async () => {
+		process.env[serviceKey] = 'true';
+		process.env[`${serviceKey}_show_button`] = 'true';
+
+		await initCustomOAuthServices();
+
+		const call = getServiceCall(serviceName);
+		expect(call).to.not.equal(undefined);
+		expect(call?.args[1].showButton).to.equal(true);
+	});
+});


### PR DESCRIPTION
## Summary
- preserve explicit `showButton: false` when creating custom OAuth settings
- keep default login button visibility when `Accounts_OAuth_Custom_<Provider>_show_button` is omitted in env-based setup
- add unit coverage for both `addOAuthService` and `initCustomOAuthServices` paths

## Problem
Custom OAuth setup had two conflicting behaviors:
- explicit `false` for `show_button` was coerced to `true`
- env initialization always passed a boolean, so omitted `_show_button` became `false` after the nullish fix

## Testing
- `yarn .testunit:server -- --grep "(addOAuthService|initCustomOAuthServices)"`
- `yarn eslint server/lib/oauth/addOAuthService.ts server/lib/oauth/initCustomOAuthServices.ts tests/unit/server/lib/oauth/addOAuthService.spec.ts tests/unit/server/lib/oauth/initCustomOAuthServices.spec.ts`

Closes #39381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed OAuth service configuration to properly respect explicit button visibility settings.

* **Tests**
  * Added unit tests to validate OAuth service configuration and initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->