### PR TITLE
fix(video-recorder): only enable Send after a recording exists

### DIFF
--- a/apps/meteor/app/ui/client/lib/recorderjs/videoRecorder.spec.ts
+++ b/apps/meteor/app/ui/client/lib/recorderjs/videoRecorder.spec.ts
@@ -174,6 +174,10 @@ describe('VideoRecorder', () => {
 			expect(VideoRecorder.getSupportedMimeTypes()).toBe('video/webm; codecs=vp8,opus');
 		});
 
+		it('should return false when stopRecording is called without active recording', () => {
+			expect(VideoRecorder.stopRecording()).toBe(false);
+		});
+
 		it('should handle permission errors', async () => {
 			getUserMediaMock.mockRejectedValue(new Error('Permission denied'));
 

--- a/apps/meteor/app/ui/client/lib/recorderjs/videoRecorder.ts
+++ b/apps/meteor/app/ui/client/lib/recorderjs/videoRecorder.ts
@@ -142,12 +142,13 @@ class VideoRecorder {
 
 	public stopRecording() {
 		if (!this.started || !this.recording || !this.mediaRecorder) {
-			return;
+			return false;
 		}
 
 		this.mediaRecorder.stop();
 		this.recording.set(false);
 		delete this.mediaRecorder;
+		return true;
 	}
 }
 

--- a/apps/meteor/client/views/composer/VideoMessageRecorder/VideoMessageRecorder.tsx
+++ b/apps/meteor/client/views/composer/VideoMessageRecorder/VideoMessageRecorder.tsx
@@ -44,8 +44,9 @@ const VideoMessageRecorder = ({ rid, tmid, reference }: VideoMessageRecorderProp
 	const [time, setTime] = useState<string | undefined>();
 	const [recordingState, setRecordingState] = useState<'idle' | 'loading' | 'recording'>('idle');
 	const [recordingInterval, setRecordingInterval] = useState<ReturnType<typeof setInterval> | null>(null);
+	const [recordingAvailable, setRecordingAvailable] = useState(false);
 	const isRecording = recordingState === 'recording';
-	const sendButtonDisabled = !(VideoRecorder.cameraStarted.get() && !(recordingState === 'recording'));
+	const sendButtonDisabled = !recordingAvailable || recordingState === 'recording';
 
 	const chat = useChat();
 
@@ -54,7 +55,8 @@ const VideoMessageRecorder = ({ rid, tmid, reference }: VideoMessageRecorderProp
 			clearInterval(recordingInterval);
 		}
 		setRecordingInterval(null);
-		VideoRecorder.stopRecording();
+		const hadRecording = VideoRecorder.stopRecording();
+		setRecordingAvailable(hadRecording);
 		UserAction.stop(rid, USER_ACTIVITIES.USER_RECORDING, { tmid });
 		setRecordingState('idle');
 	};
@@ -64,6 +66,7 @@ const VideoMessageRecorder = ({ rid, tmid, reference }: VideoMessageRecorderProp
 			stopVideoRecording(rid, tmid);
 		} else {
 			VideoRecorder.record();
+			setRecordingAvailable(false);
 			setRecordingState('recording');
 			UserAction.performContinuously(rid, USER_ACTIVITIES.USER_RECORDING, { tmid });
 			setTime('00:00');
@@ -91,6 +94,7 @@ const VideoMessageRecorder = ({ rid, tmid, reference }: VideoMessageRecorderProp
 		VideoRecorder.stop(cb);
 		setTime(undefined);
 		stopVideoRecording(rid, tmid);
+		setRecordingAvailable(false);
 	};
 
 	const handleCancel = useEffectEvent(() => {
@@ -98,6 +102,7 @@ const VideoMessageRecorder = ({ rid, tmid, reference }: VideoMessageRecorderProp
 		chat?.composer?.setRecordingVideo(false);
 		setTime(undefined);
 		stopVideoRecording(rid, tmid);
+		setRecordingAvailable(false);
 	});
 
 	useEffect(() => {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes
- Fix video recorder send button logic in VideoMessageRecorder.tsx
- Only enable `Send` when recording data is actually available, not merely when the camera preview is active
- Added `recordingAvailable` state and reset behavior during recording/cancel/send flows
- Updated recorder helper videoRecorder.ts so `stopRecording()` reports whether a recording actually existed
- Added regression test coverage in videoRecorder.spec.ts

## Issue(s)
- Fixes bug where “Send” was enabled without recording

## Steps to test or reproduce
1. Open the message composer video recorder
2. Start recording
3. Stop without creating a valid recording
4. Confirm the `Send` button remains disabled
5. Confirm `Send` becomes enabled only after a real recording is available

## Further comments
- This is a small focused bug fix
- Only the recorder UI state and helper behavior were changed
- No additional feature or documentation changes were required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Send button logic in video message recorder to only enable when an actual recording exists, preventing incomplete submissions.

* **Tests**
  * Added unit test coverage for edge cases in video recording functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->