### PR TITLE
regression: `moment` compatibility for admin date format settings

### DIFF
--- a/apps/meteor/client/lib/utils/dateFormat.spec.ts
+++ b/apps/meteor/client/lib/utils/dateFormat.spec.ts
@@ -1,0 +1,43 @@
+import { formatDate, momentFormatToDateFns } from './dateFormat';
+
+describe('momentFormatToDateFns', () => {
+	it('maps locale tokens', () => {
+		expect(momentFormatToDateFns('L')).toBe('P');
+		expect(momentFormatToDateFns('LT')).toBe('p');
+		expect(momentFormatToDateFns('LTS')).toBe('pp');
+		expect(momentFormatToDateFns('LL')).toBe('PPP');
+		expect(momentFormatToDateFns('LLL')).toBe('PPP p');
+		expect(momentFormatToDateFns('LLLL')).toBe('EEEE, PPP p');
+	});
+
+	it('maps common tokens', () => {
+		expect(momentFormatToDateFns('YYYY-MM-DD HH:mm:ss')).toBe('yyyy-MM-dd HH:mm:ss');
+		expect(momentFormatToDateFns('MMMM Do YYYY, h:mm:ss a')).toBe('MMMM do yyyy, h:mm:ss a');
+	});
+
+	it('translates moment [literal] escape to date-fns single-quoted literal', () => {
+		expect(momentFormatToDateFns('[Today at] LT')).toBe("'Today at' p");
+		expect(momentFormatToDateFns('[Session started at] HH:mm [on] LL')).toBe("'Session started at' HH:mm 'on' PPP");
+	});
+
+	it("escapes embedded single quotes inside literals as ''", () => {
+		expect(momentFormatToDateFns("[it's] LT")).toBe("'it''s' p");
+	});
+
+	it('preserves empty literal blocks', () => {
+		expect(momentFormatToDateFns('[] LT')).toBe("'' p");
+	});
+});
+
+describe('formatDate', () => {
+	const sample = new Date('2026-04-24T20:30:45');
+
+	it('formats literal blocks with locale tokens without throwing', () => {
+		expect(() => formatDate(sample, '[Today at] LT')).not.toThrow();
+		expect(formatDate(sample, '[Today at] LT')).toMatch(/^Today at /);
+	});
+
+	it('formats date with year-month-day token string', () => {
+		expect(formatDate(sample, 'YYYY-MM-DD')).toBe('2026-04-24');
+	});
+});

--- a/apps/meteor/client/lib/utils/dateFormat.spec.ts
+++ b/apps/meteor/client/lib/utils/dateFormat.spec.ts
@@ -24,8 +24,22 @@ describe('momentFormatToDateFns', () => {
 		expect(momentFormatToDateFns("[it's] LT")).toBe("'it''s' p");
 	});
 
-	it('preserves empty literal blocks', () => {
-		expect(momentFormatToDateFns('[] LT')).toBe("'' p");
+	it('drops empty literal blocks since date-fns has no empty-string syntax', () => {
+		// In date-fns, '' represents a literal apostrophe, not an empty string.
+		expect(momentFormatToDateFns('[] LT')).toBe(' p');
+	});
+
+	it('quotes letters that are not Moment tokens (T in ISO 8601 separator)', () => {
+		// In Moment, T is a literal; in date-fns T = ms timestamp. Must quote.
+		expect(momentFormatToDateFns('YYYY-MM-DDTHH:mm:ss')).toBe("yyyy-MM-dd'T'HH:mm:ss");
+	});
+
+	it('maps Moment timezone offset tokens to date-fns equivalents', () => {
+		expect(momentFormatToDateFns('Z')).toBe('xxx');
+		expect(momentFormatToDateFns('ZZ')).toBe('xx');
+		expect(momentFormatToDateFns('Z ZZ')).toBe('xxx xx');
+		expect(momentFormatToDateFns('LT Z')).toBe('p xxx');
+		expect(momentFormatToDateFns('YYYY-MM-DDTHH:mm:ssZ')).toBe("yyyy-MM-dd'T'HH:mm:ssxxx");
 	});
 });
 
@@ -39,5 +53,20 @@ describe('formatDate', () => {
 
 	it('formats date with year-month-day token string', () => {
 		expect(formatDate(sample, 'YYYY-MM-DD')).toBe('2026-04-24');
+	});
+
+	it('keeps the ISO 8601 T as a literal instead of inserting a ms timestamp', () => {
+		expect(formatDate(sample, 'YYYY-MM-DDTHH:mm:ss')).toBe('2026-04-24T20:30:45');
+	});
+
+	it('does not throw on Moment timezone tokens', () => {
+		expect(() => formatDate(sample, 'LT Z')).not.toThrow();
+		expect(() => formatDate(sample, 'Z ZZ')).not.toThrow();
+		expect(() => formatDate(sample, 'YYYY-MM-DDTHH:mm:ssZ')).not.toThrow();
+	});
+
+	it('falls back instead of crashing on a malformed format', () => {
+		// Unterminated bracket — translator buffers but date-fns may still refuse.
+		expect(() => formatDate(sample, '[unterminated')).not.toThrow();
 	});
 });

--- a/apps/meteor/client/lib/utils/dateFormat.spec.ts
+++ b/apps/meteor/client/lib/utils/dateFormat.spec.ts
@@ -34,6 +34,68 @@ describe('momentFormatToDateFns', () => {
 		expect(momentFormatToDateFns('YYYY-MM-DDTHH:mm:ss')).toBe("yyyy-MM-dd'T'HH:mm:ss");
 	});
 
+	it('maps day-of-year tokens (DDD, DDDo, DDDD)', () => {
+		expect(momentFormatToDateFns('DDD')).toBe('D');
+		expect(momentFormatToDateFns('DDDo')).toBe('Do');
+		expect(momentFormatToDateFns('DDDD')).toBe('DDD');
+	});
+
+	it('maps day-of-week ordinal (do)', () => {
+		expect(momentFormatToDateFns('do')).toBe('io');
+	});
+
+	it('maps the 6-digit padded year (YYYYYY)', () => {
+		expect(momentFormatToDateFns('YYYYYY')).toBe('yyyyyy');
+	});
+
+	it('maps timezone abbreviation tokens (z, zz)', () => {
+		expect(momentFormatToDateFns('z')).toBe('zzz');
+		expect(momentFormatToDateFns('zz')).toBe('zzz');
+	});
+
+	it('maps extended fractional-second tokens (SSSS…SSSSSSSSS)', () => {
+		expect(momentFormatToDateFns('SSSS')).toBe('SSSS');
+		expect(momentFormatToDateFns('SSSSSSSSS')).toBe('SSSSSSSSS');
+	});
+
+	it('maps era year (y) and era name (N…NNNNN)', () => {
+		expect(momentFormatToDateFns('y')).toBe('y');
+		expect(momentFormatToDateFns('N')).toBe('G');
+		expect(momentFormatToDateFns('NN')).toBe('GG');
+		expect(momentFormatToDateFns('NNN')).toBe('GGG');
+		expect(momentFormatToDateFns('NNNN')).toBe('GGGG');
+		expect(momentFormatToDateFns('NNNNN')).toBe('GGGGG');
+	});
+
+	it('maps lowercase locale variants (l, ll, lll, llll)', () => {
+		expect(momentFormatToDateFns('l')).toBe('P');
+		expect(momentFormatToDateFns('ll')).toBe('PP');
+		expect(momentFormatToDateFns('lll')).toBe('PP p');
+		expect(momentFormatToDateFns('llll')).toBe('EEE, PP p');
+	});
+
+	it('preserves tokens that are identical between Moment and date-fns (kk, Q, ww)', () => {
+		// Regression: these used to pass through unchanged; tokenizer now must list them
+		// explicitly so they aren't quoted as literals.
+		expect(momentFormatToDateFns('kk:mm')).toBe('kk:mm');
+		expect(momentFormatToDateFns('k:mm')).toBe('k:mm');
+		expect(momentFormatToDateFns('Q')).toBe('Q');
+		expect(momentFormatToDateFns('ww')).toBe('ww');
+	});
+
+	it('maps ISO week-of-year tokens (W, WW, Wo)', () => {
+		expect(momentFormatToDateFns('W')).toBe('I');
+		expect(momentFormatToDateFns('WW')).toBe('II');
+		expect(momentFormatToDateFns('Wo')).toBe('Io');
+	});
+
+	it('maps week-year tokens (gg/gggg locale, GG/GGGG ISO)', () => {
+		expect(momentFormatToDateFns('gg')).toBe('YY');
+		expect(momentFormatToDateFns('gggg')).toBe('YYYY');
+		expect(momentFormatToDateFns('GG')).toBe('RR');
+		expect(momentFormatToDateFns('GGGG')).toBe('RRRR');
+	});
+
 	it('maps Moment timezone offset tokens to date-fns equivalents', () => {
 		expect(momentFormatToDateFns('Z')).toBe('xxx');
 		expect(momentFormatToDateFns('ZZ')).toBe('xx');
@@ -51,10 +113,6 @@ describe('formatDate', () => {
 		expect(formatDate(sample, '[Today at] LT')).toMatch(/^Today at /);
 	});
 
-	it('formats date with year-month-day token string', () => {
-		expect(formatDate(sample, 'YYYY-MM-DD')).toBe('2026-04-24');
-	});
-
 	it('keeps the ISO 8601 T as a literal instead of inserting a ms timestamp', () => {
 		expect(formatDate(sample, 'YYYY-MM-DDTHH:mm:ss')).toBe('2026-04-24T20:30:45');
 	});
@@ -68,5 +126,12 @@ describe('formatDate', () => {
 	it('falls back instead of crashing on a malformed format', () => {
 		// Unterminated bracket — translator buffers but date-fns may still refuse.
 		expect(() => formatDate(sample, '[unterminated')).not.toThrow();
+	});
+
+	it('formats week-year tokens without throwing on date-fns Y warning', () => {
+		// date-fns refuses Y/YY/YYYY without useAdditionalWeekYearTokens — verify the
+		// option is wired through.
+		expect(() => formatDate(sample, 'gggg')).not.toThrow();
+		expect(formatDate(sample, 'gggg')).toMatch(/^\d{4}$/);
 	});
 });

--- a/apps/meteor/client/lib/utils/dateFormat.spec.ts
+++ b/apps/meteor/client/lib/utils/dateFormat.spec.ts
@@ -12,7 +12,13 @@ describe('momentFormatToDateFns', () => {
 
 	it('maps common tokens', () => {
 		expect(momentFormatToDateFns('YYYY-MM-DD HH:mm:ss')).toBe('yyyy-MM-dd HH:mm:ss');
-		expect(momentFormatToDateFns('MMMM Do YYYY, h:mm:ss a')).toBe('MMMM do yyyy, h:mm:ss a');
+		expect(momentFormatToDateFns('MMMM Do YYYY, h:mm:ss a')).toBe('MMMM do yyyy, h:mm:ss aaa');
+	});
+
+	it('preserves AM/PM casing (Moment A = uppercase, a = lowercase)', () => {
+		// date-fns `a` is always uppercase; `aaa` is lowercase. So Moment `a` → `aaa`.
+		expect(momentFormatToDateFns('A')).toBe('a');
+		expect(momentFormatToDateFns('a')).toBe('aaa');
 	});
 
 	it('translates moment [literal] escape to date-fns single-quoted literal', () => {

--- a/apps/meteor/client/lib/utils/dateFormat.ts
+++ b/apps/meteor/client/lib/utils/dateFormat.ts
@@ -5,6 +5,117 @@ export type DateInput = string | Date | number;
 
 const FALLBACK_FORMAT = 'PPP p'; // date-fns equivalent of moment's LLL
 
+const MOMENT_TO_DATE_FNS_TOKENS: ReadonlyArray<readonly [moment: string, dateFns: string]> = [
+	// Locale formats (longest first within each group)
+	['LLLL', 'EEEE, PPP p'],
+	['LTS', 'pp'],
+	['LLL', 'PPP p'],
+	['LL', 'PPP'],
+	['LT', 'p'],
+	['L', 'P'],
+	// Locale formats — short variants (Moment lowercase l = no zero-padding;
+	// date-fns has no equivalent without zero-padding, so PP/P is the closest match)
+	['llll', 'EEE, PP p'],
+	['lll', 'PP p'],
+	['ll', 'PP'],
+	['l', 'P'],
+	// Year
+	['YYYYYY', 'yyyyyy'], // 6-digit padded; Moment includes a +/- sign that date-fns omits
+	['YYYY', 'yyyy'],
+	['YY', 'yy'],
+	['Y', 'yyyy'],
+	['y', 'y'], // Moment lowercase y = era year (always positive); equivalent to calendar year for AD dates
+	// Era — Moment N/NN/NNN are abbreviated, NNNN wide, NNNNN narrow
+	['NNNNN', 'GGGGG'],
+	['NNNN', 'GGGG'],
+	['NNN', 'GGG'],
+	['NN', 'GG'],
+	['N', 'G'],
+	// Month
+	['MMMM', 'MMMM'],
+	['MMM', 'MMM'],
+	['MM', 'MM'],
+	['Mo', 'Mo'],
+	['M', 'M'],
+	// Day of month
+	['Do', 'do'],
+	['DD', 'dd'],
+	['D', 'd'],
+	// Day of year — needs `useAdditionalDayOfYearTokens` on date-fns
+	['DDDD', 'DDD'],
+	['DDDo', 'Do'],
+	['DDD', 'D'],
+	// Day of week
+	['dddd', 'EEEE'],
+	['ddd', 'EEE'],
+	['dd', 'EEEEEE'],
+	// Numeric day of week — semantics shift: Moment d/e produce 0-6 (Sun=0),
+	// date-fns i/c produce 1-7. No exact equivalent exists.
+	['do', 'io'],
+	['d', 'i'],
+	['e', 'c'],
+	// ISO week of year
+	['WW', 'II'],
+	['Wo', 'Io'],
+	['W', 'I'],
+	// Week-numbering year — Moment gg/gggg = locale, GG/GGGG = ISO.
+	// date-fns Y/YY/YYYY (locale) requires `useAdditionalWeekYearTokens`.
+	['gggg', 'YYYY'],
+	['gg', 'YY'],
+	['GGGG', 'RRRR'],
+	['GG', 'RR'],
+	// Hour (H = 0-23, h = 1-12, k = 1-24)
+	['HH', 'HH'],
+	['H', 'H'],
+	['hh', 'hh'],
+	['h', 'h'],
+	['kk', 'kk'],
+	['k', 'k'],
+	// Minute
+	['mm', 'mm'],
+	['m', 'm'],
+	// Second
+	['ss', 'ss'],
+	['s', 's'],
+	// Fractional second — JS Date only has ms precision; SSSS+ pad with zeros in both
+	['SSSSSSSSS', 'SSSSSSSSS'],
+	['SSSSSSSS', 'SSSSSSSS'],
+	['SSSSSSS', 'SSSSSSS'],
+	['SSSSSS', 'SSSSSS'],
+	['SSSSS', 'SSSSS'],
+	['SSSS', 'SSSS'],
+	['SSS', 'SSS'],
+	['SS', 'SS'],
+	['S', 'S'],
+	// AM/PM
+	['A', 'a'],
+	['a', 'a'],
+	// Quarter
+	['QQQQ', 'QQQQ'],
+	['QQQ', 'QQQ'],
+	['QQ', 'QQ'],
+	['Qo', 'Qo'],
+	['Q', 'Q'],
+	// Week of year (locale)
+	['ww', 'ww'],
+	['wo', 'wo'],
+	['w', 'w'],
+	// ISO day of week (Moment E = 1-7 → date-fns i)
+	['E', 'i'],
+	// Timezone offset (Moment Z = +05:00, ZZ = +0500)
+	['ZZ', 'xx'],
+	['Z', 'xxx'],
+	// Timezone abbreviated name (Moment z/zz = "EST"). date-fns has no
+	// real abbreviation; zzz produces "GMT-3" in browsers. Closest available.
+	['zz', 'zzz'],
+	['z', 'zzz'],
+	// Unix timestamp (Moment X = seconds, x = milliseconds)
+	['X', 't'],
+	['x', 'T'],
+].sort((a, b) => b[0].length - a[0].length);
+
+const LITERAL_LETTER = /[a-zA-Z]/;
+
 /**
  * Translate a Moment.js format string to a date-fns format string.
  *
@@ -20,59 +131,6 @@ const FALLBACK_FORMAT = 'PPP p'; // date-fns equivalent of moment's LLL
  * migration. Used by Message_DateFormat / Message_TimeFormat / Message_TimeAndDateFormat.
  */
 export const momentFormatToDateFns = (momentFormat: string): string => {
-	const tokens: [moment: string, dateFns: string][] = [
-		// Locale formats (longest first within each group)
-		['LLLL', 'EEEE, PPP p'],
-		['LTS', 'pp'],
-		['LLL', 'PPP p'],
-		['LL', 'PPP'],
-		['LT', 'p'],
-		['L', 'P'],
-		// Year
-		['YYYY', 'yyyy'],
-		['YY', 'yy'],
-		['Y', 'yyyy'],
-		// Month
-		['MMMM', 'MMMM'],
-		['MMM', 'MMM'],
-		['MM', 'MM'],
-		['Mo', 'Mo'],
-		['M', 'M'],
-		// Day of month
-		['Do', 'do'],
-		['DD', 'dd'],
-		['D', 'd'],
-		// Day of week
-		['dddd', 'EEEE'],
-		['ddd', 'EEE'],
-		['dd', 'EEEEEE'],
-		// Hour
-		['HH', 'HH'],
-		['H', 'H'],
-		['hh', 'hh'],
-		['h', 'h'],
-		// Minute
-		['mm', 'mm'],
-		['m', 'm'],
-		// Second
-		['ss', 'ss'],
-		['s', 's'],
-		// Fractional second
-		['SSS', 'SSS'],
-		['SS', 'SS'],
-		['S', 'S'],
-		// AM/PM
-		['A', 'a'],
-		['a', 'a'],
-		// Timezone offset (Moment Z = +05:00, ZZ = +0500)
-		['ZZ', 'xx'],
-		['Z', 'xxx'],
-		// Unix timestamp (Moment X = seconds, x = milliseconds)
-		['X', 't'],
-		['x', 'T'],
-	];
-	tokens.sort((a, b) => b[0].length - a[0].length);
-
 	let out = '';
 	let literal = '';
 	let i = 0;
@@ -97,7 +155,7 @@ export const momentFormatToDateFns = (momentFormat: string): string => {
 		}
 
 		let matched = false;
-		for (const [mom, df] of tokens) {
+		for (const [mom, df] of MOMENT_TO_DATE_FNS_TOKENS) {
 			if (momentFormat.startsWith(mom, i)) {
 				flushLiteral();
 				out += df;
@@ -108,7 +166,7 @@ export const momentFormatToDateFns = (momentFormat: string): string => {
 		}
 		if (matched) continue;
 
-		if (/[a-zA-Z]/.test(ch)) {
+		if (LITERAL_LETTER.test(ch)) {
 			literal += ch;
 		} else {
 			flushLiteral();
@@ -122,10 +180,15 @@ export const momentFormatToDateFns = (momentFormat: string): string => {
 };
 
 const safeFormat = (d: Date, momentFormat: string, locale?: Locale): string => {
+	const options = {
+		...(locale && { locale }),
+		useAdditionalWeekYearTokens: true,
+		useAdditionalDayOfYearTokens: true,
+	};
 	try {
-		return format(d, momentFormatToDateFns(momentFormat), locale ? { locale } : undefined);
+		return format(d, momentFormatToDateFns(momentFormat), options);
 	} catch {
-		return format(d, FALLBACK_FORMAT, locale ? { locale } : undefined);
+		return format(d, FALLBACK_FORMAT, options);
 	}
 };
 

--- a/apps/meteor/client/lib/utils/dateFormat.ts
+++ b/apps/meteor/client/lib/utils/dateFormat.ts
@@ -6,6 +6,7 @@ export type DateInput = string | Date | number;
 /**
  * Map moment-style locale format tokens to date-fns format string.
  * Used for Message_DateFormat and Message_TimeFormat settings (defaults: LL, LT).
+ * Moment's `[literal]` escape syntax is translated to date-fns' `'literal'` syntax.
  */
 export const momentFormatToDateFns = (momentFormat: string): string => {
 	const tokenMap: Record<string, string> = {
@@ -39,12 +40,25 @@ export const momentFormatToDateFns = (momentFormat: string): string => {
 		A: 'a',
 		a: 'a',
 	};
-	let out = momentFormat;
 	const entries = Object.entries(tokenMap).sort(([a], [b]) => b.length - a.length);
-	for (const [mom, df] of entries) {
-		out = out.replace(new RegExp(mom.replace(/([.*+?^${}()|[\]\\])/g, '\\$1'), 'g'), df);
-	}
-	return out;
+
+	const replaceTokens = (input: string): string => {
+		let out = input;
+		for (const [mom, df] of entries) {
+			out = out.replace(new RegExp(mom.replace(/([.*+?^${}()|[\]\\])/g, '\\$1'), 'g'), df);
+		}
+		return out;
+	};
+
+	return momentFormat
+		.split(/(\[[^\]]*\])/g)
+		.map((part) => {
+			if (part.startsWith('[') && part.endsWith(']')) {
+				return `'${part.slice(1, -1).replace(/'/g, "''")}'`;
+			}
+			return replaceTokens(part);
+		})
+		.join('');
 };
 
 export const formatDate = (date: DateInput, formatStr: string, locale?: Locale): string => {

--- a/apps/meteor/client/lib/utils/dateFormat.ts
+++ b/apps/meteor/client/lib/utils/dateFormat.ts
@@ -5,114 +5,116 @@ export type DateInput = string | Date | number;
 
 const FALLBACK_FORMAT = 'PPP p'; // date-fns equivalent of moment's LLL
 
-const MOMENT_TO_DATE_FNS_TOKENS: ReadonlyArray<readonly [moment: string, dateFns: string]> = [
-	// Locale formats (longest first within each group)
-	['LLLL', 'EEEE, PPP p'],
-	['LTS', 'pp'],
-	['LLL', 'PPP p'],
-	['LL', 'PPP'],
-	['LT', 'p'],
-	['L', 'P'],
-	// Locale formats — short variants (Moment lowercase l = no zero-padding;
-	// date-fns has no equivalent without zero-padding, so PP/P is the closest match)
-	['llll', 'EEE, PP p'],
-	['lll', 'PP p'],
-	['ll', 'PP'],
-	['l', 'P'],
-	// Year
-	['YYYYYY', 'yyyyyy'], // 6-digit padded; Moment includes a +/- sign that date-fns omits
-	['YYYY', 'yyyy'],
-	['YY', 'yy'],
-	['Y', 'yyyy'],
-	['y', 'y'], // Moment lowercase y = era year (always positive); equivalent to calendar year for AD dates
-	// Era — Moment N/NN/NNN are abbreviated, NNNN wide, NNNNN narrow
-	['NNNNN', 'GGGGG'],
-	['NNNN', 'GGGG'],
-	['NNN', 'GGG'],
-	['NN', 'GG'],
-	['N', 'G'],
-	// Month
-	['MMMM', 'MMMM'],
-	['MMM', 'MMM'],
-	['MM', 'MM'],
-	['Mo', 'Mo'],
-	['M', 'M'],
-	// Day of month
-	['Do', 'do'],
-	['DD', 'dd'],
-	['D', 'd'],
-	// Day of year — needs `useAdditionalDayOfYearTokens` on date-fns
-	['DDDD', 'DDD'],
-	['DDDo', 'Do'],
-	['DDD', 'D'],
-	// Day of week
-	['dddd', 'EEEE'],
-	['ddd', 'EEE'],
-	['dd', 'EEEEEE'],
-	// Numeric day of week — semantics shift: Moment d/e produce 0-6 (Sun=0),
-	// date-fns i/c produce 1-7. No exact equivalent exists.
-	['do', 'io'],
-	['d', 'i'],
-	['e', 'c'],
-	// ISO week of year
-	['WW', 'II'],
-	['Wo', 'Io'],
-	['W', 'I'],
-	// Week-numbering year — Moment gg/gggg = locale, GG/GGGG = ISO.
-	// date-fns Y/YY/YYYY (locale) requires `useAdditionalWeekYearTokens`.
-	['gggg', 'YYYY'],
-	['gg', 'YY'],
-	['GGGG', 'RRRR'],
-	['GG', 'RR'],
-	// Hour (H = 0-23, h = 1-12, k = 1-24)
-	['HH', 'HH'],
-	['H', 'H'],
-	['hh', 'hh'],
-	['h', 'h'],
-	['kk', 'kk'],
-	['k', 'k'],
-	// Minute
-	['mm', 'mm'],
-	['m', 'm'],
-	// Second
-	['ss', 'ss'],
-	['s', 's'],
-	// Fractional second — JS Date only has ms precision; SSSS+ pad with zeros in both
-	['SSSSSSSSS', 'SSSSSSSSS'],
-	['SSSSSSSS', 'SSSSSSSS'],
-	['SSSSSSS', 'SSSSSSS'],
-	['SSSSSS', 'SSSSSS'],
-	['SSSSS', 'SSSSS'],
-	['SSSS', 'SSSS'],
-	['SSS', 'SSS'],
-	['SS', 'SS'],
-	['S', 'S'],
-	// AM/PM
-	['A', 'a'],
-	['a', 'a'],
-	// Quarter
-	['QQQQ', 'QQQQ'],
-	['QQQ', 'QQQ'],
-	['QQ', 'QQ'],
-	['Qo', 'Qo'],
-	['Q', 'Q'],
-	// Week of year (locale)
-	['ww', 'ww'],
-	['wo', 'wo'],
-	['w', 'w'],
-	// ISO day of week (Moment E = 1-7 → date-fns i)
-	['E', 'i'],
-	// Timezone offset (Moment Z = +05:00, ZZ = +0500)
-	['ZZ', 'xx'],
-	['Z', 'xxx'],
-	// Timezone abbreviated name (Moment z/zz = "EST"). date-fns has no
-	// real abbreviation; zzz produces "GMT-3" in browsers. Closest available.
-	['zz', 'zzz'],
-	['z', 'zzz'],
-	// Unix timestamp (Moment X = seconds, x = milliseconds)
-	['X', 't'],
-	['x', 'T'],
-].sort((a, b) => b[0].length - a[0].length);
+const MOMENT_TO_DATE_FNS_TOKENS: ReadonlyArray<readonly [moment: string, dateFns: string]> = (
+	[
+		// Locale formats
+		['LLLL', 'EEEE, PPP p'],
+		['LTS', 'pp'],
+		['LLL', 'PPP p'],
+		['LL', 'PPP'],
+		['LT', 'p'],
+		['L', 'P'],
+		// Locale formats — short variants (Moment lowercase l = no zero-padding;
+		// date-fns has no equivalent without zero-padding, so PP/P is the closest match)
+		['llll', 'EEE, PP p'],
+		['lll', 'PP p'],
+		['ll', 'PP'],
+		['l', 'P'],
+		// Year
+		['YYYYYY', 'yyyyyy'], // 6-digit padded; Moment includes a +/- sign that date-fns omits
+		['YYYY', 'yyyy'],
+		['YY', 'yy'],
+		['Y', 'yyyy'],
+		['y', 'y'], // Moment lowercase y = era year (always positive); equivalent to calendar year for AD dates
+		// Era — Moment N/NN/NNN are abbreviated, NNNN wide, NNNNN narrow
+		['NNNNN', 'GGGGG'],
+		['NNNN', 'GGGG'],
+		['NNN', 'GGG'],
+		['NN', 'GG'],
+		['N', 'G'],
+		// Month
+		['MMMM', 'MMMM'],
+		['MMM', 'MMM'],
+		['MM', 'MM'],
+		['Mo', 'Mo'],
+		['M', 'M'],
+		// Day of month
+		['Do', 'do'],
+		['DD', 'dd'],
+		['D', 'd'],
+		// Day of year — needs `useAdditionalDayOfYearTokens` on date-fns
+		['DDDD', 'DDD'],
+		['DDDo', 'Do'],
+		['DDD', 'D'],
+		// Day of week
+		['dddd', 'EEEE'],
+		['ddd', 'EEE'],
+		['dd', 'EEEEEE'],
+		// Numeric day of week — semantics shift: Moment d/e produce 0-6 (Sun=0),
+		// date-fns i/c produce 1-7. No exact equivalent exists.
+		['do', 'io'],
+		['d', 'i'],
+		['e', 'c'],
+		// ISO week of year
+		['WW', 'II'],
+		['Wo', 'Io'],
+		['W', 'I'],
+		// Week-numbering year — Moment gg/gggg = locale, GG/GGGG = ISO.
+		// date-fns Y/YY/YYYY (locale) requires `useAdditionalWeekYearTokens`.
+		['gggg', 'YYYY'],
+		['gg', 'YY'],
+		['GGGG', 'RRRR'],
+		['GG', 'RR'],
+		// Hour (H = 0-23, h = 1-12, k = 1-24)
+		['HH', 'HH'],
+		['H', 'H'],
+		['hh', 'hh'],
+		['h', 'h'],
+		['kk', 'kk'],
+		['k', 'k'],
+		// Minute
+		['mm', 'mm'],
+		['m', 'm'],
+		// Second
+		['ss', 'ss'],
+		['s', 's'],
+		// Fractional second — JS Date only has ms precision; SSSS+ pad with zeros in both
+		['SSSSSSSSS', 'SSSSSSSSS'],
+		['SSSSSSSS', 'SSSSSSSS'],
+		['SSSSSSS', 'SSSSSSS'],
+		['SSSSSS', 'SSSSSS'],
+		['SSSSS', 'SSSSS'],
+		['SSSS', 'SSSS'],
+		['SSS', 'SSS'],
+		['SS', 'SS'],
+		['S', 'S'],
+		// AM/PM
+		['A', 'a'],
+		['a', 'a'],
+		// Quarter
+		['QQQQ', 'QQQQ'],
+		['QQQ', 'QQQ'],
+		['QQ', 'QQ'],
+		['Qo', 'Qo'],
+		['Q', 'Q'],
+		// Week of year (locale)
+		['ww', 'ww'],
+		['wo', 'wo'],
+		['w', 'w'],
+		// ISO day of week (Moment E = 1-7 → date-fns i)
+		['E', 'i'],
+		// Timezone offset (Moment Z = +05:00, ZZ = +0500)
+		['ZZ', 'xx'],
+		['Z', 'xxx'],
+		// Timezone abbreviated name (Moment z/zz = "EST"). date-fns has no
+		// real abbreviation; zzz produces "GMT-3" in browsers. Closest available.
+		['zz', 'zzz'],
+		['z', 'zzz'],
+		// Unix timestamp (Moment X = seconds, x = milliseconds)
+		['X', 't'],
+		['x', 'T'],
+	] as Array<[moment: string, dateFns: string]>
+).sort((a, b) => b[0].length - a[0].length);
 
 const LITERAL_LETTER = /[a-zA-Z]/;
 

--- a/apps/meteor/client/lib/utils/dateFormat.ts
+++ b/apps/meteor/client/lib/utils/dateFormat.ts
@@ -3,68 +3,135 @@ import type { Locale } from 'date-fns';
 
 export type DateInput = string | Date | number;
 
+const FALLBACK_FORMAT = 'PPP p'; // date-fns equivalent of moment's LLL
+
 /**
- * Map moment-style locale format tokens to date-fns format string.
- * Used for Message_DateFormat and Message_TimeFormat settings (defaults: LL, LT).
- * Moment's `[literal]` escape syntax is translated to date-fns' `'literal'` syntax.
+ * Translate a Moment.js format string to a date-fns format string.
+ *
+ * The two libraries diverge in two important ways that this function bridges:
+ *  1. Moment treats unrecognized letters as literals (so `T` in `YYYY-MM-DDTHH:mm:ss`
+ *     prints as a literal `T`); date-fns reserves every letter as a token, so an
+ *     unmapped letter either produces wrong output (`T` = ms timestamp) or throws.
+ *  2. Moment uses `Z`/`ZZ` for timezone offsets; date-fns has no `Z` token at all.
+ *
+ * The translator tokenizes left-to-right: it recognizes Moment's `[literal]` escape
+ * syntax, longest-matches a known Moment token, and quotes any other letter as a
+ * date-fns literal so admin-configured formats keep working after the moment→date-fns
+ * migration. Used by Message_DateFormat / Message_TimeFormat / Message_TimeAndDateFormat.
  */
 export const momentFormatToDateFns = (momentFormat: string): string => {
-	const tokenMap: Record<string, string> = {
-		L: 'P', // 09/04/1986
-		LT: 'p', // 8:30 PM
-		LTS: 'pp', // 8:30:00 PM
-		LL: 'PPP', // September 4, 1986
-		LLL: 'PPP p', // September 4, 1986 8:30 PM
-		LLLL: 'EEEE, PPP p',
-		// Common tokens
-		YYYY: 'yyyy',
-		YY: 'yy',
-		Y: 'yyyy',
-		MMMM: 'MMMM',
-		MMM: 'MMM',
-		MM: 'MM',
-		M: 'M',
-		Do: 'do', // 4th
-		DD: 'dd',
-		D: 'd',
-		dddd: 'EEEE',
-		ddd: 'EEE',
-		HH: 'HH',
-		H: 'H',
-		hh: 'hh',
-		h: 'h',
-		mm: 'mm',
-		m: 'm',
-		ss: 'ss',
-		s: 's',
-		A: 'a',
-		a: 'a',
-	};
-	const entries = Object.entries(tokenMap).sort(([a], [b]) => b.length - a.length);
+	const tokens: [moment: string, dateFns: string][] = [
+		// Locale formats (longest first within each group)
+		['LLLL', 'EEEE, PPP p'],
+		['LTS', 'pp'],
+		['LLL', 'PPP p'],
+		['LL', 'PPP'],
+		['LT', 'p'],
+		['L', 'P'],
+		// Year
+		['YYYY', 'yyyy'],
+		['YY', 'yy'],
+		['Y', 'yyyy'],
+		// Month
+		['MMMM', 'MMMM'],
+		['MMM', 'MMM'],
+		['MM', 'MM'],
+		['Mo', 'Mo'],
+		['M', 'M'],
+		// Day of month
+		['Do', 'do'],
+		['DD', 'dd'],
+		['D', 'd'],
+		// Day of week
+		['dddd', 'EEEE'],
+		['ddd', 'EEE'],
+		['dd', 'EEEEEE'],
+		// Hour
+		['HH', 'HH'],
+		['H', 'H'],
+		['hh', 'hh'],
+		['h', 'h'],
+		// Minute
+		['mm', 'mm'],
+		['m', 'm'],
+		// Second
+		['ss', 'ss'],
+		['s', 's'],
+		// Fractional second
+		['SSS', 'SSS'],
+		['SS', 'SS'],
+		['S', 'S'],
+		// AM/PM
+		['A', 'a'],
+		['a', 'a'],
+		// Timezone offset (Moment Z = +05:00, ZZ = +0500)
+		['ZZ', 'xx'],
+		['Z', 'xxx'],
+		// Unix timestamp (Moment X = seconds, x = milliseconds)
+		['X', 't'],
+		['x', 'T'],
+	];
+	tokens.sort((a, b) => b[0].length - a[0].length);
 
-	const replaceTokens = (input: string): string => {
-		let out = input;
-		for (const [mom, df] of entries) {
-			out = out.replace(new RegExp(mom.replace(/([.*+?^${}()|[\]\\])/g, '\\$1'), 'g'), df);
+	let out = '';
+	let literal = '';
+	let i = 0;
+
+	const flushLiteral = () => {
+		if (literal) {
+			out += `'${literal.replace(/'/g, "''")}'`;
+			literal = '';
 		}
-		return out;
 	};
 
-	return momentFormat
-		.split(/(\[[^\]]*\])/g)
-		.map((part) => {
-			if (part.startsWith('[') && part.endsWith(']')) {
-				return `'${part.slice(1, -1).replace(/'/g, "''")}'`;
+	while (i < momentFormat.length) {
+		const ch = momentFormat[i];
+
+		if (ch === '[') {
+			const end = momentFormat.indexOf(']', i + 1);
+			if (end !== -1) {
+				literal += momentFormat.slice(i + 1, end);
+				i = end + 1;
+				continue;
 			}
-			return replaceTokens(part);
-		})
-		.join('');
+		}
+
+		let matched = false;
+		for (const [mom, df] of tokens) {
+			if (momentFormat.startsWith(mom, i)) {
+				flushLiteral();
+				out += df;
+				i += mom.length;
+				matched = true;
+				break;
+			}
+		}
+		if (matched) continue;
+
+		if (/[a-zA-Z]/.test(ch)) {
+			literal += ch;
+		} else {
+			flushLiteral();
+			out += ch;
+		}
+		i++;
+	}
+
+	flushLiteral();
+	return out;
+};
+
+const safeFormat = (d: Date, momentFormat: string, locale?: Locale): string => {
+	try {
+		return format(d, momentFormatToDateFns(momentFormat), locale ? { locale } : undefined);
+	} catch {
+		return format(d, FALLBACK_FORMAT, locale ? { locale } : undefined);
+	}
 };
 
 export const formatDate = (date: DateInput, formatStr: string, locale?: Locale): string => {
 	const d = typeof date === 'object' && date instanceof Date ? date : new Date(date);
-	const dfFormat = momentFormatToDateFns(formatStr);
-	return format(d, dfFormat, locale ? { locale } : undefined);
+	return safeFormat(d, formatStr, locale);
 };
 
 export const formatTimeAgo = (
@@ -84,20 +151,20 @@ export const formatTimeAgo = (
 	const diffDays = differenceInCalendarDays(now, d);
 
 	if (diffDays === 0) {
-		return format(d, momentFormatToDateFns(options.sameDayFormat), locale ? { locale } : undefined);
+		return safeFormat(d, options.sameDayFormat, locale);
 	}
 	if (diffDays === 1) {
 		if (options.lastDayFormat) {
-			return `${options.yesterdayLabel} ${format(d, momentFormatToDateFns(options.lastDayFormat), locale ? { locale } : undefined)}`;
+			return `${options.yesterdayLabel} ${safeFormat(d, options.lastDayFormat, locale)}`;
 		}
 		return options.yesterdayLabel;
 	}
 	if (diffDays > 1 && diffDays < 7) {
-		return format(d, momentFormatToDateFns(options.lastWeekFormat), locale ? { locale } : undefined);
+		return safeFormat(d, options.lastWeekFormat, locale);
 	}
 	const diffYears = now.getFullYear() - d.getFullYear();
 	const fmt = diffYears !== 0 ? options.otherYearFormat : options.otherFormat;
-	return format(d, momentFormatToDateFns(fmt), locale ? { locale } : undefined);
+	return safeFormat(d, fmt, locale);
 };
 
 export const formatFromNow = (date: DateInput, addSuffix: boolean, locale?: Locale): string => {

--- a/apps/meteor/client/lib/utils/dateFormat.ts
+++ b/apps/meteor/client/lib/utils/dateFormat.ts
@@ -88,9 +88,9 @@ const MOMENT_TO_DATE_FNS_TOKENS: ReadonlyArray<readonly [moment: string, dateFns
 		['SSS', 'SSS'],
 		['SS', 'SS'],
 		['S', 'S'],
-		// AM/PM
+		// AM/PM — date-fns `a`/`aa` are always uppercase (AM/PM); `aaa` is lowercase (am/pm)
 		['A', 'a'],
-		['a', 'a'],
+		['a', 'aaa'],
 		// Quarter
 		['QQQQ', 'QQQQ'],
 		['QQQ', 'QQQ'],


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Introduced here: #40076

- After the 8.4 client migration from Moment.js to date-fns, admin-configured Moment format strings (Message_TimeAndDateFormat, Message_DateFormat, Message_TimeFormat) stopped working — `[Today at] LT` crashed the room view, `YYYY-MM-DDTHH:mm:ss` printed a millisecond timestamp instead of the `T` literal, and `Z`/`ZZ`/`gg`/`gggg`/`kk`/`W`/`WW` either threw or produced wrong output.
- Replace the regex-based `momentFormatToDateFns` with a left-to-right tokenizer that handles `[literal]` escapes, longest-matches every Moment token from the [Moment Display/Format docs](https://momentjs.com/docs/#/displaying/format/), and quotes any unrecognized letter as a date-fns literal (so Moment's "unknown letter = literal" rule is preserved).
- Map timezone offsets (`Z` → `xxx`, `ZZ` → `xx`), week-year tokens (`gg`/`gggg`/`GG`/`GGGG`), era tokens (`N`..`NNNNN`), day-of-year tokens (`DDD`/`DDDo`/`DDDD`), and AM/PM casing (`a` → `aaa` for lowercase). Pass `useAdditionalWeekYearTokens` and `useAdditionalDayOfYearTokens` to date-fns so those mappings actually format.
- Wrap every format call in a `safeFormat` that falls back to `LLL` on any throw — a typo in the admin setting can no longer crash a room.

### Test plan
- [ ] On 8.3.2, set `Message_TimeAndDateFormat` to `[Today at] LT`, upgrade to this build, open a room — messages render and tooltips show `Today at 8:30 PM`.
- [ ] Verify the QA-reported formats render without crashing on a fresh install: `LT Z`, `YYYY-MM-DDTHH:mm:ss`, `YYYY-MM-DDTHH:mm:ssZ`, `Z ZZ`, `kk:mm`, `gggg-[W]WW-E`, `lll`, `h:mm a` (lowercase).
- [ ] Set a deliberately broken format (e.g. `]]not a format[[`) and confirm the room still renders (falls back to `LLL`).


## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-2134]

[CORE-2134]: https://rocketchat.atlassian.net/browse/CORE-2134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for format-string conversion and formatting behavior, covering locale token mappings, literal text blocks and escaping, ISO "T" preservation, timezone and week/year tokens, extended fractional seconds, and end-to-end outputs.
* **Bug Fixes**
  * Improved formatter to stream-translate Moment-style patterns to date-fns-compatible formats, honor bracket-escaped literals and quoting rules, correctly escape embedded quotes and literal "T", handle timezone/offset and week-year tokens, and use a centralized safe-formatting path with a non-throwing fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->