### PR TITLE
chore: Remove unused teamId from ABAC tests and team typings

### DIFF
--- a/.changeset/remove-unused-teamid.md
+++ b/.changeset/remove-unused-teamid.md
@@ -3,5 +3,4 @@
 '@rocket.chat/meteor': patch
 ---
 
-
 fix: remove unused teamId parameter from teams.updateRoom callers

--- a/.changeset/remove-unused-teamid.md
+++ b/.changeset/remove-unused-teamid.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/rest-typings': patch
+'@rocket.chat/meteor': patch
+---
+
+fix: remove unused teamId parameter from teams.updateRoom callers

--- a/.changeset/remove-unused-teamid.md
+++ b/.changeset/remove-unused-teamid.md
@@ -3,4 +3,5 @@
 '@rocket.chat/meteor': patch
 ---
 
+
 fix: remove unused teamId parameter from teams.updateRoom callers

--- a/apps/meteor/tests/end-to-end/api/abac.ts
+++ b/apps/meteor/tests/end-to-end/api/abac.ts
@@ -747,8 +747,7 @@ const addAbacAttributesToUserDirectly = async (userId: string, abacAttributes: I
 			const setDefaultRes = await request
 				.post(`${v1}/teams.updateRoom`)
 				.set(credentials)
-				// TODO: teamId is accepted but never used by the endpoint handler — callers should stop sending it
-				.send({ teamId, roomId: teamPrivateRoomId, isDefault: true })
+				.send({ roomId: teamPrivateRoomId, isDefault: true })
 				.expect(200);
 
 			if (setDefaultRes.body?.room?.teamDefault) {
@@ -797,8 +796,7 @@ const addAbacAttributesToUserDirectly = async (userId: string, abacAttributes: I
 			await request
 				.post(`${v1}/teams.updateRoom`)
 				.set(credentials)
-				// TODO: teamId is accepted but never used by the endpoint handler — callers should stop sending it
-				.send({ teamId, roomId: teamDefaultRoomId, isDefault: false })
+				.send({ roomId: teamDefaultRoomId, isDefault: false })
 				.expect(200);
 
 			await request
@@ -989,8 +987,7 @@ const addAbacAttributesToUserDirectly = async (userId: string, abacAttributes: I
 			await request
 				.post(`${v1}/teams.updateRoom`)
 				.set(credentials)
-				// TODO: teamId is accepted but never used by the endpoint handler — callers should stop sending it
-				.send({ teamId: teamIdForConversion, roomId: teamRoomId, isDefault: true })
+				.send({ roomId: teamRoomId, isDefault: true })
 				.expect(400)
 				.expect((res) => {
 					expect(res.body.success).to.be.false;

--- a/packages/rest-typings/src/v1/teams/TeamsUpdateRoomProps.ts
+++ b/packages/rest-typings/src/v1/teams/TeamsUpdateRoomProps.ts
@@ -3,8 +3,6 @@ import { ajv } from '../Ajv';
 export type TeamsUpdateRoomProps = {
 	roomId: string;
 	isDefault: boolean;
-	// TODO: teamId is accepted but never used by the endpoint handler — callers should stop sending it
-	teamId?: string;
 };
 
 const teamsUpdateRoomPropsSchema = {
@@ -12,8 +10,6 @@ const teamsUpdateRoomPropsSchema = {
 	properties: {
 		roomId: { type: 'string' },
 		isDefault: { type: 'boolean' },
-		// TODO: teamId is accepted but never used by the endpoint handler — callers should stop sending it
-		teamId: { type: 'string' },
 	},
 	required: ['roomId', 'isDefault'],
 	additionalProperties: false,


### PR DESCRIPTION
fix #40209

- [x] I have read the Contributing Guide
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally
- [ ] I have added tests (if applicable)
- [ ] I have added documentation (if applicable)
- [x] Any dependent changes are merge

 Done changes by removal of teamId from
 - [apps/meteor/tests/end-to-end/api/abac.ts](https://github.com/RocketChat/Rocket.Chat/blob/865178a065bdea432a5d3abc13732126612feb12/apps/meteor/tests/end-to-end/api/abac.ts#L750-L755)
 - [packages/rest-typings/src/v1/teams/TeamsUpdateRoomProps.ts](https://github.com/RocketChat/Rocket.Chat/blob/865178a065bdea432a5d3abc13732126612feb12/packages/rest-typings/src/v1/teams/TeamsUpdateRoomProps.ts#L6-L11)
 
Closes #40209

## Steps to test or reproduce
- go to apps/meteor/tests/end-to-end/api/abac.ts
- changes in line 750, 800, 992
- go to packages/rest-typings/src/v1/teams/TeamsUpdateRoomProps.ts
- changes in line 6, 15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unused teamId parameter from the teams.updateRoom API so requests now rely only on roomId and isDefault, preventing validation issues.

* **Tests**
  * Updated end-to-end tests to align with the streamlined request payloads and expected outcomes.

* **Chores**
  * Added a changeset to release these fixes as patch updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->