### PR TITLE
fix(ui): prevent message overflow and ensure proper text wrapping in chat UI

### DIFF
--- a/apps/meteor/client/startup/startup.ts
+++ b/apps/meteor/client/startup/startup.ts
@@ -9,6 +9,8 @@ import { synchronizeUserData, removeLocalUserData } from '../lib/userData';
 import { fireGlobalEvent } from '../lib/utils/fireGlobalEvent';
 import { watchUserId } from '../meteor/user';
 
+import '../styles/custom.css';
+
 Meteor.startup(() => {
 	let status: UserStatus | undefined = undefined;
 	Tracker.autorun(async () => {

--- a/apps/meteor/client/styles/custom.css
+++ b/apps/meteor/client/styles/custom.css
@@ -1,0 +1,45 @@
+/* 
+ * Fix: Ensure proper wrapping of long text inside message containers.
+ *
+ * Problem:
+ * Long unbroken text (URLs, emails, continuous strings) was not wrapping,
+ * causing overflow and breaking the chat layout.
+ *
+ * Solution:
+ * - Enabled normal white-space behavior
+ * - Applied word-break and overflow-wrap to handle long tokens
+ * - Allowed content to remain visible within container boundaries
+ */
+
+.rcx-message-thread__message,
+.rcx-message-thread__origin,
+.rcx-message-body {
+	white-space: normal !important;
+	word-break: break-word;
+	overflow-wrap: break-word;
+	overflow: visible !important;
+}
+
+/* 
+ * Fix: Disable line-clamp in thread preview to prevent text truncation issues.
+ *
+ * Problem:
+ * The use of -webkit-line-clamp with overflow: hidden prevented proper
+ * wrapping of long unbroken text, leading to text overlap and layout break.
+ *
+ * Solution:
+ * - Disabled line-clamp behavior
+ * - Restored default block layout for proper text flow
+ * - Allowed full content rendering to ensure correct wrapping
+ *
+ * Note:
+ * This may display full message content instead of a truncated preview,
+ * but ensures UI stability for edge cases.
+ */
+
+.rcx-message-body--clamp {
+	display: block !important;
+	line-clamp: unset !important;
+	-webkit-line-clamp: unset !important;
+	overflow: visible !important;
+}


### PR DESCRIPTION
## Problem

Long text such as URLs, email addresses, and continuous strings without spaces was not wrapping correctly in chat messages and omnichannel transfer comments. This caused the message container to overflow and break the layout, especially in thread previews and omnichannel transfer scenarios.

Related issue: #26723

---

## Solution

- Enabled proper text wrapping using:
  - `overflow-wrap: break-word`
  - `word-break: break-word`
- Disabled line clamping to ensure full content visibility:
  - Removed `-webkit-line-clamp` behavior
  - Set `overflow` to visible where necessary
- Ensured consistent rendering across:
  - Chat messages
  - Thread preview
  - Omnichannel transfer comments

---

## Testing

The fix was verified with the following cases:

- Long continuous strings without spaces
- Long URLs
- Long email addresses

In all scenarios, text wraps correctly within the container without breaking the layout.

---

## Notes

- Changes are limited to message rendering styles
- No impact on unrelated components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced message display styling to ensure long, unbroken text wraps correctly and remains fully visible within its container, preventing unwanted text overflow and truncation in message threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->