### PR TITLE
ci: add actionlint workflow

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+paths:
+ .github/workflows/**/*.yml:
+   ignore: ['file "dist/index\.js" does not exist in .*/packages/release-action']

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -85,7 +85,6 @@ runs:
         GITHUB_REF: ${{ github.ref }}
       run: |
         set -o xtrace
-        export DENO_VERSION="$DENO_VERSION"
 
         # Removes unnecessary swc cores and sharp binaries to reduce image size
         swc_arch='x64'

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -4,8 +4,10 @@ description: 'Build Docker images for Rocket.Chat and related services'
 inputs:
   CR_USER:
     required: true
+    description: 'GitHub Container Registry username'
   CR_PAT:
     required: true
+    description: 'GitHub Container Registry Personal Access Token'
   deno-version:
     required: true
     description: 'Deno version'
@@ -57,7 +59,7 @@ runs:
         rm Rocket.Chat.tar.gz
 
     - name: Set up Docker
-      if: inputs.setup-docker == true
+      if: inputs.setup-docker == 'true'
       uses: docker/setup-docker-action@v4
       with:
         daemon-config: |

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -72,14 +72,25 @@ runs:
 
     - name: Build Docker images
       shell: bash
+      env:
+        DENO_VERSION: ${{ inputs.deno-version }}
+        INPUT_ARCH: ${{ inputs.arch }}
+        INPUT_SERVICE: ${{ inputs.service }}
+        INPUT_PUBLISH_IMAGE: ${{ inputs.publish-image }}
+        INPUT_TYPE: ${{ inputs.type }}
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        GITHUB_SERVER_URL: ${{ github.server_url }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
+        GITHUB_REF: ${{ github.ref }}
       run: |
         set -o xtrace
-        export DENO_VERSION="${{ inputs.deno-version }}"
+        export DENO_VERSION="$DENO_VERSION"
 
         # Removes unnecessary swc cores and sharp binaries to reduce image size
         swc_arch='x64'
-        if [[ "${{ inputs.service }}" == 'rocketchat' ]]; then
-          if [[ "${{ inputs.arch }}" == 'arm64' ]]; then
+        if [[ "$INPUT_SERVICE" == 'rocketchat' ]]; then
+          if [[ "$INPUT_ARCH" == 'arm64' ]]; then
             swc_arch='arm64'
           fi
 
@@ -92,50 +103,53 @@ runs:
           find /tmp/build/bundle/programs/server/npm/node_modules/@rocket.chat/apps-engine/node_modules/@esbuild -type d -name 'linux-*' -not -name "*-${swc_arch}" -exec rm -rf {} +
         fi
 
-        if [[ "${{ inputs.publish-image }}" == 'true' ]]; then
+        if [[ "$INPUT_PUBLISH_IMAGE" == 'true' ]]; then
           LOAD_OR_PUSH="--push"
         else
           LOAD_OR_PUSH="--load"
         fi
 
         # Get image name from docker-compose-ci.yml since rocketchat image is different from service name (rocket.chat)
-        IMAGE=$(docker compose -f docker-compose-ci.yml config --format json 2>/dev/null | jq -r --arg s "${{ inputs.service }}" '.services[$s].image')
+        IMAGE=$(docker compose -f docker-compose-ci.yml config --format json 2>/dev/null | jq -r --arg s "$INPUT_SERVICE" '.services[$s].image')
 
         docker buildx bake \
           -f docker-compose-ci.yml \
           ${LOAD_OR_PUSH} \
           --allow=fs.read=/tmp/build \
-          --set "*.tags+=${IMAGE}-gha-run-${{ github.run_id }}" \
-          --set "*.labels.org.opencontainers.image.description=Build run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-          --set "*.labels.org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}" \
-          --set *.platform=linux/${{ inputs.arch }} \
+          --set "*.tags+=${IMAGE}-gha-run-${GITHUB_RUN_ID}" \
+          --set "*.labels.org.opencontainers.image.description=Build run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+          --set "*.labels.org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+          --set "*.platform=linux/${INPUT_ARCH}" \
           --set *.cache-from=type=gha \
           --set *.cache-to=type=gha,mode=max \
           --provenance=false \
           --sbom=false \
           --metadata-file "/tmp/meta.json" \
-          "${{ inputs.service }}"
+          "$INPUT_SERVICE"
 
         echo "Contents of /tmp/meta.json:"
         cat /tmp/meta.json
 
-        if [[ "${{ inputs.publish-image }}" == 'true' ]]; then
-          SERVICE_SUFFIX=${{ inputs.service == 'rocketchat' && inputs.type == 'coverage' && (github.event_name == 'release' || github.ref == 'refs/heads/develop') && '-cov' || '' }}
+        if [[ "$INPUT_PUBLISH_IMAGE" == 'true' ]]; then
+          SERVICE_SUFFIX=''
+          if [[ "$INPUT_SERVICE" == 'rocketchat' && "$INPUT_TYPE" == 'coverage' ]] && [[ "$GITHUB_EVENT_NAME" == 'release' || "$GITHUB_REF" == 'refs/heads/develop' ]]; then
+            SERVICE_SUFFIX='-cov'
+          fi
 
-          mkdir -p /tmp/manifests/${{ inputs.service }}${SERVICE_SUFFIX}/${{ inputs.arch }}
+          mkdir -p "/tmp/manifests/${INPUT_SERVICE}${SERVICE_SUFFIX}/${INPUT_ARCH}"
 
           # Get digest and image info
-          DIGEST=$(jq -r '.["${{ inputs.service }}"].["containerimage.digest"]' "/tmp/meta.json")
+          DIGEST=$(jq -r --arg service "$INPUT_SERVICE" '.[$service].["containerimage.digest"]' "/tmp/meta.json")
           IMAGE_NO_TAG=$(echo "$IMAGE" | sed 's/:.*$//')
           FULL_IMAGE="${IMAGE_NO_TAG}@${DIGEST}"
 
           echo "Inspecting image: $FULL_IMAGE"
 
           # Inspect the image and save complete manifest with sizes (using -v for verbose)
-          docker manifest inspect -v "$FULL_IMAGE" > "/tmp/manifests/${{ inputs.service }}${SERVICE_SUFFIX}/${{ inputs.arch }}/manifest.json"
+          docker manifest inspect -v "$FULL_IMAGE" > "/tmp/manifests/${INPUT_SERVICE}${SERVICE_SUFFIX}/${INPUT_ARCH}/manifest.json"
 
-          echo "Saved manifest to /tmp/manifests/${{ inputs.service }}${SERVICE_SUFFIX}/${{ inputs.arch }}/manifest.json"
-          cat "/tmp/manifests/${{ inputs.service }}${SERVICE_SUFFIX}/${{ inputs.arch }}/manifest.json" | jq '.'
+          echo "Saved manifest to /tmp/manifests/${INPUT_SERVICE}${SERVICE_SUFFIX}/${INPUT_ARCH}/manifest.json"
+          cat "/tmp/manifests/${INPUT_SERVICE}${SERVICE_SUFFIX}/${INPUT_ARCH}/manifest.json" | jq '.'
         fi
 
     - name: Save Docker image as artifact

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -1,4 +1,5 @@
 name: 'Build Docker'
+description: 'Build Docker images for Rocket.Chat and related services'
 
 inputs:
   CR_USER:
@@ -8,7 +9,6 @@ inputs:
   deno-version:
     required: true
     description: 'Deno version'
-    type: string
   arch:
     required: false
     description: 'Architecture'
@@ -16,7 +16,6 @@ inputs:
   service:
     required: false
     description: 'Container to build'
-    type: string
   publish-image:
     required: false
     description: 'Publish image'
@@ -24,7 +23,7 @@ inputs:
   setup-docker:
     required: false
     description: 'Setup Docker'
-    default: true
+    default: 'true'
   type:
     required: false
     description: 'production or coverage'

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -154,19 +154,23 @@ runs:
     - name: Save Docker image as artifact
       if: inputs.publish-image == 'false' && inputs.arch == 'amd64'
       shell: bash
+      env:
+        SERVICE: ${{ inputs.service }}
+        ARCH: ${{ inputs.arch }}
+        TYPE: ${{ inputs.type }}
       run: |
         set -o xtrace
 
         # Get image name from docker-compose-ci.yml
-        IMAGE=$(docker compose -f docker-compose-ci.yml config --format json 2>/dev/null | jq -r --arg s "${{ inputs.service }}" '.services[$s].image')
+        IMAGE=$(docker compose -f docker-compose-ci.yml config --format json 2>/dev/null | jq -r --arg s "$SERVICE" '.services[$s].image')
 
         # Create directory for image archives
         mkdir -p /tmp/docker-images
 
         # Save the image to a tar file
-        docker save "${IMAGE}" -o "/tmp/docker-images/${{ inputs.service }}-${{ inputs.arch }}-${{ inputs.type }}.tar"
+        docker save "${IMAGE}" -o "/tmp/docker-images/${SERVICE}-${ARCH}-${TYPE}.tar"
 
-        echo "Saved image to /tmp/docker-images/${{ inputs.service }}-${{ inputs.arch }}-${{ inputs.type }}.tar"
+        echo "Saved image to /tmp/docker-images/${SERVICE}-${ARCH}-${TYPE}.tar"
         ls -lh /tmp/docker-images/
 
     - name: Upload Docker image artifact

--- a/.github/actions/meteor-build/action.yml
+++ b/.github/actions/meteor-build/action.yml
@@ -1,4 +1,5 @@
 name: 'Meteor Build'
+description: 'Build Meteor bundle for production or coverage'
 
 inputs:
   type:
@@ -8,22 +9,18 @@ inputs:
   reset-meteor:
     required: false
     description: 'Reset Meteor'
-    type: boolean
   node-version:
     required: true
     description: 'Node version'
-    type: string
   NPM_TOKEN:
     required: false
     description: 'NPM token'
   deno-version:
     required: true
     description: 'Deno version'
-    type: string
   source-hash:
     required: true
     description: 'RC cache id (e.g. packages-build-cache-key + meteor apps/meteor archive hash from CI)'
-    type: string
 
 runs:
   using: composite

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -11,16 +11,13 @@ inputs:
   install:
     required: false
     description: 'Install dependencies'
-    type: boolean
   type:
     required: false
     description: 'development or production'
-    type: string
     default: 'development'
   deno-version:
     required: true
     description: 'Deno version'
-    type: string
   NPM_TOKEN:
     required: false
     description: 'NPM token'

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,4 +1,5 @@
 name: Setup Playwright
+description: 'Setup Playwright binaries and dependencies'
 
 runs:
   using: 'composite'

--- a/.github/actions/update-version-durability/action.yml
+++ b/.github/actions/update-version-durability/action.yml
@@ -5,23 +5,18 @@ inputs:
   LTS_VERSIONS:
     required: true
     description: Comma separated list of LTS versions
-    type: string
   GH_TOKEN:
     required: true
     description: GitHub API Token
-    type: string
   D360_TOKEN:
     required: true
     description: Document360 API Token
-    type: string
   D360_ARTICLE_ID:
     required: true
     description: Document360 Article ID
-    type: string
   PUBLISH:
     required: true
     description: Publish Draft
-    type: boolean
 
 runs:
   using: node20

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,14 @@
+name: Lint GitHub Actions workflows
+on: [push, pull_request]
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check workflow files
+        run: |
+          echo "::add-matcher::.github/actionlint-matcher.json"
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color
+        shell: bash

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -9,6 +9,10 @@ jobs:
       - name: Check workflow files
         run: |
           echo "::add-matcher::.github/actionlint-matcher.json"
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ACTIONLINT_VERSION=1.7.8
+          curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSLO "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+          grep " actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz$" "actionlint_${ACTIONLINT_VERSION}_checksums.txt" | sha256sum -c -
+          tar -xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" actionlint
           ./actionlint -color
         shell: bash

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -5,7 +5,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check workflow files
         run: |
           echo "::add-matcher::.github/actionlint-matcher.json"

--- a/.github/workflows/auto-close-duplicates.yml
+++ b/.github/workflows/auto-close-duplicates.yml
@@ -1,5 +1,5 @@
 name: Auto-close duplicate issues
-description: Auto-closes issues that are duplicates of existing issues
+
 on:
   schedule:
     - cron: '0 9 * * *'

--- a/.github/workflows/ci-code-check.yml
+++ b/.github/workflows/ci-code-check.yml
@@ -58,8 +58,10 @@ jobs:
       - name: Cache observability (typecheck)
         if: matrix.check == 'ts'
         run: |
-          echo "### TypeScript incremental cache" >> $GITHUB_STEP_SUMMARY
-          echo "- **exact hit**: \`${{ steps.restore-typecheck.outputs.cache-hit }}\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### TypeScript incremental cache"
+            echo "- **exact hit**: \`${{ steps.restore-typecheck.outputs.cache-hit }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Install Meteor
         shell: bash
@@ -105,8 +107,10 @@ jobs:
       - name: Cache observability (eslint)
         if: matrix.check == 'lint'
         run: |
-          echo "### ESLint cache" >> $GITHUB_STEP_SUMMARY
-          echo "- **exact hit**: \`${{ steps.restore-eslint.outputs.cache-hit }}\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### ESLint cache"
+            echo "- **exact hit**: \`${{ steps.restore-eslint.outputs.cache-hit }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Lint
         if: matrix.check == 'lint'

--- a/.github/workflows/ci-code-check.yml
+++ b/.github/workflows/ci-code-check.yml
@@ -70,7 +70,7 @@ jobs:
           METEOR_TOOL_DIRECTORY=$(dirname "$METEOR_SYMLINK_TARGET")
           set -e
           LAUNCHER=$HOME/.meteor/$METEOR_TOOL_DIRECTORY/scripts/admin/launch-meteor
-          if [ -e $LAUNCHER ]
+          if [ -e "$LAUNCHER" ]
           then
             echo "Cached Meteor bin found, restoring it"
             sudo cp "$LAUNCHER" "/usr/local/bin/meteor"

--- a/.github/workflows/ci-test-e2e.yml
+++ b/.github/workflows/ci-test-e2e.yml
@@ -59,6 +59,8 @@ on:
         required: false
       REPORTER_JIRA_ROCKETCHAT_API_KEY:
         required: false
+      NPM_TOKEN:
+        required: false
 
 env:
   MONGO_URL: mongodb://localhost:27017/rocketchat?replicaSet=rs0&directConnection=true

--- a/.github/workflows/ci-test-e2e.yml
+++ b/.github/workflows/ci-test-e2e.yml
@@ -213,12 +213,12 @@ jobs:
         run: |
           set -o xtrace
 
-          npm run testapi
+          npm run testapi || s=$?
 
           docker compose -f ../../docker-compose-ci.yml stop
 
           ls -la "$COVERAGE_DIR"
-          exit "$s"
+          exit "${s:-0}"
 
       - name: E2E Test API (Livechat)
         if: inputs.type == 'api-livechat'
@@ -229,12 +229,12 @@ jobs:
         run: |
           set -o xtrace
 
-          npm run testapi:livechat
+          npm run testapi:livechat || s=$?
 
           docker compose -f ../../docker-compose-ci.yml stop
 
           ls -la "$COVERAGE_DIR"
-          exit "$s"
+          exit "${s:-0}"
 
       - name: E2E Test UI (${{ matrix.shard }}/${{ inputs.total-shard }})
         if: inputs.type == 'ui'

--- a/.github/workflows/ci-test-e2e.yml
+++ b/.github/workflows/ci-test-e2e.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Set DEBUG_LOG_LEVEL (debug enabled)
         if: runner.debug == '1'
-        run: echo "DEBUG_LOG_LEVEL=2" >> $GITHUB_ENV
+        run: echo "DEBUG_LOG_LEVEL=2" >> "$GITHUB_ENV"
 
       - name: Start httpbin container and wait for it to be ready
         if: inputs.type == 'api' || inputs.type == 'api-livechat'
@@ -170,8 +170,8 @@ jobs:
         run: |
           set -o xtrace
 
-          mkdir -p $COVERAGE_DIR
-          chmod 777 $COVERAGE_DIR
+          mkdir -p "$COVERAGE_DIR"
+          chmod 777 "$COVERAGE_DIR"
 
       - name: Start containers for CE
         if: inputs.release == 'ce'
@@ -195,7 +195,7 @@ jobs:
         run: |
           docker ps
 
-          until echo "$(docker compose -f docker-compose-ci.yml logs ddp-streamer-service)" | grep -q "NetworkBroker started successfully"; do
+          until docker compose -f docker-compose-ci.yml logs ddp-streamer-service | grep -q "NetworkBroker started successfully"; do
             echo "Waiting 'ddp-streamer' to start up"
             ((c++)) && ((c==10)) && docker compose -f docker-compose-ci.yml logs ddp-streamer-service && exit 1
             sleep 10
@@ -217,8 +217,8 @@ jobs:
 
           docker compose -f ../../docker-compose-ci.yml stop
 
-          ls -la $COVERAGE_DIR
-          exit $s
+          ls -la "$COVERAGE_DIR"
+          exit "$s"
 
       - name: E2E Test API (Livechat)
         if: inputs.type == 'api-livechat'
@@ -233,8 +233,8 @@ jobs:
 
           docker compose -f ../../docker-compose-ci.yml stop
 
-          ls -la $COVERAGE_DIR
-          exit $s
+          ls -la "$COVERAGE_DIR"
+          exit "$s"
 
       - name: E2E Test UI (${{ matrix.shard }}/${{ inputs.total-shard }})
         if: inputs.type == 'ui'
@@ -269,8 +269,8 @@ jobs:
         if: inputs.type == 'ui' && inputs.coverage == matrix.mongodb-version
         working-directory: ./apps/meteor
         run: |
-          npx nyc merge .nyc_output ${COVERAGE_DIR}/${COVERAGE_FILE_NAME}
-          ls -la $COVERAGE_DIR || true
+          npx nyc merge .nyc_output "${COVERAGE_DIR}/${COVERAGE_FILE_NAME}"
+          ls -la "$COVERAGE_DIR" || true
 
       - name: Store playwright test trace
         if: inputs.type == 'ui' && always()

--- a/.github/workflows/ci-test-storybook.yml
+++ b/.github/workflows/ci-test-storybook.yml
@@ -13,6 +13,8 @@ on:
     secrets:
       CODECOV_TOKEN:
         required: true
+      NPM_TOKEN:
+        required: false
 
 env:
   TOOL_NODE_FLAGS: ${{ vars.TOOL_NODE_FLAGS }}

--- a/.github/workflows/ci-test-unit.yml
+++ b/.github/workflows/ci-test-unit.yml
@@ -15,6 +15,8 @@ on:
     secrets:
       CODECOV_TOKEN:
         required: false
+      NPM_TOKEN:
+        required: false
 
 env:
   MONGO_URL: mongodb://localhost:27017/rocketchat?replicaSet=rs0&directConnection=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,9 +189,11 @@ jobs:
 
       - name: Cache observability (packages-build)
         run: |
-          echo "### 📦 packages-build cache" >> $GITHUB_STEP_SUMMARY
-          echo "- **hit**: \`${{ steps.packages-cache-build.outputs.cache-hit }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **key**: \`${{ needs.release-versions.outputs.packages-build-cache-key }}\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### 📦 packages-build cache"
+            echo "- **hit**: \`${{ steps.packages-cache-build.outputs.cache-hit }}\`"
+            echo "- **key**: \`${{ needs.release-versions.outputs.packages-build-cache-key }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master
@@ -217,9 +219,11 @@ jobs:
       - name: Cache observability (node_modules)
         if: steps.packages-cache-build.outputs.cache-hit != 'true'
         run: |
-          echo "### 🟢 node_modules cache" >> $GITHUB_STEP_SUMMARY
-          echo "- **deno cache hit**: \`${{ steps.setup-node-packages.outputs.cache-deno-hit }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **node_modules size**: \`$(du -sh node_modules 2>/dev/null | cut -f1 || echo 'n/a')\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### 🟢 node_modules cache"
+            echo "- **deno cache hit**: \`${{ steps.setup-node-packages.outputs.cache-deno-hit }}\`"
+            echo "- **node_modules size**: \`$(du -sh node_modules 2>/dev/null | cut -f1 || echo 'n/a')\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Cache vite
         uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           echo "GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
           echo "GITHUB_BASE_REF: $GITHUB_BASE_REF"
           echo "github.event_name: ${{ github.event_name }}"
-          cat $GITHUB_EVENT_PATH
+          cat "$GITHUB_EVENT_PATH"
 
       - uses: actions/checkout@v6
         # with:
@@ -74,24 +74,24 @@ jobs:
           # Uncomment the following line to include the run ID in the hash and disable caching between runs
           # SOURCE_HASH=$(sha256sum /tmp/RocketChat-source.tar | awk '{ print $1 }')-${{ github.run_id }}
 
-          echo hash=${SOURCE_HASH}
+          echo "hash=${SOURCE_HASH}"
 
-          echo hash=${SOURCE_HASH} >> $GITHUB_OUTPUT
+          echo "hash=${SOURCE_HASH}" >> "$GITHUB_OUTPUT"
 
       - id: var
         run: |
           LOWERCASE_REPOSITORY=$(echo "${{ github.repository_owner }}" | tr "[:upper:]" "[:lower:]")
 
           echo "LOWERCASE_REPOSITORY: ${LOWERCASE_REPOSITORY}"
-          echo "lowercase-repo=${LOWERCASE_REPOSITORY}" >> $GITHUB_OUTPUT
+          echo "lowercase-repo=${LOWERCASE_REPOSITORY}" >> "$GITHUB_OUTPUT"
 
           NODE_VERSION=$(node -p "require('./package.json').engines.node")
           echo "NODE_VERSION: ${NODE_VERSION}"
-          echo "node-version=${NODE_VERSION}" >> $GITHUB_OUTPUT
+          echo "node-version=${NODE_VERSION}" >> "$GITHUB_OUTPUT"
 
           DENO_VERSION=$(awk '$1=="deno"{ print $2 }' .tool-versions)
           echo "DENO_VERSION: ${DENO_VERSION}"
-          echo "deno-version=${DENO_VERSION}" >> $GITHUB_OUTPUT
+          echo "deno-version=${DENO_VERSION}" >> "$GITHUB_OUTPUT"
 
       - id: ci-cache-keys
         run: |
@@ -109,7 +109,7 @@ jobs:
             RELEASE="release-candidate"
           fi
           echo "RELEASE: ${RELEASE}"
-          echo "release=${RELEASE}" >> $GITHUB_OUTPUT
+          echo "release=${RELEASE}" >> "$GITHUB_OUTPUT"
 
       - id: latest
         run: |
@@ -118,7 +118,7 @@ jobs:
               awk -F/ '$NF !~ /rc|beta/ { print $NF; exit }'
           )"
           echo "LATEST_RELEASE: ${LATEST_RELEASE}"
-          echo "latest-release=${LATEST_RELEASE}" >> $GITHUB_OUTPUT
+          echo "latest-release=${LATEST_RELEASE}" >> "$GITHUB_OUTPUT"
 
       - id: docker
         run: |
@@ -130,7 +130,7 @@ jobs:
           # Docker tags cannot contain '/'; merge queue refs do (e.g. gh-readonly-queue/develop/pr-123-sha)
           DOCKER_TAG="${DOCKER_TAG//\//-}"
           echo "DOCKER_TAG: ${DOCKER_TAG}"
-          echo "gh-docker-tag=${DOCKER_TAG}" >> $GITHUB_OUTPUT
+          echo "gh-docker-tag=${DOCKER_TAG}" >> "$GITHUB_OUTPUT"
 
   notify-draft-services:
     name: 🚀 Notify external services - draft
@@ -240,8 +240,7 @@ jobs:
       - name: Archive packages build output
         if: steps.packages-cache-build.outputs.cache-hit != 'true'
         run: |
-          tar -czf /tmp/RocketChat-packages-build.tar.gz \
-            $(git ls-files -oi --exclude-standard -- ':(exclude)node_modules/*' ':(exclude)**/node_modules/*' ':(exclude)**/.meteor/*' ':(exclude)**/.turbo/*' ':(exclude).turbo/*' ':(exclude)**/.yarn/*' ':(exclude).yarn/*' ':(exclude).git/*')
+          git ls-files -oi --exclude-standard -- ':(exclude)node_modules/*' ':(exclude)**/node_modules/*' ':(exclude)**/.meteor/*' ':(exclude)**/.turbo/*' ':(exclude).turbo/*' ':(exclude)**/.yarn/*' ':(exclude).yarn/*' ':(exclude).git/*' | tar -czf /tmp/RocketChat-packages-build.tar.gz -T -
 
       - name: Upload packages build artifact
         uses: actions/upload-artifact@v7
@@ -426,12 +425,13 @@ jobs:
             echo "Creating manifest for $service"
 
             # Extract digests from manifest.json files
+            # shellcheck disable=SC2016
             mapfile -t refs < <(
               find "$service_dir" -type f -name 'manifest.json' -print0 \
                 | xargs -0 -I{} jq -r '.Descriptor.digest as $digest | .Ref | split("@")[0] + "@" + $digest' {}
             )
 
-            echo "Digest for ${service}: ${refs[@]}"
+            echo "Digest for ${service}: ${refs[*]}"
 
             # Get image name from docker-compose-ci.yml since rocketchat image is different from service name (rocket.chat)
             if [ "$service" == "rocketchat-cov" ]; then
@@ -440,14 +440,14 @@ jobs:
               IMAGE=$(docker compose -f docker-compose-ci.yml config --format json 2>/dev/null | jq -r --arg s "$service" '.services[$s].image')
             fi
 
-            echo $IMAGE
+            echo "$IMAGE"
 
             docker buildx imagetools create \
               --debug \
               --annotation "manifest-descriptor:org.opencontainers.image.description=Build run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
               --tag "${IMAGE}" \
               --tag "${IMAGE}-gha-run-${{ github.run_id }}" \
-              ${refs[@]}
+              "${refs[@]}"
           done
 
   track-image-sizes:
@@ -853,30 +853,28 @@ jobs:
         run: |
           REPO_VERSION=$(node -p "require('./package.json').version")
 
-          if [[ '${{ github.event_name }}' = 'release' ]]; then
-            GIT_TAG="${GITHUB_REF#*tags/}"
+          if [[ "${{ github.event_name }}" = 'release' ]]; then
             ARTIFACT_NAME="${REPO_VERSION}"
           else
-            GIT_TAG=""
             ARTIFACT_NAME="${REPO_VERSION}.$GITHUB_SHA"
           fi;
 
           ROCKET_DEPLOY_DIR="/tmp/deploy"
-          FILENAME="$ROCKET_DEPLOY_DIR/rocket.chat-$ARTIFACT_NAME.tgz";
+          FILENAME="$ROCKET_DEPLOY_DIR/rocket.chat-$ARTIFACT_NAME.tgz"
 
           aws s3 cp s3://rocketchat/sign.key.gpg .github/sign.key.gpg
 
-          mkdir -p $ROCKET_DEPLOY_DIR
+          mkdir -p "$ROCKET_DEPLOY_DIR"
 
           cp .github/sign.key.gpg /tmp
-          gpg --yes --batch --passphrase=$GPG_PASSWORD /tmp/sign.key.gpg
+          gpg --yes --batch --passphrase="$GPG_PASSWORD" /tmp/sign.key.gpg
           gpg --allow-secret-key-import --import /tmp/sign.key
           rm /tmp/sign.key
 
           ln -s /tmp/build/Rocket.Chat.tar.gz "$FILENAME"
           gpg --armor --detach-sign "$FILENAME"
 
-          aws s3 cp $ROCKET_DEPLOY_DIR/ s3://download.rocket.chat/build/ --recursive
+          aws s3 cp "$ROCKET_DEPLOY_DIR/" s3://download.rocket.chat/build/ --recursive
 
   docker-image-publish:
     name: 🚀 Publish Docker Images (DockerHub)
@@ -939,8 +937,8 @@ jobs:
 
             echo "RELEASE: $RELEASE"
 
-            if [[ $RELEASE == 'latest' ]]; then
-              if [[ '${{ needs.release-versions.outputs.latest-release }}' == $GITHUB_REF_NAME ]]; then
+            if [[ "$RELEASE" == 'latest' ]]; then
+              if [[ '${{ needs.release-versions.outputs.latest-release }}' == "$GITHUB_REF_NAME" ]]; then
                 TAGS+=("$RELEASE")
               fi
             else
@@ -1039,7 +1037,7 @@ jobs:
               https://releases.rocket.chat/update
 
           # Makes build fail if the release isn't there
-          curl --fail https://releases.rocket.chat/$RC_VERSION/info
+          curl --fail "https://releases.rocket.chat/$RC_VERSION/info"
 
   docs-update:
     name: Update Version Durability

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
   release:
     types: [published]
   pull_request:
-    branches: '**'
+    branches:
+      - '**'
     paths-ignore:
       - '**.md'
   merge_group:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,6 +526,7 @@ jobs:
     secrets:
       CR_USER: ${{ secrets.CR_USER }}
       CR_PAT: ${{ secrets.CR_PAT }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   test-api-livechat:
     name: 🔨 Test API Livechat (CE)
@@ -542,6 +543,7 @@ jobs:
     secrets:
       CR_USER: ${{ secrets.CR_USER }}
       CR_PAT: ${{ secrets.CR_PAT }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   test-ui:
     name: 🔨 Test UI (CE)
@@ -563,6 +565,7 @@ jobs:
     secrets:
       CR_USER: ${{ secrets.CR_USER }}
       CR_PAT: ${{ secrets.CR_PAT }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       QASE_API_TOKEN: ${{ secrets.QASE_API_TOKEN }}
       REPORTER_ROCKETCHAT_API_KEY: ${{ secrets.REPORTER_ROCKETCHAT_API_KEY }}
       REPORTER_ROCKETCHAT_URL: ${{ secrets.REPORTER_ROCKETCHAT_URL }}
@@ -587,6 +590,7 @@ jobs:
     secrets:
       CR_USER: ${{ secrets.CR_USER }}
       CR_PAT: ${{ secrets.CR_PAT }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   test-api-livechat-ee:
     name: 🔨 Test API Livechat (EE)
@@ -607,6 +611,7 @@ jobs:
     secrets:
       CR_USER: ${{ secrets.CR_USER }}
       CR_PAT: ${{ secrets.CR_PAT }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   test-ui-ee:
     name: 🔨 Test UI (EE)
@@ -630,6 +635,7 @@ jobs:
     secrets:
       CR_USER: ${{ secrets.CR_USER }}
       CR_PAT: ${{ secrets.CR_PAT }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       QASE_API_TOKEN: ${{ secrets.QASE_API_TOKEN }}
       REPORTER_ROCKETCHAT_API_KEY: ${{ secrets.REPORTER_ROCKETCHAT_API_KEY }}
       REPORTER_ROCKETCHAT_URL: ${{ secrets.REPORTER_ROCKETCHAT_URL }}

--- a/.github/workflows/dedupe-issues.yml
+++ b/.github/workflows/dedupe-issues.yml
@@ -1,5 +1,5 @@
 name: Rocket.Chat Issue Dedupe
-description: Automatically dedupe GitHub issues using AI
+
 on:
   issues:
     types: [opened]
@@ -27,7 +27,7 @@ jobs:
         with:
           prompt: '/dedupe ${{ github.repository }}/issues/${{ github.event.issue.number || inputs.issue_number }}'
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-sonnet-4-5-20250929'
+          model: 'claude-sonnet-4-5-20250929'
           claude_env: |
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/packages/release-action/action.yml
+++ b/packages/release-action/action.yml
@@ -10,8 +10,8 @@ inputs:
     required: false
 
 runs:
-  using: "node20"
-  main: "dist/index.js"
+  using: "node24"
+  main: "src/index.ts"
 
 branding:
   icon: "package"

--- a/packages/release-action/action.yml
+++ b/packages/release-action/action.yml
@@ -10,8 +10,8 @@ inputs:
     required: false
 
 runs:
-  using: "node24"
-  main: "src/index.ts"
+  using: "node20"
+  main: "dist/index.js"
 
 branding:
   icon: "package"


### PR DESCRIPTION
This PR introduces strict static analysis for our GitHub Actions workflows using `actionlint` and resolves all existing syntax and `shellcheck` violations. 

During the cleanup, a critical silent bug was discovered and fixed in the E2E testing workflows where failing tests would bypass Docker cleanup steps, potentially leaving zombie containers on the runners. Additionally, the local `release-action` fails a check because the `dist/index.js` file isn't present before build, so this particular check is ignored in the config file.

### 🛠️ Key Changes

**1. Added Actionlint**
* Added `.github/workflows/actionlint.yml` to automatically lint workflow files on `push` and `pull_request`.
* This will prevent future syntax errors, undefined inputs, and unsafe bash scripting in our CI pipeline.

**2. Fixed Zombie Container Bug in E2E Tests (`ci-test-e2e.yml`)**
* **Bug:** Previously, if `npm run testapi` failed, Bash's `set -e` would instantly terminate the script, skipping the `docker compose stop` cleanup command.
* **Fix:** Implemented exit code capturing (`npm run testapi || s=$?`) to absorb the failure, guarantee the Docker cleanup commands execute, and properly exit with the captured status code (`exit "${s:-0}"`).

**3. Resolved Shellcheck & Workflow Syntax Errors**
* Fixed multiple `SC2086` (word splitting) warnings in `ci.yml`, `ci-test-e2e.yml`, and `ci-code-check.yml` by wrapping variables in double quotes.
* Fixed `SC2016` (expressions don't expand in single quotes) by adding a `# shellcheck disable=SC2016` directive for intentional `jq` single-quote usage in `ci.yml`.
* Removed invalid `type` keys from input definitions in `.github/actions/meteor-build/action.yml` and `.github/actions/build-docker/action.yml`.
* Added missing `NPM_TOKEN` to the `secrets` context in `ci-test-storybook.yml` and `ci-test-unit.yml`.
* Added missing `description` key to `.github/actions/setup-playwright/action.yml`.
* Removed invalid `description` key at the root of `dedupe-issues.yml`.

### 🧪 How to test
Review the CI checks on this PR. The new `actionlint` job should pass cleanly, and the E2E tests should properly spin up, execute, and tear down the Docker containers regardless of test success/failure. 

 Task: [FIPS-19]

[FIPS-19]: https://rocketchat.atlassian.net/browse/FIPS-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow linting with actionlint, including a matcher for structured diagnostics.
  * New workflow to run actionlint automatically on pushes and PRs.
  * Reusable workflows now accept an optional NPM_TOKEN secret.

* **Bug Fixes**
  * Improved shell quoting and safer command handling across CI workflows to avoid path/whitespace issues.

* **Chores**
  * Updated action metadata and simplified input schemas; refined Docker build/publish workflow steps for robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->