### PR TITLE
fix: use emoji _id instead of filter key for collection data lookup 

### DIFF
--- a/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
+++ b/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
@@ -227,7 +227,7 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 
 						return Object.keys(collection)
 							.map((_id) => {
-								const data = collection[key];
+								const data = collection[_id];
 								return { _id, data };
 							})
 							.filter(
@@ -284,7 +284,7 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 
 					return Object.keys(collection)
 						.map((_id) => {
-							const data = collection[key];
+							const data = collection[_id];
 							return { _id, data };
 						})
 						.filter(


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
While exploring `ComposerPopupProvider.tsx` during #40167, I found another bug in the same file.

 ```ts                                                                                                                                                           
  // Before (broken)                                                                                                                                              
  .map((_id) => {                                                                                                                                               
      const data = collection[key]; // key = ':sm' (filter string, not emoji id)                                                                                  
      return { _id, data };                                                     
  })           
```
                                                                                                                                                               
key is the filter string (e.g. :sm), not the emoji's actual id. So every emoji in the list was getting the data of the filter string — which mostly doesn't exist — instead of its own data.     

```ts                                                                                                                                                                                                                                                                                                 
  // After (fixed)
  .map((_id) => {
      const data = collection[_id]; // use the emoji's own id
      return { _id, data };                                                                                                                                       
  })
```

 This fix applies to both the emoji send popup (triggered by :) and the reaction add popup (triggered by +:).                                                                                                                              
  

## Steps to test or reproduce                                                                                                                                      

1. Open message composer and type :sm                                                                                                                           
2. Check emoji popup — emojis were receiving wrong/undefined data from collection
3. After fix — each emoji correctly receives its own data                                                                                                       
                                                                                                                                                                
                                                                                                                           
## Further comments
Found this bug while exploring ComposerPopupProvider.tsx during #40167. Both emoji popup configs had the same bug.      



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed emoji suggestion retrieval in the composer popup to ensure correct emoji items are displayed when using emoji triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->