### PR TITLE
fix(apps): handle multiple results returned from /apps/installed endpoint

### DIFF
--- a/apps/meteor/client/apps/orchestrator.ts
+++ b/apps/meteor/client/apps/orchestrator.ts
@@ -49,6 +49,9 @@ class AppClientOrchestrator {
 	public async getInstalledApps(): Promise<App[]> {
 		const result = await sdk.rest.get<'/apps/installed'>('/apps/installed', { includeClusterStatus: 'true' });
 
+		if(Array.isArray(result)){
+			return result[0]?.apps ?? [];
+		}
 		if ('apps' in result) {
 			// TODO: chapter day: multiple results are returned, but we only need one
 			return result.apps as App[];


### PR DESCRIPTION
## Description

The `/apps/installed` endpoint may return multiple results when `includeClusterStatus=true`, particularly in clustered environments.

The current implementation assumes that the response always contains a single object with an `apps` property. However, if the API returns multiple results (for example, responses from different nodes in a cluster), the existing logic may fail and throw an error.

This change ensures that when the response is an array, the client safely uses the first result to retrieve the list of installed apps.

## Changes
- Added handling for array responses returned by `/apps/installed`
- Ensured the client works with both single-node and clustered responses
- Prevented potential runtime errors caused by unexpected response formats

## Notes
This change addresses the TODO comment in `orchestrator.ts` regarding multiple results returned from the `/apps/installed` API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed app loading to handle different API response formats, ensuring installed apps display correctly in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->