### PR TITLE
fix(admin): prevent admin from deleting own account in Users panel

### DIFF
--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -353,6 +353,10 @@ API.v1.addRoute(
 			const user = await getUserFromParams(this.bodyParams);
 			const { confirmRelinquish = false } = this.bodyParams;
 
+			if (this.userId === user._id) {
+				return API.v1.failure('Cannot delete your own account');
+			}
+
 			const { deletedRooms } = await deleteUser(user._id, confirmRelinquish, this.userId);
 
 			return API.v1.success({ deletedRooms });

--- a/apps/meteor/client/views/admin/users/hooks/useDeleteUserAction.tsx
+++ b/apps/meteor/client/views/admin/users/hooks/useDeleteUserAction.tsx
@@ -15,6 +15,7 @@ import { useMemo } from 'react';
 
 import type { AdminUserAction } from './useAdminUserInfoActions';
 import { useConfirmOwnerChanges } from './useConfirmOwnerChanges';
+import { useUserId } from '@rocket.chat/ui-contexts';
 
 export const useDeleteUserAction = (userId: IUser['_id'], onChange: () => void, onReload: () => void): AdminUserAction | undefined => {
 	const t = useTranslation();
@@ -33,7 +34,7 @@ export const useDeleteUserAction = (userId: IUser['_id'], onChange: () => void, 
 
 	const deleteUserQuery = useMemo(() => ({ userId, confirmRelinquish: false }), [userId]);
 	const deleteUserEndpoint = useEndpoint('POST', '/v1/users.delete');
-
+	const currentUserId = useUserId();
 	const deleteUser = (): Promise<void> =>
 		confirmOwnerChanges(
 			async (confirm = false) => {
@@ -64,12 +65,12 @@ export const useDeleteUserAction = (userId: IUser['_id'], onChange: () => void, 
 		);
 	});
 
-	return canDeleteUser
-		? {
-				icon: 'trash',
-				content: t('Delete'),
-				onClick: confirmDeleteUser,
-				variant: 'danger',
-			}
-		: undefined;
+	return canDeleteUser && !!currentUserId && currentUserId !== userId
+	? {
+		icon: 'trash',
+		content: t('Delete'),
+		onClick: confirmDeleteUser,
+		variant: 'danger',
+		}
+	: undefined;
 };


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

An admin can delete their own account from the Admin > Users panel without 
any restriction. This breaks the active session immediately and can leave 
the workspace without an admin if no other admin exists.

This PR adds a check using `useUserId` to compare the currently logged-in 
user's ID against the target user's ID. If they match, the Delete action 
is not returned, hiding the option from the actions menu.

## Issue(s)
Fixes #39728

## Steps to test or reproduce
1. Log in as admin
2. Go to Admin > Users
3. Find your own user in the list
4. Click the three-dot actions menu

**Before this fix:**
Delete option is visible and functional on your own account.
<img width="1575" height="474" alt="image" src="https://github.com/user-attachments/assets/ca273e83-78ae-4448-8ecc-f66052dc1aa8" />


**After this fix:**
Delete option is not shown for the currently logged-in user's own account.
<img width="1575" height="552" alt="image" src="https://github.com/user-attachments/assets/db1a298c-f594-4f71-ad26-e334a9ac2fc6" />

## Further comments
The fix is in `useDeleteUserAction.tsx`. Added `useUserId` from `@rocket.chat/ui-contexts` to get the current user's ID and compare it against the target `userId`. If they match, the hook returns `undefined`, which hides the Delete action from the menu entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin panel “Delete user” action is now disabled when attempting to delete the currently logged-in admin account.
  * Server now prevents deleting your own account and returns an explicit failure when a self-delete is attempted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->