### PR TITLE
refactor: migrate Add Existing modal to GenericModal

### DIFF
--- a/apps/meteor/client/views/teams/contextualBar/channels/AddExistingModal/AddExistingModal.tsx
+++ b/apps/meteor/client/views/teams/contextualBar/channels/AddExistingModal/AddExistingModal.tsx
@@ -1,17 +1,10 @@
 import type { IRoom } from '@rocket.chat/core-typings';
 import {
 	Box,
-	Button,
 	Field,
 	FieldLabel,
-	Modal,
-	ModalClose,
-	ModalContent,
-	ModalFooter,
-	ModalFooterControllers,
-	ModalHeader,
-	ModalTitle,
 } from '@rocket.chat/fuselage';
+import { GenericModal } from '@rocket.chat/ui-client';
 import { useToastMessageDispatch, useEndpoint } from '@rocket.chat/ui-contexts';
 import { memo, useCallback } from 'react';
 import { useForm, Controller } from 'react-hook-form';
@@ -29,7 +22,6 @@ type AddExistingModalProps = {
 	reload?: () => void;
 };
 
-// TODO: Use GenericModal instead of Modal
 const AddExistingModal = ({ teamId, onClose, reload }: AddExistingModalProps) => {
 	const { t } = useTranslation();
 	const dispatchToastMessage = useToastMessageDispatch();
@@ -62,33 +54,28 @@ const AddExistingModal = ({ teamId, onClose, reload }: AddExistingModalProps) =>
 	);
 
 	return (
-		<Modal
+		<GenericModal
+			variant='warning'
 			aria-label={t('Team_Add_existing_channels')}
+			icon={null}
+			title={t('Team_Add_existing_channels')}
+			cancelText={t('Cancel')}
+			confirmText={t('Add')}
+			onCancel={onClose}
+			onClose={onClose}
+			onDismiss={onClose}
+			confirmDisabled={!isDirty}
 			wrapperFunction={(props) => <Box is='form' onSubmit={handleSubmit(handleAddChannels)} {...props} />}
 		>
-			<ModalHeader>
-				<ModalTitle>{t('Team_Add_existing_channels')}</ModalTitle>
-				<ModalClose onClick={onClose} />
-			</ModalHeader>
-			<ModalContent>
-				<Field mbe={24}>
-					<FieldLabel>{t('Channels')}</FieldLabel>
-					<Controller
-						control={control}
-						name='rooms'
-						render={({ field: { value, onChange } }) => <RoomsAvailableForTeamsAutoComplete value={value} onChange={onChange} />}
-					/>
-				</Field>
-			</ModalContent>
-			<ModalFooter>
-				<ModalFooterControllers>
-					<Button onClick={onClose}>{t('Cancel')}</Button>
-					<Button disabled={!isDirty} type='submit' primary>
-						{t('Add')}
-					</Button>
-				</ModalFooterControllers>
-			</ModalFooter>
-		</Modal>
+			<Field mbe={24}>
+				<FieldLabel>{t('Channels')}</FieldLabel>
+				<Controller
+					control={control}
+					name='rooms'
+					render={({ field: { value, onChange } }) => <RoomsAvailableForTeamsAutoComplete value={value} onChange={onChange} />}
+				/>
+			</Field>
+		</GenericModal>
 	);
 };
 


### PR DESCRIPTION
Refactors the Add Existing Channels modal to use `GenericModal` instead of manually composing `Modal` sections, while preserving the same user behavior and flow.

Closes  #40068 

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized the Add Existing Channels modal interface, upgrading the internal component structure for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->