### PR TITLE
perf(client): stop subscribing AuthorizationProvider to Subscriptions globally

### DIFF
--- a/apps/meteor/client/providers/AuthorizationProvider.tsx
+++ b/apps/meteor/client/providers/AuthorizationProvider.tsx
@@ -12,6 +12,8 @@ type AuthorizationProviderProps = {
 
 const noopSubscribe = (): (() => void) => () => undefined;
 
+const subscribeToSubscriptions = (onStoreChange: () => void): (() => void) => Subscriptions.use.subscribe(onStoreChange);
+
 const AuthorizationProvider = ({ children }: AuthorizationProviderProps) => {
 	const isReady = PermissionsCachedStore.useReady();
 
@@ -24,14 +26,16 @@ const AuthorizationProvider = ({ children }: AuthorizationProviderProps) => {
 
 	const userId = useUserId();
 
-	// Reactive snapshots of every store the authorization helpers read. The
-	// provider re-renders whenever any of them change, and the new context
-	// value (memoized below) flows down so consumers re-render through React
-	// instead of through Tracker.
+	// Reactive snapshots of the three stores that change infrequently (admin-driven
+	// or login-time only). A re-render here propagates the new auth answer through
+	// context to every consumer without forcing them to re-evaluate `hasPermission`
+	// for unrelated traffic. Subscriptions.use is intentionally NOT observed here
+	// — it updates on every incoming message, member change, and unread-count flip,
+	// so subscribing globally would re-render every gated component on every chat
+	// frame. Subscription-scoped permission checks subscribe per-call below.
 	const usersState = useSyncExternalStore(Users.use.subscribe, () => Users.use.getState());
 	const permissionsState = useSyncExternalStore(Permissions.use.subscribe, () => Permissions.use.getState());
 	const rolesState = useSyncExternalStore(Roles.use.subscribe, () => Roles.use.getState());
-	const subscriptionsState = useSyncExternalStore(Subscriptions.use.subscribe, () => Subscriptions.use.getState());
 
 	const auth = useMemo(
 		() =>
@@ -40,27 +44,42 @@ const AuthorizationProvider = ({ children }: AuthorizationProviderProps) => {
 				getUserRoles: (id) => usersState.get(id)?.roles,
 				getPermission: (id) => permissionsState.get(id),
 				getRoleScope: (id) => rolesState.get(id)?.scope,
-				hasSubscriptionRole: (rid, roleId) => subscriptionsState.find((s) => s.rid === rid)?.roles?.includes(roleId) ?? false,
+				// Read Subscriptions live — reactivity for scoped checks is wired through
+				// the per-call subscribe returned by queryPermission/queryRole below.
+				hasSubscriptionRole: (rid, roleId) =>
+					Subscriptions.use
+						.getState()
+						.find((s) => s.rid === rid)
+						?.roles?.includes(roleId) ?? false,
 				isReady: () => true,
 			}),
-		[userId, usersState, permissionsState, rolesState, subscriptionsState],
+		[userId, usersState, permissionsState, rolesState],
 	);
 
 	const contextValue = useMemo(
 		(): ContextType<typeof AuthorizationContext> => ({
+			// Callers without `scope` never touch Subscriptions (the factory short-circuits
+			// at the role-scope gate). They rely on context-value identity for re-renders
+			// from Users/Permissions/Roles changes — which is why subscribe is noop.
+			// Callers with a `scope` (room id) DO touch Subscriptions, so we attach a
+			// per-call subscribe to that store so they re-evaluate when subscriptions
+			// for the relevant room flip without dragging the rest of the tree along.
 			queryPermission: (permission, scope, scopeRoles) => [
-				noopSubscribe,
+				scope !== undefined ? subscribeToSubscriptions : noopSubscribe,
 				() => auth.hasPermission(String(permission), scope ? String(scope) : undefined, scopeRoles),
 			],
 			queryAtLeastOnePermission: (permissions, scope) => [
-				noopSubscribe,
+				scope !== undefined ? subscribeToSubscriptions : noopSubscribe,
 				() => auth.hasAtLeastOnePermission(permissions.map(String), scope ? String(scope) : undefined),
 			],
 			queryAllPermissions: (permissions, scope) => [
-				noopSubscribe,
+				scope !== undefined ? subscribeToSubscriptions : noopSubscribe,
 				() => auth.hasAllPermission(permissions.map(String), scope ? String(scope) : undefined),
 			],
-			queryRole: (role, scope) => [noopSubscribe, () => !!userId && auth.hasRole(userId, String(role), scope)],
+			queryRole: (role, scope) => [
+				scope !== undefined ? subscribeToSubscriptions : noopSubscribe,
+				() => !!userId && auth.hasRole(userId, String(role), scope),
+			],
 			getRoles: () => Roles.state.records,
 			subscribeToRoles: (callback) => Roles.use.subscribe(callback),
 		}),


### PR DESCRIPTION
> Stacked on top of #40493 (\`refactor/authorization-functions-factory\`).

## Summary

The previous PR (#40493) observed \`Users\` + \`Permissions\` + \`Roles\` + \`Subscriptions\` via \`useSyncExternalStore\` at the provider level. Any change to any of those stores re-renders the provider, which re-renders every consumer of \`usePermission\` / \`useAtLeastOnePermission\` / \`useAllPermissions\` / \`useRole\`. \`Subscriptions\` updates on every incoming message, every unread-count flip, every member change — i.e. constantly during normal chat usage — so all 232 permission-gated components in the tree were churning React passes on every chat frame.

Of those 232 consumers, **179 (77%) call the hooks without a \`scope\` arg**. The factory short-circuits at the role-scope gate before touching \`Subscriptions\`, so those callers never depend on \`Subscriptions\` reactivity. Only the **53** consumers that pass a room id need \`Subscriptions\` to fire re-renders, and they care about subscription changes for that specific room anyway.

## Strategy

- Provider keeps a **global subscribe on Users + Permissions + Roles** (admin-driven, infrequent — re-render fan-out is acceptable).
- \`Subscriptions\` reads go **live** via \`Subscriptions.use.getState()\` inside the factory's \`hasSubscriptionRole\` accessor.
- \`queryPermission\` / \`queryAtLeastOnePermission\` / \`queryAllPermissions\` / \`queryRole\` return a **per-call subscribe**: noop when no scope is passed, \`Subscriptions.use.subscribe\` when scope is set.

## Impact

| Cenário | #40493 | Com este PR |
|--------|-------|-----|
| \`usePermission('foo')\` (179 callers) | re-render em cada msg | noop |
| \`usePermission('foo', rid)\` (53 callers) | re-render em cada msg | re-render só em Subs change (esperado) |
| admin altera Permissions/Roles | re-render | re-render (raro) |

Net: 77% of permission-gated components stop re-rendering on every chat frame. The remaining 23% still react to subscription changes for the room they're gating on — same as before — but only to that store, and without dragging the rest of the tree through React reconciliation.

## Test plan

- [x] \`yarn eslint\` on the changed file: 0 errors.
- [x] \`tsc --noEmit\` on \`apps/meteor\` is clean.
- [ ] Manual: admin assigns a Subscription-scoped role to a user in a room → permission-gated UI in that room updates without reload.
- [ ] Manual: open a busy room; permission-gated UI elsewhere in the app (e.g. /account, admin pages) does not re-render on every incoming message.
- [ ] Manual: admin removes a role from the current user → permission-gated UI updates without reload (Roles store change). 

 Task: [ARCH-2147]

[ARCH-2147]: https://rocketchat.atlassian.net/browse/ARCH-2147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized authorization context reactivity to reduce unnecessary re-renders and improve application performance. Permission checks now re-evaluate dynamically only when relevant subscription data changes, enhancing the responsiveness and efficiency of permission-gated features throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40530)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->