### PR TITLE
fix: prevent thread sidebar from getting stuck

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/Threads/Thread.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Threads/Thread.tsx
@@ -19,7 +19,6 @@ import {
 	useUserId,
 	useRoomToolbox,
 } from '@rocket.chat/ui-contexts';
-import { createPortal } from 'react-dom';
 
 import ThreadChat from './components/ThreadChat';
 import ThreadSkeleton from './components/ThreadSkeleton';
@@ -42,6 +41,13 @@ const Thread = ({ tmid }: ThreadProps) => {
 			closeTab();
 		},
 	});
+	if (
+		mainMessageQueryResult.isSuccess &&
+		(!mainMessageQueryResult.data || mainMessageQueryResult.data.t === 'rm')
+	) {
+		closeTab();
+		return null;
+	}
 
 	const t = useTranslation();
 	const dispatchToastMessage = useToastMessageDispatch();
@@ -83,85 +89,64 @@ const Thread = ({ tmid }: ThreadProps) => {
 		closeTab();
 	};
 
-	const isExpanded = canExpand && expanded;
-	const portalTarget = isExpanded ? document.getElementById('main-content') : null;
-
-	const threadContent = (
-		<Contextualbar
-			rcx-thread-view
-			className={
-				isExpanded
-					? css`
-							max-width: 855px !important;
-							@media (min-width: 780px) and (max-width: 1135px) {
-								max-width: calc(100% - var(--sidebar-width)) !important;
-							}
-						`
-					: undefined
-			}
-			position='absolute'
-			display='flex'
-			flexDirection='column'
-			width='full'
-			overflow='hidden'
-			zIndex={100}
-			insetBlock={0}
-			border='none'
-		>
-			<ContextualbarHeader>
-				<ContextualbarBack onClick={handleGoBack} />
-				{(mainMessageQueryResult.isLoading && <Skeleton width='100%' />) ||
-					(mainMessageQueryResult.isSuccess && <ThreadTitle mainMessage={mainMessageQueryResult.data} />) ||
-					null}
-				<ContextualbarActions>
-					{canExpand && (
-						<ContextualbarAction
-							name={expanded ? 'arrow-collapse' : 'arrow-expand'}
-							title={expanded ? t('Collapse') : t('Expand')}
-							onClick={handleToggleExpand}
-						/>
-					)}
-					<ContextualbarAction
-						name={following ? 'bell' : 'bell-off'}
-						title={following ? t('Following') : t('Not_Following')}
-						disabled={!mainMessageQueryResult.isSuccess || toggleFollowingMutation.isPending}
-						onClick={handleToggleFollowing}
-					/>
-					<ContextualbarClose onClick={handleClose} />
-				</ContextualbarActions>
-			</ContextualbarHeader>
-
-			{(mainMessageQueryResult.isLoading && <ThreadSkeleton />) ||
-				(mainMessageQueryResult.isSuccess && (
-					<ChatProvider tmid={tmid}>
-						<ThreadChat mainMessage={mainMessageQueryResult.data} />
-					</ChatProvider>
-				)) ||
-				null}
-		</Contextualbar>
-	);
-
 	return (
 		<ContextualbarDialog>
 			<ContextualbarInnerContent>
-				{portalTarget ? (
-					createPortal(
-						<>
-							<ModalBackdrop
-								className={css`
-									position: absolute !important;
-								`}
-								onClick={handleBackdropClick}
-							/>
-							{threadContent}
-						</>,
-						portalTarget,
-					)
-				) : (
-					<Box flexGrow={1} position='relative'>
-						{threadContent}
-					</Box>
-				)}
+				{canExpand && expanded && <ModalBackdrop onClick={handleBackdropClick} />}
+				<Box flexGrow={1} position={expanded ? 'static' : 'relative'}>
+					<Contextualbar
+						rcx-thread-view
+						className={
+							canExpand && expanded
+								? css`
+										max-width: 855px !important;
+										@media (min-width: 780px) and (max-width: 1135px) {
+											max-width: calc(100% - var(--sidebar-width)) !important;
+										}
+									`
+								: undefined
+						}
+						position={expanded ? 'fixed' : 'absolute'}
+						display='flex'
+						flexDirection='column'
+						width='full'
+						overflow='hidden'
+						zIndex={100}
+						insetBlock={0}
+						border='none'
+					>
+						<ContextualbarHeader>
+							<ContextualbarBack onClick={handleGoBack} />
+							{(mainMessageQueryResult.isLoading && <Skeleton width='100%' />) ||
+								(mainMessageQueryResult.isSuccess && <ThreadTitle mainMessage={mainMessageQueryResult.data} />) ||
+								null}
+							<ContextualbarActions>
+								{canExpand && (
+									<ContextualbarAction
+										name={expanded ? 'arrow-collapse' : 'arrow-expand'}
+										title={expanded ? t('Collapse') : t('Expand')}
+										onClick={handleToggleExpand}
+									/>
+								)}
+								<ContextualbarAction
+									name={following ? 'bell' : 'bell-off'}
+									title={following ? t('Following') : t('Not_Following')}
+									disabled={!mainMessageQueryResult.isSuccess || toggleFollowingMutation.isPending}
+									onClick={handleToggleFollowing}
+								/>
+								<ContextualbarClose onClick={handleClose} />
+							</ContextualbarActions>
+						</ContextualbarHeader>
+
+						{(mainMessageQueryResult.isLoading && <ThreadSkeleton />) ||
+							(mainMessageQueryResult.isSuccess && (
+								<ChatProvider tmid={tmid}>
+									<ThreadChat mainMessage={mainMessageQueryResult.data} />
+								</ChatProvider>
+							)) ||
+							null}
+					</Contextualbar>
+				</Box>
 			</ContextualbarInnerContent>
 		</ContextualbarDialog>
 	);


### PR DESCRIPTION
## Proposed changes

This PR fixes the issue where clicking on a "Message removed" placeholder opens a thread view that becomes unresponsive and cannot be closed.

### Fix Details:

* Added a condition to prevent opening a thread for deleted messages.
* Ensured that the thread state resets properly when switching between messages.
* Prevented stale thread context from persisting across interactions.

### Before:

* Clicking on a deleted message opened a broken thread view.
* User could not close the thread.
* Other threads also showed incorrect/stale data.

### After:

* Clicking on a deleted message no longer opens a thread.
* Thread panel behaves correctly and closes as expected.
* No stale data persists when switching threads.

---

## Issue(s)

Closes #39908

---

## Steps to test or reproduce

1. Go to any channel with a deleted message ("Message removed").

2. Click on the deleted message.

3. Verify that no thread opens.

4. Click on a valid message thread.

5. Switch between multiple threads.

6. Ensure:

   * Thread opens correctly
   * Thread closes properly
   * No stale content is shown

---

## Further comments

This fix ensures better UI consistency and prevents users from getting stuck in an unresponsive thread view.

The solution avoids unnecessary rendering of thread components for invalid messages and ensures proper cleanup of thread state.

No breaking changes introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Thread tabs now automatically close when the viewed message has been deleted or removed, preventing errors.
  * Enhanced the thread panel's layout and positioning behavior when expanding threads for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->