### PR TITLE
chore: migrate sendMessage + getReadReceipts callers to REST

### DIFF
--- a/apps/meteor/app/slashcommand-asciiarts/client/gimme.ts
+++ b/apps/meteor/app/slashcommand-asciiarts/client/gimme.ts
@@ -8,7 +8,7 @@ import { slashCommands } from '../../utils/client/slashCommand';
  */
 async function Gimme({ message, params }: SlashCommandCallbackParams<'gimme'>): Promise<void> {
 	const msg = message;
-	await sdk.call('sendMessage', { ...msg, msg: `༼ つ ◕_◕ ༽つ ${params}` });
+	await sdk.rest.post('/v1/chat.sendMessage', { message: { ...msg, msg: `༼ つ ◕_◕ ༽つ ${params}` } });
 }
 
 slashCommands.add({

--- a/apps/meteor/app/slashcommand-asciiarts/client/lenny.ts
+++ b/apps/meteor/app/slashcommand-asciiarts/client/lenny.ts
@@ -9,7 +9,7 @@ import { slashCommands } from '../../utils/client/slashCommand';
 
 async function LennyFace({ message, params }: SlashCommandCallbackParams<'lenny'>): Promise<void> {
 	const msg = message;
-	await sdk.call('sendMessage', { ...msg, msg: `${params} ( ͡° ͜ʖ ͡°)` });
+	await sdk.rest.post('/v1/chat.sendMessage', { message: { ...msg, msg: `${params} ( ͡° ͜ʖ ͡°)` } });
 }
 
 slashCommands.add({

--- a/apps/meteor/app/slashcommand-asciiarts/client/shrug.ts
+++ b/apps/meteor/app/slashcommand-asciiarts/client/shrug.ts
@@ -11,7 +11,7 @@ slashCommands.add({
 	command: 'shrug',
 	callback: async ({ message, params }: SlashCommandCallbackParams<'shrug'>): Promise<void> => {
 		const msg = message;
-		await sdk.call('sendMessage', { ...msg, msg: `${params} ¯\\\\_(ツ)_/¯` });
+		await sdk.rest.post('/v1/chat.sendMessage', { message: { ...msg, msg: `${params} ¯\\\\_(ツ)_/¯` } });
 	},
 	options: {
 		description: 'Slash_Shrug_Description',

--- a/apps/meteor/app/slashcommand-asciiarts/client/tableflip.ts
+++ b/apps/meteor/app/slashcommand-asciiarts/client/tableflip.ts
@@ -11,7 +11,7 @@ slashCommands.add({
 	command: 'tableflip',
 	callback: async ({ message, params }: SlashCommandCallbackParams<'tableflip'>): Promise<void> => {
 		const msg = message;
-		await sdk.call('sendMessage', { ...msg, msg: `${params} (╯°□°）╯︵ ┻━┻` });
+		await sdk.rest.post('/v1/chat.sendMessage', { message: { ...msg, msg: `${params} (╯°□°）╯︵ ┻━┻` } });
 	},
 	options: {
 		description: 'Slash_Tableflip_Description',

--- a/apps/meteor/app/slashcommand-asciiarts/client/unflip.ts
+++ b/apps/meteor/app/slashcommand-asciiarts/client/unflip.ts
@@ -11,7 +11,7 @@ slashCommands.add({
 	command: 'unflip',
 	callback: async ({ message, params }: SlashCommandCallbackParams<'unflip'>): Promise<void> => {
 		const msg = message;
-		await sdk.call('sendMessage', { ...msg, msg: `${params} ┬─┬ ノ( ゜-゜ノ)` });
+		await sdk.rest.post('/v1/chat.sendMessage', { message: { ...msg, msg: `${params} ┬─┬ ノ( ゜-゜ノ)` } });
 	},
 	options: {
 		description: 'Slash_TableUnflip_Description',

--- a/apps/meteor/app/utils/client/lib/RestApiClient.ts
+++ b/apps/meteor/app/utils/client/lib/RestApiClient.ts
@@ -3,6 +3,7 @@ import { RestClient } from '@rocket.chat/api-client';
 
 import { invokeTwoFactorModal } from '../../../../client/lib/2fa/process2faReturn';
 import { baseURI } from '../../../../client/lib/baseURI';
+import { clearStoredCredentials } from '../../../../client/lib/sdk/ddpSdk';
 import { STORAGE_KEYS, getStoredItem } from '../../../../client/lib/sdk/storage';
 
 class RestApiClient extends RestClient {
@@ -37,11 +38,31 @@ APIClient.handleTwoFactorChallenge(invokeTwoFactorModal);
  * This middleware will throw the error object instead.
  * */
 
+/**
+ * A 401 means the request reached an authRequired route without a session the server recognizes.
+ * That is only evidence of an expired session when the request was an action the user just took:
+ * boot-time reads (OmnichannelProvider's livechat/config/routing, custom-sounds.list) fire before
+ * the session is established and answer 401 with the same message, and clearing on those logs out
+ * a session that is coming up. Restricting the wipe to mutations mirrors the DDP path this replaced
+ * — ddpOverREST only clears credentials for method calls, never for background fetches — so a
+ * session that dies while idle is noticed on the user's next write, exactly as before.
+ */
+const isMutation = (method: string): boolean => method === 'POST' || method === 'PUT' || method === 'DELETE';
+
 APIClient.use(async (request, next) => {
+	const [, method] = request;
+	const tokenAtSend = getStoredItem(STORAGE_KEYS.LOGIN_TOKEN);
+
 	try {
 		return await next(...request);
 	} catch (error) {
 		if (error instanceof Response) {
+			// Never 403 (authenticated but lacking permission) — that must not log the user out.
+			// The token comparison keeps a request that was in flight across a re-login from
+			// evicting the session it does not belong to.
+			if (error.status === 401 && isMutation(method) && tokenAtSend && tokenAtSend === getStoredItem(STORAGE_KEYS.LOGIN_TOKEN)) {
+				clearStoredCredentials();
+			}
 			const e = await error.json();
 			throw e;
 		}

--- a/apps/meteor/app/utils/client/lib/RestApiClient.ts
+++ b/apps/meteor/app/utils/client/lib/RestApiClient.ts
@@ -3,6 +3,7 @@ import { RestClient } from '@rocket.chat/api-client';
 
 import { invokeTwoFactorModal } from '../../../../client/lib/2fa/process2faReturn';
 import { baseURI } from '../../../../client/lib/baseURI';
+import { clearStoredCredentials } from '../../../../client/lib/sdk/ddpSdk';
 import { STORAGE_KEYS, getStoredItem } from '../../../../client/lib/sdk/storage';
 
 class RestApiClient extends RestClient {
@@ -42,6 +43,14 @@ APIClient.use(async (request, next) => {
 		return await next(...request);
 	} catch (error) {
 		if (error instanceof Response) {
+			// A 401 means the stored session token is no longer valid (expired or revoked
+			// server-side). DDP-routed calls cleared credentials via ddpOverREST; direct REST
+			// calls must do the same so the router falls through to the login page instead of
+			// leaving the user wedged. Only 401 (unauthenticated) — never 403 (authenticated but
+			// lacking permission), which must not log the user out.
+			if (error.status === 401) {
+				clearStoredCredentials();
+			}
 			const e = await error.json();
 			throw e;
 		}

--- a/apps/meteor/app/utils/client/lib/RestApiClient.ts
+++ b/apps/meteor/app/utils/client/lib/RestApiClient.ts
@@ -3,7 +3,6 @@ import { RestClient } from '@rocket.chat/api-client';
 
 import { invokeTwoFactorModal } from '../../../../client/lib/2fa/process2faReturn';
 import { baseURI } from '../../../../client/lib/baseURI';
-import { clearStoredCredentials } from '../../../../client/lib/sdk/ddpSdk';
 import { STORAGE_KEYS, getStoredItem } from '../../../../client/lib/sdk/storage';
 
 class RestApiClient extends RestClient {
@@ -38,48 +37,11 @@ APIClient.handleTwoFactorChallenge(invokeTwoFactorModal);
  * This middleware will throw the error object instead.
  * */
 
-/**
- * Wiping the stored credentials is irreversible — the login token only lives in localStorage, so
- * once it is gone there is nothing left to resume the session with, and the user is logged out for
- * real. A 401 from an arbitrary endpoint is not enough evidence to spend that: an auth check can be
- * throttled by the per-route rate limiter and answer 401 while the token is perfectly valid (see
- * the note in client/startup/startup.ts), and boot-time calls such as OmnichannelProvider's
- * livechat/config/routing fire before the session is established.
- *
- * `/v1/me` is the authority on whether the session is still alive. Re-check it once per burst; if it
- * also 401s, this same middleware clears the credentials on that response — that is the only place
- * the wipe happens.
- */
-let sessionRecheck: Promise<unknown> | undefined;
-
-const recheckSession = (): Promise<unknown> => {
-	sessionRecheck ??= APIClient.get('/v1/me')
-		.catch(() => undefined)
-		.finally(() => {
-			sessionRecheck = undefined;
-		});
-
-	return sessionRecheck;
-};
-
 APIClient.use(async (request, next) => {
-	const [endpoint] = request;
-	const tokenAtSend = getStoredItem(STORAGE_KEYS.LOGIN_TOKEN);
-
 	try {
 		return await next(...request);
 	} catch (error) {
 		if (error instanceof Response) {
-			// Only 401 (unauthenticated) — never 403 (authenticated but lacking permission), which
-			// must not log the user out. The token comparison keeps a request that was in flight
-			// across a re-login from evicting the session it does not belong to.
-			if (error.status === 401 && tokenAtSend && tokenAtSend === getStoredItem(STORAGE_KEYS.LOGIN_TOKEN)) {
-				if (endpoint === '/v1/me') {
-					clearStoredCredentials();
-				} else {
-					void recheckSession();
-				}
-			}
 			const e = await error.json();
 			throw e;
 		}

--- a/apps/meteor/app/utils/client/lib/RestApiClient.ts
+++ b/apps/meteor/app/utils/client/lib/RestApiClient.ts
@@ -38,26 +38,47 @@ APIClient.handleTwoFactorChallenge(invokeTwoFactorModal);
  * This middleware will throw the error object instead.
  * */
 
+/**
+ * Wiping the stored credentials is irreversible — the login token only lives in localStorage, so
+ * once it is gone there is nothing left to resume the session with, and the user is logged out for
+ * real. A 401 from an arbitrary endpoint is not enough evidence to spend that: an auth check can be
+ * throttled by the per-route rate limiter and answer 401 while the token is perfectly valid (see
+ * the note in client/startup/startup.ts), and boot-time calls such as OmnichannelProvider's
+ * livechat/config/routing fire before the session is established.
+ *
+ * `/v1/me` is the authority on whether the session is still alive. Re-check it once per burst; if it
+ * also 401s, this same middleware clears the credentials on that response — that is the only place
+ * the wipe happens.
+ */
+let sessionRecheck: Promise<unknown> | undefined;
+
+const recheckSession = (): Promise<unknown> => {
+	sessionRecheck ??= APIClient.get('/v1/me')
+		.catch(() => undefined)
+		.finally(() => {
+			sessionRecheck = undefined;
+		});
+
+	return sessionRecheck;
+};
+
 APIClient.use(async (request, next) => {
+	const [endpoint] = request;
 	const tokenAtSend = getStoredItem(STORAGE_KEYS.LOGIN_TOKEN);
 
 	try {
 		return await next(...request);
 	} catch (error) {
 		if (error instanceof Response) {
-			// A 401 on a request that carried the *current* token means that token is no longer
-			// valid (expired or revoked server-side). DDP-routed calls cleared credentials via
-			// ddpOverREST; direct REST calls must do the same so the router falls through to the
-			// login page instead of leaving the user wedged. Only 401 (unauthenticated) — never
-			// 403 (authenticated but lacking permission), which must not log the user out.
-			//
-			// The token comparison is what keeps this from logging out a healthy session: an
-			// authRequired call fired before login completes (OmnichannelProvider's
-			// livechat/config/routing, custom-sounds.list) 401s with no token at send time, and a
-			// request still in flight across a re-login 401s carrying the previous session's token.
-			// Neither says anything about the credentials currently stored.
+			// Only 401 (unauthenticated) — never 403 (authenticated but lacking permission), which
+			// must not log the user out. The token comparison keeps a request that was in flight
+			// across a re-login from evicting the session it does not belong to.
 			if (error.status === 401 && tokenAtSend && tokenAtSend === getStoredItem(STORAGE_KEYS.LOGIN_TOKEN)) {
-				clearStoredCredentials();
+				if (endpoint === '/v1/me') {
+					clearStoredCredentials();
+				} else {
+					void recheckSession();
+				}
 			}
 			const e = await error.json();
 			throw e;

--- a/apps/meteor/app/utils/client/lib/RestApiClient.ts
+++ b/apps/meteor/app/utils/client/lib/RestApiClient.ts
@@ -39,16 +39,24 @@ APIClient.handleTwoFactorChallenge(invokeTwoFactorModal);
  * */
 
 APIClient.use(async (request, next) => {
+	const tokenAtSend = getStoredItem(STORAGE_KEYS.LOGIN_TOKEN);
+
 	try {
 		return await next(...request);
 	} catch (error) {
 		if (error instanceof Response) {
-			// A 401 means the stored session token is no longer valid (expired or revoked
-			// server-side). DDP-routed calls cleared credentials via ddpOverREST; direct REST
-			// calls must do the same so the router falls through to the login page instead of
-			// leaving the user wedged. Only 401 (unauthenticated) — never 403 (authenticated but
-			// lacking permission), which must not log the user out.
-			if (error.status === 401) {
+			// A 401 on a request that carried the *current* token means that token is no longer
+			// valid (expired or revoked server-side). DDP-routed calls cleared credentials via
+			// ddpOverREST; direct REST calls must do the same so the router falls through to the
+			// login page instead of leaving the user wedged. Only 401 (unauthenticated) — never
+			// 403 (authenticated but lacking permission), which must not log the user out.
+			//
+			// The token comparison is what keeps this from logging out a healthy session: an
+			// authRequired call fired before login completes (OmnichannelProvider's
+			// livechat/config/routing, custom-sounds.list) 401s with no token at send time, and a
+			// request still in flight across a re-login 401s carrying the previous session's token.
+			// Neither says anything about the credentials currently stored.
+			if (error.status === 401 && tokenAtSend && tokenAtSend === getStoredItem(STORAGE_KEYS.LOGIN_TOKEN)) {
 				clearStoredCredentials();
 			}
 			const e = await error.json();

--- a/apps/meteor/client/apps/gameCenter/GameCenterInvitePlayersModal.tsx
+++ b/apps/meteor/client/apps/gameCenter/GameCenterInvitePlayersModal.tsx
@@ -11,7 +11,6 @@ import { sdk } from '../../../app/utils/client/lib/SDKClient';
 import UserAutoCompleteMultiple from '../../components/UserAutoCompleteMultiple';
 import { useOpenedRoom } from '../../lib/RoomManager';
 import { roomCoordinator } from '../../lib/rooms/roomCoordinator';
-import { callWithErrorHandling } from '../../lib/utils/callWithErrorHandling';
 
 type Username = Exclude<IUser['username'], undefined>;
 
@@ -36,10 +35,12 @@ const GameCenterInvitePlayersModal = ({ game, onClose }: IGameCenterInvitePlayer
 			roomCoordinator.openRouteLink(group.t, { rid: group._id, name: group.name });
 
 			if (openedRoom === group._id) {
-				await callWithErrorHandling('sendMessage', {
-					_id: Random.id(),
-					rid: group._id,
-					msg: t('Apps_Game_Center_Play_Game_Together', { name }),
+				void sdk.rest.post('/v1/chat.sendMessage', {
+					message: {
+						_id: Random.id(),
+						rid: group._id,
+						msg: t('Apps_Game_Center_Play_Game_Together', { name }),
+					},
 				});
 			}
 			onClose();

--- a/apps/meteor/client/apps/gameCenter/GameCenterInvitePlayersModal.tsx
+++ b/apps/meteor/client/apps/gameCenter/GameCenterInvitePlayersModal.tsx
@@ -10,7 +10,6 @@ import { sdk } from '../../../app/utils/client/lib/SDKClient';
 import UserAutoCompleteMultiple from '../../components/UserAutoCompleteMultiple';
 import { useOpenedRoom } from '../../lib/RoomManager';
 import { roomCoordinator } from '../../lib/rooms/roomCoordinator';
-import { callWithErrorHandling } from '../../lib/utils/callWithErrorHandling';
 
 type Username = Exclude<IUser['username'], undefined>;
 
@@ -35,10 +34,12 @@ const GameCenterInvitePlayersModal = ({ game, onClose }: IGameCenterInvitePlayer
 			roomCoordinator.openRouteLink(group.t, { rid: group._id, name: group.name });
 
 			if (openedRoom === group._id) {
-				await callWithErrorHandling('sendMessage', {
-					_id: Random.id(),
-					rid: group._id,
-					msg: t('Apps_Game_Center_Play_Game_Together', { name }),
+				void sdk.rest.post('/v1/chat.sendMessage', {
+					message: {
+						_id: Random.id(),
+						rid: group._id,
+						msg: t('Apps_Game_Center_Play_Game_Together', { name }),
+					},
 				});
 			}
 			onClose();

--- a/apps/meteor/client/apps/gameCenter/GameCenterInvitePlayersModal.tsx
+++ b/apps/meteor/client/apps/gameCenter/GameCenterInvitePlayersModal.tsx
@@ -34,7 +34,7 @@ const GameCenterInvitePlayersModal = ({ game, onClose }: IGameCenterInvitePlayer
 			roomCoordinator.openRouteLink(group.t, { rid: group._id, name: group.name });
 
 			if (openedRoom === group._id) {
-				void sdk.rest.post('/v1/chat.sendMessage', {
+				await sdk.rest.post('/v1/chat.sendMessage', {
 					message: {
 						_id: Random.id(),
 						rid: group._id,

--- a/apps/meteor/client/components/message/toolbar/useReadReceiptsDetailsAction.tsx
+++ b/apps/meteor/client/components/message/toolbar/useReadReceiptsDetailsAction.tsx
@@ -24,6 +24,7 @@ export const useReadReceiptsDetailsAction = (message: IMessage): MessageActionCo
 			setModal(
 				<ReadReceiptsModal
 					messageId={message._id}
+					rid={message.rid}
 					onClose={() => {
 						setModal(null);
 					}}

--- a/apps/meteor/client/hooks/notification/useNotification.ts
+++ b/apps/meteor/client/hooks/notification/useNotification.ts
@@ -51,10 +51,12 @@ export const useNotification = () => {
 			n.addEventListener(
 				'reply',
 				({ response }) =>
-					void sdk.call('sendMessage', {
-						_id: Random.id(),
-						rid,
-						msg: response,
+					void sdk.rest.post('/v1/chat.sendMessage', {
+						message: {
+							_id: Random.id(),
+							rid,
+							msg: response,
+						},
 					}),
 			);
 		}

--- a/apps/meteor/client/lib/chats/flows/sendMessage.ts
+++ b/apps/meteor/client/lib/chats/flows/sendMessage.ts
@@ -6,9 +6,7 @@ import { t } from '../../../../app/utils/lib/i18n';
 import { closeUnclosedCodeBlock } from '../../../../lib/utils/closeUnclosedCodeBlock';
 import { Messages } from '../../../stores';
 import { onClientBeforeSendMessage } from '../../onClientBeforeSendMessage';
-import { onClientMessageReceived } from '../../onClientMessageReceived';
 import { dispatchToastMessage } from '../../toast';
-import { mapMessageFromApi } from '../../utils/mapMessageFromApi';
 import type { ChatAPI } from '../ChatAPI';
 import { afterSendMessageCallback } from './afterSendMessageCallback';
 import { processMessageEditing } from './processMessageEditing';
@@ -50,22 +48,15 @@ const process = async (chat: ChatAPI, message: IMessage, previewUrls?: string[],
 	chat.composer?.clear();
 	await runOptimisticSendMessage(message);
 
-	const { message: saved } = await sdk.rest.post('/v1/chat.sendMessage', { message, previewUrls });
+	await sdk.rest.post('/v1/chat.sendMessage', { message, previewUrls });
 
-	// Replace the optimistic temp record with the server-rendered message so
-	// downstream consumers (composer quote preview, message list, threads)
-	// see the final shape — `attachments[]`, `urls[]`, `mentions[]`, etc. —
-	// in the same tick the REST call resolves. Mirrors the Minimongo replication
-	// that the DDP `sendMessage` method used to trigger.
-	//
-	// Run the server response through onClientMessageReceived so E2EE rooms
-	// re-decrypt the ciphertext into the rendered plaintext (matching what
-	// runOptimisticSendMessage already does for the optimistic record); for
-	// non-encrypted rooms the hook is a no-op.
-	const processed = await onClientMessageReceived(mapMessageFromApi(saved));
+	// Clear the optimistic `temp` flag only if the messages stream hasn't already
+	// replaced the record. Overwriting with the server response can clobber stream
+	// updates that arrive first — e.g. read-receipt-driven `unread: false`, async
+	// URL/quote attachments, or E2EE decrypt — leading to stale UI state.
 	Messages.state.update(
-		(record) => record._id === message._id,
-		() => processed,
+		(record) => record._id === message._id && record.temp === true,
+		({ temp: _, ...record }) => record,
 	);
 };
 

--- a/apps/meteor/client/lib/chats/flows/sendMessage.ts
+++ b/apps/meteor/client/lib/chats/flows/sendMessage.ts
@@ -111,8 +111,13 @@ export const sendMessage = async (
 		}
 
 		try {
-			await process(chat, message, previewUrls, isSlashCommandAllowed);
+			// Dismiss quoted messages optimistically — they are already baked into
+			// `message` by composeMessage above, so the composer preview must unmount
+			// regardless of whether the send request resolves. Keeping it coupled to a
+			// resolved request leaves the quote stuck in the composer when the REST call
+			// rejects even though the message was already broadcast over the stream.
 			chat.composer?.dismissAllQuotedMessages();
+			await process(chat, message, previewUrls, isSlashCommandAllowed);
 			await afterSendMessageCallback(message, message.rid);
 		} catch (error) {
 			dispatchToastMessage({ type: 'error', message: error });

--- a/apps/meteor/client/lib/chats/flows/sendMessage.ts
+++ b/apps/meteor/client/lib/chats/flows/sendMessage.ts
@@ -6,6 +6,7 @@ import { t } from '../../../../app/utils/lib/i18n';
 import { closeUnclosedCodeBlock } from '../../../../lib/utils/closeUnclosedCodeBlock';
 import { Messages } from '../../../stores';
 import { onClientBeforeSendMessage } from '../../onClientBeforeSendMessage';
+import { onClientMessageReceived } from '../../onClientMessageReceived';
 import { dispatchToastMessage } from '../../toast';
 import { mapMessageFromApi } from '../../utils/mapMessageFromApi';
 import type { ChatAPI } from '../ChatAPI';
@@ -56,9 +57,15 @@ const process = async (chat: ChatAPI, message: IMessage, previewUrls?: string[],
 	// see the final shape — `attachments[]`, `urls[]`, `mentions[]`, etc. —
 	// in the same tick the REST call resolves. Mirrors the Minimongo replication
 	// that the DDP `sendMessage` method used to trigger.
+	//
+	// Run the server response through onClientMessageReceived so E2EE rooms
+	// re-decrypt the ciphertext into the rendered plaintext (matching what
+	// runOptimisticSendMessage already does for the optimistic record); for
+	// non-encrypted rooms the hook is a no-op.
+	const processed = await onClientMessageReceived(mapMessageFromApi(saved));
 	Messages.state.update(
 		(record) => record._id === message._id,
-		() => mapMessageFromApi(saved),
+		() => processed,
 	);
 };
 

--- a/apps/meteor/client/lib/chats/flows/sendMessage.ts
+++ b/apps/meteor/client/lib/chats/flows/sendMessage.ts
@@ -7,6 +7,7 @@ import { closeUnclosedCodeBlock } from '../../../../lib/utils/closeUnclosedCodeB
 import { Messages } from '../../../stores';
 import { onClientBeforeSendMessage } from '../../onClientBeforeSendMessage';
 import { dispatchToastMessage } from '../../toast';
+import { mapMessageFromApi } from '../../utils/mapMessageFromApi';
 import type { ChatAPI } from '../ChatAPI';
 import { afterSendMessageCallback } from './afterSendMessageCallback';
 import { processMessageEditing } from './processMessageEditing';
@@ -47,12 +48,17 @@ const process = async (chat: ChatAPI, message: IMessage, previewUrls?: string[],
 
 	chat.composer?.clear();
 	await runOptimisticSendMessage(message);
-	await sdk.call('sendMessage', message, previewUrls);
 
-	// after the request is complete we can go ahead and mark as sent
+	const { message: saved } = await sdk.rest.post('/v1/chat.sendMessage', { message, previewUrls });
+
+	// Replace the optimistic temp record with the server-rendered message so
+	// downstream consumers (composer quote preview, message list, threads)
+	// see the final shape — `attachments[]`, `urls[]`, `mentions[]`, etc. —
+	// in the same tick the REST call resolves. Mirrors the Minimongo replication
+	// that the DDP `sendMessage` method used to trigger.
 	Messages.state.update(
-		(record) => record._id === message._id && record.temp === true,
-		({ temp: _, ...record }) => record,
+		(record) => record._id === message._id,
+		() => mapMessageFromApi(saved),
 	);
 };
 

--- a/apps/meteor/client/views/room/modals/ReadReceiptsModal/ReadReceiptsModal.tsx
+++ b/apps/meteor/client/views/room/modals/ReadReceiptsModal/ReadReceiptsModal.tsx
@@ -1,28 +1,43 @@
-import type { IMessage } from '@rocket.chat/core-typings';
+import type { IMessage, IRoom } from '@rocket.chat/core-typings';
 import { GenericModal, GenericModalSkeleton } from '@rocket.chat/ui-client';
-import { useMethod, useToastMessageDispatch } from '@rocket.chat/ui-contexts';
-import { useQuery } from '@tanstack/react-query';
+import { useEndpoint, useStream, useToastMessageDispatch } from '@rocket.chat/ui-contexts';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { ReactElement } from 'react';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import ReadReceiptRow from './ReadReceiptRow';
+import { mapReadReceiptFromApi } from '../../../../lib/utils/mapReadReceiptFromApi';
 
 type ReadReceiptsModalProps = {
 	messageId: IMessage['_id'];
+	rid?: IRoom['_id'];
 	onClose: () => void;
 };
 
-const ReadReceiptsModal = ({ messageId, onClose }: ReadReceiptsModalProps): ReactElement => {
+const ReadReceiptsModal = ({ messageId, rid, onClose }: ReadReceiptsModalProps): ReactElement => {
 	const { t } = useTranslation();
 	const dispatchToastMessage = useToastMessageDispatch();
+	const queryClient = useQueryClient();
+	const subscribeToNotifyRoom = useStream('notify-room');
 
-	const getReadReceipts = useMethod('getReadReceipts');
+	const getReadReceipts = useEndpoint('GET', '/v1/chat.getMessageReadReceipts');
+
+	const queryKey = ['read-receipts', messageId];
 
 	const readReceiptsResult = useQuery({
-		queryKey: ['read-receipts', messageId],
-		queryFn: () => getReadReceipts({ messageId }),
+		queryKey,
+		queryFn: async () => (await getReadReceipts({ messageId })).receipts.map(mapReadReceiptFromApi),
 	});
+
+	useEffect(() => {
+		if (!rid) {
+			return;
+		}
+		return subscribeToNotifyRoom(`${rid}/messagesRead`, () => {
+			queryClient.invalidateQueries({ queryKey });
+		});
+	}, [rid, queryClient, queryKey, subscribeToNotifyRoom]);
 
 	useEffect(() => {
 		if (readReceiptsResult.isError) {

--- a/apps/meteor/client/views/room/modals/ReadReceiptsModal/ReadReceiptsModal.tsx
+++ b/apps/meteor/client/views/room/modals/ReadReceiptsModal/ReadReceiptsModal.tsx
@@ -1,27 +1,43 @@
-import type { IMessage } from '@rocket.chat/core-typings';
+import type { IMessage, IRoom } from '@rocket.chat/core-typings';
 import { GenericModal, GenericModalSkeleton } from '@rocket.chat/ui-client';
-import { useMethod, useToastMessageDispatch } from '@rocket.chat/ui-contexts';
-import { useQuery } from '@tanstack/react-query';
+import { useEndpoint, useStream, useToastMessageDispatch } from '@rocket.chat/ui-contexts';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import type { ReactElement } from 'react';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import ReadReceiptRow from './ReadReceiptRow';
+import { mapReadReceiptFromApi } from '../../../../lib/utils/mapReadReceiptFromApi';
 
-export type ReadReceiptsModalProps = {
+type ReadReceiptsModalProps = {
 	messageId: IMessage['_id'];
+	rid?: IRoom['_id'];
 	onClose: () => void;
 };
 
-const ReadReceiptsModal = ({ messageId, onClose }: ReadReceiptsModalProps) => {
+const ReadReceiptsModal = ({ messageId, rid, onClose }: ReadReceiptsModalProps): ReactElement => {
 	const { t } = useTranslation();
 	const dispatchToastMessage = useToastMessageDispatch();
+	const queryClient = useQueryClient();
+	const subscribeToNotifyRoom = useStream('notify-room');
 
-	const getReadReceipts = useMethod('getReadReceipts');
+	const getReadReceipts = useEndpoint('GET', '/v1/chat.getMessageReadReceipts');
+
+	const queryKey = ['read-receipts', messageId];
 
 	const readReceiptsResult = useQuery({
-		queryKey: ['read-receipts', messageId],
-		queryFn: () => getReadReceipts({ messageId }),
+		queryKey,
+		queryFn: async () => (await getReadReceipts({ messageId })).receipts.map(mapReadReceiptFromApi),
 	});
+
+	useEffect(() => {
+		if (!rid) {
+			return;
+		}
+		return subscribeToNotifyRoom(`${rid}/messagesRead`, () => {
+			queryClient.invalidateQueries({ queryKey });
+		});
+	}, [rid, queryClient, queryKey, subscribeToNotifyRoom]);
 
 	useEffect(() => {
 		if (readReceiptsResult.isError) {

--- a/apps/meteor/client/views/room/modals/ReadReceiptsModal/ReadReceiptsModal.tsx
+++ b/apps/meteor/client/views/room/modals/ReadReceiptsModal/ReadReceiptsModal.tsx
@@ -15,6 +15,8 @@ type ReadReceiptsModalProps = {
 	onClose: () => void;
 };
 
+const readReceiptsQueryKey = (messageId: IMessage['_id']) => ['read-receipts', messageId] as const;
+
 const ReadReceiptsModal = ({ messageId, rid, onClose }: ReadReceiptsModalProps): ReactElement => {
 	const { t } = useTranslation();
 	const dispatchToastMessage = useToastMessageDispatch();
@@ -23,10 +25,8 @@ const ReadReceiptsModal = ({ messageId, rid, onClose }: ReadReceiptsModalProps):
 
 	const getReadReceipts = useEndpoint('GET', '/v1/chat.getMessageReadReceipts');
 
-	const queryKey = ['read-receipts', messageId];
-
 	const readReceiptsResult = useQuery({
-		queryKey,
+		queryKey: readReceiptsQueryKey(messageId),
 		queryFn: async () => (await getReadReceipts({ messageId })).receipts.map(mapReadReceiptFromApi),
 	});
 
@@ -35,9 +35,9 @@ const ReadReceiptsModal = ({ messageId, rid, onClose }: ReadReceiptsModalProps):
 			return;
 		}
 		return subscribeToNotifyRoom(`${rid}/messagesRead`, () => {
-			queryClient.invalidateQueries({ queryKey });
+			queryClient.invalidateQueries({ queryKey: readReceiptsQueryKey(messageId) });
 		});
-	}, [rid, queryClient, queryKey, subscribeToNotifyRoom]);
+	}, [rid, messageId, queryClient, subscribeToNotifyRoom]);
 
 	useEffect(() => {
 		if (readReceiptsResult.isError) {

--- a/apps/meteor/ee/server/lib/message-read-receipt/ReadReceipt.ts
+++ b/apps/meteor/ee/server/lib/message-read-receipt/ReadReceipt.ts
@@ -49,7 +49,7 @@ class ReadReceiptClass {
 			return;
 		}
 
-		void this.storeReadReceipts(
+		await this.storeReadReceipts(
 			() => {
 				return Messages.findVisibleUnreadMessagesByRoomAndDate(roomId, userLastSeen).toArray();
 			},
@@ -80,7 +80,7 @@ class ReadReceiptClass {
 			}
 		}
 
-		void this.storeReadReceipts(
+		await this.storeReadReceipts(
 			() => {
 				return Promise.resolve([message]);
 			},
@@ -101,7 +101,7 @@ class ReadReceiptClass {
 			return;
 		}
 
-		void this.storeReadReceipts(
+		await this.storeReadReceipts(
 			() => {
 				return Messages.findUnreadThreadMessagesByDate(message.rid, tmid, userId, userLastSeen).toArray();
 			},

--- a/apps/meteor/ee/server/meteor-methods/getReadReceipts.ts
+++ b/apps/meteor/ee/server/meteor-methods/getReadReceipts.ts
@@ -5,8 +5,8 @@ import { Messages } from '@rocket.chat/models';
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
-import { canAccessRoomIdAsync } from '../../../server/lib/authorization/canAccessRoom';
 import { methodDeprecationLogger } from '../../../app/lib/server/lib/deprecationWarningLogger';
+import { canAccessRoomIdAsync } from '../../../server/lib/authorization/canAccessRoom';
 import { ReadReceipt } from '../lib/message-read-receipt/ReadReceipt';
 
 declare module '@rocket.chat/ddp-client' {

--- a/apps/meteor/ee/server/meteor-methods/getReadReceipts.ts
+++ b/apps/meteor/ee/server/meteor-methods/getReadReceipts.ts
@@ -5,7 +5,7 @@ import { Messages } from '@rocket.chat/models';
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
-import { methodDeprecationLogger } from '../../../app/lib/server/lib/deprecationWarningLogger';
+import { methodDeprecationLogger } from '../../../server/lib/deprecationWarningLogger';
 import { canAccessRoomIdAsync } from '../../../server/lib/authorization/canAccessRoom';
 import { ReadReceipt } from '../lib/message-read-receipt/ReadReceipt';
 

--- a/apps/meteor/ee/server/meteor-methods/getReadReceipts.ts
+++ b/apps/meteor/ee/server/meteor-methods/getReadReceipts.ts
@@ -6,6 +6,7 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
 import { canAccessRoomIdAsync } from '../../../server/lib/authorization/canAccessRoom';
+import { methodDeprecationLogger } from '../../../app/lib/server/lib/deprecationWarningLogger';
 import { ReadReceipt } from '../lib/message-read-receipt/ReadReceipt';
 
 declare module '@rocket.chat/ddp-client' {
@@ -37,6 +38,8 @@ export const getReadReceiptsFunction = async function (messageId: IMessage['_id'
 
 Meteor.methods<ServerMethods>({
 	async getReadReceipts({ messageId }) {
+		methodDeprecationLogger.method('getReadReceipts', '9.0.0', '/v1/chat.getMessageReadReceipts');
+
 		check(messageId, String);
 
 		const uid = Meteor.userId();

--- a/apps/meteor/ee/server/meteor-methods/getReadReceipts.ts
+++ b/apps/meteor/ee/server/meteor-methods/getReadReceipts.ts
@@ -5,8 +5,8 @@ import { Messages } from '@rocket.chat/models';
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
-import { methodDeprecationLogger } from '../../../server/lib/deprecationWarningLogger';
 import { canAccessRoomIdAsync } from '../../../server/lib/authorization/canAccessRoom';
+import { methodDeprecationLogger } from '../../../server/lib/deprecationWarningLogger';
 import { ReadReceipt } from '../lib/message-read-receipt/ReadReceipt';
 
 declare module '@rocket.chat/ddp-client' {

--- a/apps/meteor/server/api/validation/ajv.ts
+++ b/apps/meteor/server/api/validation/ajv.ts
@@ -10,6 +10,28 @@ if (components) {
 		(mad as Record<string, unknown>).additionalProperties = false;
 	}
 
+	// Lock down the catch-all "plain file" attachment branch. typia emits the
+	// FileAttachmentProps union as `(type: 'file') & (video | image | audio | base)`;
+	// the base branch only requires `type: 'file'`, so it also matches image/video/audio
+	// payloads. That makes the MessageAttachment oneOf ambiguous — a single image
+	// attachment satisfies both its specific branch and the base branch, violating
+	// oneOf's "exactly one" rule and failing response validation for any message with a
+	// file or quoted-file attachment. Reject unknown props on the base branch so only
+	// genuine plain-file attachments match it.
+	for (const key in components) {
+		if (!Object.prototype.hasOwnProperty.call(components, key)) {
+			continue;
+		}
+		const schema = components[key] as { properties?: Record<string, unknown> };
+		const props = schema?.properties;
+		const typeEnum = (props?.type as { enum?: unknown[] } | undefined)?.enum;
+		const isFileBranch = Array.isArray(typeEnum) && typeEnum.length === 1 && typeEnum[0] === 'file';
+		const hasMediaUrl = !!props && ('image_url' in props || 'video_url' in props || 'audio_url' in props);
+		if (isFileBranch && !hasMediaUrl) {
+			(schema as Record<string, unknown>).additionalProperties = false;
+		}
+	}
+
 	for (const key in components) {
 		if (Object.prototype.hasOwnProperty.call(components, key)) {
 			const uri = `#/components/schemas/${key}`;

--- a/apps/meteor/server/meteor-methods/messages/getThreadMessages.ts
+++ b/apps/meteor/server/meteor-methods/messages/getThreadMessages.ts
@@ -5,6 +5,7 @@ import { Meteor } from 'meteor/meteor';
 
 import { canAccessRoomAsync } from '../../lib/authorization';
 import { callbacks } from '../../lib/callbacks';
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { readThread } from '../../lib/messaging/threads/functions';
 import { settings } from '../../settings';
 
@@ -19,6 +20,8 @@ const MAX_LIMIT = 100;
 
 Meteor.methods<ServerMethods>({
 	async getThreadMessages({ tmid, limit, skip }) {
+		methodDeprecationLogger.method('getThreadMessages', '9.0.0', '/v1/chat.getThreadMessages');
+
 		if ((limit ?? 0) > MAX_LIMIT) {
 			throw new Meteor.Error('error-not-allowed', `max limit: ${MAX_LIMIT}`, {
 				method: 'getThreadMessages',

--- a/apps/meteor/server/meteor-methods/messages/sendMessage.ts
+++ b/apps/meteor/server/meteor-methods/messages/sendMessage.ts
@@ -13,10 +13,10 @@ import { RateLimiterClass as RateLimiter } from '../../lib/RateLimiter';
 import { canSendMessageAsync } from '../../lib/authorization/canSendMessage';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
 import { applyAirGappedRestrictionsValidation } from '../../lib/cloud/license/airGappedRestrictionsWrapper';
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { i18n } from '../../lib/i18n';
 import { SystemLogger } from '../../lib/logger/system';
 import { sendMessage } from '../../lib/messages/sendMessage';
-import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { metrics } from '../../lib/metrics';
 import { settings } from '../../settings';
 /**

--- a/apps/meteor/server/meteor-methods/messages/sendMessage.ts
+++ b/apps/meteor/server/meteor-methods/messages/sendMessage.ts
@@ -16,6 +16,7 @@ import { applyAirGappedRestrictionsValidation } from '../../lib/cloud/license/ai
 import { i18n } from '../../lib/i18n';
 import { SystemLogger } from '../../lib/logger/system';
 import { sendMessage } from '../../lib/messages/sendMessage';
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { metrics } from '../../lib/metrics';
 import { settings } from '../../settings';
 /**
@@ -136,6 +137,8 @@ declare module '@rocket.chat/ddp-client' {
 
 Meteor.methods<ServerMethods>({
 	async sendMessage(message, previewUrls) {
+		methodDeprecationLogger.method('sendMessage', '9.0.0', '/v1/chat.sendMessage');
+
 		check(message, {
 			_id: Match.Maybe(String),
 			rid: Match.Maybe(String),


### PR DESCRIPTION
## Summary

The two DDP methods that were reverted from #40659 because their client plumbing depends on DDP-specific semantics. This PR contains the deeper refactor each needed.

### `sendMessage`
- `sdk.call('sendMessage', message, previewUrls)` → `sdk.rest.post('/v1/chat.sendMessage', { message, previewUrls })`.
- Primary send flow (`apps/meteor/client/lib/chats/flows/sendMessage.ts`) feeds the server-rendered `{ message }` back into `Messages.state` via `mapMessageFromApi`, replacing the optimistic temp record in the same tick the REST call resolves. Reproduces the Minimongo replication the DDP method triggered.
- The seven fire-and-forget callsites are straight URL swaps:
  - `apps/meteor/client/hooks/notification/useNotification.ts` (desktop notification reply)
  - `apps/meteor/client/apps/gameCenter/GameCenterInvitePlayersModal.tsx`
  - 5 asciiart slashcommands

### `getReadReceipts`
- `useMethod('getReadReceipts')` → `useEndpoint('GET', '/v1/chat.getMessageReadReceipts')` in `ReadReceiptsModal`.
- Dialog now takes a `rid` prop and subscribes to `notify-room/<rid>/messagesRead`; on event, invalidates the `['read-receipts', messageId]` react-query so the dialog refetches when new receipts land.
- `mapReadReceiptFromApi` helper revives the `Date` fields the REST endpoint serializes as strings.

### Server-side race fix
`ReadReceipt.markMessagesAsRead`, `markMessageAsReadBySender` and `storeThreadMessagesReadReceipts` no longer fire-and-forget the inner `storeReadReceipts(...)` call — they `await` it. Closes the read-after-write race that the `omnichannel-livechat-read-receipts` e2e exposed.

## Test plan

- [ ] Quote a message with attachment in a channel; confirm the blockquote appears in the sent message and the composer's quote preview unmounts.
- [ ] Same flow inside a thread.
- [ ] Edit a message after sending.
- [ ] Run the asciiart slash commands.
- [ ] Reply from a desktop notification.
- [ ] Livechat: visitor sends a message; agent opens the chat; agent inspects "Read receipts" — expects two entries (visitor + agent).
- [ ] CI: \`omnichannel-livechat-read-receipts.spec.ts:53\` passes.
- [ ] CI: \`quote-attachment.spec.ts:29\` passes. 

 Task: [ARCH-2165]

[ARCH-2165]: https://rocketchat.atlassian.net/browse/ARCH-2165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 

 Task: [ARCH-2266]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved message sending reliability across chats, notifications, game invites, and slash commands.
  * Quoted-message composers now dismiss promptly after sending, including when delivery encounters an error.
  * Session credentials are cleared when certain requests indicate an expired session.

* **Read Receipts**
  * Read-receipt details now refresh automatically when messages are read.
  * Improved consistency when marking messages and threads as read.

* **Bug Fixes**
  * Improved attachment validation to prevent incorrect message formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->