### PR TITLE
regression: server not rejecting user's attempts to call themselves

### DIFF
--- a/apps/meteor/server/services/media-call/service.ts
+++ b/apps/meteor/server/services/media-call/service.ts
@@ -335,7 +335,9 @@ export class MediaCallService extends ServiceClassInternal implements IMediaCall
 	}
 
 	private async getRoomIdForInternalCall(call: IMediaCall): Promise<IRoom> {
-		const room = await Rooms.findOneDirectRoomContainingAllUserIDs(call.uids);
+		const uniqueUids = [...new Set(call.uids)];
+
+		const room = await Rooms.findOneDirectRoomContainingAllUserIDs(uniqueUids);
 		if (room) {
 			return room;
 		}

--- a/ee/packages/media-calls/src/internal/InternalCallProvider.ts
+++ b/ee/packages/media-calls/src/internal/InternalCallProvider.ts
@@ -13,6 +13,10 @@ export class InternalCallProvider extends BaseCallProvider {
 			throw new CallRejectedError('unsupported');
 		}
 
+		if (params.caller.id === params.callee.id) {
+			throw new CallRejectedError('unsupported');
+		}
+
 		if (await MediaCalls.hasUnfinishedCallsByUid(params.caller.id, params.parentCallId)) {
 			throw new CallRejectedError('busy');
 		}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
If an user tries to call themselves, the call will fail, but the server will still send notifications about it to the user's devices. 
Additionally, in this situation the call's message block was being sent to a random DM instead of the user's self DM.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[VMUX-85](https://rocketchat.atlassian.net/browse/VMUX-85)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[VMUX-85]: https://rocketchat.atlassian.net/browse/VMUX-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed handling of duplicate user IDs in call routing to prevent incorrect room lookups
* Prevented users from initiating calls to themselves, which is now properly rejected as unsupported

<!-- end of auto-generated comment: release notes by coderabbit.ai -->