### PR TITLE
fix(desktop): call setBadge so tray icon reflects unread count

### DIFF
--- a/.changeset/fix-tray-icon-unread-badge.md
+++ b/.changeset/fix-tray-icon-unread-badge.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes tray icon not reflecting unread message count on desktop app

--- a/apps/meteor/client/views/root/hooks/loggedIn/useUnread.ts
+++ b/apps/meteor/client/views/root/hooks/loggedIn/useUnread.ts
@@ -54,10 +54,13 @@ export const useUnread = () => {
 
 		if (unreadCount > 0) {
 			setUnread(unreadCount > 999 ? '999+' : unreadCount);
+			window.RocketChatDesktop?.setBadge(unreadCount);
 		} else if (badgeIndicator !== false) {
 			setUnread(badgeIndicator);
+			window.RocketChatDesktop?.setBadge('•');
 		} else {
 			setUnread('');
+			window.RocketChatDesktop?.setBadge(0);
 		}
 
 		fireEventUnreadChanged(unreadCount);


### PR DESCRIPTION
The web client was computing unread counts and updating the browser favicon but never calling RocketChatDesktop.setBadge(), so the desktop app's tray icon never received badge updates. This caused the tray icon to show no unread indicator regardless of message state.

Fixes #40488

## Proposed changes 

The `RocketChatDesktop.setBadge()` method is defined in the desktop API interface (`packages/desktop-api/src/index.ts`) but was never invoked from the web client. Unread counts were being computed correctly in `useUnread.ts` and used to update the browser tab favicon via `setFavicon()`, but the tray icon badge path was completely missing.

This fix adds three `setBadge` calls inside the existing `useEffect` in `useUnread.ts`, mirroring the three branches already used for `setUnread`:
- `setBadge(unreadCount)`:  numeric unread messages
- `setBadge('•')` : alert-only state (no unread count but activity)
- `setBadge(0)` : clears the badge when nothing is unread

## Issue(s)

Fixes #40488

## Steps to test or reproduce

1. Run Rocket.Chat via the desktop app on Linux (Ubuntu 24.04)
2. Receive a message in a channel you haven't read, tray icon should display the unread count badge
3. Open and read all messages, tray icon badge should clear
4. Receive an alert-only notification, tray icon should show `•`

## Further comments

The `Badge` type in `packages/desktop-api/src/index.ts` is `'•' | number`, so passing `0` to clear and `unreadCount` directly is type-safe and consistent with the existing interface contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed the desktop tray icon badge to properly display and synchronize unread message counts. The badge now accurately shows the number of unread messages, updates in real-time as new messages arrive, and clears when all messages are marked as read. Notification indicators are also properly reflected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40522)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->