### PR TITLE
test(apps): add tests for ModifyDeleter accessor

### DIFF
--- a/packages/apps-engine/tests/server/accessors/ModifyDeleter.test.ts
+++ b/packages/apps-engine/tests/server/accessors/ModifyDeleter.test.ts
@@ -86,6 +86,7 @@ describe('ModifyDeleter', () => {
 		assert.deepStrictEqual(spy.mock.calls[0].arguments, ['app-id', UserType.APP]);
 
 		await md.deleteUsers('app-id', UserType.BOT);
+		assert.strictEqual(spy.mock.calls.length, 2);
 		assert.deepStrictEqual(spy.mock.calls[1].arguments, ['app-id', UserType.BOT]);
 	});
 


### PR DESCRIPTION
Fixes #39795

adds test coverage for `ModifyDeleter` in `packages/apps-engine/src/server/accessors/`. covers all 4 methods:

- `deleteRoom` — verifies bridge delegation
- `deleteMessage` — verifies bridge delegation  
- `deleteUsers` — verifies bridge delegation for both `APP` and `BOT` types, checks return value
- `removeUsersFromRoom` — verifies normal case, boundary (exactly 50 users), and throws when exceeding 50-user limit

follows the same Alsatian pattern used by the existing accessor tests (ModifyCreator, ModifyUpdater, ModifyExtender).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying deletion and user-management operations delegate correctly to backend bridges (room, message, user).
  * Added input-boundary test ensuring removing >50 users from a room errors and prevents the removal call.
  * Ensured mocks are cleaned up after each test to avoid side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->