### PR TITLE
test(message-parser): add tests for joinEmoji behavior

### DIFF
--- a/.changeset/message-parser-joinEmoji-tests.md
+++ b/.changeset/message-parser-joinEmoji-tests.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/message-parser": patch
+---
+
+Add test coverage for joinEmoji behavior through reducePlainTexts

--- a/packages/message-parser/tests/joinEmoji.test.ts
+++ b/packages/message-parser/tests/joinEmoji.test.ts
@@ -9,19 +9,24 @@ describe('joinEmoji behavior through reducePlainTexts', () => {
 	it('merges consecutive plain texts', () => {
 		const result = reducePlainTexts([
 			plain('hello '),
-			plain('world')
+			plain('world'),
 		]);
 
-		expect(result[0].value).toBe('hello world');
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({ type: 'PLAIN_TEXT', value: 'hello world' });
 	});
 
-	it('handles emoji between plain texts', () => {
+	it('converts emoji with plain text neighbors to shortCode and merges', () => {
 		const result = reducePlainTexts([
 			plain('hello'),
 			emoji('smile'),
-			plain('world')
+			plain('world'),
 		]);
-
-		expect(result.length).toBeGreaterThan(0);
+        
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({
+			type: 'PLAIN_TEXT',
+			value: 'hello:smile:world',
+		});
 	});
 });

--- a/packages/message-parser/tests/joinEmoji.test.ts
+++ b/packages/message-parser/tests/joinEmoji.test.ts
@@ -1,0 +1,27 @@
+import { plain, emoji, reducePlainTexts } from '../src/utils';
+
+describe('joinEmoji behavior through reducePlainTexts', () => {
+	it('keeps emoji when alone', () => {
+		const result = reducePlainTexts([emoji('smile')]);
+		expect(result[0].type).toBe('EMOJI');
+	});
+
+	it('merges consecutive plain texts', () => {
+		const result = reducePlainTexts([
+			plain('hello '),
+			plain('world')
+		]);
+
+		expect(result[0].value).toBe('hello world');
+	});
+
+	it('handles emoji between plain texts', () => {
+		const result = reducePlainTexts([
+			plain('hello'),
+			emoji('smile'),
+			plain('world')
+		]);
+
+		expect(result.length).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
This PR adds a few tests covering the joinEmoji behavior through the reducePlainTexts utility.

The tests verify that:
- emojis are preserved when used alone
- consecutive plain text nodes are merged correctly
- emoji usage between text nodes does not break parsing

These tests help improve coverage and make sure the message parser handles these cases reliably.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for message parsing that verify text-joining behavior across scenarios: an emoji-only input preserves emoji output; adjacent plain text segments are concatenated into a single plain text item; and plain text separated by an emoji is joined with the emoji represented inline. These tests increase coverage for message composition edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->