### PR TITLE
feat(calendar): create generic useCalendarList hook

### DIFF
--- a/apps/meteor/client/views/calendar/hooks/useCalendarList.ts
+++ b/apps/meteor/client/views/calendar/hooks/useCalendarList.ts
@@ -1,0 +1,31 @@
+import { useEndpoint } from '@rocket.chat/ui-contexts';
+import { useQuery } from '@tanstack/react-query';
+
+/**
+ * Generic hook to fetch calendar events for a given date.
+ *
+ * This hook calls the provider-agnostic `/v1/calendar-events.list` endpoint,
+ * so it works regardless of the calendar source (Outlook, Google, CalDAV, etc.).
+ *
+ * @param date - The date for which to fetch calendar events.
+ * @returns A React Query result containing the list of calendar events.
+ */
+export const useCalendarList = (date: Date) => {
+	const calendarData = useEndpoint('GET', '/v1/calendar-events.list');
+
+	return useQuery({
+		queryKey: ['calendar', 'list', date.toISOString()],
+
+		queryFn: async () => {
+			const { data } = await calendarData({ date: date.toISOString() });
+			return data;
+		},
+	});
+};
+
+/**
+ * Convenience wrapper that fetches calendar events for today's date.
+ */
+export const useCalendarListForToday = () => {
+	return useCalendarList(new Date());
+};

--- a/apps/meteor/client/views/outlookCalendar/hooks/useOutlookCalendarList.ts
+++ b/apps/meteor/client/views/outlookCalendar/hooks/useOutlookCalendarList.ts
@@ -1,24 +1,24 @@
-import { useToastMessageDispatch, useTranslation, useEndpoint } from '@rocket.chat/ui-contexts';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useToastMessageDispatch, useTranslation } from '@rocket.chat/ui-contexts';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { useOutlookAuthenticationMutation } from './useOutlookAuthentication';
+import { useCalendarList, useCalendarListForToday } from '../../calendar/hooks/useCalendarList';
 import { syncOutlookEvents } from '../lib/syncOutlookEvents';
 
+/**
+ * @deprecated Use {@link useCalendarListForToday} from `views/calendar/hooks/useCalendarList` directly.
+ * Kept for backward compatibility with existing Outlook calendar views.
+ */
 export const useOutlookCalendarListForToday = () => {
-	return useOutlookCalendarList(new Date());
+	return useCalendarListForToday();
 };
 
+/**
+ * @deprecated Use {@link useCalendarList} from `views/calendar/hooks/useCalendarList` directly.
+ * Kept for backward compatibility with existing Outlook calendar views.
+ */
 export const useOutlookCalendarList = (date: Date) => {
-	const calendarData = useEndpoint('GET', '/v1/calendar-events.list');
-
-	return useQuery({
-		queryKey: ['outlook', 'calendar', 'list'],
-
-		queryFn: async () => {
-			const { data } = await calendarData({ date: date.toISOString() });
-			return data;
-		},
-	});
+	return useCalendarList(date);
 };
 
 export const useMutationOutlookCalendarSync = () => {
@@ -34,7 +34,7 @@ export const useMutationOutlookCalendarSync = () => {
 			await syncOutlookEvents();
 
 			await queryClient.invalidateQueries({
-				queryKey: ['outlook', 'calendar', 'list'],
+				queryKey: ['calendar', 'list'],
 			});
 
 			await checkOutlookCredentials.mutateAsync();


### PR DESCRIPTION
## Description

This PR extracts a generic `useCalendarList` hook from the Outlook-specific implementation, allowing any calendar integration (Google, CalDAV, Exchange, etc.) to reuse the same fundamental data-fetching logic.

Previously, `useOutlookCalendarList` was tightly coupled to Outlook views, despite the underlying `/v1/calendar-events.list` API endpoint being completely provider-agnostic. 

By creating a generic `useCalendarList` base hook, we are establishing the architectural foundation required for the upcoming GSoC initiative to support multiple distinct calendar sources seamlessly.

### Key Changes:
* **New Base Hook**: Created `apps/meteor/client/views/calendar/hooks/useCalendarList.ts` containing the generic fetching logic.
* **Universal Cache Keys**: Updated the React Query cache key from `['outlook', 'calendar', 'list']` to a provider-agnostic `['calendar', 'list', date]`. This ensures that cache invalidations will work universally across all future integrated calendar sources.
* **Backward Compatibility**: The original `useOutlookCalendarList` hooks have been refactored to act as thin, `@deprecated` delegates that simply call the new generic hook. This guarantees **zero breaking changes** to existing Outlook components (e.g., `OutlookEventsList`).
* **Sync Invalidation**: Updated `useMutationOutlookCalendarSync` to correctly invalidate the new generic `['calendar', 'list']` cache key upon a successful background sync.

## Related Issue
<!-- Link to your related GSoC issue here, e.g., Closes #12345 -->
Aligns with the GSoC objective of creating modular, multi-source calendar support.

## How to test
1. Navigate to the Outlook Calendar view within the app UI.
2. Ensure your Outlook calendar is authenticated and synced.
3. Verify that calendar events for today continue to load and render correctly.
4. Trigger a manual sync and verify the list updates correctly without errors (confirming the new cache invalidation keys work).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated calendar event fetching logic to improve consistency across calendar integrations.
  * Updated Outlook calendar functionality to utilize shared calendar utilities; legacy Outlook-specific calendar hooks are now deprecated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->