### PR TITLE
refactor(api): migrate statistics endpoints to chained API pattern

### DIFF
--- a/apps/meteor/app/api/server/v1/stats.ts
+++ b/apps/meteor/app/api/server/v1/stats.ts
@@ -1,13 +1,64 @@
+import type { IStats } from '@rocket.chat/core-typings';
+import type { PaginatedResult } from '@rocket.chat/rest-typings';
+import {
+	ajv,
+	isStatisticsProps,
+	isStatisticsListProps,
+	validateUnauthorizedErrorResponse,
+	validateBadRequestErrorResponse,
+} from '@rocket.chat/rest-typings';
+
 import { getStatistics, getLastStatistics } from '../../../statistics/server';
 import telemetryEvent from '../../../statistics/server/lib/telemetryEvents';
+import type { ExtractRoutesFromAPI } from '../ApiClass';
 import { API } from '../api';
 import { getPaginationItems } from '../helpers/getPaginationItems';
 
-API.v1.addRoute(
-	'statistics',
-	{ authRequired: true },
-	{
-		async get() {
+type TelemetryBody = {
+	params?: { eventName: string; [key: string]: unknown }[];
+};
+
+const TelemetryBodySchema = {
+	type: 'object',
+	properties: {
+		params: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					eventName: { type: 'string' },
+				},
+				required: ['eventName'],
+				additionalProperties: true,
+			},
+			nullable: true,
+		},
+	},
+	additionalProperties: true,
+};
+
+const isTelemetryBody = ajv.compile<TelemetryBody>(TelemetryBodySchema);
+
+const statsEndpoints = API.v1
+	.get(
+		'statistics',
+		{
+			authRequired: true,
+			query: isStatisticsProps,
+			response: {
+				200: ajv.compile<IStats & { success: true }>({
+					type: 'object',
+					additionalProperties: true,
+					properties: {
+						success: { type: 'boolean', enum: [true] },
+					},
+					required: ['success'],
+				}),
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+			},
+		},
+		async function action() {
 			const { refresh = 'false' } = this.queryParams;
 
 			return API.v1.success(
@@ -17,14 +68,30 @@ API.v1.addRoute(
 				}),
 			);
 		},
-	},
-);
-
-API.v1.addRoute(
-	'statistics.list',
-	{ authRequired: true },
-	{
-		async get() {
+	)
+	.get(
+		'statistics.list',
+		{
+			authRequired: true,
+			query: isStatisticsListProps,
+			response: {
+				200: ajv.compile<PaginatedResult<{ statistics: IStats[] }>>({
+					type: 'object',
+					properties: {
+						statistics: { type: 'array', items: { type: 'object', additionalProperties: true } },
+						count: { type: 'number' },
+						offset: { type: 'number' },
+						total: { type: 'number' },
+						success: { type: 'boolean', enum: [true] },
+					},
+					required: ['statistics', 'count', 'offset', 'total', 'success'],
+					additionalProperties: false,
+				}),
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+			},
+		},
+		async function action() {
 			const { offset, count } = await getPaginationItems(this.queryParams);
 			const { sort, fields, query } = await this.parseJsonQuery();
 
@@ -41,22 +108,40 @@ API.v1.addRoute(
 				}),
 			);
 		},
-	},
-);
-
-API.v1.addRoute(
-	'statistics.telemetry',
-	{ authRequired: true },
-	{
-		post() {
+	)
+	.post(
+		'statistics.telemetry',
+		{
+			authRequired: true,
+			body: isTelemetryBody,
+			response: {
+				200: ajv.compile<void>({
+					type: 'object',
+					properties: {
+						success: { type: 'boolean', enum: [true] },
+					},
+					required: ['success'],
+					additionalProperties: false,
+				}),
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+			},
+		},
+		function action() {
 			const events = this.bodyParams;
 
 			events?.params?.forEach((event) => {
 				const { eventName, ...params } = event;
-				void telemetryEvent.call(eventName, params);
+				void telemetryEvent.call(eventName as import('@rocket.chat/core-services').TelemetryEvents, params as any);
 			});
 
 			return API.v1.success();
 		},
-	},
-);
+	);
+
+export type StatsEndpoints = ExtractRoutesFromAPI<typeof statsEndpoints>;
+
+declare module '@rocket.chat/rest-typings' {
+	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
+	interface Endpoints extends StatsEndpoints {}
+}

--- a/packages/rest-typings/src/index.ts
+++ b/packages/rest-typings/src/index.ts
@@ -257,5 +257,7 @@ export * from './v1/cloud';
 export * from './v1/banners';
 export * from './default';
 
+export * from './v1/statistics';
+
 // Export the ajv instance for use in other packages
 export * from './v1/Ajv';


### PR DESCRIPTION
## Summary

Migrates all 3 statistics-related REST API endpoints from the legacy `API.v1.addRoute()` pattern to the new chained router API with full AJV validation and typed response schemas.

### Endpoints migrated:
- **`GET statistics`** — with `isStatisticsProps` query validator and typed `IStats` response
- **`GET statistics.list`** — with `isStatisticsListProps` query validator and paginated response schema
- **`POST statistics.telemetry`** — with new `isTelemetryBody` AJV validator and void response schema

### Changes:
- **`apps/meteor/app/api/server/v1/stats.ts`**: Converted all 3 `addRoute` calls to chained `.get()/.post()` pattern with response schemas for 200, 400, and 401 status codes
- **`packages/rest-typings/src/index.ts`**: Added `export * from './v1/statistics'` to re-export existing validators (`isStatisticsProps`, `isStatisticsListProps`)
- Uses `ExtractRoutesFromAPI` + module augmentation for automatic type inference
- Created local `isTelemetryBody` AJV validator for the telemetry endpoint body params

## Test plan
- [ ] Verify `GET /api/v1/statistics` returns stats with proper validation
- [ ] Verify `GET /api/v1/statistics.list` returns paginated results
- [ ] Verify `POST /api/v1/statistics.telemetry` accepts valid telemetry payloads
- [ ] Verify invalid params return 400 with proper error messages
- [ ] Verify unauthenticated requests return 401
- [ ] TypeScript compilation passes with no new errors

Part of #38876

cc @ggazzo — would appreciate your review on this migration batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new telemetry event submission endpoint for reporting application metrics.

* **Improvements**
  * Consolidated statistics API routes into a unified endpoint structure with improved organization.
  * Enhanced type safety and validation for API requests and responses.
  * Extended the public REST API surface with additional type exports for better developer integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->