### PR TITLE
regression: mobile app shows incorrect "on hold" state on voice calls

### DIFF
--- a/packages/media-signaling/src/definition/services/webrtc/IWebRTCProcessor.ts
+++ b/packages/media-signaling/src/definition/services/webrtc/IWebRTCProcessor.ts
@@ -13,6 +13,7 @@ export type WebRTCInternalStateMap = {
 	iceGathering: RTCIceGatheringState;
 	iceUntrickler: 'waiting' | 'not-waiting' | 'timeout';
 	remoteMute: boolean;
+	remoteHeld: boolean;
 };
 
 export type WebRTCUniqueEvents = {

--- a/packages/media-signaling/src/lib/services/webrtc/Processor.ts
+++ b/packages/media-signaling/src/lib/services/webrtc/Processor.ts
@@ -46,6 +46,8 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 
 	private _remoteMute = false;
 
+	private _remoteHeld = false;
+
 	private _dataChannelEnded = false;
 
 	constructor(private readonly config: WebRTCProcessorConfig) {
@@ -105,8 +107,7 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 		await this.initialization;
 
 		this.createDataChannel();
-		this.updateAudioDirectionBeforeNegotiation();
-		this.updateVideoDirectionBeforeNegotiation();
+		this.processPreNegotiation();
 
 		if (iceRestart) {
 			this.restartIce();
@@ -186,8 +187,7 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 		await this.peer.setLocalDescription(sdp);
 
 		if (sdp.type === 'answer') {
-			this.updateAudioDirectionAfterNegotiation();
-			this.updateVideoDirectionAfterNegotiation();
+			this.processPostNegotiation();
 		}
 	}
 
@@ -204,15 +204,13 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 		}
 
 		if (sdp.type === 'offer') {
-			this.updateAudioDirectionBeforeNegotiation();
-			this.updateVideoDirectionBeforeNegotiation();
+			this.processPreNegotiation();
 		}
 
 		await this.peer.setRemoteDescription(sdp);
 
 		if (sdp.type === 'answer') {
-			this.updateAudioDirectionAfterNegotiation();
-			this.updateVideoDirectionAfterNegotiation();
+			this.processPostNegotiation();
 		}
 	}
 
@@ -233,6 +231,8 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 				return this.iceGatheringWaiters.size > 0 ? 'waiting' : 'not-waiting';
 			case 'remoteMute':
 				return this._remoteMute;
+			case 'remoteHeld':
+				return this._remoteHeld;
 		}
 	}
 
@@ -247,30 +247,7 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 	}
 
 	public isRemoteHeld(): boolean {
-		if (this.stopped) {
-			return false;
-		}
-
-		if (['closed', 'failed', 'new'].includes(this.peer.connectionState)) {
-			return false;
-		}
-
-		let anyTransceiverNotSending = false;
-		const transceivers = this.getTransceivers('audio');
-
-		for (const transceiver of transceivers) {
-			if (!transceiver.currentDirection || transceiver.currentDirection === 'stopped') {
-				continue;
-			}
-
-			if (transceiver.currentDirection.includes('send')) {
-				return false;
-			}
-
-			anyTransceiverNotSending = true;
-		}
-
-		return anyTransceiverNotSending;
+		return this._remoteHeld;
 	}
 
 	public isRemoteMute(): boolean {
@@ -597,9 +574,58 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 		this.emitter.emit('internalStateChange', 'remoteMute');
 	}
 
+	private setRemoteHeld(held: boolean): void {
+		if (held === this._remoteHeld) {
+			return;
+		}
+
+		this._remoteHeld = held;
+		this.config.logger?.debug('MediaCallWebRTCProcessor.setRemoteHeld', held);
+		this.emitter.emit('internalStateChange', 'remoteHeld');
+	}
+
 	private updateMuteForRemote(): void {
 		const command: P2PCommand = this._muted ? 'mute' : 'unmute';
 		this.sendP2PCommand(command);
+	}
+
+	private processPreNegotiation(): void {
+		this.updateAudioDirectionBeforeNegotiation();
+		this.updateVideoDirectionBeforeNegotiation();
+	}
+
+	private processPostNegotiation(): void {
+		this.updateAudioDirectionAfterNegotiation();
+		this.updateVideoDirectionAfterNegotiation();
+		this.updateRemoteHeld();
+	}
+
+	private updateRemoteHeld(): void {
+		if (this.stopped) {
+			return;
+		}
+
+		if (['closed', 'failed', 'new'].includes(this.peer.connectionState)) {
+			return;
+		}
+
+		let anyTransceiverNotSending = false;
+		const transceivers = this.getTransceivers('audio');
+
+		for (const transceiver of transceivers) {
+			if (!transceiver.currentDirection || transceiver.currentDirection === 'stopped') {
+				continue;
+			}
+
+			if (transceiver.currentDirection.includes('send')) {
+				this.setRemoteHeld(false);
+				return;
+			}
+
+			anyTransceiverNotSending = true;
+		}
+
+		this.setRemoteHeld(anyTransceiverNotSending);
 	}
 
 	private registerPeerEvents() {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
We update the "on hold" status whenever an internal webrtc state changes and we determine if the call is on hold based on the currentDirection attribute of the RTCRtpTransceiver. 
This works fine on web, but on the mobile implementation of webrtc, the transceiver's currentDirection is only updated after the state change event is emitted, so we were updating the "on hold" status based on the previous direction instead of the current one. 

This PR changes it so that the "on hold" status is always updated at the end of any negotiation, instead of immediately after it becomes stable.


## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[VMUX-94](https://rocketchat.atlassian.net/browse/VMUX-94)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[VMUX-94]: https://rocketchat.atlassian.net/browse/VMUX-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced detection of remote-held state in WebRTC connections.

* **Performance**
  * Optimized remote-held state tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->