### PR TITLE
test: align system-messages MultiSelect with new fuselage a11y

### DIFF
--- a/.changeset/edit-room-info-multiselect-aria-label.md
+++ b/.changeset/edit-room-info-multiselect-aria-label.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Adds an accessible label to the system-messages multi-select in the channel edit panel so screen readers announce its purpose.

--- a/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/EditRoomInfo.spec.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/EditRoomInfo.spec.tsx
@@ -64,7 +64,7 @@ const removeSystemMessageChip = async (translationKey: string) => {
 };
 
 const selectSystemMessageOption = async (translationKey: string) => {
-	const trigger = screen.getByRole('button', { name: /Select messages to hide/i });
+	const trigger = screen.getByRole('combobox', { name: /Select messages to hide/i });
 	await userEvent.click(trigger);
 
 	const listboxes = await screen.findAllByRole('listbox', { hidden: true });

--- a/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/EditRoomInfo.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/EditRoomInfo.tsx
@@ -483,6 +483,7 @@ const EditRoomInfo = ({ room, onClickClose, onClickBack }: EditRoomInfoProps) =>
 																options={sysMesOptions}
 																disabled={!hideSysMes || isFederated}
 																placeholder={t('Select_messages_to_hide')}
+																aria-label={t('Select_messages_to_hide')}
 															/>
 														)}
 													/>


### PR DESCRIPTION
## Summary

The Unit Tests CI job is currently red on `develop` (and on every PR against it). The failure is in `EditRoomInfo.spec.tsx`, added by #40295:

```
TestingLibraryElementError: Unable to find an accessible element
with the role "button" and name `/Select messages to hide/i`
```

`@rocket.chat/fuselage` `MultiSelect` was upgraded by #40328 and the anchor now exposes `role="combobox"` and uses `aria-label`/`aria-labelledby` for the accessible name (the `placeholder` is rendered as inert children, which ARIA does not consult for combobox names). The spec was written against the previous behavior, where the anchor was a plain `<button>` named by its placeholder text — so the broken selector matched then but does not match now.

## Why CI didn't catch this earlier

The two changes that conflict travelled on **different branches** and never met until the back-merge from the release line.

| Date (UTC) | Event | Branch | Has spec? | Has new fuselage? |
|---|---|---|---|---|
| Apr 24 18:00 | #40295 (regression that adds the spec) | **master** (release-8.4.0) | yes | no |
| Apr 29 22:36 | #40328 (upgrade fuselage packages) | **develop** | no | yes |
| Apr 30 16:26 | #38225 (sidebar drafts) | develop | no | yes |
| Apr 30 19:18 | #40268 (refactor frontend) | develop | no | yes |
| Apr 30 21:24 | Release 8.4.0 cut | master | yes | no |
| Apr 30 21:31 | `Merge master into develop` (`aed3c5d85d`) | **develop** | yes | yes → red |

`957625f064` is not an ancestor of `981af327a9` — `git merge-base` between them lands on `6cd73b0fe9` from Apr 22. #40295 was labelled `regression:`, so it went into the release branch (`master`), not into `develop`.

What each CI run actually saw:

- #40295's CI ran against `master` with the old fuselage. The anchor was a plain `<button>` so `getByRole('button', { name: /Select messages to hide/i })` matched. The test was correct for the tree it ran against.
- #40328's CI ran against `develop`, which had never seen the spec. Jest in `apps/meteor/client/views/.../EditRoomInfo` only picked up `useEditRoomPermissions.spec.ts`; the new `EditRoomInfo.spec.tsx` was simply not in the tree, so there was nothing to fail.
- #38225 and #40268 ran in the same shape — `develop` still without the spec.
- `aed3c5d85d` (the back-merge from `master` into `develop` after the 8.4.0 cut) is the first commit where both pieces coexist. Unit Tests went red immediately on run [25190354848](https://github.com/RocketChat/Rocket.Chat/actions/runs/25190354848), and every PR opened against `develop` since then inherits the same failure via the merge commit CI builds.

This is a textbook merge-skew between the release branch and mainline: each side green in isolation, conflict only visible at the back-merge. The 6-day gap between #40295 landing on `master` (Apr 24) and `master` flowing back into `develop` (Apr 30) is what kept the regression hidden.

## Changes

- `EditRoomInfo.tsx` — pass `aria-label={t('Select_messages_to_hide')}` to the `MultiSelect` so the combobox has a real accessible name (a11y improvement, not just a test fix).
- `EditRoomInfo.spec.tsx` — query the trigger via `getByRole('combobox', …)` to match the new fuselage semantics.

## Test plan

- [x] `yarn jest client/views/room/contextualBar/Info/EditRoomInfo/EditRoomInfo.spec.tsx` — all 5 tests pass locally.
- [x] Unit Tests CI green.
- [x] Manual smoke: edit a channel → Advanced settings → toggle "Hide system messages" → the multi-select is announced as "Select messages to hide" by screen readers. 

 Task: [ARCH-2123]

[ARCH-2123]: https://rocketchat.atlassian.net/browse/ARCH-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced screen reader compatibility in the channel edit panel by adding accessible labels to the "Select messages to hide" multi-select control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->