### PR TITLE
[PERF] Parallelize initial database lookups in Activity Hub

### DIFF
--- a/apps/meteor/app/api/server/lib/messages.ts
+++ b/apps/meteor/app/api/server/lib/messages.ts
@@ -5,29 +5,33 @@ import type { FindOptions } from 'mongodb';
 import { canAccessRoomAsync } from '../../../authorization/server/functions/canAccessRoom';
 
 export async function findMentionedMessages({
-	uid,
-	roomId,
-	pagination: { offset, count, sort },
+    uid,
+    roomId,
+    pagination: { offset, count, sort },
 }: {
-	uid: string;
-	roomId: string;
-	pagination: { offset: number; count: number; sort: FindOptions<IMessage>['sort'] };
+    uid: string;
+    roomId: string;
+    pagination: { offset: number; count: number; sort: FindOptions<IMessage>['sort'] };
 }): Promise<{
-	messages: IMessage[];
-	count: number;
-	offset: number;
-	total: number;
+    messages: IMessage[];
+    count: number;
+    offset: number;
+    total: number;
 }> {
-	const room = await Rooms.findOneById(roomId);
-	if (!room || !(await canAccessRoomAsync(room, { _id: uid }))) {
-		throw new Error('error-not-allowed');
-	}
-	const user = await Users.findOneById<Pick<IUser, 'username'>>(uid, { projection: { username: 1 } });
-	if (!user) {
-		throw new Error('invalid-user');
-	}
+    // THE STRIKE: Fetch Room and User concurrently
+    const [room, user] = await Promise.all([
+        Rooms.findOneById(roomId),
+        Users.findOneById<Pick<IUser, 'username'>>(uid, { projection: { username: 1 } })
+    ]);
 
-	const { cursor, totalCount } = Messages.findPaginatedVisibleByMentionAndRoomId(user.username, roomId, {
+    if (!room || !(await canAccessRoomAsync(room, { _id: uid }))) {
+        throw new Error('error-not-allowed');
+    }
+    if (!user) {
+        throw new Error('invalid-user');
+    }
+
+    const { cursor, totalCount } = Messages.findPaginatedVisibleByMentionAndRoomId(user.username, roomId, {
 		sort: sort || { ts: -1 },
 		skip: offset,
 		limit: count,
@@ -44,29 +48,33 @@ export async function findMentionedMessages({
 }
 
 export async function findStarredMessages({
-	uid,
-	roomId,
-	pagination: { offset, count, sort },
+    uid,
+    roomId,
+    pagination: { offset, count, sort },
 }: {
-	uid: string;
-	roomId: string;
-	pagination: { offset: number; count: number; sort: FindOptions<IMessage>['sort'] };
+    uid: string;
+    roomId: string;
+    pagination: { offset: number; count: number; sort: FindOptions<IMessage>['sort'] };
 }): Promise<{
-	messages: IMessage[];
-	count: number;
-	offset: number;
-	total: number;
+    messages: IMessage[];
+    count: number;
+    offset: number;
+    total: number;
 }> {
-	const room = await Rooms.findOneById(roomId);
-	if (!room || !(await canAccessRoomAsync(room, { _id: uid }))) {
-		throw new Error('error-not-allowed');
-	}
-	const user = await Users.findOneById<Pick<IUser, 'username'>>(uid, { projection: { username: 1 } });
-	if (!user) {
-		throw new Error('invalid-user');
-	}
+    // THE STRIKE: Fetch Room and User concurrently
+    const [room, user] = await Promise.all([
+        Rooms.findOneById(roomId),
+        Users.findOneById<Pick<IUser, 'username'>>(uid, { projection: { username: 1 } })
+    ]);
 
-	const { cursor, totalCount } = Messages.findStarredByUserAtRoom(uid, roomId, {
+    if (!room || !(await canAccessRoomAsync(room, { _id: uid }))) {
+        throw new Error('error-not-allowed');
+    }
+    if (!user) {
+        throw new Error('invalid-user');
+    }
+
+    const { cursor, totalCount } = Messages.findStarredByUserAtRoom(uid, roomId, {
 		sort: sort || { ts: -1 },
 		skip: offset,
 		limit: count,


### PR DESCRIPTION
While auditing the Activity Hub endpoints (findMentionedMessages and findStarredMessages), I identified a sequential database lookup bottleneck.

Previously, the system would fetch the Room profile, wait for the network/database response, run the access check, and then fire a completely independent query to fetch the User profile.

This PR refactors these initial authorization lookups to execute concurrently using Promise.all. Since the User lookup does not depend on the Room lookup, parallelizing them eliminates unnecessary idle time on the Node.js event loop and directly reduces the overall API latency, especially under heavy database loads.

Type of change

[x] Improvement (non-breaking change that improves a feature, code style, or performance)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized performance of message retrieval operations by implementing concurrent data fetching for mentioned and starred messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->