### PR TITLE
fix(api): prevent cross-room data exposure via query parameter injection

### DIFF
--- a/apps/meteor/app/api/server/v1/channels.ts
+++ b/apps/meteor/app/api/server/v1/channels.ts
@@ -304,8 +304,11 @@ API.v1.addRoute(
 			const parseIds = (ids: string | undefined, field: string) =>
 				typeof ids === 'string' && ids ? { [field]: { $in: ids.split(',').map((id) => id.trim()) } } : {};
 
+			const userQuery = { ...query };
+			delete userQuery.rid;
+
 			const ourQuery = {
-				...query,
+				...userQuery,
 				rid: findResult._id,
 				...parseIds(mentionIds, 'mentions._id'),
 				...parseIds(starredIds, 'starred._id'),
@@ -1451,7 +1454,10 @@ API.v1.addRoute(
 			const { offset, count } = await getPaginationItems(this.queryParams);
 			const { sort, fields, query } = await this.parseJsonQuery();
 
-			const ourQuery = Object.assign({}, query, { rid: findResult._id });
+			const userQuery = { ...query };
+			delete userQuery.rid;
+
+			const ourQuery = Object.assign({}, userQuery, { rid: findResult._id });
 
 			if (!settings.get<boolean>('Accounts_AllowAnonymousRead')) {
 				throw new Meteor.Error('error-not-allowed', 'Enable "Allow Anonymous Read"', {

--- a/apps/meteor/app/api/server/v1/groups.ts
+++ b/apps/meteor/app/api/server/v1/groups.ts
@@ -786,8 +786,11 @@ API.v1.addRoute(
 			const parseIds = (ids: string | undefined, field: string) =>
 				typeof ids === 'string' && ids ? { [field]: { $in: ids.split(',').map((id) => id.trim()) } } : {};
 
+			const userQuery = { ...query };
+			delete userQuery.rid;
+
 			const ourQuery = {
-				...query,
+				...userQuery,
 				rid: findResult.rid,
 				...parseIds(mentionIds, 'mentions._id'),
 				...parseIds(starredIds, 'starred._id'),

--- a/apps/meteor/app/api/server/v1/im.ts
+++ b/apps/meteor/app/api/server/v1/im.ts
@@ -505,9 +505,12 @@ API.v1.addRoute(
 			const parseIds = (ids: string | undefined, field: string) =>
 				typeof ids === 'string' && ids ? { [field]: { $in: ids.split(',').map((id) => id.trim()) } } : {};
 
+			const userQuery = { ...query };
+			delete userQuery.rid;
+
 			const ourQuery = {
 				rid: room._id,
-				...query,
+				...userQuery,
 				...parseIds(mentionIds, 'mentions._id'),
 				...parseIds(starredIds, 'starred._id'),
 				...(pinned && pinned.toLowerCase() === 'true' ? { pinned: true } : {}),
@@ -557,7 +560,9 @@ API.v1.addRoute(
 
 			const { offset, count } = await getPaginationItems(this.queryParams);
 			const { sort, fields, query } = await this.parseJsonQuery();
-			const ourQuery = Object.assign({}, query, { rid: room._id });
+			const userQuery = { ...query };
+			delete userQuery.rid;
+			const ourQuery = Object.assign({}, userQuery, { rid: room._id });
 
 			const { cursor, totalCount } = Messages.findPaginated<IMessage>(ourQuery, {
 				sort: sort || { ts: -1 },


### PR DESCRIPTION
Fixes #39471
### Security Fix: Cross-Room Data Exposure via Query Parameter Injection

When the legacy unsafe query mode (`ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS=TRUE`) is enabled, user-supplied query parameters can override the server-enforced room constraint (`rid`). Due to the spread order in query merging, an attacker could supply a custom `rid` and access messages from rooms they are not a member of.

### Root Cause
User-provided query parameters were merged with server constraints using object spread syntax, allowing the attacker-controlled `rid` to override the enforced room ID.

### Changes
- Sanitized user-supplied query parameters before merging with server constraints.
- Removed protected key `rid` from user query input.
- Ensured server-enforced `rid` always takes precedence.

### Affected Endpoints
- `/api/v1/im.messages`
- `/api/v1/channels.messages`
- `/api/v1/groups.messages`

### Security Impact
Prevents authenticated users from accessing messages and files from rooms they do not have permission to access.

### Testing
Verified that requests attempting to override `rid` through query parameters are ignored and only authorized room messages are returned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented client-supplied room IDs from affecting message queries across channels, groups, and direct messages so server-determined room scoping is always enforced.
  * Excluded hidden messages from direct message results to ensure hidden content is not returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->