### PR TITLE
refactor(client): inject stream/list functions into userStatuses

### DIFF
--- a/apps/meteor/client/lib/userStatuses.ts
+++ b/apps/meteor/client/lib/userStatuses.ts
@@ -1,14 +1,16 @@
 import { UserStatus } from '@rocket.chat/core-typings';
 import type { ICustomUserStatus } from '@rocket.chat/core-typings';
 
-import { sdk } from '../../app/utils/client/lib/SDKClient';
-
 export type UserStatusDescriptor = {
 	id: string;
 	name: string;
 	statusType: UserStatus;
 	localizeName: boolean;
 };
+
+export type UserStatusStreamCallback = (data: { userStatusData: ICustomUserStatus }) => void;
+export type UserStatusStreamer = (event: 'updateCustomUserStatus' | 'deleteCustomUserStatus', cb: UserStatusStreamCallback) => () => void;
+export type UserStatusLister = () => Promise<ICustomUserStatus[] | null | undefined>;
 
 export class UserStatuses implements Iterable<UserStatusDescriptor> {
 	public invisibleAllowed = true;
@@ -58,8 +60,8 @@ export class UserStatuses implements Iterable<UserStatusDescriptor> {
 		}
 	}
 
-	public async sync() {
-		const result = await sdk.call('listCustomUserStatus');
+	public async sync(listCustomUserStatus: UserStatusLister) {
+		const result = await listCustomUserStatus();
 		if (!result) {
 			return;
 		}
@@ -69,20 +71,20 @@ export class UserStatuses implements Iterable<UserStatusDescriptor> {
 		}
 	}
 
-	public watch(cb?: () => void) {
-		const updateSubscription = sdk.stream('notify-logged', ['updateCustomUserStatus'], (data) => {
+	public watch(stream: UserStatusStreamer, cb?: () => void) {
+		const unsubscribeUpdate = stream('updateCustomUserStatus', (data) => {
 			this.put(this.createFromCustom(data.userStatusData));
 			cb?.();
 		});
 
-		const deleteSubscription = sdk.stream('notify-logged', ['deleteCustomUserStatus'], (data) => {
+		const unsubscribeDelete = stream('deleteCustomUserStatus', (data) => {
 			this.delete(data.userStatusData._id);
 			cb?.();
 		});
 
 		return () => {
-			updateSubscription.stop();
-			deleteSubscription.stop();
+			unsubscribeUpdate();
+			unsubscribeDelete();
 		};
 	}
 }

--- a/apps/meteor/client/navbar/NavBarSettingsToolbar/UserMenu/hooks/useStatusItems.tsx
+++ b/apps/meteor/client/navbar/NavBarSettingsToolbar/UserMenu/hooks/useStatusItems.tsx
@@ -1,7 +1,7 @@
 import { Box } from '@rocket.chat/fuselage';
 import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { clientCallbacks } from '@rocket.chat/ui-client';
-import { useEndpoint, useSetting } from '@rocket.chat/ui-contexts';
+import { useEndpoint, useMethod, useSetting, useStream } from '@rocket.chat/ui-contexts';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -20,13 +20,15 @@ export const useStatusItems = (): GenericMenuItemProps[] => {
 	userStatuses.invisibleAllowed = useSetting('Accounts_AllowInvisibleStatusOption', true);
 
 	const queryClient = useQueryClient();
+	const stream = useStream('notify-logged');
+	const listCustomUserStatus = useMethod('listCustomUserStatus');
 
 	useEffect(
 		() =>
-			userStatuses.watch(() => {
+			userStatuses.watch(stream, () => {
 				queryClient.setQueryData(['user-statuses'], Array.from(userStatuses));
 			}),
-		[queryClient],
+		[queryClient, stream],
 	);
 
 	const { t } = useTranslation();
@@ -46,7 +48,7 @@ export const useStatusItems = (): GenericMenuItemProps[] => {
 	const { data: statuses } = useQuery({
 		queryKey: ['user-statuses'],
 		queryFn: async () => {
-			await userStatuses.sync();
+			await userStatuses.sync(listCustomUserStatus);
 			return Array.from(userStatuses);
 		},
 		staleTime: Infinity,


### PR DESCRIPTION
## Summary

- `client/lib/userStatuses.ts` dropped its hard import of `sdk` and now takes the streaming callback (`watch(stream, cb?)`) and the list method (`sync(listCustomUserStatus)`) as parameters.
- The only consumer, `client/navbar/NavBarSettingsToolbar/UserMenu/hooks/useStatusItems.tsx`, was updated to obtain those values via the existing `useStream`/`useMethod` hooks from `@rocket.chat/ui-contexts`.

## Why

Inverting the dependency removes the coupling between `userStatuses` and the SDK module. Storybook (and unit tests) can render any consumer of `useStatusItems` without having to mock the `SDKClient` module or stub `Meteor.connection.subscribe`, because both functions now flow through the `ServerContext` already mocked by `@rocket.chat/mock-providers`.

## Test plan

- [ ] App boot exercises status updates as before (custom-status added/removed by another client appears live in the user menu).
- [ ] `yarn tsc --noEmit --skipLibCheck` passes.
- [ ] Existing menus/components consuming `userStatuses` continue to work unchanged. 

 Task: [ARCH-2152]

[ARCH-2152]: https://rocketchat.atlassian.net/browse/ARCH-2152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture for user status management to better support dependency injection and streamlined data synchronization patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40567)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->