### PR TITLE
fix(uikit-playground): update activeScreen/activeProject correctly after deletion

### DIFF
--- a/apps/uikit-playground/src/Context/reducer.ts
+++ b/apps/uikit-playground/src/Context/reducer.ts
@@ -194,6 +194,7 @@ const reducer = (state: initialStateType, action: IAction) => {
 			return { ...state };
 		}
 		case ActionTypes.DeleteScreen: {
+			const deletedScreenIndex = state.projects[activeProject].screens.indexOf(action.payload);
 			delete state.screens[action.payload];
 			const project = state.projects[activeProject];
 			project.screens = project.screens.filter((id) => id !== action.payload);
@@ -203,17 +204,37 @@ const reducer = (state: initialStateType, action: IAction) => {
 			project.flowNodes = project.flowNodes.filter((node) => node.id !== action.payload);
 
 			if (project.screens.length > 0) {
-				state.activeScreen = project.screens[0];
+				if (action.payload === activeScreen) {
+					const newIndex = Math.min(deletedScreenIndex, project.screens.length - 1);
+					state.activeScreen = project.screens[newIndex];
+				}
 			} else {
 				delete state.projects[activeProject];
 				const remainingProjectIds = Object.keys(state.projects);
 				if (remainingProjectIds.length > 0) {
 					const nextProjectId = remainingProjectIds[0];
 					state.activeProject = nextProjectId;
-					state.activeScreen = state.projects[nextProjectId].screens[0] || '';
+					state.activeScreen = state.projects[nextProjectId].screens[0];
 				} else {
-					state.activeProject = '';
-					state.activeScreen = '';
+					const newProjectId = getUniqueId();
+					const newScreenId = getUniqueId();
+					state.projects[newProjectId] = {
+						id: newProjectId,
+						name: 'Untitled Project',
+						screens: [newScreenId],
+						date: getDate(),
+						flowEdges: [],
+						flowNodes: [],
+					};
+					state.screens[newScreenId] = {
+						id: newScreenId,
+						name: 'Untitled Screen',
+						date: getDate(),
+						payload: { surface: SurfaceOptions.Message, blocks: [] },
+						actionPreview: {},
+					};
+					state.activeProject = newProjectId;
+					state.activeScreen = newScreenId;
 				}
 			}
 
@@ -304,14 +325,37 @@ const reducer = (state: initialStateType, action: IAction) => {
 				return {
 					...state,
 					activeProject: nextProjectId,
-					activeScreen: state.projects[nextProjectId].screens[0] || '',
+					activeScreen: state.projects[nextProjectId].screens[0],
 				};
 			}
 
+			const newProjectId = getUniqueId();
+			const newScreenId = getUniqueId();
 			return {
 				...state,
-				activeProject: '',
-				activeScreen: '',
+				projects: {
+					...state.projects,
+					[newProjectId]: {
+						id: newProjectId,
+						name: 'Untitled Project',
+						screens: [newScreenId],
+						date: getDate(),
+						flowEdges: [],
+						flowNodes: [],
+					},
+				},
+				screens: {
+					...state.screens,
+					[newScreenId]: {
+						id: newScreenId,
+						name: 'Untitled Screen',
+						date: getDate(),
+						payload: { surface: SurfaceOptions.Message, blocks: [] },
+						actionPreview: {},
+					},
+				},
+				activeProject: newProjectId,
+				activeScreen: newScreenId,
 			};
 		}
 		case ActionTypes.RenameProject: {


### PR DESCRIPTION
  ## Description
  Fixes incorrect state management in UIKit Playground when deleting screens and projects.

  ## Related Issue
  Closes #39240

  ## Changes Made

  ### DeleteScreen reducer:
  - **Fixed crash:** Previously, when the last screen was deleted, the reducer deleted the project but then tried to access `state.projects[activeProject].flowEdges` — causing a crash
  because the project no longer existed
  - **Fixed stale reference:** Clean up flowEdges and flowNodes **before** potentially deleting the project
  - **Added fallback:** When all screens are deleted and the project is removed, `activeProject` and `activeScreen` now fall back to the first remaining project instead of leaving stale
  references

  ### DeleteProject reducer:
  - **Added fallback:** Previously always set `activeProject: ''` even when other projects existed. Now falls back to the first remaining project
  - **Replaced `.map()` with `.forEach()`** for the delete side effect (lint best practice)
  - **Removed `console.log`** from production code

  ## Manual Testing
  1. Open UIKit Playground
  2. Create two projects with multiple screens
  3. Delete the active screen — active screen should switch to the next remaining screen
  4. Delete all screens in a project — project should be removed, active project should switch to the remaining one
  5. Delete a project directly — active project should switch to the remaining one
  6. Delete all projects — activeProject and activeScreen should be empty strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a screen now removes associated flow connections and selects the nearest remaining screen; if no screens remain, a new untitled project and screen are created and selected.
  * Deleting a project preserves the current selection when removing a non-active project; if the active project is removed, the next project/screen is auto-selected or a new untitled project/screen is created.

* **Chores**
  * Removed stray debug logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->