### PR TITLE
fix: normalize legacy Intl timezone names to IANA canonical

### DIFF
--- a/apps/meteor/client/hooks/useTimezoneNameList.ts
+++ b/apps/meteor/client/hooks/useTimezoneNameList.ts
@@ -1,9 +1,8 @@
+import { getTimezoneNames } from '@rocket.chat/tools';
 import { useMemo } from 'react';
 
-const getTimeZoneNames = (): string[] => {
-	const intl = Intl as typeof Intl & { supportedValuesOf?(key: 'timeZone'): string[] };
-	const names = typeof intl.supportedValuesOf === 'function' ? intl.supportedValuesOf('timeZone') : [];
-	return names.includes('UTC') ? names : ['UTC', ...names];
-};
-
-export const useTimezoneNameList = (): string[] => useMemo(() => getTimeZoneNames(), []);
+export const useTimezoneNameList = (): string[] =>
+	useMemo(() => {
+		const names = getTimezoneNames();
+		return names.includes('UTC') ? names : ['UTC', ...names];
+	}, []);

--- a/packages/tools/src/timezone.spec.ts
+++ b/packages/tools/src/timezone.spec.ts
@@ -1,4 +1,4 @@
-import { canonicalizeTimezone } from './timezone';
+import { canonicalizeTimezone, getTimezoneNames } from './timezone';
 
 describe('canonicalizeTimezone', () => {
 	it('returns the same value for a canonical IANA zone', () => {
@@ -22,8 +22,36 @@ describe('canonicalizeTimezone', () => {
 		expect(canonicalizeTimezone('Japan')).toBe('Asia/Tokyo');
 	});
 
+	it('resolves legacy IANA names to modern canonical names', () => {
+		expect(canonicalizeTimezone('Asia/Calcutta')).toBe('Asia/Kolkata');
+		expect(canonicalizeTimezone('Asia/Katmandu')).toBe('Asia/Kathmandu');
+		expect(canonicalizeTimezone('Asia/Rangoon')).toBe('Asia/Yangon');
+		expect(canonicalizeTimezone('Asia/Saigon')).toBe('Asia/Ho_Chi_Minh');
+		expect(canonicalizeTimezone('Europe/Kiev')).toBe('Europe/Kyiv');
+		expect(canonicalizeTimezone('America/Godthab')).toBe('America/Nuuk');
+		expect(canonicalizeTimezone('Pacific/Enderbury')).toBe('Pacific/Kanton');
+	});
+
+	it('preserves modern canonical names as-is', () => {
+		expect(canonicalizeTimezone('Asia/Kolkata')).toBe('Asia/Kolkata');
+		expect(canonicalizeTimezone('Europe/Kyiv')).toBe('Europe/Kyiv');
+		expect(canonicalizeTimezone('Asia/Ho_Chi_Minh')).toBe('Asia/Ho_Chi_Minh');
+	});
+
 	it('returns the input unchanged when it is not a recognized zone', () => {
 		const input = 'Not/A_Zone';
 		expect(canonicalizeTimezone(input)).toBe(input);
+	});
+});
+
+describe('getTimezoneNames', () => {
+	it('returns modern canonical names instead of legacy ones', () => {
+		const names = getTimezoneNames();
+		expect(names).toContain('Asia/Kolkata');
+		expect(names).not.toContain('Asia/Calcutta');
+		expect(names).toContain('Europe/Kyiv');
+		expect(names).not.toContain('Europe/Kiev');
+		expect(names).toContain('Asia/Yangon');
+		expect(names).not.toContain('Asia/Rangoon');
 	});
 });

--- a/packages/tools/src/timezone.ts
+++ b/packages/tools/src/timezone.ts
@@ -32,7 +32,7 @@ export const canonicalizeTimezone = (name: string): string => {
 export const getTimezoneNames = (): string[] => {
 	const intl = Intl as typeof Intl & { supportedValuesOf?(key: 'timeZone'): string[] };
 	const zones = typeof intl.supportedValuesOf === 'function' ? intl.supportedValuesOf('timeZone') : [];
-	return zones.map((name) => LEGACY_TO_CANONICAL[name] ?? name);
+	return zones.map((name) => LEGACY_TO_CANONICAL[name] ?? name).sort();
 };
 
 export const guessTimezoneFromOffset = (offset: string | number): string => {

--- a/packages/tools/src/timezone.ts
+++ b/packages/tools/src/timezone.ts
@@ -1,3 +1,40 @@
+// Zones where Node/browser Intl returns a legacy IANA name instead of the
+// current canonical one. Workaround until Temporal lands (~late 2026).
+// Source: https://data.iana.org/time-zones/tzdb/backward
+// Ref: https://github.com/tc39/proposal-temporal/issues/3249
+const LEGACY_TO_CANONICAL: Record<string, string> = {
+	'America/Buenos_Aires': 'America/Argentina/Buenos_Aires',
+	'America/Catamarca': 'America/Argentina/Catamarca',
+	'America/Cordoba': 'America/Argentina/Cordoba',
+	'America/Godthab': 'America/Nuuk',
+	'America/Indianapolis': 'America/Indiana/Indianapolis',
+	'America/Jujuy': 'America/Argentina/Jujuy',
+	'America/Louisville': 'America/Kentucky/Louisville',
+	'America/Mendoza': 'America/Argentina/Mendoza',
+	'Asia/Calcutta': 'Asia/Kolkata',
+	'Asia/Katmandu': 'Asia/Kathmandu',
+	'Asia/Rangoon': 'Asia/Yangon',
+	'Asia/Saigon': 'Asia/Ho_Chi_Minh',
+	'Atlantic/Faeroe': 'Atlantic/Faroe',
+	'Europe/Kiev': 'Europe/Kyiv',
+	'Pacific/Enderbury': 'Pacific/Kanton',
+};
+
+export const canonicalizeTimezone = (name: string): string => {
+	try {
+		const resolved = new Intl.DateTimeFormat(undefined, { timeZone: name }).resolvedOptions().timeZone;
+		return LEGACY_TO_CANONICAL[resolved] ?? resolved;
+	} catch {
+		return name;
+	}
+};
+
+export const getTimezoneNames = (): string[] => {
+	const intl = Intl as typeof Intl & { supportedValuesOf?(key: 'timeZone'): string[] };
+	const zones = typeof intl.supportedValuesOf === 'function' ? intl.supportedValuesOf('timeZone') : [];
+	return zones.map((name) => LEGACY_TO_CANONICAL[name] ?? name);
+};
+
 export const guessTimezoneFromOffset = (offset: string | number): string => {
 	const hours = Number(offset);
 	const totalMinutes = Math.round(hours * 60);
@@ -21,7 +58,7 @@ export const guessTimezoneFromOffset = (offset: string | number): string => {
 		const tzHours = match[1] ? parseInt(match[1], 10) : 0;
 		const tzMinutes = match[2] ? parseInt(match[2], 10) * (tzHours < 0 ? -1 : 1) : 0;
 		if (tzHours * 60 + tzMinutes === totalMinutes) {
-			return tz;
+			return LEGACY_TO_CANONICAL[tz] ?? tz;
 		}
 	}
 
@@ -33,12 +70,7 @@ export const guessTimezoneFromOffset = (offset: string | number): string => {
 	return `Etc/GMT${intHours > 0 ? '-' : '+'}${Math.abs(intHours)}`;
 };
 
-export const guessTimezone = (): string => new Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-export const canonicalizeTimezone = (name: string): string => {
-	try {
-		return new Intl.DateTimeFormat(undefined, { timeZone: name }).resolvedOptions().timeZone;
-	} catch {
-		return name;
-	}
+export const guessTimezone = (): string => {
+	const resolved = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+	return LEGACY_TO_CANONICAL[resolved] ?? resolved;
 };


### PR DESCRIPTION
## Proposed changes

After #40076 migrated from `moment.tz.names()` to `Intl.supportedValuesOf('timeZone')`, Node's Intl API returns legacy IANA names for 15 zones (e.g. `Asia/Calcutta` instead of `Asia/Kolkata`). This is a [known ICU/CLDR issue](https://github.com/tc39/proposal-temporal/issues/3249), expected to be fixed with the Temporal API (~late 2026).

Adds a static map of the 15 affected zones in `@rocket.chat/tools` (from the [IANA backward file](https://data.iana.org/time-zones/tzdb/backward)) and applies it in `canonicalizeTimezone()`, `getTimezoneNames()`, `guessTimezone()`, and `guessTimezoneFromOffset()`.

Builds on top of #40305.

## Issue(s)

- [CORE-2137](https://rocketchat.atlassian.net/browse/CORE-2137)

## Steps to test or reproduce

Omnichannel > Business Hours > Edit - search "Kolkata" in timezone dropdown, should show `Asia/Kolkata`.

## Further comments

**How we derived the 15 zones:** cross-referenced `Intl.supportedValuesOf('timeZone')` (418 zones on Node 22) with the [IANA backward file](https://data.iana.org/time-zones/tzdb/backward). For each zone in the Intl list, checked if the IANA backward file classifies it as a `Link` (alias) pointing to a different canonical name that's absent from the Intl list. The 15 matches are zones where Node's Intl returns the legacy alias instead of the current IANA canonical.

We checked `@date-fns/tz`, `@formatjs/intl-enumerator`, and `temporal-polyfill` - all delegate to the same ICU data. The IANA backward file is the only authoritative source. The map can be removed once Temporal lands.


[CORE-2137]: https://rocketchat.atlassian.net/browse/CORE-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timezone handling now consistently uses canonical timezone identifiers across the app, converting legacy/outdated names to modern equivalents for more accurate displays and behavior.
  * The timezone list returned to UI components is now sourced from a shared, canonicalized enumeration to avoid duplicates and legacy entries.

* **Tests**
  * Expanded tests to validate timezone canonicalization and the canonical timezone list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->