### PR TITLE
fix: escape regex metacharacters in from/mention search filters

### DIFF
--- a/apps/meteor/server/lib/parseMessageSearchQuery.ts
+++ b/apps/meteor/server/lib/parseMessageSearchQuery.ts
@@ -45,7 +45,7 @@ class MessageSearchQueryParser {
 			from.push(username);
 
 			this.query['u.username'] = {
-				$regex: from.join('|'),
+				$regex: from.map(escapeRegExp).join('|'),
 				$options: 'i',
 			};
 
@@ -60,7 +60,7 @@ class MessageSearchQueryParser {
 			mentions.push(username);
 
 			this.query['mentions.username'] = {
-				$regex: mentions.join('|'),
+				$regex: mentions.map(escapeRegExp).join('|'),
 				$options: 'i',
 			};
 

--- a/apps/meteor/tests/unit/server/lib/parseMessageSearchQuery.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/parseMessageSearchQuery.spec.ts
@@ -26,6 +26,27 @@ describe('parseMessageSearchQuery', () => {
 			},
 		},
 		{
+			text: 'from:rocket.cat',
+			query: {
+				'u.username': { $regex: 'rocket\\.cat', $options: 'i' },
+			},
+			options: { projection: {}, sort: { ts: -1 }, skip: 0, limit: 20 },
+		},
+		{
+			text: 'mention:john.doe',
+			query: {
+				'mentions.username': { $regex: 'john\\.doe', $options: 'i' },
+			},
+			options: { projection: {}, sort: { ts: -1 }, skip: 0, limit: 20 },
+		},
+		{
+			text: 'from:john.doe from:jane.doe',
+			query: {
+				'u.username': { $regex: 'john\\.doe|jane\\.doe', $options: 'i' },
+			},
+			options: { projection: {}, sort: { ts: -1 }, skip: 0, limit: 20 },
+		},
+		{
 			text: 'has:star',
 			query: { 'starred._id': params.user._id },
 			options: { projection: {}, sort: { ts: -1 }, skip: 0, limit: 20 },


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
`consumeFrom` and `consumeMention` in `parseMessageSearchQuery.ts` were joining user-supplied usernames directly into a MongoDB `$regex` pattern without escaping. Since `.` is a valid character in Rocket.Chat usernames, the dot was silently treated as a regex wildcard (any character) instead of a literal dot.

For example, searching `from:rocket.cat` produced the pattern `rocket.cat`, which matched `rocketXcat`, `rocket_cat`, or any username where the dot position is any character returning broader results than intended.

The fix applies `escapeRegExp` to each username before building the alternation pattern, consistent with how `consumeLabel`, `consumeFileDescription`, and `consumeFileTitle` already handle user input in the same file. Three regression tests are added covering dotted usernames in `from:`, `mention:`, and a multi-token `from:` case.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://github.com/RocketChat/Rocket.Chat/issues/39927

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Create two users: `rocket.cat` and `rocketXcat` (any character in place of the dot).
2. Have both users send messages in a shared channel.
3. Search using `from:rocket.cat`.
4. Before fix: results include messages from both users.
5. After fix: results include only messages from `rocket.cat`.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
`escapeRegExp` was already imported at line 2 of the file and used in three other `$regex`-producing methods. The omission in `consumeFrom` and `consumeMention` was an oversight. No architectural changes, no new dependencies. The only characters realistically affected under the default username policy are `.` and `-`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved message search reliability for queries containing usernames with special characters. The `from:` and `mention:` search commands now correctly handle special characters in usernames, ensuring accurate pattern matching when searching for messages from or mentioning users with names containing characters such as dots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->