### PR TITLE
Fix omnichannel analytics DateRangePicker locale override

### DIFF
--- a/apps/meteor/client/views/omnichannel/analytics/DateRangePicker.spec.tsx
+++ b/apps/meteor/client/views/omnichannel/analytics/DateRangePicker.spec.tsx
@@ -1,0 +1,15 @@
+import moment from 'moment';
+
+describe('DateRangePicker', () => {
+	it('does not override global Moment locale during import', () => {
+		const previousLocale = moment.locale();
+		try {
+			moment.locale('pt-br');
+			jest.resetModules();
+			require('./DateRangePicker');
+			expect(moment.locale()).toBe('pt-br');
+		} finally {
+			moment.locale(previousLocale);
+		}
+	});
+});

--- a/apps/meteor/client/views/omnichannel/analytics/DateRangePicker.tsx
+++ b/apps/meteor/client/views/omnichannel/analytics/DateRangePicker.tsx
@@ -7,8 +7,6 @@ import type { ComponentProps, FormEvent } from 'react';
 import { useState, useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
-moment.locale('en');
-
 type DateRangePickerProps = Omit<ComponentProps<typeof Box>, 'onChange'> & {
 	onChange(range: { start: string; end: string }): void;
 };


### PR DESCRIPTION
## Proposed changes

- Removed the hard-coded global `moment.locale('en')` call from DateRangePicker.tsx
- Added DateRangePicker.spec.tsx
  - regression test ensures importing `DateRangePicker` does not override global Moment locale

## Issue(s)

- No issue linked

## Steps to test or reproduce

1. Run the new regression test for the component
   - `cd apps/meteor && npx jest client/views/omnichannel/analytics/DateRangePicker.spec.tsx --runInBand`
2. Confirm the new test passes
3. Optionally verify the analytics date range picker still renders and preset selection works as expected in the Omnichannel Analytics UI

## Further comments

- This fix prevents a component import from affecting global Moment locale state, which could otherwise break date formatting in other parts of the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issue where DateRangePicker was overriding the global locale setting.

* **Tests**
  * Added test coverage to verify DateRangePicker does not modify global locale settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->