### PR TITLE
fix: Livechat-Add check for scrollPosition before restoring scroll

### DIFF
--- a/packages/livechat/src/widget.ts
+++ b/packages/livechat/src/widget.ts
@@ -150,7 +150,7 @@ const updateWidgetStyle = (isOpened: boolean) => {
 		document.body.classList.add('rc-livechat-mobile-full-screen');
 	} else {
 		document.body.classList.remove('rc-livechat-mobile-full-screen');
-		if (smallScreen) {
+		if (smallScreen && typeof scrollPosition !== "undefined") {
 			document.documentElement.scrollTop = scrollPosition;
 		}
 	}


### PR DESCRIPTION
Mobile - after loading widget with delay, website scrolls to top. This is unintended behaviour caused by this line of code. We should not call it without checking if scrollPosition has been saved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scroll position restoration when exiting the livechat widget's mobile full-screen mode. Scroll position is now correctly restored only when a previously saved position exists, preventing unexpected scroll behavior on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->