### PR TITLE
regression: restore reactive ConnectionStatusBar updates during reconnection

### DIFF
--- a/apps/meteor/client/lib/sdk/meteorBackedSdk.ts
+++ b/apps/meteor/client/lib/sdk/meteorBackedSdk.ts
@@ -2,6 +2,7 @@ import type { DDPSDK } from '@rocket.chat/ddp-client';
 import { Emitter } from '@rocket.chat/emitter';
 import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
+import { Tracker } from 'meteor/tracker';
 
 import { parseDDP } from './ddpProtocol';
 
@@ -28,33 +29,29 @@ const safeMeteorStatus = (): { status: string; connected: boolean; retryCount?: 
 };
 
 const onMeteorStatusChange = (cb: () => void): (() => void) => {
-	// Subscribe to Meteor's underlying WebSocket lifecycle events directly instead
-	// of riding Meteor.status's Tracker reactivity. The stream is the canonical
-	// non-reactive source: `'reset'` fires when a new DDP session is established
-	// (effectively the "connected" signal — see socket-stream-client.js), and
-	// `'disconnect'` fires when the WebSocket drops or each retry attempt restarts.
-	// `'connected'` is intentionally NOT subscribed: the stream's allowed event
-	// list is `['message', 'reset', 'disconnect']` and `on('connected')` throws
-	// `Error: unknown event type: connected`. Throwing here would propagate up
-	// through `connection.on(...)` callers (notably `CachedStore.performInitialization`)
-	// and abort their initialization before `setupListener()` runs, silently
-	// breaking real-time stream subscriptions for settings, subscriptions, etc.
-	const stream = Meteor.connection?._stream;
-	if (!stream || typeof stream.on !== 'function') {
-		// Test / SSR environment with a stubbed Meteor — no stream to subscribe to.
+	// Drive notifications off Meteor.status's Tracker reactivity. Listening to
+	// `_stream` events directly misses the `connecting`↔`waiting` transitions
+	// and the per-second `retryTime` ticks that Meteor mutates internally
+	// without restarting the socket, leaving ConnectionStatusBar stuck on a
+	// stale status while reconnection retries run.
+	if (typeof Meteor.status !== 'function' || typeof Tracker?.autorun !== 'function') {
+		// Test / SSR environment with a stubbed Meteor — nothing to subscribe to.
 		return noopUnsubscribe;
 	}
-	let stopped = false;
-	const handler = (): void => {
-		if (!stopped) cb();
-	};
-	stream.on('reset', handler);
-	stream.on('disconnect', handler);
-	// Meteor's stream `on` doesn't expose an `off`; flip a flag instead so the
-	// stale listener becomes a no-op once stopBridge runs.
-	return () => {
-		stopped = true;
-	};
+	let firstRun = true;
+	const computation = Tracker.autorun(() => {
+		try {
+			Meteor.status();
+		} catch {
+			return;
+		}
+		if (firstRun) {
+			firstRun = false;
+			return;
+		}
+		cb();
+	});
+	return () => computation.stop();
 };
 
 const meteorStatusToSdkStatus = (): string => {

--- a/apps/meteor/client/providers/ServerProvider.tsx
+++ b/apps/meteor/client/providers/ServerProvider.tsx
@@ -156,6 +156,16 @@ const ensureStatusBridge = (): void => {
 
 const subscribeStatus = (cb: () => void): (() => void) => {
 	ensureStatusBridge();
+	// Close the race between the cachedStatus computed at module load and the
+	// first event delivered through the bridge: status may have changed in
+	// between (e.g. the socket connected before <ServerProvider> mounted), and
+	// useSyncExternalStore would otherwise surface the stale snapshot until
+	// the next external transition.
+	const next = computeStatus();
+	if (!isStatusEqual(cachedStatus, next)) {
+		cachedStatus = next;
+		cb();
+	}
 	statusListeners.add(cb);
 	return () => {
 		statusListeners.delete(cb);


### PR DESCRIPTION
## Summary

- `ServerProvider` now drives its status snapshot off `Meteor.status`'s Tracker reactivity (via `meteorBackedSdk.onMeteorStatusChange`) instead of `Meteor.connection._stream` `reset`/`disconnect` events. Stream events only fire when the socket itself reconnects or drops, so internal `connecting`↔`waiting` cycles and per-second `retryTime` ticks were silently dropped — `ConnectionStatusBar` stayed pinned on a stale status (or never appeared) while a reconnection ran.
- `subscribeStatus` recomputes the snapshot immediately after wiring the bridge so the value `useSyncExternalStore` returns on first mount can't stay stuck on whatever `cachedStatus` was at module load, closing the race when the socket connected before `<ServerProvider>` mounted.

Regression from #40482.

## Test plan

- [ ] Boot the app with DevTools open, throttle network or hit the WS endpoint with a temporary block, and observe `ConnectionStatusBar` cycling through `connecting` → `waiting` → `connecting` with the countdown ticking down each second instead of freezing.
- [ ] Pause the WS server, let the bar reach `waiting`, resume the server, and confirm the bar disappears as soon as Meteor's status flips back to `connected` (no manual page refresh needed).
- [ ] Hard reload while the dev server is offline: bar should render with the current status on mount instead of staying on whatever was captured at module evaluation.
- [ ] Re-run with `SDK_TRANSPORT_ENABLED=true` to confirm the SDK-transport branch still behaves the same.


https://rocketchat.atlassian.net/browse/CORE-2203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection status synchronization to prevent stale status data on initialization, ensuring accurate server connectivity information is displayed immediately when the app loads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->