### PR TITLE
Improvement: Toggle user info on participant name tap in 1:1 DM

### DIFF
--- a/apps/meteor/client/views/room/body/RoomForeword/RoomForeword.tsx
+++ b/apps/meteor/client/views/room/body/RoomForeword/RoomForeword.tsx
@@ -1,5 +1,5 @@
 import type { IRoom, IUser } from '@rocket.chat/core-typings';
-import { isDirectMessageRoom } from '@rocket.chat/core-typings';
+import { isDirectMessageRoom, isMultipleDirectMessageRoom } from '@rocket.chat/core-typings';
 import { Flex, Box } from '@rocket.chat/fuselage';
 import { UserAvatar } from '@rocket.chat/ui-avatar';
 import type { ReactElement } from 'react';
@@ -26,6 +26,8 @@ const RoomForeword = ({ user, room }: RoomForewordProps): ReactElement | null =>
 		return null;
 	}
 
+	const isOneToOneDm = !isMultipleDirectMessageRoom(room);
+
 	return (
 		<Box is='div' flexGrow={1} display='flex' justifyContent='center' flexDirection='column' mb={8}>
 			<Flex.Item grow={1}>
@@ -41,7 +43,7 @@ const RoomForeword = ({ user, room }: RoomForewordProps): ReactElement | null =>
 				{t('Direct_message_you_have_joined')}
 			</Box>
 			<Box is='div' flexGrow={1} display='flex' justifyContent='center'>
-				<RoomForewordUsernameList usernames={usernames} />
+				<RoomForewordUsernameList isOneToOneDm={isOneToOneDm} usernames={usernames} />
 			</Box>
 		</Box>
 	);

--- a/apps/meteor/client/views/room/body/RoomForeword/RoomForewordUsernameList.tsx
+++ b/apps/meteor/client/views/room/body/RoomForeword/RoomForewordUsernameList.tsx
@@ -4,13 +4,17 @@ import { Margins } from '@rocket.chat/fuselage';
 import RoomForewordUsernameListItem from './RoomForewordUsernameListItem';
 import { roomCoordinator } from '../../../../lib/rooms/roomCoordinator';
 
-type RoomForewordUsernameListProps = { usernames: Array<NonNullable<IUser['username']>> };
+type RoomForewordUsernameListProps = {
+	isOneToOneDm: boolean;
+	usernames: Array<NonNullable<IUser['username']>>;
+};
 
-const RoomForewordUsernameList = ({ usernames }: RoomForewordUsernameListProps) => {
+const RoomForewordUsernameList = ({ isOneToOneDm, usernames }: RoomForewordUsernameListProps) => {
 	return (
 		<Margins inline={4}>
 			{usernames.map((username) => (
 				<RoomForewordUsernameListItem
+					isOneToOneDm={isOneToOneDm}
 					username={username}
 					key={username}
 					href={roomCoordinator.getRouteLink('d', { name: username }) || undefined}

--- a/apps/meteor/client/views/room/body/RoomForeword/RoomForewordUsernameListItem.tsx
+++ b/apps/meteor/client/views/room/body/RoomForeword/RoomForewordUsernameListItem.tsx
@@ -1,17 +1,73 @@
 import type { IUser } from '@rocket.chat/core-typings';
 import { Icon, Tag, Skeleton } from '@rocket.chat/fuselage';
+import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
 import { useUserDisplayName } from '@rocket.chat/ui-client';
+import { useRoomToolbox } from '@rocket.chat/ui-contexts';
+import type { KeyboardEvent, MouseEvent } from 'react';
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { useUserInfoQuery } from '../../../../hooks/useUserInfoQuery';
 
 type RoomForewordUsernameListItemProps = {
 	href: string | undefined;
+	isOneToOneDm: boolean;
 	username: NonNullable<IUser['username']>;
 };
 
-const RoomForewordUsernameListItem = ({ username, href }: RoomForewordUsernameListItemProps) => {
+const RoomForewordUsernameListItem = ({ username, href, isOneToOneDm }: RoomForewordUsernameListItemProps) => {
+	const { t } = useTranslation();
+	const { openTab, closeTab, tab, context } = useRoomToolbox();
 	const { data, isLoading, isError, isSuccess } = useUserInfoQuery({ username });
 	const displayName = useUserDisplayName({ name: data?.user?.name, username });
+
+	const toggleUserInfo = useEffectEvent(() => {
+		if (tab?.id === 'user-info') {
+			const routeContext = context ?? '';
+			if (routeContext === username || routeContext === '') {
+				closeTab();
+				return;
+			}
+		}
+		openTab('user-info', username);
+	});
+
+	const handleClick = useCallback(
+		(event: MouseEvent<HTMLElement>) => {
+			event.preventDefault();
+			toggleUserInfo();
+		},
+		[toggleUserInfo],
+	);
+
+	const handleKeyDown = useCallback(
+		(event: KeyboardEvent<HTMLElement>) => {
+			if (event.key === 'Enter' || event.key === ' ') {
+				event.preventDefault();
+				toggleUserInfo();
+			}
+		},
+		[toggleUserInfo],
+	);
+
+	if (isOneToOneDm) {
+		return (
+			<Tag
+				icon={<Icon name='user' size='x20' />}
+				data-username={username}
+				large
+				role='button'
+				tabIndex={0}
+				aria-label={`${t('User_Info')}: ${displayName || username}`}
+				onClick={handleClick}
+				onKeyDown={handleKeyDown}
+			>
+				{isLoading && <Skeleton variant='rect' />}
+				{isError && username}
+				{isSuccess && displayName}
+			</Tag>
+		);
+	}
 
 	return (
 		<Tag icon={<Icon name='user' size='x20' />} data-username={username} large href={href}>


### PR DESCRIPTION

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
In a 1:1 direct message, the room foreword (“You have joined a new direct message with …”) renders the other participant’s name as a link to the same DM route. Clicking it re-navigates to the current room, which causes a visible flicker and provides no useful action.

### Solution
For 1:1 DMs only (!isMultipleDirectMessageRoom(room)), the participant Tag no longer uses href navigation. Instead it uses useRoomToolbox() to openTab('user-info', username), matching the behavior used elsewhere for DM user info (e.g. UserCardProvider).

### Toggle behavior (aligned with the room header / toolbox flow):
- If User Info is already open for this 1:1 case (tab is user-info and route context is empty or equals the other user’s username), the next click closes the panel via closeTab().
- Otherwise it opens User Info for that username.

### Scope
- Only 1:1 DMs are changed. Multi-user DMs keep the previous href behavior.

### Files
- apps/meteor/client/views/room/body/RoomForeword/RoomForeword.tsx
- apps/meteor/client/views/room/body/RoomForeword/RoomForewordUsernameList.tsx
- apps/meteor/client/views/room/body/RoomForeword/RoomForewordUsernameListItem.tsx

https://github.com/user-attachments/assets/c6b4e9ca-e613-44c0-b613-da6bec118120

## After

https://github.com/user-attachments/assets/c25ff58f-175d-4f8e-9589-7ef06beab39e


## Issue(s)
Issue #40514

## Steps to test or reproduce
1. Create or open a 1:1 Direct message with another user (only you and that user in the room).
2. Scroll to the top of the message list so the room foreword is visible.
3. Click the participant name in the foreword
4. Expected: User Info opens in the contextual panel (same as opening user info for that DM participant), no navigation flicker.
5. Click the same name again.
- Expected: User Info closes.
6. Open User Info from the room header / title flow (existing behavior), then click the foreword name again.
- Expected: Panel toggles consistently (no duplicate navigation to the same DM).
7. Open a multi-user DM (if available), open the foreword, click a participant name.
- Expected: Behavior is unchanged from before (still uses link / href as previously).




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard accessibility (Enter/Space keys) for username interactions in direct messages.
  * Enhanced username interactions to open user profile information directly instead of navigation.

* **Improvements**
  * Refined username display styling for one-to-one direct message rooms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40516)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->