### PR TITLE
fix: improve TOTP field detection for password managers

### DIFF
--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
@@ -49,7 +49,7 @@ const TwoFactorTotpModal = ({ onConfirm, onClose, onDismiss, invalidAttempt }: T
 						{t('Enter_the_code_provided_by_your_authentication_app_to_continue')}
 					</FieldLabel>
 					<FieldRow>
-						<TextInput id={id} ref={ref} value={code} onChange={onChange} placeholder={t('Enter_code_here')}></TextInput>
+						<TextInput id={id} ref={ref} value={code} onChange={onChange} placeholder={t('Enter_code_here')} autoComplete='one-time-code'inputMode='numeric' ></TextInput>
 					</FieldRow>
 					{invalidAttempt && <FieldError>{t('Invalid_password')}</FieldError>}
 				</Field>


### PR DESCRIPTION
Title: fix: improve TOTP field detection for password managers

Proposed changes:

"This PR addresses issue #30025 by adding autoComplete='one-time-code' and inputMode='numeric' to the TOTP input field within TwoFactorTotpModal.tsx. This change ensures that password managers like KeePassXC correctly detect the field, improving the user authentication experience, especially on mobile devices."

Issue(s): #30025

Steps to test or reproduce:

"1. Log into your Rocket.Chat instance.
2. Go to Account Settings > Security and enable Two-Factor Authentication.
3. Log out and log back in to trigger the TOTP prompt.
4. Observe that the TOTP field now properly supports autofill from password managers."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced two-factor authentication code input field with improved device compatibility
  * Better support for browser and mobile input features when entering verification codes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->