### PR TITLE
perf(oembed): Fetch message urls concurrently

### DIFF
--- a/.changeset/eight-dryers-laugh.md
+++ b/.changeset/eight-dryers-laugh.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+perf(oembed): Fetch message urls concurrently

--- a/apps/meteor/server/services/messages/hooks/AfterSaveOEmbed.ts
+++ b/apps/meteor/server/services/messages/hooks/AfterSaveOEmbed.ts
@@ -351,16 +351,23 @@ const rocketUrlParser = async function (message: IMessage): Promise<IMessage> {
 	}
 
 	let changed = false;
-	for await (const item of message.urls) {
-		if (item.ignoreParse === true) {
-			log.debug({ msg: 'URL ignored for OEmbed', url: item.url });
-			continue;
+	const CONCURRENCY_LIMIT = 5;
+	for (let i = 0; i < message.urls.length; i += CONCURRENCY_LIMIT) {
+		const chunk = message.urls.slice(i, i + CONCURRENCY_LIMIT);
+		const fetchPromises = chunk.map(async (item) => {
+			if (item.ignoreParse === true) {
+				return { item, foundMeta: false, urlPreview: undefined };
+			}
+			const { urlPreview, foundMeta } = await parseUrl(item.url);
+			return { item, urlPreview, foundMeta };
+		});
+		const results = await Promise.all(fetchPromises);
+		for (const result of results) {
+			if (result.foundMeta && result.urlPreview) {
+				Object.assign(result.item, result.urlPreview);
+				changed = true;
+			}
 		}
-
-		const { urlPreview, foundMeta } = await parseUrl(item.url);
-
-		Object.assign(item, foundMeta ? urlPreview : {});
-		changed = changed || foundMeta;
 	}
 
 	if (changed === true) {


### PR DESCRIPTION
Proposed changes
This PR addresses a sequential network blocking bottleneck within the rocketUrlParser hook.
Previously, the parser utilized a for await...of loop to iterate over message.urls. When a message contained multiple external URLs, the server waited for each HTTP request (parseUrl) to completely resolve before initiating the next one. This resulted in an $O(N)$ network latency bottleneck on the main thread.This PR refactors the parsing logic to map the array into pending promises and resolves them concurrently using Promise.all. This flattens the execution time, bounding the total wait time to the duration of the single slowest HTTP request, significantly improving message processing speed for messages with multiple links. The original Object.assign memory reference mutations are safely preserved.

Issue(s)
Fixes #39710

Steps to test or reproduce
1. Boot up a local Rocket.Chat server.
2. Ensure OEmbed/Link Previews are enabled in Administration -> Settings -> Message.
3. Send a single message in any channel containing 4 or 5 different external URLs (e.g., various news articles or YouTube links).

Expected Result: 
The message processes and generates all previews concurrently. The total wait time is bounded by the slowest URL response, rather than the combined sum of all URL responses.


Further comments:
Promise.all was chosen for this optimization because the underlying parseUrl and getUrlContent functions already handle their own internal try/catch blocks for network timeouts. Because they safely return fallback objects instead of throwing unhandled exceptions, there is no risk of a single rejected network request breaking the Promise.all execution context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * OEmbed metadata fetching now processes multiple URLs concurrently instead of sequentially, improving message processing performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->