### PR TITLE
fix: blank notifications when a voice call ends

### DIFF
--- a/.changeset/eighty-experts-sort.md
+++ b/.changeset/eighty-experts-sort.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/ui-voip': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes empty notifications sent when a voice call ends

--- a/apps/meteor/app/lib/server/functions/sendMessage.ts
+++ b/apps/meteor/app/lib/server/functions/sendMessage.ts
@@ -13,9 +13,10 @@ import { afterSaveMessage } from '../lib/afterSaveMessage';
 import { notifyOnRoomChangedById } from '../lib/notifyListener';
 import { validateCustomMessageFields } from '../lib/validateCustomMessageFields';
 
-type SendMessageOptions = {
+export type SendMessageOptions = {
 	upsert?: boolean;
 	previewUrls?: string[];
+	skipNotifications?: boolean;
 };
 
 // TODO: most of the types here are wrong, but I don't want to change them now
@@ -289,7 +290,7 @@ export const sendMessage = async function (user: any, message: any, room: any, o
 		void Apps.self?.triggerEvent(messageEvent, message);
 	}
 
-	await afterSaveMessage(message, room, user);
+	await afterSaveMessage(message, room, user, { options });
 
 	void notifyOnRoomChangedById(message.rid);
 

--- a/apps/meteor/app/lib/server/lib/afterSaveMessage.ts
+++ b/apps/meteor/app/lib/server/lib/afterSaveMessage.ts
@@ -4,10 +4,28 @@ import type { Updater } from '@rocket.chat/models';
 import { Rooms } from '@rocket.chat/models';
 
 import { callbacks } from '../../../../server/lib/callbacks';
+import type { SendMessageOptions } from '../functions/sendMessage';
 
-export async function afterSaveMessage(message: IMessage, room: IRoom, user: IUser, roomUpdater?: Updater<IRoom>): Promise<IMessage> {
+export async function afterSaveMessage(
+	message: IMessage,
+	room: IRoom,
+	user: IUser,
+	{
+		roomUpdater,
+		options,
+	}: {
+		roomUpdater?: Updater<IRoom>;
+		options?: SendMessageOptions;
+	} = {},
+): Promise<IMessage> {
 	const updater = roomUpdater ?? Rooms.getUpdater();
-	const data: IMessage = (await callbacks.run('afterSaveMessage', message, { room, user, roomUpdater: updater })) as unknown as IMessage;
+
+	const data: IMessage = (await callbacks.run('afterSaveMessage', message, {
+		room,
+		user,
+		roomUpdater: updater,
+		options,
+	})) as unknown as IMessage;
 
 	if (!roomUpdater && updater.hasChanges()) {
 		await Rooms.updateFromUpdater({ _id: room._id }, updater);
@@ -19,8 +37,21 @@ export async function afterSaveMessage(message: IMessage, room: IRoom, user: IUs
 	return data;
 }
 
-export function afterSaveMessageAsync(message: IMessage, room: IRoom, user: IUser, roomUpdater: Updater<IRoom> = Rooms.getUpdater()): void {
-	callbacks.runAsync('afterSaveMessage', message, { room, user, roomUpdater });
+export function afterSaveMessageAsync(
+	message: IMessage,
+	room: IRoom,
+	user: IUser,
+	{
+		roomUpdater: updater,
+		options,
+	}: {
+		roomUpdater?: Updater<IRoom>;
+		options?: SendMessageOptions;
+	} = {},
+): void {
+	const roomUpdater = updater ?? Rooms.getUpdater();
+
+	callbacks.runAsync('afterSaveMessage', message, { room, user, roomUpdater, options });
 
 	if (roomUpdater.hasChanges()) {
 		void Rooms.updateFromUpdater({ _id: room._id }, roomUpdater);

--- a/apps/meteor/app/lib/server/lib/sendNotificationsOnMessage.ts
+++ b/apps/meteor/app/lib/server/lib/sendNotificationsOnMessage.ts
@@ -417,7 +417,13 @@ settings.watch('Troubleshoot_Disable_Notifications', (value) => {
 
 	callbacks.add(
 		'afterSaveMessage',
-		(message, { room }) => sendAllNotifications(message, room),
+		(message, { room, options }) => {
+			if (options?.skipNotifications) {
+				return message;
+			}
+
+			return sendAllNotifications(message, room);
+		},
 		callbacks.priority.LOW,
 		'sendNotificationsOnMessage',
 	);

--- a/apps/meteor/app/threads/server/hooks/aftersavemessage.ts
+++ b/apps/meteor/app/threads/server/hooks/aftersavemessage.ts
@@ -4,6 +4,7 @@ import { Messages } from '@rocket.chat/models';
 import { Meteor } from 'meteor/meteor';
 
 import { callbacks } from '../../../../server/lib/callbacks';
+import type { SendMessageOptions } from '../../../lib/server/functions/sendMessage';
 import { notifyOnMessageChange } from '../../../lib/server/lib/notifyListener';
 import { updateThreadUsersSubscriptions, getMentions } from '../../../lib/server/lib/notifyUsersOnMessage';
 import { sendMessageNotifications } from '../../../lib/server/lib/sendNotificationsOnMessage';
@@ -39,7 +40,7 @@ const notification = async (message: IMessage, room: IRoom, replies: string[]) =
 	return message;
 };
 
-export async function processThreads(message: IMessage, room: IRoom) {
+export async function processThreads(message: IMessage, room: IRoom, options?: SendMessageOptions) {
 	if (!message.tmid) {
 		return message;
 	}
@@ -61,7 +62,9 @@ export async function processThreads(message: IMessage, room: IRoom) {
 
 	await notifyUsersOnReply(message, replies);
 	await metaData(message, parentMessage, replies);
-	await notification(message, room, replies);
+	if (!options?.skipNotifications) {
+		await notification(message, room, replies);
+	}
 	void notifyOnMessageChange({
 		id: message.tmid,
 	});
@@ -77,8 +80,8 @@ Meteor.startup(() => {
 		}
 		callbacks.add(
 			'afterSaveMessage',
-			async (message, { room }) => {
-				return processThreads(message, room);
+			async (message, { room, options }) => {
+				return processThreads(message, room, options);
 			},
 			callbacks.priority.LOW,
 			'threads-after-save-message',

--- a/apps/meteor/server/lib/callbacks.ts
+++ b/apps/meteor/server/lib/callbacks.ts
@@ -24,6 +24,7 @@ import type { FilterOperators } from 'mongodb';
 
 import { Callbacks } from './callbacks/callbacksBase';
 import type { ILoginAttempt } from '../../app/authentication/server/ILoginAttempt';
+import type { SendMessageOptions } from '../../app/lib/server/functions/sendMessage';
 import type { IBusinessHourBehavior } from '../../app/livechat/server/business-hour/AbstractBusinessHour';
 import type { CloseRoomParams } from '../../app/livechat/server/lib/localTypes';
 
@@ -46,7 +47,10 @@ interface EventLikeCallbackSignatures {
 	'afterDeleteUser': (user: IUser) => void;
 	'afterFileUpload': (params: { user: IUser; room: IRoom; message: IMessage }) => void;
 	'afterRoomNameChange': (params: { room: IRoom; name: string; oldName: string; user: IUser }) => void;
-	'afterSaveMessage': (message: IMessage, params: { room: IRoom; user: IUser; roomUpdater?: Updater<IRoom> }) => void;
+	'afterSaveMessage': (
+		message: IMessage,
+		params: { room: IRoom; user: IUser; roomUpdater?: Updater<IRoom>; options?: SendMessageOptions },
+	) => void;
 	'afterOmnichannelSaveMessage': (message: IMessage, constant: { room: IOmnichannelRoom; roomUpdater: Updater<IOmnichannelRoom> }) => void;
 	'livechat.removeAgentDepartment': (params: { departmentId: ILivechatDepartmentRecord['_id']; agentsId: ILivechatAgent['_id'][] }) => void;
 	'livechat.saveAgentDepartment': (params: { departmentId: ILivechatDepartmentRecord['_id']; agentsId: ILivechatAgent['_id'][] }) => void;

--- a/apps/meteor/server/services/media-call/service.ts
+++ b/apps/meteor/server/services/media-call/service.ts
@@ -12,10 +12,11 @@ import { callServer, type IMediaCallServerSettings } from '@rocket.chat/media-ca
 import { isClientMediaSignal, type ClientMediaSignal, type ServerMediaSignal } from '@rocket.chat/media-signaling';
 import type { InsertionModel } from '@rocket.chat/model-typings';
 import { CallHistory, MediaCalls, Rooms, Users } from '@rocket.chat/models';
-import { getHistoryMessagePayload } from '@rocket.chat/ui-voip/dist/ui-kit/getHistoryMessagePayload';
+import { callStateToTranslationKey, getHistoryMessagePayload } from '@rocket.chat/ui-voip/dist/ui-kit/getHistoryMessagePayload';
 
 import { sendMessage } from '../../../app/lib/server/functions/sendMessage';
 import { settings } from '../../../app/settings/server';
+import { i18n } from '../../lib/i18n';
 import { createDirectMessage } from '../../methods/createDirectMessage';
 
 const logger = new Logger('media-call service');
@@ -187,6 +188,10 @@ export class MediaCallService extends ServiceClassInternal implements IMediaCall
 		}
 	}
 
+	private getLanguageForUser(user: IUser): string {
+		return user.language || settings.get('Language') || 'en';
+	}
+
 	private async sendHistoryMessage(call: IMediaCall, room: IRoom): Promise<void> {
 		const userId = call.caller.id || call.createdBy?.id; // I think this should always be the caller, since during a transfer the createdBy contact is the one that transferred the call
 
@@ -196,12 +201,16 @@ export class MediaCallService extends ServiceClassInternal implements IMediaCall
 		}
 
 		const state = this.getCallHistoryItemState(call);
+		const skipNotifications = state !== 'not-answered' || call.hangupReason === 'rejected';
+		const i18nKey = callStateToTranslationKey(state).i18n?.key;
+
+		const msg = i18nKey ? i18n.t(i18nKey, { lng: this.getLanguageForUser(user) }) : '';
 		const duration = this.getCallDuration(call);
 
-		const record = getHistoryMessagePayload(state, duration, call._id);
+		const record = getHistoryMessagePayload(state, duration, call._id, msg);
 
 		try {
-			const message = await sendMessage(user, record, room);
+			const message = await sendMessage(user, record, room, { skipNotifications });
 
 			if ('_id' in message) {
 				await CallHistory.updateMany({ callId: call._id }, { $set: { messageId: message._id } });

--- a/packages/ui-voip/src/ui-kit/getHistoryMessagePayload.spec.ts
+++ b/packages/ui-voip/src/ui-kit/getHistoryMessagePayload.spec.ts
@@ -177,9 +177,9 @@ describe('getHistoryMessagePayload', () => {
 	});
 
 	it('should return correct payload for "not-answered" state', () => {
-		const result = getHistoryMessagePayload('not-answered', undefined, 'callid');
+		const result = getHistoryMessagePayload('not-answered', undefined, 'callid', 'call was not answered');
 		expect(result).toEqual({
-			msg: '',
+			msg: 'call was not answered',
 			groupable: false,
 			blocks: [
 				{

--- a/packages/ui-voip/src/ui-kit/getHistoryMessagePayload.ts
+++ b/packages/ui-voip/src/ui-kit/getHistoryMessagePayload.ts
@@ -76,13 +76,14 @@ export const getHistoryMessagePayload = (
 	callState: CallHistoryItemState,
 	callDuration: number | undefined,
 	callId?: string,
+	msg: string = '',
 ): Pick<IMessage, 'msg' | 'groupable'> & { blocks: [InfoCardBlock] } => {
 	const callStateTranslationKey = callStateToTranslationKey(callState);
 	const icon = callStateToIcon(callState);
 	const callDurationFormatted = getFormattedCallDuration(callDuration);
 
 	return {
-		msg: '',
+		msg,
 		groupable: false,
 		blocks: [
 			{


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes (including videos or screenshots)
- Disable notifications for the message that is inserted into rooms when a voice call ends, except for calls that were not answered nor rejected.
- Added state text to those message so that it can be used as fallback in any place that can't render blocks (such as the notifications)

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[PRD-230](https://rocketchat.atlassian.net/browse/PRD-230)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[PRD-230]: https://rocketchat.atlassian.net/browse/PRD-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed empty notifications being sent when voice calls end
  * Prevents notifications from triggering for unanswered or rejected calls
  * Enhanced call history messages with localized content instead of empty text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->