### PR TITLE
fix: quote attachments not rendering when client hostname differs from `Site_Url`

### DIFF
--- a/.changeset/shy-pillows-repair.md
+++ b/.changeset/shy-pillows-repair.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes quote attachments not rendering when client hostname differs from Site_Url

--- a/apps/meteor/server/services/messages/hooks/BeforeSaveJumpToMessage.ts
+++ b/apps/meteor/server/services/messages/hooks/BeforeSaveJumpToMessage.ts
@@ -1,10 +1,14 @@
-import QueryString from 'querystring';
 import URL from 'url';
 
-import type { MessageAttachment, IMessage, IUser, IOmnichannelRoom, IRoom } from '@rocket.chat/core-typings';
+import type { MessageAttachment, MessageUrl, IMessage, IUser, IOmnichannelRoom, IRoom } from '@rocket.chat/core-typings';
 import { isOmnichannelRoom, isQuoteAttachment } from '@rocket.chat/core-typings';
 
 import { createQuoteAttachment } from '../../../../lib/createQuoteAttachment';
+
+const getMessageIdFromUrl = (url: string): string | undefined => {
+	const { query } = URL.parse(url, true);
+	return typeof query?.msg === 'string' ? query.msg : undefined;
+};
 
 const recursiveRemoveAttachments = (attachments: MessageAttachment, deep = 1, quoteChainLimit: number): MessageAttachment => {
 	if (attachments && isQuoteAttachment(attachments)) {
@@ -80,7 +84,6 @@ export class BeforeSaveJumpToMessage {
 		user: Pick<IUser, '_id' | 'username' | 'name' | 'language'>;
 		config: {
 			chainLimit: number;
-			siteUrl: string;
 			useRealName: boolean;
 		};
 	}): Promise<IMessage> {
@@ -92,27 +95,15 @@ export class BeforeSaveJumpToMessage {
 			return message;
 		}
 
-		const linkedMessages = message.urls
-			.filter((item) => item.url.includes(config.siteUrl))
-			.map((item) => {
-				const urlObj = URL.parse(item.url);
+		const linkedMessages: { msgId: string; urlItem: MessageUrl }[] = [];
+		for (const urlItem of message.urls) {
+			const msgId = getMessageIdFromUrl(urlItem.url);
+			if (msgId) {
+				linkedMessages.push({ msgId, urlItem });
+			}
+		}
 
-				// if the URL doesn't have query params (doesn't reference message) skip
-				if (!urlObj.query) {
-					return;
-				}
-
-				const { msg: msgId } = QueryString.parse(urlObj.query);
-
-				if (typeof msgId !== 'string') {
-					return;
-				}
-
-				return { msgId, url: item.url };
-			})
-			.filter(Boolean);
-
-		const msgs = await this.getMessages(linkedMessages.map((linkedMsg) => linkedMsg?.msgId) as string[]);
+		const msgs = await this.getMessages(linkedMessages.map((linkedMsg) => linkedMsg.msgId));
 
 		const validMessages = msgs.filter((msg) => validateAttachmentDeepness(msg, config.chainLimit));
 
@@ -138,17 +129,8 @@ export class BeforeSaveJumpToMessage {
 
 		const quotes = [];
 
-		for (const item of message.urls) {
-			if (!item.url.includes(config.siteUrl)) {
-				continue;
-			}
-
-			const linkedMessage = linkedMessages.find((msg) => msg?.url === item.url);
-			if (!linkedMessage) {
-				continue;
-			}
-
-			const messageFromUrl = validMessages.find((msg) => msg._id === linkedMessage.msgId);
+		for (const { msgId, urlItem } of linkedMessages) {
+			const messageFromUrl = validMessages.find((msg) => msg._id === msgId);
 			if (!messageFromUrl) {
 				continue;
 			}
@@ -157,9 +139,10 @@ export class BeforeSaveJumpToMessage {
 				continue;
 			}
 
-			item.ignoreParse = true;
+			// prevent OEmbed from also fetching this URL for a link preview
+			urlItem.ignoreParse = true;
 
-			quotes.push(createQuoteAttachment(messageFromUrl, item.url, useRealName, this.getUserAvatarURL(messageFromUrl.u.username)));
+			quotes.push(createQuoteAttachment(messageFromUrl, urlItem.url, useRealName, this.getUserAvatarURL(messageFromUrl.u.username)));
 		}
 
 		if (quotes.length > 0) {

--- a/apps/meteor/server/services/messages/service.ts
+++ b/apps/meteor/server/services/messages/service.ts
@@ -254,7 +254,6 @@ export class MessageService extends ServiceClassInternal implements IMessageServ
 			user,
 			config: {
 				chainLimit: settings.get<number>('Message_QuoteChainLimit'),
-				siteUrl: settings.get<string>('Site_Url'),
 				useRealName: settings.get<boolean>('UI_Use_Real_Name'),
 			},
 		});

--- a/apps/meteor/tests/unit/server/services/messages/hooks/BeforeSaveJumpToMessage.tests.ts
+++ b/apps/meteor/tests/unit/server/services/messages/hooks/BeforeSaveJumpToMessage.tests.ts
@@ -61,17 +61,13 @@ describe('Create attachments for message URLs', () => {
 		const message = await jumpToMessage.createAttachmentForMessageURLs({
 			message: createMessage('hey'),
 			user: createUser(),
-			config: {
-				chainLimit: 10,
-				siteUrl: 'https://open.rocket.chat',
-				useRealName: true,
-			},
+			config: { chainLimit: 10, useRealName: true },
 		});
 
 		return expect(message).to.not.have.property('urls');
 	});
 
-	it('should do nothing if URL is not from SiteUrl', async () => {
+	it('should do nothing if URL does not have a msg query parameter', async () => {
 		const jumpToMessage = new BeforeSaveJumpToMessage({
 			getMessages: async () => [createMessage('linked message', { _id: 'linked' })],
 			getRooms: async () => [createRoom()],
@@ -89,47 +85,14 @@ describe('Create attachments for message URLs', () => {
 				],
 			}),
 			user: createUser(),
-			config: {
-				chainLimit: 10,
-				siteUrl: 'https://open.rocket.chat',
-				useRealName: true,
-			},
+			config: { chainLimit: 10, useRealName: true },
 		});
 
 		expect(message).to.have.property('urls').of.length(1);
 		expect(message).to.not.have.property('attachments');
 	});
 
-	it('should do nothing if URL is from SiteUrl but not have a query string', async () => {
-		const jumpToMessage = new BeforeSaveJumpToMessage({
-			getMessages: async () => [createMessage('linked message', { _id: 'linked' })],
-			getRooms: async () => [createRoom()],
-			canAccessRoom: async () => true,
-			getUserAvatarURL: () => 'url',
-		});
-
-		const message = await jumpToMessage.createAttachmentForMessageURLs({
-			message: createMessage('hey', {
-				urls: [
-					{
-						url: 'https://open.rocket.chat',
-						meta: {},
-					},
-				],
-			}),
-			user: createUser(),
-			config: {
-				chainLimit: 10,
-				siteUrl: 'https://open.rocket.chat',
-				useRealName: true,
-			},
-		});
-
-		expect(message).to.have.property('urls').of.length(1);
-		expect(message).to.not.have.property('attachments');
-	});
-
-	it('should do nothing if URL is from SiteUrl but not have a msgId query string', async () => {
+	it('should do nothing if URL has a non-msg query parameter', async () => {
 		const jumpToMessage = new BeforeSaveJumpToMessage({
 			getMessages: async () => [createMessage('linked message', { _id: 'linked' })],
 			getRooms: async () => [createRoom()],
@@ -147,18 +110,74 @@ describe('Create attachments for message URLs', () => {
 				],
 			}),
 			user: createUser(),
-			config: {
-				chainLimit: 10,
-				siteUrl: 'https://open.rocket.chat',
-				useRealName: true,
-			},
+			config: { chainLimit: 10, useRealName: true },
 		});
 
 		expect(message).to.have.property('urls').of.length(1);
 		expect(message).to.not.have.property('attachments');
 	});
 
-	it('should do nothing if it do not find a msg from the URL', async () => {
+	it('should reject query parameter pollution (msg[$gt]=)', async () => {
+		const jumpToMessage = new BeforeSaveJumpToMessage({
+			getMessages: async () => [createMessage('linked message', { _id: 'linked' })],
+			getRooms: async () => [createRoom()],
+			canAccessRoom: async () => true,
+			getUserAvatarURL: () => 'url',
+		});
+
+		const message = await jumpToMessage.createAttachmentForMessageURLs({
+			message: createMessage('hey', {
+				urls: [
+					{
+						url: 'https://open.rocket.chat/?msg[$gt]=',
+						meta: {},
+					},
+				],
+			}),
+			user: createUser(),
+			config: { chainLimit: 10, useRealName: true },
+		});
+
+		expect(message).to.have.property('urls').of.length(1);
+		expect(message).to.not.have.property('attachments');
+	});
+
+	it('should create quote attachment even when client hostname differs from server (e.g. localhost vs 127.0.0.1)', async () => {
+		const jumpToMessage = new BeforeSaveJumpToMessage({
+			getMessages: async () => [createMessage('linked message', { _id: 'linked' })],
+			getRooms: async () => [createRoom()],
+			canAccessRoom: async () => true,
+			getUserAvatarURL: () => 'url',
+		});
+
+		const message = await jumpToMessage.createAttachmentForMessageURLs({
+			message: createMessage('hey', {
+				urls: [
+					{
+						url: 'http://localhost:3000/channel/general?msg=linked',
+						meta: {},
+					},
+				],
+			}),
+			user: createUser(),
+			config: { chainLimit: 10, useRealName: true },
+		});
+
+		expect(message).to.have.property('urls').and.to.have.lengthOf(1);
+
+		const [url] = message.urls ?? [];
+		expect(url).to.include({
+			url: 'http://localhost:3000/channel/general?msg=linked',
+			ignoreParse: true,
+		});
+
+		expect(message).to.have.property('attachments').and.to.have.lengthOf(1);
+
+		const [attachment] = message.attachments ?? [];
+		expect(attachment).to.have.property('text', 'linked message');
+	});
+
+	it('should do nothing if it does not find a message from the URL', async () => {
 		const jumpToMessage = new BeforeSaveJumpToMessage({
 			getMessages: async () => [],
 			getRooms: async () => [createRoom()],
@@ -176,11 +195,7 @@ describe('Create attachments for message URLs', () => {
 				],
 			}),
 			user: createUser(),
-			config: {
-				chainLimit: 10,
-				siteUrl: 'https://open.rocket.chat',
-				useRealName: true,
-			},
+			config: { chainLimit: 10, useRealName: true },
 		});
 
 		expect(message).to.have.property('urls').of.length(1);
@@ -205,18 +220,14 @@ describe('Create attachments for message URLs', () => {
 				],
 			}),
 			user: createUser(),
-			config: {
-				chainLimit: 10,
-				siteUrl: 'https://open.rocket.chat',
-				useRealName: true,
-			},
+			config: { chainLimit: 10, useRealName: true },
 		});
 
 		expect(message).to.have.property('urls').of.length(1);
 		expect(message).to.not.have.property('attachments');
 	});
 
-	it('should do nothing if user dont have access to the room of the message from the URL', async () => {
+	it('should do nothing if user does not have access to the room of the message from the URL', async () => {
 		const jumpToMessage = new BeforeSaveJumpToMessage({
 			getMessages: async () => [createMessage('linked message', { _id: 'linked' })],
 			getRooms: async () => [createRoom()],
@@ -234,11 +245,7 @@ describe('Create attachments for message URLs', () => {
 				],
 			}),
 			user: createUser(),
-			config: {
-				chainLimit: 10,
-				siteUrl: 'https://open.rocket.chat',
-				useRealName: true,
-			},
+			config: { chainLimit: 10, useRealName: true },
 		});
 
 		expect(message).to.have.property('urls').of.length(1);
@@ -272,11 +279,7 @@ describe('Create attachments for message URLs', () => {
 				],
 			}),
 			user: createUser(),
-			config: {
-				chainLimit: 10,
-				siteUrl: 'https://open.rocket.chat',
-				useRealName: true,
-			},
+			config: { chainLimit: 10, useRealName: true },
 		});
 
 		expect(message).to.have.property('urls').and.to.have.lengthOf(1);
@@ -317,11 +320,7 @@ describe('Create attachments for message URLs', () => {
 				],
 			}),
 			user: createUser(),
-			config: {
-				chainLimit: 10,
-				siteUrl: 'https://open.rocket.chat',
-				useRealName: true,
-			},
+			config: { chainLimit: 10, useRealName: true },
 		});
 
 		expect(message).to.have.property('attachments').and.to.have.lengthOf(0);
@@ -349,11 +348,7 @@ describe('Create attachments for message URLs', () => {
 				],
 			}),
 			user: createUser(),
-			config: {
-				chainLimit: 10,
-				siteUrl: 'https://open.rocket.chat',
-				useRealName: true,
-			},
+			config: { chainLimit: 10, useRealName: true },
 		});
 
 		expect(message).to.have.property('attachments').and.to.have.lengthOf(1);
@@ -379,11 +374,7 @@ describe('Create attachments for message URLs', () => {
 				],
 			}),
 			user: createUser(),
-			config: {
-				chainLimit: 10,
-				siteUrl: 'https://open.rocket.chat',
-				useRealName: true,
-			},
+			config: { chainLimit: 10, useRealName: true },
 		});
 
 		expect(message).to.have.property('urls').and.to.have.lengthOf(1);
@@ -453,7 +444,6 @@ describe('Create attachments for message URLs', () => {
 			user: createUser(),
 			config: {
 				chainLimit: 3,
-				siteUrl: 'https://open.rocket.chat',
 				useRealName: true,
 			},
 		});
@@ -536,7 +526,6 @@ describe('Create attachments for message URLs', () => {
 			user: createUser(),
 			config: {
 				chainLimit: 3,
-				siteUrl: 'https://open.rocket.chat',
 				useRealName: true,
 			},
 		});
@@ -567,11 +556,7 @@ describe('Create attachments for message URLs', () => {
 				token: 'livechatToken',
 			}),
 			user: createUser(),
-			config: {
-				chainLimit: 10,
-				siteUrl: 'https://open.rocket.chat',
-				useRealName: true,
-			},
+			config: { chainLimit: 10, useRealName: true },
 		});
 
 		expect(message).to.have.property('urls').and.to.have.lengthOf(1);
@@ -609,11 +594,7 @@ describe('Create attachments for message URLs', () => {
 				token: 'another-token',
 			}),
 			user: createUser(),
-			config: {
-				chainLimit: 10,
-				siteUrl: 'https://open.rocket.chat',
-				useRealName: true,
-			},
+			config: { chainLimit: 10, useRealName: true },
 		});
 
 		expect(message).to.have.property('urls').and.to.have.lengthOf(1);
@@ -653,7 +634,6 @@ describe('Create attachments for message URLs', () => {
 			user: createUser(),
 			config: {
 				chainLimit: 1,
-				siteUrl: 'https://open.rocket.chat',
 				useRealName: true,
 			},
 		});
@@ -708,7 +688,6 @@ describe('Create attachments for message URLs', () => {
 			user: createUser(),
 			config: {
 				chainLimit: 1,
-				siteUrl: 'https://open.rocket.chat',
 				useRealName: true,
 			},
 		});


### PR DESCRIPTION
## Proposed changes

Quote attachments (the quoted message block) were not rendered when the client hostname differed from the server's `Site_Url` setting (e.g. `localhost` vs `127.0.0.1`, or behind a reverse proxy).

The root cause was a strict `url.includes(siteUrl)` check in `BeforeSaveJumpToMessage` that silently dropped the quote URL when hostnames didn't match.

The fix replaces this with `getMessageIdFromUrl()`, which identifies quote permalinks by the `?msg=` query parameter instead. Security is preserved by the existing `getMessages` + `canAccessRoom` checks downstream. The `typeof` check on the query param also prevents NoSQL injection via parameter pollution (`?msg[$gt]=`).

## Issues

Reported here https://github.com/RocketChat/Rocket.Chat/pull/40078#issuecomment-4217736780.
- [CORE-2094](https://rocketchat.atlassian.net/browse/CORE-2094)

## Steps to test or reproduce

1. Set `Site_Url` to `http://127.0.0.1:3000`
2. Access Rocket.Chat via `http://localhost:3000`
3. Send a message in a channel
4. Click the message menu > Quote (or Reply in DM)
5. Send the reply
6. **Before fix:** the quoted message block does not appear
7. **After fix:** the quoted message block renders correctly

## Further comments

- Removed `siteUrl` from the `createAttachmentForMessageURLs` config since it's no longer used
- Removed `QueryString` import in favor of `URL.parse(url, true)` which parses query strings directly
- Added unit test for hostname mismatch scenario and query parameter pollution


[CORE-2094]: https://rocketchat.atlassian.net/browse/CORE-2094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed quote attachments failing to render when the client hostname differs from the Site_Url setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [CORE-2095]