### PR TITLE
refactor(client): switch settings.watch to settings.peek where reactivity is dead

### DIFF
--- a/apps/meteor/client/lib/rooms/roomTypes/direct.ts
+++ b/apps/meteor/client/lib/rooms/roomTypes/direct.ts
@@ -35,7 +35,7 @@ roomCoordinator.add(
 				case RoomSettingsEnum.JOIN_CODE:
 					return false;
 				case RoomSettingsEnum.E2E:
-					return settings.watch('E2E_Enable') === true;
+					return settings.peek('E2E_Enable') === true;
 				default:
 					return true;
 			}
@@ -73,7 +73,7 @@ roomCoordinator.add(
 				return;
 			}
 
-			if (settings.watch('UI_Use_Real_Name') && subscription.fname) {
+			if (settings.peek('UI_Use_Real_Name') && subscription.fname) {
 				return subscription.fname;
 			}
 

--- a/apps/meteor/client/lib/rooms/roomTypes/private.ts
+++ b/apps/meteor/client/lib/rooms/roomTypes/private.ts
@@ -32,7 +32,7 @@ roomCoordinator.add(
 				case RoomSettingsEnum.REACT_WHEN_READ_ONLY:
 					return Boolean(!room.broadcast && room.ro);
 				case RoomSettingsEnum.E2E:
-					return settings.watch('E2E_Enable') === true;
+					return settings.peek('E2E_Enable') === true;
 				case RoomSettingsEnum.SYSTEM_MESSAGES:
 				default:
 					return true;
@@ -55,7 +55,7 @@ roomCoordinator.add(
 			if (roomData.prid || isRoomFederated(roomData)) {
 				return roomData.fname;
 			}
-			if (settings.watch('UI_Allow_room_names_with_special_chars')) {
+			if (settings.peek('UI_Allow_room_names_with_special_chars')) {
 				return roomData.fname || roomData.name;
 			}
 

--- a/apps/meteor/client/lib/rooms/roomTypes/public.ts
+++ b/apps/meteor/client/lib/rooms/roomTypes/public.ts
@@ -53,7 +53,7 @@ roomCoordinator.add(
 			if (roomData.prid || isRoomFederated(roomData)) {
 				return roomData.fname;
 			}
-			if (settings.watch('UI_Allow_room_names_with_special_chars')) {
+			if (settings.peek('UI_Allow_room_names_with_special_chars')) {
 				return roomData.fname || roomData.name;
 			}
 			return roomData.name;

--- a/apps/meteor/client/views/account/sidebarItems.tsx
+++ b/apps/meteor/client/views/account/sidebarItems.tsx
@@ -14,7 +14,7 @@ export const {
 		href: '/account/profile',
 		i18nLabel: 'Profile',
 		icon: 'user',
-		permissionGranted: (): boolean => settings.watch('Accounts_AllowUserProfileChange') ?? true,
+		permissionGranted: (): boolean => settings.peek('Accounts_AllowUserProfileChange') ?? true,
 	},
 	{
 		href: '/account/preferences',
@@ -26,15 +26,15 @@ export const {
 		i18nLabel: 'Security',
 		icon: 'lock',
 		permissionGranted: (): boolean =>
-			(settings.watch('Accounts_TwoFactorAuthentication_Enabled') ?? true) ||
-			(settings.watch('E2E_Enable') ?? false) ||
-			(settings.watch('Accounts_AllowPasswordChange') ?? true),
+			(settings.peek('Accounts_TwoFactorAuthentication_Enabled') ?? true) ||
+			(settings.peek('E2E_Enable') ?? false) ||
+			(settings.peek('Accounts_AllowPasswordChange') ?? true),
 	},
 	{
 		href: '/account/integrations',
 		i18nLabel: 'Integrations',
 		icon: 'code',
-		permissionGranted: (): boolean => settings.watch('Webdav_Integration_Enabled') ?? false,
+		permissionGranted: (): boolean => settings.peek('Webdav_Integration_Enabled') ?? false,
 	},
 	{
 		href: '/account/tokens',
@@ -53,7 +53,7 @@ export const {
 		i18nLabel: 'Feature_preview',
 		icon: 'flask',
 		badge: () => <FeaturePreviewBadge />,
-		permissionGranted: () => settings.watch('Accounts_AllowFeaturePreview') && defaultFeaturesPreview?.length > 0,
+		permissionGranted: () => settings.peek('Accounts_AllowFeaturePreview') && defaultFeaturesPreview?.length > 0,
 	},
 	{
 		href: '/account/accessibility-and-appearance',


### PR DESCRIPTION
## Summary

\`settings.watch\` wraps \`PublicSettings\` via \`meteor/watch\` — it returns the current value AND, if the caller is inside a \`Tracker.autorun\`, subscribes the autorun to invalidate when the setting changes. The four remaining client-side call sites all live inside callbacks executed from React render paths, **none of which are inside \`Tracker.autorun\`**. The "reactivity" never reaches React: when the setting changes, the Tracker side-effect fires but the React tree doesn't re-render, so the sidebar item or room directive only updates after the user navigates or refreshes.

Switch the 11 \`settings.watch(...)\` reads to the existing non-reactive \`settings.peek(...)\` sibling. Same value, no Tracker subscribe, identical observable behaviour. This drops one of the last consumers of \`meteor/watch.ts\`; the cleanup PR will delete the bridge once the remaining consumers (\`UserPreferenceProvider.queryPreference\` after #40491, \`hasPermission\`/\`hasRole\` after #40493) land.

## Files

- \`client/lib/rooms/roomTypes/private.ts\` (2 calls: \`E2E_Enable\`, \`UI_Allow_room_names_with_special_chars\`)
- \`client/lib/rooms/roomTypes/direct.ts\` (2 calls: \`E2E_Enable\`, \`UI_Use_Real_Name\`)
- \`client/lib/rooms/roomTypes/public.ts\` (1 call: \`UI_Allow_room_names_with_special_chars\`)
- \`client/views/account/sidebarItems.tsx\` (6 calls: \`Accounts_AllowUserProfileChange\`, \`Accounts_TwoFactorAuthentication_Enabled\`, \`E2E_Enable\`, \`Accounts_AllowPasswordChange\`, \`Webdav_Integration_Enabled\`, \`Accounts_AllowFeaturePreview\`)

## Test plan

E2E coverage we lean on:

- [ ] \`tests/e2e/account-security.spec.ts\` — toggles \`Accounts_AllowPasswordChange\` / \`Accounts_TwoFactorAuthentication_Enabled\` / \`E2E_Enable\`; verifies the Security section visibility in \`/account/security\`.
- [ ] \`tests/e2e/feature-preview.spec.ts\` — verifies the Feature Preview item under \`/account\`.
- [ ] \`tests/e2e/search-discussion.spec.ts\` — exercises \`UI_Allow_room_names_with_special_chars\`.
- [ ] E2EE channel-creation suite under \`tests/e2e/e2e-encryption/\`.

Settings without dedicated E2E coverage (manual smoke):
- [ ] \`Accounts_AllowUserProfileChange\` → admin OFF, reload, /account/profile sidebar item should disappear.
- [ ] \`Webdav_Integration_Enabled\` → admin ON, reload, /account/integrations sidebar item should appear.
- [ ] \`UI_Use_Real_Name\` → toggle, open a DM, name should reflect Full Name vs username.

Lint + tsc:
- [x] \`yarn eslint\` on the 4 changed files: 0 errors.
- [x] \`tsc --noEmit\` on \`apps/meteor\` is clean. 

 Task: [ARCH-2143]

[ARCH-2143]: https://rocketchat.atlassian.net/browse/ARCH-2143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched internal settings checks to a non-reactive access method across room type behaviors and account sidebar entries to improve performance and consistency. No user-facing behavior or permissions changed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40494)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->