### PR TITLE
fix: remove reactions on user deletion

### DIFF
--- a/.changeset/fuzzy-coins-rhyme.md
+++ b/.changeset/fuzzy-coins-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/models': patch
+'@rocket.chat/meteor': patch
+---
+
+fix: remove user reactions from messages on user deletion

--- a/apps/meteor/app/lib/server/functions/deleteUser.ts
+++ b/apps/meteor/app/lib/server/functions/deleteUser.ts
@@ -163,8 +163,9 @@ export async function deleteUser(userId: string, confirmRelinquish = false, dele
 				replaceByUser: { _id: userToReplaceWhenUnlinking._id, username: userToReplaceWhenUnlinking?.username, alias: nameAlias },
 			});
 		}
+		await Messages.removeReactionsByUsername(user.username);
 	}
-    await Messages.removeReactionsByUsername(user.username);
+    
 	// Remove user from users database
 	await Users.removeById(userId);
 

--- a/packages/model-typings/src/models/IMessagesModel.ts
+++ b/packages/model-typings/src/models/IMessagesModel.ts
@@ -128,6 +128,7 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 	findLivechatClosingMessage(rid: IRoom['_id'], options?: FindOptions<IMessage>): Promise<IMessage | null>;
 
 	setReactions(messageId: string, reactions: IMessage['reactions']): Promise<UpdateResult>;
+	removeReactionsByUsername(username: string): Promise<void>
 	keepHistoryForToken(token: string): Promise<UpdateResult | Document>;
 	setRoomIdByToken(token: string, rid: string): Promise<UpdateResult | Document>;
 	createWithTypeRoomIdMessageUserAndUnread(

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -700,7 +700,7 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 
 		while (await pointer.hasNext()) {
 			const message = await pointer.next();
-			if (!message.reactions) continue;
+			if (!message?.reactions) continue;
 
 			let updated = false;
 			for (const [emoji, data] of Object.entries(message.reactions as Record<string, { usernames?: string[] }>)) {


### PR DESCRIPTION
## Proposed changes

This PR fixes an issue where reactions from deleted users persist in message documents.

Currently, reactions store usernames, and during user deletion, these references are not cleaned up. As a result, deleted users continue to appear in reactions across messages.

## Changes introduced:

Added `removeReactionsByUsername(username)` in the Messages model
Iterates through messages containing **reactions** and removes the deleted username from all reaction arrays
Cleans up empty reaction entries (removes emoji keys with no users)
Unsets the reactions field entirely if it becomes empty
Integrated this cleanup into the `deleteUser` flow 

##  Approach:

Used a Mongo query with `$objectToArray` to efficiently filter only relevant messages (handling dynamic emoji keys)
Per-document updates are performed in application code to safely handle dynamic reaction structures

## Further comments

Reactions are stored under dynamic emoji keys ( 👍, ❤️), which makes bulk updates using fixed field paths difficult.
To handle this safely:

Mongo is used to filter only messages containing the username in reactions
Application-level logic iterates through dynamic keys and performs precise updates

This approach prioritizes correctness and maintainability while avoiding complex aggregation-based updates.

## Issue

fixes #39700 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure message reactions from a deleted user are always removed, regardless of how the account was erased. Empty reaction entries are cleaned up so deleted users no longer leave lingering reaction data, improving message integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->