### PR TITLE
refactor(api): migrate commands endpoints to chained API pattern

### DIFF
--- a/apps/meteor/app/api/server/v1/commands.ts
+++ b/apps/meteor/app/api/server/v1/commands.ts
@@ -46,7 +46,6 @@ const CommandsListParamsSchema = {
 		offset: { type: 'number', nullable: true },
 		sort: { type: 'string', nullable: true },
 		query: { type: 'string', nullable: true },
-		fields: { type: 'string', nullable: true },
 	},
 	required: [],
 	additionalProperties: false,
@@ -344,13 +343,14 @@ const commandsEndpoints = API.v1
 					required: ['commands', 'appsLoaded', 'offset', 'count', 'total', 'success'],
 					additionalProperties: false,
 				}),
+				400: validateBadRequestErrorResponse,
 				401: validateUnauthorizedErrorResponse,
 			},
 		},
 		async function action() {
 			if (!Apps.self?.isLoaded()) {
 				return {
-					statusCode: 202 as const, // Accepted - apps are not ready, so the list is incomplete. Retry later
+					statusCode: 202 as const,
 					body: {
 						success: true as const,
 						commands: [] as object[],


### PR DESCRIPTION
## Summary

Migrates the remaining 4 commands-related REST API endpoints from the legacy `API.v1.addRoute()` pattern to the new chained router API with full AJV validation and typed response schemas.

### Endpoints migrated:
- **`GET commands.list`** — with new `isCommandsListParams` query validator; handles special 202 status when apps aren't loaded
- **`POST commands.run`** — with new `isCommandsRunBody` body validator for command execution
- **`GET commands.preview`** — with new `isCommandsPreviewQuery` query validator for fetching slash command previews
- **`POST commands.preview`** — with new `isCommandsPreviewBody` body validator for executing preview items

### Changes:
- **`apps/meteor/app/api/server/v1/commands.ts`**: Converted all 4 remaining `addRoute` calls to chained pattern, merged with existing `commands.get` endpoint
- Created 4 new local AJV validators: `isCommandsListParams`, `isCommandsRunBody`, `isCommandsPreviewQuery`, `isCommandsPreviewBody`
- Special handling for `commands.list` 202 status code (apps not loaded) with dedicated response schema
- Preserved the existing `processQueryOptionsOnResult` helper function
- Uses `ExtractRoutesFromAPI` + module augmentation for automatic type inference

### Notable implementation details:
- `commands.list` returns 202 when apps aren't loaded, requiring a dedicated 202 response schema alongside the standard 200
- `commands.preview` POST casts `previewItem` to `SlashCommandPreviewItem` for type compatibility
- `commands.preview` GET handles potentially undefined preview with fallback: `preview ?? { i18nTitle: '', items: [] }`

## Test plan
- [ ] Verify `GET /api/v1/commands.list` returns paginated command list
- [ ] Verify `GET /api/v1/commands.list` returns 202 when apps not loaded
- [ ] Verify `POST /api/v1/commands.run` executes slash commands
- [ ] Verify `GET /api/v1/commands.preview` returns command previews
- [ ] Verify `POST /api/v1/commands.preview` executes preview items
- [ ] Verify existing `GET /api/v1/commands.get` still works
- [ ] Verify invalid params return 400 with proper error messages
- [ ] TypeScript compilation passes with no new errors

Part of #38876

cc @ggazzo — would appreciate your review on this migration batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Improvements**
  * Consolidated commands endpoints for list, run, and preview into a single consistent surface.
  * Added request validators and standardized request/response schemas; broadened accepted payloads and explicit success indicators.
  * Returns 202 when apps aren’t ready and supports richer list query options (pagination, sorting, filtering).

* **Bug Fixes**
  * Improved forbidden/access-denied responses with clearer, specific error messages and consistent handling across endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->