### PR TITLE
refactor: centralize embedded subscription fetch and eliminate duplicate room calls

### DIFF
--- a/.changeset/eight-clouds-count.md
+++ b/.changeset/eight-clouds-count.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes intermittent "Channel Not Joined" screen when opening rooms in embedded mode.

--- a/apps/meteor/client/views/room/RoomOpenerEmbedded.tsx
+++ b/apps/meteor/client/views/room/RoomOpenerEmbedded.tsx
@@ -1,8 +1,7 @@
-import type { RoomType } from '@rocket.chat/core-typings';
+import type { ISubscription, RoomType } from '@rocket.chat/core-typings';
 import { Box, States, StatesIcon, StatesSubtitle, StatesTitle } from '@rocket.chat/fuselage';
 import { Header } from '@rocket.chat/ui-client';
-import { useEndpoint, useStream, useUserId } from '@rocket.chat/ui-contexts';
-import { useQuery } from '@tanstack/react-query';
+import { useStream, useUserId } from '@rocket.chat/ui-contexts';
 import type { ReactElement } from 'react';
 import { lazy, Suspense, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -10,15 +9,12 @@ import { useTranslation } from 'react-i18next';
 import NotSubscribedRoom from './NotSubscribedRoom';
 import RoomSkeleton from './RoomSkeleton';
 import { useOpenRoom } from './hooks/useOpenRoom';
-import { LegacyRoomManager } from '../../../app/ui-utils/client';
 import { SubscriptionsCachedStore } from '../../cachedStores';
 import { getErrorMessage } from '../../lib/errorHandling';
 import { NotAuthorizedError } from '../../lib/errors/NotAuthorizedError';
 import { NotSubscribedToRoomError } from '../../lib/errors/NotSubscribedToRoomError';
 import { OldUrlRoomError } from '../../lib/errors/OldUrlRoomError';
 import { RoomNotFoundError } from '../../lib/errors/RoomNotFoundError';
-import { subscriptionsQueryKeys } from '../../lib/queryKeys';
-import { mapSubscriptionFromApi } from '../../lib/utils/mapSubscriptionFromApi';
 
 const RoomProvider = lazy(() => import('./providers/RoomProvider'));
 const RoomNotFound = lazy(() => import('./RoomNotFound'));
@@ -34,47 +30,23 @@ type RoomOpenerProps = {
 const RoomOpenerEmbedded = ({ type, reference }: RoomOpenerProps): ReactElement => {
 	const { data, error, isSuccess, isError, isLoading } = useOpenRoom({ type, reference });
 	const uid = useUserId();
-
-	const getSubscription = useEndpoint('GET', '/v1/subscriptions.getOne');
-
 	const subscribeToNotifyUser = useStream('notify-user');
 
 	const rid = data?.rid;
-	const { data: subscriptionData, refetch } = useQuery({
-		queryKey: rid ? subscriptionsQueryKeys.subscription(rid) : [],
-		queryFn: () => {
-			if (!rid) {
-				throw new Error('Room not found');
-			}
-			return getSubscription({ roomId: rid });
-		},
-		enabled: !!rid,
-	});
 
 	useEffect(() => {
-		if (!subscriptionData?.subscription) {
+		if (!uid || !rid) {
 			return;
 		}
 
-		SubscriptionsCachedStore.upsertSubscription(mapSubscriptionFromApi(subscriptionData.subscription));
-
-		// yes this must be done here, this is already called in useOpenRoom, but it skips subscription streams because of the subscriptions list is empty
-		// now that we inserted the subscription, we can open the room
-		LegacyRoomManager.open({ typeName: type + reference, rid: subscriptionData.subscription.rid });
-	}, [subscriptionData, type, rid, reference]);
-
-	useEffect(() => {
-		if (!uid) {
-			return;
-		}
 		return subscribeToNotifyUser(`${uid}/subscriptions-changed`, (event, sub) => {
 			if (sub.rid !== rid || event === 'removed') {
 				return;
 			}
 
-			refetch();
+			SubscriptionsCachedStore.upsertSubscription(sub as ISubscription);
 		});
-	}, [refetch, rid, subscribeToNotifyUser, uid]);
+	}, [rid, subscribeToNotifyUser, uid]);
 
 	const { t } = useTranslation();
 

--- a/apps/meteor/client/views/room/RoomOpenerEmbedded.tsx
+++ b/apps/meteor/client/views/room/RoomOpenerEmbedded.tsx
@@ -8,13 +8,13 @@ import { useTranslation } from 'react-i18next';
 
 import NotSubscribedRoom from './NotSubscribedRoom';
 import RoomSkeleton from './RoomSkeleton';
-import { useOpenRoom } from './hooks/useOpenRoom';
 import { SubscriptionsCachedStore } from '../../cachedStores';
 import { getErrorMessage } from '../../lib/errorHandling';
 import { NotAuthorizedError } from '../../lib/errors/NotAuthorizedError';
 import { NotSubscribedToRoomError } from '../../lib/errors/NotSubscribedToRoomError';
 import { OldUrlRoomError } from '../../lib/errors/OldUrlRoomError';
 import { RoomNotFoundError } from '../../lib/errors/RoomNotFoundError';
+import { useEmbeddedRoomState } from '../root/MainLayout/EmbeddedPreload';
 
 const RoomProvider = lazy(() => import('./providers/RoomProvider'));
 const RoomNotFound = lazy(() => import('./RoomNotFound'));
@@ -28,7 +28,7 @@ type RoomOpenerProps = {
 };
 
 const RoomOpenerEmbedded = ({ type, reference }: RoomOpenerProps): ReactElement => {
-	const { data, error, isSuccess, isError, isLoading } = useOpenRoom({ type, reference });
+	const { data, error, isSuccess, isError } = useEmbeddedRoomState();
 	const uid = useUserId();
 	const subscribeToNotifyUser = useStream('notify-user');
 
@@ -53,7 +53,6 @@ const RoomOpenerEmbedded = ({ type, reference }: RoomOpenerProps): ReactElement 
 	return (
 		<Box display='flex' w='full' h='full'>
 			<Suspense fallback={<RoomSkeleton />}>
-				{isLoading && <RoomSkeleton />}
 				{isSuccess && (
 					<RoomProvider rid={data.rid}>
 						<Room />

--- a/apps/meteor/client/views/room/hooks/useOpenRoom.ts
+++ b/apps/meteor/client/views/room/hooks/useOpenRoom.ts
@@ -1,16 +1,18 @@
 import { isPublicRoom, type IRoom, type RoomType } from '@rocket.chat/core-typings';
 import { getObjectKeys } from '@rocket.chat/tools';
-import { useMethod, usePermission, useRoute, useSetting, useUser } from '@rocket.chat/ui-contexts';
+import { useEndpoint, useMethod, usePermission, useRoute, useSetting, useUser } from '@rocket.chat/ui-contexts';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
 import { useOpenRoomMutation } from './useOpenRoomMutation';
 import { roomFields } from '../../../../lib/publishFields';
+import { SubscriptionsCachedStore } from '../../../cachedStores';
 import { NotAuthorizedError } from '../../../lib/errors/NotAuthorizedError';
 import { NotSubscribedToRoomError } from '../../../lib/errors/NotSubscribedToRoomError';
 import { OldUrlRoomError } from '../../../lib/errors/OldUrlRoomError';
 import { RoomNotFoundError } from '../../../lib/errors/RoomNotFoundError';
 import { roomsQueryKeys } from '../../../lib/queryKeys';
+import { mapSubscriptionFromApi } from '../../../lib/utils/mapSubscriptionFromApi';
 import { Rooms } from '../../../stores';
 
 export function useOpenRoom({ type, reference }: { type: RoomType; reference: string }) {
@@ -19,6 +21,7 @@ export function useOpenRoom({ type, reference }: { type: RoomType; reference: st
 	const allowAnonymousRead = useSetting('Accounts_AllowAnonymousRead', true);
 	const getRoomByTypeAndName = useMethod('getRoomByTypeAndName');
 	const createDirectMessage = useMethod('createDirectMessage');
+	const getSubscription = useEndpoint('GET', '/v1/subscriptions.getOne');
 	const directRoute = useRoute('direct');
 	const openRoom = useOpenRoomMutation();
 
@@ -73,6 +76,19 @@ export function useOpenRoom({ type, reference }: { type: RoomType; reference: st
 			}
 
 			const { LegacyRoomManager } = await import('../../../../app/ui-utils/client');
+
+			// The subscription may not be in the store yet — mainly in embedded mode, which skips
+			// the full subscription list preload. Fetch it on demand if missing.
+			if (user && !Subscriptions.state.find((record) => record.rid === reference || record.name === reference)) {
+				try {
+					const { subscription } = await getSubscription({ roomId: room._id });
+					if (subscription) {
+						await SubscriptionsCachedStore.upsertSubscription(mapSubscriptionFromApi(subscription));
+					}
+				} catch {
+					// Fall through to existing not-subscribed handling.
+				}
+			}
 
 			const sub = Subscriptions.state.find((record) => record.rid === reference || record.name === reference);
 

--- a/apps/meteor/client/views/room/hooks/useOpenRoomParams.ts
+++ b/apps/meteor/client/views/room/hooks/useOpenRoomParams.ts
@@ -1,0 +1,35 @@
+import type { RoomType } from '@rocket.chat/core-typings';
+import { useRouter } from '@rocket.chat/ui-contexts';
+import { useLayoutEffect, useState } from 'react';
+
+import { roomCoordinator } from '../../../lib/rooms/roomCoordinator';
+
+type OpenRoomParams = { type: RoomType; reference: string };
+
+const extractFromRouter = (router: ReturnType<typeof useRouter>): OpenRoomParams | null => {
+	const routeName = router.getRouteName();
+	if (!routeName) {
+		return null;
+	}
+
+	const identifier = roomCoordinator.getRouteNameIdentifier(routeName);
+	if (!identifier) {
+		return null;
+	}
+
+	const directives = roomCoordinator.getRoomDirectives(identifier);
+	if (!directives?.extractOpenRoomParams) {
+		return null;
+	}
+
+	return directives.extractOpenRoomParams(router.getRouteParameters());
+};
+
+export const useOpenRoomParams = (): OpenRoomParams | null => {
+	const router = useRouter();
+	const [params, setParams] = useState(() => extractFromRouter(router));
+
+	useLayoutEffect(() => router.subscribeToRouteChange(() => setParams(extractFromRouter(router))), [router]);
+
+	return params;
+};

--- a/apps/meteor/client/views/root/MainLayout/EmbeddedPreload.tsx
+++ b/apps/meteor/client/views/root/MainLayout/EmbeddedPreload.tsx
@@ -1,75 +1,40 @@
-import { useEndpoint, useMethod, useRouter, useUserId } from '@rocket.chat/ui-contexts';
-import { useQuery } from '@tanstack/react-query';
-import type { ReactElement, ReactNode } from 'react';
-import { useEffect, useMemo } from 'react';
+import { createContext, useContext, useEffect, type ReactElement, type ReactNode } from 'react';
 
+import EmbeddedRoomPreload from './EmbeddedRoomPreload';
 import { RoomsCachedStore, SubscriptionsCachedStore } from '../../../cachedStores';
-import { roomsQueryKeys } from '../../../lib/queryKeys';
-import { roomCoordinator } from '../../../lib/rooms/roomCoordinator';
-import { mapSubscriptionFromApi } from '../../../lib/utils/mapSubscriptionFromApi';
+import type { useOpenRoom } from '../../room/hooks/useOpenRoom';
+import { useOpenRoomParams } from '../../room/hooks/useOpenRoomParams';
 import PageLoading from '../PageLoading';
 import { useMainReady } from '../hooks/useMainReady';
 
+type EmbeddedRoomState = ReturnType<typeof useOpenRoom>;
+
+export const EmbeddedRoomContext = createContext<EmbeddedRoomState | null>(null);
+
+export const useEmbeddedRoomState = (): EmbeddedRoomState => {
+	const ctx = useContext(EmbeddedRoomContext);
+	if (!ctx) {
+		throw new Error('useEmbeddedRoomState must be used inside EmbeddedPreload');
+	}
+	return ctx;
+};
+
 const EmbeddedPreload = ({ children }: { children: ReactNode }): ReactElement => {
 	const ready = useMainReady();
-	const router = useRouter();
-	const uid = useUserId();
-
-	const roomParams = useMemo(() => {
-		const routeName = router.getRouteName();
-		if (!routeName) {
-			return null;
-		}
-
-		const identifier = roomCoordinator.getRouteNameIdentifier(routeName);
-		if (!identifier) {
-			return null;
-		}
-
-		const directives = roomCoordinator.getRoomDirectives(identifier);
-		if (!directives?.extractOpenRoomParams) {
-			return null;
-		}
-
-		return directives.extractOpenRoomParams(router.getRouteParameters());
-	}, [router]);
-
-	const getRoomByTypeAndName = useMethod('getRoomByTypeAndName');
-	const getSubscription = useEndpoint('GET', '/v1/subscriptions.getOne');
-
-	const shouldFetch = !!roomParams && !!uid;
-
-	const { isLoading, isSuccess, isError } = useQuery({
-		queryKey: roomParams ? roomsQueryKeys.roomReference(roomParams.reference, roomParams.type, uid ?? undefined) : [],
-		queryFn: async () => {
-			if (!roomParams) {
-				return null;
-			}
-
-			const roomData = await getRoomByTypeAndName(roomParams.type, roomParams.reference);
-			if (!roomData?._id) {
-				return null;
-			}
-
-			const subResult = await getSubscription({ roomId: roomData._id });
-			if (subResult.subscription) {
-				SubscriptionsCachedStore.upsertSubscription(mapSubscriptionFromApi(subResult.subscription));
-			}
-
-			return subResult;
-		},
-		enabled: shouldFetch,
-		retry: false,
-	});
+	const params = useOpenRoomParams();
 
 	useEffect(() => {
-		if (!shouldFetch || isSuccess || isError) {
+		if (!params) {
 			SubscriptionsCachedStore.setReady(true);
 			RoomsCachedStore.setReady(true);
 		}
-	}, [shouldFetch, isSuccess, isError]);
+	}, [params]);
 
-	if (!ready || (shouldFetch && isLoading)) {
+	if (params) {
+		return <EmbeddedRoomPreload params={params}>{children}</EmbeddedRoomPreload>;
+	}
+
+	if (!ready) {
 		return <PageLoading />;
 	}
 

--- a/apps/meteor/client/views/root/MainLayout/EmbeddedPreload.tsx
+++ b/apps/meteor/client/views/root/MainLayout/EmbeddedPreload.tsx
@@ -39,7 +39,7 @@ const EmbeddedPreload = ({ children }: { children: ReactNode }): ReactElement =>
 
 	const shouldFetch = !!roomParams && !!uid;
 
-	const { isLoading } = useQuery({
+	const { isLoading, isSuccess, isError } = useQuery({
 		queryKey: roomParams ? roomsQueryKeys.roomReference(roomParams.reference, roomParams.type, uid ?? undefined) : [],
 		queryFn: async () => {
 			if (!roomParams) {
@@ -63,11 +63,11 @@ const EmbeddedPreload = ({ children }: { children: ReactNode }): ReactElement =>
 	});
 
 	useEffect(() => {
-		if (!shouldFetch || !isLoading) {
+		if (!shouldFetch || isSuccess || isError) {
 			SubscriptionsCachedStore.setReady(true);
 			RoomsCachedStore.setReady(true);
 		}
-	}, [shouldFetch, isLoading]);
+	}, [shouldFetch, isSuccess, isError]);
 
 	if (!ready || (shouldFetch && isLoading)) {
 		return <PageLoading />;

--- a/apps/meteor/client/views/root/MainLayout/EmbeddedPreload.tsx
+++ b/apps/meteor/client/views/root/MainLayout/EmbeddedPreload.tsx
@@ -1,19 +1,75 @@
+import { useEndpoint, useMethod, useRouter, useUserId } from '@rocket.chat/ui-contexts';
+import { useQuery } from '@tanstack/react-query';
 import type { ReactElement, ReactNode } from 'react';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { RoomsCachedStore, SubscriptionsCachedStore } from '../../../cachedStores';
+import { roomsQueryKeys } from '../../../lib/queryKeys';
+import { roomCoordinator } from '../../../lib/rooms/roomCoordinator';
+import { mapSubscriptionFromApi } from '../../../lib/utils/mapSubscriptionFromApi';
 import PageLoading from '../PageLoading';
 import { useMainReady } from '../hooks/useMainReady';
 
 const EmbeddedPreload = ({ children }: { children: ReactNode }): ReactElement => {
 	const ready = useMainReady();
+	const router = useRouter();
+	const uid = useUserId();
+
+	const roomParams = useMemo(() => {
+		const routeName = router.getRouteName();
+		if (!routeName) {
+			return null;
+		}
+
+		const identifier = roomCoordinator.getRouteNameIdentifier(routeName);
+		if (!identifier) {
+			return null;
+		}
+
+		const directives = roomCoordinator.getRoomDirectives(identifier);
+		if (!directives?.extractOpenRoomParams) {
+			return null;
+		}
+
+		return directives.extractOpenRoomParams(router.getRouteParameters());
+	}, [router]);
+
+	const getRoomByTypeAndName = useMethod('getRoomByTypeAndName');
+	const getSubscription = useEndpoint('GET', '/v1/subscriptions.getOne');
+
+	const shouldFetch = !!roomParams && !!uid;
+
+	const { isLoading } = useQuery({
+		queryKey: roomParams ? roomsQueryKeys.roomReference(roomParams.reference, roomParams.type, uid ?? undefined) : [],
+		queryFn: async () => {
+			if (!roomParams) {
+				return null;
+			}
+
+			const roomData = await getRoomByTypeAndName(roomParams.type, roomParams.reference);
+			if (!roomData?._id) {
+				return null;
+			}
+
+			const subResult = await getSubscription({ roomId: roomData._id });
+			if (subResult.subscription) {
+				SubscriptionsCachedStore.upsertSubscription(mapSubscriptionFromApi(subResult.subscription));
+			}
+
+			return subResult;
+		},
+		enabled: shouldFetch,
+		retry: false,
+	});
 
 	useEffect(() => {
-		SubscriptionsCachedStore.setReady(true);
-		RoomsCachedStore.setReady(true);
-	}, [ready]);
+		if (!shouldFetch || !isLoading) {
+			SubscriptionsCachedStore.setReady(true);
+			RoomsCachedStore.setReady(true);
+		}
+	}, [shouldFetch, isLoading]);
 
-	if (!ready) {
+	if (!ready || (shouldFetch && isLoading)) {
 		return <PageLoading />;
 	}
 

--- a/apps/meteor/client/views/root/MainLayout/EmbeddedRoomPreload.tsx
+++ b/apps/meteor/client/views/root/MainLayout/EmbeddedRoomPreload.tsx
@@ -1,0 +1,34 @@
+import type { RoomType } from '@rocket.chat/core-typings';
+import { useEffect, type ReactElement, type ReactNode } from 'react';
+
+import { RoomsCachedStore, SubscriptionsCachedStore } from '../../../cachedStores';
+import { useOpenRoom } from '../../room/hooks/useOpenRoom';
+import PageLoading from '../PageLoading';
+import { EmbeddedRoomContext } from './EmbeddedPreload';
+import { useMainReady } from '../hooks/useMainReady';
+
+const EmbeddedRoomPreload = ({
+	params,
+	children,
+}: {
+	params: { type: RoomType; reference: string };
+	children: ReactNode;
+}): ReactElement => {
+	const ready = useMainReady();
+	const state = useOpenRoom(params);
+
+	useEffect(() => {
+		if (!state.isLoading) {
+			SubscriptionsCachedStore.setReady(true);
+			RoomsCachedStore.setReady(true);
+		}
+	}, [state.isLoading]);
+
+	if (!ready || state.isLoading) {
+		return <PageLoading />;
+	}
+
+	return <EmbeddedRoomContext.Provider value={state}>{children}</EmbeddedRoomContext.Provider>;
+};
+
+export default EmbeddedRoomPreload;


### PR DESCRIPTION
## Proposed changes

`EmbeddedPreload` and `useOpenRoom` both called `getRoomByTypeAndName` - the room was fetched twice per navigation in embedded mode.

**Solution:** `EmbeddedPreload` now drives `useOpenRoom` directly and passes the resolved state via context to `RoomOpenerEmbedded`. The subscription fetch (needed because embedded mode skips the full `.listen()` preload) was moved into `useOpenRoom` itself, so there's a single source of truth for the entire open-room flow.

**What changed:**
- `useOpenRoom` - fetches the room's subscription on demand when it's not in the store
- `useOpenRoomParams` (new) - reusable hook that extracts `{type, reference}` from the current route
- `EmbeddedPreload` - orchestrates `useOpenRoom`, exposes result via context
- `EmbeddedRoomPreload` (new) - handles the room preload lifecycle (split from `EmbeddedPreload` to satisfy `react/no-multi-comp`)
- `RoomOpenerEmbedded` - consumes the context instead of calling `useOpenRoom` again

**Normal (non-embedded) flow is unchanged** - the subscription fetch only runs when the sub isn't already in state.

## Issue(s)

Follow-up to #40100 ([CORE-1555](https://rocketchat.atlassian.net/browse/CORE-1555))

## Steps to test or reproduce

1. **Embedded, subscribed user**: open `/channel/general?layout=embedded` with a non-admin user (without `preview-c-room`). Room should load normally.
2. **Embedded, non-subscribed user**: open a public channel the user isn't a member of in embedded mode. Should show "Channel Not Joined".
3. **Normal flow**: open any room via the sidebar. Should work exactly as before - no behavior change.

[CORE-1555]: https://rocketchat.atlassian.net/browse/CORE-1555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription data availability in embedded room views, ensuring subscriptions are properly fetched and cached.

* **Refactor**
  * Reorganized embedded room initialization and state management for better performance and reliability during room loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->