### PR TITLE
feat: add admin user behaviour metrics endpoint

### DIFF
--- a/apps/meteor/app/api/server/index.ts
+++ b/apps/meteor/app/api/server/index.ts
@@ -45,6 +45,7 @@ import './v1/mailer';
 import './v1/teams';
 import './v1/moderation';
 import './v1/uploads';
+import './v1/behaviourMetrics';
 
 // This has to come last so all endpoints are registered before generating the OpenAPI documentation
 import './default/openApi';

--- a/apps/meteor/app/api/server/v1/behaviourMetrics.ts
+++ b/apps/meteor/app/api/server/v1/behaviourMetrics.ts
@@ -1,0 +1,134 @@
+import { Users, Messages } from '@rocket.chat/models';
+import {
+	ajv,
+	isUsersBehaviourMetricsParamsGET,
+	validateBadRequestErrorResponse,
+	validateUnauthorizedErrorResponse,
+	validateForbiddenErrorResponse,
+} from '@rocket.chat/rest-typings';
+
+import { API } from '../api';
+
+// Response schema for AJV validation
+const behaviourMetricsResponseSchema = ajv.compile<{
+	userId: string;
+	windowDays: number;
+	accountAgeDays: number;
+	metrics: {
+		messagesSent: number;
+		messagesPerHour: number;
+		distinctRoomsMessaged: number;
+		dmRoomsMessaged: number;
+		urlMessages: number;
+		urlDensity: number;
+	};
+}>({
+	type: 'object',
+	properties: {
+		userId: { type: 'string' },
+		windowDays: { type: 'number' },
+		accountAgeDays: { type: 'number' },
+		metrics: {
+			type: 'object',
+			properties: {
+				messagesSent: { type: 'number' },
+				messagesPerHour: { type: 'number' },
+				distinctRoomsMessaged: { type: 'number' },
+				dmRoomsMessaged: { type: 'number' },
+				urlMessages: { type: 'number' },
+				urlDensity: { type: 'number' },
+			},
+			required: ['messagesSent', 'messagesPerHour', 'distinctRoomsMessaged', 'dmRoomsMessaged', 'urlMessages', 'urlDensity'],
+			additionalProperties: false,
+		},
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['userId', 'windowDays', 'accountAgeDays', 'metrics', 'success'],
+	additionalProperties: false,
+});
+
+API.v1.get(
+	'admin/users/behaviour-metrics',
+	{
+		authRequired: true,
+		permissionsRequired: ['view-moderation-console'],
+		query: isUsersBehaviourMetricsParamsGET,
+		response: {
+			200: behaviourMetricsResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
+		},
+	},
+	async function action() {
+		const { userId, days = 7 } = this.queryParams;
+
+		// 1. Validate user exists
+		const user = await Users.findOneById(userId, { projection: { _id: 1, createdAt: 1 } });
+		if (!user) {
+			return API.v1.failure('error-invalid-user', 'User not found');
+		}
+
+		// 2. Calculate time window
+		const windowMs = days * 24 * 60 * 60 * 1000;
+		const windowStart = new Date(Date.now() - windowMs);
+		const totalHours = days * 24;
+
+		// 3. Aggregation pipeline on messages collection
+		// Single aggregation to get: messagesSent, distinctRooms, dmRooms, urlMessages
+		const pipeline = [
+			{ $match: { 'u._id': userId, ts: { $gte: windowStart }, t: { $exists: false } } },
+			{
+				$lookup: {
+					from: 'rocketchat_room',
+					localField: 'rid',
+					foreignField: '_id',
+					as: 'room',
+					pipeline: [{ $project: { t: 1 } }],
+				},
+			},
+			{ $unwind: { path: '$room', preserveNullAndEmptyArrays: true } },
+			{
+				$group: {
+					_id: null,
+					messagesSent: { $sum: 1 },
+					distinctRooms: { $addToSet: '$rid' },
+					dmRooms: {
+						$addToSet: {
+							$cond: [{ $eq: ['$room.t', 'd'] }, '$rid', '$$REMOVE'],
+						},
+					},
+					urlMessages: {
+						$sum: {
+							$cond: [{ $and: [{ $isArray: '$urls' }, { $gt: [{ $size: '$urls' }, 0] }] }, 1, 0],
+						},
+					},
+				},
+			},
+		];
+
+		const [result] = await Messages.col.aggregate(pipeline).toArray();
+
+		const messagesSent = result?.messagesSent ?? 0;
+		const distinctRoomsMessaged = result?.distinctRooms?.length ?? 0;
+		const dmRoomsMessaged = result?.dmRooms?.length ?? 0;
+		const urlMessages = result?.urlMessages ?? 0;
+
+		// 4. Build response
+		const accountAgeDays = Math.floor((Date.now() - user.createdAt.getTime()) / (1000 * 60 * 60 * 24));
+
+		return API.v1.success({
+			userId,
+			windowDays: days,
+			accountAgeDays,
+			metrics: {
+				messagesSent,
+				messagesPerHour: totalHours > 0 ? parseFloat((messagesSent / totalHours).toFixed(2)) : 0,
+				distinctRoomsMessaged,
+				dmRoomsMessaged,
+				urlMessages,
+				urlDensity: messagesSent > 0 ? parseFloat((urlMessages / messagesSent).toFixed(2)) : 0,
+			},
+		});
+	},
+);

--- a/apps/meteor/tests/end-to-end/api/behaviour-metrics.ts
+++ b/apps/meteor/tests/end-to-end/api/behaviour-metrics.ts
@@ -1,0 +1,211 @@
+import type { Credentials } from '@rocket.chat/api-client';
+import type { IUser } from '@rocket.chat/core-typings';
+import { expect } from 'chai';
+import { after, before, describe, it } from 'mocha';
+import type { Response } from 'supertest';
+
+import { getCredentials, api, request, credentials } from '../../data/api-data';
+import { password } from '../../data/user';
+import { createUser, login, deleteUser } from '../../data/users.helper';
+
+describe('[admin/users/behaviour-metrics]', () => {
+	before((done) => getCredentials(done));
+
+	let testUser: IUser;
+
+	before(async () => {
+		testUser = await createUser();
+	});
+
+	after(async () => {
+		await deleteUser(testUser);
+	});
+
+	// Test 1: Admin can access the endpoint
+	it('should return behaviour metrics for a valid user', async () => {
+		await request
+			.get(api('admin/users/behaviour-metrics'))
+			.set(credentials)
+			.query({ userId: testUser._id })
+			.expect('Content-Type', 'application/json')
+			.expect(200)
+			.expect((res: Response) => {
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('userId', testUser._id);
+				expect(res.body).to.have.property('windowDays', 7);
+				expect(res.body).to.have.property('accountAgeDays').and.to.be.a('number');
+				expect(res.body).to.have.property('metrics').and.to.be.an('object');
+
+				const { metrics } = res.body;
+				expect(metrics).to.have.property('messagesSent').and.to.be.a('number');
+				expect(metrics).to.have.property('messagesPerHour').and.to.be.a('number');
+				expect(metrics).to.have.property('distinctRoomsMessaged').and.to.be.a('number');
+				expect(metrics).to.have.property('dmRoomsMessaged').and.to.be.a('number');
+				expect(metrics).to.have.property('urlMessages').and.to.be.a('number');
+				expect(metrics).to.have.property('urlDensity').and.to.be.a('number');
+			});
+	});
+
+	// Test 2: Normal user cannot access the endpoint
+	it('should return 403 for non-admin user', async () => {
+		const normalUser = await createUser();
+		const normalUserCredentials: Credentials = await login(normalUser.username, password);
+
+		try {
+			await request
+				.get(api('admin/users/behaviour-metrics'))
+				.set(normalUserCredentials)
+				.query({ userId: testUser._id })
+				.expect('Content-Type', 'application/json')
+				.expect(403)
+				.expect((res: Response) => {
+					expect(res.body).to.have.property('success', false);
+				});
+		} finally {
+			await deleteUser(normalUser);
+		}
+	});
+
+	// Test 3: Invalid days value is rejected
+	it('should return 400 for invalid days value', async () => {
+		await request
+			.get(api('admin/users/behaviour-metrics'))
+			.set(credentials)
+			.query({ userId: testUser._id, days: 14 })
+			.expect('Content-Type', 'application/json')
+			.expect(400)
+			.expect((res: Response) => {
+				expect(res.body).to.have.property('success', false);
+			});
+	});
+
+	// Test 4: Missing userId is rejected
+	it('should return 400 when userId is missing', async () => {
+		await request
+			.get(api('admin/users/behaviour-metrics'))
+			.set(credentials)
+			.query({ days: 7 })
+			.expect('Content-Type', 'application/json')
+			.expect(400)
+			.expect((res: Response) => {
+				expect(res.body).to.have.property('success', false);
+			});
+	});
+
+	// Test 5: Zero-message user returns safe defaults (no NaN/Infinity)
+	it('should return zero metrics for a user with no messages', async () => {
+		const freshUser = await createUser();
+
+		try {
+			await request
+				.get(api('admin/users/behaviour-metrics'))
+				.set(credentials)
+				.query({ userId: freshUser._id })
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res: Response) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('userId', freshUser._id);
+					expect(res.body).to.have.property('windowDays', 7);
+					expect(res.body).to.have.property('accountAgeDays').and.to.be.a('number');
+					expect(res.body).to.have.property('metrics').and.to.be.an('object');
+
+					const { metrics } = res.body;
+					expect(metrics.messagesSent).to.equal(0);
+					expect(metrics.messagesPerHour).to.equal(0);
+					expect(metrics.distinctRoomsMessaged).to.equal(0);
+					expect(metrics.dmRoomsMessaged).to.equal(0);
+					expect(metrics.urlMessages).to.equal(0);
+					expect(metrics.urlDensity).to.equal(0);
+
+					// Verify no NaN or Infinity values
+					Object.values(metrics).forEach((value) => {
+						expect(Number.isFinite(value)).to.equal(true);
+					});
+				});
+		} finally {
+			await deleteUser(freshUser);
+		}
+	});
+
+	// Test 6: days=1 is no longer allowed
+	it('should return 400 for days=1', async () => {
+		await request
+			.get(api('admin/users/behaviour-metrics'))
+			.set(credentials)
+			.query({ userId: testUser._id, days: 1 })
+			.expect('Content-Type', 'application/json')
+			.expect(400)
+			.expect((res: Response) => {
+				expect(res.body).to.have.property('success', false);
+			});
+	});
+
+	// Test 7: Metrics are calculated correctly
+	describe('metrics calculation', () => {
+		let metricsUser: IUser;
+		let metricsUserCredentials: Credentials;
+
+		before(async () => {
+			metricsUser = await createUser();
+			metricsUserCredentials = await login(metricsUser.username, password);
+		});
+
+		after(async () => {
+			await deleteUser(metricsUser);
+		});
+
+		it('should correctly calculate message metrics', async () => {
+			// Send some messages as the test user to the GENERAL channel
+			const messagesToSend = [
+				{ msg: 'Test behaviour metric message 1' },
+				{ msg: 'Test behaviour metric message 2' },
+				{ msg: 'Check out https://example.com for more info' },
+			];
+
+			for (const message of messagesToSend) {
+				await request
+					.post(api('chat.sendMessage'))
+					.set(metricsUserCredentials)
+					.send({
+						message: {
+							rid: 'GENERAL',
+							...message,
+						},
+					})
+					.expect(200);
+			}
+
+			// Now fetch behaviour metrics for the user (using days=7, the default)
+			await request
+				.get(api('admin/users/behaviour-metrics'))
+				.set(credentials)
+				.query({ userId: metricsUser._id, days: 7 })
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res: Response) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('userId', metricsUser._id);
+					expect(res.body).to.have.property('windowDays', 7);
+
+					const { metrics } = res.body;
+					// The user sent at least 3 messages
+					expect(metrics.messagesSent).to.be.at.least(3);
+					// messagesPerHour should be > 0
+					expect(metrics.messagesPerHour).to.be.greaterThan(0);
+					// At least 1 distinct room (GENERAL)
+					expect(metrics.distinctRoomsMessaged).to.be.at.least(1);
+					// At least 1 message with a URL
+					expect(metrics.urlMessages).to.be.at.least(1);
+					// urlDensity should be > 0 and <= 1
+					expect(metrics.urlDensity).to.be.greaterThan(0);
+					expect(metrics.urlDensity).to.be.at.most(1);
+
+					// Verify all metrics are finite numbers
+					Object.values(metrics).forEach((value) => {
+						expect(Number.isFinite(value)).to.equal(true);
+					});
+				});
+		});
+	});
+});

--- a/packages/rest-typings/src/v1/users.ts
+++ b/packages/rest-typings/src/v1/users.ts
@@ -124,7 +124,47 @@ export type DefaultUserInfo = Pick<
 	| 'freeSwitchExtension'
 >;
 
+export type UsersBehaviourMetricsParamsGET = {
+	userId: string;
+	days?: 7 | 30 | 90;
+};
+
+const UsersBehaviourMetricsParamsGETSchema = {
+	type: 'object',
+	properties: {
+		userId: {
+			type: 'string',
+			minLength: 1,
+		},
+		days: {
+			type: 'number',
+			enum: [7, 30, 90],
+			nullable: true,
+		},
+	},
+	required: ['userId'],
+	additionalProperties: false,
+};
+
+export const isUsersBehaviourMetricsParamsGET = ajv.compile<UsersBehaviourMetricsParamsGET>(UsersBehaviourMetricsParamsGETSchema);
+
 export type UsersEndpoints = {
+	'/v1/admin/users/behaviour-metrics': {
+		GET: (params: UsersBehaviourMetricsParamsGET) => {
+			userId: string;
+			windowDays: number;
+			accountAgeDays: number;
+			metrics: {
+				messagesSent: number;
+				messagesPerHour: number;
+				distinctRoomsMessaged: number;
+				dmRoomsMessaged: number;
+				urlMessages: number;
+				urlDensity: number;
+			};
+		};
+	};
+
 	'/v1/users.2fa.enableEmail': {
 		POST: () => void;
 	};

--- a/packages/rest-typings/src/v1/users.ts
+++ b/packages/rest-typings/src/v1/users.ts
@@ -125,7 +125,7 @@ export type DefaultUserInfo = Pick<
 >;
 
 export type UsersBehaviourMetricsParamsGET = {
-	userId: string;
+	userId: IUser['_id'];
 	days?: 7 | 30 | 90;
 };
 
@@ -151,7 +151,7 @@ export const isUsersBehaviourMetricsParamsGET = ajv.compile<UsersBehaviourMetric
 export type UsersEndpoints = {
 	'/v1/admin/users/behaviour-metrics': {
 		GET: (params: UsersBehaviourMetricsParamsGET) => {
-			userId: string;
+			userId: IUser['_id'];
 			windowDays: number;
 			accountAgeDays: number;
 			metrics: {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR adds a new admin REST API endpoint:

`GET /api/v1/admin/users/behaviour-metrics`

The endpoint provides aggregated behavioural metrics for a user over a selected time window (7, 30, or 90 days). The intention is to support moderation systems, anti-spam tooling, Apps Engine integrations, and external services without requiring direct database access.

This implementation includes:

* total messages sent
* messages per hour
* distinct rooms messaged
* DM rooms messaged
* URL message count
* URL density
* account age in days

A few implementation details:

* Added request validation for `userId` and `days`
* Restricted `days` to `7`, `30`, and `90`
* Added permission protection using `view-moderation-console`
* Excluded system messages from calculations
* Ensured no message content or raw URLs are exposed
* Added E2E coverage for validation, permissions, and metric calculations

Example response from local testing:

```json id="6oqqzf"
{
  "success": true,
  "userId": "biLHtwo3543Makq3J",
  "windowDays": 7,
  "accountAgeDays": 0,
  "metrics": {
    "messagesSent": 9,
    "messagesPerHour": 0.05,
    "distinctRoomsMessaged": 1,
    "dmRoomsMessaged": 0,
    "urlMessages": 1,
    "urlDensity": 0.11
  }
}
```

## Issue(s)

Related to the behavioural metrics feature request proposed for moderation and anti-spam tooling.

Issue reference:closes
#40004 
<img width="753" height="26" alt="Screenshot 2026-05-13 at 8 23 01 PM" src="https://github.com/user-attachments/assets/8a3dab28-fdae-4f87-8c31-3ec74b28bb8a" />


## Steps to test or reproduce

1. Start Rocket.Chat locally
2. Login as an admin user
3. Send messages in channels and/or DMs
4. Open the browser console and run:

```javascript id="rdh0b9"
const userId = Meteor.userId();

fetch(`/api/v1/admin/users/behaviour-metrics?userId=${userId}&days=7`, {
  headers: {
    'X-Auth-Token': Accounts._storedLoginToken(),
    'X-User-Id': Meteor.userId()
  }
})
.then(res => res.json())
.then(data => console.log(data));
```

5. Verify that the returned metrics update correctly based on sent messages and URLs

Additional checks performed:

* invalid `days` values return `400`
* missing `userId` returns `400`
* unauthenticated requests are rejected
* non-admin users cannot access the endpoint

## Further comments

I intentionally kept this PR focused on aggregate metrics only to keep the scope smaller and easier to review.

Features such as:

* risk scoring
* spam flags
* hourly breakdowns
* frontend/admin dashboard integration

can be added later as follow-up improvements if needed.
<img width="1469" height="469" alt="Screenshot 2026-05-13 at 8 24 25 PM" src="https://github.com/user-attachments/assets/2ee80a29-98c3-4a57-ac59-adb0de6d80af" />
<img width="753" height="26" alt="Screenshot 2026-05-13 at 8 23 01 PM" src="https://github.com/user-attachments/assets/fd93bfd0-20b9-499e-b250-56fd8418c217" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Introduced admin endpoint to view user messaging behavior metrics over configurable periods (7, 30, or 90 days). Metrics include message counts, messaging frequency, room engagement, direct message activity, URL usage, and account age.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40509)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->