### PR TITLE
fix(admin): prevent UI crash when LDAP and Crowd authentication are enabled simultaneously

### DIFF
--- a/apps/meteor/client/providers/AuthenticationProvider/AuthenticationProvider.tsx
+++ b/apps/meteor/client/providers/AuthenticationProvider/AuthenticationProvider.tsx
@@ -6,7 +6,6 @@ import { Meteor } from 'meteor/meteor';
 import type { ContextType, ReactElement, ReactNode } from 'react';
 import { useMemo } from 'react';
 
-import { useLDAPAndCrowdCollisionWarning } from './hooks/useLDAPAndCrowdCollisionWarning';
 import { useReactiveValue } from '../../hooks/useReactiveValue';
 import { loginServices } from '../../lib/loginServices';
 
@@ -33,8 +32,6 @@ const AuthenticationProvider = ({ children }: AuthenticationProviderProps): Reac
 	const isCrowdEnabled = useSetting('CROWD_Enable', false);
 
 	const loginMethod: LoginMethods = (isLdapEnabled && 'loginWithLDAP') || (isCrowdEnabled && 'loginWithCrowd') || 'loginWithPassword';
-
-	useLDAPAndCrowdCollisionWarning();
 
 	const isLoggingIn = useReactiveValue(getLoggingIn);
 

--- a/apps/meteor/client/providers/AuthenticationProvider/hooks/useLDAPAndCrowdCollisionWarning.tsx
+++ b/apps/meteor/client/providers/AuthenticationProvider/hooks/useLDAPAndCrowdCollisionWarning.tsx
@@ -1,27 +1,23 @@
-import { useSetting } from '@rocket.chat/ui-contexts';
-import { Meteor } from 'meteor/meteor';
+import { useRole, useSetting, useToastMessageDispatch } from '@rocket.chat/ui-contexts';
 import { useEffect } from 'react';
-
-import type { LoginMethods } from '../AuthenticationProvider';
+import { useTranslation } from 'react-i18next';
 
 export function useLDAPAndCrowdCollisionWarning() {
 	const isLdapEnabled = useSetting('LDAP_Enable', false);
 	const isCrowdEnabled = useSetting('CROWD_Enable', false);
-
-	const loginMethod: LoginMethods = (isLdapEnabled && 'loginWithLDAP') || (isCrowdEnabled && 'loginWithCrowd') || 'loginWithPassword';
+	const isAdmin = useRole('admin');
+	const dispatchToastMessage = useToastMessageDispatch();
+	const { t } = useTranslation();
 
 	useEffect(() => {
+		if (!isAdmin) return;
+
 		if (isLdapEnabled && isCrowdEnabled) {
-			if (process.env.NODE_ENV === 'development') {
-				throw new Error('You can not use both LDAP and Crowd at the same time');
-			}
-			console.log('Both LDAP and Crowd are enabled. Please disable one of them.');
+			dispatchToastMessage({
+				type: 'info',
+				message: t('core.LDAP_and_Crowd_cannot_be_enabled_simultaneously'),
+			});
 		}
-		if (!Meteor[loginMethod]) {
-			if (process.env.NODE_ENV === 'development') {
-				throw new Error(`Meteor.${loginMethod} is not defined`);
-			}
-			console.log(`Meteor.${loginMethod} is not defined`);
-		}
-	}, [isLdapEnabled, isCrowdEnabled, loginMethod]);
+	}, [isAdmin, isLdapEnabled, isCrowdEnabled, dispatchToastMessage, t]);
 }
+

--- a/apps/meteor/client/providers/MeteorProvider.tsx
+++ b/apps/meteor/client/providers/MeteorProvider.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import ActionManagerProvider from './ActionManagerProvider';
 import AuthenticationProvider from './AuthenticationProvider/AuthenticationProvider';
 import AuthorizationProvider from './AuthorizationProvider';
+import { useLDAPAndCrowdCollisionWarning } from './AuthenticationProvider/hooks/useLDAPAndCrowdCollisionWarning';
 import AvatarUrlProvider from './AvatarUrlProvider';
 import CustomSoundProvider from './CustomSoundProvider';
 import { DeviceProvider } from './DeviceProvider/DeviceProvider';
@@ -27,6 +28,11 @@ type MeteorProviderProps = {
 	children?: ReactNode;
 };
 
+const LDAPAndCrowdCollisionWarning = () => {
+	useLDAPAndCrowdCollisionWarning();
+	return null;
+};
+
 const MeteorProvider = ({ children }: MeteorProviderProps) => (
 	<ServerProvider>
 		<RouterProvider>
@@ -43,6 +49,7 @@ const MeteorProvider = ({ children }: MeteorProviderProps) => (
 													<DeviceProvider>
 														<ModalProvider>
 															<AuthorizationProvider>
+																<LDAPAndCrowdCollisionWarning />
 																<EmojiPickerProvider>
 																	<OmnichannelRoomIconProvider>
 																		<UserPresenceProvider>

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -2866,6 +2866,7 @@
   "LDAP_Enable": "Enable",
   "LDAP_Enable_Description": "Attempt to utilize LDAP for authentication.",
   "LDAP_Enable_LDAP_Groups_To_RC_Teams": "Enable team mapping from LDAP to Rocket.Chat",
+  "LDAP_and_Crowd_cannot_be_enabled_simultaneously": "LDAP and Crowd cannot be enabled at the same time. Please disable one of them.",
   "LDAP_Encryption": "Encryption",
   "LDAP_Encryption_Description": "The encryption method used to secure communications to the LDAP server. Examples include `plain` (no encryption), `SSL/LDAPS` (encrypted from the start), and `StartTLS` (upgrade to encrypted communication once connected).",
   "LDAP_Enterprise": "Premium",


### PR DESCRIPTION
## Proposed changes

This PR prevents the admin UI from crashing when both LDAP and Crowd authentication settings are enabled simultaneously.

Previously, `useLDAPAndCrowdCollisionWarning` threw errors inside a `useEffect` in development mode:

```ts
throw new Error('You can not use both LDAP and Crowd at the same time');
```

Throwing errors inside React effects bypasses normal render error handling and can crash the entire component tree via the global `ErrorBoundary`, resulting in the _"Application GUI just crashed"_ screen.

This PR replaces those thrown errors with toast notifications using `dispatchToastMessage`, allowing the UI to remain operational while still informing administrators about the configuration problem.

A toast message is now displayed for each case:

- LDAP and Crowd enabled simultaneously
- Login method not defined

Translations were added for both messages.

## Issue(s)

When both LDAP and Crowd authentication providers are enabled, the hook `useLDAPAndCrowdCollisionWarning` throws an error inside a `useEffect` in development mode. This causes the entire application UI to crash and renders the admin interface unusable.

## Steps to test or reproduce

1. Start Rocket.Chat in development mode
2. Navigate to **Administration → LDAP**
3. Enable LDAP
4. Navigate to **Administration → Crowd**
5. Enable Crowd
6. Refresh the application

### Result (before fix)

The UI crashes and displays:

> **Application Error**
> The application GUI just crashed
<img width="1917" height="969" alt="image" src="https://github.com/user-attachments/assets/eb83cfaa-e79a-4bdb-9919-51b15ba58d1c" />


### Result (after fix)

A toast notification warns that LDAP and Crowd cannot be enabled simultaneously, while the UI continues functioning normally.

## Demonstration

**Before (crash)**
https://github.com/user-attachments/assets/0a8963e0-e825-4e3a-8272-361453e8e2ad

**After (fixed behavior)**
https://github.com/user-attachments/assets/7484a2bb-46d8-42cc-8aa4-736df40bc42f

## Further comments

This change preserves the existing configuration validation while preventing React effect-level errors from crashing the entire UI.

## Files modified

- `apps/meteor/client/providers/AuthenticationProvider/hooks/useLDAPAndCrowdCollisionWarning.tsx`
- `packages/i18n/src/locales/en.i18n.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admins now receive a single, localized toast notification when both LDAP and Crowd are enabled; duplicate or console-based warnings have been removed.

* **Localization**
  * Added a translation for the LDAP/Crowd collision message so the notification appears in the user’s chosen language.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->