### PR TITLE
fix(livechat): cleanup widget listeners and intervals on teardown/re-init

### DIFF
--- a/packages/livechat/src/widget.ts
+++ b/packages/livechat/src/widget.ts
@@ -61,6 +61,10 @@ let smallScreen = false;
 let scrollPosition: number;
 let widgetHeight: number;
 let popoutWindow: Window | null = null;
+let messageListener: ((event: MessageEvent<LivechatMessageEventData<InternalWidgetAPI>>) => void) | null = null;
+let navigationIntervalId: ReturnType<typeof setInterval> | null = null;
+let mediaQueryList: MediaQueryList | null = null;
+let mediaQueryListener: ((event: MediaQueryList | MediaQueryListEvent) => void) | null = null;
 
 export const VALID_CALLBACKS = [
 	'chat-maximized',
@@ -101,6 +105,43 @@ function clearAllCallbacks() {
 	callbacks.events().forEach((callback) => {
 		callbacks.off(callback, () => undefined);
 	});
+}
+
+function clearWidgetListeners() {
+	if (messageListener) {
+		window.removeEventListener('message', messageListener);
+		messageListener = null;
+	}
+
+	if (mediaQueryList && mediaQueryListener) {
+		if (typeof mediaQueryList.removeEventListener === 'function') {
+			mediaQueryList.removeEventListener('change', mediaQueryListener);
+		} else {
+			mediaQueryList.removeListener(mediaQueryListener as (event: MediaQueryListEvent) => void);
+		}
+		mediaQueryList = null;
+		mediaQueryListener = null;
+	}
+
+	if (navigationIntervalId !== null) {
+		clearInterval(navigationIntervalId);
+		navigationIntervalId = null;
+	}
+}
+
+function cleanupWidget() {
+	clearWidgetListeners();
+
+	if (widget && widget.parentNode) {
+		widget.parentNode.removeChild(widget);
+	}
+
+	widget = null;
+	iframe = null;
+	popoutWindow = null;
+	ready = false;
+	currentPage.href = document.location.href;
+	currentPage.title = document.title;
 }
 
 const formatMessage = (action: keyof HooksWidgetAPI, ...params: Parameters<HooksWidgetAPI[keyof HooksWidgetAPI]>) => ({
@@ -215,8 +256,15 @@ const createWidget = (url: string) => {
 		callHook('setParentUrl', window.location.href);
 	};
 
-	const mediaQueryList = window.matchMedia('screen and (max-device-width: 480px)');
-	mediaQueryList.addListener(handleMediaQueryTest);
+	mediaQueryList = window.matchMedia('screen and (max-device-width: 480px)');
+	mediaQueryListener = handleMediaQueryTest;
+
+	if (typeof mediaQueryList.addEventListener === 'function') {
+		mediaQueryList.addEventListener('change', mediaQueryListener);
+	} else {
+		mediaQueryList.addListener(mediaQueryListener);
+	}
+
 	handleMediaQueryTest(mediaQueryList);
 };
 
@@ -503,7 +551,7 @@ const api: InternalWidgetAPI = {
 	},
 
 	removeWidget() {
-		document.body.removeChild(widget as Node);
+		cleanupWidget();
 	},
 
 	callback(eventName, data) {
@@ -681,11 +729,20 @@ function listenForMessageOnce<K extends keyof InternalWidgetAPI>(
 }
 
 const attachMessageListener = () => {
-	window.addEventListener('message', onNewMessage, false);
+	if (messageListener) {
+		window.removeEventListener('message', messageListener);
+	}
+
+	messageListener = onNewMessage;
+	window.addEventListener('message', messageListener, false);
 };
 
 const trackNavigation = () => {
-	setInterval(() => {
+	if (navigationIntervalId !== null) {
+		clearInterval(navigationIntervalId);
+	}
+
+	navigationIntervalId = window.setInterval(() => {
 		if (document.location.href !== currentPage.href) {
 			pageVisited('url');
 			currentPage.href = document.location.href;
@@ -699,6 +756,8 @@ const trackNavigation = () => {
 };
 
 const init = (url: string) => {
+	cleanupWidget();
+
 	const trimmedUrl = url.trim();
 	if (!trimmedUrl) {
 		return;


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
<img width="698" height="562" alt="image" src="https://github.com/user-attachments/assets/92e8a4d0-3d96-4529-b74a-413a4384155f" />

- Fixed livechat widget teardown / re-initialization leak in widget.ts
- Added `cleanupWidget()` to:
  - remove stale widget DOM
  - unregister `window` `message` listener
  - remove `matchMedia` media query listener
  - clear the navigation tracking interval
- Updated `init()` to run cleanup before creating a new widget
- Updated `removeWidget()` to use the centralized cleanup flow

## Issue(s)

- Fixes livechat widget teardown/re-init listener and interval leak
- Addresses stale widget lifecycle cleanup in the embedded livechat widget

## Steps to test or reproduce

1. Open a page with the Rocket.Chat livechat widget enabled
2. Trigger widget teardown or re-initialization (for example, remove and re-create the widget)
3. Verify:
   - the old widget DOM is removed
   - no duplicate `message` listeners remain
   - the old navigation interval is cleared
   - the new widget initializes normally
4. Optional: use browser dev tools to inspect event listeners and confirm only one `message` listener remains after re-init

## Further comments

- This is a focused bug fix for the livechat widget runtime cleanup flow.
- widget.ts is the only file changed.
- Local TS validation could not be completed in the current environment due to missing project dependencies for `tsc`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced widget cleanup and removal to ensure proper deallocation of listeners, intervals, and DOM resources.
  * Prevented duplicate message event handlers from accumulating during widget operations.
  * Improved navigation tracking to clear existing intervals before starting new ones.
  * Strengthened widget reinitialization to clear previous instances and state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->