### PR TITLE
test: log last request body/query/response on test or hook failure

### DIFF
--- a/apps/meteor/.mocharc.api.js
+++ b/apps/meteor/.mocharc.api.js
@@ -10,5 +10,6 @@ module.exports = /** @satisfies {import('mocha').MochaOptions} */ ({
 	bail: false,
 	retries: 0,
 	file: 'tests/end-to-end/teardown.ts',
+	reporter: 'tests/end-to-end/reporter.ts',
 	spec: ['tests/end-to-end/api/*.ts', 'tests/end-to-end/api/helpers/**/*', 'tests/end-to-end/api/methods/**/*', 'tests/end-to-end/apps/*'],
 });

--- a/apps/meteor/tests/end-to-end/reporter.ts
+++ b/apps/meteor/tests/end-to-end/reporter.ts
@@ -1,0 +1,23 @@
+import Mocha from 'mocha';
+
+import { getLastRequest } from './teardown';
+
+const { EVENT_TEST_FAIL } = Mocha.Runner.constants;
+
+module.exports = class FailDumpReporter extends Mocha.reporters.Spec {
+	constructor(runner: Mocha.Runner, options: Mocha.MochaOptions) {
+		super(runner, options);
+		runner.on(EVENT_TEST_FAIL, (runnable) => {
+			const { lastUrl, lastMethod, lastBody, lastQuery, lastResponse } = getLastRequest();
+			console.log({
+				where: runnable.fullTitle(),
+				type: runnable.type,
+				lastUrl,
+				lastMethod,
+				lastBody,
+				lastQuery,
+				lastResponse: lastResponse?.text,
+			});
+		});
+	}
+};

--- a/apps/meteor/tests/end-to-end/teardown.ts
+++ b/apps/meteor/tests/end-to-end/teardown.ts
@@ -8,7 +8,7 @@ let lastUrl: string;
 let lastMethod: string;
 let lastBody: unknown;
 let lastQuery: unknown;
-let lastResponse: Response;
+let lastResponse: Response | undefined;
 
 methods.forEach((method) => {
 	const original = request[method];
@@ -17,6 +17,7 @@ methods.forEach((method) => {
 		lastMethod = method;
 		lastBody = undefined;
 		lastQuery = undefined;
+		lastResponse = undefined;
 
 		const test = original(url);
 		const originalSend = test.send.bind(test);

--- a/apps/meteor/tests/end-to-end/teardown.ts
+++ b/apps/meteor/tests/end-to-end/teardown.ts
@@ -1,4 +1,3 @@
-import { afterEach } from 'mocha';
 import type { Response } from 'supertest';
 
 import { request } from '../data/api-data';
@@ -7,6 +6,8 @@ const methods = ['get', 'post', 'put', 'del', 'delete'] as const;
 
 let lastUrl: string;
 let lastMethod: string;
+let lastBody: unknown;
+let lastQuery: unknown;
 let lastResponse: Response;
 
 methods.forEach((method) => {
@@ -14,18 +15,25 @@ methods.forEach((method) => {
 	request[method] = function (url) {
 		lastUrl = url;
 		lastMethod = method;
-		return original(url).expect((res) => {
+		lastBody = undefined;
+		lastQuery = undefined;
+
+		const test = original(url);
+		const originalSend = test.send.bind(test);
+		const originalQuery = test.query.bind(test);
+		test.send = (data) => {
+			lastBody = data;
+			return originalSend(data);
+		};
+		test.query = (data) => {
+			lastQuery = data;
+			return originalQuery(data);
+		};
+
+		return test.expect((res) => {
 			lastResponse = res;
 		});
 	};
 });
 
-afterEach(async function () {
-	if (this.currentTest?.state === 'failed') {
-		console.log({
-			lastUrl,
-			lastMethod,
-			lastResponse: lastResponse.text,
-		});
-	}
-});
+export const getLastRequest = () => ({ lastUrl, lastMethod, lastBody, lastQuery, lastResponse });


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Logs for API fails would be now:
```
{
  where: '[ABAC] (Enterprise Only) "before all" hook in "[ABAC] (Enterprise Only)"',
  type: 'hook',
  lastUrl: '/api/v1/abac/attributes',
  lastMethod: 'get',
  lastBody: undefined,
  lastQuery: undefined,
  lastResponse: '{"success":false,"error":"You must be logged in to do this.","status":"error","message":"You must be logged in to do this."}'
}
```

which gives more info on what happened.

It's a small change for normal tests (`it`) because we had some logging around those. However, if the failure was on a `before`/`after` hook, we didn't have the visibility and the current approach (an afterEach) didn't work for this specific case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test diagnostics with a new failure reporter that captures and prints the last request and response when a test fails.
  * Enhanced request capturing during tests (URL, method, body, query, and response) and exposed an accessor to retrieve that context for better debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [CORE-2174]

[CORE-2174]: https://rocketchat.atlassian.net/browse/CORE-2174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ