### PR TITLE
fix(message-parser): correct parameter types for timestampFromIsoTime

### DIFF
--- a/packages/message-parser/src/utils.ts
+++ b/packages/message-parser/src/utils.ts
@@ -290,13 +290,13 @@ export const timestampFromIsoTime = ({
 	milliseconds,
 	timezone,
 }: {
-	year: string[];
-	month: string[];
-	day: string[];
-	hours: string[];
-	minutes: string[];
-	seconds: string[];
-	milliseconds?: string[];
+	year: string;
+	month: string;
+	day: string;
+	hours: string;
+	minutes: string;
+	seconds: string;
+	milliseconds?: string;
 	timezone?: string;
 }) => {
 	const date =


### PR DESCRIPTION
### Summary

The `timestampFromIsoTime` function defined parameters as `string[]`, but the PEG parser grammar passes plain `string` values using `join()`.

### Changes

Updated the parameter types from `string[]` to `string` to match the actual usage.

### Impact

Improves type correctness in the message parser without changing runtime behavior.

Fixes #39375


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization of timestamp parsing utility to improve code maintainability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->