### PR TITLE
fix: add missing BlockContext argument to renderTextObject in SectionBlock

### DIFF
--- a/.changeset/fix-sectionblock-missing-context.md
+++ b/.changeset/fix-sectionblock-missing-context.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/fuselage-ui-kit": patch
+---
+
+fix: add missing BlockContext argument to renderTextObject in SectionBlock

--- a/packages/fuselage-ui-kit/src/blocks/SectionBlock.tsx
+++ b/packages/fuselage-ui-kit/src/blocks/SectionBlock.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Grid, GridItem } from '@rocket.chat/fuselage';
-import type * as UiKit from '@rocket.chat/ui-kit';
+import * as UiKit from '@rocket.chat/ui-kit';
 import type { ReactElement } from 'react';
 import { memo, useMemo } from 'react';
 
@@ -28,7 +28,7 @@ const SectionBlock = ({ className, block, surfaceRenderer }: SectionBlockProps):
 			<GridItem>
 				{text && (
 					<Box is='span' fontScale='p2' color='default'>
-						{surfaceRenderer.renderTextObject(text, 0)}
+						{surfaceRenderer.renderTextObject(text, 0, UiKit.BlockContext.NONE)}
 					</Box>
 				)}
 				{fields && <Fields fields={fields} surfaceRenderer={surfaceRenderer} />}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Adds the missing third `context` argument to the `renderTextObject` call in `SectionBlock.tsx`, fixing the TypeScript build error introduced by #39268.

### Changes:

1. **`packages/fuselage-ui-kit/src/blocks/SectionBlock.tsx`**:
   - Changed `import type * as UiKit` to `import * as UiKit` (runtime import needed for `BlockContext` const enum)
   - Added `UiKit.BlockContext.NONE` as the third argument to `surfaceRenderer.renderTextObject(text, 0, UiKit.BlockContext.NONE)`

### Context

After the refactor in #39268 (`refactor(ui-kit): Remove UiKit deprecations`), the `renderTextObject` signature changed to require 3 arguments: `(textObject, index, context)`. The `SectionBlock.tsx` call was the only one in `fuselage-ui-kit` that wasn't updated — every other call (in `ActionsBlock`, `CalloutBlock`, `ImageBlock`, `InputBlock`, `ButtonElement`, `SectionBlock.Fields`, etc.) already passes `UiKit.BlockContext.NONE` as the third argument.

## Issue(s)

Closes #39493

## Steps to test or reproduce

1. Checkout `develop` branch before this fix
2. Run `yarn dev` — observe `TS2554: Expected 3 arguments, but got 2` in `SectionBlock.tsx`
3. Apply this fix
4. Run `yarn dev` — `@rocket.chat/fuselage-ui-kit` compiles with 0 errors

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Patched the SectionBlock component to include a previously missing context argument in text rendering operations. This fix ensures the component maintains proper context state throughout block operations, preventing rendering errors and improving overall stability of section block displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->