### PR TITLE
fix: custom OAuth users stuck in pending when ManuallyApproveNewUsers is enabled

### DIFF
--- a/apps/meteor/app/custom-oauth/server/custom_oauth_server.js
+++ b/apps/meteor/app/custom-oauth/server/custom_oauth_server.js
@@ -471,6 +471,14 @@ export class CustomOAuth {
 				return true;
 			}
 
+			// Ensure OAuth users respect the ManuallyApproveNewUsers setting.
+			// Without this, new OAuth users are created with active: false (pending)
+			// because onCreateUserAsync only sets active if user.active is undefined,
+			// and the custom OAuth path never sets it explicitly (unlike SAML).
+			if (user.active === undefined) {
+				user.active = !settings.get('Accounts_ManuallyApproveNewUsers');
+			}
+
 			if (this.usernameField) {
 				user.username = user.services[this.name].username;
 			}


### PR DESCRIPTION
## Description
When `Accounts_ManuallyApproveNewUsers` is enabled, new users created via 
custom OAuth (e.g. Authentik, generic OIDC) were left with `active: false` 
and could not log in, receiving a misleading `User not found [401]` error.

A user WAS created in the backend (visible in admin panel) but login failed 
because the user was in pending state.

## Root Cause
`onCreateUserAsync` in `authentication/server/startup/index.js` sets:
```js
user.active = user.active !== undefined ? user.active : !settings.get('Accounts_ManuallyApproveNewUsers');
```
The custom OAuth path never explicitly sets `user.active` before insertion, 
so it always defaulted to `false` when manual approval was enabled.

SAML handles this correctly by explicitly setting `active` before inserting 
the user doc. This fix brings custom OAuth to parity with SAML.

## Fix
Set `user.active` explicitly in the `validateNewUser` callback in 
`custom_oauth_server.js`, matching the same logic SAML uses.

## Fixes
Fixes #38722

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where custom OAuth user registrations were not properly respecting the "Manually Approve New Users" server setting. New OAuth users will now have their activation status correctly set upon registration based on the configured approval requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->