### PR TITLE
regression: timezone field blank for legacy aliases

### DIFF
--- a/apps/meteor/client/hooks/useTimezoneNameList.ts
+++ b/apps/meteor/client/hooks/useTimezoneNameList.ts
@@ -1,9 +1,8 @@
+import { getTimezoneNames } from '@rocket.chat/tools';
 import { useMemo } from 'react';
 
-const getTimeZoneNames = (): string[] => {
-	const intl = Intl as typeof Intl & { supportedValuesOf?(key: 'timeZone'): string[] };
-	const names = typeof intl.supportedValuesOf === 'function' ? intl.supportedValuesOf('timeZone') : [];
-	return names.includes('UTC') ? names : ['UTC', ...names];
-};
-
-export const useTimezoneNameList = (): string[] => useMemo(() => getTimeZoneNames(), []);
+export const useTimezoneNameList = (): string[] =>
+	useMemo(() => {
+		const names = getTimezoneNames();
+		return names.includes('UTC') ? names : ['UTC', ...names];
+	}, []);

--- a/apps/meteor/client/hooks/useTimezoneNameList.ts
+++ b/apps/meteor/client/hooks/useTimezoneNameList.ts
@@ -2,7 +2,8 @@ import { useMemo } from 'react';
 
 const getTimeZoneNames = (): string[] => {
 	const intl = Intl as typeof Intl & { supportedValuesOf?(key: 'timeZone'): string[] };
-	return typeof intl.supportedValuesOf === 'function' ? intl.supportedValuesOf('timeZone') : [];
+	const names = typeof intl.supportedValuesOf === 'function' ? intl.supportedValuesOf('timeZone') : [];
+	return names.includes('UTC') ? names : ['UTC', ...names];
 };
 
 export const useTimezoneNameList = (): string[] => useMemo(() => getTimeZoneNames(), []);

--- a/apps/meteor/client/views/admin/settings/Setting/inputs/SelectTimezoneSettingInput.tsx
+++ b/apps/meteor/client/views/admin/settings/Setting/inputs/SelectTimezoneSettingInput.tsx
@@ -1,4 +1,5 @@
 import { Field, FieldHint, FieldLabel, FieldRow, Select } from '@rocket.chat/fuselage';
+import { canonicalizeTimezone } from '@rocket.chat/tools';
 import type { ReactElement } from 'react';
 
 import { useTimezoneNameList } from '../../../../../hooks/useTimezoneNameList';
@@ -38,7 +39,7 @@ function SelectTimezoneSettingInput({
 			<FieldRow>
 				<Select
 					id={_id}
-					value={value}
+					value={typeof value === 'string' ? canonicalizeTimezone(value) : value}
 					placeholder={placeholder}
 					disabled={disabled}
 					readOnly={readonly}

--- a/apps/meteor/client/views/omnichannel/businessHours/EditBusinessHours.tsx
+++ b/apps/meteor/client/views/omnichannel/businessHours/EditBusinessHours.tsx
@@ -1,6 +1,7 @@
 import type { ILivechatBusinessHour, LivechatBusinessHourTypes, Serialized } from '@rocket.chat/core-typings';
 import { Box, Button, ButtonGroup } from '@rocket.chat/fuselage';
 import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
+import { canonicalizeTimezone } from '@rocket.chat/tools';
 import { Page, PageFooter, PageHeader, PageScrollableContentWithShadow } from '@rocket.chat/ui-client';
 import { useToastMessageDispatch, useTranslation, useRouter, useEndpoint } from '@rocket.chat/ui-contexts';
 import { useId } from 'react';
@@ -14,7 +15,7 @@ import { useRemoveBusinessHour } from './useRemoveBusinessHour';
 
 const getInitialData = (businessHourData: Serialized<ILivechatBusinessHour> | undefined) => ({
 	name: businessHourData?.name || '',
-	timezoneName: businessHourData?.timezone?.name || 'America/Sao_Paulo',
+	timezoneName: canonicalizeTimezone(businessHourData?.timezone?.name || 'America/Sao_Paulo'),
 	daysOpen: (businessHourData?.workHours || defaultWorkHours()).filter(({ open }) => !!open).map(({ day }) => day),
 	daysTime: (businessHourData?.workHours || defaultWorkHours())
 		.filter(({ open }) => !!open)

--- a/packages/tools/src/timezone.spec.ts
+++ b/packages/tools/src/timezone.spec.ts
@@ -1,4 +1,4 @@
-import { canonicalizeTimezone } from './timezone';
+import { canonicalizeTimezone, getTimezoneNames } from './timezone';
 
 describe('canonicalizeTimezone', () => {
 	it('returns the same value for a canonical IANA zone', () => {
@@ -22,8 +22,36 @@ describe('canonicalizeTimezone', () => {
 		expect(canonicalizeTimezone('Japan')).toBe('Asia/Tokyo');
 	});
 
+	it('resolves legacy IANA names to modern canonical names', () => {
+		expect(canonicalizeTimezone('Asia/Calcutta')).toBe('Asia/Kolkata');
+		expect(canonicalizeTimezone('Asia/Katmandu')).toBe('Asia/Kathmandu');
+		expect(canonicalizeTimezone('Asia/Rangoon')).toBe('Asia/Yangon');
+		expect(canonicalizeTimezone('Asia/Saigon')).toBe('Asia/Ho_Chi_Minh');
+		expect(canonicalizeTimezone('Europe/Kiev')).toBe('Europe/Kyiv');
+		expect(canonicalizeTimezone('America/Godthab')).toBe('America/Nuuk');
+		expect(canonicalizeTimezone('Pacific/Enderbury')).toBe('Pacific/Kanton');
+	});
+
+	it('preserves modern canonical names as-is', () => {
+		expect(canonicalizeTimezone('Asia/Kolkata')).toBe('Asia/Kolkata');
+		expect(canonicalizeTimezone('Europe/Kyiv')).toBe('Europe/Kyiv');
+		expect(canonicalizeTimezone('Asia/Ho_Chi_Minh')).toBe('Asia/Ho_Chi_Minh');
+	});
+
 	it('returns the input unchanged when it is not a recognized zone', () => {
 		const input = 'Not/A_Zone';
 		expect(canonicalizeTimezone(input)).toBe(input);
+	});
+});
+
+describe('getTimezoneNames', () => {
+	it('returns modern canonical names instead of legacy ones', () => {
+		const names = getTimezoneNames();
+		expect(names).toContain('Asia/Kolkata');
+		expect(names).not.toContain('Asia/Calcutta');
+		expect(names).toContain('Europe/Kyiv');
+		expect(names).not.toContain('Europe/Kiev');
+		expect(names).toContain('Asia/Yangon');
+		expect(names).not.toContain('Asia/Rangoon');
 	});
 });

--- a/packages/tools/src/timezone.spec.ts
+++ b/packages/tools/src/timezone.spec.ts
@@ -1,0 +1,29 @@
+import { canonicalizeTimezone } from './timezone';
+
+describe('canonicalizeTimezone', () => {
+	it('returns the same value for a canonical IANA zone', () => {
+		expect(canonicalizeTimezone('America/Sao_Paulo')).toBe('America/Sao_Paulo');
+	});
+
+	it('resolves plain UTC to UTC', () => {
+		expect(canonicalizeTimezone('UTC')).toBe('UTC');
+	});
+
+	it('resolves Etc/UTC and Etc/GMT to UTC', () => {
+		expect(canonicalizeTimezone('Etc/UTC')).toBe('UTC');
+		expect(canonicalizeTimezone('Etc/GMT')).toBe('UTC');
+	});
+
+	it('resolves legacy moment aliases to their canonical zone', () => {
+		expect(canonicalizeTimezone('GMT')).toBe('UTC');
+		expect(canonicalizeTimezone('Zulu')).toBe('UTC');
+		expect(canonicalizeTimezone('Universal')).toBe('UTC');
+		expect(canonicalizeTimezone('US/Pacific')).toBe('America/Los_Angeles');
+		expect(canonicalizeTimezone('Japan')).toBe('Asia/Tokyo');
+	});
+
+	it('returns the input unchanged when it is not a recognized zone', () => {
+		const input = 'Not/A_Zone';
+		expect(canonicalizeTimezone(input)).toBe(input);
+	});
+});

--- a/packages/tools/src/timezone.ts
+++ b/packages/tools/src/timezone.ts
@@ -1,3 +1,40 @@
+// Zones where Node/browser Intl returns a legacy IANA name instead of the
+// current canonical one. Workaround until Temporal lands (~late 2026).
+// Source: https://data.iana.org/time-zones/tzdb/backward
+// Ref: https://github.com/tc39/proposal-temporal/issues/3249
+const LEGACY_TO_CANONICAL: Record<string, string> = {
+	'America/Buenos_Aires': 'America/Argentina/Buenos_Aires',
+	'America/Catamarca': 'America/Argentina/Catamarca',
+	'America/Cordoba': 'America/Argentina/Cordoba',
+	'America/Godthab': 'America/Nuuk',
+	'America/Indianapolis': 'America/Indiana/Indianapolis',
+	'America/Jujuy': 'America/Argentina/Jujuy',
+	'America/Louisville': 'America/Kentucky/Louisville',
+	'America/Mendoza': 'America/Argentina/Mendoza',
+	'Asia/Calcutta': 'Asia/Kolkata',
+	'Asia/Katmandu': 'Asia/Kathmandu',
+	'Asia/Rangoon': 'Asia/Yangon',
+	'Asia/Saigon': 'Asia/Ho_Chi_Minh',
+	'Atlantic/Faeroe': 'Atlantic/Faroe',
+	'Europe/Kiev': 'Europe/Kyiv',
+	'Pacific/Enderbury': 'Pacific/Kanton',
+};
+
+export const canonicalizeTimezone = (name: string): string => {
+	try {
+		const resolved = new Intl.DateTimeFormat(undefined, { timeZone: name }).resolvedOptions().timeZone;
+		return LEGACY_TO_CANONICAL[resolved] ?? resolved;
+	} catch {
+		return name;
+	}
+};
+
+export const getTimezoneNames = (): string[] => {
+	const intl = Intl as typeof Intl & { supportedValuesOf?(key: 'timeZone'): string[] };
+	const zones = typeof intl.supportedValuesOf === 'function' ? intl.supportedValuesOf('timeZone') : [];
+	return zones.map((name) => LEGACY_TO_CANONICAL[name] ?? name).sort();
+};
+
 export const guessTimezoneFromOffset = (offset: string | number): string => {
 	const hours = Number(offset);
 	const totalMinutes = Math.round(hours * 60);
@@ -21,7 +58,7 @@ export const guessTimezoneFromOffset = (offset: string | number): string => {
 		const tzHours = match[1] ? parseInt(match[1], 10) : 0;
 		const tzMinutes = match[2] ? parseInt(match[2], 10) * (tzHours < 0 ? -1 : 1) : 0;
 		if (tzHours * 60 + tzMinutes === totalMinutes) {
-			return tz;
+			return LEGACY_TO_CANONICAL[tz] ?? tz;
 		}
 	}
 
@@ -33,12 +70,7 @@ export const guessTimezoneFromOffset = (offset: string | number): string => {
 	return `Etc/GMT${intHours > 0 ? '-' : '+'}${Math.abs(intHours)}`;
 };
 
-export const guessTimezone = (): string => new Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-export const canonicalizeTimezone = (name: string): string => {
-	try {
-		return new Intl.DateTimeFormat(undefined, { timeZone: name }).resolvedOptions().timeZone;
-	} catch {
-		return name;
-	}
+export const guessTimezone = (): string => {
+	const resolved = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+	return LEGACY_TO_CANONICAL[resolved] ?? resolved;
 };

--- a/packages/tools/src/timezone.ts
+++ b/packages/tools/src/timezone.ts
@@ -34,3 +34,11 @@ export const guessTimezoneFromOffset = (offset: string | number): string => {
 };
 
 export const guessTimezone = (): string => new Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+export const canonicalizeTimezone = (name: string): string => {
+	try {
+		return new Intl.DateTimeFormat(undefined, { timeZone: name }).resolvedOptions().timeZone;
+	} catch {
+		return name;
+	}
+};


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
## Summary

Restores compatibility for legacy timezone aliases (`UTC`, `Etc/UTC`, `US/Pacific`, `Japan`, …) that were lost when #40076 migrated the timezone list from `moment.tz.names()` (597 zones) to `Intl.supportedValuesOf('timeZone')` (418 zones). Any `Select` fed by `useTimezoneNameList` — Business Hours and the admin Timezone setting — rendered empty for workspaces whose saved value was one of the 179 dropped aliases.

- Add `canonicalizeTimezone` in `@rocket.chat/tools` — resolves legacy aliases to their canonical IANA zone via `Intl.DateTimeFormat`, falling back to the input on invalid values.
- Ensure `UTC` is always present in `useTimezoneNameList`, since `Intl.supportedValuesOf` omits it on several ICU versions.
- Apply canonicalization when loading the saved value in `EditBusinessHours` and `SelectTimezoneSettingInput`, so existing documents render correctly and are gradually rewritten to canonical form on save.

## Test plan

- [ ] On a workspace with a Business Hour saved as `timezone.name === "UTC"` (pre-8.4), open it on this branch — field shows `UTC`, save persists `UTC`.
- [ ] Repeat with `US/Pacific` — field shows `America/Los_Angeles`, saves as `America/Los_Angeles`.
- [ ] Admin → General → Timezone: a legacy-aliased value loads into the select.


## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-2135]

[CORE-2135]: https://rocketchat.atlassian.net/browse/CORE-2135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timezone handling improved: selection lists use canonical timezone names and always include UTC.

* **Bug Fixes**
  * Timezone values are now normalized in admin settings and business hours so selections behave consistently across the UI.

* **Tests**
  * Added tests covering timezone canonicalization and the returned timezone list to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->