### PR TITLE
fix: prevent duplicate toast on invite link generation

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/RoomMembers/InviteUsers/InviteUsersWithData.tsx
+++ b/apps/meteor/client/views/room/contextualBar/RoomMembers/InviteUsers/InviteUsersWithData.tsx
@@ -19,6 +19,7 @@ type InviteUsersWithDataProps = {
 const InviteUsersWithData = ({ rid, onClickBack }: InviteUsersWithDataProps): ReactElement => {
 	const t = useTranslation();
 	const dispatchToastMessage = useToastMessageDispatch();
+
 	const [
 		{
 			isEditing,
@@ -29,6 +30,9 @@ const InviteUsersWithData = ({ rid, onClickBack }: InviteUsersWithDataProps): Re
 		isEditing: false,
 		daysAndMaxUses: { days: '1', maxUses: '0' },
 	});
+
+	// 🔥 NEW: guard to prevent duplicate toast
+	const [toastShown, setToastShown] = useState(false);
 
 	const { closeTab } = useRoomToolbox();
 	const format = useFormatDateAndTime();
@@ -81,14 +85,21 @@ const InviteUsersWithData = ({ rid, onClickBack }: InviteUsersWithDataProps): Re
 		queryFn: async () => findOrCreateInvite({ rid, days: Number(days), maxUses: Number(maxUses) }),
 	});
 
+	// ✅ FIXED: prevent duplicate toast
 	useEffect(() => {
-		if (isSuccess) {
+		if (isSuccess && !toastShown) {
 			dispatchToastMessage({ type: 'success', message: t('Invite_link_generated') });
+			setToastShown(true);
 		}
-	}, [dispatchToastMessage, isSuccess, t]);
+	}, [dispatchToastMessage, isSuccess, t, toastShown]);
 
 	const handleGenerateLink = useEffectEvent((daysAndMaxUses: { days: string; maxUses: string }) => {
-		setInviteState((prevState) => ({ ...prevState, daysAndMaxUses, isEditing: false }));
+		setInviteState((prevState) => ({
+			...prevState,
+			daysAndMaxUses,
+			isEditing: false,
+		}));
+		setToastShown(false); // 🔥 reset for new generation
 	});
 
 	if (isError) {

--- a/apps/meteor/client/views/room/contextualBar/RoomMembers/InviteUsers/InviteUsersWithData.tsx
+++ b/apps/meteor/client/views/room/contextualBar/RoomMembers/InviteUsers/InviteUsersWithData.tsx
@@ -31,7 +31,7 @@ const InviteUsersWithData = ({ rid, onClickBack }: InviteUsersWithDataProps): Re
 		daysAndMaxUses: { days: '1', maxUses: '0' },
 	});
 
-	// 🔥 NEW: guard to prevent duplicate toast
+
 	const [toastShown, setToastShown] = useState(false);
 
 	const { closeTab } = useRoomToolbox();
@@ -85,7 +85,7 @@ const InviteUsersWithData = ({ rid, onClickBack }: InviteUsersWithDataProps): Re
 		queryFn: async () => findOrCreateInvite({ rid, days: Number(days), maxUses: Number(maxUses) }),
 	});
 
-	// ✅ FIXED: prevent duplicate toast
+	
 	useEffect(() => {
 		if (isSuccess && !toastShown) {
 			dispatchToastMessage({ type: 'success', message: t('Invite_link_generated') });
@@ -99,7 +99,7 @@ const InviteUsersWithData = ({ rid, onClickBack }: InviteUsersWithDataProps): Re
 			daysAndMaxUses,
 			isEditing: false,
 		}));
-		setToastShown(false); // 🔥 reset for new generation
+		setToastShown(false);
 	});
 
 	if (isError) {


### PR DESCRIPTION
##  Issue
Duplicate toast notifications were shown when generating an invite link.

##  Fix
Added a state-based guard (`toastShown`) to ensure the toast is displayed only once, even if the component re-renders or the query refetches.

## Reason
The `useEffect` was triggering multiple times due to changes in `isSuccess`, causing duplicate toasts.

##  Testing
- Generated invite link
- Verified only one toast appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate success toast notifications during user invitation flows—success messages now display only once per invitation action.
  * Reset the invitation toast state when regenerating/editing invite links so subsequent invite actions can show the success message again.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->