### PR TITLE
chore: new env var `USE_ROOM_SEARCH_INDEX` to scope messages text index by room

### DIFF
--- a/.changeset/room-search-index.md
+++ b/.changeset/room-search-index.md
@@ -1,0 +1,8 @@
+---
+'@rocket.chat/meteor': minor
+'@rocket.chat/models': minor
+---
+
+Adds the `USE_ROOM_SEARCH_INDEX` environment variable. When set to `true`, the messages collection's text index is created as `{ rid: 1, msg: 'text' }` instead of the default `{ msg: 'text' }`. The compound shape lets per-room `$text` searches use `rid` as a prefix, dramatically reducing the portion of the index scanned on workspaces where global search is disabled.
+
+The index is reconciled on every startup: if the existing text index already matches the desired shape, nothing happens; otherwise the stale text index is dropped and the desired one is recreated. Unsetting the variable on a later boot reverts to the default shape.

--- a/apps/meteor/server/startup/ensureMessagesTextIndex.ts
+++ b/apps/meteor/server/startup/ensureMessagesTextIndex.ts
@@ -1,0 +1,87 @@
+import { Messages } from '@rocket.chat/models';
+
+import { SystemLogger } from '../lib/logger/system';
+
+const { USE_ROOM_SEARCH_INDEX = 'false' } = process.env;
+
+// MongoDB stores a text index's key with `_fts: 'text'` / `_ftsx: 1` placeholders
+// and tracks the original text fields in `weights`. Classify by looking at the
+// non-placeholder prefix fields plus weights.
+const classifyTextIndex = (idx: { key: Record<string, unknown>; weights?: Record<string, number> }) => {
+	const { weights, key } = idx;
+	if (weights?.msg !== 1 || Object.keys(weights).length !== 1) {
+		return 'other';
+	}
+
+	const prefix = Object.keys(key).filter((k) => k !== '_fts' && k !== '_ftsx');
+	if (prefix.length === 0) {
+		return 'default';
+	}
+
+	if (prefix.length === 1 && prefix[0] === 'rid' && key.rid === 1) {
+		return 'room-scoped';
+	}
+
+	return 'other';
+};
+
+export const ensureMessagesTextIndex = async (): Promise<void> => {
+	const desiredShape = USE_ROOM_SEARCH_INDEX === 'true' ? 'room-scoped' : 'default';
+
+	SystemLogger.debug({
+		msg: 'checking messages text index',
+		USE_ROOM_SEARCH_INDEX,
+		desired: desiredShape,
+	});
+
+	let existing;
+	try {
+		existing = await Messages.col.indexes();
+	} catch (err) {
+		SystemLogger.error({ msg: 'failed to list messages indexes; skipping text index check', err });
+		return;
+	}
+
+	const textIndexes = existing.filter((idx) => Object.values(idx.key).includes('text'));
+	const matching = textIndexes.find((idx) => classifyTextIndex(idx) === desiredShape);
+	const stale = textIndexes.filter((idx) => idx !== matching);
+
+	if (matching && stale.length === 0) {
+		SystemLogger.debug({ msg: 'messages text index already matches desired shape', name: matching.name });
+		return;
+	}
+
+	for (const idx of stale) {
+		if (!idx.name) {
+			continue;
+		}
+		SystemLogger.startup({
+			msg: 'dropping messages text index; may take several minutes on large databases',
+			name: idx.name,
+			shape: classifyTextIndex(idx),
+		});
+		try {
+			await Messages.col.dropIndex(idx.name);
+			SystemLogger.startup({ msg: 'dropped messages text index', name: idx.name });
+		} catch (err) {
+			SystemLogger.error({ msg: 'failed to drop messages text index; aborting', name: idx.name, err });
+			return;
+		}
+	}
+
+	if (matching) {
+		SystemLogger.debug({ msg: 'messages text index already matches desired shape', name: matching.name });
+		return;
+	}
+
+	SystemLogger.startup({
+		msg: 'creating messages text index; may take several minutes on large databases',
+		shape: desiredShape,
+	});
+	try {
+		const name = await Messages.col.createIndex(desiredShape === 'room-scoped' ? { rid: 1, msg: 'text' } : { msg: 'text' });
+		SystemLogger.startup({ msg: 'created messages text index', name, shape: desiredShape });
+	} catch (err) {
+		SystemLogger.error({ msg: 'failed to create messages text index', shape: desiredShape, err });
+	}
+};

--- a/apps/meteor/server/startup/index.ts
+++ b/apps/meteor/server/startup/index.ts
@@ -1,6 +1,7 @@
 import './appcache';
 import './callbacks';
 import { startCronJobs } from './cron';
+import { ensureMessagesTextIndex } from './ensureMessagesTextIndex';
 import './initialData';
 import './serverRunning';
 import './coreApps';
@@ -18,6 +19,7 @@ export const startup = async () => {
 	await generateFederationKeys();
 
 	setImmediate(() => startCronJobs());
+	setImmediate(() => ensureMessagesTextIndex());
 	// only starts network broker if running in micro services mode
 	if (!isRunningMs()) {
 		require('./localServices');

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -52,7 +52,9 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			{ key: { 'editedBy._id': 1 }, sparse: true },
 			{ key: { 'rid': 1, 't': 1, 'u._id': 1 } },
 			{ key: { expireAt: 1 }, expireAfterSeconds: 0 },
-			{ key: { msg: 'text' } },
+			// The text index on `msg` is managed at startup by `ensureMessagesTextIndex`
+			// because its shape is controlled by the `USE_ROOM_SEARCH_INDEX` env var
+			// (default `{ msg: 'text' }` vs. room-scoped `{ rid: 1, msg: 'text' }`).
 			{ key: { 'file._id': 1 }, sparse: true },
 			{ key: { 'files._id': 1 }, sparse: true },
 			{ key: { 'mentions.username': 1 }, sparse: true },


### PR DESCRIPTION
## Summary

- Adds the `USE_ROOM_SEARCH_INDEX` env var. When set to `"true"`, the `rocketchat_message` text index is built as `{ rid: 1, msg: 'text' }` so per-room `$text` searches use `rid` as a prefix and scan a much smaller portion of the index. When unset (or anything other than `"true"`), reverts to the default `{ msg: 'text' }`.
- The index is reconciled on every boot in a non-blocking startup task (`setImmediate(() => ensureMessagesTextIndex())` in `apps/meteor/server/startup/index.ts`). If the existing text index already matches the desired shape it is a no-op; otherwise the stale text index is dropped and the desired one is created.
- Removed the `{ msg: 'text' }` entry from `MessagesRaw.modelIndexes()`. MongoDB allows only one text index per collection, so leaving it there would have collided with the env-driven swap on startup. The text index is now owned exclusively by the startup script.
- Progress is reported through `SystemLogger.startup` (drop/create operations, with a duration warning on large databases) and `SystemLogger.debug` (no-op steady-state checks). Failures go through `SystemLogger.error`.

Refs [CORE-2154](https://rocketchat.atlassian.net/browse/CORE-2154). Context: repeated MongoDB outages on large SaaS workspaces (BBTS, Cruzeiro do Sul) were traced to `$text` queries against `rocketchat_message` scanning the whole text index even when constrained to a single room. SRE has been manually patching the index on the largest databases per affected customer; this PR makes the room-scoped shape opt-in via env var so it can be applied without manual DB intervention.

## Test plan

- [x] Boot with no env var on a workspace that has the default index — verify the `checking messages text index ... desired: default` log fires and that `db.rocketchat_message.getIndexes()` shows `{ msg: 'text' }` unchanged.
- [x] Boot with `USE_ROOM_SEARCH_INDEX=true` on the same workspace — verify the dropping/creating logs fire and the resulting index has key `{ rid: 1, _fts: 'text', _ftsx: 1 }` with `weights: { msg: 1 }`.
- [x] Boot again with `USE_ROOM_SEARCH_INDEX=true` (no DB change) — verify only the debug "already matches" log fires and no drop/create happens.
- [x] Unset `USE_ROOM_SEARCH_INDEX` and reboot — verify the room-scoped index is dropped and the default `{ msg: 'text' }` is recreated.
- [x] Run a `$text` search constrained to a single room with the room-scoped index in place and confirm the explain plan uses the `rid` prefix.
- [x] Confirm startup is not blocked by the index work (server begins serving requests before index build finishes on large datasets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-2154]: https://rocketchat.atlassian.net/browse/CORE-2154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional USE_ROOM_SEARCH_INDEX environment variable to enable room-scoped message text search.

* **Improvements**
  * Startup now automatically reconciles message text indexes to match the chosen search mode, recreating stale indexes as needed and reverting when the variable is unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->