### PR TITLE
[Fix] TOTP input autofill hints

### DIFF
--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.spec.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.spec.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { useTranslation } from 'react-i18next';
+import type { ReactNode } from 'react';
+
+jest.mock('react-i18next', () => ({
+	useTranslation: jest.fn(),
+}));
+
+jest.mock(
+	'@rocket.chat/ui-client',
+	() => ({
+		GenericModal: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	}),
+	{ virtual: true },
+);
+
+jest.mock('./TwoFactorModal', () => ({
+	Method: {
+		TOTP: 'totp',
+	},
+}));
+
+import TwoFactorTotpModal from './TwoFactorTotpModal';
+
+describe('TwoFactorTotpModal', () => {
+	it('renders the TOTP input with one-time-code autofill hints', () => {
+		jest.mocked(useTranslation).mockReturnValue({
+			t: (key: string) => key,
+			i18n: {} as never,
+		});
+
+		render(<TwoFactorTotpModal onConfirm={jest.fn()} onClose={jest.fn()} />);
+
+		const input = screen.getByRole('textbox', { name: 'Enter_the_code_provided_by_your_authentication_app_to_continue' });
+
+		expect(input).toHaveAttribute('autocomplete', 'one-time-code');
+		expect(input).toHaveAttribute('inputmode', 'numeric');
+		expect(input).toHaveAttribute('name', 'totp');
+	});
+});

--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
@@ -49,7 +49,17 @@ const TwoFactorTotpModal = ({ onConfirm, onClose, onDismiss, invalidAttempt }: T
 						{t('Enter_the_code_provided_by_your_authentication_app_to_continue')}
 					</FieldLabel>
 					<FieldRow>
-						<TextInput id={id} ref={ref} value={code} onChange={onChange} placeholder={t('Enter_code_here')}></TextInput>
+						<TextInput
+							id={id}
+							ref={ref}
+							type='text'
+							name='totp'
+							autoComplete='one-time-code'
+							inputMode='numeric'
+							value={code}
+							onChange={onChange}
+							placeholder={t('Enter_code_here')}
+						/>
 					</FieldRow>
 					{invalidAttempt && <FieldError>{t('Invalid_password')}</FieldError>}
 				</Field>


### PR DESCRIPTION
## What this does
Adds autofill-friendly attributes to the TOTP input in the two-factor modal:
- `autocomplete="one-time-code"`
- `inputMode="numeric"`
- `name="totp"`

This helps password managers and one-time-code autofill recognize the field correctly.

## Testing
- Added a focused client test for `TwoFactorTotpModal`
- Ran:

```bash
cd apps/meteor
corepack yarn .testunit:jest client/components/TwoFactorModal/TwoFactorTotpModal.spec.tsx --config jest.config.ts --selectProjects client --runInBand


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for the TOTP two-factor authentication modal, validating component rendering and input field attributes.

* **Bug Fixes**
  * Enhanced the TOTP entry input field with improved browser auto-fill support, better accessibility, and numeric input mode optimization for a streamlined authentication experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->