### PR TITLE
fix: trim whitespace from IP whitelist entries in login protection

### DIFF
--- a/.changeset/fix-ip-whitelist-trim-spaces.md
+++ b/.changeset/fix-ip-whitelist-trim-spaces.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+fix: trim whitespace from IP whitelist entries in login protection

--- a/apps/meteor/app/authentication/server/lib/restrictLoginAttempts.ts
+++ b/apps/meteor/app/authentication/server/lib/restrictLoginAttempts.ts
@@ -47,7 +47,10 @@ const notifyFailedLogin = async (ipOrUsername: string, blockedUntil: Date, faile
 };
 
 export const isValidLoginAttemptByIp = async (ip: string): Promise<boolean> => {
-	const whitelist = String(settings.get('Block_Multiple_Failed_Logins_Ip_Whitelist')).split(',');
+	const whitelist = String(settings.get('Block_Multiple_Failed_Logins_Ip_Whitelist'))
+		.split(',')
+		.map((ip) => ip.trim())
+		.filter(Boolean);
 
 	if (
 		!settings.get('Block_Multiple_Failed_Logins_Enabled') ||

--- a/apps/meteor/app/authentication/server/lib/restrictLoginAttempts.ts
+++ b/apps/meteor/app/authentication/server/lib/restrictLoginAttempts.ts
@@ -49,7 +49,7 @@ const notifyFailedLogin = async (ipOrUsername: string, blockedUntil: Date, faile
 export const isValidLoginAttemptByIp = async (ip: string): Promise<boolean> => {
 	const whitelist = String(settings.get('Block_Multiple_Failed_Logins_Ip_Whitelist'))
 		.split(',')
-		.map((ip) => ip.trim())
+		.map((entry) => entry.trim())
 		.filter(Boolean);
 
 	if (

--- a/apps/meteor/app/authentication/server/lib/restrictLoginAttempts.ts
+++ b/apps/meteor/app/authentication/server/lib/restrictLoginAttempts.ts
@@ -49,7 +49,7 @@ const notifyFailedLogin = async (ipOrUsername: string, blockedUntil: Date, faile
 export const isValidLoginAttemptByIp = async (ip: string): Promise<boolean> => {
 	const whitelist = String(settings.get('Block_Multiple_Failed_Logins_Ip_Whitelist'))
 		.split(',')
-		.map((entry) => entry.trim())
+		.map((rawIp) => rawIp.trim())
 		.filter(Boolean);
 
 	if (


### PR DESCRIPTION
## Description

When admins configure the `Block_Multiple_Failed_Logins_Ip_Whitelist` setting with spaces after commas (e.g. `127.0.0.1, 192.168.0.1`), the IP matching fails because the entries aren't trimmed.

This adds `.map((ip) => ip.trim()).filter(Boolean)` to the whitelist parsing to normalize entries before comparison.

### Changes
- `apps/meteor/app/authentication/server/lib/restrictLoginAttempts.ts` - added trim/filter to whitelist parsing
### Testing
- Verified that IPs with surrounding whitespace are now correctly matched
- - No regressions in existing login protection behavior
Closes #39915

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login protection to correctly handle IP whitelist entries with surrounding whitespace and to ignore empty values, reducing incorrect blocking of legitimate login attempts.
* **Chores**
  * Added a patch release note documenting the IP whitelist whitespace trimming fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->