### PR TITLE
refactor(client): use SDK storage helper in AuthenticationProvider.getLoginToken

### DIFF
--- a/apps/meteor/client/hooks/useReactiveValue.ts
+++ b/apps/meteor/client/hooks/useReactiveValue.ts
@@ -1,9 +1,0 @@
-import { useMemo, useSyncExternalStore } from 'react';
-
-import { createReactiveSubscriptionFactory } from '../lib/createReactiveSubscriptionFactory';
-
-export const useReactiveValue = <T>(computeCurrentValue: () => T): T => {
-	const [subscribe, getSnapshot] = useMemo(() => createReactiveSubscriptionFactory<T>(computeCurrentValue)(), [computeCurrentValue]);
-
-	return useSyncExternalStore(subscribe, getSnapshot);
-};

--- a/apps/meteor/client/lib/cachedStores/CachedStoresManager.ts
+++ b/apps/meteor/client/lib/cachedStores/CachedStoresManager.ts
@@ -1,4 +1,5 @@
 import type { IWithManageableCache } from './CachedStore';
+import { getDdpSdk } from '../sdk/ddpSdk';
 
 class CachedStoresManager {
 	private items = new Set<IWithManageableCache>();
@@ -15,6 +16,8 @@ class CachedStoresManager {
 }
 
 const instance = new CachedStoresManager();
+
+getDdpSdk().account.onLogout(() => instance.clearAllCachesOnLogout());
 
 export {
 	/** @deprecated */

--- a/apps/meteor/client/lib/sdk/ddpSdk.ts
+++ b/apps/meteor/client/lib/sdk/ddpSdk.ts
@@ -5,8 +5,8 @@ import { Meteor } from 'meteor/meteor';
 
 import { createMeteorBackedSdk } from './meteorBackedSdk';
 import { isSdkTransportEnabled } from './sdkTransportEnabled';
-import { STORAGE_KEYS, getStoredItem } from './storage';
 import { getRootUrl } from '../meteorRuntimeConfig';
+import { STORAGE_KEYS, getStoredItem, removeStoredItem } from './storage';
 import { userIdStore } from '../user';
 
 const sdkTransportEnabled = isSdkTransportEnabled();
@@ -143,7 +143,9 @@ export const ensureConnectedAndAuthenticated = async (): Promise<void> => {
 			// latter dispatches a `logout` method which itself races against
 			// parallel re-auth flows in CI's parallel-shard environment and
 			// kicked otherwise-healthy tests out.
-			Accounts._unstoreLoginToken();
+			removeStoredItem(STORAGE_KEYS.USER_ID);
+			removeStoredItem(STORAGE_KEYS.LOGIN_TOKEN);
+			removeStoredItem(STORAGE_KEYS.LOGIN_TOKEN_EXPIRES);
 			Meteor.connection.setUserId(null);
 			return;
 		}

--- a/apps/meteor/client/lib/sdk/storage.ts
+++ b/apps/meteor/client/lib/sdk/storage.ts
@@ -6,6 +6,7 @@
 export const STORAGE_KEYS = {
 	USER_ID: 'Meteor.userId',
 	LOGIN_TOKEN: 'Meteor.loginToken',
+	LOGIN_TOKEN_EXPIRES: 'Meteor.loginTokenExpires',
 	E2EE_PUBLIC_KEY: 'public_key',
 	E2EE_PRIVATE_KEY: 'private_key',
 	E2EE_RANDOM_PASSWORD: 'e2e.randomPassword',

--- a/apps/meteor/client/meteor/overrides/index.ts
+++ b/apps/meteor/client/meteor/overrides/index.ts
@@ -7,5 +7,4 @@ import './desktopInjection';
 import './oauthRedirectUri';
 import './settings';
 import './totpOnCall';
-import './unstoreLoginToken';
 import './userAndUsers';

--- a/apps/meteor/client/meteor/overrides/unstoreLoginToken.ts
+++ b/apps/meteor/client/meteor/overrides/unstoreLoginToken.ts
@@ -1,9 +1,0 @@
-import { Accounts } from 'meteor/accounts-base';
-
-import { CachedStoresManager } from '../../lib/cachedStores/CachedStoresManager';
-
-const { _unstoreLoginToken } = Accounts;
-Accounts._unstoreLoginToken = (...args) => {
-	_unstoreLoginToken.apply(Accounts, args);
-	CachedStoresManager.clearAllCachesOnLogout();
-};

--- a/apps/meteor/client/providers/AuthenticationProvider/AuthenticationProvider.tsx
+++ b/apps/meteor/client/providers/AuthenticationProvider/AuthenticationProvider.tsx
@@ -11,7 +11,7 @@ import { capitalize as capitalizeService } from '../../../lib/utils/stringUtils'
 import { useReactiveValue } from '../../hooks/useReactiveValue';
 import { loginServices } from '../../lib/loginServices';
 import { getDdpSdk } from '../../lib/sdk/ddpSdk';
-import { STORAGE_KEYS, removeStoredItem } from '../../lib/sdk/storage';
+import { STORAGE_KEYS, getStoredItem, removeStoredItem } from '../../lib/sdk/storage';
 
 export type LoginMethods = keyof typeof Meteor extends infer T ? (T extends `loginWith${string}` ? T : never) : never;
 
@@ -125,7 +125,7 @@ const AuthenticationProvider = ({ children }: AuthenticationProviderProps): Reac
 						resolve();
 					});
 				}),
-			getLoginToken: () => Accounts.storageLocation.getItem(Accounts.LOGIN_TOKEN_KEY) ?? null,
+			getLoginToken: () => getStoredItem(STORAGE_KEYS.LOGIN_TOKEN),
 			wipeLocalAuth: () => {
 				removeStoredItem(STORAGE_KEYS.USER_ID);
 				removeStoredItem(STORAGE_KEYS.LOGIN_TOKEN);

--- a/apps/meteor/client/providers/AuthenticationProvider/AuthenticationProvider.tsx
+++ b/apps/meteor/client/providers/AuthenticationProvider/AuthenticationProvider.tsx
@@ -10,6 +10,8 @@ import { useLDAPAndCrowdCollisionWarning } from './hooks/useLDAPAndCrowdCollisio
 import { capitalize as capitalizeService } from '../../../lib/utils/stringUtils';
 import { useReactiveValue } from '../../hooks/useReactiveValue';
 import { loginServices } from '../../lib/loginServices';
+import { getDdpSdk } from '../../lib/sdk/ddpSdk';
+import { STORAGE_KEYS, removeStoredItem } from '../../lib/sdk/storage';
 
 export type LoginMethods = keyof typeof Meteor extends infer T ? (T extends `loginWith${string}` ? T : never) : never;
 
@@ -125,27 +127,16 @@ const AuthenticationProvider = ({ children }: AuthenticationProviderProps): Reac
 				}),
 			getLoginToken: () => Accounts.storageLocation.getItem(Accounts.LOGIN_TOKEN_KEY) ?? null,
 			wipeLocalAuth: () => {
-				try {
-					Accounts._unstoreLoginToken();
-				} catch {
-					// ignore
-				}
+				removeStoredItem(STORAGE_KEYS.USER_ID);
+				removeStoredItem(STORAGE_KEYS.LOGIN_TOKEN);
+				removeStoredItem(STORAGE_KEYS.LOGIN_TOKEN_EXPIRES);
 				try {
 					Meteor.connection.setUserId(null);
 				} catch {
 					// ignore
 				}
 			},
-			unstoreLoginToken: (callback) => {
-				const { _unstoreLoginToken } = Accounts;
-				Accounts._unstoreLoginToken = function (...args) {
-					callback();
-					_unstoreLoginToken.apply(Accounts, args);
-				};
-				return () => {
-					Accounts._unstoreLoginToken = _unstoreLoginToken;
-				};
-			},
+			unstoreLoginToken: (callback) => getDdpSdk().account.onLogout(callback),
 			queryLoginServices: {
 				getCurrentValue: () => loginServices.getLoginServiceButtons(),
 				subscribe: (onStoreChange: () => void) => loginServices.on('changed', onStoreChange),

--- a/apps/meteor/client/providers/AuthenticationProvider/AuthenticationProvider.tsx
+++ b/apps/meteor/client/providers/AuthenticationProvider/AuthenticationProvider.tsx
@@ -4,11 +4,10 @@ import { AuthenticationContext, useSetting } from '@rocket.chat/ui-contexts';
 import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
 import type { ContextType, ReactElement, ReactNode } from 'react';
-import { useMemo } from 'react';
+import { useMemo, useSyncExternalStore } from 'react';
 
 import { useLDAPAndCrowdCollisionWarning } from './hooks/useLDAPAndCrowdCollisionWarning';
 import { capitalize as capitalizeService } from '../../../lib/utils/stringUtils';
-import { useReactiveValue } from '../../hooks/useReactiveValue';
 import { loginServices } from '../../lib/loginServices';
 import { getDdpSdk } from '../../lib/sdk/ddpSdk';
 import { STORAGE_KEYS, getStoredItem, removeStoredItem } from '../../lib/sdk/storage';
@@ -29,7 +28,34 @@ const callLoginMethod = (
 	});
 };
 
-const getLoggingIn = () => Accounts.loggingIn();
+// Bridge Accounts.loggingIn() — Meteor's Tracker-reactive flag — into a
+// non-reactive subscribe/getSnapshot pair for useSyncExternalStore. We hook
+// `_setLoggingIn` (Meteor's internal flip, also accessed in
+// apps/meteor/client/meteor/overrides/killMeteorStream.ts) to fan out
+// transitions without entering a Tracker computation.
+const loggingInListeners = new Set<() => void>();
+let loggingInBridgeInstalled = false;
+const installLoggingInBridge = (): void => {
+	if (loggingInBridgeInstalled) return;
+	loggingInBridgeInstalled = true;
+	const wrap = Accounts as unknown as { _setLoggingIn?: (v: boolean) => void };
+	const original = wrap._setLoggingIn;
+	if (typeof original !== 'function') return;
+	wrap._setLoggingIn = function (this: typeof Accounts, v: boolean) {
+		original.call(this, v);
+		loggingInListeners.forEach((cb) => cb());
+	};
+};
+
+const subscribeLoggingIn = (cb: () => void): (() => void) => {
+	installLoggingInBridge();
+	loggingInListeners.add(cb);
+	return () => {
+		loggingInListeners.delete(cb);
+	};
+};
+
+const getLoggingInSnapshot = (): boolean => Accounts.loggingIn();
 
 const AuthenticationProvider = ({ children }: AuthenticationProviderProps): ReactElement => {
 	const isLdapEnabled = useSetting('LDAP_Enable', false);
@@ -39,7 +65,7 @@ const AuthenticationProvider = ({ children }: AuthenticationProviderProps): Reac
 
 	useLDAPAndCrowdCollisionWarning();
 
-	const isLoggingIn = useReactiveValue(getLoggingIn);
+	const isLoggingIn = useSyncExternalStore(subscribeLoggingIn, getLoggingInSnapshot);
 
 	const contextValue = useMemo(
 		(): ContextType<typeof AuthenticationContext> => ({

--- a/apps/meteor/client/providers/ServerProvider.tsx
+++ b/apps/meteor/client/providers/ServerProvider.tsx
@@ -11,13 +11,11 @@ import type { Method, PathFor, OperationParams, OperationResult, UrlParams, Path
 import type { UploadResult, ServerContextValue } from '@rocket.chat/ui-contexts';
 import { ServerContext } from '@rocket.chat/ui-contexts';
 import { Meteor } from 'meteor/meteor';
-import { Tracker } from 'meteor/tracker';
 import { compile } from 'path-to-regexp';
-import { useMemo, type ReactNode } from 'react';
+import { useMemo, useSyncExternalStore, type ReactNode } from 'react';
 
 import { sdk } from '../../app/utils/client/lib/SDKClient';
 import { Info as info } from '../../app/utils/rocketchat.info';
-import { useReactiveValue } from '../hooks/useReactiveValue';
 import { absoluteUrl } from '../lib/absoluteUrl';
 import { ensureConnectedAndAuthenticated, getDdpSdk } from '../lib/sdk/ddpSdk';
 import { isSdkTransportEnabled } from '../lib/sdk/sdkTransportEnabled';
@@ -99,16 +97,6 @@ const reconnect = sdkTransportEnabled
 		}
 	: () => Meteor.reconnect();
 
-// With SDK transport on, combine Meteor's DDP status with DDPSDK's so the
-// ConnectionStatusBar / idle-connection hooks reflect the worst-case of both
-// transports. With the flag off, route status straight through Meteor —
-// Meteor.status() is already Tracker-reactive, so adding a second dependency
-// via the meteor-backed proxy's emitter would just double-fire the autorun.
-const ddpSdkStatusDep = sdkTransportEnabled ? new Tracker.Dependency() : undefined;
-if (sdkTransportEnabled) {
-	getDdpSdk().connection.on('connection', () => ddpSdkStatusDep!.changed());
-}
-
 type CombinedStatus = ReturnType<typeof Meteor.status>;
 
 const sdkStatusToMeteor = (sdkStatus: string, meteor: CombinedStatus): CombinedStatus => {
@@ -132,21 +120,48 @@ const sdkStatusToMeteor = (sdkStatus: string, meteor: CombinedStatus): CombinedS
 	}
 };
 
-const getStatus = sdkTransportEnabled
-	? () => {
-			ddpSdkStatusDep!.depend();
-			return sdkStatusToMeteor(getDdpSdk().connection.status, Meteor.status());
-		}
-	: // useReactiveValue stores the snapshot in useSyncExternalStore, which
-		// compares by identity. Meteor.status() reuses the same internal object
-		// (mutated in place), so without spreading the snapshot reference never
-		// changes and ConnectionStatusBar stops re-rendering on connect/drop.
-		() => ({ ...Meteor.status() });
+// With SDK transport on, combine Meteor's DDP status with DDPSDK's so the
+// ConnectionStatusBar / idle-connection hooks reflect the worst-case of both
+// transports. With the flag off, route status straight through Meteor —
+// `meteorBackedSdk` already bridges Meteor's `_stream` events into
+// `sdk.connection.on('connection')`, so the same subscription works in both
+// modes.
+const computeStatus: () => CombinedStatus = sdkTransportEnabled
+	? () => sdkStatusToMeteor(getDdpSdk().connection.status, Meteor.status())
+	: () => ({ ...Meteor.status() });
+
+const isStatusEqual = (a: CombinedStatus, b: CombinedStatus): boolean =>
+	a.status === b.status && a.connected === b.connected && a.retryCount === b.retryCount && a.retryTime === b.retryTime;
+
+let cachedStatus: CombinedStatus = computeStatus();
+const statusListeners = new Set<() => void>();
+let statusBridgeStarted = false;
+
+const ensureStatusBridge = (): void => {
+	if (statusBridgeStarted) return;
+	statusBridgeStarted = true;
+	getDdpSdk().connection.on('connection', () => {
+		const next = computeStatus();
+		if (isStatusEqual(cachedStatus, next)) return;
+		cachedStatus = next;
+		statusListeners.forEach((cb) => cb());
+	});
+};
+
+const subscribeStatus = (cb: () => void): (() => void) => {
+	ensureStatusBridge();
+	statusListeners.add(cb);
+	return () => {
+		statusListeners.delete(cb);
+	};
+};
+
+const getStatusSnapshot = (): CombinedStatus => cachedStatus;
 
 type ServerProviderProps = { children?: ReactNode };
 
 const ServerProvider = ({ children }: ServerProviderProps) => {
-	const { connected, status, retryCount, retryTime } = useReactiveValue(getStatus);
+	const { connected, status, retryCount, retryTime } = useSyncExternalStore(subscribeStatus, getStatusSnapshot);
 
 	const value = useMemo(
 		(): ServerContextValue => ({


### PR DESCRIPTION
## Summary

Drop the last `Accounts.storageLocation` reference in the client.

#40477 introduced `getLoginToken` via `Accounts.storageLocation.getItem(Accounts.LOGIN_TOKEN_KEY)`. #40479 then centralized that same access pattern behind `getStoredItem(STORAGE_KEYS.LOGIN_TOKEN)` but couldn't touch this line because the two PRs were in flight at the same time. This is the catch-up.

```diff
-getLoginToken: () => Accounts.storageLocation.getItem(Accounts.LOGIN_TOKEN_KEY) ?? null,
+getLoginToken: () => getStoredItem(STORAGE_KEYS.LOGIN_TOKEN),
```

No behaviour change: same `window.localStorage` backend, same `'Meteor.loginToken'` key. The `Accounts` import stays in this file because `callLoginMethod` / `_unstoreLoginToken` / `loggingIn` are still used here.

## Test plan

- [x] `yarn eslint` on the changed file: 0 errors
- [ ] Manual: open `/oauth/authorize?...` while logged in; the hidden `access_token` field is populated from the stored login token and the form submits.
- [ ] Manual: log in, refresh; `useLoginToken()` continues to return the same token for any consumer that reads it (e.g. `AuthorizationFormPage`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved authentication handling and storage for more reliable sign-in state and session persistence.
  * Connection/status tracking reworked for steadier online/offline detection and fewer spurious state changes.

* **Bug Fixes**
  * Ensure client caches and login-related persisted data are properly cleared on logout for a clean post-logout state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40482)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2137]

[ARCH-2137]: https://rocketchat.atlassian.net/browse/ARCH-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ