### PR TITLE
fix: Fix truncation of Livechat transfer comments

### DIFF
--- a/apps/meteor/app/theme/client/main.css
+++ b/apps/meteor/app/theme/client/main.css
@@ -14,3 +14,17 @@
 @import url('imports/general/theme_old.css');
 @import url('./rocketchat.font.css');
 @import url('../../../node_modules/@rocket.chat/fuselage/dist/fuselage.css');
+
+/* Fix truncation of Livechat transfer comments */
+.rcx-message-system__container,
+.rcx-message-system__body {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: unset;
+  word-break: break-word;
+}
+
+/* Ensure name aligns with top of multiline message */
+.rcx-message-system__block {
+  align-items: flex-start;
+}


### PR DESCRIPTION
## Proposed changes

This PR fixes an issue where transfer comments in Livechat system messages are truncated and displayed with `...` when the comment exceeds a single line.

After inspecting, I found that system messages inherit styles from Fuselage (`.rcx-message-system`) that force the content onto a single line using `white-space: nowrap`, `overflow: hidden`, and `text-overflow: ellipsis`.

As a result, longer transfer comments are truncated and not fully visible to agents.

This change overrides those styles so the message body can wrap across multiple lines, allowing the full transfer comment to be displayed.

Screenshot of the fix is attached below.

<img width="2684" height="1414" alt="image" src="https://github.com/user-attachments/assets/2d9fee23-df07-4b79-9416-5669f6351c69" />

## Issue(s)

Closes #26723

---

## Steps to test or reproduce

1. Start a Livechat conversation.
2. Transfer the conversation to another agent.
3. Add a long comment during the transfer.
4. Observe the system message in the chat.

### Before this fix
The comment is truncated and displayed with `...`.

### After this fix
The full comment is displayed and wraps across multiple lines correctly.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed text truncation and alignment issues in Livechat transfer comments. Transfer comments now display fully and maintain proper alignment when spanning multiple lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->