### PR TITLE
chore(agenda): correct failReason type and remove dead code in saveJob

### DIFF
--- a/packages/agenda/src/Agenda.ts
+++ b/packages/agenda/src/Agenda.ts
@@ -575,9 +575,7 @@ export class Agenda extends EventEmitter {
 			const id = job.attrs._id;
 
 			const props = job.toJSON();
-			// delete props._id;
-			// delete props.unique;
-			// delete props.uniqueOpts;
+
 
 			// Store name of agenda queue as last modifier in job data
 			props.lastModifiedBy = this._name;

--- a/packages/agenda/src/definition/IJob.ts
+++ b/packages/agenda/src/definition/IJob.ts
@@ -18,7 +18,7 @@ export interface IJob {
 
 	priority?: number;
 
-	failReason?: string | Error;
+	failReason?: string;
 	failCount?: number;
 
 	lastModifiedBy?: string;


### PR DESCRIPTION

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
`failReason` in `IJob` was typed as `string | Error` but `fail()` always 
converts `Error` instances to their message string before storing, making 
the `Error` branch of the union impossible at runtime. Updated the type 
to `string` to reflect actual behavior.

Also removed three commented-out delete statements in `saveJob` that were 
made redundant when `toJSON()` was refactored to exclude `_id`, `unique`, 
and `uniqueOpts` via destructuring. The comments implied these fields might 
still be present in `props` when they aren't, which was misleading.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up commented-out code from job persistence logic to improve code clarity and maintainability.

* **Updates**
  * Job failure reason field now accepts string values exclusively. Support for Error object instances has been removed. Code passing Error objects to this field will require updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->