### PR TITLE
feat(message-parser): Migrate PlainRun rule to TypeScript with parser infrastructure

### DIFF
--- a/.changeset/free-webs-end.md
+++ b/.changeset/free-webs-end.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/message-parser': major
+---
+
+Migrate PlainRun parser rule from PEG.js to TypeScript with incremental migration infrastructure. Establishes shared type contract (`ParseResult`, `ParserFunction`), grammar bridge utilities (`callTsParser`), and consolidated parser functions destination (`src/parser/grammar.ts`). Parser output remains bit-identical to original implementation.

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -260,7 +260,17 @@ InlineEmoticon = emo:Emoticon & (EmoticonNeighbor / InlineItemPattern) { return 
 // Match "-" only when "-_-" is followed by more (so "-_-italic" → plain+italic); don't match when "-_-" is the full emoticon
 PlainRunBeforeEmoticon = "-" &("_" "-" .) { return plain('-'); }
 
-PlainRun = run:$[^*_~`:\n<\[\]! \t()\\|]+ { return plain(run); }
+PlainRun = & { return peg$currPos < input.length; } . {
+  const { parsePlainRun } = require('./parser/grammar');
+  const { callTsParser } = require('./parser/utils');
+  peg$currPos--;
+  const result = callTsParser(parsePlainRun, input, peg$currPos);
+  if (result !== null) {
+    peg$currPos = result.newPos;
+    return result.node;
+  }
+  return peg$FAILED;
+}
 
 EscapedTimestampRules
   = "\\" "<t:" rawDate:$(Unixtime / ISO8601Date / ISO8601DateWithoutMilliseconds / Timestamp) ":" format:TimestampType ">" {

--- a/packages/message-parser/src/parser/grammar.ts
+++ b/packages/message-parser/src/parser/grammar.ts
@@ -1,0 +1,19 @@
+import { plain } from '../utils';
+import type { ParseResult } from './types';
+
+const SPECIAL_CHARS = new Set(['*', '_', '~', '`', ':', '\n', '<', '[', ']', '!', ' ', '\t', '(', ')', '\\', '|']);
+
+/**
+ * Parses one or more consecutive non-special characters starting at `pos`.
+ * Equivalent to: PlainRun = run:$[^*_~`:\n<\[\]! \t()\\|]+ { return plain(run); }
+ */
+export function parsePlainRun(input: string, pos: number): ParseResult {
+	if (pos >= input.length || SPECIAL_CHARS.has(input[pos])) {
+		return { success: false };
+	}
+	let end = pos + 1;
+	while (end < input.length && !SPECIAL_CHARS.has(input[end])) {
+		end++;
+	}
+	return { success: true, node: plain(input.substring(pos, end)), newPos: end };
+}

--- a/packages/message-parser/src/parser/types.ts
+++ b/packages/message-parser/src/parser/types.ts
@@ -1,0 +1,22 @@
+import type { ASTNode } from '../definitions';
+import type { Options } from '../index';
+
+/**
+ * Discriminated union returned by every migrated parser function.
+ * On success: the parsed AST node and the new cursor position.
+ * On failure: no additional data (the caller must not advance the cursor).
+ *
+ * Invariant: on success, `newPos >= pos` (cursor never moves backwards).
+ */
+export type ParseResult = { success: true; node: ASTNode; newPos: number } | { success: false };
+
+/**
+ * Signature for a migrated parser function that does not need parse options.
+ */
+export type ParserFunction = (input: string, pos: number) => ParseResult;
+
+/**
+ * Signature for a migrated parser function that needs the parse options
+ * (e.g., for katex.dollarSyntax, emoticons, customDomains).
+ */
+export type ParserFunctionWithOptions = (input: string, pos: number, options: Options) => ParseResult;

--- a/packages/message-parser/src/parser/utils.ts
+++ b/packages/message-parser/src/parser/utils.ts
@@ -1,0 +1,51 @@
+import type { ASTNode } from '../definitions';
+import type { Options } from '../index';
+import type { ParserFunction, ParserFunctionWithOptions } from './types';
+
+/**
+ * Calls a TypeScript parser function from a PEG.js semantic predicate action.
+ *
+ * Returns `{ node, newPos }` on success so the grammar action can:
+ *   1. Assign `peg$currPos = result.newPos`
+ *   2. Return `result.node`
+ *
+ * Returns `null` on failure so the grammar action can return `FAILED`.
+ * Any exception thrown by the parser function is caught and logged to
+ * `console.error` so that a bug in a migrated rule degrades gracefully
+ * (the grammar backtracks) rather than crashing the entire parser.
+ */
+export function callTsParser(parser: ParserFunction, input: string, pos: number): { node: ASTNode; newPos: number } | null {
+	try {
+		const result = parser(input, pos);
+		if (result.success) {
+			return { node: result.node, newPos: result.newPos };
+		}
+		return null;
+	} catch (err) {
+		console.error('[callTsParser] parser threw an exception:', err);
+		return null;
+	}
+}
+
+/**
+ * Same as `callTsParser` but forwards the PEG.js `options` object to a
+ * `ParserFunctionWithOptions` (e.g., rules that need katex.dollarSyntax,
+ * emoticons, or customDomains from the parse options).
+ */
+export function callTsParserWithOptions(
+	parser: ParserFunctionWithOptions,
+	input: string,
+	pos: number,
+	options: Options,
+): { node: ASTNode; newPos: number } | null {
+	try {
+		const result = parser(input, pos, options);
+		if (result.success) {
+			return { node: result.node, newPos: result.newPos };
+		}
+		return null;
+	} catch (err) {
+		console.error('[callTsParserWithOptions] parser threw an exception:', err);
+		return null;
+	}
+}


### PR DESCRIPTION
## Overview
This PR implements the first phase of the PEG.js to TypeScript migration for the message parser. It establishes the migration infrastructure and migrates the `PlainRun` rule as a proof-of-concept.

## Changes

### New Files
- **`src/parser/types.ts`**: Shared type contract for all migrated parser functions
  - `ParseResult` discriminated union (success/failure variants)
  - `ParserFunction` and `ParserFunctionWithOptions` type aliases
  
- **`src/parser/utils.ts`**: Grammar bridge utilities
  - `callTsParser()`: Translates between PEG.js runtime and TypeScript `ParseResult`
  - `callTsParserWithOptions()`: Same as above but forwards parse options
  - Exception handling and logging for parser errors

- **`src/parser/grammar.ts`**: Consolidated destination for all migrated parser functions
  - `parsePlainRun()`: TypeScript implementation of the PlainRun rule
  - Character-by-character scanning (no regex) matching the original PEG rule behavior
  - Proper cursor position tracking with `newPos >= pos` invariant

### Modified Files
- **`src/grammar.pegjs`**: Updated PlainRun rule to delegate to TypeScript
  - Replaced inline character class with semantic predicate that calls `parsePlainRun`
  - Uses `callTsParser` bridge utility for proper error handling
  - Maintains identical parsing behavior and AST output

## Testing
- All existing tests pass without modification
- Parser output is bit-identical to the original PEG.js implementation
- TypeScript strict mode validation passes

## Migration Strategy
This PR establishes the pattern for incremental rule migration:
1. Each rule is migrated one at a time to `src/parser/grammar.ts`
2. The PEG.js grammar shrinks incrementally as rules are replaced
3. The parser remains in a working state after each migration
4. Once all rules are migrated, `grammar.pegjs` will be deleted entirely
