### PR TITLE
[bug]: add validation for avatar_url in incoming webhooks

### DIFF
--- a/apps/meteor/app/lib/server/functions/processWebhookMessage.ts
+++ b/apps/meteor/app/lib/server/functions/processWebhookMessage.ts
@@ -21,6 +21,7 @@ type Payload = {
 	icon_emoji?: IMessage['emoji'];
 	emoji?: IMessage['emoji']; // overridden if icon_emoji is present
 	icon_url?: IMessage['avatar'];
+	avatar_url?: IMessage['avatar'];
 	avatar?: IMessage['avatar']; // overridden if icon_url is present
 	attachments?: IMessage['attachments'];
 	parseUrls?: boolean;
@@ -106,8 +107,18 @@ const buildMessage = (messageObj: Payload, defaultValues: DefaultValues) => {
 		customFields: messageObj.customFields,
 	};
 
-	if (!_.isEmpty(messageObj.icon_url) || !_.isEmpty(messageObj.avatar)) {
-		message.avatar = messageObj.icon_url || messageObj.avatar;
+	if (!_.isEmpty(messageObj.icon_url) || !_.isEmpty(messageObj.avatar_url) || !_.isEmpty(messageObj.avatar)) {
+		const avatarUrl = messageObj.icon_url || messageObj.avatar_url || messageObj.avatar;
+		if (avatarUrl) {
+// -- Ensure avatar_url is a valid URL to prevent malformed webhook payloads:)
+	
+			try {
+				new URL(avatarUrl);
+			} catch {
+				throw new Meteor.Error('invalid-avatar-url', 'Invalid avatar URL');
+			}
+		}
+		message.avatar = avatarUrl;
 	} else if (!_.isEmpty(messageObj.icon_emoji) || !_.isEmpty(messageObj.emoji)) {
 		message.emoji = messageObj.icon_emoji || messageObj.emoji;
 	} else if (!_.isEmpty(defaultValues.avatar)) {


### PR DESCRIPTION
## Fixed:
- Add avatar_url field to Payload type for better webhook compatibility
- Update avatar handling to check icon_url, avatar_url, and avatar
- Add URL validation to prevent malformed webhook payloads
- Throws error if avatar URL is invalid

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes 
This change introduces URL validation using the JavaScript URL constructor to verify that the provided avatar_url is a valid URL before it is accepted.

```
avatar_url: Match.Optional(Match.Where((url: string) => {
  try {
    new URL(url);
    return true;
  } catch {
    throw new Match.Error('Invalid avatar URL');
  }
}))

```
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue
#39877 


<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
After implementing the change
1. Valid URLs pass validation.
2. Invalid values ("abc123") throw a validation error.
3. Existing webhook functionality continues to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webhooks now support avatar URLs. Users can specify custom avatars via the avatar URL field in webhook payloads. Avatar resolution follows a priority system: icon URL takes precedence, followed by avatar URL, then the avatar field. Added validation ensures only properly formatted URLs are accepted, preventing invalid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->