### PR TITLE
fix: validate avatar URL in incoming integrations

### DIFF
--- a/apps/meteor/app/integrations/server/methods/incoming/addIncomingIntegration.ts
+++ b/apps/meteor/app/integrations/server/methods/incoming/addIncomingIntegration.ts
@@ -73,6 +73,17 @@ export const addIncomingIntegration = async (userId: string, integration: INewIn
 		}
 	}
 
+	// ✅ Avatar URL validation
+	if (integration.avatar && integration.avatar.trim() !== '') {
+		try {
+			new URL(integration.avatar);
+		} catch {
+			throw new Meteor.Error('error-invalid-avatar-url', 'Avatar URL must be a valid URL', {
+				method: 'addIncomingIntegration',
+			});
+		}
+	}
+
 	if (!integration.username || typeof integration.username.valueOf() !== 'string' || integration.username.trim() === '') {
 		throw new Meteor.Error('error-invalid-username', 'Invalid username', {
 			method: 'addIncomingIntegration',


### PR DESCRIPTION
This PR adds validation for the avatar field in incoming webhook integrations to ensure that only valid URLs are accepted.

Previously, the avatar field accepted any string value, allowing invalid inputs such as:

avatar: "abc123"

This could lead to UI rendering issues when Rocket.Chat attempts to display the avatar for webhook messages.

With this change:

If avatar is a non-empty string, it is validated using the URL constructor.
Invalid URLs will throw a Meteor.Error, preventing incorrect data from being stored.
Valid URLs continue to work as expected.

This ensures better data integrity and prevents UI issues caused by malformed avatar values.

Closes #39877

Steps to test or reproduce:

Go to Incoming Webhook integration creation.

Provide an invalid avatar value:

avatar: "abc123"
Before the fix:
Integration gets created successfully ❌
Avatar may not render correctly
After the fix:
API throws an error: Avatar URL must be a valid URL ✅

Provide a valid URL:

avatar: "https://example.com/avatar.png"
Integration is created successfully ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Incoming integrations now properly validate avatar URLs and display an error message when an invalid URL is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->