### PR TITLE
fix: avoid full collection fetch in getAllUserMentionsByChannel

### DIFF
--- a/apps/meteor/app/api/server/v1/channels.ts
+++ b/apps/meteor/app/api/server/v1/channels.ts
@@ -432,19 +432,20 @@ API.v1.addRoute(
 			const { offset, count } = await getPaginationItems(this.queryParams);
 			const { sort } = await this.parseJsonQuery();
 
-			const mentions = await getUserMentionsByChannel(this.userId, roomId, {
-				sort: sort || { ts: 1 },
-				skip: offset,
-				limit: count,
-			});
-
-			const allMentions = await getUserMentionsByChannel(this.userId, roomId, {});
+			const [mentions, total] = await Promise.all([
+				getUserMentionsByChannel(this.userId, roomId, {
+					sort: sort || { ts: 1 },
+					skip: offset,
+					limit: count,
+				}),
+				Messages.countVisibleByMentionAndRoomId(this.user.username, roomId),
+			]);
 
 			return API.v1.success({
 				mentions,
 				count: mentions.length,
 				offset,
-				total: allMentions.length,
+				total,
 			});
 		},
 	},

--- a/packages/model-typings/src/models/IMessagesModel.ts
+++ b/packages/model-typings/src/models/IMessagesModel.ts
@@ -39,6 +39,8 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 
 	findVisibleByMentionAndRoomId(username: IUser['username'], rid: IRoom['_id'], options?: FindOptions<IMessage>): FindCursor<IMessage>;
 
+	countVisibleByMentionAndRoomId(username: IUser['username'], rid: IRoom['_id']): Promise<number>;
+
 	findStarredByUserAtRoom(userId: IUser['_id'], roomId: IRoom['_id'], options?: FindOptions<IMessage>): FindPaginated<FindCursor<IMessage>>;
 
 	findPaginatedByRoomIdAndType(

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -91,6 +91,16 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 		return this.find(query, options);
 	}
 
+	countVisibleByMentionAndRoomId(username: IUser['username'], rid: IRoom['_id']): Promise<number> {
+		const query: Filter<IMessage> = {
+			'_hidden': { $ne: true },
+			'mentions.username': username,
+			rid,
+		};
+
+		return this.countDocuments(query);
+	}
+
 	findPaginatedVisibleByMentionAndRoomId(
 		username: IUser['username'],
 		rid: IRoom['_id'],


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

The `channels.getAllUserMentionsByChannel` endpoint was calling `getUserMentionsByChannel` twice, once for paginated results and once with empty options `{}` to compute `total` for `length`. The second call fetches all matching documents into memory just to count them.

This PR replaces the second call with a new `countVisibleByMentionAndRoomId` method on the Messages model. Both calls now run in parallel via `Promise.all`.

This follows the existing pattern already used throughout the codebase like `countVisibleByRoomIdBetweenTimestampsInclusive`, `countPinned`,  `countStarred` in Messages.ts

No behavior change
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Further comments
**Before:** 2 sequential DB calls, second fetches all documents into memory
**After:**  2 parallel DB calls, second uses countDocuments (returns integer only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized mention retrieval to load paged mentions and compute totals in parallel, reducing latency while preserving response format.
  * Improved server-side counting of visible mentions so total counts are accurate and returned faster without changing how results appear to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->