### PR TITLE
chore(message-parser): add test coverage for isNodeOfType guard

### DIFF
--- a/.changeset/message-parser-guards-coverage.md
+++ b/.changeset/message-parser-guards-coverage.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/message-parser": patch
+---
+
+Add test coverage for isNodeOfType guard bringing branch coverage to 100%

--- a/packages/message-parser/tests/guards.test.ts
+++ b/packages/message-parser/tests/guards.test.ts
@@ -1,0 +1,27 @@
+import { isNodeOfType } from '../src/guards';
+
+describe('isNodeOfType', () => {
+	it('returns true when value has matching type', () => {
+		expect(isNodeOfType({ type: 'PLAIN_TEXT', value: 'hi' }, 'PLAIN_TEXT')).toBe(true);
+	});
+
+	it('returns false for null', () => {
+		expect(isNodeOfType(null, 'PLAIN_TEXT')).toBe(false);
+	});
+
+	it('returns false for non-object', () => {
+		expect(isNodeOfType('string', 'PLAIN_TEXT')).toBe(false);
+	});
+
+	it('returns false when type does not match', () => {
+		expect(isNodeOfType({ type: 'BOLD', value: [] }, 'PLAIN_TEXT')).toBe(false);
+	});
+
+	it('returns false when type property is missing', () => {
+		expect(isNodeOfType({ value: 'hi' }, 'PLAIN_TEXT')).toBe(false);
+	});
+
+	it('returns false for undefined', () => {
+		expect(isNodeOfType(undefined, 'PLAIN_TEXT')).toBe(false);
+	});
+});


### PR DESCRIPTION
guards.ts had 60% statement coverage and 0% branch coverage.

This PR adds a dedicated test suite covering all branches of isNodeOfType:
- matching type returns true
- null returns false
- non-object returns false
- mismatched type returns false
- missing type property returns false
- undefined returns false

All 594 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for message parsing type validation, increasing reliability across various input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->