### PR TITLE
fix: ensure readable error messages in room action toast notifications

### DIFF
--- a/apps/meteor/client/views/hooks/roomActions/useArchiveRoom.tsx
+++ b/apps/meteor/client/views/hooks/roomActions/useArchiveRoom.tsx
@@ -13,7 +13,10 @@ export const useArchiveRoom = (room: Pick<IRoom, RoomAdminFieldsType>) => {
 			await archiveAction({ rid: room._id, action: room.archived ? 'unarchive' : 'archive' });
 			dispatchToastMessage({ type: 'success', message: room.archived ? t('Room_has_been_unarchived') : t('Room_has_been_archived') });
 		} catch (error) {
-			dispatchToastMessage({ type: 'error', message: error });
+			dispatchToastMessage({
+				type: 'error',
+				message: error instanceof Error ? error.message : String(error),
+			});
 		}
 	});
 

--- a/apps/meteor/client/views/hooks/roomActions/useDeleteRoom.tsx
+++ b/apps/meteor/client/views/hooks/roomActions/useDeleteRoom.tsx
@@ -40,7 +40,10 @@ export const useDeleteRoom = (room: IRoom | Pick<IRoom, RoomAdminFieldsType>, { 
 			return router.navigate('/home');
 		},
 		onError: (error) => {
-			dispatchToastMessage({ type: 'error', message: error });
+			dispatchToastMessage({
+				type: 'error',
+				message: error instanceof Error ? error.message : String(error),
+			});
 		},
 		onSettled: () => {
 			setModal(null);
@@ -59,7 +62,10 @@ export const useDeleteRoom = (room: IRoom | Pick<IRoom, RoomAdminFieldsType>, { 
 			return router.navigate('/home');
 		},
 		onError: (error) => {
-			dispatchToastMessage({ type: 'error', message: error });
+			dispatchToastMessage({
+				type: 'error',
+				message: error instanceof Error ? error.message : String(error),
+			});
 		},
 		onSettled: () => {
 			setModal(null);


### PR DESCRIPTION
Fixes #39499 
## Discription

This PR improves error handling in room action hooks by ensuring that error objects are converted into readable messages before being displayed in toast notifications.

Previously, error objects were passed directly to `dispatchToastMessage`. When the API returned an `Error` object instead of a string, the toast could display `[object Object]`, which is not helpful for users.

## Changes

Updated error handling to ensure that a readable message is always displayed:

```ts
message: error instanceof Error ? error.message : String(error)
```

## Affected files

* `apps/meteor/client/views/hooks/roomActions/useArchiveRoom.tsx`
* `apps/meteor/client/views/hooks/roomActions/useDeleteRoom.tsx`

## Result

* Ensures consistent and readable error messages in the UI




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message handling when archiving and deleting rooms or teams. Error notifications now display more reliably instead of occasionally showing raw error objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->