### PR TITLE
feat!: add migration to drop legacy unique index from read_receipts

### DIFF
--- a/apps/meteor/server/startup/migrations/index.ts
+++ b/apps/meteor/server/startup/migrations/index.ts
@@ -41,5 +41,6 @@ import './v332';
 import './v333';
 import './v334';
 import './v335';
+import './v336';
 
 export * from './xrun';

--- a/apps/meteor/server/startup/migrations/v336.ts
+++ b/apps/meteor/server/startup/migrations/v336.ts
@@ -11,9 +11,12 @@ addMigration({
 
 		const targetIndex = indexes.find((idx) => {
 			return (
-				idx.key?.roomId === 1 &&
-				idx.key?.userId === 1 &&
-				idx.key?.messageId === 1
+				idx.unique === true &&
+				idx.key &&
+				Object.keys(idx.key).length === 3 &&
+				idx.key.roomId === 1 &&
+				idx.key.userId === 1 &&
+				idx.key.messageId === 1
 			);
 		});
 

--- a/apps/meteor/server/startup/migrations/v336.ts
+++ b/apps/meteor/server/startup/migrations/v336.ts
@@ -1,0 +1,24 @@
+import { addMigration } from '../../lib/migrations';
+import { getRawCollection } from '@rocket.chat/models';
+
+addMigration({
+	version: 336,
+	name: 'Drop legacy unique index from read_receipts',
+	async up() {
+		const collection = getRawCollection('read_receipts');
+
+		const indexes = await collection.indexes();
+
+		const targetIndex = indexes.find((idx) => {
+			return (
+				idx.key?.roomId === 1 &&
+				idx.key?.userId === 1 &&
+				idx.key?.messageId === 1
+			);
+		});
+
+		if (targetIndex) {
+			await collection.dropIndex(targetIndex.name);
+		}
+	},
+});


### PR DESCRIPTION
## Description

Adds a database migration to remove the legacy unique index on 
`(roomId, userId, messageId)` from the `read_receipts` collection.

## Why

The unique index was removed from the model as part of changes where 
uniqueness is now handled via the `_id` field. However, this index may still 
exist in databases from older versions, causing conflicts and potential 
duplicate key errors during operations like archiving.

## Changes

- Added migration `v336` to safely drop the legacy index
- The migration checks for the existence of the index before removing it
- Ensures backward compatibility for users upgrading to newer versions

## Notes

- The migration is idempotent and will not fail if the index does not exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Conditionally removed a legacy unique database index on read receipts to improve reliability and prevent potential conflicts during message read tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->