### PR TITLE
test: add missing tests for toolbox pre and pos slots in RoomHeader

### DIFF
--- a/apps/meteor/client/views/room/Header/RoomHeader.spec.tsx
+++ b/apps/meteor/client/views/room/Header/RoomHeader.spec.tsx
@@ -61,5 +61,14 @@ describe('RoomHeader', () => {
 			render(<RoomHeader room={mockedRoom} slots={{ toolbox: { content: <div>Slotted Toolbox</div> } }} />, { wrapper: appRoot });
 			expect(screen.getByText('Slotted Toolbox')).toBeInTheDocument();
 		});
+		it('should render toolbox pre slot', () => {
+			render(<RoomHeader room={mockedRoom} slots={{ toolbox: { pre: <div>Pre Item</div> } }} />, { wrapper: appRoot });
+			expect(screen.getByText('Pre Item')).toBeInTheDocument();
+		});
+
+		it('should render toolbox pos slot', () => {
+			render(<RoomHeader room={mockedRoom} slots={{ toolbox: { pos: <div>Pos Item</div> } }} />, { wrapper: appRoot });
+			expect(screen.getByText('Pos Item')).toBeInTheDocument();
+		});
 	});
 });


### PR DESCRIPTION
While working on my GSoC proposal related to **Room Header button ordering**, I was exploring the `RoomHeader` component and its associated tests. During this review, I noticed that the component supports additional toolbox slot props (`toolbox.pre` and `toolbox.pos`) but the current test suite does not verify their rendering.

Specifically, the `RoomHeader` implementation renders these slots inside `HeaderToolbar`:

```tsx
{slots?.toolbox?.pre}
{slots?.toolbox?.content || <RoomToolbox />}
{slots?.toolbox?.pos}
```
However, the existing tests only cover:

default toolbox rendering

hidden toolbox behavior

custom `toolbox.content`

There are no tests validating that `toolbox.pre` and `toolbox.pos` are rendered correctly.

### Changes

This PR adds two small test cases to improve coverage:

- Verify that `slots.toolbox.pre` renders inside the toolbar.
- Verify that `slots.toolbox.pos` renders inside the toolbar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for toolbox slot rendering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->