### PR TITLE
chore(ddp-streamer): invalidate publication user cache on watch.users

### DIFF
--- a/ee/apps/ddp-streamer/src/DDPStreamer.ts
+++ b/ee/apps/ddp-streamer/src/DDPStreamer.ts
@@ -14,6 +14,7 @@ import { Autoupdate } from './lib/Autoupdate';
 import { proxy } from './proxy';
 import { ListenersModule } from '../../../../apps/meteor/server/modules/listeners/listeners.module';
 import type { NotificationsModule } from '../../../../apps/meteor/server/modules/notifications/notifications.module';
+import { invalidate as invalidatePublicationUserCache } from '../../../../apps/meteor/server/modules/streamer/publication-user-cache';
 import { StreamerCentral } from '../../../../apps/meteor/server/modules/streamer/streamer.module';
 
 const { PORT = 4000 } = process.env;
@@ -83,6 +84,16 @@ export class DDPStreamer extends ServiceClass {
 
 		this.onEvent('meteor.clientVersionUpdated', (versions): void => {
 			Autoupdate.updateVersion(versions);
+		});
+
+		// The publication user cache lives inside the NotificationsModule process. In a
+		// microservices deployment, ddp-streamer hosts that module but does not host
+		// MeteorService, so the watch.users invalidation registered in
+		// apps/meteor/server/services/meteor/service.ts never reaches this process.
+		// Without this listener, role/ban/user changes would only propagate after the
+		// 60s TTL expires.
+		this.onEvent('watch.users', (data): void => {
+			invalidatePublicationUserCache(data.id);
 		});
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #39667.

The publication user cache introduced in #39667 lives inside the `NotificationsModule` process. In a microservices deployment, `ddp-streamer` hosts that module but does **not** host `MeteorService`, so the `watch.users` invalidation hook registered in `apps/meteor/server/services/meteor/service.ts` never reaches the streamer process.

Without this listener, role/ban/user changes only propagate to streamer permission checks (`Authorization.canAccessRoom`, `hasPermission`, `hasAtLeastOnePermission`, etc.) after the 60s TTL expires. This PR subscribes to `watch.users` in `DDPStreamer` and invalidates the local cache.

## Impact

* Monolith: no behavior change (`MeteorService` already invalidates locally).
* Microservices (`ddp-streamer`): role/ban/user updates now invalidate immediately instead of waiting up to 60s.

## Test plan

- [ ] Microservices deployment: revoke a role from a user, verify the relevant stream (e.g. livechat / canned responses / settings) rejects within one event round-trip rather than after 60s.
- [ ] Monolith: confirm no regression in cache hit rate / permission checks.
- [ ] Verify ddp-streamer build/lint passes. 

 Task: [ARCH-2155]

[ARCH-2155]: https://rocketchat.atlassian.net/browse/ARCH-2155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User data in notifications is now synchronized promptly when user information is updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->