### PR TITLE
fix: hide 'Delete all closed chats' button when user lacks `remove-closed-livechat-rooms` permission

### DIFF
--- a/.changeset/ten-lizards-divide.md
+++ b/.changeset/ten-lizards-divide.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixes issue that displayed the 'Delete all closed chats' button when user lacks `remove-closed-livechat-rooms` permission

--- a/apps/meteor/client/views/omnichannel/directory/chats/ChatsTable/ChatsTableFilter.spec.tsx
+++ b/apps/meteor/client/views/omnichannel/directory/chats/ChatsTable/ChatsTableFilter.spec.tsx
@@ -1,0 +1,70 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import ChatsTableFilter from './ChatsTableFilter';
+import type { ChatsContextValue } from '../../contexts/ChatsContext';
+
+jest.mock('../../contexts/ChatsContext', () => ({
+	useChatsContext: (): ChatsContextValue => ({
+		filtersQuery: {
+			guest: '',
+			servedBy: [],
+			status: 'all',
+			department: [],
+			from: '',
+			to: '',
+			tags: [],
+			units: [],
+		},
+		setFiltersQuery: jest.fn(),
+		resetFiltersQuery: jest.fn(),
+		displayFilters: {
+			from: undefined,
+			to: undefined,
+			guest: undefined,
+			servedBy: undefined,
+			department: undefined,
+			status: undefined,
+			tags: undefined,
+		},
+		removeFilter: jest.fn(),
+		hasAppliedFilters: false,
+		textInputRef: null,
+	}),
+}));
+
+jest.mock('../../hooks/useOmnichannelDirectoryRouter', () => ({
+	useOmnichannelDirectoryRouter: () => ({
+		navigate: jest.fn(),
+		getRouteName: jest.fn(),
+	}),
+}));
+
+describe('ChatsTableFilter', () => {
+	it('should show the "More" kebab menu when user has "remove-closed-livechat-rooms" permission', async () => {
+		render(<ChatsTableFilter />, {
+			wrapper: mockAppRoot().withPermission('remove-closed-livechat-rooms').build(),
+		});
+
+		expect(screen.getByRole('button', { name: 'More' })).toBeInTheDocument();
+	});
+
+	it('should not show the "More" kebab menu when user lacks "remove-closed-livechat-rooms" permission', async () => {
+		render(<ChatsTableFilter />, {
+			wrapper: mockAppRoot().build(),
+		});
+
+		expect(screen.queryByRole('button', { name: 'More' })).not.toBeInTheDocument();
+	});
+
+	it('should show "Delete all closed chats" option inside the menu when user has the permission', async () => {
+		render(<ChatsTableFilter />, {
+			wrapper: mockAppRoot().withPermission('remove-closed-livechat-rooms').build(),
+		});
+
+		await userEvent.click(screen.getByRole('button', { name: 'More' }));
+
+		expect(await screen.findByRole('menuitem', { name: 'Delete_all_closed_chats' })).toBeInTheDocument();
+	});
+});

--- a/apps/meteor/client/views/omnichannel/directory/chats/ChatsTable/ChatsTableFilter.tsx
+++ b/apps/meteor/client/views/omnichannel/directory/chats/ChatsTable/ChatsTableFilter.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Chip } from '@rocket.chat/fuselage';
 import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
 import { GenericMenu, GenericModal } from '@rocket.chat/ui-client';
-import { useEndpoint, useSetModal, useToastMessageDispatch } from '@rocket.chat/ui-contexts';
+import { useEndpoint, usePermission, useSetModal, useToastMessageDispatch } from '@rocket.chat/ui-contexts';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 
@@ -16,6 +16,7 @@ const ChatsTableFilter = () => {
 	const omnichannelDirectoryRouter = useOmnichannelDirectoryRouter();
 	const queryClient = useQueryClient();
 	const removeClosedRooms = useEndpoint('POST', '/v1/livechat/rooms.removeAllClosedRooms');
+	const canRemoveAllClosedChats = usePermission('remove-closed-livechat-rooms');
 
 	const { filtersQuery, displayFilters, setFiltersQuery, removeFilter, textInputRef } = useChatsContext();
 
@@ -35,19 +36,21 @@ const ChatsTableFilter = () => {
 		setModal(<GenericModal variant='danger' onConfirm={onDeleteAll} onCancel={() => setModal(null)} confirmText={t('Delete')} />);
 	});
 
-	const menuItems = [
-		{
-			items: [
+	const menuItems = canRemoveAllClosedChats
+		? [
 				{
-					id: 'delete-all-closed-chats',
-					variant: 'danger',
-					icon: 'trash',
-					content: t('Delete_all_closed_chats'),
-					onClick: handleRemoveAllClosed,
-				} as const,
-			],
-		},
-	];
+					items: [
+						{
+							id: 'delete-all-closed-chats',
+							variant: 'danger',
+							icon: 'trash',
+							content: t('Delete_all_closed_chats'),
+							onClick: handleRemoveAllClosed,
+						} as const,
+					],
+				},
+			]
+		: [];
 
 	return (
 		<>
@@ -67,7 +70,7 @@ const ChatsTableFilter = () => {
 				>
 					{t('Filters')}
 				</Button>
-				<GenericMenu placement='bottom-end' detached title={t('More')} sections={menuItems} />
+				{menuItems.length > 0 && <GenericMenu placement='bottom-end' detached title={t('More')} sections={menuItems} />}
 			</FilterByText>
 			<Box display='flex' flexWrap='wrap' mbe={4}>
 				{Object.entries(displayFilters).map(([value, label], index) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed changes (including videos or screenshots)

The "Delete all closed chats" menu item in the Omnichannel Contact Center kebab menu was always visible, regardless of whether the user had the `remove-closed-livechat-rooms` permission. While the backend correctly enforced the permission (returning `error-unauthorized`), the frontend did not gate the button's visibility.

This PR adds a `usePermission('remove-closed-livechat-rooms')` check in `ChatsTableFilter.tsx` to:
- Conditionally include the "Delete all closed chats" item in the kebab menu only when the user has the permission
- Hide the entire kebab menu ("More" button) when there are no permitted menu items

This follows the same pattern already used in `ChatsTable.tsx` for the single-room `remove-closed-livechat-room` permission check.

Unit tests are included to verify:
- The "More" kebab menu is shown when the user has the `remove-closed-livechat-rooms` permission
- The "More" kebab menu is hidden when the user lacks the permission
- The "Delete all closed chats" menu item appears inside the menu when the permission is granted

## Steps to test or reproduce

1. Remove the `remove-closed-livechat-rooms` permission from all roles in Admin > Permissions
2. Navigate to Omnichannel Contact Center > Chats tab
3. **Before fix:** The kebab menu ("More") button is visible and clicking "Delete all closed chats" shows an unauthorized error
4. **After fix:** The kebab menu ("More") button is hidden entirely since the only action it contained is now gated by the permission
5. Re-add the permission to any role and verify the menu reappears with the "Delete all closed chats" option

## Further comments

The change is minimal and isolated to `ChatsTableFilter.tsx`. Only one file is modified for the fix, adding one `usePermission` hook call and conditionally rendering the menu items and the menu component itself. A companion test file validates the permission gating behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

[SUP-1031](https://rocketchat.atlassian.net/browse/SUP-1031)

<div><a href="https://cursor.com/agents/bc-30886de9-99c0-40f4-b177-b1487112bb3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30886de9-99c0-40f4-b177-b1487112bb3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[SUP-1031]: https://rocketchat.atlassian.net/browse/SUP-1031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricts the "Delete all closed chats" option to users with the required permission and only shows the actions menu when there are available options.
* **Tests**
  * Adds tests verifying the conditional display of the actions menu and the "Delete all closed chats" option based on permissions.
* **Chores**
  * Adds a changeset noting the patch release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40492)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->