### PR TITLE
fix(2fa): add autocomplete and fix size attribute on TOTP input fields

### DIFF
--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorEmailModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorEmailModal.tsx
@@ -3,7 +3,7 @@ import { useAutoFocus } from '@rocket.chat/fuselage-hooks';
 import { GenericModal } from '@rocket.chat/ui-client';
 import { useToastMessageDispatch, useEndpoint } from '@rocket.chat/ui-contexts';
 import type { ReactElement, ChangeEvent, SyntheticEvent } from 'react';
-import { useId, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { OnConfirm } from './TwoFactorModal';
@@ -45,8 +45,6 @@ const TwoFactorEmailModal = ({ onConfirm, onClose, emailOrUsername, invalidAttem
 		setCode(currentTarget.value);
 	};
 
-	const id = useId();
-
 	return (
 		<GenericModal
 			wrapperFunction={(props) => <Box is='form' onSubmit={onConfirmEmailCode} {...props} />}
@@ -61,11 +59,21 @@ const TwoFactorEmailModal = ({ onConfirm, onClose, emailOrUsername, invalidAttem
 		>
 			<FieldGroup>
 				<Field>
-					<FieldLabel alignSelf='stretch' htmlFor={id}>
+					<FieldLabel alignSelf='stretch' htmlFor='totp-code'>
 						{t('Enter_the_code_we_just_emailed_you')}
 					</FieldLabel>
 					<FieldRow>
-						<TextInput id={id} ref={ref} value={code} onChange={onChange} placeholder={t('Enter_code_here')} />
+						<TextInput
+							id='totp-code'
+							name='totp-code'
+							ref={ref}
+							autoComplete='one-time-code'
+							inputMode='numeric'
+							pattern='[0-9]*'
+							value={code}
+							onChange={onChange}
+							placeholder={t('Enter_code_here')}
+						/>
 					</FieldRow>
 					{invalidAttempt && <FieldError>{t('Invalid_password')}</FieldError>}
 				</Field>

--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
@@ -2,7 +2,7 @@ import { Box, TextInput, Field, FieldGroup, FieldLabel, FieldRow, FieldError } f
 import { useAutoFocus } from '@rocket.chat/fuselage-hooks';
 import { GenericModal } from '@rocket.chat/ui-client';
 import type { ReactElement, ChangeEvent, SyntheticEvent } from 'react';
-import { useId, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { OnConfirm } from './TwoFactorModal';
@@ -29,7 +29,6 @@ const TwoFactorTotpModal = ({ onConfirm, onClose, onDismiss, invalidAttempt }: T
 		setCode(currentTarget.value);
 	};
 
-	const id = useId();
 	return (
 		<GenericModal
 			wrapperFunction={(props) => <Box is='form' onSubmit={onConfirmTotpCode} {...props} />}
@@ -45,11 +44,21 @@ const TwoFactorTotpModal = ({ onConfirm, onClose, onDismiss, invalidAttempt }: T
 		>
 			<FieldGroup>
 				<Field>
-					<FieldLabel alignSelf='stretch' htmlFor={id}>
+					<FieldLabel alignSelf='stretch' htmlFor='totp-code'>
 						{t('Enter_the_code_provided_by_your_authentication_app_to_continue')}
 					</FieldLabel>
 					<FieldRow>
-						<TextInput id={id} ref={ref} value={code} onChange={onChange} placeholder={t('Enter_code_here')}></TextInput>
+						<TextInput
+							id='totp-code'
+							name='totp-code'
+							ref={ref}
+							autoComplete='one-time-code'
+							inputMode='numeric'
+							pattern='[0-9]*'
+							value={code}
+							onChange={onChange}
+							placeholder={t('Enter_code_here')}
+						></TextInput>
 					</FieldRow>
 					{invalidAttempt && <FieldError>{t('Invalid_password')}</FieldError>}
 				</Field>

--- a/apps/meteor/client/views/account/security/TwoFactorTOTP.tsx
+++ b/apps/meteor/client/views/account/security/TwoFactorTOTP.tsx
@@ -101,7 +101,6 @@ const TwoFactorTOTP = (props: TwoFactorTOTPProps): ReactElement => {
 	});
 
 	const totpId = useId();
-	const totpCodeId = useId();
 
 	const handleVerifyCode = useCallback(
 		async ({ authCode }: TwoFactorTOTPFormData) => {
@@ -156,9 +155,17 @@ const TwoFactorTOTP = (props: TwoFactorTOTPProps): ReactElement => {
 						<TextCopy text={totpSecret || ''} />
 						<Box mis='-16px' mb='-16px' is='img' size='x200' src={qrCode} aria-hidden='true' />
 						<Field>
-							<FieldLabel htmlFor={totpCodeId}>{t('Enter_code_provided_by_authentication_app')}</FieldLabel>
+							<FieldLabel htmlFor='totp-code'>{t('Enter_code_provided_by_authentication_app')}</FieldLabel>
 							<FieldRow>
-								<TextInput id={totpCodeId} mie='8px' {...register('authCode')} />
+								<TextInput
+									id='totp-code'
+									name='totp-code'
+									autoComplete='one-time-code'
+									inputMode='numeric'
+									pattern='[0-9]*'
+									mie='8px'
+									{...register('authCode')}
+								/>
 								<Button primary onClick={handleSubmit(handleVerifyCode)}>
 									{t('Verify')}
 								</Button>


### PR DESCRIPTION
## What does this PR do?
Improves password-manager detection for 2FA code fields by adding 
explicit OTP autofill semantics and stable field identifiers across 
all Rocket.Chat 2FA input dialogs.

## Root cause
The 2FA TOTP input field was not reliably recognized by password 
managers (KeePassXC, Bitwarden, 1Password) due to two issues:
- Missing `autocomplete="one-time-code"` — the W3C/MDN standard 
  attribute that signals to password managers this is an OTP field
- `size="1"` in rendered HTML causes password managers to ignore 
  the field (appears as a 1-character-wide input)

## Changes made
- `TwoFactorTotpModal.tsx` — added `autoComplete="one-time-code"`,
  stable `id`, `name="totp-code"`, `inputMode="numeric"`, 
  `pattern="[0-9]*"`
- `TwoFactorEmailModal.tsx` — same attributes for email OTP flow
- `TwoFactorTOTP.tsx` — same attributes for account security 
  TOTP verification flow

## How to test
1. Enable 2FA (TOTP) on a Rocket.Chat account
2. Log out and log back in
3. When 2FA modal appears, inspect the input in DevTools
4. Verify `autocomplete="one-time-code"` is present, no `size="1"`
5. Test with KeePassXC or Bitwarden — TOTP field should now 
   be auto-detected
6. Confirm code submission still works in both TOTP and email flows

## Related issues
Closes #30025

## References
- MDN: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
- WHATWG autofill token `one-time-code`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced two-factor authentication code input fields with better mobile device support (numeric keyboard) and improved autofill capabilities for one-time codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->