### PR TITLE
refactor: standardize error response schema across app endpoints

### DIFF
--- a/apps/meteor/ee/server/apps/communication/endpoints/appGeneralLogsHandler.ts
+++ b/apps/meteor/ee/server/apps/communication/endpoints/appGeneralLogsHandler.ts
@@ -3,22 +3,7 @@ import { isAppLogsProps, ajv } from '@rocket.chat/rest-typings';
 import { getPaginationItems } from '../../../../../app/api/server/helpers/getPaginationItems';
 import type { AppsRestApi } from '../rest';
 import { makeAppLogsQuery } from './lib/makeAppLogsQuery';
-
-// TODO: this is a very common error response schema. We should find a way to standardize it.
-const errorResponse = ajv.compile<{
-	success: false;
-	error: string;
-}>({
-	additionalProperties: false,
-	type: 'object',
-	properties: {
-		error: { type: 'string' },
-		status: { type: 'string', nullable: true },
-		message: { type: 'string', nullable: true },
-		success: { type: 'boolean', description: 'Indicates if the request was successful.' },
-	},
-	required: ['success', 'error'],
-});
+import {errorResponse} from './lib/errorResponse';
 
 export const registerAppGeneralLogsHandler = ({ api, _orch }: AppsRestApi) =>
 	void api.get(

--- a/apps/meteor/ee/server/apps/communication/endpoints/appLogsDistinctInstanceHandler.ts
+++ b/apps/meteor/ee/server/apps/communication/endpoints/appLogsDistinctInstanceHandler.ts
@@ -1,34 +1,9 @@
 import { ajv } from '@rocket.chat/rest-typings';
 
 import type { AppsRestApi } from '../rest';
+import {errorResponse} from './lib/errorResponse';
 
 // This might be a good candidate for a default validator function exported by @rocket.chat/rest-typings
-const errorResponse = ajv.compile<{
-	success: false;
-	error: string;
-}>({
-	additionalProperties: false,
-	type: 'object',
-	properties: {
-		error: {
-			type: 'string',
-		},
-		status: {
-			type: 'string',
-			nullable: true,
-		},
-		message: {
-			type: 'string',
-			nullable: true,
-		},
-		success: {
-			type: 'boolean',
-			description: 'Indicates if the request was successful.',
-		},
-	},
-	required: ['success', 'error'],
-});
-
 export const registerAppLogsDistinctInstanceHandler = ({ api, _orch }: AppsRestApi) =>
 	void api.get(
 		':id/logs/distinctValues',

--- a/apps/meteor/ee/server/apps/communication/endpoints/appLogsExportHandler.ts
+++ b/apps/meteor/ee/server/apps/communication/endpoints/appLogsExportHandler.ts
@@ -8,22 +8,10 @@ import type { AppsRestApi } from '../rest';
 import { makeAppLogsQuery } from './lib/makeAppLogsQuery';
 import { APIClass } from '../../../../../app/api/server/ApiClass';
 import type { APIActionContext } from '../../../../../app/api/server/router';
+import {errorResponse} from './lib/errorResponse';
 
-const isErrorResponse = ajv.compile<{
-	success: false;
-	error: string;
-}>({
-	type: 'object',
-	properties: {
-		success: {
-			type: 'boolean',
-			enum: [false],
-		},
-		error: {
-			type: 'string',
-		},
-	},
-});
+
+
 
 class ExportHandlerAPI extends APIClass {
 	public override async authenticatedRoute(routeContext: APIActionContext): Promise<IUser | null> {
@@ -64,9 +52,9 @@ export const registerAppLogsExportHandler = ({ api, _manager, _orch }: AppsRestA
 						},
 					},
 				}),
-				400: isErrorResponse,
-				401: isErrorResponse,
-				404: isErrorResponse,
+				400: errorResponse,
+				401: errorResponse,
+				404: errorResponse,
 			},
 		},
 

--- a/apps/meteor/ee/server/apps/communication/endpoints/appLogsHandler.ts
+++ b/apps/meteor/ee/server/apps/communication/endpoints/appLogsHandler.ts
@@ -3,21 +3,8 @@ import { isAppLogsProps, ajv } from '@rocket.chat/rest-typings';
 import { getPaginationItems } from '../../../../../app/api/server/helpers/getPaginationItems';
 import type { AppsRestApi } from '../rest';
 import { makeAppLogsQuery } from './lib/makeAppLogsQuery';
+import {errorResponse} from './lib/errorResponse';
 
-const errorResponse = ajv.compile<{
-	success: false;
-	error: string;
-}>({
-	additionalProperties: false,
-	type: 'object',
-	properties: {
-		error: { type: 'string' },
-		status: { type: 'string', nullable: true },
-		message: { type: 'string', nullable: true },
-		success: { type: 'boolean', description: 'Indicates if the request was successful.' },
-	},
-	required: ['success', 'error'],
-});
 
 export const registerAppLogsHandler = ({ api, _manager, _orch }: AppsRestApi) =>
 	void api.get(

--- a/apps/meteor/ee/server/apps/communication/endpoints/lib/errorResponse.ts
+++ b/apps/meteor/ee/server/apps/communication/endpoints/lib/errorResponse.ts
@@ -1,0 +1,29 @@
+import { ajv } from '@rocket.chat/rest-typings';
+export const errorResponse = ajv.compile<{
+	success: false;
+	error: string;
+	status?: string;
+	message?: string;
+}>({
+	type: 'object',
+	additionalProperties: false,
+	properties: {
+		success: {
+			type: 'boolean',
+			enum: [false],
+			description: 'Indicates if the request was successful.',
+		},
+		error: {
+			type: 'string',
+		},
+		status: {
+			type: 'string',
+			nullable: true,
+		},
+		message: {
+			type: 'string',
+			nullable: true,
+		},
+	},
+	required: ['success', 'error'],
+});


### PR DESCRIPTION
## Description

This PR standardizes the error response schema across app-related API endpoints.

### Changes
- Extracted a shared `errorResponse` schema using AJV
- Removed duplicated schema definitions from multiple handlers
- Ensured consistent validation across endpoints

### Notes
- No changes to API response structure
- This is a refactor-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate error response handling code across app communication endpoints into a shared utility module to improve code organization and reduce maintenance overhead without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->