### PR TITLE
chore(deps): upgrade node from 22.22.2 to 22.22.3

### DIFF
--- a/.github/workflows/update-version-durability.yml
+++ b/.github/workflows/update-version-durability.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22.22.2
+          node-version: 22.22.3
 
       - name: Install dependencies
         run: |

--- a/apps/meteor/.docker/Dockerfile.alpine
+++ b/apps/meteor/.docker/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM node:22.22.2-alpine3.23 AS builder
+FROM node:22.22.3-alpine3.23 AS builder
 
 ENV LANG=C.UTF-8
 
@@ -20,7 +20,7 @@ RUN cd /app/bundle/programs/server \
     && find /app/bundle/programs/server/npm/node_modules -type f -name '*.map' -delete \
     && find /app/bundle/programs/web.browser -type f -name '*.map' -delete
 
-FROM node:22.22.2-alpine3.23
+FROM node:22.22.3-alpine3.23
 
 LABEL maintainer="buildmaster@rocket.chat"
 

--- a/apps/meteor/.docker/Dockerfile.debian
+++ b/apps/meteor/.docker/Dockerfile.debian
@@ -2,7 +2,7 @@ ARG DENO_VERSION="1.37.1"
 
 FROM denoland/deno:bin-${DENO_VERSION} as deno
 
-FROM node:22.22.2-bullseye-slim
+FROM node:22.22.3-bullseye-slim
 
 LABEL maintainer="buildmaster@rocket.chat"
 

--- a/apps/meteor/ee/server/services/Dockerfile
+++ b/apps/meteor/ee/server/services/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.2-alpine3.23 as build
+FROM node:22.22.3-alpine3.23 as build
 
 WORKDIR /app
 
@@ -28,7 +28,7 @@ RUN yarn install
 RUN yarn workspace @rocket.chat/core-typings run build \
     && yarn workspace @rocket.chat/rest-typings run build
 
-FROM node:22.22.2-alpine3.23
+FROM node:22.22.3-alpine3.23
 
 ARG SERVICE
 

--- a/ee/apps/account-service/Dockerfile
+++ b/ee/apps/account-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.2-alpine3.23 AS builder
+FROM node:22.22.3-alpine3.23 AS builder
 
 ARG SERVICE
 
@@ -87,7 +87,7 @@ WORKDIR /app/ee/apps/${SERVICE}
 
 RUN yarn workspaces focus --production
 
-FROM node:22.22.2-alpine3.23
+FROM node:22.22.3-alpine3.23
 
 ARG SERVICE
 

--- a/ee/apps/authorization-service/Dockerfile
+++ b/ee/apps/authorization-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.2-alpine3.23 AS builder
+FROM node:22.22.3-alpine3.23 AS builder
 
 ARG SERVICE
 
@@ -93,7 +93,7 @@ WORKDIR /app/ee/apps/${SERVICE}
 
 RUN yarn workspaces focus --production
 
-FROM node:22.22.2-alpine3.23
+FROM node:22.22.3-alpine3.23
 
 ARG SERVICE
 

--- a/ee/apps/ddp-streamer/Dockerfile
+++ b/ee/apps/ddp-streamer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.2-alpine3.23 AS builder
+FROM node:22.22.3-alpine3.23 AS builder
 
 ARG SERVICE
 
@@ -90,7 +90,7 @@ WORKDIR /app/ee/apps/${SERVICE}
 
 RUN yarn workspaces focus --production
 
-FROM node:22.22.2-alpine3.23
+FROM node:22.22.3-alpine3.23
 
 ARG SERVICE
 

--- a/ee/apps/omnichannel-transcript/Dockerfile
+++ b/ee/apps/omnichannel-transcript/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.2-alpine3.23 AS builder
+FROM node:22.22.3-alpine3.23 AS builder
 
 ARG SERVICE
 
@@ -100,7 +100,7 @@ WORKDIR /app/ee/apps/${SERVICE}
 
 RUN yarn workspaces focus --production
 
-FROM node:22.22.2-alpine3.23
+FROM node:22.22.3-alpine3.23
 
 ARG SERVICE
 

--- a/ee/apps/presence-service/Dockerfile
+++ b/ee/apps/presence-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.2-alpine3.23 AS builder
+FROM node:22.22.3-alpine3.23 AS builder
 
 ARG SERVICE
 
@@ -88,7 +88,7 @@ WORKDIR /app/ee/apps/${SERVICE}
 
 RUN yarn workspaces focus --production
 
-FROM node:22.22.2-alpine3.23
+FROM node:22.22.3-alpine3.23
 
 ARG SERVICE
 

--- a/ee/apps/queue-worker/Dockerfile
+++ b/ee/apps/queue-worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.2-alpine3.23 AS builder
+FROM node:22.22.3-alpine3.23 AS builder
 
 ARG SERVICE
 
@@ -100,7 +100,7 @@ WORKDIR /app/ee/apps/${SERVICE}
 
 RUN yarn workspaces focus --production
 
-FROM node:22.22.2-alpine3.23
+FROM node:22.22.3-alpine3.23
 
 ARG SERVICE
 

--- a/package.json
+++ b/package.json
@@ -172,11 +172,11 @@
 	},
 	"packageManager": "yarn@4.12.0",
 	"engines": {
-		"node": "22.22.2",
+		"node": "22.22.3",
 		"yarn": "4.12.0"
 	},
 	"volta": {
-		"node": "22.22.2",
+		"node": "22.22.3",
 		"yarn": "4.12.0"
 	},
 	"houston": {

--- a/packages/message-parser/package.json
+++ b/packages/message-parser/package.json
@@ -67,7 +67,7 @@
 		"webpack-cli": "~5.1.4"
 	},
 	"engines": {
-		"node": "22.22.2"
+		"node": "22.22.3"
 	},
 	"volta": {
 		"extends": "../../package.json"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Node.js from 22.22.2 to 22.22.3 across CI workflow, Docker images, service builds, and package configuration to ensure consistent runtime versions and build environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2154]

[ARCH-2154]: https://rocketchat.atlassian.net/browse/ARCH-2154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ