### PR TITLE
test: improve coverage for useRoomToolboxActions

### DIFF
--- a/apps/meteor/client/views/room/Header/RoomToolbox/hooks/useRoomToolboxActions.spec.ts
+++ b/apps/meteor/client/views/room/Header/RoomToolbox/hooks/useRoomToolboxActions.spec.ts
@@ -40,6 +40,50 @@ describe('useRoomToolboxActions', () => {
 		});
 		expect(result.current.featuredActions).toMatchObject(actions.filter((action) => action.featured));
 	});
+
+	it('should return empty visibleActions when roomToolboxExpanded is false', () => {
+		const { result } = renderHook(
+			() => useRoomToolboxActions({ actions, openTab: () => undefined }),
+			{
+				wrapper: mockAppRoot()
+					.withLayout({ roomToolboxExpanded: false })
+					.build(),
+			}
+		);
+
+		expect(result.current.visibleActions).toEqual([]);
+	});
+
+	it('should not create hiddenActions when exactly 6 normal actions exist', () => {
+		const sixActions = actions.slice(0, 6).map(a => ({ ...a, featured: false }));
+
+		const { result } = renderHook(
+			() => useRoomToolboxActions({ actions: sixActions, openTab: () => undefined }),
+			{
+				wrapper: mockAppRoot()
+					.withLayout({ roomToolboxExpanded: true })
+					.build(),
+			}
+		);
+
+		expect(result.current.visibleActions.length).toBe(6);
+		expect(result.current.hiddenActions.length).toBe(0);
+	});
+
+	it('should exclude disabled actions from hiddenActions', () => {
+		const disabledAction = { ...actions[0], disabled: true };
+
+		const { result } = renderHook(
+			() => useRoomToolboxActions({ actions: [disabledAction], openTab: () => undefined }),
+			{
+				wrapper: mockAppRoot()
+					.withLayout({ roomToolboxExpanded: false })
+					.build(),
+			}
+		);
+
+		expect(result.current.hiddenActions.length).toBe(0);
+	});
 });
 
 const appsActions: RoomToolboxActionConfig[] = [


### PR DESCRIPTION
This PR improves unit test coverage for the useRoomToolboxActions hook by adding edge case tests.

The added tests cover:

- behavior when the toolbox is collapsed (no visible actions)
- boundary condition when exactly 6 actions exist
- filtering of disabled actions from hiddenActions

These additions improve reliability and ensure correct behavior of action distribution logic in the room header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for room toolbox actions to validate proper behavior under different layout states and action configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->