### PR TITLE
chore: add compound index { tmid: 1, ts: -1 } to messages collection

### DIFF
--- a/.changeset/compound-index-thread-replies.md
+++ b/.changeset/compound-index-thread-replies.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Speed up paginated thread reply loads on large workspaces by adding a compound index `{ tmid: 1, ts: -1 }` on the messages collection. Without it, the query planner can fall back to scanning the `ts_1` index in time order and filtering by `tmid` in memory, which becomes very expensive on collections with millions of messages.

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -69,6 +69,7 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 
 			// threads
 			{ key: { tmid: 1 }, sparse: true },
+			{ key: { tmid: 1, ts: -1 }, sparse: true }, // used for paginated thread reply loads (chat.getThreadMessages)
 			{ key: { tcount: 1, tlm: 1 }, sparse: true },
 			{ key: { rid: 1, tlm: -1 }, partialFilterExpression: { tcount: { $exists: true } } }, // used for the List Threads
 			{ key: { rid: 1, tcount: 1 } }, // used for the List Threads Count

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -69,7 +69,7 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 
 			// threads
 			{ key: { tmid: 1 }, sparse: true },
-			{ key: { tmid: 1, ts: -1 }, sparse: true }, // used for paginated thread reply loads (chat.getThreadMessages)
+			{ key: { tmid: 1, ts: -1 }, sparse: true },
 			{ key: { tcount: 1, tlm: 1 }, sparse: true },
 			{ key: { rid: 1, tlm: -1 }, partialFilterExpression: { tcount: { $exists: true } } }, // used for the List Threads
 			{ key: { rid: 1, tcount: 1 } }, // used for the List Threads Count


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Adds a compound index `{ tmid: 1, ts: -1 }` (sparse) on the `rocketchat_message` collection.

**Why.** The current `tmid_1` index (sparse) covers thread membership lookups, but it does not satisfy the `sort: { ts: -1 }` clause used by paginated thread reply loads (`chat.getThreadMessages`, REST `/api/v1/chat.getThreadMessages`, and the corresponding `find({ tmid }).sort({ ts: -1 }).limit(N)` calls). On large workspaces MongoDB's planner can pick `IXSCAN { ts: 1 }` instead — walking the global time index from newest backwards and filtering by `tmid` in memory. This works fine when the messages collection is small, but as it grows into the millions of documents the same query repeatedly degrades into a near-full collection scan. The planner is also seen to flap (`replanned: true`, `replanReason: "cached plan was less efficient"`) between the two indexes, which causes intermittent multi-second response times for any client opening a thread.

The new compound index covers both the equality filter on `tmid` and the descending sort on `ts`, so the query is served entirely from the index and a single bounded scan returns exactly the requested page.

The index is `sparse`, so only thread replies (messages with `tmid`) are indexed — the storage cost on the (much larger) set of regular messages without `tmid` is zero.

### Benchmark — production workspace, `rocketchat_message` ≈ 5M documents (~5.2 GB)

Heaviest thread on this workspace contains 957 replies. Same query (`find({ _hidden: { $ne: true }, tmid: <id> }).sort({ ts: -1 })`) with three plans forced via `hint(...)`, three different `limit` values to show how each plan scales:

| Plan (forced via `hint`)             | limit | keysExamined | executionMs |
|--------------------------------------|------:|-------------:|------------:|
| `ts_1` (planner's choice on this WS) |    50 |       81 889 |         167 |
| `tmid_1` (current upstream index)    |    50 |          957 |           3 |
| `tmid_1_ts_-1` (this PR)             |    50 |       **50** |       **0** |
| `ts_1`                               |    10 |       81 843 |         169 |
| `tmid_1`                             |    10 |          957 |           3 |
| `tmid_1_ts_-1` (this PR)             |    10 |       **10** |       **0** |
| `ts_1`                               |  none |    5 053 665 |       9 405 |
| `tmid_1`                             |  none |          957 |           3 |
| `tmid_1_ts_-1` (this PR)             |  none |          957 |           2 |

`docsExamined` is omitted because for this query it is always equal to `keysExamined` — the `_hidden: { $ne: true }` predicate is not covered by any of the candidate indexes, so every matched key requires a document fetch.

What the table shows:

- `ts_1` — **scales with the messages collection**: limit barely matters, every page costs the same overscan, and the no-limit query scans the entire 5M-row collection (9.4 s).
- `tmid_1` — scales with the thread size: it can find the right rows but cannot honour `sort: { ts: -1 }` from the index, so all 957 thread documents are fetched and sorted in memory regardless of pagination.
- `tmid_1_ts_-1` — scales with the page size: `keysExamined == limit`. This is the only plan where opening a thread costs O(page) rather than O(thread) or O(collection).

For threads where the planner picks `ts_1` and gets unlucky (replanning), real production slow-query log entries on the same workspace report `keysExamined: 5,049,435 / docsExamined: 5,049,435` for a single thread page load — i.e. an effective full collection scan.

## Issue(s)

Open reports about slow queries on `rocketchat_message`:

- #24512 — Long mongodb queries in 4.X versions
- #31031 — Slow queries (rocketchat_message, rocketchat_uploads etc) after upgrade

## Steps to test or reproduce

On any workspace large enough that `rocketchat_message` is in the millions, pick a thread with at least a few hundred replies and run:

```js
const tmid = "<some_thread_root_id>";

// What the planner can pick today on large collections — overscan
db.rocketchat_message
  .find({ _hidden: { $ne: true }, tmid })
  .sort({ ts: -1 }).limit(50)
  .hint({ ts: 1 })
  .explain("executionStats").executionStats;

// Default behaviour (no hint) — after this PR the planner will pick tmid_1_ts_-1
db.rocketchat_message
  .find({ _hidden: { $ne: true }, tmid })
  .sort({ ts: -1 }).limit(50)
  .explain("executionStats").executionStats;
```

`totalKeysExamined` should equal the requested page size. End-to-end test: open the same thread in the client and observe time-to-first-reply render.

## Further comments

- The change mirrors prior small index additions to this collection (e.g. #38087 for `files._id`).
- No migration is required — `modelIndexes()` is reconciled at startup; `createIndex` is idempotent on existing keys.
- Sparse on the same key set as the existing `tmid_1` index, so the additional storage cost is bounded by the number of threaded replies (a small fraction of total messages on typical workspaces).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database performance for paginated thread reply loading on large workspaces, resulting in faster response times and smoother navigation when browsing long message threads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->