### PR TITLE
regression: restore scroll position on channel change

### DIFF
--- a/apps/meteor/client/views/room/MessageList/MessageList.spec.tsx
+++ b/apps/meteor/client/views/room/MessageList/MessageList.spec.tsx
@@ -142,14 +142,12 @@ describe('MessageList scroll position', () => {
 			update: jest.fn(),
 		};
 		(RoomManager.getStore as jest.Mock).mockReturnValue(store);
-		mockVirtualizerHandle.findItemIndex.mockReturnValue(4);
 
 		render(<MessageList {...defaultProps} />, { wrapper: root.build() });
 
 		expect(screen.getByTestId('message-list')).toBeInTheDocument();
-		expect(mockVirtualizerHandle.findItemIndex).toHaveBeenCalledWith(123);
-		expect(mockVirtualizerHandle.scrollToIndex).toHaveBeenCalledWith(4, { align: 'start' });
-		expect(mockVirtualizerHandle.scrollTo).not.toHaveBeenCalled();
+		expect(mockVirtualizerHandle.scrollTo).toHaveBeenCalledWith(123);
+		expect(mockVirtualizerHandle.scrollToIndex).not.toHaveBeenCalled();
 	});
 
 	it('should jump to bottom if atBottom is true', () => {

--- a/apps/meteor/client/views/room/MessageList/MessageList.tsx
+++ b/apps/meteor/client/views/room/MessageList/MessageList.tsx
@@ -85,6 +85,9 @@ export const MessageList = function MessageList({
 
 	const handlePrepend = useCallback(
 		(offset: number) => {
+			if (!isRoomInitialized.current) {
+				return;
+			}
 			// If the offset is less than 200, it means the user is reaching the top of the list,
 			// so the prepend need to be enabled for smooth scrolling,
 			// if the prepend is enabled when a new message is added, the list will misalign.
@@ -141,14 +144,7 @@ export const MessageList = function MessageList({
 
 				setShouldJumpToBottom(false);
 
-				const index = virtualizerRef.current?.findItemIndex(store?.scroll);
-				if (index !== undefined) {
-					virtualizerRef.current?.scrollToIndex(index, {
-						align: 'start',
-					});
-				} else {
-					virtualizerRef.current?.scrollTo(store?.scroll);
-				}
+				virtualizerRef.current?.scrollTo(store?.scroll);
 				isAtBottom.current = false;
 				isRoomInitialized.current = true;
 				return;


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Switching between channels was not restoring the previously scrolled position - the list re-opened either at the bottom or in an inconsistent place - because `MessageList`'s init effect was relying on a two-step `findItemIndex` + `scrollToIndex` restore, which is unreliable against a freshly-mounted virtualizer whose row cache is still being populated. It also let `handlePrepend` run before initialization finished, which could corrupt the saved offset.

This PR replaces the brittle two-step restore with a single `scrollTo(store.scroll)` against the saved offset, and short-circuits `handlePrepend` until `isRoomInitialized` is true.

Depends on https://github.com/RocketChat/Rocket.Chat/pull/40757.

## Issue(s)

- [CORE-2271](https://rocketchat.atlassian.net/browse/CORE-2271) - Switching channels does not restore scroll position sometimes

## Steps to test or reproduce

In a channel with enough messages to scroll:

1. Open the channel, scroll to the middle, note a visible message.
2. Switch to another channel via the sidebar.
3. Switch back to the original channel -> the previously visible message is restored at the top of the viewport (instead of the list re-opening at the bottom).

## Further comments


[CORE-2271]: https://rocketchat.atlassian.net/browse/CORE-2271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ