### PR TITLE
feat(desktop-api): add openInBrowser to IRocketChatDesktop

### DIFF
--- a/.changeset/desktop-api-open-in-browser.md
+++ b/.changeset/desktop-api-open-in-browser.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/desktop-api': minor
+---
+
+Add optional `openInBrowser(url)` method to `IRocketChatDesktop`. Desktop clients can expose this to let the server frontend request that a URL be opened in the user's native browser instead of inside the Electron webview — used by flows that must leave the app, such as phishing-resistant MFA redirects to external identity providers.

--- a/packages/desktop-api/src/index.ts
+++ b/packages/desktop-api/src/index.ts
@@ -62,5 +62,6 @@ export interface IRocketChatDesktop {
 	clearOutlookCredentials: () => void;
 	setUserToken: (token: string, userId: string) => void;
 	openDocumentViewer: (url: string, format: string, options: any) => void;
+	openInBrowser?: (url: string) => void;
 	reloadServer: () => void;
 }


### PR DESCRIPTION
## Proposed changes

Declares an optional `openInBrowser(url: string): void` method on `IRocketChatDesktop` so the server frontend can ask the desktop (Electron) app to open a URL in the user's native browser instead of inside the Electron webview.

Implemented on the desktop side in RocketChat/Rocket.Chat.Electron#3310 — the preload validates `http:` / `https:` only and routes through the existing `browserLauncher.openExternal` path so the user's selected-browser setting is honored.

Optional modifier (`openInBrowser?`) keeps older desktop-app versions type-compatible; frontend callers must null-check.

## Why this targets `feat/phishing-resistant-mfa`

Phishing-resistant MFA redirects users to external identity providers. When running inside the desktop app, those redirects should open in the system browser (so passkeys / platform authenticators resolve correctly) instead of the embedded webview.

This PR only declares the type so the MFA branch can begin using it in a follow-up commit — call-site integration is deliberately out of scope here.

## Issue(s)

N/A — type-surface addition.

## Steps to test or reproduce

- `yarn workspace @rocket.chat/desktop-api typecheck`
- `yarn changeset status`

## Further comments

Changeset included. Depends on a `@rocket.chat/desktop-api` publish with this method before the MFA call site can compile without an any-cast, but the optional modifier means no consumer is forced to update immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added optional capability to open URLs in the system browser instead of within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
[PRM-34]

[PRM-34]: https://rocketchat.atlassian.net/browse/PRM-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ