### PR TITLE
fix: slack importer not importing messages correctly

### DIFF
--- a/.changeset/mean-mails-pay.md
+++ b/.changeset/mean-mails-pay.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes Slack messages being incorrectly saved on import

--- a/apps/meteor/app/importer/server/classes/converters/MessageConverter.ts
+++ b/apps/meteor/app/importer/server/classes/converters/MessageConverter.ts
@@ -1,5 +1,6 @@
 import type { IImportMessageRecord, IMessage as IDBMessage, IImportMessage, IImportMessageReaction } from '@rocket.chat/core-typings';
 import { Rooms } from '@rocket.chat/models';
+import { removeEmpty } from '@rocket.chat/tools';
 import limax from 'limax';
 
 import type { UserIdentification, MentionedChannel } from './ConverterCache';
@@ -84,7 +85,7 @@ export class MessageConverter extends RecordConverter<IImportMessageRecord> {
 		const mentions = data.mentions && (await this.convertMessageMentions(data));
 		const channels = data.channels && (await this.convertMessageChannels(data));
 
-		return {
+		return removeEmpty({
 			rid,
 			u: {
 				_id: creator._id,
@@ -110,7 +111,7 @@ export class MessageConverter extends RecordConverter<IImportMessageRecord> {
 			alias: data.alias,
 			...(data._id ? { _id: data._id } : {}),
 			...(data.reactions ? { reactions: await this.convertMessageReactions(data.reactions) } : {}),
-		};
+		});
 	}
 
 	protected async convertMessageChannels(message: IImportMessage): Promise<MentionedChannel[] | undefined> {

--- a/apps/meteor/tests/unit/app/importer/server/messageConverter.spec.ts
+++ b/apps/meteor/tests/unit/app/importer/server/messageConverter.spec.ts
@@ -92,6 +92,16 @@ describe('Message Converter', () => {
 				});
 		});
 
+		it('should not have properties with undefined values', async () => {
+			const converter = new MessageConverter({ workInMemory: true });
+
+			const converted = await converter.buildMessageObject(messageToImport, 'general', { _id: 'rocket.cat', username: 'rocket.cat' });
+
+			Object.entries(converted).forEach(([key, value]) => {
+				expect(value, `Property "${key}" should not be undefined`).to.not.be.undefined;
+			});
+		});
+
 		// #TODO: Validate all message attributes
 	});
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
**What is the issue?**
Currently, when importing messages from Slack, standard messages are being saved to the database with explicit `null` values for properties that should simply not exist (such as `tmid`, `tlm`, `editedBy`, and `t`). 
This is a regression caused by a global MongoDB configuration change (`ignoreUndefined: false`). Because the driver no longer drops `undefined` fields automatically, it serializes them as `null`. This breaks the frontend UI, causing standard messages to incorrectly display the "View Thread" button or fail to render properly.

**What is the solution?**
This PR fixes the issue at the application layer. I wrapped the return value of `buildMessageObject` inside `MessageConverter.ts` with the `@rocket.chat/tools` `removeEmpty` utility. This ensures that any `undefined` or `null` values naturally produced by the Slack parser are stripped from the payload *before* insertion, keeping the database records clean and restoring expected UI behavior.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-1195 Investigate Slack Import Not Importing Messages](https://rocketchat.atlassian.net/browse/CORE-1195)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Get a standard Slack export `.zip` file (make sure it contains regular messages, not just threads).
2. Start the Rocket.Chat local environment in this branch.
3. Go to **Administration > Workspace > Import > Click on `Import new file`**.
4. Select **Slack** and upload your `.zip` file.
5. Complete the import process.
6. Navigate to the imported channel.
7. Verify that standard messages render correctly.
8. **Crucial:** Ensure that standard messages do **not** display the "View Thread" button (this was the main symptom of `tlm` being saved as `null`).

### Database Verification (The real proof)
1. Open MongoDB Compass (or the Mongo shell) and connect to your local DB.
2. Query the `rocketchat_message` collection for the newly imported messages.
3. **Expected Result:** Fields like `tmid`, `tlm`, `t`, and `editedBy` should completely **omit** from the document, rather than existing with a `null` value.
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Slack messages were incorrectly saved during import

<!-- end of auto-generated comment: release notes by coderabbit.ai -->