### PR TITLE
fix: remove ghost reactions when a user is deleted

### DIFF
--- a/apps/meteor/app/lib/server/functions/deleteUser.ts
+++ b/apps/meteor/app/lib/server/functions/deleteUser.ts
@@ -110,7 +110,8 @@ export async function deleteUser(userId: string, confirmRelinquish = false, dele
 
 		const rids = subscribedRooms.map((room) => room.rid);
 		void notifyOnRoomChangedById(rids);
-
+        // Remove deleted user's username from all message reactions
+       await Messages.removeReactionsByUsername(user.username);
 		await Subscriptions.removeByUserId(userId);
 
 		// Remove user as livechat agent

--- a/packages/model-typings/src/models/IMessagesModel.ts
+++ b/packages/model-typings/src/models/IMessagesModel.ts
@@ -297,4 +297,5 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 	countStarred(options?: CountDocumentsOptions): Promise<number>;
 	removeFileAttachmentsByMessageIds(_ids: string[], replaceWith?: MessageAttachment): Promise<Document | UpdateResult>;
 	clearFilesByMessageIds(_ids: string[]): Promise<Document | UpdateResult>;
+	removeReactionsByUsername(username: string): Promise<void>;
 }

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -1842,4 +1842,15 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			},
 		);
 	}
+	async removeReactionsByUsername(username: string): Promise<void> {
+    await this.col.updateMany(
+        { 'reactions': { $exists: true } },
+        {
+            $pull: { 'reactions.$[bucket].usernames': username } as any,
+        },
+        {
+            arrayFilters: [{ 'bucket.usernames': username }],
+        },
+    );
+}
 }


### PR DESCRIPTION
When a user is deleted from the workspace, their username was not being removed from message reactions stored in the rocketchat_message collection. Rocket.Chat stores reactions using usernames directly inside the message document as reactions: { ":emoji:": { usernames: ["userA", "userB"] } } instead of user IDs, which means the standard user deletion cascade does not clean up these references. As a result, deleted users continued to appear as having reacted to messages, creating ghost reactions that reference usernames no longer present in the users collection.

To fix this, a new method removeReactionsByUsername() was added to the MessagesRaw model and the IMessagesModel interface. This method uses MongoDB's arrayFilters with the $[bucket] positional operator to efficiently remove the deleted user's username from every reaction bucket across all message documents in a single updateMany call. The method is then invoked inside deleteUser.ts as part of the existing user deletion flow, right before subscriptions are removed, ensuring no orphan reaction references remain after a user is deleted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where reactions from deleted users were not being properly removed from messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->