### PR TITLE
chore: migrate rooms.getDiscussions endpoint to new API format with AJV validation

### DIFF
--- a/apps/meteor/app/api/server/v1/rooms.ts
+++ b/apps/meteor/app/api/server/v1/rooms.ts
@@ -495,7 +495,7 @@ API.v1.addRoute(
 
 const roomsGetDiscussionsEndpoint = API.v1.get('rooms.getDiscussions', {
 	authRequired: true,
-	query: ajv.compile<{
+	query: ajvQuery.compile<{
 		roomId?: string;
 		roomName?: string;
 		offset?: number;

--- a/apps/meteor/app/api/server/v1/rooms.ts
+++ b/apps/meteor/app/api/server/v1/rooms.ts
@@ -76,12 +76,12 @@ export async function findRoomByIdOrName({
 	checkedArchived = true,
 }: {
 	params:
-		| {
-				roomId?: string;
-		  }
-		| {
-				roomName?: string;
-		  };
+	| {
+		roomId?: string;
+	}
+	| {
+		roomName?: string;
+	};
 	checkedArchived?: boolean;
 }): Promise<IRoom> {
 	if (
@@ -493,39 +493,80 @@ API.v1.addRoute(
 	},
 );
 
-API.v1.addRoute(
-	'rooms.getDiscussions',
-	{ authRequired: true },
-	{
-		async get() {
-			const room = await findRoomByIdOrName({ params: this.queryParams });
-			const { offset, count } = await getPaginationItems(this.queryParams);
-			const { sort, fields, query } = await this.parseJsonQuery();
-
-			if (!room || !(await canAccessRoomAsync(room, { _id: this.userId }))) {
-				return API.v1.failure('not-allowed', 'Not Allowed');
-			}
-
-			const ourQuery = Object.assign(query, { prid: room._id });
-
-			const { cursor, totalCount } = await Rooms.findPaginated(ourQuery, {
-				sort: sort || { fname: 1 },
-				skip: offset,
-				limit: count,
-				projection: fields,
-			});
-
-			const [discussions, total] = await Promise.all([cursor.toArray(), totalCount]);
-
-			return API.v1.success({
-				discussions,
-				count: discussions.length,
-				offset,
-				total,
-			});
+const roomsGetDiscussionsEndpoint = API.v1.get('rooms.getDiscussions', {
+	authRequired: true,
+	query: ajv.compile<{
+		roomId?: string;
+		roomName?: string;
+		offset?: number;
+		count?: number;
+	}>({
+		type: 'object',
+		properties: {
+			roomId: { type: 'string', description: 'The ID of the room' },
+			roomName: { type: 'string', description: 'The name of the room' },
+			offset: { type: 'number', description: 'Number of items to skip' },
+			count: { type: 'number', description: 'Number of items to return' },
 		},
+		anyOf: [{ required: ['roomId'] }, { required: ['roomName'] }],
+		additionalProperties: false,
+	}),
+	response: {
+		200: ajv.compile<{
+			success: true;
+			discussions: Record<string, unknown>[];
+			count: number;
+			offset: number;
+			total: number;
+		}>({
+			type: 'object',
+			properties: {
+				discussions: {
+					type: 'array',
+					items: { type: 'object' },
+				},
+				count: { type: 'number' },
+				offset: { type: 'number' },
+				total: { type: 'number' },
+				success: { type: 'boolean', enum: [true] },
+			},
+			required: ['discussions', 'count', 'offset', 'total', 'success'],
+			additionalProperties: false,
+		}),
+		400: validateBadRequestErrorResponse,
+		401: validateUnauthorizedErrorResponse,
 	},
-);
+}, async function action() {
+	const room = await findRoomByIdOrName({ params: this.queryParams });
+
+	if (!room || !(await canAccessRoomAsync(room, { _id: this.userId }))) {
+		return API.v1.failure('not-allowed', 'Not Allowed');
+	}
+
+	const { offset, count } = await getPaginationItems(this.queryParams);
+	const { sort, fields, query } = await this.parseJsonQuery();
+
+	const ourQuery = Object.assign(query, { prid: room._id });
+
+	const { cursor, totalCount } = await Rooms.findPaginated(ourQuery, {
+		sort: sort || { fname: 1 },
+		skip: offset,
+		limit: count,
+		projection: fields,
+	});
+
+	const [discussions, total] = await Promise.all([
+		cursor.toArray(),
+		totalCount,
+	]);
+
+	return API.v1.success({
+		discussions,
+		count: discussions.length,
+		offset,
+		total,
+	});
+});
 
 API.v1.addRoute(
 	'rooms.images',
@@ -970,21 +1011,21 @@ API.v1.addRoute(
 
 type RoomsFavorite =
 	| {
-			roomId: string;
-			favorite: boolean;
-	  }
+		roomId: string;
+		favorite: boolean;
+	}
 	| {
-			roomName: string;
-			favorite: boolean;
-	  };
+		roomName: string;
+		favorite: boolean;
+	};
 
 type RoomsLeave =
 	| {
-			roomId: string;
-	  }
+		roomId: string;
+	}
 	| {
-			roomName: string;
-	  };
+		roomName: string;
+	};
 
 const isRoomGetRolesPropsSchema = {
 	type: 'object',
@@ -1377,9 +1418,10 @@ export const roomEndpoints = API.v1
 	);
 type RoomEndpoints = ExtractRoutesFromAPI<typeof roomEndpoints> &
 	ExtractRoutesFromAPI<typeof roomDeleteEndpoint> &
-	ExtractRoutesFromAPI<typeof roomsSaveNotificationEndpoint>;
+	ExtractRoutesFromAPI<typeof roomsSaveNotificationEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsGetDiscussionsEndpoint>;
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends RoomEndpoints {}
+	interface Endpoints extends RoomEndpoints { }
 }

--- a/packages/rest-typings/src/v1/rooms.ts
+++ b/packages/rest-typings/src/v1/rooms.ts
@@ -493,7 +493,6 @@ export type Notifications = {
 	emailNotifications?: string;
 };
 
-type RoomsGetDiscussionsProps = PaginatedRequest<BaseRoomsProps>;
 
 type RoomsMuteUnmuteUser = { userId: string; roomId: string } | { username: string; roomId: string };
 
@@ -926,12 +925,6 @@ export type RoomsEndpoints = {
 			update: IRoom[];
 			remove: IRoom[];
 		};
-	};
-
-	'/v1/rooms.getDiscussions': {
-		GET: (params: RoomsGetDiscussionsProps) => PaginatedResult<{
-			discussions: IRoom[];
-		}>;
 	};
 
 	'/v1/rooms.isMember': {


### PR DESCRIPTION
## Proposed changes

This PR migrates the `rooms.getDiscussions` endpoint from the deprecated `addRoute` pattern to the new `API.v1.get` format with AJV-based validation.
The endpoint now uses schema-driven validation for query parameters and response, aligning it with the OpenAPI-based API structure.

---

## Issue(s)

N/A (part of ongoing OpenAPI migration effort)

---

## Steps to test or reproduce

1. Send a GET request to `/api/v1/rooms.getDiscussions` with:

   * Required: `roomId` or `roomName`
   * Optional: `offset`, `count`

2. Verify response:

   * `{ success: true, discussions: [...], count, offset, total }`

3. Validate error cases:

   * Missing both `roomId` and `roomName` should fail validation
   * Invalid types for `offset` or `count` should be rejected by AJV

---

## Further comments

* This change replaces implicit query handling with explicit AJV validation.
* Existing business logic remains unchanged:
  * Room access validation
  * Pagination handling via `getPaginationItems`
  * Query parsing via `parseJsonQuery`
* Removed legacy typings from `rest-typings` and replaced with `ExtractRoutesFromAPI` for automatic typing generation.
* This follows the same migration pattern used across similar endpoints.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation and explicit error responses for the rooms.getDiscussions endpoint to ensure correct parameters and consistent 200/400/401 responses.

* **Refactor**
  * Consolidated the rooms.getDiscussions endpoint definition into a single, shared endpoint declaration for clearer API behavior.

* **Chores**
  * Updated public API typings to reflect the new endpoint exposure (removed the prior separate props/endpoint alias).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->