### PR TITLE
chore: migrate users.getStatus endpoint to new OpenAPI pattern with AJV validation

### DIFF
--- a/.changeset/migrate-users-getStatus-openapi.md
+++ b/.changeset/migrate-users-getStatus-openapi.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/meteor": patch
+"@rocket.chat/rest-typings": patch
+---
+
+Migrates the `users.getStatus` REST API endpoint from the legacy `API.v1.addRoute` pattern to the new chained `API.v1.get()` pattern with AJV response schema validation and OpenAPI documentation support.

--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -19,7 +19,7 @@ import {
 	isUsersCheckUsernameAvailabilityParamsGET,
 	isUsersSendConfirmationEmailParamsPOST,
 	ajv,
-	validateBadRequestErrorResponse,
+	validateForbiddenErrorResponse,
 	validateUnauthorizedErrorResponse,
 } from '@rocket.chat/rest-typings';
 import { getLoginExpirationInMs, wrapExceptions } from '@rocket.chat/tools';
@@ -878,6 +878,47 @@ const usersEndpoints = API.v1
 
 			return API.v1.success({ suggestions });
 		},
+	)
+	.get(
+		'users.getStatus',
+		{
+			authRequired: true,
+			response: {
+				401: validateUnauthorizedErrorResponse,
+				200: ajv.compile<{
+					_id?: string;
+					status: 'online' | 'offline' | 'away' | 'busy';
+					connectionStatus?: 'online' | 'offline' | 'away' | 'busy';
+				}>({
+					type: 'object',
+					properties: {
+						success: { type: 'boolean', enum: [true] },
+						_id: { type: 'string' },
+						status: { type: 'string', enum: ['online', 'offline', 'away', 'busy'] },
+						connectionStatus: { type: 'string', enum: ['online', 'offline', 'away', 'busy'] },
+					},
+					required: ['success', 'status'],
+					additionalProperties: false,
+				}),
+			},
+		},
+		async function action() {
+			if (isUserFromParams(this.queryParams, this.userId, this.user)) {
+				const user: IUser | null = await Users.findOneById(this.userId);
+				return API.v1.success({
+					_id: user?._id,
+					connectionStatus: (user?.statusConnection || 'offline') as 'online' | 'offline' | 'away' | 'busy',
+					status: (user?.status || 'offline') as 'online' | 'offline' | 'away' | 'busy',
+				});
+			}
+
+			const user = await getUserFromParams(this.queryParams);
+
+			return API.v1.success({
+				_id: user._id,
+				status: (user.status || 'offline') as 'online' | 'offline' | 'away' | 'busy',
+			});
+		},
 	);
 
 API.v1.addRoute(
@@ -1513,38 +1554,6 @@ API.v1.addRoute(
 			});
 
 			return API.v1.success();
-		},
-	},
-);
-
-// status: 'online' | 'offline' | 'away' | 'busy';
-// message?: string;
-// _id: string;
-// connectionStatus?: 'online' | 'offline' | 'away' | 'busy';
-// };
-
-API.v1.addRoute(
-	'users.getStatus',
-	{ authRequired: true },
-	{
-		async get() {
-			if (isUserFromParams(this.queryParams, this.userId, this.user)) {
-				const user: IUser | null = await Users.findOneById(this.userId);
-				return API.v1.success({
-					_id: user?._id,
-					// message: user.statusText,
-					connectionStatus: (user?.statusConnection || 'offline') as 'online' | 'offline' | 'away' | 'busy',
-					status: (user?.status || 'offline') as 'online' | 'offline' | 'away' | 'busy',
-				});
-			}
-
-			const user = await getUserFromParams(this.queryParams);
-
-			return API.v1.success({
-				_id: user._id,
-				// message: user.statusText,
-				status: (user.status || 'offline') as 'online' | 'offline' | 'away' | 'busy',
-			});
 		},
 	},
 );

--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -19,7 +19,7 @@ import {
 	isUsersCheckUsernameAvailabilityParamsGET,
 	isUsersSendConfirmationEmailParamsPOST,
 	ajv,
-	validateForbiddenErrorResponse,
+	validateBadRequestErrorResponse,
 	validateUnauthorizedErrorResponse,
 } from '@rocket.chat/rest-typings';
 import { getLoginExpirationInMs, wrapExceptions } from '@rocket.chat/tools';

--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -889,6 +889,7 @@ const usersEndpoints = API.v1
 					_id?: string;
 					status: 'online' | 'offline' | 'away' | 'busy';
 					connectionStatus?: 'online' | 'offline' | 'away' | 'busy';
+					message?: string;
 				}>({
 					type: 'object',
 					properties: {
@@ -896,6 +897,7 @@ const usersEndpoints = API.v1
 						_id: { type: 'string' },
 						status: { type: 'string', enum: ['online', 'offline', 'away', 'busy'] },
 						connectionStatus: { type: 'string', enum: ['online', 'offline', 'away', 'busy'] },
+						message: { type: 'string' },
 					},
 					required: ['success', 'status'],
 					additionalProperties: false,
@@ -909,6 +911,7 @@ const usersEndpoints = API.v1
 					_id: user?._id,
 					connectionStatus: (user?.statusConnection || 'offline') as 'online' | 'offline' | 'away' | 'busy',
 					status: (user?.status || 'offline') as 'online' | 'offline' | 'away' | 'busy',
+					message: user?.statusText,
 				});
 			}
 
@@ -917,6 +920,7 @@ const usersEndpoints = API.v1
 			return API.v1.success({
 				_id: user._id,
 				status: (user.status || 'offline') as 'online' | 'offline' | 'away' | 'busy',
+				message: user?.statusText,
 			});
 		},
 	);

--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -911,7 +911,7 @@ const usersEndpoints = API.v1
 					_id: user?._id,
 					connectionStatus: (user?.statusConnection || 'offline') as 'online' | 'offline' | 'away' | 'busy',
 					status: (user?.status || 'offline') as 'online' | 'offline' | 'away' | 'busy',
-					message: user?.statusText,
+					...(user?.statusText && { message: user.statusText }),
 				});
 			}
 
@@ -920,7 +920,7 @@ const usersEndpoints = API.v1
 			return API.v1.success({
 				_id: user._id,
 				status: (user.status || 'offline') as 'online' | 'offline' | 'away' | 'busy',
-				message: user?.statusText,
+				...(user?.statusText && { message: user.statusText }),
 			});
 		},
 	);

--- a/packages/rest-typings/src/v1/users.ts
+++ b/packages/rest-typings/src/v1/users.ts
@@ -318,15 +318,6 @@ export type UsersEndpoints = {
 		POST: (params: { message?: string; status?: UserStatus; userId?: string; username?: string; user?: string }) => void;
 	};
 
-	'/v1/users.getStatus': {
-		GET: () => {
-			status: 'online' | 'offline' | 'away' | 'busy';
-			message?: string;
-			_id?: string;
-			connectionStatus?: 'online' | 'offline' | 'away' | 'busy';
-		};
-	};
-
 	'/v1/users.info': {
 		GET: (params: UsersInfoParamsGet) => {
 			user: IUser & { rooms?: Pick<ISubscription, 'rid' | 'name' | 't' | 'roles' | 'unread'>[] };


### PR DESCRIPTION
## Proposed changes

Migrates the `users.getStatus` REST API endpoint from the legacy `API.v1.addRoute` pattern to the new chained `API.v1.get()` pattern with AJV response schema validation and OpenAPI documentation support.

Closes #34983

## Endpoints migrated

| Endpoint | Method | Old Pattern | New Pattern |
|---|---|---|---|
| `users.getStatus` | GET | `addRoute.get()` | `.get()` chained |

## Architectural changes

- Replaced legacy `API.v1.addRoute('users.getStatus', ...)` with the new chained `.get('users.getStatus', ...)` method
- Added AJV response schema for 200 response with `status`, `_id`, and `connectionStatus` fields
- Added `401: validateUnauthorizedErrorResponse` for unauthorized access handling
- Wired up `ExtractRoutesFromAPI` + `declare module` for automatic type inference
- Removed manual `/v1/users.getStatus` typing from `rest-typings` (now inferred via module augmentation)

## Files changed

- `apps/meteor/app/api/server/v1/users.ts` — Main migration
- `packages/rest-typings/src/v1/users.ts` — Removed old manual typing

## Related project

This continues the REST API migration effort described in the **GSoC 2026 project: Replace old REST API definitions over the new API**.

cc @diego-sampaio @ggazzo

This PR is part of the ongoing REST API migration effort tracked in RocketChat/Rocket.Chat-Open-API#150


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated users.getStatus into a single, modernized GET route with stronger response validation.
  * When requesting your own status, responses may include both status and connectionStatus.
  * Endpoint requires authentication.

* **Documentation**
  * OpenAPI documentation for users.getStatus updated.

* **Chores**
  * Release entry and package patch updates included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->