### PR TITLE
fix: restrict permissions/get to users with permission

### DIFF
--- a/apps/meteor/app/authorization/server/streamer/permissions/index.ts
+++ b/apps/meteor/app/authorization/server/streamer/permissions/index.ts
@@ -4,6 +4,7 @@ import { Permissions } from '@rocket.chat/models';
 import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import type { WithId } from 'mongodb';
+import { hasPermission } from '@rocket.chat/core-services';
 
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -32,7 +33,11 @@ export const permissionsGetMethod = async (
 Meteor.methods<ServerMethods>({
 	async 'permissions/get'(updatedAt?: Date) {
 		check(updatedAt, Match.Maybe(Date));
-		// TODO: should we return this for non logged users?
+
+		if (!this.userId || !(await hasPermission(this.userId, 'view-permissions'))) {
+			throw new Meteor.Error('error-not-authorized');
+		}
+
 		// TODO: we could cache this collection
 
 		return permissionsGetMethod(updatedAt);


### PR DESCRIPTION
## Proposed changes
This PR restricts access to the `permissions/get` method to authenticated users.

Currently, the method can be accessed without authentication (see existing TODO), which may expose permission data unintentionally.

This change:
- Requires a valid `userId`
- Adds a permission check using `view-permissions`

This aligns the method with other protected server endpoints and improves security consistency.

## Issues
fixes #39821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authorization enforcement on the permissions retrieval endpoint. Only users with proper credentials can now access permission records. Unauthorized access attempts will be rejected with an appropriate error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->