### PR TITLE
feat(auth): Add telemetry for dormant and deactivated account login attempts

### DIFF
--- a/.changeset/gsoc-telemetry-fix.md
+++ b/.changeset/gsoc-telemetry-fix.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+feat(auth): Add telemetry for dormant and deactivated account login attempts

--- a/.changeset/nice-geckos-applaud.md
+++ b/.changeset/nice-geckos-applaud.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+feat(auth): Add telemetry for dormant and deactivated account login attempts

--- a/apps/meteor/app/authentication/server/lib/logLoginAttempts.ts
+++ b/apps/meteor/app/authentication/server/lib/logLoginAttempts.ts
@@ -26,6 +26,17 @@ export const logFailedLoginAttempts = (login: ILoginAttempt): void => {
 	if (!settings.get('Login_Logs_UserAgent')) {
 		userAgent = '-';
 	}
+	let isDeactivated = false;
+	let daysInactive = 0;
+	const reason = login.error?.reason || login.error?.message;
+
+	if (login.user) {
+		isDeactivated = login.user.active === false;
+		if (login.user.lastLogin) {
+			const msInactive = Date.now() - new Date(login.user.lastLogin).getTime();
+			daysInactive = Math.floor(msInactive / (1000 * 60 * 60 * 24));
+		}
+	}
 	SystemLogger.info({
 		msg: 'Failed login detected',
 		user,
@@ -33,5 +44,8 @@ export const logFailedLoginAttempts = (login: ILoginAttempt): void => {
 		forwardedFor,
 		realIp,
 		userAgent,
+		...(reason && { reason }),
+		...(isDeactivated && { accountStatus: 'deactivated', deactivatedWarning: 'Login attempt on deactivated account' }),
+		...(daysInactive >= 180 && { daysInactive, dormantWarning: 'Login attempt on dormant account' })
 	});
 };


### PR DESCRIPTION
## Proposed changes
Currently, `logFailedLoginAttempts` logs basic connection details (IP, User-Agent) but lacks specific telemetry regarding the targeted account's active state, and swallows the actual error reason. 

In preparation for the **GSoC 2026 project "Warning and Reporting for Login Attempts from Inactive Users"**, this PR injects lightweight, context-aware telemetry into the authentication flow. 

Specifically, it flags failed login attempts targeting:
1. **Deactivated accounts** (`user.active === false`)
2. **Dormant accounts** (Accounts with no `lastLogin` activity for 180+ days)

It also exposes the underlying `login.error.reason` to the logger so server admins have the necessary context for the failure rather than a generic "Failed login detected" message.

## Issue(s)
N/A - GSoC 2026 Preparatory Work / Proactive Code Audit.

## Steps to test or reproduce
1. **Standard Failure:** Attempt to log in with an incorrect password for a normal, active user. Verify the server logs output the standard failure message (with the new `reason` field) but no extra bloat.
2. **Deactivated Account Target:** Deactivate a user via the Admin panel. Attempt to log in as that user. Verify the server logs include `accountStatus: 'deactivated'` and the associated warning.
3. **Dormant Account Target:** (Requires DB tweak) Set a test user's `lastLogin` date to >180 days in the past. Attempt to log in with a bad password. Verify the server logs output `daysInactive: X` and the dormant account warning.

## Further comments
To ensure this telemetry adds **zero bloat** to standard failed login logs, I utilized the conditional spread pattern (`...(condition && { key: value })`). If a normal, active user types a bad password, the resulting log object remains perfectly clean and unchanged, preventing unnecessary database/log clutter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced login-attempt telemetry to detect dormant accounts (inactive ≥180 days) and deactivated accounts.
  * Improved failed-login logging with added context: failure reason, account status, inactivity days, and contextual warnings.

* **Chores**
  * Added release metadata entries to publish this patch with the new auth telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->