### PR TITLE
chore: import shared helpers in timestamp.test.ts

### DIFF
--- a/packages/message-parser/tests/timestamp.test.ts
+++ b/packages/message-parser/tests/timestamp.test.ts
@@ -1,14 +1,7 @@
 import { parse } from '../src';
+import { paragraph, plain, bold, strike } from './helpers';
 
-const plain = (value: string) => ({ type: 'PLAIN_TEXT' as const, value });
-
-const paragraph = (value: Array<Record<string, unknown>>) => ({ type: 'PARAGRAPH' as const, value });
-
-const bold = (value: Array<Record<string, unknown>>) => ({ type: 'BOLD' as const, value });
-
-const strike = (value: Array<Record<string, unknown>>) => ({ type: 'STRIKE' as const, value });
-
-const timestampNode = (value: string, format: 't' | 'T' | 'd' | 'D' | 'f' | 'F' | 'R' = 't') => ({
+export const timestampNode = (value: string, format: 't' | 'T' | 'd' | 'D' | 'f' | 'F' | 'R' = 't') => ({
 	type: 'TIMESTAMP' as const,
 	value: {
 		timestamp: value,
@@ -42,7 +35,6 @@ test.each([
 test.each([
 	['<t:2025-07-22T10:00:00.000+00:00:R>', [paragraph([timestampNode('1753178400', 'R')])]],
 	['<t:2025-07-22T10:00:00+00:00:R>', [paragraph([timestampNode('1753178400', 'R')])]],
-
 	['<t:2025-07-24T20:19:58.154+00:00:R>', [paragraph([timestampNode('1753388398', 'R')])]],
 ])('parses %p', (input, output) => {
 	expect(parse(input)).toMatchObject(output);


### PR DESCRIPTION
## Proposed changes

Remove inline helper definitions from `timestamp.test.ts` and import them from the shared `helpers.ts file`.


**Before**
```typescript
// defined inline in timestamp.test.ts
const plain = (value: string) => ({ type: 'PLAIN_TEXT' as const, value });
const paragraph = (value: Array<Record<string, unknown>>) => ({ type: 'PARAGRAPH' as const, value });
const bold = (value: Array<Record<string, unknown>>) => ({ type: 'BOLD' as const, value });
const strike = (value: Array<Record<string, unknown>>) => ({ type: 'STRIKE' as const, value });
```

**After**

```typescript
import { paragraph, plain, bold, strike } from './helpers';
```

## Issue(s)
Closes #39683

## Steps to reproduce

See `packages/message-parser/tests/timestamp.test.ts`

## Testing

- No behavior change — tests remain exactly the same
- Verify all timestamp tests still pass after the change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored timestamp test utilities for improved maintainability by consolidating helper function imports from a shared module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->