### PR TITLE
fix: Preserve edit mode while cancelling message deletion

### DIFF
--- a/apps/meteor/app/ui/client/lib/ChatMessages.ts
+++ b/apps/meteor/app/ui/client/lib/ChatMessages.ts
@@ -12,6 +12,7 @@ import { processSetReaction } from '../../../../client/lib/chats/flows/processSe
 import { processSlashCommand } from '../../../../client/lib/chats/flows/processSlashCommand';
 import { processTooLongMessage } from '../../../../client/lib/chats/flows/processTooLongMessage';
 import { replyBroadcast } from '../../../../client/lib/chats/flows/replyBroadcast';
+import { requestEditMessageDeletion } from '../../../../client/lib/chats/flows/requestEditMessageDeletion';
 import { requestMessageDeletion } from '../../../../client/lib/chats/flows/requestMessageDeletion';
 import { sendMessage } from '../../../../client/lib/chats/flows/sendMessage';
 import { uploadFiles } from '../../../../client/lib/chats/flows/uploadFiles';
@@ -181,6 +182,7 @@ export class ChatMessages implements ChatAPI {
 			processMessageUploads: processMessageUploads.bind(null, this),
 			processSetReaction: processSetReaction.bind(null, this),
 			requestMessageDeletion: requestMessageDeletion.bind(this, this),
+			requestEditMessageDeletion: requestEditMessageDeletion.bind(this, this),
 			replyBroadcast: replyBroadcast.bind(null, this),
 		};
 	}

--- a/apps/meteor/client/lib/chats/ChatAPI.ts
+++ b/apps/meteor/client/lib/chats/ChatAPI.ts
@@ -181,6 +181,7 @@ export type ChatAPI = {
 		readonly processMessageUploads: (message: IMessage) => Promise<boolean>;
 		readonly processSetReaction: (message: Pick<IMessage, 'msg'>) => Promise<boolean>;
 		readonly requestMessageDeletion: (message: IMessage) => Promise<void>;
+		readonly requestEditMessageDeletion: (message: IMessage) => Promise<void>;
 		readonly replyBroadcast: (message: IMessage) => Promise<void>;
 	};
 };

--- a/apps/meteor/client/lib/chats/flows/requestEditMessageDeletion.ts
+++ b/apps/meteor/client/lib/chats/flows/requestEditMessageDeletion.ts
@@ -1,0 +1,36 @@
+import type { IMessage } from '@rocket.chat/core-typings';
+import { imperativeModal } from '@rocket.chat/ui-client';
+
+import { t } from '../../../../app/utils/lib/i18n';
+import DeleteMessageConfirmModal from '../../../views/room/modals/DeleteMessageConfirmModal';
+import { dispatchToastMessage } from '../../toast';
+import type { ChatAPI } from '../ChatAPI';
+
+export const requestEditMessageDeletion = async (chat: ChatAPI, message: IMessage): Promise<void> => {
+	if (!(await chat.data.canDeleteMessage(message))) {
+		dispatchToastMessage({ type: 'error', message: t('Message_deleting_blocked') });
+		return;
+	}
+
+	const room = message.drid ? await chat.data.getDiscussionByID(message.drid) : undefined;
+
+	await new Promise<void>((resolve, reject) => {
+		const onCloseModal = async (): Promise<void> => {
+			imperativeModal.close();
+			chat.composer?.focus();
+			resolve();
+		};
+
+		imperativeModal.open({
+			component: DeleteMessageConfirmModal,
+			props: {
+				room,
+				chat,
+				resolve,
+				reject,
+				message,
+				onCancel: onCloseModal,
+			},
+		});
+	});
+};

--- a/apps/meteor/client/lib/chats/flows/sendMessage.ts
+++ b/apps/meteor/client/lib/chats/flows/sendMessage.ts
@@ -126,8 +126,7 @@ export const sendMessage = async (
 				return false;
 			}
 
-			await chat.currentEditingMessage.reset();
-			await chat.flows.requestMessageDeletion(originalMessage);
+			await chat.flows.requestEditMessageDeletion(originalMessage);
 			return false;
 		} catch (error) {
 			dispatchToastMessage({ type: 'error', message: error });

--- a/apps/meteor/tests/e2e/message-actions.spec.ts
+++ b/apps/meteor/tests/e2e/message-actions.spec.ts
@@ -307,11 +307,12 @@ test.describe.serial('message-actions', () => {
 
 	test('keeps edit mode after cancel and deletes on confirm', async ({ page }) => {
 		const composer = page.getByLabel('Room composer');
+		const composerTextbox = page.getByRole('textbox', { name: `Message #${targetChannel}` });
 
 		const editLastMessageBlank = async () => {
 			await poHomeChannel.content.openLastMessageMenu();
 			await page.getByRole('menuitem', { name: 'Edit' }).click();
-			await page.getByRole('textbox', { name: `Message #${targetChannel}` }).fill('');
+			await composerTextbox.fill('');
 			await page.keyboard.press('Enter');
 		};
 
@@ -327,7 +328,7 @@ test.describe.serial('message-actions', () => {
 			await poHomeChannel.content.btnModalCancel.click();
 
 			await expect(composer).toContainText('Editing message');
-			await expect(composer.locator('textarea[name="msg"]')).toHaveValue('');
+			await expect(composerTextbox).toHaveValue('');
 			await expect(poHomeChannel.content.lastUserMessageBody).toHaveText('This is a message to edit');
 		});
 

--- a/apps/meteor/tests/e2e/message-actions.spec.ts
+++ b/apps/meteor/tests/e2e/message-actions.spec.ts
@@ -304,4 +304,40 @@ test.describe.serial('message-actions', () => {
 		await poHomeChannel.navbar.openChat(forwardChannel);
 		await expect(poHomeChannel.content.lastUserMessage).toContainText(filename);
 	});
+
+	test('keeps edit mode after cancel and deletes on confirm', async ({ page }) => {
+		const composer = page.getByLabel('Room composer');
+
+		const editLastMessageBlank = async () => {
+			await poHomeChannel.content.openLastMessageMenu();
+			await page.getByRole('menuitem', { name: 'Edit' }).click();
+			await page.getByRole('textbox', { name: `Message #${targetChannel}` }).fill('');
+			await page.keyboard.press('Enter');
+		};
+
+		await poHomeChannel.content.sendMessage('Dummy message');
+		await poHomeChannel.content.sendMessage('This is a message to edit');
+
+		await test.step('show delete confirmation', async () => {
+			await editLastMessageBlank();
+			await expect(page.getByRole('dialog', { name: 'Are you sure?' })).toBeVisible();
+		});
+
+		await test.step('stay in edit mode after cancel', async () => {
+			await poHomeChannel.content.btnModalCancel.click();
+
+			await expect(composer).toContainText('Editing message');
+			await expect(composer.locator('textarea[name="msg"]')).toHaveValue('');
+			await expect(poHomeChannel.content.lastUserMessageBody).toHaveText('This is a message to edit');
+		});
+
+		await test.step('delete message on confirm', async () => {
+			await editLastMessageBlank();
+
+			await poHomeChannel.content.btnModalConfirmDelete.click();
+
+			await expect(composer).not.toContainText('Editing message');
+			await expect(poHomeChannel.content.lastUserMessageBody).not.toHaveText('This is a message to edit');
+		});
+	});
 });


### PR DESCRIPTION
Fixes #35650 where editing a message and submitting a blank message, a deletion confirmation modal pops up. Cancelling the action **preserves** the Edit mode for that message. Currently, cancelling from the modal removes the Edit mode inside the Composer, which is an unintended bug.

## Preview of bugfix

https://github.com/user-attachments/assets/d983ac09-9d4c-448f-a5de-98c52fe85081

## Steps to reproduce the bug

1. Edit a message in the chatroom
2. Clear the textbox and then press Send
3. A modal pops up, asking to confirm message deletion.
4. Cancelling removes the Edit mode status

## Further comments
- This PR is an updated commit based on #35653 
- Added a playwright test to assert this behaviour in the `message-actions.spec.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-facing flow to request deletion of a message while editing, with permission checks, confirmation dialog, and proper composer refocus when cancelled.
  * Improved safeguards to prevent accidental removal of edited messages.

* **Tests**
  * Added end-to-end tests covering the edit+delete lifecycle, including both cancel and confirm scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->