### PR TITLE
fix: call abort() in useEffect cleanup to cancel WebDAV request on unmount 

### DIFF
--- a/apps/meteor/client/views/room/webdav/SaveToWebdavModal.tsx
+++ b/apps/meteor/client/views/room/webdav/SaveToWebdavModal.tsx
@@ -57,7 +57,7 @@ const SaveToWebdavModal = ({ onClose, data }: SaveToWebdavModalProps): ReactElem
 		return value?.map(({ _id, ...current }) => [_id, getWebdavServerName(current)]) ?? [];
 	}, [value]);
 
-	useEffect(() => fileRequest.current?.abort, []);
+	useEffect(() => () => fileRequest.current?.abort(), []);
 
 	const handleSaveFile = ({ accountId }: { accountId: IWebdavAccount['_id'] }): void => {
 		setIsLoading(true);


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

In `SaveToWebdavModal.tsx`, the `useEffect` cleanup was returning a reference to `fileRequest.current?.abort` instead of calling it:

```ts                                                                                                                                                           
  // Before (broken)
  useEffect(() => fileRequest.current?.abort, []);      
```                                                                                                          
                                                  
This meant that when the modal was closed mid-upload, the in-progress XMLHttpRequest was never cancelled — leaving a hanging network request and causing a memory leak.   

```ts
// After (fixed)
 useEffect(() => () => fileRequest.current?.abort(), []);
```
 Now when the modal unmounts, abort() is actually invoked, properly cancelling the WebDAV upload request.                                                        
                               

## Impact                                                                                                                                                          
                  
  - Cancels in-flight WebDAV requests when modal is closed mid-upload                                                                                             
  - Prevents memory leaks from hanging XHR requests

## Steps to test or reproduce

1. Open a room and click the WebDAV save option on any message attachment
2. Select a WebDAV account and start the file upload                                                                                                            
3. Close the modal mid-upload                                                                                                                                   
4. Before fix: request continues in background (visible in browser DevTools → Network tab)                                                                      
5. After fix: request is immediately cancelled on modal close    


## Further comments
One-character-class fix — the cleanup arrow function was missing its invocation parentheses, so `abort` was never called.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where file upload requests were not properly cancelled when closing the save dialog, ensuring better resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->