### PR TITLE
fix: skip SSRF validation with custom oauth. fixes #39328

### DIFF
--- a/apps/meteor/app/custom-oauth/server/custom_oauth_server.js
+++ b/apps/meteor/app/custom-oauth/server/custom_oauth_server.js
@@ -137,6 +137,8 @@ export class CustomOAuth {
 
 		try {
 			const request = await fetch(`${this.tokenPath}`, {
+				// SECURITY: URL can only be configured by users with enough privileges. It's ok to disable this check here.
+				ignoreSsrfValidation: true,
 				method: 'POST',
 				headers,
 				body: params,
@@ -174,7 +176,8 @@ export class CustomOAuth {
 		}
 
 		try {
-			const request = await fetch(`${this.identityPath}`, { method: 'GET', headers, params });
+			// SECURITY: URL can only be configured by users with enough privileges. It's ok to disable this check here.
+			const request = await fetch(`${this.identityPath}`, { ignoreSsrfValidation: true, method: 'GET', headers, params });
 
 			if (!request.ok) {
 				throw new Error(request.statusText);


### PR DESCRIPTION
Skipping validation is safe because the OIDC server URL was configured by a user with enough privileges


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth authentication request handling to enhance compatibility with various OAuth provider configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->