### PR TITLE
feat(calendar): implement Create Event modal and wire to API

### DIFF
--- a/apps/meteor/client/views/calendar/CreateEventModal/CreateEventModal.tsx
+++ b/apps/meteor/client/views/calendar/CreateEventModal/CreateEventModal.tsx
@@ -1,0 +1,189 @@
+import { 
+	Box,
+	Button, 
+	ButtonGroup, 
+	Field, 
+	FieldLabel, 
+	FieldRow, 
+	FieldError, 
+	TextInput, 
+	TextAreaInput, 
+	Select, 
+	ToggleSwitch, 
+	Modal, 
+	ModalHeader, 
+	ModalTitle, 
+	ModalClose, 
+	ModalContent, 
+	ModalFooter 
+} from '@rocket.chat/fuselage';
+import { useTranslation, useEndpoint, useToastMessageDispatch } from '@rocket.chat/ui-contexts';
+import { useQueryClient } from '@tanstack/react-query';
+import type { ReactElement } from 'react';
+import React from 'react';
+import { useForm, Controller } from 'react-hook-form';
+
+type CreateEventModalProps = {
+	onClose: () => void;
+};
+
+type CreateEventFormValues = {
+	subject: string;
+	description?: string;
+	startTime: string;
+	endTime?: string;
+	meetingUrl?: string;
+	reminderMinutesBeforeStart?: string;
+	busy: boolean;
+};
+
+const CreateEventModal = ({ onClose }: CreateEventModalProps): ReactElement => {
+	const t = useTranslation();
+	const dispatchToastMessage = useToastMessageDispatch();
+	const queryClient = useQueryClient();
+	const createEvent = useEndpoint('POST', '/v1/calendar-events.create');
+
+	const {
+		register,
+		handleSubmit,
+		control,
+		formState: { errors, isValid, isSubmitting },
+	} = useForm<CreateEventFormValues>({
+		mode: 'onChange',
+		defaultValues: {
+			busy: true,
+			reminderMinutesBeforeStart: '15',
+		},
+	});
+
+	const onSubmit = async (data: CreateEventFormValues) => {
+		try {
+			await createEvent({
+				subject: data.subject,
+				description: data.description || undefined,
+				startTime: new Date(data.startTime).toISOString(),
+				endTime: data.endTime ? new Date(data.endTime).toISOString() : undefined,
+				meetingUrl: data.meetingUrl || undefined,
+				reminderMinutesBeforeStart: data.reminderMinutesBeforeStart ? parseInt(data.reminderMinutesBeforeStart, 10) : undefined,
+				busy: data.busy,
+			});
+
+			dispatchToastMessage({ type: 'success', message: t('Event_Created_Successfully') });
+			queryClient.invalidateQueries({ queryKey: ['calendar', 'list'] });
+			onClose();
+		} catch (error) {
+			dispatchToastMessage({ type: 'error', message: error });
+		}
+	};
+
+	const reminderOptions: [string, string][] = [
+		['0', t('At_time_of_event')],
+		['5', t('5_minutes_before')],
+		['10', t('10_minutes_before')],
+		['15', t('15_minutes_before')],
+		['30', t('30_minutes_before')],
+		['60', t('1_hour_before')],
+	];
+
+	return (
+		<Modal wrapperFunction={(wrapper) => <form onSubmit={handleSubmit(onSubmit)}>{wrapper}</form>}>
+			<ModalHeader>
+				<ModalTitle>{t('Create_Event')}</ModalTitle>
+				<ModalClose onClick={onClose} />
+			</ModalHeader>
+			<ModalContent>
+				<Field mbe={24}>
+					<FieldLabel required>{t('Subject')}</FieldLabel>
+					<FieldRow>
+						<TextInput
+							placeholder={t('Event_Subject')}
+							{...register('subject', { required: t('Field_required') })}
+							error={errors.subject?.message}
+						/>
+					</FieldRow>
+					{errors.subject && <FieldError>{errors.subject.message}</FieldError>}
+				</Field>
+
+				<Field mbe={24}>
+					<FieldLabel required>{t('Start_Time')}</FieldLabel>
+					<FieldRow>
+						<TextInput
+							type='datetime-local'
+							{...register('startTime', { required: t('Field_required') })}
+							error={errors.startTime?.message}
+						/>
+					</FieldRow>
+					{errors.startTime && <FieldError>{errors.startTime.message}</FieldError>}
+				</Field>
+
+				<Field mbe={24}>
+					<FieldLabel>{t('End_Time')}</FieldLabel>
+					<FieldRow>
+						<TextInput
+							type='datetime-local'
+							{...register('endTime')}
+						/>
+					</FieldRow>
+				</Field>
+
+				<Field mbe={24}>
+					<FieldLabel>{t('Meeting_URL')}</FieldLabel>
+					<FieldRow>
+						<TextInput
+							type='url'
+							placeholder='https://...'
+							{...register('meetingUrl')}
+						/>
+					</FieldRow>
+				</Field>
+
+				<Field mbe={24}>
+					<FieldLabel>{t('Description')}</FieldLabel>
+					<FieldRow>
+						<TextAreaInput
+							rows={3}
+							{...register('description')}
+						/>
+					</FieldRow>
+				</Field>
+
+				<Field mbe={24}>
+					<FieldLabel>{t('Reminder')}</FieldLabel>
+					<FieldRow>
+						<Controller
+							name='reminderMinutesBeforeStart'
+							control={control}
+							render={({ field }) => <Select {...field} options={reminderOptions} />}
+						/>
+					</FieldRow>
+				</Field>
+
+				<Field mbe={16}>
+					<Box display='flex' alignItems='center'>
+						<FieldLabel mbe={0}>{t('Show_as_busy')}</FieldLabel>
+						<Controller
+							name='busy'
+							control={control}
+							render={({ field }) => (
+								<ToggleSwitch
+									checked={field.value}
+									onChange={field.onChange}
+								/>
+							)}
+						/>
+					</Box>
+				</Field>
+			</ModalContent>
+			<ModalFooter>
+				<ButtonGroup align='end'>
+					<Button onClick={onClose}>{t('Cancel')}</Button>
+					<Button primary type='submit' loading={isSubmitting} disabled={!isValid}>
+						{t('Save')}
+					</Button>
+				</ButtonGroup>
+			</ModalFooter>
+		</Modal>
+	);
+};
+
+export default CreateEventModal;

--- a/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventsList.tsx
+++ b/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventsList.tsx
@@ -9,12 +9,14 @@ import {
 	ContextualbarContent,
 	ContextualbarFooter,
 	ContextualbarDialog,
+	imperativeModal,
 } from '@rocket.chat/ui-client';
 import { useTranslation, useUser } from '@rocket.chat/ui-contexts';
 import type { ReactElement } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
 import OutlookEventItem from './OutlookEventItem';
+import CreateEventModal from '../../calendar/CreateEventModal/CreateEventModal';
 import { getErrorMessage } from '../../../lib/errorHandling';
 import { useOutlookAuthentication } from '../hooks/useOutlookAuthentication';
 import { useMutationOutlookCalendarSync, useOutlookCalendarListForToday } from '../hooks/useOutlookCalendarList';
@@ -86,6 +88,7 @@ const OutlookEventsList = ({ onClose, changeRoute }: OutlookEventsListProps): Re
 			</ContextualbarContent>
 			<ContextualbarFooter>
 				<ButtonGroup stretch>
+					{authEnabled && <Button onClick={() => imperativeModal.open({ component: CreateEventModal, props: { onClose: imperativeModal.close } })}>{t('Create_Event')}</Button>}
 					{authEnabled && <Button onClick={changeRoute}>{t('Calendar_settings')}</Button>}
 					{outlookUrl && (
 						<Button icon='new-window' onClick={() => window.open(outlookUrl, '_blank')}>


### PR DESCRIPTION
## Description

This PR implements a missing UI component to interface with the existing `/v1/calendar-events.create` API. Users can now natively create new calendar events directly from the Rocket.Chat client.

### Key Changes:
- **New Component**: Built `CreateEventModal.tsx` utilizing `@rocket.chat/fuselage` components for a native layout (`Modal`, `TextInput`, `TextAreaInput`, `Select`, `ToggleSwitch`).
- **Form State Validation**: Managed input state with `react-hook-form` to ensure required fields like `Subject` and `StartTime` are provided before submission.
- **Provider-Agnostic Setup**: Kept the modal inside the generic `views/calendar` directory instead of Outlook-specific files, paving the way for the GSoC multi-calendar architecture.
- **UI Action Integration**: Wired the modal to open via a generic "Create Event" button added tightly into the `OutlookEventsList` sidebar.
- **Sync/Invalidation**: Form submission securely dispatches to the `.create` API endpoint, fires a success/error toast via `useToastMessageDispatch`, and aggressively invalidates the `['calendar', 'list']` React Query cache so the UI magically refreshes to show the new event.

## Related Issue
<!-- Link your GSoC or related objective issue here -->
Solves the gap of missing event-creation UI for the calendar integration.

## How to test
1. Open the Outlook Calendar sidebar.
2. Click the new **Create Event** button.
3. Fill out the form (e.g., Subject, Start Time, Description, Meeting URL).
4. Save the event and note the Success Toast message.
5. Verify that the event successfully fetches and populates within your sidebar!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a modal dialog for creating new calendar events with form fields for event subject, start/end times, meeting URLs, descriptions, and reminder settings.
  * Added action button in Outlook calendar view to open the event creation modal.
  * Events creation includes validation feedback and success/error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->