### PR TITLE
chore(deps): bump deps via resolution and direct deps bump

### DIFF
--- a/apps/meteor/package.json
+++ b/apps/meteor/package.json
@@ -192,7 +192,7 @@
 		"date-fns": "~4.1.0",
 		"date.js": "~0.3.3",
 		"debug": "~4.3.7",
-		"dompurify": "~3.3.2",
+		"dompurify": "~3.4.0",
 		"drachtio-srf": "patch:drachtio-srf@npm%3A5.0.12#~/.yarn/patches/drachtio-srf-npm-5.0.12-b0b1afaad6.patch",
 		"ejson": "^2.2.3",
 		"emailreplyparser": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
 		"markdown-it": "^14.1.1",
 		"minimist": "1.2.6",
 		"mongodb": "6.10.0",
+		"protobufjs": "7.5.5",
+		"webdav/axios": "0.31.1",
 		"picomatch@npm:^2.0.4": "^2.3.2",
 		"picomatch@npm:^2.2.1": "^2.3.2",
 		"picomatch@npm:^2.2.3": "^2.3.2",

--- a/packages/gazzodown/package.json
+++ b/packages/gazzodown/package.json
@@ -22,7 +22,7 @@
 	},
 	"dependencies": {
 		"date-fns": "~4.1.0",
-		"dompurify": "~3.3.2",
+		"dompurify": "~3.4.0",
 		"highlight.js": "11.8.0",
 		"react-error-boundary": "^3.1.4",
 		"react-stately": "~3.17.0"

--- a/packages/livechat/package.json
+++ b/packages/livechat/package.json
@@ -37,7 +37,7 @@
 		"ajv-formats": "^3.0.1",
 		"css-vars-ponyfill": "^2.4.9",
 		"date-fns": "~4.1.0",
-		"dompurify": "~3.3.2",
+		"dompurify": "~3.4.0",
 		"emoji-mart": "^3.0.1",
 		"history": "~5.3.0",
 		"i18next": "~23.4.9",

--- a/packages/media-signaling/package.json
+++ b/packages/media-signaling/package.json
@@ -2,7 +2,6 @@
 	"name": "@rocket.chat/media-signaling",
 	"description": "Rocket.Chat signaling client for media calls",
 	"version": "0.2.0",
-	"private": false,
 	"license": "MIT",
 	"homepage": "https://github.com/RocketChat/Rocket.Chat/#readme",
 	"repository": {

--- a/packages/ui-client/package.json
+++ b/packages/ui-client/package.json
@@ -19,7 +19,7 @@
 	},
 	"dependencies": {
 		"@rocket.chat/onboarding-ui": "~0.36.2",
-		"dompurify": "~3.3.2"
+		"dompurify": "~3.4.0"
 	},
 	"devDependencies": {
 		"@react-aria/toolbar": "^3.0.0-nightly.5042",

--- a/packages/web-ui-registration/package.json
+++ b/packages/web-ui-registration/package.json
@@ -17,7 +17,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"dompurify": "~3.3.2"
+		"dompurify": "~3.4.0"
 	},
 	"devDependencies": {
 		"@rocket.chat/core-typings": "workspace:~",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9406,7 +9406,7 @@ __metadata:
     "@types/react": "npm:~18.3.27"
     "@types/react-dom": "npm:~18.3.7"
     date-fns: "npm:~4.1.0"
-    dompurify: "npm:~3.3.2"
+    dompurify: "npm:~3.4.0"
     eslint: "npm:~9.39.3"
     highlight.js: "npm:11.8.0"
     i18next: "npm:~23.4.9"
@@ -9608,7 +9608,7 @@ __metadata:
     cssnano: "npm:^7.0.7"
     date-fns: "npm:~4.1.0"
     desvg-loader: "npm:^0.1.0"
-    dompurify: "npm:~3.3.2"
+    dompurify: "npm:~3.4.0"
     emoji-mart: "npm:^3.0.1"
     eslint: "npm:~9.39.3"
     file-loader: "npm:^6.2.0"
@@ -9745,6 +9745,7 @@ __metadata:
     "@types/jest": "npm:~30.0.0"
     "@types/node": "npm:~22.16.5"
     eslint: "npm:~9.39.3"
+    fast-check: "npm:^4.6.0"
     jest: "npm:~30.2.0"
     npm-run-all: "npm:^4.1.5"
     peggy: "npm:4.1.1"
@@ -10011,7 +10012,7 @@ __metadata:
     date.js: "npm:~0.3.3"
     debug: "npm:~4.3.7"
     docker-compose: "npm:^0.24.8"
-    dompurify: "npm:~3.3.2"
+    dompurify: "npm:~3.4.0"
     drachtio-srf: "patch:drachtio-srf@npm%3A5.0.12#~/.yarn/patches/drachtio-srf-npm-5.0.12-b0b1afaad6.patch"
     ejson: "npm:^2.2.3"
     emailreplyparser: "npm:^0.0.5"
@@ -10859,7 +10860,7 @@ __metadata:
     "@types/jest": "npm:~30.0.0"
     "@types/react": "npm:~18.3.27"
     "@types/react-dom": "npm:~18.3.7"
-    dompurify: "npm:~3.3.2"
+    dompurify: "npm:~3.4.0"
     eslint: "npm:~9.39.3"
     i18next: "npm:~23.4.9"
     jest: "npm:~30.2.0"
@@ -11184,7 +11185,7 @@ __metadata:
     "@testing-library/react": "npm:~16.3.2"
     "@types/react": "npm:~18.3.27"
     "@types/react-dom": "npm:~18.3.7"
-    dompurify: "npm:~3.3.2"
+    dompurify: "npm:~3.4.0"
     eslint: "npm:~9.39.3"
     i18next: "npm:~23.4.9"
     react: "npm:~18.3.1"
@@ -16851,14 +16852,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.30.0":
-  version: 0.30.0
-  resolution: "axios@npm:0.30.0"
+"axios@npm:0.31.1":
+  version: 0.31.1
+  resolution: "axios@npm:0.31.1"
   dependencies:
     follow-redirects: "npm:^1.15.4"
-    form-data: "npm:^4.0.0"
+    form-data: "npm:^4.0.4"
     proxy-from-env: "npm:^1.1.0"
-  checksum: 10/55f4fc3b009d335e25c68b8a26efe2cd6a7f33e632894e304804f6d31863661b9667c92a4ad3489f57358cfa1e5fefaa2e10bb4089f2fa600b0b3e2cfa8f0954
+  checksum: 10/097dffdc0ab1229fd2f2e792d038e81272568e8280217933f4ad68234761ffebe2b51468f6190f5d98eb3df9511800083f74f78dda4c6229b24b4f9d98d300e5
   languageName: node
   linkType: hard
 
@@ -20509,15 +20510,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:~3.3.2":
-  version: 3.3.2
-  resolution: "dompurify@npm:3.3.2"
+"dompurify@npm:~3.4.0":
+  version: 3.4.0
+  resolution: "dompurify@npm:3.4.0"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10/3ca02559677ce6d9583a500f21ffbb6b9e88f1af99f69fa0d0d9442cddbac98810588c869f8b435addb5115492d6e49870024bca322169b941bafedb99c7f281
+  checksum: 10/ead40b78ec51cd451f2c74fada4233ee0afeafdbab54af2f4a4bd5d4d138ac04d0d85140e79f533803ecfd1c3758edc1176087039c1e7217824f9794a9d34d2c
   languageName: node
   linkType: hard
 
@@ -22258,6 +22259,15 @@ __metadata:
   version: 1.4.1
   resolution: "extsprintf@npm:1.4.1"
   checksum: 10/bfd6d55f3c0c04d826fe0213264b383c03f32825af6b1ff777f3f2dc49467e599361993568d75b7b19a8ea1bb08c8e7cd8c3d87d179ced91bb0dcf81ca6938e0
+  languageName: node
+  linkType: hard
+
+"fast-check@npm:^4.6.0":
+  version: 4.7.0
+  resolution: "fast-check@npm:4.7.0"
+  dependencies:
+    pure-rand: "npm:^8.0.0"
+  checksum: 10/fabe4cb8296dc893c3ac49dc2c1564e60aec7ab5774d8f71b6e0952d32ad2f93e320234e5fd8a671490060f35a6bba96df339ee8c8e3597eff946c74df9a3920
   languageName: node
   linkType: hard
 
@@ -31717,9 +31727,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.2.5, protobufjs@npm:^7.3.0":
-  version: 7.4.0
-  resolution: "protobufjs@npm:7.4.0"
+"protobufjs@npm:7.5.5":
+  version: 7.5.5
+  resolution: "protobufjs@npm:7.5.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -31733,7 +31743,7 @@ __metadata:
     "@protobufjs/utf8": "npm:^1.1.0"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10/408423506610f70858d7593632f4a6aa4f05796c90fd632be9b9252457c795acc71aa6d3b54bb7f48a890141728fee4ca3906723ccea6c202ad71f21b3879b8b
+  checksum: 10/048898023a38d22f5fc9a1bcf0dcce5cfbcd37fb00753bd72283720eee7e2cb6055b23957542e5bcdc136379af66203a2ddb8d8c39d11f73169bacf07885fedd
   languageName: node
   linkType: hard
 
@@ -31841,6 +31851,13 @@ __metadata:
   version: 7.0.1
   resolution: "pure-rand@npm:7.0.1"
   checksum: 10/c61a576fda5032ec9763ecb000da4a8f19263b9e2f9ae9aa2759c8fbd9dc6b192b2ce78391ebd41abb394a5fedb7bcc4b03c9e6141ac8ab20882dd5717698b80
+  languageName: node
+  linkType: hard
+
+"pure-rand@npm:^8.0.0":
+  version: 8.4.0
+  resolution: "pure-rand@npm:8.4.0"
+  checksum: 10/baaee81b6647c89e426458fa0a6fcf51a42315db3db6a2c1c48d676813dd7cebf46dc56d352ce352c3bdfacd5a965b9c7783ba2a92f38cf2e64a9a8186469c3e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This PR bumps a couple of dependencies that have CVEs by applying resolutions and bumping them directly.

## Issue(s)
https://rocketchat.atlassian.net/browse/SB-983

## Steps to test or reproduce
N/A

## Further comments
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dompurify dependency to version 3.4.0 across multiple packages
  * Added dependency resolution entries for protobufjs and axios to ensure consistent versioning
  * Updated package configuration for improved stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->