### PR TITLE
fix: remove non-null assertion in Twilio validateFileUpload (use nullish coalescing)

### DIFF
--- a/apps/meteor/server/services/omnichannel-integrations/providers/twilio.ts
+++ b/apps/meteor/server/services/omnichannel-integrations/providers/twilio.ts
@@ -161,8 +161,8 @@ export class Twilio implements ISMSProvider {
 			return '';
 		}
 
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return publicFilePath!;
+		// publicFilePath is guaranteed truthy here (checked above)
+		return publicFilePath ?? '';
 	}
 
 	async send(


### PR DESCRIPTION
## What does this PR do?


Removes an unsafe non-null assertion (`publicFilePath!`) and its accompanying ESLint suppression (`// eslint-disable-next-line @typescript-eslint/no-non-null-assertion`) in the [validateFileUpload](file:///d:/Codes/Code/Open%20Source/RocketChat/Rocket.Chat/apps/meteor/server/services/omnichannel-integrations/providers/twilio.ts#121-167) private method of the [Twilio](file:///d:/Codes/Code/Open%20Source/RocketChat/Rocket.Chat/apps/meteor/server/services/omnichannel-integrations/providers/twilio.ts#49-296) SMS provider.

## Why?

The `publicFilePath` variable comes from an optional destructuring default:

```ts
const { rid, userId, fileUpload: { size, type, publicFilePath } = { size: 0, type: 'invalid' } } = extraData;
```

The default value `{ size: 0, type: 'invalid' }` does **not** include `publicFilePath`, so TypeScript correctly infers it as `string | undefined`. The `!` assertion overrides this and suppresses the type error, which hides a potential runtime issue.

However, the control flow already handles the falsy case — line 144 contains:

```ts
} else if (!publicFilePath) {
    reason = i18n.t('FileUpload_NotAllowed', { lng });
}
```

And at line 158–162, if `reason` is set, the function returns `''` early. So by line 165, `publicFilePath` **is** guaranteed to be truthy at runtime — but TypeScript can't infer this from the destructuring.

## Fix

Replace the non-null assertion with a safe nullish coalescing fallback that expresses the same intent transparently:

```ts
// Before
// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
return publicFilePath!;

// After
// publicFilePath is guaranteed truthy here (checked above)
return publicFilePath ?? '';
```

## Impact

- Removes `eslint-disable-next-line @typescript-eslint/no-non-null-assertion`  
- Removes `!` non-null assertion  
- Functionally equivalent — the `?? ''` fallback is unreachable but documents intent clearly  
- Clean, safe TypeScript — no type errors, no suppressions  
- No behavior change  

## Files changed

- [apps/meteor/server/services/omnichannel-integrations/providers/twilio.ts](file:///d:/Codes/Code/Open%20Source/RocketChat/Rocket.Chat/apps/meteor/server/services/omnichannel-integrations/providers/twilio.ts)

## Testing

No behavior change. Existing unit tests in [apps/meteor/tests/unit/server/services/omnichannel-integrations/providers/twilio.spec.ts](file:///d:/Codes/Code/Open%20Source/RocketChat/Rocket.Chat/apps/meteor/tests/unit/server/services/omnichannel-integrations/providers/twilio.spec.ts) continue to cover the Twilio provider's request validation logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in Twilio integration to improve service reliability and prevent potential issues that could interrupt omnichannel communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->