### PR TITLE
feat: added a new enum for grant types

### DIFF
--- a/apps/meteor/app/cloud/server/functions/finishOAuthAuthorization.ts
+++ b/apps/meteor/app/cloud/server/functions/finishOAuthAuthorization.ts
@@ -6,7 +6,7 @@ import { SystemLogger } from '../../../../server/lib/logger/system';
 import { settings } from '../../../settings/server';
 import { userScopes } from '../oauthScopes';
 import { getRedirectUri } from './getRedirectUri';
-
+import { GrantType } from '/server/oauth2-server/model';
 export async function finishOAuthAuthorization(code: string, state: string) {
 	if (settings.get<string>('Cloud_Workspace_Registration_State') !== state) {
 		throw new Meteor.Error('error-invalid-state', 'Invalid state provided', {
@@ -28,7 +28,7 @@ export async function finishOAuthAuthorization(code: string, state: string) {
 			params: new URLSearchParams({
 				client_id: clientId,
 				client_secret: clientSecret,
-				grant_type: 'authorization_code',
+				grant_type: GrantType.AuthorizationCode,
 				scope,
 				code,
 				redirect_uri: getRedirectUri(),

--- a/apps/meteor/app/custom-oauth/server/custom_oauth_server.js
+++ b/apps/meteor/app/custom-oauth/server/custom_oauth_server.js
@@ -122,7 +122,7 @@ export class CustomOAuth {
 		const params = new URLSearchParams({
 			code: query.code,
 			redirect_uri: OAuth._redirectUri(this.name, config),
-			grant_type: 'authorization_code',
+			grant_type: GrantType.AuthorizationCode,
 			state: query.state,
 		});
 

--- a/apps/meteor/packages/linkedin-oauth/linkedin-server.js
+++ b/apps/meteor/packages/linkedin-oauth/linkedin-server.js
@@ -2,7 +2,7 @@ import { Accounts } from 'meteor/accounts-base';
 import { fetch } from 'meteor/fetch';
 import { OAuth } from 'meteor/oauth';
 import { ServiceConfiguration } from 'meteor/service-configuration';
-
+import { GrantType } from '/server/oauth2-server/model';
 export const Linkedin = {};
 
 // returns an object containing:
@@ -16,7 +16,7 @@ const getTokenResponse = async function (query) {
 	try {
 		// Request an access token
 		const body = new URLSearchParams({
-			grant_type: 'authorization_code',
+			grant_type: GrantType.AuthorizationCode,
 			client_id: config.clientId,
 			client_secret: OAuth.openSecret(config.secret),
 			code: query.code,

--- a/apps/meteor/server/oauth2-server/model.ts
+++ b/apps/meteor/server/oauth2-server/model.ts
@@ -13,11 +13,15 @@ import { OAuthApps, OAuthAuthCodes, OAuthAccessTokens, OAuthRefreshTokens } from
 export type ModelConfig = {
 	debug?: boolean;
 };
+export enum GrantType {
+	AuthorizationCode = 'authorization_code',
+	RefreshToken = 'refresh_token',
+}
 
 export class Model implements AuthorizationCodeModel, RefreshTokenModel {
 	private debug: boolean;
 
-	private grants = ['authorization_code', 'refresh_token'];
+	private grants = [GrantType.AuthorizationCode, GrantType.RefreshToken];
 
 	constructor(config: ModelConfig = {}) {
 		this.debug = !!config.debug;

--- a/apps/meteor/tests/end-to-end/api/oauth-server.ts
+++ b/apps/meteor/tests/end-to-end/api/oauth-server.ts
@@ -3,6 +3,7 @@ import { after, before, describe, it } from 'mocha';
 import type { Response } from 'supertest';
 
 import { getCredentials, api, request, credentials } from '../../data/api-data';
+import { GrantType } from '/server/oauth2-server/model';
 
 describe('[OAuth Server]', () => {
 	let oAuthAppId: string;
@@ -88,7 +89,7 @@ describe('[OAuth Server]', () => {
 				.post(`/oauth/token`)
 				.type('form')
 				.send({
-					grant_type: 'authorization_code',
+					grant_type: GrantType.AuthorizationCode,
 					code,
 					client_id: clientId,
 					client_secret: clientSecret,


### PR DESCRIPTION
Added an `enum` for `GrantType` to replace previously hardcoded strings in the authentication flow. 

- `GrantType.AuthorizationCode` replaces `"authorization_code"`
- `GrantType.RefreshToken` replaces `"refresh_token"`

This improves **type safety**, **readability**, and reduces chance of typos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated OAuth grant type handling across multiple modules to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->