### PR TITLE
fix: remove catch (e: any) type assertion in Twilio SMS provider

### DIFF
--- a/apps/meteor/server/services/omnichannel-integrations/providers/twilio.ts
+++ b/apps/meteor/server/services/omnichannel-integrations/providers/twilio.ts
@@ -226,11 +226,12 @@ export class Twilio implements ISMSProvider {
 				isSuccess: result.status !== 'failed',
 				resultMsg: result.status,
 			};
-		} catch (e: any) {
-			await notifyAgent(userId, rid, e.message);
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			await notifyAgent(userId, rid, message);
 			return {
 				isSuccess: false,
-				resultMsg: e.message,
+				resultMsg: message,
 			};
 		}
 	}


### PR DESCRIPTION
This PR removes the `any` type assertion from the `catch` clause in the Twilio provider `send` method and safely handles errors using TypeScript's `unknown` catch variable behavior.

### Problem

The existing implementation used:

```ts
catch (e: any)
```

and accessed `e.message` directly. If a non-`Error` value is thrown (e.g. a string or number), `e.message` becomes `undefined`, which results in agents receiving an unclear `"undefined"` notification.

### Solution

Use type narrowing to safely extract the message:

```ts
catch (e) {
  const message = e instanceof Error ? e.message : String(e);
}
```

This ensures:

* compatibility with TypeScript 4.4+ `useUnknownInCatchVariables`
* safe access to the error message
* meaningful fallback messages for non-Error throws

### Impact

* Improves runtime safety
* Removes the `any` assertion
* Ensures agents always receive a readable error message

### Scope

* 1 file changed
* defensive error handling improvement
* no behavioral change for standard `Error` throws

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in Twilio message delivery to prevent runtime errors and ensure consistent error messaging when exceptions occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->