### PR TITLE
refactor(client): replace Accounts.storageLocation with SDK storage helper

### DIFF
--- a/apps/meteor/app/utils/client/lib/RestApiClient.ts
+++ b/apps/meteor/app/utils/client/lib/RestApiClient.ts
@@ -1,9 +1,9 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { RestClient } from '@rocket.chat/api-client';
-import { Accounts } from 'meteor/accounts-base';
 
 import { invokeTwoFactorModal } from '../../../../client/lib/2fa/process2faReturn';
 import { baseURI } from '../../../../client/lib/baseURI';
+import { STORAGE_KEYS, getStoredItem } from '../../../../client/lib/sdk/storage';
 
 class RestApiClient extends RestClient {
 	override getCredentials():
@@ -12,10 +12,7 @@ class RestApiClient extends RestClient {
 				'X-Auth-Token': string;
 		  }
 		| undefined {
-		const [uid, token] = [
-			Accounts.storageLocation.getItem(Accounts.USER_ID_KEY),
-			Accounts.storageLocation.getItem(Accounts.LOGIN_TOKEN_KEY),
-		];
+		const [uid, token] = [getStoredItem(STORAGE_KEYS.USER_ID), getStoredItem(STORAGE_KEYS.LOGIN_TOKEN)];
 
 		if (!uid || !token) {
 			return;

--- a/apps/meteor/client/lib/e2ee/rocketchat.e2e.ts
+++ b/apps/meteor/client/lib/e2ee/rocketchat.e2e.ts
@@ -8,7 +8,6 @@ import { isTruthy } from '@rocket.chat/tools';
 import { imperativeModal } from '@rocket.chat/ui-client';
 import type { SubscriptionWithRoom } from '@rocket.chat/ui-contexts';
 import sampleSize from 'lodash/sampleSize';
-import { Accounts } from 'meteor/accounts-base';
 
 import type { E2EEState } from './E2EEState';
 import * as Rsa from './crypto/rsa';
@@ -28,6 +27,7 @@ import SaveE2EPasswordModal from '../../views/e2e/SaveE2EPasswordModal';
 import * as banners from '../banners';
 import type { LegacyBannerPayload } from '../banners';
 import { getDdpSdk } from '../sdk/ddpSdk';
+import { STORAGE_KEYS, getStoredItem, removeStoredItem, setStoredItem } from '../sdk/storage';
 import { settings } from '../settings';
 import { dispatchToastMessage } from '../toast';
 import { mapMessageFromApi } from '../utils/mapMessageFromApi';
@@ -315,8 +315,8 @@ class E2E extends Emitter {
 
 	getKeysFromLocalStorage(): KeyPair {
 		return {
-			public_key: Accounts.storageLocation.getItem('public_key'),
-			private_key: Accounts.storageLocation.getItem('private_key'),
+			public_key: getStoredItem(STORAGE_KEYS.E2EE_PUBLIC_KEY),
+			private_key: getStoredItem(STORAGE_KEYS.E2EE_PRIVATE_KEY),
 		};
 	}
 
@@ -335,7 +335,7 @@ class E2E extends Emitter {
 					imperativeModal.close();
 				},
 				onConfirm: () => {
-					Accounts.storageLocation.removeItem('e2e.randomPassword');
+					removeStoredItem(STORAGE_KEYS.E2EE_RANDOM_PASSWORD);
 					this.setState('READY');
 					dispatchToastMessage({ type: 'success', message: t('E2E_encryption_enabled') });
 					this.closeAlert();
@@ -403,7 +403,7 @@ class E2E extends Emitter {
 			await this.persistKeys(this.getKeysFromLocalStorage(), await this.createRandomPassword());
 		}
 
-		const randomPassword = Accounts.storageLocation.getItem('e2e.randomPassword');
+		const randomPassword = getStoredItem(STORAGE_KEYS.E2EE_RANDOM_PASSWORD);
 		if (randomPassword) {
 			this.setState('SAVE_PASSWORD');
 			this.openAlert({
@@ -422,8 +422,8 @@ class E2E extends Emitter {
 		span.info(this.state);
 		this.closeAlert();
 
-		Accounts.storageLocation.removeItem('public_key');
-		Accounts.storageLocation.removeItem('private_key');
+		removeStoredItem(STORAGE_KEYS.E2EE_PUBLIC_KEY);
+		removeStoredItem(STORAGE_KEYS.E2EE_PRIVATE_KEY);
 		this.instancesByRoomId = {};
 		this.privateKey = undefined;
 		this.publicKey = undefined;
@@ -438,8 +438,8 @@ class E2E extends Emitter {
 	async changePassword(newPassword: string): Promise<void> {
 		await this.persistKeys(this.getKeysFromLocalStorage(), newPassword, { force: true });
 
-		if (Accounts.storageLocation.getItem('e2e.randomPassword')) {
-			Accounts.storageLocation.setItem('e2e.randomPassword', newPassword);
+		if (getStoredItem(STORAGE_KEYS.E2EE_RANDOM_PASSWORD)) {
+			setStoredItem(STORAGE_KEYS.E2EE_RANDOM_PASSWORD, newPassword);
 		}
 	}
 
@@ -464,13 +464,13 @@ class E2E extends Emitter {
 
 	async loadKeys({ public_key, private_key }: { public_key: string; private_key: string }): Promise<void> {
 		const span = log.span('loadKeys');
-		Accounts.storageLocation.setItem('public_key', public_key);
+		setStoredItem(STORAGE_KEYS.E2EE_PUBLIC_KEY, public_key);
 		this.publicKey = public_key;
 
 		try {
 			this.privateKey = await Rsa.importPrivateKey(JSON.parse(private_key));
 
-			Accounts.storageLocation.setItem('private_key', private_key);
+			setStoredItem(STORAGE_KEYS.E2EE_PRIVATE_KEY, private_key);
 		} catch (error) {
 			this.setState('ERROR');
 			return span.error('Error importing private key: ', error);
@@ -494,7 +494,7 @@ class E2E extends Emitter {
 			const publicKey = await Rsa.exportPublicKey(keyPair.publicKey);
 
 			this.publicKey = JSON.stringify(publicKey);
-			Accounts.storageLocation.setItem('public_key', JSON.stringify(publicKey));
+			setStoredItem(STORAGE_KEYS.E2EE_PUBLIC_KEY, JSON.stringify(publicKey));
 		} catch (error) {
 			this.setState('ERROR');
 			return span.set('error', error).error('Error exporting public key');
@@ -503,7 +503,7 @@ class E2E extends Emitter {
 		try {
 			const privateKey = await Rsa.exportPrivateKey(keyPair.privateKey);
 
-			Accounts.storageLocation.setItem('private_key', JSON.stringify(privateKey));
+			setStoredItem(STORAGE_KEYS.E2EE_PRIVATE_KEY, JSON.stringify(privateKey));
 		} catch (error) {
 			this.setState('ERROR');
 			return span.set('error', error).error('Error exporting private key');
@@ -518,7 +518,7 @@ class E2E extends Emitter {
 
 	async createRandomPassword(): Promise<string> {
 		const randomPassword = await generatePassphrase();
-		Accounts.storageLocation.setItem('e2e.randomPassword', randomPassword);
+		setStoredItem(STORAGE_KEYS.E2EE_RANDOM_PASSWORD, randomPassword);
 		return randomPassword;
 	}
 

--- a/apps/meteor/client/lib/sdk/ddpSdk.ts
+++ b/apps/meteor/client/lib/sdk/ddpSdk.ts
@@ -5,6 +5,7 @@ import { Meteor } from 'meteor/meteor';
 
 import { createMeteorBackedSdk } from './meteorBackedSdk';
 import { isSdkTransportEnabled } from './sdkTransportEnabled';
+import { STORAGE_KEYS, getStoredItem } from './storage';
 import { userIdStore } from '../user';
 
 const sdkTransportEnabled = isSdkTransportEnabled();
@@ -66,7 +67,7 @@ export const getDdpSdk = (): DDPSDK => {
 	return instance;
 };
 
-const readStoredLoginToken = (): string | null => (typeof window !== 'undefined' ? window.localStorage.getItem('Meteor.loginToken') : null);
+const readStoredLoginToken = (): string | null => getStoredItem(STORAGE_KEYS.LOGIN_TOKEN);
 
 let inflightLogin: Promise<void> | undefined;
 

--- a/apps/meteor/client/lib/sdk/storage.ts
+++ b/apps/meteor/client/lib/sdk/storage.ts
@@ -1,0 +1,22 @@
+// Single point of access to the client-side persistent storage that
+// Rocket.Chat shares with Meteor's accounts-base. Reads and writes use
+// window.localStorage under the hood; the keys mirror the names Meteor
+// originally wrote so sessions persist across the Meteor → SDK migration.
+
+export const STORAGE_KEYS = {
+	USER_ID: 'Meteor.userId',
+	LOGIN_TOKEN: 'Meteor.loginToken',
+	E2EE_PUBLIC_KEY: 'public_key',
+	E2EE_PRIVATE_KEY: 'private_key',
+	E2EE_RANDOM_PASSWORD: 'e2e.randomPassword',
+} as const;
+
+export type StorageKey = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];
+
+const getStorage = (): Storage | undefined => (typeof window !== 'undefined' ? window.localStorage : undefined);
+
+export const getStoredItem = (key: string): string | null => getStorage()?.getItem(key) ?? null;
+
+export const setStoredItem = (key: string, value: string): void => getStorage()?.setItem(key, value);
+
+export const removeStoredItem = (key: string): void => getStorage()?.removeItem(key);

--- a/apps/meteor/client/meteor/login/saml.ts
+++ b/apps/meteor/client/meteor/login/saml.ts
@@ -4,6 +4,7 @@ import { Meteor } from 'meteor/meteor';
 
 import { type LoginCallback, callLoginMethod, handleLogin } from '../../lib/2fa/overrideLoginMethod';
 import { absoluteUrl } from '../../lib/absoluteUrl';
+import { STORAGE_KEYS, removeStoredItem } from '../../lib/sdk/storage';
 import { settings } from '../../lib/settings';
 
 declare module 'meteor/meteor' {
@@ -73,7 +74,7 @@ Meteor.logout = async function (...args) {
 
 				// Remove the userId from the client to prevent calls to the server while the logout is processed.
 				// If the logout fails, the userId will be reloaded on the resume call
-				Accounts.storageLocation.removeItem(Accounts.USER_ID_KEY);
+				removeStoredItem(STORAGE_KEYS.USER_ID);
 
 				// A nasty bounce: 'result' has the SAML LogoutRequest but we need a proper 302 to redirected from the server.
 				window.location.replace(absoluteUrl(`_saml/sloRedirect/${provider}/?redirect=${encodeURIComponent(result)}`));


### PR DESCRIPTION
## Summary

`Accounts.storageLocation` is just `window.localStorage` with a Meteor alias. Replace the four direct consumers with a small helper in `apps/meteor/client/lib/sdk/storage.ts` so no client code outside the Meteor bridges has to import from `meteor/accounts-base` for storage access.

- New `STORAGE_KEYS` (mirrors the existing Meteor key names so sessions persist across the migration) and `getStoredItem` / `setStoredItem` / `removeStoredItem` helpers.
- `RestApiClient.getCredentials()` reads `USER_ID` / `LOGIN_TOKEN` through the helper instead of `Accounts.storageLocation.getItem`.
- `rocketchat.e2e.ts` swaps its 12 `Accounts.storageLocation.*` calls (public_key, private_key, e2e.randomPassword) for the helper. The `Accounts` import stays for `Accounts.onLogout`, which is migrated separately in #40442.
- `saml.ts` replaces the lone `Accounts.storageLocation.removeItem(USER_ID_KEY)`.
- `ddpSdk.ts` collapses its private `readStoredLoginToken` into `getStoredItem(STORAGE_KEYS.LOGIN_TOKEN)` so there's only one definition of the token key path.

Out of scope: `Accounts.onLogin/onLogout/onPageLoadLogin/onEmailVerificationLink` (#40442), `Accounts._unstoreLoginToken` / `_storedLoginToken`, `Accounts.LoginCancelledError`, `Accounts.registerClientLoginFunction`, `Accounts.oauth.credentialRequestCompleteHandler`. The `AuthorizationFormPage.tsx` usage is handled by #40477's `useLoginToken` hook.

No behaviour change: same `window.localStorage` backend, same key names.

## Test plan

- [ ] Fresh login persists across page reload: `Meteor.userId` and `Meteor.loginToken` keys still appear in DevTools › Application › Local Storage, and the app stays logged in after refresh.
- [ ] E2EE flow: enable E2EE on an account, reload, confirm `public_key` / `private_key` are read back correctly and rooms decrypt; change password and confirm `e2e.randomPassword` updates.
- [ ] REST credentials: any authenticated REST call (e.g. send a message) still carries the correct `X-User-Id` / `X-Auth-Token` headers.
- [ ] SAML SLO logout: with a SAML provider configured for SLO, click Logout and verify the user id is cleared and the SLO redirect happens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized client-side storage for authentication tokens, session identifiers, and end-to-end encryption keys/passwords.
  * Updated login/token handling to read from the centralized storage.
  * E2EE key saving/clearing now uses the new storage layer.
  * SAML logout now cleans up the locally stored user identifier via the centralized storage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40479)
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2133]

[ARCH-2133]: https://rocketchat.atlassian.net/browse/ARCH-2133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ