### PR TITLE
fix(navbar): prevent Escape key from resetting search when not active

### DIFF
--- a/apps/meteor/client/navbar/NavBarSearch/NavBarSearch.tsx
+++ b/apps/meteor/client/navbar/NavBarSearch/NavBarSearch.tsx
@@ -63,16 +63,18 @@ const NavBarSearch = () => {
 			},
 			'Escape': (event) => {
 				const activeElement = document.activeElement;
-				if (activeElement !== triggerRef.current) return;
+
+				if (activeElement !== triggerRef.current && !state.isOpen) return;
+
 				event.preventDefault();
 				handleEscSearch();
-			},
+			}
 		});
 
 		return (): void => {
 			unsubscribe();
 		};
-	}, [focusManager, handleEscSearch, setFocus]);
+	}, [focusManager, handleEscSearch, setFocus, state]);
 
 	return (
 		<FormProvider {...methods}>


### PR DESCRIPTION
FIx #39462 
### Description

The Escape key listener in NavBarSearch.tsx was attached globally using tinykeys(window). Because of this, pressing Escape anywhere in the application triggered handleEscSearch(), even when the search input was not focused or the search dropdown was not open.

This PR adds a guard to ensure that the Escape handler only runs when the search input is active.

### Steps to reproduce

1. Start the Rocket.Chat development server

2. Open the application

3. Do not open the Navbar search

4. Focus the chat input

5. Press Escape

### Actual behavior

Escape triggers handleEscSearch() even when the search is not active.

### Expected behavior

Escape should reset the search only when the search input is focused or the search dropdown is open.


https://github.com/user-attachments/assets/439275f9-23e9-41a7-9055-c6dafa145882



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined escape key handling in the search bar to be context-aware. The escape key now checks whether the search input is focused before acting, preventing unintended closures or interference with other interactive elements.
  * Improved focus/interaction reliability so the search list responds more predictably across keyboard and focus transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->