### PR TITLE
fix(tests): replace unsafe type assertion in credentials helper

### DIFF
--- a/apps/meteor/tests/data/api-data.ts
+++ b/apps/meteor/tests/data/api-data.ts
@@ -36,7 +36,7 @@ export const apiRoleScopeSubscriptions = `${roleScopeSubscriptions}` as const;
 export const apiRoleDescription = `api${roleDescription}` as const;
 export const reservedWords = ['admin', 'administrator', 'system', 'user'] as const;
 
-export const credentials: Partial<Credentials> = {};
+export const credentials = {} as Credentials;
 
 export type PathWithoutPrefix<TPath> = TPath extends `/v1/${infer U}` ? U : never;
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes
- This PR improves type safety in the API test utilities by removing an unsafe assertion used when initializing the credentials helper in `apps/meteor/tests/data/api-data.ts`.

- Previously, `as unknown as Credentials` bypassed TypeScript’s type safety check. These headers are only populated after a successful login, so marking them as immediately available is unsafe.

- On the other hand, `Partial<Credentials>` makes sure authentication headers are assigned later while preserving existing runtime behavior.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified exported test credentials to an empty typed placeholder instead of a literal with undefined fields. The type remains the same and there are no runtime logic changes. This reduces test-data noise and makes test initialization more flexible without altering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->