### PR TITLE
docs: update OAuth URI parsing comment for clarity

### DIFF
--- a/.changeset/docs-oauth-uri-comment.md
+++ b/.changeset/docs-oauth-uri-comment.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Docs: update OAuth URI list parsing comment for clarity

--- a/apps/meteor/app/oauth2-server-config/server/admin/functions/parseUriList.ts
+++ b/apps/meteor/app/oauth2-server-config/server/admin/functions/parseUriList.ts
@@ -13,5 +13,5 @@ export const parseUriList = (userUri: string) => {
 		uriList.push(uri);
 	});
 
-	return uriList.join(','); // TODO: This is a hack because the original code was returning a string or an array of strings
+	return uriList.join(','); // Normalize to a comma-delimited string for consistent storage.
 };


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This pull request improves code documentation by replacing an outdated `TODO` comment in the OAuth URI parsing logic with a more accurate and professional description of the function's behavior.

Specifically, in `apps/meteor/app/oauth2-server-config/server/admin/functions/parseUriList.ts`, the comment explaining the `.join(',')` operation was updated. Previously, it incorrectly labeled the join operation as a "hack". The new comment correctly clarifies that the function normalizes the input into a comma-delimited string to ensure consistent storage formats for OAuth redirect URIs.

A changeset has been included for this documentation update.

## Issue(s)

<!-- Since this is a code documentation cleanup, you can leave this blank -->

## Steps to test or reproduce

No testing required as this is a comment-only documentation fix that does not alter any logic.

## Further comments

This change was originally part of a larger PR (#38476) but has been split into this atomic, single-concern PR to make the review process easier for maintainers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified OAuth URI configuration documentation to better reflect standard processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->