### PR TITLE
fix: save and return PKCE code_challenge in OAuth2 authorization code

### DIFF
--- a/.changeset/fix-pkce-code-verifier.md
+++ b/.changeset/fix-pkce-code-verifier.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/meteor": patch
+"@rocket.chat/core-typings": patch
+---
+
+fix: PKCE code verifier now correctly saved and verified in third-party OAuth2 login flow

--- a/apps/meteor/server/oauth2-server/model.ts
+++ b/apps/meteor/server/oauth2-server/model.ts
@@ -116,13 +116,15 @@ export class Model implements AuthorizationCodeModel, RefreshTokenModel {
 				grants: client.grants,
 			},
 			redirectUri: code.redirectUri,
+			codeChallenge: code.codeChallenge,
+			codeChallengeMethod: code.codeChallengeMethod,
 		};
 
 		return authCode;
 	}
 
 	async saveAuthorizationCode(
-		code: Pick<AuthorizationCode, 'authorizationCode' | 'expiresAt' | 'redirectUri' | 'scope'>,
+		code: Pick<AuthorizationCode, 'authorizationCode' | 'expiresAt' | 'redirectUri' | 'scope' | 'codeChallenge' | 'codeChallengeMethod'>,
 		client: Client,
 		user: User,
 	): Promise<AuthorizationCode | Falsey> {
@@ -150,6 +152,8 @@ export class Model implements AuthorizationCodeModel, RefreshTokenModel {
 					userId: user.id,
 					expires: code.expiresAt,
 					redirectUri: code.redirectUri,
+					codeChallenge: code.codeChallenge,
+    				codeChallengeMethod: code.codeChallengeMethod,
 				},
 			},
 			{ upsert: true },

--- a/apps/meteor/tests/end-to-end/api/oauth-server.ts
+++ b/apps/meteor/tests/end-to-end/api/oauth-server.ts
@@ -175,4 +175,91 @@ describe('[OAuth Server]', () => {
 				});
 		});
 	});
+
+	describe('[PKCE flow]', () => {
+    let pkceAppId: string;
+    let pkceClientId: string;
+    let pkceClientSecret: string;
+    let pkceCode: string;
+    let pkceCodeVerifier: string;
+    let pkceAccessToken: string;
+    const pkceRedirectUri = 'http://asd.com';
+
+    function generateCodeVerifier(): string {
+        const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
+        let result = '';
+        for (let i = 0; i < 64; i++) {
+            result += chars.charAt(Math.floor(Math.random() * chars.length));
+        }
+        return result;
+    }
+
+    async function generateCodeChallenge(verifier: string): Promise<string> {
+        const encoder = new TextEncoder();
+        const data = encoder.encode(verifier);
+        const digest = await crypto.subtle.digest('SHA-256', data);
+        const base64 = btoa(String.fromCharCode(...new Uint8Array(digest)));
+        return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    }
+
+    after(async () => {
+    if (pkceAppId) {
+        await request.post(api('oauth-apps.delete')).set(credentials).send({ appId: pkceAppId }).expect(200);
+    }
+});
+
+    it('should create oauth app for PKCE test', async () => {
+        await request
+            .post(api('oauth-apps.create'))
+            .set(credentials)
+            .send({ name: 'pkce-test-app', redirectUri: pkceRedirectUri, active: true })
+            .expect(200)
+            .expect((res: Response) => {
+                expect(res.body).to.have.property('success', true);
+                pkceAppId = res.body.application._id;
+                pkceClientId = res.body.application.clientId;
+                pkceClientSecret = res.body.application.clientSecret;
+            });
+    });
+
+    it('should authorize with PKCE code_challenge and retrieve code', async () => {
+        pkceCodeVerifier = generateCodeVerifier();
+        const pkceCodeChallenge = await generateCodeChallenge(pkceCodeVerifier);
+
+        const params = new URLSearchParams({
+            response_type: 'code',
+            state: 'pkcetest123',
+            code_challenge: pkceCodeChallenge,
+            code_challenge_method: 'S256',
+        });
+
+        await request
+            .post(`/oauth/authorize?${params.toString()}`)
+            .type('form')
+            .send({ token: credentials['X-Auth-Token'], client_id: pkceClientId, response_type: 'code', redirect_uri: pkceRedirectUri, allow: 'yes' })
+            .expect(302)
+            .expect((res: Response) => {
+                const location = new URL(res.headers.location);
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                pkceCode = location.searchParams.get('code')!;
+                expect(pkceCode).to.be.a('string');
+            });
+    });
+
+    it('should exchange code + code_verifier for access token', async () => {
+        await request
+            .post('/oauth/token')
+            .type('form')
+            .send({ grant_type: 'authorization_code', code: pkceCode, client_id: pkceClientId, client_secret: pkceClientSecret, redirect_uri: pkceRedirectUri, code_verifier: pkceCodeVerifier })
+            .expect(200)
+            .expect((res: Response) => {
+                expect(res.body).to.have.property('access_token');
+                pkceAccessToken = res.body.access_token;
+            });
+    });
+
+    it('should access /oauth/userinfo with PKCE access token', async () => {
+        await request.get('/oauth/userinfo').auth(pkceAccessToken, { type: 'bearer' }).expect(200);
+    });
+});
 });

--- a/packages/core-typings/src/IOAuthAuthCode.ts
+++ b/packages/core-typings/src/IOAuthAuthCode.ts
@@ -5,4 +5,6 @@ export interface IOAuthAuthCode {
 	userId: string;
 	expires: Date;
 	redirectUri: string;
+	codeChallenge?: string;
+	codeChallengeMethod?: string;
 }


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The PKCE flow in Rocket.Chat's third-party OAuth2 login was broken. When a client
initiated authorization with a `code_challenge`, the `saveAuthorizationCode` method
was silently dropping the `codeChallenge` and `codeChallengeMethod` fields due to a
restrictive `Pick<>` type — so they were never saved to MongoDB.

When the client then sent the `code_verifier` at the token endpoint,
`getAuthorizationCode` had nothing to return for those fields, leaving the
`@node-oauth/oauth2-server` library with nothing to verify against, resulting in
`invalid_grant: code verifier is invalid`.

**Fix:**
- Added `codeChallenge?` and `codeChallengeMethod?` to `IOAuthAuthCode` interface
- Widened `Pick<>` type in `saveAuthorizationCode` to include both PKCE fields
- Persisted both fields to MongoDB in the `$set` block
- Returned both fields from `getAuthorizationCode` so the library can verify them

The implicit flow (no PKCE) is completely unaffected.

## Issue(s)

Fixes #39459
Related to #35419

## Steps to test or reproduce

1. Create a third-party OAuth app in Admin > Third-party login
2. Go to https://oauthdebugger.com/debug
3. Fill in the Authorization URI, Client ID, and Token URI
4. Enable "Use PKCE?" and select SHA-256
5. Send the request and authorize at Rocket.Chat
6. Before fix: token exchange fails with `invalid_grant: code verifier is invalid`
7. After fix: token exchange succeeds and returns an access token

## Further comments

This is a follow-up to #35419 which was partially fixed in #37707.
That PR fixed the implicit flow but the PKCE flow remained broken.
A new e2e test covering the full PKCE flow has been added to `oauth-server.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PKCE code verifier is now correctly saved and verified in third‑party OAuth2 login flows.

* **Tests**
  * Added end-to-end tests covering PKCE workflows: app authorization, code generation, token exchange, and userinfo access.

* **Chores**
  * Patch release note added to the changelog for the PKCE fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->