### PR TITLE
chore(deps): bump hono from 4.12.5 to 4.12.14 (combines #40260, #40258)

### DIFF
--- a/apps/meteor/package.json
+++ b/apps/meteor/package.json
@@ -215,7 +215,7 @@
 		"gravatar": "^1.8.2",
 		"he": "^1.2.0",
 		"highlight.js": "11.8.0",
-		"hono": "4.12.5",
+		"hono": "4.12.14",
 		"http-proxy-agent": "^7.0.2",
 		"human-interval": "^2.0.1",
 		"i18next-http-backend": "^1.4.5",

--- a/packages/http-router/package.json
+++ b/packages/http-router/package.json
@@ -22,7 +22,7 @@
 		"@rocket.chat/rest-typings": "workspace:^",
 		"ajv": "^8.17.1",
 		"express": "^4.21.2",
-		"hono": "4.12.5",
+		"hono": "4.12.14",
 		"qs": "^6.14.2"
 	},
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9553,7 +9553,7 @@ __metadata:
     ajv: "npm:^8.17.1"
     eslint: "npm:~9.39.4"
     express: "npm:^4.21.2"
-    hono: "npm:4.12.5"
+    hono: "npm:4.12.14"
     jest: "npm:~30.2.0"
     qs: "npm:^6.14.2"
     supertest: "npm:~7.1.4"
@@ -10138,7 +10138,7 @@ __metadata:
     gravatar: "npm:^1.8.2"
     he: "npm:^1.2.0"
     highlight.js: "npm:11.8.0"
-    hono: "npm:4.12.5"
+    hono: "npm:4.12.14"
     http-proxy-agent: "npm:^7.0.2"
     human-interval: "npm:^2.0.1"
     i18next: "npm:~23.4.9"
@@ -24087,10 +24087,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:4.12.5":
-  version: 4.12.5
-  resolution: "hono@npm:4.12.5"
-  checksum: 10/3d03cf2885f7c75325869a178bc94291a17a656002b930dc91456cb177366f6f344c7c90c09707c1fcb4c6e40b1f33fac98f1622628061628cabadcf8cf6d3fd
+"hono@npm:4.12.14":
+  version: 4.12.14
+  resolution: "hono@npm:4.12.14"
+  checksum: 10/2e620adb89e773a7e982dee8d8c9917f79c71b89cb051b5bc0d2aa91b5318373e90ba7a236bdc4762dc36026c1d7e5e979d6b48cf1dbbe44fc524a5c4df227d9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Combines the two Dependabot PRs that bump hono from `4.12.5` (pinned in #40172) to `4.12.14`:

- #40258 — bumps hono in `/packages/http-router`
- #40260 — bumps hono in `/apps/meteor`

Both are needed together because hono is consumed by both packages. Merging individually would leave one package on the older pinned version.

## Context

In #40172 hono was pinned to exactly `4.12.5` after we observed CI failures (ABAC, iframe auth) while rolling up several patch-level bumps simultaneously. Subsequent investigation pointed at `cron` (moment-timezone → luxon) and `@noble/ed25519` as primary culprits — those were reverted. It's possible hono 4.12.14 now works fine in isolation; this PR tests that hypothesis.

## Hono changelog highlights (v4.12.6 → v4.12.14)

- v4.12.6: ReDoS fix in `accept` parser
- v4.12.9: `parseBody` removed from bodyCache; CORS reflects origin on credentials+wildcard
- v4.12.12: Security fixes for setCookie/getCookie name validation, static middleware path normalization, SSG path traversal, IPv4-mapped IPv6 IP restriction
- v4.12.14: JSX attribute validation; AWS Lambda header handling

## Test plan
- [ ] CI passes all suites (unit, API CE/EE, API Livechat CE/EE, UI CE/EE, Federation Matrix)
- [ ] If CI fails, the failing tests confirm hono as the root cause — not cron / noble-ed25519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `hono` HTTP routing framework from version 4.12.5 to 4.12.14 across multiple packages in the application stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2111]

[ARCH-2111]: https://rocketchat.atlassian.net/browse/ARCH-2111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ