### PR TITLE
refactor(api): migrate rooms.nameExists endpoint to new API.v1 format

### DIFF
--- a/apps/meteor/app/api/server/v1/rooms.ts
+++ b/apps/meteor/app/api/server/v1/rooms.ts
@@ -104,20 +104,31 @@ export async function findRoomByIdOrName({
 	return room;
 }
 
-API.v1.addRoute(
+const RoomNameExistsEndpoint = API.v1.get(
 	'rooms.nameExists',
 	{
 		authRequired: true,
-		validateParams: isGETRoomsNameExists,
-	},
-	{
-		async get() {
-			const { roomName } = this.queryParams;
-
-			const room = await Rooms.findOneByName(roomName, { projection: { _id: 1 } });
-
-			return API.v1.success({ exists: !!room });
+		query: isGETRoomsNameExists,
+		response: {
+			200: ajv.compile({
+				type: 'object',
+				properties: {
+					exists: { type: 'boolean' },
+					success: { type: 'boolean', enum: [true] },
+				},
+				required: ['exists', 'success'],
+				additionalProperties: false,
+			}),
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
 		},
+	},
+	async function action() {
+		const { roomName } = this.queryParams;
+
+		const room = await Rooms.findOneByName(roomName, { projection: { _id: 1 } });
+
+		return API.v1.success({ exists: !!room });
 	},
 );
 
@@ -1238,7 +1249,8 @@ export const roomEndpoints = API.v1
 type RoomEndpoints = ExtractRoutesFromAPI<typeof roomEndpoints> &
 	ExtractRoutesFromAPI<typeof roomEndpoints> &
 	ExtractRoutesFromAPI<typeof roomDeleteEndpoint> &
-	ExtractRoutesFromAPI<typeof roomsSaveNotificationEndpoint>;
+	ExtractRoutesFromAPI<typeof roomsSaveNotificationEndpoint> &
+	ExtractRoutesFromAPI<typeof RoomNameExistsEndpoint>;
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface

--- a/packages/rest-typings/src/v1/rooms.ts
+++ b/packages/rest-typings/src/v1/rooms.ts
@@ -800,12 +800,6 @@ export type RoomsEndpoints = {
 		}) => { message: IMessage | null };
 	};
 
-	'/v1/rooms.nameExists': {
-		GET: (params: { roomName: string }) => {
-			exists: boolean;
-		};
-	};
-
 	'/v1/rooms.get': {
 		GET: (params: { updatedSince: string }) => {
 			update: IRoom[];


### PR DESCRIPTION
## Description

This PR migrates the `rooms.nameExists` endpoint from the deprecated
`API.v1.addRoute` format to the new `API.v1.get` route declaration.

The migration aligns the endpoint with the current REST API standards
used across the Rocket.Chat codebase.

## Changes

- Replaced `API.v1.addRoute` with `API.v1.get`
- Added AJV validation for the query parameter (`roomName`)
- Added response schema validation
- Preserved existing endpoint behavior and response structure

## Related Request

```http
GET /api/v1/rooms.nameExists?roomName=general
```
## Successful run
<img width="1077" height="82" alt="image" src="https://github.com/user-attachments/assets/41353854-190a-44e7-b15a-e5d71d83b1ba" />

fixes #39588



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured rooms.nameExists API endpoint with explicit authentication requirements and clearly defined response schemas for HTTP 200, 400, and 401 statuses.
  * Updated endpoint implementation with enhanced input validation and standardized response formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->