### PR TITLE
fix: remove visitor token from visitors.info endpoint

### DIFF
--- a/.changeset/perky-tires-invite.md
+++ b/.changeset/perky-tires-invite.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Ensures the visitor token is not present in the visitors.info response

--- a/apps/meteor/app/livechat/server/api/lib/visitors.ts
+++ b/apps/meteor/app/livechat/server/api/lib/visitors.ts
@@ -6,7 +6,7 @@ import { callbacks } from '../../../../../server/lib/callbacks';
 import { canAccessRoomAsync } from '../../../../authorization/server/functions/canAccessRoom';
 
 export async function findVisitorInfo({ visitorId }: { visitorId: IVisitor['_id'] }) {
-	const visitor = await LivechatVisitors.findOneEnabledById(visitorId);
+	const visitor = await LivechatVisitors.findOneEnabledById(visitorId, { projection: { token: 0 } });
 	if (!visitor) {
 		throw new Error('visitor-not-found');
 	}

--- a/apps/meteor/tests/end-to-end/api/livechat/09-visitors.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/09-visitors.ts
@@ -567,6 +567,18 @@ describe('LIVECHAT - visitors', () => {
 					expect(res.body.visitor._id).to.be.equal(visitor._id);
 				});
 		});
+		it('should not return the visitor token', async () => {
+			await request
+				.get(api('livechat/visitors.info'))
+				.query({ visitorId: visitor._id })
+				.set(credentials)
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res: Response) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body.visitor).to.not.have.property('token');
+				});
+		});
 	});
 
 	describe('livechat/visitors.pagesVisited', () => {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
As seen here, https://developer.rocket.chat/apidocs/get-visitor-information-by-id-1, `token` is returned in the response. It looks like there's no use case for the token to be present in the response and it would be a good security practice to remove it altogether.

## Issue(s)
https://rocketchat.atlassian.net/browse/VLN-367

## Steps to test or reproduce
- N/A

## Further comments
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security issue where visitor authentication tokens were being exposed in the `visitors.info` API response. The system now properly excludes sensitive token data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40501)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->