### PR TITLE
regression: fix multiple compounding keys in sequence

### DIFF
--- a/apps/meteor/client/views/room/composer/messageBox/wrapSelection.spec.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/wrapSelection.spec.ts
@@ -1,0 +1,191 @@
+import { handleSelectionWrapping } from './wrapSelection';
+import type { ChatAPI, ComposerAPI } from '../../../../lib/chats/ChatAPI';
+
+const createTextarea = (value: string, selectionStart: number, selectionEnd: number): HTMLTextAreaElement => {
+	const textarea = document.createElement('textarea');
+	textarea.value = value;
+	textarea.selectionStart = selectionStart;
+	textarea.selectionEnd = selectionEnd;
+	return textarea;
+};
+
+const createMockComposer = (text: string): Pick<ComposerAPI, 'text' | 'wrapSelection'> => ({
+	text,
+	wrapSelection: jest.fn(() => ({ selectionStart: 0, selectionEnd: 0, value: '' })),
+});
+
+const createInputEvent = (textarea: HTMLTextAreaElement, data: string, isComposing = false): InputEvent => {
+	const event = new InputEvent('input', {
+		data,
+		inputType: 'insertText',
+		isComposing,
+		bubbles: true,
+		cancelable: true,
+	});
+
+	Object.defineProperty(event, 'target', { value: textarea, writable: false });
+
+	return event;
+};
+
+describe('handleSelectionWrapping', () => {
+	describe('dead key / IME composition scenarios', () => {
+		it('should NOT wrap when the selected text is the same character just typed (dead key double-press)', () => {
+			// Simulates: user presses ' twice on a Brazilian/international keyboard
+			// After composition ends, the browser has:
+			// - inserted the character ' into the textarea
+			// - selected it (selectionStart=0, selectionEnd=1)
+			// - fired an InputEvent with data="'"
+			const textarea = createTextarea("'", 0, 1);
+			const composer = createMockComposer("'");
+			const chat = { composer } as unknown as ChatAPI;
+
+			const event = createInputEvent(textarea, "'");
+
+			const result = handleSelectionWrapping(event, chat);
+
+			expect(result).toBe(false);
+			expect(composer.wrapSelection).not.toHaveBeenCalled();
+		});
+
+		it('should NOT wrap when dead key composition produces a character mid-text', () => {
+			// User is typing "hello'" — the dead key inserts ' and selects it
+			const textarea = createTextarea("hello'", 5, 6);
+			const composer = createMockComposer("hello'");
+			const chat = { composer } as unknown as ChatAPI;
+
+			const event = createInputEvent(textarea, "'");
+
+			const result = handleSelectionWrapping(event, chat);
+
+			expect(result).toBe(false);
+			expect(composer.wrapSelection).not.toHaveBeenCalled();
+		});
+
+		it('should NOT wrap when backtick dead key is pressed twice', () => {
+			const textarea = createTextarea('`', 0, 1);
+			const composer = createMockComposer('`');
+			const chat = { composer } as unknown as ChatAPI;
+
+			const event = createInputEvent(textarea, '`');
+
+			const result = handleSelectionWrapping(event, chat);
+
+			expect(result).toBe(false);
+			expect(composer.wrapSelection).not.toHaveBeenCalled();
+		});
+
+		it('should NOT wrap when tilde dead key is pressed twice', () => {
+			const textarea = createTextarea('˜', 0, 1);
+			const composer = createMockComposer('˜');
+			const chat = { composer } as unknown as ChatAPI;
+
+			const event = createInputEvent(textarea, '˜');
+
+			const result = handleSelectionWrapping(event, chat);
+
+			expect(result).toBe(false);
+			expect(composer.wrapSelection).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('legitimate wrapping scenarios', () => {
+		it('should wrap when user selects text and types a wrapping character', () => {
+			// User selects "hello" and types '
+			const textarea = createTextarea('hello', 0, 5);
+			const composer = createMockComposer('hello');
+			const chat = { composer } as unknown as ChatAPI;
+
+			const event = createInputEvent(textarea, "'");
+
+			const result = handleSelectionWrapping(event, chat);
+
+			expect(result).toBe(true);
+			expect(composer.wrapSelection).toHaveBeenCalledWith("'{{text}}'");
+		});
+
+		it('should wrap when user selects partial text and types a wrapping character', () => {
+			// User selects "world" in "hello world" and types *
+			const textarea = createTextarea('hello world', 6, 11);
+			const composer = createMockComposer('hello world');
+			const chat = { composer } as unknown as ChatAPI;
+
+			const event = createInputEvent(textarea, '*');
+
+			const result = handleSelectionWrapping(event, chat);
+
+			expect(result).toBe(true);
+			expect(composer.wrapSelection).toHaveBeenCalledWith('*{{text}}*');
+		});
+
+		it('should wrap with backtick when text is selected', () => {
+			const textarea = createTextarea('some code here', 5, 9);
+			const composer = createMockComposer('some code here');
+			const chat = { composer } as unknown as ChatAPI;
+
+			const event = createInputEvent(textarea, '`');
+
+			const result = handleSelectionWrapping(event, chat);
+
+			expect(result).toBe(true);
+			expect(composer.wrapSelection).toHaveBeenCalledWith('`{{text}}`');
+		});
+	});
+
+	describe('no-op scenarios', () => {
+		it('should return false when there is no selection (cursor only)', () => {
+			const textarea = createTextarea('hello', 3, 3);
+			const composer = createMockComposer('hello');
+			const chat = { composer } as unknown as ChatAPI;
+
+			const event = createInputEvent(textarea, "'");
+
+			const result = handleSelectionWrapping(event, chat);
+
+			expect(result).toBe(false);
+			expect(composer.wrapSelection).not.toHaveBeenCalled();
+		});
+
+		it('should return false when there is no composer', () => {
+			const textarea = createTextarea('hello', 0, 5);
+			const chat = {} as unknown as ChatAPI;
+
+			const event = createInputEvent(textarea, "'");
+
+			const result = handleSelectionWrapping(event, chat);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false for non-wrapping characters', () => {
+			const textarea = createTextarea('hello', 0, 5);
+			const composer = createMockComposer('hello');
+			const chat = { composer } as unknown as ChatAPI;
+
+			const event = createInputEvent(textarea, 'a');
+
+			const result = handleSelectionWrapping(event, chat);
+
+			expect(result).toBe(false);
+			expect(composer.wrapSelection).not.toHaveBeenCalled();
+		});
+
+		it('should return false when event.data is null', () => {
+			const textarea = createTextarea('hello', 0, 5);
+			const composer = createMockComposer('hello');
+			const chat = { composer } as unknown as ChatAPI;
+
+			const event = new InputEvent('input', {
+				data: null,
+				inputType: 'deleteContentBackward',
+				bubbles: true,
+			});
+			Object.defineProperty(event, 'target', { value: textarea, writable: false });
+
+			const result = handleSelectionWrapping(event, chat);
+
+			expect(result).toBe(false);
+			expect(composer.wrapSelection).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/apps/meteor/client/views/room/composer/messageBox/wrapSelection.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/wrapSelection.ts
@@ -30,6 +30,14 @@ export const handleSelectionWrapping = (event: InputEvent, chat: ChatAPI): boole
 	const input = event.target as HTMLTextAreaElement;
 	const { selectionStart, selectionEnd } = input;
 
+	const testSelection = input.value.slice(selectionStart, selectionEnd);
+	// if the selection is the same of the data, return false
+	if (testSelection === event.data) {
+		return false;
+	}
+	if (event.data === chat.composer?.text) {
+		return false;
+	}
 	if (selectionStart === selectionEnd) {
 		return false;
 	}


### PR DESCRIPTION
## Problem

On international keyboards (e.g. Brazilian ABNT), characters like `'`, `` ` ``, `~`, `^` are **dead keys**. To type them literally, the user must press the key **twice**. During this process:

1. The first keypress starts an IME composition — nothing visible happens yet.
2. The second keypress completes the composition, producing the actual character (e.g. `'`).
3. The browser fires an `InputEvent` where `event.data` is the composed character, and the textarea momentarily has a selection range covering that character (i.e. `selectionStart !== selectionEnd`).

The `handleSelectionWrapping` function was interpreting this temporary IME selection as an intentional text selection by the user, causing it to **wrap the character with itself** (e.g. turning `'` into `''`). This made it impossible to type dead key characters normally in the message composer.

## Solution

Added early-return guards in `handleSelectionWrapping` to detect and skip IME/dead key false positives:

- If the currently selected text is identical to `event.data`, it means the "selection" is just the IME composition artifact — not a real user selection. Return `false`.
- If `event.data` matches the entire composer text, it's also a composition side-effect. Return `false`.

These checks run before the existing `selectionStart === selectionEnd` guard, so legitimate wrapping (user selects text, then types a wrapping character) continues to work as expected.

## Test coverage

Added `wrapSelection.spec.ts` with 11 tests covering:
- **Dead key scenarios**: double-press of `'`, `` ` ``, `˜` — both at the start and mid-text
- **Legitimate wrapping**: confirms real selections still get wrapped correctly
- **No-op scenarios**: no selection, no composer, non-wrapping characters, null event data

## Steps to reproduce

1. Use a keyboard layout with dead keys (e.g. Brazilian Portuguese ABNT2)
2. Open any chat room in Rocket.Chat
3. Type any text in the message composer
4. Try to type a dead key character (e.g. `'` or `` ` ``) by pressing the key twice
5. **Before fix**: the character gets incorrectly wrapped (e.g. `'text'` or duplicated)
6. **After fix**: the character is inserted normally

[ARCH-2054](https://rocketchat.atlassian.net/browse/ARCH-2054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[ARCH-2054]: https://rocketchat.atlassian.net/browse/ARCH-2054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for message composer selection wrapping behavior validation across multiple input scenarios and edge cases, ensuring proper handling of international text input and composition contexts.

* **Bug Fixes**
  * Fixed message composer text wrapping issues that occurred during IME composition and dead-key input, improving stability for users with international keyboards and text input methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->