### PR TITLE
docs: Add TSDoc to critical core-services interfaces

### DIFF
--- a/packages/core-services/src/types/IMessageService.ts
+++ b/packages/core-services/src/types/IMessageService.ts
@@ -1,8 +1,21 @@
 import type { IMessage, MessageTypesValues, IUser, IRoom, AtLeast, MessageUrl } from '@rocket.chat/core-typings';
 
 export interface IMessageService {
+	/**
+	 * Sends a message from a user to a room.
+	 */
 	sendMessage({ fromId, rid, msg }: { fromId: string; rid: string; msg: string }): Promise<IMessage>;
+
+	/**
+	 * Saves a system message to a room.
+	 * @param type The type of system message (e.g., 'room_changed_name').
+	 * @param rid The room ID.
+	 * @param message The message text.
+	 * @param user The user who triggered the system message.
+	 * @param extraData Additional message data.
+	 */
 	saveSystemMessage<T = IMessage>(
+
 		type: MessageTypesValues,
 		rid: string,
 		message: string,

--- a/packages/core-services/src/types/IRoomService.ts
+++ b/packages/core-services/src/types/IRoomService.ts
@@ -22,9 +22,21 @@ export interface ICreateRoomParams<T extends IRoom = IRoom> {
 	options?: ICreateRoomOptions;
 }
 export interface IRoomService {
+	/**
+	 * Adds a user to a room by their UID.
+	 */
 	addMember(uid: string, rid: string): Promise<boolean>;
+
+	/**
+	 * Creates a new room.
+	 */
 	create<T extends IRoom = IRoom>(uid: string, params: ICreateRoomParams<T>): Promise<IRoom>;
+
+	/**
+	 * Creates a direct message room between two users.
+	 */
 	createDirectMessage(data: { to: string; from: string }): Promise<{ rid: string }>;
+
 	createDirectMessageWithMultipleUsers(members: string[], creatorId: string): Promise<{ rid: string }>;
 	addUserToRoom(
 		roomId: string,


### PR DESCRIPTION
Closes #39570

This PR adds TSDoc documentation to the 'IMessageService' and 'IRoomService' interfaces in '@rocket.chat/core-services'. Documenting these core interfaces improves the developer experience by providing immediate context within the IDE and ensuring better maintainability of internal service interactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message sending functionality.
  * Added system message saving capability.

* **Documentation**
  * Improved documentation for room management methods including adding members, creating rooms, and initiating direct messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->