### PR TITLE
regression: remove incorrect userId requirement from im.close validation schema

### DIFF
--- a/apps/meteor/app/api/server/v1/im.ts
+++ b/apps/meteor/app/api/server/v1/im.ts
@@ -155,11 +155,8 @@ const DmClosePropsSchema = {
 		roomId: {
 			type: 'string',
 		},
-		userId: {
-			type: 'string',
-		},
 	},
-	required: ['roomId', 'userId'],
+	required: ['roomId'],
 	additionalProperties: false,
 };
 

--- a/apps/meteor/tests/end-to-end/api/direct-message.ts
+++ b/apps/meteor/tests/end-to-end/api/direct-message.ts
@@ -959,7 +959,6 @@ describe('[Direct Messages]', () => {
 			.set(credentials)
 			.send({
 				roomId: directMessage._id,
-				userId: user._id,
 			})
 			.expect('Content-Type', 'application/json')
 			.expect(200)


### PR DESCRIPTION
This PR fixes a validation schema bug introduced in #38974.

The commit incorrectly added `userId` as a required field in the `DmClosePropsSchema` validation schema. This causes an error message ("must have required property userId") to be displayed when users attempt to hide a DM room, even though the operation succeeds.

Root cause:
- The validation schema required both `roomId` and `userId` in the request body
- The client only sends `roomId` (correctly, since userId is obtained from the authenticated session)
- The endpoint handler itself uses `this.userId` from the session, not from the request body
- AJV validation fails before the handler runs, but the operation still proceeds

## Proposed changes (including videos or screenshots)
1. Removed `userId` from the `DmClosePropsSchema` properties and required array in `apps/meteor/app/api/server/v1/im.ts`
2. Updated the e2e test to match the corrected schema (removed `userId` from the test request)

## Issue(s)
- [CORE-1957](https://rocketchat.atlassian.net/browse/CORE-1957)

## Steps to test or reproduce
Before fix:
1. Open the chat application
2. Navigate to any DM room
3. Open the room options menu
4. Click on "Hide Room"
5. Observe error message displayed (though room gets hidden)

After fix:
1. Repeat the same steps
2. Room should be hidden without any error message

## Further comments
I don't think it needs a changeset, since it's a fix for something we broke and resolved within the same sprint.


[CORE-1957]: https://rocketchat.atlassian.net/browse/CORE-1957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the direct message close API endpoint by removing the unnecessary userId requirement. The `/im.close` endpoint now only requires the `roomId` parameter, streamlining the request payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->