### PR TITLE
chore: add empty-message parser test and clarify OAuth URI normalization comment

### DIFF
--- a/.changeset/friendly-wombats-clarify.md
+++ b/.changeset/friendly-wombats-clarify.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Clarify the OAuth redirect URI normalization comment in `parseUriList`.

--- a/.changeset/test-empty-message-parse.md
+++ b/.changeset/test-empty-message-parse.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Test: add unit test for empty message parsing in `parseMessageTextToAstMarkdown`

--- a/apps/meteor/app/oauth2-server-config/server/admin/functions/parseUriList.ts
+++ b/apps/meteor/app/oauth2-server-config/server/admin/functions/parseUriList.ts
@@ -13,5 +13,5 @@ export const parseUriList = (userUri: string) => {
 		uriList.push(uri);
 	});
 
-	return uriList.join(','); // TODO: This is a hack because the original code was returning a string or an array of strings
+	return uriList.join(','); // Normalize the input into a comma-delimited string so redirect URIs are stored consistently.
 };

--- a/apps/meteor/client/lib/parseMessageTextToAstMarkdown.spec.ts
+++ b/apps/meteor/client/lib/parseMessageTextToAstMarkdown.spec.ts
@@ -145,6 +145,15 @@ describe('parseMessageTextToAstMarkdown', () => {
 		);
 	});
 
+	it('should return an empty md array for empty messages', () => {
+		const emptyMessage: IMessage = {
+			...baseMessage,
+			msg: '',
+		};
+
+		expect(parseMessageTextToAstMarkdown(emptyMessage, parseOptions, autoTranslateOptions).md).toStrictEqual([]);
+	});
+
 	describe('translated', () => {
 		const translatedMessage: ITranslatedMessage = {
 			...baseMessage,


### PR DESCRIPTION
This pull request introduces a clarification to the OAuth redirect URI normalization comment and adds a unit test to improve coverage for empty message parsing. The most important changes are summarized below:

**Comment Clarification**

* Clarified the comment in `parseUriList` to explain that redirect URIs are normalized into a comma-delimited string for consistent storage. [[1]](diffhunk://#diff-eb43f64ecf8f36c6ab57e0287e82e12fb98d5d30daa732ad1bcd0135d439d3a4L16-R16) [[2]](diffhunk://#diff-42122f1bb2d133f0a98da67028dd330364f437536f4b714505f05b632684d00dR1-R5)

**Testing Improvements**

* Added a unit test in `parseMessageTextToAstMarkdown.spec.ts` to verify that empty messages result in an empty markdown (`md`) array, ensuring correct handling of this edge case. [[1]](diffhunk://#diff-bba35711877548e90cddb61443527d3702c43e49077829f7025702e42dbab0ebR148-R156) [[2]](diffhunk://#diff-9ea7ea02e56287d30dcc2f5ed035b43080f888d8a43cab64df3a2abf1e140935R1-R5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for empty message parsing scenarios to ensure proper edge case handling.

* **Documentation**
  * Clarified inline documentation regarding OAuth redirect URI normalization and storage formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->