### PR TITLE
chore: migrate chat.getMentionedMessages endpoint to new OpenAPI pattern with AJV validation

### DIFF
--- a/.changeset/migrate-chat-getMentionedMessages-to-openapi.md
+++ b/.changeset/migrate-chat-getMentionedMessages-to-openapi.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/meteor': minor
+'@rocket.chat/rest-typings': minor
+---
+
+Migrated chat.getMentionedMessages endpoint to new OpenAPI pattern with AJV validation

--- a/apps/meteor/app/api/server/v1/chat.ts
+++ b/apps/meteor/app/api/server/v1/chat.ts
@@ -1,5 +1,5 @@
 import { Message } from '@rocket.chat/core-services';
-import type { IMessage, IThreadMainMessage } from '@rocket.chat/core-typings';
+import type { IMessage, IThreadMainMessage, IRoom } from '@rocket.chat/core-typings';
 import { MessageTypes } from '@rocket.chat/message-types';
 import { Messages, Users, Rooms, Subscriptions } from '@rocket.chat/models';
 import {
@@ -16,7 +16,6 @@ import {
 	isChatSendMessageProps,
 	isChatIgnoreUserProps,
 	isChatGetPinnedMessagesProps,
-	isChatGetMentionedMessagesProps,
 	isChatReactProps,
 	isChatGetDeletedMessagesProps,
 	isChatSyncThreadsListProps,
@@ -274,6 +273,39 @@ const ChatUnpinMessageSchema = {
 const isChatPinMessageProps = ajv.compile<ChatPinMessage>(ChatPinMessageSchema);
 
 const isChatUnpinMessageProps = ajv.compile<ChatUnpinMessage>(ChatUnpinMessageSchema);
+
+type GetMentionedMessages = {
+	roomId: IRoom['_id'];
+	count?: number;
+	offset?: number;
+	sort?: string;
+};
+
+const GetMentionedMessagesSchema = {
+	type: 'object',
+	properties: {
+		roomId: {
+			type: 'string',
+			minLength: 1,
+		},
+		count: {
+			type: 'number',
+			nullable: true,
+		},
+		offset: {
+			type: 'number',
+			nullable: true,
+		},
+		sort: {
+			type: 'string',
+			nullable: true,
+		},
+	},
+	required: ['roomId'],
+	additionalProperties: false,
+};
+
+const isChatGetMentionedMessagesLocalProps = ajv.compile<GetMentionedMessages>(GetMentionedMessagesSchema);
 
 const chatEndpoints = API.v1
 	.post(
@@ -557,6 +589,51 @@ const chatEndpoints = API.v1
 			await unfollowMessage(this.user, { mid });
 
 			return API.v1.success();
+		},
+	)
+	.get(
+		'chat.getMentionedMessages',
+		{
+			authRequired: true,
+			query: isChatGetMentionedMessagesLocalProps,
+			response: {
+				200: ajv.compile<{
+					messages: IMessage[];
+					count: number;
+					offset: number;
+					total: number;
+					success: boolean;
+				}>({
+					type: 'object',
+					properties: {
+						messages: { type: 'array' },
+						count: { type: 'number' },
+						offset: { type: 'number' },
+						total: { type: 'number' },
+						success: { type: 'boolean', enum: [true] },
+					},
+					required: ['messages', 'count', 'offset', 'total', 'success'],
+					additionalProperties: false,
+				}),
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+			},
+		},
+		async function action() {
+			const { roomId } = this.queryParams;
+			const { sort } = await this.parseJsonQuery();
+			const { offset, count } = await getPaginationItems(this.queryParams);
+
+			const messages = await findMentionedMessages({
+				uid: this.userId,
+				roomId,
+				pagination: {
+					offset,
+					count,
+					sort,
+				},
+			});
+			return API.v1.success(messages);
 		},
 	);
 
@@ -953,30 +1030,6 @@ API.v1.addRoute(
 					remove: await Messages.trashFindDeletedAfter(updatedSinceDate, { ...query, tmid }, { projection: fields, sort }).toArray(),
 				},
 			});
-		},
-	},
-);
-
-API.v1.addRoute(
-	'chat.getMentionedMessages',
-	{ authRequired: true, validateParams: isChatGetMentionedMessagesProps },
-	{
-		async get() {
-			const { roomId } = this.queryParams;
-			const { sort } = await this.parseJsonQuery();
-			const { offset, count } = await getPaginationItems(this.queryParams);
-
-			const messages = await findMentionedMessages({
-				uid: this.userId,
-				roomId,
-				pagination: {
-					offset,
-					count,
-					sort,
-				},
-			});
-
-			return API.v1.success(messages);
 		},
 	},
 );

--- a/packages/rest-typings/src/v1/chat.ts
+++ b/packages/rest-typings/src/v1/chat.ts
@@ -562,39 +562,6 @@ const GetPinnedMessagesSchema = {
 
 export const isChatGetPinnedMessagesProps = ajv.compile<GetPinnedMessages>(GetPinnedMessagesSchema);
 
-type GetMentionedMessages = {
-	roomId: IRoom['_id'];
-	count?: number;
-	offset?: number;
-	sort?: string;
-};
-
-const GetMentionedMessagesSchema = {
-	type: 'object',
-	properties: {
-		roomId: {
-			type: 'string',
-			minLength: 1,
-		},
-		count: {
-			type: 'number',
-			nullable: true,
-		},
-		offset: {
-			type: 'number',
-			nullable: true,
-		},
-		sort: {
-			type: 'string',
-			nullable: true,
-		},
-	},
-	required: ['roomId'],
-	additionalProperties: false,
-};
-
-export const isChatGetMentionedMessagesProps = ajv.compile<GetMentionedMessages>(GetMentionedMessagesSchema);
-
 type ChatSyncMessages = {
 	roomId: IRoom['_id'];
 	lastUpdate?: string;
@@ -956,14 +923,6 @@ export type ChatEndpoints = {
 	};
 	'/v1/chat.getPinnedMessages': {
 		GET: (params: GetPinnedMessages) => {
-			messages: IMessage[];
-			count: number;
-			offset: number;
-			total: number;
-		};
-	};
-	'/v1/chat.getMentionedMessages': {
-		GET: (params: GetMentionedMessages) => {
 			messages: IMessage[];
 			count: number;
 			offset: number;


### PR DESCRIPTION


<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

Migrated `chat.getMentionedMessages` endpoint from legacy `addRoute` pattern to the new chained API definition style with AJV validation and OpenAPI documentation support

- Replaced `addRoute` with new `.get()` chained pattern
- Added AJV schema validation for query params ( `roomId` , `count` , `offset` , `sort` )
- Added response validation for 200, 400, 401
- Removed manual validation checks since AJV handles them automatically
- Removed old manual typings from `rest-typings`

## Issue(s)
https://github.com/RocketChat/Rocket.Chat-Open-API/pull/150

## Steps to test or reproduce
1. Sent a GET request to `/api/v1/chat.getMentionedMessages` with valid `roomId`
2. Verify it returns 200 with `messages` , `count` , `offset` , `total`
3. Sent without `roomId` and verify 400 error returns
4. Send with invalid `roomId` and verify 400 error returns
5. Check Swagger UI shows endpoint documentation correctly

Swagger UI - chat.getMentionedMessages (200)
<img width="1822" height="902" alt="image" src="https://github.com/user-attachments/assets/e6416fd4-16b3-4b81-813f-9b2a0f2a079d" />

Swagger UI - chat.getMentionedMessages (400)
<img width="1837" height="747" alt="image" src="https://github.com/user-attachments/assets/f7dd35d9-3e87-4de1-9987-7ea24d21e9c6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated the `chat.getMentionedMessages` endpoint to use a new OpenAPI validation pattern, consolidating API validation logic and improving consistency across the API infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->