### PR TITLE
refactor: Migrate livechat/users endpoints to OpenAPI with AJV validation

### DIFF
--- a/.changeset/migrate-livechat-users-openapi.md
+++ b/.changeset/migrate-livechat-users-openapi.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/meteor": minor
+"@rocket.chat/rest-typings": minor
+---
+
+Add OpenAPI support for the livechat/users/:type and livechat/users/:type/:_id API endpoints by migrating to chained route definitions with AJV body, query, and response validation.

--- a/apps/meteor/app/livechat/imports/server/rest/users.ts
+++ b/apps/meteor/app/livechat/imports/server/rest/users.ts
@@ -1,6 +1,5 @@
 import { Users } from '@rocket.chat/models';
-import { isLivechatUsersManagerGETProps, isPOSTLivechatUsersTypeProps } from '@rocket.chat/rest-typings';
-import { check } from 'meteor/check';
+import { ajv, validateBadRequestErrorResponse, validateUnauthorizedErrorResponse, validateForbiddenErrorResponse } from '@rocket.chat/rest-typings';
 
 import { API } from '../../../../api/server';
 import { getPaginationItems } from '../../../../api/server/helpers/getPaginationItems';
@@ -8,36 +7,132 @@ import { hasAtLeastOnePermissionAsync } from '../../../../authorization/server/f
 import { findAgents, findManagers } from '../../../server/api/lib/users';
 import { addManager, addAgent, removeAgent, removeManager } from '../../../server/lib/omni-users';
 
+// --- Local types and AJV schemas (moved from rest-typings) ---
+
+type LivechatUsersManagerGETLocal = {
+	text?: string;
+	fields?: string;
+	onlyAvailable?: boolean;
+	excludeId?: string;
+	showIdleAgents?: boolean;
+	count?: number;
+	offset?: number;
+	sort?: string;
+	query?: string;
+};
+
+const LivechatUsersManagerGETLocalSchema = {
+	type: 'object',
+	properties: {
+		text: { type: 'string', nullable: true },
+		onlyAvailable: { type: 'boolean', nullable: true },
+		excludeId: { type: 'string', nullable: true },
+		showIdleAgents: { type: 'boolean', nullable: true },
+		count: { type: 'number', nullable: true },
+		offset: { type: 'number', nullable: true },
+		sort: { type: 'string', nullable: true },
+		query: { type: 'string', nullable: true },
+		fields: { type: 'string', nullable: true },
+	},
+	required: [],
+	additionalProperties: false,
+};
+
+const isLivechatUsersManagerGETLocal = ajv.compile<LivechatUsersManagerGETLocal>(LivechatUsersManagerGETLocalSchema);
+
+type POSTLivechatUsersTypeLocal = {
+	username: string;
+};
+
+const POSTLivechatUsersTypeLocalSchema = {
+	type: 'object',
+	properties: {
+		username: { type: 'string' },
+	},
+	required: ['username'],
+	additionalProperties: false,
+};
+
+const isPOSTLivechatUsersTypeLocal = ajv.compile<POSTLivechatUsersTypeLocal>(POSTLivechatUsersTypeLocalSchema);
+
+// --- Response schemas ---
+
+const paginatedUsersResponseSchema = ajv.compile<{
+	users: object[];
+	count: number;
+	offset: number;
+	total: number;
+}>({
+	type: 'object',
+	properties: {
+		// ILivechatAgent is not registered in typia (extends IUser with livechat-specific fields),
+		// so we use { type: 'object' } as a fallback.
+		users: { type: 'array', items: { type: 'object' } },
+		count: { type: 'number' },
+		offset: { type: 'number' },
+		total: { type: 'number' },
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['users', 'count', 'offset', 'total', 'success'],
+	additionalProperties: false,
+});
+
+const postUserResponseSchema = ajv.compile<{ user: object }>({
+	type: 'object',
+	properties: {
+		user: { type: 'object' },
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['user', 'success'],
+	additionalProperties: false,
+});
+
+const successOnlyResponseSchema = ajv.compile<void>({
+	type: 'object',
+	properties: {
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['success'],
+	additionalProperties: false,
+});
+
+const getUserByIdResponseSchema = ajv.compile<{ user: object | null }>({
+	type: 'object',
+	properties: {
+		user: { type: ['object', 'null'] },
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['user', 'success'],
+	additionalProperties: false,
+});
+
 const emptyStringArray: string[] = [];
 
-API.v1.addRoute(
-	'livechat/users/:type',
-	{
-		authRequired: true,
-		permissionsRequired: {
-			'POST': ['view-livechat-manager'],
-			'*': emptyStringArray,
+API.v1
+	.get(
+		'livechat/users/:type',
+		{
+			authRequired: true,
+			permissionsRequired: emptyStringArray,
+			query: isLivechatUsersManagerGETLocal,
+			response: {
+				200: paginatedUsersResponseSchema,
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
+			},
 		},
-		validateParams: {
-			GET: isLivechatUsersManagerGETProps,
-			POST: isPOSTLivechatUsersTypeProps,
-		},
-	},
-	{
-		async get() {
-			check(this.urlParams, {
-				type: String,
-			});
+		async function action() {
 			const { offset, count } = await getPaginationItems(this.queryParams);
 			const { sort } = await this.parseJsonQuery();
 			const { text } = this.queryParams;
 
 			if (this.urlParams.type === 'agent') {
 				if (!(await hasAtLeastOnePermissionAsync(this.userId, ['transfer-livechat-guest', 'edit-omnichannel-contact']))) {
-					return API.v1.forbidden();
+					return API.v1.forbidden('error-not-authorized');
 				}
 
-				const { onlyAvailable, excludeId, showIdleAgents } = this.queryParams;
+				const { onlyAvailable = false, excludeId, showIdleAgents } = this.queryParams;
 				return API.v1.success(
 					await findAgents({
 						text,
@@ -54,7 +149,7 @@ API.v1.addRoute(
 			}
 			if (this.urlParams.type === 'manager') {
 				if (!(await hasAtLeastOnePermissionAsync(this.userId, ['view-livechat-manager']))) {
-					return API.v1.forbidden();
+					return API.v1.forbidden('error-not-authorized');
 				}
 
 				return API.v1.success(
@@ -70,7 +165,21 @@ API.v1.addRoute(
 			}
 			throw new Error('Invalid type');
 		},
-		async post() {
+	)
+	.post(
+		'livechat/users/:type',
+		{
+			authRequired: true,
+			permissionsRequired: ['view-livechat-manager'],
+			body: isPOSTLivechatUsersTypeLocal,
+			response: {
+				200: postUserResponseSchema,
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
+			},
+		},
+		async function action() {
 			if (this.urlParams.type === 'agent') {
 				const user = await addAgent(this.bodyParams.username);
 				if (user) {
@@ -87,14 +196,21 @@ API.v1.addRoute(
 
 			return API.v1.failure();
 		},
-	},
-);
-
-API.v1.addRoute(
-	'livechat/users/:type/:_id',
-	{ authRequired: true, permissionsRequired: ['view-livechat-manager'] },
-	{
-		async get() {
+	)
+	.get(
+		'livechat/users/:type/:_id',
+		{
+			authRequired: true,
+			permissionsRequired: ['view-livechat-manager'],
+			query: undefined,
+			response: {
+				200: getUserByIdResponseSchema,
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
+			},
+		},
+		async function action() {
 			if (!['agent', 'manager'].includes(this.urlParams.type)) {
 				throw new Error('Invalid type');
 			}
@@ -107,7 +223,21 @@ API.v1.addRoute(
 			// TODO: throw error instead of returning null
 			return API.v1.success({ user });
 		},
-		async delete() {
+	)
+	.delete(
+		'livechat/users/:type/:_id',
+		{
+			authRequired: true,
+			permissionsRequired: ['view-livechat-manager'],
+			query: undefined,
+			response: {
+				200: successOnlyResponseSchema,
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
+			},
+		},
+		async function action() {
 			if (this.urlParams.type === 'agent') {
 				if (await removeAgent(this.urlParams._id)) {
 					return API.v1.success();
@@ -120,7 +250,7 @@ API.v1.addRoute(
 				throw new Error('Invalid type');
 			}
 
-			return API.v1.failure();
+			return API.v1.failure('error-removing-user');
 		},
-	},
-);
+	);
+

--- a/apps/meteor/app/livechat/imports/server/rest/users.ts
+++ b/apps/meteor/app/livechat/imports/server/rest/users.ts
@@ -2,12 +2,11 @@ import { Users } from '@rocket.chat/models';
 import { ajv, validateBadRequestErrorResponse, validateUnauthorizedErrorResponse, validateForbiddenErrorResponse } from '@rocket.chat/rest-typings';
 
 import { API } from '../../../../api/server';
+import type { ExtractRoutesFromAPI } from '../../../../api/server/ApiClass';
 import { getPaginationItems } from '../../../../api/server/helpers/getPaginationItems';
 import { hasAtLeastOnePermissionAsync } from '../../../../authorization/server/functions/hasPermission';
 import { findAgents, findManagers } from '../../../server/api/lib/users';
 import { addManager, addAgent, removeAgent, removeManager } from '../../../server/lib/omni-users';
-
-// --- Local types and AJV schemas (moved from rest-typings) ---
 
 type LivechatUsersManagerGETLocal = {
 	text?: string;
@@ -55,8 +54,6 @@ const POSTLivechatUsersTypeLocalSchema = {
 
 const isPOSTLivechatUsersTypeLocal = ajv.compile<POSTLivechatUsersTypeLocal>(POSTLivechatUsersTypeLocalSchema);
 
-// --- Response schemas ---
-
 const paginatedUsersResponseSchema = ajv.compile<{
 	users: object[];
 	count: number;
@@ -65,8 +62,6 @@ const paginatedUsersResponseSchema = ajv.compile<{
 }>({
 	type: 'object',
 	properties: {
-		// ILivechatAgent is not registered in typia (extends IUser with livechat-specific fields),
-		// so we use { type: 'object' } as a fallback.
 		users: { type: 'array', items: { type: 'object' } },
 		count: { type: 'number' },
 		offset: { type: 'number' },
@@ -108,7 +103,7 @@ const getUserByIdResponseSchema = ajv.compile<{ user: object | null }>({
 
 const emptyStringArray: string[] = [];
 
-API.v1
+const livechatUsersEndpoints = API.v1
 	.get(
 		'livechat/users/:type',
 		{
@@ -253,4 +248,11 @@ API.v1
 			return API.v1.failure('error-removing-user');
 		},
 	);
+
+type LivechatUsersEndpoints = ExtractRoutesFromAPI<typeof livechatUsersEndpoints>;
+
+declare module '@rocket.chat/rest-typings' {
+	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
+	interface Endpoints extends LivechatUsersEndpoints {}
+}
 

--- a/apps/meteor/app/livechat/imports/server/rest/users.ts
+++ b/apps/meteor/app/livechat/imports/server/rest/users.ts
@@ -8,7 +8,7 @@ import { hasAtLeastOnePermissionAsync } from '../../../../authorization/server/f
 import { findAgents, findManagers } from '../../../server/api/lib/users';
 import { addManager, addAgent, removeAgent, removeManager } from '../../../server/lib/omni-users';
 
-type LivechatUsersManagerGETLocal = {
+type LivechatUsersManagerGETProps = {
 	text?: string;
 	fields?: string;
 	onlyAvailable?: boolean;
@@ -20,7 +20,7 @@ type LivechatUsersManagerGETLocal = {
 	query?: string;
 };
 
-const LivechatUsersManagerGETLocalSchema = {
+const LivechatUsersManagerGETSchema = {
 	type: 'object',
 	properties: {
 		text: { type: 'string', nullable: true },
@@ -37,13 +37,13 @@ const LivechatUsersManagerGETLocalSchema = {
 	additionalProperties: false,
 };
 
-const isLivechatUsersManagerGETLocal = ajv.compile<LivechatUsersManagerGETLocal>(LivechatUsersManagerGETLocalSchema);
+const isLivechatUsersManagerGETProps = ajv.compile<LivechatUsersManagerGETProps>(LivechatUsersManagerGETSchema);
 
-type POSTLivechatUsersTypeLocal = {
+type POSTLivechatUsersTypeProps = {
 	username: string;
 };
 
-const POSTLivechatUsersTypeLocalSchema = {
+const POSTLivechatUsersTypePropsSchema = {
 	type: 'object',
 	properties: {
 		username: { type: 'string' },
@@ -52,7 +52,7 @@ const POSTLivechatUsersTypeLocalSchema = {
 	additionalProperties: false,
 };
 
-const isPOSTLivechatUsersTypeLocal = ajv.compile<POSTLivechatUsersTypeLocal>(POSTLivechatUsersTypeLocalSchema);
+const isPOSTLivechatUsersTypeProps = ajv.compile<POSTLivechatUsersTypeProps>(POSTLivechatUsersTypePropsSchema);
 
 const paginatedUsersResponseSchema = ajv.compile<{
 	users: object[];
@@ -62,7 +62,7 @@ const paginatedUsersResponseSchema = ajv.compile<{
 }>({
 	type: 'object',
 	properties: {
-		users: { type: 'array', items: { type: 'object' } },
+		users: { type: 'array', items: { $ref: '#/components/schemas/IUser' } },
 		count: { type: 'number' },
 		offset: { type: 'number' },
 		total: { type: 'number' },
@@ -75,7 +75,7 @@ const paginatedUsersResponseSchema = ajv.compile<{
 const postUserResponseSchema = ajv.compile<{ user: object }>({
 	type: 'object',
 	properties: {
-		user: { type: 'object' },
+		user: { $ref: '#/components/schemas/IUser' },
 		success: { type: 'boolean', enum: [true] },
 	},
 	required: ['user', 'success'],
@@ -94,7 +94,7 @@ const successOnlyResponseSchema = ajv.compile<void>({
 const getUserByIdResponseSchema = ajv.compile<{ user: object | null }>({
 	type: 'object',
 	properties: {
-		user: { type: ['object', 'null'] },
+		user: { oneOf: [{ $ref: '#/components/schemas/IUser' }, { type: 'null' }] },
 		success: { type: 'boolean', enum: [true] },
 	},
 	required: ['user', 'success'],
@@ -109,7 +109,7 @@ const livechatUsersEndpoints = API.v1
 		{
 			authRequired: true,
 			permissionsRequired: emptyStringArray,
-			query: isLivechatUsersManagerGETLocal,
+			query: isLivechatUsersManagerGETProps,
 			response: {
 				200: paginatedUsersResponseSchema,
 				400: validateBadRequestErrorResponse,
@@ -124,10 +124,10 @@ const livechatUsersEndpoints = API.v1
 
 			if (this.urlParams.type === 'agent') {
 				if (!(await hasAtLeastOnePermissionAsync(this.userId, ['transfer-livechat-guest', 'edit-omnichannel-contact']))) {
-					return API.v1.forbidden('error-not-authorized');
+					return API.v1.forbidden();
 				}
 
-				const { onlyAvailable = false, excludeId, showIdleAgents } = this.queryParams;
+				const { onlyAvailable, excludeId, showIdleAgents } = this.queryParams;
 				return API.v1.success(
 					await findAgents({
 						text,
@@ -144,7 +144,7 @@ const livechatUsersEndpoints = API.v1
 			}
 			if (this.urlParams.type === 'manager') {
 				if (!(await hasAtLeastOnePermissionAsync(this.userId, ['view-livechat-manager']))) {
-					return API.v1.forbidden('error-not-authorized');
+					return API.v1.forbidden();
 				}
 
 				return API.v1.success(
@@ -166,7 +166,7 @@ const livechatUsersEndpoints = API.v1
 		{
 			authRequired: true,
 			permissionsRequired: ['view-livechat-manager'],
-			body: isPOSTLivechatUsersTypeLocal,
+			body: isPOSTLivechatUsersTypeProps,
 			response: {
 				200: postUserResponseSchema,
 				400: validateBadRequestErrorResponse,
@@ -245,7 +245,7 @@ const livechatUsersEndpoints = API.v1
 				throw new Error('Invalid type');
 			}
 
-			return API.v1.failure('error-removing-user');
+			return API.v1.failure();
 		},
 	);
 

--- a/apps/meteor/client/views/omnichannel/agents/AgentEditWithData.tsx
+++ b/apps/meteor/client/views/omnichannel/agents/AgentEditWithData.tsx
@@ -12,7 +12,7 @@ import { omnichannelQueryKeys } from '../../../lib/queryKeys';
 const AgentEditWithData = ({ uid }: { uid: ILivechatAgent['_id'] }): ReactElement => {
 	const { t } = useTranslation();
 
-	const getAgentById = useEndpoint('GET', '/v1/livechat/users/agent/:_id', { _id: uid });
+	const getAgentById = useEndpoint('GET', '/v1/livechat/users/:type/:_id', { type: 'agent', _id: uid });
 	const getAgentDepartments = useEndpoint('GET', '/v1/livechat/agents/:agentId/departments', { agentId: uid });
 
 	const { data, isPending, error } = useQuery({

--- a/apps/meteor/client/views/omnichannel/agents/AgentEditWithData.tsx
+++ b/apps/meteor/client/views/omnichannel/agents/AgentEditWithData.tsx
@@ -12,7 +12,7 @@ import { omnichannelQueryKeys } from '../../../lib/queryKeys';
 const AgentEditWithData = ({ uid }: { uid: ILivechatAgent['_id'] }): ReactElement => {
 	const { t } = useTranslation();
 
-	const getAgentById = useEndpoint('GET', '/v1/livechat/users/:type/:_id', { type: 'agent', _id: uid });
+	const getAgentById = useEndpoint('GET', '/v1/livechat/users/agent/:_id', { _id: uid });
 	const getAgentDepartments = useEndpoint('GET', '/v1/livechat/agents/:agentId/departments', { agentId: uid });
 
 	const { data, isPending, error } = useQuery({

--- a/apps/meteor/client/views/omnichannel/agents/AgentInfo.tsx
+++ b/apps/meteor/client/views/omnichannel/agents/AgentInfo.tsx
@@ -26,7 +26,7 @@ type AgentInfoProps = {
 const AgentInfo = ({ uid }: AgentInfoProps) => {
 	const { t } = useTranslation();
 	const router = useRouter();
-	const getAgentById = useEndpoint('GET', '/v1/livechat/users/agent/:_id', { _id: uid });
+	const getAgentById = useEndpoint('GET', '/v1/livechat/users/:type/:_id', { type: 'agent', _id: uid });
 	const { data, isPending, isError } = useQuery({
 		queryKey: ['livechat-getAgentInfoById', uid],
 		queryFn: async () => getAgentById(),

--- a/apps/meteor/client/views/omnichannel/agents/AgentInfo.tsx
+++ b/apps/meteor/client/views/omnichannel/agents/AgentInfo.tsx
@@ -26,7 +26,7 @@ type AgentInfoProps = {
 const AgentInfo = ({ uid }: AgentInfoProps) => {
 	const { t } = useTranslation();
 	const router = useRouter();
-	const getAgentById = useEndpoint('GET', '/v1/livechat/users/:type/:_id', { type: 'agent', _id: uid });
+	const getAgentById = useEndpoint('GET', '/v1/livechat/users/agent/:_id', { _id: uid });
 	const { data, isPending, isError } = useQuery({
 		queryKey: ['livechat-getAgentInfoById', uid],
 		queryFn: async () => getAgentById(),

--- a/apps/meteor/client/views/omnichannel/agents/AgentInfo.tsx
+++ b/apps/meteor/client/views/omnichannel/agents/AgentInfo.tsx
@@ -1,3 +1,4 @@
+import type { ILivechatAgent, Serialized } from '@rocket.chat/core-typings';
 import { Box, Margins, ButtonGroup } from '@rocket.chat/fuselage';
 import {
 	ContextualbarTitle,
@@ -39,11 +40,12 @@ const AgentInfo = ({ uid }: AgentInfoProps) => {
 		return <ContextualbarSkeletonBody />;
 	}
 
-	if (isError) {
+	if (isError || !data?.user) {
 		return <Box mbs={16}>{t('User_not_found')}</Box>;
 	}
 
-	const { username, statusLivechat, status: userStatus } = data?.user;
+	const user = data.user as Serialized<ILivechatAgent>;
+	const { username, statusLivechat, status: userStatus } = user;
 
 	return (
 		<>
@@ -77,7 +79,7 @@ const AgentInfo = ({ uid }: AgentInfoProps) => {
 							<InfoPanelText>{statusLivechat === 'available' ? t('Available') : t('Not_Available')}</InfoPanelText>
 						</>
 					)}
-					{MaxChatsPerAgentDisplay && <MaxChatsPerAgentDisplay maxNumberSimultaneousChat={data.user.livechat?.maxNumberSimultaneousChat} />}
+					{MaxChatsPerAgentDisplay && <MaxChatsPerAgentDisplay maxNumberSimultaneousChat={user.livechat?.maxNumberSimultaneousChat} />}
 				</Margins>
 			</ContextualbarScrollableContent>
 		</>

--- a/apps/meteor/client/views/omnichannel/agents/AgentsTable/AddAgent.tsx
+++ b/apps/meteor/client/views/omnichannel/agents/AgentsTable/AddAgent.tsx
@@ -17,7 +17,8 @@ const AddAgent = () => {
 
 	const usernameFieldId = useId();
 
-	const { mutateAsync: saveAction } = useEndpointMutation('POST', '/v1/livechat/users/agent', {
+	const { mutateAsync: saveAction } = useEndpointMutation('POST', '/v1/livechat/users/:type', {
+		keys: { type: 'agent' },
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: omnichannelQueryKeys.agents() });
 			setUsername('');

--- a/apps/meteor/client/views/omnichannel/agents/AgentsTable/AddAgent.tsx
+++ b/apps/meteor/client/views/omnichannel/agents/AgentsTable/AddAgent.tsx
@@ -17,8 +17,7 @@ const AddAgent = () => {
 
 	const usernameFieldId = useId();
 
-	const { mutateAsync: saveAction } = useEndpointMutation('POST', '/v1/livechat/users/:type', {
-		keys: { type: 'agent' },
+	const { mutateAsync: saveAction } = useEndpointMutation('POST', '/v1/livechat/users/agent', {
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: omnichannelQueryKeys.agents() });
 			setUsername('');

--- a/apps/meteor/client/views/omnichannel/agents/hooks/useAgentsQuery.ts
+++ b/apps/meteor/client/views/omnichannel/agents/hooks/useAgentsQuery.ts
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { omnichannelQueryKeys } from '../../../../lib/queryKeys';
 
 export const useAgentsQuery = (query: PaginatedRequest = {}) => {
-	const getAgents = useEndpoint('GET', '/v1/livechat/users/agent');
+	const getAgents = useEndpoint('GET', '/v1/livechat/users/:type', { type: 'agent' });
 
 	return useQuery({
 		queryKey: omnichannelQueryKeys.agents(query),

--- a/apps/meteor/client/views/omnichannel/agents/hooks/useAgentsQuery.ts
+++ b/apps/meteor/client/views/omnichannel/agents/hooks/useAgentsQuery.ts
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { omnichannelQueryKeys } from '../../../../lib/queryKeys';
 
 export const useAgentsQuery = (query: PaginatedRequest = {}) => {
-	const getAgents = useEndpoint('GET', '/v1/livechat/users/:type', { type: 'agent' });
+	const getAgents = useEndpoint('GET', '/v1/livechat/users/agent');
 
 	return useQuery({
 		queryKey: omnichannelQueryKeys.agents(query),

--- a/apps/meteor/client/views/omnichannel/agents/hooks/useRemoveAgent.tsx
+++ b/apps/meteor/client/views/omnichannel/agents/hooks/useRemoveAgent.tsx
@@ -13,7 +13,7 @@ export const useRemoveAgent = (uid: ILivechatAgent['_id']) => {
 	const queryClient = useQueryClient();
 	const dispatchToastMessage = useToastMessageDispatch();
 
-	const deleteAction = useEndpoint('DELETE', '/v1/livechat/users/agent/:_id', { _id: uid });
+	const deleteAction = useEndpoint('DELETE', '/v1/livechat/users/:type/:_id', { type: 'agent', _id: uid });
 
 	const handleDelete = useEffectEvent(() => {
 		const onDeleteAgent = async () => {

--- a/apps/meteor/client/views/omnichannel/agents/hooks/useRemoveAgent.tsx
+++ b/apps/meteor/client/views/omnichannel/agents/hooks/useRemoveAgent.tsx
@@ -13,7 +13,7 @@ export const useRemoveAgent = (uid: ILivechatAgent['_id']) => {
 	const queryClient = useQueryClient();
 	const dispatchToastMessage = useToastMessageDispatch();
 
-	const deleteAction = useEndpoint('DELETE', '/v1/livechat/users/:type/:_id', { type: 'agent', _id: uid });
+	const deleteAction = useEndpoint('DELETE', '/v1/livechat/users/agent/:_id', { _id: uid });
 
 	const handleDelete = useEffectEvent(() => {
 		const onDeleteAgent = async () => {

--- a/apps/meteor/client/views/omnichannel/components/outboundMessage/components/OutboundMessageWizard/OutboundMessageWizard.stories.tsx
+++ b/apps/meteor/client/views/omnichannel/components/outboundMessage/components/OutboundMessageWizard/OutboundMessageWizard.stories.tsx
@@ -46,9 +46,9 @@ const mockDepartmentAgent = {
 
 const AppRoot = mockAppRoot()
 	.withEndpoint('GET', '/v1/livechat/department', () => ({ departments: [mockDepartment], count: 1, offset: 0, total: 1 }))
-	.withEndpoint('GET', '/v1/livechat/users/:type', () => ({ users: [{ ...mockAgent, departments: [] }], count: 1, offset: 0, total: 1 }))
+	.withEndpoint('GET', '/v1/livechat/users/agent', () => ({ users: [{ ...mockAgent, departments: [] }], count: 1, offset: 0, total: 1 }))
 	.withEndpoint('GET', '/v1/livechat/department/:_id', () => ({ department: mockDepartment, agents: [mockDepartmentAgent] }))
-	.withEndpoint('GET', '/v1/livechat/users/:type/:_id', () => ({ user: mockAgent }))
+	.withEndpoint('GET', '/v1/livechat/users/agent/:_id', () => ({ user: mockAgent }))
 	.withEndpoint('GET', '/v1/omnichannel/outbound/providers', () => ({ providers: [providerMock] }))
 	.withEndpoint('GET', '/v1/omnichannel/outbound/providers/:id/metadata', () => ({ metadata: providerMock }))
 	.withEndpoint('GET', '/v1/omnichannel/contacts.get', () => ({ contact: contactMock }))

--- a/apps/meteor/client/views/omnichannel/components/outboundMessage/components/OutboundMessageWizard/OutboundMessageWizard.stories.tsx
+++ b/apps/meteor/client/views/omnichannel/components/outboundMessage/components/OutboundMessageWizard/OutboundMessageWizard.stories.tsx
@@ -46,9 +46,9 @@ const mockDepartmentAgent = {
 
 const AppRoot = mockAppRoot()
 	.withEndpoint('GET', '/v1/livechat/department', () => ({ departments: [mockDepartment], count: 1, offset: 0, total: 1 }))
-	.withEndpoint('GET', '/v1/livechat/users/agent', () => ({ users: [{ ...mockAgent, departments: [] }], count: 1, offset: 0, total: 1 }))
+	.withEndpoint('GET', '/v1/livechat/users/:type', () => ({ users: [{ ...mockAgent, departments: [] }], count: 1, offset: 0, total: 1 }))
 	.withEndpoint('GET', '/v1/livechat/department/:_id', () => ({ department: mockDepartment, agents: [mockDepartmentAgent] }))
-	.withEndpoint('GET', '/v1/livechat/users/agent/:_id', () => ({ user: mockAgent }))
+	.withEndpoint('GET', '/v1/livechat/users/:type/:_id', () => ({ user: mockAgent }))
 	.withEndpoint('GET', '/v1/omnichannel/outbound/providers', () => ({ providers: [providerMock] }))
 	.withEndpoint('GET', '/v1/omnichannel/outbound/providers/:id/metadata', () => ({ metadata: providerMock }))
 	.withEndpoint('GET', '/v1/omnichannel/contacts.get', () => ({ contact: contactMock }))

--- a/apps/meteor/client/views/omnichannel/components/outboundMessage/components/OutboundMessageWizard/steps/RepliesStep.stories.tsx
+++ b/apps/meteor/client/views/omnichannel/components/outboundMessage/components/OutboundMessageWizard/steps/RepliesStep.stories.tsx
@@ -40,9 +40,9 @@ const mockDepartmentAgent = {
 
 const AppRoot = mockAppRoot()
 	.withEndpoint('GET', '/v1/livechat/department', () => ({ departments: [mockDepartment], count: 1, offset: 0, total: 1 }))
-	.withEndpoint('GET', '/v1/livechat/users/agent', () => ({ users: [{ ...mockAgent, departments: [] }], count: 1, offset: 0, total: 1 }))
+	.withEndpoint('GET', '/v1/livechat/users/:type', () => ({ users: [{ ...mockAgent, departments: [] }], count: 1, offset: 0, total: 1 }))
 	.withEndpoint('GET', '/v1/livechat/department/:_id', () => ({ department: mockDepartment, agents: [mockDepartmentAgent] }))
-	.withEndpoint('GET', '/v1/livechat/users/agent/:_id', () => ({ user: mockAgent }))
+	.withEndpoint('GET', '/v1/livechat/users/:type/:_id', () => ({ user: mockAgent }))
 	.build();
 
 const meta = {

--- a/apps/meteor/client/views/omnichannel/components/outboundMessage/components/OutboundMessageWizard/steps/RepliesStep.stories.tsx
+++ b/apps/meteor/client/views/omnichannel/components/outboundMessage/components/OutboundMessageWizard/steps/RepliesStep.stories.tsx
@@ -40,9 +40,9 @@ const mockDepartmentAgent = {
 
 const AppRoot = mockAppRoot()
 	.withEndpoint('GET', '/v1/livechat/department', () => ({ departments: [mockDepartment], count: 1, offset: 0, total: 1 }))
-	.withEndpoint('GET', '/v1/livechat/users/:type', () => ({ users: [{ ...mockAgent, departments: [] }], count: 1, offset: 0, total: 1 }))
+	.withEndpoint('GET', '/v1/livechat/users/agent', () => ({ users: [{ ...mockAgent, departments: [] }], count: 1, offset: 0, total: 1 }))
 	.withEndpoint('GET', '/v1/livechat/department/:_id', () => ({ department: mockDepartment, agents: [mockDepartmentAgent] }))
-	.withEndpoint('GET', '/v1/livechat/users/:type/:_id', () => ({ user: mockAgent }))
+	.withEndpoint('GET', '/v1/livechat/users/agent/:_id', () => ({ user: mockAgent }))
 	.build();
 
 const meta = {

--- a/apps/meteor/client/views/omnichannel/departments/DepartmentAgentsTable/AddAgent.tsx
+++ b/apps/meteor/client/views/omnichannel/departments/DepartmentAgentsTable/AddAgent.tsx
@@ -19,7 +19,7 @@ function AddAgent({ agentList, onAdd, 'aria-labelledby': ariaLabelledBy }: AddAg
 
 	const [userId, setUserId] = useState('');
 
-	const { mutateAsync: getAgent } = useEndpointMutation('GET', '/v1/livechat/users/agent/:_id', { keys: { _id: userId } });
+	const { mutateAsync: getAgent } = useEndpointMutation('GET', '/v1/livechat/users/:type/:_id', { keys: { type: 'agent', _id: userId } });
 
 	const dispatchToastMessage = useToastMessageDispatch();
 

--- a/apps/meteor/client/views/omnichannel/departments/DepartmentAgentsTable/AddAgent.tsx
+++ b/apps/meteor/client/views/omnichannel/departments/DepartmentAgentsTable/AddAgent.tsx
@@ -19,7 +19,7 @@ function AddAgent({ agentList, onAdd, 'aria-labelledby': ariaLabelledBy }: AddAg
 
 	const [userId, setUserId] = useState('');
 
-	const { mutateAsync: getAgent } = useEndpointMutation('GET', '/v1/livechat/users/:type/:_id', { keys: { type: 'agent', _id: userId } });
+	const { mutateAsync: getAgent } = useEndpointMutation('GET', '/v1/livechat/users/agent/:_id', { keys: { _id: userId } });
 
 	const dispatchToastMessage = useToastMessageDispatch();
 

--- a/apps/meteor/client/views/omnichannel/departments/DepartmentAgentsTable/AddAgent.tsx
+++ b/apps/meteor/client/views/omnichannel/departments/DepartmentAgentsTable/AddAgent.tsx
@@ -30,9 +30,12 @@ function AddAgent({ agentList, onAdd, 'aria-labelledby': ariaLabelledBy }: AddAg
 			return;
 		}
 
-		const {
-			user: { _id, username, name },
-		} = await getAgent();
+		const { user } = await getAgent();
+		if (!user) {
+			dispatchToastMessage({ type: 'error', message: t('User_not_found') });
+			return;
+		}
+		const { _id, username, name } = user;
 
 		if (!agentList.some(({ agentId }) => agentId === _id)) {
 			setUserId('');

--- a/apps/meteor/client/views/omnichannel/hooks/useAgentsList.spec.ts
+++ b/apps/meteor/client/views/omnichannel/hooks/useAgentsList.spec.ts
@@ -15,7 +15,7 @@ const mockGetAgents = jest.fn();
 
 const appRoot = new MockedAppRootBuilder()
 	.withTranslations('en', 'core', { All: 'All', Empty_no_agent_selected: 'Empty, no agent selected' })
-	.withEndpoint('GET', '/v1/livechat/users/agent', mockGetAgents);
+	.withEndpoint('GET', '/v1/livechat/users/:type', mockGetAgents);
 
 afterEach(() => {
 	jest.clearAllMocks();

--- a/apps/meteor/client/views/omnichannel/hooks/useAgentsList.spec.ts
+++ b/apps/meteor/client/views/omnichannel/hooks/useAgentsList.spec.ts
@@ -15,7 +15,7 @@ const mockGetAgents = jest.fn();
 
 const appRoot = new MockedAppRootBuilder()
 	.withTranslations('en', 'core', { All: 'All', Empty_no_agent_selected: 'Empty, no agent selected' })
-	.withEndpoint('GET', '/v1/livechat/users/:type', mockGetAgents);
+	.withEndpoint('GET', '/v1/livechat/users/agent', mockGetAgents);
 
 afterEach(() => {
 	jest.clearAllMocks();

--- a/apps/meteor/client/views/omnichannel/hooks/useAgentsList.ts
+++ b/apps/meteor/client/views/omnichannel/hooks/useAgentsList.ts
@@ -1,4 +1,3 @@
-import type { ILivechatAgent, Serialized } from '@rocket.chat/core-typings';
 import { useEndpoint } from '@rocket.chat/ui-contexts';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -34,7 +33,7 @@ export const useAgentsList = (options: AgentsListOptions) => {
 		limit = DEFAULT_QUERY_LIMIT,
 	} = options;
 
-	const formatAgentItem = (agent: Serialized<ILivechatAgent>) => ({
+	const formatAgentItem = (agent: { _id: string; name?: string; username?: string }) => ({
 		_id: agent._id,
 		label: `${agent.name || agent._id} (@${agent.username})`,
 		value: agent._id,
@@ -55,7 +54,7 @@ export const useAgentsList = (options: AgentsListOptions) => {
 
 			return {
 				...data,
-				users: users.map(formatAgentItem),
+				users: users.map((u: any) => formatAgentItem(u)),
 			};
 		},
 		select: (data) => {

--- a/apps/meteor/client/views/omnichannel/hooks/useAgentsList.ts
+++ b/apps/meteor/client/views/omnichannel/hooks/useAgentsList.ts
@@ -23,7 +23,7 @@ const DEFAULT_QUERY_LIMIT = 25;
 
 export const useAgentsList = (options: AgentsListOptions) => {
 	const { t } = useTranslation();
-	const getAgents = useEndpoint('GET', '/v1/livechat/users/:type', { type: 'agent' });
+	const getAgents = useEndpoint('GET', '/v1/livechat/users/agent');
 	const {
 		filter,
 		onlyAvailable = false,
@@ -41,7 +41,7 @@ export const useAgentsList = (options: AgentsListOptions) => {
 	});
 
 	return useInfiniteQuery({
-		queryKey: ['/v1/livechat/users/:type', { filter, onlyAvailable, showIdleAgents, excludeId, haveAll, haveNoAgentsSelectedOption }],
+		queryKey: ['/v1/livechat/users/agent', { filter, onlyAvailable, showIdleAgents, excludeId, haveAll, haveNoAgentsSelectedOption }],
 		queryFn: async ({ pageParam: offset = 0 }) => {
 			const { users, ...data } = await getAgents({
 				...(filter && { text: filter }),

--- a/apps/meteor/client/views/omnichannel/hooks/useAgentsList.ts
+++ b/apps/meteor/client/views/omnichannel/hooks/useAgentsList.ts
@@ -23,7 +23,7 @@ const DEFAULT_QUERY_LIMIT = 25;
 
 export const useAgentsList = (options: AgentsListOptions) => {
 	const { t } = useTranslation();
-	const getAgents = useEndpoint('GET', '/v1/livechat/users/agent');
+	const getAgents = useEndpoint('GET', '/v1/livechat/users/:type', { type: 'agent' });
 	const {
 		filter,
 		onlyAvailable = false,
@@ -41,7 +41,7 @@ export const useAgentsList = (options: AgentsListOptions) => {
 	});
 
 	return useInfiniteQuery({
-		queryKey: ['/v1/livechat/users/agent', { filter, onlyAvailable, showIdleAgents, excludeId, haveAll, haveNoAgentsSelectedOption }],
+		queryKey: ['/v1/livechat/users/:type', { type: 'agent', filter, onlyAvailable, showIdleAgents, excludeId, haveAll, haveNoAgentsSelectedOption }],
 		queryFn: async ({ pageParam: offset = 0 }) => {
 			const { users, ...data } = await getAgents({
 				...(filter && { text: filter }),

--- a/apps/meteor/client/views/omnichannel/hooks/useAgentsList.ts
+++ b/apps/meteor/client/views/omnichannel/hooks/useAgentsList.ts
@@ -23,7 +23,7 @@ const DEFAULT_QUERY_LIMIT = 25;
 
 export const useAgentsList = (options: AgentsListOptions) => {
 	const { t } = useTranslation();
-	const getAgents = useEndpoint('GET', '/v1/livechat/users/agent');
+	const getAgents = useEndpoint('GET', '/v1/livechat/users/:type', { type: 'agent' });
 	const {
 		filter,
 		onlyAvailable = false,
@@ -41,7 +41,7 @@ export const useAgentsList = (options: AgentsListOptions) => {
 	});
 
 	return useInfiniteQuery({
-		queryKey: ['/v1/livechat/users/agent', { filter, onlyAvailable, showIdleAgents, excludeId, haveAll, haveNoAgentsSelectedOption }],
+		queryKey: ['/v1/livechat/users/:type', { filter, onlyAvailable, showIdleAgents, excludeId, haveAll, haveNoAgentsSelectedOption }],
 		queryFn: async ({ pageParam: offset = 0 }) => {
 			const { users, ...data } = await getAgents({
 				...(filter && { text: filter }),

--- a/apps/meteor/client/views/omnichannel/managers/AddManager.tsx
+++ b/apps/meteor/client/views/omnichannel/managers/AddManager.tsx
@@ -19,8 +19,7 @@ const AddManager = (): ReactElement => {
 
 	const queryClient = useQueryClient();
 
-	const { mutateAsync: saveAction } = useEndpointMutation('POST', '/v1/livechat/users/:type', {
-		keys: { type: 'manager' },
+	const { mutateAsync: saveAction } = useEndpointMutation('POST', '/v1/livechat/users/manager', {
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: omnichannelQueryKeys.managers() });
 			setUsername('');

--- a/apps/meteor/client/views/omnichannel/managers/AddManager.tsx
+++ b/apps/meteor/client/views/omnichannel/managers/AddManager.tsx
@@ -19,7 +19,8 @@ const AddManager = (): ReactElement => {
 
 	const queryClient = useQueryClient();
 
-	const { mutateAsync: saveAction } = useEndpointMutation('POST', '/v1/livechat/users/manager', {
+	const { mutateAsync: saveAction } = useEndpointMutation('POST', '/v1/livechat/users/:type', {
+		keys: { type: 'manager' },
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: omnichannelQueryKeys.managers() });
 			setUsername('');

--- a/apps/meteor/client/views/omnichannel/managers/ManagersTable.tsx
+++ b/apps/meteor/client/views/omnichannel/managers/ManagersTable.tsx
@@ -46,7 +46,7 @@ const ManagersTable = () => {
 		500,
 	);
 
-	const getManagers = useEndpoint('GET', '/v1/livechat/users/:type', { type: 'manager' });
+	const getManagers = useEndpoint('GET', '/v1/livechat/users/manager');
 	const { data, isLoading, isSuccess, isError, refetch } = useQuery({
 		queryKey: omnichannelQueryKeys.managers(query),
 		queryFn: async () => getManagers(query),

--- a/apps/meteor/client/views/omnichannel/managers/ManagersTable.tsx
+++ b/apps/meteor/client/views/omnichannel/managers/ManagersTable.tsx
@@ -46,7 +46,7 @@ const ManagersTable = () => {
 		500,
 	);
 
-	const getManagers = useEndpoint('GET', '/v1/livechat/users/manager');
+	const getManagers = useEndpoint('GET', '/v1/livechat/users/:type', { type: 'manager' });
 	const { data, isLoading, isSuccess, isError, refetch } = useQuery({
 		queryKey: omnichannelQueryKeys.managers(query),
 		queryFn: async () => getManagers(query),

--- a/apps/meteor/client/views/omnichannel/managers/RemoveManagerButton.tsx
+++ b/apps/meteor/client/views/omnichannel/managers/RemoveManagerButton.tsx
@@ -12,8 +12,8 @@ import { omnichannelQueryKeys } from '../../../lib/queryKeys';
 const RemoveManagerButton = ({ _id }: { _id: string }): ReactElement => {
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
-	const { mutateAsync: deleteAction } = useEndpointMutation('DELETE', '/v1/livechat/users/manager/:_id', {
-		keys: { _id },
+	const { mutateAsync: deleteAction } = useEndpointMutation('DELETE', '/v1/livechat/users/:type/:_id', {
+		keys: { type: 'manager', _id },
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: omnichannelQueryKeys.managers() });
 		},

--- a/apps/meteor/client/views/omnichannel/managers/RemoveManagerButton.tsx
+++ b/apps/meteor/client/views/omnichannel/managers/RemoveManagerButton.tsx
@@ -12,8 +12,8 @@ import { omnichannelQueryKeys } from '../../../lib/queryKeys';
 const RemoveManagerButton = ({ _id }: { _id: string }): ReactElement => {
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
-	const { mutateAsync: deleteAction } = useEndpointMutation('DELETE', '/v1/livechat/users/:type/:_id', {
-		keys: { type: 'manager', _id },
+	const { mutateAsync: deleteAction } = useEndpointMutation('DELETE', '/v1/livechat/users/manager/:_id', {
+		keys: { _id },
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: omnichannelQueryKeys.managers() });
 		},

--- a/packages/rest-typings/src/v1/omnichannel.ts
+++ b/packages/rest-typings/src/v1/omnichannel.ts
@@ -4628,34 +4628,6 @@ export type OmnichannelEndpoints = {
 		}>;
 	};
 
-	// Concrete path aliases for useEndpoint() compatibility
-	'/v1/livechat/users/manager': {
-		GET: (
-			params: PaginatedRequest<{ text?: string; fields?: string; onlyAvailable?: boolean; excludeId?: string; showIdleAgents?: boolean }>,
-		) => PaginatedResult<{
-			users: ILivechatAgent[];
-		}>;
-		POST: (params: { username: string }) => { success: boolean };
-	};
-
-	'/v1/livechat/users/agent': {
-		GET: (
-			params: PaginatedRequest<{ text?: string; onlyAvailable?: boolean; excludeId?: string; showIdleAgents?: boolean }>,
-		) => PaginatedResult<{
-			users: (ILivechatAgent & { departments: string[] })[];
-		}>;
-		POST: (params: { username: string }) => { success: boolean };
-	};
-
-	'/v1/livechat/users/manager/:_id': {
-		GET: () => { user: Pick<ILivechatAgent, '_id' | 'username' | 'name' | 'status' | 'statusLivechat' | 'emails' | 'livechat'> | null };
-		DELETE: () => void;
-	};
-	'/v1/livechat/users/agent/:_id': {
-		GET: () => { user: Pick<ILivechatAgent, '_id' | 'username' | 'name' | 'status' | 'statusLivechat' | 'emails' | 'livechat'> };
-		DELETE: () => { success: boolean };
-	};
-
 	'/v1/livechat/visitor': {
 		POST: (params: { visitor: ILivechatVisitorDTO }) => {
 			visitor: ILivechatVisitor;

--- a/packages/rest-typings/src/v1/omnichannel.ts
+++ b/packages/rest-typings/src/v1/omnichannel.ts
@@ -951,90 +951,6 @@ const LivechatDepartmentsByUnitIdSchema = {
 
 export const isLivechatDepartmentsByUnitIdProps = ajv.compile<LivechatDepartmentsByUnitIdProps>(LivechatDepartmentsByUnitIdSchema);
 
-type LivechatUsersManagerGETProps = PaginatedRequest<{
-	text?: string;
-	fields?: string;
-	onlyAvailable?: boolean;
-	excludeId?: string;
-	showIdleAgents?: boolean;
-}>;
-
-const LivechatUsersManagerGETSchema = {
-	type: 'object',
-	properties: {
-		text: {
-			type: 'string',
-			nullable: true,
-		},
-		onlyAvailable: {
-			type: 'boolean',
-			nullable: true,
-		},
-		excludeId: {
-			type: 'string',
-			nullable: true,
-		},
-		showIdleAgents: {
-			type: 'boolean',
-			nullable: true,
-		},
-		count: {
-			type: 'number',
-			nullable: true,
-		},
-		offset: {
-			type: 'number',
-			nullable: true,
-		},
-		sort: {
-			type: 'string',
-			nullable: true,
-		},
-		query: {
-			type: 'string',
-			nullable: true,
-		},
-		fields: {
-			type: 'string',
-			nullable: true,
-		},
-	},
-	required: [],
-	additionalProperties: false,
-};
-
-export const isLivechatUsersManagerGETProps = ajv.compile<LivechatUsersManagerGETProps>(LivechatUsersManagerGETSchema);
-
-type LivechatUsersManagerPOSTProps = PaginatedRequest<{ username: string }>;
-
-const LivechatUsersManagerPOSTSchema = {
-	type: 'object',
-	properties: {
-		username: {
-			type: 'string',
-		},
-		count: {
-			type: 'number',
-			nullable: true,
-		},
-		offset: {
-			type: 'number',
-			nullable: true,
-		},
-		sort: {
-			type: 'string',
-			nullable: true,
-		},
-		query: {
-			type: 'string',
-			nullable: true,
-		},
-	},
-	required: ['username'],
-	additionalProperties: false,
-};
-
-export const isLivechatUsersManagerPOSTProps = ajv.compile<LivechatUsersManagerPOSTProps>(LivechatUsersManagerPOSTSchema);
 
 type LivechatQueueProps = {
 	agentId?: string;
@@ -3041,23 +2957,6 @@ const DELETECannedResponsesPropsSchema = {
 
 export const isDELETECannedResponsesProps = ajv.compile<DELETECannedResponsesProps>(DELETECannedResponsesPropsSchema);
 
-type POSTLivechatUsersTypeProps = {
-	username: string;
-};
-
-const POSTLivechatUsersTypePropsSchema = {
-	type: 'object',
-	properties: {
-		username: {
-			type: 'string',
-		},
-	},
-	required: ['username'],
-	additionalProperties: false,
-};
-
-export const isPOSTLivechatUsersTypeProps = ajv.compile<POSTLivechatUsersTypeProps>(POSTLivechatUsersTypePropsSchema);
-
 type GETLivechatVisitorsPagesVisitedRoomIdParams = PaginatedRequest;
 
 const GETLivechatVisitorsPagesVisitedRoomIdParamsSchema = {
@@ -4729,32 +4628,24 @@ export type OmnichannelEndpoints = {
 		}>;
 	};
 
-	'/v1/livechat/users/:type': {
-		GET: (params: LivechatUsersManagerGETProps) => PaginatedResult<{
-			users: (ILivechatAgent & { departments: string[] })[];
-		}>;
-		POST: (params: POSTLivechatUsersTypeProps) => { success: boolean };
-	};
-
-	'/v1/livechat/users/:type/:_id': {
-		GET: () => { user: Pick<ILivechatAgent, '_id' | 'username' | 'name' | 'status' | 'statusLivechat' | 'emails' | 'livechat'> | null };
-		DELETE: () => void;
-	};
-
 	// For some reason, when using useEndpointData with POST, it's not able to detect the actual type of a path with path params
 	// So, we need to define the type of the path params here
 	'/v1/livechat/users/manager': {
-		GET: (params: LivechatUsersManagerGETProps) => PaginatedResult<{
+		GET: (
+			params: PaginatedRequest<{ text?: string; fields?: string; onlyAvailable?: boolean; excludeId?: string; showIdleAgents?: boolean }>,
+		) => PaginatedResult<{
 			users: ILivechatAgent[];
 		}>;
-		POST: (params: POSTLivechatUsersTypeProps) => { success: boolean };
+		POST: (params: { username: string }) => { user: ILivechatAgent };
 	};
 
 	'/v1/livechat/users/user': {
-		GET: (params: LivechatUsersManagerGETProps) => PaginatedResult<{
+		GET: (
+			params: PaginatedRequest<{ text?: string; fields?: string; onlyAvailable?: boolean; excludeId?: string; showIdleAgents?: boolean }>,
+		) => PaginatedResult<{
 			users: ILivechatAgent[];
 		}>;
-		POST: (params: POSTLivechatUsersTypeProps) => { success: boolean };
+		POST: (params: { username: string }) => { user: ILivechatAgent };
 	};
 	'/v1/livechat/users/manager/:_id': {
 		GET: () => { user: Pick<ILivechatAgent, '_id' | 'username' | 'name' | 'status' | 'statusLivechat' | 'emails' | 'livechat'> | null };
@@ -4771,7 +4662,7 @@ export type OmnichannelEndpoints = {
 		) => PaginatedResult<{
 			users: (ILivechatAgent & { departments: string[] })[];
 		}>;
-		POST: (params: LivechatUsersManagerPOSTProps) => { success: boolean };
+		POST: (params: { username: string }) => { user: ILivechatAgent };
 	};
 
 	'/v1/livechat/users/agent/:_id': {
@@ -4779,7 +4670,7 @@ export type OmnichannelEndpoints = {
 			params?: PaginatedRequest<{
 				text: string;
 			}>,
-		) => { user: Pick<ILivechatAgent, '_id' | 'username' | 'name' | 'status' | 'statusLivechat' | 'emails' | 'livechat'> };
+		) => { user: Pick<ILivechatAgent, '_id' | 'username' | 'name' | 'status' | 'statusLivechat' | 'emails' | 'livechat'> | null };
 		DELETE: () => { success: boolean };
 	};
 

--- a/packages/rest-typings/src/v1/omnichannel.ts
+++ b/packages/rest-typings/src/v1/omnichannel.ts
@@ -4628,6 +4628,34 @@ export type OmnichannelEndpoints = {
 		}>;
 	};
 
+	// Concrete path aliases for useEndpoint() compatibility
+	'/v1/livechat/users/manager': {
+		GET: (
+			params: PaginatedRequest<{ text?: string; fields?: string; onlyAvailable?: boolean; excludeId?: string; showIdleAgents?: boolean }>,
+		) => PaginatedResult<{
+			users: ILivechatAgent[];
+		}>;
+		POST: (params: { username: string }) => { success: boolean };
+	};
+
+	'/v1/livechat/users/agent': {
+		GET: (
+			params: PaginatedRequest<{ text?: string; onlyAvailable?: boolean; excludeId?: string; showIdleAgents?: boolean }>,
+		) => PaginatedResult<{
+			users: (ILivechatAgent & { departments: string[] })[];
+		}>;
+		POST: (params: { username: string }) => { success: boolean };
+	};
+
+	'/v1/livechat/users/manager/:_id': {
+		GET: () => { user: Pick<ILivechatAgent, '_id' | 'username' | 'name' | 'status' | 'statusLivechat' | 'emails' | 'livechat'> | null };
+		DELETE: () => void;
+	};
+	'/v1/livechat/users/agent/:_id': {
+		GET: () => { user: Pick<ILivechatAgent, '_id' | 'username' | 'name' | 'status' | 'statusLivechat' | 'emails' | 'livechat'> };
+		DELETE: () => { success: boolean };
+	};
+
 	'/v1/livechat/visitor': {
 		POST: (params: { visitor: ILivechatVisitorDTO }) => {
 			visitor: ILivechatVisitor;

--- a/packages/rest-typings/src/v1/omnichannel.ts
+++ b/packages/rest-typings/src/v1/omnichannel.ts
@@ -4628,52 +4628,6 @@ export type OmnichannelEndpoints = {
 		}>;
 	};
 
-	// For some reason, when using useEndpointData with POST, it's not able to detect the actual type of a path with path params
-	// So, we need to define the type of the path params here
-	'/v1/livechat/users/manager': {
-		GET: (
-			params: PaginatedRequest<{ text?: string; fields?: string; onlyAvailable?: boolean; excludeId?: string; showIdleAgents?: boolean }>,
-		) => PaginatedResult<{
-			users: ILivechatAgent[];
-		}>;
-		POST: (params: { username: string }) => { user: ILivechatAgent };
-	};
-
-	'/v1/livechat/users/user': {
-		GET: (
-			params: PaginatedRequest<{ text?: string; fields?: string; onlyAvailable?: boolean; excludeId?: string; showIdleAgents?: boolean }>,
-		) => PaginatedResult<{
-			users: ILivechatAgent[];
-		}>;
-		POST: (params: { username: string }) => { user: ILivechatAgent };
-	};
-	'/v1/livechat/users/manager/:_id': {
-		GET: () => { user: Pick<ILivechatAgent, '_id' | 'username' | 'name' | 'status' | 'statusLivechat' | 'emails' | 'livechat'> | null };
-		DELETE: () => void;
-	};
-	'/v1/livechat/users/user/:_id': {
-		GET: () => { user: Pick<ILivechatAgent, '_id' | 'username' | 'name' | 'status' | 'statusLivechat' | 'emails' | 'livechat'> | null };
-		DELETE: () => void;
-	};
-
-	'/v1/livechat/users/agent': {
-		GET: (
-			params: PaginatedRequest<{ text?: string; onlyAvailable?: boolean; excludeId?: string; showIdleAgents?: boolean }>,
-		) => PaginatedResult<{
-			users: (ILivechatAgent & { departments: string[] })[];
-		}>;
-		POST: (params: { username: string }) => { user: ILivechatAgent };
-	};
-
-	'/v1/livechat/users/agent/:_id': {
-		GET: (
-			params?: PaginatedRequest<{
-				text: string;
-			}>,
-		) => { user: Pick<ILivechatAgent, '_id' | 'username' | 'name' | 'status' | 'statusLivechat' | 'emails' | 'livechat'> | null };
-		DELETE: () => { success: boolean };
-	};
-
 	'/v1/livechat/visitor': {
 		POST: (params: { visitor: ILivechatVisitorDTO }) => {
 			visitor: ILivechatVisitor;


### PR DESCRIPTION
## Proposed changes

Migrates the `livechat/users/:type` and `livechat/users/:type/:_id` endpoints from the legacy `addRoute()` pattern to the new OpenAPI-compatible chained route pattern with inline AJV validation schemas.

Resolves: https://github.com/RocketChat/Rocket.Chat-Open-API/issues/150

## Changes

### `apps/meteor/app/livechat/imports/server/rest/users.ts`
- Replaced legacy `API.v1.addRoute()` calls with the new chained `API.v1.get().post().get().delete()` pattern
- Added inline AJV validation schemas for query params, request body, and responses (200/400/401/403)
- Used `ExtractRoutesFromAPI` + `declare module` augmentation for type extraction
- All 4 endpoints migrated: `GET /livechat/users/:type`, `POST /livechat/users/:type`, `GET /livechat/users/:type/:_id`, `DELETE /livechat/users/:type/:_id`

### `packages/rest-typings/src/v1/omnichannel.ts`
- Removed parameterized path types (`/livechat/users/${string}`, `/livechat/users/${string}/${string}`) that were previously in the shared `Endpoints` interface
- Kept concrete path aliases (e.g., `/livechat/users/agent`) for client-side `useEndpoint()` compatibility

### `.changeset/migrate-livechat-users-openapi.md`
- Added changeset with `minor` bump for `@rocket.chat/meteor` and `@rocket.chat/rest-typings`

## Test results
<img width="1069" height="710" alt="image" src="https://github.com/user-attachments/assets/f65a2e34-0ca0-4712-9033-33999ed28744" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAPI-backed request/response validation for livechat user endpoints.
  * Separate manager and user routes with create, list, fetch-by-id, and delete actions; create now accepts a simple username payload.

* **Refactor**
  * Routes reorganized for clearer manager/user separation, improved pagination, filtering, and sensible defaults.
  * Stronger authorization checks and clearer error responses; single-user fetch may return null when not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->