### PR TITLE
fix: fix truncation of Livechat transfer comments

### DIFF
--- a/.changeset/fix-livechat-transfer-comment-wrap.md
+++ b/.changeset/fix-livechat-transfer-comment-wrap.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+fix: Fix truncation of Livechat transfer comments

--- a/apps/meteor/app/theme/client/main.css
+++ b/apps/meteor/app/theme/client/main.css
@@ -14,3 +14,19 @@
 @import url('imports/general/theme_old.css');
 @import url('./rocketchat.font.css');
 @import url('../../../node_modules/@rocket.chat/fuselage/dist/fuselage.css');
+
+/* Fix truncation of Livechat transfer comments (#26723) */
+[data-system-message-type="livechat_transfer_history"] .rcx-message-system__body,
+[data-system-message-type="livechat_transfer_history_fallback"] .rcx-message-system__body {
+	white-space: normal;
+	overflow: visible;
+	text-overflow: unset;
+	overflow-wrap: anywhere;
+	word-break: normal;
+}
+
+[data-system-message-type="livechat_transfer_history"] .rcx-message-system__block,
+[data-system-message-type="livechat_transfer_history_fallback"] .rcx-message-system__block {
+	flex-wrap: wrap;
+	align-items: flex-start;
+}

--- a/apps/meteor/app/theme/client/main.css
+++ b/apps/meteor/app/theme/client/main.css
@@ -21,8 +21,7 @@
 	white-space: normal;
 	overflow: visible;
 	text-overflow: unset;
-	overflow-wrap: anywhere;
-	word-break: normal;
+	overflow-wrap: break-word;
 }
 
 [data-system-message-type="livechat_transfer_history"] .rcx-message-system__block,


### PR DESCRIPTION
This PR addresses the issue where Omnichannel transfer comments were being truncated and not wrapping to multiple lines, often ending with an ellipsis. It introduces a properly-scoped CSS fix using the data-system-message-type attribute selector ('livechat_transfer_history' and 'livechat_transfer_history_fallback') to allow the 'MessageSystemBody' text to wrap across multiple lines without globally overriding the system message styles.

## Issue(s)

Closes #26723 
## Type of change

- [x] Bug Fixes
- [ ] - [ ] New Features
- [ ] - [ ] Dependencies
- [ ] - [ ] Blueprints
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md) doc
- [x] - [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat)
- [x] - [x] Lint and unit tests pass locally with my changes
- [x] - [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] - [x] I have added necessary documentation (if appropriate)
- [x] - [x] Any dependent changes have been merged and published in downstream modules
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
*     * Fixed truncation of Livechat transfer comments, allowing full text to display properly without being cut off or wrapped incorrectly.