### PR TITLE
fix: escape regex metacharacters in from and mention search filtersFix search regex escape

### DIFF
--- a/apps/meteor/server/lib/parseMessageSearchQuery.ts
+++ b/apps/meteor/server/lib/parseMessageSearchQuery.ts
@@ -45,7 +45,7 @@ class MessageSearchQueryParser {
 			from.push(username);
 
 			this.query['u.username'] = {
-				$regex: from.join('|'),
+				$regex: `^(?:${from.map((u) => escapeRegExp(u)).join('|')})$`,
 				$options: 'i',
 			};
 
@@ -60,7 +60,7 @@ class MessageSearchQueryParser {
 			mentions.push(username);
 
 			this.query['mentions.username'] = {
-				$regex: mentions.join('|'),
+				$regex: `^(?:${mentions.map((u) => escapeRegExp(u)).join('|')})$`,
 				$options: 'i',
 			};
 


### PR DESCRIPTION
Problem
Usernames containing special regex characters like "." were not escaped in from: and mention: filters.

Because of this, searching like from:rocket.cat matched unintended usernames such as rocketXcat or rocket_cat, since "." was treated as a regex wildcard.

Solution
Applied escapeRegExp to usernames before building the regex pattern.
Updated both consumeFrom and consumeMention functions.

Result
Search now correctly matches exact usernames only.
Prevents unintended results caused by regex interpretation.

Consistency
This fix follows the same approach already used in other filters like consumeLabel, consumeFileTitle, and consumeFileDescription.

Testing
Verified manually by searching from:rocket.cat and confirming only correct user messages are returned.

Issue
Fixes #39927

I noticed similar escaping logic already exists in other filters, so I aligned this fix with existing patterns for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced message search functionality to improve accuracy when searching by username. Searches now match complete usernames precisely rather than partial matches, providing more relevant results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->