### PR TITLE
fix(client): sync profile avatar editor state across cancel, save, an…

### DIFF
--- a/.changeset/fix-profile-avatar-state-sync.md
+++ b/.changeset/fix-profile-avatar-state-sync.md
@@ -1,0 +1,7 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fix profile avatar editor state inconsistencies after cancel, save, and reset cycles.
+
+Re-uploading the same file after cancelling no longer silently fails (the file input is now reset between selections so the change event always fires). The avatar editor's local preview is now cleared in sync with form-level resets, so cancelling restores the user's saved avatar and saving no longer leaves a stale preview behind. The reset preview URL also includes the user's etag so it busts the browser cache when the saved avatar actually changes.

--- a/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
+++ b/apps/meteor/client/components/avatar/UserAvatarEditor/UserAvatarEditor.tsx
@@ -3,8 +3,8 @@ import { Box, Button, Avatar, IconButton } from '@rocket.chat/fuselage';
 import { Field, FieldLabel, FieldRow, FieldError, TextInput } from '@rocket.chat/fuselage-forms';
 import { UserAvatar } from '@rocket.chat/ui-avatar';
 import { useToastMessageDispatch, useSetting } from '@rocket.chat/ui-contexts';
-import type { ChangeEvent } from 'react';
-import { useState, useCallback } from 'react';
+import type { ReactElement, ChangeEvent } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { UserAvatarSuggestion } from './UserAvatarSuggestion';
@@ -17,13 +17,14 @@ import { isValidImageFormat } from '../../../lib/utils/isValidImageFormat';
 export type UserAvatarEditorProps = {
 	currentUsername: IUser['username'];
 	username: IUser['username'];
+	avatarObj?: AvatarObject;
 	setAvatarObj: (obj: AvatarObject) => void;
 	disabled?: boolean;
 	etag: IUser['avatarETag'];
 	name: IUser['name'];
 };
 
-function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disabled, etag }: UserAvatarEditorProps) {
+function UserAvatarEditor({ currentUsername, username, avatarObj, setAvatarObj, name, disabled, etag }: UserAvatarEditorProps): ReactElement {
 	const { t } = useTranslation();
 	const useFullNameForDefaultAvatar = useSetting('UI_Use_Name_Avatar');
 	const rotateImages = useSetting('FileUpload_RotateImages');
@@ -31,6 +32,18 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 	const [newAvatarSource, setNewAvatarSource] = useState<string>();
 	const dispatchToastMessage = useToastMessageDispatch();
 	const [avatarUrlError, setAvatarUrlError] = useState<string | undefined>(undefined);
+	const previousAvatarObjRef = useRef(avatarObj);
+
+	useEffect(() => {
+		const previous = previousAvatarObjRef.current;
+		previousAvatarObjRef.current = avatarObj;
+
+		if (previous && !avatarObj) {
+			setNewAvatarSource(undefined);
+			setAvatarFromUrl('');
+			setAvatarUrlError(undefined);
+		}
+	}, [avatarObj]);
 
 	const setUploadedPreview = useCallback(
 		async (file: File, avatarObj: AvatarObject) => {
@@ -74,7 +87,8 @@ function UserAvatarEditor({ currentUsername, username, setAvatarObj, name, disab
 	};
 
 	const clickReset = (): void => {
-		setNewAvatarSource(`/avatar/%40${useFullNameForDefaultAvatar ? name : username}`);
+		const defaultAvatarUsername = useFullNameForDefaultAvatar ? name : username;
+		setNewAvatarSource(`/avatar/%40${defaultAvatarUsername}${etag ? `?etag=${etag}` : ''}`);
 		setAvatarObj('reset');
 	};
 

--- a/apps/meteor/client/hooks/useSingleFileInput.ts
+++ b/apps/meteor/client/hooks/useSingleFileInput.ts
@@ -54,6 +54,7 @@ export const useSingleFileInput = (
 			const formData = new FormData();
 			formData.append(fileField, file);
 			onSetFile(file, formData);
+			fileInput.value = '';
 		};
 
 		fileInput.addEventListener('change', handleFiles, false);
@@ -63,7 +64,12 @@ export const useSingleFileInput = (
 		};
 	}, [fileField, fileType, onSetFile, maxSize, onError]);
 
-	const onClick = useStableCallback(() => ref?.current?.click());
+	const onClick = useStableCallback(() => {
+		if (ref.current) {
+			ref.current.value = '';
+		}
+		ref?.current?.click();
+	});
 	const reset = useStableCallback(() => {
 		if (ref.current) {
 			ref.current.value = '';

--- a/apps/meteor/client/views/account/profile/AccountProfileForm.tsx
+++ b/apps/meteor/client/views/account/profile/AccountProfileForm.tsx
@@ -175,7 +175,7 @@ const AccountProfileForm = (props: AllHTMLAttributes<HTMLFormElement>) => {
 
 			await updateAvatar();
 			dispatchToastMessage({ type: 'success', message: t('Profile_saved_successfully') });
-			reset(values);
+			reset({ email, name, username, statusType, statusText, nickname, bio, customFields, avatar: '' });
 		} catch (error) {
 			dispatchToastMessage({ type: 'error', message: error });
 		}
@@ -191,12 +191,13 @@ const AccountProfileForm = (props: AllHTMLAttributes<HTMLFormElement>) => {
 					<Controller
 						control={control}
 						name='avatar'
-						render={({ field: { onChange } }) => (
+						render={({ field: { onChange, value } }) => (
 							<UserAvatarEditor
 								etag={user?.avatarETag}
 								currentUsername={user?.username}
 								name={userFullName}
 								username={username}
+								avatarObj={value}
 								setAvatarObj={onChange}
 								disabled={!allowUserAvatarChange}
 							/>


### PR DESCRIPTION
## Proposed changes

Closes #38697.

The "My Account → Profile" avatar editor's local preview state was not synchronized with the parent form's `avatar` field, and the hidden `<input type="file">` was never reset between selections. This caused several inconsistencies after cancel/save/reset cycles:

- Re-uploading the **same** file after Cancel produced no preview (file input's `change` event doesn't fire when the value is unchanged).
- Cancelling after a click on Reset/Initials sometimes left a stale preview instead of restoring the saved avatar.
- Reset → Save would leave the old photo's URL still rendered because the cached image URL had no cache-buster.

### Changes
- **`useSingleFileInput`** — clear the file input's value before each `click()` and after each successful selection so the same file always re-fires the `change` event.
- **`UserAvatarEditor`** — accept the form's current `avatar` value as a prop and clear the local preview state in a `useEffect` whenever the form transitions from a set value back to empty (i.e. a Cancel/Save reset).
- **`AccountProfileForm`** — pass the watched `avatar` value down to `UserAvatarEditor`, and include `avatar: ''` in the post-save `reset()` so the editor sees the transition.
- The reset preview URL now includes the user's `etag` to bust the browser cache when the saved avatar changes.

## Issue(s)
Closes #38697.

## Steps to test or reproduce

1. Go to **My Account → Profile**.
2. **Test A:** Upload a picture → Cancel → upload the **same** picture again → preview reappears immediately.
3. **Test B:** Upload a picture → Save → profile photo updates.
4. **Test C:** Upload a picture → click Reset/Initials → Cancel → preview restores to the previously saved avatar.
5. **Test D:** Upload a picture → Save → click Reset/Initials → Save → avatar resets to initials in your profile.

## Further comments
The broader UI cache (sidebar, header avatar) refreshing without a full page reload is a separate `useUser` invalidation concern and is out of scope here — this PR fixes the editor state itself.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile avatar editor state sync across cancel, save, and reset flows.
  * Avatar file input now clears after selection and before re-opening, ensuring the same file can be re-selected after cancel.
  * Canceling the editor correctly restores the saved avatar and removes any local preview.
  * Saving an avatar no longer leaves stale preview imagery.
  * Profile form reset now triggers only after a successful save.
  * Avatar refresh now uses cache-busting based on the user’s ETag when the saved avatar changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->