### PR TITLE
refactor: Reduce as any usage in core functions

### DIFF
--- a/apps/meteor/server/lib/rooms/addUserToRoom.ts
+++ b/apps/meteor/server/lib/rooms/addUserToRoom.ts
@@ -60,8 +60,8 @@ export const addUserToRoom = async (
 		// Not "duplicated": we're moving away from callbacks so this is a patch function. We should migrate the next one to be a patch or use this same patch, instead of calling both
 		await beforeAddUserToRoomPatch([userToBeAdded.username!], room, inviterUser);
 		await beforeAddUserToRoom.run({ user: userToBeAdded, inviter: inviterUser }, room);
-	} catch (error) {
-		throw new Meteor.Error((error as any)?.message);
+	} catch (error: unknown) {
+		throw new Meteor.Error(error instanceof Error ? error.message : String(error));
 	}
 
 	// TODO: are we calling this twice?

--- a/apps/meteor/server/lib/users/setUserActiveStatus.ts
+++ b/apps/meteor/server/lib/users/setUserActiveStatus.ts
@@ -157,12 +157,12 @@ export async function setUserActiveStatus(
 	const email = {
 		to: String(destinations),
 		from: String(settings.get('From_Email')),
-		subject: subject({ active } as any),
+		subject: subject({ active }),
 		html: html({
 			active,
-			name: user.name,
-			username: user.username,
-		} as any),
+			name: user.name || '',
+			username: user.username || '',
+		}),
 	};
 
 	void Mailer.sendNoWrap(email);


### PR DESCRIPTION
Closes #39568

This PR reduces the usage of 'as any' type casting in the core logic within 'apps/meteor/app/lib'.
Specifically:
- Updated 'addUserToRoom.ts' to use 'unknown' and 'instanceof Error' for safer error handling.
- Refined the 'UserActivated' interface in 'setUserActiveStatus.ts' and removed manual casts.

These changes help leverage TypeScript's safety checks and improve overall code reliability in the message and user handling pipelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when adding users to rooms, including safer handling of unexpected errors.
  * Fixed activation emails so missing user details are displayed as blank values instead of undefined text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->