### PR TITLE
feat: add schema definition for logs array items

### DIFF
--- a/apps/meteor/ee/server/apps/communication/endpoints/appLogsHandler.ts
+++ b/apps/meteor/ee/server/apps/communication/endpoints/appLogsHandler.ts
@@ -19,6 +19,37 @@ const errorResponse = ajv.compile<{
 	required: ['success', 'error'],
 });
 
+
+const logItemSchema = {
+  type: 'object',
+  properties: {
+    appId: { type: 'string' },
+    method: { type: 'string' },
+    entries: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: true,
+      },
+    },
+    startTime: { type: 'string' },
+    endTime: { type: 'string' },
+    totalTime: { type: 'number' },
+    instanceId: { type: 'string', nullable: true },
+    _createdAt: { type: 'string' },
+  },
+  required: [
+    'appId',
+    'method',
+    'entries',
+    'startTime',
+    'endTime',
+    'totalTime',
+    '_createdAt',
+  ],
+  additionalProperties: false,
+};
+
 export const registerAppLogsHandler = ({ api, _manager, _orch }: AppsRestApi) =>
 	void api.get(
 		':id/logs',
@@ -31,7 +62,7 @@ export const registerAppLogsHandler = ({ api, _manager, _orch }: AppsRestApi) =>
 					type: 'object',
 					properties: {
 						offset: { type: 'number' },
-						logs: { type: 'array' ,items:{type:'object',additionalProperties: true}},
+						logs: { type: 'array',items: logItemSchema},
 						count: { type: 'number' },
 						total: { type: 'number' },
 						success: { type: 'boolean' },

--- a/apps/meteor/ee/server/apps/communication/endpoints/appLogsHandler.ts
+++ b/apps/meteor/ee/server/apps/communication/endpoints/appLogsHandler.ts
@@ -31,7 +31,7 @@ export const registerAppLogsHandler = ({ api, _manager, _orch }: AppsRestApi) =>
 					type: 'object',
 					properties: {
 						offset: { type: 'number' },
-						logs: { type: 'array' },
+						logs: { type: 'array' ,items:{type:'object',additionalProperties: true}},
 						count: { type: 'number' },
 						total: { type: 'number' },
 						success: { type: 'boolean' },


### PR DESCRIPTION
## Description

This PR defines a schema for the `logs` array items in the app logs endpoint.

### Changes
- Added `items` schema for `logs` array
- Ensures better validation and clarity of response structure

### Notes
- Used a flexible schema with `additionalProperties: true`
- No changes to existing API behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the API schema for the app logs endpoint: the logs response now enforces a defined structure for each log entry (required fields, nullable instance ID allowed, timestamps and duration included) and rejects unexpected properties, improving response validation and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->