### PR TITLE
feat: add `@rocket.chat/env` package for centralized env var validation

### DIFF
--- a/packages/env/jest.config.ts
+++ b/packages/env/jest.config.ts
@@ -1,0 +1,6 @@
+import server from '@rocket.chat/jest-presets/server';
+import type { Config } from 'jest';
+
+export default {
+	preset: server.preset,
+} satisfies Config;

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "@rocket.chat/env",
+	"version": "0.0.1",
+	"private": true,
+	"main": "./dist/index.js",
+	"typings": "./dist/index.d.ts",
+	"files": [
+		"/dist"
+	],
+	"scripts": {
+		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
+		"lint": "eslint .",
+		"lint:fix": "eslint --fix .",
+		"testunit": "jest --passWithNoTests"
+	},
+	"dependencies": {
+		"ajv": "^8.17.1"
+	},
+	"devDependencies": {
+		"@rocket.chat/tsconfig": "workspace:*",
+		"@types/jest": "~30.0.0",
+		"eslint": "~9.39.3",
+		"jest": "~30.2.0",
+		"ts-jest": "~29.4.6",
+		"typescript": "~5.9.3"
+	},
+	"volta": {
+		"extends": "../../package.json"
+	}
+}

--- a/packages/env/src/env.ts
+++ b/packages/env/src/env.ts
@@ -1,4 +1,4 @@
 import { parseEnv } from './parse';
-import type { RocketChatEnv } from './types';
+import type { IRocketChatEnv } from './types';
 
-export const env: Readonly<RocketChatEnv> = parseEnv();
+export const env: Readonly<IRocketChatEnv> = parseEnv();

--- a/packages/env/src/env.ts
+++ b/packages/env/src/env.ts
@@ -1,0 +1,4 @@
+import { parseEnv } from './parse';
+import type { RocketChatEnv } from './types';
+
+export const env: Readonly<RocketChatEnv> = parseEnv();

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,4 +1,4 @@
-export type { RocketChatEnv } from './types';
+export type { IRocketChatEnv } from './types';
 export { envSchema } from './schema';
 export { parseEnv } from './parse';
 export { env } from './env';

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,0 +1,4 @@
+export type { RocketChatEnv } from './types';
+export { envSchema } from './schema';
+export { parseEnv } from './parse';
+export { env } from './env';

--- a/packages/env/src/parse.spec.ts
+++ b/packages/env/src/parse.spec.ts
@@ -1,0 +1,120 @@
+import { parseEnv } from './parse';
+
+const MINIMAL_VALID = { MONGO_URL: 'mongodb://localhost:27017/rocketchat' };
+
+describe('parseEnv', () => {
+	it('should throw if MONGO_URL is missing', () => {
+		expect(() => parseEnv({})).toThrow('Environment variable validation failed');
+	});
+
+	it('should throw if MONGO_URL is empty', () => {
+		expect(() => parseEnv({ MONGO_URL: '' })).toThrow('Environment variable validation failed');
+	});
+
+	it('should return a valid config with only MONGO_URL', () => {
+		const result = parseEnv(MINIMAL_VALID);
+		expect(result.MONGO_URL).toBe('mongodb://localhost:27017/rocketchat');
+	});
+
+	describe('defaults', () => {
+		it('should apply string defaults', () => {
+			const result = parseEnv(MINIMAL_VALID);
+			expect(result.ADMIN_NAME).toBe('Administrator');
+			expect(result.ADMIN_USERNAME).toBe('admin');
+			expect(result.BIND_IP).toBe('0.0.0.0');
+			expect(result.DEPLOY_METHOD).toBe('tar');
+			expect(result.DEPLOY_PLATFORM).toBe('selfinstall');
+			expect(result.INSTANCE_IP).toBe('localhost');
+		});
+
+		it('should apply number defaults', () => {
+			const result = parseEnv(MINIMAL_VALID);
+			expect(result.PORT).toBe(3000);
+			expect(result.EVENT_LOOP_LAG_MS).toBe(70);
+			expect(result.HEAP_USAGE_PERCENT).toBe(0.85);
+			expect(result.HTTP_FORWARDED_COUNT).toBe(0);
+			expect(result.MAX_RESUME_LOGIN_TOKENS).toBe(50);
+		});
+
+		it('should allow overriding defaults', () => {
+			const result = parseEnv({ ...MINIMAL_VALID, PORT: '8080', ADMIN_NAME: 'Root' });
+			expect(result.PORT).toBe(8080);
+			expect(result.ADMIN_NAME).toBe('Root');
+		});
+	});
+
+	describe('type coercion', () => {
+		it('should coerce string numbers to numbers', () => {
+			const result = parseEnv({ ...MINIMAL_VALID, PORT: '9090', EVENT_LOOP_LAG_MS: '100' });
+			expect(result.PORT).toBe(9090);
+			expect(result.EVENT_LOOP_LAG_MS).toBe(100);
+		});
+
+		it('should coerce optional number strings', () => {
+			const result = parseEnv({ ...MINIMAL_VALID, PROMETHEUS_PORT: '9100', HTTP_DEFAULT_TIMEOUT: '5000' });
+			expect(result.PROMETHEUS_PORT).toBe(9100);
+			expect(result.HTTP_DEFAULT_TIMEOUT).toBe(5000);
+		});
+	});
+
+	describe('boolean coercion', () => {
+		it('should coerce "true" to true', () => {
+			const result = parseEnv({ ...MINIMAL_VALID, TEST_MODE: 'true' });
+			expect(result.TEST_MODE).toBe(true);
+		});
+
+		it('should coerce "false" to false', () => {
+			const result = parseEnv({ ...MINIMAL_VALID, TEST_MODE: 'false' });
+			expect(result.TEST_MODE).toBe(false);
+		});
+
+		it('should coerce "yes" to true', () => {
+			const result = parseEnv({ ...MINIMAL_VALID, DISABLE_INTEGRATION_SCRIPTS: 'yes' });
+			expect(result.DISABLE_INTEGRATION_SCRIPTS).toBe(true);
+		});
+
+		it('should coerce "no" to false', () => {
+			const result = parseEnv({ ...MINIMAL_VALID, DISABLE_INTEGRATION_SCRIPTS: 'no' });
+			expect(result.DISABLE_INTEGRATION_SCRIPTS).toBe(false);
+		});
+
+		it('should coerce "YES" (uppercase) to true', () => {
+			const result = parseEnv({ ...MINIMAL_VALID, TEST_MODE: 'YES' });
+			expect(result.TEST_MODE).toBe(true);
+		});
+
+		it('should leave boolean undefined when not provided', () => {
+			const result = parseEnv(MINIMAL_VALID);
+			expect(result.TEST_MODE).toBeUndefined();
+		});
+	});
+
+	describe('additional properties', () => {
+		it('should strip unknown env vars from the result', () => {
+			const result = parseEnv({ ...MINIMAL_VALID, UNKNOWN_VAR: 'value', ANOTHER: '123' });
+			expect((result as Record<string, unknown>).UNKNOWN_VAR).toBeUndefined();
+			expect((result as Record<string, unknown>).ANOTHER).toBeUndefined();
+		});
+	});
+
+	describe('freeze', () => {
+		it('should return a frozen object', () => {
+			const result = parseEnv(MINIMAL_VALID);
+			expect(Object.isFrozen(result)).toBe(true);
+		});
+	});
+
+	describe('optional strings', () => {
+		it('should include optional strings when provided', () => {
+			const result = parseEnv({ ...MINIMAL_VALID, ADMIN_EMAIL: 'admin@example.com', REG_TOKEN: 'abc123' });
+			expect(result.ADMIN_EMAIL).toBe('admin@example.com');
+			expect(result.REG_TOKEN).toBe('abc123');
+		});
+
+		it('should leave optional strings undefined when not provided', () => {
+			const result = parseEnv(MINIMAL_VALID);
+			expect(result.ADMIN_EMAIL).toBeUndefined();
+			expect(result.TRANSPORTER).toBeUndefined();
+		});
+	});
+});

--- a/packages/env/src/parse.ts
+++ b/packages/env/src/parse.ts
@@ -1,0 +1,68 @@
+import Ajv from 'ajv';
+
+import { envSchema } from './schema';
+import type { RocketChatEnv } from './types';
+
+const BOOLEAN_KEYS: (keyof RocketChatEnv)[] = [
+	'ADMIN_EMAIL_VERIFIED',
+	'ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS',
+	'AUTO_ACCEPT_FINGERPRINT',
+	'BYPASS_MONGO_VALIDATION',
+	'BYPASS_NODEJS_VALIDATION',
+	'DEBUG_DISABLE_USER_AUDIT',
+	'DEBUG_SETTINGS',
+	'DISABLE_ANIMATION',
+	'DISABLE_CUSTOM_SCRIPTS',
+	'DISABLE_INTEGRATION_SCRIPTS',
+	'DISABLE_MESSAGE_PARSER',
+	'DISABLE_MESSAGE_ROUNDTRIP_TRACKING',
+	'DISABLE_PRIVATE_APP_INSTALLATION',
+	'EXIT_UNHANDLEDPROMISEREJECTION',
+	'FREEZE_INTEGRATION_SCRIPTS',
+	'IMPORTER_SKIP_APPS_EVENT',
+	'SKIP_MONGODEPRECATION_CHECK',
+	'TEST_MODE',
+];
+
+function normalizeBooleans(raw: Record<string, string | undefined>): Record<string, string | undefined> {
+	const copy = { ...raw };
+	for (const key of BOOLEAN_KEYS) {
+		const val = copy[key]?.toLowerCase();
+		if (val === 'yes') {
+			copy[key] = 'true';
+		} else if (val === 'no') {
+			copy[key] = 'false';
+		}
+	}
+	return copy;
+}
+
+function stripUndefined(obj: Record<string, unknown>): Record<string, unknown> {
+	const result: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(obj)) {
+		if (value !== undefined) {
+			result[key] = value;
+		}
+	}
+	return result;
+}
+
+export function parseEnv(raw: Record<string, string | undefined> = process.env): Readonly<RocketChatEnv> {
+	const ajv = new Ajv({
+		coerceTypes: true,
+		useDefaults: true,
+		removeAdditional: 'all',
+		allErrors: true,
+	});
+
+	const validate = ajv.compile<RocketChatEnv>(envSchema);
+	const normalized = normalizeBooleans(raw);
+	const data = stripUndefined(normalized);
+
+	if (!validate(data)) {
+		const errors = validate.errors?.map((e) => `  ${e.instancePath || '/'}: ${e.message}`).join('\n');
+		throw new Error(`Environment variable validation failed:\n${errors}`);
+	}
+
+	return Object.freeze(data);
+}

--- a/packages/env/src/parse.ts
+++ b/packages/env/src/parse.ts
@@ -1,9 +1,9 @@
 import Ajv from 'ajv';
 
 import { envSchema } from './schema';
-import type { RocketChatEnv } from './types';
+import type { IRocketChatEnv } from './types';
 
-const BOOLEAN_KEYS: (keyof RocketChatEnv)[] = [
+const BOOLEAN_KEYS: (keyof IRocketChatEnv)[] = [
 	'ADMIN_EMAIL_VERIFIED',
 	'ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS',
 	'AUTO_ACCEPT_FINGERPRINT',
@@ -47,7 +47,7 @@ function stripUndefined(obj: Record<string, unknown>): Record<string, unknown> {
 	return result;
 }
 
-export function parseEnv(raw: Record<string, string | undefined> = process.env): Readonly<RocketChatEnv> {
+export function parseEnv(raw: Record<string, string | undefined> = process.env): Readonly<IRocketChatEnv> {
 	const ajv = new Ajv({
 		coerceTypes: true,
 		useDefaults: true,
@@ -55,7 +55,7 @@ export function parseEnv(raw: Record<string, string | undefined> = process.env):
 		allErrors: true,
 	});
 
-	const validate = ajv.compile<RocketChatEnv>(envSchema);
+	const validate = ajv.compile<IRocketChatEnv>(envSchema);
 	const normalized = normalizeBooleans(raw);
 	const data = stripUndefined(normalized);
 

--- a/packages/env/src/schema.ts
+++ b/packages/env/src/schema.ts
@@ -1,0 +1,79 @@
+export const envSchema = {
+	type: 'object' as const,
+	required: ['MONGO_URL'],
+	additionalProperties: true,
+	properties: {
+		// Required
+		MONGO_URL: { type: 'string' as const, minLength: 1 },
+
+		// Optional with defaults — strings
+		ADMIN_NAME: { type: 'string' as const, default: 'Administrator' },
+		ADMIN_USERNAME: { type: 'string' as const, default: 'admin' },
+		BIND_IP: { type: 'string' as const, default: '0.0.0.0' },
+		DEPLOY_METHOD: { type: 'string' as const, default: 'tar' },
+		DEPLOY_PLATFORM: { type: 'string' as const, default: 'selfinstall' },
+		INSTANCE_IP: { type: 'string' as const, default: 'localhost' },
+
+		// Optional with defaults — numbers
+		EVENT_LOOP_LAG_MS: { type: 'number' as const, default: 70 },
+		HEAP_USAGE_PERCENT: { type: 'number' as const, default: 0.85 },
+		HTTP_FORWARDED_COUNT: { type: 'number' as const, default: 0 },
+		MAX_RESUME_LOGIN_TOKENS: { type: 'number' as const, default: 50 },
+		PORT: { type: 'number' as const, default: 3000 },
+
+		// Optional strings
+		ADMIN_EMAIL: { type: 'string' as const, nullable: true },
+		ADMIN_PASS: { type: 'string' as const, nullable: true },
+		BUGSNAG_CLIENT: { type: 'string' as const, nullable: true },
+		CLOUD_SUPPORTED_VERSIONS: { type: 'string' as const, nullable: true },
+		CLOUD_SUPPORTED_VERSIONS_TOKEN: { type: 'string' as const, nullable: true },
+		DEPLOYMENT_ID: { type: 'string' as const, nullable: true },
+		FILE_STORAGE_CUSTOM_USER_AGENT: { type: 'string' as const, nullable: true },
+		INITIAL_USER: { type: 'string' as const, nullable: true },
+		OVERWRITE_INTERNAL_MARKETPLACE_URL: { type: 'string' as const, nullable: true },
+		OVERWRITE_INTERNAL_RELEASE_URL: { type: 'string' as const, nullable: true },
+		RATE_LIMITER_LOGGER: { type: 'string' as const, nullable: true },
+		RC_DISABLE_STATISTICS_REPORTING: { type: 'string' as const, nullable: true },
+		REG_TOKEN: { type: 'string' as const, nullable: true },
+		ROCKET_CHAT_DEPRECATION_THROW_ERRORS_FOR_VERSIONS_UNDER: { type: 'string' as const, nullable: true },
+		ROCKETCHAT_LICENSE: { type: 'string' as const, nullable: true },
+		SETTINGS_BLOCKED: { type: 'string' as const, nullable: true },
+		SETTINGS_HIDDEN: { type: 'string' as const, nullable: true },
+		SETTINGS_REQUIRED_ON_WIZARD: { type: 'string' as const, nullable: true },
+		TCP_PORT: { type: 'string' as const, nullable: true },
+		TRANSPORTER: { type: 'string' as const, nullable: true },
+		TRANSPORTER_EXTRA: { type: 'string' as const, nullable: true },
+
+		// Optional booleans
+		ADMIN_EMAIL_VERIFIED: { type: 'boolean' as const, nullable: true },
+		ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS: { type: 'boolean' as const, nullable: true },
+		AUTO_ACCEPT_FINGERPRINT: { type: 'boolean' as const, nullable: true },
+		BYPASS_MONGO_VALIDATION: { type: 'boolean' as const, nullable: true },
+		BYPASS_NODEJS_VALIDATION: { type: 'boolean' as const, nullable: true },
+		DEBUG_DISABLE_USER_AUDIT: { type: 'boolean' as const, nullable: true },
+		DEBUG_SETTINGS: { type: 'boolean' as const, nullable: true },
+		DISABLE_ANIMATION: { type: 'boolean' as const, nullable: true },
+		DISABLE_CUSTOM_SCRIPTS: { type: 'boolean' as const, nullable: true },
+		DISABLE_INTEGRATION_SCRIPTS: { type: 'boolean' as const, nullable: true },
+		DISABLE_MESSAGE_PARSER: { type: 'boolean' as const, nullable: true },
+		DISABLE_MESSAGE_ROUNDTRIP_TRACKING: { type: 'boolean' as const, nullable: true },
+		DISABLE_PRIVATE_APP_INSTALLATION: { type: 'boolean' as const, nullable: true },
+		EXIT_UNHANDLEDPROMISEREJECTION: { type: 'boolean' as const, nullable: true },
+		FREEZE_INTEGRATION_SCRIPTS: { type: 'boolean' as const, nullable: true },
+		IMPORTER_SKIP_APPS_EVENT: { type: 'boolean' as const, nullable: true },
+		SKIP_MONGODEPRECATION_CHECK: { type: 'boolean' as const, nullable: true },
+		TEST_MODE: { type: 'boolean' as const, nullable: true },
+
+		// Optional numbers
+		HTTP_DEFAULT_TIMEOUT: { type: 'number' as const, nullable: true },
+		PROMETHEUS_PORT: { type: 'number' as const, nullable: true },
+		RATE_LIMITER_SLOWDOWN_RATE: { type: 'number' as const, nullable: true },
+
+		// System pass-through
+		HOME: { type: 'string' as const, nullable: true },
+		HOMEPATH: { type: 'string' as const, nullable: true },
+		NODE_ENV: { type: 'string' as const, nullable: true },
+		TMPDIR: { type: 'string' as const, nullable: true },
+		USERPROFILE: { type: 'string' as const, nullable: true },
+	},
+};

--- a/packages/env/src/types.ts
+++ b/packages/env/src/types.ts
@@ -1,4 +1,4 @@
-export interface RocketChatEnv {
+export interface IRocketChatEnv {
 	// Required
 	MONGO_URL: string;
 

--- a/packages/env/src/types.ts
+++ b/packages/env/src/types.ts
@@ -1,0 +1,74 @@
+export interface RocketChatEnv {
+	// Required
+	MONGO_URL: string;
+
+	// Optional with defaults — strings
+	ADMIN_NAME: string;
+	ADMIN_USERNAME: string;
+	BIND_IP: string;
+	DEPLOY_METHOD: string;
+	DEPLOY_PLATFORM: string;
+	INSTANCE_IP: string;
+
+	// Optional with defaults — numbers
+	EVENT_LOOP_LAG_MS: number;
+	HEAP_USAGE_PERCENT: number;
+	HTTP_FORWARDED_COUNT: number;
+	MAX_RESUME_LOGIN_TOKENS: number;
+	PORT: number;
+
+	// Optional strings
+	ADMIN_EMAIL?: string;
+	ADMIN_PASS?: string;
+	BUGSNAG_CLIENT?: string;
+	CLOUD_SUPPORTED_VERSIONS?: string;
+	CLOUD_SUPPORTED_VERSIONS_TOKEN?: string;
+	DEPLOYMENT_ID?: string;
+	FILE_STORAGE_CUSTOM_USER_AGENT?: string;
+	INITIAL_USER?: string;
+	OVERWRITE_INTERNAL_MARKETPLACE_URL?: string;
+	OVERWRITE_INTERNAL_RELEASE_URL?: string;
+	RATE_LIMITER_LOGGER?: string;
+	RC_DISABLE_STATISTICS_REPORTING?: string;
+	REG_TOKEN?: string;
+	ROCKET_CHAT_DEPRECATION_THROW_ERRORS_FOR_VERSIONS_UNDER?: string;
+	ROCKETCHAT_LICENSE?: string;
+	SETTINGS_BLOCKED?: string;
+	SETTINGS_HIDDEN?: string;
+	SETTINGS_REQUIRED_ON_WIZARD?: string;
+	TCP_PORT?: string;
+	TRANSPORTER?: string;
+	TRANSPORTER_EXTRA?: string;
+
+	// Optional booleans
+	ADMIN_EMAIL_VERIFIED?: boolean;
+	ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS?: boolean;
+	AUTO_ACCEPT_FINGERPRINT?: boolean;
+	BYPASS_MONGO_VALIDATION?: boolean;
+	BYPASS_NODEJS_VALIDATION?: boolean;
+	DEBUG_DISABLE_USER_AUDIT?: boolean;
+	DEBUG_SETTINGS?: boolean;
+	DISABLE_ANIMATION?: boolean;
+	DISABLE_CUSTOM_SCRIPTS?: boolean;
+	DISABLE_INTEGRATION_SCRIPTS?: boolean;
+	DISABLE_MESSAGE_PARSER?: boolean;
+	DISABLE_MESSAGE_ROUNDTRIP_TRACKING?: boolean;
+	DISABLE_PRIVATE_APP_INSTALLATION?: boolean;
+	EXIT_UNHANDLEDPROMISEREJECTION?: boolean;
+	FREEZE_INTEGRATION_SCRIPTS?: boolean;
+	IMPORTER_SKIP_APPS_EVENT?: boolean;
+	SKIP_MONGODEPRECATION_CHECK?: boolean;
+	TEST_MODE?: boolean;
+
+	// Optional numbers
+	HTTP_DEFAULT_TIMEOUT?: number;
+	PROMETHEUS_PORT?: number;
+	RATE_LIMITER_SLOWDOWN_RATE?: number;
+
+	// System pass-through
+	HOME?: string;
+	HOMEPATH?: string;
+	NODE_ENV?: string;
+	TMPDIR?: string;
+	USERPROFILE?: string;
+}

--- a/packages/env/tsconfig.json
+++ b/packages/env/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "@rocket.chat/tsconfig/server.json",
+	"compilerOptions": {
+		"declaration": true,
+		"rootDir": "./src",
+		"outDir": "./dist"
+	},
+	"include": ["./src/**/*"],
+	"exclude": ["./src/**/*.spec.ts"]
+}


### PR DESCRIPTION
https://rocketchat.atlassian.net/browse/PI-132

## Summary

- Adds new `@rocket.chat/env` package that centralizes environment variable validation using AJV schemas
- Provides a typed, frozen `env` singleton with fail-fast behavior if required vars (e.g. `MONGO_URL`) are missing
- Handles boolean coercion (`'true'`/`'yes'` → `true`), string-to-number coercion, and default values
- Covers all 59 env vars used in `apps/meteor/` (excluding dynamically mutated ones like `MAIL_URL`)

### Usage after migration (future PRs):
```typescript
// Before:
const port = parseInt(String(process.env.PORT)) || 3000;
const testMode = process.env.TEST_MODE === 'true';

// After:
import { env } from '@rocket.chat/env';
env.PORT       // number, defaults to 3000
env.TEST_MODE  // boolean | undefined
```

## Test plan

- [x] 18 unit tests passing with 100% statement coverage
- [ ] Build succeeds (`yarn build` in `packages/env/`)
- [ ] Validate startup fails without `MONGO_URL`
- [ ] Validate defaults are applied correctly
- [ ] Validate boolean/number coercion works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added schema-driven environment configuration: validates required MongoDB URL, applies sensible defaults, coerces types (strings→numbers/booleans), strips unknown vars, and returns an immutable parsed config with clear validation errors.
* **Tests**
  * Added thorough tests covering validation failures, defaults, type coercion, boolean variants, unknown-field stripping, and immutability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->