### PR TITLE
chore: remove misleading main field from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
 		"url": "git+https://github.com/RocketChat/Rocket.Chat.git"
 	},
 	"license": "MIT",
-	"author": "",
-	"main": "index.js",
 	"workspaces": [
 		"apps/*",
 		"packages/*",


### PR DESCRIPTION
Removes the "main" field from the root package.json as this repository is a private monorepo and not intended to be consumed as a package.

Also removes the empty "author" field for cleaner metadata.

Closes #39884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined root package configuration by removing unused metadata fields, improving project setup clarity while maintaining full monorepo functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->