### PR TITLE
fix: remove unused teamId from teams.updateRoom callers

### DIFF
--- a/.changeset/remove-unused-teamid.md
+++ b/.changeset/remove-unused-teamid.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/rest-typings': patch
+'@rocket.chat/meteor': patch
+---
+
+fix: remove unused teamId parameter from teams.updateRoom callers

--- a/apps/meteor/tests/end-to-end/api/abac.ts
+++ b/apps/meteor/tests/end-to-end/api/abac.ts
@@ -738,7 +738,7 @@ const addAbacAttributesToUserDirectly = async (userId: string, abacAttributes: I
 			const setDefaultRes = await request
 				.post(`${v1}/teams.updateRoom`)
 				.set(credentials)
-				.send({ teamId, roomId: teamPrivateRoomId, isDefault: true })
+				.send({ roomId: teamPrivateRoomId, isDefault: true })
 				.expect(200);
 
 			if (setDefaultRes.body?.room?.teamDefault) {
@@ -787,7 +787,7 @@ const addAbacAttributesToUserDirectly = async (userId: string, abacAttributes: I
 			await request
 				.post(`${v1}/teams.updateRoom`)
 				.set(credentials)
-				.send({ teamId, roomId: teamDefaultRoomId, isDefault: false })
+				.send({ roomId: teamDefaultRoomId, isDefault: false })
 				.expect(200);
 
 			await request
@@ -978,7 +978,7 @@ const addAbacAttributesToUserDirectly = async (userId: string, abacAttributes: I
 			await request
 				.post(`${v1}/teams.updateRoom`)
 				.set(credentials)
-				.send({ teamId: teamIdForConversion, roomId: teamRoomId, isDefault: true })
+				.send({ roomId: teamRoomId, isDefault: true })
 				.expect(400)
 				.expect((res) => {
 					expect(res.body.success).to.be.false;

--- a/packages/rest-typings/src/v1/teams/TeamsUpdateRoomProps.ts
+++ b/packages/rest-typings/src/v1/teams/TeamsUpdateRoomProps.ts
@@ -1,0 +1,18 @@
+import { ajv } from '../Ajv';
+
+export type TeamsUpdateRoomProps = {
+	roomId: string;
+	isDefault: boolean;
+};
+
+const teamsUpdateRoomPropsSchema = {
+	type: 'object',
+	properties: {
+		roomId: { type: 'string' },
+		isDefault: { type: 'boolean' },
+	},
+	required: ['roomId', 'isDefault'],
+	additionalProperties: false,
+};
+
+export const isTeamsUpdateRoomProps = ajv.compile<TeamsUpdateRoomProps>(teamsUpdateRoomPropsSchema);


### PR DESCRIPTION
### Description

Closes #40209

`teamId` is accepted by the `teams.updateRoom` endpoint but never used by the handler. This PR removes it from:

- `TeamsUpdateRoomProps` type definition and Ajv validation schema
- 3 `.send()` calls in `abac.ts` e2e tests that were passing `teamId` unnecessarily

No behavior change — the endpoint already ignores this parameter. Setting `additionalProperties: false` in the schema means unknown props are silently dropped, so callers sending `teamId` today would already have it ignored.

### Changes

- `packages/rest-typings/src/v1/teams/TeamsUpdateRoomProps.ts` — removed `teamId` from type and schema
- `apps/meteor/tests/end-to-end/api/abac.ts` — removed `teamId` from 3 `teams.updateRoom` calls (lines 741, 790, 981)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Removed unused `teamId` parameter from the `teams.updateRoom` API endpoint. This change streamlines request payloads and improves API usability for developers. When updating team rooms, applications now require only the `roomId` and `isDefault` parameters. This reduces integration complexity, eliminates confusion around unnecessary parameters, and simplifies the overall developer experience when managing team room configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->