### PR TITLE
fix: intermittent "Channel Not Joined" screen in embedded mode

### DIFF
--- a/.changeset/eight-clouds-count.md
+++ b/.changeset/eight-clouds-count.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes intermittent "Channel Not Joined" screen when opening rooms in embedded mode.

--- a/apps/meteor/client/views/room/RoomOpenerEmbedded.tsx
+++ b/apps/meteor/client/views/room/RoomOpenerEmbedded.tsx
@@ -1,8 +1,7 @@
-import type { RoomType } from '@rocket.chat/core-typings';
+import type { ISubscription, RoomType } from '@rocket.chat/core-typings';
 import { Box, States, StatesIcon, StatesSubtitle, StatesTitle } from '@rocket.chat/fuselage';
 import { Header } from '@rocket.chat/ui-client';
-import { useEndpoint, useStream, useUserId } from '@rocket.chat/ui-contexts';
-import { useQuery } from '@tanstack/react-query';
+import { useStream, useUserId } from '@rocket.chat/ui-contexts';
 import type { ReactElement } from 'react';
 import { lazy, Suspense, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -10,15 +9,12 @@ import { useTranslation } from 'react-i18next';
 import NotSubscribedRoom from './NotSubscribedRoom';
 import RoomSkeleton from './RoomSkeleton';
 import { useOpenRoom } from './hooks/useOpenRoom';
-import { LegacyRoomManager } from '../../../app/ui-utils/client';
 import { SubscriptionsCachedStore } from '../../cachedStores';
 import { getErrorMessage } from '../../lib/errorHandling';
 import { NotAuthorizedError } from '../../lib/errors/NotAuthorizedError';
 import { NotSubscribedToRoomError } from '../../lib/errors/NotSubscribedToRoomError';
 import { OldUrlRoomError } from '../../lib/errors/OldUrlRoomError';
 import { RoomNotFoundError } from '../../lib/errors/RoomNotFoundError';
-import { subscriptionsQueryKeys } from '../../lib/queryKeys';
-import { mapSubscriptionFromApi } from '../../lib/utils/mapSubscriptionFromApi';
 
 const RoomProvider = lazy(() => import('./providers/RoomProvider'));
 const RoomNotFound = lazy(() => import('./RoomNotFound'));
@@ -34,47 +30,23 @@ type RoomOpenerProps = {
 const RoomOpenerEmbedded = ({ type, reference }: RoomOpenerProps): ReactElement => {
 	const { data, error, isSuccess, isError, isLoading } = useOpenRoom({ type, reference });
 	const uid = useUserId();
-
-	const getSubscription = useEndpoint('GET', '/v1/subscriptions.getOne');
-
 	const subscribeToNotifyUser = useStream('notify-user');
 
 	const rid = data?.rid;
-	const { data: subscriptionData, refetch } = useQuery({
-		queryKey: rid ? subscriptionsQueryKeys.subscription(rid) : [],
-		queryFn: () => {
-			if (!rid) {
-				throw new Error('Room not found');
-			}
-			return getSubscription({ roomId: rid });
-		},
-		enabled: !!rid,
-	});
 
 	useEffect(() => {
-		if (!subscriptionData?.subscription) {
+		if (!uid || !rid) {
 			return;
 		}
 
-		SubscriptionsCachedStore.upsertSubscription(mapSubscriptionFromApi(subscriptionData.subscription));
-
-		// yes this must be done here, this is already called in useOpenRoom, but it skips subscription streams because of the subscriptions list is empty
-		// now that we inserted the subscription, we can open the room
-		LegacyRoomManager.open({ typeName: type + reference, rid: subscriptionData.subscription.rid });
-	}, [subscriptionData, type, rid, reference]);
-
-	useEffect(() => {
-		if (!uid) {
-			return;
-		}
 		return subscribeToNotifyUser(`${uid}/subscriptions-changed`, (event, sub) => {
 			if (sub.rid !== rid || event === 'removed') {
 				return;
 			}
 
-			refetch();
+			SubscriptionsCachedStore.upsertSubscription(sub as ISubscription);
 		});
-	}, [refetch, rid, subscribeToNotifyUser, uid]);
+	}, [rid, subscribeToNotifyUser, uid]);
 
 	const { t } = useTranslation();
 

--- a/apps/meteor/client/views/root/MainLayout/EmbeddedPreload.tsx
+++ b/apps/meteor/client/views/root/MainLayout/EmbeddedPreload.tsx
@@ -39,7 +39,7 @@ const EmbeddedPreload = ({ children }: { children: ReactNode }): ReactElement =>
 
 	const shouldFetch = !!roomParams && !!uid;
 
-	const { isLoading } = useQuery({
+	const { isLoading, isSuccess, isError } = useQuery({
 		queryKey: roomParams ? roomsQueryKeys.roomReference(roomParams.reference, roomParams.type, uid ?? undefined) : [],
 		queryFn: async () => {
 			if (!roomParams) {
@@ -63,11 +63,11 @@ const EmbeddedPreload = ({ children }: { children: ReactNode }): ReactElement =>
 	});
 
 	useEffect(() => {
-		if (!shouldFetch || !isLoading) {
+		if (!shouldFetch || isSuccess || isError) {
 			SubscriptionsCachedStore.setReady(true);
 			RoomsCachedStore.setReady(true);
 		}
-	}, [shouldFetch, isLoading]);
+	}, [shouldFetch, isSuccess, isError]);
 
 	if (!ready || (shouldFetch && isLoading)) {
 		return <PageLoading />;

--- a/apps/meteor/client/views/root/MainLayout/EmbeddedPreload.tsx
+++ b/apps/meteor/client/views/root/MainLayout/EmbeddedPreload.tsx
@@ -1,19 +1,75 @@
+import { useEndpoint, useMethod, useRouter, useUserId } from '@rocket.chat/ui-contexts';
+import { useQuery } from '@tanstack/react-query';
 import type { ReactElement, ReactNode } from 'react';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { RoomsCachedStore, SubscriptionsCachedStore } from '../../../cachedStores';
+import { roomsQueryKeys } from '../../../lib/queryKeys';
+import { roomCoordinator } from '../../../lib/rooms/roomCoordinator';
+import { mapSubscriptionFromApi } from '../../../lib/utils/mapSubscriptionFromApi';
 import PageLoading from '../PageLoading';
 import { useMainReady } from '../hooks/useMainReady';
 
 const EmbeddedPreload = ({ children }: { children: ReactNode }): ReactElement => {
 	const ready = useMainReady();
+	const router = useRouter();
+	const uid = useUserId();
+
+	const roomParams = useMemo(() => {
+		const routeName = router.getRouteName();
+		if (!routeName) {
+			return null;
+		}
+
+		const identifier = roomCoordinator.getRouteNameIdentifier(routeName);
+		if (!identifier) {
+			return null;
+		}
+
+		const directives = roomCoordinator.getRoomDirectives(identifier);
+		if (!directives?.extractOpenRoomParams) {
+			return null;
+		}
+
+		return directives.extractOpenRoomParams(router.getRouteParameters());
+	}, [router]);
+
+	const getRoomByTypeAndName = useMethod('getRoomByTypeAndName');
+	const getSubscription = useEndpoint('GET', '/v1/subscriptions.getOne');
+
+	const shouldFetch = !!roomParams && !!uid;
+
+	const { isLoading } = useQuery({
+		queryKey: roomParams ? roomsQueryKeys.roomReference(roomParams.reference, roomParams.type, uid ?? undefined) : [],
+		queryFn: async () => {
+			if (!roomParams) {
+				return null;
+			}
+
+			const roomData = await getRoomByTypeAndName(roomParams.type, roomParams.reference);
+			if (!roomData?._id) {
+				return null;
+			}
+
+			const subResult = await getSubscription({ roomId: roomData._id });
+			if (subResult.subscription) {
+				SubscriptionsCachedStore.upsertSubscription(mapSubscriptionFromApi(subResult.subscription));
+			}
+
+			return subResult;
+		},
+		enabled: shouldFetch,
+		retry: false,
+	});
 
 	useEffect(() => {
-		SubscriptionsCachedStore.setReady(true);
-		RoomsCachedStore.setReady(true);
-	}, [ready]);
+		if (!shouldFetch || !isLoading) {
+			SubscriptionsCachedStore.setReady(true);
+			RoomsCachedStore.setReady(true);
+		}
+	}, [shouldFetch, isLoading]);
 
-	if (!ready) {
+	if (!ready || (shouldFetch && isLoading)) {
 		return <PageLoading />;
 	}
 


### PR DESCRIPTION
## Proposed changes

In embedded mode, `EmbeddedPreload` was calling `SubscriptionsCachedStore.setReady(true)` before `init()` finished loading subscription data. If `useOpenRoom` checked `Subscriptions.state` before `init()` populated it, `sub` was undefined - causing `NotSubscribedToRoomError` and a "Channel Not Joined" screen on public channels for users without `preview-c-room` permission.

This PR moves subscription fetching into `EmbeddedPreload`, ensuring data is cached **before** marking the store as ready. `RoomOpenerEmbedded` is simplified to only listen for real-time updates via `notify-user`.

## Issue(s)
- [CORE-1555](https://rocketchat.atlassian.net/browse/CORE-1555)

## Steps to test or reproduce

1. Use a **non-admin user** (without `preview-c-room` permission) who is a member of a public channel.
2. Open the channel directly in embedded mode: `/channel/general?layout=embedded`
3. **Before**: "Channel Not Joined" screen (more reliable in CI). **After**: Room loads correctly.

[CORE-1555]: https://rocketchat.atlassian.net/browse/CORE-1555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent "Channel Not Joined" screen issue when opening public channels in embedded mode for non-admin users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
