### PR TITLE
Release 8.3.2

### DIFF
--- a/.changeset/bump-patch-1776093752957.md
+++ b/.changeset/bump-patch-1776093752957.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Bump @rocket.chat/meteor version.

--- a/.changeset/khaki-eggs-provide.md
+++ b/.changeset/khaki-eggs-provide.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/apps-engine': patch
+'@rocket.chat/meteor': patch
+---
+
+Security Hotfix (https://docs.rocket.chat/docs/security-fixes-and-updates)

--- a/apps/meteor/ee/server/apps/communication/endpoints/appGeneralLogsHandler.ts
+++ b/apps/meteor/ee/server/apps/communication/endpoints/appGeneralLogsHandler.ts
@@ -7,7 +7,7 @@ import { makeAppLogsQuery } from './lib/makeAppLogsQuery';
 export const registerAppGeneralLogsHandler = ({ api, _orch }: AppsRestApi) =>
 	void api.addRoute(
 		'logs',
-		{ authRequired: true, permissionRequired: ['manage-apps'], validateParams: isAppLogsProps },
+		{ authRequired: true, permissionsRequired: ['manage-apps'], validateParams: isAppLogsProps },
 		{
 			async get() {
 				const { offset, count } = await getPaginationItems(this.queryParams);

--- a/apps/meteor/ee/server/apps/communication/endpoints/appLogsHandler.ts
+++ b/apps/meteor/ee/server/apps/communication/endpoints/appLogsHandler.ts
@@ -7,7 +7,7 @@ import { makeAppLogsQuery } from './lib/makeAppLogsQuery';
 export const registerAppLogsHandler = ({ api, _manager, _orch }: AppsRestApi) =>
 	void api.addRoute(
 		':id/logs',
-		{ authRequired: true, permissionRequired: ['manage-apps'], validateParams: isAppLogsProps },
+		{ authRequired: true, permissionsRequired: ['manage-apps'], validateParams: isAppLogsProps },
 		{
 			async get() {
 				const proxiedApp = _manager.getOneById(this.urlParams.id);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11366,7 +11366,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.2.5
-    "@rocket.chat/ui-contexts": 29.0.0
+    "@rocket.chat/ui-contexts": 29.0.1
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version management configuration updated to record patch bumps.

* **Bug Fixes**
  * Authorization configuration for app logs endpoints standardized to ensure consistent permission checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- release-notes-start -->
<!-- This content is automatically generated. Changing this will not reflect on the final release log -->

_You can see below a preview of the release change log:_

# 8.3.2

### Engine versions

- Node: `22.16.0`
- Deno: `1.43.5`
- MongoDB: `8.0`
- Apps-Engine: `1.61.1`

### Patch Changes

*   Bump @rocket.chat/meteor version.

*   ([#40130](https://github.com/RocketChat/Rocket.Chat/pull/40130) by [@dionisio-bot](https://github.com/dionisio-bot)) Security Hotfix (https://docs.rocket.chat/docs/security-fixes-and-updates)

*   <details><summary>Updated dependencies [356a6026dda4821a3e28752def7c8619ac860975]:</summary>

    *   @rocket.chat/apps-engine@1.61.1
    *   @rocket.chat/presence@0.2.55
    *   @rocket.chat/apps@0.6.8
    *   @rocket.chat/core-services@0.13.4
    *   @rocket.chat/core-typings@8.3.2
    *   @rocket.chat/fuselage-ui-kit@29.0.2
    *   @rocket.chat/rest-typings@8.3.2
    *   @rocket.chat/ui-voip@19.0.2
    *   @rocket.chat/abac@0.1.8
    *   @rocket.chat/federation-matrix@0.1.2
    *   @rocket.chat/license@1.1.15
    *   @rocket.chat/media-calls@0.3.2
    *   @rocket.chat/omnichannel-services@0.3.52
    *   @rocket.chat/pdf-worker@0.3.34
    *   @rocket.chat/api-client@0.2.55
    *   @rocket.chat/cron@0.1.55
    *   @rocket.chat/gazzodown@29.0.2
    *   @rocket.chat/http-router@7.9.22
    *   @rocket.chat/message-types@0.1.1
    *   @rocket.chat/model-typings@2.1.4
    *   @rocket.chat/ui-avatar@25.0.2
    *   @rocket.chat/ui-client@29.0.2
    *   @rocket.chat/ui-contexts@29.0.2
    *   @rocket.chat/web-ui-registration@29.0.2
    *   @rocket.chat/models@2.1.4
    *   @rocket.chat/server-cloud-communication@0.0.3
    *   @rocket.chat/network-broker@0.2.34
    *   @rocket.chat/omni-core-ee@0.0.20
    *   @rocket.chat/ui-video-conf@29.0.2
    *   @rocket.chat/instance-status@0.1.55
    *   @rocket.chat/omni-core@0.0.20
    *   @rocket.chat/server-fetch@0.1.4

    </details>

<!-- release-notes-end -->