### PR TITLE
fix: current device logout showing error

### DIFF
--- a/.changeset/all-baths-cry.md
+++ b/.changeset/all-baths-cry.md
@@ -1,0 +1,8 @@
+---
+'@rocket.chat/model-typings': minor
+'@rocket.chat/core-typings': minor
+'@rocket.chat/models': minor
+'@rocket.chat/meteor': minor
+---
+
+Adds `current` field to `DeviceManagementSession` type and `currentLoginToken` parameter to `aggregateSessionsByUserId`, allowing the sessions endpoint to identify and flag the caller's active session.

--- a/.changeset/forty-stars-bathe.md
+++ b/.changeset/forty-stars-bathe.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes error message being shown when logging out current device via Device Management despite successful logout.

--- a/apps/meteor/client/hooks/useDeviceLogout.tsx
+++ b/apps/meteor/client/hooks/useDeviceLogout.tsx
@@ -14,7 +14,11 @@ import { useTranslation } from 'react-i18next';
 
 import { deviceManagementQueryKeys } from '../lib/queryKeys';
 
-export const useDeviceLogout = (sessionId: string, endpoint: '/v1/sessions/logout' | '/v1/sessions/logout.me'): (() => void) => {
+export const useDeviceLogout = (
+	sessionId: string,
+	endpoint: '/v1/sessions/logout' | '/v1/sessions/logout.me',
+	isCurrentSession?: boolean,
+): (() => void) => {
 	const { t } = useTranslation();
 	const setModal = useSetModal();
 	const dispatchToastMessage = useToastMessageDispatch();
@@ -26,15 +30,13 @@ export const useDeviceLogout = (sessionId: string, endpoint: '/v1/sessions/logou
 	const queryClient = useQueryClient();
 	const logoutEndpoint = useEndpoint('POST', endpoint);
 
-	const isOwnSessionLogout = endpoint === '/v1/sessions/logout.me';
-
 	const handleCloseContextualBar = useCallback(() => deviceManagementRouter.push({}), [deviceManagementRouter]);
 	const isContextualBarOpen = routeId === sessionId;
 
 	const { mutate: logoutDevice } = useMutation({
 		mutationFn: logoutEndpoint,
 		onSettled: () => {
-			if (isOwnSessionLogout) {
+			if (isCurrentSession) {
 				setModal(null);
 				logout();
 			} else {

--- a/apps/meteor/client/hooks/useDeviceLogout.tsx
+++ b/apps/meteor/client/hooks/useDeviceLogout.tsx
@@ -1,10 +1,17 @@
 import { GenericModal } from '@rocket.chat/ui-client';
-import { useSetModal, useToastMessageDispatch, useRoute, useRouteParameter } from '@rocket.chat/ui-contexts';
-import { useQueryClient } from '@tanstack/react-query';
-import { useCallback } from 'react';
+import {
+	useSetModal,
+	useToastMessageDispatch,
+	useRoute,
+	useRouteParameter,
+	useEndpoint,
+	useSessionDispatch,
+	UserContext,
+} from '@rocket.chat/ui-contexts';
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+import { useCallback, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useEndpointMutation } from './useEndpointMutation';
 import { deviceManagementQueryKeys } from '../lib/queryKeys';
 
 export const useDeviceLogout = (sessionId: string, endpoint: '/v1/sessions/logout' | '/v1/sessions/logout.me'): (() => void) => {
@@ -13,29 +20,40 @@ export const useDeviceLogout = (sessionId: string, endpoint: '/v1/sessions/logou
 	const dispatchToastMessage = useToastMessageDispatch();
 	const deviceManagementRouter = useRoute('device-management');
 	const routeId = useRouteParameter('id');
+	const setForceLogout = useSessionDispatch('forceLogout');
+	const { logout } = useContext(UserContext);
 
 	const queryClient = useQueryClient();
+	const logoutEndpoint = useEndpoint('POST', endpoint);
 
-	const { mutateAsync: logoutDevice } = useEndpointMutation('POST', endpoint, {
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: deviceManagementQueryKeys.all });
-			isContextualBarOpen && handleCloseContextualBar();
-			dispatchToastMessage({ type: 'success', message: t('Device_Logged_Out') });
-		},
-		onSettled: () => {
-			setModal(null);
-		},
-	});
+	const isOwnSessionLogout = endpoint === '/v1/sessions/logout.me';
 
 	const handleCloseContextualBar = useCallback(() => deviceManagementRouter.push({}), [deviceManagementRouter]);
-
 	const isContextualBarOpen = routeId === sessionId;
+
+	const { mutate: logoutDevice } = useMutation({
+		mutationFn: logoutEndpoint,
+		onSettled: () => {
+			if (isOwnSessionLogout) {
+				setModal(null);
+				logout();
+			} else {
+				queryClient.invalidateQueries({ queryKey: deviceManagementQueryKeys.all });
+				if (isContextualBarOpen) {
+					handleCloseContextualBar();
+				}
+				dispatchToastMessage({ type: 'success', message: t('Device_Logged_Out') });
+				setModal(null);
+			}
+		},
+		throwOnError: false,
+	});
 
 	return useCallback(() => {
 		const closeModal = () => setModal(null);
 
-		const handleLogoutDevice = async () => {
-			await logoutDevice({ sessionId });
+		const handleLogoutDevice = () => {
+			logoutDevice({ sessionId });
 		};
 
 		setModal(
@@ -44,12 +62,15 @@ export const useDeviceLogout = (sessionId: string, endpoint: '/v1/sessions/logou
 				variant='danger'
 				confirmText={t('Logout_Device')}
 				cancelText={t('Cancel')}
-				onConfirm={handleLogoutDevice}
+				onConfirm={() => {
+					setForceLogout(true);
+					handleLogoutDevice();
+				}}
 				onCancel={closeModal}
 				onClose={closeModal}
 			>
 				{t('Device_Logout_Text')}
 			</GenericModal>,
 		);
-	}, [setModal, t, logoutDevice, sessionId]);
+	}, [setModal, t, logoutDevice, sessionId, setForceLogout]);
 };

--- a/apps/meteor/client/hooks/useDeviceLogout.tsx
+++ b/apps/meteor/client/hooks/useDeviceLogout.tsx
@@ -1,13 +1,5 @@
 import { GenericModal } from '@rocket.chat/ui-client';
-import {
-	useSetModal,
-	useToastMessageDispatch,
-	useRoute,
-	useRouteParameter,
-	useEndpoint,
-	useSessionDispatch,
-	UserContext,
-} from '@rocket.chat/ui-contexts';
+import { useSetModal, useToastMessageDispatch, useRoute, useRouteParameter, useEndpoint, UserContext } from '@rocket.chat/ui-contexts';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { useCallback, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -24,7 +16,6 @@ export const useDeviceLogout = (
 	const dispatchToastMessage = useToastMessageDispatch();
 	const deviceManagementRouter = useRoute('device-management');
 	const routeId = useRouteParameter('id');
-	const setForceLogout = useSessionDispatch('forceLogout');
 	const { logout } = useContext(UserContext);
 
 	const queryClient = useQueryClient();
@@ -64,15 +55,12 @@ export const useDeviceLogout = (
 				variant='danger'
 				confirmText={t('Logout_Device')}
 				cancelText={t('Cancel')}
-				onConfirm={() => {
-					setForceLogout(true);
-					handleLogoutDevice();
-				}}
+				onConfirm={handleLogoutDevice}
 				onCancel={closeModal}
 				onClose={closeModal}
 			>
 				{t('Device_Logout_Text')}
 			</GenericModal>,
 		);
-	}, [setModal, t, logoutDevice, sessionId, setForceLogout]);
+	}, [setModal, t, logoutDevice, sessionId]);
 };

--- a/apps/meteor/client/views/account/deviceManagement/DeviceManagementAccountTable/DeviceManagementAccountRow.tsx
+++ b/apps/meteor/client/views/account/deviceManagement/DeviceManagementAccountTable/DeviceManagementAccountRow.tsx
@@ -13,14 +13,15 @@ type DevicesRowProps = {
 	deviceType?: string;
 	deviceOSName?: string;
 	loginAt: string;
+	current?: boolean;
 };
 
-const DeviceManagementAccountRow = ({ _id, deviceName, deviceType = 'browser', deviceOSName, loginAt }: DevicesRowProps) => {
+const DeviceManagementAccountRow = ({ _id, deviceName, deviceType = 'browser', deviceOSName, loginAt, current }: DevicesRowProps) => {
 	const { t } = useTranslation();
 	const formatDateAndTime = useFormatDateAndTime();
 	const mediaQuery = useMediaQuery('(min-width: 1024px)');
 
-	const handleDeviceLogout = useDeviceLogout(_id, '/v1/sessions/logout.me');
+	const handleDeviceLogout = useDeviceLogout(_id, '/v1/sessions/logout.me', current);
 
 	return (
 		<GenericTableRow key={_id} aria-label={_id}>

--- a/apps/meteor/client/views/account/deviceManagement/DeviceManagementAccountTable/DeviceManagementAccountRow.tsx
+++ b/apps/meteor/client/views/account/deviceManagement/DeviceManagementAccountTable/DeviceManagementAccountRow.tsx
@@ -28,7 +28,12 @@ const DeviceManagementAccountRow = ({ _id, deviceName, deviceType = 'browser', d
 			<GenericTableCell>
 				<Box display='flex' alignItems='center'>
 					<DeviceIcon deviceType={deviceType} />
-					{deviceName && <Box withTruncatedText>{deviceName}</Box>}
+					{deviceName && (
+						<Box withTruncatedText>
+							{deviceName}
+							{current && ` (${t('current')})`}
+						</Box>
+					)}
 				</Box>
 			</GenericTableCell>
 			<GenericTableCell>{deviceOSName || ''}</GenericTableCell>

--- a/apps/meteor/client/views/account/deviceManagement/DeviceManagementAccountTable/DeviceManagementAccountRow.tsx
+++ b/apps/meteor/client/views/account/deviceManagement/DeviceManagementAccountTable/DeviceManagementAccountRow.tsx
@@ -14,14 +14,22 @@ type DevicesRowProps = {
 	deviceType?: string;
 	deviceOSName?: string;
 	loginAt: string;
+	current?: boolean;
 };
 
-const DeviceManagementAccountRow = ({ _id, deviceName, deviceType = 'browser', deviceOSName, loginAt }: DevicesRowProps): ReactElement => {
+const DeviceManagementAccountRow = ({
+	_id,
+	deviceName,
+	deviceType = 'browser',
+	deviceOSName,
+	loginAt,
+	current,
+}: DevicesRowProps): ReactElement => {
 	const { t } = useTranslation();
 	const formatDateAndTime = useFormatDateAndTime();
 	const mediaQuery = useMediaQuery('(min-width: 1024px)');
 
-	const handleDeviceLogout = useDeviceLogout(_id, '/v1/sessions/logout.me');
+	const handleDeviceLogout = useDeviceLogout(_id, '/v1/sessions/logout.me', current);
 
 	return (
 		<GenericTableRow key={_id} aria-label={_id}>

--- a/apps/meteor/client/views/account/deviceManagement/DeviceManagementAccountTable/DeviceManagementAccountTable.tsx
+++ b/apps/meteor/client/views/account/deviceManagement/DeviceManagementAccountTable/DeviceManagementAccountTable.tsx
@@ -66,6 +66,7 @@ const DeviceManagementAccountTable = () => {
 					deviceType={session.device?.type}
 					deviceOSName={session.device?.os.name}
 					loginAt={session.loginAt}
+					current={session.current}
 				/>
 			)}
 			current={current}

--- a/apps/meteor/client/views/account/deviceManagement/DeviceManagementAccountTable/DeviceManagementAccountTable.tsx
+++ b/apps/meteor/client/views/account/deviceManagement/DeviceManagementAccountTable/DeviceManagementAccountTable.tsx
@@ -67,6 +67,7 @@ const DeviceManagementAccountTable = (): ReactElement => {
 					deviceType={session.device?.type}
 					deviceOSName={session.device?.os.name}
 					loginAt={session.loginAt}
+					current={session.current}
 				/>
 			)}
 			current={current}

--- a/apps/meteor/ee/server/api/sessions.ts
+++ b/apps/meteor/ee/server/api/sessions.ts
@@ -95,7 +95,14 @@ API.v1.addRoute(
 				return API.v1.failure('error-invalid-sort-keys');
 			}
 
-			const sessions = await Sessions.aggregateSessionsByUserId({ uid: this.userId, search, sort, offset, count });
+			const sessions = await Sessions.aggregateSessionsByUserId({
+				uid: this.userId,
+				search,
+				sort,
+				offset,
+				count,
+				currentLoginToken: this.token,
+			});
 			return API.v1.success(sessions);
 		},
 	},

--- a/packages/core-typings/src/ISession.ts
+++ b/packages/core-typings/src/ISession.ts
@@ -75,7 +75,9 @@ export type OSSessionAggregation = Pick<ISession, '_id'> & {
 	time: number;
 };
 
-export type DeviceManagementSession = Pick<ISession, '_id' | 'sessionId' | 'device' | 'host' | 'ip' | 'logoutAt' | 'userId' | 'loginAt'>;
+export type DeviceManagementSession = Pick<ISession, '_id' | 'sessionId' | 'device' | 'host' | 'ip' | 'logoutAt' | 'userId' | 'loginAt'> & {
+	current?: boolean;
+};
 
 export type DeviceManagementPopulatedSession = DeviceManagementSession & {
 	_user: Pick<IUser, 'name' | 'username' | 'avatarETag' | 'avatarOrigin'>;

--- a/packages/core-typings/src/ISession.ts
+++ b/packages/core-typings/src/ISession.ts
@@ -76,7 +76,9 @@ export type OSSessionAggregation = Pick<ISession, '_id'> & {
 	time: number;
 };
 
-export type DeviceManagementSession = Pick<ISession, '_id' | 'sessionId' | 'device' | 'host' | 'ip' | 'logoutAt' | 'userId' | 'loginAt'>;
+export type DeviceManagementSession = Pick<ISession, '_id' | 'sessionId' | 'device' | 'host' | 'ip' | 'logoutAt' | 'userId' | 'loginAt'> & {
+	current?: boolean;
+};
 
 export type DeviceManagementPopulatedSession = DeviceManagementSession & {
 	_user: Pick<IUser, 'name' | 'username' | 'avatarETag' | 'avatarOrigin'>;

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -7281,5 +7281,6 @@
   "No_changes_to_save": "No changes to save",
   "Avatar_preview_updated": "Avatar preview updated",
   "Select_message_from_user": "Select message from {{username}}",
-  "Select_message_from_user_with_preview": "Select message from {{username}}: {{message}}"
+  "Select_message_from_user_with_preview": "Select message from {{username}}: {{message}}",
+  "current": "current"
 }

--- a/packages/model-typings/src/models/ISessionsModel.ts
+++ b/packages/model-typings/src/models/ISessionsModel.ts
@@ -43,12 +43,14 @@ export interface ISessionsModel extends IBaseModel<ISession> {
 		search,
 		offset,
 		count,
+		currentLoginToken,
 	}: {
 		uid: string;
 		sort?: Record<CustomSortOp, 1 | -1>;
 		search?: string | null;
 		offset?: number;
 		count?: number;
+		currentLoginToken?: string;
 	}): Promise<{ sessions: Array<DeviceManagementSession>; count: number; offset: number; total: number }>;
 
 	getActiveUsersBetweenDates({ start, end }: DestructuredRange): Promise<ISession[]>;

--- a/packages/models/src/models/Sessions.ts
+++ b/packages/models/src/models/Sessions.ts
@@ -748,12 +748,14 @@ export class SessionsRaw extends BaseRaw<ISession> implements ISessionsModel {
 		search,
 		offset = 0,
 		count = 10,
+		currentLoginToken,
 	}: {
 		uid: string;
 		sort?: Record<CustomSortOp, 1 | -1>;
 		search?: string | null;
 		offset?: number;
 		count?: number;
+		currentLoginToken?: string;
 	}): Promise<PaginatedResult<{ sessions: DeviceManagementSession[] }>> {
 		const searchQuery = search ? [{ searchTerm: { $regex: search, $options: 'i' } }] : [];
 
@@ -824,6 +826,15 @@ export class SessionsRaw extends BaseRaw<ISession> implements ISessionsModel {
 				host: 1,
 				ip: 1,
 				loginAt: 1,
+				...(currentLoginToken && {
+					current: {
+						$cond: {
+							if: { $eq: ['$_id', currentLoginToken] },
+							then: true,
+							else: false,
+						},
+					},
+				}),
 			},
 		};
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
[CORE-2033](https://rocketchat.atlassian.net/browse/CORE-2033)
<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

issue:
- calling the logout API endpoint `/v1/sessions/logout.me` triggered a refetch of the device list
- at that point the user was already logged out, causing a 401 authentication error
- the 401 error displayed the "Something went wrong" page briefly before redirecting to login

solution:
- Conditional query invalidation: 
	- detect when logging out own session (`/v1/sessions/logout.me`) vs logging out other users' sessions
	- for own session logout, skip query invalidation entirely since the user is being logged out anyway
- Add `throwOnError: false` to the mutation to prevent errors from reaching React error boundaries

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-2033]: https://rocketchat.atlassian.net/browse/CORE-2033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device Management now marks your currently active session, including a localized “(current)” indicator in the device list.
  * The sessions list can flag the caller’s active session so it’s visibly identified as current.

* **Bug Fixes**
  * Logging out your current device no longer shows an incorrect error after a successful logout.
  * Logout flow/UI updates are now consistent between current vs. other sessions, including modal and notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->