### PR TITLE
fix: save recent emojis when selected from composer popup and fix emoji sort 

### DIFF
--- a/apps/meteor/client/views/room/composer/hooks/useComposerBoxPopup.ts
+++ b/apps/meteor/client/views/room/composer/hooks/useComposerBoxPopup.ts
@@ -110,6 +110,7 @@ export const useComposerBoxPopup = <T extends { _id: string; sort?: number }>(
 				end: chat?.composer?.selection.start,
 			});
 		}
+		option.onSelect?.(item);
 		setOptionIndex(-1);
 		setFocused(undefined);
 	});

--- a/apps/meteor/client/views/room/contexts/ComposerPopupContext.ts
+++ b/apps/meteor/client/views/room/contexts/ComposerPopupContext.ts
@@ -20,6 +20,7 @@ export type ComposerPopupOption<T extends { _id: string; sort?: number } = { _id
 	preview?: boolean;
 
 	getValue: (item: T) => string;
+	onSelect?: (item: T) => void
 
 	renderItem?: ({ item }: { item: T }) => ReactElement;
 	disabled?: boolean;

--- a/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
+++ b/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
@@ -203,15 +203,8 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 						const aPartial = a._id.startsWith(key) ? 1 : 0;
 						const bPartial = b._id.startsWith(key) ? 1 : 0;
 
-						let aScore = aExact + aPartial;
-						let bScore = bExact + bPartial;
-
-						if (recents.includes(a._id)) {
-							aScore += recents.indexOf(a._id) + 1;
-						}
-						if (recents.includes(b._id)) {
-							bScore += recents.indexOf(b._id) + 1;
-						}
+						const aScore = aExact + aPartial;
+						const bScore = bExact + bPartial;
 
 						if (aScore > bScore) {
 							return -1;
@@ -219,7 +212,20 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 						if (aScore < bScore) {
 							return 1;
 						}
-						return 0;
+
+						const aRecent = recents.indexOf(a._id);
+						const bRecent = recents.indexOf(b._id);
+
+						if (aRecent === bRecent) {
+							return 0;
+						}
+						if (aRecent === -1) {
+							return 1;
+						}
+						if (bRecent === -1) {
+							return -1;
+						}
+						return aRecent - bRecent;
 					};
 					const filterRegex = new RegExp(escapeRegExp(filter), 'i');
 					const key = `:${filter}`;

--- a/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
+++ b/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
@@ -28,6 +28,7 @@ import { ComposerPopupContext, createMessageBoxPopupConfig } from '../contexts/C
 import useCannedResponsesQuery from './hooks/useCannedResponsesQuery';
 import { normalizeUsername } from '../../../../lib/utils/normalizeUsername';
 import { pipe } from '../../../lib/cachedStores/pipe';
+import {useEmojiPickerData} from '../../../contexts/EmojiPickerContext';
 
 export type CannedResponse = { _id: string; shortcut: string; text: string };
 
@@ -84,6 +85,7 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 	const queryClient = useQueryClient();
 	const uid = useUserId();
 	const call = useMethod('getSlashCommandPreviews');
+	const { addRecentEmoji } = useEmojiPickerData(); 
 
 	const value: ComposerPopupContextValue = useMemo(() => {
 		return [
@@ -182,7 +184,7 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 					return rooms as unknown as ComposerBoxPopupRoomProps[];
 				},
 				getValue: (item) => `${item.name || item.fname}`,
-				renderItem: ({ item }) => <ComposerBoxPopupRoom {...item} />,
+				renderItem: ({ item }) => <ComposerBoxPopupRoom {...item} />,  
 			}) as any,
 			useEmoji &&
 				createMessageBoxPopupConfig<ComposerBoxPopupEmojiProps>({
@@ -242,6 +244,7 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 					},
 					getValue: (item) => `${item._id.substring(1)}`,
 					renderItem: ({ item }) => <ComposerBoxPopupEmoji {...item} />,
+					onSelect: (item) => addRecentEmoji(item._id.slice(1, -1)),
 				}),
 			createMessageBoxPopupConfig<ComposerBoxPopupEmojiProps>({
 				title: t('Emoji'),
@@ -256,7 +259,7 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 
 					const emojiSort = (recents: string[]) => (a: { _id: string }, b: { _id: string }) => {
 						let idA = a._id;
-						let idB = a._id;
+						let idB = b._id;
 
 						if (recents.includes(a._id)) {
 							idA = recents.indexOf(a._id) + idA;
@@ -299,6 +302,7 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 				},
 				getValue: (item) => `${item._id}`,
 				renderItem: ({ item }) => <ComposerBoxPopupEmoji {...item} />,
+				onSelect: (item) => addRecentEmoji(item._id.slice(1, -1)),
 			}),
 
 			createMessageBoxPopupConfig<ComposerBoxPopupSlashCommandProps>({
@@ -387,6 +391,7 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 			}),
 		].filter(Boolean);
 	}, [
+		addRecentEmoji,
 		call,
 		cannedResponseEnabled,
 		encrypted,

--- a/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
+++ b/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
@@ -5,7 +5,7 @@ import { escapeRegExp } from '@rocket.chat/string-helpers';
 import type { SubscriptionWithRoom } from '@rocket.chat/ui-contexts';
 import { useMethod, useSetting, useUserId, useUserPreference } from '@rocket.chat/ui-contexts';
 import { useQueryClient } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -28,7 +28,7 @@ import { ComposerPopupContext, createMessageBoxPopupConfig } from '../contexts/C
 import useCannedResponsesQuery from './hooks/useCannedResponsesQuery';
 import { normalizeUsername } from '../../../../lib/utils/normalizeUsername';
 import { pipe } from '../../../lib/cachedStores/pipe';
-import {useEmojiPickerData} from '../../../contexts/EmojiPickerContext';
+import { EmojiPickerContext } from '../../../contexts/EmojiPickerContext';
 
 export type CannedResponse = { _id: string; shortcut: string; text: string };
 
@@ -85,7 +85,8 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 	const queryClient = useQueryClient();
 	const uid = useUserId();
 	const call = useMethod('getSlashCommandPreviews');
-	const { addRecentEmoji } = useEmojiPickerData(); 
+	const emojiPickerContext = useContext(EmojiPickerContext);
+	const addRecentEmoji = emojiPickerContext?.addRecentEmoji ?? (() => undefined);
 
 	const value: ComposerPopupContextValue = useMemo(() => {
 		return [
@@ -172,8 +173,8 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 					const predicate = (record: SubscriptionWithRoom): boolean =>
 						Boolean(
 							(record.fname?.match(filterRegex) || record.name?.match(filterRegex)) &&
-								!record.federated &&
-								(record.t === 'c' || record.t === 'p'),
+							!record.federated &&
+							(record.t === 'c' || record.t === 'p'),
 						);
 
 					const records = transform(Subscriptions.state.filter(predicate));
@@ -184,68 +185,68 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 					return rooms as unknown as ComposerBoxPopupRoomProps[];
 				},
 				getValue: (item) => `${item.name || item.fname}`,
-				renderItem: ({ item }) => <ComposerBoxPopupRoom {...item} />,  
+				renderItem: ({ item }) => <ComposerBoxPopupRoom {...item} />,
 			}) as any,
 			useEmoji &&
-				createMessageBoxPopupConfig<ComposerBoxPopupEmojiProps>({
-					trigger: ':',
-					title: t('Emoji'),
-					triggerLength: 2,
-					getItemsFromLocal: async (filter: string) => {
-						const exactFinalTone = new RegExp('^tone[1-5]:*$');
-						const colorBlind = new RegExp('tone[1-5]:*$');
-						const seeColor = new RegExp('_t(?:o|$)(?:n|$)(?:e|$)(?:[1-5]|$)(?::|$)$');
+			createMessageBoxPopupConfig<ComposerBoxPopupEmojiProps>({
+				trigger: ':',
+				title: t('Emoji'),
+				triggerLength: 2,
+				getItemsFromLocal: async (filter: string) => {
+					const exactFinalTone = new RegExp('^tone[1-5]:*$');
+					const colorBlind = new RegExp('tone[1-5]:*$');
+					const seeColor = new RegExp('_t(?:o|$)(?:n|$)(?:e|$)(?:[1-5]|$)(?::|$)$');
 
-						const emojiSort = (recents: string[]) => (a: { _id: string }, b: { _id: string }) => {
-							const aExact = a._id === key ? 2 : 0;
-							const bExact = b._id === key ? 2 : 0;
-							const aPartial = a._id.startsWith(key) ? 1 : 0;
-							const bPartial = b._id.startsWith(key) ? 1 : 0;
+					const emojiSort = (recents: string[]) => (a: { _id: string }, b: { _id: string }) => {
+						const aExact = a._id === key ? 2 : 0;
+						const bExact = b._id === key ? 2 : 0;
+						const aPartial = a._id.startsWith(key) ? 1 : 0;
+						const bPartial = b._id.startsWith(key) ? 1 : 0;
 
-							let aScore = aExact + aPartial;
-							let bScore = bExact + bPartial;
+						let aScore = aExact + aPartial;
+						let bScore = bExact + bPartial;
 
-							if (recents.includes(a._id)) {
-								aScore += recents.indexOf(a._id) + 1;
-							}
-							if (recents.includes(b._id)) {
-								bScore += recents.indexOf(b._id) + 1;
-							}
+						if (recents.includes(a._id)) {
+							aScore += recents.indexOf(a._id) + 1;
+						}
+						if (recents.includes(b._id)) {
+							bScore += recents.indexOf(b._id) + 1;
+						}
 
-							if (aScore > bScore) {
-								return -1;
-							}
-							if (aScore < bScore) {
-								return 1;
-							}
-							return 0;
-						};
-						const filterRegex = new RegExp(escapeRegExp(filter), 'i');
-						const key = `:${filter}`;
+						if (aScore > bScore) {
+							return -1;
+						}
+						if (aScore < bScore) {
+							return 1;
+						}
+						return 0;
+					};
+					const filterRegex = new RegExp(escapeRegExp(filter), 'i');
+					const key = `:${filter}`;
 
-						const recents = recentEmojis.map((item) => `:${item}:`);
+					const recents = recentEmojis.map((item) => `:${item}:`);
 
-						const collection = emoji.list;
+					const collection = emoji.list;
 
-						return Object.keys(collection)
-							.map((_id) => {
-								const data = collection[key];
-								return { _id, data };
-							})
-							.filter(
-								({ _id }) =>
-									filterRegex.test(_id) && (exactFinalTone.test(_id.substring(key.length)) || seeColor.test(key) || !colorBlind.test(_id)),
-							)
-							.sort(emojiSort(recents))
-							.slice(0, 10);
-					},
-					getItemsFromServer: async () => {
-						return [];
-					},
-					getValue: (item) => `${item._id.substring(1)}`,
-					renderItem: ({ item }) => <ComposerBoxPopupEmoji {...item} />,
-					onSelect: (item) => addRecentEmoji(item._id.slice(1, -1)),
-				}),
+					return Object.keys(collection)
+						.map((_id) => {
+							const data = collection[key];
+							return { _id, data };
+						})
+						.filter(
+							({ _id }) =>
+								filterRegex.test(_id) && (exactFinalTone.test(_id.substring(key.length)) || seeColor.test(key) || !colorBlind.test(_id)),
+						)
+						.sort(emojiSort(recents))
+						.slice(0, 10);
+				},
+				getItemsFromServer: async () => {
+					return [];
+				},
+				getValue: (item) => `${item._id.substring(1)}`,
+				renderItem: ({ item }) => <ComposerBoxPopupEmoji {...item} />,
+				onSelect: (item) => addRecentEmoji(item._id.slice(1, -1)),
+			}),
 			createMessageBoxPopupConfig<ComposerBoxPopupEmojiProps>({
 				title: t('Emoji'),
 				trigger: '\\+:',
@@ -343,34 +344,34 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 				getItemsFromServer: async () => [],
 			}),
 			cannedResponseEnabled &&
-				isOmnichannel &&
-				createMessageBoxPopupConfig<{
-					_id: string;
-					text: string;
-					shortcut: string;
-				}>({
-					title: t('Canned_Responses'),
-					trigger: '!',
-					prefix: '',
-					triggerAnywhere: true,
-					renderItem: ({ item }) => <ComposerBoxPopupCannedResponse {...item} />,
-					getItemsFromLocal: async (filter: string) => {
-						const exp = new RegExp(filter, 'i');
-						// TODO: this is bad, but can only be fixed by refactoring the whole thing
-						const cannedResponses = queryClient.getQueryData<CannedResponse[]>(cannedResponsesQueryKeys.all) ?? [];
-						return cannedResponses
-							.filter((record) => record.shortcut.match(exp))
-							.sort((a, b) => a.shortcut.localeCompare(b.shortcut))
-							.slice(0, 11)
-							.map((record) => ({
-								_id: record._id,
-								text: record.text,
-								shortcut: record.shortcut,
-							}));
-					},
-					getItemsFromServer: async () => [],
-					getValue: (item) => item.text,
-				}),
+			isOmnichannel &&
+			createMessageBoxPopupConfig<{
+				_id: string;
+				text: string;
+				shortcut: string;
+			}>({
+				title: t('Canned_Responses'),
+				trigger: '!',
+				prefix: '',
+				triggerAnywhere: true,
+				renderItem: ({ item }) => <ComposerBoxPopupCannedResponse {...item} />,
+				getItemsFromLocal: async (filter: string) => {
+					const exp = new RegExp(filter, 'i');
+					// TODO: this is bad, but can only be fixed by refactoring the whole thing
+					const cannedResponses = queryClient.getQueryData<CannedResponse[]>(cannedResponsesQueryKeys.all) ?? [];
+					return cannedResponses
+						.filter((record) => record.shortcut.match(exp))
+						.sort((a, b) => a.shortcut.localeCompare(b.shortcut))
+						.slice(0, 11)
+						.map((record) => ({
+							_id: record._id,
+							text: record.text,
+							shortcut: record.shortcut,
+						}));
+				},
+				getItemsFromServer: async () => [],
+				getValue: (item) => item.text,
+			}),
 			createMessageBoxPopupConfig({
 				title: previewTitle,
 				matchSelectorRegex: /(?:^)(\/[\w\d\S]+ )[^]*$/,


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Two related bugs were found and fixed in the emoji composer popup: 

 **Bug 1 — Recent emojis never saved from composer popup**  

When a user selected an emoji using the `:` or `+:` trigger in the message composer, `addRecentEmoji` was never called. This meant `emoji.recent` in localStorage was never populated, so the "recently used" sorting had no data to work with.


Fix: Added an `onSelect` callback to `ComposerPopupOption` type and wired it up in both emoji popup configs to call `addRecentEmoji` on selection.    


**Bug 2 — Broken sort in `+:` emoji reaction popup**    

 In the `emojiSort` function for the `+:` trigger, `idB` was incorrectly assigned `a._id` instead of `b._id`, causing every comparison to return `0` (equal) and 
  making the sort completely ineffective.
                                                                                                                                                                  
  ```ts                                                                                                                                                           
  // Before (broken)
  let idA = a._id;                                                                                                                                                
  let idB = a._id; // ← always comparing a against itself
                                                                                                                                                                  
  // After (fixed)
  let idA = a._id;                                                                                                                                                
  let idB = b._id;
```

**Before Fix: Recently used emojis never appeared at the top. Order was random.**        

<img width="482" height="114" alt="Screenshot 2026-04-15 at 2 15 15 PM" src="https://github.com/user-attachments/assets/42b3e328-44db-4a2d-912b-7bb35f9a3d13" />


<img width="600" height="446" alt="Screenshot 2026-04-15 at 2 11 45 PM" src="https://github.com/user-attachments/assets/2fd05f18-13b9-45ec-98a8-e51e8897b130" />

And because of this `emoji.recent` in localStorage was never populated


**After Fix: Recently used emojis correctly appear at the top of the popup.**

<img width="482" height="114" alt="Screenshot 2026-04-15 at 2 15 15 PM" src="https://github.com/user-attachments/assets/75f7d739-e553-493d-8a37-b83cd5041050" />

<img width="600" height="462" alt="Screenshot 2026-04-15 at 2 16 16 PM" src="https://github.com/user-attachments/assets/01638bae-67ea-4590-96a8-ecf13bb88656" />

And now this `emoji.recent` in localStorage is populated correctly


<img width="472" height="45" alt="Screenshot 2026-04-15 at 2 17 31 PM" src="https://github.com/user-attachments/assets/30d54538-9941-4dde-981c-e1f2ba7d0104" />


## Steps to test or reproduce
 1. Open any room or DM                                                                                                                                          
 2. Type smirk: in the composer and select it from the popup to send
 3. Now type +:smi in the composer                                                                                                                               
 4. Before fix: smirk: does not appear at the top                                                                                                              
 5. After fix: smirk: appears at the top as a recently used emoji             

## Further comments
The root cause was that the composer popup had no mechanism to notify the emoji system when an emoji was selected. The fix adds an optional onSelect callback to ComposerPopupOption which is generic enough to be used by other popup types in the future if needed.
                                                                                                        


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composer popups can run item-specific onSelect actions when an option is chosen.
  * Emoji picker now saves recently used emojis for faster access.

* **Bug Fixes**
  * Fixed emoji ordering so recently used and search results sort correctly.

* **Refactor**
  * Improved emoji selection handling and stability for popup behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->