### PR TITLE
perf(client): narrow AuthorizationProvider's User snapshot to .roles

### DIFF
--- a/apps/meteor/client/providers/AuthorizationProvider.tsx
+++ b/apps/meteor/client/providers/AuthorizationProvider.tsx
@@ -1,3 +1,4 @@
+import type { IUser } from '@rocket.chat/core-typings';
 import { AuthorizationContext, useUserId } from '@rocket.chat/ui-contexts';
 import type { ContextType, ReactNode } from 'react';
 import { useMemo, useSyncExternalStore } from 'react';
@@ -6,6 +7,12 @@ import { createAuthorizationFunctions } from '../../app/authorization/lib/create
 import { PermissionsCachedStore } from '../cachedStores';
 import { Permissions, Roles, Subscriptions, Users } from '../stores';
 
+// Only the slice of IUser that the authorization helpers actually read.
+// Snapshotting just `roles` (instead of the full user document) keeps the
+// provider from re-rendering on presence/status updates, last-login flips,
+// avatar etag changes, etc. — none of which affect any permission answer.
+type AuthorizableUser = Pick<IUser, '_id' | 'roles'>;
+
 type AuthorizationProviderProps = {
 	children?: ReactNode;
 };
@@ -13,6 +20,11 @@ type AuthorizationProviderProps = {
 const noopSubscribe = (): (() => void) => () => undefined;
 
 const subscribeToSubscriptions = (onStoreChange: () => void): (() => void) => Subscriptions.use.subscribe(onStoreChange);
+
+const selectUserRoles = (userId: IUser['_id'] | undefined): AuthorizableUser['roles'] | undefined => {
+	if (!userId) return undefined;
+	return Users.use.getState().get(userId)?.roles;
+};
 
 const AuthorizationProvider = ({ children }: AuthorizationProviderProps) => {
 	const isReady = PermissionsCachedStore.useReady();
@@ -26,22 +38,30 @@ const AuthorizationProvider = ({ children }: AuthorizationProviderProps) => {
 
 	const userId = useUserId();
 
-	// Reactive snapshots of the three stores that change infrequently (admin-driven
-	// or login-time only). A re-render here propagates the new auth answer through
-	// context to every consumer without forcing them to re-evaluate `hasPermission`
-	// for unrelated traffic. Subscriptions.use is intentionally NOT observed here
-	// — it updates on every incoming message, member change, and unread-count flip,
-	// so subscribing globally would re-render every gated component on every chat
-	// frame. Subscription-scoped permission checks subscribe per-call below.
-	const usersState = useSyncExternalStore(Users.use.subscribe, () => Users.use.getState());
+	// Permissions and Roles change infrequently (admin-driven or login-time only);
+	// observing the whole map is cheap and re-renders propagate the new auth
+	// answers through context to every consumer.
 	const permissionsState = useSyncExternalStore(Permissions.use.subscribe, () => Permissions.use.getState());
 	const rolesState = useSyncExternalStore(Roles.use.subscribe, () => Roles.use.getState());
+	// For Users, only the current user's `roles` array is relevant for auth
+	// decisions (hooks dispatch via getCurrentUserId; `userHasAllPermission` with
+	// an arbitrary userId has no real callers). Subscribing to the full Users map
+	// would re-render the provider on every presence update for every user. The
+	// custom getSnapshot returns the same array reference until the current
+	// user's roles actually change, so useSyncExternalStore short-circuits via
+	// Object.is and the provider stays still through unrelated user churn.
+	const currentUserRoles = useSyncExternalStore(Users.use.subscribe, () => selectUserRoles(userId));
+	// Subscriptions.use is intentionally NOT observed here — it updates on every
+	// incoming message, member change, and unread-count flip. Subscription-scoped
+	// permission checks subscribe per-call below.
 
 	const auth = useMemo(
 		() =>
 			createAuthorizationFunctions({
 				getCurrentUserId: () => userId,
-				getUserRoles: (id) => usersState.get(id)?.roles,
+				// Fast path for the only userId hook consumers ever pass; live read for
+				// any other userId (only userHasAllPermission can reach this branch).
+				getUserRoles: (id) => (id === userId ? currentUserRoles : Users.use.getState().get(id)?.roles),
 				getPermission: (id) => permissionsState.get(id),
 				getRoleScope: (id) => rolesState.get(id)?.scope,
 				// Read Subscriptions live — reactivity for scoped checks is wired through
@@ -53,7 +73,7 @@ const AuthorizationProvider = ({ children }: AuthorizationProviderProps) => {
 						?.roles?.includes(roleId) ?? false,
 				isReady: () => true,
 			}),
-		[userId, usersState, permissionsState, rolesState],
+		[userId, currentUserRoles, permissionsState, rolesState],
 	);
 
 	const contextValue = useMemo(


### PR DESCRIPTION
> Stacked on top of #40530.

## Summary

#40530 narrowed Subscriptions reactivity. \`Users.use\` was still observed in full: every Users record update — presence, status, last login, avatar etag — re-rendered the provider and re-evaluated \`hasPermission\` for every gated component in the tree. None of those fields affect any auth answer.

The authorization factory only ever reads \`Users.use.getState().get(id)?.roles\`, and in practice that \`id\` is always the current user (the few callers of \`userHasAllPermission\` with an arbitrary userId don't exist in the codebase today). Introduce an \`AuthorizableUser = Pick<IUser, '_id' | 'roles'>\` type for documentation and switch the provider's Users subscription to a selector that returns just the current user's roles array.

Zustand preserves the \`roles\` array reference across updates that don't touch that field, so \`useSyncExternalStore\`'s \`Object.is\` comparison keeps the provider still through presence churn — re-rendering only when the current user's role assignments actually change. For the (untaken) arbitrary-userId path, the factory still falls back to a live store read.

## Behaviour

| Trigger | Before this PR | After |
|---|---|---|
| Another user changes presence | provider re-renders | no re-render |
| Current user's avatar updates | provider re-renders | no re-render |
| Current user is granted/loses a role | provider re-renders | provider re-renders (correct) |
| Admin alters a permission's role list | provider re-renders | provider re-renders (correct) |
| Admin alters a role's scope | provider re-renders | provider re-renders (correct) |

## Test plan

- [x] \`yarn eslint\` on the changed file: 0 errors.
- [x] \`tsc --noEmit\` on \`apps/meteor\` is clean.
- [ ] Manual: in a busy DM, watch React DevTools' Profiler — the AuthorizationProvider should not appear in the commit list on every incoming presence/status update.
- [ ] Manual: admin grants the current user a new role → permission-gated UI updates without reload.
- [ ] Manual: admin removes a role from the current user → permission-gated UI updates without reload. 

 Task: [ARCH-2148]

[ARCH-2148]: https://rocketchat.atlassian.net/browse/ARCH-2148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized authorization provider reactivity to reduce unnecessary UI re-renders, improving overall application performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40531)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->