### PR TITLE
chore: Implement user caching for publication access

### DIFF
--- a/apps/meteor/server/modules/notifications/notifications.module.ts
+++ b/apps/meteor/server/modules/notifications/notifications.module.ts
@@ -6,6 +6,7 @@ import { Rooms, Subscriptions, Users } from '@rocket.chat/models';
 import type { ImporterProgress } from '../../../app/importer/server/classes/ImporterProgress';
 import { emit, StreamPresence } from '../../../app/notifications/server/lib/Presence';
 import { SystemLogger } from '../../lib/logger/system';
+import { getCachedUserForPublication } from '../streamer/publication-user-cache';
 import { Streamer as StreamerModule } from '../streamer/streamer.module';
 import type { IStreamer, IStreamerConstructor } from '../streamer/types';
 
@@ -103,13 +104,14 @@ export class NotificationsModule {
 				return false;
 			}
 
-			const user = this.userId ? { _id: this.userId } : undefined;
-			return Authorization.canReadRoom(room, user, extraData);
+			const user = await getCachedUserForPublication(this);
+			return Authorization.canReadRoom(room, user ?? undefined, extraData);
 		});
 
 		this.streamRoomMessage.allowRead('__my_messages__', 'all');
 		this.streamRoomMessage.allowEmit('__my_messages__', async function (_eventName, { rid }) {
-			if (!this.userId) {
+			const user = await getCachedUserForPublication(this);
+			if (!user) {
 				return false;
 			}
 
@@ -119,12 +121,12 @@ export class NotificationsModule {
 					return false;
 				}
 
-				const canAccess = await Authorization.canAccessRoom(room, { _id: this.userId });
+				const canAccess = await Authorization.canAccessRoom(room, user);
 				if (!canAccess) {
 					return false;
 				}
 
-				const roomParticipant = await Subscriptions.countByRoomIdAndUserId(room._id, this.userId);
+				const roomParticipant = await Subscriptions.countByRoomIdAndUserId(room._id, user._id);
 
 				return {
 					roomParticipant: roomParticipant > 0,
@@ -140,10 +142,11 @@ export class NotificationsModule {
 		this.streamAll.allowWrite('none');
 		this.streamAll.allowRead('all');
 		this.streamLogged.allowRead('private-settings-changed', async function () {
-			if (this.userId == null) {
+			const user = await getCachedUserForPublication(this);
+			if (!user) {
 				return false;
 			}
-			return Authorization.hasAtLeastOnePermission(this.userId, [
+			return Authorization.hasAtLeastOnePermission(user, [
 				'view-privileged-setting',
 				'edit-privileged-setting',
 				'manage-selected-settings',
@@ -173,10 +176,11 @@ export class NotificationsModule {
 				return !!room && room.t === 'l' && room.v.token === extraData.token;
 			}
 
-			if (!this.userId) {
+			const user = await getCachedUserForPublication(this);
+			if (!user) {
 				return false;
 			}
-			const canAccess = await Authorization.canAccessRoomId(room._id, this.userId);
+			const canAccess = await Authorization.canAccessRoom(room, user);
 
 			return canAccess;
 		});
@@ -318,19 +322,17 @@ export class NotificationsModule {
 
 		this.streamCannedResponses.allowWrite('none');
 		this.streamCannedResponses.allowRead(async function () {
-			return (
-				!!this.userId &&
-				!!(await Settings.get('Canned_Responses_Enable')) &&
-				Authorization.hasPermission(this.userId, 'view-canned-responses')
-			);
+			const user = await getCachedUserForPublication(this);
+			return !!user && !!(await Settings.get('Canned_Responses_Enable')) && Authorization.hasPermission(user, 'view-canned-responses');
 		});
 
 		this.streamIntegrationHistory.allowWrite('none');
 		this.streamIntegrationHistory.allowRead(async function () {
-			if (!this.userId) {
+			const user = await getCachedUserForPublication(this);
+			if (!user) {
 				return false;
 			}
-			return Authorization.hasAtLeastOnePermission(this.userId, ['manage-outgoing-integrations', 'manage-own-outgoing-integrations']);
+			return Authorization.hasAtLeastOnePermission(user, ['manage-outgoing-integrations', 'manage-own-outgoing-integrations']);
 		});
 
 		this.streamLivechatRoom.allowRead(async (roomId, extraData) => {
@@ -351,12 +353,14 @@ export class NotificationsModule {
 
 		this.streamLivechatQueueData.allowWrite('none');
 		this.streamLivechatQueueData.allowRead(async function () {
-			return this.userId ? Authorization.hasPermission(this.userId, 'view-l-room') : false;
+			const user = await getCachedUserForPublication(this);
+			return user ? Authorization.hasPermission(user, 'view-l-room') : false;
 		});
 
 		this.streamRoomData.allowWrite('none');
 		this.streamRoomData.allowRead(async function (rid) {
-			if (!this.userId) {
+			const user = await getCachedUserForPublication(this);
+			if (!user) {
 				return false;
 			}
 
@@ -366,7 +370,7 @@ export class NotificationsModule {
 					return false;
 				}
 
-				const canAccess = await Authorization.canAccessRoom(room, { _id: this.userId });
+				const canAccess = await Authorization.canAccessRoom(room, user);
 				if (!canAccess) {
 					return false;
 				}

--- a/apps/meteor/server/modules/streamer/publication-user-cache.ts
+++ b/apps/meteor/server/modules/streamer/publication-user-cache.ts
@@ -3,7 +3,10 @@ import { Users } from '@rocket.chat/models';
 
 import type { IPublication } from './types';
 
-type CacheEntry = { user: Pick<IUser, '_id' | 'roles'>; timeout: NodeJS.Timeout };
+type CacheEntry = {
+	user: IUser; // Pick<IUser, '_id' | 'roles'>
+	timeout: NodeJS.Timeout;
+};
 
 const CACHE_PROJECTION = { _id: 1, roles: 1 } as const;
 const CACHE_TIMEOUT = 1000 * 60;

--- a/apps/meteor/server/modules/streamer/publication-user-cache.ts
+++ b/apps/meteor/server/modules/streamer/publication-user-cache.ts
@@ -29,7 +29,7 @@ export async function getCachedUserForPublication(publication: IPublication): Pr
 
 		cacheByPublication.set(userId, { user, timeout });
 	}
-	return value;
+	return user;
 }
 
 export function invalidate(userId: string): CacheEntry['user'] | null {

--- a/apps/meteor/server/modules/streamer/publication-user-cache.ts
+++ b/apps/meteor/server/modules/streamer/publication-user-cache.ts
@@ -1,0 +1,40 @@
+import type { IUser } from '@rocket.chat/core-typings';
+import { Users } from '@rocket.chat/models';
+
+import type { IPublication } from './types';
+
+const CACHE_PROJECTION = { _id: 1, roles: 1 } as const;
+
+/** Cache keyed by publication so entries can be GC'd when the subscription is gone. */
+const cacheByPublication = new WeakMap<IPublication, { user: IUser | null; userId: string }>();
+
+/** User ids that received watch.users; next get for a publication with that userId will refetch. */
+const invalidatedUserIds = new Set<string>();
+
+export async function getCachedUserForPublication(publication: IPublication): Promise<IUser | null> {
+	const userId = publication.userId ?? publication._session?.userId ?? undefined;
+	if (userId == null || userId === '') {
+		return null;
+	}
+
+	const entry = cacheByPublication.get(publication);
+	if (entry) {
+		if (invalidatedUserIds.has(entry.userId)) {
+			const user = await Users.findOneById(entry.userId, { projection: CACHE_PROJECTION });
+			const value = user ?? null;
+			cacheByPublication.set(publication, { user: value, userId: entry.userId });
+			invalidatedUserIds.delete(entry.userId);
+			return value;
+		}
+		return entry.user;
+	}
+
+	const user = await Users.findOneById(userId, { projection: CACHE_PROJECTION });
+	const value = user ?? null;
+	cacheByPublication.set(publication, { user: value, userId });
+	return value;
+}
+
+export function invalidate(userId: string): void {
+	invalidatedUserIds.add(userId);
+}

--- a/apps/meteor/server/modules/streamer/publication-user-cache.ts
+++ b/apps/meteor/server/modules/streamer/publication-user-cache.ts
@@ -3,38 +3,37 @@ import { Users } from '@rocket.chat/models';
 
 import type { IPublication } from './types';
 
+type CacheEntry = { user: Pick<IUser, '_id' | 'roles'>; timeout: NodeJS.Timeout };
+
 const CACHE_PROJECTION = { _id: 1, roles: 1 } as const;
 const CACHE_TIMEOUT = 1000 * 60;
-const cacheByPublication = new Map<string, { user: Pick<IUser, '_id' | 'roles'>; timeout: NodeJS.Timeout }>();
+const cacheByPublication = new Map<string, CacheEntry>();
 
-export async function getCachedUserForPublication(publication: IPublication): Promise<Pick<IUser, '_id' | 'roles'> | null> {
+export async function getCachedUserForPublication(publication: IPublication): Promise<CacheEntry['user'] | null> {
 	const userId = publication.userId ?? publication._session?.userId ?? undefined;
 	if (userId == null || userId === '') {
 		return null;
 	}
 
-	const entry = cacheByPublication.get(userId);
+	const value = invalidate(userId);
 
-	if (entry) {
-		clearTimeout(entry.timeout);
-		entry.timeout = setTimeout(() => {
-			cacheByPublication.delete(userId);
-		}, CACHE_TIMEOUT);
-		return entry.user;
-	}
+	const user = value ?? (await Users.findOneById<CacheEntry['user']>(userId, { projection: CACHE_PROJECTION }));
 
-	const user = await Users.findOneById<Pick<IUser, '_id' | 'roles'>>(userId, { projection: CACHE_PROJECTION });
-	const value = user ?? null;
-	if (value) {
+	if (user) {
 		const timeout = setTimeout(() => {
-			cacheByPublication.delete(userId);
+			invalidate(userId);
 		}, CACHE_TIMEOUT);
 
-		cacheByPublication.set(userId, { user: value, timeout });
+		cacheByPublication.set(userId, { user, timeout });
 	}
 	return value;
 }
 
-export function invalidate(userId: string): void {
-	cacheByPublication.delete(userId);
+export function invalidate(userId: string): CacheEntry['user'] | null {
+	const entry = cacheByPublication.get(userId);
+	if (entry) {
+		clearTimeout(entry.timeout);
+		cacheByPublication.delete(userId);
+	}
+	return entry?.user ?? null;
 }

--- a/apps/meteor/server/modules/streamer/publication-user-cache.ts
+++ b/apps/meteor/server/modules/streamer/publication-user-cache.ts
@@ -4,37 +4,37 @@ import { Users } from '@rocket.chat/models';
 import type { IPublication } from './types';
 
 const CACHE_PROJECTION = { _id: 1, roles: 1 } as const;
+const CACHE_TIMEOUT = 1000 * 60;
+const cacheByPublication = new Map<string, { user: Pick<IUser, '_id' | 'roles'>; timeout: NodeJS.Timeout }>();
 
-/** Cache keyed by publication so entries can be GC'd when the subscription is gone. */
-const cacheByPublication = new WeakMap<IPublication, { user: IUser | null; userId: string }>();
-
-/** User ids that received watch.users; next get for a publication with that userId will refetch. */
-const invalidatedUserIds = new Set<string>();
-
-export async function getCachedUserForPublication(publication: IPublication): Promise<IUser | null> {
+export async function getCachedUserForPublication(publication: IPublication): Promise<Pick<IUser, '_id' | 'roles'> | null> {
 	const userId = publication.userId ?? publication._session?.userId ?? undefined;
 	if (userId == null || userId === '') {
 		return null;
 	}
 
-	const entry = cacheByPublication.get(publication);
+	const entry = cacheByPublication.get(userId);
+
 	if (entry) {
-		if (invalidatedUserIds.has(entry.userId)) {
-			const user = await Users.findOneById(entry.userId, { projection: CACHE_PROJECTION });
-			const value = user ?? null;
-			cacheByPublication.set(publication, { user: value, userId: entry.userId });
-			invalidatedUserIds.delete(entry.userId);
-			return value;
-		}
+		clearTimeout(entry.timeout);
+		entry.timeout = setTimeout(() => {
+			cacheByPublication.delete(userId);
+		}, CACHE_TIMEOUT);
 		return entry.user;
 	}
 
-	const user = await Users.findOneById(userId, { projection: CACHE_PROJECTION });
+	const user = await Users.findOneById<Pick<IUser, '_id' | 'roles'>>(userId, { projection: CACHE_PROJECTION });
 	const value = user ?? null;
-	cacheByPublication.set(publication, { user: value, userId });
+	if (value) {
+		const timeout = setTimeout(() => {
+			cacheByPublication.delete(userId);
+		}, CACHE_TIMEOUT);
+
+		cacheByPublication.set(userId, { user: value, timeout });
+	}
 	return value;
 }
 
 export function invalidate(userId: string): void {
-	invalidatedUserIds.add(userId);
+	cacheByPublication.delete(userId);
 }

--- a/apps/meteor/server/modules/streamer/publication-user-cache.ts
+++ b/apps/meteor/server/modules/streamer/publication-user-cache.ts
@@ -3,40 +3,53 @@ import { Users } from '@rocket.chat/models';
 
 import type { IPublication } from './types';
 
+type CachedUser = IUser; // Pick<IUser, '_id' | 'roles'>;
+
 type CacheEntry = {
-	user: IUser; // Pick<IUser, '_id' | 'roles'>
+	user: Promise<CachedUser | null>;
 	timeout: NodeJS.Timeout;
 };
 
 const CACHE_PROJECTION = { _id: 1, roles: 1 } as const;
 const CACHE_TIMEOUT = 1000 * 60;
-const cacheByPublication = new Map<string, CacheEntry>();
+const cacheByUserId = new Map<string, CacheEntry>();
 
-export async function getCachedUserForPublication(publication: IPublication): Promise<CacheEntry['user'] | null> {
-	const userId = publication.userId ?? publication._session?.userId ?? undefined;
-	if (userId == null || userId === '') {
-		return null;
+export function getCachedUserForPublication(publication: IPublication): Promise<CachedUser | null> {
+	const userId = publication.userId ?? publication._session?.userId;
+	if (!userId) {
+		return Promise.resolve(null);
 	}
 
-	const value = invalidate(userId);
-
-	const user = value ?? (await Users.findOneById<CacheEntry['user']>(userId, { projection: CACHE_PROJECTION }));
-
-	if (user) {
-		const timeout = setTimeout(() => {
-			invalidate(userId);
-		}, CACHE_TIMEOUT);
-
-		cacheByPublication.set(userId, { user, timeout });
+	const existing = cacheByUserId.get(userId);
+	if (existing) {
+		return existing.user;
 	}
-	return user;
+
+	const userPromise = Users.findOneById<CachedUser>(userId, { projection: CACHE_PROJECTION });
+
+	const timeout = setTimeout(() => {
+		invalidate(userId);
+	}, CACHE_TIMEOUT);
+
+	cacheByUserId.set(userId, { user: userPromise, timeout });
+
+	userPromise.then(
+		(user: CachedUser | null) => {
+			if (!user) {
+				invalidate(userId);
+			}
+		},
+		() => invalidate(userId),
+	);
+
+	return userPromise;
 }
 
-export function invalidate(userId: string): CacheEntry['user'] | null {
-	const entry = cacheByPublication.get(userId);
-	if (entry) {
-		clearTimeout(entry.timeout);
-		cacheByPublication.delete(userId);
+export function invalidate(userId: string): void {
+	const entry = cacheByUserId.get(userId);
+	if (!entry) {
+		return;
 	}
-	return entry?.user ?? null;
+	clearTimeout(entry.timeout);
+	cacheByUserId.delete(userId);
 }

--- a/apps/meteor/server/services/meteor/service.ts
+++ b/apps/meteor/server/services/meteor/service.ts
@@ -20,6 +20,7 @@ import { getURL } from '../../../app/utils/server/getURL';
 import { configureEmailInboxes } from '../../features/EmailInbox/EmailInbox';
 import { roomCoordinator } from '../../lib/rooms/roomCoordinator';
 import { ListenersModule } from '../../modules/listeners/listeners.module';
+import { invalidate as invalidatePublicationUserCache } from '../../modules/streamer/publication-user-cache';
 
 const disableMsgRoundtripTracking = ['yes', 'true'].includes(String(process.env.DISABLE_MESSAGE_ROUNDTRIP_TRACKING).toLowerCase());
 
@@ -78,6 +79,8 @@ export class MeteorService extends ServiceClassInternal implements IMeteor {
 		});
 
 		this.onEvent('watch.users', async (data) => {
+			invalidatePublicationUserCache(data.id);
+
 			if (data.clientAction === 'updated' && data.diff) {
 				processOnChange(data.diff, data.id);
 			}


### PR DESCRIPTION
This pull request introduces a user caching mechanism for publication contexts in the notifications module, aiming to optimize repeated user lookups and improve performance. The main change is the addition of a cache layer for user data (specifically user ID and roles) that is used in permission and authorization checks throughout the notifications streaming system. The cache is automatically invalidated when user data changes, ensuring consistency.

Key changes include:

**User Caching Implementation:**
* Added a new utility function `getCachedUserForPublication` in `publication-user-cache.ts` to cache user objects (with `_id` and `roles`) per publication context for a short period, reducing repeated database queries.
* Provided an `invalidate` function to clear the cache for a user when their data changes.

**Integration with Notifications Module:**
* Replaced direct usage of `this.userId` with calls to `getCachedUserForPublication` throughout `notifications.module.ts`, ensuring all permission and room access checks use the cached user object. This affects methods like `allowRead`, `allowEmit`, and various authorization checks. [[1]](diffhunk://#diff-edfe14d771733772040fab9bcc199f1479440878140b506593a1db9abf158e60R9) [[2]](diffhunk://#diff-edfe14d771733772040fab9bcc199f1479440878140b506593a1db9abf158e60L101-R109) [[3]](diffhunk://#diff-edfe14d771733772040fab9bcc199f1479440878140b506593a1db9abf158e60L117-R124) [[4]](diffhunk://#diff-edfe14d771733772040fab9bcc199f1479440878140b506593a1db9abf158e60L138-R144) [[5]](diffhunk://#diff-edfe14d771733772040fab9bcc199f1479440878140b506593a1db9abf158e60L171-R178) [[6]](diffhunk://#diff-edfe14d771733772040fab9bcc199f1479440878140b506593a1db9abf158e60L316-R330) [[7]](diffhunk://#diff-edfe14d771733772040fab9bcc199f1479440878140b506593a1db9abf158e60L349-R358) [[8]](diffhunk://#diff-edfe14d771733772040fab9bcc199f1479440878140b506593a1db9abf158e60L364-R368)

**Cache Invalidation on User Updates:**
* Hooked into user update events in `service.ts` to call `invalidatePublicationUserCache`, ensuring the cache is cleared when a user's data changes. [[1]](diffhunk://#diff-f496dff8824623ac9304177cd27847fae4df8654aaea5e1014f8214bb6fe06eeR23) [[2]](diffhunk://#diff-f496dff8824623ac9304177cd27847fae4df8654aaea5e1014f8214bb6fe06eeR82-R83)

These changes collectively improve the efficiency of user permission checks in the server's notification streaming logic while maintaining up-to-date authorization data.

 Task: [ARCH-2056]

[ARCH-2056]: https://rocketchat.atlassian.net/browse/ARCH-2056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved notification delivery by caching user information, reducing repeated lookups and speeding updates.

* **Reliability**
  * Strengthened permission and access checks across notification streams for more consistent behavior.
  * Added room context (type and name) to some notification payloads for clearer information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->