### PR TITLE
feat: add @rocket.chat/gazzodown-alt package for real-time WYSIWYG rendering

### DIFF
--- a/packages/gazzodown-alt/package.json
+++ b/packages/gazzodown-alt/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@rocket.chat/gazzodown-alt",
+	"version": "0.0.1",
+	"private": true,
+	"main": "./dist/index.js",
+	"typings": "./dist/index.d.ts",
+	"files": [
+		"/dist"
+	],
+	"scripts": {
+		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		"dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
+		"lint": "eslint .",
+		"lint:fix": "eslint --fix .",
+		"typecheck": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@rocket.chat/message-parser": "workspace:^",
+		"@rocket.chat/tsconfig": "workspace:*",
+		"@types/react": "~19.2.17",
+		"eslint": "~9.39.3",
+		"react": "~19.2.7",
+		"typescript": "~5.9.3"
+	},
+	"peerDependencies": {
+		"@rocket.chat/message-parser": "0.31.34",
+		"react": "*"
+	},
+	"volta": {
+		"extends": "../../package.json"
+	}
+}

--- a/packages/gazzodown-alt/src/ComposerBoldSpan.tsx
+++ b/packages/gazzodown-alt/src/ComposerBoldSpan.tsx
@@ -1,0 +1,24 @@
+import type * as MessageParser from '@rocket.chat/message-parser';
+import type { ReactElement } from 'react';
+
+import { renderInlineBlock } from './renderInlineBlock';
+
+type MessageBlock =
+	| MessageParser.Emoji
+	| MessageParser.ChannelMention
+	| MessageParser.UserMention
+	| MessageParser.Link
+	| MessageParser.MarkupExcluding<MessageParser.Bold>
+	| MessageParser.InlineCode;
+
+type ComposerBoldSpanProps = {
+	children: MessageBlock[];
+};
+
+const ComposerBoldSpan = ({ children }: ComposerBoldSpanProps): ReactElement => (
+	<>
+		*<strong>{children.map((block, index) => renderInlineBlock(block, index))}</strong>*
+	</>
+);
+
+export default ComposerBoldSpan;

--- a/packages/gazzodown-alt/src/ComposerCodeBlock.tsx
+++ b/packages/gazzodown-alt/src/ComposerCodeBlock.tsx
@@ -1,0 +1,31 @@
+import type * as MessageParser from '@rocket.chat/message-parser';
+import type { ReactElement } from 'react';
+import { useMemo } from 'react';
+
+type ComposerCodeBlockProps = {
+	language?: string;
+	lines: MessageParser.CodeLine[];
+};
+
+const codeBlockStyle = {
+	fontFamily: 'var(--rcx-font-family-mono, monospace)',
+	backgroundColor: 'var(--rcx-color-surface-tint, rgba(0, 0, 0, 0.05))',
+	borderRadius: '4px',
+	padding: '4px 8px',
+	display: 'inline-block',
+	verticalAlign: 'top',
+	maxWidth: '100%',
+	whiteSpace: 'pre-wrap' as const,
+} as const;
+
+const ComposerCodeBlock = ({ language, lines }: ComposerCodeBlockProps): ReactElement => {
+	const text = useMemo(() => {
+		const code = lines.map((line) => line.value.value).join('\n');
+		const fence = language && language !== 'none' ? `\`\`\`${language}` : '```';
+		return `${fence}\n${code}\n\`\`\``;
+	}, [language, lines]);
+
+	return <code style={codeBlockStyle}>{text}</code>;
+};
+
+export default ComposerCodeBlock;

--- a/packages/gazzodown-alt/src/ComposerCodeElement.tsx
+++ b/packages/gazzodown-alt/src/ComposerCodeElement.tsx
@@ -1,0 +1,20 @@
+import type { ReactElement } from 'react';
+
+type ComposerCodeElementProps = {
+	code: string;
+};
+
+const codeStyle = {
+	fontFamily: 'var(--rcx-font-family-mono, monospace)',
+	backgroundColor: 'var(--rcx-color-surface-tint, rgba(0, 0, 0, 0.05))',
+	borderRadius: '3px',
+	padding: '0 4px',
+} as const;
+
+const ComposerCodeElement = ({ code }: ComposerCodeElementProps): ReactElement => (
+	<>
+		`<code style={codeStyle}>{code}</code>`
+	</>
+);
+
+export default ComposerCodeElement;

--- a/packages/gazzodown-alt/src/ComposerEmojiElement.tsx
+++ b/packages/gazzodown-alt/src/ComposerEmojiElement.tsx
@@ -1,0 +1,47 @@
+import type * as MessageParser from '@rocket.chat/message-parser';
+import type { ReactElement } from 'react';
+import { memo, useContext, useMemo } from 'react';
+
+import { ComposerMarkupContext } from './ComposerMarkupContext';
+
+type ComposerEmojiElementProps = MessageParser.Emoji;
+
+const ComposerEmojiElement = (emoji: ComposerEmojiElementProps): ReactElement => {
+	const { convertAsciiToEmoji, useEmoji, detectEmoji } = useContext(ComposerMarkupContext);
+
+	const asciiEmoji = useMemo(
+		() => ('shortCode' in emoji && emoji.value.value !== emoji.shortCode ? emoji.value.value : undefined),
+		[emoji],
+	);
+
+	if (!useEmoji && 'shortCode' in emoji) {
+		return <>{emoji.shortCode === emoji.value.value ? `:${emoji.shortCode}:` : emoji.value.value}</>;
+	}
+
+	if (!convertAsciiToEmoji && asciiEmoji) {
+		return <>{asciiEmoji}</>;
+	}
+
+	const fallback = 'unicode' in emoji ? emoji.unicode : `:${('shortCode' in emoji && emoji.shortCode) || ''}:`;
+
+	const descriptors = detectEmoji?.(fallback);
+	if (descriptors && descriptors.length > 0) {
+		return (
+			<>
+				{descriptors.map(({ name, className, image, content }, i) => (
+					<span key={i} title={name} className={className} style={image ? { backgroundImage: `url(${image})` } : undefined}>
+						{content}
+					</span>
+				))}
+			</>
+		);
+	}
+
+	return (
+		<span role='img' aria-label={fallback}>
+			{fallback}
+		</span>
+	);
+};
+
+export default memo(ComposerEmojiElement);

--- a/packages/gazzodown-alt/src/ComposerInlineElements.tsx
+++ b/packages/gazzodown-alt/src/ComposerInlineElements.tsx
@@ -1,0 +1,23 @@
+import type * as MessageParser from '@rocket.chat/message-parser';
+import type { ReactElement } from 'react';
+
+import ComposerPlainSpan from './ComposerPlainSpan';
+import { renderInlineBlock } from './renderInlineBlock';
+
+type ComposerInlineElementsProps = {
+	children: (MessageParser.Inlines | { fallback: MessageParser.Plain; type: undefined })[];
+};
+
+const ComposerInlineElements = ({ children }: ComposerInlineElementsProps): ReactElement => (
+	<>
+		{children.map((child, index) => {
+			if (child.type === undefined) {
+				return <ComposerPlainSpan key={index} text={child.fallback.value} />;
+			}
+
+			return renderInlineBlock(child, index);
+		})}
+	</>
+);
+
+export default ComposerInlineElements;

--- a/packages/gazzodown-alt/src/ComposerItalicSpan.tsx
+++ b/packages/gazzodown-alt/src/ComposerItalicSpan.tsx
@@ -1,0 +1,24 @@
+import type * as MessageParser from '@rocket.chat/message-parser';
+import type { ReactElement } from 'react';
+
+import { renderInlineBlock } from './renderInlineBlock';
+
+type MessageBlock =
+	| MessageParser.Emoji
+	| MessageParser.ChannelMention
+	| MessageParser.UserMention
+	| MessageParser.Link
+	| MessageParser.MarkupExcluding<MessageParser.Italic>
+	| MessageParser.InlineCode;
+
+type ComposerItalicSpanProps = {
+	children: MessageBlock[];
+};
+
+const ComposerItalicSpan = ({ children }: ComposerItalicSpanProps): ReactElement => (
+	<>
+		_<em>{children.map((block, index) => renderInlineBlock(block, index))}</em>_
+	</>
+);
+
+export default ComposerItalicSpan;

--- a/packages/gazzodown-alt/src/ComposerLinkSpan.tsx
+++ b/packages/gazzodown-alt/src/ComposerLinkSpan.tsx
@@ -1,0 +1,37 @@
+import type * as MessageParser from '@rocket.chat/message-parser';
+import type { ReactElement } from 'react';
+
+import ComposerBoldSpan from './ComposerBoldSpan';
+import ComposerItalicSpan from './ComposerItalicSpan';
+import ComposerPlainSpan from './ComposerPlainSpan';
+import ComposerStrikeSpan from './ComposerStrikeSpan';
+
+type ComposerLinkSpanProps = {
+	href: string;
+	label: MessageParser.Markup | MessageParser.Markup[];
+};
+
+const ComposerLinkSpan = ({ href, label }: ComposerLinkSpanProps): ReactElement => {
+	const labelArray = Array.isArray(label) ? label : [label];
+
+	return (
+		<span title={href} style={{ textDecoration: 'underline', color: 'var(--rcx-color-font-info, #156FF5)' }}>
+			{labelArray.map((child, index) => {
+				switch (child.type) {
+					case 'PLAIN_TEXT':
+						return <ComposerPlainSpan key={index} text={child.value} />;
+					case 'STRIKE':
+						return <ComposerStrikeSpan key={index}>{child.value}</ComposerStrikeSpan>;
+					case 'ITALIC':
+						return <ComposerItalicSpan key={index}>{child.value}</ComposerItalicSpan>;
+					case 'BOLD':
+						return <ComposerBoldSpan key={index}>{child.value}</ComposerBoldSpan>;
+					default:
+						return null;
+				}
+			})}
+		</span>
+	);
+};
+
+export default ComposerLinkSpan;

--- a/packages/gazzodown-alt/src/ComposerMarkup.tsx
+++ b/packages/gazzodown-alt/src/ComposerMarkup.tsx
@@ -1,0 +1,105 @@
+import type * as MessageParser from '@rocket.chat/message-parser';
+import type { CSSProperties, ReactElement } from 'react';
+import { memo } from 'react';
+
+import ComposerCodeBlock from './ComposerCodeBlock';
+import ComposerInlineElements from './ComposerInlineElements';
+import ComposerPlainSpan from './ComposerPlainSpan';
+
+type ComposerMarkupProps = {
+	tokens: MessageParser.Root;
+};
+
+/**
+ * Real-time WYSIWYG-friendly markup renderer.
+ *
+ * Unlike the standard `Markup` from `@rocket.chat/gazzodown`, this component:
+ * - Renders paragraphs as `<span>` instead of `<div>` for inline layout
+ * - Represents line breaks with `\n` characters instead of `<br>` tags
+ * - Avoids heavy Fuselage dependencies (MessageHighlight, CheckBox, etc.)
+ * - Is optimized for re-rendering on every keystroke
+ *
+ * It consumes the same AST produced by `@rocket.chat/message-parser` (grammar.pegjs),
+ * making it a drop-in replacement for the rendering layer.
+ */
+const ComposerMarkup = ({ tokens }: ComposerMarkupProps): ReactElement => (
+	<>
+		{tokens.map((block, index) => {
+			switch (block.type) {
+				case 'PARAGRAPH':
+					return (
+						<span key={index}>
+							<ComposerInlineElements>{block.value}</ComposerInlineElements>
+							{'\n'}
+						</span>
+					);
+
+				case 'HEADING':
+					return (
+						<span key={index} style={headingStyles[block.level]}>
+							{`${'#'.repeat(block.level)} `}
+							{block.value.map((plain, pidx) => (
+								<ComposerPlainSpan key={pidx} text={typeof plain.value === 'string' ? plain.value : ''} />
+							))}
+							{'\n'}
+						</span>
+					);
+
+				case 'QUOTE':
+					return (
+						<span key={index} style={quoteStyle}>
+							{block.value.map((paragraph, pidx) => (
+								<span key={pidx}>
+									{'> '}
+									<ComposerInlineElements>{paragraph.value}</ComposerInlineElements>
+									{'\n'}
+								</span>
+							))}
+						</span>
+					);
+
+				case 'SPOILER_BLOCK':
+					return (
+						<span key={index} style={spoilerBlockStyle}>
+							{block.value.map((paragraph, pidx) => (
+								<span key={pidx}>
+									<ComposerInlineElements>{paragraph.value}</ComposerInlineElements>
+									{'\n'}
+								</span>
+							))}
+						</span>
+					);
+
+				case 'CODE':
+					return <ComposerCodeBlock key={index} language={block.language} lines={block.value} />;
+
+				case 'LINE_BREAK':
+					return <span key={index}>{'\n'}</span>;
+
+				default:
+					return null;
+			}
+		})}
+	</>
+);
+
+const headingStyles: Record<1 | 2 | 3 | 4, CSSProperties> = {
+	1: { fontWeight: 'bold', fontSize: '1.5em' },
+	2: { fontWeight: 'bold', fontSize: '1.3em' },
+	3: { fontWeight: 'bold', fontSize: '1.1em' },
+	4: { fontWeight: 'bold', fontSize: '1em' },
+};
+
+const quoteStyle: CSSProperties = {
+	borderInlineStart: '2px solid var(--rcx-color-stroke-light, #ccc)',
+	paddingInlineStart: '8px',
+	color: 'var(--rcx-color-font-secondary-info, #666)',
+};
+
+const spoilerBlockStyle: CSSProperties = {
+	backgroundColor: 'var(--rcx-color-surface-tint, rgba(0, 0, 0, 0.08))',
+	borderRadius: '2px',
+	padding: '0 2px',
+};
+
+export default memo(ComposerMarkup);

--- a/packages/gazzodown-alt/src/ComposerMarkupContext.ts
+++ b/packages/gazzodown-alt/src/ComposerMarkupContext.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+
+export type ComposerMarkupContextValue = {
+	detectEmoji?: (text: string) => { name: string; className: string; image?: string; content: string }[];
+	resolveUserMention?: (mention: string) => { _id: string; username?: string; name?: string } | undefined;
+	resolveChannelMention?: (mention: string) => { _id: string; name?: string; fname?: string } | undefined;
+	convertAsciiToEmoji?: boolean;
+	useEmoji?: boolean;
+};
+
+export const ComposerMarkupContext = createContext<ComposerMarkupContextValue>({});

--- a/packages/gazzodown-alt/src/ComposerMentionChannel.tsx
+++ b/packages/gazzodown-alt/src/ComposerMentionChannel.tsx
@@ -1,0 +1,28 @@
+import type { ReactElement } from 'react';
+import { memo, useContext, useMemo } from 'react';
+
+import { ComposerMarkupContext } from './ComposerMarkupContext';
+
+type ComposerMentionChannelProps = {
+	mention: string;
+};
+
+const mentionStyle = {
+	fontWeight: 'bold' as const,
+	color: 'var(--rcx-color-font-info, #156FF5)',
+	cursor: 'default',
+};
+
+const ComposerMentionChannel = ({ mention }: ComposerMentionChannelProps): ReactElement => {
+	const { resolveChannelMention } = useContext(ComposerMarkupContext);
+
+	const resolved = useMemo(() => resolveChannelMention?.(mention), [mention, resolveChannelMention]);
+
+	if (!resolved) {
+		return <span style={mentionStyle}>#{mention}</span>;
+	}
+
+	return <span style={mentionStyle}>#{resolved.fname ?? mention}</span>;
+};
+
+export default memo(ComposerMentionChannel);

--- a/packages/gazzodown-alt/src/ComposerMentionUser.tsx
+++ b/packages/gazzodown-alt/src/ComposerMentionUser.tsx
@@ -1,0 +1,32 @@
+import type { ReactElement } from 'react';
+import { memo, useContext, useMemo } from 'react';
+
+import { ComposerMarkupContext } from './ComposerMarkupContext';
+
+type ComposerMentionUserProps = {
+	mention: string;
+};
+
+const mentionStyle = {
+	fontWeight: 'bold' as const,
+	color: 'var(--rcx-color-font-info, #156FF5)',
+	cursor: 'default',
+};
+
+const ComposerMentionUser = ({ mention }: ComposerMentionUserProps): ReactElement => {
+	const { resolveUserMention } = useContext(ComposerMarkupContext);
+
+	const resolved = useMemo(() => resolveUserMention?.(mention), [mention, resolveUserMention]);
+
+	if (!resolved) {
+		return <span style={mentionStyle}>@{mention}</span>;
+	}
+
+	return (
+		<span style={mentionStyle} data-uid={resolved._id}>
+			@{resolved.username ?? mention}
+		</span>
+	);
+};
+
+export default memo(ComposerMentionUser);

--- a/packages/gazzodown-alt/src/ComposerPlainSpan.tsx
+++ b/packages/gazzodown-alt/src/ComposerPlainSpan.tsx
@@ -1,0 +1,10 @@
+import type { ReactElement } from 'react';
+import { memo } from 'react';
+
+type ComposerPlainSpanProps = {
+	text: string;
+};
+
+const ComposerPlainSpan = ({ text }: ComposerPlainSpanProps): ReactElement => <>{text}</>;
+
+export default memo(ComposerPlainSpan);

--- a/packages/gazzodown-alt/src/ComposerSpoilerSpan.tsx
+++ b/packages/gazzodown-alt/src/ComposerSpoilerSpan.tsx
@@ -1,0 +1,26 @@
+import type * as MessageParser from '@rocket.chat/message-parser';
+import type { ReactElement } from 'react';
+
+import ComposerInlineElements from './ComposerInlineElements';
+
+type ComposerSpoilerSpanProps = {
+	children: MessageParser.Spoiler['value'];
+};
+
+const spoilerStyle = {
+	backgroundColor: 'var(--rcx-color-surface-tint, rgba(0, 0, 0, 0.08))',
+	borderRadius: '2px',
+	padding: '0 2px',
+} as const;
+
+const ComposerSpoilerSpan = ({ children }: ComposerSpoilerSpanProps): ReactElement => (
+	<>
+		||
+		<span style={spoilerStyle}>
+			<ComposerInlineElements>{children}</ComposerInlineElements>
+		</span>
+		||
+	</>
+);
+
+export default ComposerSpoilerSpan;

--- a/packages/gazzodown-alt/src/ComposerStrikeSpan.tsx
+++ b/packages/gazzodown-alt/src/ComposerStrikeSpan.tsx
@@ -1,0 +1,25 @@
+import type * as MessageParser from '@rocket.chat/message-parser';
+import type { ReactElement } from 'react';
+
+import { renderInlineBlock } from './renderInlineBlock';
+
+type MessageBlock =
+	| MessageParser.Timestamp
+	| MessageParser.Emoji
+	| MessageParser.ChannelMention
+	| MessageParser.UserMention
+	| MessageParser.Link
+	| MessageParser.MarkupExcluding<MessageParser.Strike>
+	| MessageParser.InlineCode;
+
+type ComposerStrikeSpanProps = {
+	children: MessageBlock[];
+};
+
+const ComposerStrikeSpan = ({ children }: ComposerStrikeSpanProps): ReactElement => (
+	<>
+		~<del>{children.map((block, index) => renderInlineBlock(block, index))}</del>~
+	</>
+);
+
+export default ComposerStrikeSpan;

--- a/packages/gazzodown-alt/src/index.ts
+++ b/packages/gazzodown-alt/src/index.ts
@@ -1,0 +1,15 @@
+export { default as ComposerMarkup } from './ComposerMarkup';
+export { ComposerMarkupContext } from './ComposerMarkupContext';
+export type { ComposerMarkupContextValue } from './ComposerMarkupContext';
+export { default as ComposerCodeBlock } from './ComposerCodeBlock';
+export { default as ComposerInlineElements } from './ComposerInlineElements';
+export { default as ComposerPlainSpan } from './ComposerPlainSpan';
+export { default as ComposerBoldSpan } from './ComposerBoldSpan';
+export { default as ComposerItalicSpan } from './ComposerItalicSpan';
+export { default as ComposerStrikeSpan } from './ComposerStrikeSpan';
+export { default as ComposerLinkSpan } from './ComposerLinkSpan';
+export { default as ComposerCodeElement } from './ComposerCodeElement';
+export { default as ComposerEmojiElement } from './ComposerEmojiElement';
+export { default as ComposerMentionUser } from './ComposerMentionUser';
+export { default as ComposerMentionChannel } from './ComposerMentionChannel';
+export { default as ComposerSpoilerSpan } from './ComposerSpoilerSpan';

--- a/packages/gazzodown-alt/src/renderInlineBlock.tsx
+++ b/packages/gazzodown-alt/src/renderInlineBlock.tsx
@@ -1,0 +1,50 @@
+import type * as MessageParser from '@rocket.chat/message-parser';
+import type { ReactElement } from 'react';
+
+import ComposerBoldSpan from './ComposerBoldSpan';
+import ComposerCodeElement from './ComposerCodeElement';
+import ComposerEmojiElement from './ComposerEmojiElement';
+import ComposerItalicSpan from './ComposerItalicSpan';
+import ComposerLinkSpan from './ComposerLinkSpan';
+import ComposerMentionChannel from './ComposerMentionChannel';
+import ComposerMentionUser from './ComposerMentionUser';
+import ComposerPlainSpan from './ComposerPlainSpan';
+import ComposerSpoilerSpan from './ComposerSpoilerSpan';
+import ComposerStrikeSpan from './ComposerStrikeSpan';
+
+export const renderInlineBlock = (block: MessageParser.Inlines, index: number): ReactElement | null => {
+	switch (block.type) {
+		case 'BOLD':
+			return <ComposerBoldSpan key={index}>{block.value}</ComposerBoldSpan>;
+
+		case 'ITALIC':
+			return <ComposerItalicSpan key={index}>{block.value}</ComposerItalicSpan>;
+
+		case 'STRIKE':
+			return <ComposerStrikeSpan key={index}>{block.value}</ComposerStrikeSpan>;
+
+		case 'SPOILER':
+			return <ComposerSpoilerSpan key={index}>{block.value}</ComposerSpoilerSpan>;
+
+		case 'LINK':
+			return <ComposerLinkSpan key={index} href={block.value.src.value} label={block.value.label} />;
+
+		case 'PLAIN_TEXT':
+			return <ComposerPlainSpan key={index} text={block.value} />;
+
+		case 'MENTION_USER':
+			return <ComposerMentionUser key={index} mention={block.value.value} />;
+
+		case 'MENTION_CHANNEL':
+			return <ComposerMentionChannel key={index} mention={block.value.value} />;
+
+		case 'INLINE_CODE':
+			return <ComposerCodeElement key={index} code={block.value.value} />;
+
+		case 'EMOJI':
+			return <ComposerEmojiElement key={index} {...block} />;
+
+		default:
+			return null;
+	}
+};

--- a/packages/gazzodown-alt/tsconfig.build.json
+++ b/packages/gazzodown-alt/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist"
+	},
+	"exclude": ["./src/**/*.spec.ts", "./src/**/*.spec.tsx"]
+}

--- a/packages/gazzodown-alt/tsconfig.json
+++ b/packages/gazzodown-alt/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@rocket.chat/tsconfig/client.json",
+	"compilerOptions": {
+		"rootDirs": ["./src", "./"]
+	},
+	"include": ["./src/**/*"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9337,6 +9337,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rocket.chat/gazzodown-alt@workspace:packages/gazzodown-alt":
+  version: 0.0.0-use.local
+  resolution: "@rocket.chat/gazzodown-alt@workspace:packages/gazzodown-alt"
+  dependencies:
+    "@rocket.chat/message-parser": "workspace:^"
+    "@rocket.chat/tsconfig": "workspace:*"
+    "@types/react": "npm:~19.2.17"
+    eslint: "npm:~9.39.3"
+    react: "npm:~19.2.7"
+    typescript: "npm:~5.9.3"
+  peerDependencies:
+    "@rocket.chat/message-parser": 0.31.34
+    react: "*"
+  languageName: unknown
+  linkType: soft
+
 "@rocket.chat/gazzodown@workspace:^, @rocket.chat/gazzodown@workspace:packages/gazzodown":
   version: 0.0.0-use.local
   resolution: "@rocket.chat/gazzodown@workspace:packages/gazzodown"
@@ -21365,7 +21381,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:~9.39.4":
+"eslint@npm:~9.39.3, eslint@npm:~9.39.4":
   version: 9.39.4
   resolution: "eslint@npm:9.39.4"
   dependencies:


### PR DESCRIPTION
https://rocketchat.atlassian.net/browse/RTC-1

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed changes (including videos or screenshots)

Adds a new `@rocket.chat/gazzodown-alt` package that provides an alternative to `@rocket.chat/gazzodown`, optimized for real-time rendering in WYSIWYG text fields (composer/editor contexts).

### Problem
The existing `gazzodown` package renders message markup using block-level elements (`<div>` for paragraphs, `<br>` for line breaks), which causes issues with newlines when used inside a WYSIWYG input field for real-time preview rendering.

### Solution
The new `gazzodown-alt` package consumes the **same AST** produced by `@rocket.chat/message-parser` (the same `grammar.pegjs` file), but outputs inline-friendly React elements suitable for real-time rendering as the user types:

| Feature | gazzodown | gazzodown-alt |
|---------|-----------|---------------|
| Paragraph rendering | `<div>` (block) | `<span>` (inline) |
| Line breaks | `<br>` tags | `\n` characters |
| Dependencies | Fuselage (MessageHighlight, CheckBox, IconButton), hljs, dompurify, date-fns, react-stately | Zero runtime deps (only React peer) |
| Emoji rendering | Full EmojiRenderer with DOMPurify | Lightweight via context-provided `detectEmoji` |
| Mentions | Fuselage MessageHighlight + click handlers | Simple styled `<span>` elements |
| Code blocks | hljs syntax highlighting + copy button | Plain `<code>` with monospace styling |
| Use case | Message display (read-only) | Composer/editor (real-time WYSIWYG) |

### Key design decisions
- **Inline-first layout**: Everything renders as `<span>` to avoid disrupting the flow of a WYSIWYG text field
- **Same AST contract**: `ComposerMarkup` accepts `tokens: MessageParser.Root` just like `Markup`
- **Customizable via context**: `ComposerMarkupContext` provides emoji detection, mention resolution
- **All components individually exportable**: Consumers can compose their own rendering if needed

### Supported markup
Inline: bold, italic, strike, spoiler, links, plain text, inline code, user/channel mentions, emoji (incl. custom emoji).
Block: paragraph, heading, quote, spoiler block, code block, line break.

Unsupported for now (fall through to no-op): images, colors, timestamps, KaTeX (inline + block), ordered/unordered lists, tasks, big emoji. These may be added later as the WYSIWYG use case requires them.

### Exported components
- `ComposerMarkup` — Main renderer (drop-in alternative for `Markup`)
- `ComposerMarkupContext` — Context for emoji/mention resolution
- `ComposerInlineElements` — Inline element dispatcher
- Individual elements: `ComposerBoldSpan`, `ComposerItalicSpan`, `ComposerStrikeSpan`, `ComposerLinkSpan`, `ComposerCodeElement`, `ComposerCodeBlock`, `ComposerEmojiElement`, `ComposerMentionUser`, `ComposerMentionChannel`, `ComposerSpoilerSpan`, `ComposerPlainSpan`

## Steps to test or reproduce

1. Import `ComposerMarkup` from `@rocket.chat/gazzodown-alt`
2. Parse input text with `@rocket.chat/message-parser`'s `parse()` function
3. Render `<ComposerMarkup tokens={parsedTokens} />` inside a WYSIWYG text field
4. Verify that the output uses inline elements and handles newlines correctly

```tsx
import { parse } from '@rocket.chat/message-parser';
import { ComposerMarkup } from '@rocket.chat/gazzodown-alt';

const tokens = parse('Hello **world**\nNew line here');
// Renders as inline spans with \n for line breaks
<ComposerMarkup tokens={tokens} />
Further comments
This package intentionally has zero runtime dependencies beyond React (peer dep). It avoids Fuselage components, hljs, dompurify, and other heavy dependencies that gazzodown uses, keeping the bundle lightweight for real-time re-rendering on every keystroke.

<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the `@rocket.chat/gazzodown-alt` package with new composer rendering components for markup, inline elements, bold/italic/strike/spoiler, links, code blocks/inline code, emojis, and user/channel mentions.
  * Added a shared rendering context to drive emoji and mention resolution.
* **Bug Fixes**
  * Improved fallback rendering for unsupported inline/markup types and enhanced emoji output formatting based on available data and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->