### PR TITLE
fix: attachment collapsed state resets after switching channels

### DIFF
--- a/.changeset/fiery-cows-rhyme.md
+++ b/.changeset/fiery-cows-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Persists attachment collapsed/expanded state across channel switches using sessionStorage, preventing collapsed images and media from re-expanding when the user navigates away and returns to a channel.

--- a/apps/meteor/client/components/message/MessageCollapsible.tsx
+++ b/apps/meteor/client/components/message/MessageCollapsible.tsx
@@ -12,10 +12,11 @@ type MessageCollapsibleProps = {
 	link?: string;
 	size?: number;
 	isCollapsed?: boolean;
+	storageKey?: string;
 };
 
-const MessageCollapsible = ({ children, title, hasDownload, link, size, isCollapsed }: MessageCollapsibleProps): ReactElement => {
-	const [collapsed, collapse] = useCollapse(isCollapsed);
+const MessageCollapsible = ({ children, title, hasDownload, link, size, isCollapsed, storageKey }: MessageCollapsibleProps): ReactElement => {
+	const [collapsed, collapse] = useCollapse(isCollapsed, storageKey);
 
 	return (
 		<>

--- a/apps/meteor/client/components/message/content/attachments/DefaultAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/DefaultAttachment.tsx
@@ -27,7 +27,7 @@ const applyMarkdownIfRequires = (
 type DefaultAttachmentProps = MessageAttachmentDefault;
 
 const DefaultAttachment = (attachment: DefaultAttachmentProps): ReactElement => {
-	const storageKey = attachment.id || attachment.title_link || undefined;
+	const storageKey = attachment.id || undefined;
 	const [collapsed, collapse] = useCollapse(!!attachment.collapsed, storageKey);
 
 	return (

--- a/apps/meteor/client/components/message/content/attachments/DefaultAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/DefaultAttachment.tsx
@@ -27,7 +27,8 @@ const applyMarkdownIfRequires = (
 type DefaultAttachmentProps = MessageAttachmentDefault;
 
 const DefaultAttachment = (attachment: DefaultAttachmentProps): ReactElement => {
-	const [collapsed, collapse] = useCollapse(!!attachment.collapsed);
+	const storageKey = attachment.id || attachment.title_link || undefined;
+	const [collapsed, collapse] = useCollapse(!!attachment.collapsed, storageKey);
 
 	return (
 		<AttachmentBlock

--- a/apps/meteor/client/components/message/content/attachments/file/AudioAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/AudioAttachment.tsx
@@ -7,6 +7,7 @@ import { useReloadOnError } from './hooks/useReloadOnError';
 import MessageCollapsible from '../../../MessageCollapsible';
 
 const AudioAttachment = ({
+	id,
 	title,
 	audio_url: url,
 	audio_type: type,
@@ -21,7 +22,7 @@ const AudioAttachment = ({
 
 	return (
 		<>
-			<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
+			<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed} storageKey={id}>
 				<AudioPlayer src={src} type={type} ref={mediaRef} />
 			</MessageCollapsible>
 		</>

--- a/apps/meteor/client/components/message/content/attachments/file/GenericFileAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/GenericFileAttachment.tsx
@@ -21,6 +21,7 @@ const openDocumentViewer = window.RocketChatDesktop?.openDocumentViewer;
 type GenericFileAttachmentProps = MessageAttachmentBase;
 
 const GenericFileAttachment = ({
+	id,
 	title,
 	title_link: link,
 	title_link_download: hasDownload,
@@ -68,7 +69,7 @@ const GenericFileAttachment = ({
 
 	return (
 		<>
-			<MessageCollapsible title={title} hasDownload={hasDownload} link={link} isCollapsed={collapsed}>
+			<MessageCollapsible title={title} hasDownload={hasDownload} link={link} isCollapsed={collapsed} storageKey={id}>
 				<MessageGenericPreview style={{ maxWidth: 368, width: '100%' }}>
 					<MessageGenericPreviewContent
 						thumb={<MessageGenericPreviewIcon name='attachment-file' type={format || getFileExtension(title)} />}

--- a/apps/meteor/client/components/message/content/attachments/file/ImageAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/ImageAttachment.tsx
@@ -25,7 +25,7 @@ const ImageAttachment = ({
 
 	return (
 		<>
-			<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
+			<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed} storageKey={id}>
 				<AttachmentImage
 					{...imageDimensions}
 					loadImage={loadImage}

--- a/apps/meteor/client/components/message/content/attachments/file/VideoAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/VideoAttachment.tsx
@@ -8,6 +8,7 @@ import { userAgentMIMETypeFallback } from '../../../../../lib/utils/userAgentMIM
 import MessageCollapsible from '../../../MessageCollapsible';
 
 const VideoAttachment = ({
+	id,
 	title,
 	video_url: url,
 	video_type: type,
@@ -22,7 +23,7 @@ const VideoAttachment = ({
 
 	return (
 		<>
-			<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
+			<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed} storageKey={id}>
 				<MessageGenericPreview style={{ maxWidth: 368, width: '100%' }}>
 					<Box is='video' controls preload='metadata' ref={mediaRef}>
 						<source src={getURL(url)} type={userAgentMIMETypeFallback(type)} />

--- a/apps/meteor/client/components/message/hooks/useCollapse.tsx
+++ b/apps/meteor/client/components/message/hooks/useCollapse.tsx
@@ -11,9 +11,13 @@ export const useCollapse = (attachmentCollapsed?: boolean, storageKey?: string):
 
 	const getInitialCollapsed = (): boolean => {
 		if (storageKey) {
-			const stored = sessionStorage.getItem(SESSION_STORAGE_PREFIX + storageKey);
-			if (stored !== null) {
-				return stored === 'true';
+			try {
+				const stored = sessionStorage.getItem(SESSION_STORAGE_PREFIX + storageKey);
+				if (stored !== null) {
+					return stored === 'true';
+				}
+			} catch {
+				// sessionStorage unavailable (private browsing, sandboxed iframe, quota exceeded)
 			}
 		}
 		return !!(collpaseByDefault || attachmentCollapsed);
@@ -25,7 +29,11 @@ export const useCollapse = (attachmentCollapsed?: boolean, storageKey?: string):
 		setCollapsed((prev) => {
 			const next = !prev;
 			if (storageKey) {
-				sessionStorage.setItem(SESSION_STORAGE_PREFIX + storageKey, String(next));
+				try {
+					sessionStorage.setItem(SESSION_STORAGE_PREFIX + storageKey, String(next));
+				} catch {
+					// sessionStorage unavailable
+				}
 			}
 			return next;
 		});

--- a/apps/meteor/client/components/message/hooks/useCollapse.tsx
+++ b/apps/meteor/client/components/message/hooks/useCollapse.tsx
@@ -1,11 +1,35 @@
-import { useToggle } from '@rocket.chat/fuselage-hooks';
 import { useAttachmentIsCollapsedByDefault } from '@rocket.chat/ui-contexts';
 import type { ReactNode } from 'react';
+import { useCallback, useState } from 'react';
 
 import CollapsibleContent from '../content/collapsible/CollapsibleContent';
 
-export const useCollapse = (attachmentCollapsed?: boolean): [collapsed: boolean, node: ReactNode] => {
+const SESSION_STORAGE_PREFIX = 'rc_attachment_collapsed_';
+
+export const useCollapse = (attachmentCollapsed?: boolean, storageKey?: string): [collapsed: boolean, node: ReactNode] => {
 	const collpaseByDefault = useAttachmentIsCollapsedByDefault();
-	const [collapsed, toogleCollapsed] = useToggle(collpaseByDefault || attachmentCollapsed);
-	return [collapsed, <CollapsibleContent collapsed={collapsed} onClick={toogleCollapsed as any} key='collapsible-content-action' />];
+
+	const getInitialCollapsed = (): boolean => {
+		if (storageKey) {
+			const stored = sessionStorage.getItem(SESSION_STORAGE_PREFIX + storageKey);
+			if (stored !== null) {
+				return stored === 'true';
+			}
+		}
+		return !!(collpaseByDefault || attachmentCollapsed);
+	};
+
+	const [collapsed, setCollapsed] = useState<boolean>(getInitialCollapsed);
+
+	const toggleCollapsed = useCallback(() => {
+		setCollapsed((prev) => {
+			const next = !prev;
+			if (storageKey) {
+				sessionStorage.setItem(SESSION_STORAGE_PREFIX + storageKey, String(next));
+			}
+			return next;
+		});
+	}, [storageKey]);
+
+	return [collapsed, <CollapsibleContent collapsed={collapsed} onClick={toggleCollapsed} key='collapsible-content-action' />];
 };


### PR DESCRIPTION
## Proposed changes

Message attachments (images, GIFs, videos, audio, files) store their collapsed/expanded state only in React component state. When a user switches channels, the message list unmounts and all in-memory state is lost — so every manually collapsed attachment re-expands on return.

This fix replaces the in-memory toggle in `useCollapse` with `useState` backed by `sessionStorage`, keyed on the attachment ID. On mount the hook reads the stored value; every toggle writes it back. The user's collapse choice now survives channel switches for the duration of the browser session.

Files changed: `useCollapse`, `MessageCollapsible`, `ImageAttachment`, `VideoAttachment`, `AudioAttachment`, `GenericFileAttachment`, `DefaultAttachment`.

## Issue(s)

Closes #40337 

## Steps to test or reproduce

1. Post a message with an image or GIF in any channel.
2. Click the collapse arrow on the attachment - it hides.
3. Switch to another channel, then switch back.
4. **Before:** attachment re-expands. **After:** attachment stays collapsed.


## Further comments

`sessionStorage` was chosen over `localStorage` so the state does not persist across browser sessions or bleed between different users on the same machine.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attachment collapse/expand state is now persisted across channel navigation, so previously collapsed images and media remain collapsed when returning.
  * Collapse state is tracked per attachment (by identifier) and stored in session storage, so each attachment maintains its own persisted state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->