### PR TITLE
chore: migrate rooms.nameExists endpoint to new API format with AJV v…

### DIFF
--- a/apps/meteor/app/api/server/v1/rooms.ts
+++ b/apps/meteor/app/api/server/v1/rooms.ts
@@ -76,12 +76,12 @@ export async function findRoomByIdOrName({
 	checkedArchived = true,
 }: {
 	params:
-		| {
-				roomId?: string;
-		  }
-		| {
-				roomName?: string;
-		  };
+	| {
+		roomId?: string;
+	}
+	| {
+		roomName?: string;
+	};
 	checkedArchived?: boolean;
 }): Promise<IRoom> {
 	if (
@@ -110,21 +110,51 @@ export async function findRoomByIdOrName({
 	return room;
 }
 
-API.v1.addRoute(
-	'rooms.nameExists',
+const roomNameExistsEndpoint = API.v1.get('rooms.nameExists',
 	{
 		authRequired: true,
-		validateParams: isGETRoomsNameExists,
-	},
-	{
-		async get() {
-			const { roomName } = this.queryParams;
-
-			const room = await Rooms.findOneByName(roomName, { projection: { _id: 1 } });
-
-			return API.v1.success({ exists: !!room });
+		//required query validation using ajv
+		query: ajv.compile<{ roomName: string }>({
+			type: 'object',
+			properties: {
+				roomName: {
+					type: 'string',
+					description: 'The name of the room to check',
+				},
+			},
+			required: ['roomName'],
+			additionalProperties: false,
+		}),
+		//response validation
+		response: {
+			200: ajv.compile<{
+				exists: boolean,
+				success: true
+			}>({
+				type: 'object',
+				properties: {
+					exists: {
+						type: 'boolean',
+					},
+					success: {
+						type: 'boolean',
+						enum: [true],
+					},
+				},
+				required: ['exists', 'success'],
+				additionalProperties: false
+			}),
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse
 		},
 	},
+	async function action() {
+		const { roomName } = this.queryParams;
+		const room = await Rooms.findOneByName(roomName, {
+			projection: { _id: 1 },
+		});
+		return API.v1.success({ exists: !!room });
+	}
 );
 
 const roomDeleteEndpoint = API.v1.post(
@@ -970,21 +1000,21 @@ API.v1.addRoute(
 
 type RoomsFavorite =
 	| {
-			roomId: string;
-			favorite: boolean;
-	  }
+		roomId: string;
+		favorite: boolean;
+	}
 	| {
-			roomName: string;
-			favorite: boolean;
-	  };
+		roomName: string;
+		favorite: boolean;
+	};
 
 type RoomsLeave =
 	| {
-			roomId: string;
-	  }
+		roomId: string;
+	}
 	| {
-			roomName: string;
-	  };
+		roomName: string;
+	};
 
 const isRoomGetRolesPropsSchema = {
 	type: 'object',
@@ -1377,9 +1407,10 @@ export const roomEndpoints = API.v1
 	);
 type RoomEndpoints = ExtractRoutesFromAPI<typeof roomEndpoints> &
 	ExtractRoutesFromAPI<typeof roomDeleteEndpoint> &
-	ExtractRoutesFromAPI<typeof roomsSaveNotificationEndpoint>;
+	ExtractRoutesFromAPI<typeof roomsSaveNotificationEndpoint> &
+	ExtractRoutesFromAPI<typeof roomNameExistsEndpoint>;
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends RoomEndpoints {}
+	interface Endpoints extends RoomEndpoints { }
 }

--- a/packages/rest-typings/src/v1/rooms.ts
+++ b/packages/rest-typings/src/v1/rooms.ts
@@ -915,12 +915,6 @@ export type RoomsEndpoints = {
 		};
 	};
 
-	'/v1/rooms.nameExists': {
-		GET: (params: { roomName: string }) => {
-			exists: boolean;
-		};
-	};
-
 	'/v1/rooms.get': {
 		GET: (params: { updatedSince: string }) => {
 			update: IRoom[];


### PR DESCRIPTION
## Proposed changes

This PR migrates the `rooms.nameExists` endpoint from the deprecated `addRoute` pattern to the new `API.v1.get` format.
AJV schema validation has been added for both query parameters and response, aligning the endpoint with the OpenAPI-based API structure.

### Details of changes:

* Migrated `rooms.nameExists` to `API.v1.get`
* Added AJV validation for:
  * Query params (`roomName`)
  * Response (`{ exists: boolean, success: true }`)
* Removed deprecated `addRoute` usage
* Updated typings using `ExtractRoutesFromAPI`
* Removed legacy definition from `rest-typings`

---

## Issue(s)
N/A (part of OpenAPI migration effort)

---

## Steps to test or reproduce

1. Send a GET request to `/api/v1/rooms.nameExists?roomName=<name>`
2. Verify response:
   * `{ success: true, exists: true }` if room exists
   * `{ success: true, exists: false }` if room does not exist
3. Ensure validation fails for missing or invalid `roomName`

---

## Further comments

This change follows the established migration pattern used across similar endpoints and ensures consistency with the new API structure. No functional changes were introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced validation for the room name existence endpoint with improved request and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->