### PR TITLE
Add tests for plain text, empty messages, and link parsing in message parser

### DIFF
--- a/apps/meteor/client/lib/parseMessageTextToAstMarkdown.spec.ts
+++ b/apps/meteor/client/lib/parseMessageTextToAstMarkdown.spec.ts
@@ -351,9 +351,25 @@ it('should parse link correctly', () => {
 
 	const result = parseMessageTextToAstMarkdown(message, parseOptions, autoTranslateOptions);
 
-	// we check structure safely (because link AST may vary slightly)
-	expect(result.md).toBeDefined();
-	expect(result.md.length).toBeGreaterThan(0);
+	const expected: Root = [
+		{
+			type: 'PARAGRAPH',
+			value: [
+				{
+					type: 'LINK',
+					value: [
+						{
+							type: 'PLAIN_TEXT',
+							value: 'Google',
+						},
+					],
+					url: 'https://google.com',
+				},
+			],
+		},
+	];
+
+	expect(result.md).toStrictEqual(expected);
 });
 });
 


### PR DESCRIPTION
### Summary
Added additional test cases to improve coverage of parseMessageTextToAstMarkdown.

### Changes
- Added test for plain text messages
- Added test for empty messages
- Added test for link parsing

### Purpose
This improves test coverage and ensures correct handling of basic and edge-case message formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for message parsing to verify plain-text messages produce a single paragraph, empty messages produce no content, and Markdown link syntax is parsed into a link with correct URL and link text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->