### PR TITLE
fix: users.presence ignoring comma-separated IDs after OpenAPI migration

### DIFF
--- a/.changeset/fix-presence-comma-ids.md
+++ b/.changeset/fix-presence-comma-ids.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/meteor': patch
+'@rocket.chat/rest-typings': patch
+---
+
+Fixes the `users.presence` endpoint returning an empty array when called with multiple comma-separated IDs, caused by `ajvQuery` coercing the string into a single-element array after the OpenAPI migration

--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -1392,6 +1392,48 @@ describe('[Users]', () => {
 					.end(done);
 			});
 
+			it('should return presence for a single id', async () => {
+				const res = await request
+					.get(api('users.presence'))
+					.query({ ids: 'rocket.cat' })
+					.set(credentials)
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('full', false);
+				expect(res.body).to.have.property('users').that.is.an('array').with.lengthOf(1);
+				expect(res.body.users[0]).to.have.property('_id', 'rocket.cat');
+			});
+
+			it('should correctly parse comma-separated ids and not return an empty result', async () => {
+				const res = await request
+					.get(api('users.presence'))
+					.query({ ids: `rocket.cat,${credentials['X-User-Id']}` })
+					.set(credentials)
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('full', false);
+				// only rocket.cat is guaranteed to be online; admin may be offline
+				expect(res.body.users.map((u: IUser) => u._id)).to.include('rocket.cat');
+			});
+
+			it('should return presence for repeated ids params', async () => {
+				const res = await request
+					.get(api('users.presence'))
+					.query(`ids=rocket.cat&ids=${credentials['X-User-Id']}`)
+					.set(credentials)
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('full', false);
+				// only rocket.cat is guaranteed to be online; admin may be offline
+				expect(res.body.users.map((u: IUser) => u._id)).to.include('rocket.cat');
+			});
+
 			it('should return full list of online users for more than 10 minutes in the past', (done) => {
 				const date = new Date();
 				date.setMinutes(date.getMinutes() - 11);

--- a/packages/rest-typings/src/v1/users/UsersPresenceParamsGET.ts
+++ b/packages/rest-typings/src/v1/users/UsersPresenceParamsGET.ts
@@ -10,7 +10,8 @@ const UsersPresenceParamsGetSchema = {
 	properties: {
 		from: { type: 'string', nullable: true },
 		ids: {
-			anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+			type: ['string', 'array'],
+			items: { type: 'string' },
 		},
 	},
 	additionalProperties: false,


### PR DESCRIPTION
### Proposed changes

**Regression in 8.4.0**: `GET /v1/users.presence?ids=id1,id2,id3` returns an empty array when called with multiple comma-separated IDs. Single ID works fine. This breaks user presence on mobile, where everyone appears offline.

**Root cause:** PR #39553 (OpenAPI migration) added `ajvQuery` validation with `anyOf: [string, array]`. Combined with `ajvQuery`'s `coerceTypes: 'array'`, AJV coerces `"id1,id2"` into `["id1,id2"]` (single-element array), skipping the `.split(',')` logic.

**The endpoint accepts three formats:**
- `?ids=userId1` - single ID (string)
- `?ids=userId1&ids=userId2` - repeated params (array)
- `?ids=userId1,userId2` - comma-separated (string, but AJV coerces to `["userId1,userId2"]` — broken case)

**Fix:**
- Replaced `anyOf` with `type: ['string', 'array']` to avoid AJV coercion issues ([ajv#1140](https://github.com/ajv-validator/ajv/issues/1140))

### Issue(s)

- Regression introduced by #39553
- [CORE-2194](https://rocketchat.atlassian.net/browse/CORE-2194)

### Steps to test or reproduce

1. `GET /v1/users.presence?ids=<userId>` - single ID, returns the user
2. `GET /v1/users.presence?ids=<userId1>,<userId2>` - comma-separated, returns empty (before fix), returns both (after fix)
3. `GET /v1/users.presence?ids=<userId1>&ids=<userId2>` - repeated params, returns both


[CORE-2194]: https://rocketchat.atlassian.net/browse/CORE-2194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `users.presence` endpoint to correctly handle multiple comma-separated user IDs instead of returning an empty array.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40513)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->