### PR TITLE
fix: Livechat_accept_chats_with_no_agents omnichannel setting not being respected

### DIFF
--- a/.changeset/wet-pandas-pump.md
+++ b/.changeset/wet-pandas-pump.md
@@ -5,4 +5,4 @@
 '@rocket.chat/meteor': patch
 ---
 
-Fixed an issue where the Omnichannel routing system ignored the `Livechat_accept_chats_with_no_agents` setting. The agent availability queries have been updated to properly evaluate this setting, ensuring offline agents are correctly included in the routing pool when allowed.
+Fixes an issue where the Omnichannel routing system ignored the `Livechat_accept_chats_with_no_agents` setting. Now, offline agents are correctly considered for assignment when the setting allows it.

--- a/.changeset/wet-pandas-pump.md
+++ b/.changeset/wet-pandas-pump.md
@@ -1,0 +1,8 @@
+---
+'@rocket.chat/model-typings': patch
+'@rocket.chat/omni-core': patch
+'@rocket.chat/models': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixed an issue where the Omnichannel routing system ignored the `Livechat_accept_chats_with_no_agents` setting. The agent availability queries have been updated to properly evaluate this setting, ensuring offline agents are correctly included in the routing pool when allowed.

--- a/apps/meteor/app/apps/server/bridges/livechat.ts
+++ b/apps/meteor/app/apps/server/bridges/livechat.ts
@@ -226,6 +226,7 @@ export class AppLivechatBridge extends LivechatBridge {
 
 		const livechatVisitor = await registerGuest(registerData, {
 			shouldConsiderIdleAgent: settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+			shouldConsiderOfflineAgent: settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
 		});
 
 		if (!livechatVisitor) {
@@ -255,6 +256,7 @@ export class AppLivechatBridge extends LivechatBridge {
 
 		const livechatVisitor = await registerGuest(registerData, {
 			shouldConsiderIdleAgent: settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+			shouldConsiderOfflineAgent: settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
 		});
 
 		return this.orch.getConverters()?.get('visitors').convertVisitor(livechatVisitor);

--- a/apps/meteor/app/livechat/imports/server/rest/sms.ts
+++ b/apps/meteor/app/livechat/imports/server/rest/sms.ts
@@ -73,7 +73,8 @@ const defineVisitor = async (smsNumber: string, targetDepartment?: string) => {
 		data.department = targetDepartment;
 	}
 
-	const livechatVisitor = await registerGuest(data, { shouldConsiderIdleAgent: settings.get<boolean>('Livechat_enabled_when_agent_idle') });
+	const livechatVisitor = await registerGuest(data, { shouldConsiderIdleAgent: settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+  shouldConsiderOfflineAgent: settings.get<boolean>('Livechat_accept_chats_with_no_agents')});
 
 	if (!livechatVisitor) {
 		throw new Meteor.Error('error-invalid-visitor', 'Invalid visitor');

--- a/apps/meteor/app/livechat/server/api/v1/message.ts
+++ b/apps/meteor/app/livechat/server/api/v1/message.ts
@@ -272,7 +272,10 @@ API.v1.addRoute(
 					guest.connectionData = normalizeHttpHeaderData(this.request.headers);
 				}
 
-				visitor = await registerGuest(guest, { shouldConsiderIdleAgent: settings.get<boolean>('Livechat_enabled_when_agent_idle') });
+				visitor = await registerGuest(guest, {
+					shouldConsiderIdleAgent: settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+					shouldConsiderOfflineAgent: settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
+				});
 				if (!visitor) {
 					throw new Error('error-livechat-visitor-registration');
 				}

--- a/apps/meteor/app/livechat/server/api/v1/visitor.ts
+++ b/apps/meteor/app/livechat/server/api/v1/visitor.ts
@@ -59,7 +59,10 @@ API.v1.addRoute(
 				connectionData: normalizeHttpHeaderData(this.request.headers),
 			};
 
-			const visitor = await registerGuest(guest, { shouldConsiderIdleAgent: settings.get<boolean>('Livechat_enabled_when_agent_idle') });
+			const visitor = await registerGuest(guest, {
+				shouldConsiderIdleAgent: settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+				shouldConsiderOfflineAgent: settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
+			});
 			if (!visitor) {
 				throw new Meteor.Error('error-livechat-visitor-registration', 'Error registering visitor', {
 					method: 'livechat/visitor',

--- a/apps/meteor/app/livechat/server/lib/Helper.ts
+++ b/apps/meteor/app/livechat/server/lib/Helper.ts
@@ -496,7 +496,12 @@ export const forwardRoomToAgent = async (room: IOmnichannelRoom, transferData: T
 	if (!agentId) {
 		throw new Error('error-invalid-agent');
 	}
-	const user = await Users.findOneOnlineAgentById(agentId, settings.get<boolean>('Livechat_enabled_when_agent_idle'));
+	const user = await Users.findOneOnlineAgentById(
+		agentId,
+		settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+		settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
+		{},
+	);
 	if (!user) {
 		logger.debug({
 			msg: 'Agent is offline. Cannot forward',
@@ -657,7 +662,12 @@ export const forwardRoomToDepartment = async (room: IOmnichannelRoom, guest: ILi
 			departmentId,
 			agentId,
 		});
-		const user = await Users.findOneOnlineAgentById(agentId, settings.get<boolean>('Livechat_enabled_when_agent_idle'));
+		const user = await Users.findOneOnlineAgentById(
+			agentId,
+			settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+			settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
+			{},
+		);
 		if (!user) {
 			throw new Error('error-user-is-offline');
 		}

--- a/apps/meteor/app/livechat/server/lib/QueueManager.ts
+++ b/apps/meteor/app/livechat/server/lib/QueueManager.ts
@@ -443,7 +443,12 @@ export class QueueManager {
 
 		let defaultAgent: SelectedAgent | undefined;
 		const isAgentAvailable = (username: string) =>
-			Users.findOneOnlineAgentByUserList(username, { projection: { _id: 1 } }, settings.get<boolean>('Livechat_enabled_when_agent_idle'));
+			Users.findOneOnlineAgentByUserList(
+				username,
+				{ projection: { _id: 1 } },
+				settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+				settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
+			);
 
 		if (servedBy?.username && (await isAgentAvailable(servedBy.username))) {
 			defaultAgent = { agentId: servedBy._id, username: servedBy.username };

--- a/apps/meteor/app/livechat/server/lib/RoutingManager.ts
+++ b/apps/meteor/app/livechat/server/lib/RoutingManager.ts
@@ -111,7 +111,12 @@ export const RoutingManager: Routing = {
 		if (
 			!agent ||
 			(agent.username &&
-				!(await Users.findOneOnlineAgentByUserList(agent.username, {}, settings.get<boolean>('Livechat_enabled_when_agent_idle'))) &&
+				!(await Users.findOneOnlineAgentByUserList(
+					agent.username,
+					{},
+					settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+					settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
+				)) &&
 				!(await allowAgentSkipQueue(agent)))
 		) {
 			logger.debug({ msg: 'Agent offline or invalid. Using routing method to get next agent', inquiryId: inquiry._id });

--- a/apps/meteor/app/livechat/server/lib/departmentsLib.ts
+++ b/apps/meteor/app/livechat/server/lib/departmentsLib.ts
@@ -295,6 +295,7 @@ export async function checkOnlineForDepartment(departmentId: string) {
 		depUsers.map((agent) => agent.username),
 		{ projection: { _id: 1 } },
 		settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+		settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
 	);
 
 	return !!onlineForDep;
@@ -304,5 +305,9 @@ export async function getOnlineForDepartment(departmentId: string) {
 	const agents = await LivechatDepartmentAgents.findByDepartmentId(departmentId, { projection: { username: 1 } }).toArray();
 	const usernames = agents.map(({ username }) => username);
 
-	return Users.findOnlineUserFromList<ILivechatAgent>([...new Set(usernames)], settings.get<boolean>('Livechat_enabled_when_agent_idle'));
+	return Users.findOnlineUserFromList<ILivechatAgent>(
+		[...new Set(usernames)],
+		settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+		settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
+	);
 }

--- a/apps/meteor/app/livechat/server/lib/routing/AutoSelection.ts
+++ b/apps/meteor/app/livechat/server/lib/routing/AutoSelection.ts
@@ -35,10 +35,16 @@ class AutoSelection implements IRoutingMethod {
 				settings.get<boolean>('Livechat_enabled_when_agent_idle'),
 				ignoreAgentId,
 				extraQuery,
+				settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
 			);
 		}
 
-		return Users.getNextAgent(ignoreAgentId, extraQuery, settings.get<boolean>('Livechat_enabled_when_agent_idle'));
+		return Users.getNextAgent(
+			ignoreAgentId,
+			extraQuery,
+			settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+			settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
+		);
 	}
 }
 

--- a/apps/meteor/app/livechat/server/lib/routing/External.ts
+++ b/apps/meteor/app/livechat/server/lib/routing/External.ts
@@ -61,6 +61,7 @@ class ExternalQueue implements IRoutingMethod {
 					result.username,
 					{},
 					settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+					settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
 				);
 
 				if (!agent?.username) {

--- a/apps/meteor/app/livechat/server/lib/service-status.ts
+++ b/apps/meteor/app/livechat/server/lib/service-status.ts
@@ -8,13 +8,21 @@ import { settings } from '../../../settings/server';
 
 export async function getOnlineAgents(department?: string, agent?: SelectedAgent | null): Promise<FindCursor<ILivechatAgent> | undefined> {
 	if (agent?.agentId) {
-		return Users.findOnlineAgents(agent.agentId, settings.get<boolean>('Livechat_enabled_when_agent_idle'));
+		return Users.findOnlineAgents(
+			agent.agentId,
+			settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+			settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
+		);
 	}
 
 	if (department) {
 		return getOnlineForDepartment(department);
 	}
-	return Users.findOnlineAgents(undefined, settings.get<boolean>('Livechat_enabled_when_agent_idle'));
+	return Users.findOnlineAgents(
+		undefined,
+		settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+		settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
+	);
 }
 
 export async function online(department?: string, skipNoAgentSetting = false, skipFallbackCheck = false): Promise<boolean> {
@@ -43,7 +51,11 @@ export async function online(department?: string, skipNoAgentSetting = false, sk
 
 export async function checkOnlineAgents(department?: string, agent?: { agentId: string }, skipFallbackCheck = false): Promise<boolean> {
 	if (agent?.agentId) {
-		return Users.checkOnlineAgents(agent.agentId, settings.get<boolean>('Livechat_enabled_when_agent_idle'));
+		return Users.checkOnlineAgents(
+			agent.agentId,
+			settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+			settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
+		);
 	}
 
 	if (department) {
@@ -62,7 +74,11 @@ export async function checkOnlineAgents(department?: string, agent?: { agentId: 
 		return checkOnlineAgents(dep?.fallbackForwardDepartment);
 	}
 
-	return Users.checkOnlineAgents(undefined, settings.get<boolean>('Livechat_enabled_when_agent_idle'));
+	return Users.checkOnlineAgents(
+		undefined,
+		settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+		settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
+	);
 }
 
 async function countBotAgents(department?: string) {

--- a/apps/meteor/app/livechat/server/lib/takeInquiry.ts
+++ b/apps/meteor/app/livechat/server/lib/takeInquiry.ts
@@ -26,12 +26,18 @@ export const takeInquiry = async (
 		});
 	}
 
-	const user = await Users.findOneOnlineAgentById(userId, settings.get<boolean>('Livechat_enabled_when_agent_idle'));
+	const user = await Users.findOneOnlineAgentById(
+		userId,
+		settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+		settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
+		{},
+	);
 	if (!user) {
 		throw new Meteor.Error('error-agent-status-service-offline', 'Agent status is offline or Omnichannel service is not active', {
 			method: 'livechat:takeInquiry',
 			...(process.env.TEST_MODE && {
 				Livechat_enabled_when_agent_idle: settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+				Livechat_accept_chats_with_no_agents: settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
 				user: await Users.findOneById(userId),
 			}),
 		});

--- a/apps/meteor/ee/app/livechat-enterprise/server/hooks/handleNextAgentPreferredEvents.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/hooks/handleNextAgentPreferredEvents.ts
@@ -23,9 +23,14 @@ const getDefaultAgent = async ({ username, id }: { username?: string; id?: strin
 	}
 
 	if (id) {
-		const agent = await Users.findOneOnlineAgentById(id, settings.get<boolean>('Livechat_enabled_when_agent_idle'), {
-			projection: { _id: 1, username: 1 },
-		});
+		const agent = await Users.findOneOnlineAgentById(
+			id,
+			settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+			settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
+			{
+				projection: { _id: 1, username: 1 },
+			},
+		);
 		if (agent) {
 			return normalizeDefaultAgent(agent);
 		}
@@ -43,6 +48,7 @@ const getDefaultAgent = async ({ username, id }: { username?: string; id?: strin
 			username || [],
 			{ projection: { _id: 1, username: 1 } },
 			settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+			settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
 		),
 	);
 };
@@ -131,6 +137,7 @@ checkDefaultAgentOnNewRoom.patch(async (_next, defaultAgent, { visitorId, source
 			usernameByRoom,
 			{ projection: { _id: 1, username: 1 } },
 			settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+			settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
 		),
 	);
 	return lastRoomAgent;

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/routing/LoadBalancing.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/routing/LoadBalancing.ts
@@ -32,15 +32,18 @@ class LoadBalancing {
 
 	async getNextAgent(department?: string, ignoreAgentId?: string) {
 		const enabledWhenIdle = settings.get<boolean>('Livechat_enabled_when_agent_idle');
+		const enabledWhenOffline = settings.get<boolean>('Livechat_accept_chats_with_no_agents');
+
 		const extraQuery = await getChatLimitsQuery(department);
-		const unavailableUsers = await Users.getUnavailableAgents(department, extraQuery, enabledWhenIdle);
-		logger.debug({ msg: 'Ignoring unavailable agents from assignment', unavailableUsers, department, enabledWhenIdle });
+		const unavailableUsers = await Users.getUnavailableAgents(department, extraQuery, enabledWhenIdle, enabledWhenOffline);
+		logger.debug({ msg: 'Ignoring unavailable agents from assignment', unavailableUsers, department, enabledWhenIdle, enabledWhenOffline });
 
 		const nextAgent = await Users.getNextLeastBusyAgent(
 			department,
 			ignoreAgentId,
 			enabledWhenIdle,
 			unavailableUsers.map((u) => u.username),
+			enabledWhenOffline,
 		);
 		if (!nextAgent) {
 			return;

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/routing/LoadRotation.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/routing/LoadRotation.ts
@@ -31,16 +31,18 @@ class LoadRotation {
 
 	public async getNextAgent(department?: string, ignoreAgentId?: string): Promise<IOmnichannelCustomAgent | undefined> {
 		const enabledWhenIdle = settings.get<boolean>('Livechat_enabled_when_agent_idle');
+		const enabledWhenOffline = settings.get<boolean>('Livechat_accept_chats_with_no_agents');
 
 		const extraQuery = await getChatLimitsQuery(department);
-		const unavailableUsers = await Users.getUnavailableAgents(department, extraQuery, enabledWhenIdle);
-		logger.debug({ msg: 'Ignoring unavailable agents from assignment', unavailableUsers, department, enabledWhenIdle });
+		const unavailableUsers = await Users.getUnavailableAgents(department, extraQuery, enabledWhenIdle, enabledWhenOffline);
+		logger.debug({ msg: 'Ignoring unavailable agents from assignment', unavailableUsers, department, enabledWhenIdle, enabledWhenOffline });
 
 		const nextAgent = await Users.getLastAvailableAgentRouted(
 			department,
 			ignoreAgentId,
 			enabledWhenIdle,
 			unavailableUsers.map((user) => user.username),
+			enabledWhenOffline,
 		);
 		if (!nextAgent?.username) {
 			return;

--- a/apps/meteor/ee/server/models/raw/Users.ts
+++ b/apps/meteor/ee/server/models/raw/Users.ts
@@ -10,6 +10,7 @@ declare module '@rocket.chat/model-typings' {
 			departmentId: string,
 			customFilter: Filter<AvailableAgentsAggregation>,
 			enabledWhenIdle?: boolean,
+			enabledWhenOffline?: boolean,
 		): Promise<Pick<AvailableAgentsAggregation, 'username'>[]>;
 	}
 }
@@ -23,6 +24,7 @@ export class UsersEE extends UsersRaw {
 		departmentId: string,
 		customFilter: Filter<AvailableAgentsAggregation>,
 		enabledWhenIdle = false,
+		enabledWhenOffline = false,
 	): Promise<Pick<AvailableAgentsAggregation, 'username'>[]> {
 		// if department is provided, remove the agents that are not from the selected department
 		const departmentFilter = departmentId
@@ -53,7 +55,7 @@ export class UsersEE extends UsersRaw {
 			.aggregate<AvailableAgentsAggregation>(
 				[
 					{
-						$match: queryStatusAgentOnline({}, enabledWhenIdle),
+						$match: queryStatusAgentOnline({}, enabledWhenIdle, enabledWhenOffline),
 					},
 					...departmentFilter,
 					{

--- a/apps/meteor/server/features/EmailInbox/EmailInbox_Incoming.ts
+++ b/apps/meteor/server/features/EmailInbox/EmailInbox_Incoming.ts
@@ -48,7 +48,10 @@ async function getGuestByEmail(email: string, name: string, department = ''): Pr
 			email,
 			department,
 		},
-		{ shouldConsiderIdleAgent: settings.get<boolean>('Livechat_enabled_when_agent_idle') },
+		{
+			shouldConsiderIdleAgent: settings.get<boolean>('Livechat_enabled_when_agent_idle'),
+			shouldConsiderOfflineAgent: settings.get<boolean>('Livechat_accept_chats_with_no_agents'),
+		},
 	);
 
 	if (!livechatVisitor) {

--- a/apps/meteor/tests/end-to-end/api/livechat/24-routing.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/24-routing.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 import type { Credentials } from '@rocket.chat/api-client';
-import type { ILivechatDepartment, IUser } from '@rocket.chat/core-typings';
+import { UserStatus } from '@rocket.chat/core-typings';
+import type { ILivechatDepartment, IUser, ILivechatAgent } from '@rocket.chat/core-typings';
 import { expect } from 'chai';
 import { after, before, describe, it } from 'mocha';
 
@@ -13,10 +14,12 @@ import {
 	createLivechatRoom,
 	getLivechatRoomInfo,
 	makeAgentUnavailable,
+	switchLivechatStatus,
 } from '../../../data/livechat/rooms';
-import { updateSetting } from '../../../data/permissions.helper';
+import { getAgent } from '../../../data/livechat/users';
+import { getSettingValueById, updateSetting } from '../../../data/permissions.helper';
 import { password } from '../../../data/user';
-import { createUser, deleteUser, login, setUserActiveStatus } from '../../../data/users.helper';
+import { createUser, deleteUser, login, setUserActiveStatus, setUserStatus } from '../../../data/users.helper';
 import { IS_EE } from '../../../e2e/config/constants';
 
 (IS_EE ? describe : describe.skip)('Omnichannel - Routing', () => {
@@ -393,6 +396,52 @@ import { IS_EE } from '../../../e2e/config/constants';
 				expect(roomInfo.servedBy).to.be.an('object').that.has.property('_id').that.is.not.equal(testUser3.user._id);
 			});
 		});
+		describe('Auto_Selection - Livechat_accept_chats_with_no_agents', async () => {
+			let initialSettingValue: any;
+			let testUserInitialState: ILivechatAgent;
+			let testUser3InitialState: ILivechatAgent;
+
+			before(async () => {
+				testUserInitialState = await getAgent(testUser.user._id);
+				testUser3InitialState = await getAgent(testUser3.user._id);
+				initialSettingValue = await getSettingValueById('Livechat_accept_chats_with_no_agents');
+			});
+
+			after(async () => {
+				await updateSetting('Livechat_accept_chats_with_no_agents', initialSettingValue);
+				await switchLivechatStatus(testUserInitialState.statusLivechat, testUser.credentials);
+				await switchLivechatStatus(testUser3InitialState.statusLivechat, testUser3.credentials);
+				await setUserStatus(testUser3.credentials, testUser3InitialState.status);
+			});
+			describe('Livechat_accept_chats_with_no_agents is false', () => {
+				before(async () => {
+					await updateSetting('Livechat_accept_chats_with_no_agents', false);
+					await switchLivechatStatus('not-available', testUser.credentials);
+					await switchLivechatStatus('available', testUser3.credentials);
+					await setUserStatus(testUser3.credentials, UserStatus.OFFLINE);
+				});
+
+				it('should fail to start a conversation if there is an available but offline agent and Livechat_accept_chats_with_no_agents is false', async () => {
+					const visitor = await createVisitor(testDepartment._id);
+					const { body } = await request.get(api('livechat/room')).query({ token: visitor.token }).expect(400);
+					expect(body.error).to.be.equal('Sorry, no online agents [no-agent-online]');
+				});
+			});
+			describe('Livechat_accept_chats_with_no_agents is true', () => {
+				before(async () => {
+					await updateSetting('Livechat_accept_chats_with_no_agents', true);
+					await switchLivechatStatus('available', testUser3.credentials);
+					await setUserStatus(testUser3.credentials, UserStatus.OFFLINE);
+				});
+				it('should accept a conversation and route to an offline agent', async () => {
+					const visitor = await createVisitor(testDepartment._id);
+					const room = await createLivechatRoom(visitor.token);
+					const roomInfo = await getLivechatRoomInfo(room._id);
+					expect(roomInfo.servedBy).to.be.an('object');
+					expect(roomInfo.servedBy?._id).to.be.equal(testUser3.user._id);
+				});
+			});
+		});
 	});
 	describe('Load Balancing', () => {
 		before(async () => {
@@ -474,6 +523,53 @@ import { IS_EE } from '../../../e2e/config/constants';
 			expect(roomInfo.servedBy).to.be.an('object');
 			expect(roomInfo.servedBy?._id).to.be.equal(testUser2.user._id);
 		});
+		describe('Load_Balancing - Livechat_accept_chats_with_no_agents', async () => {
+			let initialSettingValue: any;
+			let testUserInitialState: ILivechatAgent;
+			let testUser2InitialState: ILivechatAgent;
+
+			before(async () => {
+				testUserInitialState = await getAgent(testUser.user._id);
+				testUser2InitialState = await getAgent(testUser2.user._id);
+				initialSettingValue = await getSettingValueById('Livechat_accept_chats_with_no_agents');
+			});
+
+			after(async () => {
+				await updateSetting('Livechat_accept_chats_with_no_agents', initialSettingValue);
+				await switchLivechatStatus(testUserInitialState.statusLivechat, testUser.credentials);
+				await switchLivechatStatus(testUser2InitialState.statusLivechat, testUser2.credentials);
+				await setUserStatus(testUser2.credentials, testUser2InitialState.status);
+			});
+			describe('Livechat_accept_chats_with_no_agents is false', () => {
+				before(async () => {
+					await updateSetting('Livechat_accept_chats_with_no_agents', false);
+					await switchLivechatStatus('not-available', testUser.credentials);
+					await switchLivechatStatus('available', testUser2.credentials);
+					await setUserStatus(testUser2.credentials, UserStatus.OFFLINE);
+				});
+
+				it('should fail to start a conversation if there is an available but offline agent and Livechat_accept_chats_with_no_agents is false', async () => {
+					const visitor = await createVisitor(testDepartment._id);
+					const { body } = await request.get(api('livechat/room')).query({ token: visitor.token }).expect(400);
+					expect(body.error).to.be.equal('Sorry, no online agents [no-agent-online]');
+				});
+			});
+			describe('Livechat_accept_chats_with_no_agents is true', () => {
+				before(async () => {
+					await updateSetting('Livechat_accept_chats_with_no_agents', true);
+					await switchLivechatStatus('available', testUser2.credentials);
+					await setUserStatus(testUser2.credentials, UserStatus.OFFLINE);
+				});
+				it('should accept a conversation and route to an offline agent', async () => {
+					const visitor = await createVisitor(testDepartment._id);
+					const room = await createLivechatRoom(visitor.token);
+					const roomInfo = await getLivechatRoomInfo(room._id);
+
+					expect(roomInfo.servedBy).to.be.an('object');
+					expect(roomInfo.servedBy?._id).to.be.equal(testUser2.user._id);
+				});
+			});
+		});
 	});
 	describe('Load Rotation', () => {
 		before(async () => {
@@ -554,6 +650,53 @@ import { IS_EE } from '../../../e2e/config/constants';
 
 			expect(roomInfo.servedBy).to.be.an('object');
 			expect(roomInfo.servedBy?._id).to.be.equal(testUser.user._id);
+		});
+		describe('Load_Rotation - Livechat_accept_chats_with_no_agents', async () => {
+			let initialSettingValue: any;
+			let testUserInitialState: ILivechatAgent;
+			let testUser2InitialState: ILivechatAgent;
+
+			before(async () => {
+				testUserInitialState = await getAgent(testUser.user._id);
+				testUser2InitialState = await getAgent(testUser2.user._id);
+				initialSettingValue = await getSettingValueById('Livechat_accept_chats_with_no_agents');
+			});
+
+			after(async () => {
+				await updateSetting('Livechat_accept_chats_with_no_agents', initialSettingValue);
+				await switchLivechatStatus(testUserInitialState.statusLivechat, testUser.credentials);
+				await switchLivechatStatus(testUser2InitialState.statusLivechat, testUser2.credentials);
+				await setUserStatus(testUser2.credentials, testUser2InitialState.status);
+			});
+			describe('Livechat_accept_chats_with_no_agents is false', () => {
+				before(async () => {
+					await updateSetting('Livechat_accept_chats_with_no_agents', false);
+					await switchLivechatStatus('not-available', testUser.credentials);
+					await switchLivechatStatus('available', testUser2.credentials);
+					await setUserStatus(testUser2.credentials, UserStatus.OFFLINE);
+				});
+
+				it('should fail to start a conversation if there is an available but offline agent and Livechat_accept_chats_with_no_agents is false', async () => {
+					const visitor = await createVisitor(testDepartment._id);
+					const { body } = await request.get(api('livechat/room')).query({ token: visitor.token }).expect(400);
+					expect(body.error).to.be.equal('Sorry, no online agents [no-agent-online]');
+				});
+			});
+			describe('Livechat_accept_chats_with_no_agents is true', () => {
+				before(async () => {
+					await updateSetting('Livechat_accept_chats_with_no_agents', true);
+					await switchLivechatStatus('available', testUser2.credentials);
+					await setUserStatus(testUser2.credentials, UserStatus.OFFLINE);
+				});
+				it('should accept a conversation and route to an offline agent', async () => {
+					const visitor = await createVisitor(testDepartment._id);
+					const room = await createLivechatRoom(visitor.token);
+					const roomInfo = await getLivechatRoomInfo(room._id);
+
+					expect(roomInfo.servedBy).to.be.an('object');
+					expect(roomInfo.servedBy?._id).to.be.equal(testUser2.user._id);
+				});
+			});
 		});
 	});
 });

--- a/packages/model-typings/src/models/ILivechatDepartmentAgentsModel.ts
+++ b/packages/model-typings/src/models/ILivechatDepartmentAgentsModel.ts
@@ -58,6 +58,7 @@ export interface ILivechatDepartmentAgentsModel extends IBaseModel<ILivechatDepa
 		isLivechatEnabledWhenAgentIdle?: boolean,
 		ignoreAgentId?: ILivechatDepartmentAgents['agentId'],
 		extraQuery?: Filter<AvailableAgentsAggregation>,
+		acceptChatsWithNoAgents?: boolean,
 	): Promise<Pick<ILivechatDepartmentAgents, '_id' | 'agentId' | 'departmentId' | 'username'> | null | undefined>;
 	getBotsForDepartment(departmentId: string): Promise<undefined | FindCursor<ILivechatDepartmentAgents>>;
 	countBotsForDepartment(departmentId: string): Promise<number>;

--- a/packages/model-typings/src/models/IUsersModel.ts
+++ b/packages/model-typings/src/models/IUsersModel.ts
@@ -9,7 +9,6 @@ import type {
 	AtLeast,
 	ILivechatAgentStatus,
 	IMeteorLoginToken,
-	IRoom,
 } from '@rocket.chat/core-typings';
 import type {
 	Document,
@@ -111,12 +110,14 @@ export interface IUsersModel extends IBaseModel<IUser> {
 		ignoreAgentId?: string,
 		isEnabledWhenAgentIdle?: boolean,
 		ignoreUsernames?: string[],
+		acceptChatsWithNoAgents?: boolean,
 	): Promise<{ agentId: string; username?: string; lastRoutingTime?: Date; count: number }>;
 	getLastAvailableAgentRouted(
 		department?: string,
 		ignoreAgentId?: string,
 		isEnabledWhenAgentIdle?: boolean,
 		ignoreUsernames?: string[],
+		acceptChatsWithNoAgents?: boolean,
 	): Promise<{ agentId: string; username?: string; lastRoutingTime?: Date }>;
 
 	setLastRoutingTime(userId: IUser['_id']): Promise<WithId<IUser> | null>;
@@ -166,7 +167,6 @@ export interface IUsersModel extends IBaseModel<IUser> {
 
 	setAbacAttributesById(userId: IUser['_id'], attributes: NonNullable<IUser['abacAttributes']>): Promise<IUser | null>;
 	unsetAbacAttributesById(userId: IUser['_id']): Promise<IUser | null>;
-	findActiveByRoomIds(roomIds: IRoom['_id'][], options?: FindOptions<IUser>): FindCursor<IUser>;
 
 	updateStatusText(_id: IUser['_id'], statusText: string, options?: UpdateOptions): Promise<UpdateResult>;
 
@@ -252,17 +252,20 @@ export interface IUsersModel extends IBaseModel<IUser> {
 	findOnlineUserFromList<T extends Document = ILivechatAgent>(
 		userList: string | string[],
 		isLivechatEnabledWhenAgentIdle?: boolean,
+		acceptChatsWithNoAgents?: boolean,
 	): FindCursor<T>;
 	countOnlineUserFromList(userList: string | string[], isLivechatEnabledWhenAgentIdle?: boolean): Promise<number>;
 	getUnavailableAgents(
 		departmentId?: string,
 		extraQuery?: Filter<AvailableAgentsAggregation>,
 		isLivechatEnabledWhenIdle?: boolean,
+		acceptChatsWithNoAgents?: boolean,
 	): Promise<Pick<AvailableAgentsAggregation, 'username'>[]>;
 	findOneOnlineAgentByUserList(
 		userList: string[] | string,
 		options?: FindOptions<IUser>,
 		isLivechatEnabledWhenAgentIdle?: boolean,
+		acceptChatsWithNoAgents?: boolean,
 	): Promise<IUser | null>;
 
 	findBotAgents<T extends Document = ILivechatAgent>(usernameList?: string | string[]): FindCursor<T>;
@@ -283,13 +286,18 @@ export interface IUsersModel extends IBaseModel<IUser> {
 		loginTokenObject: AtLeast<IPersonalAccessToken, 'type' | 'name'>;
 	}): Promise<UpdateResult>;
 	findPersonalAccessTokenByTokenNameAndUserId({ userId, tokenName }: { userId: IUser['_id']; tokenName: string }): Promise<IUser | null>;
-	checkOnlineAgents(agentId?: string, isLivechatEnabledWhenIdle?: boolean): Promise<boolean>;
-	findOnlineAgents<T extends Document = ILivechatAgent>(agentId?: IUser['_id'], isLivechatEnabledWhenIdle?: boolean): FindCursor<T>;
+	checkOnlineAgents(agentId?: string, isLivechatEnabledWhenIdle?: boolean, acceptChatsWithNoAgents?: boolean): Promise<boolean>;
+	findOnlineAgents<T extends Document = ILivechatAgent>(
+		agentId?: IUser['_id'],
+		isLivechatEnabledWhenIdle?: boolean,
+		acceptChatsWithNoAgents?: boolean,
+	): FindCursor<T>;
 	countOnlineAgents(agentId: string): Promise<number>;
 	findOneBotAgent<T extends Document = ILivechatAgent>(): Promise<T | null>;
 	findOneOnlineAgentById(
 		agentId: string,
 		isLivechatEnabledWhenAgentIdle?: boolean,
+		acceptChatsWithNoAgents?: boolean,
 		options?: FindOptions<IUser>,
 	): Promise<ILivechatAgent | null>;
 	findAgents(): FindCursor<ILivechatAgent>;
@@ -298,6 +306,7 @@ export interface IUsersModel extends IBaseModel<IUser> {
 		ignoreAgentId?: string,
 		extraQuery?: Filter<AvailableAgentsAggregation>,
 		enabledWhenAgentIdle?: boolean,
+		acceptChatsWithNoAgents?: boolean,
 	): Promise<{ agentId: string; username?: string } | null>;
 	getNextBotAgent(ignoreAgentId?: string): Promise<{ agentId: string; username?: string } | null>;
 	setLivechatStatus(userId: string, status: ILivechatAgentStatus): Promise<UpdateResult>;

--- a/packages/model-typings/src/models/IUsersModel.ts
+++ b/packages/model-typings/src/models/IUsersModel.ts
@@ -9,6 +9,7 @@ import type {
 	AtLeast,
 	ILivechatAgentStatus,
 	IMeteorLoginToken,
+	IRoom,
 } from '@rocket.chat/core-typings';
 import type {
 	Document,
@@ -167,6 +168,7 @@ export interface IUsersModel extends IBaseModel<IUser> {
 
 	setAbacAttributesById(userId: IUser['_id'], attributes: NonNullable<IUser['abacAttributes']>): Promise<IUser | null>;
 	unsetAbacAttributesById(userId: IUser['_id']): Promise<IUser | null>;
+	findActiveByRoomIds(roomIds: IRoom['_id'][], options?: FindOptions<IUser>): FindCursor<IUser>;
 
 	updateStatusText(_id: IUser['_id'], statusText: string, options?: UpdateOptions): Promise<UpdateResult>;
 

--- a/packages/models/src/helpers/omnichannel/agentStatus.ts
+++ b/packages/models/src/helpers/omnichannel/agentStatus.ts
@@ -7,32 +7,42 @@ import type { Filter } from 'mongodb';
  * * According to product rules, the primary conditions for auto-assignment are:
  * - User must have the 'livechat-agent' role.
  * - Livechat service status (`statusLivechat`) must be 'available'.
- * - User's global status must NOT be 'offline' (Bots are exempt from this rule).
+ * - User's global status must NOT be 'offline' Exceptions: Bots are exempt from this rule, and this check is skipped entirely if the `acceptChatsWithNoAgents` setting is enabled (allowing offline human agents to be assigned).
  * - If the "Accept new omnichannel requests when the agent is idle" (aka `Livechat_enabled_when_agent_idle`) setting is OFF,
  * then the statusConnection must NOT be 'away'.
  */
-export const queryStatusAgentOnline = (extraFilters = {}, isLivechatEnabledWhenAgentIdle?: boolean): Filter<IUser> => ({
+export const queryStatusAgentOnline = (
+	extraFilters = {},
+	isLivechatEnabledWhenAgentIdle?: boolean,
+	acceptChatsWithNoAgents?: boolean,
+): Filter<IUser> => ({
 	statusLivechat: 'available',
 	roles: 'livechat-agent',
 	// ignore deactivated users
 	active: true,
-	$or: [
-		{ roles: 'bot' },
-		{
-			status: {
-				$exists: true,
-				$ne: UserStatus.OFFLINE,
+	...(!acceptChatsWithNoAgents && {
+		$or: [
+			{ roles: 'bot' },
+			{
+				status: {
+					$exists: true,
+					$ne: UserStatus.OFFLINE,
+				},
 			},
-		},
-	],
+		],
+	}),
 	...extraFilters,
 	...(isLivechatEnabledWhenAgentIdle === false && {
 		statusConnection: { $ne: 'away' },
 	}),
 });
 
-export const queryAvailableAgentsForSelection = (extraFilters = {}, isLivechatEnabledWhenAgentIdle?: boolean): Filter<IUser> => ({
-	...queryStatusAgentOnline(extraFilters, isLivechatEnabledWhenAgentIdle),
+export const queryAvailableAgentsForSelection = (
+	extraFilters = {},
+	isLivechatEnabledWhenAgentIdle?: boolean,
+	acceptChatsWithNoAgents?: boolean,
+): Filter<IUser> => ({
+	...queryStatusAgentOnline(extraFilters, isLivechatEnabledWhenAgentIdle, acceptChatsWithNoAgents),
 	$and: [
 		{
 			$or: [{ agentLocked: { $exists: false } }, { agentLockedAt: { $lt: new Date(Date.now() - 5000) } }],

--- a/packages/models/src/models/LivechatDepartmentAgents.ts
+++ b/packages/models/src/models/LivechatDepartmentAgents.ts
@@ -178,6 +178,7 @@ export class LivechatDepartmentAgentsRaw extends BaseRaw<ILivechatDepartmentAgen
 		isLivechatEnabledWhenAgentIdle?: boolean,
 		ignoreAgentId?: ILivechatDepartmentAgents['agentId'],
 		extraQuery?: Filter<AvailableAgentsAggregation>,
+		acceptChatsWithNoAgents?: boolean,
 	): Promise<Pick<ILivechatDepartmentAgents, '_id' | 'agentId' | 'departmentId' | 'username'> | null | undefined> {
 		const agents = await this.findByDepartmentId(departmentId).toArray();
 
@@ -188,14 +189,15 @@ export class LivechatDepartmentAgentsRaw extends BaseRaw<ILivechatDepartmentAgen
 		const onlineUsers = await Users.findOnlineUserFromList(
 			agents.map((agent) => agent.username),
 			isLivechatEnabledWhenAgentIdle,
+			acceptChatsWithNoAgents,
 		).toArray();
 
 		const onlineUsernames = onlineUsers.map((user) => user.username).filter(isStringValue);
 
 		// get fully booked agents, to ignore them from the query
-		const currentUnavailableAgents = (await Users.getUnavailableAgents(departmentId, extraQuery, isLivechatEnabledWhenAgentIdle)).map(
-			(u) => u.username,
-		);
+		const currentUnavailableAgents = (
+			await Users.getUnavailableAgents(departmentId, extraQuery, isLivechatEnabledWhenAgentIdle, acceptChatsWithNoAgents)
+		).map((u) => u.username);
 
 		const query: Filter<ILivechatDepartmentAgents> = {
 			departmentId,

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -143,6 +143,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOneAndUpdate({ _id }, { $unset: { abacAttributes: 1 } }, { returnDocument: 'after' });
 	}
 
+	findActiveByRoomIds(roomIds: IRoom['_id'][], options?: FindOptions<IUser>) {
+		return this.find({ active: true, __rooms: { $in: roomIds } }, options);
+	}
+
 	/**
 	 * @param {string} uid
 	 * @param {IRole['_id'][]} roles list of role ids

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -143,10 +143,6 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOneAndUpdate({ _id }, { $unset: { abacAttributes: 1 } }, { returnDocument: 'after' });
 	}
 
-	findActiveByRoomIds(roomIds: IRoom['_id'][], options?: FindOptions<IUser>) {
-		return this.find({ active: true, __rooms: { $in: roomIds } }, options);
-	}
-
 	/**
 	 * @param {string} uid
 	 * @param {IRole['_id'][]} roles list of role ids
@@ -560,10 +556,12 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		ignoreAgentId?: string,
 		isEnabledWhenAgentIdle?: boolean,
 		ignoreUsernames?: string[],
+		acceptChatsWithNoAgents?: boolean,
 	): Promise<{ agentId: string; username?: string; lastRoutingTime?: Date; count: number; departments?: any[] }> {
 		const match = queryAvailableAgentsForSelection(
 			{ ...(ignoreAgentId && { _id: { $ne: ignoreAgentId } }), ...(ignoreUsernames?.length && { username: { $nin: ignoreUsernames } }) },
 			isEnabledWhenAgentIdle,
+			acceptChatsWithNoAgents,
 		);
 
 		const departmentFilter = department
@@ -641,10 +639,12 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		ignoreAgentId?: string,
 		isEnabledWhenAgentIdle?: boolean,
 		ignoreUsernames?: string[],
+		acceptChatsWithNoAgents?: boolean,
 	): Promise<{ agentId: string; username?: string; lastRoutingTime?: Date; departments?: any[] }> {
 		const match = queryAvailableAgentsForSelection(
 			{ ...(ignoreAgentId && { _id: { $ne: ignoreAgentId } }), ...(ignoreUsernames?.length && { username: { $nin: ignoreUsernames } }) },
 			isEnabledWhenAgentIdle,
+			acceptChatsWithNoAgents,
 		);
 		const departmentFilter = department
 			? [
@@ -1620,13 +1620,17 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		});
 	}
 
-	findOnlineUserFromList<T extends Document = ILivechatAgent>(userList: string | string[], isLivechatEnabledWhenAgentIdle?: boolean) {
+	findOnlineUserFromList<T extends Document = ILivechatAgent>(
+		userList: string | string[],
+		isLivechatEnabledWhenAgentIdle?: boolean,
+		acceptChatsWithNoAgents?: boolean,
+	) {
 		// TODO: Create class Agent
 		const username = {
 			$in: ([] as string[]).concat(userList),
 		};
 
-		const query = queryStatusAgentOnline({ username }, isLivechatEnabledWhenAgentIdle);
+		const query = queryStatusAgentOnline({ username }, isLivechatEnabledWhenAgentIdle, acceptChatsWithNoAgents);
 
 		return this.find<T>(query);
 	}
@@ -1642,13 +1646,18 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.countDocuments(query);
 	}
 
-	findOneOnlineAgentByUserList(userList: string | string[], options?: FindOptions<IUser>, isLivechatEnabledWhenAgentIdle?: boolean) {
+	findOneOnlineAgentByUserList(
+		userList: string | string[],
+		options?: FindOptions<IUser>,
+		isLivechatEnabledWhenAgentIdle?: boolean,
+		acceptChatsWithNoAgents?: boolean,
+	) {
 		// TODO:: Create class Agent
 		const username = {
 			$in: ([] as string[]).concat(userList),
 		};
 
-		const query = queryStatusAgentOnline({ username }, isLivechatEnabledWhenAgentIdle);
+		const query = queryStatusAgentOnline({ username }, isLivechatEnabledWhenAgentIdle, acceptChatsWithNoAgents);
 
 		return this.findOne(query, options);
 	}
@@ -1657,6 +1666,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		_departmentId?: string,
 		_extraQuery?: Filter<AvailableAgentsAggregation>,
 		_isLivechatEnabledWhenAgentIdle?: boolean,
+		_acceptChatsWithNoAgent?: boolean,
 	): Promise<Pick<AvailableAgentsAggregation, 'username'>[]> {
 		return [];
 	}
@@ -1865,16 +1875,20 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOne(query);
 	}
 
-	async checkOnlineAgents(agentId: IUser['_id'], isLivechatEnabledWhenAgentIdle?: boolean) {
+	async checkOnlineAgents(agentId: IUser['_id'], isLivechatEnabledWhenAgentIdle?: boolean, acceptChatsWithNoAgents?: boolean) {
 		// TODO:: Create class Agent
-		const query = queryStatusAgentOnline(agentId && { _id: agentId }, isLivechatEnabledWhenAgentIdle);
+		const query = queryStatusAgentOnline(agentId && { _id: agentId }, isLivechatEnabledWhenAgentIdle, acceptChatsWithNoAgents);
 
 		return !!(await this.findOne(query));
 	}
 
-	findOnlineAgents<T extends Document = ILivechatAgent>(agentId?: IUser['_id'], isLivechatEnabledWhenAgentIdle?: boolean) {
+	findOnlineAgents<T extends Document = ILivechatAgent>(
+		agentId?: IUser['_id'],
+		isLivechatEnabledWhenAgentIdle?: boolean,
+		acceptChatsWithNoAgents?: boolean,
+	) {
 		// TODO:: Create class Agent
-		const query = queryStatusAgentOnline(agentId && { _id: agentId }, isLivechatEnabledWhenAgentIdle);
+		const query = queryStatusAgentOnline(agentId && { _id: agentId }, isLivechatEnabledWhenAgentIdle, acceptChatsWithNoAgents);
 
 		return this.find<T>(query);
 	}
@@ -1900,10 +1914,11 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 	findOneOnlineAgentById<T extends Document = ILivechatAgent>(
 		_id: IUser['_id'],
 		isLivechatEnabledWhenAgentIdle?: boolean,
+		acceptChatsWithNoAgents?: boolean,
 		options?: FindOptions<IUser>,
 	) {
 		// TODO: Create class Agent
-		const query = queryStatusAgentOnline({ _id }, isLivechatEnabledWhenAgentIdle);
+		const query = queryStatusAgentOnline({ _id }, isLivechatEnabledWhenAgentIdle, acceptChatsWithNoAgents);
 
 		return this.findOne<T>(query, options);
 	}
@@ -1927,17 +1942,24 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 	}
 
 	// 2
-	async getNextAgent(ignoreAgentId?: string, extraQuery?: Filter<AvailableAgentsAggregation>, enabledWhenAgentIdle?: boolean) {
+	async getNextAgent(
+		ignoreAgentId?: string,
+		extraQuery?: Filter<AvailableAgentsAggregation>,
+		enabledWhenAgentIdle?: boolean,
+		acceptChatsWithNoAgents?: boolean,
+	) {
 		// TODO: Create class Agent
 		// fetch all unavailable agents, and exclude them from the selection
-		const unavailableAgents = (await this.getUnavailableAgents(undefined, extraQuery, enabledWhenAgentIdle)).map((u) => u.username);
+		const unavailableAgents = (await this.getUnavailableAgents(undefined, extraQuery, enabledWhenAgentIdle, acceptChatsWithNoAgents)).map(
+			(u) => u.username,
+		);
 		const extraFilters = {
 			...(ignoreAgentId && { _id: { $ne: ignoreAgentId } }),
 			// limit query to remove booked agents
 			username: { $nin: unavailableAgents },
 		};
 
-		const query = queryAvailableAgentsForSelection(extraFilters, enabledWhenAgentIdle);
+		const query = queryAvailableAgentsForSelection(extraFilters, enabledWhenAgentIdle, acceptChatsWithNoAgents);
 
 		const sort: Record<string, SortDirection> = {
 			livechatCount: 1,

--- a/packages/omni-core/src/visitor/create.spec.ts
+++ b/packages/omni-core/src/visitor/create.spec.ts
@@ -69,7 +69,9 @@ describe('registerGuest', () => {
 		it('should throw error when token is not provided', async () => {
 			const guestData = {};
 
-			await expect(registerGuest(guestData, { shouldConsiderIdleAgent: false })).rejects.toThrow('error-invalid-token');
+			await expect(registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false })).rejects.toThrow(
+				'error-invalid-token',
+			);
 		});
 
 		it('should throw error when token is empty string', async () => {
@@ -77,7 +79,9 @@ describe('registerGuest', () => {
 				token: '',
 			};
 
-			await expect(registerGuest(guestData, { shouldConsiderIdleAgent: false })).rejects.toThrow('error-invalid-token');
+			await expect(registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false })).rejects.toThrow(
+				'error-invalid-token',
+			);
 		});
 	});
 
@@ -106,11 +110,13 @@ describe('registerGuest', () => {
 				email,
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			expect(mockValidateEmail).toHaveBeenCalledWith('test@example.com');
 			expect(findContactByEmailAndContactManagerSpy).toHaveBeenCalledWith('test@example.com');
-			expect(findOneOnlineAgentByIdSpy).toHaveBeenCalledWith(agentId, false, { projection: { _id: 1, username: 1, name: 1, emails: 1 } });
+			expect(findOneOnlineAgentByIdSpy).toHaveBeenCalledWith(agentId, false, false, {
+				projection: { _id: 1, username: 1, name: 1, emails: 1 },
+			});
 
 			// Verify the data passed to updateOneByIdOrToken
 			expect(updateOneByIdOrTokenSpy).toHaveBeenCalledWith(
@@ -147,7 +153,7 @@ describe('registerGuest', () => {
 				email,
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			// Verify contact manager is not included in the data
 			expect(updateOneByIdOrTokenSpy).toHaveBeenCalledWith(
@@ -175,7 +181,7 @@ describe('registerGuest', () => {
 				email,
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			expect(mockValidateEmail).toHaveBeenCalledWith('test@example.com');
 			expect(findContactByEmailAndContactManagerSpy).toHaveBeenCalledWith('test@example.com');
@@ -207,7 +213,7 @@ describe('registerGuest', () => {
 				department,
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			expect(findOneByIdOrNameSpy).toHaveBeenCalledWith(department, { projection: { _id: 1 } });
 
@@ -236,7 +242,9 @@ describe('registerGuest', () => {
 				department,
 			};
 
-			await expect(registerGuest(guestData, { shouldConsiderIdleAgent: false })).rejects.toThrow('error-invalid-department');
+			await expect(registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false })).rejects.toThrow(
+				'error-invalid-department',
+			);
 
 			// Verify updateOneByIdOrToken is not called when department validation fails
 			expect(updateOneByIdOrTokenSpy).not.toHaveBeenCalled();
@@ -257,7 +265,7 @@ describe('registerGuest', () => {
 				department,
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			// Department validation should be skipped
 			expect(findOneByIdOrNameSpy).not.toHaveBeenCalled();
@@ -289,7 +297,7 @@ describe('registerGuest', () => {
 				name: 'Updated Name',
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			expect(getVisitorByTokenSpy).toHaveBeenCalledWith(token, { projection: { _id: 1 } });
 
@@ -322,7 +330,7 @@ describe('registerGuest', () => {
 				phone: { number: phoneNumber },
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			expect(findOneVisitorByPhoneSpy).toHaveBeenCalledWith(phoneNumber);
 
@@ -355,7 +363,7 @@ describe('registerGuest', () => {
 				email,
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			expect(findOneGuestByEmailAddressSpy).toHaveBeenCalledWith(email);
 
@@ -387,7 +395,7 @@ describe('registerGuest', () => {
 				username,
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			// Verify new visitor data is created with provided values
 			expect(updateOneByIdOrTokenSpy).toHaveBeenCalledWith(
@@ -415,7 +423,7 @@ describe('registerGuest', () => {
 				token,
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			expect(getNextVisitorUsernameSpy).toHaveBeenCalled();
 
@@ -445,7 +453,7 @@ describe('registerGuest', () => {
 				username: providedUsername,
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			expect(getNextVisitorUsernameSpy).not.toHaveBeenCalled();
 
@@ -476,7 +484,7 @@ describe('registerGuest', () => {
 				phone: { number: phoneNumber },
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			expect(updateOneByIdOrTokenSpy).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -504,7 +512,7 @@ describe('registerGuest', () => {
 				email,
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			expect(updateOneByIdOrTokenSpy).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -529,7 +537,7 @@ describe('registerGuest', () => {
 				token,
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			expect(updateOneByIdOrTokenSpy).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -555,7 +563,7 @@ describe('registerGuest', () => {
 				status,
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			expect(updateOneByIdOrTokenSpy).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -590,7 +598,7 @@ describe('registerGuest', () => {
 				connectionData,
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			expect(updateOneByIdOrTokenSpy).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -624,7 +632,7 @@ describe('registerGuest', () => {
 				connectionData,
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			expect(updateOneByIdOrTokenSpy).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -654,7 +662,7 @@ describe('registerGuest', () => {
 				connectionData,
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			expect(updateOneByIdOrTokenSpy).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -684,7 +692,7 @@ describe('registerGuest', () => {
 				token,
 			};
 
-			const result = await registerGuest(guestData, { shouldConsiderIdleAgent: false });
+			const result = await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
 			expect(result).toBeNull();
 			expect(updateOneByIdOrTokenSpy).toHaveBeenCalledWith(
@@ -710,12 +718,14 @@ describe('registerGuest', () => {
 				email,
 			};
 
-			await expect(registerGuest(guestData, { shouldConsiderIdleAgent: false })).rejects.toThrow('Invalid email');
+			await expect(registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false })).rejects.toThrow(
+				'Invalid email',
+			);
 		});
 	});
 
 	describe('shouldConsiderIdleAgent parameter', () => {
-		it('should pass shouldConsiderIdleAgent to findOneOnlineAgentById', async () => {
+		it('should pass shouldConsiderIdleAgent and shouldConsiderOfflineAgent to findOneOnlineAgentById', async () => {
 			const token = 'test-token';
 			const email = 'test@example.com';
 			const agentId = 'agent-123';
@@ -743,11 +753,12 @@ describe('registerGuest', () => {
 				email,
 			};
 
-			await registerGuest(guestData, { shouldConsiderIdleAgent: true });
+			await registerGuest(guestData, { shouldConsiderIdleAgent: true, shouldConsiderOfflineAgent: true });
 
 			expect(findOneOnlineAgentByIdSpy).toHaveBeenCalledWith(
 				agentId,
 				true, // shouldConsiderIdleAgent should be true
+				true, // shouldConsiderOfflineAgent should be true
 				{ projection: { _id: 1, username: 1, name: 1, emails: 1 } },
 			);
 

--- a/packages/omni-core/src/visitor/create.ts
+++ b/packages/omni-core/src/visitor/create.ts
@@ -17,7 +17,7 @@ type RegisterGuestType = Partial<Pick<ILivechatVisitor, 'token' | 'name' | 'depa
 export const registerGuest = makeFunction(
 	async (
 		{ id, token, name, phone, email, department, username, connectionData, status = UserStatus.ONLINE, externalIds }: RegisterGuestType,
-		{ shouldConsiderIdleAgent }: { shouldConsiderIdleAgent: boolean },
+		{ shouldConsiderIdleAgent, shouldConsiderOfflineAgent }: { shouldConsiderIdleAgent: boolean; shouldConsiderOfflineAgent: boolean },
 	): Promise<ILivechatVisitor | null> => {
 		if (!token) {
 			throw Error('error-invalid-token');
@@ -40,7 +40,7 @@ export const registerGuest = makeFunction(
 
 			const contact = await LivechatContacts.findContactByEmailAndContactManager(visitorEmail);
 			if (contact?.contactManager) {
-				const agent = await Users.findOneOnlineAgentById(contact.contactManager, shouldConsiderIdleAgent, {
+				const agent = await Users.findOneOnlineAgentById(contact.contactManager, shouldConsiderIdleAgent, shouldConsiderOfflineAgent, {
 					projection: { _id: 1, username: 1, name: 1, emails: 1 },
 				});
 				if (agent?.username && agent.name && agent.emails) {


### PR DESCRIPTION

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
The changes made in this PR were done following [product team given directives](https://rocketchat.atlassian.net/browse/CORE-1853?focusedCommentId=78966).
- Added a third parameter named `acceptChatsWithNoAgents` to methods that fetch available agents. It basically passes the value of the `Livechat_enabled_when_agent_offline` setting downstream, to be able to process it and resolve offline agents to the visitor in case its value is true. This was made since after fixing the query, I've found out that `Livechat_enabled_when_agent_offline` wasn't being respected, and previously it "worked" (and note the quotation marks) because our query wasn't filtering out offline users at all.
- Added tests to validate this setting works properly following our modern practices. Created a new task for the modernization of the suite (CORE-1985).
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-1972 Fix 'Livechat_accept_chats_with_no_agents' omnichannel setting not being respected](https://rocketchat.atlassian.net/browse/CORE-1972)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Before testing, you'd need to have a EE license and to create at least two agents and a department with them. Also, you'll need to go to Settings -> Omnichannel -> Queue Management, enable the Waiting queue option and then set Max. number of simultaneous chats to only 1.
- Test that when two agents belong to the same department, each with a conversation limit of 1, and one agent is already handling a visitor while the other one is offline, and the setting `Livechat_accept_chats_with_no_agents` is enabled, the new visitor isn't queued, but routed to the offline agent.
- You could test the opposite case too, disabling the `Livechat_accept_chats_with_no_agents` setting.
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The Livechat setting to accept chats when no agents are online now correctly affects agent selection and routing, allowing offline agents to be considered when enabled.

* **Tests**
  * Added end-to-end tests validating routing (Auto Selection, Load Balancing, Load Rotation) behavior with the setting enabled and disabled.

* **Chores**
  * Updated typings and models to support the expanded agent-selection options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->