### PR TITLE
test(message-parser): tighten AST assertions

### DIFF
--- a/packages/message-parser/tests/abuse.test.ts
+++ b/packages/message-parser/tests/abuse.test.ts
@@ -254,5 +254,5 @@ test.each([
 		],
 	],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/any.test.ts
+++ b/packages/message-parser/tests/any.test.ts
@@ -6,5 +6,5 @@ test.each([
 	['free text, with comma', [paragraph([plain('free text, with comma')])]],
 	['free text with unxpected/unfinished blocks *bold_', [paragraph([plain('free text with unxpected/unfinished blocks *bold_')])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/blockquotes.test.ts
+++ b/packages/message-parser/tests/blockquotes.test.ts
@@ -43,5 +43,5 @@ As Rocket Cat said:
 		[quote([paragraph([plain('meowww')]), paragraph([plain('')]), paragraph([plain('grr.')])])],
 	],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/codeFence.test.ts
+++ b/packages/message-parser/tests/codeFence.test.ts
@@ -68,5 +68,5 @@ code
 		[code([codeLine(plain(`# code`)), codeLine(plain(`**code**`))])],
 	],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/color.test.ts
+++ b/packages/message-parser/tests/color.test.ts
@@ -10,9 +10,6 @@ test.each([
 	['color:#c7', [paragraph([plain('color:#c7')])], undefined],
 	['color:#zzz', [paragraph([plain('color:#zzz')])], undefined],
 ])('parses %p', (input, output, disabledOutput) => {
-	expect(parse(input, { colors: true })).toMatchObject(output);
-
-	if (disabledOutput) {
-		expect(parse(input, { colors: false })).toMatchObject(disabledOutput);
-	}
+	expect(parse(input, { colors: true })).toEqual(output);
+	expect(parse(input, { colors: false })).toEqual(disabledOutput ?? output);
 });

--- a/packages/message-parser/tests/email.test.ts
+++ b/packages/message-parser/tests/email.test.ts
@@ -47,5 +47,5 @@ test.each([
 	['My email is fake@gmail.c', [paragraph([plain('My email is fake@gmail.c')])]],
 	['My email is fake@gmail.comf', [paragraph([plain('My email is fake@gmail.comf')])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/emoji.test.ts
+++ b/packages/message-parser/tests/emoji.test.ts
@@ -31,7 +31,7 @@ test.each([
 	['Hi :+1:', [paragraph([plain('Hi '), emoji('+1')])]],
 	['Hi :+1_tone4:', [paragraph([plain('Hi '), emoji('+1_tone4')])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });
 
 // Tests for unicode emojis
@@ -58,5 +58,5 @@ test.each([
 	['👆🏺', [bigEmoji([emojiUnicode('👆'), emojiUnicode('🏺')])]],
 	['Hi 👍', [paragraph([plain('Hi '), emojiUnicode('👍')])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/emoticons.test.ts
+++ b/packages/message-parser/tests/emoticons.test.ts
@@ -66,5 +66,5 @@ test.each([
 	['Hi:)', [paragraph([plain('Hi:)')])]],
 	['@#@#! :)@!@', [paragraph([plain('@#@#! :)@!@')])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input, { emoticons: true })).toMatchObject(output);
+	expect(parse(input, { emoticons: true })).toEqual(output);
 });

--- a/packages/message-parser/tests/emphasis.test.ts
+++ b/packages/message-parser/tests/emphasis.test.ts
@@ -126,5 +126,5 @@ test.each([
 	],
 	['something__ __and italic__', [paragraph([plain('something__ '), italic([plain('and italic')])])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input, { emoticons: false })).toMatchObject(output);
+	expect(parse(input, { emoticons: false })).toEqual(output);
 });

--- a/packages/message-parser/tests/emphasisWithEmoticons.test.ts
+++ b/packages/message-parser/tests/emphasisWithEmoticons.test.ts
@@ -54,5 +54,5 @@ test.each([
 	],
 	['-_-italic content-_-', [paragraph([plain('-'), italic([plain('-italic content-')]), plain('-')])]],
 ])('parses emphasisWithEmoticons %p', (input, output) => {
-	expect(parse(input, { emoticons: true })).toMatchObject(output);
+	expect(parse(input, { emoticons: true })).toEqual(output);
 });

--- a/packages/message-parser/tests/escaped.test.ts
+++ b/packages/message-parser/tests/escaped.test.ts
@@ -16,5 +16,5 @@ test.each([
 	['\\[foo]: /url "not a reference"', [paragraph([plain('\\[foo]: /url "not a reference"')])]],
 	['\\&ouml; not a character entity', [paragraph([plain('\\&ouml; not a character entity')])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/heading.test.ts
+++ b/packages/message-parser/tests/heading.test.ts
@@ -45,5 +45,5 @@ test.each([
 	['# Hello\n', [heading([plain('Hello')], 1), lineBreak()]],
 	['# # Hello\n', [heading([plain('# Hello')], 1), lineBreak()]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/image.test.ts
+++ b/packages/message-parser/tests/image.test.ts
@@ -8,5 +8,5 @@ test.each([
 	],
 	['![](https://rocket.chat/assets/img/header/logo.svg)', [paragraph([image('https://rocket.chat/assets/img/header/logo.svg')])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/inlineCode.test.ts
+++ b/packages/message-parser/tests/inlineCode.test.ts
@@ -8,5 +8,5 @@ test.each([
 	['`@rocket.chat`', [paragraph([inlineCode(plain('@rocket.chat'))])]],
 	['`@rocket.chat/message-parser`', [paragraph([inlineCode(plain('@rocket.chat/message-parser'))])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/inlineCodeStrike.test.ts
+++ b/packages/message-parser/tests/inlineCodeStrike.test.ts
@@ -10,5 +10,5 @@ test.each([
 		[paragraph([strike([italic([bold([inlineCode(plain('Striking Inline Code with Bold'))])])])])],
 	],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/katex.test.ts
+++ b/packages/message-parser/tests/katex.test.ts
@@ -18,5 +18,5 @@ test.each([
 	],
 	['Easy as \\(E = mc^2\\), right?', [paragraph([plain('Easy as '), inlineKatex('E = mc^2'), plain(', right?')])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input, { katex: { parenthesisSyntax: true } })).toMatchObject(output);
+	expect(parse(input, { katex: { parenthesisSyntax: true } })).toEqual(output);
 });

--- a/packages/message-parser/tests/lineBreak.test.ts
+++ b/packages/message-parser/tests/lineBreak.test.ts
@@ -25,5 +25,5 @@ test2
 		[paragraph([plain('test')]), lineBreak(), lineBreak(), lineBreak(), paragraph([plain('test2')])],
 	],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/link.test.ts
+++ b/packages/message-parser/tests/link.test.ts
@@ -413,5 +413,5 @@ Text after line break`,
 	['[link](https://example.com/path/to/func(param))', [paragraph([link('https://example.com/path/to/func(param)', [plain('link')])])]],
 	['[link](https://example.com/path/(section)/page)', [paragraph([link('https://example.com/path/(section)/page', [plain('link')])])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/mention.test.ts
+++ b/packages/message-parser/tests/mention.test.ts
@@ -18,5 +18,5 @@ test.each([
 	['@Кириллица', [paragraph([mentionUser('Кириллица')])]],
 	['test @Кириллица test', [paragraph([plain('test '), mentionUser('Кириллица'), plain(' test')])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/orderedList.test.ts
+++ b/packages/message-parser/tests/orderedList.test.ts
@@ -25,5 +25,5 @@ test.each([
 		],
 	],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/phoneNumber.test.ts
+++ b/packages/message-parser/tests/phoneNumber.test.ts
@@ -22,5 +22,5 @@ test.each([
 	['+123-4', [paragraph([plain('+123-4')])]],
 	['5+51231', [paragraph([plain('5+51231')])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/spoiler.test.ts
+++ b/packages/message-parser/tests/spoiler.test.ts
@@ -8,7 +8,7 @@ describe('spoiler parsing', () => {
 		['||__i__ ~~s~~||', [paragraph([spoiler([italic([plain('i')]), plain(' '), strike([plain('s')])])])]],
 		['||unclosed', [paragraph([plain('||unclosed')])]],
 	])('parses basic spoilers: %p', (input, output) => {
-		expect(parse(input)).toMatchObject(output);
+		expect(parse(input)).toEqual(output);
 	});
 
 	test.each([
@@ -45,6 +45,6 @@ describe('spoiler parsing', () => {
 		// Spoiler at start and end
 		['||start|| middle ||end||', [paragraph([spoiler([plain('start')]), plain(' middle '), spoiler([plain('end')])])]],
 	])('parses edge cases: %p', (input, output) => {
-		expect(parse(input)).toMatchObject(output);
+		expect(parse(input)).toEqual(output);
 	});
 });

--- a/packages/message-parser/tests/spoilerBlock.test.ts
+++ b/packages/message-parser/tests/spoilerBlock.test.ts
@@ -25,6 +25,6 @@ after`,
 			[paragraph([plain('before')]), spoilerBlock([paragraph([plain('hidden')])]), lineBreak(), paragraph([plain('after')])],
 		],
 	])('parses block spoilers: %p', (input, output) => {
-		expect(parse(input)).toMatchObject(output);
+		expect(parse(input)).toEqual(output);
 	});
 });

--- a/packages/message-parser/tests/strikethrough.test.ts
+++ b/packages/message-parser/tests/strikethrough.test.ts
@@ -44,5 +44,5 @@ test.each([
 	['Rocket cat says ~~Hello~~', [paragraph([plain(`Rocket cat says `), strike([plain('Hello')])])]],
 	['He said ~~Hello~~ to her', [paragraph([plain(`He said `), strike([plain('Hello')]), plain(` to her`)])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/strongEmphasis.test.ts
+++ b/packages/message-parser/tests/strongEmphasis.test.ts
@@ -64,5 +64,5 @@ test.each([
 	['*bold with a kissing emoji :* *', [paragraph([bold([plain('bold with a kissing emoji :')]), plain(' *')])]],
 	['*bold with a kissing emoji :* ', [paragraph([bold([plain('bold with a kissing emoji :')]), plain(' ')])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/tasks.test.ts
+++ b/packages/message-parser/tests/tasks.test.ts
@@ -32,5 +32,5 @@ test.each([
 		],
 	],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/timestamp.test.ts
+++ b/packages/message-parser/tests/timestamp.test.ts
@@ -22,21 +22,21 @@ test.each([
 	[`<t:1708551317:R>`, [paragraph([timestampNode('1708551317', 'R')])]],
 	['hello <t:1708551317>', [paragraph([plain('hello '), timestampNode('1708551317')])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });
 
 test.each([
 	['<t:1708551317:I>', [paragraph([plain('<t:1708551317:I>')])]],
 	['<t:17>', [paragraph([plain('<t:17>')])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });
 
 test.each([
 	['~<t:1708551317>~', [paragraph([strike([timestampNode('1708551317')])])]],
 	['*<t:1708551317>*', [paragraph([bold([plain('<t:1708551317>')])])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });
 
 test.each([
@@ -45,7 +45,7 @@ test.each([
 
 	['<t:2025-07-24T20:19:58.154+00:00:R>', [paragraph([timestampNode('1753388398', 'R')])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });
 
 describe('relative hour timestamp parsing', () => {
@@ -64,6 +64,6 @@ describe('relative hour timestamp parsing', () => {
 		['<t:10:00:05+00:00>', [paragraph([timestampNode('1753178405')])]],
 		['<t:10:00+00:00>', [paragraph([timestampNode('1753178400')])]],
 	])('parses %p', (input, output) => {
-		expect(parse(input)).toMatchObject(output);
+		expect(parse(input)).toEqual(output);
 	});
 });

--- a/packages/message-parser/tests/unorderedList.test.ts
+++ b/packages/message-parser/tests/unorderedList.test.ts
@@ -72,5 +72,5 @@ test.each([
 	//     [paragraph([])],
 	//   ],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });

--- a/packages/message-parser/tests/url.test.ts
+++ b/packages/message-parser/tests/url.test.ts
@@ -131,7 +131,7 @@ test.each([
 	['https://www.google.com!', [paragraph([link('https://www.google.com'), plain('!')])]],
 	['visit www.google.com.', [paragraph([plain('visit '), link('//www.google.com', [plain('www.google.com')]), plain('.')])]],
 ])('parses %p', (input, output) => {
-	expect(parse(input)).toMatchObject(output);
+	expect(parse(input)).toEqual(output);
 });
 
 describe('autoLink with custom hosts settings comming from Rocket.Chat', () => {
@@ -140,42 +140,42 @@ describe('autoLink with custom hosts settings comming from Rocket.Chat', () => {
 		['gitlab.local', [paragraph([link('//gitlab.local', [plain('gitlab.local')])])]],
 		['internaltool.intranet', [paragraph([link('//internaltool.intranet', [plain('internaltool.intranet')])])]],
 	])('parses %p', (input, output) => {
-		expect(parse(input, { customDomains: ['local', 'intranet'] })).toMatchObject(output);
+		expect(parse(input, { customDomains: ['local', 'intranet'] })).toEqual(output);
 	});
 });
 
 describe('autoLink WITHOUT custom hosts settings comming from Rocket.Chat', () => {
 	test.each([['https://internaltool.testt', [paragraph([plain('https://internaltool.testt')])]]])('parses %p', (input, output) => {
-		expect(parse(input, { customDomains: ['local'] })).toMatchObject(output);
+		expect(parse(input, { customDomains: ['local'] })).toEqual(output);
 	});
 });
 
 describe('autoLink helper function', () => {
 	it('should preserve the original protocol if the protocol is http or https', () => {
-		expect(autoLink('https://rocket.chat/test')).toMatchObject(link('https://rocket.chat/test'));
+		expect(autoLink('https://rocket.chat/test')).toEqual(link('https://rocket.chat/test'));
 
-		expect(autoLink('http://rocket.chat/test')).toMatchObject(link('http://rocket.chat/test'));
+		expect(autoLink('http://rocket.chat/test')).toEqual(link('http://rocket.chat/test'));
 	});
 
 	it('should preserve the original protocol even if for custom protocols', () => {
-		expect(autoLink('custom://rocket.chat/test')).toMatchObject(link('custom://rocket.chat/test'));
+		expect(autoLink('custom://rocket.chat/test')).toEqual(link('custom://rocket.chat/test'));
 	});
 
 	it('should return // as the protocol if // is the protocol specified', () => {
-		expect(autoLink('//rocket.chat/test')).toMatchObject(link('//rocket.chat/test'));
+		expect(autoLink('//rocket.chat/test')).toEqual(link('//rocket.chat/test'));
 	});
 
 	it("should return an url concatenated '//' if the url has no protocol", () => {
-		expect(autoLink('rocket.chat/test')).toMatchObject(link('//rocket.chat/test', [plain('rocket.chat/test')]));
+		expect(autoLink('rocket.chat/test')).toEqual(link('//rocket.chat/test', [plain('rocket.chat/test')]));
 	});
 
 	it("should return an url concatenated '//' if the url has no protocol and has sub-domain", () => {
-		expect(autoLink('spark-public.s3.amazonaws.com')).toMatchObject(
+		expect(autoLink('spark-public.s3.amazonaws.com')).toEqual(
 			link('//spark-public.s3.amazonaws.com', [plain('spark-public.s3.amazonaws.com')]),
 		);
 	});
 
 	it("should return an plain text url due to invalid TLD that's validate with the external library TLDTS", () => {
-		expect(autoLink('rocket.chattt/url_path')).toMatchObject(plain('rocket.chattt/url_path'));
+		expect(autoLink('rocket.chattt/url_path')).toEqual(plain('rocket.chattt/url_path'));
 	});
 });


### PR DESCRIPTION
## Summary
- replace parser test `toMatchObject` assertions with strict `toEqual` checks
- make AST test expectations fail on extra fields or structural drift
- remove the conditional `expect` pattern in `color.test.ts` while preserving test intent

## Testing
- ran the `packages/message-parser` test suite locally: 29 suites passed, 588 tests passed
- ran eslint on the changed parser test files

Refs #39295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions across the message parser test suite to enforce stricter equality validation. This improves test reliability and precision by ensuring parsed outputs match expected structures exactly, eliminating tolerance for unintended variations that could mask parsing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->