### PR TITLE
fix: coerce boolean parameter in loadSurroundingMessages check

### DIFF
--- a/.changeset/fix-load-surrounding-type.md
+++ b/.changeset/fix-load-surrounding-type.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+fix: coerce string to boolean for showThreadMessages in loadSurroundingMessages

--- a/apps/meteor/server/methods/loadSurroundingMessages.ts
+++ b/apps/meteor/server/methods/loadSurroundingMessages.ts
@@ -29,6 +29,11 @@ Meteor.methods<ServerMethods>({
 	async loadSurroundingMessages(message, limit = 50, showThreadMessages = true) {
 		check(message, Object);
 		check(limit, Number);
+
+		if (typeof showThreadMessages === 'string') {
+			showThreadMessages = showThreadMessages === 'true';
+		}
+
 		check(showThreadMessages, Boolean);
 
 		if (!Meteor.userId()) {


### PR DESCRIPTION
Fixes #40119

## Problem

`loadSurroundingMessages` method throws `Match error: Expected boolean, got string` at line 32 because the `showThreadMessages` parameter arrives as a string instead of a boolean via DDP.

## Changes

In `apps/meteor/server/methods/loadSurroundingMessages.ts`, added a type coercion before the `check()` call:

```ts
if (typeof showThreadMessages === 'string') {
    showThreadMessages = showThreadMessages === 'true';
}
```

This converts the string `"true"`/`"false"` to a proper boolean before Meteor's `check(showThreadMessages, Boolean)` runs.

## AI Disclosure

- [x] I used an AI tool to help with this PR
  - **Tool:** Claude — used to find the file location. Fix was written by me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of input formats when loading surrounding messages so the thread-display option is correctly interpreted (e.g., when provided as text), ensuring consistent behavior and accurate message context display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->