### PR TITLE
fix: move pagination reset out of useMemo into useEffect in RoomsTable

### DIFF
--- a/.changeset/odd-hats-kneel.md
+++ b/.changeset/odd-hats-kneel.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+fix: move pagination reset out of useMemo into useEffect in RoomsTable

--- a/apps/meteor/client/views/admin/rooms/RoomsTable.tsx
+++ b/apps/meteor/client/views/admin/rooms/RoomsTable.tsx
@@ -13,7 +13,7 @@ import {
 import { useEndpoint } from '@rocket.chat/ui-contexts';
 import { useQuery } from '@tanstack/react-query';
 import type { ReactElement, MutableRefObject } from 'react';
-import { useRef, useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import RoomRow from './RoomRow';
@@ -33,22 +33,17 @@ const RoomsTable = ({ reload }: { reload: MutableRefObject<() => void> }): React
 
 	const [roomFilters, setRoomFilters] = useState<RoomFilters>({ searchText: '', types: [] });
 
-	const prevRoomFilterText = useRef<string>(roomFilters.searchText);
-
 	const { sortBy, sortDirection, setSort } = useSort<'name' | 't' | 'usersCount' | 'msgs' | 'default' | 'featured' | 'ts'>('name');
 	const { current, itemsPerPage, setItemsPerPage, setCurrent, ...paginationProps } = usePagination();
 	const searchText = useDebouncedValue(roomFilters.searchText, 500);
 
 	const query = useDebouncedValue(
-		useMemo(() => {
-			if (searchText !== prevRoomFilterText.current) {
-				setCurrent(0);
-			}
-			return {
+		useMemo(
+			() => ({
 				filter: searchText || '',
 				sort: `{ "${sortBy}": ${sortDirection === 'asc' ? 1 : -1} }`,
 				count: itemsPerPage,
-				offset: searchText === prevRoomFilterText.current ? current : 0,
+				offset: current,
 				types: (roomFilters.types.length ? [...roomFilters.types.map((roomType) => roomType.id)] : DEFAULT_TYPES) as unknown as (
 					| 'c'
 					| 'd'
@@ -57,11 +52,11 @@ const RoomsTable = ({ reload }: { reload: MutableRefObject<() => void> }): React
 					| 'discussions'
 					| 'teams'
 				)[],
-			};
-		}, [searchText, sortBy, sortDirection, itemsPerPage, current, roomFilters.types, setCurrent]),
+			}),
+			[searchText, sortBy, sortDirection, itemsPerPage, current, roomFilters.types],
+		),
 		500,
 	);
-
 	const getAdminRooms = useEndpoint('GET', '/v1/rooms.adminRooms');
 
 	const { data, refetch, isSuccess, isLoading, isError } = useQuery({
@@ -74,8 +69,8 @@ const RoomsTable = ({ reload }: { reload: MutableRefObject<() => void> }): React
 	}, [reload, refetch]);
 
 	useEffect(() => {
-		prevRoomFilterText.current = searchText;
-	}, [searchText]);
+		setCurrent(0);
+	}, [searchText, setCurrent]);
 
 	const headers = (
 		<>
@@ -144,7 +139,11 @@ const RoomsTable = ({ reload }: { reload: MutableRefObject<() => void> }): React
 				<>
 					<GenericTable>
 						<GenericTableHeader>{headers}</GenericTableHeader>
-						<GenericTableBody>{data.rooms?.map((room) => <RoomRow key={room._id} room={room} />)}</GenericTableBody>
+						<GenericTableBody>
+							{data.rooms?.map((room) => (
+								<RoomRow key={room._id} room={room} />
+							))}
+						</GenericTableBody>
 					</GenericTable>
 					<Pagination
 						divider


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
The `setCurrent(0)` state setter was being called inside a `useMemo` 
callback to reset pagination when the search text changes. Calling state 
setters inside `useMemo` is a side effect during render, which React 
explicitly prohibits — memos must be pure computations.

This PR moves the pagination reset into a `useEffect` that watches 
`searchText`, and removes the now-unnecessary `prevRoomFilterText` ref 
and `useRef` import.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Fixes #40589

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
No visual regression expected. The pagination reset behavior on search 
text change is preserved — it now happens correctly in a useEffect 
instead of as a side effect during render.

To verify: navigate to Admin > Rooms, type in the search box, confirm 
pagination resets to page 1.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Checked UsersTable.tsx and ChannelsTable.tsx — neither has this pattern. 
Fix is isolated to RoomsTable.tsx.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin Rooms: searching now reliably resets pagination to the first page so results and sorting remain consistent.
* **Style / UI**
  * Minor rendering cleanup in the Rooms table for improved clarity and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->