### PR TITLE
test: add empty-message parsing coverage for markdown AST

### DIFF
--- a/.changeset/test-empty-message-parse.md
+++ b/.changeset/test-empty-message-parse.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Test: add unit test for empty message parsing in `parseMessageTextToAstMarkdown`

--- a/apps/meteor/client/lib/parseMessageTextToAstMarkdown.spec.ts
+++ b/apps/meteor/client/lib/parseMessageTextToAstMarkdown.spec.ts
@@ -145,6 +145,15 @@ describe('parseMessageTextToAstMarkdown', () => {
 		);
 	});
 
+	it('should return an empty md array for empty messages', () => {
+		const emptyMessage: IMessage = {
+			...baseMessage,
+			msg: '',
+		};
+
+		expect(parseMessageTextToAstMarkdown(emptyMessage, parseOptions, autoTranslateOptions).md).toStrictEqual([]);
+	});
+
 	describe('translated', () => {
 		const translatedMessage: ITranslatedMessage = {
 			...baseMessage,


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR adds a focused unit test for message parsing behavior when the input message text is empty.

Changes included:
1. Added a test case in apps/meteor/client/lib/parseMessageTextToAstMarkdown.spec.ts to verify an empty message (`msg: ''`) produces an empty `md` array.
2. Added a patch changeset in .changeset/test-empty-message-parse.md.

Why this is useful:
1. Covers an edge case explicitly.
2. Prevents regressions in markdown parsing behavior for empty messages.
3. Improves confidence in parser output consistency.

## Issue(s)

N/A

## Steps to test or reproduce

1. Run the relevant test suite for message parsing.
2. Confirm the new test `should return an empty md array for empty messages` passes.

## Further comments

This is a test-only change and does not modify parser runtime logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test coverage for empty message parsing scenarios to ensure reliable handling of edge cases in message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->