### PR TITLE
feat(apps): export ENGINE_VERSION from definition layer

### DIFF
--- a/docs/apps-engine-migration.md
+++ b/docs/apps-engine-migration.md
@@ -23,3 +23,4 @@ Besides that, migrating app management code away from a public package enables u
 To make this migration easier to understand and review, we're using a stacked PR approach on Github - similar to a feature branch but disallowing sibling PRs. They are:
 
 - [40395](https://github.com/RocketChat/Rocket.Chat/pull/40395) The feature branch itself. It will accumulate the changes of the whole stack.
+- [40183](https://github.com/RocketChat/Rocket.Chat/pull/40183) Replaces `AppPackageParser.getEngineVersion()` - which resolved the version by traversing the filesystem relative to `__dirname` - with a direct import of `ENGINE_VERSION`. This will support the migration of the `AppPackageParser` class itself.

--- a/packages/apps-engine/src/definition/version.ts
+++ b/packages/apps-engine/src/definition/version.ts
@@ -1,0 +1,11 @@
+/**
+ * The version of the Apps-Engine package.
+ * Consumed by host-side code (e.g. AppPackageParser) to validate app compatibility
+ * without relying on filesystem path traversal.
+ *
+ * Uses require() instead of a static import so TypeScript does not resolve the path
+ * at compile time. The compiled output lands at definition/version.js, so
+ * '../package.json' correctly points to the package root at runtime.
+ */
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+export const ENGINE_VERSION: string = (require('../package.json') as { version: string }).version;

--- a/packages/apps-engine/src/definition/version.ts
+++ b/packages/apps-engine/src/definition/version.ts
@@ -4,8 +4,13 @@
  * without relying on filesystem path traversal.
  *
  * Uses require() instead of a static import so TypeScript does not resolve the path
- * at compile time. The compiled output lands at definition/version.js, so
- * '../package.json' correctly points to the package root at runtime.
+ * at compile time.
+ *
+ * When running for tests, using ts-node, package.json is located two levels above the current file.
+ * When running in production, package.json is located one level above the compiled version of this file.
  */
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-export const ENGINE_VERSION: string = (require('../package.json') as { version: string }).version;
+const runningFromSource = __dirname.endsWith('src/definition');
+const requirePath = runningFromSource ? '../../package.json' : '../package.json';
+
+// eslint-disable-next-line import/no-dynamic-require, @typescript-eslint/no-require-imports -- Paths are bounded, we just need to decide which package.json file to target
+export const ENGINE_VERSION: string = require(requirePath).version;

--- a/packages/apps-engine/src/server/compiler/AppPackageParser.ts
+++ b/packages/apps-engine/src/server/compiler/AppPackageParser.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import * as path from 'path';
 
 import * as AdmZip from 'adm-zip';
@@ -8,18 +7,15 @@ import { v4 as uuidv4 } from 'uuid';
 import { AppImplements } from '.';
 import type { IParseAppPackageResult } from './IParseAppPackageResult';
 import type { IAppInfo } from '../../definition/metadata/IAppInfo';
+import { ENGINE_VERSION } from '../../definition/version';
 import { RequiredApiVersionError } from '../errors';
 
 export class AppPackageParser {
-	public static uuid4Regex = /^[0-9a-fA-f]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
+	public static uuid4Regex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
 
 	private allowedIconExts: Array<string> = ['.png', '.jpg', '.jpeg', '.gif'];
 
-	private appsEngineVersion: string;
-
-	constructor() {
-		this.appsEngineVersion = this.getEngineVersion();
-	}
+	private appsEngineVersion: string = ENGINE_VERSION;
 
 	public async unpackageApp(appPackage: Buffer): Promise<IParseAppPackageResult> {
 		const zip = new AdmZip(appPackage);
@@ -142,22 +138,5 @@ export class AppPackageParser {
 		const base64 = entry.getData().toString('base64');
 
 		return `data:image/${ext.replace('.', '')};base64,${base64}`;
-	}
-
-	private getEngineVersion(): string {
-		const devLocation = path.join(__dirname, '../../../package.json');
-		const prodLocation = path.join(__dirname, '../../package.json');
-
-		let info: { version: string };
-
-		if (fs.existsSync(devLocation)) {
-			info = JSON.parse(fs.readFileSync(devLocation, 'utf8'));
-		} else if (fs.existsSync(prodLocation)) {
-			info = JSON.parse(fs.readFileSync(prodLocation, 'utf8'));
-		} else {
-			throw new Error('Could not find the Apps TypeScript Definition Package Version!');
-		}
-
-		return info.version.replace(/^[^0-9]/, '').split('-')[0];
 	}
 }

--- a/packages/apps-engine/tsconfig.json
+++ b/packages/apps-engine/tsconfig.json
@@ -10,6 +10,7 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "moduleResolution": "node",
+        "resolveJsonModule": true,
         "types": ["node"],
         "lib": ["es2017", "dom"],
         "rootDir": "./src",


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Adds `src/definition/version.ts` which reads the package version via `resolveJsonModule` and exports it as `ENGINE_VERSION`.

Replaces `AppPackageParser.getEngineVersion()` — which resolved the version by traversing the filesystem relative to `__dirname` — with a direct import of `ENGINE_VERSION`. This removes the assumption that `package.json` lives at a predictable relative path, which will break when `AppPackageParser` moves to a different package during the
apps-engine split.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Related to the "Apps-Engine split" stack:

- #40395 
- This PR
- #40184  
- #40185 
- #40186 
- #40343 

Deprecated
- #40187
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Engine version is now fixed at build time rather than discovered at runtime, improving startup reliability and consistency and reducing runtime file access.
* **Chores**
  * Build configuration updated to support JSON imports, making builds and version handling more robust.
* **Documentation**
  * Migration guide updated to reflect the new version-handling approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->