### PR TITLE
fix: add TEST_MODE=true to OAuth ratelimiter's 'skip'

### DIFF
--- a/apps/meteor/server/configuration/configurePassport.ts
+++ b/apps/meteor/server/configuration/configurePassport.ts
@@ -56,6 +56,7 @@ export const configurePassport = (settings: ICachedSettings) => {
 		windowMs: settings.get<number>('API_Enable_Rate_Limiter_Limit_Time_Default'),
 		max: settings.get<number>('API_Enable_Rate_Limiter_Limit_Calls_Default'),
 		skip: () =>
+			process.env.TEST_MODE === 'true' ||
 			settings.get<boolean>('API_Enable_Rate_Limiter') !== true ||
 			(process.env.NODE_ENV === 'development' && settings.get<boolean>('API_Enable_Rate_Limiter_Dev') !== true),
 		handler: (_req, res) => {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
The OAuth ratelimiter introduced in the https://github.com/RocketChat/Rocket.Chat/pull/39760 doesn't skip properly when running in the CI. This PR adds `TEST_MODE=true` to it.

## Issue(s)
https://rocketchat.atlassian.net/browse/SB-997

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated OAuth authentication rate limiting configuration to skip enforcement during test mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->