### PR TITLE
refactor(api): consolidate cloud endpoint validators and type definitions

### DIFF
--- a/.changeset/swift-ways-leave.md
+++ b/.changeset/swift-ways-leave.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/rest-typings': minor
+'@rocket.chat/meteor': minor
+---
+
+Migrates cloud endpoint validators (`cloud.manualRegister`, `cloud.createRegistrationIntent`, `cloud.confirmationPoll`) from `rest-typings` into the API implementation, aligning them with the OpenAPI typed route pattern

--- a/apps/meteor/app/api/server/v1/cloud.ts
+++ b/apps/meteor/app/api/server/v1/cloud.ts
@@ -1,8 +1,5 @@
 import type { CloudRegistrationIntentData, CloudConfirmationPollData, CloudRegistrationStatus } from '@rocket.chat/core-typings';
 import {
-	isCloudConfirmationPollProps,
-	isCloudCreateRegistrationIntentProps,
-	isCloudManualRegisterProps,
 	ajv,
 	validateUnauthorizedErrorResponse,
 	validateForbiddenErrorResponse,
@@ -23,7 +20,51 @@ import { retrieveRegistrationStatus } from '../../../cloud/server/functions/retr
 import { saveRegistrationData, saveRegistrationDataManual } from '../../../cloud/server/functions/saveRegistrationData';
 import { startRegisterWorkspaceSetupWizard } from '../../../cloud/server/functions/startRegisterWorkspaceSetupWizard';
 import { syncWorkspace } from '../../../cloud/server/functions/syncWorkspace';
+import type { ExtractRoutesFromAPI } from '../ApiClass';
 import { API } from '../api';
+
+type CloudManualRegister = {
+	cloudBlob: string;
+};
+
+type CloudCreateRegistrationIntent = {
+	resend: boolean;
+	email: string;
+};
+
+type CloudConfirmationPoll = {
+	deviceCode: string;
+	resend?: string;
+};
+
+const CloudConfirmationPollSchema = {
+	type: 'object',
+	properties: {
+		deviceCode: { type: 'string' },
+		resend: { type: 'string' },
+	},
+	required: ['deviceCode'],
+	additionalProperties: false,
+};
+
+const CloudCreateRegistrationIntentSchema = {
+	type: 'object',
+	properties: {
+		resend: { type: 'boolean' },
+		email: { type: 'string' },
+	},
+	required: ['resend', 'email'],
+	additionalProperties: false,
+};
+
+const CloudManualRegisterSchema = {
+	type: 'object',
+	properties: {
+		cloudBlob: { type: 'string' },
+	},
+	required: ['cloudBlob'],
+	additionalProperties: false,
+};
 
 const successResponseSchema = ajv.compile<void>({
 	type: 'object',
@@ -31,6 +72,12 @@ const successResponseSchema = ajv.compile<void>({
 	required: ['success'],
 	additionalProperties: false,
 });
+
+const isCloudConfirmationPollProps = ajv.compile<CloudConfirmationPoll>(CloudConfirmationPollSchema);
+
+const isCloudCreateRegistrationIntentProps = ajv.compile<CloudCreateRegistrationIntent>(CloudCreateRegistrationIntentSchema);
+
+const isCloudManualRegisterProps = ajv.compile<CloudManualRegister>(CloudManualRegisterSchema);
 
 const manualRegisterResponseSchema = ajv.compile<void>({
 	type: 'object',
@@ -94,218 +141,214 @@ const checkoutUrlResponseSchema = ajv.compile<{ url: string }>({
 	additionalProperties: false,
 });
 
-API.v1.post(
-	'cloud.manualRegister',
-	{
-		authRequired: true,
-		permissionsRequired: ['register-on-cloud'],
-		body: isCloudManualRegisterProps,
-		response: {
-			200: manualRegisterResponseSchema,
-			400: validateBadRequestErrorResponse,
-			401: validateUnauthorizedErrorResponse,
-			403: validateForbiddenErrorResponse,
+const cloudEndpoints = API.v1
+	.post(
+		'cloud.manualRegister',
+		{
+			authRequired: true,
+			permissionsRequired: ['register-on-cloud'],
+			body: isCloudManualRegisterProps,
+			response: {
+				200: manualRegisterResponseSchema,
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
+			},
 		},
-	},
-	async function action() {
-		const registrationInfo = await retrieveRegistrationStatus();
+		async function action() {
+			const registrationInfo = await retrieveRegistrationStatus();
 
-		if (registrationInfo.workspaceRegistered) {
-			return API.v1.failure('Workspace is already registered');
-		}
-
-		const settingsData = JSON.parse(Buffer.from(this.bodyParams.cloudBlob, 'base64').toString());
-
-		await saveRegistrationDataManual(settingsData);
-
-		return API.v1.success();
-	},
-);
-
-API.v1.post(
-	'cloud.createRegistrationIntent',
-	{
-		authRequired: true,
-		permissionsRequired: ['manage-cloud'],
-		body: isCloudCreateRegistrationIntentProps,
-		response: {
-			200: createRegistrationIntentResponseSchema,
-			400: validateBadRequestErrorResponse,
-			401: validateUnauthorizedErrorResponse,
-			403: validateForbiddenErrorResponse,
-		},
-	},
-	async function action() {
-		const intentData = await startRegisterWorkspaceSetupWizard(this.bodyParams.resend, this.bodyParams.email);
-
-		if (intentData) {
-			return API.v1.success({ intentData });
-		}
-
-		return API.v1.failure('Invalid query');
-	},
-);
-
-API.v1.post(
-	'cloud.registerPreIntent',
-	{
-		authRequired: true,
-		permissionsRequired: ['manage-cloud'],
-		response: {
-			200: registerPreIntentResponseSchema,
-			401: validateUnauthorizedErrorResponse,
-			403: validateForbiddenErrorResponse,
-		},
-	},
-	async function action() {
-		return API.v1.success({ offline: !(await registerPreIntentWorkspaceWizard()) });
-	},
-);
-
-API.v1.get(
-	'cloud.confirmationPoll',
-	{
-		authRequired: true,
-		permissionsRequired: ['manage-cloud'],
-		query: isCloudConfirmationPollProps,
-		response: {
-			200: confirmationPollResponseSchema,
-			400: validateBadRequestErrorResponse,
-			401: validateUnauthorizedErrorResponse,
-			403: validateForbiddenErrorResponse,
-		},
-	},
-	async function action() {
-		const { deviceCode } = this.queryParams;
-
-		const pollData = await getConfirmationPoll(deviceCode);
-		if (pollData) {
-			if ('successful' in pollData && pollData.successful) {
-				await saveRegistrationData(pollData.payload);
+			if (registrationInfo.workspaceRegistered) {
+				return API.v1.failure('Workspace is already registered');
 			}
-			return API.v1.success({ pollData });
-		}
 
-		return API.v1.failure('Invalid query');
-	},
-);
+			const settingsData = JSON.parse(Buffer.from(this.bodyParams.cloudBlob, 'base64').toString());
 
-API.v1.get(
-	'cloud.registrationStatus',
-	{
-		authRequired: true,
-		permissionsRequired: ['manage-cloud'],
-		response: {
-			200: registrationStatusResponseSchema,
-			401: validateUnauthorizedErrorResponse,
-			403: validateForbiddenErrorResponse,
-		},
-	},
-	async function action() {
-		const registrationStatus = await retrieveRegistrationStatus();
-
-		return API.v1.success({ registrationStatus });
-	},
-);
-
-API.v1.post(
-	'cloud.syncWorkspace',
-	{
-		authRequired: true,
-		permissionsRequired: ['manage-cloud'],
-		rateLimiterOptions: { numRequestsAllowed: 2, intervalTimeInMS: 60000 },
-		response: {
-			200: successResponseSchema,
-			400: validateBadRequestErrorResponse,
-			401: validateUnauthorizedErrorResponse,
-			403: validateForbiddenErrorResponse,
-		},
-	},
-	async function action() {
-		try {
-			await syncWorkspace();
+			await saveRegistrationDataManual(settingsData);
 
 			return API.v1.success();
-		} catch (error) {
-			return API.v1.failure('Error during workspace sync');
-		}
-	},
-);
-
-API.v1.post(
-	'cloud.removeLicense',
-	{
-		authRequired: true,
-		permissionsRequired: ['manage-cloud'],
-		rateLimiterOptions: { numRequestsAllowed: 2, intervalTimeInMS: 60000 },
-		response: {
-			200: successResponseSchema,
-			400: validateBadRequestErrorResponse,
-			401: validateUnauthorizedErrorResponse,
-			403: validateForbiddenErrorResponse,
 		},
-	},
-	async function action() {
-		try {
-			await removeLicense();
-			return API.v1.success();
-		} catch (error) {
-			switch (true) {
-				case error instanceof CloudWorkspaceRegistrationError:
-				case error instanceof CloudWorkspaceAccessTokenEmptyError:
-				case error instanceof CloudWorkspaceAccessTokenError: {
-					SystemLogger.info({
-						msg: 'Manual license removal failed',
-						endpoint: 'cloud.removeLicense',
-						error,
-					});
-					break;
-				}
-				default: {
-					SystemLogger.error({
-						msg: 'Manual license removal failed',
-						endpoint: 'cloud.removeLicense',
-						error,
-					});
-					break;
-				}
+	)
+	.post(
+		'cloud.createRegistrationIntent',
+		{
+			authRequired: true,
+			permissionsRequired: ['manage-cloud'],
+			body: isCloudCreateRegistrationIntentProps,
+			response: {
+				200: createRegistrationIntentResponseSchema,
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
+			},
+		},
+		async function action() {
+			const intentData = await startRegisterWorkspaceSetupWizard(this.bodyParams.resend, this.bodyParams.email);
+
+			if (intentData) {
+				return API.v1.success({ intentData });
 			}
-			return API.v1.failure('License removal failed');
-		}
-	},
-);
+
+			return API.v1.failure('Invalid query');
+		},
+	)
+	.post(
+		'cloud.registerPreIntent',
+		{
+			authRequired: true,
+			permissionsRequired: ['manage-cloud'],
+			response: {
+				200: registerPreIntentResponseSchema,
+				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
+			},
+		},
+		async function action() {
+			return API.v1.success({ offline: !(await registerPreIntentWorkspaceWizard()) });
+		},
+	)
+	.get(
+		'cloud.confirmationPoll',
+		{
+			authRequired: true,
+			permissionsRequired: ['manage-cloud'],
+			query: isCloudConfirmationPollProps,
+			response: {
+				200: confirmationPollResponseSchema,
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
+			},
+		},
+		async function action() {
+			const { deviceCode } = this.queryParams;
+
+			const pollData = await getConfirmationPoll(deviceCode);
+			if (pollData) {
+				if ('successful' in pollData && pollData.successful) {
+					await saveRegistrationData(pollData.payload);
+				}
+				return API.v1.success({ pollData });
+			}
+
+			return API.v1.failure('Invalid query');
+		},
+	)
+	.get(
+		'cloud.registrationStatus',
+		{
+			authRequired: true,
+			permissionsRequired: ['manage-cloud'],
+			response: {
+				200: registrationStatusResponseSchema,
+				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
+			},
+		},
+		async function action() {
+			const registrationStatus = await retrieveRegistrationStatus();
+
+			return API.v1.success({ registrationStatus });
+		},
+	)
+	.post(
+		'cloud.syncWorkspace',
+		{
+			authRequired: true,
+			permissionsRequired: ['manage-cloud'],
+			rateLimiterOptions: { numRequestsAllowed: 2, intervalTimeInMS: 60000 },
+			response: {
+				200: successResponseSchema,
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
+			},
+		},
+		async function action() {
+			try {
+				await syncWorkspace();
+
+				return API.v1.success();
+			} catch (error) {
+				return API.v1.failure('Error during workspace sync');
+			}
+		},
+	)
+	.post(
+		'cloud.removeLicense',
+		{
+			authRequired: true,
+			permissionsRequired: ['manage-cloud'],
+			rateLimiterOptions: { numRequestsAllowed: 2, intervalTimeInMS: 60000 },
+			response: {
+				200: successResponseSchema,
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
+			},
+		},
+		async function action() {
+			try {
+				await removeLicense();
+				return API.v1.success();
+			} catch (error) {
+				switch (true) {
+					case error instanceof CloudWorkspaceRegistrationError:
+					case error instanceof CloudWorkspaceAccessTokenEmptyError:
+					case error instanceof CloudWorkspaceAccessTokenError: {
+						SystemLogger.info({
+							msg: 'Manual license removal failed',
+							endpoint: 'cloud.removeLicense',
+							error,
+						});
+						break;
+					}
+					default: {
+						SystemLogger.error({
+							msg: 'Manual license removal failed',
+							endpoint: 'cloud.removeLicense',
+							error,
+						});
+						break;
+					}
+				}
+				return API.v1.failure('License removal failed');
+			}
+		},
+	)
+	.get(
+		'cloud.checkoutUrl',
+		{
+			authRequired: true,
+			permissionsRequired: ['manage-cloud'],
+			response: {
+				200: checkoutUrlResponseSchema,
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
+			},
+		},
+		async function action() {
+			const checkoutUrl = await getCheckoutUrl();
+
+			if (!checkoutUrl.url) {
+				return API.v1.failure();
+			}
+
+			return API.v1.success({ url: checkoutUrl.url });
+		},
+	);
+
+type CloudEndpoints = ExtractRoutesFromAPI<typeof cloudEndpoints>;
 
 /**
  * Declaring endpoint here because we don't want this available to the sdk client
  */
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
-	interface Endpoints {
+	interface Endpoints extends CloudEndpoints {
 		'/v1/cloud.checkoutUrl': {
 			GET: () => { url: string };
 		};
 	}
 }
-
-API.v1.get(
-	'cloud.checkoutUrl',
-	{
-		authRequired: true,
-		permissionsRequired: ['manage-cloud'],
-		response: {
-			200: checkoutUrlResponseSchema,
-			400: validateBadRequestErrorResponse,
-			401: validateUnauthorizedErrorResponse,
-			403: validateForbiddenErrorResponse,
-		},
-	},
-	async function action() {
-		const checkoutUrl = await getCheckoutUrl();
-
-		if (!checkoutUrl.url) {
-			return API.v1.failure();
-		}
-
-		return API.v1.success({ url: checkoutUrl.url });
-	},
-);

--- a/packages/rest-typings/src/v1/cloud.ts
+++ b/packages/rest-typings/src/v1/cloud.ts
@@ -1,64 +1,24 @@
-import type { CloudRegistrationIntentData, CloudConfirmationPollData, CloudRegistrationStatus } from '@rocket.chat/core-typings';
-
-import { ajv, ajvQuery } from './Ajv';
+import type { CloudRegistrationIntentData, CloudConfirmationPollData } from '@rocket.chat/core-typings';
 
 type CloudManualRegister = {
 	cloudBlob: string;
 };
 
-const CloudManualRegisterSchema = {
-	type: 'object',
-	properties: {
-		cloudBlob: {
-			type: 'string',
-		},
-	},
-	required: ['cloudBlob'],
-	additionalProperties: false,
-};
-
-export const isCloudManualRegisterProps = ajv.compile<CloudManualRegister>(CloudManualRegisterSchema);
 
 type CloudCreateRegistrationIntent = {
 	resend: boolean;
 	email: string;
 };
 
-const CloudCreateRegistrationIntentSchema = {
-	type: 'object',
-	properties: {
-		resend: {
-			type: 'boolean',
-		},
-		email: {
-			type: 'string',
-		},
-	},
-	required: ['resend', 'email'],
-	additionalProperties: false,
-};
-
-export const isCloudCreateRegistrationIntentProps = ajv.compile<CloudCreateRegistrationIntent>(CloudCreateRegistrationIntentSchema);
 
 type CloudConfirmationPoll = {
 	deviceCode: string;
 	resend?: string;
 };
 
-const CloudConfirmationPollSchema = {
-	type: 'object',
-	properties: {
-		deviceCode: {
-			type: 'string',
-			minLength: 1,
-		},
-	},
-	required: ['deviceCode'],
-	additionalProperties: false,
-};
 
-export const isCloudConfirmationPollProps = ajvQuery.compile<CloudConfirmationPoll>(CloudConfirmationPollSchema);
-
+// These endpoints are still used by ui-client, so they remain here for now.
+// Remove them from the typings once ui-client no longer depends on them.
 export type CloudEndpoints = {
 	'/v1/cloud.manualRegister': {
 		POST: (params: CloudManualRegister) => void;
@@ -77,14 +37,5 @@ export type CloudEndpoints = {
 		GET: (params: CloudConfirmationPoll) => {
 			pollData: CloudConfirmationPollData;
 		};
-	};
-	'/v1/cloud.registrationStatus': {
-		GET: () => { registrationStatus: CloudRegistrationStatus };
-	};
-	'/v1/cloud.syncWorkspace': {
-		POST: () => { success: boolean };
-	};
-	'/v1/cloud.removeLicense': {
-		POST: () => { success: boolean };
 	};
 };


### PR DESCRIPTION
## Changes

As part of the ongoing migration of REST API endpoints to the OpenAPI-compatible typed route pattern, the cloud endpoints were left in an incomplete state — validators were defined in `@rocket.chat/rest-typings` and imported into the implementation, which doesn't align with how the new pattern works.

This PR completes that migration for the cloud endpoints:

- Inlines `isCloudManualRegisterProps`, `isCloudCreateRegistrationIntentProps`, and `isCloudConfirmationPollProps` validators directly into `cloud.ts` using local AJV schemas
- Chains all endpoint definitions using the fluent API pattern (`API.v1.post(...).get(...).post(...)`)
- Extracts the `CloudEndpoints` type from the chained definition via `ExtractRoutesFromAPI` instead of duplicating it in `rest-typings`
- Removes the now-unused validator exports and `CloudRegistrationStatus` import from `rest-typings`
- Updates the module augmentation to extend from the implementation-derived type
- Keeps the `CloudEndpoints` type export in `rest-typings` for ui-client compatibility

## Issue(s)

https://github.com/RocketChat/Rocket.Chat-Open-API/pull/150/ — continuation of internal OpenAPI migration work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cloud API validation and routing consolidated into a single, consistent implementation for improved reliability and maintainability.
  * Typings updated to reflect the consolidated API surface.
  * Removed three cloud endpoints: registrationStatus, syncWorkspace, and removeLicense — clients relying on these should migrate accordingly.

* **Chore**
  * Internal package versions bumped to align with the API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->