### PR TITLE
chore: Define hovered CSS outside of `OutlookEventItem`

### DIFF
--- a/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventItem.tsx
+++ b/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventItem.tsx
@@ -57,7 +57,6 @@ const OutlookEventItem = ({ subject, description, startTime, meetingUrl }: Outlo
 				<Box fontScale='h4'>{subject}</Box>
 				<Box fontScale='c1'>{formatDateAndTime(startTime)}</Box>
 			</Box>
-
 			<Box>
 				{meetingUrl && (
 					<Button onClick={handleMeetingClick} small>


### PR DESCRIPTION
Description

This PR moves the "hovered" CSS definition outside the "OutlookEventItem" component.

Previously, the CSS hook was created inside the component, which caused it to be recreated on every render. By defining it outside the component, the style is created once and reused across renders.

Changes

- Moved "hovered" css definition outside the component
- No functional behavior changes

Related Issue

Closes #39385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Outlook calendar event's Join button now displays localized text.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [COMM-147]

[COMM-147]: https://rocketchat.atlassian.net/browse/COMM-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ