### PR TITLE
feat(calendar): Add endTime display to calendar event items

### DIFF
--- a/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventItem.tsx
+++ b/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventItem.tsx
@@ -5,6 +5,7 @@ import { useSetModal } from '@rocket.chat/ui-contexts';
 import { useTranslation } from 'react-i18next';
 
 import { useFormatDateAndTime } from '../../../hooks/useFormatDateAndTime';
+import { useFormatTime } from '../../../hooks/useFormatTime';
 import { usePreventPropagation } from '../../../hooks/usePreventPropagation';
 import OutlookCalendarEventModal from '../OutlookCalendarEventModal';
 import { useOutlookOpenCall } from '../hooks/useOutlookOpenCall';
@@ -22,10 +23,11 @@ const hovered = css`
 	}
 `;
 
-const OutlookEventItem = ({ subject, description, startTime, meetingUrl }: OutlookEventItemProps) => {
+const OutlookEventItem = ({ subject, description, startTime, endTime, meetingUrl }: OutlookEventItemProps) => {
 	const { t } = useTranslation();
 	const setModal = useSetModal();
 	const formatDateAndTime = useFormatDateAndTime();
+	const formatTime = useFormatTime();
 	const openCall = useOutlookOpenCall(meetingUrl);
 	const handleMeetingClick = usePreventPropagation(openCall);
 
@@ -55,7 +57,10 @@ const OutlookEventItem = ({ subject, description, startTime, meetingUrl }: Outlo
 		>
 			<Box>
 				<Box fontScale='h4'>{subject}</Box>
-				<Box fontScale='c1'>{formatDateAndTime(startTime)}</Box>
+				<Box fontScale='c1'>
+					{formatDateAndTime(startTime)}
+					{endTime && ` - ${formatTime(endTime)}`}
+				</Box>
 			</Box>
 			<Box>
 				{meetingUrl && (


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

- [x] I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- [x] I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Proposed changes (including videos or screenshots)
Currently, in the Outlook Events sidebar, only the `startTime` of an event is displayed to the user. This leaves out critical context regarding the meeting's duration. 

This PR updates `OutlookEventItem.tsx` to conditionally display the `endTime` right next to the `startTime` (e.g., `March 28, 2026 10:00 AM - 11:00 AM`). We utilize the `useFormatTime` hook so only the time portion of the `endTime` is displayed, preventing repetitive date text rendering. Note that this falls back gracefully if `endTime` is undefined (which is supported in `ICalendarEvent`).

*(This PR is raised as an initial contribution towards the GSoC Personal Calendar project proposal).*

## Issue(s)
N/A (Related to Google Summer of Code 'Personal Calendar' Preparation)

## Steps to test or reproduce
1. Setup and sync the Outlook Calendar integration in your workspace.
2. Open the Outlook Calendar contextual sidebar to view your events.
3. Observe that events with a specified end time will now correctly display their duration.

## Further comments
This is a small UI/UX enhancement to better support the upcoming Personal Calendar features!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Outlook calendar events now display end times in addition to start times, showing the complete time range for each event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->