### PR TITLE
fix(composer): prevent cursor misalignment on wrapped lines with spaces

### DIFF
--- a/apps/meteor/client/views/room/composer/RoomComposer/hooks/useAutoGrow.ts
+++ b/apps/meteor/client/views/room/composer/RoomComposer/hooks/useAutoGrow.ts
@@ -3,61 +3,61 @@ import type { CSSProperties, MutableRefObject, RefCallback } from 'react';
 import { useCallback } from 'react';
 
 function shouldScrollToBottom(textarea: HTMLTextAreaElement) {
-	const isCursorAtBottom = textarea.selectionEnd === textarea.value.length;
-	const isScrolledToBottom = textarea.scrollTop + textarea.clientHeight === textarea.scrollHeight;
+    const isCursorAtBottom = textarea.selectionEnd === textarea.value.length;
+    const isScrolledToBottom = textarea.scrollTop + textarea.clientHeight === textarea.scrollHeight;
 
-	return isCursorAtBottom || isScrolledToBottom;
+    return isCursorAtBottom || isScrolledToBottom;
 }
 
 export const useAutoGrow = (
-	ref: MutableRefObject<HTMLTextAreaElement | null>,
-	hideTextArea?: boolean,
+    ref: MutableRefObject<HTMLTextAreaElement | null>,
+    hideTextArea?: boolean,
 ): {
-	textAreaStyle: CSSProperties;
-	autoGrowRef: RefCallback<HTMLTextAreaElement>;
+    textAreaStyle: CSSProperties;
+    autoGrowRef: RefCallback<HTMLTextAreaElement>;
 } => {
-	const autoGrowRef = useSafeRefCallback(
-		useCallback(
-			(node: HTMLTextAreaElement) => {
-				ref.current = node;
+    const autoGrowRef = useSafeRefCallback(
+        useCallback(
+            (node: HTMLTextAreaElement) => {
+                ref.current = node;
 
-				const resize = () => {
-					const shouldScroll = shouldScrollToBottom(node);
+                const resize = () => {
+                    const shouldScroll = shouldScrollToBottom(node);
 
-					node.style.height = '0';
-					node.style.height = `${node.scrollHeight}px`;
+                    node.style.height = '0';
+                    node.style.height = `${node.scrollHeight}px`;
 
-					if (shouldScroll) {
-						node.scrollTop = node.scrollHeight;
-					}
-				};
+                    if (shouldScroll) {
+                        node.scrollTop = node.scrollHeight;
+                    }
+                };
 
-				const resizeObserver = new ResizeObserver(resize);
+                const resizeObserver = new ResizeObserver(resize);
 
-				resizeObserver.observe(node);
+                resizeObserver.observe(node);
 
-				node.addEventListener('input', resize);
+                node.addEventListener('input', resize);
 
-				return () => {
-					resizeObserver.disconnect();
-					node.removeEventListener('input', resize);
-				};
-			},
-			[ref],
-		),
-	);
+                return () => {
+                    resizeObserver.disconnect();
+                    node.removeEventListener('input', resize);
+                };
+            },
+            [ref],
+        ),
+    );
 
-	return {
-		autoGrowRef,
-		textAreaStyle: {
-			...(hideTextArea && {
-				visibility: 'hidden',
-			}),
-			whiteSpace: 'pre-wrap',
-			wordWrap: 'break-word',
-			overflowWrap: 'break-word',
-			willChange: 'contents',
-			wordBreak: 'normal',
-		},
-	};
+    return {
+        autoGrowRef,
+        textAreaStyle: {
+            ...(hideTextArea && {
+                visibility: 'hidden',
+            }),
+            whiteSpace: 'break-spaces', 
+            wordWrap: 'break-word',
+            overflowWrap: 'break-word',
+            willChange: 'contents',
+            wordBreak: 'normal',
+        },
+    };
 };


### PR DESCRIPTION
## Proposed changes
This PR fixes the issue where the cursor becomes misaligned in the message composer when a user types a long message that wraps to the next line and adds trailing spaces. 

By changing the CSS `white-space` property from `pre-wrap` to `break-spaces` inside `useAutoGrow.ts`, the browser correctly handles the trailing spaces and breaks them to the next line, keeping the cursor visually aligned with the text.

Fixes #39329

## Issue(s)
- Closes #39329

## Steps to test or reproduce
1. Go to any chat room.
2. Type a long sentence until the text is about to wrap to a new line.
3. Press `Space` continuously.
4. The cursor now stays aligned and moves correctly to the next line instead of misaligning.

## Checklist
- [x] I have read the Contributing Guide.
- [x] I have signed the CLA.
- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] I have added necessary documentation (if applicable).
- [ ] Any dependent changes have been merged and published in downstream modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved whitespace handling in the room composer textarea for more consistent text display and wrapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->