### PR TITLE
fix: clear search navbar input only when focused on esc key event

### DIFF
--- a/apps/meteor/client/navbar/NavBarSearch/NavBarSearch.tsx
+++ b/apps/meteor/client/navbar/NavBarSearch/NavBarSearch.tsx
@@ -62,8 +62,10 @@ const NavBarSearch = () => {
 				setFocus('filterText');
 			},
 			'Escape': (event) => {
-				event.preventDefault();
-				handleEscSearch();
+				if (state.isOpen || document.activeElement === triggerRef.current) {
+					event.preventDefault();
+					handleEscSearch();
+				}
 			},
 		});
 


### PR DESCRIPTION
fix: Prevent global Escape key press from unexpectedly clearing search
<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - [x] I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - [x] I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - [x] Lint and unit tests pass locally with my changes
  - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
  - [ ] I have added necessary documentation (if applicable)
  - [ ] Any dependent changes have been merged and published in downstream modules
-->
## Proposed changes (including videos or screenshots)
**The Problem:**
Currently, the `Escape` key listener within [NavBarSearch.tsx](cci:7://file://wsl.localhost/Ubuntu/home/anushka/OpenSourceProjects/Rocket.Chat/apps/meteor/client/navbar/NavBarSearch/NavBarSearch.tsx:0:0-0:0) is attached globally to the `window` object using `tinykeys`. This causes an issue where pressing `Escape` anywhere in the application triggers the `handleEscSearch()` function, clearing and resetting the search even when the search input is not focused or the search dropdown list is completely closed.
**The Fix:**
This PR modifies the event handler to verify whether the search component is currently active before taking action. It verifies that the search input is focused (`document.activeElement === triggerRef.current`) or the search dropdown is visibly open (`state.isOpen`). The `event.preventDefault()` and `handleEscSearch()` functions are now appropriately restricted to execute only when the user is actively interacting with the search.
https://github.com/user-attachments/assets/b46069ec-7b9a-4749-9f39-24926a1340e1
## Issue(s)
Closes #39462
## Steps to test or reproduce
1. Open the application and click away from the Navbar search input (ensure it is not focused).
2. Press the `Escape` key.
3. Observe that the search state is no longer unintentionally cleared or modified.
4. Now, click on the search input to focus it, or type something to open the search dropdown.
5. Press the `Escape` key.
6. Verify that the search input correctly resets and the dropdown closes as intended.
## Further comments
This change preserves the intended accessibility shortcuts of [NavBarSearch](cci:1://file://wsl.localhost/Ubuntu/home/anushka/OpenSourceProjects/Rocket.Chat/apps/meteor/client/navbar/NavBarSearch/NavBarSearch.tsx:15:0-96:2) without unintentionally interfering with other components that may rely on `Escape` key functionality globally.






## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Escape key handling in search navigation — the key now only closes search when the overlay is open or focus is on the search trigger, preventing unintended closures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->