### PR TITLE
fix: make date chip gliding work with new virtualized list system

### DIFF
--- a/apps/meteor/client/views/room/hooks/useDateScroll.ts
+++ b/apps/meteor/client/views/room/hooks/useDateScroll.ts
@@ -145,18 +145,15 @@ export const useDateScroll = (margin = 8): useDateScrollReturn => {
 		5,
 		[list, margin, setBubbleDate],
 	);
-	// TODO: Make the chip "gliding" work with the new sistem.
-	// const listStyle =
-	// 	bubbleDate.show && bubbleDate.date
-	// 		? css`
-	// 				position: relative;
-	// 				& [data-time='${bubbleDate.date.replaceAll(/[-T:.]/g, '').substring(0, 8)}'] {
-	// 					opacity: 0;
-	// 				}
-	// 			`
-	// 		: undefined;
-
-	const listStyle = undefined;
+	const listStyle =
+	bubbleDate.show && bubbleDate.date
+		? css`
+				position: relative;
+				& [data-id='${new Date(bubbleDate.date).getTime()}'] {
+					opacity: 0;
+				}
+			`
+		: undefined;
 
 	return {
 		handleDateScroll,


### PR DESCRIPTION
**### Proposed changes**
The floating date chip "gliding" effect was broken after the migration to the new virtualized list system.
The old code used a CSS selector targeting data-time='YYYYMMDD' to hide the date divider behind the floating chip. However, the new system uses data-id with a Unix timestamp instead.
Updated the listStyle CSS selector in useDateScroll.ts to target data-id using new Date(bubbleDate.date).getTime() to match the correct divider element and restore the gliding behavior.
**### Issue(s)**
Related to the TODO comment at **useDateScroll.ts#L148**
**### Steps to test or reproduce**

Open any room with many messages
Scroll up quickly through the message list
Observe the floating date chip at the top
The date divider behind the chip should now be hidden (opacity: 0)
Previously the divider was visible behind the chip — now it is correctly hidden

**### Further comments**
The removed TODO comment confirms this was a known issue left for future fixing after the virtualized list migration. No new dependencies or breaking changes introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the display of date dividers when scrolling through message history in rooms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->