### PR TITLE
refactor: Improve type safety and resolve FIXME in sendMessage.ts

### DIFF
--- a/apps/meteor/server/lib/messages/sendMessage.ts
+++ b/apps/meteor/server/lib/messages/sendMessage.ts
@@ -203,7 +203,7 @@ export function prepareMessageObject(
 	const { _id, username, name } = user;
 	message.u = {
 		_id,
-		username: username as string, // FIXME: this is wrong but I don't want to change it now
+		username: username || '',
 		name,
 	};
 	message.rid = rid;
@@ -222,7 +222,12 @@ export function prepareMessageObject(
  * Caller of the function should verify the Message_MaxAllowedSize if needed.
  * There might be same use cases which needs to override this setting. Example - sending error logs.
  */
-export const sendMessage = async function (user: any, message: any, room: any, options: SendMessageOptions = {}) {
+export const sendMessage = async function (
+	user: { _id: string; username?: string; name?: string },
+	message: Partial<IMessage>,
+	room: Pick<IRoom, '_id'>,
+	options: SendMessageOptions = {},
+) {
 	const { upsert = false, previewUrls } = options;
 
 	if (!user || !message || !room._id) {


### PR DESCRIPTION
Closes #39560

This PR addresses long-standing technical debt in the core 'sendMessage.ts' function:
1. Resolves the 'FIXME' by removing the manual type cast on 'username' and providing a safe fallback.
2. Replaces several 'any' types in 'sendMessage' and helper functions with stronger type definitions from '@rocket.chat/core-typings'.
3. Improves overall maintainability and reduces the risk of runtime errors in the message-sending pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message author information handling when a username is unavailable, preventing missing or inconsistent username values from appearing in message data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->