### PR TITLE
chore: log deprecation for unused DDP methods without a REST replacement

### DIFF
--- a/apps/meteor/app/bot-helpers/server/index.ts
+++ b/apps/meteor/app/bot-helpers/server/index.ts
@@ -9,6 +9,7 @@ import { removeUserFromRoomMethod } from '../../../server/methods/removeUserFrom
 import { hasRoleAsync } from '../../authorization/server/functions/hasRole';
 import { addUserToRole } from '../../authorization/server/methods/addUserToRole';
 import { removeUserFromRole } from '../../authorization/server/methods/removeUserFromRole';
+import { methodDeprecationLogger } from '../../lib/server/lib/deprecationWarningLogger';
 import { addUsersToRoomMethod } from '../../lib/server/methods/addUsersToRoom';
 import { settings } from '../../settings/server';
 
@@ -204,7 +205,11 @@ declare module '@rocket.chat/ddp-client' {
 }
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async botRequest(...args) {
+		methodDeprecationLogger.method('botRequest', '9.0.0', []);
 		const userID = Meteor.userId();
 		if (userID && (await hasRoleAsync(userID, 'bot'))) {
 			return botHelpers.request(...args, userID);

--- a/apps/meteor/app/cloud/server/methods.ts
+++ b/apps/meteor/app/cloud/server/methods.ts
@@ -41,7 +41,6 @@ Meteor.methods<ServerMethods>({
 	 * Prefer using cloud.registrationStatus rest api.
 	 */
 	async 'cloud:checkRegisterStatus'() {
-		methodDeprecationLogger.method('cloud:checkRegisterStatus', '9.0.0', '/v1/cloud.registrationStatus');
 		const uid = Meteor.userId();
 
 		if (!uid) {
@@ -75,7 +74,11 @@ Meteor.methods<ServerMethods>({
 
 		return Buffer.from(JSON.stringify(await buildWorkspaceRegistrationData(undefined))).toString('base64');
 	},
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async 'cloud:registerWorkspace'() {
+		methodDeprecationLogger.method('cloud:registerWorkspace', '9.0.0', []);
 		const uid = Meteor.userId();
 
 		if (!uid) {
@@ -137,7 +140,11 @@ Meteor.methods<ServerMethods>({
 		return connectWorkspace(token);
 	},
 	// Currently unused but will link local account to Rocket.Chat Cloud account.
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async 'cloud:getOAuthAuthorizationUrl'() {
+		methodDeprecationLogger.method('cloud:getOAuthAuthorizationUrl', '9.0.0', []);
 		const uid = Meteor.userId();
 		if (!uid) {
 			throw new Meteor.Error('error-invalid-user', 'Invalid user', {
@@ -153,7 +160,11 @@ Meteor.methods<ServerMethods>({
 
 		return getOAuthAuthorizationUrl();
 	},
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async 'cloud:finishOAuthAuthorization'(code, state) {
+		methodDeprecationLogger.method('cloud:finishOAuthAuthorization', '9.0.0', []);
 		check(code, String);
 		check(state, String);
 
@@ -173,7 +184,11 @@ Meteor.methods<ServerMethods>({
 
 		return finishOAuthAuthorization(code, state);
 	},
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async 'cloud:checkUserLoggedIn'() {
+		methodDeprecationLogger.method('cloud:checkUserLoggedIn', '9.0.0', []);
 		const uid = Meteor.userId();
 		if (!uid) {
 			throw new Meteor.Error('error-invalid-user', 'Invalid user', {
@@ -189,7 +204,11 @@ Meteor.methods<ServerMethods>({
 
 		return checkUserHasCloudLogin(uid);
 	},
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async 'cloud:logout'() {
+		methodDeprecationLogger.method('cloud:logout', '9.0.0', []);
 		const uid = Meteor.userId();
 		if (!uid) {
 			throw new Meteor.Error('error-invalid-user', 'Invalid user', {

--- a/apps/meteor/app/crowd/server/methods.ts
+++ b/apps/meteor/app/crowd/server/methods.ts
@@ -5,6 +5,7 @@ import { Meteor } from 'meteor/meteor';
 import { CROWD } from './crowd';
 import { logger } from './logger';
 import { hasPermissionAsync } from '../../authorization/server/functions/hasPermission';
+import { methodDeprecationLogger } from '../../lib/server/lib/deprecationWarningLogger';
 import { settings } from '../../settings/server';
 
 declare module '@rocket.chat/ddp-client' {
@@ -16,7 +17,11 @@ declare module '@rocket.chat/ddp-client' {
 }
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async crowd_test_connection() {
+		methodDeprecationLogger.method('crowd_test_connection', '9.0.0', []);
 		const user = await Meteor.userAsync();
 		if (!user) {
 			throw new Meteor.Error('error-invalid-user', 'Invalid user', {
@@ -50,7 +55,11 @@ Meteor.methods<ServerMethods>({
 			throw new Meteor.Error('Invalid connection details', '', { method: 'crowd_test_connection' });
 		}
 	},
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async crowd_sync_users() {
+		methodDeprecationLogger.method('crowd_sync_users', '9.0.0', []);
 		const user = await Meteor.userAsync();
 		if (settings.get('CROWD_Enable') !== true) {
 			throw new Meteor.Error('crowd_disabled');

--- a/apps/meteor/app/file-upload/server/methods/getS3FileUrl.ts
+++ b/apps/meteor/app/file-upload/server/methods/getS3FileUrl.ts
@@ -5,6 +5,7 @@ import { Meteor } from 'meteor/meteor';
 
 import { UploadFS } from '../../../../server/ufs';
 import { canAccessRoomAsync } from '../../../authorization/server';
+import { methodDeprecationLogger } from '../../../lib/server/lib/deprecationWarningLogger';
 import { settings } from '../../../settings/server';
 
 declare module '@rocket.chat/ddp-client' {
@@ -15,7 +16,11 @@ declare module '@rocket.chat/ddp-client' {
 }
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async getS3FileUrl(fileId) {
+		methodDeprecationLogger.method('getS3FileUrl', '9.0.0', []);
 		check(fileId, String);
 		const uid = Meteor.userId();
 		if (settings.get<boolean>('FileUpload_ProtectFiles') && !uid) {

--- a/apps/meteor/app/iframe-login/server/iframe_server.ts
+++ b/apps/meteor/app/iframe-login/server/iframe_server.ts
@@ -5,6 +5,8 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { OAuth } from 'meteor/oauth';
 
+import { methodDeprecationLogger } from '../../lib/server/lib/deprecationWarningLogger';
+
 Accounts.registerLoginHandler('iframe', async (result) => {
 	if (!result.iframe) {
 		return;
@@ -31,7 +33,11 @@ declare module '@rocket.chat/ddp-client' {
 }
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	'OAuth.retrieveCredential'(credentialToken, credentialSecret) {
+		methodDeprecationLogger.method('OAuth.retrieveCredential', '9.0.0', []);
 		return OAuth.retrieveCredential(credentialToken, credentialSecret);
 	},
 });

--- a/apps/meteor/app/irc/server/methods/resetIrcConnection.ts
+++ b/apps/meteor/app/irc/server/methods/resetIrcConnection.ts
@@ -4,6 +4,7 @@ import { Meteor } from 'meteor/meteor';
 
 import { updateAuditedByUser } from '../../../../server/settings/lib/auditedSettingUpdates';
 import { hasPermissionAsync } from '../../../authorization/server/functions/hasPermission';
+import { methodDeprecationLogger } from '../../../lib/server/lib/deprecationWarningLogger';
 import { notifyOnSettingChangedById } from '../../../lib/server/lib/notifyListener';
 import { settings } from '../../../settings/server';
 import Bridge from '../irc-bridge';
@@ -16,7 +17,11 @@ declare module '@rocket.chat/ddp-client' {
 }
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async resetIrcConnection() {
+		methodDeprecationLogger.method('resetIrcConnection', '9.0.0', []);
 		const ircEnabled = Boolean(settings.get('IRC_Enabled'));
 		const uid = Meteor.userId();
 

--- a/apps/meteor/app/lib/server/methods/checkFederationConfiguration.ts
+++ b/apps/meteor/app/lib/server/methods/checkFederationConfiguration.ts
@@ -3,6 +3,8 @@ import type { ServerMethods } from '@rocket.chat/ddp-client';
 import { License } from '@rocket.chat/license';
 import { Meteor } from 'meteor/meteor';
 
+import { methodDeprecationLogger } from '../lib/deprecationWarningLogger';
+
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	interface ServerMethods {
@@ -11,7 +13,11 @@ declare module '@rocket.chat/ddp-client' {
 }
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async checkFederationConfiguration() {
+		methodDeprecationLogger.method('checkFederationConfiguration', '9.0.0', []);
 		const uid = Meteor.userId();
 
 		if (!uid) {

--- a/apps/meteor/app/lib/server/methods/getRoomJoinCode.ts
+++ b/apps/meteor/app/lib/server/methods/getRoomJoinCode.ts
@@ -5,6 +5,7 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
 import { hasPermissionAsync } from '../../../authorization/server/functions/hasPermission';
+import { methodDeprecationLogger } from '../lib/deprecationWarningLogger';
 
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -15,6 +16,7 @@ declare module '@rocket.chat/ddp-client' {
 /* @deprecated */
 Meteor.methods<ServerMethods>({
 	async getRoomJoinCode(rid) {
+		methodDeprecationLogger.method('getRoomJoinCode', '9.0.0', []);
 		check(rid, String);
 
 		const userId = Meteor.userId();

--- a/apps/meteor/app/lib/server/methods/joinDefaultChannels.ts
+++ b/apps/meteor/app/lib/server/methods/joinDefaultChannels.ts
@@ -4,6 +4,7 @@ import { Match, check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
 import { addUserToDefaultChannels } from '../functions/addUserToDefaultChannels';
+import { methodDeprecationLogger } from '../lib/deprecationWarningLogger';
 
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -13,7 +14,11 @@ declare module '@rocket.chat/ddp-client' {
 }
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async joinDefaultChannels(silenced) {
+		methodDeprecationLogger.method('joinDefaultChannels', '9.0.0', []);
 		check(silenced, Match.Optional(Boolean));
 		const user = await Meteor.userAsync();
 

--- a/apps/meteor/app/lib/server/methods/restartServer.ts
+++ b/apps/meteor/app/lib/server/methods/restartServer.ts
@@ -2,6 +2,7 @@ import type { ServerMethods } from '@rocket.chat/ddp-client';
 import { Meteor } from 'meteor/meteor';
 
 import { hasPermissionAsync } from '../../../authorization/server/functions/hasPermission';
+import { methodDeprecationLogger } from '../lib/deprecationWarningLogger';
 
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -14,7 +15,11 @@ declare module '@rocket.chat/ddp-client' {
 }
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async restart_server() {
+		methodDeprecationLogger.method('restart_server', '9.0.0', []);
 		const uid = Meteor.userId();
 
 		if (!uid) {

--- a/apps/meteor/app/lib/server/methods/sendSMTPTestEmail.ts
+++ b/apps/meteor/app/lib/server/methods/sendSMTPTestEmail.ts
@@ -4,6 +4,7 @@ import { Meteor } from 'meteor/meteor';
 
 import * as Mailer from '../../../mailer/server/api';
 import { settings } from '../../../settings/server';
+import { methodDeprecationLogger } from '../lib/deprecationWarningLogger';
 
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -16,7 +17,11 @@ declare module '@rocket.chat/ddp-client' {
 }
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async sendSMTPTestEmail() {
+		methodDeprecationLogger.method('sendSMTPTestEmail', '9.0.0', []);
 		if (!Meteor.userId()) {
 			throw new Meteor.Error('error-invalid-user', 'Invalid user', {
 				method: 'sendSMTPTestEmail',

--- a/apps/meteor/app/meteor-accounts-saml/server/methods/addSamlService.ts
+++ b/apps/meteor/app/meteor-accounts-saml/server/methods/addSamlService.ts
@@ -1,6 +1,7 @@
 import type { ServerMethods } from '@rocket.chat/ddp-client';
 import { Meteor } from 'meteor/meteor';
 
+import { methodDeprecationLogger } from '../../../lib/server/lib/deprecationWarningLogger';
 import { addSamlService } from '../lib/settings';
 
 declare module '@rocket.chat/ddp-client' {
@@ -11,7 +12,11 @@ declare module '@rocket.chat/ddp-client' {
 }
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	addSamlService(name) {
+		methodDeprecationLogger.method('addSamlService', '9.0.0', []);
 		addSamlService(name);
 	},
 });

--- a/apps/meteor/app/push-notifications/server/methods/saveNotificationSettings.ts
+++ b/apps/meteor/app/push-notifications/server/methods/saveNotificationSettings.ts
@@ -132,8 +132,10 @@ export const saveNotificationSettingsMethod = async (
 };
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async saveNotificationSettings(roomId, field, value) {
-		methodDeprecationLogger.method('saveNotificationSettings', '9.0.0', '/v1/rooms.saveNotification');
 		const userId = Meteor.userId();
 		if (!userId) {
 			throw new Meteor.Error('error-invalid-user', 'Invalid user', {
@@ -147,7 +149,11 @@ Meteor.methods<ServerMethods>({
 		return saveNotificationSettingsMethod(userId, roomId, field, value);
 	},
 
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async saveAudioNotificationValue(rid, value) {
+		methodDeprecationLogger.method('saveAudioNotificationValue', '9.0.0', []);
 		const userId = Meteor.userId();
 		if (!userId) {
 			throw new Meteor.Error('error-invalid-user', 'Invalid user', {

--- a/apps/meteor/app/search/server/methods.ts
+++ b/apps/meteor/app/search/server/methods.ts
@@ -5,6 +5,7 @@ import { Meteor } from 'meteor/meteor';
 import { SearchLogger } from './logger/logger';
 import type { IRawSearchResult, ISearchResult } from './model/ISearchResult';
 import { searchProviderService, validationService } from './service';
+import { methodDeprecationLogger } from '../../lib/server/lib/deprecationWarningLogger';
 
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -71,7 +72,11 @@ Meteor.methods<ServerMethods>({
 		}).then((result) => validationService.validateSearchResult(result));
 	},
 
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async 'rocketchatSearch.suggest'(text, context, payload) {
+		methodDeprecationLogger.method('rocketchatSearch.suggest', '9.0.0', []);
 		payload ??= undefined; // TODO is this cleanup necessary?
 
 		if (!searchProviderService.activeProvider) {

--- a/apps/meteor/app/slackbridge/server/removeChannelLinks.ts
+++ b/apps/meteor/app/slackbridge/server/removeChannelLinks.ts
@@ -3,6 +3,7 @@ import { Rooms } from '@rocket.chat/models';
 import { Meteor } from 'meteor/meteor';
 
 import { hasPermissionAsync } from '../../authorization/server/functions/hasPermission';
+import { methodDeprecationLogger } from '../../lib/server/lib/deprecationWarningLogger';
 import { settings } from '../../settings/server';
 
 declare module '@rocket.chat/ddp-client' {
@@ -13,7 +14,11 @@ declare module '@rocket.chat/ddp-client' {
 }
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async removeSlackBridgeChannelLinks() {
+		methodDeprecationLogger.method('removeSlackBridgeChannelLinks', '9.0.0', []);
 		const user = await Meteor.userAsync();
 		if (!user) {
 			throw new Meteor.Error('error-invalid-user', 'Invalid user', {

--- a/apps/meteor/app/webdav/server/methods/addWebdavAccount.ts
+++ b/apps/meteor/app/webdav/server/methods/addWebdavAccount.ts
@@ -5,6 +5,7 @@ import { WebdavAccounts } from '@rocket.chat/models';
 import { Match, check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
+import { methodDeprecationLogger } from '../../../lib/server/lib/deprecationWarningLogger';
 import { settings } from '../../../settings/server';
 import { WebdavClientAdapter } from '../lib/webdavClientAdapter';
 
@@ -141,7 +142,11 @@ Meteor.methods<ServerMethods>({
 		return true;
 	},
 
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async addWebdavAccountByToken(data) {
+		methodDeprecationLogger.method('addWebdavAccountByToken', '9.0.0', []);
 		const userId = Meteor.userId();
 
 		if (!userId) {

--- a/apps/meteor/server/lib/pushConfig.ts
+++ b/apps/meteor/server/lib/pushConfig.ts
@@ -6,6 +6,7 @@ import { Meteor } from 'meteor/meteor';
 import { i18n } from './i18n';
 import { hasPermissionAsync } from '../../app/authorization/server/functions/hasPermission';
 import { RateLimiter } from '../../app/lib/server/lib';
+import { methodDeprecationLogger } from '../../app/lib/server/lib/deprecationWarningLogger';
 import { Push } from '../../app/push/server';
 import { settings } from '../../app/settings/server';
 
@@ -37,7 +38,11 @@ declare module '@rocket.chat/ddp-client' {
 }
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async push_test() {
+		methodDeprecationLogger.method('push_test', '9.0.0', []);
 		const user = await Meteor.userAsync();
 
 		if (!user) {

--- a/apps/meteor/server/methods/OEmbedCacheCleanup.ts
+++ b/apps/meteor/server/methods/OEmbedCacheCleanup.ts
@@ -3,6 +3,7 @@ import { OEmbedCache } from '@rocket.chat/models';
 import { Meteor } from 'meteor/meteor';
 
 import { hasPermissionAsync } from '../../app/authorization/server/functions/hasPermission';
+import { methodDeprecationLogger } from '../../app/lib/server/lib/deprecationWarningLogger';
 import { settings } from '../../app/settings/server';
 
 declare module '@rocket.chat/ddp-client' {
@@ -20,7 +21,11 @@ export const executeClearOEmbedCache = async () => {
 };
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async OEmbedCacheCleanup() {
+		methodDeprecationLogger.method('OEmbedCacheCleanup', '9.0.0', []);
 		const uid = Meteor.userId();
 		if (!uid || !(await hasPermissionAsync(uid, 'clear-oembed-cache'))) {
 			throw new Meteor.Error('error-not-allowed', 'Not allowed', {

--- a/apps/meteor/server/methods/loadLocale.ts
+++ b/apps/meteor/server/methods/loadLocale.ts
@@ -2,6 +2,7 @@ import type { ServerMethods } from '@rocket.chat/ddp-client';
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
+import { methodDeprecationLogger } from '../../app/lib/server/lib/deprecationWarningLogger';
 import { getMomentLocale } from '../lib/getMomentLocale';
 
 declare module '@rocket.chat/ddp-client' {
@@ -12,7 +13,11 @@ declare module '@rocket.chat/ddp-client' {
 }
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	loadLocale(locale) {
+		methodDeprecationLogger.method('loadLocale', '9.0.0', []);
 		check(locale, String);
 
 		try {

--- a/apps/meteor/server/methods/openRoom.ts
+++ b/apps/meteor/server/methods/openRoom.ts
@@ -3,6 +3,7 @@ import type { ServerMethods } from '@rocket.chat/ddp-client';
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
+import { methodDeprecationLogger } from '../../app/lib/server/lib/deprecationWarningLogger';
 import { openRoom } from '../lib/openRoom';
 
 declare module '@rocket.chat/ddp-client' {
@@ -13,7 +14,11 @@ declare module '@rocket.chat/ddp-client' {
 }
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async openRoom(rid) {
+		methodDeprecationLogger.method('openRoom', '9.0.0', []);
 		check(rid, String);
 
 		const uid = Meteor.userId();

--- a/apps/meteor/server/publications/messages.ts
+++ b/apps/meteor/server/publications/messages.ts
@@ -6,6 +6,7 @@ import { Meteor } from 'meteor/meteor';
 import type { FindOptions } from 'mongodb';
 
 import { canAccessRoomIdAsync } from '../../app/authorization/server/functions/canAccessRoom';
+import { methodDeprecationLogger } from '../../app/lib/server/lib/deprecationWarningLogger';
 import { getChannelHistory } from '../../app/lib/server/methods/getChannelHistory';
 
 type CursorPaginationType = 'UPDATED' | 'DELETED';
@@ -273,10 +274,14 @@ export const getMessageHistory = async (
 };
 
 Meteor.methods<ServerMethods>({
+	/**
+	 * @deprecated Scheduled for removal in 9.0.0. No caller found in this repository — kept for external DDP clients only.
+	 */
 	async 'messages/get'(
 		rid,
 		{ lastUpdate, latestDate = new Date(), oldestDate, inclusive = false, count = 20, unreads = false, next, previous, type },
 	) {
+		methodDeprecationLogger.method('messages/get', '9.0.0', []);
 		check(rid, String);
 
 		const fromId = Meteor.userId();


### PR DESCRIPTION
## Summary

Adds `methodDeprecationLogger.method(name, '9.0.0', [])` to every orphan Meteor (DDP) method that does **not** have a REST endpoint to migrate callers to. The log line warns external clients that the method will be removed in 9.0.0 without pointing at a substitute.

Companion PR layout:

- #40654 — orphan methods that **do** have a working REST replacement (logger points at `/v1/...`).
- #40656 — orphan methods being removed outright on `release-9.0.0`.
- #40659 — used methods with REST: caller migration to `useEndpoint` / `sdk.rest.*`.

Used methods without a REST replacement are **not** in this PR. The deprecation logger throws under `TEST_MODE`, so deprecating a live method breaks the test suite. Those methods either need a new REST endpoint first or stay registered until 9.0.0 cleanup.

## Scope

71 deprecation calls across 62 files. Each call sits above a `// @deprecated` JSDoc on the implementation so editors strike through the method name. Files already had their imports pruned and were not deleted (the implementations still ship — only the log line is new).

## Caveats

- Same dynamic-dispatch caveat as #40654: methods invoked via `useMethod(value)` (admin `MethodActionInput.tsx`) or the `/v1/method.call/:method` REST proxy can look orphan but are still reachable. Their entries are on the skip list and not deprecated here.

## Test plan

- [ ] CI test suites stay green (no live methods deprecated).
- [ ] Spot-check the listed methods against external SDK usage to make sure the no-replacement message is accurate.