### PR TITLE
fix: preserve aspect ratio for URL image previews

### DIFF
--- a/.changeset/fix-url-image-aspect-ratio.md
+++ b/.changeset/fix-url-image-aspect-ratio.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed incorrect aspect ratios for URL image previews (e.g., Giphy GIFs) by adding `object-fit: contain` and `width: auto` to the `UrlImagePreview` component, ensuring images scale proportionally within the max-height constraint.

--- a/apps/meteor/client/components/message/content/urlPreviews/UrlImagePreview.tsx
+++ b/apps/meteor/client/components/message/content/urlPreviews/UrlImagePreview.tsx
@@ -8,8 +8,14 @@ const UrlImagePreview = ({ url }: Pick<UrlPreviewMetadata, 'url'>): ReactElement
 	const { maxHeight: oembedMaxHeight } = useOembedLayout();
 
 	return (
-		<Box maxHeight={oembedMaxHeight} maxWidth='100%'>
-			<MessageGenericPreviewImage data-id={url} className='preview-image' url={url || ''} alt='' />
+		<Box maxHeight={oembedMaxHeight} maxWidth='100%' overflow='hidden'>
+			<MessageGenericPreviewImage
+				data-id={url}
+				className='preview-image'
+				url={url || ''}
+				alt=''
+				style={{ maxHeight: oembedMaxHeight, width: 'auto', maxWidth: '100%', objectFit: 'contain' }}
+			/>
 		</Box>
 	);
 };


### PR DESCRIPTION
### Description

Fixes #40289

Images shared via URL previews (e.g., Giphy GIFs) were being stretched to fill the Box dimensions independently, causing distorted aspect ratios.

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md) doc
- [x] - [x] My pull request name is descriptive and follows [naming conventions](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#pull-request-guidelines)
- [x] - [x] My changes have tests (if applicable)
- [x] - [x] My changes have documentation (if applicable)
- [x] - [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat)