### PR TITLE
fix(api): handle empty query parameter in emoji-custom.list

### DIFF
--- a/apps/meteor/app/api/server/helpers/parseJsonQuery.ts
+++ b/apps/meteor/app/api/server/helpers/parseJsonQuery.ts
@@ -112,9 +112,15 @@ export async function parseJsonQuery(api: GenericRouteExecutionContext): Promise
 	let query: Record<string, any> = {};
 	if (typeof params?.query === 'string' && isUnsafeQueryParamsAllowed) {
 		apiDeprecationLogger.parameter(route, 'query', '9.0.0', response, messageGenerator);
-		try {
-			query = ejson.parse(params.query);
-			query = clean(query, pathAllowConf.def);
+
+		const queryParam = params.query.trim();
+	
+		if (queryParam === '') {
+			query = {};
+		} else {
+			try {
+				query = ejson.parse(queryParam);
+				query = clean(query, pathAllowConf.def);
 		} catch (e) {
 			logger.warn({
 				msg: 'Invalid query parameter provided',
@@ -124,6 +130,7 @@ export async function parseJsonQuery(api: GenericRouteExecutionContext): Promise
 			throw new Meteor.Error('error-invalid-query', `Invalid query parameter provided: \"${params.query}\"`, {
 				helperMethod: 'parseJsonQuery',
 			});
+		}	
 		}
 	}
 


### PR DESCRIPTION
Fixes an issue where the API `/api/v1/emoji-custom.list` fails when the `query` parameter is passed as an empty string.

Previously, an empty query (`query=`) caused a JSON parsing error, which resulted in the emoji picker not displaying any custom emojis.

This change ensures that when the query parameter is empty, it is treated as an empty object `{}` instead of being parsed, preventing the API from throwing an error.

Closes #39834

1. Open the custom emoji picker in the web UI.
2. Observe the network request to `/api/v1/emoji-custom.list?query=`.
3. Before the fix: API throws "Invalid query parameter" error and no emojis are shown.
4. After the fix: No error occurs and custom emojis are displayed correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved query parameter handling to properly process trimmed input and handle empty queries more robustly. API requests with extraneous whitespace in query parameters will now be processed more consistently, with better validation of malformed queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->