### PR TITLE
refactor(client): replace useReactiveValue with useSyncExternalStore in providers

### DIFF
--- a/.changeset/sdk-status-loggingin-providers.md
+++ b/.changeset/sdk-status-loggingin-providers.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Replace `useReactiveValue` (Tracker-based) with `useSyncExternalStore` in `ServerProvider` and `AuthenticationProvider`. `ServerProvider` now subscribes directly to `sdk.connection.on('connection', …)` for status updates and drops its standalone `Tracker.Dependency` (`ddpSdkStatusDep`); `AuthenticationProvider` observes `Accounts.loggingIn()` transitions via a one-time monkey-patch of `Accounts._setLoggingIn` (the same private API already used by `killMeteorStream`). `useReactiveValue` had no remaining consumers after this and is removed. `createReactiveSubscriptionFactory` stays — `AuthorizationProvider` and `UserProvider`'s `queryPreference` still depend on its Tracker-driven reactivity.

--- a/.changeset/sdk-status-loggingin-providers.md
+++ b/.changeset/sdk-status-loggingin-providers.md
@@ -1,5 +1,0 @@
----
-'@rocket.chat/meteor': patch
----
-
-Replace `useReactiveValue` (Tracker-based) with `useSyncExternalStore` in `ServerProvider` and `AuthenticationProvider`. `ServerProvider` now subscribes directly to `sdk.connection.on('connection', …)` for status updates and drops its standalone `Tracker.Dependency` (`ddpSdkStatusDep`); `AuthenticationProvider` observes `Accounts.loggingIn()` transitions via a one-time monkey-patch of `Accounts._setLoggingIn` (the same private API already used by `killMeteorStream`). `useReactiveValue` had no remaining consumers after this and is removed. `createReactiveSubscriptionFactory` stays — `AuthorizationProvider` and `UserProvider`'s `queryPreference` still depend on its Tracker-driven reactivity.

--- a/apps/meteor/client/hooks/useReactiveValue.ts
+++ b/apps/meteor/client/hooks/useReactiveValue.ts
@@ -1,9 +1,0 @@
-import { useMemo, useSyncExternalStore } from 'react';
-
-import { createReactiveSubscriptionFactory } from '../lib/createReactiveSubscriptionFactory';
-
-export const useReactiveValue = <T>(computeCurrentValue: () => T): T => {
-	const [subscribe, getSnapshot] = useMemo(() => createReactiveSubscriptionFactory<T>(computeCurrentValue)(), [computeCurrentValue]);
-
-	return useSyncExternalStore(subscribe, getSnapshot);
-};

--- a/apps/meteor/client/providers/AuthenticationProvider/AuthenticationProvider.tsx
+++ b/apps/meteor/client/providers/AuthenticationProvider/AuthenticationProvider.tsx
@@ -4,11 +4,10 @@ import { AuthenticationContext, useSetting } from '@rocket.chat/ui-contexts';
 import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
 import type { ContextType, ReactElement, ReactNode } from 'react';
-import { useMemo } from 'react';
+import { useMemo, useSyncExternalStore } from 'react';
 
 import { useLDAPAndCrowdCollisionWarning } from './hooks/useLDAPAndCrowdCollisionWarning';
 import { capitalize as capitalizeService } from '../../../lib/utils/stringUtils';
-import { useReactiveValue } from '../../hooks/useReactiveValue';
 import { loginServices } from '../../lib/loginServices';
 import { getDdpSdk } from '../../lib/sdk/ddpSdk';
 import { STORAGE_KEYS, getStoredItem, removeStoredItem } from '../../lib/sdk/storage';
@@ -29,7 +28,34 @@ const callLoginMethod = (
 	});
 };
 
-const getLoggingIn = () => Accounts.loggingIn();
+// Bridge Accounts.loggingIn() — Meteor's Tracker-reactive flag — into a
+// non-reactive subscribe/getSnapshot pair for useSyncExternalStore. We hook
+// `_setLoggingIn` (Meteor's internal flip, also accessed in
+// apps/meteor/client/meteor/overrides/killMeteorStream.ts) to fan out
+// transitions without entering a Tracker computation.
+const loggingInListeners = new Set<() => void>();
+let loggingInBridgeInstalled = false;
+const installLoggingInBridge = (): void => {
+	if (loggingInBridgeInstalled) return;
+	loggingInBridgeInstalled = true;
+	const wrap = Accounts as unknown as { _setLoggingIn?: (v: boolean) => void };
+	const original = wrap._setLoggingIn;
+	if (typeof original !== 'function') return;
+	wrap._setLoggingIn = function (this: typeof Accounts, v: boolean) {
+		original.call(this, v);
+		loggingInListeners.forEach((cb) => cb());
+	};
+};
+
+const subscribeLoggingIn = (cb: () => void): (() => void) => {
+	installLoggingInBridge();
+	loggingInListeners.add(cb);
+	return () => {
+		loggingInListeners.delete(cb);
+	};
+};
+
+const getLoggingInSnapshot = (): boolean => Accounts.loggingIn();
 
 const AuthenticationProvider = ({ children }: AuthenticationProviderProps): ReactElement => {
 	const isLdapEnabled = useSetting('LDAP_Enable', false);
@@ -39,7 +65,7 @@ const AuthenticationProvider = ({ children }: AuthenticationProviderProps): Reac
 
 	useLDAPAndCrowdCollisionWarning();
 
-	const isLoggingIn = useReactiveValue(getLoggingIn);
+	const isLoggingIn = useSyncExternalStore(subscribeLoggingIn, getLoggingInSnapshot);
 
 	const contextValue = useMemo(
 		(): ContextType<typeof AuthenticationContext> => ({

--- a/apps/meteor/client/providers/ServerProvider.tsx
+++ b/apps/meteor/client/providers/ServerProvider.tsx
@@ -11,13 +11,11 @@ import type { Method, PathFor, OperationParams, OperationResult, UrlParams, Path
 import type { UploadResult, ServerContextValue } from '@rocket.chat/ui-contexts';
 import { ServerContext } from '@rocket.chat/ui-contexts';
 import { Meteor } from 'meteor/meteor';
-import { Tracker } from 'meteor/tracker';
 import { compile } from 'path-to-regexp';
-import { useMemo, type ReactNode } from 'react';
+import { useMemo, useSyncExternalStore, type ReactNode } from 'react';
 
 import { sdk } from '../../app/utils/client/lib/SDKClient';
 import { Info as info } from '../../app/utils/rocketchat.info';
-import { useReactiveValue } from '../hooks/useReactiveValue';
 import { absoluteUrl } from '../lib/absoluteUrl';
 import { ensureConnectedAndAuthenticated, getDdpSdk } from '../lib/sdk/ddpSdk';
 import { isSdkTransportEnabled } from '../lib/sdk/sdkTransportEnabled';
@@ -99,16 +97,6 @@ const reconnect = sdkTransportEnabled
 		}
 	: () => Meteor.reconnect();
 
-// With SDK transport on, combine Meteor's DDP status with DDPSDK's so the
-// ConnectionStatusBar / idle-connection hooks reflect the worst-case of both
-// transports. With the flag off, route status straight through Meteor —
-// Meteor.status() is already Tracker-reactive, so adding a second dependency
-// via the meteor-backed proxy's emitter would just double-fire the autorun.
-const ddpSdkStatusDep = sdkTransportEnabled ? new Tracker.Dependency() : undefined;
-if (sdkTransportEnabled) {
-	getDdpSdk().connection.on('connection', () => ddpSdkStatusDep!.changed());
-}
-
 type CombinedStatus = ReturnType<typeof Meteor.status>;
 
 const sdkStatusToMeteor = (sdkStatus: string, meteor: CombinedStatus): CombinedStatus => {
@@ -132,21 +120,48 @@ const sdkStatusToMeteor = (sdkStatus: string, meteor: CombinedStatus): CombinedS
 	}
 };
 
-const getStatus = sdkTransportEnabled
-	? () => {
-			ddpSdkStatusDep!.depend();
-			return sdkStatusToMeteor(getDdpSdk().connection.status, Meteor.status());
-		}
-	: // useReactiveValue stores the snapshot in useSyncExternalStore, which
-		// compares by identity. Meteor.status() reuses the same internal object
-		// (mutated in place), so without spreading the snapshot reference never
-		// changes and ConnectionStatusBar stops re-rendering on connect/drop.
-		() => ({ ...Meteor.status() });
+// With SDK transport on, combine Meteor's DDP status with DDPSDK's so the
+// ConnectionStatusBar / idle-connection hooks reflect the worst-case of both
+// transports. With the flag off, route status straight through Meteor —
+// `meteorBackedSdk` already bridges Meteor's `_stream` events into
+// `sdk.connection.on('connection')`, so the same subscription works in both
+// modes.
+const computeStatus: () => CombinedStatus = sdkTransportEnabled
+	? () => sdkStatusToMeteor(getDdpSdk().connection.status, Meteor.status())
+	: () => ({ ...Meteor.status() });
+
+const isStatusEqual = (a: CombinedStatus, b: CombinedStatus): boolean =>
+	a.status === b.status && a.connected === b.connected && a.retryCount === b.retryCount && a.retryTime === b.retryTime;
+
+let cachedStatus: CombinedStatus = computeStatus();
+const statusListeners = new Set<() => void>();
+let statusBridgeStarted = false;
+
+const ensureStatusBridge = (): void => {
+	if (statusBridgeStarted) return;
+	statusBridgeStarted = true;
+	getDdpSdk().connection.on('connection', () => {
+		const next = computeStatus();
+		if (isStatusEqual(cachedStatus, next)) return;
+		cachedStatus = next;
+		statusListeners.forEach((cb) => cb());
+	});
+};
+
+const subscribeStatus = (cb: () => void): (() => void) => {
+	ensureStatusBridge();
+	statusListeners.add(cb);
+	return () => {
+		statusListeners.delete(cb);
+	};
+};
+
+const getStatusSnapshot = (): CombinedStatus => cachedStatus;
 
 type ServerProviderProps = { children?: ReactNode };
 
 const ServerProvider = ({ children }: ServerProviderProps) => {
-	const { connected, status, retryCount, retryTime } = useReactiveValue(getStatus);
+	const { connected, status, retryCount, retryTime } = useSyncExternalStore(subscribeStatus, getStatusSnapshot);
 
 	const value = useMemo(
 		(): ServerContextValue => ({


### PR DESCRIPTION
> Stacked on top of #40445 (still in draft).

## Summary

\`useReactiveValue\` had only 2 consumers — \`ServerProvider\` and \`AuthenticationProvider\` — both wired through \`useReactiveValue → createReactiveSubscriptionFactory → Tracker.autorun\`. Both now use \`useSyncExternalStore\` directly with bespoke subscribe/getSnapshot pairs, eliminating Tracker from these paths.

- **\`ServerProvider\`**: subscribe directly on \`sdk.connection.on('connection', …)\`. Works in both transport modes since the previous PR's bridge made the Meteor pass-through emit \`'connection'\` from \`Meteor.connection._stream\` events. Snapshot is cached with a shallow-equality check so \`useSyncExternalStore\` only triggers re-renders when \`status\`/\`connected\`/\`retryCount\`/\`retryTime\` actually change. The standalone \`Tracker.Dependency\` (\`ddpSdkStatusDep\`) is gone — the SDK's own emitter is the single source of transition events now.
- **\`AuthenticationProvider\`**: subscribe via a one-time monkey-patch of \`Accounts._setLoggingIn\` (Meteor's internal flip, same private API already used by \`killMeteorStream.ts:49\`) to fan out logging-in transitions without entering a Tracker context.
- **\`useReactiveValue\`**: deleted. No remaining consumers.

\`createReactiveSubscriptionFactory\` stays — \`AuthorizationProvider\` (permission queries) and \`UserProvider\` (\`queryPreference\`) still rely on its Tracker bridge for reading \`hasPermission\` / \`hasRole\` / \`getUserPreference\` reactively. Migrating those is a follow-up that requires changing the underlying read APIs to expose explicit subscribers.

## Net Tracker imports

Before this PR: 7 client files. After: 6 (\`userAndUsers.ts\`, \`stubMeteorStream.ts\`, \`Cursor.ts\`, \`ObserveHandle.ts\`, \`watch.ts\`, \`createReactiveSubscriptionFactory.ts\`).

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] grep confirms only the 6 expected files still import \`meteor/tracker\`
- [ ] Manual: \`ConnectionStatusBar\` reflects connection drops/reconnects (DevTools → Network → Offline) in flag-OFF and flag-ON; reconnect countdown still works (uses internal \`setInterval\`, not reactive on retryTime)
- [ ] Manual: page reload while logged in shows correct \`isLoggingIn\` lifecycle (initial \`true\` during auto-resume, \`false\` after) — verifying \`useStoreCookiesOnLogin\` writes \`rc_token\` and \`useUpdateVideoConfUser\` updates after resume
- [ ] Manual: explicit login form submit → \`isLoggingIn\` flips true while in flight, false on completion 

 Task: [ARCH-2138]

[ARCH-2138]: https://rocketchat.atlassian.net/browse/ARCH-2138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal state management patterns in core authentication and connection providers to improve code maintainability and alignment with modern React standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->