### PR TITLE
fix(agenda): prevent duplicate scheduled jobs using unique constraint

### DIFF
--- a/packages/agenda/src/Agenda.ts
+++ b/packages/agenda/src/Agenda.ts
@@ -374,6 +374,9 @@ export class Agenda extends EventEmitter {
 
 	private async _createScheduledJob(when: string | Date, name: string, data: IJob['data']): Promise<Job> {
 		const job = this.create(name, data);
+
+        job.unique({ name }, { insertOnly: true });
+
 		await job.schedule(when).save();
 		return job;
 	}


### PR DESCRIPTION
## Summary
Fixes an issue where duplicate jobs are created when scheduling the same job multiple times using Agenda.

Closes #40252

## Problem
When calling `schedule()` multiple times with identical parameters, multiple duplicate jobs are inserted into MongoDB.

This occurs because `_createScheduledJob()` does not enforce uniqueness at the database level.

## Solution
This PR enforces uniqueness at the job level using:

`job.unique({ name }, { insertOnly: true });`

This prevents duplicate job insertions for identical scheduling requests.

## Changes
- Added uniqueness constraint in `_createScheduledJob()`
- Prevents duplicate jobs from being inserted into the database

## Testing
- Scheduled the same job multiple times using a test script
- Verified that only one job is stored in MongoDB
- Re-ran multiple times to confirm no duplicates are created


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled job handling to prevent duplicate jobs with the same name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->