### PR TITLE
fix(message-parser): parse timestamps inside formatted text

### DIFF
--- a/.changeset/fix-timestamp-parser.md
+++ b/.changeset/fix-timestamp-parser.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/message-parser": patch
+---
+
+Fix timestamps not being parsed inside bold and italic formatted text

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -528,7 +528,8 @@ ItalicContentItem = ItalicContentPreferentialItem / ItalicContentFallbackItem
 
 ItalicContentPreferentialItem = item:ItalicContentPreferentialItemPattern { skipItalicEmoji = false; return item; }
 
-ItalicContentPreferentialItemPattern = Whitespace
+ItalicContentPreferentialItemPattern = TimestampRules
+  /Whitespace
   / InlineCode
   / MaybeReferences
   / UserMention
@@ -553,7 +554,7 @@ BoldContent = & { skipBoldEmoji = false; return true; } text:BoldContentItem+ { 
 
 BoldContentPreferentialItem = item:BoldContentPreferentialItemPattern { skipBoldEmoji = false; return item; }
 
-BoldContentPreferentialItemPattern = Whitespace / InlineCode / MaybeReferences / UserMention / ChannelMention / MaybeItalic / MaybeStrikethrough / BoldEmoji / BoldEmoticon
+BoldContentPreferentialItemPattern = TimestampRules/Whitespace / InlineCode / MaybeReferences / UserMention / ChannelMention / MaybeItalic / MaybeStrikethrough / BoldEmoji / BoldEmoticon
 
 BoldContentFallbackItem = item:BoldContentFallbackItemPattern { skipBoldEmoji = true; return item; }
 

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -528,8 +528,10 @@ ItalicContentItem = ItalicContentPreferentialItem / ItalicContentFallbackItem
 
 ItalicContentPreferentialItem = item:ItalicContentPreferentialItemPattern { skipItalicEmoji = false; return item; }
 
-ItalicContentPreferentialItemPattern = TimestampRules
-  /Whitespace
+// Allow timestamps (<t:...>) to be parsed inside italic content
+ItalicContentPreferentialItemPattern =
+  TimestampRules
+  / Whitespace
   / InlineCode
   / MaybeReferences
   / UserMention
@@ -554,7 +556,18 @@ BoldContent = & { skipBoldEmoji = false; return true; } text:BoldContentItem+ { 
 
 BoldContentPreferentialItem = item:BoldContentPreferentialItemPattern { skipBoldEmoji = false; return item; }
 
-BoldContentPreferentialItemPattern = TimestampRules/Whitespace / InlineCode / MaybeReferences / UserMention / ChannelMention / MaybeItalic / MaybeStrikethrough / BoldEmoji / BoldEmoticon
+// Allow timestamps (<t:...>) to be parsed inside bold content
+BoldContentPreferentialItemPattern =
+  TimestampRules
+  / Whitespace
+  / InlineCode
+  / MaybeReferences
+  / UserMention
+  / ChannelMention
+  / MaybeItalic
+  / MaybeStrikethrough
+  / BoldEmoji
+  / BoldEmoticon
 
 BoldContentFallbackItem = item:BoldContentFallbackItemPattern { skipBoldEmoji = true; return item; }
 

--- a/packages/message-parser/tests/timestamp.test.ts
+++ b/packages/message-parser/tests/timestamp.test.ts
@@ -1,3 +1,4 @@
+import { timeStamp } from 'node:console';
 import { parse } from '../src';
 
 const plain = (value: string) => ({ type: 'PLAIN_TEXT' as const, value });
@@ -34,7 +35,7 @@ test.each([
 
 test.each([
 	['~<t:1708551317>~', [paragraph([strike([timestampNode('1708551317')])])]],
-	['*<t:1708551317>*', [paragraph([bold([plain('<t:1708551317>')])])]],
+	['*<t:1708551317>*', [paragraph([bold([timestampNode('1708551317')])])]],
 ])('parses %p', (input, output) => {
 	expect(parse(input)).toMatchObject(output);
 });

--- a/packages/message-parser/tests/timestamp.test.ts
+++ b/packages/message-parser/tests/timestamp.test.ts
@@ -35,7 +35,16 @@ test.each([
 
 test.each([
 	['~<t:1708551317>~', [paragraph([strike([timestampNode('1708551317')])])]],
-	['*<t:1708551317>*', [paragraph([bold([timestampNode('1708551317')])])]],
+	['**<t:1708551317>**', [paragraph([bold([timestampNode('1708551317')])])]],
+	['**hello <t:1708551317> world**', [
+		paragraph([
+			bold([
+				plain('hello '),
+				timestampNode('1708551317'),
+				plain(' world'),
+			]),
+		]),
+	]],
 ])('parses %p', (input, output) => {
 	expect(parse(input)).toMatchObject(output);
 });

--- a/packages/message-parser/tests/timestamp.test.ts
+++ b/packages/message-parser/tests/timestamp.test.ts
@@ -1,4 +1,3 @@
-import { timeStamp } from 'node:console';
 import { parse } from '../src';
 
 const plain = (value: string) => ({ type: 'PLAIN_TEXT' as const, value });
@@ -6,6 +5,8 @@ const plain = (value: string) => ({ type: 'PLAIN_TEXT' as const, value });
 const paragraph = (value: Array<Record<string, unknown>>) => ({ type: 'PARAGRAPH' as const, value });
 
 const bold = (value: Array<Record<string, unknown>>) => ({ type: 'BOLD' as const, value });
+
+const italic = (value: Array<Record<string, unknown>>) => ({ type: 'ITALIC' as const, value });
 
 const strike = (value: Array<Record<string, unknown>>) => ({ type: 'STRIKE' as const, value });
 
@@ -36,6 +37,8 @@ test.each([
 test.each([
 	['~<t:1708551317>~', [paragraph([strike([timestampNode('1708551317')])])]],
 	['**<t:1708551317>**', [paragraph([bold([timestampNode('1708551317')])])]],
+	['_<t:1708551317>_', [paragraph([italic([timestampNode('1708551317')])])]],
+
 	['**hello <t:1708551317> world**', [
 		paragraph([
 			bold([


### PR DESCRIPTION
Fixes an issue where `<t:...>` timestamps were not parsed when used
inside formatted text such as bold or strike.

This updates the parser grammar so `TimestampRules` are included in
the bold and italic preferential parsing patterns.

Additionally, a test case was added to verify timestamps inside
formatted text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timestamps inside bold and italic text are now recognized as inline content rather than being skipped or rejected.

* **Tests**
  * Updated tests to reflect structured timestamp nodes and to validate timestamp parsing within formatted content.

* **Chores**
  * Prepared a patch release entry for the message parser to document the timestamp parsing fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->