### PR TITLE
fix: visitorEmails and phone visitor fields being reordered alphabetically

### DIFF
--- a/.changeset/loud-ligers-explode.md
+++ b/.changeset/loud-ligers-explode.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/models': patch
+---
+
+Fixes array resorting when appending visitor emails and phones

--- a/.changeset/loud-ligers-explode.md
+++ b/.changeset/loud-ligers-explode.md
@@ -2,4 +2,4 @@
 '@rocket.chat/models': patch
 ---
 
-Fixes array resorting when appending visitor emails and phones
+Fixes array resorting when appending visitor emails/phones to ensure chat transcripts are sent to the correct registration email.

--- a/packages/models/src/models/LivechatVisitors.ts
+++ b/packages/models/src/models/LivechatVisitors.ts
@@ -384,7 +384,6 @@ export class LivechatVisitorsRaw extends BaseRaw<ILivechatVisitor> implements IL
 			return Promise.resolve();
 		}
 
-
 		// Temporary workaround for legacy data.
 		// Some old records have 'visitorEmails' or 'phone' set to 'null', which breaks the $addToSet below.
 		// Pending Product decision: either run a proper DB migration to fix all nulls,

--- a/packages/models/src/models/LivechatVisitors.ts
+++ b/packages/models/src/models/LivechatVisitors.ts
@@ -369,7 +369,7 @@ export class LivechatVisitorsRaw extends BaseRaw<ILivechatVisitor> implements IL
 		return this.deleteOne({ _id });
 	}
 
-	saveGuestEmailPhoneById(_id: string, emails: string[], phones: string[]): Promise<UpdateResult | Document | void> {
+	async saveGuestEmailPhoneById(_id: string, emails: string[], phones: string[]): Promise<UpdateResult | Document | void> {
 		const saveEmail = ([] as string[])
 			.concat(emails)
 			.filter((email) => email?.trim())
@@ -384,16 +384,22 @@ export class LivechatVisitorsRaw extends BaseRaw<ILivechatVisitor> implements IL
 			return Promise.resolve();
 		}
 
-		// the only reason we're using $setUnion here instead of $addToSet is because
-		// old visitors might have `visitorEmails` or `phone` as `null` which would cause $addToSet to fail
-		return this.updateOne({ _id }, [
+		if (saveEmail.length) {
+			await this.updateOne({ _id, visitorEmails: null as any }, { $set: { visitorEmails: [] } });
+		}
+		if (savePhone.length) {
+			await this.updateOne({ _id, phone: null }, { $set: { phone: [] } });
+		}
+
+		return this.updateOne(
+			{ _id },
 			{
-				$set: {
-					...(saveEmail.length && { visitorEmails: { $setUnion: [{ $ifNull: ['$visitorEmails', []] }, saveEmail] } }),
-					...(savePhone.length && { phone: { $setUnion: [{ $ifNull: ['$phone', []] }, savePhone] } }),
+				$addToSet: {
+					...(saveEmail.length && { visitorEmails: { $each: saveEmail } }),
+					...(savePhone.length && { phone: { $each: savePhone } }),
 				},
 			},
-		]);
+		);
 	}
 
 	removeContactManagerByUsername(manager: string): Promise<Document | UpdateResult> {

--- a/packages/models/src/models/LivechatVisitors.ts
+++ b/packages/models/src/models/LivechatVisitors.ts
@@ -384,6 +384,7 @@ export class LivechatVisitorsRaw extends BaseRaw<ILivechatVisitor> implements IL
 			return Promise.resolve();
 		}
 
+		// TODO: Lead Capture features: Either create a migration script fixing records or deprecate it
 		// Temporary workaround for legacy data.
 		// Some old records have 'visitorEmails' or 'phone' set to 'null', which breaks the $addToSet below.
 		// Pending Product decision: either run a proper DB migration to fix all nulls,

--- a/packages/models/src/models/LivechatVisitors.ts
+++ b/packages/models/src/models/LivechatVisitors.ts
@@ -384,6 +384,11 @@ export class LivechatVisitorsRaw extends BaseRaw<ILivechatVisitor> implements IL
 			return Promise.resolve();
 		}
 
+
+		// Temporary workaround for legacy data.
+		// Some old records have 'visitorEmails' or 'phone' set to 'null', which breaks the $addToSet below.
+		// Pending Product decision: either run a proper DB migration to fix all nulls,
+		// or deprecate this feature entirely. Remove this once a decision is made.
 		if (saveEmail.length) {
 			await this.updateOne({ _id, visitorEmails: null as any }, { $set: { visitorEmails: [] } });
 		}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
### Cause
Using $setUnion inside an aggregation pipeline caused the arrays to be sorted alphabetically, losing the chronological insertion order, and when trying to send the transcript, the first email from the array is picked. That made that if some alphabetically previous email was appended to the array, then the transcript will wrongly be sent there.
### Solution
Replaced the pipeline with a standard $addToSet to append items properly, and added a quick lazy migration to handle legacy null values before updating. Product team is researching whether this feature should be deprecated or not, and based on their answer, I'll take next steps:
If they tell us to deprecate it: A PR deprecating the feature and no database migration, since it wouldn't make sense.
If the tell us to keep it: Database migration fixing old records with null values and a follow up task to remove the conditions added on this PR.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[SUP-1009 visitorEmails is populated with every email in a conversation and that affects transcripts](https://rocketchat.atlassian.net/browse/SUP-1009)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1- Create a workspace with EE license, omnichannel enabled and create a department with an available agent.
2- Make sure `Livechat_lead_phone_regex` and `Livechat_lead_email_regex` settings are enabled (by default, they are)
3- Create a livechat visitor in `http://localhost:3000/livechat` and start a conversation with the agent. 
4- Test edge cases by forcing the visitor record to have `visitorEmails` or `phone` values as `null`. Also note that the arrays are no longer sorting alphabetically after each update.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Livechat: fixed incorrect ordering when adding visitor email addresses and phone numbers so newly added contacts appear correctly without reordering existing entries.
  * Livechat: ensures visitors with previously missing contact lists are handled gracefully and chat transcripts are sent to the correct registration email.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->