### PR TITLE
 fix: pass error message string instead of Error object to toast dispatcher  

### DIFF
--- a/apps/meteor/client/hooks/useClipboardWithToast.ts
+++ b/apps/meteor/client/hooks/useClipboardWithToast.ts
@@ -9,6 +9,6 @@ export default function useClipboardWithToast(text: string): UseClipboardReturn 
 
 	return useClipboard(text, {
 		onCopySuccess: useEffectEvent(() => dispatchToastMessage({ type: 'success', message: t('Copied') })),
-		onCopyError: useEffectEvent((e?: Error) => dispatchToastMessage({ type: 'error', message: e })),
+		onCopyError: useEffectEvent((e?: Error) => dispatchToastMessage({ type: 'error', message: e instanceof Error ? e.message : String(e) })),
 	});
 }

--- a/apps/meteor/client/views/room/composer/ComposerJoinWithPassword.tsx
+++ b/apps/meteor/client/views/room/composer/ComposerJoinWithPassword.tsx
@@ -27,7 +27,7 @@ const ComposerJoinWithPassword = (): ReactElement => {
 			});
 		} catch (error: any) {
 			setError('joinCode', { type: error.errorType, message: error.error });
-			dispatchToastMessage({ type: 'error', message: error instanceof Error ? error.message : String(error) });
+			dispatchToastMessage({ type: 'error', message: error instanceof Error ? error.message : (error as any).error ?? String(error) }); 
 		}
 	};
 

--- a/apps/meteor/client/views/room/composer/ComposerJoinWithPassword.tsx
+++ b/apps/meteor/client/views/room/composer/ComposerJoinWithPassword.tsx
@@ -27,7 +27,7 @@ const ComposerJoinWithPassword = (): ReactElement => {
 			});
 		} catch (error: any) {
 			setError('joinCode', { type: error.errorType, message: error.error });
-			dispatchToastMessage({ type: 'error', message: error });
+			dispatchToastMessage({ type: 'error', message: error instanceof Error ? error.message : String(error) });
 		}
 	};
 

--- a/apps/meteor/client/views/room/composer/ComposerMessage.tsx
+++ b/apps/meteor/client/views/room/composer/ComposerMessage.tsx
@@ -34,7 +34,7 @@ const ComposerMessage = ({ tmid, onSend, ...props }: ComposerMessageProps): Reac
 				try {
 					await chat?.data?.joinRoom();
 				} catch (error) {
-					dispatchToastMessage({ type: 'error', message: error });
+					dispatchToastMessage({ type: 'error', message: error instanceof Error ? error.message : String(error) });
 					throw error;
 				}
 			},
@@ -61,7 +61,7 @@ const ComposerMessage = ({ tmid, onSend, ...props }: ComposerMessageProps): Reac
 					});
 					if (newMessageSent) onSend?.();
 				} catch (error) {
-					dispatchToastMessage({ type: 'error', message: error });
+					dispatchToastMessage({ type: 'error', message: error instanceof Error ? error.message : String(error) });
 				}
 			},
 			onTyping: async (): Promise<void> => {

--- a/apps/meteor/client/views/room/composer/ComposerOmnichannel/ComposerOmnichannelInquiry.tsx
+++ b/apps/meteor/client/views/room/composer/ComposerOmnichannel/ComposerOmnichannelInquiry.tsx
@@ -35,7 +35,7 @@ export const ComposerOmnichannelInquiry = (): ReactElement => {
 		try {
 			await takeInquiry({ inquiryId: result.data.inquiry._id, options: { clientAction: true } });
 		} catch (error) {
-			dispatchToastMessage({ type: 'error', message: error });
+			dispatchToastMessage({ type: 'error', message: error instanceof Error ? error.message : String(error) });
 		}
 	};
 

--- a/apps/meteor/client/views/room/composer/ComposerOmnichannel/ComposerOmnichannelJoin.tsx
+++ b/apps/meteor/client/views/room/composer/ComposerOmnichannel/ComposerOmnichannelJoin.tsx
@@ -22,7 +22,7 @@ export const ComposerOmnichannelJoin = (): ReactElement => {
 							roomId: room._id,
 						});
 					} catch (error) {
-						dispatchToastMessage({ type: 'error', message: error });
+						dispatchToastMessage({ type: 'error', message: error instanceof Error ? error.message : String(error) });
 					}
 				}}
 			>

--- a/apps/meteor/client/views/room/composer/ComposerOmnichannel/hooks/useResumeChatOnHoldMutation.ts
+++ b/apps/meteor/client/views/room/composer/ComposerOmnichannel/hooks/useResumeChatOnHoldMutation.ts
@@ -26,7 +26,7 @@ export const useResumeChatOnHoldMutation = (
 			return options?.onSuccess?.(data, rid, context);
 		},
 		onError: (error) => {
-			dispatchToastMessage({ type: 'error', message: error });
+			dispatchToastMessage({ type: 'error', message: error instanceof Error ? error.message : String(error) });
 		},
 	});
 };

--- a/apps/meteor/client/views/room/composer/ComposerReadOnly.tsx
+++ b/apps/meteor/client/views/room/composer/ComposerReadOnly.tsx
@@ -19,7 +19,7 @@ const ComposerReadOnly = (): ReactElement => {
 		mutationFn: () => joinChannel({ roomId: room._id }),
 
 		onError: (error: unknown) => {
-			dispatchToastMessage({ type: 'error', message: error });
+			dispatchToastMessage({ type: 'error', message: error instanceof Error ? error.message : String(error) });
 		},
 	});
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

In multiple composer files and `useClipboardWithToast.ts`, the `dispatchToastMessage` was being called with an `Error` object directly as the `message` field:

                                                                                                                                                                
  ```ts
  // Before (broken)                                                                                                                                              
  dispatchToastMessage({ type: 'error', message: error });
```
                                                                                                                                                                  
Since message expects a string, passing an Error object causes the toast to display **[object Object]** instead of the actual error message — making error toasts completely uninformative to the user.                                                                                                                           
                  
  Fix       

```ts                                                                                                                                                              
 // After (fixed)                                                                                                                                                
  dispatchToastMessage({ type: 'error', message: error instanceof Error ? error.message : String(error) });
```

This correctly extracts the error message string in all cases.                                                                                                  
  
  Files changed                                                                                                                                                   
                  
  - `apps/meteor/client/hooks/useClipboardWithToast.ts`                                                                                                           
  - `apps/meteor/client/views/room/composer/ComposerReadOnly.tsx`
  - `apps/meteor/client/views/room/composer/ComposerMessage.tsx`                                                                                                  
  - `apps/meteor/client/views/room/composer/ComposerJoinWithPassword.tsx`
  - `apps/meteor/client/views/room/composer/ComposerOmnichannel/ComposerOmnichannelInquiry.tsx`                                                                   
  - `apps/meteor/client/views/room/composer/ComposerOmnichannel/ComposerOmnichannelJoin.tsx`                                                                      
  - `apps/meteor/client/views/room/composer/ComposerOmnichannel/hooks/useResumeChatOnHoldMutation.ts`                                                                                         
                  


## Steps to test or reproduce

 1. In any room, trigger an error in the composer (e.g. try joining a channel that fails)                                                                        
 2. Before fix: toast shows [object Object]
 3. After fix: toast shows the actual error message        


## Further comments
Same pattern fixed across 7 files in the composer area.    



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error notifications across the composer UI: toast messages now consistently show readable, human-friendly text instead of raw error objects. This yields clearer feedback for failures when sending messages, joining rooms, taking inquiries, resuming chats on hold, and in read-only composer views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->