### PR TITLE
chore: slim barrel imports for react-aria, react-stately and zod (-799 KB)

### DIFF
--- a/.yarn/patches/react-aria-npm-3.37.0-83959bd2fa.patch
+++ b/.yarn/patches/react-aria-npm-3.37.0-83959bd2fa.patch
@@ -1,0 +1,316 @@
+diff --git a/dist/import.mjs b/dist/import.mjs
+index a13ba8b37e27230ec01d4c31140127912208666c..97d6aa506f273263c2a99a9bc80731ac2c38eea6 100644
+--- a/dist/import.mjs
++++ b/dist/import.mjs
+@@ -1,50 +1,14 @@
+-/*
+- * Copyright 2020 Adobe. All rights reserved.
+- * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+- * you may not use this file except in compliance with the License. You may obtain a copy
+- * of the License at http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing, software distributed under
+- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+- * OF ANY KIND, either express or implied. See the License for the specific language
+- * governing permissions and limitations under the License.
+- */
+-
+-export {useBreadcrumbItem, useBreadcrumbs} from '@react-aria/breadcrumbs';
+-export {useButton, useToggleButton, useToggleButtonGroup, useToggleButtonGroupItem} from '@react-aria/button';
+-export {useCalendar, useCalendarCell, useCalendarGrid, useRangeCalendar} from '@react-aria/calendar';
+-export {useCheckbox, useCheckboxGroup, useCheckboxGroupItem} from '@react-aria/checkbox';
+-export {useColorArea, useColorChannelField, useColorField, useColorSlider, useColorSwatch, useColorWheel} from '@react-aria/color';
+-export {useComboBox} from '@react-aria/combobox';
+-export {useDateField, useDatePicker, useDateRangePicker, useDateSegment, useTimeField} from '@react-aria/datepicker';
+-export {useDialog} from '@react-aria/dialog';
+-export {useDisclosure} from '@react-aria/disclosure';
+-export {useDrag, useDrop, useDraggableCollection, useDroppableCollection, useDroppableItem, useDropIndicator, useDraggableItem, useClipboard, DragPreview, ListDropTargetDelegate, DIRECTORY_DRAG_TYPE, isDirectoryDropItem, isFileDropItem, isTextDropItem} from '@react-aria/dnd';
++// Slim barrel: only exports actually used
++export {useButton} from '@react-aria/button';
+ export {FocusRing, FocusScope, useFocusManager, useFocusRing, useFocusable} from '@react-aria/focus';
+-export {I18nProvider, useCollator, useDateFormatter, useFilter, useLocale, useLocalizedStringFormatter, useMessageFormatter, useNumberFormatter} from '@react-aria/i18n';
++export {useNumberFormatter} from '@react-aria/i18n';
+ export {useFocus, useFocusVisible, useFocusWithin, useHover, useInteractOutside, useKeyboard, useMove, usePress, useLongPress} from '@react-aria/interactions';
+-export {useField, useLabel} from '@react-aria/label';
+-export {useGridList, useGridListItem, useGridListSelectionCheckbox} from '@react-aria/gridlist';
+-export {useLink} from '@react-aria/link';
+ export {useListBox, useListBoxSection, useOption} from '@react-aria/listbox';
+-export {useMenu, useMenuItem, useMenuSection, useMenuTrigger, useSubmenuTrigger} from '@react-aria/menu';
+-export {useMeter} from '@react-aria/meter';
+-export {useNumberField} from '@react-aria/numberfield';
+-export {DismissButton, ModalProvider, Overlay, OverlayContainer, OverlayProvider, useModal, useModalOverlay, useModalProvider, useOverlay, useOverlayPosition, useOverlayTrigger, usePopover, usePreventScroll} from '@react-aria/overlays';
+-export {useProgressBar} from '@react-aria/progress';
+-export {useRadio, useRadioGroup} from '@react-aria/radio';
+-export {useSearchField} from '@react-aria/searchfield';
+-export {HiddenSelect, useHiddenSelect, useSelect} from '@react-aria/select';
+-export {ListKeyboardDelegate} from '@react-aria/selection';
++export {useMenu, useMenuItem, useMenuSection, useMenuTrigger} from '@react-aria/menu';
++export {DismissButton, Overlay, useOverlayTrigger, usePopover} from '@react-aria/overlays';
++export {HiddenSelect, useSelect} from '@react-aria/select';
+ export {useSeparator} from '@react-aria/separator';
+-export {SSRProvider, useIsSSR} from '@react-aria/ssr';
+ export {useSlider, useSliderThumb} from '@react-aria/slider';
+-export {useSwitch} from '@react-aria/switch';
+-export {useTable, useTableCell, useTableColumnHeader, useTableColumnResize, useTableHeaderRow, useTableRow, useTableRowGroup, useTableSelectAllCheckbox, useTableSelectionCheckbox} from '@react-aria/table';
+-export {useTab, useTabList, useTabPanel} from '@react-aria/tabs';
+-export {useTag, useTagGroup} from '@react-aria/tag';
+-export {useTextField} from '@react-aria/textfield';
+-export {useTooltip, useTooltipTrigger} from '@react-aria/tooltip';
+-export {chain, mergeProps, useId, useObjectRef, RouterProvider} from '@react-aria/utils';
++export {chain, mergeProps, useId, useObjectRef} from '@react-aria/utils';
+ export {VisuallyHidden, useVisuallyHidden} from '@react-aria/visually-hidden';
+-
++export {useDialog} from '@react-aria/dialog';
+diff --git a/dist/main.js b/dist/main.js
+index b6a2ce3a780a09aeb416d7330ffcf6fd0b36b218..98e720a4660bdcd0384509786d04681a8ba98886 100644
+--- a/dist/main.js
++++ b/dist/main.js
+@@ -1,172 +1,15 @@
+ "use strict";
+-
+ exports.__esModule = true;
+-exports.useRadioGroup = exports.useRadio = exports.useProgressBar = exports.usePreventScroll = exports.usePress = exports.usePopover = exports.useOverlayTrigger = exports.useOverlayPosition = exports.useOverlay = exports.useOption = exports.useObjectRef = exports.useNumberFormatter = exports.useNumberField = exports.useMove = exports.useModalProvider = exports.useModalOverlay = exports.useModal = exports.useMeter = exports.useMessageFormatter = exports.useMenuTrigger = exports.useMenuSection = exports.useMenuItem = exports.useMenu = exports.useLongPress = exports.useLocalizedStringFormatter = exports.useLocale = exports.useListBoxSection = exports.useListBox = exports.useLink = exports.useLabel = exports.useKeyboard = exports.useIsSSR = exports.useInteractOutside = exports.useId = exports.useHover = exports.useHiddenSelect = exports.useGridListSelectionCheckbox = exports.useGridListItem = exports.useGridList = exports.useFocusable = exports.useFocusWithin = exports.useFocusVisible = exports.useFocusRing = exports.useFocusManager = exports.useFocus = exports.useFilter = exports.useField = exports.useDroppableItem = exports.useDroppableCollection = exports.useDropIndicator = exports.useDrop = exports.useDraggableItem = exports.useDraggableCollection = exports.useDrag = exports.useDisclosure = exports.useDialog = exports.useDateSegment = exports.useDateRangePicker = exports.useDatePicker = exports.useDateFormatter = exports.useDateField = exports.useComboBox = exports.useColorWheel = exports.useColorSwatch = exports.useColorSlider = exports.useColorField = exports.useColorChannelField = exports.useColorArea = exports.useCollator = exports.useClipboard = exports.useCheckboxGroupItem = exports.useCheckboxGroup = exports.useCheckbox = exports.useCalendarGrid = exports.useCalendarCell = exports.useCalendar = exports.useButton = exports.useBreadcrumbs = exports.useBreadcrumbItem = exports.mergeProps = exports.isTextDropItem = exports.isFileDropItem = exports.isDirectoryDropItem = exports.chain = exports.VisuallyHidden = exports.SSRProvider = exports.RouterProvider = exports.OverlayProvider = exports.OverlayContainer = exports.Overlay = exports.ModalProvider = exports.ListKeyboardDelegate = exports.ListDropTargetDelegate = exports.I18nProvider = exports.HiddenSelect = exports.FocusScope = exports.FocusRing = exports.DragPreview = exports.DismissButton = exports.DIRECTORY_DRAG_TYPE = void 0;
+-exports.useVisuallyHidden = exports.useTooltipTrigger = exports.useTooltip = exports.useToggleButtonGroupItem = exports.useToggleButtonGroup = exports.useToggleButton = exports.useTimeField = exports.useTextField = exports.useTagGroup = exports.useTag = exports.useTableSelectionCheckbox = exports.useTableSelectAllCheckbox = exports.useTableRowGroup = exports.useTableRow = exports.useTableHeaderRow = exports.useTableColumnResize = exports.useTableColumnHeader = exports.useTableCell = exports.useTable = exports.useTabPanel = exports.useTabList = exports.useTab = exports.useSwitch = exports.useSubmenuTrigger = exports.useSliderThumb = exports.useSlider = exports.useSeparator = exports.useSelect = exports.useSearchField = exports.useRangeCalendar = void 0;
+-var _breadcrumbs = require("@react-aria/breadcrumbs");
+-exports.useBreadcrumbItem = _breadcrumbs.useBreadcrumbItem;
+-exports.useBreadcrumbs = _breadcrumbs.useBreadcrumbs;
+-var _button = require("@react-aria/button");
+-exports.useButton = _button.useButton;
+-exports.useToggleButton = _button.useToggleButton;
+-exports.useToggleButtonGroup = _button.useToggleButtonGroup;
+-exports.useToggleButtonGroupItem = _button.useToggleButtonGroupItem;
+-var _calendar = require("@react-aria/calendar");
+-exports.useCalendar = _calendar.useCalendar;
+-exports.useCalendarCell = _calendar.useCalendarCell;
+-exports.useCalendarGrid = _calendar.useCalendarGrid;
+-exports.useRangeCalendar = _calendar.useRangeCalendar;
+-var _checkbox = require("@react-aria/checkbox");
+-exports.useCheckbox = _checkbox.useCheckbox;
+-exports.useCheckboxGroup = _checkbox.useCheckboxGroup;
+-exports.useCheckboxGroupItem = _checkbox.useCheckboxGroupItem;
+-var _color = require("@react-aria/color");
+-exports.useColorArea = _color.useColorArea;
+-exports.useColorChannelField = _color.useColorChannelField;
+-exports.useColorField = _color.useColorField;
+-exports.useColorSlider = _color.useColorSlider;
+-exports.useColorSwatch = _color.useColorSwatch;
+-exports.useColorWheel = _color.useColorWheel;
+-var _combobox = require("@react-aria/combobox");
+-exports.useComboBox = _combobox.useComboBox;
+-var _datepicker = require("@react-aria/datepicker");
+-exports.useDateField = _datepicker.useDateField;
+-exports.useDatePicker = _datepicker.useDatePicker;
+-exports.useDateRangePicker = _datepicker.useDateRangePicker;
+-exports.useDateSegment = _datepicker.useDateSegment;
+-exports.useTimeField = _datepicker.useTimeField;
+-var _dialog = require("@react-aria/dialog");
+-exports.useDialog = _dialog.useDialog;
+-var _disclosure = require("@react-aria/disclosure");
+-exports.useDisclosure = _disclosure.useDisclosure;
+-var _dnd = require("@react-aria/dnd");
+-exports.useDrag = _dnd.useDrag;
+-exports.useDrop = _dnd.useDrop;
+-exports.useDraggableCollection = _dnd.useDraggableCollection;
+-exports.useDroppableCollection = _dnd.useDroppableCollection;
+-exports.useDroppableItem = _dnd.useDroppableItem;
+-exports.useDropIndicator = _dnd.useDropIndicator;
+-exports.useDraggableItem = _dnd.useDraggableItem;
+-exports.useClipboard = _dnd.useClipboard;
+-exports.DragPreview = _dnd.DragPreview;
+-exports.ListDropTargetDelegate = _dnd.ListDropTargetDelegate;
+-exports.DIRECTORY_DRAG_TYPE = _dnd.DIRECTORY_DRAG_TYPE;
+-exports.isDirectoryDropItem = _dnd.isDirectoryDropItem;
+-exports.isFileDropItem = _dnd.isFileDropItem;
+-exports.isTextDropItem = _dnd.isTextDropItem;
+-var _focus = require("@react-aria/focus");
+-exports.FocusRing = _focus.FocusRing;
+-exports.FocusScope = _focus.FocusScope;
+-exports.useFocusManager = _focus.useFocusManager;
+-exports.useFocusRing = _focus.useFocusRing;
+-exports.useFocusable = _focus.useFocusable;
+-var _i18n = require("@react-aria/i18n");
+-exports.I18nProvider = _i18n.I18nProvider;
+-exports.useCollator = _i18n.useCollator;
+-exports.useDateFormatter = _i18n.useDateFormatter;
+-exports.useFilter = _i18n.useFilter;
+-exports.useLocale = _i18n.useLocale;
+-exports.useLocalizedStringFormatter = _i18n.useLocalizedStringFormatter;
+-exports.useMessageFormatter = _i18n.useMessageFormatter;
+-exports.useNumberFormatter = _i18n.useNumberFormatter;
+-var _interactions = require("@react-aria/interactions");
+-exports.useFocus = _interactions.useFocus;
+-exports.useFocusVisible = _interactions.useFocusVisible;
+-exports.useFocusWithin = _interactions.useFocusWithin;
+-exports.useHover = _interactions.useHover;
+-exports.useInteractOutside = _interactions.useInteractOutside;
+-exports.useKeyboard = _interactions.useKeyboard;
+-exports.useMove = _interactions.useMove;
+-exports.usePress = _interactions.usePress;
+-exports.useLongPress = _interactions.useLongPress;
+-var _label = require("@react-aria/label");
+-exports.useField = _label.useField;
+-exports.useLabel = _label.useLabel;
+-var _gridlist = require("@react-aria/gridlist");
+-exports.useGridList = _gridlist.useGridList;
+-exports.useGridListItem = _gridlist.useGridListItem;
+-exports.useGridListSelectionCheckbox = _gridlist.useGridListSelectionCheckbox;
+-var _link = require("@react-aria/link");
+-exports.useLink = _link.useLink;
+-var _listbox = require("@react-aria/listbox");
+-exports.useListBox = _listbox.useListBox;
+-exports.useListBoxSection = _listbox.useListBoxSection;
+-exports.useOption = _listbox.useOption;
+-var _menu = require("@react-aria/menu");
+-exports.useMenu = _menu.useMenu;
+-exports.useMenuItem = _menu.useMenuItem;
+-exports.useMenuSection = _menu.useMenuSection;
+-exports.useMenuTrigger = _menu.useMenuTrigger;
+-exports.useSubmenuTrigger = _menu.useSubmenuTrigger;
+-var _meter = require("@react-aria/meter");
+-exports.useMeter = _meter.useMeter;
+-var _numberfield = require("@react-aria/numberfield");
+-exports.useNumberField = _numberfield.useNumberField;
+-var _overlays = require("@react-aria/overlays");
+-exports.DismissButton = _overlays.DismissButton;
+-exports.ModalProvider = _overlays.ModalProvider;
+-exports.Overlay = _overlays.Overlay;
+-exports.OverlayContainer = _overlays.OverlayContainer;
+-exports.OverlayProvider = _overlays.OverlayProvider;
+-exports.useModal = _overlays.useModal;
+-exports.useModalOverlay = _overlays.useModalOverlay;
+-exports.useModalProvider = _overlays.useModalProvider;
+-exports.useOverlay = _overlays.useOverlay;
+-exports.useOverlayPosition = _overlays.useOverlayPosition;
+-exports.useOverlayTrigger = _overlays.useOverlayTrigger;
+-exports.usePopover = _overlays.usePopover;
+-exports.usePreventScroll = _overlays.usePreventScroll;
+-var _progress = require("@react-aria/progress");
+-exports.useProgressBar = _progress.useProgressBar;
+-var _radio = require("@react-aria/radio");
+-exports.useRadio = _radio.useRadio;
+-exports.useRadioGroup = _radio.useRadioGroup;
+-var _searchfield = require("@react-aria/searchfield");
+-exports.useSearchField = _searchfield.useSearchField;
+-var _select = require("@react-aria/select");
+-exports.HiddenSelect = _select.HiddenSelect;
+-exports.useHiddenSelect = _select.useHiddenSelect;
+-exports.useSelect = _select.useSelect;
+-var _selection = require("@react-aria/selection");
+-exports.ListKeyboardDelegate = _selection.ListKeyboardDelegate;
+-var _separator = require("@react-aria/separator");
+-exports.useSeparator = _separator.useSeparator;
+-var _ssr = require("@react-aria/ssr");
+-exports.SSRProvider = _ssr.SSRProvider;
+-exports.useIsSSR = _ssr.useIsSSR;
+-var _slider = require("@react-aria/slider");
+-exports.useSlider = _slider.useSlider;
+-exports.useSliderThumb = _slider.useSliderThumb;
+-var _switch = require("@react-aria/switch");
+-exports.useSwitch = _switch.useSwitch;
+-var _table = require("@react-aria/table");
+-exports.useTable = _table.useTable;
+-exports.useTableCell = _table.useTableCell;
+-exports.useTableColumnHeader = _table.useTableColumnHeader;
+-exports.useTableColumnResize = _table.useTableColumnResize;
+-exports.useTableHeaderRow = _table.useTableHeaderRow;
+-exports.useTableRow = _table.useTableRow;
+-exports.useTableRowGroup = _table.useTableRowGroup;
+-exports.useTableSelectAllCheckbox = _table.useTableSelectAllCheckbox;
+-exports.useTableSelectionCheckbox = _table.useTableSelectionCheckbox;
+-var _tabs = require("@react-aria/tabs");
+-exports.useTab = _tabs.useTab;
+-exports.useTabList = _tabs.useTabList;
+-exports.useTabPanel = _tabs.useTabPanel;
+-var _tag = require("@react-aria/tag");
+-exports.useTag = _tag.useTag;
+-exports.useTagGroup = _tag.useTagGroup;
+-var _textfield = require("@react-aria/textfield");
+-exports.useTextField = _textfield.useTextField;
+-var _tooltip = require("@react-aria/tooltip");
+-exports.useTooltip = _tooltip.useTooltip;
+-exports.useTooltipTrigger = _tooltip.useTooltipTrigger;
+-var _utils = require("@react-aria/utils");
+-exports.chain = _utils.chain;
+-exports.mergeProps = _utils.mergeProps;
+-exports.useId = _utils.useId;
+-exports.useObjectRef = _utils.useObjectRef;
+-exports.RouterProvider = _utils.RouterProvider;
+-var _visuallyHidden = require("@react-aria/visually-hidden");
+-exports.VisuallyHidden = _visuallyHidden.VisuallyHidden;
+-exports.useVisuallyHidden = _visuallyHidden.useVisuallyHidden;
++var _button = require("@react-aria/button"); exports.useButton = _button.useButton;
++var _focus = require("@react-aria/focus"); exports.FocusRing = _focus.FocusRing; exports.FocusScope = _focus.FocusScope; exports.useFocusManager = _focus.useFocusManager; exports.useFocusRing = _focus.useFocusRing; exports.useFocusable = _focus.useFocusable;
++var _i18n = require("@react-aria/i18n"); exports.useNumberFormatter = _i18n.useNumberFormatter;
++var _interactions = require("@react-aria/interactions"); exports.useFocus = _interactions.useFocus; exports.useFocusVisible = _interactions.useFocusVisible; exports.useFocusWithin = _interactions.useFocusWithin; exports.useHover = _interactions.useHover; exports.useInteractOutside = _interactions.useInteractOutside; exports.useKeyboard = _interactions.useKeyboard; exports.useMove = _interactions.useMove; exports.usePress = _interactions.usePress; exports.useLongPress = _interactions.useLongPress;
++var _listbox = require("@react-aria/listbox"); exports.useListBox = _listbox.useListBox; exports.useListBoxSection = _listbox.useListBoxSection; exports.useOption = _listbox.useOption;
++var _menu = require("@react-aria/menu"); exports.useMenu = _menu.useMenu; exports.useMenuItem = _menu.useMenuItem; exports.useMenuSection = _menu.useMenuSection; exports.useMenuTrigger = _menu.useMenuTrigger;
++var _overlays = require("@react-aria/overlays"); exports.DismissButton = _overlays.DismissButton; exports.Overlay = _overlays.Overlay; exports.useOverlayTrigger = _overlays.useOverlayTrigger; exports.usePopover = _overlays.usePopover;
++var _select = require("@react-aria/select"); exports.HiddenSelect = _select.HiddenSelect; exports.useSelect = _select.useSelect;
++var _separator = require("@react-aria/separator"); exports.useSeparator = _separator.useSeparator;
++var _slider = require("@react-aria/slider"); exports.useSlider = _slider.useSlider; exports.useSliderThumb = _slider.useSliderThumb;
++var _utils = require("@react-aria/utils"); exports.chain = _utils.chain; exports.mergeProps = _utils.mergeProps; exports.useId = _utils.useId; exports.useObjectRef = _utils.useObjectRef;
++var _visuallyHidden = require("@react-aria/visually-hidden"); exports.VisuallyHidden = _visuallyHidden.VisuallyHidden; exports.useVisuallyHidden = _visuallyHidden.useVisuallyHidden;
++var _dialog = require("@react-aria/dialog"); exports.useDialog = _dialog.useDialog;
+diff --git a/dist/module.js b/dist/module.js
+index a13ba8b37e27230ec01d4c31140127912208666c..97d6aa506f273263c2a99a9bc80731ac2c38eea6 100644
+--- a/dist/module.js
++++ b/dist/module.js
+@@ -1,50 +1,14 @@
+-/*
+- * Copyright 2020 Adobe. All rights reserved.
+- * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+- * you may not use this file except in compliance with the License. You may obtain a copy
+- * of the License at http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing, software distributed under
+- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+- * OF ANY KIND, either express or implied. See the License for the specific language
+- * governing permissions and limitations under the License.
+- */
+-
+-export {useBreadcrumbItem, useBreadcrumbs} from '@react-aria/breadcrumbs';
+-export {useButton, useToggleButton, useToggleButtonGroup, useToggleButtonGroupItem} from '@react-aria/button';
+-export {useCalendar, useCalendarCell, useCalendarGrid, useRangeCalendar} from '@react-aria/calendar';
+-export {useCheckbox, useCheckboxGroup, useCheckboxGroupItem} from '@react-aria/checkbox';
+-export {useColorArea, useColorChannelField, useColorField, useColorSlider, useColorSwatch, useColorWheel} from '@react-aria/color';
+-export {useComboBox} from '@react-aria/combobox';
+-export {useDateField, useDatePicker, useDateRangePicker, useDateSegment, useTimeField} from '@react-aria/datepicker';
+-export {useDialog} from '@react-aria/dialog';
+-export {useDisclosure} from '@react-aria/disclosure';
+-export {useDrag, useDrop, useDraggableCollection, useDroppableCollection, useDroppableItem, useDropIndicator, useDraggableItem, useClipboard, DragPreview, ListDropTargetDelegate, DIRECTORY_DRAG_TYPE, isDirectoryDropItem, isFileDropItem, isTextDropItem} from '@react-aria/dnd';
++// Slim barrel: only exports actually used
++export {useButton} from '@react-aria/button';
+ export {FocusRing, FocusScope, useFocusManager, useFocusRing, useFocusable} from '@react-aria/focus';
+-export {I18nProvider, useCollator, useDateFormatter, useFilter, useLocale, useLocalizedStringFormatter, useMessageFormatter, useNumberFormatter} from '@react-aria/i18n';
++export {useNumberFormatter} from '@react-aria/i18n';
+ export {useFocus, useFocusVisible, useFocusWithin, useHover, useInteractOutside, useKeyboard, useMove, usePress, useLongPress} from '@react-aria/interactions';
+-export {useField, useLabel} from '@react-aria/label';
+-export {useGridList, useGridListItem, useGridListSelectionCheckbox} from '@react-aria/gridlist';
+-export {useLink} from '@react-aria/link';
+ export {useListBox, useListBoxSection, useOption} from '@react-aria/listbox';
+-export {useMenu, useMenuItem, useMenuSection, useMenuTrigger, useSubmenuTrigger} from '@react-aria/menu';
+-export {useMeter} from '@react-aria/meter';
+-export {useNumberField} from '@react-aria/numberfield';
+-export {DismissButton, ModalProvider, Overlay, OverlayContainer, OverlayProvider, useModal, useModalOverlay, useModalProvider, useOverlay, useOverlayPosition, useOverlayTrigger, usePopover, usePreventScroll} from '@react-aria/overlays';
+-export {useProgressBar} from '@react-aria/progress';
+-export {useRadio, useRadioGroup} from '@react-aria/radio';
+-export {useSearchField} from '@react-aria/searchfield';
+-export {HiddenSelect, useHiddenSelect, useSelect} from '@react-aria/select';
+-export {ListKeyboardDelegate} from '@react-aria/selection';
++export {useMenu, useMenuItem, useMenuSection, useMenuTrigger} from '@react-aria/menu';
++export {DismissButton, Overlay, useOverlayTrigger, usePopover} from '@react-aria/overlays';
++export {HiddenSelect, useSelect} from '@react-aria/select';
+ export {useSeparator} from '@react-aria/separator';
+-export {SSRProvider, useIsSSR} from '@react-aria/ssr';
+ export {useSlider, useSliderThumb} from '@react-aria/slider';
+-export {useSwitch} from '@react-aria/switch';
+-export {useTable, useTableCell, useTableColumnHeader, useTableColumnResize, useTableHeaderRow, useTableRow, useTableRowGroup, useTableSelectAllCheckbox, useTableSelectionCheckbox} from '@react-aria/table';
+-export {useTab, useTabList, useTabPanel} from '@react-aria/tabs';
+-export {useTag, useTagGroup} from '@react-aria/tag';
+-export {useTextField} from '@react-aria/textfield';
+-export {useTooltip, useTooltipTrigger} from '@react-aria/tooltip';
+-export {chain, mergeProps, useId, useObjectRef, RouterProvider} from '@react-aria/utils';
++export {chain, mergeProps, useId, useObjectRef} from '@react-aria/utils';
+ export {VisuallyHidden, useVisuallyHidden} from '@react-aria/visually-hidden';
+-
++export {useDialog} from '@react-aria/dialog';

--- a/.yarn/patches/react-stately-npm-3.17.0-264cc7a43c.patch
+++ b/.yarn/patches/react-stately-npm-3.17.0-264cc7a43c.patch
@@ -1,0 +1,149 @@
+diff --git a/dist/main.js b/dist/main.js
+index 8e3aafa76ccbbc4491666e9593220378c3e79c18..2ed9b74c20b63fb1f9e8552d61343b26540f78d9 100644
+--- a/dist/main.js
++++ b/dist/main.js
+@@ -1,98 +1,8 @@
+ "use strict";
+-
+ exports.__esModule = true;
+-exports.useTreeState = exports.useTooltipTriggerState = exports.useToggleState = exports.useTabListState = exports.Cell = exports.Row = exports.Column = exports.TableBody = exports.TableHeader = exports.useTableState = exports.useMultipleSelectionState = exports.useSliderState = exports.useSelectState = exports.useSearchFieldState = exports.useRadioGroupState = exports.useOverlayTriggerState = exports.useNumberFieldState = exports.useMenuTriggerState = exports.useSingleSelectListState = exports.useListState = exports.useTreeData = exports.useListData = exports.useAsyncList = exports.useCollection = exports.Section = exports.Item = exports.useTimeFieldState = exports.useDateRangePickerState = exports.useDatePickerState = exports.useDateFieldState = exports.useComboBoxState = exports.useCheckboxGroupState = exports.useRangeCalendarState = exports.useCalendarState = void 0;
+-
+-var _calendar = require("@react-stately/calendar");
+-
+-exports.useCalendarState = _calendar.useCalendarState;
+-exports.useRangeCalendarState = _calendar.useRangeCalendarState;
+-
+-var _checkbox = require("@react-stately/checkbox");
+-
+-exports.useCheckboxGroupState = _checkbox.useCheckboxGroupState;
+-
+-var _combobox = require("@react-stately/combobox");
+-
+-exports.useComboBoxState = _combobox.useComboBoxState;
+-
+-var _datepicker = require("@react-stately/datepicker");
+-
+-exports.useDateFieldState = _datepicker.useDateFieldState;
+-exports.useDatePickerState = _datepicker.useDatePickerState;
+-exports.useDateRangePickerState = _datepicker.useDateRangePickerState;
+-exports.useTimeFieldState = _datepicker.useTimeFieldState;
+-
+-var _collections = require("@react-stately/collections");
+-
+-exports.Item = _collections.Item;
+-exports.Section = _collections.Section;
+-exports.useCollection = _collections.useCollection;
+-
+-var _data = require("@react-stately/data");
+-
+-exports.useAsyncList = _data.useAsyncList;
+-exports.useListData = _data.useListData;
+-exports.useTreeData = _data.useTreeData;
+-
+-var _list = require("@react-stately/list");
+-
+-exports.useListState = _list.useListState;
+-exports.useSingleSelectListState = _list.useSingleSelectListState;
+-
+-var _menu = require("@react-stately/menu");
+-
+-exports.useMenuTriggerState = _menu.useMenuTriggerState;
+-
+-var _numberfield = require("@react-stately/numberfield");
+-
+-exports.useNumberFieldState = _numberfield.useNumberFieldState;
+-
+-var _overlays = require("@react-stately/overlays");
+-
+-exports.useOverlayTriggerState = _overlays.useOverlayTriggerState;
+-
+-var _radio = require("@react-stately/radio");
+-
+-exports.useRadioGroupState = _radio.useRadioGroupState;
+-
+-var _searchfield = require("@react-stately/searchfield");
+-
+-exports.useSearchFieldState = _searchfield.useSearchFieldState;
+-
+-var _select = require("@react-stately/select");
+-
+-exports.useSelectState = _select.useSelectState;
+-
+-var _slider = require("@react-stately/slider");
+-
+-exports.useSliderState = _slider.useSliderState;
+-
+-var _selection = require("@react-stately/selection");
+-
+-exports.useMultipleSelectionState = _selection.useMultipleSelectionState;
+-
+-var _table = require("@react-stately/table");
+-
+-exports.useTableState = _table.useTableState;
+-exports.TableHeader = _table.TableHeader;
+-exports.TableBody = _table.TableBody;
+-exports.Column = _table.Column;
+-exports.Row = _table.Row;
+-exports.Cell = _table.Cell;
+-
+-var _tabs = require("@react-stately/tabs");
+-
+-exports.useTabListState = _tabs.useTabListState;
+-
+-var _toggle = require("@react-stately/toggle");
+-
+-exports.useToggleState = _toggle.useToggleState;
+-
+-var _tooltip = require("@react-stately/tooltip");
+-
+-exports.useTooltipTriggerState = _tooltip.useTooltipTriggerState;
+-
+-var _tree = require("@react-stately/tree");
+-
+-exports.useTreeState = _tree.useTreeState;
++var _collections = require("@react-stately/collections"); exports.Item = _collections.Item; exports.Section = _collections.Section;
++var _menu = require("@react-stately/menu"); exports.useMenuTriggerState = _menu.useMenuTriggerState;
++var _overlays = require("@react-stately/overlays"); exports.useOverlayTriggerState = _overlays.useOverlayTriggerState;
++var _select = require("@react-stately/select"); exports.useSelectState = _select.useSelectState;
++var _slider = require("@react-stately/slider"); exports.useSliderState = _slider.useSliderState;
++var _tree = require("@react-stately/tree"); exports.useTreeState = _tree.useTreeState;
+diff --git a/dist/module.js b/dist/module.js
+index 37bdb24af4a8310cc702b2d9c1effe6aac261424..c098533fc2bbeb6b203d4350c2dcdd6e6663afd3 100644
+--- a/dist/module.js
++++ b/dist/module.js
+@@ -1,33 +1,7 @@
+-/*
+- * Copyright 2020 Adobe. All rights reserved.
+- * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+- * you may not use this file except in compliance with the License. You may obtain a copy
+- * of the License at http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing, software distributed under
+- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+- * OF ANY KIND, either express or implied. See the License for the specific language
+- * governing permissions and limitations under the License.
+- */
+-
+-
+-export {useCalendarState, useRangeCalendarState} from '@react-stately/calendar';
+-export {useCheckboxGroupState} from '@react-stately/checkbox';
+-export {useComboBoxState} from '@react-stately/combobox';
+-export {useDateFieldState, useDatePickerState, useDateRangePickerState, useTimeFieldState} from '@react-stately/datepicker';
+-export {Item, Section, useCollection} from '@react-stately/collections';
+-export {useAsyncList, useListData, useTreeData} from '@react-stately/data';
+-export {useListState, useSingleSelectListState} from '@react-stately/list';
++// Slim barrel: only exports actually used
++export {Item, Section} from '@react-stately/collections';
+ export {useMenuTriggerState} from '@react-stately/menu';
+-export {useNumberFieldState} from '@react-stately/numberfield';
+ export {useOverlayTriggerState} from '@react-stately/overlays';
+-export {useRadioGroupState} from '@react-stately/radio';
+-export {useSearchFieldState} from '@react-stately/searchfield';
+ export {useSelectState} from '@react-stately/select';
+ export {useSliderState} from '@react-stately/slider';
+-export {useMultipleSelectionState} from '@react-stately/selection';
+-export {useTableState, TableHeader, TableBody, Column, Row, Cell} from '@react-stately/table';
+-export {useTabListState} from '@react-stately/tabs';
+-export {useToggleState} from '@react-stately/toggle';
+-export {useTooltipTriggerState} from '@react-stately/tooltip';
+ export {useTreeState} from '@react-stately/tree';

--- a/.yarn/patches/zod-npm-4.3.6-a096e305e6.patch
+++ b/.yarn/patches/zod-npm-4.3.6-a096e305e6.patch
@@ -1,0 +1,105 @@
+diff --git a/v4/classic/external.cjs b/v4/classic/external.cjs
+index ee133825d44ab44b86dd8aef6bd985653ebde06c..ea74468d20c2371f9c4d8941467e3b7fe93a00ef 100644
+--- a/v4/classic/external.cjs
++++ b/v4/classic/external.cjs
+@@ -29,7 +29,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
+     return (mod && mod.__esModule) ? mod : { "default": mod };
+ };
+ Object.defineProperty(exports, "__esModule", { value: true });
+-exports.coerce = exports.iso = exports.ZodISODuration = exports.ZodISOTime = exports.ZodISODate = exports.ZodISODateTime = exports.locales = exports.fromJSONSchema = exports.toJSONSchema = exports.NEVER = exports.util = exports.TimePrecision = exports.flattenError = exports.formatError = exports.prettifyError = exports.treeifyError = exports.regexes = exports.clone = exports.$brand = exports.$input = exports.$output = exports.config = exports.registry = exports.globalRegistry = exports.core = void 0;
++exports.coerce = exports.iso = exports.ZodISODuration = exports.ZodISOTime = exports.ZodISODate = exports.ZodISODateTime = exports.fromJSONSchema = exports.toJSONSchema = exports.NEVER = exports.util = exports.TimePrecision = exports.flattenError = exports.formatError = exports.prettifyError = exports.treeifyError = exports.regexes = exports.clone = exports.$brand = exports.$input = exports.$output = exports.config = exports.registry = exports.globalRegistry = exports.core = void 0;
+ exports.core = __importStar(require("../core/index.cjs"));
+ __exportStar(require("./schemas.cjs"), exports);
+ __exportStar(require("./checks.cjs"), exports);
+@@ -60,7 +60,7 @@ var json_schema_processors_js_1 = require("../core/json-schema-processors.cjs");
+ Object.defineProperty(exports, "toJSONSchema", { enumerable: true, get: function () { return json_schema_processors_js_1.toJSONSchema; } });
+ var from_json_schema_js_1 = require("./from-json-schema.cjs");
+ Object.defineProperty(exports, "fromJSONSchema", { enumerable: true, get: function () { return from_json_schema_js_1.fromJSONSchema; } });
+-exports.locales = __importStar(require("../locales/index.cjs"));
++// locales removed from barrel
+ // iso
+ // must be exported from top-level
+ // https://github.com/colinhacks/zod/issues/4491
+diff --git a/v4/classic/external.js b/v4/classic/external.js
+index 9567900bbb57099481c0ea5864fbf697d62021a5..98ee2af29038deca6c38c46c24d5fb14725e40f0 100644
+--- a/v4/classic/external.js
++++ b/v4/classic/external.js
+@@ -11,7 +11,7 @@ config(en());
+ export { globalRegistry, registry, config, $output, $input, $brand, clone, regexes, treeifyError, prettifyError, formatError, flattenError, TimePrecision, util, NEVER, } from "../core/index.js";
+ export { toJSONSchema } from "../core/json-schema-processors.js";
+ export { fromJSONSchema } from "./from-json-schema.js";
+-export * as locales from "../locales/index.js";
++// locales removed from barrel
+ // iso
+ // must be exported from top-level
+ // https://github.com/colinhacks/zod/issues/4491
+diff --git a/v4/core/index.cjs b/v4/core/index.cjs
+index c3fa303104a191d142a5212f69e7954cba3606a7..44bdc3437c6a88971c1c85b63024213880fe0fff 100644
+--- a/v4/core/index.cjs
++++ b/v4/core/index.cjs
+@@ -26,7 +26,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
+     return result;
+ };
+ Object.defineProperty(exports, "__esModule", { value: true });
+-exports.JSONSchema = exports.JSONSchemaGenerator = exports.toJSONSchema = exports.locales = exports.regexes = exports.util = void 0;
++exports.JSONSchema = exports.JSONSchemaGenerator = exports.toJSONSchema = exports.regexes = exports.util = void 0;
+ __exportStar(require("./core.cjs"), exports);
+ __exportStar(require("./parse.cjs"), exports);
+ __exportStar(require("./errors.cjs"), exports);
+@@ -35,7 +35,7 @@ __exportStar(require("./checks.cjs"), exports);
+ __exportStar(require("./versions.cjs"), exports);
+ exports.util = __importStar(require("./util.cjs"));
+ exports.regexes = __importStar(require("./regexes.cjs"));
+-exports.locales = __importStar(require("../locales/index.cjs"));
++// locales removed from barrel
+ __exportStar(require("./registries.cjs"), exports);
+ __exportStar(require("./doc.cjs"), exports);
+ __exportStar(require("./api.cjs"), exports);
+diff --git a/v4/core/index.js b/v4/core/index.js
+index d334515bf004600f2e55ff85e3730f1b2f2ff703..4ff979844ba18d012893064b01889bf70ec245c8 100644
+--- a/v4/core/index.js
++++ b/v4/core/index.js
+@@ -6,7 +6,7 @@ export * from "./checks.js";
+ export * from "./versions.js";
+ export * as util from "./util.js";
+ export * as regexes from "./regexes.js";
+-export * as locales from "../locales/index.js";
++// locales removed from barrel
+ export * from "./registries.js";
+ export * from "./doc.js";
+ export * from "./api.js";
+diff --git a/v4/mini/external.cjs b/v4/mini/external.cjs
+index 0d0079d94d94010b51abe23042418adbc6077b7f..fd3acb42a12dde65f383eb2c3f46a9108dd8c865 100644
+--- a/v4/mini/external.cjs
++++ b/v4/mini/external.cjs
+@@ -26,7 +26,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
+     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+ };
+ Object.defineProperty(exports, "__esModule", { value: true });
+-exports.coerce = exports.ZodMiniISODuration = exports.ZodMiniISOTime = exports.ZodMiniISODate = exports.ZodMiniISODateTime = exports.iso = exports.locales = exports.toJSONSchema = exports.NEVER = exports.util = exports.TimePrecision = exports.flattenError = exports.formatError = exports.prettifyError = exports.treeifyError = exports.regexes = exports.clone = exports.$brand = exports.$input = exports.$output = exports.config = exports.registry = exports.globalRegistry = exports.core = void 0;
++exports.coerce = exports.ZodMiniISODuration = exports.ZodMiniISOTime = exports.ZodMiniISODate = exports.ZodMiniISODateTime = exports.iso = exports.toJSONSchema = exports.NEVER = exports.util = exports.TimePrecision = exports.flattenError = exports.formatError = exports.prettifyError = exports.treeifyError = exports.regexes = exports.clone = exports.$brand = exports.$input = exports.$output = exports.config = exports.registry = exports.globalRegistry = exports.core = void 0;
+ exports.core = __importStar(require("../core/index.cjs"));
+ __exportStar(require("./parse.cjs"), exports);
+ __exportStar(require("./schemas.cjs"), exports);
+@@ -49,7 +49,7 @@ Object.defineProperty(exports, "util", { enumerable: true, get: function () { re
+ Object.defineProperty(exports, "NEVER", { enumerable: true, get: function () { return index_js_1.NEVER; } });
+ var json_schema_processors_js_1 = require("../core/json-schema-processors.cjs");
+ Object.defineProperty(exports, "toJSONSchema", { enumerable: true, get: function () { return json_schema_processors_js_1.toJSONSchema; } });
+-exports.locales = __importStar(require("../locales/index.cjs"));
++// locales removed from barrel
+ /** A special constant with type `never` */
+ // export const NEVER = {} as never;
+ // iso
+diff --git a/v4/mini/external.js b/v4/mini/external.js
+index d6523c153e213be110c21b370164b5eca1cdf744..7a1addf9ce6e331e56c943867bf04cf199745145 100644
+--- a/v4/mini/external.js
++++ b/v4/mini/external.js
+@@ -4,7 +4,7 @@ export * from "./schemas.js";
+ export * from "./checks.js";
+ export { globalRegistry, registry, config, $output, $input, $brand, clone, regexes, treeifyError, prettifyError, formatError, flattenError, TimePrecision, util, NEVER, } from "../core/index.js";
+ export { toJSONSchema } from "../core/json-schema-processors.js";
+-export * as locales from "../locales/index.js";
++// locales removed from barrel
+ /** A special constant with type `never` */
+ // export const NEVER = {} as never;
+ // iso

--- a/apps/meteor/client/components/ImageGallery/ImageGallery.tsx
+++ b/apps/meteor/client/components/ImageGallery/ImageGallery.tsx
@@ -1,8 +1,8 @@
+import { FocusScope } from '@react-aria/focus';
 import type { IUpload } from '@rocket.chat/core-typings';
 import { css } from '@rocket.chat/css-in-js';
 import { Box, ButtonGroup, IconButton, Palette, PaletteStyleTag, Throbber, spacing } from '@rocket.chat/fuselage';
 import { useRef, useState } from 'react';
-import { FocusScope } from 'react-aria';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Navigation, Zoom, Keyboard, A11y } from 'swiper/modules/index.mjs';

--- a/apps/meteor/client/components/ResultsLiveRegion.tsx
+++ b/apps/meteor/client/components/ResultsLiveRegion.tsx
@@ -1,4 +1,4 @@
-import { VisuallyHidden } from 'react-aria';
+import { VisuallyHidden } from '@react-aria/visually-hidden';
 import { useTranslation } from 'react-i18next';
 
 const ResultsLiveRegion = ({ shouldAnnounce, itemCount }: { shouldAnnounce: boolean; itemCount: number }) => {

--- a/apps/meteor/client/components/UserCard/UserCardDialog.tsx
+++ b/apps/meteor/client/components/UserCard/UserCardDialog.tsx
@@ -1,8 +1,8 @@
+import type { AriaDialogProps } from '@react-aria/dialog';
+import { useDialog } from '@react-aria/dialog';
 import { Box } from '@rocket.chat/fuselage';
 import type { ComponentProps } from 'react';
 import { useRef } from 'react';
-import type { AriaDialogProps } from 'react-aria';
-import { useDialog } from 'react-aria';
 
 type UserCardDialogProps = AriaDialogProps & ComponentProps<typeof Box>;
 

--- a/apps/meteor/client/navbar/NavBarNavigation.tsx
+++ b/apps/meteor/client/navbar/NavBarNavigation.tsx
@@ -1,6 +1,6 @@
+import { FocusScope } from '@react-aria/focus';
 import { NavBarGroup, NavBarItem, Box } from '@rocket.chat/fuselage';
 import { useLayout, useRouter } from '@rocket.chat/ui-contexts';
-import { FocusScope } from 'react-aria';
 import { useTranslation } from 'react-i18next';
 
 import NavBarSearch from './NavBarSearch';

--- a/apps/meteor/client/navbar/NavBarSearch/NavBarSearch.tsx
+++ b/apps/meteor/client/navbar/NavBarSearch/NavBarSearch.tsx
@@ -1,10 +1,11 @@
+import { useFocusManager } from '@react-aria/focus';
+import { useOverlayTrigger } from '@react-aria/overlays';
+import { useOverlayTriggerState } from '@react-stately/overlays';
 import { Box, Icon, IconButton, TextInput } from '@rocket.chat/fuselage';
 import { useEffectEvent, useMergedRefs } from '@rocket.chat/fuselage-hooks';
 import { useCallback, useEffect, useRef } from 'react';
-import { useFocusManager, useOverlayTrigger } from 'react-aria';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { useOverlayTriggerState } from 'react-stately';
 import tinykeys from 'tinykeys';
 
 import NavBarSearchListBox from './NavBarSearchListbox';

--- a/apps/meteor/client/navbar/NavBarSearch/NavBarSearchListbox.tsx
+++ b/apps/meteor/client/navbar/NavBarSearch/NavBarSearchListbox.tsx
@@ -1,11 +1,11 @@
+import type { OverlayTriggerAria } from '@react-aria/overlays';
+import type { OverlayTriggerState } from '@react-stately/overlays';
 import { Box, Tile } from '@rocket.chat/fuselage';
 import { useDebouncedValue, useEffectEvent, useOutsideClick } from '@rocket.chat/fuselage-hooks';
 import { CustomScrollbars } from '@rocket.chat/ui-client';
 import { useRef } from 'react';
-import type { OverlayTriggerAria } from 'react-aria';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import type { OverlayTriggerState } from 'react-stately';
 
 import NavBarSearchNoResults from './NavBarSearchNoResults';
 import NavBarSearchRow from './NavBarSearchRow';

--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchClick.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchClick.ts
@@ -1,5 +1,5 @@
+import type { OverlayTriggerState } from '@react-stately/overlays';
 import { useCallback } from 'react';
-import type { OverlayTriggerState } from 'react-stately';
 
 export const useSearchClick = (state: OverlayTriggerState) => {
 	const handleClick = useCallback(() => {

--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchFocus.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchFocus.ts
@@ -1,6 +1,6 @@
+import type { OverlayTriggerState } from '@react-stately/overlays';
 import { useLayout } from '@rocket.chat/ui-contexts';
 import { useCallback, useEffect } from 'react';
-import type { OverlayTriggerState } from 'react-stately';
 
 export const useSearchFocus = (state: OverlayTriggerState) => {
 	const { navbar } = useLayout();

--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchNavigation.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchNavigation.ts
@@ -1,7 +1,7 @@
+import { useFocusManager } from '@react-aria/focus';
+import type { OverlayTriggerState } from '@react-stately/overlays';
 import type { KeyboardEvent } from 'react';
 import { useCallback } from 'react';
-import { useFocusManager } from 'react-aria';
-import type { OverlayTriggerState } from 'react-stately';
 
 export const isOption = (node: Element) => node.getAttribute('role') === 'option';
 

--- a/apps/meteor/client/sidebar/RoomList/useSidebarListNavigation.ts
+++ b/apps/meteor/client/sidebar/RoomList/useSidebarListNavigation.ts
@@ -1,5 +1,5 @@
+import { useFocusManager } from '@react-aria/focus';
 import { useCallback } from 'react';
-import { useFocusManager } from 'react-aria';
 
 const isListItem = (node: EventTarget) => (node as HTMLElement).classList.contains('rcx-sidebar-v2-item');
 const isCollapseGroup = (node: EventTarget) => (node as HTMLElement).classList.contains('rcx-sidebar-v2-collapse-group__bar');

--- a/apps/meteor/client/sidebar/SidebarRegion.tsx
+++ b/apps/meteor/client/sidebar/SidebarRegion.tsx
@@ -1,8 +1,8 @@
+import { FocusScope } from '@react-aria/focus';
 import { css } from '@rocket.chat/css-in-js';
 import { Box } from '@rocket.chat/fuselage';
 import { useLayout } from '@rocket.chat/ui-contexts';
 import { memo } from 'react';
-import { FocusScope } from 'react-aria';
 
 import Sidebar from './Sidebar';
 

--- a/apps/meteor/client/views/account/accessibility/AccessibilityPage.tsx
+++ b/apps/meteor/client/views/account/accessibility/AccessibilityPage.tsx
@@ -1,3 +1,4 @@
+import { VisuallyHidden } from '@react-aria/visually-hidden';
 import { css } from '@rocket.chat/css-in-js';
 import type { SelectOption } from '@rocket.chat/fuselage';
 import { Accordion, AccordionItem, Box, Button, ButtonGroup } from '@rocket.chat/fuselage';
@@ -16,7 +17,6 @@ import { ExternalLink, Page, PageHeader, PageScrollableContentWithShadow, PageFo
 import { useTranslation, useToastMessageDispatch, useEndpoint, useSetting } from '@rocket.chat/ui-contexts';
 import { useMutation } from '@tanstack/react-query';
 import { useId, useMemo } from 'react';
-import { VisuallyHidden } from 'react-aria';
 import { Controller, useForm } from 'react-hook-form';
 
 import { fontSizes } from './fontSizes';

--- a/apps/meteor/client/views/account/profile/AccountProfileForm.tsx
+++ b/apps/meteor/client/views/account/profile/AccountProfileForm.tsx
@@ -1,3 +1,4 @@
+import { VisuallyHidden } from '@react-aria/visually-hidden';
 import type { IUser } from '@rocket.chat/core-typings';
 import { css } from '@rocket.chat/css-in-js';
 import { Box, Button, Icon } from '@rocket.chat/fuselage';
@@ -15,7 +16,6 @@ import {
 import { useMutation } from '@tanstack/react-query';
 import type { AllHTMLAttributes, ReactElement } from 'react';
 import { useCallback } from 'react';
-import { VisuallyHidden } from 'react-aria';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import type { AccountProfileFormValues } from './getProfileInitialValues';

--- a/apps/meteor/client/views/modal/uikit/ModalBlock.tsx
+++ b/apps/meteor/client/views/modal/uikit/ModalBlock.tsx
@@ -1,3 +1,4 @@
+import { FocusScope } from '@react-aria/focus';
 import {
 	Modal,
 	AnimatedVisibility,
@@ -15,7 +16,6 @@ import { UiKitComponent, UiKitModal, modalParser } from '@rocket.chat/fuselage-u
 import type * as UiKit from '@rocket.chat/ui-kit';
 import type { FormEvent, FormEventHandler, ReactElement } from 'react';
 import { useId, useCallback, useEffect, useMemo, useRef } from 'react';
-import { FocusScope } from 'react-aria';
 
 import { getButtonStyle } from './getButtonStyle';
 import { getURL } from '../../../../app/utils/client/getURL';

--- a/apps/meteor/client/views/navigation/NavigationRegion.tsx
+++ b/apps/meteor/client/views/navigation/NavigationRegion.tsx
@@ -1,8 +1,8 @@
+import { FocusScope } from '@react-aria/focus';
 import { css } from '@rocket.chat/css-in-js';
 import { Box } from '@rocket.chat/fuselage';
 import { useLayout, useLayoutSizes } from '@rocket.chat/ui-contexts';
 import { memo } from 'react';
-import { FocusScope } from 'react-aria';
 
 import Sidebar from './sidebar';
 import SidePanel from './sidepanel';

--- a/apps/meteor/client/views/navigation/sidebar/RoomList/useSidebarListNavigation.ts
+++ b/apps/meteor/client/views/navigation/sidebar/RoomList/useSidebarListNavigation.ts
@@ -1,5 +1,5 @@
+import { useFocusManager } from '@react-aria/focus';
 import { useCallback } from 'react';
-import { useFocusManager } from 'react-aria';
 
 const isListItem = (node: EventTarget) =>
 	(node as HTMLElement).classList.contains('rcx-sidebar-v2-item') && (node as HTMLElement).parentElement?.role === 'listitem';

--- a/apps/meteor/client/views/room/Room.tsx
+++ b/apps/meteor/client/views/room/Room.tsx
@@ -1,10 +1,10 @@
+import { FocusScope } from '@react-aria/focus';
 import { isInviteSubscription } from '@rocket.chat/core-typings';
 import { ContextualbarSkeleton } from '@rocket.chat/ui-client';
 import { useSetting, useRoomToolbox, useUserId } from '@rocket.chat/ui-contexts';
 import { useMediaCallOpenRoomTracker } from '@rocket.chat/ui-voip';
 import type { ReactElement } from 'react';
 import { createElement, lazy, memo, Suspense } from 'react';
-import { FocusScope } from 'react-aria';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
 

--- a/apps/meteor/client/views/room/contextualBar/VideoConference/VideoConfPopups/VideoConfPopup/TimedVideoConfPopup.tsx
+++ b/apps/meteor/client/views/room/contextualBar/VideoConference/VideoConfPopups/VideoConfPopup/TimedVideoConfPopup.tsx
@@ -1,3 +1,4 @@
+import { useFocusManager } from '@react-aria/focus';
 import type { IRoom } from '@rocket.chat/core-typings';
 import { useUserRoom } from '@rocket.chat/ui-contexts';
 import {
@@ -10,7 +11,6 @@ import {
 } from '@rocket.chat/ui-video-conf';
 import type { ReactElement } from 'react';
 import { useEffect, useState } from 'react';
-import { useFocusManager } from 'react-aria';
 
 import IncomingPopup from './IncomingPopup';
 import OutgoingPopup from './OutgoingPopup';

--- a/apps/meteor/client/views/room/contextualBar/VideoConference/VideoConfPopups/VideoConfPopups.tsx
+++ b/apps/meteor/client/views/room/contextualBar/VideoConference/VideoConfPopups/VideoConfPopups.tsx
@@ -1,3 +1,4 @@
+import { FocusScope } from '@react-aria/focus';
 import { useCustomSound } from '@rocket.chat/ui-contexts';
 import type { VideoConfPopupPayload } from '@rocket.chat/ui-video-conf';
 import {
@@ -9,7 +10,6 @@ import {
 } from '@rocket.chat/ui-video-conf';
 import type { ReactElement } from 'react';
 import { lazy, Suspense, useEffect, useMemo } from 'react';
-import { FocusScope } from 'react-aria';
 
 import VideoConfPopupPortal from '../../../../../portals/VideoConfPopupPortal';
 

--- a/apps/meteor/client/views/room/hooks/useMessageListNavigation.ts
+++ b/apps/meteor/client/views/room/hooks/useMessageListNavigation.ts
@@ -1,7 +1,6 @@
-import { createFocusManager } from '@react-aria/focus';
+import { createFocusManager, useFocusManager } from '@react-aria/focus';
 import type { RefCallback } from 'react';
 import { useCallback } from 'react';
-import { useFocusManager } from 'react-aria';
 
 const isListItem = (node: EventTarget) =>
 	(node as HTMLElement).getAttribute('role') === 'listitem' || (node as HTMLElement).getAttribute('role') === 'link';

--- a/apps/meteor/client/views/room/providers/UserCardProvider.tsx
+++ b/apps/meteor/client/views/room/providers/UserCardProvider.tsx
@@ -1,10 +1,10 @@
+import { useOverlayTrigger } from '@react-aria/overlays';
+import { useOverlayTriggerState } from '@react-stately/overlays';
 import { Popover } from '@rocket.chat/fuselage';
 import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
 import { useRoomToolbox, UserCardContext } from '@rocket.chat/ui-contexts';
 import type { ComponentProps, ReactNode, UIEvent } from 'react';
 import { Suspense, lazy, useCallback, useMemo, useRef, useState } from 'react';
-import { useOverlayTrigger } from 'react-aria';
-import { useOverlayTriggerState } from 'react-stately';
 
 import { useRoom } from '../contexts/RoomContext';
 

--- a/docs/bundle-optimization-react-aria.md
+++ b/docs/bundle-optimization-react-aria.md
@@ -1,4 +1,4 @@
-# Bundle Optimization: barrel import patches (react-aria, react-stately)
+# Bundle Optimization: barrel import patches (react-aria, react-stately, zod)
 
 ## The Problem
 
@@ -53,6 +53,60 @@ This is the correct long-term fix, but alone it was not enough because `@rocket.
 | Main JS (minified) | 3688 KB | 3199 KB | **-489 KB (-13%)** |
 | Main JS (gzip) | 939 KB | 841 KB | **-98 KB (-10%)** |
 
+---
+
+## Zod v4 locale barrel
+
+### The Problem
+
+Zod v4 re-exports all 50 locale files from its main entry point:
+
+```js
+// zod/v4/classic/external.js
+export * as locales from "../locales/index.js";
+```
+
+This means `import { z } from 'zod'` pulls in error messages for Arabic, Hebrew, Thai, Russian, and 46 other languages — even though Rocket.Chat only uses the English locale (loaded by default via `config(en())`).
+
+**Measured impact:** 147 KB (50 locale files) out of 278 KB total for zod — **53% of the zod bundle was unused locale data**.
+
+### The Solution
+
+A `yarn patch` on `zod@4.3.6` removes the `export * as locales` line from the barrel. The English locale (`en.js`) remains loaded since it's imported separately by `config(en())`. All other locales remain available for explicit import if needed:
+
+```typescript
+// Still works:
+import pt from 'zod/v4/locales/pt';
+import { config } from 'zod';
+config(pt());
+```
+
+### What requires attention
+
+#### Upgrading zod
+
+When upgrading zod, the patch must be re-created:
+
+1. Remove the old patch reference from `package.json` resolutions
+2. Delete `.yarn/patches/zod-*.patch`
+3. Run `yarn install`
+4. Run `yarn patch zod@npm:<new-version>`
+5. Remove the `export * as locales` line from `v4/classic/external.js`
+6. Remove the `exports.locales` require from `v4/classic/external.cjs`
+7. Run `yarn patch-commit -s <patch-folder>`
+
+#### If zod locales are needed at runtime
+
+If a feature requires localized zod error messages (e.g., form validation in the user's language), import the specific locale directly instead of relying on the barrel:
+
+```typescript
+import de from 'zod/v4/locales/de';
+import { config } from 'zod';
+config(de());
+```
+
+This loads only the one locale needed (~3 KB) instead of all 50 (~147 KB).
+
 ## What requires attention
 
 ### Adding new react-aria hooks or components
@@ -96,6 +150,8 @@ If there are new exports, add them to the yarn patch.
 ### The long-term fix
 
 The react-aria/react-stately yarn patches are a workaround. The proper fix is for `@rocket.chat/fuselage` to import from sub-packages directly instead of the barrel, which eliminates the need for those patches entirely. Once that is done, only the direct sub-package imports in source code are needed.
+
+The zod patch is a workaround for a design choice in zod v4 (`export * as locales` in the main barrel). This may be addressed upstream — track https://github.com/colinhacks/zod for changes to the locale export strategy.
 
 ## How to analyze the bundle
 

--- a/docs/bundle-optimization-react-aria.md
+++ b/docs/bundle-optimization-react-aria.md
@@ -1,0 +1,118 @@
+# Bundle Optimization: barrel import patches (react-aria, react-stately)
+
+## The Problem
+
+Meteor's bundler (`standard-minifier-js`) does **not** perform tree-shaking. When any code imports from the `react-aria` barrel package:
+
+```typescript
+import { FocusScope } from 'react-aria';
+```
+
+Meteor resolves the barrel's entry point, which re-exports **all 43 sub-packages** (`@react-aria/dnd`, `@react-aria/calendar`, `@react-aria/table`, etc.). Since there is no dead-code elimination, every sub-package ends up in the main JS bundle — even if only `FocusScope` is used.
+
+The same applies to `react-stately` (20 sub-packages).
+
+**Measured impact before the fix:** 832 KB of react-aria + react-stately in the main bundle, of which ~700 KB was unused code.
+
+## The Solution
+
+Two complementary changes:
+
+### 1. Yarn patches on the barrel packages
+
+`yarn patch` replaces the barrel entry points (`dist/main.js`, `dist/module.js`, `dist/import.mjs`) with slim versions that only re-export the sub-packages actually used.
+
+The patches live in `.yarn/patches/` and are referenced in `package.json` resolutions. They are applied automatically on every `yarn install`.
+
+**react-aria** — retained sub-packages:
+`button`, `focus`, `i18n`, `interactions`, `listbox`, `menu`, `overlays`, `select`, `separator`, `slider`, `utils`, `visually-hidden`, `dialog`
+
+**react-stately** — retained sub-packages:
+`collections`, `menu`, `overlays`, `select`, `slider`, `tree`
+
+### 2. Direct sub-package imports in source code
+
+All imports across `apps/meteor` and workspace packages (`gazzodown`, `ui-client`, `ui-contexts`, `ui-voip`) were changed from barrel to direct sub-package imports:
+
+```typescript
+// Before
+import { FocusScope } from 'react-aria';
+import { useOverlayTriggerState } from 'react-stately';
+
+// After
+import { FocusScope } from '@react-aria/focus';
+import { useOverlayTriggerState } from '@react-stately/overlays';
+```
+
+This is the correct long-term fix, but alone it was not enough because `@rocket.chat/fuselage` (published npm package) still uses `require("react-aria")` internally via its UMD build. The yarn patch covers that case.
+
+## Results (react-aria + react-stately)
+
+| Metric | Before | After | Delta |
+|---|---|---|---|
+| Main JS (minified) | 3688 KB | 3199 KB | **-489 KB (-13%)** |
+| Main JS (gzip) | 939 KB | 841 KB | **-98 KB (-10%)** |
+
+## What requires attention
+
+### Adding new react-aria hooks or components
+
+If you need to use a react-aria hook or component that is **not** in the slim barrel (e.g., `useCalendar`, `useTable`, `useDrag`), you must:
+
+1. **Import from the sub-package directly** (preferred):
+   ```typescript
+   import { useCalendar } from '@react-aria/calendar';
+   ```
+
+2. **Or update the yarn patch** if the import comes from a dependency you don't control (like `@rocket.chat/fuselage`):
+   ```bash
+   yarn patch react-aria@npm:3.37.0
+   # Add the missing export to dist/import.mjs, dist/module.js, and dist/main.js
+   yarn patch-commit -s <patch-folder>
+   ```
+
+### Upgrading react-aria / react-stately versions
+
+When upgrading these packages, the yarn patches must be re-created for the new version:
+
+1. Remove the old patch references from `package.json` resolutions
+2. Delete the old `.yarn/patches/react-aria-*.patch` and `react-stately-*.patch` files
+3. Run `yarn install` to get the unpatched version
+4. Run `yarn patch react-aria@npm:<new-version>` and re-apply the slim barrel
+5. Run `yarn patch react-stately@npm:<new-version>` and re-apply the slim barrel
+6. Verify no new exports are needed by running the app and checking for runtime errors
+
+### Upgrading @rocket.chat/fuselage
+
+When the fuselage package is updated, check if it uses any new react-aria exports. You can verify with:
+
+```bash
+grep -oE 'react_aria_1\.[a-zA-Z]+' node_modules/@rocket.chat/fuselage/dist/fuselage.development.js | sort -u
+grep -oE 'react_stately_1\.[a-zA-Z]+' node_modules/@rocket.chat/fuselage/dist/fuselage.development.js | sort -u
+```
+
+If there are new exports, add them to the yarn patch.
+
+### The long-term fix
+
+The react-aria/react-stately yarn patches are a workaround. The proper fix is for `@rocket.chat/fuselage` to import from sub-packages directly instead of the barrel, which eliminates the need for those patches entirely. Once that is done, only the direct sub-package imports in source code are needed.
+
+## How to analyze the bundle
+
+Meteor generates a `.stats.json` file alongside each build. To inspect it:
+
+```bash
+# Find the latest stats file
+ls -t .meteor/local/build/programs/web.browser/*.stats.json | head -1
+
+# Quick summary
+python3 -c "
+import json
+with open('<stats-file>') as f:
+    data = json.load(f)
+print(f'Total: {data[\"totalMinifiedBytes\"]/1024:.0f} KB')
+print(f'Gzip:  {data[\"totalMinifiedGzipBytes\"]/1024:.0f} KB')
+"
+```
+
+The stats file contains a per-package breakdown in `minifiedBytesByPackage`, with `packages/modules.js` containing a nested tree of every npm module included in the main bundle.

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
 		"yoga-layout@npm:^3.2.1": "patch:yoga-layout@npm%3A3.2.1#~/.yarn/patches/yoga-layout-npm-3.2.1-51ec934670.patch",
 		"@react-pdf/layout@npm:^4.4.2": "patch:@react-pdf/layout@npm%3A4.4.2#~/.yarn/patches/@react-pdf-layout-npm-4.4.2-6c2e3312fa.patch",
 		"react-aria@npm:~3.37.0": "patch:react-aria@npm%3A3.37.0#~/.yarn/patches/react-aria-npm-3.37.0-83959bd2fa.patch",
-		"react-stately@npm:~3.35.0": "patch:react-stately@npm%3A3.17.0#~/.yarn/patches/react-stately-npm-3.17.0-264cc7a43c.patch"
+		"react-stately@npm:~3.35.0": "patch:react-stately@npm%3A3.17.0#~/.yarn/patches/react-stately-npm-3.17.0-264cc7a43c.patch",
+		"zod@npm:^3.25.0 || ^4.0.0": "patch:zod@npm%3A4.3.6#~/.yarn/patches/zod-npm-4.3.6-a096e305e6.patch",
+		"zod@npm:~4.3.6": "patch:zod@npm%3A4.3.6#~/.yarn/patches/zod-npm-4.3.6-a096e305e6.patch"
 	},
 	"dependencies": {
 		"@types/stream-buffers": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
 		"mongodb": "6.10.0",
 		"underscore": "1.13.7",
 		"yoga-layout@npm:^3.2.1": "patch:yoga-layout@npm%3A3.2.1#~/.yarn/patches/yoga-layout-npm-3.2.1-51ec934670.patch",
-		"@react-pdf/layout@npm:^4.4.2": "patch:@react-pdf/layout@npm%3A4.4.2#~/.yarn/patches/@react-pdf-layout-npm-4.4.2-6c2e3312fa.patch"
+		"@react-pdf/layout@npm:^4.4.2": "patch:@react-pdf/layout@npm%3A4.4.2#~/.yarn/patches/@react-pdf-layout-npm-4.4.2-6c2e3312fa.patch",
+		"react-aria@npm:~3.37.0": "patch:react-aria@npm%3A3.37.0#~/.yarn/patches/react-aria-npm-3.37.0-83959bd2fa.patch",
+		"react-stately@npm:~3.35.0": "patch:react-stately@npm%3A3.17.0#~/.yarn/patches/react-stately-npm-3.17.0-264cc7a43c.patch"
 	},
 	"dependencies": {
 		"@types/stream-buffers": "^3.0.8",

--- a/packages/gazzodown/src/MarkupInteractionContext.ts
+++ b/packages/gazzodown/src/MarkupInteractionContext.ts
@@ -1,8 +1,8 @@
+import type { AriaButtonProps } from '@react-aria/button';
 import type { MessageMention } from '@rocket.chat/core-typings';
 import type * as MessageParser from '@rocket.chat/message-parser';
 import type { FormEvent, UIEvent } from 'react';
 import { createContext } from 'react';
-import type { AriaButtonProps } from 'react-aria';
 
 export type UserMention = MessageMention;
 export type ChannelMention = MessageMention;

--- a/packages/ui-client/src/components/Contextualbar/ContextualbarDialog.tsx
+++ b/packages/ui-client/src/components/Contextualbar/ContextualbarDialog.tsx
@@ -1,8 +1,9 @@
+import type { AriaDialogProps } from '@react-aria/dialog';
+import { useDialog } from '@react-aria/dialog';
+import { FocusScope } from '@react-aria/focus';
 import { useLayoutSizes, useLayoutContextualBarPosition, useRoomToolbox } from '@rocket.chat/ui-contexts';
 import type { ComponentProps } from 'react';
 import { useCallback, useRef } from 'react';
-import type { AriaDialogProps } from 'react-aria';
-import { FocusScope, useDialog } from 'react-aria';
 
 import Contextualbar from './Contextualbar';
 import ContextualbarResizable from './ContextualbarResizable';

--- a/packages/ui-client/src/components/Modal/ModalRegion.tsx
+++ b/packages/ui-client/src/components/Modal/ModalRegion.tsx
@@ -5,7 +5,7 @@ import { lazy, Suspense } from 'react';
 import ModalBackdrop from './ModalBackdrop';
 import ModalPortal from './ModalPortal';
 
-const FocusScope = lazy(() => import('react-aria').then((module) => ({ default: module.FocusScope })));
+const FocusScope = lazy(() => import('@react-aria/focus').then((module) => ({ default: module.FocusScope })));
 
 const ModalRegion = () => {
 	const currentModal = useCurrentModal();

--- a/packages/ui-contexts/src/UserCardContext.ts
+++ b/packages/ui-contexts/src/UserCardContext.ts
@@ -1,7 +1,7 @@
+import type { AriaButtonProps } from '@react-aria/button';
+import type { OverlayTriggerState } from '@react-stately/overlays';
 import type { MutableRefObject, UIEvent } from 'react';
 import { createContext } from 'react';
-import type { AriaButtonProps } from 'react-aria';
-import type { OverlayTriggerState } from 'react-stately';
 
 export type UserCardContextValue = {
 	openUserCard: (e: UIEvent, username: string) => void;

--- a/packages/ui-voip/src/components/Keypad/Key.tsx
+++ b/packages/ui-voip/src/components/Keypad/Key.tsx
@@ -1,6 +1,7 @@
+import { useLongPress, usePress } from '@react-aria/interactions';
+import { mergeProps } from '@react-aria/utils';
 import { css } from '@rocket.chat/css-in-js';
 import { Box, Button } from '@rocket.chat/fuselage';
-import { mergeProps, useLongPress, usePress } from 'react-aria';
 import { useTranslation } from 'react-i18next';
 
 type KeyProps = {

--- a/packages/ui-voip/src/components/Keypad/Keypad.tsx
+++ b/packages/ui-voip/src/components/Keypad/Keypad.tsx
@@ -1,5 +1,5 @@
+import { FocusScope } from '@react-aria/focus';
 import { Box } from '@rocket.chat/fuselage';
-import { FocusScope } from 'react-aria';
 
 import Key from './Key';
 

--- a/packages/ui-voip/src/components/Widget/Widget.tsx
+++ b/packages/ui-voip/src/components/Widget/Widget.tsx
@@ -1,8 +1,8 @@
+import { FocusScope } from '@react-aria/focus';
 import { Palette } from '@rocket.chat/fuselage';
 import styled from '@rocket.chat/styled';
 import type { ComponentProps, ReactNode } from 'react';
 import { useLayoutEffect } from 'react';
-import { FocusScope } from 'react-aria';
 
 import { DragContext } from './WidgetDraggableContext';
 import { useDraggable } from '../../hooks';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3378,6 +3378,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@date-fns/tz@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "@date-fns/tz@npm:1.4.1"
+  checksum: 10/062097590005cce3da4c7d9880f9c77d386cff5b4dd58fa3dde3c346a8b2e4f4a8025a613306351a7cad8eb71178a0f67b4840d5884f73aa4c759085fac92063
+  languageName: node
+  linkType: hard
+
 "@discoveryjs/json-ext@npm:^0.5.0":
   version: 0.5.7
   resolution: "@discoveryjs/json-ext@npm:0.5.7"
@@ -8218,7 +8225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-stately/data@npm:^3.12.1, @react-stately/data@npm:^3.6.1":
+"@react-stately/data@npm:^3.6.1":
   version: 3.12.1
   resolution: "@react-stately/data@npm:3.12.1"
   dependencies:
@@ -9174,7 +9181,7 @@ __metadata:
     ts-patch: "npm:^3.3.0"
     typescript: "npm:~5.9.3"
     typia: "patch:typia@npm%3A9.7.2#~/.yarn/patches/typia-npm-9.7.2-5c5d9c80b4.patch"
-    zod: "npm:~4.3.6"
+    zod: "patch:zod@npm%3A4.3.6#~/.yarn/patches/zod-npm-4.3.6-a096e305e6.patch"
   languageName: unknown
   linkType: soft
 
@@ -9968,6 +9975,7 @@ __metadata:
     "@bugsnag/js": "npm:~7.20.2"
     "@bugsnag/plugin-react": "npm:~7.19.0"
     "@datastructures-js/priority-queue": "npm:^6.3.5"
+    "@date-fns/tz": "npm:^1.4.1"
     "@faker-js/faker": "npm:~8.0.2"
     "@google-cloud/storage": "npm:^7.15.0"
     "@kaciras/deasync": "npm:^1.1.0"
@@ -10338,7 +10346,7 @@ __metadata:
     xml2js: "npm:~0.6.2"
     yaqrcode: "npm:^0.2.1"
     yoga-layout: "patch:yoga-layout@npm%3A3.2.1#~/.yarn/patches/yoga-layout-npm-3.2.1-51ec934670.patch"
-    zod: "npm:~4.3.6"
+    zod: "patch:zod@npm%3A4.3.6#~/.yarn/patches/zod-npm-4.3.6-a096e305e6.patch"
     zustand: "npm:~5.0.10"
   languageName: unknown
   linkType: soft
@@ -10949,7 +10957,6 @@ __metadata:
     "@types/jest": "npm:~30.0.0"
     eslint: "npm:~9.39.3"
     jest: "npm:~30.2.0"
-    moment-timezone: "npm:^0.5.48"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft
@@ -11309,7 +11316,6 @@ __metadata:
     codemirror: "npm:^6.0.2"
     eslint: "npm:~9.39.3"
     eslint4b-prebuilt: "npm:^6.7.2"
-    moment: "npm:^2.30.1"
     prettier: "npm:~3.3.3"
     rc-scrollbars: "npm:^1.1.6"
     react: "npm:~18.3.1"
@@ -32348,7 +32354,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-aria@npm:~3.37.0":
+"react-aria@npm:3.37.0":
   version: 3.37.0
   resolution: "react-aria@npm:3.37.0"
   dependencies:
@@ -32395,6 +32401,56 @@ __metadata:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
   checksum: 10/e510ce17009e6cad3e9198c5164c325dc06bf3bba6ae50bd41ce9cfdb53fa620bf7c1bc678089737d43607bc222ea1aa0e5ddb19614a0650e3fdf4eb25ac820c
+  languageName: node
+  linkType: hard
+
+"react-aria@patch:react-aria@npm%3A3.37.0#~/.yarn/patches/react-aria-npm-3.37.0-83959bd2fa.patch":
+  version: 3.37.0
+  resolution: "react-aria@patch:react-aria@npm%3A3.37.0#~/.yarn/patches/react-aria-npm-3.37.0-83959bd2fa.patch::version=3.37.0&hash=e69ffb"
+  dependencies:
+    "@internationalized/string": "npm:^3.2.5"
+    "@react-aria/breadcrumbs": "npm:^3.5.20"
+    "@react-aria/button": "npm:^3.11.1"
+    "@react-aria/calendar": "npm:^3.7.0"
+    "@react-aria/checkbox": "npm:^3.15.1"
+    "@react-aria/color": "npm:^3.0.3"
+    "@react-aria/combobox": "npm:^3.11.1"
+    "@react-aria/datepicker": "npm:^3.13.0"
+    "@react-aria/dialog": "npm:^3.5.21"
+    "@react-aria/disclosure": "npm:^3.0.1"
+    "@react-aria/dnd": "npm:^3.8.1"
+    "@react-aria/focus": "npm:^3.19.1"
+    "@react-aria/gridlist": "npm:^3.10.1"
+    "@react-aria/i18n": "npm:^3.12.5"
+    "@react-aria/interactions": "npm:^3.23.0"
+    "@react-aria/label": "npm:^3.7.14"
+    "@react-aria/link": "npm:^3.7.8"
+    "@react-aria/listbox": "npm:^3.14.0"
+    "@react-aria/menu": "npm:^3.17.0"
+    "@react-aria/meter": "npm:^3.4.19"
+    "@react-aria/numberfield": "npm:^3.11.10"
+    "@react-aria/overlays": "npm:^3.25.0"
+    "@react-aria/progress": "npm:^3.4.19"
+    "@react-aria/radio": "npm:^3.10.11"
+    "@react-aria/searchfield": "npm:^3.8.0"
+    "@react-aria/select": "npm:^3.15.1"
+    "@react-aria/selection": "npm:^3.22.0"
+    "@react-aria/separator": "npm:^3.4.5"
+    "@react-aria/slider": "npm:^3.7.15"
+    "@react-aria/ssr": "npm:^3.9.7"
+    "@react-aria/switch": "npm:^3.6.11"
+    "@react-aria/table": "npm:^3.16.1"
+    "@react-aria/tabs": "npm:^3.9.9"
+    "@react-aria/tag": "npm:^3.4.9"
+    "@react-aria/textfield": "npm:^3.16.0"
+    "@react-aria/tooltip": "npm:^3.7.11"
+    "@react-aria/utils": "npm:^3.27.0"
+    "@react-aria/visually-hidden": "npm:^3.8.19"
+    "@react-types/shared": "npm:^3.27.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/cd2092e40b2f8f74cdd4c9d090755075559174d3a1fcbdab0ffb68ddaeb2a7f57c257e75c308314f1bb2ca143439eec6ecf1ec33b37d7abd25e673d465c1e411
   languageName: node
   linkType: hard
 
@@ -32658,7 +32714,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-stately@npm:~3.17.0":
+"react-stately@npm:3.17.0, react-stately@npm:~3.17.0":
   version: 3.17.0
   resolution: "react-stately@npm:3.17.0"
   dependencies:
@@ -32689,38 +32745,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-stately@npm:~3.35.0":
-  version: 3.35.0
-  resolution: "react-stately@npm:3.35.0"
+"react-stately@patch:react-stately@npm%3A3.17.0#~/.yarn/patches/react-stately-npm-3.17.0-264cc7a43c.patch":
+  version: 3.17.0
+  resolution: "react-stately@patch:react-stately@npm%3A3.17.0#~/.yarn/patches/react-stately-npm-3.17.0-264cc7a43c.patch::version=3.17.0&hash=e13f63"
   dependencies:
-    "@react-stately/calendar": "npm:^3.7.0"
-    "@react-stately/checkbox": "npm:^3.6.11"
-    "@react-stately/collections": "npm:^3.12.1"
-    "@react-stately/color": "npm:^3.8.2"
-    "@react-stately/combobox": "npm:^3.10.2"
-    "@react-stately/data": "npm:^3.12.1"
-    "@react-stately/datepicker": "npm:^3.12.0"
-    "@react-stately/disclosure": "npm:^3.0.1"
-    "@react-stately/dnd": "npm:^3.5.1"
-    "@react-stately/form": "npm:^3.1.1"
-    "@react-stately/list": "npm:^3.11.2"
-    "@react-stately/menu": "npm:^3.9.1"
-    "@react-stately/numberfield": "npm:^3.9.9"
-    "@react-stately/overlays": "npm:^3.6.13"
-    "@react-stately/radio": "npm:^3.10.10"
-    "@react-stately/searchfield": "npm:^3.5.9"
-    "@react-stately/select": "npm:^3.6.10"
-    "@react-stately/selection": "npm:^3.19.0"
-    "@react-stately/slider": "npm:^3.6.1"
-    "@react-stately/table": "npm:^3.13.1"
-    "@react-stately/tabs": "npm:^3.7.1"
-    "@react-stately/toggle": "npm:^3.8.1"
-    "@react-stately/tooltip": "npm:^3.5.1"
-    "@react-stately/tree": "npm:^3.8.7"
-    "@react-types/shared": "npm:^3.27.0"
+    "@react-stately/calendar": "npm:^3.0.2"
+    "@react-stately/checkbox": "npm:^3.2.1"
+    "@react-stately/collections": "npm:^3.4.3"
+    "@react-stately/combobox": "npm:^3.2.1"
+    "@react-stately/data": "npm:^3.6.1"
+    "@react-stately/datepicker": "npm:^3.0.2"
+    "@react-stately/list": "npm:^3.5.3"
+    "@react-stately/menu": "npm:^3.4.1"
+    "@react-stately/numberfield": "npm:^3.2.1"
+    "@react-stately/overlays": "npm:^3.4.1"
+    "@react-stately/radio": "npm:^3.5.1"
+    "@react-stately/searchfield": "npm:^3.3.1"
+    "@react-stately/select": "npm:^3.3.1"
+    "@react-stately/selection": "npm:^3.10.3"
+    "@react-stately/slider": "npm:^3.2.1"
+    "@react-stately/table": "npm:^3.4.0"
+    "@react-stately/tabs": "npm:^3.2.1"
+    "@react-stately/toggle": "npm:^3.4.1"
+    "@react-stately/tooltip": "npm:^3.2.1"
+    "@react-stately/tree": "npm:^3.3.3"
+    "@react-types/shared": "npm:^3.14.1"
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10/5977fab93e55d110dc3d009137b97ac9281c2539239958be7743466c16d10da4c7d2a98c65295621be411bbc5f3941fdd15ac3546363d01829ecc430bf3d2604
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 10/0c34b5ca78d7a6407518a78f6b526d261661ab47ca204aea867d4e84e5e3f501316b3b234c7a2ad91e98f193d1df2babf92ec5bfca3ef8f2a18a627f0708631d
   languageName: node
   linkType: hard
 
@@ -38669,10 +38721,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.25.0 || ^4.0.0, zod@npm:~4.3.6":
+"zod@npm:4.3.6":
   version: 4.3.6
   resolution: "zod@npm:4.3.6"
   checksum: 10/25fc0f62e01b557b4644bf0b393bbaf47542ab30877c37837ea8caf314a8713d220c7d7fe51f68ffa72f0e1018ddfa34d96f1973d23033f5a2a5a9b6b9d9da01
+  languageName: node
+  linkType: hard
+
+"zod@patch:zod@npm%3A4.3.6#~/.yarn/patches/zod-npm-4.3.6-a096e305e6.patch":
+  version: 4.3.6
+  resolution: "zod@patch:zod@npm%3A4.3.6#~/.yarn/patches/zod-npm-4.3.6-a096e305e6.patch::version=4.3.6&hash=5b64de"
+  checksum: 10/7e9f9e3bef6a7aa9c859841837824b1bc95063c77afbe6dbb4bdb247b70c84aef505ddfc77a693e3dabe2e9182d2ccb497df6bd3f5b045a705e189c906dc8dfc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Adds `yarn patch` for `react-aria` and `react-stately` that slim their barrel entry points to only re-export the sub-packages actually consumed
- Adds `yarn patch` for `zod` that removes `export * as locales` from all barrel entry points (classic, core, mini — ESM and CJS)
- Replaces `from 'react-aria'` barrel imports with direct sub-package imports (`@react-aria/focus`, `@react-aria/overlays`, etc.) across `apps/meteor` and workspace packages

## Motivation

Meteor's bundler does not tree-shake. Three barrel packages were pulling in large amounts of unused code:

| Package | Before | After | Saved |
|---|---|---|---|
| `react-aria` | 641 KB | 168 KB | **-474 KB** |
| `react-stately` | 190 KB | 30 KB | **-160 KB** |
| `zod` (locales) | 278 KB | 134 KB | **-144 KB** |

## Results

| Metric | Before | After | Delta |
|---|---|---|---|
| Main JS (minified) | 3688 KB | 2889 KB | **-799 KB (-22%)** |
| Main JS (gzip) | 939 KB | 772 KB | **-167 KB (-18%)** |

## Patches

- `.yarn/patches/react-aria-npm-3.37.0-*.patch` — slim barrel to 13 sub-packages (removed 30 unused: dnd, calendar, table, color, datepicker, etc.)
- `.yarn/patches/react-stately-npm-3.17.0-*.patch` — slim barrel to 6 sub-packages (removed 14 unused: color, datepicker, table, data, etc.)
- `.yarn/patches/zod-npm-4.3.6-*.patch` — remove `export * as locales` from all entry points (50 locale files, only English is used)

See `docs/bundle-optimization-react-aria.md` for maintenance instructions.

## Test plan

- [ ] App starts and all UI interactions work (FocusScope, menus, selects, sliders, overlays, VoIP keypad)
- [ ] Zod validation works (schemas, error messages in English)
- [ ] Bundle size reduction verified via `.stats.json`
- [ ] Existing test suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced numerous React Aria / React Stately barrel imports with scoped sub-package imports across the UI to standardize imports.

* **Chores**
  * Added patched dependency resolutions for react-aria, react-stately, and zod in package.json.

* **Documentation**
  * Added a bundle-optimization guide explaining mitigation steps and measured bundle-size improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

 Task: [ARCH-2097]

[ARCH-2097]: https://rocketchat.atlassian.net/browse/ARCH-2097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ