### PR TITLE
chore: migrate rooms.changeArchivationState to new api pattern

### DIFF
--- a/.changeset/migrate-rooms-changeArchivationState-endpoint.md
+++ b/.changeset/migrate-rooms-changeArchivationState-endpoint.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/meteor': minor
+'@rocket.chat/rest-typings': minor
+---
+
+Migrates `rooms.changeArchivationState` to the chained API pattern and removes its dedicated manual validator export from rest-typings in favor of endpoint-local schema definition.

--- a/apps/meteor/app/api/server/v1/rooms.ts
+++ b/apps/meteor/app/api/server/v1/rooms.ts
@@ -16,7 +16,6 @@ import {
 	isRoomsCleanHistoryProps,
 	isRoomsOpenProps,
 	isRoomsMembersOrderedByRoleProps,
-	isRoomsChangeArchivationStateProps,
 	isRoomsHideProps,
 	isRoomsInviteProps,
 	validateBadRequestErrorResponse,
@@ -717,25 +716,6 @@ API.v1.addRoute(
 );
 
 API.v1.addRoute(
-	'rooms.changeArchivationState',
-	{ authRequired: true, validateParams: isRoomsChangeArchivationStateProps },
-	{
-		async post() {
-			const { rid, action } = this.bodyParams;
-
-			let result;
-			if (action === 'archive') {
-				result = await executeArchiveRoom(this.userId, rid);
-			} else {
-				result = await executeUnarchiveRoom(this.userId, rid);
-			}
-
-			return API.v1.success({ result });
-		},
-	},
-);
-
-API.v1.addRoute(
 	'rooms.export',
 	{ authRequired: true, validateParams: isRoomsExportProps },
 	{
@@ -1041,6 +1021,18 @@ const isRoomsLeavePropsSchema = {
 
 const isRoomsFavoriteProps = ajv.compile<RoomsFavorite>(RoomsFavoriteSchema);
 const isRoomsLeaveProps = ajv.compile<RoomsLeave>(isRoomsLeavePropsSchema);
+const isRoomsChangeArchivationStateProps = ajv.compile<{
+	rid: string;
+	action?: string;
+}>({
+	type: 'object',
+	properties: {
+		rid: { type: 'string' },
+		action: { type: 'string', nullable: true },
+	},
+	required: ['rid'],
+	additionalProperties: false,
+});
 const roomsBannedUsersResponseSchema = ajv.compile<{
 	success: true;
 	bannedUsers: RequiredField<Pick<IUser, '_id' | 'username' | 'name'>, '_id' | 'username'>[];
@@ -1373,6 +1365,41 @@ export const roomEndpoints = API.v1
 				offset,
 				total,
 			});
+		},
+	)
+	.post(
+		'rooms.changeArchivationState',
+		{
+			authRequired: true,
+			body: isRoomsChangeArchivationStateProps,
+			response: {
+				200: ajv.compile<{
+					success: true;
+					result: unknown;
+				}>({
+					type: 'object',
+					properties: {
+						success: { type: 'boolean', enum: [true] },
+						result: {},
+					},
+					required: ['success', 'result'],
+					additionalProperties: false,
+				}),
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+			},
+		},
+		async function action() {
+			const { rid, action } = this.bodyParams;
+
+			let result;
+			if (action === 'archive') {
+				result = await executeArchiveRoom(this.userId, rid);
+			} else {
+				result = await executeUnarchiveRoom(this.userId, rid);
+			}
+
+			return API.v1.success({ result });
 		},
 	);
 type RoomEndpoints = ExtractRoutesFromAPI<typeof roomEndpoints> &

--- a/packages/rest-typings/src/v1/rooms.ts
+++ b/packages/rest-typings/src/v1/rooms.ts
@@ -330,25 +330,6 @@ const RoomsAdminRoomsGetRoomSchema = {
 
 export const isRoomsAdminRoomsGetRoomProps = ajv.compile<RoomsAdminRoomsGetRoomProps>(RoomsAdminRoomsGetRoomSchema);
 
-type RoomsChangeArchivationStateProps = { rid: string; action?: string };
-
-const RoomsChangeArchivationStateSchema = {
-	type: 'object',
-	properties: {
-		rid: {
-			type: 'string',
-		},
-		action: {
-			type: 'string',
-			nullable: true,
-		},
-	},
-	required: ['rid'],
-	additionalProperties: false,
-};
-
-export const isRoomsChangeArchivationStateProps = ajv.compile<RoomsChangeArchivationStateProps>(RoomsChangeArchivationStateSchema);
-
 type RoomsSaveRoomSettingsProps = {
 	rid: string;
 	roomAvatar?: string;
@@ -883,12 +864,6 @@ export type RoomsEndpoints = {
 		POST: (params: RoomsSaveRoomSettingsProps) => {
 			success: boolean;
 			rid: string;
-		};
-	};
-
-	'/v1/rooms.changeArchivationState': {
-		POST: (params: RoomsChangeArchivationStateProps) => {
-			success: boolean;
 		};
 	};
 


### PR DESCRIPTION
## Summary
This PR migrates `rooms.changeArchivationState` to the new API route style and removes its dedicated validator definition from `rest-typings`, keeping the schema local to the endpoint implementation.

## What changed
- Migrated `rooms.changeArchivationState` from deprecated `API.v1.addRoute(...)` to chained `roomEndpoints.post(...)`.
- Replaced `validateParams` usage with `body` schema for the migrated endpoint.
- Added inline response validation (`200`, `400`, `401`) on the migrated route.
- Removed the dedicated `isRoomsChangeArchivationStateProps` schema/type export from `rest-typings`.

tracked in :- https://github.com/RocketChat/Rocket.Chat-Open-API/pull/150

## Why
- Aligns with API migration guidelines (`addRoute` and `validateParams` deprecation).
- Reduces coupling to shared manual validator exports in `rest-typings`.
- Keeps validation close to endpoint behavior for this migrated route.

## Validation
- Type diagnostics on changed files: no errors.
- ESLint on changed files: no errors (warnings only, pre-existing in API file context).
- `yarn testapi -- --grep "rooms.changeArchivationState"`: no matching tests found (`0 passing`).

## Scope
- Only migration-related changes for `rooms.changeArchivationState`.
- No unrelated endpoint behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored the `rooms.changeArchivationState` API endpoint to an updated architectural pattern with improved validation and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->