### PR TITLE
regression: hide system messages toggle in edit room not clearing existing filters

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/EditRoomInfo.spec.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/EditRoomInfo.spec.tsx
@@ -1,0 +1,174 @@
+import type { IRoomWithRetentionPolicy } from '@rocket.chat/core-typings';
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import EditRoomInfo from './EditRoomInfo';
+import { createFakeRoom } from '../../../../../../tests/mocks/data';
+
+jest.mock('../../../../../lib/rooms/roomCoordinator', () => ({
+	roomCoordinator: {
+		getRoomDirectives: () => ({
+			allowRoomSettingChange: () => true,
+		}),
+		getRoomName: (_t: string, room: { name?: string }) => room.name ?? 'test-room',
+	},
+}));
+
+jest.mock('../../../../../components/avatar/RoomAvatarEditor', () => ({
+	__esModule: true,
+	default: () => null,
+}));
+
+const noop = () => undefined;
+
+const createRoom = (sysMes?: string[]) =>
+	createFakeRoom<IRoomWithRetentionPolicy>({
+		t: 'c',
+		name: 'test-room',
+		...(sysMes && { sysMes: sysMes as IRoomWithRetentionPolicy['sysMes'] }),
+	});
+
+const buildAppRoot = (saveFn: jest.Mock, room: IRoomWithRetentionPolicy) =>
+	mockAppRoot()
+		.withJohnDoe()
+		.withPermission('edit-room')
+		.withEndpoint('POST', '/v1/rooms.saveRoomSettings', saveFn as never)
+		.withEndpoint('POST', '/v1/rooms.changeArchivationState', () => ({ success: true }) as never)
+		.withEndpoint('GET', '/v1/rooms.nameExists', () => ({ exists: false }) as never)
+		.withSetting('UTF8_Channel_Names_Validation', '[0-9a-zA-Z-_.]+')
+		.withSetting('UI_Allow_room_names_with_special_chars', true)
+		.withSetting('RetentionPolicy_Enabled', false)
+		.withTranslations('en', 'core', {
+			Save: 'Save',
+			Hide_System_Messages: 'Hide system messages',
+			Advanced_settings: 'Advanced settings',
+			Select_messages_to_hide: 'Select messages to hide',
+		})
+		.withRoom(room)
+		.build();
+
+const openAdvancedSettings = async () => {
+	await userEvent.click(await screen.findByRole('button', { name: /Advanced settings/i }));
+};
+
+const findHideSysMesToggle = () => screen.findByLabelText(/Hide system messages/i);
+
+const clickSave = async () => {
+	await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+};
+
+const removeSystemMessageChip = async (translationKey: string) => {
+	const chip = screen.getByRole('button', { name: new RegExp(translationKey, 'i') });
+	await userEvent.click(chip);
+};
+
+const selectSystemMessageOption = async (translationKey: string) => {
+	const trigger = screen.getByRole('button', { name: /Select messages to hide/i });
+	await userEvent.click(trigger);
+
+	const listboxes = await screen.findAllByRole('listbox', { hidden: true });
+	const listbox = listboxes.find((el) => within(el).queryAllByRole('option', { hidden: true }).length > 0);
+
+	if (!listbox) {
+		throw new Error('Could not find a listbox containing options');
+	}
+
+	const optionEl = within(listbox).getByText(translationKey).closest('li[role="option"]');
+
+	if (!optionEl) {
+		throw new Error(`Could not find option with text "${translationKey}"`);
+	}
+
+	await userEvent.click(optionEl);
+};
+
+it('should send systemMessages: [] when hideSysMes is toggled OFF', async () => {
+	const saveFn = jest.fn((_data: Record<string, unknown>) => ({ rid: 'room-id', success: true }));
+	const room = createRoom(['au', 'ru']);
+
+	render(<EditRoomInfo room={room} onClickClose={noop} onClickBack={noop} />, { wrapper: buildAppRoot(saveFn, room) });
+	await openAdvancedSettings();
+
+	const toggle = await findHideSysMesToggle();
+	expect(toggle).toBeChecked();
+
+	await userEvent.click(toggle);
+	expect(toggle).not.toBeChecked();
+
+	await clickSave();
+	await waitFor(() => expect(saveFn).toHaveBeenCalled());
+
+	expect(saveFn.mock.calls[0][0]).toEqual(expect.objectContaining({ systemMessages: [] }));
+});
+
+it('should send selected systemMessages when user selects message types to hide', async () => {
+	const saveFn = jest.fn((_data: Record<string, unknown>) => ({ rid: 'room-id', success: true }));
+	const room = createRoom();
+
+	render(<EditRoomInfo room={room} onClickClose={noop} onClickBack={noop} />, { wrapper: buildAppRoot(saveFn, room) });
+	await openAdvancedSettings();
+
+	const toggle = await findHideSysMesToggle();
+	await userEvent.click(toggle);
+	expect(toggle).toBeChecked();
+
+	await selectSystemMessageOption('Message_HideType_au');
+
+	await clickSave();
+	await waitFor(() => expect(saveFn).toHaveBeenCalled());
+
+	expect(saveFn.mock.calls[0][0]).toEqual(expect.objectContaining({ systemMessages: expect.arrayContaining(['au']) }));
+});
+
+it('should send existing systemMessages when toggle is turned ON without changing selection', async () => {
+	const saveFn = jest.fn((_data: Record<string, unknown>) => ({ rid: 'room-id', success: true }));
+	const room = createRoom();
+
+	render(<EditRoomInfo room={room} onClickClose={noop} onClickBack={noop} />, { wrapper: buildAppRoot(saveFn, room) });
+	await openAdvancedSettings();
+
+	const toggle = await findHideSysMesToggle();
+	expect(toggle).not.toBeChecked();
+
+	await userEvent.click(toggle);
+	expect(toggle).toBeChecked();
+
+	await clickSave();
+	await waitFor(() => expect(saveFn).toHaveBeenCalled());
+
+	expect(saveFn.mock.calls[0][0]).toEqual(expect.objectContaining({ systemMessages: [] }));
+});
+
+it('should send updated systemMessages when only the multi-select is changed', async () => {
+	const saveFn = jest.fn((_data: Record<string, unknown>) => ({ rid: 'room-id', success: true }));
+	const room = createRoom(['ru']);
+
+	render(<EditRoomInfo room={room} onClickClose={noop} onClickBack={noop} />, { wrapper: buildAppRoot(saveFn, room) });
+	await openAdvancedSettings();
+
+	const toggle = await findHideSysMesToggle();
+	expect(toggle).toBeChecked();
+
+	await removeSystemMessageChip('Message_HideType_ru');
+	await selectSystemMessageOption('Message_HideType_au');
+
+	await clickSave();
+	await waitFor(() => expect(saveFn).toHaveBeenCalled());
+
+	expect(saveFn.mock.calls[0][0]).toEqual(expect.objectContaining({ systemMessages: expect.arrayContaining(['au']) }));
+});
+
+it('should NOT send systemMessages when something else changed', async () => {
+	const saveFn = jest.fn((_data: Record<string, unknown>) => ({ rid: 'room-id', success: true }));
+	const room = createRoom(['au']);
+
+	render(<EditRoomInfo room={room} onClickClose={noop} onClickBack={noop} />, { wrapper: buildAppRoot(saveFn, room) });
+
+	await userEvent.type(await screen.findByRole('textbox', { name: 'Topic' }), 'new topic');
+
+	await clickSave();
+	await waitFor(() => expect(saveFn).toHaveBeenCalled());
+
+	expect(saveFn.mock.calls[0][0]).not.toHaveProperty('systemMessages');
+});

--- a/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/EditRoomInfo.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/EditRoomInfo.tsx
@@ -170,10 +170,9 @@ const EditRoomInfo = ({ room, onClickClose, onClickBack }: EditRoomInfoProps) =>
 					rid: room._id,
 					...data,
 					...((data.joinCode || 'joinCodeRequired' in data) && { joinCode: joinCodeRequired ? data.joinCode : '' }),
-					...(data.systemMessages &&
-						!hideSysMes && {
-							systemMessages: data.systemMessages,
-						}),
+					...((dirtyFields.hideSysMes || dirtyFields.systemMessages) && {
+						systemMessages: hideSysMes ? data.systemMessages ?? defaultValues.systemMessages : [],
+					}),
 					retentionEnabled,
 					retentionOverrideGlobal,
 					...(retentionEnabled &&

--- a/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/EditRoomInfo.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/EditRoomInfo.tsx
@@ -171,7 +171,7 @@ const EditRoomInfo = ({ room, onClickClose, onClickBack }: EditRoomInfoProps) =>
 					...data,
 					...((data.joinCode || 'joinCodeRequired' in data) && { joinCode: joinCodeRequired ? data.joinCode : '' }),
 					...((dirtyFields.hideSysMes || dirtyFields.systemMessages) && {
-						systemMessages: hideSysMes ? data.systemMessages ?? defaultValues.systemMessages : [],
+						systemMessages: hideSysMes ? (data.systemMessages ?? defaultValues.systemMessages) : [],
 					}),
 					retentionEnabled,
 					retentionOverrideGlobal,


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Fixes a regression where disabling the "Hide System Messages" toggle in Room Info Edit does not clear previously selected system message filters.

Introduced in PR #39553 refactored the `systemMessages` payload logic in `EditRoomInfo.tsx` from:

```typescript
...((data.systemMessages || !hideSysMes) && {
    systemMessages: hideSysMes && data.systemMessages,
}),
```

to:

```typescript
...(data.systemMessages &&
    !hideSysMes && {
        systemMessages: data.systemMessages,
    }),
```

This new logic **never fires when the toggle is turned off**, because `data.systemMessages` (dirty multi-select) and `!hideSysMes` (toggle off) are contradictory — the multi-select is disabled when the toggle is off, so `systemMessages` is never dirty in that state. The backend requires the `systemMessages` key to be present in the payload to trigger the update, so omitting it silently skips the clear.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

[CORE-2130](https://rocketchat.atlassian.net/browse/CORE-2130)

[CORE-2130]: https://rocketchat.atlassian.net/browse/CORE-2130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room info save behavior for system-message visibility: toggling hide now correctly records an explicit empty selection when disabled, sends selected message types when enabled, and only includes these settings when they were changed.

* **Tests**
  * Added tests covering hide-toggle and multi-select combinations, ensuring save requests reflect the expected system-message payloads across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->