### PR TITLE
chore: migrate rooms.cleanHistory endpoint to new API format with AJV validation

### DIFF
--- a/apps/meteor/app/api/server/v1/rooms.ts
+++ b/apps/meteor/app/api/server/v1/rooms.ts
@@ -76,12 +76,12 @@ export async function findRoomByIdOrName({
 	checkedArchived = true,
 }: {
 	params:
-		| {
-				roomId?: string;
-		  }
-		| {
-				roomName?: string;
-		  };
+	| {
+		roomId?: string;
+	}
+	| {
+		roomName?: string;
+	};
 	checkedArchived?: boolean;
 }): Promise<IRoom> {
 	if (
@@ -372,54 +372,94 @@ const roomsSaveNotificationEndpoint = API.v1.post(
 	},
 );
 
-API.v1.addRoute(
-	'rooms.cleanHistory',
-	{ authRequired: true, validateParams: isRoomsCleanHistoryProps },
+const roomsCleanHistoryEndpoint = API.v1.post('rooms.cleanHistory',
 	{
-		async post() {
-			const room = await findRoomByIdOrName({ params: this.bodyParams });
-			const { _id } = room;
+		authRequired: true,
+		body: ajv.compile<{
+			roomId?: string;
+			roomName?: string;
+			latest: string;
+			oldest: string;
+			inclusive?: boolean;
+			limit?: number;
+			excludePinned?: boolean | string | number;
+			filesOnly?: boolean | string | number;
+			ignoreThreads?: boolean | string | number;
+			ignoreDiscussion?: boolean | string | number;
+			users?: string[];
 
-			if (!room || !(await canAccessRoomAsync(room, { _id: this.userId }))) {
-				return API.v1.failure('User does not have access to the room [error-not-allowed]', 'error-not-allowed');
-			}
-
-			const {
-				latest,
-				oldest,
-				inclusive = false,
-				limit,
-				excludePinned,
-				filesOnly,
-				ignoreThreads,
-				ignoreDiscussion,
-				users,
-			} = this.bodyParams;
-
-			if (!latest) {
-				return API.v1.failure('Body parameter "latest" is required.');
-			}
-
-			if (!oldest) {
-				return API.v1.failure('Body parameter "oldest" is required.');
-			}
-
-			const count = await cleanRoomHistoryMethod(this.userId, {
-				roomId: _id,
-				latest: new Date(latest),
-				oldest: new Date(oldest),
-				inclusive,
-				limit,
-				excludePinned: [true, 'true', 1, '1'].includes(excludePinned ?? false),
-				filesOnly: [true, 'true', 1, '1'].includes(filesOnly ?? false),
-				ignoreThreads: [true, 'true', 1, '1'].includes(ignoreThreads ?? false),
-				ignoreDiscussion: [true, 'true', 1, '1'].includes(ignoreDiscussion ?? false),
-				fromUsers: users?.filter(isTruthy) || [],
-			});
-
-			return API.v1.success({ _id, count });
+		}>({
+			type: 'object',
+			properties: {
+				roomId: { type: 'string' },
+				roomName: { type: 'string' },
+				latest: { type: 'string', description: 'The end date of the range' },
+				oldest: { type: 'string', description: 'The start date of the range' },
+				inclusive: { type: 'boolean' },
+				limit: { type: 'number' },
+				excludePinned: { type: ['boolean', 'string', 'number'] },
+				filesOnly: { type: ['boolean', 'string', 'number'] },
+				ignoreThreads: { type: ['boolean', 'string', 'number'] },
+				ignoreDiscussion: { type: ['boolean', 'string', 'number'] },
+				users: { type: 'array', items: { type: 'string' } }
+			},
+			required: ['latest', 'oldest'],
+			additionalProperties: false
+		}),
+		response: {
+			200: ajv.compile<{
+				_id: string;
+				count: number;
+				success: true;
+			}>({
+				type: 'object',
+				properties: {
+					_id: { type: 'string' },
+					count: { type: 'number' },
+					success: { type: 'boolean', enum: [true] },
+				},
+				required: ['_id', 'count', 'success'],
+				additionalProperties: false,
+			}),
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
 		},
 	},
+	async function action() {
+		const room = await findRoomByIdOrName({ params: this.bodyParams });
+
+		if (!room || !(await canAccessRoomAsync(room, { _id: this.userId }))) {
+			return API.v1.failure('User does not have access to the room [error-not-allowed]', 'error-not-allowed');
+		}
+		const { _id } = room;
+
+		const {
+			latest,
+			oldest,
+			inclusive = false,
+			limit,
+			excludePinned,
+			filesOnly,
+			ignoreThreads,
+			ignoreDiscussion,
+			users,
+		} = this.bodyParams;
+
+		const count = await cleanRoomHistoryMethod(this.userId, {
+			roomId: _id,
+			latest: new Date(latest),
+			oldest: new Date(oldest),
+			inclusive,
+			limit,
+			excludePinned: [true, 'true', 1, '1'].includes(excludePinned ?? false),
+			filesOnly: [true, 'true', 1, '1'].includes(filesOnly ?? false),
+			ignoreThreads: [true, 'true', 1, '1'].includes(ignoreThreads ?? false),
+			ignoreDiscussion: [true, 'true', 1, '1'].includes(ignoreDiscussion ?? false),
+			fromUsers: users?.filter(isTruthy) || [],
+		});
+
+		return API.v1.success({ _id, count });
+	}
 );
 
 API.v1.addRoute(
@@ -970,21 +1010,21 @@ API.v1.addRoute(
 
 type RoomsFavorite =
 	| {
-			roomId: string;
-			favorite: boolean;
-	  }
+		roomId: string;
+		favorite: boolean;
+	}
 	| {
-			roomName: string;
-			favorite: boolean;
-	  };
+		roomName: string;
+		favorite: boolean;
+	};
 
 type RoomsLeave =
 	| {
-			roomId: string;
-	  }
+		roomId: string;
+	}
 	| {
-			roomName: string;
-	  };
+		roomName: string;
+	};
 
 const isRoomGetRolesPropsSchema = {
 	type: 'object',
@@ -1377,9 +1417,10 @@ export const roomEndpoints = API.v1
 	);
 type RoomEndpoints = ExtractRoutesFromAPI<typeof roomEndpoints> &
 	ExtractRoutesFromAPI<typeof roomDeleteEndpoint> &
-	ExtractRoutesFromAPI<typeof roomsSaveNotificationEndpoint>;
+	ExtractRoutesFromAPI<typeof roomsSaveNotificationEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsCleanHistoryEndpoint>;
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends RoomEndpoints {}
+	interface Endpoints extends RoomEndpoints { }
 }

--- a/apps/meteor/app/api/server/v1/rooms.ts
+++ b/apps/meteor/app/api/server/v1/rooms.ts
@@ -404,6 +404,10 @@ const roomsCleanHistoryEndpoint = API.v1.post('rooms.cleanHistory',
 				users: { type: 'array', items: { type: 'string' } }
 			},
 			required: ['latest', 'oldest'],
+			anyOf: [
+				{ required: ['roomId'] },
+				{ required: ['roomName'] }
+			],
 			additionalProperties: false
 		}),
 		response: {

--- a/packages/rest-typings/src/v1/rooms.ts
+++ b/packages/rest-typings/src/v1/rooms.ts
@@ -854,9 +854,6 @@ export type RoomsEndpoints = {
 		};
 	};
 
-	'/v1/rooms.cleanHistory': {
-		POST: (params: RoomsCleanHistoryProps) => { _id: IRoom['_id']; count: number; success: boolean };
-	};
 
 	'/v1/rooms.createDiscussion': {
 		POST: (params: RoomsCreateDiscussionProps) => {


### PR DESCRIPTION
## Proposed changes

This PR migrates the `rooms.cleanHistory` endpoint from the deprecated `addRoute` pattern to the new `API.v1.post` format.

AJV schema validation has been added for both request body and response, aligning the endpoint with the OpenAPI-based API structure.

---

## Details of changes

* Migrated `rooms.cleanHistory` to `API.v1.post`
* Added AJV validation for:

  * Request body (roomId/roomName, latest, oldest, and optional filters)
  * Response (`{ _id: string, count: number, success: true }`)
* Preserved existing business logic, including:

  * Room lookup using `findRoomByIdOrName`
  * Permission checks with `canAccessRoomAsync`
  * Boolean normalization for optional flags
* Removed deprecated `addRoute` usage
* Updated typings using `ExtractRoutesFromAPI`
* Removed legacy definition from `rest-typings`

---

## Issue(s)

N/A (part of OpenAPI migration effort)

---

## Steps to test or reproduce

1. Send a POST request to `/api/v1/rooms.cleanHistory` with a valid body:

   * Required fields: `latest`, `oldest`
   * Optional: `roomId` or `roomName`, filters like `excludePinned`, `filesOnly`, etc.
2. Verify response:

   * `{ success: true, _id: <roomId>, count: <number> }`
3. Ensure validation fails for missing required fields (`latest`, `oldest`)
4. Ensure access is denied for unauthorized users

---

## Further comments

This change follows the established migration pattern used across similar endpoints and ensures consistency with the new API structure. No functional changes were introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal rework of the rooms.cleanHistory API: request/response validation and handling have been modernized and typings cleaned up. No change to runtime behavior; responses remain the same.
* **Bug Fixes**
  * Improved validation leads to clearer error responses for malformed requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->