### PR TITLE
fix: prevent global Escape key from resetting Navbar search when inactive

### DIFF
--- a/.changeset/fix-escape-key-search.md
+++ b/.changeset/fix-escape-key-search.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+fix: prevent global Escape key from resetting Navbar search when search is not active

--- a/apps/meteor/client/navbar/NavBarSearch/NavBarSearch.tsx
+++ b/apps/meteor/client/navbar/NavBarSearch/NavBarSearch.tsx
@@ -62,6 +62,9 @@ const NavBarSearch = () => {
 				setFocus('filterText');
 			},
 			'Escape': (event) => {
+				if (triggerRef.current !== document.activeElement && !state.isOpen) {
+					return;
+				}
 				event.preventDefault();
 				handleEscSearch();
 			},
@@ -70,7 +73,7 @@ const NavBarSearch = () => {
 		return (): void => {
 			unsubscribe();
 		};
-	}, [focusManager, handleEscSearch, setFocus]);
+	}, [focusManager, handleEscSearch, setFocus, state.isOpen]);
 
 	return (
 		<FormProvider {...methods}>


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Prevents the global Escape key handler from resetting the Navbar search when the search is not active.

### Root cause

The `tinykeys` Escape handler in `NavBarSearch.tsx` was attached globally to `window` without any guard. Pressing Escape anywhere in the app (e.g., while typing in the chat input) would trigger `handleEscSearch()`, resetting the search state unnecessarily.

### Fix

Added a guard condition that checks whether the search is actually active before handling the Escape key:

```tsx
'Escape': (event) => {
    if (triggerRef.current !== document.activeElement && !state.isOpen) {
        return;
    }
    event.preventDefault();
    handleEscSearch();
},
```

The Escape key now only resets the search when:
- The search input is focused (`triggerRef.current === document.activeElement`), OR
- The search dropdown is open (`state.isOpen`)

## Issue(s)

Closes #39462

## Steps to test or reproduce

1. Open the Rocket.Chat app
2. **Do not** open the Navbar search
3. Focus the chat input
4. Press Escape
5. **Before**: Escape triggers `handleEscSearch()` even when search is inactive
6. **After**: Escape has no effect on the search when it's not active

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where pressing the Escape key would reset the Navbar search even when the search feature was not actively in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->