### PR TITLE
ci: reusable action for restoring packages

### DIFF
--- a/.github/actions/restore-packages/action.yml
+++ b/.github/actions/restore-packages/action.yml
@@ -1,0 +1,16 @@
+name: 'Restore Packages Build'
+description: 'Downloads and unpacks the packages build artifact'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Restore packages build
+      uses: actions/download-artifact@v8
+      with:
+        name: packages-build
+        path: /tmp
+
+    - name: Unpack packages build
+      shell: bash
+      run: |
+        tar -xzf /tmp/RocketChat-packages-build.tar.gz -C .

--- a/.github/workflows/ci-code-check.yml
+++ b/.github/workflows/ci-code-check.yml
@@ -43,16 +43,7 @@ jobs:
 
       - uses: rharkor/caching-for-turbo@v1.8
 
-      - name: Restore packages build
-        uses: actions/download-artifact@v8
-        with:
-          name: packages-build
-          path: /tmp
-
-      - name: Unpack packages build
-        shell: bash
-        run: |
-          tar -xzf /tmp/RocketChat-packages-build.tar.gz -C .
+      - uses: ./.github/actions/restore-packages
 
       - name: Cache TypeCheck
         uses: actions/cache@v5

--- a/.github/workflows/ci-test-e2e.yml
+++ b/.github/workflows/ci-test-e2e.yml
@@ -125,16 +125,7 @@ jobs:
 
       - uses: rharkor/caching-for-turbo@v1.8
 
-      - name: Restore packages build
-        uses: actions/download-artifact@v8
-        with:
-          name: packages-build
-          path: /tmp
-
-      - name: Unpack packages build
-        shell: bash
-        run: |
-          tar -xzf /tmp/RocketChat-packages-build.tar.gz -C .
+      - uses: ./.github/actions/restore-packages
 
       # Download Docker images from build artifacts
       - name: Download Docker images

--- a/.github/workflows/ci-test-storybook.yml
+++ b/.github/workflows/ci-test-storybook.yml
@@ -37,16 +37,7 @@ jobs:
 
       - uses: rharkor/caching-for-turbo@v1.8
 
-      - name: Restore packages build
-        uses: actions/download-artifact@v8
-        with:
-          name: packages-build
-          path: /tmp
-
-      - name: Unpack packages build
-        shell: bash
-        run: |
-          tar -xzf /tmp/RocketChat-packages-build.tar.gz -C .
+      - uses: ./.github/actions/restore-packages
 
       - uses: ./.github/actions/setup-playwright
 

--- a/.github/workflows/ci-test-unit.yml
+++ b/.github/workflows/ci-test-unit.yml
@@ -41,16 +41,7 @@ jobs:
 
       - uses: rharkor/caching-for-turbo@v1.8
 
-      - name: Restore packages build
-        uses: actions/download-artifact@v8
-        with:
-          name: packages-build
-          path: /tmp
-
-      - name: Unpack packages build
-        shell: bash
-        run: |
-          tar -xzf /tmp/RocketChat-packages-build.tar.gz -C .
+      - uses: ./.github/actions/restore-packages
 
       - name: Unit Test
         run: yarn testunit --concurrency=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,16 +296,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Restore packages build
-        uses: actions/download-artifact@v8
-        with:
-          name: packages-build
-          path: /tmp
-
-      - name: Unpack packages build
-        shell: bash
-        run: |
-          tar -xzf /tmp/RocketChat-packages-build.tar.gz -C .
+      - uses: ./.github/actions/restore-packages
 
       # we only build and publish the actual docker images if not a PR from a fork
       - name: Image ${{ matrix.service[0] }}


### PR DESCRIPTION
Across multiple workflows, we repeat the exact same steps to download and extract the build payload:

```yml
- name: Restore packages build
  uses: actions/download-artifact@v8
  with:
    name: packages-build
    path: /tmp
- name: Unpack packages build
  shell: bash
  run: |
    tar -xzf /tmp/RocketChat-packages-build.tar.gz -C .
```


In order to make our workflow files cleaner and easier to maintain if artifact naming or paths ever change, we should create a new composite action (e.g., .github/actions/restore-packages) to encapsulate these steps.

 Task: [CORE-1948]

[CORE-1948]: https://rocketchat.atlassian.net/browse/CORE-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a reusable CI action to restore packaged build artifacts and replaced duplicate download-and-unpack steps across multiple workflows, consolidating package restoration into a single invocation to simplify CI and improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->