### PR TITLE
fix: Serve Inter font asset properly

### DIFF
--- a/apps/meteor/public/fonts/InterVariable.woff2
+++ b/apps/meteor/public/fonts/InterVariable.woff2
@@ -1,0 +1,1 @@
+../../node_modules/@rocket.chat/fuselage/dist/fonts/InterVariable.woff2


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

It adds a symlink for the server public folder map the Inter font file, used by Fuselage. 

 Task: [ARCH-2053]

[ARCH-2053]: https://rocketchat.atlassian.net/browse/ARCH-2053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ