### PR TITLE
feat: Add script to check translation key usage inside packages

### DIFF
--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -26,6 +26,7 @@
 	"scripts": {
 		"build": "rm -rf dist && tsc -p tsconfig.build.json && node --experimental-transform-types ./src/scripts/build.mts",
 		"check": "node --experimental-transform-types ./src/scripts/check.mts",
+		"check-keys": "node --experimental-transform-types ./src/scripts/check-translation-keys.mts",
 		"lint": "eslint && node --experimental-transform-types ./src/scripts/check.mts",
 		"lint:fix": "eslint --fix && node --experimental-transform-types ./src/scripts/check.mts --fix",
 		"replace-sprintf": "node --experimental-transform-types ./src/scripts/replace-sprintf.mts",

--- a/packages/i18n/src/scripts/check-translation-keys.mts
+++ b/packages/i18n/src/scripts/check-translation-keys.mts
@@ -1,0 +1,197 @@
+/**
+ * Validates that all translation keys used via `t()` (useTranslation) or backend `t`/`i18n.t`
+ * exist in the English base locale (en.i18n.json).
+ *
+ * Usage:
+ *   node check-translation-keys.mts [--package=NAME] [--backend]
+ *
+ * Options:
+ *   --package=NAME   Only check the given package (e.g. ui-voip). Omit to check all.
+ *   --backend        Also check backend files (apps/meteor) that use utils/lib/i18n or server/lib/i18n.
+ */
+
+import type { Dirent } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { argv, exit, stderr } from 'node:process';
+import { parseArgs, styleText } from 'node:util';
+
+import { baseLanguage, readResource, rootDirectory } from './common.mts';
+
+const REPO_ROOT = join(rootDirectory, '..', '..');
+
+const SKIP_FILE_PATTERNS = [/\.(test|spec)\.(ts|tsx)$/i, /\.(stories|story)\.(ts|tsx)$/i];
+
+const FRONTEND_T_REGEX = /\bt\s*\(\s*['"]([^'"]+)['"]/g;
+const BACKEND_T_REGEX = /\bt\s*\(\s*['"]([^'"]+)['"]/g;
+const BACKEND_I18N_T_REGEX = /\bi18n\.t\s*\(\s*['"]([^'"]+)['"]/g;
+
+const USE_TRANSLATION_PATTERN = /useTranslation\s*[(\[]?/;
+// Matches imports of t or i18n from backend i18n (utils/lib/i18n, server/lib/i18n, or relative ../i18n).
+// Excludes npm imports (e.g. @rocket.chat/i18n).
+const BACKEND_I18N_IMPORT_PATTERN = /from\s+['"](?![^'"]*@)[^'"]*(?:utils\/lib\/i18n|server\/lib\/i18n|(?:\.\.\/)+i18n)(?:\.ts)?['"]/;
+
+function shouldSkipFile(path: string): boolean {
+	return SKIP_FILE_PATTERNS.some((re) => re.test(path));
+}
+
+function isRelevantExtension(path: string): boolean {
+	return /\.(ts|tsx)$/.test(path);
+}
+
+async function* walkDir(dir: string, baseDir: string): AsyncGenerator<string> {
+	let entries: Dirent<string>[];
+	try {
+		entries = await readdir(dir, { withFileTypes: true });
+	} catch {
+		return;
+	}
+	for (const entry of entries) {
+		const full = join(dir, entry.name);
+		const relative = full.slice(baseDir.length + 1);
+		if (entry?.isDirectory()) {
+			if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === '.git') continue;
+			yield* walkDir(full, baseDir);
+		} else if (isRelevantExtension(relative) && !shouldSkipFile(relative)) {
+			yield full;
+		}
+	}
+}
+
+function collectFrontendSearchDirs(packageName: string | undefined): string[] {
+	const packagesDir = join(REPO_ROOT, 'packages');
+	const eePackagesDir = join(REPO_ROOT, 'ee', 'packages');
+	if (packageName) {
+		const inPackages = join(packagesDir, packageName);
+		const inEe = join(eePackagesDir, packageName);
+		return [inPackages, inEe].filter((d) => d);
+	}
+	return [packagesDir, eePackagesDir];
+}
+
+function collectBackendSearchDirs(): string[] {
+	return [join(REPO_ROOT, 'apps', 'meteor')];
+}
+
+async function getFilesToScan(
+	packageName: string | undefined,
+	includeBackend: boolean,
+): Promise<{ path: string; mode: 'frontend' | 'backend' }[]> {
+	const out: { path: string; mode: 'frontend' | 'backend' }[] = [];
+
+	const frontendDirs = collectFrontendSearchDirs(packageName);
+	for (const dir of frontendDirs) {
+		try {
+			for await (const file of walkDir(dir, dir)) {
+				out.push({ path: file, mode: 'frontend' });
+			}
+		} catch {
+			// directory may not exist when filtering by package
+		}
+	}
+
+	if (includeBackend) {
+		for (const dir of collectBackendSearchDirs()) {
+			try {
+				for await (const file of walkDir(dir, dir)) {
+					out.push({ path: file, mode: 'backend' });
+				}
+			} catch {
+				// ignore
+			}
+		}
+	}
+
+	return out;
+}
+
+function extractKeysFromContent(content: string, regex: RegExp): { key: string; index: number }[] {
+	const results: { key: string; index: number }[] = [];
+	const re = new RegExp(regex.source, 'g');
+	let m;
+	while ((m = re.exec(content)) !== null) {
+		results.push({ key: m[1], index: m.index });
+	}
+	return results;
+}
+
+function lineAndColumn(content: string, index: number): { line: number; column: number } {
+	const before = content.slice(0, index);
+	const line = (before.match(/\n/g) ?? []).length + 1;
+	const lastNewline = before.lastIndexOf('\n');
+	const column = index - lastNewline;
+	return { line, column };
+}
+
+async function main(): Promise<void> {
+	const { values } = parseArgs({
+		args: argv.slice(2),
+		options: {
+			package: { type: 'string', short: 'p' },
+			backend: { type: 'boolean', short: 'b', default: false },
+		},
+	});
+
+	const packageName = values.package;
+	const includeBackend = values.backend ?? false;
+
+	const validKeys = new Set<string>(Object.keys(await readResource(baseLanguage)));
+	const files = await getFilesToScan(packageName, includeBackend);
+
+	let errorCount = 0;
+	// const stderrSupportsColor = styleText('blue', '.', { stream: stderr }) !== '.';
+
+	const report = (file: string, line: number, key: string) => {
+		const rel = file.startsWith(REPO_ROOT) ? file.slice(REPO_ROOT.length + 1) : file;
+		console.error(
+			styleText('red', '✘', { stream: stderr }),
+			styleText('gray', `${rel}:${line}`, { stream: stderr }),
+			'Missing translation key:',
+			styleText('yellow', key, { stream: stderr }),
+		);
+		errorCount++;
+	};
+
+	for (const { path: filePath, mode } of files) {
+		const content = await readFile(filePath, 'utf8');
+
+		if (mode === 'frontend') {
+			if (!USE_TRANSLATION_PATTERN.test(content)) continue;
+			const matches = extractKeysFromContent(content, FRONTEND_T_REGEX);
+			for (const { key, index } of matches) {
+				if (!validKeys.has(key)) {
+					const { line } = lineAndColumn(content, index);
+					report(filePath, line, key);
+				}
+			}
+			continue;
+		}
+
+		if (mode === 'backend') {
+			if (!BACKEND_I18N_IMPORT_PATTERN.test(content)) continue;
+			const tMatches = extractKeysFromContent(content, BACKEND_T_REGEX);
+			const i18nMatches = extractKeysFromContent(content, BACKEND_I18N_T_REGEX);
+			const seen = new Set<number>();
+			for (const { key, index } of [...tMatches, ...i18nMatches]) {
+				if (seen.has(index)) continue;
+				seen.add(index);
+				if (!validKeys.has(key)) {
+					const { line } = lineAndColumn(content, index);
+					report(filePath, line, key);
+				}
+			}
+		}
+	}
+
+	if (errorCount > 0) {
+		console.error(styleText('red', `\n${errorCount} missing translation key(s) found.`, { stream: stderr }));
+		exit(1);
+	}
+
+	console.log(styleText('green', 'All translation keys are valid.'));
+}
+
+main().catch((err) => {
+	console.error(err);
+	exit(1);
+});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Introduces a new script that checks if the used translation keys in a certain package exist in the reference `en.i18n.json` file.

Usage:
`yarn workspace @rocket.chat/i18n --package=<PACKAGE_NAME> --backend`
`--package=<PACKAGE_NAME>`: Name of the package that you want to check. E.g `ui-voip`, `ui-client` etc.
`--backend`: Optional boolean flag to include searching for usage in backend files.

Example usage:
`yarn workspace @rocket.chat/i18n check-keys --package=ui-voip`
Output:
<img width="861" height="134" alt="image" src="https://github.com/user-attachments/assets/4bb37971-c217-47fd-895b-aad2759b3ec8" />
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
We used to have this "feature" before we changed to `react-i18next` as static TS checks. Once we moved to the new package we lost that functionality. Since then it's become more common to have broken translations because of typos or just forgetfulness, so this script aims to streamline this process and help catch issues more easily before they go into production.