### PR TITLE
fix(custom-oauth): pass SSRF allowlist to all fetch calls in CustomOAuth

### DIFF
--- a/apps/meteor/app/custom-oauth/server/custom_oauth_server.js
+++ b/apps/meteor/app/custom-oauth/server/custom_oauth_server.js
@@ -142,11 +142,11 @@ export class CustomOAuth {
 
 		try {
 			const request = await fetch(`${this.tokenPath}`, {
-				// SECURITY: URL can only be configured by users with enough privileges. It's ok to disable this check here.
-				ignoreSsrfValidation: true,
+				// SECURITY: URL can only be configured by privileged admins. Enforcing SSRF allowlist instead of full bypass.
 				method: 'POST',
 				headers,
 				body: params,
+				allowList: settings.get('SSRF_Allowlist')
 			});
 
 			if (!request.ok) {
@@ -181,8 +181,8 @@ export class CustomOAuth {
 		}
 
 		try {
-			// SECURITY: URL can only be configured by users with enough privileges. It's ok to disable this check here.
-			const request = await fetch(`${this.identityPath}`, { method: 'GET', headers, params, ignoreSsrfValidation: true });
+			// SECURITY: URL can only be configured by privileged admins. Enforcing SSRF allowlist instead of full bypass.
+			const request = await fetch(`${this.identityPath}`, { method: 'GET', headers, params, allowList: settings.get('SSRF_Allowlist') });
 
 			if (!request.ok) {
 				throw new Error(request.statusText);
@@ -288,9 +288,8 @@ export class CustomOAuth {
 		}
 
 		try {
-			// SECURITY: URL can only be configured by users with enough privileges. It's ok to disable this check here.
-			const request = await fetch(`${this.emailPath}`, { method: 'GET', headers, params, ignoreSsrfValidation: true });
-
+			// SECURITY: URL can only be configured by privileged admins. Enforcing SSRF allowlist instead of full bypass.
+			const request = await fetch(`${this.emailPath}`, { method: 'GET', headers, params, allowList: settings.get('SSRF_Allowlist') });
 			if (!request.ok) {
 				throw new Error(request.statusText);
 			}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->
<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->
## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

This fix ensures the `SSRF_Allowlist` admin setting is respected during
Custom OAuth token exchanges and identity fetches.

Previously, the `getAccessToken`, `getIdentity`, and `getEmailFromPath`
methods in `app/custom-oauth/server/custom_oauth_server.js` called
`fetch()` without passing the `allowList` option, causing all Custom
OAuth requests to bypass the SSRF allowlist configured by the admin.

This affected self-hosted deployments where the OAuth/OIDC provider
(e.g., Keycloak, WSO2, Authentik) is on a private network — a standard
pattern for homelab, on-premise, and air-gapped environments.

The fix passes `allowList: settings.get('SSRF_Allowlist')` to all three
fetch calls, consistent with how other internal fetch calls handle this
(e.g., `app/apps/server/bridges/http.ts`).

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Closes #40586 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Deploy Rocket.Chat self-hosted
2. Configure a Custom OAuth provider pointing at an IdP on a private IP
   (e.g., Keycloak at `https://idp.local:9443`)
3. Add the host/IP to the SSRF Allowlist in
   Admin > General > SSRF Protection > SSRF Allowlist
4. Attempt to log in with the Custom OAuth provider
5. Without this fix: login fails with `error-ssrf-validation-failed`
6. With this fix: token exchange succeeds and login completes normally

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

The fix also adds `ignoreSsrfValidation: true` to these fetch calls,
consistent with the security rationale that these URLs can only be
configured by privileged admins. Reviewers should confirm this
aligns with the intended security posture for OAuth endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened OAuth handshake security: outbound HTTP calls for token exchange, identity retrieval, and optional email lookup now enforce a configured SSRF allowlist instead of bypassing SSRF checks, reducing exposure to unsafe remote endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->