### PR TITLE
fix(VideoConferenceBlock): handle error state separately from loading…

### DIFF
--- a/packages/fuselage-ui-kit/src/blocks/VideoConferenceBlock/VideoConferenceBlock.tsx
+++ b/packages/fuselage-ui-kit/src/blocks/VideoConferenceBlock/VideoConferenceBlock.tsx
@@ -109,9 +109,24 @@ const VideoConferenceBlock = ({ block }: VideoConferenceBlockProps): ReactElemen
 			: t('joined');
 	}, [displayAvatars, t, result.data?.users.length]);
 
-	if (result.isPending || result.isError) {
-		// TODO: error handling
+	if (result.isPending) {
 		return <VideoConfMessageSkeleton />;
+	}
+
+	if (result.isError) {
+		return (
+			<VideoConfMessage>
+				<VideoConfMessageRow>
+					<VideoConfMessageContent>
+						<VideoConfMessageIcon />
+						<VideoConfMessageText>{t('Call_not_found')}</VideoConfMessageText>
+					</VideoConfMessageContent>
+				</VideoConfMessageRow>
+				<VideoConfMessageFooter>
+					<VideoConfMessageFooterText>{t('Call_not_found_error')}</VideoConfMessageFooterText>
+				</VideoConfMessageFooter>
+			</VideoConfMessage>
+		);
 	}
 
 	const { data } = result;


### PR DESCRIPTION

# fix(VideoConferenceBlock): show error message instead of skeleton on fetch failure
  
## Proposed changes                                                                                                                 
  When the video conference data fetch fails (e.g. invalid call ID, network issue),
  the component was displaying a loading skeleton indefinitely with no feedback to the user.

  This PR separates the `isPending` and `isError` states so that:
  - `isPending` → shows the skeleton (unchanged)
  - `isError` → shows a proper error message using the existing `Call_not_found`
    and `Call_not_found_error` i18n keys and the existing `VideoConfMessage` components.

  ## Issue(s)

  ## Steps to test or reproduce

  1. Render a VideoConferenceBlock with an invalid or non-existent callId
  2. Before: an infinite loading skeleton is shown
  3. After: "Call not found" error message is displayed with an explanation

  ## Further comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video conference call error handling to display a "Call not found" message instead of showing an indefinite loading state when the call is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->