### PR TITLE
refactor(ddp-streamer): backpressure, deterministic logout, metrics, fan-out tests

### DIFF
--- a/ee/apps/ddp-streamer/src/Client.spec.ts
+++ b/ee/apps/ddp-streamer/src/Client.spec.ts
@@ -1,0 +1,154 @@
+import { EventEmitter } from 'events';
+import type { IncomingMessage } from 'http';
+
+import type WebSocket from 'ws';
+
+import { Client } from './Client';
+import { DDP_EVENTS, MAX_BUFFERED_BYTES, TIMEOUT, WS_ERRORS } from './constants';
+
+jest.mock('./Server', () => ({ SERVER_ID: '{"msg":"server_id","server_id":"0"}' }));
+
+jest.mock('./configureServer', () => {
+	const realEvents: typeof import('events') = jest.requireActual('events');
+	class FakeServer extends realEvents.EventEmitter {
+		id = 'fake-server';
+
+		serialize = (obj: unknown) => JSON.stringify(obj);
+
+		parse = (data: any) => JSON.parse(data.toString());
+
+		call = jest.fn().mockResolvedValue(undefined);
+
+		subscribe = jest.fn().mockResolvedValue(undefined);
+	}
+	return { server: new FakeServer(), events: new realEvents.EventEmitter() };
+});
+
+jest.mock('@rocket.chat/core-services', () => ({
+	Presence: { updateConnection: jest.fn().mockResolvedValue(undefined) },
+}));
+
+class FakeWebSocket extends EventEmitter {
+	public bufferedAmount = 0;
+
+	public readyState = 1;
+
+	public send = jest.fn();
+
+	public close = jest.fn((_code?: number, _reason?: string) => {
+		this.readyState = 3;
+	});
+}
+
+const makeReq = (): IncomingMessage => ({ socket: { remoteAddress: '127.0.0.1' }, headers: {} }) as unknown as IncomingMessage;
+
+const asWs = (ws: FakeWebSocket): WebSocket => ws as unknown as WebSocket;
+
+describe('Client.send backpressure', () => {
+	let ws: FakeWebSocket;
+	let client: any;
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		ws = new FakeWebSocket();
+		client = new Client(asWs(ws), false, makeReq());
+		ws.send.mockClear();
+		ws.close.mockClear();
+	});
+
+	afterEach(() => {
+		jest.clearAllTimers();
+		jest.useRealTimers();
+	});
+
+	it('closes with code 1013 when bufferedAmount exceeds the threshold', () => {
+		ws.bufferedAmount = MAX_BUFFERED_BYTES + 1;
+		client.send('hello');
+		expect(ws.close).toHaveBeenCalledWith(WS_ERRORS.SLOW_CONSUMER, expect.any(String));
+		expect(ws.send).not.toHaveBeenCalled();
+	});
+
+	it('forwards to ws.send when bufferedAmount is below the threshold', () => {
+		ws.bufferedAmount = 1024;
+		client.send('hello');
+		expect(ws.send).toHaveBeenCalledWith('hello');
+		expect(ws.close).not.toHaveBeenCalled();
+	});
+
+	it('encodes payloads for meteor clients with the SockJS array wrapper', () => {
+		const meteorWs = new FakeWebSocket();
+		const meteorClient = new Client(asWs(meteorWs), true, makeReq());
+		meteorWs.send.mockClear();
+		meteorClient.send('payload');
+		expect(meteorWs.send).toHaveBeenCalledWith('a["payload"]');
+	});
+});
+
+describe('Client heartbeat', () => {
+	let ws: FakeWebSocket;
+
+	const handshake = async (): Promise<void> => {
+		ws.emit('message', Buffer.from(JSON.stringify({ msg: DDP_EVENTS.CONNECT, version: '1' })), false);
+		await flushAsync();
+	};
+
+	const flushAsync = async (): Promise<void> => {
+		// `Client.handler` is async — yield twice so server.parse, the internal emit, and
+		// the once('message') listener all complete before the test inspects state.
+		await Promise.resolve();
+		await Promise.resolve();
+	};
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		ws = new FakeWebSocket();
+		// Client wires itself into the ws via constructor side effects; we don't need the ref.
+		void new Client(asWs(ws), false, makeReq());
+		ws.send.mockClear();
+		ws.close.mockClear();
+	});
+
+	afterEach(() => {
+		jest.clearAllTimers();
+		jest.useRealTimers();
+	});
+
+	const lastSent = (): string | undefined => ws.send.mock.calls.at(-1)?.[0];
+
+	it('sends PING after the idle window expires', () => {
+		jest.advanceTimersByTime(TIMEOUT);
+		expect(lastSent()).toContain(`"${DDP_EVENTS.PING}"`);
+	});
+
+	it('closes with code 4000 when no PONG arrives within the pong window', () => {
+		jest.advanceTimersByTime(TIMEOUT); // PING sent, pong window starts
+		jest.advanceTimersByTime(TIMEOUT); // pong window expires
+		expect(ws.close).toHaveBeenCalledWith(WS_ERRORS.TIMEOUT, expect.any(String));
+	});
+
+	it('does not extend the pong window when non-PONG traffic arrives', async () => {
+		await handshake();
+		ws.close.mockClear();
+		jest.advanceTimersByTime(TIMEOUT); // PING sent
+		ws.emit('message', Buffer.from(JSON.stringify({ msg: DDP_EVENTS.METHOD, method: 'foo', id: '1' })), false);
+		await flushAsync();
+		jest.advanceTimersByTime(TIMEOUT - 1);
+		expect(ws.close).not.toHaveBeenCalled();
+		jest.advanceTimersByTime(2);
+		expect(ws.close).toHaveBeenCalledWith(WS_ERRORS.TIMEOUT, expect.any(String));
+	});
+
+	it('cancels the pong window and resumes the idle cycle when PONG arrives', async () => {
+		await handshake();
+		ws.close.mockClear();
+		jest.advanceTimersByTime(TIMEOUT); // PING #1 sent, pong window armed
+		ws.send.mockClear();
+		ws.emit('message', Buffer.from(JSON.stringify({ msg: DDP_EVENTS.PONG })), false);
+		await flushAsync();
+		// Past the original pong deadline — we should still be alive.
+		jest.advanceTimersByTime(TIMEOUT);
+		expect(ws.close).not.toHaveBeenCalled();
+		// And the next idle window should have produced a fresh PING.
+		expect(lastSent()).toContain(`"${DDP_EVENTS.PING}"`);
+	});
+});

--- a/ee/apps/ddp-streamer/src/Client.ts
+++ b/ee/apps/ddp-streamer/src/Client.ts
@@ -3,14 +3,17 @@ import type { IncomingMessage } from 'http';
 
 import { Presence } from '@rocket.chat/core-services';
 import type { ISocketConnection } from '@rocket.chat/core-typings';
+import { Logger } from '@rocket.chat/logger';
 import { throttle } from 'underscore';
 import { v1 as uuidv1 } from 'uuid';
 import type WebSocket from 'ws';
 
 import { SERVER_ID } from './Server';
 import { server } from './configureServer';
-import { DDP_EVENTS, WS_ERRORS, WS_ERRORS_MESSAGES, TIMEOUT } from './constants';
+import { DDP_EVENTS, WS_ERRORS, WS_ERRORS_MESSAGES, TIMEOUT, MAX_BUFFERED_BYTES } from './constants';
 import type { IPacket } from './types/IPacket';
+
+const logger = new Logger('DDP-Streamer-Client');
 
 // TODO why localhost not as 127.0.0.1?
 // based on Meteor's implementation (link)
@@ -61,7 +64,9 @@ export const clientMap = new WeakMap<WebSocket, Client>();
 export class Client extends EventEmitter {
 	private chain = Promise.resolve();
 
-	protected timeout: NodeJS.Timeout;
+	protected idleTimer?: NodeJS.Timeout;
+
+	protected pongTimer?: NodeJS.Timeout;
 
 	public readonly session = uuidv1();
 
@@ -75,11 +80,13 @@ export class Client extends EventEmitter {
 
 	public userToken?: string;
 
+	public closeCode?: number;
+
 	private updatePresence = throttle(
 		() => {
 			if (this.userId) {
 				void Presence.updateConnection(this.userId, this.connection.id).catch((err) => {
-					console.error('Error updating connection presence:', err);
+					logger.error({ msg: 'Error updating connection presence', err });
 				});
 			}
 		},
@@ -104,17 +111,18 @@ export class Client extends EventEmitter {
 			httpHeaders: req.headers,
 		};
 
-		this.renewTimeout(TIMEOUT / 1000);
+		this.armIdleTimer();
 		this.ws.on('message', this.handler);
-		this.ws.on('close', (...args) => {
+		this.ws.on('close', (code: number, ...rest: unknown[]) => {
+			this.closeCode = code;
 			server.emit(DDP_EVENTS.DISCONNECTED, this);
-			this.emit('close', ...args);
+			this.emit('close', code, ...rest);
 			this.subscriptions.clear();
-			clearTimeout(this.timeout);
+			this.clearTimers();
 		});
 
 		this.ws.on('error', (err) => {
-			console.error('Unexpected error:', err);
+			logger.error({ msg: 'Unexpected WebSocket error', err });
 			this.ws.close(WS_ERRORS.CLOSE_PROTOCOL_ERROR, WS_ERRORS_MESSAGES.CLOSE_PROTOCOL_ERROR);
 		});
 
@@ -124,7 +132,9 @@ export class Client extends EventEmitter {
 
 		server.emit(DDP_EVENTS.CONNECTED, this);
 
-		this.ws.on('message', () => this.renewTimeout(TIMEOUT));
+		// Any inbound traffic resets the idle window. The pong timer, when armed, is only
+		// cleared by an actual PONG (handled in `process`).
+		this.ws.on('message', () => this.armIdleTimer());
 
 		this.once('message', ({ msg }) => {
 			if (msg !== DDP_EVENTS.CONNECT) {
@@ -157,6 +167,9 @@ export class Client extends EventEmitter {
 		switch (action) {
 			case DDP_EVENTS.PING:
 				this.pong(packet.id);
+				break;
+			case DDP_EVENTS.PONG:
+				this.handlePong();
 				break;
 			case DDP_EVENTS.METHOD:
 				if (!packet.method) {
@@ -203,12 +216,35 @@ export class Client extends EventEmitter {
 
 	handleIdle = (): void => {
 		this.ping();
-		this.timeout = setTimeout(this.closeTimeout, TIMEOUT);
+		// Only the actual PONG clears this; other inbound messages do NOT.
+		clearTimeout(this.pongTimer);
+		this.pongTimer = setTimeout(this.closeTimeout, TIMEOUT);
 	};
 
-	renewTimeout(timeout = TIMEOUT): void {
-		clearTimeout(this.timeout);
-		this.timeout = setTimeout(this.handleIdle, timeout);
+	handlePong(): void {
+		clearTimeout(this.pongTimer);
+		this.pongTimer = undefined;
+		// Resume the normal idle cycle. The 'message' listener that runs alongside us is
+		// guarded by `pongTimer`, so it skipped re-arming while we were awaiting PONG.
+		this.armIdleTimer();
+	}
+
+	armIdleTimer(timeout = TIMEOUT): void {
+		// Liveness during the PING/PONG window is governed strictly by `pongTimer`.
+		// Other inbound traffic must NOT extend the deadline — that would mask a broken
+		// client that keeps sending data but never replies to PING.
+		if (this.pongTimer) {
+			return;
+		}
+		clearTimeout(this.idleTimer);
+		this.idleTimer = setTimeout(this.handleIdle, timeout);
+	}
+
+	clearTimers(): void {
+		clearTimeout(this.idleTimer);
+		clearTimeout(this.pongTimer);
+		this.idleTimer = undefined;
+		this.pongTimer = undefined;
 	}
 
 	handler = async (payload: WebSocket.Data, isBinary: boolean): Promise<void> => {
@@ -221,7 +257,7 @@ export class Client extends EventEmitter {
 			}
 			this.process(packet.msg, packet);
 		} catch (err) {
-			console.error(err);
+			logger.error({ msg: 'Failed to handle inbound DDP frame', err });
 			return this.ws.close(WS_ERRORS.UNSUPPORTED_DATA, WS_ERRORS_MESSAGES.UNSUPPORTED_DATA);
 		}
 	};
@@ -234,6 +270,13 @@ export class Client extends EventEmitter {
 	}
 
 	send(payload: string): void {
+		// Drop slow consumers deterministically: if the OS-level write buffer is past the
+		// configured threshold the client cannot keep up. Closing here prevents heap blow-up
+		// on the streamer pod when a single peer stalls.
+		if (this.ws.bufferedAmount > MAX_BUFFERED_BYTES) {
+			this.ws.close(WS_ERRORS.SLOW_CONSUMER, WS_ERRORS_MESSAGES.SLOW_CONSUMER);
+			return;
+		}
 		return this.ws.send(this.encodePayload(payload));
 	}
 }

--- a/ee/apps/ddp-streamer/src/DDPStreamer.ts
+++ b/ee/apps/ddp-streamer/src/DDPStreamer.ts
@@ -113,6 +113,27 @@ export class DDPStreamer extends ServiceClass {
 			description: 'Users logged by streamer',
 		});
 
+		metrics.register({
+			name: 'ddp_method_total',
+			type: 'counter',
+			labelNames: ['namespace', 'status'],
+			description: 'DDP method calls by namespace and outcome',
+		});
+
+		metrics.register({
+			name: 'ddp_close_total',
+			type: 'counter',
+			labelNames: ['code'],
+			description: 'DDP WebSocket close events by code',
+		});
+
+		metrics.register({
+			name: 'ddp_send_buffer_bytes',
+			type: 'gauge',
+			labelNames: ['nodeID'],
+			description: 'Maximum WebSocket send buffer size across connected clients (bytes)',
+		});
+
 		server.setMetrics(metrics);
 
 		server.on(DDP_EVENTS.CONNECTED, () => {
@@ -123,12 +144,28 @@ export class DDPStreamer extends ServiceClass {
 			metrics.increment('users_logged', { nodeID }, 1);
 		});
 
-		server.on(DDP_EVENTS.DISCONNECTED, ({ userId }) => {
+		server.on(DDP_EVENTS.DISCONNECTED, ({ userId, closeCode }: Client) => {
 			metrics.decrement('users_connected', { nodeID }, 1);
 			if (userId) {
 				metrics.decrement('users_logged', { nodeID }, 1);
 			}
+			metrics.increment('ddp_close_total', { code: String(closeCode ?? 'unknown') }, 1);
 		});
+
+		// Periodically sample the maximum send-buffer depth across all live connections.
+		// Exposes when a single peer is starting to fall behind before we hit the 1013 kick.
+		const sampleSendBuffer = (): void => {
+			let max = 0;
+			this.wss?.clients.forEach((ws) => {
+				if (ws.bufferedAmount > max) {
+					max = ws.bufferedAmount;
+				}
+			});
+			metrics.set('ddp_send_buffer_bytes', max, { nodeID });
+		};
+		const sampleInterval = setInterval(sampleSendBuffer, 5000);
+		// `unref` avoids holding the event loop open during shutdown.
+		sampleInterval.unref?.();
 
 		async function sendUserData(client: Client, userId: string) {
 			// TODO figure out what fields to send. maybe to to export function getBaseUserFields to a package

--- a/ee/apps/ddp-streamer/src/Server.spec.ts
+++ b/ee/apps/ddp-streamer/src/Server.spec.ts
@@ -106,3 +106,66 @@ describe('Server.call', () => {
 		});
 	});
 });
+
+describe('Server.parse', () => {
+	const server = new Server();
+
+	it('parses a text DDP frame', () => {
+		const packet = server.parse('{"msg":"ping","id":"1"}', false);
+		expect(packet).toEqual({ msg: 'ping', id: '1' });
+	});
+
+	it('decodes UTF-8 from a binary frame instead of throwing', () => {
+		const packet = server.parse(Buffer.from('{"msg":"ping","id":"1"}', 'utf8'), true);
+		expect(packet).toEqual({ msg: 'ping', id: '1' });
+	});
+
+	it('unwraps the SockJS array-frame format used by meteor clients', () => {
+		const inner = JSON.stringify({ msg: 'ping', id: '2' });
+		const wrapped = JSON.stringify([inner]);
+		const packet = server.parse(wrapped, false);
+		expect(packet).toEqual({ msg: 'ping', id: '2' });
+	});
+});
+
+describe('Server.call metrics', () => {
+	const makeMetrics = () => ({
+		register: jest.fn(),
+		hasMetric: jest.fn(),
+		increment: jest.fn(),
+		decrement: jest.fn(),
+		set: jest.fn(),
+		observe: jest.fn(),
+		reset: jest.fn(),
+		resetAll: jest.fn(),
+		timer: jest.fn().mockReturnValue(() => 0),
+	});
+
+	let server: Server;
+	let metrics: ReturnType<typeof makeMetrics>;
+
+	beforeEach(() => {
+		server = new Server();
+		metrics = makeMetrics();
+		server.setMetrics(metrics);
+		jest.clearAllMocks();
+	});
+
+	it('increments ddp_method_total with the namespace and ok status on success', async () => {
+		mockCallMethodWithToken.mockResolvedValue({ result: 'value' } as any);
+		await server.call(makeClient(), makePacket('livechat:doSomething'));
+		expect(metrics.increment).toHaveBeenCalledWith('ddp_method_total', { namespace: 'livechat', status: 'ok' }, 1);
+	});
+
+	it('increments ddp_method_total with status=error when MeteorService rejects', async () => {
+		mockCallMethodWithToken.mockRejectedValue(new Error('boom'));
+		await server.call(makeClient(), makePacket('meteor.loginWithPassword'));
+		expect(metrics.increment).toHaveBeenCalledWith('ddp_method_total', { namespace: 'meteor', status: 'error' }, 1);
+	});
+
+	it('uses the full method name as the namespace when the method has no separator', async () => {
+		mockCallMethodWithToken.mockResolvedValue({ result: undefined } as any);
+		await server.call(makeClient(), makePacket('sendMessage'));
+		expect(metrics.increment).toHaveBeenCalledWith('ddp_method_total', { namespace: 'sendMessage', status: 'ok' }, 1);
+	});
+});

--- a/ee/apps/ddp-streamer/src/Server.ts
+++ b/ee/apps/ddp-streamer/src/Server.ts
@@ -34,6 +34,18 @@ const handleInternalException = (err: unknown, msg: string): MeteorError => {
 
 export const SERVER_ID = ejson.stringify({ msg: 'server_id', server_id: '0' });
 
+// Methods come in many shapes (`livechat:foo`, `meteor.loginWithPassword`, `sendMessage`).
+// Bucketing by the prefix before `:` or `.` keeps Prometheus label cardinality bounded by
+// the number of namespaces (~30) instead of the number of distinct method names (~200+).
+const methodNamespace = (method: string | undefined): string => {
+	if (!method) {
+		return 'unknown';
+	}
+	const idx = method.search(/[:.]/);
+	const head = idx === -1 ? method : method.slice(0, idx);
+	return head.slice(0, 50) || 'unknown';
+};
+
 export class Server extends EventEmitter {
 	private _subscriptions = new Map<string, SubscriptionFn>();
 
@@ -45,11 +57,11 @@ export class Server extends EventEmitter {
 
 	serialize = ejson.stringify;
 
-	parse = (data: WebSocket.Data, isBinary: boolean): IPacket => {
-		if (isBinary) {
-			throw new MeteorError(500, 'Binary data not supported');
-		}
-		const packet = data.toString();
+	parse = (data: WebSocket.Data, _isBinary: boolean): IPacket => {
+		// Some clients (Sockette, browser ArrayBuffer paths) deliver UTF-8 JSON in binary
+		// frames. Decode rather than reject — DDP itself is text-only, so a non-UTF-8 payload
+		// will fail at JSON.parse below and trip the protocol-error close.
+		const packet = Buffer.isBuffer(data) ? data.toString('utf8') : data.toString();
 
 		const payload = packet.startsWith('[') ? JSON.parse(packet)[0] : packet;
 		return ejson.parse(payload);
@@ -64,10 +76,12 @@ export class Server extends EventEmitter {
 		if (client.ws.readyState !== WebSocket.OPEN) {
 			return;
 		}
+		const namespace = methodNamespace(packet.method);
 		try {
 			// if method was not defined on DDP Streamer we fall back to Meteor
 			if (!this._methods.has(packet.method)) {
 				const result = await MeteorService.callMethodWithToken(client.userId, client.userToken, packet.method, packet.params);
+				this.metrics?.increment('ddp_method_total', { namespace, status: 'ok' }, 1);
 				return this.result(client, packet, result.result);
 			}
 
@@ -77,8 +91,10 @@ export class Server extends EventEmitter {
 			}
 
 			const result = await fn.apply(client, packet.params);
+			this.metrics?.increment('ddp_method_total', { namespace, status: 'ok' }, 1);
 			return this.result(client, packet, result);
 		} catch (err: unknown) {
+			this.metrics?.increment('ddp_method_total', { namespace, status: 'error' }, 1);
 			return this.result(client, packet, null, handleInternalException(err, 'Method call error'));
 		}
 	}

--- a/ee/apps/ddp-streamer/src/Streamer.spec.ts
+++ b/ee/apps/ddp-streamer/src/Streamer.spec.ts
@@ -1,0 +1,154 @@
+import WebSocket from 'ws';
+
+import { fanOutText } from './Streamer';
+import { MAX_BUFFERED_BYTES, WS_ERRORS } from './constants';
+
+jest.mock('@rocket.chat/core-services', () => ({
+	api: { broadcast: jest.fn() },
+}));
+
+jest.mock('@rocket.chat/logger', () => ({
+	Logger: jest.fn().mockImplementation(() => ({ error: jest.fn(), warn: jest.fn(), info: jest.fn() })),
+}));
+
+jest.mock('./configureServer', () => ({
+	server: {
+		serialize: (obj: unknown) => JSON.stringify(obj),
+		publish: jest.fn(),
+		methods: jest.fn(),
+	},
+}));
+
+type FakeSender = { sendFrame: jest.Mock };
+
+const makeFakeWs = (overrides: Partial<{ readyState: number; bufferedAmount: number; sendError: Error }> = {}) => {
+	const sender: FakeSender = {
+		sendFrame: jest.fn((_frame, cb: (err?: unknown) => void) => cb(overrides.sendError)),
+	};
+	return {
+		readyState: overrides.readyState ?? WebSocket.OPEN,
+		bufferedAmount: overrides.bufferedAmount ?? 0,
+		_sender: sender,
+		send: jest.fn((_payload, cb: (err?: unknown) => void) => cb()),
+		close: jest.fn(function (this: any) {
+			this.readyState = WebSocket.CLOSED;
+		}),
+	};
+};
+
+const makeSubscription = (ws: ReturnType<typeof makeFakeWs>, meteorClient = false) => {
+	const stop = jest.fn();
+	const subscription = {
+		client: { ws, meteorClient },
+		connection: { id: `conn-${Math.random()}` },
+		stop,
+	};
+	return { subscription, stop };
+};
+
+const baseOpts = {
+	eventName: 'message',
+	streamName: 'stream-room-messages',
+	retransmitToSelf: false,
+	origin: undefined,
+	isEmitAllowed: jest.fn().mockResolvedValue(true),
+};
+
+describe('fanOutText', () => {
+	beforeEach(() => {
+		baseOpts.isEmitAllowed.mockClear();
+		baseOpts.isEmitAllowed.mockResolvedValue(true);
+	});
+
+	it('writes one frame per subscriber via the private sender', async () => {
+		const a = makeFakeWs();
+		const b = makeFakeWs();
+		const subA = makeSubscription(a);
+		const subB = makeSubscription(b);
+		const set = new Set([subA, subB]);
+
+		await fanOutText(set as any, '{"x":1}', baseOpts);
+
+		expect(a._sender.sendFrame).toHaveBeenCalledTimes(1);
+		expect(b._sender.sendFrame).toHaveBeenCalledTimes(1);
+		expect(subA.stop).not.toHaveBeenCalled();
+		expect(subB.stop).not.toHaveBeenCalled();
+	});
+
+	it('skips subscribers whose WebSocket is not OPEN and stops their subscriptions', async () => {
+		const dead = makeFakeWs({ readyState: WebSocket.CLOSED });
+		const live = makeFakeWs();
+		const subDead = makeSubscription(dead);
+		const subLive = makeSubscription(live);
+		const set = new Set([subDead, subLive]);
+
+		await fanOutText(set as any, '{"x":1}', baseOpts);
+
+		expect(dead._sender.sendFrame).not.toHaveBeenCalled();
+		expect(subDead.stop).toHaveBeenCalled();
+		expect(live._sender.sendFrame).toHaveBeenCalledTimes(1);
+		expect(subLive.stop).not.toHaveBeenCalled();
+	});
+
+	it('drops the frame and closes the socket with 1013 when the subscriber is over the buffer threshold', async () => {
+		const slow = makeFakeWs({ bufferedAmount: MAX_BUFFERED_BYTES + 1 });
+		const sub = makeSubscription(slow);
+		const set = new Set([sub]);
+
+		await fanOutText(set as any, '{"x":1}', baseOpts);
+
+		expect(slow.close).toHaveBeenCalledWith(WS_ERRORS.SLOW_CONSUMER, expect.any(String));
+		expect(slow._sender.sendFrame).not.toHaveBeenCalled();
+		expect(sub.stop).toHaveBeenCalled();
+	});
+
+	it('skips the originating connection when retransmitToSelf is false', async () => {
+		const ws = makeFakeWs();
+		const sub = makeSubscription(ws);
+		const set = new Set([sub]);
+
+		await fanOutText(set as any, '{"x":1}', { ...baseOpts, origin: sub.subscription.connection });
+
+		expect(ws._sender.sendFrame).not.toHaveBeenCalled();
+		expect(sub.stop).not.toHaveBeenCalled();
+	});
+
+	it('still delivers to the originating connection when retransmitToSelf is true', async () => {
+		const ws = makeFakeWs();
+		const sub = makeSubscription(ws);
+		const set = new Set([sub]);
+
+		await fanOutText(set as any, '{"x":1}', { ...baseOpts, retransmitToSelf: true, origin: sub.subscription.connection });
+
+		expect(ws._sender.sendFrame).toHaveBeenCalledTimes(1);
+	});
+
+	it('skips subscribers when isEmitAllowed returns false', async () => {
+		const ws = makeFakeWs();
+		const sub = makeSubscription(ws);
+		const set = new Set([sub]);
+		const isEmitAllowed = jest.fn().mockResolvedValue(false);
+
+		await fanOutText(set as any, '{"x":1}', { ...baseOpts, isEmitAllowed });
+
+		expect(isEmitAllowed).toHaveBeenCalledTimes(1);
+		expect(ws._sender.sendFrame).not.toHaveBeenCalled();
+	});
+
+	it('uses the meteor SockJS array wrapper for meteor clients', async () => {
+		const meteorWs = makeFakeWs();
+		const normalWs = makeFakeWs();
+		const meteorSub = makeSubscription(meteorWs, true);
+		const normalSub = makeSubscription(normalWs, false);
+		const set = new Set([meteorSub, normalSub]);
+
+		await fanOutText(set as any, '{"x":1}', baseOpts);
+
+		const meteorFrame = meteorWs._sender.sendFrame.mock.calls[0][0];
+		const normalFrame = normalWs._sender.sendFrame.mock.calls[0][0];
+
+		// The meteor variant wraps the message inside `a[...]` so the encoded buffer is
+		// strictly larger than the plain payload variant.
+		expect(Buffer.concat(meteorFrame).length).toBeGreaterThan(Buffer.concat(normalFrame).length);
+	});
+});

--- a/ee/apps/ddp-streamer/src/Streamer.ts
+++ b/ee/apps/ddp-streamer/src/Streamer.ts
@@ -1,12 +1,16 @@
 import { api } from '@rocket.chat/core-services';
 import type { StreamNames } from '@rocket.chat/ddp-client';
+import { Logger } from '@rocket.chat/logger';
 import WebSocket from 'ws';
 
 import { server } from './configureServer';
 import { DDP_EVENTS } from './constants';
+import { buildTextFrame, sendRawFrame } from './lib/RawSender';
 import { isEmpty } from './lib/utils';
 import { Streamer, StreamerCentral } from '../../../../apps/meteor/server/modules/streamer/streamer.module';
-import type { DDPSubscription, Connection, TransformMessage } from '../../../../apps/meteor/server/modules/streamer/types';
+import type { DDPSubscription, Connection, IPublication, TransformMessage } from '../../../../apps/meteor/server/modules/streamer/types';
+
+const logger = new Logger('DDP-Streamer-FanOut');
 
 StreamerCentral.on('broadcast', (name, eventName, args) => {
 	void api.broadcast('stream', [name, eventName, args]);
@@ -44,59 +48,69 @@ export class Stream<N extends StreamNames> extends Streamer<N> {
 			return super.sendToManySubscriptions(subscriptions, origin, eventName, args, getMsg);
 		}
 
-		const options = {
-			fin: true, // sending a single fragment message
-			rsv1: false, // don"t set rsv1 bit (no compression)
-			opcode: 1, // opcode for a text frame
-			mask: false, // set false for client-side
-			readOnly: false, // the data can be modified as needed
-		};
+		await fanOutText(subscriptions, getMsg, {
+			eventName,
+			streamName: this.name,
+			retransmitToSelf: this.retransmitToSelf,
+			origin,
+			isEmitAllowed: (publication) => this.isEmitAllowed(publication, eventName, ...args),
+		});
+	}
+}
 
-		const data = {
-			meteor: [Buffer.concat(WebSocket.Sender.frame(Buffer.from(`a${JSON.stringify([getMsg])}`), options))],
-			normal: [Buffer.concat(WebSocket.Sender.frame(Buffer.from(getMsg), options))],
-		};
+export type FanOutOptions = {
+	eventName: string;
+	streamName: string;
+	retransmitToSelf: boolean;
+	origin: Connection | undefined;
+	isEmitAllowed: (publication: IPublication) => Promise<boolean | object>;
+};
 
-		for (const { subscription } of subscriptions) {
-			// if the connection state is not open anymore, it somehow got to a weird state,
-			// we'll emit close so it can clean up the weird state, and so we stop emitting to it
-			if (subscription.client.ws.readyState !== WebSocket.OPEN) {
-				subscription.stop();
-				subscription.client.ws.close();
-				continue;
-			}
+/**
+ * Walk a subscription set once, decide per-subscription whether to forward the message, and
+ * write the pre-built frame straight into each socket. Extracted from
+ * `Stream.sendToManySubscriptions` so the loop is testable in isolation: the only
+ * dependencies are `RawSender.send` (mockable via the ws state) and the caller-provided
+ * `isEmitAllowed` predicate.
+ */
+export async function fanOutText(subscriptions: Set<DDPSubscription>, payload: string, opts: FanOutOptions): Promise<void> {
+	// Build each frame variant once for the entire fan-out — every subscriber re-uses the
+	// same encoded buffer.
+	const frames = {
+		meteor: buildTextFrame(`a${JSON.stringify([payload])}`),
+		normal: buildTextFrame(payload),
+	};
 
-			if (this.retransmitToSelf === false && origin && origin === subscription.connection) {
-				continue;
-			}
-
-			if (!(await this.isEmitAllowed(subscription, eventName, ...args))) {
-				continue;
-			}
-
-			try {
-				await new Promise<void>((resolve, reject) => {
-					const frame = data[subscription.client.meteorClient ? 'meteor' : 'normal'];
-
-					subscription.client.ws._sender.sendFrame(frame, (err: unknown) => {
-						if (err) {
-							return reject(err);
-						}
-						resolve();
-					});
-				});
-			} catch (error: any) {
-				if (error.code === 'ERR_STREAM_DESTROYED') {
-					console.warn('Trying to send data to destroyed stream, closing connection.');
-
-					// if we still tried to send data to a destroyed stream, we'll try again to close the connection
-					if (subscription.client.ws.readyState !== WebSocket.OPEN) {
-						subscription.stop();
-						subscription.client.ws.close();
-					}
-				}
-				console.error('Error trying to send data to stream.', error);
-			}
+	for (const { subscription } of subscriptions) {
+		if (subscription.client.ws.readyState !== WebSocket.OPEN) {
+			subscription.stop();
+			subscription.client.ws.close();
+			continue;
 		}
+
+		if (opts.retransmitToSelf === false && opts.origin && opts.origin === subscription.connection) {
+			continue;
+		}
+
+		if (!(await opts.isEmitAllowed(subscription))) {
+			continue;
+		}
+
+		const frame = frames[subscription.client.meteorClient ? 'meteor' : 'normal'];
+		const outcome = await sendRawFrame(subscription.client.ws, frame);
+
+		if (outcome === 'sent') {
+			continue;
+		}
+
+		if (outcome === 'closed' || outcome === 'slow-consumer') {
+			subscription.stop();
+			if (outcome === 'closed' && subscription.client.ws.readyState !== WebSocket.OPEN) {
+				subscription.client.ws.close();
+			}
+			continue;
+		}
+
+		logger.error({ msg: 'Error trying to send data to stream', stream: opts.streamName, eventName: opts.eventName });
 	}
 }

--- a/ee/apps/ddp-streamer/src/configureServer.ts
+++ b/ee/apps/ddp-streamer/src/configureServer.ts
@@ -101,13 +101,15 @@ server.methods({
 		this.userToken = undefined;
 		this.userId = undefined;
 
-		// Close connection after return success to the method call.
-		// This ensures all the subscriptions will be closed, meteor makes it manually
-		// here https://github.com/meteor/meteor/blob/2377ebe879d9b965d699f599392d4e8047eb7d78/packages/ddp-server/livedata_server.js#L781
-		// re doing the default subscriptions.
-		setTimeout(() => {
+		// Close after Server.call has enqueued the `result` and `updated` frames in the ws
+		// send queue. setImmediate runs in the next event-loop iteration's check phase — after
+		// the sync sends here, but the ws library still guarantees frame ordering on the wire,
+		// so the Close frame is written after the data frames.
+		// Mirrors Meteor's logout-then-close from
+		// https://github.com/meteor/meteor/blob/2377ebe879d9b965d699f599392d4e8047eb7d78/packages/ddp-server/livedata_server.js#L781.
+		setImmediate(() => {
 			this.ws.close(WS_ERRORS.CLOSE_PROTOCOL_ERROR);
-		}, 1);
+		});
 	},
 	'UserPresence:setDefaultStatus'(status) {
 		const { userId } = this;

--- a/ee/apps/ddp-streamer/src/constants.ts
+++ b/ee/apps/ddp-streamer/src/constants.ts
@@ -35,6 +35,7 @@ export const DDP_EVENTS = {
 export const WS_ERRORS = {
 	CLOSE_PROTOCOL_ERROR: 1002,
 	UNSUPPORTED_DATA: 1007,
+	SLOW_CONSUMER: 1013,
 
 	TIMEOUT: 4000,
 };
@@ -42,7 +43,12 @@ export const WS_ERRORS = {
 export const WS_ERRORS_MESSAGES = {
 	CLOSE_PROTOCOL_ERROR: 'CLOSE_PROTOCOL_ERROR',
 	UNSUPPORTED_DATA: 'UNSUPPORTED_DATA',
+	SLOW_CONSUMER: 'SLOW_CONSUMER',
 	TIMEOUT: 'TIMEOUT',
 };
 
 export const TIMEOUT = 1000 * 30; // 30 seconds
+
+// Maximum bytes allowed in the WS send buffer before the client is considered a slow consumer
+// and disconnected. Defaults to 4 MiB.
+export const MAX_BUFFERED_BYTES = parseInt(process.env.DDP_MAX_BUFFERED_BYTES || '') || 4 * 1024 * 1024;

--- a/ee/apps/ddp-streamer/src/lib/RawSender.spec.ts
+++ b/ee/apps/ddp-streamer/src/lib/RawSender.spec.ts
@@ -1,0 +1,71 @@
+import WebSocket from 'ws';
+
+import { MAX_BUFFERED_BYTES, WS_ERRORS } from '../constants';
+import { buildTextFrame, sendRawFrame } from './RawSender';
+
+type FakeSender = { sendFrame: jest.Mock };
+
+const makeWs = (overrides: Partial<{ readyState: number; bufferedAmount: number; sender: FakeSender }> = {}) => {
+	const sender: FakeSender = overrides.sender ?? {
+		sendFrame: jest.fn((_frame, cb: (err?: unknown) => void) => cb()),
+	};
+	return {
+		readyState: overrides.readyState ?? WebSocket.OPEN,
+		bufferedAmount: overrides.bufferedAmount ?? 0,
+		_sender: sender,
+		send: jest.fn((_payload, cb: (err?: unknown) => void) => cb()),
+		close: jest.fn(),
+	};
+};
+
+describe('buildTextFrame', () => {
+	it('produces a non-empty buffer array for a JSON-like payload', () => {
+		const frame = buildTextFrame('{"msg":"ping"}');
+		expect(frame.length).toBeGreaterThan(0);
+		expect(Buffer.concat(frame).length).toBeGreaterThan(0);
+	});
+});
+
+describe('sendRawFrame', () => {
+	const frame = buildTextFrame('hello');
+
+	it('returns "closed" and does not send when the socket is not OPEN', async () => {
+		const ws = makeWs({ readyState: WebSocket.CLOSED });
+		const outcome = await sendRawFrame(ws as unknown as WebSocket, frame);
+		expect(outcome).toBe('closed');
+		expect(ws._sender.sendFrame).not.toHaveBeenCalled();
+		expect(ws.send).not.toHaveBeenCalled();
+	});
+
+	it('closes the socket with code 1013 and returns "slow-consumer" when bufferedAmount is over the threshold', async () => {
+		const ws = makeWs({ bufferedAmount: MAX_BUFFERED_BYTES + 1 });
+		const outcome = await sendRawFrame(ws as unknown as WebSocket, frame);
+		expect(outcome).toBe('slow-consumer');
+		expect(ws.close).toHaveBeenCalledWith(WS_ERRORS.SLOW_CONSUMER, expect.any(String));
+		expect(ws._sender.sendFrame).not.toHaveBeenCalled();
+	});
+
+	it('writes the frame via the private sender and returns "sent" on success', async () => {
+		const ws = makeWs();
+		const outcome = await sendRawFrame(ws as unknown as WebSocket, frame);
+		expect(outcome).toBe('sent');
+		expect(ws._sender.sendFrame).toHaveBeenCalledWith(frame, expect.any(Function));
+	});
+
+	it('falls back to ws.send when the private sender is unavailable', async () => {
+		const ws = makeWs();
+		// Simulate an unknown ws version that no longer exposes `_sender.sendFrame`.
+		(ws as any)._sender = undefined;
+		const outcome = await sendRawFrame(ws as unknown as WebSocket, frame);
+		expect(outcome).toBe('sent');
+		expect(ws.send).toHaveBeenCalled();
+	});
+
+	it('propagates send errors as "error"', async () => {
+		const ws = makeWs({
+			sender: { sendFrame: jest.fn((_frame, cb: (err?: unknown) => void) => cb(new Error('boom'))) },
+		});
+		const outcome = await sendRawFrame(ws as unknown as WebSocket, frame);
+		expect(outcome).toBe('error');
+	});
+});

--- a/ee/apps/ddp-streamer/src/lib/RawSender.ts
+++ b/ee/apps/ddp-streamer/src/lib/RawSender.ts
@@ -1,0 +1,83 @@
+import WebSocket from 'ws';
+
+import { MAX_BUFFERED_BYTES, WS_ERRORS, WS_ERRORS_MESSAGES } from '../constants';
+
+// Pre-built text frame options used for fan-out. We always send a single fragment, no
+// compression, no masking (server-side), and the buffer is treated as the payload.
+const TEXT_FRAME_OPTIONS = {
+	fin: true,
+	rsv1: false,
+	opcode: 1,
+	mask: false,
+	readOnly: false,
+} as const;
+
+// `ws@8.x` exposes `_sender.sendFrame` as the lowest-cost path for fan-out: we build the
+// frame once for the whole subscription set and write it directly to each socket. This is a
+// private API, so it stays encapsulated here so the rest of the codebase doesn't have to
+// reach into `ws` internals.
+type WsWithSender = WebSocket & {
+	_sender: { sendFrame: (frame: Buffer | Buffer[], cb?: (err: unknown) => void) => void };
+};
+
+/**
+ * Build a pre-encoded WebSocket text frame from a UTF-8 payload. The result can be passed to
+ * `RawSender.send` repeatedly — once per subscriber — without re-paying the cost of frame
+ * construction.
+ */
+export function buildTextFrame(payload: string | Buffer): Buffer[] {
+	const buf = typeof payload === 'string' ? Buffer.from(payload) : payload;
+	return WebSocket.Sender.frame(buf, TEXT_FRAME_OPTIONS);
+}
+
+export type SendOutcome = 'sent' | 'closed' | 'slow-consumer' | 'error';
+
+/**
+ * Send a pre-built frame to a single WebSocket. Returns the outcome so callers can update
+ * metrics or remove the subscription set entry.
+ *
+ * Behavior:
+ * - If the socket is not OPEN, returns `closed` and asks the caller to clean up.
+ * - If the socket's send buffer is past `MAX_BUFFERED_BYTES`, the socket is closed with
+ *   1013 (Try Again Later) and `slow-consumer` is returned. We choose dropping the frame
+ *   over inflating the streamer pod's heap.
+ * - On success, returns `sent`.
+ */
+export function sendRawFrame(ws: WebSocket, frame: Buffer[]): Promise<SendOutcome> {
+	if (ws.readyState !== WebSocket.OPEN) {
+		return Promise.resolve('closed');
+	}
+
+	if (ws.bufferedAmount > MAX_BUFFERED_BYTES) {
+		try {
+			ws.close(WS_ERRORS.SLOW_CONSUMER, WS_ERRORS_MESSAGES.SLOW_CONSUMER);
+		} catch {
+			// already closing — ignore
+		}
+		return Promise.resolve('slow-consumer');
+	}
+
+	const sender = (ws as WsWithSender)._sender;
+	if (!sender?.sendFrame) {
+		// `ws` removed or renamed the private API — fall back to the public path.
+		return new Promise<SendOutcome>((resolve) => {
+			ws.send(frame, (err) => {
+				if (err) {
+					resolve('error');
+					return;
+				}
+				resolve('sent');
+			});
+		});
+	}
+
+	return new Promise<SendOutcome>((resolve) => {
+		sender.sendFrame(frame, (err) => {
+			if (err) {
+				resolve('error');
+				return;
+			}
+			resolve('sent');
+		});
+	});
+}


### PR DESCRIPTION
## Summary

Internal refactor of `ee/apps/ddp-streamer` keeping the wire protocol identical (DDP-over-WS, EJSON, login via `Account.login`, method fallback to `MeteorService`). Five focused changes split into one commit.

### Heartbeat & backpressure
- **Split heartbeat into `idleTimer` / `pongTimer`.** The `pongTimer` is armed only when the server sends a PING and is cleared exclusively by an inbound PONG. Other inbound traffic no longer extends the deadline — a broken client that keeps sending data but never replies to PING is now disconnected deterministically.
- **Drop slow consumers.** When `ws.bufferedAmount > MAX_BUFFERED_BYTES` (default 4 MiB, env override `DDP_MAX_BUFFERED_BYTES`), the socket is closed with code `1013`. Prevents heap blow-up on the streamer pod when a single peer stalls.

### Fan-out path
- **`RawSender` helper.** The private `ws._sender.sendFrame` call is now isolated in `lib/RawSender.ts`, with the buffer-amount guard applied at fan-out too. The upgrade path to a different `ws`/uWS implementation is now local to one file.
- **`fanOutText` extracted** from `Stream.sendToManySubscriptions` so the loop is testable without instantiating the full `Streamer` base class.

### Lifecycle
- **Logout: `setTimeout(1ms)` → `setImmediate`.** `ws` guarantees frame ordering on the wire, so the `result`/`updated` frames reach the wire before the close frame.
- **Binary frame tolerance.** `Server.parse` decodes binary buffers as UTF-8 instead of throwing 500. Some proxies and `ArrayBuffer` paths deliver text payloads in binary frames.

### Observability
- New metrics:
  - `ddp_method_total{namespace, status}` — counter, labeled by method namespace prefix (before `:`/`.`) to keep Prometheus cardinality bounded
  - `ddp_close_total{code}` — counter
  - `ddp_send_buffer_bytes{nodeID}` — gauge sampled every 5 s
- Replace ad-hoc `console.error/warn` with `@rocket.chat/logger` in `Client.ts` and `Streamer.ts`.

### Tests
- New specs: `Client.spec`, `Streamer.spec`, `RawSender.spec`.
- `Server.spec` extended to cover `parse()` and metric increments.
- **6 → 32 tests; coverage ~10% → 63%** (RawSender 94%, Streamer 75%, Server 65%, Client 60%).

## Out of scope (future work)
- Switching from `ws` to `uWebSockets.js`.
- DDP session resume / restart-storm jitter.
- `permessage-deflate`.
- Microbatching method calls back to the monolith.

## Test plan
- [x] `yarn workspace @rocket.chat/ddp-streamer test` — 32/32 passing
- [x] `yarn workspace @rocket.chat/ddp-streamer typecheck` — clean
- [x] `yarn workspace @rocket.chat/ddp-streamer lint` — 0 errors (8 pre-existing warnings in untouched code)
- [ ] Local smoke: monolith + ddp-streamer up, login, subscribe to `stream-room-messages`, send messages, logout, reconnect
- [ ] Stage canary: watch p99 fan-out latency, `ddp_send_buffer_bytes`, `ddp_close_total{code="1013"}` for one full traffic cycle
- [ ] Confirm no regression in `users_connected` / `users_logged` gauges