### PR TITLE
feat: restrict @all and @here autocomplete by user permissions

### DIFF
--- a/apps/meteor/client/views/room/providers/ComposerPopupProvider.spec.tsx
+++ b/apps/meteor/client/views/room/providers/ComposerPopupProvider.spec.tsx
@@ -1,0 +1,100 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { render, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
+
+import ComposerPopupProvider from './ComposerPopupProvider';
+import { useComposerPopupOptions } from '../contexts/ComposerPopupContext';
+import FakeRoomProvider from '../../../../tests/mocks/client/FakeRoomProvider';
+import { createFakeRoom } from '../../../../tests/mocks/data';
+
+const mockGrantedPermissions = new Set<string>();
+
+jest.mock('../../../../app/authorization/client', () => ({
+	hasAtLeastOnePermission: (permissions: string[] | string) => {
+		const permissionList = Array.isArray(permissions) ? permissions : [permissions];
+
+		return permissionList.some((permission) => mockGrantedPermissions.has(permission));
+	},
+}));
+
+jest.mock('../../../../app/utils/client', () => ({
+	slashCommands: {
+		commands: {},
+	},
+}));
+
+type PopupOptionsConsumerProps = {
+	onReady: (options: ReturnType<typeof useComposerPopupOptions>) => void;
+};
+
+const PopupOptionsConsumer = ({ onReady }: PopupOptionsConsumerProps) => {
+	const options = useComposerPopupOptions();
+
+	useEffect(() => {
+		onReady(options);
+	}, [onReady, options]);
+
+	return null;
+};
+
+const renderProvider = async (permissions: string[] = []) => {
+	mockGrantedPermissions.clear();
+	permissions.forEach((permission) => mockGrantedPermissions.add(permission));
+
+	const room = createFakeRoom({ t: 'c' });
+	const appRoot = mockAppRoot().build();
+
+	let popupOptions: ReturnType<typeof useComposerPopupOptions> | undefined;
+
+	render(
+		<FakeRoomProvider roomOverrides={room}>
+			<ComposerPopupProvider room={room}>
+				<PopupOptionsConsumer
+					onReady={(options) => {
+						popupOptions = options;
+					}}
+				/>
+			</ComposerPopupProvider>
+		</FakeRoomProvider>,
+		{ wrapper: appRoot },
+	);
+
+	await waitFor(() => expect(popupOptions).toBeDefined());
+
+	const mentionPopup = popupOptions?.find(({ trigger }) => trigger === '@');
+	expect(mentionPopup).toBeDefined();
+
+	const items = await mentionPopup?.getItemsFromLocal?.('');
+
+	return items?.map(({ _id }) => _id) ?? [];
+};
+
+describe('ComposerPopupProvider', () => {
+	it('does not show @all or @here in autocomplete when user does not have permissions', async () => {
+		const itemIds = await renderProvider();
+
+		expect(itemIds).not.toContain('all');
+		expect(itemIds).not.toContain('here');
+	});
+
+	it('shows only @all when user has mention-all permission', async () => {
+		const itemIds = await renderProvider(['mention-all']);
+
+		expect(itemIds).toContain('all');
+		expect(itemIds).not.toContain('here');
+	});
+
+	it('shows only @here when user has mention-here permission', async () => {
+		const itemIds = await renderProvider(['mention-here']);
+
+		expect(itemIds).toContain('here');
+		expect(itemIds).not.toContain('all');
+	});
+
+	it('shows both @all and @here when user has both permissions', async () => {
+		const itemIds = await renderProvider(['mention-all', 'mention-here']);
+
+		expect(itemIds).toContain('all');
+		expect(itemIds).toContain('here');
+	});
+});

--- a/apps/meteor/client/views/room/providers/ComposerPopupProvider.spec.tsx
+++ b/apps/meteor/client/views/room/providers/ComposerPopupProvider.spec.tsx
@@ -10,10 +10,10 @@ import { createFakeRoom } from '../../../../tests/mocks/data';
 const mockGrantedPermissions = new Set<string>();
 
 jest.mock('../../../../app/authorization/client', () => ({
-	hasAtLeastOnePermission: (permissions: string[] | string) => {
+	hasAtLeastOnePermission: (permissions: string[] | string, scope?: string) => {
 		const permissionList = Array.isArray(permissions) ? permissions : [permissions];
 
-		return permissionList.some((permission) => mockGrantedPermissions.has(permission));
+		return permissionList.some((permission) => mockGrantedPermissions.has(`${scope}:${permission}`));
 	},
 }));
 
@@ -38,10 +38,11 @@ const PopupOptionsConsumer = ({ onReady }: PopupOptionsConsumerProps) => {
 };
 
 const renderProvider = async (permissions: string[] = []) => {
-	mockGrantedPermissions.clear();
-	permissions.forEach((permission) => mockGrantedPermissions.add(permission));
+	const room = createFakeRoom({ _id: 'permission-scoped-room', t: 'c' });
 
-	const room = createFakeRoom({ t: 'c' });
+	mockGrantedPermissions.clear();
+	permissions.forEach((permission) => mockGrantedPermissions.add(`${room._id}:${permission}`));
+
 	const appRoot = mockAppRoot().build();
 
 	let popupOptions: ReturnType<typeof useComposerPopupOptions> | undefined;

--- a/apps/meteor/client/views/room/providers/ComposerPopupProvider.spec.tsx
+++ b/apps/meteor/client/views/room/providers/ComposerPopupProvider.spec.tsx
@@ -3,19 +3,8 @@ import { render, waitFor } from '@testing-library/react';
 import { useEffect } from 'react';
 
 import ComposerPopupProvider from './ComposerPopupProvider';
-import { useComposerPopupOptions } from '../contexts/ComposerPopupContext';
-import FakeRoomProvider from '../../../../tests/mocks/client/FakeRoomProvider';
 import { createFakeRoom } from '../../../../tests/mocks/data';
-
-const mockGrantedPermissions = new Set<string>();
-
-jest.mock('../../../../app/authorization/client', () => ({
-	hasAtLeastOnePermission: (permissions: string[] | string, scope?: string) => {
-		const permissionList = Array.isArray(permissions) ? permissions : [permissions];
-
-		return permissionList.some((permission) => mockGrantedPermissions.has(`${scope}:${permission}`));
-	},
-}));
+import { useComposerPopupOptions } from '../contexts/ComposerPopupContext';
 
 jest.mock('../../../../app/utils/client', () => ({
 	slashCommands: {
@@ -40,23 +29,18 @@ const PopupOptionsConsumer = ({ onReady }: PopupOptionsConsumerProps) => {
 const renderProvider = async (permissions: string[] = []) => {
 	const room = createFakeRoom({ _id: 'permission-scoped-room', t: 'c' });
 
-	mockGrantedPermissions.clear();
-	permissions.forEach((permission) => mockGrantedPermissions.add(`${room._id}:${permission}`));
-
-	const appRoot = mockAppRoot().build();
+	const appRoot = permissions.reduce((builder, permission) => builder.withPermission(permission), mockAppRoot().withRoom(room)).build();
 
 	let popupOptions: ReturnType<typeof useComposerPopupOptions> | undefined;
 
 	render(
-		<FakeRoomProvider roomOverrides={room}>
-			<ComposerPopupProvider room={room}>
-				<PopupOptionsConsumer
-					onReady={(options) => {
-						popupOptions = options;
-					}}
-				/>
-			</ComposerPopupProvider>
-		</FakeRoomProvider>,
+		<ComposerPopupProvider room={room}>
+			<PopupOptionsConsumer
+				onReady={(options) => {
+					popupOptions = options;
+				}}
+			/>
+		</ComposerPopupProvider>,
 		{ wrapper: appRoot },
 	);
 
@@ -72,30 +56,30 @@ const renderProvider = async (permissions: string[] = []) => {
 
 describe('ComposerPopupProvider', () => {
 	it('does not show @all or @here in autocomplete when user does not have permissions', async () => {
-		const itemIds = await renderProvider();
+		const view = await renderProvider();
 
-		expect(itemIds).not.toContain('all');
-		expect(itemIds).not.toContain('here');
+		expect(view).not.toContain('all');
+		expect(view).not.toContain('here');
 	});
 
 	it('shows only @all when user has mention-all permission', async () => {
-		const itemIds = await renderProvider(['mention-all']);
+		const view = await renderProvider(['mention-all']);
 
-		expect(itemIds).toContain('all');
-		expect(itemIds).not.toContain('here');
+		expect(view).toContain('all');
+		expect(view).not.toContain('here');
 	});
 
 	it('shows only @here when user has mention-here permission', async () => {
-		const itemIds = await renderProvider(['mention-here']);
+		const view = await renderProvider(['mention-here']);
 
-		expect(itemIds).toContain('here');
-		expect(itemIds).not.toContain('all');
+		expect(view).toContain('here');
+		expect(view).not.toContain('all');
 	});
 
 	it('shows both @all and @here when user has both permissions', async () => {
-		const itemIds = await renderProvider(['mention-all', 'mention-here']);
+		const view = await renderProvider(['mention-all', 'mention-here']);
 
-		expect(itemIds).toContain('all');
-		expect(itemIds).toContain('here');
+		expect(view).toContain('all');
+		expect(view).toContain('here');
 	});
 });

--- a/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
+++ b/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
@@ -3,7 +3,7 @@ import { isOmnichannelRoom } from '@rocket.chat/core-typings';
 import { useLocalStorage } from '@rocket.chat/fuselage-hooks';
 import { escapeRegExp } from '@rocket.chat/string-helpers';
 import type { SubscriptionWithRoom } from '@rocket.chat/ui-contexts';
-import { useMethod, useSetting, useUserId, useUserPreference } from '@rocket.chat/ui-contexts';
+import { useAtLeastOnePermission, useMethod, useSetting, useUserId, useUserPreference } from '@rocket.chat/ui-contexts';
 import { useQueryClient } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
@@ -84,6 +84,8 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 	const queryClient = useQueryClient();
 	const uid = useUserId();
 	const call = useMethod('getSlashCommandPreviews');
+	const canMentionAll = useAtLeastOnePermission(['mention-all'], rid);
+	const canMentionHere = useAtLeastOnePermission(['mention-here'], rid);
 
 	const value: ComposerPopupContextValue = useMemo(() => {
 		return [
@@ -93,9 +95,6 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 				getItemsFromLocal: async (filter: string) => {
 					const filterRegex = filter && new RegExp(escapeRegExp(filter), 'i');
 					const items: ComposerBoxPopupUserProps[] = [];
-
-					const canMentionAll = hasAtLeastOnePermission('mention-all', rid);
-					const canMentionHere = hasAtLeastOnePermission('mention-here', rid);
 
 					const roomMessageUsers = getLastRecentUsers(rid, uid!)
 						.filter((u) => {
@@ -391,6 +390,8 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 		].filter(Boolean);
 	}, [
 		call,
+		canMentionAll,
+		canMentionHere,
 		cannedResponseEnabled,
 		encrypted,
 		i18n,

--- a/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
+++ b/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
@@ -94,6 +94,9 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 					const filterRegex = filter && new RegExp(escapeRegExp(filter), 'i');
 					const items: ComposerBoxPopupUserProps[] = [];
 
+					const canMentionAll = hasAtLeastOnePermission('mention-all', rid);
+					const canMentionHere = hasAtLeastOnePermission('mention-here', rid);
+
 					const roomMessageUsers = getLastRecentUsers(rid, uid!)
 						.filter((u) => {
 							if (!filterRegex) return true;
@@ -106,7 +109,7 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 							suggestion: true,
 						}));
 
-					if (!filterRegex || filterRegex.test('all')) {
+					if (canMentionAll && (!filterRegex || filterRegex.test('all'))) {
 						items.push({
 							_id: 'all',
 							username: 'all',
@@ -116,7 +119,7 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 						});
 					}
 
-					if (!filterRegex || filterRegex.test('here')) {
+					if (canMentionHere && (!filterRegex || filterRegex.test('here'))) {
 						items.push({
 							_id: 'here',
 							username: 'here',


### PR DESCRIPTION
## Proposed changes
The Compose mentions list currently shows `@all` and `@here` regardless of the user's permissions, whether they are allowed to or not. This change introduces only showing the allowed tags.

## Issue(s)
This feature request has been implemented in React Native based on this feature request:
https://github.com/RocketChat/feature-requests/issues/871

Reference to the merged PR in the React Native Rocket Chat repository:
https://github.com/RocketChat/Rocket.Chat.ReactNative/pull/6821

## Screenshots

- User with no mention permissions

<img width="1358" height="386" alt="image" src="https://github.com/user-attachments/assets/e6c94191-b4c2-4a73-a283-785feaa93db3" />  


- User with only `mention-all` permission  

<img width="1358" height="386" alt="image" src="https://github.com/user-attachments/assets/e29e29d9-3601-4b9c-b85c-60d5feb8d08c" />  


- User with only `mention-here` permission  

<img width="1358" height="386" alt="image" src="https://github.com/user-attachments/assets/3c5b1be2-5ee8-415e-b293-bd79f8c5787d" />  


- User with both permissions 

<img width="1358" height="386" alt="image" src="https://github.com/user-attachments/assets/c1a1f01d-fd0b-42c3-9203-1c3a9703e8fe" />  


## Further comments
Unit tests have been added for the above feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mention autocomplete now respects room-specific permissions for @all and @here, showing those options only when allowed.

* **Tests**
  * Added automated tests confirming permission-gated visibility of @ mention suggestions across permission combinations to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40262)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->