### PR TITLE
fix(ui): add autocomplete="one-time-code" to 2FA inputs

### DIFF
--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorEmailModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorEmailModal.tsx
@@ -65,7 +65,7 @@ const TwoFactorEmailModal = ({ onConfirm, onClose, emailOrUsername, invalidAttem
 						{t('Enter_the_code_we_just_emailed_you')}
 					</FieldLabel>
 					<FieldRow>
-						<TextInput id={id} ref={ref} value={code} onChange={onChange} placeholder={t('Enter_code_here')} />
+						<TextInput id={id} ref={ref} value={code} onChange={onChange} placeholder={t('Enter_code_here')} autoComplete='one-time-code' />
 					</FieldRow>
 					{invalidAttempt && <FieldError>{t('Invalid_password')}</FieldError>}
 				</Field>

--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
@@ -49,7 +49,7 @@ const TwoFactorTotpModal = ({ onConfirm, onClose, onDismiss, invalidAttempt }: T
 						{t('Enter_the_code_provided_by_your_authentication_app_to_continue')}
 					</FieldLabel>
 					<FieldRow>
-						<TextInput id={id} ref={ref} value={code} onChange={onChange} placeholder={t('Enter_code_here')}></TextInput>
+						<TextInput id={id} ref={ref} value={code} onChange={onChange} placeholder={t('Enter_code_here')} autoComplete='one-time-code'></TextInput>
 					</FieldRow>
 					{invalidAttempt && <FieldError>{t('Invalid_password')}</FieldError>}
 				</Field>

--- a/apps/meteor/client/views/account/security/TwoFactorTOTP.tsx
+++ b/apps/meteor/client/views/account/security/TwoFactorTOTP.tsx
@@ -158,7 +158,7 @@ const TwoFactorTOTP = (props: TwoFactorTOTPProps): ReactElement => {
 						<Field>
 							<FieldLabel htmlFor={totpCodeId}>{t('Enter_code_provided_by_authentication_app')}</FieldLabel>
 							<FieldRow>
-								<TextInput id={totpCodeId} mie='8px' {...register('authCode')} />
+								<TextInput id={totpCodeId} mie='8px' {...register('authCode')} autoComplete='one-time-code' />
 								<Button primary onClick={handleSubmit(handleVerifyCode)}>
 									{t('Verify')}
 								</Button>


### PR DESCRIPTION
This PR improves the user experience when entering two-factor authentication (2FA) codes by adding autocomplete="one-time-code" to relevant input fields.

Modern browsers and mobile devices use this attribute to detect one-time passcodes and offer automatic OTP suggestions or autofill from SMS or authenticator apps. Without this attribute, the OTP field may not be properly recognized.

The change was applied to the following components:

TwoFactorEmailModal

TwoFactorTotpModal

TwoFactorTOTP

This enhancement improves usability during authentication, especially on mobile devices.

Issue(s)

Fixes #30025

Steps to test or reproduce

Enable 2FA in Rocket.Chat.

Log out and log back in.

When prompted for the authentication code:

On supported browsers/devices, OTP suggestions should appear automatically.

Verify that the code can still be entered and submitted normally.

Further comments

This change does not affect existing logic or validation. It only improves browser compatibility with OTP autofill by using the standard HTML autocomplete="one-time-code" attribute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved browser autofill support for two-factor authentication codes. Supported browsers can now automatically populate one-time codes from authenticator apps and email-based verification, reducing manual entry and streamlining the authentication process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->