### PR TITLE
refactor(client): drop the Settings.watch method

### DIFF
--- a/apps/meteor/app/ui-message/client/messageBox/messageBoxFormatting.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/messageBoxFormatting.ts
@@ -101,6 +101,6 @@ export const formattingButtons: ReadonlyArray<FormattingButton> = [
 			}
 		},
 		link: 'https://khan.github.io/KaTeX/function-support.html',
-		condition: () => settings.watch('Katex_Enabled') ?? true,
+		condition: () => settings.peek('Katex_Enabled') ?? true,
 	},
 ] as const;

--- a/apps/meteor/app/utils/client/getRoomAvatarURL.ts
+++ b/apps/meteor/app/utils/client/getRoomAvatarURL.ts
@@ -4,7 +4,7 @@ import { getAvatarURL } from './getAvatarURL';
 import { settings } from '../../../client/lib/settings';
 
 export const getRoomAvatarURL = ({ roomId, cache = '' }: { roomId: IRoom['_id']; cache: IRoom['avatarETag'] }) => {
-	const externalSource = (settings.watch('Accounts_RoomAvatarExternalProviderUrl') || '').trim().replace(/\/$/, '');
+	const externalSource = (settings.peek('Accounts_RoomAvatarExternalProviderUrl') || '').trim().replace(/\/$/, '');
 	if (externalSource && typeof externalSource === 'string') {
 		return externalSource.replace('{roomId}', roomId);
 	}

--- a/apps/meteor/app/utils/client/getURL.ts
+++ b/apps/meteor/app/utils/client/getURL.ts
@@ -14,8 +14,8 @@ export const getURL = function (
 	cloudDeepLinkUrl?: string,
 	cacheKey?: boolean,
 ): string {
-	const cdnPrefix = settings.watch('CDN_PREFIX') || '';
-	const siteUrl = settings.watch('Site_Url') || '';
+	const cdnPrefix = settings.peek('CDN_PREFIX') || '';
+	const siteUrl = settings.peek('Site_Url') || '';
 
 	if (cacheKey) {
 		path += `${path.includes('?') ? '&' : '?'}cacheKey=${Info.version}`;

--- a/apps/meteor/app/utils/client/lib/getUserPreference.ts
+++ b/apps/meteor/app/utils/client/lib/getUserPreference.ts
@@ -43,5 +43,5 @@ export function getUserPreference<TValue>(
 	defaultValue?: TValue,
 ): TValue {
 	const user = typeof userIdOrUser === 'string' ? Users.state.get(userIdOrUser) : userIdOrUser;
-	return user?.settings?.preferences?.[key] ?? defaultValue ?? settings.watch(`Accounts_Default_User_Preferences_${key}`);
+	return user?.settings?.preferences?.[key] ?? defaultValue ?? settings.peek(`Accounts_Default_User_Preferences_${key}`);
 }

--- a/apps/meteor/app/utils/client/restrictions.ts
+++ b/apps/meteor/app/utils/client/restrictions.ts
@@ -2,8 +2,8 @@ import { settings } from '../../../client/lib/settings';
 import { fileUploadIsValidContentTypeFromSettings } from '../lib/restrictions';
 
 export const fileUploadIsValidContentType = function (type: string | undefined, customWhiteList?: string): boolean {
-	const blackList = settings.watch<string>('FileUpload_MediaTypeBlackList') ?? 'image/svg+xml';
-	const whiteList = customWhiteList ?? settings.watch<string>('FileUpload_MediaTypeWhiteList') ?? '';
+	const blackList = settings.peek<string>('FileUpload_MediaTypeBlackList') ?? 'image/svg+xml';
+	const whiteList = customWhiteList ?? settings.peek<string>('FileUpload_MediaTypeWhiteList') ?? '';
 
 	return fileUploadIsValidContentTypeFromSettings(type, whiteList, blackList);
 };

--- a/apps/meteor/client/lib/rooms/roomTypes/direct.ts
+++ b/apps/meteor/client/lib/rooms/roomTypes/direct.ts
@@ -35,7 +35,7 @@ roomCoordinator.add(
 				case RoomSettingsEnum.JOIN_CODE:
 					return false;
 				case RoomSettingsEnum.E2E:
-					return settings.watch('E2E_Enable') === true;
+					return settings.peek('E2E_Enable') === true;
 				default:
 					return true;
 			}
@@ -73,7 +73,7 @@ roomCoordinator.add(
 				return;
 			}
 
-			if (settings.watch('UI_Use_Real_Name') && subscription.fname) {
+			if (settings.peek('UI_Use_Real_Name') && subscription.fname) {
 				return subscription.fname;
 			}
 

--- a/apps/meteor/client/lib/rooms/roomTypes/private.ts
+++ b/apps/meteor/client/lib/rooms/roomTypes/private.ts
@@ -32,7 +32,7 @@ roomCoordinator.add(
 				case RoomSettingsEnum.REACT_WHEN_READ_ONLY:
 					return Boolean(!room.broadcast && room.ro);
 				case RoomSettingsEnum.E2E:
-					return settings.watch('E2E_Enable') === true;
+					return settings.peek('E2E_Enable') === true;
 				case RoomSettingsEnum.SYSTEM_MESSAGES:
 				default:
 					return true;
@@ -55,7 +55,7 @@ roomCoordinator.add(
 			if (roomData.prid || isRoomFederated(roomData)) {
 				return roomData.fname;
 			}
-			if (settings.watch('UI_Allow_room_names_with_special_chars')) {
+			if (settings.peek('UI_Allow_room_names_with_special_chars')) {
 				return roomData.fname || roomData.name;
 			}
 

--- a/apps/meteor/client/lib/rooms/roomTypes/public.ts
+++ b/apps/meteor/client/lib/rooms/roomTypes/public.ts
@@ -53,7 +53,7 @@ roomCoordinator.add(
 			if (roomData.prid || isRoomFederated(roomData)) {
 				return roomData.fname;
 			}
-			if (settings.watch('UI_Allow_room_names_with_special_chars')) {
+			if (settings.peek('UI_Allow_room_names_with_special_chars')) {
 				return roomData.fname || roomData.name;
 			}
 			return roomData.name;

--- a/apps/meteor/client/lib/settings/settings.ts
+++ b/apps/meteor/client/lib/settings/settings.ts
@@ -1,17 +1,11 @@
 import type { SettingValue } from '@rocket.chat/core-typings';
 
-import { watch } from '../../meteor/watch';
 import { PublicSettings } from '../../stores';
 
 type SettingCallback = (key: string, value: SettingValue) => void;
 
 class Settings {
 	private readonly store = PublicSettings.use;
-
-	/** Get a setting value Tracker-reactively */
-	watch<TValue = any>(_id: string): TValue | undefined {
-		return watch(this.store, (state) => state.get(_id)?.value) as TValue | undefined;
-	}
 
 	/** Get a setting value non-reactively */
 	peek<TValue = any>(_id: string): TValue | undefined {

--- a/apps/meteor/client/views/account/sidebarItems.tsx
+++ b/apps/meteor/client/views/account/sidebarItems.tsx
@@ -14,7 +14,7 @@ export const {
 		href: '/account/profile',
 		i18nLabel: 'Profile',
 		icon: 'user',
-		permissionGranted: (): boolean => settings.watch('Accounts_AllowUserProfileChange') ?? true,
+		permissionGranted: (): boolean => settings.peek('Accounts_AllowUserProfileChange') ?? true,
 	},
 	{
 		href: '/account/preferences',
@@ -26,15 +26,15 @@ export const {
 		i18nLabel: 'Security',
 		icon: 'lock',
 		permissionGranted: (): boolean =>
-			(settings.watch('Accounts_TwoFactorAuthentication_Enabled') ?? true) ||
-			(settings.watch('E2E_Enable') ?? false) ||
-			(settings.watch('Accounts_AllowPasswordChange') ?? true),
+			(settings.peek('Accounts_TwoFactorAuthentication_Enabled') ?? true) ||
+			(settings.peek('E2E_Enable') ?? false) ||
+			(settings.peek('Accounts_AllowPasswordChange') ?? true),
 	},
 	{
 		href: '/account/integrations',
 		i18nLabel: 'Integrations',
 		icon: 'code',
-		permissionGranted: (): boolean => settings.watch('Webdav_Integration_Enabled') ?? false,
+		permissionGranted: (): boolean => settings.peek('Webdav_Integration_Enabled') ?? false,
 	},
 	{
 		href: '/account/tokens',
@@ -53,7 +53,7 @@ export const {
 		i18nLabel: 'Feature_preview',
 		icon: 'flask',
 		badge: () => <FeaturePreviewBadge />,
-		permissionGranted: () => settings.watch('Accounts_AllowFeaturePreview') && defaultFeaturesPreview?.length > 0,
+		permissionGranted: () => settings.peek('Accounts_AllowFeaturePreview') && defaultFeaturesPreview?.length > 0,
 	},
 	{
 		href: '/account/accessibility-and-appearance',


### PR DESCRIPTION
> Stacked on top of #40494 (\`refactor/settings-watch-to-peek\`).

## Summary

#40494 took the four obviously-non-reactive client callers of \`settings.watch\` (room types + account sidebar items) over to \`settings.peek\`. The remaining six callers in \`apps/meteor/app/utils/client/\` and \`apps/meteor/app/ui-message/client/\` are in the exact same shape: they run inside synchronous helper functions called from React render paths, not from \`Tracker.autorun\`, so the watch-flavoured "Tracker reactivity" never made it back into the UI tree. Switch them to \`settings.peek\` too:

- \`app/utils/client/getRoomAvatarURL.ts\` (\`Accounts_RoomAvatarExternalProviderUrl\`)
- \`app/utils/client/getURL.ts\` (\`CDN_PREFIX\`, \`Site_Url\`)
- \`app/utils/client/lib/getUserPreference.ts\` (\`Accounts_Default_User_Preferences_\${key}\` fallback)
- \`app/utils/client/restrictions.ts\` (\`FileUpload_MediaTypeBlackList\`, \`FileUpload_MediaTypeWhiteList\`)
- \`app/ui-message/client/messageBox/messageBoxFormatting.ts\` (\`Katex_Enabled\`)

With every \`Settings.watch\` caller migrated, drop the method itself from \`client/lib/settings/settings.ts\` and stop importing \`meteor/watch\` from there. The bridge file lives on for now — \`meteor/user.ts\` (\`watchUserId\` / \`watchUser\`) is still consumed by \`meteor/overrides/userAndUsers.ts\`, which exits later with the rest of the overrides folder.

## Test plan

- [x] \`yarn eslint\` on the 6 changed files: 0 errors.
- [x] \`tsc --noEmit\` on \`apps/meteor\` is clean.
- [x] \`grep "settings\\.watch\\b"\` in \`apps/meteor\` (excluding server / test fixtures / settings middleware) shows zero matches.
- [ ] Manual: room avatars via \`Accounts_RoomAvatarExternalProviderUrl\` still load.
- [ ] Manual: KaTeX formatting button toggles via \`Katex_Enabled\` (one render cycle after the toggle — already the existing behaviour).
- [ ] Manual: file upload validation honours the configured whitelist/blacklist. 

 Task: [ARCH-2144]

[ARCH-2144]: https://rocketchat.atlassian.net/browse/ARCH-2144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Settings access updated to use non-reactive reads across the app and a deprecated reactive settings getter was removed. Behavior and public interfaces remain unchanged; configuration and preference reads are now more predictable and stable for end users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40495)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->