### PR TITLE
fix: support nested markdown list indentation by parsing indentLevel

### DIFF
--- a/.changeset/fix-nested-list-indentation.md
+++ b/.changeset/fix-nested-list-indentation.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/gazzodown": patch
+"@rocket.chat/message-parser": patch
+---
+
+fix: support nested markdown list indentation by parsing indentLevel

--- a/.changeset/nested-list-indentation.md
+++ b/.changeset/nested-list-indentation.md
@@ -3,4 +3,4 @@
 '@rocket.chat/gazzodown': patch
 ---
 
-fix: support nested markdown list indentation by parsing indentLevel
+fix: support nested Markdown list indentation by parsing indentLevel

--- a/.changeset/nested-list-indentation.md
+++ b/.changeset/nested-list-indentation.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/message-parser': patch
+'@rocket.chat/gazzodown': patch
+---
+
+fix: support nested markdown list indentation by parsing indentLevel

--- a/packages/gazzodown/src/blocks/OrderedListBlock.tsx
+++ b/packages/gazzodown/src/blocks/OrderedListBlock.tsx
@@ -9,8 +9,8 @@ type OrderedListBlockProps = {
 
 const OrderedListBlock = ({ items }: OrderedListBlockProps): ReactElement => (
 	<ol>
-		{items.map(({ value, number }, index) => (
-			<li key={index} value={number}>
+		{items.map(({ value, number, indentLevel }, index) => (
+			<li key={index} value={number} style={indentLevel ? { marginInlineStart: `${indentLevel * 0.5}rem` } : undefined}>
 				<InlineElements>{value}</InlineElements>
 			</li>
 		))}

--- a/packages/gazzodown/src/blocks/TaskListBlock.tsx
+++ b/packages/gazzodown/src/blocks/TaskListBlock.tsx
@@ -16,7 +16,7 @@ const TaksListBlock = ({ tasks }: TaskListBlockProps): ReactElement => {
 	return (
 		<ul className='task-list'>
 			{tasks.map((item, index) => (
-				<li key={index}>
+				<li key={index} style={item.indentLevel ? { marginInlineStart: `${item.indentLevel * 0.5}rem` } : undefined}>
 					<CheckBox checked={item.status} onChange={onTaskChecked?.(item)} /> <InlineElements>{item.value}</InlineElements>
 				</li>
 			))}

--- a/packages/gazzodown/src/blocks/UnorderedListBlock.tsx
+++ b/packages/gazzodown/src/blocks/UnorderedListBlock.tsx
@@ -10,7 +10,7 @@ type UnorderedListBlockProps = {
 const UnorderedListBlock = ({ items }: UnorderedListBlockProps): ReactElement => (
 	<ul>
 		{items.map((item, index) => (
-			<li key={index}>
+			<li key={index} style={item.indentLevel ? { marginInlineStart: `${item.indentLevel * 0.5}rem` } : undefined}>
 				<InlineElements>{item.value}</InlineElements>
 			</li>
 		))}

--- a/packages/message-parser/src/definitions.ts
+++ b/packages/message-parser/src/definitions.ts
@@ -17,6 +17,7 @@ export type ListItem = {
 	type: 'LIST_ITEM';
 	value: Inlines[];
 	number?: number;
+	indentLevel?: number;
 };
 
 export type Tasks = {
@@ -27,6 +28,7 @@ export type Task = {
 	type: 'TASK';
 	status: boolean;
 	value: Inlines[];
+	indentLevel?: number;
 };
 
 export type CodeLine = {

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -161,7 +161,7 @@ HeadingInlineItem = InlineItemPattern / !EndOfLine @Any
  */
 Tasks = items:Task+ { return tasks(items); }
 
-Task = "- [" flag:TaskFlag "]" [ \t]+ text:Inline { return task(text, flag); }
+Task = indent:[ \t]* "- [" flag:TaskFlag "]" [ \t]+ text:Inline { return task(text, flag, indent.length); }
 
 TaskFlag = "x" { return true; } / " " { return false; }
 
@@ -176,7 +176,7 @@ TaskFlag = "x" { return true; } / " " { return false; }
  */
 OrderedList = items:OrderedListItem+ { return orderedList(items); }
 
-OrderedListItem = number:Digits "." [ \t]+ text:Inline { return listItem(text, parseInt(number, 10)); }
+OrderedListItem = indent:[ \t]* number:Digits "." [ \t]+ text:Inline { return listItem(text, parseInt(number, 10), indent.length); }
 
 /**
  *
@@ -190,9 +190,9 @@ OrderedListItem = number:Digits "." [ \t]+ text:Inline { return listItem(text, p
  */
 UnorderedList = items:(UnorderedListHyphenItem+ / UnorderedListAsteriskItem+) { return unorderedList(items); }
 
-UnorderedListHyphenItem = "-" [ \t]+ text:Inline { return listItem(text); }
+UnorderedListHyphenItem = indent:[ \t]* "-" [ \t]+ text:Inline { return listItem(text, undefined, indent.length); }
 
-UnorderedListAsteriskItem = "*" [ \t]+ text:UnorderedListItemContent { return listItem(text); }
+UnorderedListAsteriskItem = indent:[ \t]* "*" [ \t]+ text:UnorderedListItemContent { return listItem(text, undefined, indent.length); }
 
 UnorderedListItemContent = value:UnorderedListItemContentItem+ !"*" EndOfLine? { return reducePlainTexts(value); }
 

--- a/packages/message-parser/src/utils.ts
+++ b/packages/message-parser/src/utils.ts
@@ -50,10 +50,11 @@ export const bigEmoji = (value: BigEmoji['value']): BigEmoji => ({
 	value,
 });
 
-export const task = (value: Task['value'], status: boolean): Task => ({
+export const task = (value: Task['value'], status: boolean, indentLevel?: number): Task => ({
 	type: 'TASK',
 	status,
 	value,
+	...(indentLevel ? { indentLevel } : {}),
 });
 
 export const inlineCode = generate('INLINE_CODE');
@@ -131,10 +132,11 @@ export const orderedList = generate('ORDERED_LIST');
 
 export const unorderedList = generate('UNORDERED_LIST');
 
-export const listItem = (text: Inlines[], number?: number): ListItem => ({
+export const listItem = (text: Inlines[], number?: number, indentLevel?: number): ListItem => ({
 	type: 'LIST_ITEM',
 	value: text,
 	...(number !== undefined && { number }),
+	...(indentLevel ? { indentLevel } : {}),
 });
 
 export const mentionUser = (() => {


### PR DESCRIPTION
## Description

Nested/multi-level markdown lists were previously rendering as flat lists without proper indentation. 

This PR modifies the `@rocket.chat/message-parser` grammar to capture the indentation spacing before `Task`, `OrderedListItem`, and `UnorderedListItem` markers. It assigns an `indentLevel` to the resulting AST `ListItem` or `Task` object.

The `@rocket.chat/gazzodown` block renderers have been updated to check for `indentLevel` and apply a `marginInlineStart` (0.5rem per level) to the corresponding `<li>` elements, restoring proper visual indentation for nested lists.

### Changes
- `packages/message-parser/src/grammar.pegjs` - capture indentation before list markers
- - `packages/message-parser/src/definitions.ts` - add `indentLevel?: number` to `ListItem` and `Task` AST types
- - `packages/message-parser/src/utils.ts` - pass `indentLevel` through AST factory functions
- - `packages/gazzodown/src/blocks/OrderedListBlock.tsx` - apply indentation styling
- - `packages/gazzodown/src/blocks/UnorderedListBlock.tsx` - apply indentation styling
- - `packages/gazzodown/src/blocks/TaskListBlock.tsx` - apply indentation styling
### Testing
- Existing parser AST tests will remain unchanged for non-indented lists since `indentLevel: 0` is omitted from the AST.
- - Visually verified nested tasks, ordered lists, and unordered lists properly indent in the UI.
Closes #40217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nested Markdown list indentation so ordered lists, unordered lists, and task lists render nested items with consistent visual indentation for improved readability.

* **Changes**
  * Enhanced Markdown parsing to capture indentation levels for list and task items, allowing the renderer to apply matching indentation when displaying nested structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->