### PR TITLE
regression: Center jumped messages in virtualized list

### DIFF
--- a/apps/meteor/client/views/room/MessageList/MessageList.tsx
+++ b/apps/meteor/client/views/room/MessageList/MessageList.tsx
@@ -81,7 +81,7 @@ export const MessageList = function MessageList({
 
 	const keepMountedMessages = useKeepMountedMessages(messages, canPreview);
 
-	useTryToJumpToMessage({ rid, virtualizerRef, setIsJumpingToMessage, messages });
+	useTryToJumpToMessage({ rid, virtualizerRef, setIsJumpingToMessage, messages, messageListItemOffset: canPreview ? 1 : 0 });
 
 	const handlePrepend = useCallback(
 		(offset: number) => {

--- a/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.spec.ts
+++ b/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.spec.ts
@@ -1,0 +1,85 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import type { MutableRefObject } from 'react';
+import type { VirtualizerHandle } from 'virtua';
+
+import useTryToJumpToMessage from './useTryToJumpToMessage';
+import { RoomHistoryManager } from '../../../../../app/ui-utils/client';
+
+const mockUseSearchParameter = jest.fn();
+const mockUseEndpoint = jest.fn();
+
+jest.mock(
+	'@rocket.chat/ui-contexts',
+	() => ({
+		useEndpoint: (...args: unknown[]) => mockUseEndpoint(...args),
+		useSearchParameter: (...args: unknown[]) => mockUseSearchParameter(...args),
+	}),
+	{ virtual: true },
+);
+
+jest.mock(
+	'@rocket.chat/core-typings',
+	() => ({
+		isThreadMainMessage: jest.fn(() => false),
+		isThreadMessage: jest.fn(() => false),
+	}),
+	{ virtual: true },
+);
+
+jest.mock('@tanstack/react-query', () => ({
+	useQuery: jest.fn(() => ({ data: undefined })),
+}));
+
+jest.mock('../../../../../app/ui-utils/client', () => ({
+	RoomHistoryManager: {
+		getSurroundingChannelMessages: jest.fn(),
+		isLoading: jest.fn(),
+	},
+}));
+
+jest.mock('../../../../lib/utils/setMessageJumpQueryStringParameter', () => ({
+	setMessageJumpQueryStringParameter: jest.fn(),
+}));
+
+jest.mock('../providers/messageHighlightSubscription', () => ({
+	clearHighlightMessage: jest.fn(),
+	setHighlightMessage: jest.fn(),
+}));
+
+describe('useTryToJumpToMessage', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		jest.useFakeTimers();
+		mockUseSearchParameter.mockReturnValue('message-2');
+		mockUseEndpoint.mockReturnValue(jest.fn());
+		jest.mocked(RoomHistoryManager.isLoading).mockReturnValue(false);
+	});
+
+	afterEach(() => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	});
+
+	it('scrolls to the message list item after the leading item offset', async () => {
+		const scrollToIndex = jest.fn();
+		const virtualizerRef = {
+			current: {
+				scrollToIndex,
+			} as unknown as VirtualizerHandle,
+		} as MutableRefObject<VirtualizerHandle | null>;
+
+		renderHook(() =>
+			useTryToJumpToMessage({
+				rid: 'room-id',
+				virtualizerRef,
+				setIsJumpingToMessage: jest.fn(),
+				messages: [{ _id: 'message-1' }, { _id: 'message-2' }],
+				messageListItemOffset: 1,
+			}),
+		);
+
+		await waitFor(() => {
+			expect(scrollToIndex).toHaveBeenCalledWith(2, { align: 'center' });
+		});
+	});
+});

--- a/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.ts
+++ b/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.ts
@@ -3,7 +3,7 @@ import { useEndpoint, useSearchParameter } from '@rocket.chat/ui-contexts';
 import { useQuery } from '@tanstack/react-query';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import { useEffect } from 'react';
-import type { WindowVirtualizerHandle } from 'virtua';
+import type { VirtualizerHandle } from 'virtua';
 
 import { RoomHistoryManager } from '../../../../../app/ui-utils/client';
 import { messagesQueryKeys } from '../../../../lib/queryKeys';
@@ -13,12 +13,19 @@ import { clearHighlightMessage, setHighlightMessage } from '../providers/message
 
 type UseTryToJumpToMessageProps = {
 	rid: string;
-	virtualizerRef: MutableRefObject<WindowVirtualizerHandle | null>;
+	virtualizerRef: MutableRefObject<VirtualizerHandle | null>;
 	setIsJumpingToMessage: Dispatch<SetStateAction<boolean>>;
 	messages: { _id: string }[];
+	messageListItemOffset?: number;
 };
 
-const useTryToJumpToMessage = ({ rid, virtualizerRef, setIsJumpingToMessage, messages }: UseTryToJumpToMessageProps) => {
+const useTryToJumpToMessage = ({
+	rid,
+	virtualizerRef,
+	setIsJumpingToMessage,
+	messages,
+	messageListItemOffset = 0,
+}: UseTryToJumpToMessageProps) => {
 	const messageJumpParam = useSearchParameter('msg');
 
 	const getMessage = useEndpoint('GET', '/v1/chat.getMessage');
@@ -62,9 +69,8 @@ const useTryToJumpToMessage = ({ rid, virtualizerRef, setIsJumpingToMessage, mes
 			return;
 		}
 
-		const messageIndex = messages.indexOf(loadedMessage);
+		const messageIndex = messages.indexOf(loadedMessage) + messageListItemOffset;
 
-		// TODO: Calculate the offset of the page, for the message to be in the center of the page
 		virtualizerRef.current?.scrollToIndex(messageIndex, {
 			align: 'center',
 		});
@@ -79,7 +85,7 @@ const useTryToJumpToMessage = ({ rid, virtualizerRef, setIsJumpingToMessage, mes
 			setIsJumpingToMessage(false);
 			setMessageJumpQueryStringParameter(null);
 		}, 1000);
-	}, [messageJumpParam, virtualizerRef, setIsJumpingToMessage, rid, messages, message]);
+	}, [messageJumpParam, virtualizerRef, setIsJumpingToMessage, rid, messages, message, messageListItemOffset]);
 };
 
 export default useTryToJumpToMessage;


### PR DESCRIPTION
 ## Proposed changes (including videos or screenshots)

  Jumping to a message now accounts for the leading item rendered before the message rows in the virtualized message list.

  That leading item is present when the room foreword or previous-message loader is shown, so using the raw message array index can center the item before the target message. The jump hook now receives the rendered-list offset from `MessageList` and applies it before calling `scrollToIndex`.

  ## Issue(s)

  Fixes #40619

  ## Steps to test or reproduce

  - Open a room from a message link that sets the `msg` query param.
  - Confirm the highlighted message is centered in the message list.
  - Run the focused message-list specs.

  ## Further comments

  Added unit coverage for the offset case so the virtualizer scrolls to the rendered message item instead of the raw message array index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message navigation accuracy in room message lists by properly accounting for preview items when jumping to specific messages.

* **Tests**
  * Added test coverage for message jump navigation to ensure correct scrolling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40661?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->