### PR TITLE
refactor(server): extract repeated settings.get calls in registerUser

### DIFF
--- a/apps/meteor/server/methods/registerUser.ts
+++ b/apps/meteor/server/methods/registerUser.ts
@@ -66,16 +66,16 @@ export const registerUser = async (
 		}),
 	);
 
-	if (settings.get('Accounts_RegistrationForm') === 'Disabled') {
+	const registrationForm = settings.get<string>('Accounts_RegistrationForm');
+	const registrationSecret = settings.get<string>('Accounts_RegistrationForm_SecretURL');
+
+	if (registrationForm === 'Disabled') {
 		throw new Meteor.Error('error-user-registration-disabled', 'User registration is disabled', {
 			method: 'registerUser',
 		});
 	}
 
-	if (
-		settings.get('Accounts_RegistrationForm') === 'Secret URL' &&
-		(!formData.secretURL || formData.secretURL !== settings.get('Accounts_RegistrationForm_SecretURL'))
-	) {
+	if (registrationForm === 'Secret URL' && (!formData.secretURL || formData.secretURL !== registrationSecret)) {
 		if (!formData.secretURL) {
 			throw new Meteor.Error('error-user-registration-secret', 'User registration is only allowed via Secret URL', {
 				method: 'registerUser',


### PR DESCRIPTION
## Proposed changes

This refactor extracts repeated `settings.get` calls within `registerUser` into local variables and reuses them across the function.

Previously, the same settings (`Accounts_RegistrationForm` and `Accounts_RegistrationForm_SecretURL`) were accessed multiple times in conditional checks. Since these values remain constant during a single execution, repeated calls were unnecessary and reduced readability.

This change:

- Computes the settings once per execution
- Reuses the computed values across conditional logic
- Improves readability by simplifying condition expressions
- Avoids duplicated function calls

No functional or API behavior changes were introduced.

## Issue(s)
fixes #39767

## Further comments

This is a non-functional refactor intended to improve code clarity and reduce duplication. Verified locally that behavior remains unchanged before and after the refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the user registration method to improve performance through more efficient settings handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->