### PR TITLE
feat: Add support for call diversion handling in media calls

### DIFF
--- a/.changeset/gold-jobs-help.md
+++ b/.changeset/gold-jobs-help.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/core-typings": minor
+"@rocket.chat/media-calls": minor
+---
+
+Adds support for call diversion handling in voice calls

--- a/ee/packages/media-calls/jest.config.ts
+++ b/ee/packages/media-calls/jest.config.ts
@@ -1,0 +1,6 @@
+import server from '@rocket.chat/jest-presets/server';
+import type { Config } from 'jest';
+
+export default {
+	preset: server.preset,
+} satisfies Config;

--- a/ee/packages/media-calls/package.json
+++ b/ee/packages/media-calls/package.json
@@ -13,6 +13,8 @@
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
+		"test": "jest",
+		"testunit": "jest",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
@@ -24,9 +26,11 @@
 		"drachtio-srf": "patch:drachtio-srf@npm%3A5.0.12#~/.yarn/patches/drachtio-srf-npm-5.0.12-b0b1afaad6.patch"
 	},
 	"devDependencies": {
+		"@rocket.chat/jest-presets": "workspace:~",
 		"@rocket.chat/tsconfig": "workspace:*",
 		"@types/jest": "~30.0.0",
 		"eslint": "~9.39.4",
+		"jest": "~30.2.0",
 		"typescript": "~5.9.3"
 	}
 }

--- a/ee/packages/media-calls/package.json
+++ b/ee/packages/media-calls/package.json
@@ -13,6 +13,8 @@
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
+		"test": "jest",
+		"testunit": "jest",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
@@ -24,9 +26,11 @@
 		"drachtio-srf": "patch:drachtio-srf@npm%3A5.0.12#~/.yarn/patches/drachtio-srf-npm-5.0.12-b0b1afaad6.patch"
 	},
 	"devDependencies": {
+		"@rocket.chat/jest-presets": "workspace:~",
 		"@rocket.chat/tsconfig": "workspace:*",
 		"@types/jest": "~30.0.0",
 		"eslint": "~9.39.5",
+		"jest": "~30.2.0",
 		"typescript": "~5.9.3"
 	}
 }

--- a/ee/packages/media-calls/src/definition/common.ts
+++ b/ee/packages/media-calls/src/definition/common.ts
@@ -16,6 +16,7 @@ export type InternalCallParams = {
 	parentCallId?: string;
 	requestedBy?: MediaCallSignedContact;
 	features: CallFeature[];
+	divertedBy?: MediaCallContact;
 };
 
 export type MediaCallHeader = AtLeast<IMediaCall, '_id' | 'caller' | 'callee'>;

--- a/ee/packages/media-calls/src/server/CallDirector.ts
+++ b/ee/packages/media-calls/src/server/CallDirector.ts
@@ -182,7 +182,8 @@ class MediaCallDirector {
 	}
 
 	public async createCall(params: CreateCallParams): Promise<IMediaCall> {
-		const { caller, callee, requestedCallId, requestedService, callerAgent, calleeAgent, parentCallId, requestedBy, features } = params;
+		const { caller, callee, requestedCallId, requestedService, callerAgent, calleeAgent, parentCallId, requestedBy, features, divertedBy } =
+			params;
 
 		// The caller must always have a contract to create the call
 		if (!caller.contractId) {
@@ -231,6 +232,7 @@ class MediaCallDirector {
 
 			...(requestedCallId && { callerRequestedId: requestedCallId }),
 			...(parentCallId && { parentCallId }),
+			...(divertedBy && { divertedBy }),
 
 			features: allowedFeatures,
 		};

--- a/ee/packages/media-calls/src/server/CallDirector.ts
+++ b/ee/packages/media-calls/src/server/CallDirector.ts
@@ -183,7 +183,8 @@ class MediaCallDirector {
 	}
 
 	public async createCall(params: CreateCallParams): Promise<IMediaCall> {
-		const { caller, callee, requestedCallId, requestedService, callerAgent, calleeAgent, parentCallId, requestedBy, features } = params;
+		const { caller, callee, requestedCallId, requestedService, callerAgent, calleeAgent, parentCallId, requestedBy, features, divertedBy } =
+			params;
 
 		// The caller must always have a contract to create the call
 		if (!caller.contractId) {
@@ -232,6 +233,7 @@ class MediaCallDirector {
 
 			...(requestedCallId && { callerRequestedId: requestedCallId }),
 			...(parentCallId && { parentCallId }),
+			...(divertedBy && { divertedBy }),
 
 			features: allowedFeatures,
 		};

--- a/ee/packages/media-calls/src/server/signals/getNewCallTransferredBy.ts
+++ b/ee/packages/media-calls/src/server/signals/getNewCallTransferredBy.ts
@@ -2,7 +2,11 @@ import type { IMediaCall } from '@rocket.chat/core-typings';
 import type { CallContact } from '@rocket.chat/media-signaling';
 
 export function getNewCallTransferredBy(call: IMediaCall): CallContact | null {
-	const { createdBy, parentCallId, caller, callee } = call;
+	const { createdBy, parentCallId, caller, callee, divertedBy } = call;
+
+	if (divertedBy) {
+		return divertedBy;
+	}
 
 	if (!createdBy || !parentCallId) {
 		return null;

--- a/ee/packages/media-calls/src/sip/providers/IncomingSipCall.ts
+++ b/ee/packages/media-calls/src/sip/providers/IncomingSipCall.ts
@@ -18,6 +18,7 @@ import { mediaCallDirector } from '../../server/CallDirector';
 import { getMediaCallServer } from '../../server/injection';
 import type { SipServerSession } from '../Session';
 import { SipError, SipErrorCodes } from '../errorCodes';
+import { parseDiversionHeader } from '../utils/parseDiversionHeader';
 
 type IncomingSipCallNegotiation = {
 	id: string;
@@ -83,6 +84,12 @@ export class IncomingSipCall extends BaseSipCall {
 
 		const caller = await this.getCallerContactFromInvite(session.sessionId, req);
 		logger.debug({ msg: 'incoming call from', callerContact: caller });
+
+		const divertedBy = await this.getDiversionContactFromInvite(req);
+		if (divertedBy) {
+			logger.debug({ msg: 'incoming call diverted by', divertedBy });
+		}
+
 		const webrtcOffer = { type: 'offer', sdp: req.body } as const;
 
 		const callerAgent = await mediaCallDirector.cast.getAgentForActorAndRole(caller, 'caller');
@@ -105,6 +112,7 @@ export class IncomingSipCall extends BaseSipCall {
 			callerAgent,
 			calleeAgent,
 			features: SIP_CALL_FEATURES,
+			...(divertedBy && { divertedBy }),
 		});
 
 		const negotiationId = await mediaCallDirector.startNewNegotiation(call, 'caller', webrtcOffer);
@@ -454,6 +462,36 @@ export class IncomingSipCall extends BaseSipCall {
 		}
 
 		return null;
+	}
+
+	private static async getDiversionContactFromInvite(req: SrfRequest): Promise<MediaCallContact | null> {
+		if (!req.has('diversion')) {
+			return null;
+		}
+
+		logger.debug({ msg: 'IncomingSipCall.getDiversionContactFromInvite' });
+
+		const parsed = parseDiversionHeader(req.get('diversion'));
+		if (!parsed) {
+			logger.warn({ msg: 'IncomingSipCall.getDiversionContactFromInvite: failed to parse Diversion header', raw: req.get('diversion') });
+			return null;
+		}
+
+		const { extension, displayName } = parsed;
+
+		const defaultContactInfo: MediaCallContactInformation = {
+			sipExtension: extension,
+			displayName: displayName || extension,
+		};
+
+		const contact = await mediaCallDirector.cast.getContactForExtensionNumber(extension, { requiredType: 'sip' }, defaultContactInfo);
+
+		return {
+			...defaultContactInfo,
+			...contact,
+			type: 'sip',
+			id: extension,
+		};
 	}
 
 	private static async getCallerContactFromInvite(sessionId: string, req: SrfRequest): Promise<MediaCallSignedContact<'sip'>> {

--- a/ee/packages/media-calls/src/sip/providers/IncomingSipCall.ts
+++ b/ee/packages/media-calls/src/sip/providers/IncomingSipCall.ts
@@ -12,6 +12,7 @@ import { mediaCallDirector } from '../../server/CallDirector';
 import { getMediaCallServer } from '../../server/injection';
 import type { SipServerSession } from '../Session';
 import { SipError, SipErrorCodes } from '../errorCodes';
+import { parseDiversionHeader } from '../utils/parseDiversionHeader';
 
 type IncomingSipCallNegotiation = {
 	id: string;
@@ -76,6 +77,12 @@ export class IncomingSipCall extends BaseSipCall {
 
 		const caller = await this.getCallerContactFromInvite(session.sessionId, req);
 		logger.debug({ msg: 'incoming call from', callerContact: caller });
+
+		const divertedBy = await this.getDiversionContactFromInvite(req);
+		if (divertedBy) {
+			logger.debug({ msg: 'incoming call diverted by', divertedBy });
+		}
+
 		const webrtcOffer = { type: 'offer', sdp: req.body } as const;
 
 		const callerAgent = await mediaCallDirector.cast.getAgentForActorAndRole(caller, 'caller');
@@ -98,6 +105,7 @@ export class IncomingSipCall extends BaseSipCall {
 			callerAgent,
 			calleeAgent,
 			features: SIP_CALL_FEATURES,
+			...(divertedBy && { divertedBy }),
 		});
 
 		const negotiationId = await mediaCallDirector.startNewNegotiation(call, 'caller', webrtcOffer);
@@ -445,6 +453,36 @@ export class IncomingSipCall extends BaseSipCall {
 		}
 
 		return null;
+	}
+
+	private static async getDiversionContactFromInvite(req: SrfRequest): Promise<MediaCallContact | null> {
+		if (!req.has('diversion')) {
+			return null;
+		}
+
+		logger.debug({ msg: 'IncomingSipCall.getDiversionContactFromInvite' });
+
+		const parsed = parseDiversionHeader(req.get('diversion'));
+		if (!parsed) {
+			logger.warn({ msg: 'IncomingSipCall.getDiversionContactFromInvite: failed to parse Diversion header', raw: req.get('diversion') });
+			return null;
+		}
+
+		const { extension, displayName } = parsed;
+
+		const defaultContactInfo: MediaCallContactInformation = {
+			sipExtension: extension,
+			displayName: displayName || extension,
+		};
+
+		const contact = await mediaCallDirector.cast.getContactForExtensionNumber(extension, { requiredType: 'sip' }, defaultContactInfo);
+
+		return {
+			...defaultContactInfo,
+			...contact,
+			type: 'sip',
+			id: extension,
+		};
 	}
 
 	private static async getCallerContactFromInvite(sessionId: string, req: SrfRequest): Promise<MediaCallSignedContact<'sip'>> {

--- a/ee/packages/media-calls/src/sip/utils/parseDiversionHeader.spec.ts
+++ b/ee/packages/media-calls/src/sip/utils/parseDiversionHeader.spec.ts
@@ -1,0 +1,105 @@
+import { parseDiversionHeader } from './parseDiversionHeader';
+
+describe('parseDiversionHeader', () => {
+	describe('unquoted display name', () => {
+		it('parses a single-word unquoted display name', () => {
+			expect(parseDiversionHeader('Alice <sip:1234@pbx.example.com>;reason=unconditional')).toEqual({
+				extension: '1234',
+				displayName: 'Alice',
+			});
+		});
+
+		it('parses a multi-word unquoted display name', () => {
+			expect(parseDiversionHeader('Alice Smith <sip:1234@pbx.example.com>')).toEqual({
+				extension: '1234',
+				displayName: 'Alice Smith',
+			});
+		});
+	});
+
+	describe('quoted display name', () => {
+		it('parses a single-word quoted display name', () => {
+			expect(parseDiversionHeader('"Alice" <sip:1234@pbx.example.com>;reason=unconditional')).toEqual({
+				extension: '1234',
+				displayName: 'Alice',
+			});
+		});
+
+		it('parses a multi-word quoted display name', () => {
+			expect(parseDiversionHeader('"Alice Smith" <sip:1234@pbx.example.com>')).toEqual({
+				extension: '1234',
+				displayName: 'Alice Smith',
+			});
+		});
+
+		it('returns undefined displayName for an empty quoted string', () => {
+			expect(parseDiversionHeader('"" <sip:1234@pbx.example.com>')).toEqual({
+				extension: '1234',
+				displayName: undefined,
+			});
+		});
+	});
+
+	describe('no display name', () => {
+		it('parses the bare angle-bracket form', () => {
+			expect(parseDiversionHeader('<sip:1234@pbx.example.com>;reason=unconditional')).toEqual({
+				extension: '1234',
+				displayName: undefined,
+			});
+		});
+	});
+
+	describe('URI variants', () => {
+		it('parses a sips: URI', () => {
+			expect(parseDiversionHeader('<sips:5678@pbx.example.com>')).toEqual({
+				extension: '5678',
+				displayName: undefined,
+			});
+		});
+
+		it('handles URI parameters after the host', () => {
+			expect(parseDiversionHeader('<sip:1234@pbx.example.com;transport=tcp>;reason=unconditional')).toEqual({
+				extension: '1234',
+				displayName: undefined,
+			});
+		});
+	});
+
+	describe('whitespace handling', () => {
+		it('trims leading and trailing whitespace from the raw value', () => {
+			expect(parseDiversionHeader('  <sip:9000@pbx.example.com>  ')).toEqual({
+				extension: '9000',
+				displayName: undefined,
+			});
+		});
+
+		it('trims extra whitespace between an unquoted display name and the angle bracket', () => {
+			expect(parseDiversionHeader('Alice   <sip:1234@pbx.example.com>')).toEqual({
+				extension: '1234',
+				displayName: 'Alice',
+			});
+		});
+	});
+
+	describe('invalid inputs', () => {
+		it('returns null for a bare addr-spec without angle brackets (not valid per RFC 5806)', () => {
+			expect(parseDiversionHeader('sip:1234@pbx.example.com')).toBeNull();
+		});
+
+		it('returns null for a URI with no user part', () => {
+			expect(parseDiversionHeader('<sip:pbx.example.com>')).toBeNull();
+		});
+
+		it('returns null for a non-SIP URI inside brackets', () => {
+			expect(parseDiversionHeader('<tel:+1234567890>')).toBeNull();
+		});
+
+		it('returns null for an empty string', () => {
+			expect(parseDiversionHeader('')).toBeNull();
+		});
+
+		it('returns null for a non-string value', () => {
+			expect(parseDiversionHeader(null as unknown as string)).toBeNull();
+		});
+	});
+});

--- a/ee/packages/media-calls/src/sip/utils/parseDiversionHeader.spec.ts
+++ b/ee/packages/media-calls/src/sip/utils/parseDiversionHeader.spec.ts
@@ -90,6 +90,10 @@ describe('parseDiversionHeader', () => {
 			expect(parseDiversionHeader('<sip:pbx.example.com>')).toBeNull();
 		});
 
+		it('returns null when there is a display name but no number in the URI', () => {
+			expect(parseDiversionHeader('Alice <sip:pbx.example.com>')).toBeNull();
+		});
+
 		it('returns null for a non-SIP URI inside brackets', () => {
 			expect(parseDiversionHeader('<tel:+1234567890>')).toBeNull();
 		});

--- a/ee/packages/media-calls/src/sip/utils/parseDiversionHeader.ts
+++ b/ee/packages/media-calls/src/sip/utils/parseDiversionHeader.ts
@@ -1,0 +1,47 @@
+export type ParsedDiversion = {
+	extension: string;
+	displayName?: string;
+};
+
+/**
+ * Parses the value of a single SIP Diversion header field (RFC 5806).
+ *
+ * Handles both name-addr forms:
+ *   "Display Name" <sip:1234@pbx.example.com>;reason=unconditional
+ *   <sip:1234@pbx.example.com>;reason=unconditional
+ *
+ * And the addr-spec form:
+ *   sip:1234@pbx.example.com;reason=unconditional
+ *
+ * Returns the SIP URI user part as `extension` and the display name when present.
+ * Returns null if the value cannot be parsed into a usable extension.
+ */
+export function parseDiversionHeader(raw: string): ParsedDiversion | null {
+	if (!raw || typeof raw !== 'string') {
+		return null;
+	}
+
+	const value = raw.trim();
+
+	let sipUri: string;
+	let displayName: string | undefined;
+
+	// name-addr: optionally quoted display name followed by angle-bracket URI
+	const nameAddrMatch = value.match(/^(?:"([^"]*)")?\s*<([^>]+)>/);
+	if (nameAddrMatch) {
+		const rawDisplayName = nameAddrMatch[1];
+		displayName = rawDisplayName ? rawDisplayName.trim() || undefined : undefined;
+		sipUri = nameAddrMatch[2];
+	} else {
+		// addr-spec: bare sip URI, parameters follow a semicolon
+		sipUri = value.split(';')[0].trim();
+	}
+
+	// Extract the user part from sip:user@host or sips:user@host
+	const uriMatch = sipUri.match(/^sips?:([^@;>\s]+)@/i);
+	if (!uriMatch?.[1]) {
+		return null;
+	}
+
+	return { extension: uriMatch[1], displayName };
+}

--- a/ee/packages/media-calls/src/sip/utils/parseDiversionHeader.ts
+++ b/ee/packages/media-calls/src/sip/utils/parseDiversionHeader.ts
@@ -29,11 +29,11 @@ export function parseDiversionHeader(raw: string): ParsedDiversion | null {
 	}
 
 	const rawDisplayName = nameAddrMatch[1] ?? nameAddrMatch[2];
-	const displayName = rawDisplayName ? rawDisplayName.trim() || undefined : undefined;
+	const displayName = rawDisplayName?.trim() || undefined;
 	const sipUri = nameAddrMatch[3];
 
 	// Extract the user part from sip:user@host or sips:user@host
-	const uriMatch = sipUri.match(/^sips?:([^@;>\s]+)@/i);
+	const uriMatch = sipUri?.match(/^sips?:([^@;>\s]+)@/i);
 	if (!uriMatch?.[1]) {
 		return null;
 	}

--- a/ee/packages/media-calls/src/sip/utils/parseDiversionHeader.ts
+++ b/ee/packages/media-calls/src/sip/utils/parseDiversionHeader.ts
@@ -6,12 +6,10 @@ export type ParsedDiversion = {
 /**
  * Parses the value of a single SIP Diversion header field (RFC 5806).
  *
- * Handles both name-addr forms:
+ * RFC 5806 mandates the name-addr form (angle brackets are always required):
+ *   Alice <sip:1234@pbx.example.com>;reason=unconditional
  *   "Display Name" <sip:1234@pbx.example.com>;reason=unconditional
  *   <sip:1234@pbx.example.com>;reason=unconditional
- *
- * And the addr-spec form:
- *   sip:1234@pbx.example.com;reason=unconditional
  *
  * Returns the SIP URI user part as `extension` and the display name when present.
  * Returns null if the value cannot be parsed into a usable extension.
@@ -23,19 +21,16 @@ export function parseDiversionHeader(raw: string): ParsedDiversion | null {
 
 	const value = raw.trim();
 
-	let sipUri: string;
-	let displayName: string | undefined;
-
-	// name-addr: optionally quoted display name followed by angle-bracket URI
-	const nameAddrMatch = value.match(/^(?:"([^"]*)")?\s*<([^>]+)>/);
-	if (nameAddrMatch) {
-		const rawDisplayName = nameAddrMatch[1];
-		displayName = rawDisplayName ? rawDisplayName.trim() || undefined : undefined;
-		sipUri = nameAddrMatch[2];
-	} else {
-		// addr-spec: bare sip URI, parameters follow a semicolon
-		sipUri = value.split(';')[0].trim();
+	// name-addr: optional display name (quoted or unquoted) followed by angle-bracket URI
+	// Group 1: quoted display name, Group 2: unquoted display name, Group 3: SIP URI
+	const nameAddrMatch = value.match(/^(?:"([^"]*)"|([^<"]+?))?\s*<([^>]+)>/);
+	if (!nameAddrMatch) {
+		return null;
 	}
+
+	const rawDisplayName = nameAddrMatch[1] ?? nameAddrMatch[2];
+	const displayName = rawDisplayName ? rawDisplayName.trim() || undefined : undefined;
+	const sipUri = nameAddrMatch[3];
 
 	// Extract the user part from sip:user@host or sips:user@host
 	const uriMatch = sipUri.match(/^sips?:([^@;>\s]+)@/i);

--- a/packages/core-typings/src/mediaCalls/IMediaCall.ts
+++ b/packages/core-typings/src/mediaCalls/IMediaCall.ts
@@ -64,6 +64,9 @@ export interface IMediaCall extends IRocketChatRecord {
 	transferredTo?: MediaCallContact;
 	transferredAt?: Date;
 
+	/** The party whose line was diverted at the SIP level (from the Diversion header), signed with the session contract */
+	divertedBy?: MediaCallContact;
+
 	uids: IUser['_id'][];
 
 	/** The list of features that may be used in this call. Values are final once the call is accepted. */

--- a/packages/core-typings/src/mediaCalls/IMediaCall.ts
+++ b/packages/core-typings/src/mediaCalls/IMediaCall.ts
@@ -64,7 +64,7 @@ export interface IMediaCall extends IRocketChatRecord {
 	transferredTo?: MediaCallContact;
 	transferredAt?: Date;
 
-	/** The party whose line was diverted at the SIP level (from the Diversion header), signed with the session contract */
+	/** The party whose line was diverted at the SIP level (from the Diversion header) */
 	divertedBy?: MediaCallContact;
 
 	uids: IUser['_id'][];

--- a/yarn.lock
+++ b/yarn.lock
@@ -9647,6 +9647,7 @@ __metadata:
   dependencies:
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/emitter": "npm:^0.32.0"
+    "@rocket.chat/jest-presets": "workspace:~"
     "@rocket.chat/logger": "workspace:^"
     "@rocket.chat/media-signaling": "workspace:^"
     "@rocket.chat/models": "workspace:^"
@@ -9654,6 +9655,7 @@ __metadata:
     "@types/jest": "npm:~30.0.0"
     drachtio-srf: "patch:drachtio-srf@npm%3A5.0.12#~/.yarn/patches/drachtio-srf-npm-5.0.12-b0b1afaad6.patch"
     eslint: "npm:~9.39.4"
+    jest: "npm:~30.2.0"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -9974,6 +9974,7 @@ __metadata:
   dependencies:
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/emitter": "workspace:~"
+    "@rocket.chat/jest-presets": "workspace:~"
     "@rocket.chat/logger": "workspace:^"
     "@rocket.chat/media-signaling": "workspace:^"
     "@rocket.chat/models": "workspace:^"
@@ -9981,6 +9982,7 @@ __metadata:
     "@types/jest": "npm:~30.0.0"
     drachtio-srf: "patch:drachtio-srf@npm%3A5.0.12#~/.yarn/patches/drachtio-srf-npm-5.0.12-b0b1afaad6.patch"
     eslint: "npm:~9.39.5"
+    jest: "npm:~30.2.0"
     typescript: "npm:~5.9.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
This pull request adds support for handling SIP call diversion by introducing a new `divertedBy` field to the media calls system. The changes allow the system to detect when an incoming SIP call has been diverted, extract the relevant contact from the SIP Diversion header, and propagate this information through the media call creation and handling process.

**SIP Diversion Support:**

* Added a new `divertedBy` field to the `IMediaCall` type and related internal call parameter types to represent the contact whose line was diverted at the SIP level.

**SIP Call Handling Improvements:**

* Enhanced `IncomingSipCall` to detect and parse the SIP Diversion header from incoming calls, extract the diverting contact, and include it when creating new calls.
* Added a new utility function `parseDiversionHeader` to parse the Diversion header and extract the extension and display name.

**Call Transfer Logic:**

* Updated `getNewCallTransferredBy` to return the `divertedBy` contact when available, ensuring accurate reporting of call transfers caused by SIP diversion.

For the UI this change is transparent and incoming diverted calls will be treated as incoming call transfers.

## Issue(s)
[DMV-5](https://rocketchat.atlassian.net/browse/DMV-5)
[DMVPR-4](https://rocketchat.atlassian.net/browse/DMVPR-4)

## Steps to test or reproduce
If you are running freeswitch in a local container you can execute the following command to test
`fs_cli -x "originate {sip_h_Diversion='\"John Doe\" <sip:sipp@[freeswitch_adress]>;reason=follow-me;privacy=off'}sofia/internal/[target_extension]@[sip_server_adress] &echo()"`

## Further comments


[DMV-5]: https://rocketchat.atlassian.net/browse/DMV-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Call diversion support: SIP Diversion headers are detected and parsed; the diverting party is recorded and shown in call records/history and transfer attribution.

* **New Utilities**
  * Added Diversion header parser for extracting diverting party info from incoming SIP invites.

* **Tests**
  * Unit tests covering Diversion header parsing for valid and invalid cases.

* **Chores**
  * Test tooling/config updated and a new test script added for the media-calls package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->