### PR TITLE
test: add e2e test for livechat visitor read receipts

### DIFF
--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-read-receipts.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-read-receipts.spec.ts
@@ -1,0 +1,83 @@
+import type { Page } from '@playwright/test';
+
+import { createFakeVisitor } from '../../mocks/data';
+import { IS_EE } from '../config/constants';
+import { createAuxContext } from '../fixtures/createAuxContext';
+import { Users } from '../fixtures/userStates';
+import { HomeOmnichannel } from '../page-objects';
+import { OmnichannelLiveChat } from '../page-objects/omnichannel';
+import { setSettingValueById } from '../utils';
+import { createAgent } from '../utils/omnichannel/agents';
+import { test, expect } from '../utils/test';
+
+const visitor = createFakeVisitor();
+
+test.use({ storageState: Users.user1.state });
+
+test.describe('OC - Livechat - Read Receipts', () => {
+	let poLiveChat: OmnichannelLiveChat;
+	let poHomeOmnichannel: HomeOmnichannel;
+	let livechatPage: Page;
+	let agentPage: Page;
+	let agent: Awaited<ReturnType<typeof createAgent>>;
+
+	test.skip(!IS_EE, 'Enterprise Only');
+
+	test.beforeAll(async ({ api, browser }) => {
+		agent = await createAgent(api, 'user1');
+
+		await Promise.all([
+			setSettingValueById(api, 'Message_Read_Receipt_Enabled', true),
+			setSettingValueById(api, 'Message_Read_Receipt_Store_Users', true),
+			setSettingValueById(api, 'UI_Use_Real_Name', true),
+		]);
+
+		({ page: agentPage } = await createAuxContext(browser, Users.user1, '/', true));
+		poHomeOmnichannel = new HomeOmnichannel(agentPage);
+
+		({ page: livechatPage } = await createAuxContext(browser, Users.user1, '/livechat', false));
+		poLiveChat = new OmnichannelLiveChat(livechatPage, api);
+	});
+
+	test.afterAll(({ api }) =>
+		Promise.all([
+			setSettingValueById(api, 'Message_Read_Receipt_Enabled', false),
+			setSettingValueById(api, 'Message_Read_Receipt_Store_Users', false),
+			setSettingValueById(api, 'UI_Use_Real_Name', false),
+			agent.delete(),
+			livechatPage.close(),
+			agentPage.close(),
+		]),
+	);
+
+	test('OC - Livechat - Read receipts should display visitor name', async () => {
+		const testMessage = 'test_message_for_read_receipts';
+
+		await test.step('send message from livechat widget', async () => {
+			await poLiveChat.page.reload();
+			await poLiveChat.openAnyLiveChat();
+			await poLiveChat.sendMessage(visitor, false);
+			await poLiveChat.onlineAgentMessage.fill(testMessage);
+			await poLiveChat.btnSendMessageToOnlineAgent.click();
+			await expect(poLiveChat.txtChatMessage(testMessage)).toBeVisible();
+		});
+
+		await test.step('agent reads the message', async () => {
+			await poHomeOmnichannel.navbar.openChat(visitor.name);
+			await expect(poHomeOmnichannel.content.lastUserMessage).toBeVisible();
+			await expect(poHomeOmnichannel.content.lastUserMessage).toContainText(testMessage);
+		});
+
+		await test.step('read receipts show both agent and visitor names', async () => {
+			await poHomeOmnichannel.content.openLastMessageMenu();
+			await agentPage.locator('role=menuitem[name="Read receipts"]').click();
+
+			const dialog = agentPage.getByRole('dialog', { name: 'Read by' });
+			const listItems = dialog.getByRole('listitem');
+			await expect(listItems).toHaveCount(2);
+			await expect(listItems.filter({ hasText: visitor.name })).toHaveCount(1);
+			await expect(listItems.filter({ hasText: 'user1' })).toHaveCount(1);
+			await dialog.getByLabel('Close').click();
+		});
+	});
+});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Adds an E2E test that verifies livechat visitor read receipts display the visitor's name correctly. The test opens a livechat widget, sends a message as a visitor, then checks that the read receipt modal on the agent side shows both the agent and the visitor with their proper names (not blank).

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-2145](https://rocketchat.atlassian.net/browse/CORE-2145)

[CORE-2145]: https://rocketchat.atlassian.net/browse/CORE-2145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive E2E test suite to validate read receipts functionality in omnichannel livechat, ensuring messages display proper read receipt status with visitor and agent information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40512)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->