### PR TITLE
fix: add timeout to CAS popup login to prevent infinite hang

### DIFF
--- a/.changeset/fix-cas-popup-timeout.md
+++ b/.changeset/fix-cas-popup-timeout.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+fix: add 120s timeout to CAS popup login to prevent infinite hang

--- a/apps/meteor/client/lib/openCASLoginPopup.ts
+++ b/apps/meteor/client/lib/openCASLoginPopup.ts
@@ -40,8 +40,10 @@ const getPopupUrl = (credentialToken: string): string => {
 	return url.href;
 };
 
+const CAS_POPUP_TIMEOUT_MS = 120_000;
+
 const waitForPopupClose = (popup: Window) => {
-	return new Promise<void>((resolve) => {
+	const pollClosed = new Promise<void>((resolve) => {
 		const checkPopupOpen = setInterval(() => {
 			if (popup.closed || popup.closed === undefined) {
 				clearInterval(checkPopupOpen);
@@ -49,6 +51,19 @@ const waitForPopupClose = (popup: Window) => {
 			}
 		}, 100);
 	});
+
+	const timeout = new Promise<never>((_, reject) => {
+		setTimeout(() => {
+			try {
+				popup.close();
+			} catch {
+				// popup may already be closed or cross-origin
+			}
+			reject(new Error('CAS login timed out. Please try again.'));
+		}, CAS_POPUP_TIMEOUT_MS);
+	});
+
+	return Promise.race([pollClosed, timeout]);
 };
 
 export const openCASLoginPopup = async (credentialToken: string) => {


### PR DESCRIPTION
## Summary

Closes #40153

- `openCASLoginPopup()` polls `popup.closed` every 100ms with no timeout, causing the login flow to hang indefinitely if the popup never closes
- Added a 120-second timeout using `Promise.race()` that rejects with a user-friendly error message and attempts to close the stale popup
- No changes to the happy path -- if the popup closes normally, the timeout is never triggered

## Changes

- `apps/meteor/client/lib/openCASLoginPopup.ts`: Wrapped the polling promise in `Promise.race()` alongside a 120-second timeout promise that rejects with `"CAS login timed out. Please try again."`

## Test plan

- [ ] Verify CAS login still works normally when the popup closes as expected
- [ ] Simulate a stuck popup (e.g. block the CAS redirect) and confirm the login rejects with the timeout error after ~120 seconds instead of hanging forever

---

> [!NOTE]
> This PR was authored with assistance from an AI coding tool (Claude Code by Anthropic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CAS login popup now enforces a 120-second timeout for authentication attempts. If the process doesn't complete within this timeframe, the popup will be closed and a timeout error shown to the user, preventing indefinite hangs and improving the reliability and responsiveness of the login flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->