### PR TITLE
fix: narrow IModerationReport ts type from Date | string to Date

### DIFF
--- a/.changeset/fix-moderation-audit-ts-type.md
+++ b/.changeset/fix-moderation-audit-ts-type.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/core-typings": patch
+"@rocket.chat/meteor": patch
+---
+
+fix: narrow IModerationReport `ts` type from `Date | string` to `Date` to resolve AJV oneOf validation failure

--- a/apps/meteor/app/api/server/v1/moderation.ts
+++ b/apps/meteor/app/api/server/v1/moderation.ts
@@ -21,12 +21,6 @@ import { getPaginationItems } from '../helpers/getPaginationItems';
 
 type ReportMessage = Pick<IModerationReport, '_id' | 'message' | 'ts' | 'room'>;
 
-// TODO: IModerationAudit defines `ts` as `Date | string` which generates a oneOf in JSON Schema.
-// When the aggregation returns `ts` as an ISO date string, it matches both `Date` (format: "date-time")
-// and `string` schemas simultaneously, causing AJV oneOf validation to fail with "passingSchemas: 0,1".
-// Until the core-typings type is revised (either narrowing `ts` to `string` to match what MongoDB
-// aggregation actually returns, or adjusting the AJV schema generation for union types), we use a
-// relaxed inline schema here that accepts `ts` as a string.
 const paginatedReportsResponseSchema = ajv.compile<{ reports: IModerationAudit[]; count: number; offset: number; total: number }>({
 	type: 'object',
 	properties: {
@@ -59,12 +53,6 @@ const paginatedReportsResponseSchema = ajv.compile<{ reports: IModerationAudit[]
 	additionalProperties: false,
 });
 
-// TODO: IModerationAudit defines `ts` as `Date | string` which generates a oneOf in JSON Schema.
-// When the aggregation returns `ts` as an ISO date string, it matches both `Date` (format: "date-time")
-// and `string` schemas simultaneously, causing AJV oneOf validation to fail with "passingSchemas: 0,1".
-// Until the core-typings type is revised (either narrowing `ts` to `string` to match what MongoDB
-// aggregation actually returns, or adjusting the AJV schema generation for union types), we use a
-// relaxed inline schema here that accepts `ts` as a string.
 const paginatedUserReportsResponseSchema = ajv.compile<{
 	reports: (Pick<UserReport, '_id' | 'reportedUser' | 'ts'> & { count: number })[];
 	count: number;
@@ -115,12 +103,6 @@ const reportedMessagesResponseSchema = ajv.compile<{
 	additionalProperties: false,
 });
 
-// TODO: IModerationAudit defines `ts` as `Date | string` which generates a oneOf in JSON Schema.
-// When the aggregation returns `ts` as an ISO date string, it matches both `Date` (format: "date-time")
-// and `string` schemas simultaneously, causing AJV oneOf validation to fail with "passingSchemas: 0,1".
-// Until the core-typings type is revised (either narrowing `ts` to `string` to match what MongoDB
-// aggregation actually returns, or adjusting the AJV schema generation for union types), we use a
-// relaxed inline schema here that accepts `ts` as a string.
 const reportsByUserIdResponseSchema = ajv.compile<{
 	user: IUser | null;
 	reports: IModerationReport[];
@@ -148,12 +130,6 @@ const successResponseSchema = ajv.compile<void>({
 	additionalProperties: false,
 });
 
-// TODO: IModerationAudit defines `ts` as `Date | string` which generates a oneOf in JSON Schema.
-// When the aggregation returns `ts` as an ISO date string, it matches both `Date` (format: "date-time")
-// and `string` schemas simultaneously, causing AJV oneOf validation to fail with "passingSchemas: 0,1".
-// Until the core-typings type is revised (either narrowing `ts` to `string` to match what MongoDB
-// aggregation actually returns, or adjusting the AJV schema generation for union types), we use a
-// relaxed inline schema here that accepts `ts` as a string.
 const reportInfoResponseSchema = ajv.compile<{ report: IModerationReport | null }>({
 	type: 'object',
 	properties: {
@@ -503,12 +479,6 @@ API.v1.post(
 	},
 );
 
-// TODO: IModerationAudit defines `ts` as `Date | string` which generates a oneOf in JSON Schema.
-// When the aggregation returns `ts` as an ISO date string, it matches both `Date` (format: "date-time")
-// and `string` schemas simultaneously, causing AJV oneOf validation to fail with "passingSchemas: 0,1".
-// Until the core-typings type is revised (either narrowing `ts` to `string` to match what MongoDB
-// aggregation actually returns, or adjusting the AJV schema generation for union types), we use a
-// relaxed inline schema here that accepts `ts` as a string.
 const reportsByMsgIdResponseSchema = ajv.compile<{
 	reports: Pick<IModerationReport, '_id' | 'description' | 'reportedBy' | 'ts' | 'room'>[];
 	count: number;

--- a/docs/api-endpoint-migration.md
+++ b/docs/api-endpoint-migration.md
@@ -417,28 +417,9 @@ For these cases, keep using `{ type: 'object' }` as a placeholder.
 
 ### Known Pitfall: `Date | string` unions
 
-Some core-typings define timestamp fields as `Date | string` (e.g., `IModerationAudit.ts`, `IModerationReport.ts`). When typia generates the JSON Schema for these fields, it creates a `oneOf` with two branches: one for `Date` (which maps to `{ type: "string", format: "date-time" }`) and one for `string` (which maps to `{ type: "string" }`).
+When core-typings define timestamp fields as `Date | string`, typia generates a JSON Schema `oneOf` with two branches: `{ type: "string", format: "date-time" }` and `{ type: "string" }`. An ISO date string satisfies **both** schemas simultaneously, causing AJV to fail with `passingSchemas: 0,1`.
 
-The problem: an ISO date string like `"2026-03-11T16:07:21.755Z"` satisfies **both** schemas simultaneously, causing AJV to fail with:
-
-```
-must match exactly one schema in oneOf (passingSchemas: 0,1)
-```
-
-This happens because `oneOf` requires **exactly one** match, but the value is both a valid `date-time` string and a valid `string`.
-
-**Workaround**: Use a relaxed inline schema instead of `$ref` for these types, defining `ts` as `{ type: 'string' }`. Add a `TODO` comment referencing this issue so it can be tracked:
-
-```typescript
-// TODO: IModerationAudit defines `ts` as `Date | string` which generates a oneOf in JSON Schema.
-// When the aggregation returns `ts` as an ISO date string, it matches both `Date` (format: "date-time")
-// and `string` schemas simultaneously, causing AJV oneOf validation to fail with "passingSchemas: 0,1".
-// Until the core-typings type is revised (either narrowing `ts` to `string` to match what MongoDB
-// aggregation actually returns, or adjusting the AJV schema generation for union types), we use a
-// relaxed inline schema here that accepts `ts` as a string.
-```
-
-**Long-term fix**: Revise the core-typings to narrow `ts` to `string` (which is what MongoDB aggregation pipelines and `JSON.stringify` actually return), or adjust the AJV/typia schema generation to handle `Date | string` unions correctly (e.g., using `anyOf` instead of `oneOf`, or collapsing `Date` into `string`).
+**Fix**: Narrow the type to `Date` in core-typings. MongoDB stores timestamps as `Date` objects, and JSON serialization produces ISO date strings that correctly match the `date-time` format schema. This was applied to `IModerationReport.ts` in [#39551](https://github.com/RocketChat/Rocket.Chat/issues/39551).
 
 ### Adding a new type to typia
 

--- a/packages/core-typings/src/IModerationReport.ts
+++ b/packages/core-typings/src/IModerationReport.ts
@@ -8,7 +8,7 @@ export interface IModerationReport extends IRocketChatRecord {
 	room?: Pick<IRoom, '_id' | 'name' | 'fname' | 't' | 'federated' | 'prid'>;
 	reportedUser?: Pick<IUser, '_id' | 'username' | 'name' | 'emails' | 'createdAt'>;
 	description: string;
-	ts: Date | string;
+	ts: Date;
 	reportedBy: Pick<IUser, '_id' | 'username' | 'name' | 'createdAt'>;
 	/**
 	 * Right now we're assuming neither Room Info or User Info changes.


### PR DESCRIPTION
<!-- This is a pull request template. -->
<!-- Use the title to describe PR changes in the imperative mood. -->

## Proposed changes (including videos or screenshots)

Narrows the `ts` type on `IModerationReport` from `Date | string` to `Date`, fixing the AJV `oneOf` validation failure described in #39551.

### Changes:

1. **`packages/core-typings/src/IModerationReport.ts`** - Changed `ts: Date | string` to `ts: Date`
2. **`apps/meteor/app/api/server/v1/moderation.ts`** - Removed 5 TODO workaround comment blocks (30 lines) that documented the `oneOf` issue
3. **`docs/api-endpoint-migration.md`** - Updated "Known Pitfall" section to document the fix
4. **`.changeset/fix-moderation-audit-ts-type.md`** - Added changeset for `@rocket.chat/core-typings` and `@rocket.chat/meteor`

### Root cause

`IModerationReport.ts` defined `ts: Date | string`. When typia generates JSON Schema from this union, it creates a `oneOf` with:
- `{ type: "string", format: "date-time" }` (for `Date`)
- `{ type: "string" }` (for `string`)

An ISO date string like `"2026-03-11T16:07:21.755Z"` matches **both** branches, causing AJV `oneOf` to fail with `passingSchemas: 0,1`.

### Why `Date` is correct

- Reports are always created with `ts: new Date()` (both `createWithMessageDescriptionAndUserId` and `createWithDescriptionAndUser` in `ModerationReports.ts`)
- MongoDB stores `ts` as a native `Date` object
- JSON serialization produces ISO strings that match `date-time` format validation

Resolves #39551

## Issue(s)

Closes #39551

## Steps to test or reproduce

1. Apply the type change
2. Verify that moderation API endpoints (`moderation.reportsByUsers`, `moderation.userReports`, etc.) no longer fail AJV validation when returning reports with ISO date string `ts` fields

## Further comments

The inline AJV schemas in `moderation.ts` (which manually define `ts: { type: 'string' }`) remain functionally correct and are kept as-is. The TODO workaround comments are removed since the root cause is now fixed at the type level.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation issues in moderation reports with improved date type handling to enhance API reliability and data consistency.

* **Documentation**
  * Updated API migration documentation to reflect moderation report date type improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->