### PR TITLE
fix(agenda): clear failReason and failedAt on successful job completion

### DIFF
--- a/packages/agenda/src/Agenda.ts
+++ b/packages/agenda/src/Agenda.ts
@@ -474,35 +474,36 @@ export class Agenda extends EventEmitter {
 		}
 	}
 
-private async _updateJob(job: Job, props: Record<string, any>): Promise<void> {
-	const id = job.attrs._id;
+	private async _updateJob(job: Job, props: Record<string, any>): Promise<void> {
+    const id = job.attrs._id;
 
-	const $set: Record<string, any> = {};
-	const $unset: Record<string, any> = {};
+		const $set: Record<string, any> = {};
+		const $unset: Record<string, any> = {};
+		const unsetOnUndefined = new Set(['failReason', 'failedAt']);
 
-	for (const [key, value] of Object.entries(props)) {
-		if (value === undefined) {
-			$unset[key] = '';
-		} else {
-			$set[key] = value;
+		for (const [key, value] of Object.entries(props)) {
+			if (value === undefined && unsetOnUndefined.has(key)) {
+				$unset[key] = '';
+			} else if (value !== undefined) {
+				$set[key] = value;
+			}
+		}
+
+    const update: Record<string, any> = {};
+    if (Object.keys($set).length > 0) update.$set = $set;
+    if (Object.keys($unset).length > 0) update.$unset = $unset;
+
+    // Update the job and process the resulting data
+    debug('job already has _id, calling findOneAndUpdate() using _id as query');
+		try {
+			const result = await this.getCollection().findOneAndUpdate({ _id: id } as any, update, { returnDocument: 'after' });
+			result && (await this._processDbResult(job, result));
+		} catch (error) {
+			this.emit('error:database', error);
+			throw error;
 		}
 	}
 
-	const update: Record<string, any> = {};
-	if (Object.keys($set).length) update.$set = $set;
-	if (Object.keys($unset).length) update.$unset = $unset;
-
-	// Update the job and process the resulting data
-	debug('job already has _id, calling findOneAndUpdate() using _id as query');
-	try {
-		const result = await this.getCollection().findOneAndUpdate({ _id: id } as any, update, { returnDocument: 'after' });
-		result && (await this._processDbResult(job, result));
-	} catch (error) {
-		this.emit('error:database', error);
-		throw error;
-	}
-	}
-	
 	private async _saveSingleJob(job: Job, props: Record<string, any>, now: Date): Promise<void> {
 		// Job type set to 'single' so...
 		debug('job with type of "single" found');

--- a/packages/agenda/src/Agenda.ts
+++ b/packages/agenda/src/Agenda.ts
@@ -474,23 +474,35 @@ export class Agenda extends EventEmitter {
 		}
 	}
 
-	private async _updateJob(job: Job, props: Record<string, any>): Promise<void> {
-		const id = job.attrs._id;
-		const update = {
-			$set: props,
-		};
+private async _updateJob(job: Job, props: Record<string, any>): Promise<void> {
+	const id = job.attrs._id;
 
-		// Update the job and process the resulting data'
-		debug('job already has _id, calling findOneAndUpdate() using _id as query');
-		try {
-			const result = await this.getCollection().findOneAndUpdate({ _id: id } as any, update, { returnDocument: 'after' });
-			result && (await this._processDbResult(job, result));
-		} catch (error) {
-			this.emit('error:database', error);
-			throw error;
+	const $set: Record<string, any> = {};
+	const $unset: Record<string, any> = {};
+
+	for (const [key, value] of Object.entries(props)) {
+		if (value === undefined) {
+			$unset[key] = '';
+		} else {
+			$set[key] = value;
 		}
 	}
 
+	const update: Record<string, any> = {};
+	if (Object.keys($set).length) update.$set = $set;
+	if (Object.keys($unset).length) update.$unset = $unset;
+
+	// Update the job and process the resulting data
+	debug('job already has _id, calling findOneAndUpdate() using _id as query');
+	try {
+		const result = await this.getCollection().findOneAndUpdate({ _id: id } as any, update, { returnDocument: 'after' });
+		result && (await this._processDbResult(job, result));
+	} catch (error) {
+		this.emit('error:database', error);
+		throw error;
+	}
+	}
+	
 	private async _saveSingleJob(job: Job, props: Record<string, any>, now: Date): Promise<void> {
 		// Job type set to 'single' so...
 		debug('job with type of "single" found');

--- a/packages/agenda/src/Job.ts
+++ b/packages/agenda/src/Job.ts
@@ -207,6 +207,8 @@ export class Job {
 					this.fail(err);
 				} else {
 					this.attrs.lastFinishedAt = new Date();
+					this.attrs.failReason = undefined;
+    				this.attrs.failedAt = undefined;
 				}
 
 				this.attrs.lockedAt = null;


### PR DESCRIPTION
## Proposed changes
`failReason` and `failedAt` fields are never cleared when a job runs successfully 
after a previous failure. This causes stale failure data to persist indefinitely 
in `rocketchat_cron`.

Two changes:
1. `Job.ts` — clear `failReason` and `failedAt` in the success path of `jobCallback`
2. `Agenda.ts` — filter `undefined` values from `$set` into `$unset` in `_updateJob` 
   so MongoDB actually removes the fields instead of ignoring them

## Issue(s)
Closes #39755

## Steps to test
1. Manually set `failReason` and `failedAt` on a job document in `rocketchat_cron`
2. Wait for the job to run successfully on next scheduled execution
3. Verify both fields are removed from the document
Steps to test or reproduce

Before fix — job with lastFinishedAt set still showing stale failReason:
```
{
    "_id": "69b96a5e22a18cc50365c72c",
    "name": "UserDataDownload",
    "lastRunAt": "2026-03-20T05:10:00.000Z",
    "lastFinishedAt": "2026-03-20T05:10:00.004Z",
    "failReason": "Got Stuck",
    "failedAt": "2026-03-20T05:10:00.004Z"
}
```
After fix — both fields cleared after successful run:
```
{
    "_id": "69b96a5e22a18cc50365c72c",
    "name": "UserDataDownload",
    "lastRunAt": "2026-03-20T05:38:00.001Z",
    "lastFinishedAt": "2026-03-20T05:38:00.004Z"

}
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Jobs now clear previous failure details when they finish successfully, preventing stale error information from persisting.
  * Job completion timestamps are updated reliably on success.
  * Updates to job properties now only write defined changes to the database and explicitly remove select fields when unset, avoiding accidental persistence of undefined values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->