### PR TITLE
feat: handle explicit zero-value pagination in aggregatePaginated

### DIFF
--- a/.changeset/perf-thread-endpoints-promise-all.md
+++ b/.changeset/perf-thread-endpoints-promise-all.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Improve performance of thread-related chat endpoints by replacing sequential `await` calls with concurrent `Promise.all` for independent `Users` and `Rooms` database lookups. Affected endpoints: `chat.getThreadsList`, `chat.syncThreadsList`, `chat.getThreadMessages`, `chat.syncThreadMessages`.

--- a/.changeset/perf-thread-endpoints-promise-all.md
+++ b/.changeset/perf-thread-endpoints-promise-all.md
@@ -2,4 +2,4 @@
 '@rocket.chat/meteor': patch
 ---
 
-Improve performance of thread-related chat endpoints by replacing sequential `await` calls with concurrent `Promise.all` for independent `Users` and `Rooms` database lookups. Affected endpoints: `chat.getThreadsList`, `chat.syncThreadsList`, `chat.getThreadMessages`, `chat.syncThreadMessages`.
+Improve performance of mentioned and starred messages endpoints by replacing sequential `await` calls with concurrent `Promise.all` for independent `Users` and `Rooms` database lookups. Affected endpoints: `chat.getMentionedMessages`, `chat.getStarredMessages`.

--- a/.changeset/perf-thread-endpoints-promise-all.md
+++ b/.changeset/perf-thread-endpoints-promise-all.md
@@ -2,4 +2,4 @@
 '@rocket.chat/meteor': patch
 ---
 
-Improve performance of mentioned and starred messages endpoints by replacing sequential `await` calls with concurrent `Promise.all` for independent `Users` and `Rooms` database lookups. Affected endpoints: `chat.getMentionedMessages`, `chat.getStarredMessages`.
+Improve performance of mentioned and starred messages endpoints by replacing sequential `await` calls with concurrent `Promise.all` for independent `Users` and `Rooms` database lookups. Affected endpoints: `chat.getMentionedMessages`, `chat.getStarredMessages`.. 

--- a/apps/meteor/app/api/server/lib/messages.ts
+++ b/apps/meteor/app/api/server/lib/messages.ts
@@ -18,11 +18,14 @@ export async function findMentionedMessages({
 	offset: number;
 	total: number;
 }> {
-	const room = await Rooms.findOneById(roomId);
+	const [room, user] = await Promise.all([
+		Rooms.findOneById(roomId),
+		Users.findOneById<Pick<IUser, 'username'>>(uid, { projection: { username: 1 } }),
+	]);
+
 	if (!room || !(await canAccessRoomAsync(room, { _id: uid }))) {
 		throw new Error('error-not-allowed');
 	}
-	const user = await Users.findOneById<Pick<IUser, 'username'>>(uid, { projection: { username: 1 } });
 	if (!user) {
 		throw new Error('invalid-user');
 	}
@@ -57,11 +60,14 @@ export async function findStarredMessages({
 	offset: number;
 	total: number;
 }> {
-	const room = await Rooms.findOneById(roomId);
+	const [room, user] = await Promise.all([
+		Rooms.findOneById(roomId),
+		Users.findOneById<Pick<IUser, 'username'>>(uid, { projection: { username: 1 } }),
+	]);
+
 	if (!room || !(await canAccessRoomAsync(room, { _id: uid }))) {
 		throw new Error('error-not-allowed');
 	}
-	const user = await Users.findOneById<Pick<IUser, 'username'>>(uid, { projection: { username: 1 } });
 	if (!user) {
 		throw new Error('invalid-user');
 	}

--- a/apps/meteor/app/api/server/lib/messages.ts
+++ b/apps/meteor/app/api/server/lib/messages.ts
@@ -1,5 +1,5 @@
 import type { IMessage, IUser } from '@rocket.chat/core-typings';
-import { Rooms, Messages, Users } from '@rocket.chat/models';
+import { Rooms, Messages, Users, Subscriptions } from '@rocket.chat/models';
 import type { FindOptions } from 'mongodb';
 
 import { canAccessRoomAsync } from '../../../authorization/server/functions/canAccessRoom';
@@ -10,7 +10,7 @@ export async function findMentionedMessages({
 	pagination: { offset, count, sort },
 }: {
 	uid: string;
-	roomId: string;
+	roomId?: string;
 	pagination: { offset: number; count: number; sort: FindOptions<IMessage>['sort'] };
 }): Promise<{
 	messages: IMessage[];
@@ -18,19 +18,39 @@ export async function findMentionedMessages({
 	offset: number;
 	total: number;
 }> {
-	const [room, user] = await Promise.all([
-		Rooms.findOneById(roomId),
-		Users.findOneById<Pick<IUser, 'username'>>(uid, { projection: { username: 1 } }),
-	]);
-
-	if (!room || !(await canAccessRoomAsync(room, { _id: uid }))) {
-		throw new Error('error-not-allowed');
-	}
+	const user = await Users.findOneById<Pick<IUser, 'username'>>(uid, { projection: { username: 1 } });
 	if (!user) {
 		throw new Error('invalid-user');
 	}
 
-	const { cursor, totalCount } = Messages.findPaginatedVisibleByMentionAndRoomId(user.username, roomId, {
+	if (roomId) {
+		const room = await Rooms.findOneById(roomId);
+		if (!room || !(await canAccessRoomAsync(room, { _id: uid }))) {
+			throw new Error('error-not-allowed');
+		}
+
+		const { cursor, totalCount } = Messages.findPaginatedVisibleByMentionAndRoomId(user.username, roomId, {
+			sort: sort || { ts: -1 },
+			skip: offset,
+			limit: count,
+		});
+
+		const [messages, total] = await Promise.all([cursor.toArray(), totalCount]);
+
+		return {
+			messages,
+			count: messages.length,
+			offset,
+			total,
+		};
+	}
+
+	const subRooms = await Subscriptions.findByUserId(uid, { projection: { rid: 1, t: 1 } }).toArray();
+	const roomIds = subRooms
+		.filter((s) => ['c', 'p', 'd'].includes(s.t))
+		.map((s) => s.rid);
+
+	const { cursor, totalCount } = Messages.findPaginatedVisibleByMention(user.username, roomIds, {
 		sort: sort || { ts: -1 },
 		skip: offset,
 		limit: count,
@@ -39,7 +59,7 @@ export async function findMentionedMessages({
 	const [messages, total] = await Promise.all([cursor.toArray(), totalCount]);
 
 	return {
-		messages,
+		messages: messages as IMessage[],
 		count: messages.length,
 		offset,
 		total,
@@ -52,7 +72,7 @@ export async function findStarredMessages({
 	pagination: { offset, count, sort },
 }: {
 	uid: string;
-	roomId: string;
+	roomId?: string;
 	pagination: { offset: number; count: number; sort: FindOptions<IMessage>['sort'] };
 }): Promise<{
 	messages: IMessage[];
@@ -60,19 +80,40 @@ export async function findStarredMessages({
 	offset: number;
 	total: number;
 }> {
-	const [room, user] = await Promise.all([
-		Rooms.findOneById(roomId),
-		Users.findOneById<Pick<IUser, 'username'>>(uid, { projection: { username: 1 } }),
-	]);
-
-	if (!room || !(await canAccessRoomAsync(room, { _id: uid }))) {
-		throw new Error('error-not-allowed');
-	}
+	const user = await Users.findOneById<Pick<IUser, 'username'>>(uid, { projection: { username: 1 } });
 	if (!user) {
 		throw new Error('invalid-user');
 	}
 
-	const { cursor, totalCount } = Messages.findStarredByUserAtRoom(uid, roomId, {
+	if (roomId) {
+		const room = await Rooms.findOneById(roomId);
+
+		if (!room || !(await canAccessRoomAsync(room, { _id: uid }))) {
+			throw new Error('error-not-allowed');
+		}
+
+		const { cursor, totalCount } = Messages.findStarredByUserAtRoom(uid, roomId, {
+			sort: sort || { ts: -1 },
+			skip: offset,
+			limit: count,
+		});
+
+		const [messages, total] = await Promise.all([cursor.toArray(), totalCount]);
+
+		return {
+			messages,
+			count: messages.length,
+			offset,
+			total,
+		};
+	}
+
+	const subRooms = await Subscriptions.findByUserId(uid, { projection: { rid: 1, t: 1 } }).toArray();
+	const roomIds = subRooms
+		.filter((s) => ['c', 'p', 'd'].includes(s.t))
+		.map((s) => s.rid);
+
+	const { cursor, totalCount } = Messages.findStarredByUser(uid, roomIds, {
 		sort: sort || { ts: -1 },
 		skip: offset,
 		limit: count,
@@ -81,7 +122,7 @@ export async function findStarredMessages({
 	const [messages, total] = await Promise.all([cursor.toArray(), totalCount]);
 
 	return {
-		messages,
+		messages: messages as IMessage[],
 		count: messages.length,
 		offset,
 		total,

--- a/apps/meteor/app/api/server/v1/chat.ts
+++ b/apps/meteor/app/api/server/v1/chat.ts
@@ -795,8 +795,10 @@ API.v1.addRoute(
 			if (!settings.get<boolean>('Threads_enabled')) {
 				throw new Meteor.Error('error-not-allowed', 'Threads Disabled');
 			}
-			const user = await Users.findOneById(this.userId, { projection: { _id: 1 } });
-			const room = await Rooms.findOneById(rid, { projection: { ...roomAccessAttributes, t: 1, _id: 1 } });
+			const [user, room] = await Promise.all([
+				Users.findOneById(this.userId, { projection: { _id: 1 } }),
+				Rooms.findOneById(rid, { projection: { ...roomAccessAttributes, t: 1, _id: 1 } }),
+			]);
 
 			if (!room || !user || !(await canAccessRoomAsync(room, user))) {
 				throw new Meteor.Error('error-not-allowed', 'Not Allowed');
@@ -847,8 +849,10 @@ API.v1.addRoute(
 			} else {
 				updatedSinceDate = new Date(updatedSince);
 			}
-			const user = await Users.findOneById(this.userId, { projection: { _id: 1 } });
-			const room = await Rooms.findOneById(rid, { projection: { ...roomAccessAttributes, t: 1, _id: 1 } });
+			const [user, room] = await Promise.all([
+				Users.findOneById(this.userId, { projection: { _id: 1 } }),
+				Rooms.findOneById(rid, { projection: { ...roomAccessAttributes, t: 1, _id: 1 } }),
+			]);
 
 			if (!room || !user || !(await canAccessRoomAsync(room, user))) {
 				throw new Meteor.Error('error-not-allowed', 'Not Allowed');
@@ -890,8 +894,10 @@ API.v1.addRoute(
 			if (!thread?.rid) {
 				throw new Meteor.Error('error-invalid-message', 'Invalid Message');
 			}
-			const user = await Users.findOneById(this.userId, { projection: { _id: 1 } });
-			const room = await Rooms.findOneById(thread.rid, { projection: { ...roomAccessAttributes, t: 1, _id: 1 } });
+			const [user, room] = await Promise.all([
+				Users.findOneById(this.userId, { projection: { _id: 1 } }),
+				Rooms.findOneById(thread.rid, { projection: { ...roomAccessAttributes, t: 1, _id: 1 } }),
+			]);
 
 			if (!room || !user || !(await canAccessRoomAsync(room, user))) {
 				throw new Meteor.Error('error-not-allowed', 'Not Allowed');
@@ -940,9 +946,10 @@ API.v1.addRoute(
 			if (!thread?.rid) {
 				throw new Meteor.Error('error-invalid-message', 'Invalid Message');
 			}
-			// TODO: promise.all? this.user?
-			const user = await Users.findOneById(this.userId, { projection: { _id: 1 } });
-			const room = await Rooms.findOneById(thread.rid, { projection: { ...roomAccessAttributes, t: 1, _id: 1 } });
+			const [user, room] = await Promise.all([
+				Users.findOneById(this.userId, { projection: { _id: 1 } }),
+				Rooms.findOneById(thread.rid, { projection: { ...roomAccessAttributes, t: 1, _id: 1 } }),
+			]);
 
 			if (!room || !user || !(await canAccessRoomAsync(room, user))) {
 				throw new Meteor.Error('error-not-allowed', 'Not Allowed');

--- a/apps/meteor/client/views/room/contextualBar/Info/RoomInfo/ABAC/RoomInfoABACSection.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Info/RoomInfo/ABAC/RoomInfoABACSection.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 
 import { RoomIcon } from '../../../../../../components/RoomIcon';
 
-// TODO: Remove type union when ABAC is implemented
 type RoomInfoABACSectionProps = {
 	room: IRoom & {
 		abacAttributes?: {

--- a/packages/model-typings/src/models/IMessagesModel.ts
+++ b/packages/model-typings/src/models/IMessagesModel.ts
@@ -37,9 +37,21 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 		options?: FindOptions<IMessage>,
 	): FindPaginated<FindCursor<IMessage>>;
 
+	findPaginatedVisibleByMention(
+		username: IUser['username'],
+		roomIds: IRoom['_id'][],
+		options?: FindOptions<IMessage>,
+	): FindPaginated<AggregationCursor<WithId<IMessage>>>;
+
 	findVisibleByMentionAndRoomId(username: IUser['username'], rid: IRoom['_id'], options?: FindOptions<IMessage>): FindCursor<IMessage>;
 
 	findStarredByUserAtRoom(userId: IUser['_id'], roomId: IRoom['_id'], options?: FindOptions<IMessage>): FindPaginated<FindCursor<IMessage>>;
+
+	findStarredByUser(
+		userId: IUser['_id'],
+		roomIds: IRoom['_id'][],
+		options?: FindOptions<IMessage>,
+	): FindPaginated<AggregationCursor<WithId<IMessage>>>;
 
 	findPaginatedByRoomIdAndType(
 		roomId: IRoom['_id'],

--- a/packages/models/src/models/BaseRaw.ts
+++ b/packages/models/src/models/BaseRaw.ts
@@ -3,6 +3,7 @@ import type { IBaseModel, DefaultFields, ResultFields, FindPaginated, InsertionM
 import { traceInstanceMethods } from '@rocket.chat/tracing';
 import { ObjectId } from 'mongodb';
 import type {
+	AggregationCursor,
 	BulkWriteOptions,
 	ChangeStream,
 	Collection,
@@ -232,6 +233,32 @@ export abstract class BaseRaw<
 		return {
 			cursor,
 			totalCount,
+		};
+	}
+
+	protected aggregatePaginated<P extends Document = T>(
+		pipeline: Document[],
+		options: FindOptions<P> = {},
+	): FindPaginated<AggregationCursor<WithId<P>>> {
+		const countPipeline = [...pipeline, { $count: 'total' }];
+
+		const paginationPipeline = [...pipeline];
+		if (options.sort) {
+			paginationPipeline.push({ $sort: options.sort });
+		}
+		if (options.skip) {
+			paginationPipeline.push({ $skip: options.skip });
+		}
+		if (options.limit) {
+			paginationPipeline.push({ $limit: options.limit });
+		}
+
+		return {
+			cursor: this.col.aggregate<WithId<P>>(paginationPipeline),
+			totalCount: this.col
+				.aggregate<{ total: number }>(countPipeline)
+				.next()
+				.then((res) => res?.total || 0),
 		};
 	}
 

--- a/packages/models/src/models/BaseRaw.ts
+++ b/packages/models/src/models/BaseRaw.ts
@@ -246,10 +246,10 @@ export abstract class BaseRaw<
 		if (options.sort) {
 			paginationPipeline.push({ $sort: options.sort });
 		}
-		if (options.skip) {
+		if (options.skip !== undefined) {
 			paginationPipeline.push({ $skip: options.skip });
 		}
-		if (options.limit) {
+		if (options.limit !== undefined) {
 			paginationPipeline.push({ $limit: options.limit });
 		}
 

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -104,6 +104,25 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 
 		return this.findPaginated(query, options);
 	}
+    
+    findPaginatedVisibleByMention(
+    username: IUser['username'],
+    roomIds: IRoom['_id'][],                 
+    options?: FindOptions<IMessage>,
+    ): FindPaginated<AggregationCursor<WithId<IMessage>>> {
+    const pipeline: Document[] = [
+        {
+            $match: {
+                '_hidden': { $ne: true },
+                'mentions.username': username,
+                'rid': { $in: roomIds },      
+            },
+        },
+    ];
+
+    return this.aggregatePaginated<IMessage>(pipeline, options);
+    }
+
 
 	findStarredByUserAtRoom(
 		userId: IUser['_id'],
@@ -118,7 +137,24 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 
 		return this.findPaginated(query, options);
 	}
+    
+	findStarredByUser(
+    userId: IUser['_id'],
+    roomIds: IRoom['_id'][],                 
+    options?: FindOptions<IMessage>,
+    ): FindPaginated<AggregationCursor<WithId<IMessage>>> {
+    const pipeline: Document[] = [
+        {
+            $match: {
+                '_hidden': { $ne: true },
+                'starred._id': userId,
+                'rid': { $in: roomIds },      
+            },
+        },
+    ];
 
+    return this.aggregatePaginated<IMessage>(pipeline, options);
+    }
 	findPaginatedByRoomIdAndType(
 		roomId: IRoom['_id'],
 		type: IMessage['t'],

--- a/packages/rest-typings/src/v1/chat.ts
+++ b/packages/rest-typings/src/v1/chat.ts
@@ -497,7 +497,7 @@ const ChatGetMessageReadReceiptsSchema = {
 export const isChatGetMessageReadReceiptsProps = ajv.compile<ChatGetMessageReadReceipts>(ChatGetMessageReadReceiptsSchema);
 
 type GetStarredMessages = {
-	roomId: IRoom['_id'];
+	roomId?: IRoom['_id'];
 	count?: number;
 	offset?: number;
 	sort?: string;
@@ -523,7 +523,7 @@ const GetStarredMessagesSchema = {
 			nullable: true,
 		},
 	},
-	required: ['roomId'],
+	required: [],
 	additionalProperties: false,
 };
 
@@ -563,7 +563,7 @@ const GetPinnedMessagesSchema = {
 export const isChatGetPinnedMessagesProps = ajv.compile<GetPinnedMessages>(GetPinnedMessagesSchema);
 
 type GetMentionedMessages = {
-	roomId: IRoom['_id'];
+	roomId?: IRoom['_id'];
 	count?: number;
 	offset?: number;
 	sort?: string;
@@ -589,7 +589,7 @@ const GetMentionedMessagesSchema = {
 			nullable: true,
 		},
 	},
-	required: ['roomId'],
+	required: [],
 	additionalProperties: false,
 };
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes

This PR fixes pagination handling in `aggregatePaginated` by ensuring explicitly provided zero values are respected.

---

## Problem

The `aggregatePaginated` method in `packages/models/src/models/BaseRaw.ts` currently applies pagination using truthy checks:

```ts
if (options.skip) {
	paginationPipeline.push({ $skip: options.skip });
}
if (options.limit) {
	paginationPipeline.push({ $limit: options.limit });
}
```
Since 0 is falsy in JavaScript, explicit values such as skip: 0 and limit: 0 are ignored and treated as if the option was not provided.

___

## Solution
Replace truthy checks with explicit undefined checks:
```ts
if (options.skip !== undefined) {
	paginationPipeline.push({ $skip: options.skip });
}
if (options.limit !== undefined) {
	paginationPipeline.push({ $limit: options.limit });
}
```
___

## Why this matters

This ensures consistent and predictable pagination behavior for aggregation-based queries, including flows that rely on global fetch mechanisms (e.g., Activity Hub-related endpoints).

⸻

## Issue(s)

Closes #40150

⸻

## Steps to test or reproduce

     1. Call `aggregatePaginated` with:
      
               { skip: 0, limit: 10 } 
      
 	3.	Inspect the generated aggregation pipeline.
	4.	Observe that before this fix, the $skip stage is omitted when skip: 0.
	5.	After this fix, $skip: 0 is correctly included.
___

## Further comments

This issue was identified while working on failure handling and edge cases for aggregation-based data fetching as part of Activity Hub-related exploration.

The fix is minimal and scoped only to pagination option handling, without introducing side effects to other query logic.

___

## Testing
	Verified the affected code path statically in:
```ts		
packages/models/src/models/BaseRaw.ts
```
___
## Local execution of:
  
```ts
yarn workspace @rocket.chat/meteor testapi 
```
-----
         
was blocked before test execution due to missing built workspace artifacts (e.g.,  packages/models/dist/index.js).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made room ID parameter optional for `chat.getStarredMessages` and `chat.getMentionedMessages`, enabling retrieval of starred and mentioned messages across all subscribed rooms instead of a single room.

* **Performance**
  * Optimized thread-related operations by fetching user and room data concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->