### PR TITLE
refactor(api): migrate users.delete endpoint to openapi with ajv validation

### DIFF
--- a/.changeset/migrate-users-delete-to-AJV.md
+++ b/.changeset/migrate-users-delete-to-AJV.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/rest-typings': minor
+'@rocket.chat/meteor': minor
+---
+
+Migrate users.delete endpoint to make it openAPI and AJV compatible

--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -346,21 +346,6 @@ API.v1.addRoute(
 );
 
 API.v1.addRoute(
-	'users.delete',
-	{ authRequired: true, permissionsRequired: ['delete-user'] },
-	{
-		async post() {
-			const user = await getUserFromParams(this.bodyParams);
-			const { confirmRelinquish = false } = this.bodyParams;
-
-			const { deletedRooms } = await deleteUser(user._id, confirmRelinquish, this.userId);
-
-			return API.v1.success({ deletedRooms });
-		},
-	},
-);
-
-API.v1.addRoute(
 	'users.deleteOwnAccount',
 	{ authRequired: true },
 	{
@@ -877,6 +862,49 @@ const usersEndpoints = API.v1
 			const suggestions = await getAvatarSuggestionForUser(this.user);
 
 			return API.v1.success({ suggestions });
+		},
+	)
+	.post(
+		'users.delete',
+		{
+			authRequired: true,
+			permissionsRequired: ['delete-user'],
+			body: ajv.compile({
+				type: 'object',
+				properties: {
+					userId: { type: 'string' },
+					username: { type: 'string' },
+					confirmRelinquish: { type: 'boolean' },
+				},
+				additionalProperties: true,
+			}),
+			response: {
+				200: ajv.compile({
+					type: 'object',
+					properties: {
+						deletedRooms: {
+							type: 'array',
+							items: { type: 'string' },
+						},
+						success: {
+							type: 'boolean',
+							enum: [true],
+						},
+					},
+					required: ['deletedRooms', 'success'],
+					additionalProperties: false,
+				}),
+				401: validateUnauthorizedErrorResponse,
+				400: validateBadRequestErrorResponse,
+			},
+		},
+		async function action() {
+			const user = await getUserFromParams(this.bodyParams);
+			const { confirmRelinquish = false } = this.bodyParams;
+
+			const { deletedRooms } = await deleteUser(user._id, confirmRelinquish, this.userId);
+
+			return API.v1.success({ deletedRooms });
 		},
 	);
 

--- a/packages/rest-typings/src/v1/users.ts
+++ b/packages/rest-typings/src/v1/users.ts
@@ -351,10 +351,6 @@ export type UsersEndpoints = {
 		};
 	};
 
-	'/v1/users.delete': {
-		POST: (params: { userId: IUser['_id']; confirmRelinquish?: boolean }) => void;
-	};
-
 	'/v1/users.getAvatar': {
 		GET: (params: { userId?: string; username?: string; user?: string }) => void;
 	};


### PR DESCRIPTION
### Summary
This PR migrates the `users.delete` endpoint from the deprecated `API.v1.addRoute` format to the new declarative API route format.

### Changes
- Replaced `API.v1.addRoute` with `API.v1.post`
- Added request body validation
- Added response schema validation
- Maintained existing endpoint behavior

 ## Successful Runs
<img width="1613" height="636" alt="image" src="https://github.com/user-attachments/assets/97f1f0df-9d69-48fb-abd0-0ce11d29bcef" />

<img width="1583" height="506" alt="image" src="https://github.com/user-attachments/assets/4ec6ce9a-b9de-4c07-af54-ee62ffb47674" />

<img width="1462" height="522" alt="image" src="https://github.com/user-attachments/assets/422e386c-65f5-4e16-b0fb-4ea0bd4bb723" />

manual delete

<img width="1507" height="523" alt="user deleted" src="https://github.com/user-attachments/assets/c4711e67-0fab-490a-829e-6ea0abab9b3e" />


## Issues

https://github.com/RocketChat/Rocket.Chat-Open-API/pull/150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced users deletion API endpoint with improved request validation and standardized response schemas for better consistency and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->