### PR TITLE
fix(admin): prevent admin from deleting own account in Users panel

### DIFF
--- a/apps/meteor/client/views/admin/users/hooks/useDeleteUserAction.tsx
+++ b/apps/meteor/client/views/admin/users/hooks/useDeleteUserAction.tsx
@@ -10,6 +10,7 @@ import {
 	usePermission,
 	useEndpoint,
 	useTranslation,
+	useUserId,
 } from '@rocket.chat/ui-contexts';
 import { useMemo } from 'react';
 
@@ -24,6 +25,7 @@ export const useDeleteUserAction = (userId: IUser['_id'], onChange: () => void, 
 	const erasureType = useSetting('Message_ErasureType');
 	const confirmOwnerChanges = useConfirmOwnerChanges();
 	const dispatchToastMessage = useToastMessageDispatch();
+	const currentUserId = useUserId();
 
 	const handleDeletedUser = (): void => {
 		setModal();
@@ -64,7 +66,7 @@ export const useDeleteUserAction = (userId: IUser['_id'], onChange: () => void, 
 		);
 	});
 
-	return canDeleteUser
+	return canDeleteUser && userId !== currentUserId
 		? {
 				icon: 'trash',
 				content: t('Delete'),


### PR DESCRIPTION
## What changed
Added a self-deletion guard in `useDeleteUserAction.tsx` by comparing 
the target `userId` against the currently logged-in user's ID via `useUserId()`. 
The Delete action is no longer returned when an admin views their own account.

## Why
An admin could delete their own account from Admin > Users, immediately 
breaking the active session with no restriction or warning.

Closes #<issue-number>

## How to test
1. Log in as admin → Admin > Users
2. Open three-dot menu on your own account — Delete should not appear
3. Open three-dot menu on any other user — Delete should still appear

## Changes
- `useDeleteUserAction.tsx` — added `useUserId()` guard