### PR TITLE
chore: fix failing turborepo builds on Windows environments

### DIFF
--- a/apps/meteor/ee/server/services/package.json
+++ b/apps/meteor/ee/server/services/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"typecheck": "tsc --noEmit --skipLibCheck",
 		"build": "tsc",
-		"build-containers": "npm run build && docker-compose build && rm -rf ./dist",
+		"build-containers": "npm run build && docker-compose build && rimraf ./dist",
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"keywords": [
@@ -57,6 +57,7 @@
 		"@types/ws": "^8.18.1",
 		"npm-run-all": "^4.1.5",
 		"pino-pretty": "13.1.3",
+		"rimraf": "^6.0.1",
 		"ts-node": "^10.9.2",
 		"typescript": "~5.9.3"
 	},

--- a/ee/packages/federation-matrix/package.json
+++ b/ee/packages/federation-matrix/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		"build": "rimraf dist && tsc -p tsconfig.build.json",
 		"dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -50,6 +50,7 @@
 		"jest-qase-reporter": "^2.1.4",
 		"matrix-js-sdk": "^38.4.0",
 		"pino-pretty": "13.1.3",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/ee/packages/media-calls/package.json
+++ b/ee/packages/media-calls/package.json
@@ -8,8 +8,8 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
-		"build-preview": "mkdir -p ../../.preview && cp -r ./dist ../../.preview/media-calls",
+		"build": "rimraf dist && tsc -p tsconfig.json",
+		"build-preview": "shx mkdir -p ../../.preview && shx cp -r ./dist ../../.preview/media-calls",
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -27,6 +27,8 @@
 		"@rocket.chat/tsconfig": "workspace:*",
 		"@types/jest": "~30.0.0",
 		"eslint": "~9.39.3",
+		"rimraf": "^6.0.1",
+		"shx": "^0.3.4",
 		"typescript": "~5.9.3"
 	}
 }

--- a/ee/packages/omni-core-ee/package.json
+++ b/ee/packages/omni-core-ee/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"build": "rimraf dist && tsc -p tsconfig.json",
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -29,6 +29,7 @@
 		"@types/jest": "~30.0.0",
 		"eslint": "~9.39.3",
 		"jest": "~30.2.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/ee/packages/omnichannel-services/package.json
+++ b/ee/packages/omnichannel-services/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		"build": "rimraf dist && tsc -p tsconfig.build.json",
 		"dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -47,6 +47,7 @@
 		"@types/jest": "~30.0.0",
 		"eslint": "~9.39.3",
 		"jest": "~30.2.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/ee/packages/pdf-worker/package.json
+++ b/ee/packages/pdf-worker/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "tsc -p tsconfig.build.json && cp -r src/public dist/public",
+		"build": "tsc -p tsconfig.build.json && shx cp -r src/public dist/public",
 		"dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -46,6 +46,8 @@
 		"i18next": "~23.4.9",
 		"jest": "~30.2.0",
 		"react-dom": "~18.3.1",
+		"rimraf": "^6.0.1",
+		"shx": "^0.3.4",
 		"storybook": "^8.6.17",
 		"typescript": "~5.9.3"
 	},

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
 		"@types/node": "~22.16.5",
 		"eslint": "~9.39.3",
 		"eslint-plugin-you-dont-need-lodash-underscore": "~6.14.0",
+		"rimraf": "^6.0.1",
+		"shx": "^0.3.4",
 		"ts-node": "^10.9.2",
 		"turbo": "2.8.12",
 		"typescript": "~5.9.3"

--- a/packages/account-utils/package.json
+++ b/packages/account-utils/package.json
@@ -8,13 +8,14 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"build": "rimraf dist && tsc -p tsconfig.json",
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix ."
 	},
 	"devDependencies": {
 		"eslint": "~9.39.3",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/agenda/package.json
+++ b/packages/agenda/package.json
@@ -9,7 +9,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"build": "rimraf dist && tsc -p tsconfig.json",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix ."
 	},
@@ -24,6 +24,7 @@
 	"devDependencies": {
 		"@types/debug": "^4.1.12",
 		"eslint": "~9.39.3",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/apps-engine/deno-runtime/deno.lock
+++ b/packages/apps-engine/deno-runtime/deno.lock
@@ -1,73 +1,74 @@
 {
-  "version": "3",
-  "packages": {
-    "specifiers": {
-      "jsr:@std/bytes@^1.0.6": "jsr:@std/bytes@1.0.6",
-      "jsr:@std/cli@^1.0.9": "jsr:@std/cli@1.0.13",
-      "jsr:@std/streams@^1.0.16": "jsr:@std/streams@1.0.16",
-      "npm:@msgpack/msgpack@3.0.0-beta2": "npm:@msgpack/msgpack@3.0.0-beta2",
-      "npm:@rocket.chat/ui-kit@^0.31.22": "npm:@rocket.chat/ui-kit@0.31.25_@rocket.chat+icons@0.32.0",
-      "npm:acorn-walk@8.2.0": "npm:acorn-walk@8.2.0",
-      "npm:acorn@8.10.0": "npm:acorn@8.10.0",
-      "npm:astring@1.8.6": "npm:astring@1.8.6",
-      "npm:jsonrpc-lite@2.2.0": "npm:jsonrpc-lite@2.2.0",
-      "npm:stack-trace": "npm:stack-trace@0.0.10",
-      "npm:stack-trace@0.0.10": "npm:stack-trace@0.0.10",
-      "npm:uuid@8.3.2": "npm:uuid@8.3.2"
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/bytes@^1.0.6": "1.0.6",
+    "jsr:@std/cli@^1.0.9": "1.0.13",
+    "jsr:@std/io@~0.225.3": "0.225.3",
+    "jsr:@std/streams@^1.0.16": "1.0.16",
+    "npm:@msgpack/msgpack@3.0.0-beta2": "3.0.0-beta2",
+    "npm:@rocket.chat/ui-kit@~0.31.22": "0.31.25_@rocket.chat+icons@0.32.0",
+    "npm:acorn-walk@8.2.0": "8.2.0",
+    "npm:acorn@8.10.0": "8.10.0",
+    "npm:astring@1.8.6": "1.8.6",
+    "npm:jsonrpc-lite@2.2.0": "2.2.0",
+    "npm:stack-trace@*": "0.0.10",
+    "npm:stack-trace@0.0.10": "0.0.10",
+    "npm:uuid@8.3.2": "8.3.2"
+  },
+  "jsr": {
+    "@std/bytes@1.0.6": {
+      "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
     },
-    "jsr": {
-      "@std/bytes@1.0.6": {
-        "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
-      },
-      "@std/cli@1.0.13": {
-        "integrity": "5db2d95ab2dca3bca9fb6ad3c19908c314e93d6391c8b026725e4892d4615a69"
-      },
-      "@std/streams@1.0.16": {
-        "integrity": "85030627befb1767c60d4f65cb30fa2f94af1d6ee6e5b2515b76157a542e89c4",
-        "dependencies": [
-          "jsr:@std/bytes@^1.0.6"
-        ]
-      }
+    "@std/cli@1.0.13": {
+      "integrity": "5db2d95ab2dca3bca9fb6ad3c19908c314e93d6391c8b026725e4892d4615a69"
     },
-    "npm": {
-      "@msgpack/msgpack@3.0.0-beta2": {
-        "integrity": "sha512-y+l1PNV0XDyY8sM3YtuMLK5vE3/hkfId+Do8pLo/OPxfxuFAUwcGz3oiiUuV46/aBpwTzZ+mRWVMtlSKbradhw==",
-        "dependencies": {}
-      },
-      "@rocket.chat/icons@0.32.0": {
-        "integrity": "sha512-7yhhELKNLb9kUtXCvau0V+iMXraV2bOsxcPjc/ZtLR5VeeIDTeaflqRWGtLroX6f3bE+J1n5qB5zi8A4YXuH2g==",
-        "dependencies": {}
-      },
-      "@rocket.chat/ui-kit@0.31.25_@rocket.chat+icons@0.32.0": {
-        "integrity": "sha512-yTgTKDw9SMlJ6p8n0PDO6zSvox/nHYUrwCIvILQeAK6PvTrgSe/u9CvU7ATTYjnQiQ603yEGR6dxjF4euCGdNA==",
-        "dependencies": {
-          "@rocket.chat/icons": "@rocket.chat/icons@0.32.0"
-        }
-      },
-      "acorn-walk@8.2.0": {
-        "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-        "dependencies": {}
-      },
-      "acorn@8.10.0": {
-        "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-        "dependencies": {}
-      },
-      "astring@1.8.6": {
-        "integrity": "sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg==",
-        "dependencies": {}
-      },
-      "jsonrpc-lite@2.2.0": {
-        "integrity": "sha512-/cbbSxtZWs1O7R4tWqabrCM/t3N8qKUZMAg9IUqpPvUs6UyRvm6pCNYkskyKN/XU0UgffW+NY2ZRr8t0AknX7g==",
-        "dependencies": {}
-      },
-      "stack-trace@0.0.10": {
-        "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-        "dependencies": {}
-      },
-      "uuid@8.3.2": {
-        "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-        "dependencies": {}
-      }
+    "@std/io@0.225.3": {
+      "integrity": "27b07b591384d12d7b568f39e61dff966b8230559122df1e9fd11cc068f7ddd1",
+      "dependencies": [
+        "jsr:@std/bytes"
+      ]
+    },
+    "@std/streams@1.0.16": {
+      "integrity": "85030627befb1767c60d4f65cb30fa2f94af1d6ee6e5b2515b76157a542e89c4",
+      "dependencies": [
+        "jsr:@std/bytes"
+      ]
+    }
+  },
+  "npm": {
+    "@msgpack/msgpack@3.0.0-beta2": {
+      "integrity": "sha512-y+l1PNV0XDyY8sM3YtuMLK5vE3/hkfId+Do8pLo/OPxfxuFAUwcGz3oiiUuV46/aBpwTzZ+mRWVMtlSKbradhw==",
+      "deprecated": true
+    },
+    "@rocket.chat/icons@0.32.0": {
+      "integrity": "sha512-7yhhELKNLb9kUtXCvau0V+iMXraV2bOsxcPjc/ZtLR5VeeIDTeaflqRWGtLroX6f3bE+J1n5qB5zi8A4YXuH2g=="
+    },
+    "@rocket.chat/ui-kit@0.31.25_@rocket.chat+icons@0.32.0": {
+      "integrity": "sha512-yTgTKDw9SMlJ6p8n0PDO6zSvox/nHYUrwCIvILQeAK6PvTrgSe/u9CvU7ATTYjnQiQ603yEGR6dxjF4euCGdNA==",
+      "dependencies": [
+        "@rocket.chat/icons"
+      ]
+    },
+    "acorn-walk@8.2.0": {
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+    },
+    "acorn@8.10.0": {
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "bin": true
+    },
+    "astring@1.8.6": {
+      "integrity": "sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg==",
+      "bin": true
+    },
+    "jsonrpc-lite@2.2.0": {
+      "integrity": "sha512-/cbbSxtZWs1O7R4tWqabrCM/t3N8qKUZMAg9IUqpPvUs6UyRvm6pCNYkskyKN/XU0UgffW+NY2ZRr8t0AknX7g=="
+    },
+    "stack-trace@0.0.10": {
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="
+    },
+    "uuid@8.3.2": {
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": true
     }
   },
   "remote": {
@@ -113,10 +114,10 @@
   "workspace": {
     "dependencies": [
       "jsr:@std/cli@^1.0.9",
-      "jsr:@std/io@^0.225.3",
+      "jsr:@std/io@~0.225.3",
       "jsr:@std/streams@^1.0.16",
       "npm:@msgpack/msgpack@3.0.0-beta2",
-      "npm:@rocket.chat/ui-kit@^0.31.22",
+      "npm:@rocket.chat/ui-kit@~0.31.22",
       "npm:acorn-walk@8.2.0",
       "npm:acorn@8.10.0",
       "npm:astring@1.8.6",

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"build": "rimraf dist && tsc -p tsconfig.json",
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix ."
@@ -21,6 +21,7 @@
 	"devDependencies": {
 		"@rocket.chat/tsconfig": "workspace:*",
 		"eslint": "~9.39.3",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -6,7 +6,7 @@
 	"main": "./dist/base64.js",
 	"types": "./dist/base64.d.ts",
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		"build": "rimraf dist && tsc -p tsconfig.build.json",
 		"dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -17,6 +17,7 @@
 		"@rocket.chat/jest-presets": "workspace:~",
 		"@rocket.chat/tsconfig": "workspace:*",
 		"jest": "~30.2.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/cas-validate/package.json
+++ b/packages/cas-validate/package.json
@@ -9,7 +9,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"build": "rimraf dist && tsc -p tsconfig.json",
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -21,6 +21,7 @@
 	"devDependencies": {
 		"eslint": "~9.39.3",
 		"jest": "~30.2.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/core-services/package.json
+++ b/packages/core-services/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc",
+		"build": "rimraf dist && tsc",
 		"dev": "tsc --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -37,6 +37,7 @@
 		"jest": "~30.2.0",
 		"mongodb": "6.16.0",
 		"prettier": "~3.3.3",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"build": "rimraf dist && tsc -p tsconfig.json",
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix ."
@@ -24,6 +24,7 @@
 	"devDependencies": {
 		"@rocket.chat/tsconfig": "workspace:*",
 		"eslint": "~9.39.3",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/favicon/package.json
+++ b/packages/favicon/package.json
@@ -8,13 +8,14 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"build": "rimraf dist && tsc -p tsconfig.json",
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix ."
 	},
 	"devDependencies": {
 		"eslint": "~9.39.3",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/fuselage-ui-kit/package.json
+++ b/packages/fuselage-ui-kit/package.json
@@ -23,7 +23,7 @@
 		"/dist"
 	],
 	"scripts": {
-		".:build-preview-move": "mkdir -p ../../.preview/ && cp -r ./storybook-static ../../.preview/fuselage-ui-kit",
+		".:build-preview-move": "shx mkdir -p ../../.preview/ && shx cp -r ./storybook-static ../../.preview/fuselage-ui-kit",
 		".:build:clean": "rimraf dist",
 		".:build:tsc": "tsc -p tsconfig.build.json",
 		"build": "run-s .:build:clean .:build:tsc",
@@ -83,6 +83,7 @@
 		"react-i18next": "~13.2.2",
 		"react-virtuoso": "^4.12.0",
 		"rimraf": "^6.0.1",
+		"shx": "^0.3.4",
 		"storybook": "^8.6.17",
 		"storybook-dark-mode": "^4.0.2",
 		"typescript": "~5.9.3",

--- a/packages/gazzodown/package.json
+++ b/packages/gazzodown/package.json
@@ -8,8 +8,8 @@
 		"/dist"
 	],
 	"scripts": {
-		".:build-preview-move": "mkdir -p ../../.preview && cp -r ./storybook-static ../../.preview/gazzodown",
-		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		".:build-preview-move": "shx mkdir -p ../../.preview && shx cp -r ./storybook-static ../../.preview/gazzodown",
+		"build": "rimraf dist && tsc -p tsconfig.build.json",
 		"build-preview": "storybook build --quiet",
 		"build-storybook": "storybook build",
 		"dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
@@ -67,6 +67,8 @@
 		"react-dom": "~18.3.1",
 		"react-i18next": "~13.2.2",
 		"react-virtuoso": "^4.12.0",
+		"rimraf": "^6.0.1",
+		"shx": "^0.3.4",
 		"storybook": "^8.6.17",
 		"typescript": "~5.9.3",
 		"webpack": "~5.99.9"

--- a/packages/http-router/package.json
+++ b/packages/http-router/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc",
+		"build": "rimraf dist && tsc",
 		"dev": "tsc --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -33,6 +33,7 @@
 		"@types/supertest": "~6.0.3",
 		"eslint": "~9.39.3",
 		"jest": "~30.2.0",
+		"rimraf": "^6.0.1",
 		"supertest": "~7.1.4",
 		"ts-jest": "~29.4.6",
 		"typescript": "~5.9.3"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -24,7 +24,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.build.json && node --experimental-transform-types ./src/scripts/build.mts",
+		"build": "rimraf dist && tsc -p tsconfig.build.json && node --experimental-transform-types ./src/scripts/build.mts",
 		"check": "node --experimental-transform-types ./src/scripts/check.mts",
 		"lint": "eslint && node --experimental-transform-types ./src/scripts/check.mts",
 		"lint:fix": "eslint --fix && node --experimental-transform-types ./src/scripts/check.mts --fix",
@@ -40,6 +40,7 @@
 		"eslint": "~9.39.3",
 		"i18next": "~23.4.9",
 		"jest": "~30.2.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"peerDependencies": {

--- a/packages/instance-status/package.json
+++ b/packages/instance-status/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"build": "rimraf dist && tsc -p tsconfig.json",
 		"dev": "tsc --watch --preserveWatchOutput -p tsconfig.json",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -23,6 +23,7 @@
 		"eslint": "~9.39.3",
 		"mongodb": "6.16.0",
 		"prettier": "~3.3.3",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/jest-presets/package.json
+++ b/packages/jest-presets/package.json
@@ -23,7 +23,7 @@
 	],
 	"scripts": {
 		"build": "tsc",
-		"clean": "rm -rf ./dist",
+		"clean": "rimraf ./dist",
 		"lint": "eslint ."
 	},
 	"dependencies": {

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc",
+		"build": "rimraf dist && tsc",
 		"dev": "tsc --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -25,6 +25,7 @@
 		"@types/jest": "~30.0.0",
 		"eslint": "~9.39.3",
 		"jest": "~30.2.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/log-format/package.json
+++ b/packages/log-format/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"build": "rimraf dist && tsc -p tsconfig.json",
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix ."
@@ -21,6 +21,7 @@
 		"@types/chalk": "^2.2.4",
 		"@types/ejson": "^2.2.2",
 		"eslint": "~9.39.3",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"build": "rimraf dist && tsc -p tsconfig.json",
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix ."
@@ -19,6 +19,7 @@
 	},
 	"devDependencies": {
 		"eslint": "~9.39.3",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/media-signaling/package.json
+++ b/packages/media-signaling/package.json
@@ -8,8 +8,8 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
-		"build-preview": "mkdir -p ../../.preview && cp -r ./dist ../../.preview/media-signaling",
+		"build": "rimraf dist && tsc -p tsconfig.json",
+		"build-preview": "shx mkdir -p ../../.preview && shx cp -r ./dist ../../.preview/media-signaling",
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -25,6 +25,8 @@
 		"@types/jest": "~30.0.0",
 		"eslint": "~9.39.3",
 		"jest": "~30.2.0",
+		"rimraf": "^6.0.1",
+		"shx": "^0.3.4",
 		"typescript": "~5.9.3"
 	}
 }

--- a/packages/message-types/package.json
+++ b/packages/message-types/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		"build": "rimraf dist && tsc -p tsconfig.build.json",
 		"lint": "eslint .",
 		"test": "jest",
 		"testunit": "jest"
@@ -20,6 +20,7 @@
 		"i18next": "~23.4.9",
 		"jest": "~30.2.0",
 		"moment": "^2.30.1",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"peerDependencies": {

--- a/packages/mock-providers/package.json
+++ b/packages/mock-providers/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"build": "rimraf dist && tsc -p tsconfig.json",
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix ."
@@ -37,6 +37,7 @@
 		"jest": "~30.2.0",
 		"react": "~18.3.1",
 		"react-dom": "~18.3.1",
+		"rimraf": "^6.0.1",
 		"storybook": "^8.6.17",
 		"typescript": "~5.9.3"
 	},

--- a/packages/model-typings/package.json
+++ b/packages/model-typings/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"build": "rimraf dist && tsc -p tsconfig.json",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix ."
 	},
@@ -19,6 +19,7 @@
 		"@types/node-rsa": "^1.1.4",
 		"eslint": "~9.39.3",
 		"mongodb": "6.16.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc",
+		"build": "rimraf dist && tsc",
 		"dev": "tsc --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -34,6 +34,7 @@
 		"@types/node-rsa": "^1.1.4",
 		"eslint": "~9.39.3",
 		"jest": "~30.2.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/mongo-adapter/package.json
+++ b/packages/mongo-adapter/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"build": "rimraf dist && tsc -p tsconfig.json",
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -20,6 +20,7 @@
 		"eslint": "~9.39.3",
 		"jest": "~30.2.0",
 		"mongodb": "6.16.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"peerDependencies": {

--- a/packages/omni-core/package.json
+++ b/packages/omni-core/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"build": "rimraf dist && tsc -p tsconfig.json",
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -27,6 +27,7 @@
 		"@types/jest": "~30.0.0",
 		"eslint": "~9.39.3",
 		"jest": "~30.2.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/password-policies/package.json
+++ b/packages/password-policies/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc",
+		"build": "rimraf dist && tsc",
 		"dev": "tsc --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -22,6 +22,7 @@
 		"@types/jest": "~30.0.0",
 		"eslint": "~9.39.3",
 		"jest": "~30.2.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/patch-injection/package.json
+++ b/packages/patch-injection/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc",
+		"build": "rimraf dist && tsc",
 		"dev": "tsc --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -22,6 +22,7 @@
 		"@types/jest": "~30.0.0",
 		"eslint": "~9.39.3",
 		"jest": "~30.2.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/random/package.json
+++ b/packages/random/package.json
@@ -7,7 +7,7 @@
 	"browser": "./dist/main.client.js",
 	"types": "./dist/main.server.d.ts",
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		"build": "rimraf dist && tsc -p tsconfig.build.json",
 		"dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -20,6 +20,7 @@
 		"@rocket.chat/tsconfig": "workspace:*",
 		"eslint": "~9.39.3",
 		"jest": "~30.2.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/rest-typings/package.json
+++ b/packages/rest-typings/package.json
@@ -7,7 +7,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc",
+		"build": "rimraf dist && tsc",
 		"dev": "tsc --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -25,6 +25,7 @@
 		"@types/jest": "~30.0.0",
 		"eslint": "~9.39.3",
 		"mongodb": "6.16.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/server-fetch/package.json
+++ b/packages/server-fetch/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		"build": "rimraf dist && tsc -p tsconfig.build.json",
 		"dev": "tsc --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -31,6 +31,7 @@
 		"@types/node-fetch": "~2.6.13",
 		"eslint": "~9.39.3",
 		"jest": "^29.7.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/sha256/package.json
+++ b/packages/sha256/package.json
@@ -6,7 +6,7 @@
 	"main": "./dist/sha256.js",
 	"types": "./dist/sha256.d.ts",
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		"build": "rimraf dist && tsc -p tsconfig.build.json",
 		"dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -19,6 +19,7 @@
 		"@rocket.chat/tsconfig": "workspace:*",
 		"eslint": "~9.39.3",
 		"jest": "~30.2.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -12,8 +12,8 @@
 		"/preview.d.ts"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc && yarn run copy-svg",
-		"copy-svg": "cp -r ./src/logo.svg ./dist/logo.svg",
+		"build": "rimraf dist && tsc && yarn run copy-svg",
+		"copy-svg": "shx cp -r ./src/logo.svg ./dist/logo.svg",
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix ."
@@ -43,6 +43,8 @@
 		"eslint": "~9.39.3",
 		"react": "~18.3.1",
 		"react-dom": "~18.3.1",
+		"rimraf": "^6.0.1",
+		"shx": "^0.3.4",
 		"typescript": "~5.9.3"
 	},
 	"peerDependencies": {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		"build": "rimraf dist && tsc -p tsconfig.build.json",
 		"dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -26,6 +26,7 @@
 		"@types/jest": "~30.0.0",
 		"eslint": "~9.39.3",
 		"jest": "~30.2.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc",
+		"build": "rimraf dist && tsc",
 		"dev": "tsc --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -23,6 +23,7 @@
 		"@types/jest": "~30.0.0",
 		"eslint": "~9.39.3",
 		"jest": "~30.2.0",
+		"rimraf": "^6.0.1",
 		"ts-jest": "~29.4.6",
 		"typescript": "~5.9.3"
 	},

--- a/packages/ui-avatar/package.json
+++ b/packages/ui-avatar/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		"build": "rimraf dist && tsc -p tsconfig.build.json",
 		"dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -28,6 +28,7 @@
 		"react": "~18.3.1",
 		"react-dom": "~18.3.1",
 		"react-virtuoso": "^4.12.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"peerDependencies": {

--- a/packages/ui-client/package.json
+++ b/packages/ui-client/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		"build": "rimraf dist && tsc -p tsconfig.build.json",
 		"dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -58,6 +58,7 @@
 		"react-hook-form": "~7.45.4",
 		"react-i18next": "~13.2.2",
 		"react-virtuoso": "^4.12.0",
+		"rimraf": "^6.0.1",
 		"storybook": "^8.6.17",
 		"typescript": "~5.9.3"
 	},

--- a/packages/ui-composer/package.json
+++ b/packages/ui-composer/package.json
@@ -8,8 +8,8 @@
 		"/dist"
 	],
 	"scripts": {
-		".:build-preview-move": "mkdir -p ../../.preview/ && cp -r ./storybook-static ../../.preview/ui-composer",
-		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		".:build-preview-move": "shx mkdir -p ../../.preview/ && shx cp -r ./storybook-static ../../.preview/ui-composer",
+		"build": "rimraf dist && tsc -p tsconfig.build.json",
 		"build-preview": "storybook build",
 		"dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
@@ -44,6 +44,8 @@
 		"react": "~18.3.1",
 		"react-dom": "~18.3.1",
 		"react-virtuoso": "^4.12.0",
+		"rimraf": "^6.0.1",
+		"shx": "^0.3.4",
 		"storybook": "^8.6.17",
 		"typescript": "~5.9.3",
 		"webpack": "~5.99.9"

--- a/packages/ui-contexts/package.json
+++ b/packages/ui-contexts/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		"build": "rimraf dist && tsc -p tsconfig.build.json",
 		"dev": "tsc --watch --preserveWatchOutput -p tsconfig.build.json",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -41,6 +41,7 @@
 		"react": "~18.3.1",
 		"react-dom": "~18.3.1",
 		"react-virtuoso": "^4.12.0",
+		"rimraf": "^6.0.1",
 		"typescript": "~5.9.3"
 	},
 	"peerDependencies": {

--- a/packages/ui-video-conf/package.json
+++ b/packages/ui-video-conf/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		"build": "rimraf dist && tsc -p tsconfig.build.json",
 		"dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -49,6 +49,7 @@
 		"react": "~18.3.1",
 		"react-dom": "~18.3.1",
 		"react-virtuoso": "^4.12.0",
+		"rimraf": "^6.0.1",
 		"storybook": "^8.6.17",
 		"typescript": "~5.9.3",
 		"webpack": "~5.99.9"

--- a/packages/ui-voip/package.json
+++ b/packages/ui-voip/package.json
@@ -8,7 +8,7 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		"build": "rimraf dist && tsc -p tsconfig.build.json",
 		"dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
@@ -68,6 +68,7 @@
 		"react": "~18.3.1",
 		"react-dom": "~18.3.1",
 		"react-virtuoso": "^4.12.0",
+		"rimraf": "^6.0.1",
 		"storybook": "^8.6.17",
 		"typescript": "~5.9.3"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -8986,6 +8986,7 @@ __metadata:
   resolution: "@rocket.chat/account-utils@workspace:packages/account-utils"
   dependencies:
     eslint: "npm:~9.39.3"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -9002,6 +9003,7 @@ __metadata:
     human-interval: "npm:^2.0.1"
     moment-timezone: "npm:~0.5.48"
     mongodb: "npm:6.16.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -9070,6 +9072,7 @@ __metadata:
     "@rocket.chat/model-typings": "workspace:^"
     "@rocket.chat/tsconfig": "workspace:*"
     eslint: "npm:~9.39.3"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -9116,6 +9119,7 @@ __metadata:
     "@rocket.chat/jest-presets": "workspace:~"
     "@rocket.chat/tsconfig": "workspace:*"
     jest: "npm:~30.2.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -9127,6 +9131,7 @@ __metadata:
     cheerio: "npm:1.0.0"
     eslint: "npm:~9.39.3"
     jest: "npm:~30.2.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -9153,6 +9158,7 @@ __metadata:
     jest: "npm:~30.2.0"
     mongodb: "npm:6.16.0"
     prettier: "npm:~3.3.3"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -9190,6 +9196,7 @@ __metadata:
     "@rocket.chat/tsconfig": "workspace:*"
     eslint: "npm:~9.39.3"
     mongodb: "npm:6.16.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -9335,6 +9342,7 @@ __metadata:
   resolution: "@rocket.chat/favicon@workspace:packages/favicon"
   dependencies:
     eslint: "npm:~9.39.3"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -9369,6 +9377,7 @@ __metadata:
     pino: "npm:10.3.1"
     pino-pretty: "npm:13.1.3"
     reflect-metadata: "npm:^0.2.2"
+    rimraf: "npm:^6.0.1"
     sanitize-html: "npm:~2.17.0"
     tsyringe: "npm:^4.10.0"
     tweetnacl: "npm:^1.0.3"
@@ -9499,6 +9508,7 @@ __metadata:
     react-i18next: "npm:~13.2.2"
     react-virtuoso: "npm:^4.12.0"
     rimraf: "npm:^6.0.1"
+    shx: "npm:^0.3.4"
     storybook: "npm:^8.6.17"
     storybook-dark-mode: "npm:^4.0.2"
     typescript: "npm:~5.9.3"
@@ -9592,6 +9602,8 @@ __metadata:
     react-i18next: "npm:~13.2.2"
     react-stately: "npm:~3.17.0"
     react-virtuoso: "npm:^4.12.0"
+    rimraf: "npm:^6.0.1"
+    shx: "npm:^0.3.4"
     storybook: "npm:^8.6.17"
     typescript: "npm:~5.9.3"
     webpack: "npm:~5.99.9"
@@ -9627,6 +9639,7 @@ __metadata:
     hono: "npm:^4.12.5"
     jest: "npm:~30.2.0"
     qs: "npm:^6.14.1"
+    rimraf: "npm:^6.0.1"
     supertest: "npm:~7.1.4"
     ts-jest: "npm:~29.4.6"
     typescript: "npm:~5.9.3"
@@ -9643,6 +9656,7 @@ __metadata:
     eslint: "npm:~9.39.3"
     i18next: "npm:~23.4.9"
     jest: "npm:~30.2.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   peerDependencies:
     "@rocket.chat/tools": "workspace:~"
@@ -9667,6 +9681,7 @@ __metadata:
     eslint: "npm:~9.39.3"
     mongodb: "npm:6.16.0"
     prettier: "npm:~3.3.3"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -9703,6 +9718,7 @@ __metadata:
     eslint: "npm:~9.39.3"
     jest: "npm:~30.2.0"
     jose: "npm:^4.15.9"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -9839,6 +9855,7 @@ __metadata:
     chalk: "npm:^4.1.2"
     ejson: "npm:^2.2.3"
     eslint: "npm:~9.39.3"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -9850,6 +9867,7 @@ __metadata:
     "@rocket.chat/emitter": "npm:^0.32.0"
     eslint: "npm:~9.39.3"
     pino: "npm:10.3.1"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -9880,6 +9898,8 @@ __metadata:
     "@types/jest": "npm:~30.0.0"
     drachtio-srf: "patch:drachtio-srf@npm%3A5.0.12#~/.yarn/patches/drachtio-srf-npm-5.0.12-b0b1afaad6.patch"
     eslint: "npm:~9.39.3"
+    rimraf: "npm:^6.0.1"
+    shx: "npm:^0.3.4"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -9895,6 +9915,8 @@ __metadata:
     ajv: "npm:^8.17.1"
     eslint: "npm:~9.39.3"
     jest: "npm:~30.2.0"
+    rimraf: "npm:^6.0.1"
+    shx: "npm:^0.3.4"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -9942,6 +9964,7 @@ __metadata:
     i18next: "npm:~23.4.9"
     jest: "npm:~30.2.0"
     moment: "npm:^2.30.1"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   peerDependencies:
     date-fns: ~4.1.0
@@ -10363,6 +10386,7 @@ __metadata:
     react: "npm:~18.3.1"
     react-dom: "npm:~18.3.1"
     react-i18next: "npm:~13.2.2"
+    rimraf: "npm:^6.0.1"
     storybook: "npm:^8.6.17"
     typescript: "npm:~5.9.3"
   peerDependencies:
@@ -10379,6 +10403,7 @@ __metadata:
     "@types/node-rsa": "npm:^1.1.4"
     eslint: "npm:~9.39.3"
     mongodb: "npm:6.16.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -10401,6 +10426,7 @@ __metadata:
     eslint: "npm:~9.39.3"
     jest: "npm:~30.2.0"
     node-rsa: "npm:^1.1.1"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -10413,6 +10439,7 @@ __metadata:
     eslint: "npm:~9.39.3"
     jest: "npm:~30.2.0"
     mongodb: "npm:6.16.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   peerDependencies:
     mongodb: 6.10.0
@@ -10462,6 +10489,7 @@ __metadata:
     jest: "npm:~30.2.0"
     mem: "npm:^8.1.1"
     mongodb: "npm:6.16.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -10479,6 +10507,7 @@ __metadata:
     eslint: "npm:~9.39.3"
     jest: "npm:~30.2.0"
     mongodb: "npm:6.16.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -10515,6 +10544,7 @@ __metadata:
     mongo-message-queue: "npm:^1.1.0"
     mongodb: "npm:6.16.0"
     pino: "npm:10.3.1"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -10593,6 +10623,7 @@ __metadata:
     "@types/jest": "npm:~30.0.0"
     eslint: "npm:~9.39.3"
     jest: "npm:~30.2.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -10606,6 +10637,7 @@ __metadata:
     "@types/jest": "npm:~30.0.0"
     eslint: "npm:~9.39.3"
     jest: "npm:~30.2.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -10640,6 +10672,8 @@ __metadata:
     react: "npm:~18.3.1"
     react-dom: "npm:~18.3.1"
     react-i18next: "npm:~13.2.2"
+    rimraf: "npm:^6.0.1"
+    shx: "npm:^0.3.4"
     storybook: "npm:^8.6.17"
     typescript: "npm:~5.9.3"
   languageName: unknown
@@ -10776,6 +10810,7 @@ __metadata:
     "@rocket.chat/tsconfig": "workspace:*"
     eslint: "npm:~9.39.3"
     jest: "npm:~30.2.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -10826,6 +10861,7 @@ __metadata:
     ajv-formats: "npm:^3.0.1"
     eslint: "npm:~9.39.3"
     mongodb: "npm:6.16.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -10857,6 +10893,7 @@ __metadata:
     jest: "npm:^29.7.0"
     node-fetch: "npm:2.7.0"
     proxy-from-env: "npm:^1.1.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -10869,6 +10906,7 @@ __metadata:
     "@rocket.chat/tsconfig": "workspace:*"
     eslint: "npm:~9.39.3"
     jest: "npm:~30.2.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -10896,6 +10934,8 @@ __metadata:
     react: "npm:~18.3.1"
     react-dom: "npm:~18.3.1"
     react-virtuoso: "npm:^4.12.0"
+    rimraf: "npm:^6.0.1"
+    shx: "npm:^0.3.4"
     storybook: "npm:^8.6.17"
     storybook-dark-mode: "npm:^4.0.2"
     typescript: "npm:~5.9.3"
@@ -10945,6 +10985,7 @@ __metadata:
     eslint: "npm:~9.39.3"
     jest: "npm:~30.2.0"
     moment-timezone: "npm:^0.5.48"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -10959,6 +11000,7 @@ __metadata:
     "@types/jest": "npm:~30.0.0"
     eslint: "npm:~9.39.3"
     jest: "npm:~30.2.0"
+    rimraf: "npm:^6.0.1"
     ts-jest: "npm:~29.4.6"
     typescript: "npm:~5.9.3"
   languageName: unknown
@@ -10987,6 +11029,7 @@ __metadata:
     react: "npm:~18.3.1"
     react-dom: "npm:~18.3.1"
     react-virtuoso: "npm:^4.12.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   peerDependencies:
     "@rocket.chat/fuselage": "*"
@@ -11037,6 +11080,7 @@ __metadata:
     react-hook-form: "npm:~7.45.4"
     react-i18next: "npm:~13.2.2"
     react-virtuoso: "npm:^4.12.0"
+    rimraf: "npm:^6.0.1"
     storybook: "npm:^8.6.17"
     typescript: "npm:~5.9.3"
   peerDependencies:
@@ -11083,6 +11127,8 @@ __metadata:
     react: "npm:~18.3.1"
     react-dom: "npm:~18.3.1"
     react-virtuoso: "npm:^4.12.0"
+    rimraf: "npm:^6.0.1"
+    shx: "npm:^0.3.4"
     storybook: "npm:^8.6.17"
     typescript: "npm:~5.9.3"
     webpack: "npm:~5.99.9"
@@ -11121,6 +11167,7 @@ __metadata:
     react: "npm:~18.3.1"
     react-dom: "npm:~18.3.1"
     react-virtuoso: "npm:^4.12.0"
+    rimraf: "npm:^6.0.1"
     typescript: "npm:~5.9.3"
   peerDependencies:
     "@rocket.chat/core-typings": "workspace:^"
@@ -11188,6 +11235,7 @@ __metadata:
     react: "npm:~18.3.1"
     react-dom: "npm:~18.3.1"
     react-virtuoso: "npm:^4.12.0"
+    rimraf: "npm:^6.0.1"
     storybook: "npm:^8.6.17"
     typescript: "npm:~5.9.3"
     webpack: "npm:~5.99.9"
@@ -11255,6 +11303,7 @@ __metadata:
     react-dom: "npm:~18.3.1"
     react-i18next: "npm:~13.2.2"
     react-virtuoso: "npm:^4.12.0"
+    rimraf: "npm:^6.0.1"
     storybook: "npm:^8.6.17"
     typescript: "npm:~5.9.3"
   peerDependencies:
@@ -23485,7 +23534,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.0.3, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.2.0":
+"glob@npm:^7.0.0, glob@npm:^7.0.3, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.2.0":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -24751,6 +24800,13 @@ __metadata:
   version: 1.0.1
   resolution: "internmap@npm:1.0.1"
   checksum: 10/429cb9e28f393f10c73a826d71ba9e359711b7e42345bd684aba708f43b8139ce90f09b15abbf977a981474ac61615294854e5b9520d3f65187d0f6a2ff27665
+  languageName: node
+  linkType: hard
+
+"interpret@npm:^1.0.0":
+  version: 1.4.0
+  resolution: "interpret@npm:1.4.0"
+  checksum: 10/5beec568d3f60543d0f61f2c5969d44dffcb1a372fe5abcdb8013968114d4e4aaac06bc971a4c9f5bd52d150881d8ebad72a8c60686b1361f5f0522f39c0e1a3
   languageName: node
   linkType: hard
 
@@ -32933,6 +32989,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rechoir@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "rechoir@npm:0.6.2"
+  dependencies:
+    resolve: "npm:^1.1.6"
+  checksum: 10/fe76bf9c21875ac16e235defedd7cbd34f333c02a92546142b7911a0f7c7059d2e16f441fe6fb9ae203f459c05a31b2bcf26202896d89e390eda7514d5d2702b
+  languageName: node
+  linkType: hard
+
 "rechoir@npm:^0.8.0":
   version: 0.8.0
   resolution: "rechoir@npm:0.8.0"
@@ -33369,6 +33434,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve@npm:^1.1.6":
+  version: 1.22.11
+  resolution: "resolve@npm:1.22.11"
+  dependencies:
+    is-core-module: "npm:^2.16.1"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10/e1b2e738884a08de03f97ee71494335eba8c2b0feb1de9ae065e82c48997f349f77a2b10e8817e147cf610bfabc4b1cb7891ee8eaf5bf80d4ad514a34c4fab0a
+  languageName: node
+  linkType: hard
+
 "resolve@npm:^1.1.7, resolve@npm:^1.10.0, resolve@npm:^1.11.1, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.2, resolve@npm:^1.22.4, resolve@npm:^1.22.8":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
@@ -33408,6 +33486,19 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 10/c95cb98b8d3f9e2a979e6eb8b7e0b0e13f08da62607a45207275f151d640152244568a9a9cd01662a21e3746792177cbf9be1dacb88f7355edf4db49d9ee27e5
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@npm%3A^1.1.6#optional!builtin<compat/resolve>":
+  version: 1.22.11
+  resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
+  dependencies:
+    is-core-module: "npm:^2.16.1"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10/fd342cad25e52cd6f4f3d1716e189717f2522bfd6641109fe7aa372f32b5714a296ed7c238ddbe7ebb0c1ddfe0b7f71c9984171024c97cf1b2073e3e40ff71a8
   languageName: node
   linkType: hard
 
@@ -33573,6 +33664,8 @@ __metadata:
     eslint: "npm:~9.39.3"
     eslint-plugin-you-dont-need-lodash-underscore: "npm:~6.14.0"
     node-gyp: "npm:^10.2.0"
+    rimraf: "npm:^6.0.1"
+    shx: "npm:^0.3.4"
     ts-node: "npm:^10.9.2"
     turbo: "npm:2.8.12"
     typescript: "npm:~5.9.3"
@@ -33619,6 +33712,7 @@ __metadata:
     npm-run-all: "npm:^4.1.5"
     pino: "npm:10.3.1"
     pino-pretty: "npm:13.1.3"
+    rimraf: "npm:^6.0.1"
     sodium-native: "npm:^4.3.3"
     sodium-plus: "npm:^0.9.0"
     ts-node: "npm:^10.9.2"
@@ -34360,6 +34454,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"shelljs@npm:^0.8.5":
+  version: 0.8.5
+  resolution: "shelljs@npm:0.8.5"
+  dependencies:
+    glob: "npm:^7.0.0"
+    interpret: "npm:^1.0.0"
+    rechoir: "npm:^0.6.2"
+  bin:
+    shjs: bin/shjs
+  checksum: 10/f2178274b97b44332bbe9ddb78161137054f55ecf701c7a99db9552cb5478fe279ad5f5131d8a7c2f0730e01ccf0c629d01094143f0541962ce1a3d0243d23f7
+  languageName: node
+  linkType: hard
+
 "shimmer@npm:^1.2.1":
   version: 1.2.1
   resolution: "shimmer@npm:1.2.1"
@@ -34374,6 +34481,18 @@ __metadata:
     any-base: "npm:^1.1.0"
     uuid: "npm:^8.3.2"
   checksum: 10/fcd0cef08c5f3f4c1e5d1f716a9a92efbadf8131a22ba6e399f7cf9257e7f18084995e6dc3e950cc705bcdee4c4e982a752872caf1305314713fc86357d68480
+  languageName: node
+  linkType: hard
+
+"shx@npm:^0.3.4":
+  version: 0.3.4
+  resolution: "shx@npm:0.3.4"
+  dependencies:
+    minimist: "npm:^1.2.3"
+    shelljs: "npm:^0.8.5"
+  bin:
+    shx: lib/cli.js
+  checksum: 10/5271b60f7e322540799102ad6935121f10c857a995a1321357a7bffd1628674a4758a602153dc5cc126d8dc94d3489586587d3dee54dc3cac0222ca08a78e33a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR replaces Unix-specific shell commands (`rm -rf`, `cp -r`, `mkdir -p`) used in `package.json` scripts with their modern, cross-platform Node.js equivalents (`rimraf`, `shx`).

**Why this is needed:**
Native Windows environments natively lack these commands. When executing standard `yarn build` on Windows (using PowerShell or CMD), the builds crash immediately with `'rm' is not recognized as an internal or external command`.

By introducing `rimraf` and `shx` as `devDependencies` to the workspaces that need them, this PR ensures that the entire Rocket.Chat monorepo builds flawlessly and deterministically regardless of the developer's underlying operating system. 

It touches scripts inside `packages/` (e.g. `storybook-config`, `ui-composer`, `ui-kit`) and `ee/packages/` (e.g. `pdf-worker`, `omnichannel-services`). 

## Issue(s)
<!-- Leave blank unless there is an existing issue complaining about Windows builds. -->

## Steps to test or reproduce
1. Clone the repository on a native Windows machine (without WSL).
2. Run `yarn install`
3. Run `yarn build`
4. Prior to this PR, multiple packages would fail with command not found errors. With this PR, the `turbo run build` completes with Exit Code 0 across all 70+ packages.

## Further comments
- The workspace root's `package.json` and the affected packages now locally declare `shx` and `rimraf` to ensure Yarn version 4 (`nodeLinker: pnp` or standard workspaces) can safely resolve the binaries.
- This represents a critical DX (Developer Experience) improvement for contributors running Windows environments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build scripts across packages to use cross-platform utilities for improved compatibility on Windows, macOS, and Linux environments. These changes enhance build reliability and consistency without affecting application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->