### PR TITLE
fix: list pending users correctly in Admin Users tab

### DIFF
--- a/.changeset/fix-pending-users-admin-tab.md
+++ b/.changeset/fix-pending-users-admin-tab.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixes Admin > Users pending filtering and count to correctly list users who have not logged in yet, including users awaiting approval.

--- a/apps/meteor/client/views/admin/users/AdminUsersPage.tsx
+++ b/apps/meteor/client/views/admin/users/AdminUsersPage.tsx
@@ -16,6 +16,7 @@ import {
 } from '@rocket.chat/ui-client';
 import { useRouteParameter, useTranslation, useRouter, useEndpoint } from '@rocket.chat/ui-contexts';
 import { useQuery } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import type { ReactElement } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Trans } from 'react-i18next';
@@ -67,6 +68,7 @@ const AdminUsersPage = (): ReactElement => {
 
 	const paginationData = usePagination();
 	const sortData = useSort<UsersTableSortingOption>('name');
+	const queryClient = useQueryClient();
 
 	const [tab, setTab] = useState<AdminUsersTab>('all');
 	const [userFilters, setUserFilters] = useState<UsersFilters>({ text: '', roles: [] });
@@ -83,11 +85,12 @@ const AdminUsersPage = (): ReactElement => {
 		selectedRoles: useMemo(() => userFilters.roles.map((role) => role.id), [userFilters.roles]),
 	});
 
-	const pendingUsersCount = usePendingUsersCount(filteredUsersQueryResult.data?.users);
+	const pendingUsersCount = usePendingUsersCount();
 
 	const handleReload = (): void => {
 		seatsCap?.reload();
 		filteredUsersQueryResult?.refetch();
+		void queryClient.invalidateQueries({ queryKey: ['pendingUsersCount'] });
 	};
 
 	const handleTabChange = (tab: AdminUsersTab) => {

--- a/apps/meteor/client/views/admin/users/hooks/useFilteredUsers.ts
+++ b/apps/meteor/client/views/admin/users/hooks/useFilteredUsers.ts
@@ -29,8 +29,7 @@ const useFilteredUsers = ({ searchTerm, prevSearchTerm, sortData, paginationData
 			all: {},
 			pending: {
 				type: 'user',
-				status: 'deactivated',
-				inactiveReason: ['pending_approval'],
+				hasLoggedIn: false,
 			},
 			active: {
 				status: 'active',

--- a/apps/meteor/client/views/admin/users/hooks/usePendingUsersCount.ts
+++ b/apps/meteor/client/views/admin/users/hooks/usePendingUsersCount.ts
@@ -1,26 +1,22 @@
-import type { Serialized } from '@rocket.chat/core-typings';
-import type { DefaultUserInfo, UsersListStatusParamsGET } from '@rocket.chat/rest-typings';
+import type { UsersListStatusParamsGET } from '@rocket.chat/rest-typings';
 import { useEndpoint } from '@rocket.chat/ui-contexts';
 import { useQuery } from '@tanstack/react-query';
 
-const usePendingUsersCount = (users: Serialized<DefaultUserInfo[]> | undefined) => {
+const usePendingUsersCount = () => {
 	const getUsers = useEndpoint('GET', '/v1/users.listByStatus');
 
 	return useQuery({
-		queryKey: ['pendingUsersCount', users],
+		queryKey: ['pendingUsersCount'],
 
 		queryFn: async () => {
 			const payload: UsersListStatusParamsGET = {
-				status: 'deactivated',
-				inactiveReason: ['pending_approval'],
+				hasLoggedIn: false,
 				type: 'user',
 				count: 1,
 			};
 
 			return getUsers(payload);
 		},
-
-		enabled: !!users,
 		select: (data) => data?.total,
 	});
 };


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fixes Admin > Users pending filtering and count so users awaiting first login/approval are shown correctly in the Pending tab.

### What changed
- Pending tab query now uses `hasLoggedIn: false` and `type: 'user'`.
- Pending users count query now uses the same filter.
- Pending count query no longer depends on currently loaded table rows.
- Added changeset: `@rocket.chat/meteor` patch.

## Issue(s)

Closes #36621

## Steps to test or reproduce

1. Enable manual approval for new users (`Accounts_ManuallyApproveNewUsers`).
2. Register a new user.
3. Go to **Admin > Users** and open **Pending**.

Expected:
- New user appears in **Pending**.
- Pending tab count reflects the list.

Regression checks:
- After user is activated and logs in, they no longer appear in Pending.
- Active/Deactivated tabs continue to work as expected.

## Further comments

This aligns the Pending tab data and Pending badge count with the same backend filter logic.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the Admin → Users view to correctly filter and count "pending" users, ensuring the list includes both users who have not yet logged in and those awaiting administrator approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->