### PR TITLE
chore(message-parser): pre-screen, LRU cache, tldParse memo, async generator

### DIFF
--- a/packages/message-parser/src/index.ts
+++ b/packages/message-parser/src/index.ts
@@ -1,5 +1,7 @@
-import type { Root } from './definitions';
+import { BlockSplitter, BlockType } from './BlockSplitter';
+import type { Paragraph, Root } from './definitions';
 import * as grammar from './grammar.pegjs';
+import { paragraph, plain } from './utils';
 
 export type * from './definitions';
 
@@ -15,7 +17,100 @@ export type Options = {
 	customDomains?: string[];
 };
 
-export const parse = (input: string, options?: Options): Root => grammar.parse(input, options);
+const MARKDOWN_TRIGGER = /[\r\n*_~`@#:<>|!+$\\[\]()\-]|\.[A-Za-z]|^\d+\.|[⌀-➿☀-⛿\uD800-\uDBFF]/;
+
+const trivialParse = (input: string): Root | null => {
+	if (input.length === 0) return [];
+	if (input.length > 1024) return null;
+	if (MARKDOWN_TRIGGER.test(input)) return null;
+	return [paragraph([plain(input)]) as Paragraph];
+};
+
+const PARSE_CACHE_LIMIT = 512;
+const PARSE_CACHE_MAX_INPUT = 4096;
+const parseCache = new Map<string, Root>();
+
+const cacheKey = (input: string, options?: Options): string => {
+	if (!options) return `|${input}`;
+	const k = options.katex;
+	return `${options.colors ? 'c' : ''}${options.emoticons ? 'e' : ''}${k?.dollarSyntax ? 'd' : ''}${k?.parenthesisSyntax ? 'p' : ''}${
+		options.customDomains?.join(',') ?? ''
+	}|${input}`;
+};
+
+export const parse = (input: string, options?: Options): Root => {
+	const fast = trivialParse(input);
+	if (fast) return fast;
+
+	if (input.length <= PARSE_CACHE_MAX_INPUT) {
+		const key = cacheKey(input, options);
+		const hit = parseCache.get(key);
+		if (hit !== undefined) {
+			parseCache.delete(key);
+			parseCache.set(key, hit);
+			return hit;
+		}
+		const result = grammar.parse(input, options) as Root;
+		if (parseCache.size >= PARSE_CACHE_LIMIT) {
+			const firstKey = parseCache.keys().next().value;
+			if (firstKey !== undefined) parseCache.delete(firstKey);
+		}
+		parseCache.set(key, result);
+		return result;
+	}
+
+	return grammar.parse(input, options) as Root;
+};
+
+const yieldToEventLoop = (): Promise<void> =>
+	new Promise((resolve) => {
+		if (typeof queueMicrotask === 'function') {
+			queueMicrotask(resolve);
+		} else {
+			setTimeout(resolve, 0);
+		}
+	});
+
+const canChunk = (input: string): boolean => {
+	if (input.length < 32) return false;
+	if (input.includes('||')) return false;
+	return true;
+};
+
+const blockToInput = (block: ReturnType<typeof BlockSplitter.split>[number]): string => {
+	if (block.type === BlockType.CODE) {
+		const fence = '```';
+		return `${fence}${block.language ? block.language : ''}\n${block.content}\n${fence}`;
+	}
+	return block.content;
+};
+
+export async function* parseStream(input: string, options?: Options): AsyncGenerator<Root[number], void, void> {
+	if (input.length === 0) return;
+
+	if (!canChunk(input)) {
+		const all = parse(input, options);
+		for (const node of all) {
+			yield node;
+		}
+		return;
+	}
+
+	const blocks = BlockSplitter.split(input);
+	for (let i = 0; i < blocks.length; i++) {
+		const blockInput = blockToInput(blocks[i]);
+		if (blockInput.length === 0) continue;
+		const parsed = parse(blockInput, options);
+		for (const node of parsed) {
+			yield node;
+		}
+		if (i < blocks.length - 1) await yieldToEventLoop();
+	}
+}
+
+export const clearParseCache = (): void => {
+	parseCache.clear();
+};
 
 export type { Root as MarkdownAST };
 export { parse as parser };

--- a/packages/message-parser/src/utils.ts
+++ b/packages/message-parser/src/utils.ts
@@ -79,6 +79,27 @@ export const link = (src: string, label?: Markup[]): Link => ({
 let cachedAutoLinkDomains: string[] | undefined | null = null;
 let cachedAutoLinkOptions: { detectIp: boolean; allowPrivateDomains: boolean; validHosts: string[] };
 
+const TLD_CACHE_LIMIT = 256;
+const tldLinkCache = new Map<string, { isIcann: boolean; isIp: boolean; isPrivate: boolean; domain: string | null }>();
+const tldEmailCache = new Map<string, { isIcann: boolean; isIp: boolean; isPrivate: boolean }>();
+
+const memoTldLink = (src: string, opts: typeof cachedAutoLinkOptions) => {
+	const cached = tldLinkCache.get(src);
+	if (cached !== undefined) {
+		tldLinkCache.delete(src);
+		tldLinkCache.set(src, cached);
+		return cached;
+	}
+	const { isIcann, isIp, isPrivate, domain } = tldParse(src, opts);
+	const entry = { isIcann: !!isIcann, isIp: !!isIp, isPrivate: !!isPrivate, domain: domain ?? null };
+	if (tldLinkCache.size >= TLD_CACHE_LIMIT) {
+		const firstKey = tldLinkCache.keys().next().value;
+		if (firstKey !== undefined) tldLinkCache.delete(firstKey);
+	}
+	tldLinkCache.set(src, entry);
+	return entry;
+};
+
 export const autoLink = (src: string, customDomains?: string[]) => {
 	if (cachedAutoLinkDomains !== customDomains) {
 		cachedAutoLinkDomains = customDomains;
@@ -87,9 +108,10 @@ export const autoLink = (src: string, customDomains?: string[]) => {
 			allowPrivateDomains: true,
 			validHosts: ['localhost', ...(customDomains ?? [])],
 		};
+		tldLinkCache.clear();
 	}
 	const { validHosts } = cachedAutoLinkOptions;
-	const { isIcann, isIp, isPrivate, domain } = tldParse(src, cachedAutoLinkOptions);
+	const { isIcann, isIp, isPrivate, domain } = memoTldLink(src, cachedAutoLinkOptions);
 
 	if (!(isIcann || isIp || isPrivate || (domain && validHosts.includes(domain)))) {
 		return plain(src);
@@ -102,10 +124,27 @@ export const autoLink = (src: string, customDomains?: string[]) => {
 
 const autoEmailTldOptions = { detectIp: false, allowPrivateDomains: true } as const;
 
+const memoTldEmail = (href: string) => {
+	const cached = tldEmailCache.get(href);
+	if (cached !== undefined) {
+		tldEmailCache.delete(href);
+		tldEmailCache.set(href, cached);
+		return cached;
+	}
+	const { isIcann, isIp, isPrivate } = tldParse(href, autoEmailTldOptions);
+	const entry = { isIcann: !!isIcann, isIp: !!isIp, isPrivate: !!isPrivate };
+	if (tldEmailCache.size >= TLD_CACHE_LIMIT) {
+		const firstKey = tldEmailCache.keys().next().value;
+		if (firstKey !== undefined) tldEmailCache.delete(firstKey);
+	}
+	tldEmailCache.set(href, entry);
+	return entry;
+};
+
 export const autoEmail = (src: string) => {
 	const href = `mailto:${src}`;
 
-	const { isIcann, isIp, isPrivate } = tldParse(href, autoEmailTldOptions);
+	const { isIcann, isIp, isPrivate } = memoTldEmail(href);
 
 	if (!(isIcann || isIp || isPrivate)) {
 		return plain(src);


### PR DESCRIPTION
## Summary

Performance optimizations for `@rocket.chat/message-parser` without changing grammar behavior.

- **Pre-screen**: bypass Peggy for inputs with no markdown triggers; return a single plaintext paragraph immediately. Catches the bulk of trivial chat messages.
- **LRU cache** (512 entries, inputs ≤ 4KB) on `parse(input, options)`. Composite key encodes relevant options. Repeated messages (system notifications, presets, common phrases) hit the cache instead of re-parsing.
- **tldts memo** (256 entries each) around `tldParse` calls in `autoLink` and `autoEmail`. Same URL or email reused across messages skips the tldts work.
- **`parseStream` async generator**: top-level block splitter (`BlockSplitter`) feeds Peggy one block at a time and yields the event loop between blocks. Long inputs no longer block the main thread for the full parse duration.

## Notes
- `parse()` API and AST output are unchanged. Cached entries are returned by reference — callers should not mutate the AST (matches existing assumptions; `plain(...)` objects were already shared internally).
- `parseStream` is opt-in (new export). Falls back to whole-input parse when the input is short or contains constructs that span blocks (`||` block spoiler).
- For true off-main-thread parsing, callers should run `parse`/`parseStream` inside a Web Worker — async generator only frees the event loop, not the CPU.
- `BlockSplitter` is no longer dead code; `parseStream` now consumes it.

## Bench
Benchmarks reuse the same input per task, so the LRU cache dominates after the first iteration. Numbers reflect cache-hit / pre-screen behaviour, not cold parsing speed:

| Case | Before (ops/s) | After (ops/s) |
| --- | --- | --- |
| Plain text "short" | 32 | 23,542,690 |
| `**Hello world**` | 31 | 7,248,097 |
| `repeated specials` (worst-case) | 1.6 | 4,178,167 |
| URL with path | 26 | 3,976,463 |
| Realistic chat message | 18 | 2,740,404 |

Cold parsing of new inputs is unchanged — gains depend on repeat rate of real workload.

## Test plan
- [x] `yarn test` from `packages/message-parser/` — 34 suites, 634 tests passing
- [ ] Run app, open a busy channel, confirm rendering visually unchanged
- [ ] Verify no AST mutation issues downstream (renderer, search highlight, notifications)
- [ ] Optional: hook `parseStream` into composer preview / large thread render path