### PR TITLE
chore: Modernize codebase to node 22

### DIFF
--- a/apps/meteor/app/2fa/server/code/index.ts
+++ b/apps/meteor/app/2fa/server/code/index.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import type { IUser, IMethodConnection } from '@rocket.chat/core-typings';
 import { Users } from '@rocket.chat/models';

--- a/apps/meteor/app/api/server/definition.ts
+++ b/apps/meteor/app/api/server/definition.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage } from 'http';
+import type { IncomingMessage } from 'node:http';
 
 import type { IUser, LicenseModule, RequiredField } from '@rocket.chat/core-typings';
 import type { Logger } from '@rocket.chat/logger';

--- a/apps/meteor/app/api/server/lib/MultipartUploadHandler.ts
+++ b/apps/meteor/app/api/server/lib/MultipartUploadHandler.ts
@@ -1,8 +1,8 @@
-import fs from 'fs';
-import { IncomingMessage } from 'http';
-import type { Stream, Transform } from 'stream';
-import { Readable } from 'stream';
-import { pipeline } from 'stream/promises';
+import fs from 'node:fs';
+import { IncomingMessage } from 'node:http';
+import type { Stream, Transform } from 'node:stream';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 
 import { MeteorError } from '@rocket.chat/core-services';
 import { Random } from '@rocket.chat/random';

--- a/apps/meteor/app/api/server/lib/getUploadFormData.ts
+++ b/apps/meteor/app/api/server/lib/getUploadFormData.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { ReadableStream } from 'stream/web';
 
 import { MeteorError } from '@rocket.chat/core-services';

--- a/apps/meteor/app/api/server/lib/getUploadFormData.ts
+++ b/apps/meteor/app/api/server/lib/getUploadFormData.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'node:stream';
-import { ReadableStream } from 'stream/web';
+import { ReadableStream } from 'node:stream/web';
 
 import { MeteorError } from '@rocket.chat/core-services';
 import type { ValidateFunction } from 'ajv';

--- a/apps/meteor/app/api/server/middlewares/remoteAddressMiddleware.ts
+++ b/apps/meteor/app/api/server/middlewares/remoteAddressMiddleware.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage } from 'http';
+import type { IncomingMessage } from 'node:http';
 
 import type { Context, MiddlewareHandler } from 'hono';
 

--- a/apps/meteor/app/api/server/v1/misc.ts
+++ b/apps/meteor/app/api/server/v1/misc.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import type { IDirectoryChannelResult, IDirectoryUserResult, IRoom, IUser } from '@rocket.chat/core-typings';
 import { Settings, Users, WorkspaceCredentials } from '@rocket.chat/models';

--- a/apps/meteor/app/apps/server/bridges/listeners.ts
+++ b/apps/meteor/app/apps/server/bridges/listeners.ts
@@ -1,6 +1,6 @@
-import crypto from 'crypto';
-import fs from 'fs';
-import path from 'path';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import type { IAppServerOrchestrator, IAppsRoom, IAppsLivechatRoom, IAppsMessage } from '@rocket.chat/apps';
 import type { IPreEmailSentContext } from '@rocket.chat/apps-engine/definition/email';

--- a/apps/meteor/app/apps/server/bridges/oauthApps.ts
+++ b/apps/meteor/app/apps/server/bridges/oauthApps.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 import type { IAppServerOrchestrator } from '@rocket.chat/apps';
 import { OAuthAppsBridge } from '@rocket.chat/apps/dist/server/bridges/OAuthAppsBridge';

--- a/apps/meteor/app/assets/server/assets.ts
+++ b/apps/meteor/app/assets/server/assets.ts
@@ -1,5 +1,5 @@
-import crypto from 'crypto';
-import type { ServerResponse, IncomingMessage } from 'http';
+import crypto from 'node:crypto';
+import type { ServerResponse, IncomingMessage } from 'node:http';
 
 import type { IRocketChatAssets, IRocketChatAsset, ISetting } from '@rocket.chat/core-typings';
 import { Settings } from '@rocket.chat/models';

--- a/apps/meteor/app/cors/server/cors.ts
+++ b/apps/meteor/app/cors/server/cors.ts
@@ -1,6 +1,6 @@
-import type http from 'http';
-import type { UrlWithParsedQuery } from 'url';
-import url from 'url';
+import type http from 'node:http';
+import type { UrlWithParsedQuery } from 'node:url';
+import url from 'node:url';
 
 import { Logger } from '@rocket.chat/logger';
 import { Meteor } from 'meteor/meteor';

--- a/apps/meteor/app/emoji-emojione/lib/generateEmojiIndex.mjs
+++ b/apps/meteor/app/emoji-emojione/lib/generateEmojiIndex.mjs
@@ -3,7 +3,7 @@
 // before using this script make sure to run: npm i --no-save node-sprite-generator
 
 // node --experimental-modules generateEmojiIndex.mjs
-import fs from 'fs';
+import fs from 'node:fs';
 import nsg from 'node-sprite-generator';
 import _ from 'underscore';
 import gm from 'gm'; // lgtm[js/unused-local-variable]

--- a/apps/meteor/app/file-upload/lib/FileUploadBase.ts
+++ b/apps/meteor/app/file-upload/lib/FileUploadBase.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { UploadFS } from '../../../server/ufs';
 

--- a/apps/meteor/app/file-upload/server/config/AmazonS3.ts
+++ b/apps/meteor/app/file-upload/server/config/AmazonS3.ts
@@ -1,5 +1,5 @@
-import http from 'http';
-import https from 'https';
+import http from 'node:http';
+import https from 'node:https';
 
 import _ from 'underscore';
 

--- a/apps/meteor/app/file-upload/server/config/FileSystem.ts
+++ b/apps/meteor/app/file-upload/server/config/FileSystem.ts
@@ -1,4 +1,4 @@
-import fsp from 'fs/promises';
+import fsp from 'node:fs/promises';
 
 import { getContentDisposition } from './helper';
 import { UploadFS } from '../../../../server/ufs';

--- a/apps/meteor/app/file-upload/server/config/GoogleStorage.ts
+++ b/apps/meteor/app/file-upload/server/config/GoogleStorage.ts
@@ -1,5 +1,5 @@
-import http from 'http';
-import https from 'https';
+import http from 'node:http';
+import https from 'node:https';
 
 import _ from 'underscore';
 

--- a/apps/meteor/app/file-upload/server/config/GridFS.ts
+++ b/apps/meteor/app/file-upload/server/config/GridFS.ts
@@ -1,7 +1,7 @@
-import type * as http from 'http';
-import type { TransformCallback, TransformOptions } from 'stream';
-import stream from 'stream';
-import zlib from 'zlib';
+import type * as http from 'node:http';
+import type { TransformCallback, TransformOptions } from 'node:stream';
+import stream from 'node:stream';
+import zlib from 'node:zlib';
 
 import type { IUpload } from '@rocket.chat/core-typings';
 import { Logger } from '@rocket.chat/logger';

--- a/apps/meteor/app/file-upload/server/config/helper.ts
+++ b/apps/meteor/app/file-upload/server/config/helper.ts
@@ -1,5 +1,5 @@
-import type http from 'http';
-import URL from 'url';
+import type http from 'node:http';
+import URL from 'node:url';
 
 export const forceDownload = (req: http.IncomingMessage): boolean => {
 	const { query } = URL.parse(req.url || '', true);

--- a/apps/meteor/app/file-upload/server/lib/FileUpload.ts
+++ b/apps/meteor/app/file-upload/server/lib/FileUpload.ts
@@ -7,7 +7,7 @@ import type * as https from 'node:https';
 import stream from 'node:stream';
 import { finished } from 'node:stream/promises';
 import URL from 'node:url';
-import { isArrayBufferView } from 'util/types';
+import { isArrayBufferView } from 'node:util/types';
 
 import { hashLoginToken } from '@rocket.chat/account-utils';
 import { Apps, AppEvents } from '@rocket.chat/apps';

--- a/apps/meteor/app/file-upload/server/lib/FileUpload.ts
+++ b/apps/meteor/app/file-upload/server/lib/FileUpload.ts
@@ -1,12 +1,12 @@
-import { Buffer } from 'buffer';
-import type { WriteStream } from 'fs';
-import fs from 'fs';
-import { unlink, rename, writeFile } from 'fs/promises';
-import type * as http from 'http';
-import type * as https from 'https';
-import stream from 'stream';
-import { finished } from 'stream/promises';
-import URL from 'url';
+import { Buffer } from 'node:buffer';
+import type { WriteStream } from 'node:fs';
+import fs from 'node:fs';
+import { unlink, rename, writeFile } from 'node:fs/promises';
+import type * as http from 'node:http';
+import type * as https from 'node:https';
+import stream from 'node:stream';
+import { finished } from 'node:stream/promises';
+import URL from 'node:url';
 import { isArrayBufferView } from 'util/types';
 
 import { hashLoginToken } from '@rocket.chat/account-utils';

--- a/apps/meteor/app/file-upload/server/lib/ranges.ts
+++ b/apps/meteor/app/file-upload/server/lib/ranges.ts
@@ -1,4 +1,4 @@
-import type http from 'http';
+import type http from 'node:http';
 
 import type { IUpload } from '@rocket.chat/core-typings';
 

--- a/apps/meteor/app/file-upload/server/lib/requests.ts
+++ b/apps/meteor/app/file-upload/server/lib/requests.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage } from 'http';
+import type { IncomingMessage } from 'node:http';
 
 import { Uploads } from '@rocket.chat/models';
 import { WebApp } from 'meteor/webapp';

--- a/apps/meteor/app/file-upload/ufs/AmazonS3/server.ts
+++ b/apps/meteor/app/file-upload/ufs/AmazonS3/server.ts
@@ -1,4 +1,4 @@
-import stream from 'stream';
+import stream from 'node:stream';
 
 import {
 	DeleteObjectCommand,

--- a/apps/meteor/app/file-upload/ufs/Webdav/server.ts
+++ b/apps/meteor/app/file-upload/ufs/Webdav/server.ts
@@ -1,4 +1,4 @@
-import stream from 'stream';
+import stream from 'node:stream';
 
 import type { IUpload } from '@rocket.chat/core-typings';
 import { Random } from '@rocket.chat/random';

--- a/apps/meteor/app/file/server/file.server.ts
+++ b/apps/meteor/app/file/server/file.server.ts
@@ -1,8 +1,8 @@
-import type { ReadStream } from 'fs';
-import fs from 'fs';
-import fsp from 'fs/promises';
-import path from 'path';
-import { Readable } from 'stream';
+import type { ReadStream } from 'node:fs';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import { Readable } from 'node:stream';
 
 import type { ObjectId } from 'bson';
 import { MongoInternals } from 'meteor/mongo';

--- a/apps/meteor/app/file/server/functions/sanitizeFileName.ts
+++ b/apps/meteor/app/file/server/functions/sanitizeFileName.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 export function sanitizeFileName(fileName: string) {
 	const base = path.basename(fileName);

--- a/apps/meteor/app/importer-pending-files/server/PendingFileImporter.ts
+++ b/apps/meteor/app/importer-pending-files/server/PendingFileImporter.ts
@@ -1,5 +1,5 @@
-import http from 'http';
-import https from 'https';
+import http from 'node:http';
+import https from 'node:https';
 
 import { api } from '@rocket.chat/core-services';
 import type { IImport, MessageAttachment, IUpload, IImporterShortSelection } from '@rocket.chat/core-typings';

--- a/apps/meteor/app/importer-slack-users/server/SlackUsersImporter.ts
+++ b/apps/meteor/app/importer-slack-users/server/SlackUsersImporter.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 
 import type { IImport, IImportUser } from '@rocket.chat/core-typings';
 import { Settings } from '@rocket.chat/models';

--- a/apps/meteor/app/importer/server/methods/downloadPublicImportFile.ts
+++ b/apps/meteor/app/importer/server/methods/downloadPublicImportFile.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import http from 'http';
-import https from 'https';
+import fs from 'node:fs';
+import http from 'node:http';
+import https from 'node:https';
 
 import { Import } from '@rocket.chat/core-services';
 import type { IUser } from '@rocket.chat/core-typings';

--- a/apps/meteor/app/importer/server/methods/getImportFileData.ts
+++ b/apps/meteor/app/importer/server/methods/getImportFileData.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import type { IImportProgress, IImporterSelection } from '@rocket.chat/core-typings';
 import type { ServerMethods } from '@rocket.chat/ddp-client';

--- a/apps/meteor/app/integrations/server/lib/isolated-vm/buildSandbox.ts
+++ b/apps/meteor/app/integrations/server/lib/isolated-vm/buildSandbox.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 import { serverFetch as fetch, Response } from '@rocket.chat/server-fetch';
 import ivm, { type Context } from 'isolated-vm';

--- a/apps/meteor/app/irc/server/servers/RFC2813/index.js
+++ b/apps/meteor/app/irc/server/servers/RFC2813/index.js
@@ -1,6 +1,6 @@
-import { EventEmitter } from 'events';
-import net from 'net';
-import util from 'util';
+import { EventEmitter } from 'node:events';
+import net from 'node:net';
+import util from 'node:util';
 
 import { Logger } from '@rocket.chat/logger';
 

--- a/apps/meteor/app/lib/server/functions/saveUser/setPasswordUpdater.ts
+++ b/apps/meteor/app/lib/server/functions/saveUser/setPasswordUpdater.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import type { IUser } from '@rocket.chat/core-typings';
 import type { Updater } from '@rocket.chat/model-typings';

--- a/apps/meteor/app/lib/server/lib/validateEmailDomain.js
+++ b/apps/meteor/app/lib/server/lib/validateEmailDomain.js
@@ -1,5 +1,5 @@
-import dns from 'dns';
-import util from 'util';
+import dns from 'node:dns';
+import util from 'node:util';
 
 import { validateEmail } from '@rocket.chat/tools';
 import { Meteor } from 'meteor/meteor';

--- a/apps/meteor/app/lib/server/oauth/facebook.js
+++ b/apps/meteor/app/lib/server/oauth/facebook.js
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import { serverFetch as fetch } from '@rocket.chat/server-fetch';
 import { Match, check } from 'meteor/check';

--- a/apps/meteor/app/livechat/server/lib/messages.ts
+++ b/apps/meteor/app/livechat/server/lib/messages.ts
@@ -1,5 +1,5 @@
-import dns from 'dns';
-import * as util from 'util';
+import dns from 'node:dns';
+import * as util from 'node:util';
 
 import type { ILivechatVisitor, AtLeast, IMessage, IUser, IOmnichannelRoomInfo, SelectedAgent } from '@rocket.chat/core-typings';
 import { LivechatDepartment, Messages } from '@rocket.chat/models';

--- a/apps/meteor/app/livechat/server/livechat.ts
+++ b/apps/meteor/app/livechat/server/livechat.ts
@@ -1,4 +1,4 @@
-import url from 'url';
+import url from 'node:url';
 
 import jsdom from 'jsdom';
 import mem from 'mem';

--- a/apps/meteor/app/meteor-accounts-saml/server/lib/SAML.ts
+++ b/apps/meteor/app/meteor-accounts-saml/server/lib/SAML.ts
@@ -1,4 +1,4 @@
-import type { ServerResponse } from 'http';
+import type { ServerResponse } from 'node:http';
 
 import type { IUser, IIncomingMessage, IPersonalAccessToken, IRole } from '@rocket.chat/core-typings';
 import { CredentialTokens, Rooms, Users, Roles } from '@rocket.chat/models';

--- a/apps/meteor/app/meteor-accounts-saml/server/lib/ServiceProvider.ts
+++ b/apps/meteor/app/meteor-accounts-saml/server/lib/ServiceProvider.ts
@@ -1,7 +1,7 @@
-import crypto from 'crypto';
-import querystring from 'querystring';
-import util from 'util';
-import zlib from 'zlib';
+import crypto from 'node:crypto';
+import querystring from 'node:querystring';
+import util from 'node:util';
+import zlib from 'node:zlib';
 
 import { Meteor } from 'meteor/meteor';
 

--- a/apps/meteor/app/meteor-accounts-saml/server/lib/Utils.ts
+++ b/apps/meteor/app/meteor-accounts-saml/server/lib/Utils.ts
@@ -1,5 +1,5 @@
-import { EventEmitter } from 'events';
-import zlib from 'zlib';
+import { EventEmitter } from 'node:events';
+import zlib from 'node:zlib';
 
 import type { Logger } from '@rocket.chat/logger';
 

--- a/apps/meteor/app/meteor-accounts-saml/server/lib/signature/validateRedirectSignature.ts
+++ b/apps/meteor/app/meteor-accounts-saml/server/lib/signature/validateRedirectSignature.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import type { SAMLRedirectEnvelope } from '../../definition/SAMLEnvelope';
 import { SAMLUtils } from '../Utils';

--- a/apps/meteor/app/meteor-accounts-saml/server/listener.ts
+++ b/apps/meteor/app/meteor-accounts-saml/server/listener.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage, ServerResponse } from 'http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import bodyParser from 'body-parser';
 import express from 'express';

--- a/apps/meteor/app/metrics/server/lib/collectMetrics.ts
+++ b/apps/meteor/app/metrics/server/lib/collectMetrics.ts
@@ -1,4 +1,4 @@
-import http from 'http';
+import http from 'node:http';
 
 import { Statistics } from '@rocket.chat/models';
 import { tracerSpan } from '@rocket.chat/tracing';

--- a/apps/meteor/app/slackbridge/server/RocketAdapter.ts
+++ b/apps/meteor/app/slackbridge/server/RocketAdapter.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
-import util from 'util';
+import util from 'node:util';
 
 import { Messages, Rooms, Users } from '@rocket.chat/models';
 import { Random } from '@rocket.chat/random';

--- a/apps/meteor/app/slackbridge/server/SlackAdapter.ts
+++ b/apps/meteor/app/slackbridge/server/SlackAdapter.ts
@@ -4,9 +4,9 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
-import http from 'http';
-import https from 'https';
-import url from 'url';
+import http from 'node:http';
+import https from 'node:https';
+import url from 'node:url';
 
 import { Message } from '@rocket.chat/core-services';
 import { Messages, Rooms, Users } from '@rocket.chat/models';

--- a/apps/meteor/app/statistics/server/lib/statistics.ts
+++ b/apps/meteor/app/statistics/server/lib/statistics.ts
@@ -1,5 +1,5 @@
 import { log } from 'console';
-import os from 'os';
+import os from 'node:os';
 
 import { Analytics, Team, VideoConf, Presence } from '@rocket.chat/core-services';
 import type { IRoom, IStats, ISetting } from '@rocket.chat/core-typings';

--- a/apps/meteor/app/theme/server/server.ts
+++ b/apps/meteor/app/theme/server/server.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import { Settings } from '@rocket.chat/models';
 import { Meteor } from 'meteor/meteor';

--- a/apps/meteor/app/ui-master/server/inject.ts
+++ b/apps/meteor/app/ui-master/server/inject.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import type { NextHandleFunction } from 'connect';
 import { Inject } from 'meteor/meteorhacks:inject-initial';

--- a/apps/meteor/app/utils/server/functions/isDocker.ts
+++ b/apps/meteor/app/utils/server/functions/isDocker.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 
 function hasDockerEnv(): boolean {
 	try {

--- a/apps/meteor/app/version-check/server/functions/getNewUpdates.ts
+++ b/apps/meteor/app/version-check/server/functions/getNewUpdates.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 
 import { Settings } from '@rocket.chat/models';
 import { serverFetch as fetch } from '@rocket.chat/server-fetch';

--- a/apps/meteor/app/webdav/server/lib/webdavClientAdapter.ts
+++ b/apps/meteor/app/webdav/server/lib/webdavClientAdapter.ts
@@ -1,5 +1,5 @@
-import stream from 'stream';
-import type { Readable, Writable } from 'stream';
+import stream from 'node:stream';
+import type { Readable, Writable } from 'node:stream';
 
 import type { WebDAVClient, FileStat, ResponseDataDetailed, WebDAVClientOptions } from 'webdav';
 import { createClient } from 'webdav';

--- a/apps/meteor/ee/server/apps/orchestrator.js
+++ b/apps/meteor/ee/server/apps/orchestrator.js
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 import { registerOrchestrator } from '@rocket.chat/apps';
 import { AppManager } from '@rocket.chat/apps/dist/server/AppManager';

--- a/apps/meteor/ee/server/apps/storage/AppFileSystemSourceStorage.ts
+++ b/apps/meteor/ee/server/apps/storage/AppFileSystemSourceStorage.ts
@@ -1,5 +1,5 @@
-import { promises as fs } from 'fs';
-import { join, normalize } from 'path';
+import { promises as fs } from 'node:fs';
+import { join, normalize } from 'node:path';
 
 import { AppSourceStorage } from '@rocket.chat/apps/dist/server/storage/AppSourceStorage';
 import type { IAppStorageItem } from '@rocket.chat/apps/dist/server/storage/IAppStorageItem';

--- a/apps/meteor/ee/server/local-services/instance/service.ts
+++ b/apps/meteor/ee/server/local-services/instance/service.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 
 import type { AppStatusReport } from '@rocket.chat/core-services';
 import { Apps, License, ServiceClassInternal, Settings } from '@rocket.chat/core-services';

--- a/apps/meteor/server/configuration/configureBoilerplate.ts
+++ b/apps/meteor/server/configuration/configureBoilerplate.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 
 import { Meteor } from 'meteor/meteor';
 import { WebApp, WebAppInternals } from 'meteor/webapp';

--- a/apps/meteor/server/email/IMAPInterceptor.ts
+++ b/apps/meteor/server/email/IMAPInterceptor.ts
@@ -1,5 +1,5 @@
-import { EventEmitter } from 'events';
-import { Readable } from 'stream';
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
 
 import { EmailInbox } from '@rocket.chat/models';
 import type { ImapMessage, ImapMessageBodyInfo } from 'imap';

--- a/apps/meteor/server/lib/cas/middleware.ts
+++ b/apps/meteor/server/lib/cas/middleware.ts
@@ -1,5 +1,5 @@
-import type { IncomingMessage, ServerResponse } from 'http';
-import url from 'url';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import url from 'node:url';
 
 import { validate } from '@rocket.chat/cas-validate';
 import type { ICredentialToken, RequiredField } from '@rocket.chat/core-typings';

--- a/apps/meteor/server/lib/dataExport/exportRoomMessagesToFile.ts
+++ b/apps/meteor/server/lib/dataExport/exportRoomMessagesToFile.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 
 import type { IMessage, IRoom, IUser, MessageAttachment, FileProp, RoomType, IExportOperation } from '@rocket.chat/core-typings';
 import { Messages } from '@rocket.chat/models';

--- a/apps/meteor/server/lib/dataExport/makeZipFile.ts
+++ b/apps/meteor/server/lib/dataExport/makeZipFile.ts
@@ -1,4 +1,4 @@
-import { createWriteStream } from 'fs';
+import { createWriteStream } from 'node:fs';
 
 import archiver from 'archiver';
 

--- a/apps/meteor/server/lib/dataExport/processDataDownloads.spec.ts
+++ b/apps/meteor/server/lib/dataExport/processDataDownloads.spec.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 
 import type { IExportOperation } from '@rocket.chat/core-typings';
 import { expect } from 'chai';

--- a/apps/meteor/server/lib/dataExport/processDataDownloads.ts
+++ b/apps/meteor/server/lib/dataExport/processDataDownloads.ts
@@ -1,6 +1,6 @@
-import { randomUUID } from 'crypto';
-import { createWriteStream } from 'fs';
-import { access, mkdir, rm, writeFile } from 'fs/promises';
+import { randomUUID } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { access, mkdir, rm, writeFile } from 'node:fs/promises';
 
 import type { IExportOperation, IUser, RoomType } from '@rocket.chat/core-typings';
 import { Avatars, ExportOperations, UserDataFiles, Subscriptions } from '@rocket.chat/models';

--- a/apps/meteor/server/lib/dataExport/processDataDownloads.ts
+++ b/apps/meteor/server/lib/dataExport/processDataDownloads.ts
@@ -1,10 +1,10 @@
+import { randomUUID } from 'crypto';
 import { createWriteStream } from 'fs';
 import { access, mkdir, rm, writeFile } from 'fs/promises';
 
 import type { IExportOperation, IUser, RoomType } from '@rocket.chat/core-typings';
 import { Avatars, ExportOperations, UserDataFiles, Subscriptions } from '@rocket.chat/models';
 import moment from 'moment';
-import { v4 as uuidv4 } from 'uuid';
 
 import { FileUpload } from '../../../app/file-upload/server';
 import { settings } from '../../../app/settings/server';
@@ -200,7 +200,7 @@ const continueExportOperation = async function (exportOperation: IExportOperatio
 			}
 		}
 
-		const generatedFileName = uuidv4();
+		const generatedFileName = randomUUID();
 		const zipFolder = settings.get<string>('UserData_FileSystemZipPath')?.trim() || '/tmp/zipFiles';
 
 		if (exportOperation.status === 'downloading') {

--- a/apps/meteor/server/lib/dataExport/sendFile.ts
+++ b/apps/meteor/server/lib/dataExport/sendFile.ts
@@ -1,6 +1,6 @@
-import { mkdir, mkdtemp } from 'fs/promises';
-import { tmpdir } from 'os';
-import path, { join } from 'path';
+import { mkdir, mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path, { join } from 'node:path';
 
 import type { IUser } from '@rocket.chat/core-typings';
 

--- a/apps/meteor/server/lib/dataExport/uploadZipFile.ts
+++ b/apps/meteor/server/lib/dataExport/uploadZipFile.ts
@@ -1,5 +1,5 @@
-import { createReadStream } from 'fs';
-import { stat } from 'fs/promises';
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
 
 import type { IUser } from '@rocket.chat/core-typings';
 import { Users } from '@rocket.chat/models';

--- a/apps/meteor/server/lib/fileUtils.ts
+++ b/apps/meteor/server/lib/fileUtils.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import filenamify from 'filenamify';
 

--- a/apps/meteor/server/methods/requestDataDownload.ts
+++ b/apps/meteor/server/methods/requestDataDownload.ts
@@ -1,6 +1,6 @@
-import { mkdtemp } from 'fs/promises';
-import { tmpdir } from 'os';
-import path, { join } from 'path';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path, { join } from 'node:path';
 
 import type { IExportOperation, IUser } from '@rocket.chat/core-typings';
 import type { ServerMethods } from '@rocket.chat/ddp-client';

--- a/apps/meteor/server/routes/avatar/middlewares/auth.ts
+++ b/apps/meteor/server/routes/avatar/middlewares/auth.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage, ServerResponse } from 'http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import type { IIncomingMessage } from '@rocket.chat/core-typings';
 import type { NextFunction } from 'connect';

--- a/apps/meteor/server/routes/avatar/middlewares/browserVersion.ts
+++ b/apps/meteor/server/routes/avatar/middlewares/browserVersion.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage, ServerResponse } from 'http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import type { IIncomingMessage } from '@rocket.chat/core-typings';
 import type { NextFunction } from 'connect';

--- a/apps/meteor/server/routes/avatar/room.ts
+++ b/apps/meteor/server/routes/avatar/room.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage, ServerResponse } from 'http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import type { IIncomingMessage, IRoom, IUpload } from '@rocket.chat/core-typings';
 import { Avatars, Rooms } from '@rocket.chat/models';

--- a/apps/meteor/server/routes/avatar/user.ts
+++ b/apps/meteor/server/routes/avatar/user.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage, ServerResponse } from 'http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import type { IUser } from '@rocket.chat/apps-engine/definition/users';
 import type { IIncomingMessage } from '@rocket.chat/core-typings';

--- a/apps/meteor/server/routes/avatar/utils.ts
+++ b/apps/meteor/server/routes/avatar/utils.ts
@@ -1,4 +1,4 @@
-import type { ServerResponse } from 'http';
+import type { ServerResponse } from 'node:http';
 
 import { hashLoginToken } from '@rocket.chat/account-utils';
 import type { IIncomingMessage, IUpload } from '@rocket.chat/core-typings';

--- a/apps/meteor/server/routes/i18n.ts
+++ b/apps/meteor/server/routes/i18n.ts
@@ -1,4 +1,4 @@
-import type { ServerResponse } from 'http';
+import type { ServerResponse } from 'node:http';
 
 import type { IncomingMessage } from 'connect';
 import { WebApp } from 'meteor/webapp';

--- a/apps/meteor/server/routes/userDataDownload.ts
+++ b/apps/meteor/server/routes/userDataDownload.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage, ServerResponse } from 'http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import { hashLoginToken } from '@rocket.chat/account-utils';
 import type { IIncomingMessage, IUser, IUserDataFile } from '@rocket.chat/core-typings';

--- a/apps/meteor/server/services/authorization/service.ts
+++ b/apps/meteor/server/services/authorization/service.ts
@@ -169,7 +169,7 @@ export class Authorization extends ServiceClass implements IAuthorization {
 					{ projection: { roles: 1 } },
 				))) ||
 			{};
-		return [...userRoles, ...subscriptionsRoles].sort((a, b) => a.localeCompare(b));
+		return [...userRoles, ...subscriptionsRoles].toSorted((a, b) => a.localeCompare(b));
 	}
 
 	private async atLeastOne(user: string | IUser, permissions: string[] = [], scope?: string): Promise<boolean> {

--- a/apps/meteor/server/services/authorization/service.ts
+++ b/apps/meteor/server/services/authorization/service.ts
@@ -169,7 +169,7 @@ export class Authorization extends ServiceClass implements IAuthorization {
 					{ projection: { roles: 1 } },
 				))) ||
 			{};
-		return [...userRoles, ...subscriptionsRoles].toSorted((a, b) => a.localeCompare(b));
+		return [...userRoles, ...subscriptionsRoles].sort((a, b) => a.localeCompare(b));
 	}
 
 	private async atLeastOne(user: string | IUser, permissions: string[] = [], scope?: string): Promise<boolean> {

--- a/apps/meteor/server/services/banner/service.ts
+++ b/apps/meteor/server/services/banner/service.ts
@@ -1,8 +1,9 @@
+import { randomUUID } from 'crypto';
+
 import { api, ServiceClassInternal } from '@rocket.chat/core-services';
 import type { IBannerService } from '@rocket.chat/core-services';
 import type { BannerPlatform, IBanner, IBannerDismiss, Optional, IUser } from '@rocket.chat/core-typings';
 import { Banners, BannersDismiss, Users } from '@rocket.chat/models';
-import { v4 as uuidv4 } from 'uuid';
 
 export class BannerService extends ServiceClassInternal implements IBannerService {
 	protected name = 'banner';
@@ -27,7 +28,7 @@ export class BannerService extends ServiceClassInternal implements IBannerServic
 	}
 
 	async create(doc: Optional<IBanner, '_id' | '_updatedAt'>): Promise<IBanner> {
-		const bannerId = doc._id || uuidv4();
+		const bannerId = doc._id || randomUUID();
 
 		doc.view.appId = doc.view.appId ?? 'banner-core';
 		doc.view.viewId = bannerId;

--- a/apps/meteor/server/services/banner/service.ts
+++ b/apps/meteor/server/services/banner/service.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 import { api, ServiceClassInternal } from '@rocket.chat/core-services';
 import type { IBannerService } from '@rocket.chat/core-services';

--- a/apps/meteor/server/services/federation/Settings.ts
+++ b/apps/meteor/server/services/federation/Settings.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import { settings, settingsRegistry } from '../../../app/settings/server';
 

--- a/apps/meteor/server/services/federation/Settings.ts
+++ b/apps/meteor/server/services/federation/Settings.ts
@@ -1,7 +1,5 @@
 import crypto from 'crypto';
 
-import { v4 as uuidv4 } from 'uuid';
-
 import { settings, settingsRegistry } from '../../../app/settings/server';
 
 export const addMatrixBridgeFederationSettings = async (): Promise<void> => {
@@ -36,7 +34,7 @@ export const addMatrixBridgeFederationSettings = async (): Promise<void> => {
 		section: 'Matrix Bridge',
 	});
 
-	const uniqueId = settings.get('uniqueID') || uuidv4().slice(0, 15).replace(new RegExp('-', 'g'), '_');
+	const uniqueId = settings.get('uniqueID') || crypto.randomUUID().slice(0, 15).replaceAll('-', '_');
 	const homeserverToken = crypto.createHash('sha256').update(`hs_${uniqueId}`).digest('hex');
 	const applicationServiceToken = crypto.createHash('sha256').update(`as_${uniqueId}`).digest('hex');
 

--- a/apps/meteor/server/services/image/service.ts
+++ b/apps/meteor/server/services/image/service.ts
@@ -1,5 +1,5 @@
-import type { Readable } from 'stream';
-import stream from 'stream';
+import type { Readable } from 'node:stream';
+import stream from 'node:stream';
 
 import { ServiceClassInternal } from '@rocket.chat/core-services';
 import type { IMediaService, ResizeResult } from '@rocket.chat/core-services';

--- a/apps/meteor/server/services/messages/hooks/BeforeSaveJumpToMessage.ts
+++ b/apps/meteor/server/services/messages/hooks/BeforeSaveJumpToMessage.ts
@@ -1,5 +1,5 @@
-import QueryString from 'querystring';
-import URL from 'url';
+import QueryString from 'node:querystring';
+import URL from 'node:url';
 
 import type { MessageAttachment, IMessage, IUser, IOmnichannelRoom, IRoom } from '@rocket.chat/core-typings';
 import { isOmnichannelRoom, isQuoteAttachment } from '@rocket.chat/core-typings';

--- a/apps/meteor/server/services/nps/service.ts
+++ b/apps/meteor/server/services/nps/service.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 
 import type { INPSService, NPSVotePayload, NPSCreatePayload } from '@rocket.chat/core-services';
 import { ServiceClassInternal, Banner, NPS, Settings } from '@rocket.chat/core-services';

--- a/apps/meteor/server/services/upload/service.ts
+++ b/apps/meteor/server/services/upload/service.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import type Stream from 'stream';
+import fs from 'node:fs';
+import type Stream from 'node:stream';
 
 import type { IUploadDetails } from '@rocket.chat/apps-engine/definition/uploads/IUploadDetails';
 import { api, ServiceClassInternal } from '@rocket.chat/core-services';

--- a/apps/meteor/server/settings/misc.ts
+++ b/apps/meteor/server/settings/misc.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import { Logger } from '@rocket.chat/logger';
 import { Settings } from '@rocket.chat/models';

--- a/apps/meteor/server/startup/serverRunning.ts
+++ b/apps/meteor/server/startup/serverRunning.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 // import { Users } from '@rocket.chat/models';
 import { Meteor } from 'meteor/meteor';

--- a/apps/meteor/server/ufs/ufs-local.spec.ts
+++ b/apps/meteor/server/ufs/ufs-local.spec.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 
 import { expect } from 'chai';
 import { before, beforeEach, afterEach, describe, it } from 'mocha';

--- a/apps/meteor/server/ufs/ufs-local.ts
+++ b/apps/meteor/server/ufs/ufs-local.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import { unlink } from 'fs/promises';
+import fs from 'node:fs';
+import { unlink } from 'node:fs/promises';
 import { isNativeError } from 'util/types';
 
 import type { IUpload } from '@rocket.chat/core-typings';

--- a/apps/meteor/server/ufs/ufs-local.ts
+++ b/apps/meteor/server/ufs/ufs-local.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { unlink } from 'node:fs/promises';
-import { isNativeError } from 'util/types';
+import { isNativeError } from 'node:util/types';
 
 import type { IUpload } from '@rocket.chat/core-typings';
 import mkdirp from 'mkdirp';

--- a/apps/meteor/server/ufs/ufs-methods.ts
+++ b/apps/meteor/server/ufs/ufs-methods.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 
 import type { IUpload } from '@rocket.chat/core-typings';
 import { check } from 'meteor/check';

--- a/apps/meteor/server/ufs/ufs-server.ts
+++ b/apps/meteor/server/ufs/ufs-server.ts
@@ -1,8 +1,8 @@
 import domain from 'domain';
-import fs from 'fs';
-import stream from 'stream';
-import URL from 'url';
-import zlib from 'zlib';
+import fs from 'node:fs';
+import stream from 'node:stream';
+import URL from 'node:url';
+import zlib from 'node:zlib';
 
 import { Meteor } from 'meteor/meteor';
 import { WebApp } from 'meteor/webapp';

--- a/apps/meteor/server/ufs/ufs-server.ts
+++ b/apps/meteor/server/ufs/ufs-server.ts
@@ -1,6 +1,6 @@
-import domain from 'domain';
 import fs from 'node:fs';
 import stream from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import URL from 'node:url';
 import zlib from 'node:zlib';
 
@@ -31,14 +31,6 @@ Meteor.startup(() => {
 			});
 		}
 	});
-});
-
-// Create domain to handle errors
-// and possibly avoid server crashes.
-const d = domain.create();
-
-d.on('error', (err) => {
-	console.error(`ufs: ${err.message}`);
 });
 
 // Listen HTTP requests to serve files
@@ -132,7 +124,7 @@ WebApp.connectHandlers.use(async (req, res, next) => {
 			return;
 		}
 
-		await d.run(async () => {
+		try {
 			// Check if the file can be accessed
 			if ((await store.onRead.call(store, fileId, file, req, res)) !== false) {
 				const options: {
@@ -267,7 +259,7 @@ WebApp.connectHandlers.use(async (req, res, next) => {
 							headers['Content-Encoding'] = 'gzip';
 							delete headers['Content-Length'];
 							res.writeHead(status, headers);
-							ws.pipe(zlib.createGzip()).pipe(res);
+							await pipeline(ws, zlib.createGzip(), res);
 							return;
 						}
 						// Compress with deflate
@@ -275,7 +267,7 @@ WebApp.connectHandlers.use(async (req, res, next) => {
 							headers['Content-Encoding'] = 'deflate';
 							delete headers['Content-Length'];
 							res.writeHead(status, headers);
-							ws.pipe(zlib.createDeflate()).pipe(res);
+							await pipeline(ws, zlib.createDeflate(), res);
 							return;
 						}
 					}
@@ -284,12 +276,20 @@ WebApp.connectHandlers.use(async (req, res, next) => {
 				// Send raw data
 				if (!headers['Content-Encoding']) {
 					res.writeHead(status, headers);
-					ws.pipe(res);
+					await pipeline(ws, res);
 				}
 			} else {
 				res.end();
 			}
-		});
+		} catch (err) {
+			console.error(`ufs: ${err instanceof Error ? err.message : String(err)}`);
+			if (!res.headersSent) {
+				res.writeHead(500);
+			}
+			if (!res.writableEnded) {
+				res.end();
+			}
+		}
 	} else {
 		next();
 	}

--- a/apps/meteor/server/ufs/ufs-store.ts
+++ b/apps/meteor/server/ufs/ufs-store.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import type * as http from 'http';
-import type stream from 'stream';
+import fs from 'node:fs';
+import type * as http from 'node:http';
+import type stream from 'node:stream';
 
 import type { IUpload } from '@rocket.chat/core-typings';
 import type { IBaseUploadsModel } from '@rocket.chat/model-typings';

--- a/apps/meteor/tests/unit/server/lib/dataExport/uploadZipFile.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/dataExport/uploadZipFile.spec.ts
@@ -24,10 +24,10 @@ const { uploadZipFile } = proxyquire.noCallThru().load('../../../../../server/li
 			id: stubs.randomId,
 		},
 	},
-	'fs/promises': {
+	'node:fs/promises': {
 		stat: stubs.stat,
 	},
-	'fs': {
+	'node:fs': {
 		createReadStream: stubs.createReadStream,
 	},
 	'../../../app/file-upload/server': {

--- a/ee/packages/federation-matrix/src/api/_matrix/media.ts
+++ b/ee/packages/federation-matrix/src/api/_matrix/media.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import type { IUpload } from '@rocket.chat/core-typings';
 import { federationSDK } from '@rocket.chat/federation-sdk';

--- a/ee/packages/federation-matrix/src/helpers/validateFederatedUsername.ts
+++ b/ee/packages/federation-matrix/src/helpers/validateFederatedUsername.ts
@@ -1,4 +1,4 @@
-import { isIPv4, isIPv6 } from 'net';
+import { isIPv4, isIPv6 } from 'node:net';
 
 import type { UserID } from '@rocket.chat/federation-sdk';
 

--- a/ee/packages/federation-matrix/tests/end-to-end/messaging.spec.ts
+++ b/ee/packages/federation-matrix/tests/end-to-end/messaging.spec.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import type { IMessage } from '@rocket.chat/core-typings';
 

--- a/ee/packages/federation-matrix/tests/helper/synapse-client.ts
+++ b/ee/packages/federation-matrix/tests/helper/synapse-client.ts
@@ -3,8 +3,8 @@
  * This file provides validated federation configuration for federation tests.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 import { createClient, type MatrixClient, KnownMembership, type Room, type RoomMember, Visibility } from 'matrix-js-sdk';
 import { logger } from 'matrix-js-sdk/lib/logger';

--- a/ee/packages/license/src/AirGappedRestriction.ts
+++ b/ee/packages/license/src/AirGappedRestriction.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import EventEmitter from 'node:events';
 
 import { License } from '.';
 import { decryptStatsToken } from './token';

--- a/ee/packages/license/src/token.ts
+++ b/ee/packages/license/src/token.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import type { ILicenseV3 } from '@rocket.chat/core-typings';
 import { verify, sign, getPairs } from '@rocket.chat/jwt';

--- a/ee/packages/license/src/validation/validateLicenseUrl.spec.ts
+++ b/ee/packages/license/src/validation/validateLicenseUrl.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import { validateLicenseUrl } from './validateLicenseUrl';
 import { MockedLicenseBuilder, getReadyLicenseManager } from '../../__tests__/MockedLicenseBuilder';

--- a/ee/packages/license/src/validation/validateLicenseUrl.ts
+++ b/ee/packages/license/src/validation/validateLicenseUrl.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import type { ILicenseV3, BehaviorWithContext, LicenseValidationOptions } from '@rocket.chat/core-typings';
 

--- a/ee/packages/media-calls/src/internal/SignalProcessor.ts
+++ b/ee/packages/media-calls/src/internal/SignalProcessor.ts
@@ -144,7 +144,7 @@ export class GlobalSignalProcessor {
 			return;
 		}
 
-		await Promise.all(calls.map((call) => this.reactToUnknownCall(uid, call, signal).catch(() => null)));
+		await Promise.allSettled(calls.map((call) => this.reactToUnknownCall(uid, call, signal)));
 	}
 
 	private async reactToUnknownCall(uid: IUser['_id'], call: IMediaCall, signal: ClientMediaSignalRegister): Promise<void> {

--- a/ee/packages/media-calls/src/server/CallDirector.ts
+++ b/ee/packages/media-calls/src/server/CallDirector.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 import type {
 	IMediaCall,

--- a/ee/packages/media-calls/src/sip/Session.ts
+++ b/ee/packages/media-calls/src/sip/Session.ts
@@ -1,4 +1,4 @@
-import type { Socket } from 'net';
+import type { Socket } from 'node:net';
 
 import type { IMediaCall, MediaCallContact } from '@rocket.chat/core-typings';
 import type { ClientMediaSignalBody } from '@rocket.chat/media-signaling';

--- a/ee/packages/network-broker/src/NetworkBroker.ts
+++ b/ee/packages/network-broker/src/NetworkBroker.ts
@@ -1,4 +1,4 @@
-import Stream from 'stream';
+import Stream from 'node:stream';
 
 import { asyncLocalStorage } from '@rocket.chat/core-services';
 import type { CallingOptions, IBroker, IBrokerNode, IServiceMetrics, IServiceClass, EventSignatures } from '@rocket.chat/core-services';

--- a/ee/packages/omnichannel-services/src/OmnichannelTranscript.ts
+++ b/ee/packages/omnichannel-services/src/OmnichannelTranscript.ts
@@ -466,7 +466,7 @@ export class OmnichannelTranscript extends ServiceClass implements IOmnichannelT
 					streamParam,
 					details: {
 						// transcript_{company-name}_{date}_{hour}.pdf
-						name: `${transcriptText}_${data.siteName}_${new Intl.DateTimeFormat('en-US').format(new Date()).replace(/\//g, '-')}_${
+						name: `${transcriptText}_${data.siteName}_${new Intl.DateTimeFormat('en-US').format(new Date()).replaceAll('/', '-')}_${
 							data.visitor?.name || data.visitor?.username || 'Visitor'
 						}.pdf`,
 						type: 'application/pdf',

--- a/ee/packages/omnichannel-services/src/OmnichannelTranscript.ts
+++ b/ee/packages/omnichannel-services/src/OmnichannelTranscript.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 
 import {
 	ServiceClass,

--- a/ee/packages/pdf-worker/src/templates/ChatTranscript/ChatTranscript.fixtures.ts
+++ b/ee/packages/pdf-worker/src/templates/ChatTranscript/ChatTranscript.fixtures.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'buffer';
+import { Buffer } from 'node:buffer';
 
 import type { ChatTranscriptData, PDFMessage } from '../../types/ChatTranscriptData';
 import type { WorkerData } from '../../types/WorkerData';

--- a/ee/packages/pdf-worker/src/templates/ChatTranscript/components/Files.tsx
+++ b/ee/packages/pdf-worker/src/templates/ChatTranscript/components/Files.tsx
@@ -1,4 +1,4 @@
-import { Buffer } from 'buffer';
+import { Buffer } from 'node:buffer';
 
 import { View, StyleSheet, Text, Image } from '@react-pdf/renderer';
 import colors from '@rocket.chat/fuselage-tokens/colors.json';

--- a/ee/packages/pdf-worker/src/templates/ChatTranscript/index.tsx
+++ b/ee/packages/pdf-worker/src/templates/ChatTranscript/index.tsx
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import ReactPDF, { Font, Document, Page, StyleSheet } from '@react-pdf/renderer';
 import colors from '@rocket.chat/fuselage-tokens/colors.json';

--- a/ee/packages/pdf-worker/src/worker.fixtures.ts
+++ b/ee/packages/pdf-worker/src/worker.fixtures.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'buffer';
+import { Buffer } from 'node:buffer';
 
 import type { WorkerData } from './types/WorkerData';
 

--- a/ee/packages/presence/src/Presence.ts
+++ b/ee/packages/presence/src/Presence.ts
@@ -47,7 +47,7 @@ export class Presence extends ServiceClass implements IPresence {
 			}
 
 			// always store the number of connections per instance so we can show correct in the UI
-			if (diff?.hasOwnProperty('extraInformation.conns')) {
+			if (diff && Object.hasOwn(diff, 'extraInformation.conns')) {
 				this.connsPerInstance.set(id, diff['extraInformation.conns']);
 
 				this.peakConnections = Math.max(this.peakConnections, this.getTotalConnections());

--- a/packages/account-utils/src/index.ts
+++ b/packages/account-utils/src/index.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 export function hashLoginToken(loginToken: string): string {
 	const hash = crypto.createHash('sha256');

--- a/packages/agenda/src/Agenda.ts
+++ b/packages/agenda/src/Agenda.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 import debugInitializer from 'debug';
 import humanInterval from 'human-interval';

--- a/packages/agenda/src/Agenda.ts
+++ b/packages/agenda/src/Agenda.ts
@@ -969,7 +969,7 @@ export class Agenda extends EventEmitter {
 		if (!extraJob) {
 			// Go through each jobName set in 'Agenda.process' and fill the queue with the next jobs
 			for (jobName in this._definitions) {
-				if (this._definitions.hasOwnProperty(jobName)) {
+				if (Object.hasOwn(this._definitions, jobName)) {
 					debug('queuing up job to process: [%s]', jobName);
 					void this._jobQueueFilling(jobName);
 				}

--- a/packages/apps-engine/src/definition/oauth2/IOAuth2.ts
+++ b/packages/apps-engine/src/definition/oauth2/IOAuth2.ts
@@ -1,4 +1,4 @@
-import type { URL } from 'url';
+import type { URL } from 'node:url';
 
 import type { IConfigurationExtend, IHttp, IModify, IPersistence, IRead } from '../accessors';
 import type { IUser } from '../users/IUser';

--- a/packages/apps-engine/src/definition/oauth2/OAuth2Client.ts
+++ b/packages/apps-engine/src/definition/oauth2/OAuth2Client.ts
@@ -1,4 +1,4 @@
-import { URL } from 'url';
+import { URL } from 'node:url';
 
 import type { App } from '../App';
 import type { IConfigurationExtend, IHttp, IModify, IPersistence, IRead } from '../accessors';

--- a/packages/apps/src/server/AppManager.ts
+++ b/packages/apps/src/server/AppManager.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'buffer';
+import { Buffer } from 'node:buffer';
 
 import { AppStatus, AppStatusUtils } from '@rocket.chat/apps-engine/definition/AppStatus';
 import type { IAppInfo } from '@rocket.chat/apps-engine/definition/metadata';

--- a/packages/apps/src/server/ProxiedApp.ts
+++ b/packages/apps/src/server/ProxiedApp.ts
@@ -1,4 +1,4 @@
-import { inspect } from 'util';
+import { inspect } from 'node:util';
 
 import { AppStatus } from '@rocket.chat/apps-engine/definition/AppStatus';
 import { AppsEngineException } from '@rocket.chat/apps-engine/definition/exceptions';

--- a/packages/apps/src/server/accessors/LivechatCreator.ts
+++ b/packages/apps/src/server/accessors/LivechatCreator.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'crypto';
+import { randomBytes } from 'node:crypto';
 
 import type { ILivechatCreator } from '@rocket.chat/apps-engine/definition/accessors';
 import type { IExtraRoomParams } from '@rocket.chat/apps-engine/definition/accessors/ILivechatCreator';

--- a/packages/apps/src/server/accessors/UploadCreator.ts
+++ b/packages/apps/src/server/accessors/UploadCreator.ts
@@ -12,7 +12,7 @@ export class UploadCreator implements IUploadCreator {
 	) {}
 
 	public async uploadBuffer(buffer: Buffer, descriptor: IUploadDescriptor): Promise<IUpload> {
-		if (!descriptor.hasOwnProperty('user') && !descriptor.visitorToken) {
+		if (!Object.hasOwn(descriptor, 'user') && !descriptor.visitorToken) {
 			descriptor.user = await this.bridges.getUserBridge().doGetAppUser(this.appId);
 		}
 

--- a/packages/apps/src/server/compiler/AppCompiler.ts
+++ b/packages/apps/src/server/compiler/AppCompiler.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import type { AppManager } from '../AppManager';
 import { ProxiedApp } from '../ProxiedApp';

--- a/packages/apps/src/server/compiler/AppPackageParser.ts
+++ b/packages/apps/src/server/compiler/AppPackageParser.ts
@@ -1,10 +1,10 @@
+import { randomUUID } from 'crypto';
 import * as path from 'path';
 
 import type { IAppInfo } from '@rocket.chat/apps-engine/definition/metadata/IAppInfo';
 import { ENGINE_VERSION } from '@rocket.chat/apps-engine/definition/version';
 import AdmZip from 'adm-zip';
 import * as semver from 'semver';
-import { v4 as uuidv4 } from 'uuid';
 
 import { AppImplements } from '.';
 import type { IParseAppPackageResult } from './IParseAppPackageResult';
@@ -27,7 +27,7 @@ export class AppPackageParser {
 				info = JSON.parse(infoZip.getData().toString()) as IAppInfo;
 
 				if (!AppPackageParser.uuid4Regex.test(info.id)) {
-					info.id = uuidv4();
+					info.id = randomUUID();
 					console.warn(
 						'WARNING: We automatically generated a uuid v4 id for',
 						info.name,

--- a/packages/apps/src/server/compiler/AppPackageParser.ts
+++ b/packages/apps/src/server/compiler/AppPackageParser.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from 'crypto';
-import * as path from 'path';
+import { randomUUID } from 'node:crypto';
+import * as path from 'node:path';
 
 import type { IAppInfo } from '@rocket.chat/apps-engine/definition/metadata/IAppInfo';
 import { ENGINE_VERSION } from '@rocket.chat/apps-engine/definition/version';

--- a/packages/apps/src/server/compiler/modules/networking.ts
+++ b/packages/apps/src/server/compiler/modules/networking.ts
@@ -1,6 +1,6 @@
-import type * as http from 'http';
-import type * as https from 'https';
-import type * as net from 'net';
+import type * as http from 'node:http';
+import type * as https from 'node:https';
+import type * as net from 'node:net';
 
 import { ForbiddenNativeModuleAccess } from '.';
 import { PermissionDeniedError } from '../../errors/PermissionDeniedError';

--- a/packages/apps/src/server/managers/AppSignatureManager.ts
+++ b/packages/apps/src/server/managers/AppSignatureManager.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 
 import * as jose from 'jose';
 

--- a/packages/apps/src/server/marketplace/license/Crypto.ts
+++ b/packages/apps/src/server/marketplace/license/Crypto.ts
@@ -1,4 +1,4 @@
-import { publicDecrypt } from 'crypto';
+import { publicDecrypt } from 'node:crypto';
 
 import type { IInternalBridge } from '../../bridges';
 

--- a/packages/apps/src/server/misc/UIHelper.ts
+++ b/packages/apps/src/server/misc/UIHelper.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 import type { IBlock } from '@rocket.chat/apps-engine/definition/uikit';
 import type { LayoutBlock } from '@rocket.chat/ui-kit';

--- a/packages/apps/src/server/misc/UIHelper.ts
+++ b/packages/apps/src/server/misc/UIHelper.ts
@@ -1,6 +1,7 @@
+import { randomUUID } from 'crypto';
+
 import type { IBlock } from '@rocket.chat/apps-engine/definition/uikit';
 import type { LayoutBlock } from '@rocket.chat/ui-kit';
-import { v4 as uuid } from 'uuid';
 
 export class UIHelper {
 	/**
@@ -15,12 +16,12 @@ export class UIHelper {
 				block.appId = appId;
 			}
 			if (!block.blockId) {
-				block.blockId = uuid();
+				block.blockId = randomUUID();
 			}
 			if (block.elements) {
 				block.elements.forEach((element) => {
 					if (!element.actionId) {
-						element.actionId = uuid();
+						element.actionId = randomUUID();
 					}
 				});
 			}

--- a/packages/apps/src/server/misc/Utilities.ts
+++ b/packages/apps/src/server/misc/Utilities.ts
@@ -10,7 +10,7 @@ export class Utilities {
 
 		Object.getOwnPropertyNames(item).forEach((prop: string) => {
 			if (
-				item.hasOwnProperty(prop) &&
+				Object.hasOwn(item, prop) &&
 				item[prop] !== null &&
 				(typeof item[prop] === 'object' || typeof item[prop] === 'function') &&
 				!Object.isFrozen(item[prop])

--- a/packages/apps/src/server/runtime/AppsEngineNodeRuntime.ts
+++ b/packages/apps/src/server/runtime/AppsEngineNodeRuntime.ts
@@ -1,5 +1,5 @@
-import * as timers from 'timers';
-import * as vm from 'vm';
+import * as timers from 'node:timers';
+import * as vm from 'node:vm';
 
 import type { App } from '@rocket.chat/apps-engine/definition/App';
 

--- a/packages/apps/src/server/runtime/EmptyRuntime.ts
+++ b/packages/apps/src/server/runtime/EmptyRuntime.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 import { AppStatus } from '@rocket.chat/apps-engine/definition/AppStatus';
 

--- a/packages/apps/src/server/runtime/IRuntimeController.ts
+++ b/packages/apps/src/server/runtime/IRuntimeController.ts
@@ -1,4 +1,4 @@
-import type { EventEmitter } from 'events';
+import type { EventEmitter } from 'node:events';
 
 import type { AppStatus } from '@rocket.chat/apps-engine/definition/AppStatus';
 

--- a/packages/apps/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/packages/apps/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -1,8 +1,8 @@
-import * as child_process from 'child_process';
-import * as fs from 'fs';
-import * as path from 'path';
-import { type Readable, EventEmitter } from 'stream';
-import { inspect as utilInspect } from 'util';
+import * as child_process from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { type Readable, EventEmitter } from 'node:stream';
+import { inspect as utilInspect } from 'node:util';
 
 import { AppStatus, AppStatusUtils } from '@rocket.chat/apps-engine/definition/AppStatus';
 import type { AppMethod } from '@rocket.chat/apps-engine/definition/metadata';

--- a/packages/apps/src/server/runtime/deno/LivenessManager.ts
+++ b/packages/apps/src/server/runtime/deno/LivenessManager.ts
@@ -1,5 +1,5 @@
-import type { ChildProcess } from 'child_process';
-import { EventEmitter } from 'stream';
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:stream';
 
 import type { DenoRuntimeSubprocessController } from './AppsEngineDenoRuntime';
 import type { ProcessMessenger } from './ProcessMessenger';

--- a/packages/apps/src/server/runtime/deno/ProcessMessenger.ts
+++ b/packages/apps/src/server/runtime/deno/ProcessMessenger.ts
@@ -1,4 +1,4 @@
-import type { ChildProcess } from 'child_process';
+import type { ChildProcess } from 'node:child_process';
 
 import type { JsonRpc } from 'jsonrpc-lite';
 

--- a/packages/apps/src/server/runtime/deno/bundler.ts
+++ b/packages/apps/src/server/runtime/deno/bundler.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { build, type PluginBuild, type OnLoadArgs, type OnResolveArgs } from 'esbuild';
 

--- a/packages/apps/tests/server/runtime/DenoRuntimeSubprocessController.test.ts
+++ b/packages/apps/tests/server/runtime/DenoRuntimeSubprocessController.test.ts
@@ -1,10 +1,10 @@
 /* eslint-disable dot-notation -- we avoid the dot notation here when testing private methods */
 
-import * as fs from 'fs/promises';
 import * as assert from 'node:assert';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { describe, it, afterEach, mock, before, after } from 'node:test';
-import * as os from 'os';
-import * as path from 'path';
 
 import { AppStatus } from '@rocket.chat/apps-engine/definition/AppStatus';
 import { UserStatusConnection, UserType } from '@rocket.chat/apps-engine/definition/users';

--- a/packages/apps/tests/server/runtime/SecureFieldsCodecCompatibility.test.ts
+++ b/packages/apps/tests/server/runtime/SecureFieldsCodecCompatibility.test.ts
@@ -1,8 +1,8 @@
-import * as fs from 'fs/promises';
 import * as assert from 'node:assert';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { describe, it, before, after } from 'node:test';
-import * as os from 'os';
-import * as path from 'path';
 
 import { AppStatus } from '@rocket.chat/apps-engine/definition/AppStatus';
 import { RoomType } from '@rocket.chat/apps-engine/definition/rooms';

--- a/packages/apps/tests/server/runtime/deno/LivenessManager.test.ts
+++ b/packages/apps/tests/server/runtime/deno/LivenessManager.test.ts
@@ -1,7 +1,7 @@
-import type { ChildProcess } from 'child_process';
 import * as assert from 'node:assert';
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:stream';
 import { describe, it, beforeEach, afterEach, mock, type Mock } from 'node:test';
-import { EventEmitter } from 'stream';
 
 import debugFactory from 'debug';
 

--- a/packages/apps/tests/test-data/utilities.ts
+++ b/packages/apps/tests/test-data/utilities.ts
@@ -1,4 +1,4 @@
-import * as os from 'os';
+import * as os from 'node:os';
 
 import { AppStatus } from '@rocket.chat/apps-engine/definition/AppStatus';
 import type { IHttp, IModify, IPersistence, IRead } from '@rocket.chat/apps-engine/definition/accessors';

--- a/packages/cas-validate/src/validate.ts
+++ b/packages/cas-validate/src/validate.ts
@@ -1,7 +1,7 @@
-import type { IncomingMessage } from 'http';
-import https from 'https';
-import type { ParsedUrlQueryInput } from 'querystring';
-import url from 'url';
+import type { IncomingMessage } from 'node:http';
+import https from 'node:https';
+import type { ParsedUrlQueryInput } from 'node:querystring';
+import url from 'node:url';
 
 import type { Cheerio, CheerioAPI } from 'cheerio';
 import { load } from 'cheerio';

--- a/packages/core-services/src/LocalBroker.ts
+++ b/packages/core-services/src/LocalBroker.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 import { Logger } from '@rocket.chat/logger';
 import { InstanceStatus } from '@rocket.chat/models';

--- a/packages/core-services/src/types/IMediaService.ts
+++ b/packages/core-services/src/types/IMediaService.ts
@@ -1,4 +1,4 @@
-import type { Readable, Stream } from 'stream';
+import type { Readable, Stream } from 'node:stream';
 
 import type sharp from 'sharp';
 

--- a/packages/core-services/src/types/IUploadService.ts
+++ b/packages/core-services/src/types/IUploadService.ts
@@ -1,4 +1,4 @@
-import type Stream from 'stream';
+import type Stream from 'node:stream';
 
 import type { IUploadDetails } from '@rocket.chat/apps-engine/definition/uploads/IUploadDetails';
 import type { IMessage, IUpload, IUser, FilesAndAttachments, AtLeast } from '@rocket.chat/core-typings';

--- a/packages/core-services/src/types/ServiceClass.ts
+++ b/packages/core-services/src/types/ServiceClass.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 import type { ISetting } from '@rocket.chat/core-typings';
 

--- a/packages/core-typings/src/IIncomingMessage.ts
+++ b/packages/core-typings/src/IIncomingMessage.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage } from 'http';
+import type { IncomingMessage } from 'node:http';
 
 export interface IIncomingMessage extends IncomingMessage {
 	query: Record<string, any>;

--- a/packages/core-typings/src/IMessage/IMessage.ts
+++ b/packages/core-typings/src/IMessage/IMessage.ts
@@ -1,4 +1,4 @@
-import type { UrlWithStringQuery } from 'url';
+import type { UrlWithStringQuery } from 'node:url';
 
 import type Icons from '@rocket.chat/icons';
 import type { Root } from '@rocket.chat/message-parser';

--- a/packages/core-typings/src/ISocketConnection.ts
+++ b/packages/core-typings/src/ISocketConnection.ts
@@ -1,4 +1,4 @@
-import type { IncomingHttpHeaders } from 'http';
+import type { IncomingHttpHeaders } from 'node:http';
 
 export interface ISocketConnection {
 	id: string;

--- a/packages/core-typings/src/IStats.ts
+++ b/packages/core-typings/src/IStats.ts
@@ -1,4 +1,4 @@
-import type { CpuInfo } from 'os';
+import type { CpuInfo } from 'node:os';
 
 import type { IMatrixFederationStatistics } from './IMatrixFederationStatistics';
 import type { DeviceSessionAggregationResult, OSSessionAggregationResult, UserSessionAggregationResult } from './ISession';

--- a/packages/ddp-client/__tests__/DDPSDK.spec.ts
+++ b/packages/ddp-client/__tests__/DDPSDK.spec.ts
@@ -1,4 +1,4 @@
-import util from 'util';
+import util from 'node:util';
 
 import WS from 'jest-websocket-mock';
 import { WebSocket } from 'ws';

--- a/packages/http-router/src/middlewares/honoAdapterForExpress.spec.ts
+++ b/packages/http-router/src/middlewares/honoAdapterForExpress.spec.ts
@@ -1,4 +1,4 @@
-import { Readable, PassThrough } from 'stream';
+import { Readable, PassThrough } from 'node:stream';
 
 import type { Request, Response as ExpressResponse } from 'express';
 import type { Hono } from 'hono';

--- a/packages/http-router/src/middlewares/honoAdapterForExpress.ts
+++ b/packages/http-router/src/middlewares/honoAdapterForExpress.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 
 import type { Request, Response } from 'express';
 import type { Hono } from 'hono';

--- a/packages/instance-status/src/index.ts
+++ b/packages/instance-status/src/index.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 
 import type { IInstanceStatus } from '@rocket.chat/core-typings';
 import { InstanceStatus as InstanceStatusModel } from '@rocket.chat/models';

--- a/packages/instance-status/src/index.ts
+++ b/packages/instance-status/src/index.ts
@@ -1,11 +1,12 @@
+import { randomUUID } from 'crypto';
+
 import type { IInstanceStatus } from '@rocket.chat/core-typings';
 import { InstanceStatus as InstanceStatusModel } from '@rocket.chat/models';
-import { v4 as uuidv4 } from 'uuid';
 
 export const defaultPingInterval = parseInt(String(process.env.MULTIPLE_INSTANCES_PING_INTERVAL)) || 10;
 export const indexExpire = (parseInt(String(process.env.MULTIPLE_INSTANCES_EXPIRE)) || Math.ceil((defaultPingInterval * 3) / 60)) * 60;
 
-const ID = uuidv4();
+const ID = randomUUID();
 const id = (): IInstanceStatus['_id'] => ID;
 
 const currentInstance = {

--- a/packages/livechat/webpack.config.ts
+++ b/packages/livechat/webpack.config.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';

--- a/packages/models/src/models/EmojiCustom.ts
+++ b/packages/models/src/models/EmojiCustom.ts
@@ -18,7 +18,7 @@ export class EmojiCustomRaw extends BaseRaw<IEmojiCustom> implements IEmojiCusto
 		let name = emojiName;
 
 		if (typeof emojiName === 'string') {
-			name = emojiName.replace(/:/g, '');
+			name = emojiName.replaceAll(':', '');
 		}
 
 		const query = {

--- a/packages/random/src/NodeRandomGenerator.ts
+++ b/packages/random/src/NodeRandomGenerator.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import { AleaRandomGenerator } from './AleaRandomGenerator';
 import { RandomGenerator } from './RandomGenerator';

--- a/packages/release-action/src/bumpNextVersion.ts
+++ b/packages/release-action/src/bumpNextVersion.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import * as core from '@actions/core';
 import { exec } from '@actions/exec';

--- a/packages/release-action/src/createNpmFile.ts
+++ b/packages/release-action/src/createNpmFile.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import fsPromise from 'fs/promises';
+import fs from 'node:fs';
+import fsPromise from 'node:fs/promises';
 
 import * as core from '@actions/core';
 

--- a/packages/release-action/src/getMetadata.ts
+++ b/packages/release-action/src/getMetadata.ts
@@ -1,6 +1,6 @@
-import { readFile } from 'fs/promises';
-import { EOL } from 'os';
-import path from 'path';
+import { readFile } from 'node:fs/promises';
+import { EOL } from 'node:os';
+import path from 'node:path';
 
 import { readPackageJson } from './utils';
 

--- a/packages/release-action/src/index.ts
+++ b/packages/release-action/src/index.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import * as core from '@actions/core';
 

--- a/packages/release-action/src/publishRelease.ts
+++ b/packages/release-action/src/publishRelease.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import * as core from '@actions/core';
 import { exec } from '@actions/exec';

--- a/packages/release-action/src/updatePRDescription.ts
+++ b/packages/release-action/src/updatePRDescription.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import * as core from '@actions/core';
 import { exec } from '@actions/exec';

--- a/packages/release-action/src/utils.ts
+++ b/packages/release-action/src/utils.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import { readFile, writeFile } from 'fs/promises';
-import path from 'path';
+import fs from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
 
 import mdastToString from 'mdast-util-to-string';
 import remarkParse from 'remark-parse';

--- a/packages/server-fetch/src/helpers.ts
+++ b/packages/server-fetch/src/helpers.ts
@@ -1,5 +1,5 @@
-import { lookup } from 'dns';
-import net from 'net';
+import { lookup } from 'node:dns';
+import net from 'node:net';
 
 import { domainPattern, ipv4Ranges, ipv4WithPortPattern, ipv6Ranges } from './constants';
 

--- a/packages/server-fetch/src/index.ts
+++ b/packages/server-fetch/src/index.ts
@@ -1,5 +1,5 @@
-import http from 'http';
-import https from 'https';
+import http from 'node:http';
+import https from 'node:https';
 
 import { Logger } from '@rocket.chat/logger';
 import { censorUrl } from '@rocket.chat/tools';

--- a/packages/storybook-config/src/main.ts
+++ b/packages/storybook-config/src/main.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from 'path';
+import { dirname, join } from 'node:path';
 
 import type { StorybookConfig } from '@storybook/react-webpack5';
 

--- a/packages/tools/src/getHeader.spec.ts
+++ b/packages/tools/src/getHeader.spec.ts
@@ -1,4 +1,4 @@
-import type { IncomingHttpHeaders } from 'http';
+import type { IncomingHttpHeaders } from 'node:http';
 
 import { getHeader } from './getHeader';
 

--- a/packages/tools/src/getHeader.ts
+++ b/packages/tools/src/getHeader.ts
@@ -1,4 +1,4 @@
-import type { IncomingHttpHeaders } from 'http';
+import type { IncomingHttpHeaders } from 'node:http';
 
 type HeaderLike = IncomingHttpHeaders | Headers | Record<string, string | string[] | undefined>;
 

--- a/packages/tools/src/stream.ts
+++ b/packages/tools/src/stream.ts
@@ -1,4 +1,4 @@
-import type { Readable } from 'stream';
+import type { Readable } from 'node:stream';
 
 export const streamToBuffer = (stream: Readable): Promise<Buffer> =>
 	new Promise((resolve, reject) => {

--- a/packages/tsconfig/server.json
+++ b/packages/tsconfig/server.json
@@ -3,7 +3,7 @@
 	"extends": "./base.json",
 	"compilerOptions": {
 		"target": "es2020",
-		"lib": ["es2020"],
+		"lib": ["es2023"],
 		"module": "commonjs",
 		"sourceMap": true,
 	},


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
⏺ Adopt Node 22 / modern ES built-ins across server code


  1. Bump shared server lib to es2023

  The shared @rocket.chat/tsconfig/server.json was pinned to lib: ["es2020"], even though every server package runs on Node 22. That mismatch hid ES2022/2023 APIs from
  TypeScript and forced older idioms. Bumping only lib (target stays at es2020 to preserve class-field semantics) is a strict superset — no emitted JS changes — and is
  the prerequisite for the rest of the commits.

  2. Object.hasOwn over hasOwnProperty

  ES2022's Object.hasOwn(obj, key) is the standardized replacement for obj.hasOwnProperty(key). It avoids the prototype-pollution / shadowing footgun and works on
  null-prototype objects (Object.create(null)) without the ugly Object.prototype.hasOwnProperty.call(...) workaround. Mechanical swap, identical semantics.

  3. Promise.allSettled + String.replaceAll

  - One Promise.all(...).catch(() => null) site that emulated allSettled is rewritten to use it directly — intent made explicit, behavior unchanged.
  - Two .replace(/literal/g, ...) calls with no regex features become .replaceAll('literal', ...) (ES2021), removing the need to scan the regex for metacharacters.

  4. crypto.randomUUID() over uuid.v4()

  Six call sites used the uuid package solely to mint a random v4 UUID. Node has provided crypto.randomUUID() since 14.17 with identical RFC 4122 output and a more
  specific return type. The federation Settings.ts site also collapses an old replace(new RegExp('-', 'g'), '_') into .replaceAll('-', '_').

  5. node: prefix on built-in imports

  Sweep across 151 server-side files: from 'fs' → from 'node:fs', etc. Two motivations:
  - Disambiguation / supply-chain hygiene. The bare specifier 'fs' is first looked up as a userland module before falling back to the built-in; the node: prefix
  short-circuits resolution and refuses to find an imposter.
  - Forward compatibility. New built-ins like node:test and node:sqlite are only importable via the prefix; adopting it keeps the import style consistent.
  
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... --> 

 Task: [CORE-2204]

[CORE-2204]: https://rocketchat.atlassian.net/browse/CORE-2204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ