### PR TITLE
feat(integrations): show webhook script compilation status

### DIFF
--- a/apps/meteor/app/integrations/server/lib/validateOutgoingIntegration.ts
+++ b/apps/meteor/app/integrations/server/lib/validateOutgoingIntegration.ts
@@ -187,7 +187,6 @@ export const validateOutgoingIntegration = async function (
 				comments: false,
 			});
 
-			// TODO: Webhook Integration Editor should inform the user if the script is compiled successfully
 			integrationData.scriptCompiled = result?.code ?? undefined;
 			integrationData.scriptError = undefined;
 		} catch (e) {

--- a/apps/meteor/app/integrations/server/methods/incoming/addIncomingIntegration.ts
+++ b/apps/meteor/app/integrations/server/methods/incoming/addIncomingIntegration.ts
@@ -119,7 +119,6 @@ export const addIncomingIntegration = async (userId: string, integration: INewIn
 				comments: false,
 			});
 
-			// TODO: Webhook Integration Editor should inform the user if the script is compiled successfully
 			integrationData.scriptCompiled = result?.code ?? undefined;
 			delete integrationData.scriptError;
 		} catch (e) {

--- a/apps/meteor/app/integrations/server/methods/incoming/updateIncomingIntegration.ts
+++ b/apps/meteor/app/integrations/server/methods/incoming/updateIncomingIntegration.ts
@@ -97,7 +97,6 @@ export const updateIncomingIntegration = async (
 					comments: false,
 				});
 
-				// TODO: Webhook Integration Editor should inform the user if the script is compiled successfully
 				scriptCompiled = result?.code ?? undefined;
 				scriptError = undefined;
 				await Integrations.updateOne(

--- a/apps/meteor/client/views/admin/integrations/incoming/IncomingWebhookForm.tsx
+++ b/apps/meteor/client/views/admin/integrations/incoming/IncomingWebhookForm.tsx
@@ -319,6 +319,16 @@ const IncomingWebhookForm = ({ webhookData }: { webhookData?: Serialized<IIncomi
 									)}
 								/>
 							</FieldRow>
+							{webhookData?.scriptEnabled && webhookData?.scriptError && (
+								<FieldError aria-live='assertive' id={`${scriptField}-error`}>
+									{webhookData.scriptError.name}: {webhookData.scriptError.message}
+								</FieldError>
+							)}
+							{webhookData?.scriptEnabled && webhookData?.scriptCompiled && !webhookData?.scriptError && (
+								<FieldHint id={`${scriptField}-success`}>
+									{t('Integration_script_compiled_successfully')}
+								</FieldHint>
+							)}
 						</Field>
 					</FieldGroup>
 				</AccordionItem>

--- a/apps/meteor/client/views/admin/integrations/outgoing/EditOutgoingWebhook.tsx
+++ b/apps/meteor/client/views/admin/integrations/outgoing/EditOutgoingWebhook.tsx
@@ -150,7 +150,7 @@ const EditOutgoingWebhook = ({ webhookData }: EditOutgoingWebhookProps) => {
 			)}
 			<PageScrollableContentWithShadow is='form' id={formId} onSubmit={handleSubmit(handleSave)}>
 				<FormProvider {...methods}>
-					<OutgoingWebhookForm />
+					<OutgoingWebhookForm webhookData={webhookData} />
 				</FormProvider>
 			</PageScrollableContentWithShadow>
 			<PageFooter isDirty={isDirty}>

--- a/apps/meteor/client/views/admin/integrations/outgoing/OutgoingWebhookForm.tsx
+++ b/apps/meteor/client/views/admin/integrations/outgoing/OutgoingWebhookForm.tsx
@@ -1,4 +1,4 @@
-import type { IOutgoingIntegration } from '@rocket.chat/core-typings';
+import type { IOutgoingIntegration, Serialized } from '@rocket.chat/core-typings';
 import type { SelectOption } from '@rocket.chat/fuselage';
 import {
 	FieldError,
@@ -52,7 +52,7 @@ type EditOutgoingWebhookPayload = Pick<
 	| 'runOnEdits'
 >;
 
-const OutgoingWebhookForm = () => {
+const OutgoingWebhookForm = ({ webhookData }: { webhookData?: Serialized<IOutgoingIntegration> }) => {
 	const { t } = useTranslation();
 
 	const {
@@ -418,6 +418,16 @@ const OutgoingWebhookForm = () => {
 									)}
 								/>
 							</FieldRow>
+							{webhookData?.scriptEnabled && webhookData?.scriptError && (
+								<FieldError aria-live='assertive' id={`${scriptField}-error`}>
+									{webhookData.scriptError.name}: {webhookData.scriptError.message}
+								</FieldError>
+							)}
+							{webhookData?.scriptEnabled && webhookData?.scriptCompiled && !webhookData?.scriptError && (
+								<FieldHint id={`${scriptField}-success`}>
+									{t('Integration_script_compiled_successfully')}
+								</FieldHint>
+							)}
 						</Field>
 						<Field>
 							<FieldLabel>{t('Responding')}</FieldLabel>

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -2668,6 +2668,7 @@
   "Integration_Advanced_Settings": "Advanced Settings",
   "Integration_Delete_Warning": "Deleting an Integrations cannot be undone.",
   "Integration_History_Cleared": "Integration History Successfully Cleared",
+  "Integration_script_compiled_successfully": "Script compiled successfully.",
   "Integration_Incoming_WebHook": "Incoming WebHook Integration",
   "Integration_New": "New Integration",
   "Integration_Outgoing_WebHook": "Outgoing WebHook Integration",


### PR DESCRIPTION
## Proposed changes
The Webhook Integration Editor now clearly informs admins when a webhook script compiles successfully after saving.

- Incoming + Outgoing webhook forms show an inline success hint (“Script compiled successfully.”) when `scriptEnabled` is on and the server returns `scriptCompiled` (and no `scriptError`).
- Adds a i18n string for the success hint.

## Issue
Closes #40094

## Steps to test or reproduce
1. Go to **Administration → Integrations**.
2. Create or edit an **Incoming WebHook Integration**.
   - Enable **Script Enabled**.
   - Paste a valid script (no syntax errors) and save.
   - Verify the Script field shows: **“Script compiled successfully.”**
3. Edit the same incoming integration again:
   - Introduce a syntax error and save.
   - Verify an inline error appears (e.g., `SyntaxError: ...`) and the success hint is not shown.
4. Repeat steps 2–3 for an **Outgoing WebHook Integration**.

## Further comments
Script compilation already happens server-side and is persisted as `scriptCompiled` or `scriptError`; this PR makes that result visible in the editor to reduce uncertainty after saving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Script compilation feedback now displays in webhook configuration forms, showing success messages and detailed error information when scripts compile or fail.

* **Chores**
  * Added translation support and removed internal development comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->