### PR TITLE
chore(models): limit MongoDB NestedPaths to 3 levels

### DIFF
--- a/packages/model-typings/src/updater.ts
+++ b/packages/model-typings/src/updater.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import type { Join, NestedPaths, PropertyType, ArrayElement, NestedPathsOfType, UpdateFilter } from 'mongodb';
+import type { Join, NestedPaths, PropertyType, ArrayElement, KeysOfAType, UpdateFilter } from 'mongodb';
 
 export interface Updater<T extends { _id: string }> {
-	set<P extends SetProps<T>, K extends keyof P>(key: K, value: P[K]): Updater<T>;
+	set<K extends keyof SetProps<T>>(key: K, value: SetProps<T>[K]): Updater<T>;
 	unset<K extends keyof UnsetProps<T>>(key: K): Updater<T>;
 	inc<K extends keyof IncProps<T>>(key: K, value: number): Updater<T>;
 	addToSet<K extends keyof AddToSetProps<T>>(key: K, value: ArrayElementType<AddToSetProps<T>[K]>): Updater<T>;
@@ -13,15 +13,35 @@ export interface Updater<T extends { _id: string }> {
 
 type ArrayElementType<T> = T extends (infer E)[] ? E : T;
 
+/**
+ * Depth limit for NestedPaths. Starting at [1,1,1,1,1] (length 5) allows
+ * 3 more levels of recursion (MongoDB's NestedPaths stops at length 8).
+ * This covers all real usage (e.g. 'metrics.response.avg') while avoiding
+ * the exponential type expansion that happens at deeper levels.
+ */
+type NestedPathsDepthLimit = [1, 1, 1, 1, 1];
+
+/**
+ * Depth-limited version of MongoDB's NestedPathsOfType.
+ * The original uses NestedPaths<TSchema, []> (unlimited depth),
+ * which causes exponential type expansion on large schemas.
+ */
+type NestedPathsOfTypeLimited<TSchema, Type> = KeysOfAType<
+	{
+		[Property in Join<NestedPaths<TSchema, NestedPathsDepthLimit>, '.'>]: PropertyType<TSchema, Property>;
+	},
+	Type
+>;
+
 export type SetProps<TSchema extends { _id: string }> = Readonly<
 	{
-		[Property in Join<NestedPaths<TSchema, []>, '.'>]: PropertyType<TSchema, Property>;
+		[Property in Join<NestedPaths<TSchema, NestedPathsDepthLimit>, '.'>]: PropertyType<TSchema, Property>;
 	} & {
-		[Property in `${NestedPathsOfType<TSchema, any[]>}.$${`[${string}]` | ''}`]: ArrayElement<
+		[Property in `${NestedPathsOfTypeLimited<TSchema, any[]>}.$${`[${string}]` | ''}`]: ArrayElement<
 			PropertyType<TSchema, Property extends `${infer Key}.$${string}` ? Key : never>
 		>;
 	} & {
-		[Property in `${NestedPathsOfType<TSchema, Record<string, any>[]>}.$${`[${string}]` | ''}.${string}`]: any;
+		[Property in `${NestedPathsOfTypeLimited<TSchema, Record<string, any>[]>}.$${`[${string}]` | ''}.${string}`]: any;
 	}
 >;
 

--- a/packages/models/src/updater.spec.ts
+++ b/packages/models/src/updater.spec.ts
@@ -75,6 +75,45 @@ test('updater typings', () => {
 	});
 });
 
+test('updater supports nested paths up to 3 levels deep', () => {
+	const updater = new UpdaterImpl<{
+		_id: string;
+		level1: {
+			level2: {
+				level3: string;
+			};
+		};
+	}>();
+
+	// 1-level deep path
+	updater.set('level1', { level2: { level3: 'test' } });
+	// 2-level deep path
+	updater.set('level1.level2', { level3: 'test' });
+	// 3-level deep path
+	updater.set('level1.level2.level3', 'test');
+});
+
+test('updater validates keys on real schemas with nested paths', () => {
+	const updater = new UpdaterImpl<IOmnichannelRoom>();
+
+	// valid 1-level paths
+	updater.set('fname', 'test');
+	// valid 2-level paths
+	updater.set('responseBy.lastMessageTs', new Date());
+	updater.set('v.activity', ['period1']);
+	// valid 3-level paths
+	updater.inc('metrics.response.total', 1);
+	updater.set('metrics.response.avg', 42);
+	updater.set('metrics.reaction.ft', 100);
+
+	// @ts-expect-error: non-existent top-level key
+	updater.set('nonExistentField', 'hello');
+	// @ts-expect-error: non-existent nested key
+	updater.set('responseBy.nonExistent', new Date());
+	// @ts-expect-error: 'fname' is a string, not a number — inc should reject it
+	updater.inc('fname', 1);
+});
+
 test('updater $set operations', async () => {
 	const updater = new UpdaterImpl<{
 		_id: string;

--- a/packages/models/src/updater.ts
+++ b/packages/models/src/updater.ts
@@ -16,7 +16,7 @@ export class UpdaterImpl<T extends { _id: string }> implements Updater<T> {
 
 	private dirty = false;
 
-	set<P extends SetProps<T>, K extends keyof P>(key: K, value: P[K]) {
+	set<K extends keyof SetProps<T>>(key: K, value: SetProps<T>[K]) {
 		this._set = this._set ?? new Map<Keys<T>, any>();
 		this._set.set(key as Keys<T>, value);
 		return this;


### PR DESCRIPTION
## Summary

The `@rocket.chat/models` package build was taking ~72 seconds, with **95% of that time (69s) spent on type checking**. The root cause is the `Updater<T>` type in `@rocket.chat/model-typings`, which uses MongoDB's `NestedPaths<T, []>` to recursively compute every possible dot-notation path for a schema up to **8 levels deep**.

For complex types like `IOmnichannelRoom`, this produces a **union type with 1,655 members**, leading to:
- 2.6M type instantiations
- 1.97M assignability cache entries
- ~1.2GB memory usage

`tsc --generateTrace` confirmed that **`LivechatRooms.ts` alone consumed ~60s** of check time across just 4 expressions involving `Updater<IOmnichannelRoom>`.

### Changes

**1. Limit `NestedPaths` recursion depth from 8 to 3** (`packages/model-typings/src/updater.ts`)

MongoDB's `NestedPaths<T, Depth>` stops recursing when `Depth['length']` reaches 8. By starting with `[1,1,1,1,1]` (length 5), we allow 3 more levels — enough for all real usage in the codebase (deepest path: `metrics.response.avg` at depth 3).

Also created `NestedPathsOfTypeLimited` since MongoDB's `NestedPathsOfType` hardcodes `NestedPaths<T, []>` (unlimited depth).

**2. Simplify `set()` generic signature** (`packages/model-typings/src/updater.ts`, `packages/models/src/updater.ts`)

```ts
// Before — extra P variable causes redundant instantiations at every call site
set<P extends SetProps<T>, K extends keyof P>(key: K, value: P[K]): Updater<T>;

// After — SetProps<T> computed once and cached by the compiler
set<K extends keyof SetProps<T>>(key: K, value: SetProps<T>[K]): Updater<T>;
```

### Results

| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| **Total build time** | **72s** | **5s** | **93%** |
| Check time | 69s | 1.8s | 97% |
| Type instantiations | 2,653,323 | 399,255 | 85% |
| Assignability cache | 1,974,106 | 52,975 | 97% |
| Memory | ~1.2GB | ~200MB | 83% |

### Type safety

All existing type safety is preserved:
- **Key validation**: typos and non-existent paths are caught at compile time
- **Nested path support**: paths up to 3 levels deep (e.g. `metrics.response.avg`) work
- **Operator constraints**: `inc()` only accepts numeric fields, `addToSet()` only array fields, `unset()` only optional fields

### Trade-offs

- Paths deeper than 3 levels (e.g. `a.b.c.d`) would no longer be valid in the `Updater` type. No such paths exist in current usage. If ever needed, change `[1,1,1,1,1]` to `[1,1,1,1]` for depth 4.

## Test plan

- [x] All existing `updater.spec.ts` tests pass (16/16)
- [x] Added new test: `updater supports nested paths up to 3 levels deep` — verifies depth 1, 2, and 3 paths work correctly
- [x] Added new test: `updater validates keys on real schemas with nested paths` — verifies key validation, nested path checking, and operator constraints against `IOmnichannelRoom`
- [x] `tsc --noEmit` passes with zero errors on `@rocket.chat/models`
- [x] All `@ts-expect-error` directives in tests correctly trigger type errors (verified via `tsc --noEmit` — unused directives would be reported as errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved developer ergonomics and type safety for property update operations by limiting nested-path depth and simplifying update parameter typing, reducing type-system complexity and improving compile-time checks.

* **Tests**
  * Added compile-time validation tests covering valid and invalid nested property update paths across multiple depth levels to ensure correct typing and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2107]

[ARCH-2107]: https://rocketchat.atlassian.net/browse/ARCH-2107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ