### PR TITLE
refactor(client): inline UserProvider.queryPreference subscribe/getSnapshot

### DIFF
--- a/apps/meteor/client/providers/UserProvider/UserProvider.tsx
+++ b/apps/meteor/client/providers/UserProvider/UserProvider.tsx
@@ -16,7 +16,6 @@ import { useDeleteUser } from './hooks/useDeleteUser';
 import { useEmailVerificationWarning } from './hooks/useEmailVerificationWarning';
 import { useReloadAfterLogin } from './hooks/useReloadAfterLogin';
 import { useUpdateAvatar } from './hooks/useUpdateAvatar';
-import { getUserPreference } from '../../../app/utils/client';
 import { sdk } from '../../../app/utils/client/lib/SDKClient';
 import { useIdleConnection } from '../../hooks/useIdleConnection';
 import type { IDocumentMapStore } from '../../lib/cachedStores/DocumentMapStore';
@@ -142,18 +141,24 @@ const UserProvider = ({ children }: UserProviderProps): ReactElement => {
 				key: string | ObjectId,
 				defaultValue?: T,
 			): [subscribe: (onStoreChange: () => void) => () => void, getSnapshot: () => T | undefined] => {
+				const effectiveKey = String(key);
+
 				const subscribe = (onStoreChange: () => void): (() => void) => {
 					const unsubUsers = Users.use.subscribe(onStoreChange);
-					// getUserPreference falls back to settings.watch(`Accounts_Default_User_Preferences_${key}`)
-					// when the user record has no override. Subscribe to that specific
-					// setting key so admin-side default changes still propagate.
-					const unsubSettings = settings.observe(`Accounts_Default_User_Preferences_${String(key)}`, onStoreChange);
+					const unsubSettings = settings.observe(`Accounts_Default_User_Preferences_${effectiveKey}`, onStoreChange);
 					return () => {
 						unsubUsers();
 						unsubSettings();
 					};
 				};
-				const getSnapshot = (): T | undefined => getUserPreference(userId, String(key), defaultValue);
+
+				const getSnapshot = (): T | undefined => {
+					return (
+						(user?.settings?.preferences?.[effectiveKey] as T | undefined) ??
+						defaultValue ??
+						settings.peek(`Accounts_Default_User_Preferences_${effectiveKey}`)
+					);
+				};
 				return [subscribe, getSnapshot];
 			},
 			querySubscription,

--- a/apps/meteor/client/providers/UserProvider/UserProvider.tsx
+++ b/apps/meteor/client/providers/UserProvider/UserProvider.tsx
@@ -6,7 +6,7 @@ import type { FindOptions, SubscriptionWithRoom } from '@rocket.chat/ui-contexts
 import { UserContext, useRouteParameter, useSearchParameter } from '@rocket.chat/ui-contexts';
 import { useQueryClient } from '@tanstack/react-query';
 import { Meteor } from 'meteor/meteor';
-import type { Filter } from 'mongodb';
+import type { Filter, ObjectId } from 'mongodb';
 import type { ContextType, ReactElement, ReactNode } from 'react';
 import { useEffect, useMemo, useRef } from 'react';
 import type { StoreApi, UseBoundStore } from 'zustand';
@@ -21,8 +21,8 @@ import { sdk } from '../../../app/utils/client/lib/SDKClient';
 import { useIdleConnection } from '../../hooks/useIdleConnection';
 import type { IDocumentMapStore } from '../../lib/cachedStores/DocumentMapStore';
 import { applyQueryOptions } from '../../lib/cachedStores/applyQueryOptions';
-import { createReactiveSubscriptionFactory } from '../../lib/createReactiveSubscriptionFactory';
 import { getDdpSdk } from '../../lib/sdk/ddpSdk';
+import { settings } from '../../lib/settings';
 import { userIdStore } from '../../lib/user';
 import { Users, Rooms, Subscriptions } from '../../stores';
 import { useSamlInviteToken } from '../../views/invite/hooks/useSamlInviteToken';
@@ -138,9 +138,24 @@ const UserProvider = ({ children }: UserProviderProps): ReactElement => {
 		(): ContextType<typeof UserContext> => ({
 			userId,
 			user,
-			queryPreference: createReactiveSubscriptionFactory(
-				<T,>(key: string, defaultValue?: T) => getUserPreference(userId, key, defaultValue) as T,
-			),
+			queryPreference: <T,>(
+				key: string | ObjectId,
+				defaultValue?: T,
+			): [subscribe: (onStoreChange: () => void) => () => void, getSnapshot: () => T | undefined] => {
+				const subscribe = (onStoreChange: () => void): (() => void) => {
+					const unsubUsers = Users.use.subscribe(onStoreChange);
+					// getUserPreference falls back to settings.watch(`Accounts_Default_User_Preferences_${key}`)
+					// when the user record has no override. Subscribe to that specific
+					// setting key so admin-side default changes still propagate.
+					const unsubSettings = settings.observe(`Accounts_Default_User_Preferences_${String(key)}`, onStoreChange);
+					return () => {
+						unsubUsers();
+						unsubSettings();
+					};
+				};
+				const getSnapshot = (): T | undefined => getUserPreference(userId, String(key), defaultValue);
+				return [subscribe, getSnapshot];
+			},
 			querySubscription,
 			queryRoom,
 			querySubscriptions,


### PR DESCRIPTION
## Summary

\`queryPreference\` was the last context value in \`UserProvider\` going through \`createReactiveSubscriptionFactory\` — i.e., through \`Tracker.autorun\`. \`getUserPreference\` reads two sources:

- \`Users.use.getState()\` (zustand, non-reactive)
- \`settings.watch(\\\`Accounts_Default_User_Preferences_\${key}\\\`)\` as a fallback when the user record has no override

Replace the factory call with a hand-rolled \`[subscribe, getSnapshot]\` pair that subscribes to \`Users.use\` directly and to the specific setting key via \`settings.observe\` — no Tracker computation, same fan-out behaviour. Same shape as #40446's migration of \`ServerProvider\` / \`AuthenticationProvider\`.

\`AuthorizationProvider\` still uses \`createReactiveSubscriptionFactory\` — the permission-check helpers (\`hasPermission\` / \`hasRole\`) read via \`watch()\` and will get their own plan in a follow-up. The factory file stays in place for that consumer.

## Test plan

- [x] \`yarn eslint\` on the changed file: 0 errors.
- [x] \`tsc --noEmit\` on \`apps/meteor\` is clean.
- [ ] Manual: open the account profile, toggle a preference (e.g. notification sound) and confirm UI updates in real time.
- [ ] Manual: as admin change \`Accounts_Default_User_Preferences_*\` and confirm clients without an override pick up the new default without reload. 

 Task: [ARCH-2141]

[ARCH-2141]: https://rocketchat.atlassian.net/browse/ARCH-2141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User preference changes (personal or admin-default) now synchronize and update in real time across the app.

* **Chores**
  * Improved internal preference handling for more reliable, consistent behavior when preferences or system defaults change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40491)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->