### PR TITLE
fix(meteor): useMemo side-effect in RoomsTable

### DIFF
--- a/.changeset/roomstable-usememo-sideeffect.md
+++ b/.changeset/roomstable-usememo-sideeffect.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+fix(meteor): useMemo side-effect in RoomsTable

--- a/apps/meteor/client/views/admin/rooms/RoomsTable.tsx
+++ b/apps/meteor/client/views/admin/rooms/RoomsTable.tsx
@@ -41,9 +41,6 @@ const RoomsTable = ({ reload }: { reload: MutableRefObject<() => void> }): React
 
 	const query = useDebouncedValue(
 		useMemo(() => {
-			if (searchText !== prevRoomFilterText.current) {
-				setCurrent(0);
-			}
 			return {
 				filter: searchText || '',
 				sort: `{ "${sortBy}": ${sortDirection === 'asc' ? 1 : -1} }`,
@@ -58,7 +55,7 @@ const RoomsTable = ({ reload }: { reload: MutableRefObject<() => void> }): React
 					| 'teams'
 				)[],
 			};
-		}, [searchText, sortBy, sortDirection, itemsPerPage, current, roomFilters.types, setCurrent]),
+		}, [searchText, sortBy, sortDirection, itemsPerPage, current, roomFilters.types]),
 		500,
 	);
 
@@ -74,8 +71,11 @@ const RoomsTable = ({ reload }: { reload: MutableRefObject<() => void> }): React
 	}, [reload, refetch]);
 
 	useEffect(() => {
-		prevRoomFilterText.current = searchText;
-	}, [searchText]);
+		if (searchText !== prevRoomFilterText.current) {
+			setCurrent(0);
+			prevRoomFilterText.current = searchText;
+		}
+	}, [searchText, setCurrent]);
 
 	const headers = (
 		<>


### PR DESCRIPTION
Fixes #40589 by extracting the setCurrent(0) side effect from useMemo into useEffect where state mutations belong, ensuring pure computation and respecting React's rendering contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed admin rooms table pagination so it reliably returns to the first page when the search text filter changes, ensuring consistent results while typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->