### PR TITLE
feat(calendar): add date navigation (prev/next day) to calendar sidebar

### DIFF
--- a/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventsList.tsx
+++ b/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventsList.tsx
@@ -1,4 +1,4 @@
-import { Box, States, StatesIcon, StatesTitle, StatesSubtitle, ButtonGroup, Button, Throbber } from '@rocket.chat/fuselage';
+import { Box, States, StatesIcon, StatesTitle, StatesSubtitle, ButtonGroup, Button, IconButton, Throbber } from '@rocket.chat/fuselage';
 import { useResizeObserver } from '@rocket.chat/fuselage-hooks';
 import {
 	VirtualizedScrollbars,
@@ -12,12 +12,13 @@ import {
 } from '@rocket.chat/ui-client';
 import { useTranslation, useUser } from '@rocket.chat/ui-contexts';
 import type { ReactElement } from 'react';
+import { useState, useCallback } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
 import OutlookEventItem from './OutlookEventItem';
 import { getErrorMessage } from '../../../lib/errorHandling';
 import { useOutlookAuthentication } from '../hooks/useOutlookAuthentication';
-import { useMutationOutlookCalendarSync, useOutlookCalendarListForToday } from '../hooks/useOutlookCalendarList';
+import { useMutationOutlookCalendarSync, useOutlookCalendarList } from '../hooks/useOutlookCalendarList';
 import { NotOnDesktopError } from '../lib/NotOnDesktopError';
 
 type OutlookEventsListProps = {
@@ -34,7 +35,17 @@ const OutlookEventsList = ({ onClose, changeRoute }: OutlookEventsListProps): Re
 
 	const syncOutlookCalendar = useMutationOutlookCalendarSync();
 
-	const calendarListResult = useOutlookCalendarListForToday();
+	const [currentDate, setCurrentDate] = useState(() => new Date());
+
+	const handlePrevDay = useCallback(() => {
+		setCurrentDate((prev) => new Date(prev.getFullYear(), prev.getMonth(), prev.getDate() - 1));
+	}, []);
+
+	const handleNextDay = useCallback(() => {
+		setCurrentDate((prev) => new Date(prev.getFullYear(), prev.getMonth(), prev.getDate() + 1));
+	}, []);
+
+	const calendarListResult = useOutlookCalendarList(currentDate);
 
 	const { ref, contentBoxSize: { inlineSize = 378, blockSize = 1 } = {} } = useResizeObserver<HTMLElement>({
 		debounceDelay: 200,
@@ -53,6 +64,13 @@ const OutlookEventsList = ({ onClose, changeRoute }: OutlookEventsListProps): Re
 				<ContextualbarClose onClick={onClose} />
 			</ContextualbarHeader>
 			<ContextualbarContent paddingInline={0} color='default'>
+				<Box display='flex' justifyContent='space-between' alignItems='center' pi={24} pb={16}>
+					<IconButton icon='chevron-left' title={t('Previous')} onClick={handlePrevDay} />
+					<Box fontScale='p2' fontWeight={600}>
+						{new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(currentDate)}
+					</Box>
+					<IconButton icon='chevron-right' title={t('Next')} onClick={handleNextDay} />
+				</Box>
 				<Box flexGrow={1} flexShrink={1} overflow='hidden' display='flex' justifyContent='center' ref={ref}>
 					{calendarListResult.isPending && <Throbber size='x12' />}
 					{calendarListResult.isError && (


### PR DESCRIPTION
## Proposed changes
Currently, the Calendar sidebar (specifically `OutlookEventsList`) is hardcoded to only fetch and display events for the current day using `useOutlookCalendarListForToday`. This restricts users from checking events for tomorrow, next week, or past days natively within the Rocket.Chat client.

This PR introduces stateful date navigation to the calendar sidebar:
- **Date State:** Introduced a `currentDate` React state and swapped the fetch hook to the dynamic `useOutlookCalendarList(currentDate)`.
- **Navigation Controls:** Rendered a sticky horizontal navigation bar containing `<IconButton>` chevrons to increment/decrement the date, alongside a localized `Intl.DateTimeFormat` display of the active date.
- **Cache Invalidation:** React Query elegantly handles the background fetches as the date state changes, maintaining the correct query keys cleanly.

## Issue(s)
<!-- Link any related issues or GSoC goals here if applicable -->
Addresses the missing functionality of jumping to different dates inside the Calendar Contextual Bar.

## Steps to test or reproduce
1. Go to the Rocket.Chat UI and open the Calendar (Outlook) sidebar.
2. Observe the current date rendered underneath the header.
3. Click the `>` (Next Day) chevron arrow.
4. Verify that the date text updates correctly and the agenda list re-fetches to load the events scheduled for tomorrow.
5. Click `<` (Previous Day) to navigate backwards.

## Further comments
The usage of `Intl.DateTimeFormat` ensures that the date format is completely native, accessible, and requires no heavy external libraries like Moment.js to format properly. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date navigation to the Outlook Calendar events list, enabling users to view events for different dates using left and right navigation buttons.
  * Displays the currently selected date with a formatted label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->