### PR TITLE
chore(auth): prototype logging for deactivated user login attempts

### DIFF
--- a/apps/meteor/app/authentication/server/hooks/login.ts
+++ b/apps/meteor/app/authentication/server/hooks/login.ts
@@ -7,8 +7,13 @@ import { logFailedLoginAttempts } from '../lib/logLoginAttempts';
 import { saveFailedLoginAttempts, saveSuccessfulLogin } from '../lib/restrictLoginAttempts';
 
 const ignoredErrorTypes = ['totp-required', 'error-login-blocked-for-user'];
+const logger = new Logger('LoginAttempts');
 
 Accounts.onLoginFailure(async (login: ILoginAttempt) => {
+	// Prototype: Detect deactivated user login attempts
+	if (login.user?.active === false) {
+	    logger.warn(`Deactivated user attempted login - userId: ${login.user?._id}, IP: ${login.connection?.clientAddress}`);
+	}
 	// do not save specific failed login attempts
 	if (
 		settings.get('Block_Multiple_Failed_Logins_Enabled') &&


### PR DESCRIPTION
This is a small prototype to explore and validate the appropriate hooks for detecting login attempts from deactivated users. The goal is to verify how we can surface these security signals within the existing authentication flow (e.g., onLoginFailure) without introducing performance overhead.

This work is part of my preparation for the GSoC '26 proposal: "Warning and Reporting for Login Attempts from Inactive or Deactivated Users".

Changes

Implemented a structured Logger.warn signal within the onLoginFailure path.

Validated that the user?.active status is correctly identified during the failure sequence.