### PR TITLE
feat(calendar): Add actionable empty state with Create Event CTA

### DIFF
--- a/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventsList.tsx
+++ b/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventsList.tsx
@@ -1,4 +1,4 @@
-import { Box, States, StatesIcon, StatesTitle, StatesSubtitle, ButtonGroup, Button, Throbber } from '@rocket.chat/fuselage';
+import { Box, States, StatesIcon, StatesTitle, StatesSubtitle, StatesAction, StatesActions, ButtonGroup, Button, Throbber } from '@rocket.chat/fuselage';
 import { useResizeObserver } from '@rocket.chat/fuselage-hooks';
 import {
 	VirtualizedScrollbars,
@@ -65,7 +65,15 @@ const OutlookEventsList = ({ onClose, changeRoute }: OutlookEventsListProps): Re
 					{!calendarListResult.isPending && total === 0 && (
 						<States>
 							<StatesIcon name='calendar' />
-							<StatesTitle>{t('No_history')}</StatesTitle>
+							<StatesTitle>{t('No_events_for_today')}</StatesTitle>
+							<StatesSubtitle>{t('Take_a_break_or_create_an_event_to_get_started')}</StatesSubtitle>
+							{outlookUrl && (
+								<StatesActions>
+									<StatesAction icon='new-window' onClick={() => window.open(outlookUrl, '_blank')}>
+										{t('Create_Event')}
+									</StatesAction>
+								</StatesActions>
+							)}
 						</States>
 					)}
 					{calendarListResult.isSuccess && calendarListResult.data.length > 0 && (


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

- [x] I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- [x] I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Proposed changes (including videos or screenshots)
Currently, encountering an empty state in the Outlook Calendar events list displays a very generic `No_history` warning without any actionable paths for the user to resolve this (such as by creating a new event).

This PR reworks the empty state by upgrading the text to `No_events_for_today` and adding a helpful subtitle. Furthermore, it adds a "Create Event" CTA utilizing `StatesAction` that opens the user's configured `Outlook_Url` (if available), turning an abrupt dead-end into a seamless workflow.

*(This PR is raised as an initial contribution towards the GSoC Personal Calendar project proposal).*

## Issue(s)
N/A (Related to Google Summer of Code 'Personal Calendar' Preparation)

## Steps to test or reproduce
1. Setup and sync the Outlook Calendar integration in your workspace.
2. Ensure you have a day with zero events. 
3. Open the Outlook Calendar sidebar and observe the newly added actionable state.

## Further comments
This solves a UX dead-end for users looking to quickly add events directly from their Rocket.Chat client!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced the empty calendar state messaging to provide clearer guidance when no events are scheduled for the current day, including a helpful prompt encouraging users to take a break or get started by creating an event.
  * Added a new action button in the empty state that opens Outlook directly, allowing users to quickly create new events without leaving the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->