### PR TITLE
fix: remove erroneous 'service' string literal from isAvatarUrl type guard

### DIFF
--- a/apps/meteor/client/hooks/useUpdateAvatar.ts
+++ b/apps/meteor/client/hooks/useUpdateAvatar.ts
@@ -10,7 +10,7 @@ const isAvatarReset = (avatarObj: AvatarObject): avatarObj is AvatarReset => ava
 const isServiceObject = (avatarObj: AvatarObject): avatarObj is AvatarServiceObject =>
 	!isAvatarReset(avatarObj) && typeof avatarObj === 'object' && 'service' in avatarObj;
 const isAvatarUrl = (avatarObj: AvatarObject): avatarObj is AvatarUrlObj =>
-	!isAvatarReset(avatarObj) && typeof avatarObj === 'object' && 'service' && 'avatarUrl' in avatarObj;
+	!isAvatarReset(avatarObj) && typeof avatarObj === 'object' && 'avatarUrl' in avatarObj;
 
 export const useUpdateAvatar = (avatarObj: AvatarObject, userId: IUser['_id']) => {
 	const { t } = useTranslation();


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

In `useUpdateAvatar.ts`, the `isAvatarUrl` type guard had an incorrect condition:
                                                                                                                                               
  ```ts
  // Before (broken)                                                                                                                                              
  const isAvatarUrl = (avatarObj: AvatarObject): avatarObj is AvatarUrlObj =>
      !isAvatarReset(avatarObj) && typeof avatarObj === 'object' && 'service' && 'avatarUrl' in avatarObj;

```

'service' is a string literal — it is always truthy in JavaScript, so it never actually checks whether the service property exists on the object. The condition effectively reduces to:                                                                                                                                         
                                                                                                                                                                  
```ts
... && true && 'avatarUrl' in avatarObj  
```

Fix
  // After (fixed)
```ts
  const isAvatarUrl = (avatarObj: AvatarObject): avatarObj is AvatarUrlObj =>                                                                                     
      !isAvatarReset(avatarObj) && typeof avatarObj === 'object' && 'avatarUrl' in avatarObj;
 ```                                                                                                                                                          
Removed the dangling 'service' string literal. The isAvatarUrl guard should only check for the avatarUrl property — isServiceObject already handles the service property check separately.                                                                                                                                      
                                                                                

## Steps to test or reproduce

1. Check avatar update flow — setting avatar via URL                                                                                                            
2. The type guard now correctly identifies AvatarUrlObj without the redundant truthy string


## Further comments
isServiceObject (line 10-11) correctly uses 'service' in avatarObj for its check. isAvatarUrl should mirror that pattern using 'avatarUrl' in avatarObj only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed avatar URL validation logic to properly recognize and process avatar URLs through the correct API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->