### PR TITLE
fix(useFormatDate): default Message_DateFormat to 'LL' to avoid date-fns crash

### DIFF
--- a/.changeset/use-format-date-fallback.md
+++ b/.changeset/use-format-date-fallback.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixes a `date-fns` crash on routes that mount before the public settings stream finishes loading. `useFormatDate` was passing `String(undefined)` (the literal `"undefined"`) to `formatDate` while `Message_DateFormat` was momentarily unloaded — `date-fns` rejects that token because it contains an unescaped `n`. The hook now uses `'LL'` as the default token via `useSetting`'s second argument, so the formatter always receives a valid format string.

--- a/apps/meteor/client/hooks/useFormatDate.ts
+++ b/apps/meteor/client/hooks/useFormatDate.ts
@@ -4,6 +4,6 @@ import { useCallback } from 'react';
 import { formatDate } from '../lib/utils/dateFormat';
 
 export const useFormatDate = () => {
-	const format = useSetting('Message_DateFormat');
-	return useCallback((time: string | Date | number) => formatDate(time, String(format)), [format]);
+	const format = useSetting('Message_DateFormat', 'LL');
+	return useCallback((time: string | Date | number) => formatDate(time, format), [format]);
 };


### PR DESCRIPTION
## Summary

- \`useFormatDate\` was calling \`formatDate(time, String(undefined))\` whenever \`Message_DateFormat\` was momentarily unloaded — \`String(undefined)\` produces the literal string \`\"undefined\"\`, which date-fns rejects because it contains an unescaped \`n\` token.
- Reachable any time the setting is mid-load (e.g. \`/admin/info\` mounted via dynamic import while public settings are still streaming in) — surfaces as a crash on the route's first render.
- Fix: pass \`'LL'\` as \`useSetting\`'s default so the formatter always sees a valid token. Drops the now-redundant \`String()\` coercion.

## Test plan

- [ ] Visit \`/admin/info\` immediately after a hard refresh: previously crashed; now renders.
- [ ] Existing date displays in chat still format correctly when the setting eventually loads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in date formatting that occurred when message date format settings were temporarily unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2126]
found here: https://github.com/RocketChat/Rocket.Chat/pull/40301

[ARCH-2126]: https://rocketchat.atlassian.net/browse/ARCH-2126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ