### PR TITLE
chore: Set `started` flag before calling `.start` on `NetworkBroker.start`

### DIFF
--- a/ee/packages/network-broker/src/NetworkBroker.ts
+++ b/ee/packages/network-broker/src/NetworkBroker.ts
@@ -191,8 +191,15 @@ export class NetworkBroker implements IBroker {
 	}
 
 	async start(): Promise<void> {
-		this.started = Promise.resolve(true);
+		try {
+			// WE have to set this before calling `.start` as some services migth call another service (settings, likely) as part of
+			// their `started` lifecycle method. `.call` bails out early (and silently) if `started` is false, returning undefined
+			// which can affect the service startup.
+			this.started = Promise.resolve(true);
 
-		await this.broker.start();
+			await this.broker.start();
+		} catch (e) {
+			this.started = Promise.resolve(false);
+		}
 	}
 }

--- a/ee/packages/network-broker/src/NetworkBroker.ts
+++ b/ee/packages/network-broker/src/NetworkBroker.ts
@@ -192,7 +192,7 @@ export class NetworkBroker implements IBroker {
 
 	async start(): Promise<void> {
 		try {
-			// WE have to set this before calling `.start` as some services migth call another service (settings, likely) as part of
+			// We have to set this before calling `.start` as some services might call another service (settings, likely) as part of
 			// their `started` lifecycle method. `.call` bails out early (and silently) if `started` is false, returning undefined
 			// which can affect the service startup.
 			this.started = Promise.resolve(true);
@@ -200,6 +200,7 @@ export class NetworkBroker implements IBroker {
 			await this.broker.start();
 		} catch (e) {
 			this.started = Promise.resolve(false);
+			throw e;
 		}
 	}
 }

--- a/ee/packages/network-broker/src/NetworkBroker.ts
+++ b/ee/packages/network-broker/src/NetworkBroker.ts
@@ -191,8 +191,8 @@ export class NetworkBroker implements IBroker {
 	}
 
 	async start(): Promise<void> {
-		await this.broker.start();
-
 		this.started = Promise.resolve(true);
+
+		await this.broker.start();
 	}
 }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Basically, `.call` checks if `this.started` is `true`, otherwise, it returns undefined for any service call made.

Some services call the (already available) settings service as part of its boot process, which currently gives them `undefined` results.

This PR changes the flag to be setup _before_ so the services can perform other service calls (services that should be available already) while starting.

There should be no noticeable impact apart from the semantics, as all services except settings depend on settings. So if any service calls settings or license at boot, it would work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broker startup reliability: the service now marks itself as starting earlier and reliably resets its state if initialization fails, ensuring requests are not processed when the broker is not ready. This prevents the system from incorrectly treating a failed startup as successful.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [CORE-2227]

[CORE-2227]: https://rocketchat.atlassian.net/browse/CORE-2227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ