### PR TITLE
fix: show disabled status when `Presence_broadcast_disabled` is enabled

### DIFF
--- a/.changeset/long-years-flow.md
+++ b/.changeset/long-years-flow.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes user status indicator to show disabled state when presence broadcast is turned off

--- a/apps/meteor/client/lib/presence.spec.ts
+++ b/apps/meteor/client/lib/presence.spec.ts
@@ -1,0 +1,51 @@
+import { UserStatus } from '@rocket.chat/core-typings';
+
+import { Presence } from './presence';
+
+jest.mock('meteor/meteor', () => ({
+	Meteor: {
+		subscribe: jest.fn(),
+	},
+}));
+
+const mockGet = jest.fn();
+
+jest.mock('../../app/utils/client/lib/SDKClient', () => ({
+	sdk: {
+		rest: {
+			get: (...args: unknown[]) => mockGet(...args),
+		},
+	},
+}));
+
+describe('Presence fallback status', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		jest.useFakeTimers();
+		Presence.store.clear();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('should use DISABLED as fallback when status is set to disabled', async () => {
+		mockGet.mockResolvedValue({ users: [] });
+		Presence.setStatus('disabled');
+
+		Presence.listen('user1', jest.fn());
+		await jest.advanceTimersByTimeAsync(500);
+
+		expect(Presence.store.get('user1')?.status).toBe(UserStatus.DISABLED);
+	});
+
+	it('should use OFFLINE as fallback when status is set to enabled', async () => {
+		mockGet.mockResolvedValue({ users: [] });
+		Presence.setStatus('enabled');
+
+		Presence.listen('user1', jest.fn());
+		await jest.advanceTimersByTimeAsync(500);
+
+		expect(Presence.store.get('user1')?.status).toBe(UserStatus.OFFLINE);
+	});
+});

--- a/apps/meteor/client/lib/presence.ts
+++ b/apps/meteor/client/lib/presence.ts
@@ -73,6 +73,8 @@ const getPresence = ((): ((uid: UserPresence['_id']) => void) => {
 
 				const { users } = await sdk.rest.get('/v1/users.presence', params);
 
+				const fallbackStatus = status === 'disabled' ? UserStatus.DISABLED : UserStatus.OFFLINE;
+
 				users.forEach((user) => {
 					if (!store.has(user._id)) {
 						notify(user);
@@ -81,7 +83,7 @@ const getPresence = ((): ((uid: UserPresence['_id']) => void) => {
 				});
 
 				currentUids.forEach((uid) => {
-					notify({ _id: uid, status: UserStatus.OFFLINE });
+					notify({ _id: uid, status: fallbackStatus });
 				});
 
 				currentUids.clear();

--- a/apps/meteor/server/modules/listeners/listeners.module.ts
+++ b/apps/meteor/server/modules/listeners/listeners.module.ts
@@ -162,6 +162,10 @@ export class ListenersModule {
 				return;
 			}
 
+			if (settings.get('Presence_broadcast_disabled')) {
+				return;
+			}
+
 			notifications.notifyUserInThisInstance(_id, 'userData', {
 				type: 'updated',
 				id: _id,


### PR DESCRIPTION
### Proposed changes (including videos or screenshots)

When `Presence_broadcast_disabled=true` (triggered automatically with 200+ connections without Premium license), users were seeing their last known status instead of grey/disabled dots.

**Root cause:**
1. Client expected API to return data that would trigger DISABLED status logic
2. API correctly returns empty array `{ users: [] }` when disabled
3. But the existing fallback only applied OFFLINE, not DISABLED
4. Additionally, WebSocket broadcasts were still being sent via direct `api.broadcast()` calls that bypassed the `Presence.broadcastEnabled` check

**Fix:**
- **Client** (`presence.ts`): Use DISABLED as fallback status when presence is disabled, OFFLINE otherwise
- **Server** (`listeners.module.ts`): Block presence WebSocket events when `Presence_broadcast_disabled` is true
- **Tests**: Added 2 minimal tests for fallback status behavior

### Issue(s)

- [PRES-14](https://rocketchat.atlassian.net/browse/PRES-14)

### Steps to test or reproduce

1. Set `Presence_broadcast_disabled` to `true` in MongoDB:
   ```javascript
   db.rocketchat_settings.updateOne(
     { _id: 'Presence_broadcast_disabled' },
     { $set: { value: true } }
   )
   ```
2. Open two browser sessions with different users
3. Observe that user avatars show grey/disabled dots (not online/away/etc.)
4. Change status on User A → User B should NOT see the update (still grey dot)
5. Set the setting back to `false` and verify normal presence resumes

### Further comments

**Why the fix is in `listeners.module.ts` instead of at each broadcast source:**

Multiple places broadcast `presence.status` directly, bypassing `Presence.broadcast()`:
- `app/api/server/v1/users.ts`
- `app/lib/server/functions/setStatusText.ts`
- `server/services/calendar/statusEvents/applyStatusChange.ts`

The listener is the central gatekeeper - any new code broadcasting presence events will automatically be blocked when disabled, without needing to remember to add checks everywhere.

[PRES-14]: https://rocketchat.atlassian.net/browse/PRES-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed user status display when presence broadcasting is disabled. The status indicator now correctly displays a disabled state instead of showing offline for affected users, ensuring accurate status visibility throughout the application.

* **Tests**
  * Added comprehensive test coverage for presence status behavior validation to ensure correct handling of disabled and enabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->