### PR TITLE
fix: ensure login expiration setting is applied before token cleanup runs

### DIFF
--- a/apps/meteor/app/authentication/server/startup/index.js
+++ b/apps/meteor/app/authentication/server/startup/index.js
@@ -41,6 +41,19 @@ Accounts.config({
  */
 Object.assign(Accounts._defaultPublishFields.projection, (({ status, ...rest }) => rest)(getBaseUserFields(true)));
 
+// Override Meteor's _expireTokens to ensure the correct login expiration is used.
+// If loginExpirationInDays is not set (e.g., startup was disrupted before settings watcher fired),
+// read the setting directly from MongoDB before proceeding with token cleanup.
+// This prevents tokens from being incorrectly deleted using Meteor's 90-day default.
+const { _expireTokens } = Accounts;
+Accounts._expireTokens = async function (oldestValidDate, userId) {
+	if (!Accounts._options.loginExpirationInDays) {
+		const loginExpiration = await Settings.getValueById('Accounts_LoginExpiration');
+		Accounts._options.loginExpirationInDays = getLoginExpirationInDays(loginExpiration);
+	}
+	return _expireTokens.call(Accounts, oldestValidDate, userId);
+};
+
 Meteor.startup(() => {
 	settings.watchMultiple(['Accounts_LoginExpiration', 'Site_Name', 'From_Email'], () => {
 		Accounts._options.loginExpirationInDays = getLoginExpirationInDays(settings.get('Accounts_LoginExpiration'));


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Override Meteor's `_expireTokens` to read the `Accounts_LoginExpiration` setting directly from MongoDB when `loginExpirationInDays` is not set in memory.

## Issue(s)
- [SUP-1002](https://rocketchat.atlassian.net/browse/SUP-1002)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments

[SUP-1002]: https://rocketchat.atlassian.net/browse/SUP-1002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed login token expiration to consistently apply configured expiration settings, ensuring tokens expire correctly according to administrator-configured values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->