### PR TITLE
chore: Add OpenAPI support for statistics endpoint

### DIFF
--- a/.changeset/migrate-statistics-openapi.md
+++ b/.changeset/migrate-statistics-openapi.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+chore: Add OpenAPI support for statistics endpoint

--- a/apps/meteor/app/api/server/v1/stats.ts
+++ b/apps/meteor/app/api/server/v1/stats.ts
@@ -1,22 +1,50 @@
+import { ajv, ajvQuery, validateBadRequestErrorResponse, validateUnauthorizedErrorResponse } from '@rocket.chat/rest-typings';
+
 import { getStatistics, getLastStatistics } from '../../../statistics/server';
 import telemetryEvent from '../../../statistics/server/lib/telemetryEvents';
 import { API } from '../api';
 import { getPaginationItems } from '../helpers/getPaginationItems';
 
-API.v1.addRoute(
-	'statistics',
-	{ authRequired: true },
-	{
-		async get() {
-			const { refresh = 'false' } = this.queryParams;
+const StatisticsQuerySchema = {
+	type: 'object',
+	properties: {
+		refresh: { type: 'string', enum: ['true', 'false'] },
+	},
+	required: [],
+	additionalProperties: false,
+} as const;
 
-			return API.v1.success(
-				await getLastStatistics({
-					userId: this.userId,
-					refresh: refresh === 'true',
-				}),
-			);
+const isStatisticsProps = ajvQuery.compile<{ refresh?: 'true' | 'false' }>(StatisticsQuerySchema);
+
+const statisticsResponseSchema = ajv.compile<Record<string, unknown>>({
+	type: 'object',
+	properties: {
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['success'],
+	additionalProperties: true,
+});
+
+API.v1.get(
+	'statistics',
+	{
+		authRequired: true,
+		query: isStatisticsProps,
+		response: {
+			200: statisticsResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
 		},
+	},
+	async function action() {
+		const { refresh = 'false' } = this.queryParams;
+
+		return API.v1.success(
+			await getLastStatistics({
+				userId: this.userId,
+				refresh: refresh === 'true',
+			}),
+		);
 	},
 );
 


### PR DESCRIPTION
## Proposed changes

Migrates the `statistics` REST API endpoint from the deprecated `API.v1.addRoute` pattern to the new `API.v1.get` pattern with OpenAPI support.

- Replaced `API.v1.addRoute('statistics', ...)` with `API.v1.get('statistics', options, action)`
- Added AJV validation for the optional `refresh` query param
- Added OpenAPI response metadata (200, 400, 401)
- No changes to endpoint logic — behavior is identical

## Issue(s)

Relates to #34983

## Steps to test or reproduce

1. Hit `GET /api/v1/statistics` — should return stats as before
2. Hit `GET /api/v1/statistics?refresh=true` — should return fresh stats
3. Check Swagger UI — statistics endpoint should now appear with full schema

## Further comments

GSoC 2026 contributor applying for the OpenClaw Integration project. This is my qualifying PR following the same migration pattern used in #39225 and #39227.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OpenAPI schema support for the statistics endpoint, enhancing API documentation and enabling improved request/response validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->