### PR TITLE
fix: (Mobile) Voice calls failing when accepted from the lock screen

### DIFF
--- a/.changeset/fluffy-poets-check.md
+++ b/.changeset/fluffy-poets-check.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/media-signaling': minor
+---
+
+Fixes a soft lock issue where the call negotiation doesn't proceed if the call is accepted while still being initialized

--- a/packages/media-signaling/src/definition/call/IClientMediaCall.ts
+++ b/packages/media-signaling/src/definition/call/IClientMediaCall.ts
@@ -30,6 +30,7 @@ export type CallHangupReason =
 	| 'unavailable' // The actor is not available
 	| 'transfer' // one of the users requested the other be transferred to someone else
 	| 'not-answered' // max ringing duration was reached with no answer from the other user
+	| 'timeout-local-track' // Timeout waiting for the local audio track
 	| 'timeout-remote-sdp' // Timeout waiting for the remote SDP
 	| 'timeout-local-sdp' // Timeout while generating the local SDP + waiting for ICE Gathering
 	| 'timeout-activation' // Timeout connecting to the negotiated session

--- a/packages/media-signaling/src/definition/client.ts
+++ b/packages/media-signaling/src/definition/client.ts
@@ -2,6 +2,7 @@ export type ClientState =
 	| 'none' // The client doesn't recognize a specific call id at all
 	| 'pending' // The call is ringing
 	| 'accepting' // The client tried to accept the call and is wating for confirmation from the server
+	| 'waiting-for-track' // The call was accepted, but the client doesn't have a local audio stream yet
 	| 'waiting-for-offer' // The call was accepted, but the client doesn't have a webrtc offer yet
 	| 'waiting-for-answer' // The call was accepted and an offer was already sent, but the client doesn't have an answer yet
 	| 'generating-local-sdp' // The client is generating its first local sdp (offer/answer)

--- a/packages/media-signaling/src/definition/services/negotiation.ts
+++ b/packages/media-signaling/src/definition/services/negotiation.ts
@@ -4,6 +4,7 @@ export type NegotiationManagerEvents = {
 	'error': { errorCode: string; negotiationId: string };
 	'local-sdp': { negotiationId: string; sdp: RTCSessionDescriptionInit };
 	'negotiation-needed': { oldNegotiationId: string };
+	'negotiation-started': void;
 };
 
 export type NegotiationManagerConfig = {

--- a/packages/media-signaling/src/lib/Call.ts
+++ b/packages/media-signaling/src/lib/Call.ts
@@ -510,6 +510,10 @@ export class ClientMediaCall implements IClientMediaCall {
 				}
 				return 'pending';
 			case 'accepted':
+				if (!this.negotiationManager.isConfigured()) {
+					return 'waiting-for-track';
+				}
+
 				if (!this.negotiationManager.currentNegotiationId) {
 					return 'waiting-for-offer';
 				}
@@ -550,6 +554,7 @@ export class ClientMediaCall implements IClientMediaCall {
 		}
 
 		if (newInputTrack && !hadInputTrack) {
+			this.updateClientState();
 			await this.negotiationManager.processNegotiations();
 		}
 	}
@@ -1268,6 +1273,8 @@ export class ClientMediaCall implements IClientMediaCall {
 		switch (state) {
 			case 'pending':
 				return 'not-answered';
+			case 'waiting-for-track':
+				return 'timeout-local-track';
 			case 'waiting-for-offer':
 			case 'waiting-for-answer':
 				return 'timeout-remote-sdp';
@@ -1366,6 +1373,11 @@ export class ClientMediaCall implements IClientMediaCall {
 		this.config.logger?.debug('ClientMediaCall.onNegotiationNeeded', oldNegotiationId);
 
 		this.config.transporter.requestRenegotiation(this.callId, oldNegotiationId);
+	}
+
+	private onNegotiationStarted(): void {
+		this.config.logger?.debug('ClientMediaCall.onNegotiationStarted');
+		this.updateClientState();
 	}
 
 	private onNegotiationError(negotiationId: string, errorCode: string): void {
@@ -1574,6 +1586,7 @@ export class ClientMediaCall implements IClientMediaCall {
 
 		this.negotiationManager.emitter.on('local-sdp', ({ sdp, negotiationId }) => this.deliverSdp({ sdp, negotiationId }));
 		this.negotiationManager.emitter.on('negotiation-needed', ({ oldNegotiationId }) => this.onNegotiationNeeded(oldNegotiationId));
+		this.negotiationManager.emitter.on('negotiation-started', () => this.onNegotiationStarted());
 		this.negotiationManager.emitter.on('error', ({ errorCode, negotiationId }) => this.onNegotiationError(negotiationId, errorCode));
 		this.negotiationManager.setWebRTCProcessor(this.webrtcProcessor);
 	}

--- a/packages/media-signaling/src/lib/NegotiationManager.ts
+++ b/packages/media-signaling/src/lib/NegotiationManager.ts
@@ -233,9 +233,11 @@ export class NegotiationManager {
 			.process(this.webrtcProcessor)
 			// No need to handle errors here as they are already handled by the 'error' event
 			.catch(() => null);
+
+		this.emitter.emit('negotiation-started');
 	}
 
-	protected isConfigured(): this is WebRTCNegotiationManager {
+	public isConfigured(): this is WebRTCNegotiationManager {
 		if (this.call.state === 'hangup' || this.call.hidden) {
 			this.config.logger?.debug('Ignoring WebRTC negotiations due to call state.');
 			return false;

--- a/packages/media-signaling/src/lib/Session.ts
+++ b/packages/media-signaling/src/lib/Session.ts
@@ -60,7 +60,7 @@ export class MediaSignalingSession extends Emitter<MediaSignalingEvents> {
 
 	private inputTrack: MediaStreamTrack | null;
 
-	private updatingInputTrack: boolean;
+	private switchingInputTrack: boolean;
 
 	private deviceId: ConstrainDOMString | null;
 
@@ -96,7 +96,7 @@ export class MediaSignalingSession extends Emitter<MediaSignalingEvents> {
 		this.knownCalls = new Map<string, ClientMediaCall>();
 		this.ignoredCalls = new Set<string>();
 		this.inputTrack = null;
-		this.updatingInputTrack = false;
+		this.switchingInputTrack = false;
 		this.deviceId = null;
 		this.currentDeviceId = null;
 		this.callsToGetUserMedia = 0;
@@ -240,6 +240,11 @@ export class MediaSignalingSession extends Emitter<MediaSignalingEvents> {
 
 	public async setDeviceId(deviceId: ConstrainDOMString | null): Promise<void> {
 		this.deviceId = deviceId;
+
+		if (this.switchingInputTrack) {
+			this.config.logger?.warn('Audio Device was changed while the input track was being actively switched.');
+		}
+
 		// do nothing if:
 		// 1. doesn't have any input track yet
 		// 2. it's the same device id
@@ -430,40 +435,81 @@ export class MediaSignalingSession extends Emitter<MediaSignalingEvents> {
 		}
 	}
 
-	private requestInputTrackUpdate(): void {
-		if (this.updatingInputTrack || this.callsToGetUserMedia > 0) {
+	public requestInputTrackUpdate(): void {
+		// Don't do anything if we don't need to switch the track now
+		// This extra check here ensures that requestInputTrackUpdate can be called multiple times even though switchInputTrack can't
+		if (!this.shouldSwitchInputTrack()) {
 			return;
 		}
 
-		this.updateInputTrack().catch(() => null);
+		this.switchInputTrack().catch(() => null);
 	}
 
-	private async updateInputTrack(): Promise<void> {
-		this.config.logger?.debug('MediaSignalingSession.updatingInputTrack', this.callsToGetUserMedia);
-		this.updatingInputTrack = true;
+	/**
+	 * Switch ON/OFF the use of an audio input track
+	 * If there's one already in use, remove it; Otherwise, request and use a new one.
+	 * This function assumes the current state needs to change and doesn't check anything before starting the switch process
+	 * Switching OFF is straightforward: the current track is removed and stopped
+	 * Switching ON is a multi-step process:
+	 * 1. We request a new track from the media stream factory
+	 * 2. Once the media stream factory returns a valid track, we double check that we still need it
+	 * 2.1. If the track is still needed, we set it to all active calls
+	 * 2.2. If the track is no longer needed by then, we stop it and keep no reference to it
+	 *
+	 * The track state only changes by the end of the whole process, so there's no point in calling this function twice and we guard against it --
+	 * but we don't guard against external changes to the track (for example, calling setDeviceId will also change the track state)
+	 * */
+	private async switchInputTrack(): Promise<void> {
+		this.config.logger?.debug('MediaSignalingSession.switchInputTrack', this.callsToGetUserMedia);
+
+		if (this.switchingInputTrack) {
+			this.config.logger?.warn('MediaSignalingSession.switchInputTrack', 'Input Track Switcher was called twice');
+			return;
+		}
+		if (!this.shouldSwitchInputTrack()) {
+			this.config.logger?.warn('MediaSignalingSession.switchInputTrack', 'Input Track Switcher was called but is no longer needed');
+			return;
+		}
+
+		this.switchingInputTrack = true;
 
 		try {
 			if (this.inputTrack) {
-				await this.maybeStopInputTrack();
+				await this.setInputTrack(null);
 				return;
 			}
 
-			await this.maybeStartInputTrack();
+			await this.startInputTrack();
 		} finally {
-			this.updatingInputTrack = false;
-			this.config.logger?.debug('MediaSignalingSession.updatingInputTrack.finally', this.callsToGetUserMedia);
+			this.switchingInputTrack = false;
+			this.config.logger?.debug('MediaSignalingSession.switchInputTrack.finally', this.callsToGetUserMedia);
 		}
 	}
 
-	private async maybeStartInputTrack(): Promise<void> {
-		this.config.logger?.debug('MediaSignalingSession.maybeStartInputTrack');
-		for (const call of this.knownCalls.values()) {
-			if (!call.needsInputTrack()) {
-				continue;
-			}
-
-			return this.startInputTrack();
+	private shouldStartInputTrack(): boolean {
+		if (this.inputTrack) {
+			return false;
 		}
+
+		if (this.callsToGetUserMedia > 0) {
+			return false;
+		}
+
+		for (const call of this.knownCalls.values()) {
+			if (call.needsInputTrack()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private shouldSwitchInputTrack(): boolean {
+		if (this.inputTrack) {
+			return !this.mayNeedInputTrack();
+		}
+
+		return this.shouldStartInputTrack();
 	}
 
 	private getAudioConstraints(): boolean | MediaTrackConstraints {
@@ -476,10 +522,9 @@ export class MediaSignalingSession extends Emitter<MediaSignalingEvents> {
 
 	private async startInputTrack(): Promise<void> {
 		this.config.logger?.debug('MediaSignalingSession.startInputTrack', this.callsToGetUserMedia);
-
 		this.currentDeviceId = this.deviceId;
 
-		let userMedia: MediaStream | null = null;
+		let userMedia: MediaStream | null;
 		this.callsToGetUserMedia++;
 		try {
 			userMedia = await this.config.mediaStreamFactory({ audio: this.getAudioConstraints() }).catch(() => null);
@@ -487,12 +532,12 @@ export class MediaSignalingSession extends Emitter<MediaSignalingEvents> {
 			this.callsToGetUserMedia--;
 		}
 
-		this.config.logger?.debug('MediaSignalingSession.startInputTrack.done', this.callsToGetUserMedia);
-
 		// If there's multiple simultaneous attempts to get the track, only process the output of the last one
 		if (this.callsToGetUserMedia > 0) {
+			this.config.logger?.debug('MediaSignalingSession.startInputTrack.skipped', this.callsToGetUserMedia);
 			return;
 		}
+		this.config.logger?.debug('MediaSignalingSession.startInputTrack.done', this.callsToGetUserMedia);
 
 		if (!userMedia) {
 			return this.hangupCallsThatNeedInput();
@@ -543,15 +588,6 @@ export class MediaSignalingSession extends Emitter<MediaSignalingEvents> {
 		}
 
 		return false;
-	}
-
-	private async maybeStopInputTrack(): Promise<void> {
-		this.config.logger?.debug('MediaSignalingSession.maybeStopInputTrack');
-		if (this.mayNeedInputTrack()) {
-			return;
-		}
-
-		await this.setInputTrack(null);
 	}
 
 	private async setScreenVideoTrack(newVideoTrack: MediaStreamTrack | null, call: ClientMediaCall): Promise<void> {


### PR DESCRIPTION

## Proposed changes (including videos or screenshots)
Due to how the mobile app implements voice calls, when a call is accepted from the phone's lock screen it will be registered in the lib and then immediately accepted. This was causing a soft lock where the lib would never request the user's audio for that call, the negotiation would eventually timeout and the call would be dropped.

It happened because when a call is first initialized, it doesn't yet need to request the audio; only after it was accepted. The initialization would trigger the function that updates the state of audio track and it would determine the track is not yet needed, but this function has an `await` instruction that causes it to remain in the "updating" state until after the call is flagged as accepted. Once the update function completes, the call would be flagged as already updated and the state change would not be processed.

This PR changes the code so that the call will only enter the "updating" state when the track state is actually being changed (as opposed to every time it checks if it needs to change). 

In addition I've also made sure that the call's internal state will be refreshed when the first negotiation starts and I also improved the timeout code to explicitly identify when a call fails due to missing the audio track.

## Issue(s)

[VMUX-113](https://rocketchat.atlassian.net/browse/VMUX-113)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[VMUX-113]: https://rocketchat.atlassian.net/browse/VMUX-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved soft lock issue in call negotiation that could stall when calls are accepted during initialization.

* **Improvements**
  * Enhanced input track switching with improved concurrency handling and race condition protection.
  * Strengthened state management during call negotiation lifecycle for better stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->