### PR TITLE
refactor(client): centralize __meteor_runtime_config__ access

### DIFF
--- a/apps/meteor/client/lib/absoluteUrl.ts
+++ b/apps/meteor/client/lib/absoluteUrl.ts
@@ -1,6 +1,7 @@
 // There is a good chance this module may be promoted to root lib/ in the future
 
 import { baseURI } from './baseURI';
+import { getRootUrlPathPrefix } from './meteorRuntimeConfig';
 
 type AbsoluteUrlOptions = {
 	rootUrl?: string;
@@ -50,8 +51,8 @@ absoluteUrl.defaultOptions = {
 } as AbsoluteUrlOptions;
 
 export function _relativeToSiteRootUrl(link: string): string {
-	if (typeof __meteor_runtime_config__ === 'object' && link.slice(0, 1) === '/') {
-		link = (__meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '') + link;
+	if (link.startsWith('/')) {
+		link = getRootUrlPathPrefix() + link;
 	}
 
 	return link;

--- a/apps/meteor/client/lib/meteorRuntimeConfig.ts
+++ b/apps/meteor/client/lib/meteorRuntimeConfig.ts
@@ -1,0 +1,23 @@
+// Single point of access to the `__meteor_runtime_config__` globals that
+// Meteor's bootloader injects into the page (ROOT_URL and
+// ROOT_URL_PATH_PREFIX). Consumers must read/write through these helpers so
+// the eventual replacement (a static config injected at build time) is a
+// single-file swap.
+
+const getConfig = (): { ROOT_URL?: string; ROOT_URL_PATH_PREFIX?: string } | undefined => {
+	if (typeof __meteor_runtime_config__ !== 'object' || __meteor_runtime_config__ === null) {
+		return undefined;
+	}
+	return __meteor_runtime_config__;
+};
+
+export const getRootUrl = (): string | undefined => getConfig()?.ROOT_URL;
+
+export const getRootUrlPathPrefix = (): string => getConfig()?.ROOT_URL_PATH_PREFIX ?? '';
+
+export const setRootUrl = (value: string): void => {
+	const config = getConfig();
+	if (config) {
+		config.ROOT_URL = value;
+	}
+};

--- a/apps/meteor/client/lib/openCASLoginPopup.ts
+++ b/apps/meteor/client/lib/openCASLoginPopup.ts
@@ -1,4 +1,5 @@
 import { absoluteUrl } from './absoluteUrl';
+import { getRootUrlPathPrefix } from './meteorRuntimeConfig';
 import { settings } from './settings';
 
 const openCenteredPopup = (url: string, width: number, height: number) => {
@@ -31,7 +32,7 @@ const getPopupUrl = (credentialToken: string): string => {
 		throw new Error('CAS_login_url not set');
 	}
 
-	const appUrl = absoluteUrl().replace(/\/$/, '') + __meteor_runtime_config__.ROOT_URL_PATH_PREFIX;
+	const appUrl = absoluteUrl().replace(/\/$/, '') + getRootUrlPathPrefix();
 	const serviceUrl = `${appUrl}/_cas/${credentialToken}`;
 	const url = new URL(loginUrl);
 	url.searchParams.set('service', serviceUrl);

--- a/apps/meteor/client/lib/sdk/ddpSdk.ts
+++ b/apps/meteor/client/lib/sdk/ddpSdk.ts
@@ -6,6 +6,7 @@ import { Meteor } from 'meteor/meteor';
 import { createMeteorBackedSdk } from './meteorBackedSdk';
 import { isSdkTransportEnabled } from './sdkTransportEnabled';
 import { STORAGE_KEYS, getStoredItem } from './storage';
+import { getRootUrl } from '../meteorRuntimeConfig';
 import { userIdStore } from '../user';
 
 const sdkTransportEnabled = isSdkTransportEnabled();
@@ -13,7 +14,7 @@ const sdkTransportEnabled = isSdkTransportEnabled();
 const stripTrailingSlash = (value: string): string => (value.endsWith('/') ? value.slice(0, -1) : value);
 
 const computeDdpUrl = (): string => {
-	const rootUrl = typeof __meteor_runtime_config__ !== 'undefined' ? __meteor_runtime_config__.ROOT_URL : undefined;
+	const rootUrl = getRootUrl();
 	const source = rootUrl && rootUrl !== '/' ? rootUrl : window.location.origin;
 	return stripTrailingSlash(source.replace(/^http/, 'ws'));
 };

--- a/apps/meteor/client/router/index.tsx
+++ b/apps/meteor/client/router/index.tsx
@@ -14,6 +14,7 @@ import type {
 
 import { Context, Page } from './page';
 import { appLayout } from '../lib/appLayout';
+import { getRootUrlPathPrefix } from '../lib/meteorRuntimeConfig';
 import { roomCoordinator } from '../lib/rooms/roomCoordinator';
 
 export class Router implements RouterContextValue {
@@ -40,7 +41,7 @@ export class Router implements RouterContextValue {
 
 	private pathDefById = new Map<Route['pathDef'], Route['id']>();
 
-	private readonly basePath = window.__meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '';
+	private readonly basePath = getRootUrlPathPrefix();
 
 	private readonly page = new Page();
 

--- a/apps/meteor/client/views/root/hooks/loggedIn/useRootUrlChange.tsx
+++ b/apps/meteor/client/views/root/hooks/loggedIn/useRootUrlChange.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import UrlChangeModal from '../../../../components/UrlChangeModal';
+import { getRootUrl, getRootUrlPathPrefix } from '../../../../lib/meteorRuntimeConfig';
 
 export const useRootUrlChange = () => {
 	const { t } = useTranslation();
@@ -13,7 +14,7 @@ export const useRootUrlChange = () => {
 	const setModal = useSetModal();
 	const closeModal = useEffectEvent(() => setModal(null));
 
-	const currentUrl = location.origin + window.__meteor_runtime_config__.ROOT_URL_PATH_PREFIX;
+	const currentUrl = location.origin + getRootUrlPathPrefix();
 	const siteUrl = useSetting('Site_Url', '');
 	const documentDomain = useSetting('Document_Domain', '');
 	const setSiteUrl = useSettingSetValue('Site_Url');
@@ -42,7 +43,8 @@ export const useRootUrlChange = () => {
 		if (isPending || isSuccess) {
 			return;
 		}
-		if (window.__meteor_runtime_config__.ROOT_URL.replace(/\/$/, '') === currentUrl) {
+		const rootUrl = getRootUrl();
+		if (rootUrl && rootUrl.replace(/\/$/, '') === currentUrl) {
 			return;
 		}
 		const onConfirm = () => {

--- a/apps/meteor/client/views/root/hooks/useIframeCommands.ts
+++ b/apps/meteor/client/views/root/hooks/useIframeCommands.ts
@@ -7,6 +7,7 @@ import { AccountBox } from '../../../../app/ui-utils/client/lib/AccountBox';
 import { capitalize, ltrim, rtrim } from '../../../../lib/utils/stringUtils';
 import { baseURI } from '../../../lib/baseURI';
 import { loginServices } from '../../../lib/loginServices';
+import { getRootUrlPathPrefix } from '../../../lib/meteorRuntimeConfig';
 import { settings } from '../../../lib/settings';
 import { router } from '../../../providers/RouterProvider';
 
@@ -37,10 +38,7 @@ export const useIframeCommands = () => {
 					{} as Record<string, string>,
 				);
 
-				const newPath = newUrl.pathname.replace(
-					new RegExp(`^${escapeRegExp(__meteor_runtime_config__.ROOT_URL_PATH_PREFIX)}`),
-					'',
-				) as LocationPathname;
+				const newPath = newUrl.pathname.replace(new RegExp(`^${escapeRegExp(getRootUrlPathPrefix())}`), '') as LocationPathname;
 				router.navigate({
 					pathname: newPath,
 					search: { ...router.getSearchParameters(), ...newParams },

--- a/apps/meteor/client/views/root/hooks/useSettingsOnLoadSiteUrl.ts
+++ b/apps/meteor/client/views/root/hooks/useSettingsOnLoadSiteUrl.ts
@@ -1,6 +1,8 @@
 import { useSetting } from '@rocket.chat/ui-contexts';
 import { useEffect } from 'react';
 
+import { setRootUrl } from '../../../lib/meteorRuntimeConfig';
+
 export const useSettingsOnLoadSiteUrl = () => {
 	const siteUrl = useSetting('Site_Url') as string;
 
@@ -9,6 +11,6 @@ export const useSettingsOnLoadSiteUrl = () => {
 		if (value == null || value.trim() === '') {
 			return;
 		}
-		(window as any).__meteor_runtime_config__.ROOT_URL = value;
+		setRootUrl(value);
 	}, [siteUrl]);
 };


### PR DESCRIPTION
## Summary

Seven client modules read `window.__meteor_runtime_config__` directly to pull `ROOT_URL` or `ROOT_URL_PATH_PREFIX` off Meteor's bootloader-injected global. Each call site duplicated the `typeof` check and defaulting logic.

Introduce `apps/meteor/client/lib/meteorRuntimeConfig.ts` as the single entry point. It exports:

- `getRootUrl()` — returns `string | undefined`
- `getRootUrlPathPrefix()` — returns `string` (defaults to `''`)
- `setRootUrl(value)` — for the one site (`useSettingsOnLoadSiteUrl`) that updates the global when the `Site_Url` setting changes

The eventual replacement (a static config from the bundler / a server fetch) is a single-file swap.

Migrated consumers:
- `apps/meteor/client/lib/absoluteUrl.ts` (`_relativeToSiteRootUrl`)
- `apps/meteor/client/lib/openCASLoginPopup.ts` (`getPopupUrl`)
- `apps/meteor/client/lib/sdk/ddpSdk.ts` (`computeDdpUrl`)
- `apps/meteor/client/router/index.tsx` (`Router.basePath`)
- `apps/meteor/client/views/root/hooks/useSettingsOnLoadSiteUrl.ts` (now uses `setRootUrl`)
- `apps/meteor/client/views/root/hooks/useIframeCommands.ts` (`go` command regex)
- `apps/meteor/client/views/root/hooks/loggedIn/useRootUrlChange.tsx` (with a soft guard so `undefined` rootUrl no longer throws when reading `.replace()`)

Test fixtures (`absoluteUrl.spec.ts`, storybook `RouterContextMock`, `OutboundMessageUpsellModal.stories`) keep assigning the global directly since they orchestrate test state.

## Test plan

- [x] `yarn eslint` on the 8 changed files: 0 errors.
- [x] `tsc --noEmit` on `apps/meteor` is clean.
- [x] `grep __meteor_runtime_config__` in `apps/meteor/client` shows only the helper + test/story fixtures.
- [ ] Manual: server running under a subdir (e.g. `ROOT_URL=http://localhost:3000/chat`) — confirm router base path, REST `absoluteUrl`, CAS popup URL, and iframe `go` command all respect the prefix.
- [ ] Manual: admin changes `Site_Url`; the `useRootUrlChange` modal pops once and applies; `__meteor_runtime_config__.ROOT_URL` updates in the page (Site_Url change flow). 

 Task: [ARCH-2140]

[ARCH-2140]: https://rocketchat.atlassian.net/browse/ARCH-2140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized runtime configuration access used throughout the client to consistently read/update site URL and path prefix.
  * Router, login flow, iframe navigation, URL-change prompts and settings loading now derive URLs from the shared config layer for safer, more consistent URL/path handling.
  * No public APIs or option shapes were changed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40487)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->