### PR TITLE
fix: "Reply in direct message" action not visible for users with create DM permission 

### DIFF
--- a/.changeset/odd-needles-smash.md
+++ b/.changeset/odd-needles-smash.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes "Reply in direct message" action not being shown when user has permission to create DMs but no existing conversation exists.

--- a/apps/meteor/client/components/message/toolbar/useReplyInDMAction.ts
+++ b/apps/meteor/client/components/message/toolbar/useReplyInDMAction.ts
@@ -29,7 +29,7 @@ export const useReplyInDMAction = (
 		[message.u._id, user],
 	);
 
-	const shouldFindRoom = useMemo(() => !!user && canCreateDM && user._id !== message.u._id, [canCreateDM, message.u._id, user]);
+	const shouldFindRoom = useMemo(() => !!user && !canCreateDM && user._id !== message.u._id, [canCreateDM, message.u._id, user]);
 	const dmRoom = Rooms.use(useShallow((state) => (shouldFindRoom ? state.find(roomPredicate) : undefined)));
 
 	const subsPredicate = useCallback(
@@ -52,7 +52,7 @@ export const useReplyInDMAction = (
 		if (!subscription || room.t === 'd' || room.t === 'l' || isLayoutEmbedded) {
 			return false;
 		}
-		if (!!user && user._id !== message.u._id && canCreateDM) {
+		if (!!user && user._id !== message.u._id && !canCreateDM) {
 			if (!dmRoom || !dmSubs) {
 				return false;
 			}

--- a/apps/meteor/tests/e2e/message-actions.spec.ts
+++ b/apps/meteor/tests/e2e/message-actions.spec.ts
@@ -2,7 +2,7 @@ import { ADMIN_CREDENTIALS } from './config/constants';
 import { Users } from './fixtures/userStates';
 import { HomeChannel } from './page-objects';
 import { CreateNewDiscussionModal } from './page-objects/fragments';
-import { createTargetChannel, createTargetTeam } from './utils';
+import { createTargetChannel, createTargetTeam, sendTargetChannelMessage } from './utils';
 import { setUserPreferences } from './utils/setUserPreferences';
 import { expect, test } from './utils/test';
 
@@ -13,7 +13,7 @@ test.describe.serial('message-actions', () => {
 	let forwardChannel: string;
 	let forwardTeam: string;
 	test.beforeAll(async ({ api }) => {
-		targetChannel = await createTargetChannel(api);
+		targetChannel = await createTargetChannel(api, { members: ['user2'] });
 		forwardChannel = await createTargetChannel(api);
 		forwardTeam = await createTargetTeam(api);
 	});
@@ -21,13 +21,6 @@ test.describe.serial('message-actions', () => {
 		poHomeChannel = new HomeChannel(page);
 		await page.goto('/home');
 		await poHomeChannel.navbar.openChat(targetChannel);
-	});
-	test('expect reply the message in direct', async ({ page }) => {
-		await poHomeChannel.content.sendMessage('this is a message for reply in direct');
-		await poHomeChannel.content.openLastMessageMenu();
-		await page.locator('role=menuitem[name="Reply in direct message"]').click();
-
-		await expect(page).toHaveURL(/.*reply/);
 	});
 
 	test('expect reply the message', async ({ page }) => {
@@ -167,6 +160,38 @@ test.describe.serial('message-actions', () => {
 
 		const clipboardText = await page.evaluate('navigator.clipboard.readText()');
 		expect(clipboardText).toContain('http');
+	});
+
+	test.describe.serial('expect reply in direct message', () => {
+		test.use({ storageState: Users.user2.state });
+
+		test.beforeAll(async ({ api }) => {
+			await sendTargetChannelMessage(api, targetChannel, { msg: 'message from admin for reply in DM' });
+		});
+
+		test('expect option not be visible without create-d permission and no existing DM', async ({ page, api }) => {
+			expect((await api.post('/permissions.update', { permissions: [{ _id: 'create-d', roles: ['admin'] }] })).status()).toBe(200);
+
+			await poHomeChannel.content.openLastMessageMenu();
+			await expect(page.locator('role=menuitem[name="Reply in direct message"]')).toBeHidden();
+		});
+
+		test('expect option be visible and redirect to DM', async ({ page, api }) => {
+			expect(
+				(await api.post('/permissions.update', { permissions: [{ _id: 'create-d', roles: ['admin', 'user', 'bot', 'app'] }] })).status(),
+			).toBe(200);
+
+			await poHomeChannel.content.openLastMessageMenu();
+			await page.locator('role=menuitem[name="Reply in direct message"]').click();
+
+			await expect(page).toHaveURL(/.*reply/);
+		});
+
+		test.afterAll(async ({ api }) => {
+			expect(
+				(await api.post('/permissions.update', { permissions: [{ _id: 'create-d', roles: ['admin', 'user', 'bot', 'app'] }] })).status(),
+			).toBe(200);
+		});
 	});
 
 	test.describe('Preference Hide Contextual Bar by clicking outside of it Enabled', () => {

--- a/apps/meteor/tests/e2e/message-actions.spec.ts
+++ b/apps/meteor/tests/e2e/message-actions.spec.ts
@@ -165,12 +165,19 @@ test.describe.serial('message-actions', () => {
 	test.describe.serial('expect reply in direct message', () => {
 		test.use({ storageState: Users.user2.state });
 
-		let originalCreateDRoles: string[];
+		let defaultCreateDRoles: string[];
 
 		test.beforeAll(async ({ api }) => {
-			originalCreateDRoles = await getPermissionRoles(api, 'create-d');
+			defaultCreateDRoles = await getPermissionRoles(api, 'create-d');
 
 			await sendTargetChannelMessage(api, targetChannel, { msg: 'message from admin for reply in DM' });
+		});
+
+		test('expect option be visible and redirect to DM', async ({ page }) => {
+			await poHomeChannel.content.openLastMessageMenu();
+			await poHomeChannel.content.btnOptionReplyInDm.click();
+
+			await expect(page).toHaveURL(/.*reply/);
 		});
 
 		test('expect option not be visible without create-d permission and no existing DM', async ({ api }) => {
@@ -180,19 +187,8 @@ test.describe.serial('message-actions', () => {
 			await expect(poHomeChannel.content.btnOptionReplyInDm).toBeHidden();
 		});
 
-		test('expect option be visible and redirect to DM', async ({ page, api }) => {
-			expect((await api.post('/permissions.update', { permissions: [{ _id: 'create-d', roles: originalCreateDRoles }] })).status()).toBe(
-				200,
-			);
-
-			await poHomeChannel.content.openLastMessageMenu();
-			await poHomeChannel.content.btnOptionReplyInDm.click();
-
-			await expect(page).toHaveURL(/.*reply/);
-		});
-
 		test.afterAll(async ({ api }) => {
-			expect((await api.post('/permissions.update', { permissions: [{ _id: 'create-d', roles: originalCreateDRoles }] })).status()).toBe(
+			expect((await api.post('/permissions.update', { permissions: [{ _id: 'create-d', roles: defaultCreateDRoles }] })).status()).toBe(
 				200,
 			);
 		});

--- a/apps/meteor/tests/e2e/message-actions.spec.ts
+++ b/apps/meteor/tests/e2e/message-actions.spec.ts
@@ -2,7 +2,7 @@ import { ADMIN_CREDENTIALS } from './config/constants';
 import { Users } from './fixtures/userStates';
 import { HomeChannel } from './page-objects';
 import { CreateNewDiscussionModal } from './page-objects/fragments';
-import { createTargetChannel, createTargetTeam, sendTargetChannelMessage } from './utils';
+import { createTargetChannel, createTargetTeam, getPermissionRoles, sendTargetChannelMessage } from './utils';
 import { setUserPreferences } from './utils/setUserPreferences';
 import { expect, test } from './utils/test';
 
@@ -165,7 +165,11 @@ test.describe.serial('message-actions', () => {
 	test.describe.serial('expect reply in direct message', () => {
 		test.use({ storageState: Users.user2.state });
 
+		let originalCreateDRoles: string[];
+
 		test.beforeAll(async ({ api }) => {
+			originalCreateDRoles = await getPermissionRoles(api, 'create-d');
+
 			await sendTargetChannelMessage(api, targetChannel, { msg: 'message from admin for reply in DM' });
 		});
 
@@ -177,9 +181,9 @@ test.describe.serial('message-actions', () => {
 		});
 
 		test('expect option be visible and redirect to DM', async ({ page, api }) => {
-			expect(
-				(await api.post('/permissions.update', { permissions: [{ _id: 'create-d', roles: ['admin', 'user', 'bot', 'app'] }] })).status(),
-			).toBe(200);
+			expect((await api.post('/permissions.update', { permissions: [{ _id: 'create-d', roles: originalCreateDRoles }] })).status()).toBe(
+				200,
+			);
 
 			await poHomeChannel.content.openLastMessageMenu();
 			await poHomeChannel.content.btnOptionReplyInDm.click();
@@ -188,9 +192,9 @@ test.describe.serial('message-actions', () => {
 		});
 
 		test.afterAll(async ({ api }) => {
-			expect(
-				(await api.post('/permissions.update', { permissions: [{ _id: 'create-d', roles: ['admin', 'user', 'bot', 'app'] }] })).status(),
-			).toBe(200);
+			expect((await api.post('/permissions.update', { permissions: [{ _id: 'create-d', roles: originalCreateDRoles }] })).status()).toBe(
+				200,
+			);
 		});
 	});
 

--- a/apps/meteor/tests/e2e/message-actions.spec.ts
+++ b/apps/meteor/tests/e2e/message-actions.spec.ts
@@ -169,11 +169,11 @@ test.describe.serial('message-actions', () => {
 			await sendTargetChannelMessage(api, targetChannel, { msg: 'message from admin for reply in DM' });
 		});
 
-		test('expect option not be visible without create-d permission and no existing DM', async ({ page, api }) => {
+		test('expect option not be visible without create-d permission and no existing DM', async ({ api }) => {
 			expect((await api.post('/permissions.update', { permissions: [{ _id: 'create-d', roles: ['admin'] }] })).status()).toBe(200);
 
 			await poHomeChannel.content.openLastMessageMenu();
-			await expect(page.locator('role=menuitem[name="Reply in direct message"]')).toBeHidden();
+			await expect(poHomeChannel.content.btnOptionReplyInDm).toBeHidden();
 		});
 
 		test('expect option be visible and redirect to DM', async ({ page, api }) => {
@@ -182,7 +182,7 @@ test.describe.serial('message-actions', () => {
 			).toBe(200);
 
 			await poHomeChannel.content.openLastMessageMenu();
-			await page.locator('role=menuitem[name="Reply in direct message"]').click();
+			await poHomeChannel.content.btnOptionReplyInDm.click();
 
 			await expect(page).toHaveURL(/.*reply/);
 		});
@@ -209,7 +209,7 @@ test.describe.serial('message-actions', () => {
 		test('expect reply the message in direct', async ({ page }) => {
 			await poHomeChannel.content.sendMessage('this is a message for reply in direct');
 			await poHomeChannel.content.openLastMessageMenu();
-			await page.locator('role=menuitem[name="Reply in direct message"]').click();
+			await poHomeChannel.content.btnOptionReplyInDm.click();
 
 			await expect(page).toHaveURL(/.*reply/);
 		});

--- a/apps/meteor/tests/e2e/page-objects/fragments/home-content.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/home-content.ts
@@ -313,6 +313,10 @@ export class HomeContent {
 		return this.menuMore.getByRole('menuitem', { name: 'Star', exact: true });
 	}
 
+	get btnOptionReplyInDm(): Locator {
+		return this.menuMore.getByRole('menuitem', { name: 'Reply in direct message', exact: true });
+	}
+
 	get btnVoiceCall(): Locator {
 		return this.primaryRoomActionsToolbar.getByRole('button', { name: 'Voice call' });
 	}

--- a/apps/meteor/tests/e2e/utils/getPermissionRoles.ts
+++ b/apps/meteor/tests/e2e/utils/getPermissionRoles.ts
@@ -1,0 +1,7 @@
+import type { BaseTest } from './test';
+
+export const getPermissionRoles = async (api: BaseTest['api'], permissionId: string): Promise<string[]> => {
+	const res = await api.get('/permissions.listAll');
+	const { update } = await res.json();
+	return update.find((p: { _id: string }) => p._id === permissionId)?.roles ?? [];
+};

--- a/apps/meteor/tests/e2e/utils/index.ts
+++ b/apps/meteor/tests/e2e/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './create-target-channel';
 export * from './setSettingValueById';
 export * from './getSettingValueById';
+export * from './getPermissionRoles';
 export * from './setUserPreferences';
 export * from './updateOwnUserInfo';


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Introduced here: #36217

Fixes the "Reply in direct message" action not being shown in the message menu when the user has `create-d` permission but no existing DM conversation exists with the message author.

The condition `canCreateDM` was changed to `!canCreateDM` in two places, restoring the original intended logic that was accidentally inverted during a previous refactor.

## Issue(s)
- [SUP-1020](https://rocketchat.atlassian.net/browse/SUP-1020)

## Steps to test or reproduce
1. Log in as a user with `create-d` permission
2. Open a group/channel conversation
3. Find a message from another user with whom no DM exists
4. Open the message action menu
5. Verify "Reply in direct message" is now shown
6. Click it and confirm the DM opens

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[SUP-1020]: https://rocketchat.atlassian.net/browse/SUP-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "Reply in direct message" action so it appears or is hidden correctly based on DM creation permissions.
  * Fixed quote attachments to render correctly when the client hostname differs from the server URL.

* **Tests**
  * Updated end-to-end and unit tests to cover permission-dependent visibility and navigation for "Reply in direct message" and improved URL/quote parsing coverage.

* **Chores**
  * Added patch release entries documenting the fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->