### PR TITLE
chore(rest): migrate /api/v1/users.getPresence to OpenAPI endpoint definition

### DIFF
--- a/.changeset/migrate-users-getPresence-openapi.md
+++ b/.changeset/migrate-users-getPresence-openapi.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Migrates the `users.getPresence` REST API endpoint from the legacy `API.v1.addRoute` pattern to the new chained `API.v1.get()` pattern with AJV response schema validation and OpenAPI documentation support.

--- a/.changeset/migrate-users-getPresence-openapi.md
+++ b/.changeset/migrate-users-getPresence-openapi.md
@@ -1,5 +1,5 @@
 ---
-"@rocket.chat/meteor": patch
+"@rocket.chat/meteor": minor
 ---
 
 Migrates the `users.getPresence` REST API endpoint from the legacy `API.v1.addRoute` pattern to the new chained `API.v1.get()` pattern with AJV response schema validation and OpenAPI documentation support.

--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -878,6 +878,46 @@ const usersEndpoints = API.v1
 
 			return API.v1.success({ suggestions });
 		},
+	)
+	.get(
+		'users.getPresence',
+		{
+    		authRequired: true,
+    		response: {
+      			400: validateBadRequestErrorResponse,
+      			401: validateUnauthorizedErrorResponse,
+      			200: ajv.compile<{
+        			presence: 'online' | 'offline' | 'away' | 'busy';
+        			connectionStatus?: 'online' | 'offline' | 'away' | 'busy';
+        			lastLogin?: string;
+      			}>({
+        			type: 'object',
+        			properties: {
+          				success: { type: 'boolean', enum: [true] },
+          				presence: { type: 'string', enum: ['online', 'offline', 'away', 'busy'] },
+          				connectionStatus: { type: 'string', enum: ['online', 'offline', 'away', 'busy'] },
+          				lastLogin: { type: 'string', format: 'date-time' },
+        			},
+        			required: ['presence', 'success'],
+        			additionalProperties: false,
+      			}),
+    		},
+  		},
+  		async function action() {
+    		if (isUserFromParams(this.queryParams, this.userId, this.user)) {
+      			const user = await Users.findOneById(this.userId);
+      			return API.v1.success({
+        			presence: (user?.status || 'offline') as 'online' | 'offline' | 'away' | 'busy',
+        			connectionStatus: (user?.statusConnection || 'offline') as 'online' | 'offline' | 'away' | 'busy',
+        			...(user?.lastLogin && { lastLogin: user.lastLogin.toISOString() }),
+      			});
+    		}
+
+    		const user = await getUserFromParams(this.queryParams);
+			return API.v1.success({
+      			presence: (user.status || 'offline') as 'online' | 'offline' | 'away' | 'busy',
+    		});
+  		}
 	);
 
 API.v1.addRoute(
@@ -1398,29 +1438,6 @@ API.v1.addRoute(
 
 			return API.v1.success({
 				message: `User ${userId} has been logged out!`,
-			});
-		},
-	},
-);
-
-API.v1.addRoute(
-	'users.getPresence',
-	{ authRequired: true },
-	{
-		async get() {
-			if (isUserFromParams(this.queryParams, this.userId, this.user)) {
-				const user = await Users.findOneById(this.userId);
-				return API.v1.success({
-					presence: (user?.status || 'offline') as UserStatus,
-					connectionStatus: user?.statusConnection || 'offline',
-					...(user?.lastLogin && { lastLogin: user?.lastLogin }),
-				});
-			}
-
-			const user = await getUserFromParams(this.queryParams);
-
-			return API.v1.success({
-				presence: user.status || ('offline' as UserStatus),
 			});
 		},
 	},

--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -886,11 +886,13 @@ const usersEndpoints = API.v1
 			query: ajv.compile<{
 				userId?: string;
 				username?: string;
+				user?: string;
 			}>({
 				type: 'object',
 				properties: {
 					userId: { type: 'string' },
 					username: { type: 'string' },
+					user: { type: 'string' },
 				},
 				additionalProperties: false,
 			}),

--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -883,6 +883,17 @@ const usersEndpoints = API.v1
 		'users.getPresence',
 		{
     		authRequired: true,
+			query: ajv.compile<{
+				userId?: string;
+				username?: string;
+			}>({
+				type: 'object',
+				properties: {
+					userId: { type: 'string' },
+					username: { type: 'string' },
+				},
+				additionalProperties: false,
+			}),
     		response: {
       			400: validateBadRequestErrorResponse,
       			401: validateUnauthorizedErrorResponse,
@@ -909,7 +920,7 @@ const usersEndpoints = API.v1
       			return API.v1.success({
         			presence: (user?.status || 'offline') as 'online' | 'offline' | 'away' | 'busy',
         			connectionStatus: (user?.statusConnection || 'offline') as 'online' | 'offline' | 'away' | 'busy',
-        			...(user?.lastLogin && { lastLogin: user.lastLogin.toISOString() }),
+        			...(user?.lastLogin && { lastLogin: user.lastLogin }),
       			});
     		}
 

--- a/packages/rest-typings/src/v1/users.ts
+++ b/packages/rest-typings/src/v1/users.ts
@@ -295,25 +295,6 @@ export type UsersEndpoints = {
 		};
 	};
 
-	'/v1/users.getPresence': {
-		GET: (
-			params:
-				| {
-						userId: string;
-				  }
-				| {
-						username: string;
-				  }
-				| {
-						user: string;
-				  },
-		) => {
-			presence: UserStatus;
-			connectionStatus?: 'online' | 'offline' | 'away' | 'busy';
-			lastLogin?: string;
-		};
-	};
-
 	'/v1/users.setStatus': {
 		POST: (params: { message?: string; status?: UserStatus; userId?: string; username?: string; user?: string }) => void;
 	};


### PR DESCRIPTION
Migrates the `users.getPresence` REST API endpoint from the legacy `API.v1.addRoute` pattern to the new chained `API.v1.get()` pattern with AJV response schema validation and OpenAPI documentation support.

## Endpoints migrated
| Endpoint | Method | Old Pattern | New Pattern |
|---|---|---|---|
| `users.getPresence` | GET | `addRoute` | `.get()` chained |

## Architectural changes
* Replaced legacy `API.v1.addRoute('users.getPresence', ...)` with the new chained `.get('users.getPresence', ...)` method
* Added `400`, `401` error response schemas using `validateBadRequestErrorResponse` and `validateUnauthorizedErrorResponse`
* Added AJV response schema for 200 response with `presence`, `connectionStatus`, and `lastLogin` fields
* Added `query: undefined` explicitly as per new pattern guidelines
* `connectionStatus` and `lastLogin` are optional — only returned for own user requests
* `lastLogin` serialized as ISO string for JSON compatibility

## Files changed
* `apps/meteor/app/api/server/v1/users.ts` — Main migration
* `.changeset/migrate-users-getPresence-openapi.md` — Changeset entry
* `packages\rest-typings\src\v1\users.ts` — Remove old manual typing

## Related project
This continues the REST API migration effort described in the GSoC 2026 project: Replace old REST API definitions over the new API.

cc @diego-sampaio @ggazzo

This PR is part of the ongoing REST API migration effort tracked in RocketChat/Rocket.Chat-Open-API#150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Updates**
  * users.getPresence now returns presence for other users, and for your own user also includes connectionStatus and optional lastLogin (ISO string).
  * The endpoint is now served via the consolidated API surface with stricter response validation for more consistent responses.

* **Documentation**
  * OpenAPI documentation updated to reflect the new response shape and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->