### PR TITLE
regression: Apply user language locale to client-side dates

### DIFF
--- a/apps/meteor/client/hooks/useTimezoneTime.ts
+++ b/apps/meteor/client/hooks/useTimezoneTime.ts
@@ -1,8 +1,10 @@
-import { guessTimezoneFromOffset } from '@rocket.chat/tools';
 import { useState, useEffect } from 'react';
+
+import { useFormatTime } from './useFormatTime';
 
 export const useTimezoneTime = (offset: number, interval = 1000): string => {
 	const [now, setNow] = useState(() => new Date());
+	const format = useFormatTime();
 
 	useEffect(() => {
 		if (offset === undefined) {
@@ -13,9 +15,6 @@ export const useTimezoneTime = (offset: number, interval = 1000): string => {
 		return () => clearInterval(timer);
 	}, [offset, interval]);
 
-	const zone = guessTimezoneFromOffset(offset);
-	return new Intl.DateTimeFormat(undefined, {
-		timeZone: zone,
-		timeStyle: 'short',
-	}).format(now);
+	const shifted = new Date(now.getTime() + offset * 3600000 + now.getTimezoneOffset() * 60000);
+	return format(shifted);
 };

--- a/apps/meteor/client/lib/utils/setDateFnsLocale.ts
+++ b/apps/meteor/client/lib/utils/setDateFnsLocale.ts
@@ -1,0 +1,8 @@
+import { setDefaultOptions } from 'date-fns';
+
+import { getDateFnsLocale } from '../../../lib/getDateFnsLocale';
+
+export const setDateFnsLocale = async (language: string): Promise<void> => {
+	const locale = await getDateFnsLocale(language);
+	setDefaultOptions({ locale });
+};

--- a/apps/meteor/client/providers/TranslationProvider.tsx
+++ b/apps/meteor/client/providers/TranslationProvider.tsx
@@ -24,6 +24,7 @@ import { i18n } from '../../app/utils/lib/i18n';
 import { AppClientOrchestratorInstance } from '../apps/orchestrator';
 import { onLoggedIn } from '../lib/loggedIn';
 import { isRTLScriptLanguage } from '../lib/utils/isRTLScriptLanguage';
+import { setDateFnsLocale } from '../lib/utils/setDateFnsLocale';
 
 i18n.use(I18NextHttpBackend).use(initReactI18next);
 
@@ -211,6 +212,10 @@ const TranslationProvider = ({ children }: TranslationProviderProps): ReactEleme
 		],
 		[language, i18nextInstance],
 	);
+
+	useEffect(() => {
+		setDateFnsLocale(language);
+	}, [language]);
 
 	useEffect(
 		() =>

--- a/apps/meteor/lib/getDateFnsLocale.ts
+++ b/apps/meteor/lib/getDateFnsLocale.ts
@@ -1,0 +1,99 @@
+import type { Locale } from 'date-fns';
+import { enUS } from 'date-fns/locale';
+
+type LocaleLoader = () => Promise<Locale>;
+
+// Maps Rocket.Chat language codes (from packages/i18n) to date-fns locale loaders.
+// Codes without a direct date-fns counterpart fall back to the closest match, or
+// to enUS when no reasonable counterpart exists.
+const localeLoaders: Record<string, LocaleLoader> = {
+	'af': async () => (await import('date-fns/locale/af')).af,
+	'ar': async () => (await import('date-fns/locale/ar')).ar,
+	'az': async () => (await import('date-fns/locale/az')).az,
+	'be-BY': async () => (await import('date-fns/locale/be')).be,
+	'bg': async () => (await import('date-fns/locale/bg')).bg,
+	'bn-BD': async () => (await import('date-fns/locale/bn')).bn,
+	'bn-IN': async () => (await import('date-fns/locale/bn')).bn,
+	'bs': async () => (await import('date-fns/locale/bs')).bs,
+	'ca': async () => (await import('date-fns/locale/ca')).ca,
+	'cs': async () => (await import('date-fns/locale/cs')).cs,
+	'cy': async () => (await import('date-fns/locale/cy')).cy,
+	'da': async () => (await import('date-fns/locale/da')).da,
+	'de': async () => (await import('date-fns/locale/de')).de,
+	'de-AT': async () => (await import('date-fns/locale/de-AT')).deAT,
+	'de-IN': async () => (await import('date-fns/locale/de')).de,
+	'el': async () => (await import('date-fns/locale/el')).el,
+	'en': async () => (await import('date-fns/locale/en-US')).enUS,
+	'eo': async () => (await import('date-fns/locale/eo')).eo,
+	'es': async () => (await import('date-fns/locale/es')).es,
+	'et': async () => (await import('date-fns/locale/et')).et,
+	'eu': async () => (await import('date-fns/locale/eu')).eu,
+	'fa': async () => (await import('date-fns/locale/fa-IR')).faIR,
+	'fi': async () => (await import('date-fns/locale/fi')).fi,
+	'fr': async () => (await import('date-fns/locale/fr')).fr,
+	'gl': async () => (await import('date-fns/locale/gl')).gl,
+	'he': async () => (await import('date-fns/locale/he')).he,
+	'hi': async () => (await import('date-fns/locale/hi')).hi,
+	'hi-IN': async () => (await import('date-fns/locale/hi')).hi,
+	'hr': async () => (await import('date-fns/locale/hr')).hr,
+	'hu': async () => (await import('date-fns/locale/hu')).hu,
+	'id': async () => (await import('date-fns/locale/id')).id,
+	'it': async () => (await import('date-fns/locale/it')).it,
+	'ja': async () => (await import('date-fns/locale/ja')).ja,
+	'ka-GE': async () => (await import('date-fns/locale/ka')).ka,
+	'km': async () => (await import('date-fns/locale/km')).km,
+	'ko': async () => (await import('date-fns/locale/ko')).ko,
+	'ku': async () => (await import('date-fns/locale/ckb')).ckb,
+	'lt': async () => (await import('date-fns/locale/lt')).lt,
+	'lv': async () => (await import('date-fns/locale/lv')).lv,
+	'mn': async () => (await import('date-fns/locale/mn')).mn,
+	'ms-MY': async () => (await import('date-fns/locale/ms')).ms,
+	'nb': async () => (await import('date-fns/locale/nb')).nb,
+	'nl': async () => (await import('date-fns/locale/nl')).nl,
+	'nn': async () => (await import('date-fns/locale/nn')).nn,
+	'pl': async () => (await import('date-fns/locale/pl')).pl,
+	'pt': async () => (await import('date-fns/locale/pt')).pt,
+	'pt-BR': async () => (await import('date-fns/locale/pt-BR')).ptBR,
+	'ro': async () => (await import('date-fns/locale/ro')).ro,
+	'ru': async () => (await import('date-fns/locale/ru')).ru,
+	'se': async () => (await import('date-fns/locale/se')).se,
+	'sk': async () => (await import('date-fns/locale/sk')).sk,
+	'sk-SK': async () => (await import('date-fns/locale/sk')).sk,
+	'sl-SI': async () => (await import('date-fns/locale/sl')).sl,
+	'sq': async () => (await import('date-fns/locale/sq')).sq,
+	'sr': async () => (await import('date-fns/locale/sr')).sr,
+	'sv': async () => (await import('date-fns/locale/sv')).sv,
+	'ta-IN': async () => (await import('date-fns/locale/ta')).ta,
+	'th-TH': async () => (await import('date-fns/locale/th')).th,
+	'tr': async () => (await import('date-fns/locale/tr')).tr,
+	'ug': async () => (await import('date-fns/locale/ug')).ug,
+	'uk': async () => (await import('date-fns/locale/uk')).uk,
+	'vi-VN': async () => (await import('date-fns/locale/vi')).vi,
+	'zh': async () => (await import('date-fns/locale/zh-CN')).zhCN,
+	'zh-HK': async () => (await import('date-fns/locale/zh-HK')).zhHK,
+	'zh-TW': async () => (await import('date-fns/locale/zh-TW')).zhTW,
+};
+
+const resolveLoader = (language: string): LocaleLoader | undefined => {
+	if (localeLoaders[language]) {
+		return localeLoaders[language];
+	}
+	const base = language.split('-').shift();
+	if (base && localeLoaders[base]) {
+		return localeLoaders[base];
+	}
+	return undefined;
+};
+
+export const getDateFnsLocale = async (language: string): Promise<Locale> => {
+	const loader = resolveLoader(language);
+	if (!loader) {
+		return enUS;
+	}
+	try {
+		return await loader();
+	} catch (error) {
+		console.error('Error loading date-fns locale:', error);
+		return enUS;
+	}
+};


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Introduced here: #40076

Removing moment also removed `moment.locale(language)` in `TranslationProvider`, leaving `date-fns` on its default (English) regardless of the user's UI language.

So this PR aims to 
- Wire the selected language back into date-fns via `setDefaultOptions({ locale })` on language change, restoring localized output for every formatter (hooks and direct `format()` callers).
- Extract the `language to date-fns` Locale loader and place it in `apps/meteor/lib/getDateFnsLocale.ts` so the upcoming server-side moment migration can reuse the same mapping.
- `useTimezoneTime` is routed back through `useFormatTime` (as pre-migration), restoring `clockMode` and `Message_TimeFormat` support and re-aligning output with `useTimeAgo`.

## Test plan
- [ ] Switch UI language to Portuguese / French / Japanese → message timestamps, sidebar "time ago" badges, retention policy warning, engagement dashboard labels render in the selected language
- [ ] Switch to a language not in date-fns (e.g. Lao `lo`) → falls back to English cleanly, no console errors
- [ ] Flip between languages → dates re-localize immediately on language change


## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-2124]

[CORE-2124]: https://rocketchat.atlassian.net/browse/CORE-2124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Date and time formatting now automatically follow the app language and update when you change languages.
  * Locale data is loaded on demand to keep initial load size small.

* **Refactor**
  * Timezone-based time display now uses a shared formatting mechanism for more consistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->