### PR TITLE
chore: migrated rooms.isMemeber to new ajv style chained endpoint

### DIFF
--- a/apps/meteor/app/api/server/v1/rooms.ts
+++ b/apps/meteor/app/api/server/v1/rooms.ts
@@ -802,7 +802,7 @@ const isMemeberEndpoint = API.v1.get(
 				userId: { type: 'string' },
 				username: { type: 'string' },
 			},
-			required: ['roomId'],
+			oneOf: [{ required: ['roomId', 'userId'] }, { required: ['roomId', 'username'] }],
 			additionalProperties: false,
 		}),
 		response: {
@@ -832,7 +832,7 @@ const isMemeberEndpoint = API.v1.get(
 			findRoomByIdOrName({
 				params: { roomId },
 			}),
-			Users.findOneByIdOrUsername((userId || username) as string),
+			Users.findOneByIdOrUsername((userId || username)!),
 		]);
 
 		if (!user?._id) {

--- a/apps/meteor/app/api/server/v1/rooms.ts
+++ b/apps/meteor/app/api/server/v1/rooms.ts
@@ -17,6 +17,7 @@ import {
 	isRoomsInviteProps,
 	validateBadRequestErrorResponse,
 	validateUnauthorizedErrorResponse,
+	validateForbiddenErrorResponse,
 } from '@rocket.chat/rest-typings';
 import { isTruthy } from '@rocket.chat/tools';
 import { Meteor } from 'meteor/meteor';
@@ -823,28 +824,28 @@ const isMemeberEndpoint = API.v1.get(
 			}),
 			400: validateBadRequestErrorResponse,
 			401: validateUnauthorizedErrorResponse,
-			403: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 		},
 	},
 	async function action() {
 		const { roomId, userId, username } = this.queryParams;
-		const [room, user] = await Promise.all([
-			findRoomByIdOrName({
-				params: { roomId },
-			}),
-			Users.findOneByIdOrUsername((userId || username)!),
-		]);
+		const room = await findRoomByIdOrName({
+			params: { roomId },
+		});
+
+		if (!(await canAccessRoomAsync(room, { _id: this.userId }))) {
+			return API.v1.forbidden('unauthorized');
+		}
+
+		const user = await Users.findOneByIdOrUsername((userId || username)!);
 
 		if (!user?._id) {
 			return API.v1.failure('error-user-not-found');
 		}
 
-		if (await canAccessRoomAsync(room, { _id: this.user._id })) {
-			return API.v1.success({
-				isMember: (await Subscriptions.countByRoomIdAndUserId(room._id, user._id)) > 0,
-			});
-		}
-		return API.v1.forbidden('unauthorized');
+		return API.v1.success({
+			isMember: (await Subscriptions.countByRoomIdAndUserId(room._id, user._id)) > 0,
+		});
 	},
 );
 

--- a/apps/meteor/app/api/server/v1/rooms.ts
+++ b/apps/meteor/app/api/server/v1/rooms.ts
@@ -9,7 +9,6 @@ import {
 	isRoomsImagesProps,
 	isRoomsMuteUnmuteUserProps,
 	isRoomsExportProps,
-	isRoomsIsMemberProps,
 	isRoomsCleanHistoryProps,
 	isRoomsOpenProps,
 	isRoomsMembersOrderedByRoleProps,
@@ -792,34 +791,60 @@ API.v1.addRoute(
 		},
 	},
 );
-
-API.v1.addRoute(
+const isMemeberEndpoint = API.v1.get(
 	'rooms.isMember',
 	{
 		authRequired: true,
-		validateParams: isRoomsIsMemberProps,
-	},
-	{
-		async get() {
-			const { roomId, userId, username } = this.queryParams;
-			const [room, user] = await Promise.all([
-				findRoomByIdOrName({
-					params: { roomId },
-				}) as Promise<IRoom>,
-				Users.findOneByIdOrUsername(userId || username),
-			]);
-
-			if (!user?._id) {
-				return API.v1.failure('error-user-not-found');
-			}
-
-			if (await canAccessRoomAsync(room, { _id: this.user._id })) {
-				return API.v1.success({
-					isMember: (await Subscriptions.countByRoomIdAndUserId(room._id, user._id)) > 0,
-				});
-			}
-			return API.v1.forbidden();
+		query: ajv.compile<{ roomId: string; userId?: string; username?: string }>({
+			type: 'object',
+			properties: {
+				roomId: { type: 'string' },
+				userId: { type: 'string' },
+				username: { type: 'string' },
+			},
+			required: ['roomId'],
+			additionalProperties: false,
+		}),
+		response: {
+			200: ajv.compile<{ isMember: boolean }>({
+				type: 'object',
+				properties: {
+					success: {
+						type: 'boolean',
+						enum: [true],
+						description: 'Indicates if the request was successful.',
+					},
+					isMember: {
+						type: 'boolean',
+					},
+				},
+				required: ['success', 'isMember'],
+				additionalProperties: false,
+			}),
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+			403: validateUnauthorizedErrorResponse,
 		},
+	},
+	async function action() {
+		const { roomId, userId, username } = this.queryParams;
+		const [room, user] = await Promise.all([
+			findRoomByIdOrName({
+				params: { roomId },
+			}),
+			Users.findOneByIdOrUsername((userId || username) as string),
+		]);
+
+		if (!user?._id) {
+			return API.v1.failure('error-user-not-found');
+		}
+
+		if (await canAccessRoomAsync(room, { _id: this.user._id })) {
+			return API.v1.success({
+				isMember: (await Subscriptions.countByRoomIdAndUserId(room._id, user._id)) > 0,
+			});
+		}
+		return API.v1.forbidden('unauthorized');
 	},
 );
 
@@ -1236,9 +1261,9 @@ export const roomEndpoints = API.v1
 	);
 
 type RoomEndpoints = ExtractRoutesFromAPI<typeof roomEndpoints> &
-	ExtractRoutesFromAPI<typeof roomEndpoints> &
 	ExtractRoutesFromAPI<typeof roomDeleteEndpoint> &
-	ExtractRoutesFromAPI<typeof roomsSaveNotificationEndpoint>;
+	ExtractRoutesFromAPI<typeof roomsSaveNotificationEndpoint> &
+	ExtractRoutesFromAPI<typeof isMemeberEndpoint>;
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface

--- a/packages/rest-typings/src/v1/rooms.ts
+++ b/packages/rest-typings/src/v1/rooms.ts
@@ -819,10 +819,6 @@ export type RoomsEndpoints = {
 		}>;
 	};
 
-	'/v1/rooms.isMember': {
-		GET: (params: RoomsIsMemberProps) => { isMember: boolean };
-	};
-
 	'/v1/rooms.muteUser': {
 		POST: (params: RoomsMuteUnmuteUser) => void;
 	};

--- a/packages/rest-typings/src/v1/rooms.ts
+++ b/packages/rest-typings/src/v1/rooms.ts
@@ -458,21 +458,6 @@ const GETRoomsNameExistsSchema = {
 
 export const isGETRoomsNameExists = ajv.compile<GETRoomsNameExists>(GETRoomsNameExistsSchema);
 
-type RoomsIsMemberProps = { roomId: string } & ({ username: string } | { userId: string });
-
-const RoomsIsMemberPropsSchema = {
-	type: 'object',
-	properties: {
-		roomId: { type: 'string', minLength: 1 },
-		userId: { type: 'string', minLength: 1 },
-		username: { type: 'string', minLength: 1 },
-	},
-	oneOf: [{ required: ['roomId', 'userId'] }, { required: ['roomId', 'username'] }],
-	additionalProperties: false,
-};
-
-export const isRoomsIsMemberProps = ajv.compile<RoomsIsMemberProps>(RoomsIsMemberPropsSchema);
-
 export type Notifications = {
 	disableNotifications?: string;
 	muteGroupMentions?: string;


### PR DESCRIPTION
## Proposed changes

Migrates the `rooms.isMember` endpoint from the deprecated `addRoute` pattern to the typed `API.v1.get` method with AJV schema validation and automatic OpenAPI specification generation.

**Changes:**
- Replaced deprecated `addRoute` with `API.v1.get`
- Added AJV query schema validation for `roomId` (required), `userId` and `username` (optional)
- Added typed response schemas for `200`, `400`, `401`, and `403` status codes
- Returns `API.v1.forbidden('unauthorized')` when the caller cannot access the room
- Guards against unresolved user with an early `API.v1.failure('error-user-not-found')`

## Issue(s)

<!-- Link related issue if applicable -->

## Steps to test or reproduce

1. Start Rocket.Chat
2. Call `GET /api/v1/rooms.isMember?roomId=<id>&userId=<id>` as an authenticated user
3. Verify `200` response with `{ success: true, isMember: true/false }`
4. Call the same endpoint as a user without access to the room and verify a `403` response with `{ success: false, error: 'unauthorized' }`
5. Run the existing E2E tests: `yarn testapi --grep "rooms.isMember"`

## Test results
API Test
<img width="879" height="204" alt="Screenshot 2026-03-06 142214" src="https://github.com/user-attachments/assets/2687c145-8de0-4259-b6e7-d6879b668dd4" />

TypeCheck
<img width="733" height="163" alt="Screenshot 2026-03-06 142734" src="https://github.com/user-attachments/assets/3424972f-9bff-4051-aef3-ac6ebdcdfaed" />


## Further comments
tracked in :- https://github.com/RocketChat/Rocket.Chat-Open-API/pull/150
This is part of the ongoing effort to migrate all API endpoints to the typed `API.v1.*` methods, which enables automatic OpenAPI spec generation and request/response validation in test environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced rooms.isMember endpoint with explicit query-parameter validation and clearer HTTP error responses (400, 401, 403).
  * Responses now include an explicit success flag alongside membership result for clearer client handling.

* **Breaking Changes**
  * Public API typing and parameter shape for this endpoint were adjusted; clients should use the updated query parameters and response shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->