### PR TITLE
refactor: reuse `getPeriod` in `getPeriodRange` to remove duplicated lookup logic

### DIFF
--- a/apps/meteor/client/components/dashboards/periods.ts
+++ b/apps/meteor/client/components/dashboards/periods.ts
@@ -97,11 +97,6 @@ export const getPeriodRange = (
 	start: Date;
 	end: Date;
 } => {
-	const period = periods.find((period) => period.key === key);
-
-	if (!period) {
-		return periods[0].range(utc);
-	}
-
+	const period = getPeriod(key);
 	return period.range(utc);
 };


### PR DESCRIPTION
## Issue

`getPeriodRange` duplicated the period lookup logic using `periods.find(...)`, even though the same lookup already exists in `getPeriod`.  
This introduced unnecessary duplication and made the code harder to maintain.

## Solution

Refactored `getPeriodRange` to reuse the existing `getPeriod` function instead of performing its own lookup.  
This removes duplicated logic and centralizes the period lookup in one place.

## Testing

Tested locally by running the application and verifying that the period filters (e.g., Today, This week, Last 7 days, Last 30 days) still return the correct ranges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization of period lookup logic with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->