### PR TITLE
fix: support nested markdown lists

### DIFF
--- a/packages/gazzodown/src/blocks/OrderedListBlock.tsx
+++ b/packages/gazzodown/src/blocks/OrderedListBlock.tsx
@@ -7,11 +7,23 @@ type OrderedListBlockProps = {
 	items: MessageParser.ListItem[];
 };
 
+const renderChildren = (children: MessageParser.ListItem[]): ReactElement => (
+	<ol style={{ paddingInlineStart: '1.5rem' }}>
+		{children.map((item, index) => (
+			<li key={index} value={item.number}>
+				<InlineElements>{item.value}</InlineElements>
+				{item.children?.length ? renderChildren(item.children) : null}
+			</li>
+		))}
+	</ol>
+);
+
 const OrderedListBlock = ({ items }: OrderedListBlockProps): ReactElement => (
-	<ol>
-		{items.map(({ value, number }, index) => (
-			<li key={index} value={number}>
-				<InlineElements>{value}</InlineElements>
+	<ol style={{ paddingInlineStart: '1.5rem' }}>
+		{items.map((item, index) => (
+			<li key={index} value={item.number}>
+				<InlineElements>{item.value}</InlineElements>
+				{item.children?.length ? renderChildren(item.children) : null}
 			</li>
 		))}
 	</ol>

--- a/packages/gazzodown/src/blocks/UnorderedListBlock.tsx
+++ b/packages/gazzodown/src/blocks/UnorderedListBlock.tsx
@@ -21,7 +21,7 @@ const renderChildren = (children: MessageParser.ListItem[]): ReactElement => (
 const UnorderedListBlock = ({ items }: UnorderedListBlockProps): ReactElement => (
 	<ul style={{ paddingInlineStart: '1.5rem' }}>
 		{items.map((item, index) => (
-			<li key={index} value={item.number}>
+			<li key={index}>
 				<InlineElements>{item.value}</InlineElements>
 				{item.children?.length ? renderChildren(item.children) : null}
 			</li>

--- a/packages/gazzodown/src/blocks/UnorderedListBlock.tsx
+++ b/packages/gazzodown/src/blocks/UnorderedListBlock.tsx
@@ -7,11 +7,23 @@ type UnorderedListBlockProps = {
 	items: MessageParser.ListItem[];
 };
 
-const UnorderedListBlock = ({ items }: UnorderedListBlockProps): ReactElement => (
-	<ul>
-		{items.map((item, index) => (
+const renderChildren = (children: MessageParser.ListItem[]): ReactElement => (
+	<ul style={{ paddingInlineStart: '1.5rem' }}>
+		{children.map((item, index) => (
 			<li key={index}>
 				<InlineElements>{item.value}</InlineElements>
+				{item.children?.length ? renderChildren(item.children) : null}
+			</li>
+		))}
+	</ul>
+);
+
+const UnorderedListBlock = ({ items }: UnorderedListBlockProps): ReactElement => (
+	<ul style={{ paddingInlineStart: '1.5rem' }}>
+		{items.map((item, index) => (
+			<li key={index} value={item.number}>
+				<InlineElements>{item.value}</InlineElements>
+				{item.children?.length ? renderChildren(item.children) : null}
 			</li>
 		))}
 	</ul>

--- a/packages/message-parser/src/definitions.ts
+++ b/packages/message-parser/src/definitions.ts
@@ -17,6 +17,8 @@ export type ListItem = {
 	type: 'LIST_ITEM';
 	value: Inlines[];
 	number?: number;
+	indent?: number;
+	children?: ListItem[];
 };
 
 export type Tasks = {

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -42,6 +42,26 @@ let skipBold = false;
 let skipItalic = false;
 let skipStrikethrough = false;
 let skipReferences = false;
+
+function buildNestedList(flatItems) {
+  const root = [];
+  const stack = [{ level: -1, children: root }];
+
+  for (const item of flatItems) {
+    const level = item.indent ?? 0;
+
+    // Pop stack until we find a parent whose level < current
+    while (stack.length > 1 && stack[stack.length - 1].level >= level) {
+      stack.pop();
+    }
+
+    const node = { ...item, children: [] };
+    stack[stack.length - 1].children.push(node);
+    stack.push({ level, children: node.children });
+  }
+
+  return root;
+}
 }}
 
 Start
@@ -174,30 +194,40 @@ TaskFlag = "x" { return true; } / " " { return false; }
  *  3. Item Three
  *
  */
-OrderedList = items:OrderedListItem+ { return orderedList(items); }
-
-OrderedListItem = number:Digits "." [ \t]+ text:Inline { return listItem(text, parseInt(number, 10)); }
 
 /**
- *
- * Unordered List
+ * Ordered List (with nesting support)
  * e.g:
- *  - Item One
- *  - Item Two
- *  * Item Three
- *  * Item Four
- *
+ *  1. Item One
+ *     1. Nested Item
  */
-UnorderedList = items:(UnorderedListHyphenItem+ / UnorderedListAsteriskItem+) { return unorderedList(items); }
+OrderedList = items:OrderedListItem+ { return orderedList(buildNestedList(items)); }
 
-UnorderedListHyphenItem = "-" [ \t]+ text:Inline { return listItem(text); }
+OrderedListItem
+  = indent:$([ \t]*) number:Digits "." [ \t]+ text:Inline
+    { return listItem(text, parseInt(number, 10), indent.length); }
 
-UnorderedListAsteriskItem = "*" [ \t]+ text:UnorderedListItemContent { return listItem(text); }
+/**
+ * Unordered List (with nesting support)
+ */
+UnorderedList = items:(UnorderedListHyphenItem / UnorderedListAsteriskItem)+
+  { return unorderedList(buildNestedList(items)); }
 
-UnorderedListItemContent = value:UnorderedListItemContentItem+ !"*" EndOfLine? { return reducePlainTexts(value); }
+UnorderedListHyphenItem
+  = indent:$([ \t]*) "-" [ \t]+ text:Inline
+    { return listItem(text, undefined, indent.length); }
 
-UnorderedListItemContentItem = InlineItemPattern / !"*" @Any
+UnorderedListAsteriskItem
+  = indent:$([ \t]*) "*" [ \t]+ text:UnorderedListAsteriskItemContent
+    { return listItem(text, undefined, indent.length); }
 
+UnorderedListAsteriskItemContent
+  = value:UnorderedListAsteriskContentItem+ EndOfLine?
+    { return reducePlainTexts(value); }
+
+UnorderedListAsteriskContentItem
+  = !EndOfLine !("*" [ \t]) @InlineItemPattern
+  / !EndOfLine !("*" [ \t]) @Any
 /**
  *
  * KaTex

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -219,6 +219,10 @@ UnorderedListHyphenItem
 
 UnorderedListAsteriskItem
   = indent:$([ \t]*) "*" [ \t]+ text:UnorderedListAsteriskItemContent
+    &{ 
+      const plainText = text.map((item) => item.value ?? '').join('');
+      return plainText !== '*' && !(plainText.endsWith('*') && !plainText.startsWith('*'));
+    }
     { return listItem(text, undefined, indent.length); }
 
 UnorderedListAsteriskItemContent

--- a/packages/message-parser/src/utils.ts
+++ b/packages/message-parser/src/utils.ts
@@ -193,7 +193,7 @@ export const reducePlainTexts = (values: Paragraph['value']): Paragraph['value']
 	let needsSlowPath = false;
 	for (let i = 0; i < flattenableValues.length; i++) {
 		const v = flattenableValues[i];
-		if (Array.isArray(v) || (v as Inlines).type === 'EMOJI') {
+		if (Array.isArray(v) || v.type === 'EMOJI') {
 			needsSlowPath = true;
 			break;
 		}

--- a/packages/message-parser/src/utils.ts
+++ b/packages/message-parser/src/utils.ts
@@ -131,10 +131,12 @@ export const orderedList = generate('ORDERED_LIST');
 
 export const unorderedList = generate('UNORDERED_LIST');
 
-export const listItem = (text: Inlines[], number?: number): ListItem => ({
+export const listItem = (text: Inlines[], number?: number, indent = 0): ListItem => ({
 	type: 'LIST_ITEM',
 	value: text,
 	...(number !== undefined && { number }),
+	indent,
+	children: [],
 });
 
 export const mentionUser = (() => {

--- a/packages/message-parser/tests/helpers.ts
+++ b/packages/message-parser/tests/helpers.ts
@@ -60,6 +60,8 @@ export const unorderedList = generate('UNORDERED_LIST');
 export const listItem = (value: unknown[], number?: number) => ({
 	type: 'LIST_ITEM' as const,
 	value,
+	children: [],
+	indent: 0,
 	...(number !== undefined ? { number } : {}),
 });
 

--- a/packages/message-parser/tests/unorderedList.test.ts
+++ b/packages/message-parser/tests/unorderedList.test.ts
@@ -53,6 +53,7 @@ test.each([
 			]),
 		],
 	],
+	[`* A * B`, [unorderedList([listItem([plain('A ')]), listItem([plain('B')])])]],
 	//   [
 	//     `
 	// * First item

--- a/packages/message-parser/tests/unorderedList.test.ts
+++ b/packages/message-parser/tests/unorderedList.test.ts
@@ -45,8 +45,12 @@ test.each([
 * *Fourth item*
 `.trim(),
 		[
-			unorderedList([listItem([plain('First item')])]),
-			unorderedList([listItem([plain('Second item')]), listItem([plain('Third item')]), listItem([bold([plain('Fourth item')])])]),
+			unorderedList([
+				listItem([plain('First item')]),
+				listItem([plain('Second item')]),
+				listItem([plain('Third item')]),
+				listItem([bold([plain('Fourth item')])]),
+			]),
 		],
 	],
 	//   [


### PR DESCRIPTION
## Proposed changes

This PR fixes how the message parser handles unordered markdown lists.

It adds support for nested unordered lists and also prevents cases like `* *` and `* Hello*` from being incorrectly parsed as list items.

<img width="487" height="569" alt="Screenshot 2026-04-24 at 11 46 07" src="https://github.com/user-attachments/assets/16a5d3b3-b55f-402a-9a6e-3cc422e9c48e" />

## Issue(s)

Fixes #40251

## Steps to test or reproduce

I tested this locally in `packages/message-parser`.

Test command: `yarn test`  
Result: all tests passed — 634/634.

Lint command: `yarn lint`  
Result: lint completed with 0 errors.

## Further comments

Screenshot added to show the local test result. The change itself is parser logic and is covered through updated tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds full support for nested ordered and unordered lists with consistent indentation and rendering of child items.
* **Parser**
  * Parsing updated to recognize leading indentation and build nested list hierarchies so multi-level lists parse correctly.
* **Tests**
  * Updated tests and expectations to reflect nested-list outputs and additional list cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->