### PR TITLE
fix(api): direct message unread count increments for mentions-only users

### DIFF
--- a/apps/meteor/app/lib/server/lib/notifyUsersOnMessage.ts
+++ b/apps/meteor/app/lib/server/lib/notifyUsersOnMessage.ts
@@ -105,7 +105,7 @@ async function updateUsersSubscriptions(message: IMessage, room: IRoom): Promise
 		roomId: room._id,
 		uidsExclude: [message.u._id],
 		uidsInclude: userIds,
-		onlyRead: !toAll && !toHere && !unreadAllMessages,
+		onlyRead: !toAll && !toHere && !unreadAllMessages && room.t !== 'd',
 	}).toArray();
 
 	// Give priority to user mentions over group mentions
@@ -115,7 +115,7 @@ async function updateUsersSubscriptions(message: IMessage, room: IRoom): Promise
 		await Subscriptions.incGroupMentionsAndUnreadForRoomIdExcludingUserId(room._id, message.u._id, 1, groupMentionInc);
 	}
 
-	if (!toAll && !toHere && unreadAllMessages) {
+	if (!toAll && !toHere && (unreadAllMessages || room.t === 'd')) {
 		await Subscriptions.incUnreadForRoomIdExcludingUserIds(room._id, [...userIds, message.u._id], 1);
 	}
 
@@ -127,7 +127,7 @@ async function updateUsersSubscriptions(message: IMessage, room: IRoom): Promise
 
 	subs.forEach((sub) => {
 		const hasUserMention = userIds.includes(sub.u._id);
-		const shouldIncUnread = hasUserMention || toAll || toHere || unreadAllMessages;
+		const shouldIncUnread = hasUserMention || toAll || toHere || unreadAllMessages || room.t === 'd';
 		void notifyOnSubscriptionChanged(
 			{
 				...sub,


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes (including videos or screenshots)

Fixes DM unread count showing 0 for users with "Mentions Only" notification setting.

DMs now always increment unread counter regardless of notification preference.

## Issue(s)

Fixes #23977

## Steps to test or reproduce

1. Set notification preference to "Mentions Only"
2. Have someone send you a DM (no mention needed)
3. Call `/api/v1/subscriptions.get`
4. `unread` count should be > 0

## Further comments

3-line change in notifyUsersOnMessage.ts to handle DMs correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unread message counter behavior for direct messages
  * Enhanced notification handling for direct messaging conversations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->