### PR TITLE
regression: livechat visitor read receipts showing blank name

### DIFF
--- a/apps/meteor/ee/server/lib/message-read-receipt/ReadReceipt.ts
+++ b/apps/meteor/ee/server/lib/message-read-receipt/ReadReceipt.ts
@@ -1,6 +1,6 @@
 import { api } from '@rocket.chat/core-services';
-import type { IMessage, IRoom, IReadReceipt, IReadReceiptWithUser } from '@rocket.chat/core-typings';
-import { ReadReceipts, ReadReceiptsArchive, Messages, Rooms, Subscriptions, Users } from '@rocket.chat/models';
+import type { IMessage, IRoom, IUser, IReadReceipt, IReadReceiptWithUser } from '@rocket.chat/core-typings';
+import { LivechatVisitors, ReadReceipts, ReadReceiptsArchive, Messages, Rooms, Subscriptions, Users } from '@rocket.chat/models';
 
 import { notifyOnRoomChangedById, notifyOnMessageChange } from '../../../../app/lib/server/lib/notifyListener';
 import { settings } from '../../../../app/settings/server';
@@ -155,12 +155,21 @@ class ReadReceiptClass {
 
 		// get users for the receipts
 		const users = await Users.findByIds(userIds, { projection: { username: 1, name: 1 } }).toArray();
-		const usersMap = new Map(users.map((user) => [user._id, user]));
+		const usersMap: Map<string, Pick<IUser, '_id' | 'username' | 'name'>> = new Map(users.map((user) => [user._id, user]));
+
+		// Resolve livechat visitors for any unresolved user IDs
+		const unresolvedIds = userIds.filter((id) => !usersMap.has(id));
+		if (unresolvedIds.length > 0) {
+			const visitors = await LivechatVisitors.findByIds(unresolvedIds, { projection: { username: 1, name: 1 } }).toArray();
+			for (const visitor of visitors) {
+				usersMap.set(visitor._id, { _id: visitor._id, username: visitor.username, name: visitor.name });
+			}
+		}
 
 		return Promise.all(
 			receipts.map(async (receipt) => ({
 				...receipt,
-				user: usersMap.get(receipt.userId) as IReadReceiptWithUser['user'],
+				user: usersMap.get(receipt.userId),
 			})),
 		);
 	}

--- a/packages/model-typings/src/models/ILivechatVisitorsModel.ts
+++ b/packages/model-typings/src/models/ILivechatVisitorsModel.ts
@@ -15,6 +15,7 @@ import type { FindPaginated, IBaseModel } from './IBaseModel';
 
 export interface ILivechatVisitorsModel extends IBaseModel<ILivechatVisitor> {
 	findById(_id: string, options?: FindOptions<ILivechatVisitor>): FindCursor<ILivechatVisitor>;
+	findByIds(ids: string[], options?: FindOptions<ILivechatVisitor>): FindCursor<ILivechatVisitor>;
 	getVisitorByToken(token: string, options?: FindOptions<ILivechatVisitor>): Promise<ILivechatVisitor | null>;
 	findByNameRegexWithExceptionsAndConditions<P extends Document = ILivechatVisitor>(
 		searchTerm: string,

--- a/packages/models/src/models/LivechatVisitors.ts
+++ b/packages/models/src/models/LivechatVisitors.ts
@@ -507,6 +507,13 @@ export class LivechatVisitorsRaw extends BaseRaw<ILivechatVisitor> implements IL
 	updateDepartmentById(_id: string, department: string) {
 		return this.findOneAndUpdate({ _id }, { $set: { department } }, { returnDocument: 'after' });
 	}
+
+	findByIds(ids: string[], options?: FindOptions<ILivechatVisitor>): FindCursor<ILivechatVisitor> {
+		const query = {
+			_id: { $in: ids },
+		};
+		return this.find(query, options);
+	}
 }
 
 type DeepWriteable<T> = { -readonly [P in keyof T]: DeepWriteable<T[P]> };


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
This PR fixes an issue where read receipts for livechat (Omnichannel) visitors were displaying blank names instead of the visitor identity.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-2128](https://rocketchat.atlassian.net/browse/CORE-2128)

[CORE-2128]: https://rocketchat.atlassian.net/browse/CORE-2128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message read receipt enrichment to correctly handle both regular users and livechat visitors in receipt data.

* **New Features**
  * Added bulk lookup capability for retrieving multiple visitor records simultaneously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->