### PR TITLE
regression: _session socket crashes after subscription cleanup

### DIFF
--- a/apps/meteor/app/notifications/server/lib/Presence.ts
+++ b/apps/meteor/app/notifications/server/lib/Presence.ts
@@ -2,6 +2,7 @@ import type { IUser } from '@rocket.chat/core-typings';
 import type { StreamerEvents } from '@rocket.chat/ddp-client';
 import { Emitter } from '@rocket.chat/emitter';
 
+import { Streamer } from '../../../../server/modules/streamer/streamer.module';
 import type { IPublication, IStreamerConstructor, Connection, IStreamer } from '../../../../server/modules/streamer/types';
 
 type UserPresenceStreamProps = {
@@ -48,7 +49,17 @@ class UserPresence {
 
 	run = (args: UserPresenceStreamArgs): void => {
 		const payload = this.streamer.changedPayload(this.streamer.subscriptionName, args.uid, { ...args, eventName: args.uid }); // there is no good explanation to keep eventName, I just want to save one 'DDPCommon.parseDDP' on the client side, so I'm trying to fit the Meteor Streamer's payload
-		if (payload) this.publication._session?.socket?.send(payload);
+		if (!payload) {
+			return;
+		}
+		// after meteor 3.4.1 immediately after a disconnection session becomes null (which is not wrong)
+		// we were just not counting on this, session is _session so we actually should not use it
+		// now after any await, the session can potentially be null, so we need to check for that
+		if (!Streamer.isPublicationActive(this.publication)) {
+			return;
+		}
+
+		this.publication._session.socket.send(payload);
 	};
 
 	stop(): void {

--- a/apps/meteor/app/notifications/server/lib/Presence.ts
+++ b/apps/meteor/app/notifications/server/lib/Presence.ts
@@ -48,7 +48,7 @@ class UserPresence {
 
 	run = (args: UserPresenceStreamArgs): void => {
 		const payload = this.streamer.changedPayload(this.streamer.subscriptionName, args.uid, { ...args, eventName: args.uid }); // there is no good explanation to keep eventName, I just want to save one 'DDPCommon.parseDDP' on the client side, so I'm trying to fit the Meteor Streamer's payload
-		if (payload) this.publication._session.socket?.send(payload);
+		if (payload) this.publication._session?.socket?.send(payload);
 	};
 
 	stop(): void {

--- a/apps/meteor/server/modules/notifications/notifications.module.ts
+++ b/apps/meteor/server/modules/notifications/notifications.module.ts
@@ -63,7 +63,7 @@ export class NotificationsModule {
 		this.streamRoomMessage = new this.Streamer('room-messages');
 
 		this.streamRoomMessage.on('_afterPublish', async (streamer, publication: IPublication, eventName: string): Promise<void> => {
-			const { userId } = publication._session;
+			const userId = publication._session?.userId;
 			if (!userId) {
 				return;
 			}
@@ -376,7 +376,7 @@ export class NotificationsModule {
 		this.streamRoles.allowRead('logged');
 
 		this.streamUser.on('_afterPublish', async (streamer, publication: IPublication, eventName: string): Promise<void> => {
-			const { userId } = publication._session;
+			const userId = publication._session?.userId;
 			if (!userId) {
 				return;
 			}
@@ -390,7 +390,7 @@ export class NotificationsModule {
 						args,
 					});
 
-					payload && publication._session.socket?.send(payload);
+					payload && publication._session?.socket?.send(payload);
 				};
 
 				const subscriptions = await Subscriptions.find<Pick<ISubscription, 'rid'>>(

--- a/apps/meteor/server/modules/notifications/notifications.module.ts
+++ b/apps/meteor/server/modules/notifications/notifications.module.ts
@@ -6,7 +6,8 @@ import { Rooms, Subscriptions, Users } from '@rocket.chat/models';
 import type { ImporterProgress } from '../../../app/importer/server/classes/ImporterProgress';
 import { emit, StreamPresence } from '../../../app/notifications/server/lib/Presence';
 import { SystemLogger } from '../../lib/logger/system';
-import type { IStreamer, IStreamerConstructor, IPublication } from '../streamer/types';
+import { Streamer as StreamerModule } from '../streamer/streamer.module';
+import type { IStreamer, IStreamerConstructor } from '../streamer/types';
 
 export class NotificationsModule {
 	public readonly streamLogged: IStreamer<'notify-logged'>;
@@ -62,8 +63,12 @@ export class NotificationsModule {
 		this.streamPresence = StreamPresence.getInstance(Streamer, 'user-presence');
 		this.streamRoomMessage = new this.Streamer('room-messages');
 
-		this.streamRoomMessage.on('_afterPublish', async (streamer, publication: IPublication, eventName: string): Promise<void> => {
-			const userId = publication._session?.userId;
+		this.streamRoomMessage.on('_afterPublish', async (streamer, publication, eventName): Promise<void> => {
+			if (!StreamerModule.isPublicationActive(publication)) {
+				return;
+			}
+
+			const { userId } = publication._session;
 			if (!userId) {
 				return;
 			}
@@ -375,8 +380,15 @@ export class NotificationsModule {
 		this.streamRoles.allowWrite('none');
 		this.streamRoles.allowRead('logged');
 
-		this.streamUser.on('_afterPublish', async (streamer, publication: IPublication, eventName: string): Promise<void> => {
-			const userId = publication._session?.userId;
+		this.streamUser.on('_afterPublish', async (streamer, publication, eventName): Promise<void> => {
+			// after meteor 3.4.1 immediately after a disconnection session becomes null (which is not wrong)
+			// we were just not counting on this, session is _session so we actually should not use it
+			// now after any await, the session can potentially be null, so we need to check for that
+			if (!StreamerModule.isPublicationActive(publication)) {
+				return;
+			}
+
+			const { userId } = publication._session;
 			if (!userId) {
 				return;
 			}
@@ -389,8 +401,17 @@ export class NotificationsModule {
 						eventName: `${userId}/rooms-changed`,
 						args,
 					});
+					if (!payload) {
+						return;
+					}
 
-					payload && publication._session?.socket?.send(payload);
+					// after meteor 3.4.1 immediately after a disconnection session becomes null (which is not wrong)
+					// we were just not counting on this, session is _session so we actually should not use it
+					// now after any await, the session can potentially be null, so we need to check for that
+					if (!StreamerModule.isPublicationActive(publication)) {
+						return;
+					}
+					publication._session.socket.send(payload);
 				};
 
 				const subscriptions = await Subscriptions.find<Pick<ISubscription, 'rid'>>(

--- a/apps/meteor/server/modules/streamer/streamer.module.ts
+++ b/apps/meteor/server/modules/streamer/streamer.module.ts
@@ -13,6 +13,8 @@ class StreamerCentralClass<N extends keyof StreamerEvents> extends EventEmitter 
 	}
 }
 
+type ActivePublication = IPublication & { _session: NonNullable<IPublication['_session']> };
+
 export const StreamerCentral = new StreamerCentralClass();
 
 export abstract class Streamer<N extends keyof StreamerEvents> extends EventEmitter implements IStreamer<N> {
@@ -183,6 +185,14 @@ export abstract class Streamer<N extends keyof StreamerEvents> extends EventEmit
 			throw new MeteorError('not-allowed');
 		}
 
+		// after meteor 3.4.1 immediately after a disconnection session becomes null (which is not wrong)
+		// we were just not counting on this, session is _session so we actually should not use it
+		// now after any await, the session can potentially be null, so we need to check for that
+		if (!Streamer.isPublicationActive(publication)) {
+			// if the client is disconnected, we don't want to do anything, it will not have an disconnect event to undo anymore
+			throw new MeteorError('publication-client-disconnected');
+		}
+
 		const subscription = {
 			subscription: publication,
 			eventName,
@@ -197,7 +207,7 @@ export abstract class Streamer<N extends keyof StreamerEvents> extends EventEmit
 		// DDPStreamer doesn't have this
 		if (useCollection === true) {
 			// Collection compatibility
-			publication._session?.sendAdded(this.subscriptionName, 'id', {
+			publication._session.sendAdded(this.subscriptionName, 'id', {
 				eventName,
 			});
 		}
@@ -281,6 +291,10 @@ export abstract class Streamer<N extends keyof StreamerEvents> extends EventEmit
 		void this.sendToManySubscriptions(subscriptions, origin, eventName, args, msg);
 
 		return true;
+	}
+
+	static isPublicationActive(publication: IPublication): publication is ActivePublication {
+		return !publication._isDeactivated();
 	}
 
 	async sendToManySubscriptions(

--- a/apps/meteor/server/modules/streamer/streamer.module.ts
+++ b/apps/meteor/server/modules/streamer/streamer.module.ts
@@ -197,7 +197,7 @@ export abstract class Streamer<N extends keyof StreamerEvents> extends EventEmit
 		// DDPStreamer doesn't have this
 		if (useCollection === true) {
 			// Collection compatibility
-			publication._session.sendAdded(this.subscriptionName, 'id', {
+			publication._session?.sendAdded(this.subscriptionName, 'id', {
 				eventName,
 			});
 		}
@@ -301,7 +301,7 @@ export abstract class Streamer<N extends keyof StreamerEvents> extends EventEmit
 					if (allowed) {
 						const msg = typeof getMsg === 'string' ? getMsg : getMsg(this, subscription, eventName, args, allowed);
 						if (msg) {
-							subscription.subscription._session.socket?.send(msg);
+							subscription.subscription._session?.socket?.send(msg);
 						}
 					}
 				} catch (err) {

--- a/apps/meteor/server/modules/streamer/types.ts
+++ b/apps/meteor/server/modules/streamer/types.ts
@@ -10,7 +10,7 @@ export interface IPublication {
 		socket: {
 			send: (payload: string) => void;
 		};
-	};
+	} | null;
 	client: {
 		meteorClient: boolean;
 		ws: any;

--- a/apps/meteor/server/modules/streamer/types.ts
+++ b/apps/meteor/server/modules/streamer/types.ts
@@ -4,6 +4,7 @@ export type Connection = any;
 
 export interface IPublication {
 	connection: Connection;
+	_isDeactivated(): this is IPublication & { _session: null };
 	_session: {
 		sendAdded(publicationName: string, id: string, fields: Record<string, any>): void;
 		userId: string | undefined;
@@ -82,7 +83,7 @@ export interface IStreamer<N extends StreamNames> {
 
 	on<K extends StreamKeys<N>>(event: K, fn: (...data: any[]) => void): void;
 
-	on(event: '_afterPublish', fn: (streamer: this, ...data: any[]) => void): void;
+	on(event: '_afterPublish', fn: (streamer: this, publication: IPublication, eventName: string, ...data: any[]) => void): void;
 
 	removeSubscription(subscription: DDPSubscription, eventName: string): void;
 

--- a/ee/apps/ddp-streamer/src/Publication.ts
+++ b/ee/apps/ddp-streamer/src/Publication.ts
@@ -30,6 +30,10 @@ export class Publication extends EventEmitter implements IPublication {
 		this.connection = client.connection;
 	}
 
+	_isDeactivated(): this is IPublication & { _session: null } {
+		return this._session === null;
+	}
+
 	error(_error: Error): void {
 		throw new Error('Method not implemented.');
 	}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
- Added defensive null checks before sending through _session.socket in streamer and notifications delivery flows.
- Replaced direct destructuring of userId from publication._session with safe optional access.
- Guarded the collection compatibility sendAdded call to avoid accessing _session after cleanup.
- Updated streamer publication typing so _session can be null, matching current Meteor ddp-server behavior after a subscription stops.

## Issue(s)
- Fixes runtime crash: TypeError: Cannot read properties of null (reading 'socket')
- Related to Meteor ddp-server changes that null out subscription/session references after stop.

## Steps to test or reproduce
1. Start the server and connect a client that subscribes to streamer/notification events.
2. Stop or unsubscribe that client subscription.
3. Trigger server-side emits that previously attempted to send to the stopped subscription.
4. Confirm no TypeError is thrown and events continue to be processed safely.

## Further comments
- This is a defensive hardening fix and should not change behavior for active sessions.
- The change targets post-stop/session-cleanup timing windows where Meteor now sets _session to null. 

 Task: [CORE-2182]

[CORE-2182]: https://rocketchat.atlassian.net/browse/CORE-2182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications and streaming now skip sending when a publication/subscription is inactive or yields no payload, preventing runtime errors and dropped messages.
* **Refactor**
  * Consolidated publication/session liveness checks and introduced guards; session fields are now nullable and callers must handle absent session data, improving robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->