### PR TITLE
fix: Restore 'Reply in Direct Message' action in web client

### DIFF
--- a/.changeset/dull-boats-vanish.md
+++ b/.changeset/dull-boats-vanish.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/meteor': patch
+'@rocket.chat/ui-client': patch
+---
+
+Fixed 'Reply in Direct Message' action visibility by removing redundant local store checks

--- a/apps/meteor/client/components/message/toolbar/useReplyInDMAction.ts
+++ b/apps/meteor/client/components/message/toolbar/useReplyInDMAction.ts
@@ -1,13 +1,11 @@
 import { type IMessage, type ISubscription, type IRoom, isE2EEMessage } from '@rocket.chat/core-typings';
 import { useEmbeddedLayout } from '@rocket.chat/ui-client';
 import { usePermission, useRouter, useUser } from '@rocket.chat/ui-contexts';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useShallow } from 'zustand/shallow';
 
 import type { MessageActionConfig } from '../../../../app/ui-utils/client/lib/MessageAction';
 import { roomCoordinator } from '../../../lib/rooms/roomCoordinator';
-import { Rooms, Subscriptions } from '../../../stores';
 
 export const useReplyInDMAction = (
 	message: IMessage,
@@ -20,23 +18,6 @@ export const useReplyInDMAction = (
 	const canCreateDM = usePermission('create-d');
 	const isLayoutEmbedded = useEmbeddedLayout();
 	const { t } = useTranslation();
-
-	const roomPredicate = useCallback(
-		(record: IRoom): boolean => {
-			const ids = [user?._id, message.u._id].sort().join('');
-			return ids.includes(record._id);
-		},
-		[message.u._id, user],
-	);
-
-	const shouldFindRoom = useMemo(() => !!user && canCreateDM && user._id !== message.u._id, [canCreateDM, message.u._id, user]);
-	const dmRoom = Rooms.use(useShallow((state) => (shouldFindRoom ? state.find(roomPredicate) : undefined)));
-
-	const subsPredicate = useCallback(
-		(record: ISubscription) => record.rid === dmRoom?._id || record.u._id === user?._id,
-		[dmRoom, user?._id],
-	);
-	const dmSubs = Subscriptions.use(useShallow((state) => state.find(subsPredicate)));
 
 	const tooltip = useMemo(() => {
 		if (encrypted) {
@@ -52,13 +33,11 @@ export const useReplyInDMAction = (
 		if (!subscription || room.t === 'd' || room.t === 'l' || isLayoutEmbedded) {
 			return false;
 		}
-		if (!!user && user._id !== message.u._id && canCreateDM) {
-			if (!dmRoom || !dmSubs) {
-				return false;
-			}
+		if (!user || user._id === message.u._id || !canCreateDM) {
+			return false;
 		}
 		return true;
-	}, [canCreateDM, dmRoom, dmSubs, isLayoutEmbedded, message.u._id, room.t, subscription, user]);
+	}, [canCreateDM, isLayoutEmbedded, message.u._id, room.t, subscription, user]);
 
 	if (!canReplyInDM) {
 		return null;

--- a/apps/meteor/client/components/message/toolbar/useReplyInDMAction.ts
+++ b/apps/meteor/client/components/message/toolbar/useReplyInDMAction.ts
@@ -30,7 +30,7 @@ export const useReplyInDMAction = (
 	}, [encrypted, isABACEnabled, t]);
 
 	const canReplyInDM = useMemo(() => {
-		if (!subscription || room.t === 'd' || room.t === 'l' || isLayoutEmbedded) {
+		if (!subscription || (room.t !== 'c' && room.t !== 'p') || isLayoutEmbedded) {
 			return false;
 		}
 		if (!user || user._id === message.u._id || !canCreateDM) {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR restores the **"Reply in Direct Message"** message action in the web/desktop application, achieving feature parity with the mobile app.


screenshot : 
<img width="1572" height="840" alt="Screenshot From 2026-03-07 17-00-10" src="https://github.com/user-attachments/assets/6355bd66-8ad6-4cca-a277-9e51d1a24cee" />


**Technical Root Cause:**
The `useReplyInDMAction` hook previously relied on local client-side `Rooms` and `Subscriptions` stores to determine if a DM room already existed between the current user and the message author. 
* If a DM conversation had never been initiated, these stores returned `undefined`.
* The `canReplyInDM` logic required these to be truthy, effectively hiding the button for any new potential conversations.

**The Fix:**
* **Decoupled Visibility from State:** Removed the dependency on local room/subscription stores.
* **Simplified Logic:** Refactored `canReplyInDM` to check for core requirements: User is logged in, has `create-d` permission, is not the author, and is in a valid room type (Channel/Group).
* **Cleanup:** Removed several unused imports (`useShallow`, `useCallback`, `useRooms`, `useSubscriptions`) and optimized the `useMemo` dependencies.



## Issue(s)
Closes #39434

## Steps to test or reproduce
1. Open Rocket.Chat in a web browser.
2. Navigate to a public channel.
3. Find a message from a user you have **never** had a Direct Message conversation with before.
4. Open the message action menu (three dots).
5. **Expected:** The "Reply in Direct Message" option should be visible.
6. **Actual (Before Fix):** The option is missing because no pre-existing DM subscription exists in the local store.

## Further comments
The `roomCoordinator.openRouteLink` already handles the creation of a new DM room if one does not exist, so the pre-emptive store check was redundant and caused this UI regression. Removing it ensures the feature works as intended for initiating new private discussions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visibility of the "Reply in Direct Message" action in message toolbars by removing redundant checks—the action now reliably appears when users are allowed to start direct-message replies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->