### PR TITLE
regression: login hangs on loading when "Forget User Session on Window Close" is enabled

### DIFF
--- a/apps/meteor/app/ui-master/server/scripts.ts
+++ b/apps/meteor/app/ui-master/server/scripts.ts
@@ -32,9 +32,13 @@ window.addEventListener('Custom_Script_Logged_In', function() {
 window.addEventListener('Custom_Script_On_Logout', function() {
 	${settings.get('Custom_Script_On_Logout')}
 })
-`;
 
-settings.watchMultiple(['Custom_Script_Logged_Out', 'Custom_Script_Logged_In', 'Custom_Script_On_Logout'], () => {
-	const content = getContent();
-	addScript('scripts', content);
-});
+${settings.get('Accounts_ForgetUserSessionOnWindowClose') ? `window.Accounts_ForgetUserSessionOnWindowClose = true;` : ''}`;
+
+settings.watchMultiple(
+	['Custom_Script_Logged_Out', 'Custom_Script_Logged_In', 'Custom_Script_On_Logout', 'Accounts_ForgetUserSessionOnWindowClose'],
+	() => {
+		const content = getContent();
+		addScript('scripts', content);
+	},
+);

--- a/apps/meteor/app/ui-master/server/scripts.ts
+++ b/apps/meteor/app/ui-master/server/scripts.ts
@@ -32,28 +32,9 @@ window.addEventListener('Custom_Script_Logged_In', function() {
 window.addEventListener('Custom_Script_On_Logout', function() {
 	${settings.get('Custom_Script_On_Logout')}
 })
+`;
 
-${
-	settings.get('Accounts_ForgetUserSessionOnWindowClose')
-		? `
-window.addEventListener('load', function() {
-	if (window.localStorage) {
-		Object.keys(window.localStorage).forEach(function(key) {
-			window.sessionStorage.setItem(key, window.localStorage.getItem(key));
-		});
-		window.localStorage.clear();
-		Meteor._localStorage = window.sessionStorage;
-		Accounts.config({ clientStorage: 'session'  });
-	}
+settings.watchMultiple(['Custom_Script_Logged_Out', 'Custom_Script_Logged_In', 'Custom_Script_On_Logout'], () => {
+	const content = getContent();
+	addScript('scripts', content);
 });
-`
-		: ''
-}`;
-
-settings.watchMultiple(
-	['Custom_Script_Logged_Out', 'Custom_Script_Logged_In', 'Custom_Script_On_Logout', 'Accounts_ForgetUserSessionOnWindowClose'],
-	() => {
-		const content = getContent();
-		addScript('scripts', content);
-	},
-);

--- a/apps/meteor/client/lib/sdk/ddpSdk.ts
+++ b/apps/meteor/client/lib/sdk/ddpSdk.ts
@@ -53,6 +53,8 @@ export const getDdpSdk = (): DDPSDK => {
 	if (!instance) {
 		if (sdkTransportEnabled) {
 			instance = DDPSDK.create(computeDdpUrl());
+			// TODO: This is a temporary fix to ensure Accounts/Meteor and Update Session On Window Close work together.
+			instance.storage = createMeteorBackedStorage();
 			applyEjsonEncoding(instance);
 			void startConnect(instance);
 		} else {

--- a/apps/meteor/client/lib/sdk/ddpSdk.ts
+++ b/apps/meteor/client/lib/sdk/ddpSdk.ts
@@ -3,7 +3,7 @@ import EJSON from 'ejson';
 import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
 
-import { createMeteorBackedSdk } from './meteorBackedSdk';
+import { createMeteorBackedSdk, createMeteorBackedStorage } from './meteorBackedSdk';
 import { isSdkTransportEnabled } from './sdkTransportEnabled';
 import { getRootUrl } from '../meteorRuntimeConfig';
 import { STORAGE_KEYS, getStoredItem, removeStoredItem } from './storage';

--- a/apps/meteor/client/lib/sdk/ddpSdk.ts
+++ b/apps/meteor/client/lib/sdk/ddpSdk.ts
@@ -54,7 +54,13 @@ export const getDdpSdk = (): DDPSDK => {
 		if (sdkTransportEnabled) {
 			instance = DDPSDK.create(computeDdpUrl());
 			// TODO: This is a temporary fix to ensure Accounts/Meteor and Update Session On Window Close work together.
-			instance.storage = createMeteorBackedStorage();
+			try {
+				instance.storage = createMeteorBackedStorage();
+			} catch (error) {
+				// DDPSDK.create may return a sealed/frozen instance under strict mode; failing
+				// to attach the storage hook must not abort SDK bootstrap.
+				console.warn('[ddpSdk] failed to attach storage hook to SDK instance', error);
+			}
 			applyEjsonEncoding(instance);
 			void startConnect(instance);
 		} else {

--- a/apps/meteor/client/lib/sdk/meteorBackedSdk.ts
+++ b/apps/meteor/client/lib/sdk/meteorBackedSdk.ts
@@ -273,11 +273,32 @@ const createMeteorBackedAccount = () => {
 };
 
 export const createMeteorBackedStorage = () => {
+	let appliedBackend: 'local' | 'session' | undefined;
+
 	return {
 		changeStorageBackend: () => {
-			setStorageBackend(window[FORGET_SESSION_SETTING_ID] ? 'session' : 'local');
-			(Meteor._localStorage as unknown as Storage) = window[FORGET_SESSION_SETTING_ID] ? window.sessionStorage : window.localStorage;
-			Accounts.config({ clientStorage: window[FORGET_SESSION_SETTING_ID] ? 'session' : 'local' });
+			const backend: 'local' | 'session' = window[FORGET_SESSION_SETTING_ID] ? 'session' : 'local';
+
+			if (appliedBackend === backend) {
+				return;
+			}
+
+			if (!setStorageBackend(backend)) {
+				return;
+			}
+
+			(Meteor._localStorage as unknown as Storage) = backend === 'session' ? window.sessionStorage : window.localStorage;
+
+			try {
+				Accounts.config({ clientStorage: backend });
+			} catch (error) {
+				// Accounts.config throws when invoked twice with a conflicting value. Meteor's
+				// own boot may have already set clientStorage; the _localStorage reassign above
+				// is what actually switches the backend Meteor reads from, so swallow.
+				console.warn('[storage] Accounts.config(clientStorage) refused at runtime', error);
+			}
+
+			appliedBackend = backend;
 		},
 	};
 };

--- a/apps/meteor/client/lib/sdk/meteorBackedSdk.ts
+++ b/apps/meteor/client/lib/sdk/meteorBackedSdk.ts
@@ -272,7 +272,7 @@ const createMeteorBackedAccount = () => {
 	} as unknown as DDPSDK['account'];
 };
 
-const createMeteorBackedStorage = () => {
+export const createMeteorBackedStorage = () => {
 	return {
 		changeStorageBackend: () => {
 			setStorageBackend(window[FORGET_SESSION_SETTING_ID] ? 'session' : 'local');

--- a/apps/meteor/client/lib/sdk/meteorBackedSdk.ts
+++ b/apps/meteor/client/lib/sdk/meteorBackedSdk.ts
@@ -5,6 +5,7 @@ import { Meteor } from 'meteor/meteor';
 import { Tracker } from 'meteor/tracker';
 
 import { parseDDP } from './ddpProtocol';
+import { setStorageBackend } from './storage';
 
 /**
  * Meteor-backed pass-through DDPSDK used when the SDK transport is OFF.
@@ -271,12 +272,42 @@ const createMeteorBackedAccount = () => {
 	} as unknown as DDPSDK['account'];
 };
 
+const createMeteorBackedStorage = () => {
+	return {
+		changeStorageBackend: () => {
+			setStorageBackend(window[FORGET_SESSION_SETTING_ID] ? 'session' : 'local');
+			(Meteor._localStorage as unknown as Storage) = window[FORGET_SESSION_SETTING_ID] ? window.sessionStorage : window.localStorage;
+			Accounts.config({ clientStorage: window[FORGET_SESSION_SETTING_ID] ? 'session' : 'local' });
+		},
+	};
+};
+
+export const FORGET_SESSION_SETTING_ID = 'Accounts_ForgetUserSessionOnWindowClose';
+
+declare global {
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	interface Window {
+		[FORGET_SESSION_SETTING_ID]?: boolean;
+	}
+}
+
+declare module '@rocket.chat/ddp-client' {
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	interface DDPSDK {
+		storage: {
+			changeStorageBackend: () => void;
+		};
+	}
+}
+
 export const createMeteorBackedSdk = (): DDPSDK => {
 	const connection = createMeteorBackedConnection();
 	const client = createMeteorBackedClient();
 	const account = createMeteorBackedAccount();
+	const storage = createMeteorBackedStorage();
 
 	return {
+		storage,
 		connection,
 		client,
 		account,

--- a/apps/meteor/client/lib/sdk/storage.ts
+++ b/apps/meteor/client/lib/sdk/storage.ts
@@ -14,10 +14,57 @@ export const STORAGE_KEYS = {
 
 export type StorageKey = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];
 
-const getStorage = (): Storage | undefined => (typeof window !== 'undefined' ? window.localStorage : undefined);
+const getStorage = (): Storage | undefined => {
+	if (typeof window === 'undefined') {
+		return undefined;
+	}
+
+	try {
+		return storageBackend === 'session' ? window.sessionStorage : window.localStorage;
+	} catch {
+		return undefined;
+	}
+};
 
 export const getStoredItem = (key: string): string | null => getStorage()?.getItem(key) ?? null;
 
 export const setStoredItem = (key: string, value: string): void => getStorage()?.setItem(key, value);
 
 export const removeStoredItem = (key: string): void => getStorage()?.removeItem(key);
+
+type StorageBackend = 'local' | 'session';
+
+let storageBackend: StorageBackend = 'local';
+
+export const setStorageBackend = (backend: StorageBackend): void => {
+	moveLoginKeys(backend);
+	storageBackend = backend;
+};
+
+const moveLoginKeys = (backend: StorageBackend): void => {
+	if (typeof window === 'undefined') {
+		return;
+	}
+
+	const keys = [
+		STORAGE_KEYS.USER_ID,
+		STORAGE_KEYS.LOGIN_TOKEN,
+		STORAGE_KEYS.LOGIN_TOKEN_EXPIRES,
+		STORAGE_KEYS.E2EE_PUBLIC_KEY,
+		STORAGE_KEYS.E2EE_PRIVATE_KEY,
+		STORAGE_KEYS.E2EE_RANDOM_PASSWORD,
+	];
+
+	const sourceStorage = backend === 'session' ? window.localStorage : window.sessionStorage;
+	const targetStorage = backend === 'session' ? window.sessionStorage : window.localStorage;
+
+	for (const key of keys) {
+		const value = sourceStorage.getItem(key);
+		if (value === null) {
+			continue;
+		}
+
+		targetStorage.setItem(key, value);
+		sourceStorage.removeItem(key);
+	}
+};

--- a/apps/meteor/client/lib/sdk/storage.ts
+++ b/apps/meteor/client/lib/sdk/storage.ts
@@ -32,11 +32,11 @@ const getStorage = (): Storage | undefined => {
 	return getStorageForBackend(storageBackend);
 };
 
-export const getStoredItem = (key: string): string | null => getStorage()?.getItem(key) ?? null;
+export const getStoredItem = (key: StorageKey): string | null => getStorage()?.getItem(key) ?? null;
 
-export const setStoredItem = (key: string, value: string): void => getStorage()?.setItem(key, value);
+export const setStoredItem = (key: StorageKey, value: string): void => getStorage()?.setItem(key, value);
 
-export const removeStoredItem = (key: string): void => getStorage()?.removeItem(key);
+export const removeStoredItem = (key: StorageKey): void => getStorage()?.removeItem(key);
 
 let storageBackend: StorageBackend = 'local';
 
@@ -90,6 +90,7 @@ const moveLoginKeys = (backend: StorageBackend): boolean => {
 			continue;
 		}
 	}
+	sourceStorage.clear();
 
 	return true;
 };

--- a/apps/meteor/client/lib/sdk/storage.ts
+++ b/apps/meteor/client/lib/sdk/storage.ts
@@ -14,6 +14,8 @@ export const STORAGE_KEYS = {
 
 export type StorageKey = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];
 
+type StorageBackend = 'local' | 'session';
+
 const getStorageForBackend = (backend: StorageBackend): Storage | undefined => {
 	if (typeof window === 'undefined') {
 		return undefined;
@@ -36,19 +38,22 @@ export const setStoredItem = (key: string, value: string): void => getStorage()?
 
 export const removeStoredItem = (key: string): void => getStorage()?.removeItem(key);
 
-type StorageBackend = 'local' | 'session';
-
 let storageBackend: StorageBackend = 'local';
 
-export const setStorageBackend = (backend: StorageBackend): void => {
+export const setStorageBackend = (backend: StorageBackend): boolean => {
 	if (backend === storageBackend) {
-		return;
+		return true;
 	}
-	moveLoginKeys(backend);
+
+	if (!moveLoginKeys(backend)) {
+		return false;
+	}
+
 	storageBackend = backend;
+	return true;
 };
 
-const moveLoginKeys = (backend: StorageBackend): void => {
+const moveLoginKeys = (backend: StorageBackend): boolean => {
 	const keys = [
 		STORAGE_KEYS.USER_ID,
 		STORAGE_KEYS.LOGIN_TOKEN,
@@ -62,7 +67,8 @@ const moveLoginKeys = (backend: StorageBackend): void => {
 	const targetStorage = getStorageForBackend(backend);
 
 	if (!sourceStorage || !targetStorage) {
-		return;
+		console.warn('Unable to switch storage backend because source or target storage is unavailable');
+		return false;
 	}
 
 	for (const key of keys) {
@@ -84,4 +90,6 @@ const moveLoginKeys = (backend: StorageBackend): void => {
 			continue;
 		}
 	}
+
+	return true;
 };

--- a/apps/meteor/client/lib/sdk/storage.ts
+++ b/apps/meteor/client/lib/sdk/storage.ts
@@ -14,16 +14,20 @@ export const STORAGE_KEYS = {
 
 export type StorageKey = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];
 
-const getStorage = (): Storage | undefined => {
+const getStorageForBackend = (backend: StorageBackend): Storage | undefined => {
 	if (typeof window === 'undefined') {
 		return undefined;
 	}
 
 	try {
-		return storageBackend === 'session' ? window.sessionStorage : window.localStorage;
+		return backend === 'session' ? window.sessionStorage : window.localStorage;
 	} catch {
 		return undefined;
 	}
+};
+
+const getStorage = (): Storage | undefined => {
+	return getStorageForBackend(storageBackend);
 };
 
 export const getStoredItem = (key: string): string | null => getStorage()?.getItem(key) ?? null;
@@ -45,10 +49,6 @@ export const setStorageBackend = (backend: StorageBackend): void => {
 };
 
 const moveLoginKeys = (backend: StorageBackend): void => {
-	if (typeof window === 'undefined') {
-		return;
-	}
-
 	const keys = [
 		STORAGE_KEYS.USER_ID,
 		STORAGE_KEYS.LOGIN_TOKEN,
@@ -58,16 +58,30 @@ const moveLoginKeys = (backend: StorageBackend): void => {
 		STORAGE_KEYS.E2EE_RANDOM_PASSWORD,
 	];
 
-	const sourceStorage = backend === 'session' ? window.localStorage : window.sessionStorage;
-	const targetStorage = backend === 'session' ? window.sessionStorage : window.localStorage;
+	const sourceStorage = getStorageForBackend(backend === 'session' ? 'local' : 'session');
+	const targetStorage = getStorageForBackend(backend);
+
+	if (!sourceStorage || !targetStorage) {
+		return;
+	}
 
 	for (const key of keys) {
-		const value = sourceStorage.getItem(key);
+		let value: string | null;
+		try {
+			value = sourceStorage.getItem(key);
+		} catch {
+			continue;
+		}
+
 		if (value === null) {
 			continue;
 		}
 
-		targetStorage.setItem(key, value);
-		sourceStorage.removeItem(key);
+		try {
+			targetStorage.setItem(key, value);
+			sourceStorage.removeItem(key);
+		} catch {
+			continue;
+		}
 	}
 };

--- a/apps/meteor/client/lib/sdk/storage.ts
+++ b/apps/meteor/client/lib/sdk/storage.ts
@@ -37,6 +37,9 @@ type StorageBackend = 'local' | 'session';
 let storageBackend: StorageBackend = 'local';
 
 export const setStorageBackend = (backend: StorageBackend): void => {
+	if (backend === storageBackend) {
+		return;
+	}
 	moveLoginKeys(backend);
 	storageBackend = backend;
 };

--- a/apps/meteor/client/meteor/startup/accounts.ts
+++ b/apps/meteor/client/meteor/startup/accounts.ts
@@ -1,7 +1,11 @@
+import { Accounts } from 'meteor/accounts-base';
+
 import { sdk } from '../../../app/utils/client/lib/SDKClient';
 import { t } from '../../../app/utils/lib/i18n';
 import { PublicSettingsCachedStore, SubscriptionsCachedStore } from '../../cachedStores';
 import { getDdpSdk } from '../../lib/sdk/ddpSdk';
+import { setStorageBackend } from '../../lib/sdk/storage';
+import { settings } from '../../lib/settings';
 import { dispatchToastMessage } from '../../lib/toast';
 import { userIdStore } from '../../lib/user';
 import { useUserDataSyncReady } from '../../lib/userData';
@@ -45,6 +49,35 @@ const whenMainReady = (): Promise<void> => {
 		const unsubscribeUserData = useUserDataSyncReady.subscribe(checkAndResolve);
 	});
 };
+
+const FORGET_SESSION_SETTING_ID = 'Accounts_ForgetUserSessionOnWindowClose';
+
+let configuredStorageBackend: 'local' | 'session' | undefined;
+
+const configureAccountsStorage = (clientStorage: 'local' | 'session'): void => {
+	(
+		Accounts as unknown as {
+			config: (options: { clientStorage: 'local' | 'session' }) => void;
+		}
+	).config({ clientStorage });
+};
+
+const applyForgetSessionOnWindowClose = (): void => {
+	const storageBackend = settings.peek<boolean>(FORGET_SESSION_SETTING_ID) ? 'session' : 'local';
+
+	if (configuredStorageBackend === storageBackend) {
+		return;
+	}
+
+	setStorageBackend(storageBackend);
+	configureAccountsStorage(storageBackend);
+	configuredStorageBackend = storageBackend;
+};
+
+applyForgetSessionOnWindowClose();
+settings.observe(FORGET_SESSION_SETTING_ID, applyForgetSessionOnWindowClose);
+PublicSettingsCachedStore.useReady.subscribe(applyForgetSessionOnWindowClose);
+userIdStore.subscribe(applyForgetSessionOnWindowClose);
 
 getDdpSdk().account.onEmailVerificationLink(async (token: string) => {
 	try {

--- a/apps/meteor/client/meteor/startup/accounts.ts
+++ b/apps/meteor/client/meteor/startup/accounts.ts
@@ -48,18 +48,24 @@ const whenMainReady = (): Promise<void> => {
 	});
 };
 
-let configuredStorageBackend: 'local' | 'session' | undefined;
+let configuredStorageBackend: 'local' | 'session' = 'local';
 
 const applyForgetSessionOnWindowClose = (): void => {
-	const forgetSession = settings.peek<boolean>(FORGET_SESSION_SETTING_ID) ?? window[FORGET_SESSION_SETTING_ID];
+	const forgetSession = Boolean(settings.peek<boolean>(FORGET_SESSION_SETTING_ID) ?? window[FORGET_SESSION_SETTING_ID]);
 
 	const storageBackend = forgetSession ? 'session' : 'local';
 
 	if (configuredStorageBackend === storageBackend) {
 		return;
 	}
+
 	window[FORGET_SESSION_SETTING_ID] = forgetSession;
-	getDdpSdk().storage.changeStorageBackend();
+	try {
+		getDdpSdk().storage?.changeStorageBackend();
+	} catch (error) {
+		console.warn('[accounts] changeStorageBackend failed', error);
+		return;
+	}
 
 	configuredStorageBackend = storageBackend;
 };

--- a/apps/meteor/client/meteor/startup/accounts.ts
+++ b/apps/meteor/client/meteor/startup/accounts.ts
@@ -1,10 +1,8 @@
-import { Accounts } from 'meteor/accounts-base';
-
 import { sdk } from '../../../app/utils/client/lib/SDKClient';
 import { t } from '../../../app/utils/lib/i18n';
 import { PublicSettingsCachedStore, SubscriptionsCachedStore } from '../../cachedStores';
 import { getDdpSdk } from '../../lib/sdk/ddpSdk';
-import { setStorageBackend } from '../../lib/sdk/storage';
+import { FORGET_SESSION_SETTING_ID } from '../../lib/sdk/meteorBackedSdk';
 import { settings } from '../../lib/settings';
 import { dispatchToastMessage } from '../../lib/toast';
 import { userIdStore } from '../../lib/user';
@@ -50,37 +48,24 @@ const whenMainReady = (): Promise<void> => {
 	});
 };
 
-const FORGET_SESSION_SETTING_ID = 'Accounts_ForgetUserSessionOnWindowClose';
-
 let configuredStorageBackend: 'local' | 'session' | undefined;
 
-const configureAccountsStorage = (clientStorage: 'local' | 'session'): void => {
-	(
-		Accounts as unknown as {
-			config: (options: { clientStorage: 'local' | 'session' }) => void;
-		}
-	).config({ clientStorage });
-};
-
 const applyForgetSessionOnWindowClose = (): void => {
-	const storageBackend = settings.peek<boolean>(FORGET_SESSION_SETTING_ID) ? 'session' : 'local';
+	const forgetSession = settings.peek<boolean>(FORGET_SESSION_SETTING_ID) ?? window[FORGET_SESSION_SETTING_ID];
+
+	const storageBackend = forgetSession ? 'session' : 'local';
 
 	if (configuredStorageBackend === storageBackend) {
 		return;
 	}
+	window[FORGET_SESSION_SETTING_ID] = forgetSession;
+	getDdpSdk().storage.changeStorageBackend();
 
-	if (!setStorageBackend(storageBackend)) {
-		return;
-	}
-
-	configureAccountsStorage(storageBackend);
 	configuredStorageBackend = storageBackend;
 };
 
 applyForgetSessionOnWindowClose();
 settings.observe(FORGET_SESSION_SETTING_ID, applyForgetSessionOnWindowClose);
-PublicSettingsCachedStore.useReady.subscribe(applyForgetSessionOnWindowClose);
-userIdStore.subscribe(applyForgetSessionOnWindowClose);
 
 getDdpSdk().account.onEmailVerificationLink(async (token: string) => {
 	try {

--- a/apps/meteor/client/meteor/startup/accounts.ts
+++ b/apps/meteor/client/meteor/startup/accounts.ts
@@ -69,7 +69,10 @@ const applyForgetSessionOnWindowClose = (): void => {
 		return;
 	}
 
-	setStorageBackend(storageBackend);
+	if (!setStorageBackend(storageBackend)) {
+		return;
+	}
+
 	configureAccountsStorage(storageBackend);
 	configuredStorageBackend = storageBackend;
 };

--- a/apps/meteor/client/views/room/E2EESetup/RoomE2EESetup.tsx
+++ b/apps/meteor/client/views/room/E2EESetup/RoomE2EESetup.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import RoomE2EENotAllowed from './RoomE2EENotAllowed';
 import { e2e } from '../../../lib/e2ee';
+import { getStoredItem, STORAGE_KEYS } from '../../../lib/sdk/storage';
 import RoomBody from '../body/RoomBody';
 import { useRoom } from '../contexts/RoomContext';
 import { useE2EERoomState } from '../hooks/useE2EERoomState';
@@ -15,7 +16,7 @@ const RoomE2EESetup = () => {
 	const e2eRoomState = useE2EERoomState(room._id);
 
 	const { t } = useTranslation();
-	const randomPassword = localStorage.getItem('e2e.randomPassword');
+	const randomPassword = getStoredItem(STORAGE_KEYS.E2EE_RANDOM_PASSWORD);
 
 	const onSavePassword = useCallback(() => {
 		if (!randomPassword) {

--- a/apps/meteor/tests/e2e/account-forgetSessionOnWindowClose.spec.ts
+++ b/apps/meteor/tests/e2e/account-forgetSessionOnWindowClose.spec.ts
@@ -37,7 +37,17 @@ test.describe.serial('Forget session on window close setting', () => {
 			await api.post('/settings/Accounts_ForgetUserSessionOnWindowClose', { value: false });
 		});
 
-		test('Login using credentials and reload to get logged out', async ({ page, context }) => {
+		test('Login using credentials and reload to stay logged in', async ({ page }) => {
+			await poLogin.login('user1', DEFAULT_USER_CREDENTIALS.password);
+
+			await expect(page.locator('role=heading[name="Welcome to Rocket.Chat"]')).toBeVisible();
+
+			await page.reload();
+
+			await expect(page.locator('role=heading[name="Welcome to Rocket.Chat"]')).toBeVisible();
+		});
+
+		test('Login using credentials in a new tab after first tab logged in', async ({ page, context }) => {
 			await poLogin.login('user1', DEFAULT_USER_CREDENTIALS.password);
 
 			await expect(page.locator('role=heading[name="Welcome to Rocket.Chat"]')).toBeVisible();
@@ -45,7 +55,10 @@ test.describe.serial('Forget session on window close setting', () => {
 			const newPage = await context.newPage();
 			await newPage.goto('/home');
 
-			await expect(newPage.locator('role=button[name="Login"]')).toBeVisible();
+			const newPoLogin = new Login(newPage);
+			await newPoLogin.login('user1', DEFAULT_USER_CREDENTIALS.password);
+
+			await expect(newPage.locator('role=heading[name="Welcome to Rocket.Chat"]')).toBeVisible();
 		});
 	});
 });

--- a/apps/meteor/tests/e2e/account-forgetSessionOnWindowClose.spec.ts
+++ b/apps/meteor/tests/e2e/account-forgetSessionOnWindowClose.spec.ts
@@ -1,6 +1,7 @@
-import { ADMIN_CREDENTIALS, DEFAULT_USER_CREDENTIALS } from './config/constants';
+import { DEFAULT_USER_CREDENTIALS } from './config/constants';
 import { AccountSecurity, HomeChannel, Login } from './page-objects';
 import { test, expect } from './utils/test';
+import { createTestUser, type ITestUser } from './utils/user-helpers';
 
 test.describe.serial('Forget session on window close setting', () => {
 	let poLogin: Login;
@@ -62,12 +63,21 @@ test.describe.serial('Forget session on window close setting', () => {
 		});
 
 		test.describe('E2EE save password flow', () => {
+			// Dedicated throwaway user: resetE2EEPassword() calls Users.unsetLoginTokens(),
+			// which would invalidate the shared admin login token the `api` fixture
+			// authenticates with — breaking every subsequent admin-authenticated request
+			// in the worker (e.g. the next spec's beforeAll settings changes silently 401).
+			let e2eeUser: ITestUser;
+
 			test.beforeAll(async ({ api }) => {
 				await api.post('/settings/E2E_Enable', { value: true });
 				await api.post('/settings/E2E_Allow_Unencrypted_Messages', { value: false });
+
+				e2eeUser = await createTestUser(api);
 			});
 
 			test.afterAll(async ({ api }) => {
+				await e2eeUser?.delete();
 				await api.post('/settings/E2E_Allow_Unencrypted_Messages', { value: true });
 				await api.post('/settings/E2E_Enable', { value: false });
 			});
@@ -76,7 +86,7 @@ test.describe.serial('Forget session on window close setting', () => {
 				const poHomeChannel = new HomeChannel(page);
 				const poAccountSecurity = new AccountSecurity(page);
 
-				await poLogin.login(ADMIN_CREDENTIALS.username, ADMIN_CREDENTIALS.password);
+				await poLogin.login(e2eeUser.data.username, DEFAULT_USER_CREDENTIALS.password);
 				await expect(page.locator('role=heading[name="Welcome to Rocket.Chat"]')).toBeVisible();
 
 				await poAccountSecurity.goto();
@@ -84,7 +94,7 @@ test.describe.serial('Forget session on window close setting', () => {
 
 				await page.locator('role=button[name="Login"]').waitFor();
 
-				await poLogin.login(ADMIN_CREDENTIALS.username, ADMIN_CREDENTIALS.password);
+				await poLogin.login(e2eeUser.data.username, DEFAULT_USER_CREDENTIALS.password);
 				await expect(page.locator('role=heading[name="Welcome to Rocket.Chat"]')).toBeVisible();
 				await expect(poHomeChannel.bannerSaveEncryptionPassword).toBeVisible();
 				await poHomeChannel.bannerSaveEncryptionPassword.click();

--- a/apps/meteor/tests/e2e/account-forgetSessionOnWindowClose.spec.ts
+++ b/apps/meteor/tests/e2e/account-forgetSessionOnWindowClose.spec.ts
@@ -28,8 +28,7 @@ test.describe.serial('Forget session on window close setting', () => {
 		});
 	});
 
-	// TODO: Fix this test
-	test.describe.skip('Setting on', async () => {
+	test.describe('Setting on', async () => {
 		test.beforeAll(async ({ api }) => {
 			await api.post('/settings/Accounts_ForgetUserSessionOnWindowClose', { value: true });
 		});

--- a/apps/meteor/tests/e2e/account-forgetSessionOnWindowClose.spec.ts
+++ b/apps/meteor/tests/e2e/account-forgetSessionOnWindowClose.spec.ts
@@ -1,5 +1,5 @@
-import { DEFAULT_USER_CREDENTIALS } from './config/constants';
-import { Login } from './page-objects';
+import { ADMIN_CREDENTIALS, DEFAULT_USER_CREDENTIALS } from './config/constants';
+import { AccountSecurity, HomeChannel, Login } from './page-objects';
 import { test, expect } from './utils/test';
 
 test.describe.serial('Forget session on window close setting', () => {
@@ -59,6 +59,42 @@ test.describe.serial('Forget session on window close setting', () => {
 			await newPoLogin.login('user1', DEFAULT_USER_CREDENTIALS.password);
 
 			await expect(newPage.locator('role=heading[name="Welcome to Rocket.Chat"]')).toBeVisible();
+		});
+
+		test.describe('E2EE save password flow', () => {
+			test.beforeAll(async ({ api }) => {
+				await api.post('/settings/E2E_Enable', { value: true });
+				await api.post('/settings/E2E_Allow_Unencrypted_Messages', { value: false });
+			});
+
+			test.afterAll(async ({ api }) => {
+				await api.post('/settings/E2E_Allow_Unencrypted_Messages', { value: true });
+				await api.post('/settings/E2E_Enable', { value: false });
+			});
+
+			test('E2EE save password button opens modal in SAVE_PASSWORD state', async ({ page }) => {
+				const poHomeChannel = new HomeChannel(page);
+				const poAccountSecurity = new AccountSecurity(page);
+
+				await poLogin.login(ADMIN_CREDENTIALS.username, ADMIN_CREDENTIALS.password);
+				await expect(page.locator('role=heading[name="Welcome to Rocket.Chat"]')).toBeVisible();
+
+				await poAccountSecurity.goto();
+				await poAccountSecurity.resetE2EEPassword();
+
+				await page.locator('role=button[name="Login"]').waitFor();
+
+				await poLogin.login(ADMIN_CREDENTIALS.username, ADMIN_CREDENTIALS.password);
+				await expect(page.locator('role=heading[name="Welcome to Rocket.Chat"]')).toBeVisible();
+				await expect(poHomeChannel.bannerSaveEncryptionPassword).toBeVisible();
+				await poHomeChannel.bannerSaveEncryptionPassword.click();
+
+				const randomPassword = await page.evaluate(() => window.sessionStorage.getItem('e2e.randomPassword') ?? '');
+				expect(randomPassword).toBeTruthy();
+
+				await expect(poHomeChannel.dialogSaveE2EEPassword).toBeVisible();
+				await expect(poHomeChannel.dialogSaveE2EEPassword).toContainText(randomPassword);
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Reintroduces the behavior of switching from localStorage to sessionStorage when the Accounts_ForgetUserSessionOnWindowClose setting is enabled.

Unskips the test.

This fixes the workspace client being broken after enabling the setting, but it's probably not the whole story.

## Issue(s)

[CORE-2236](https://rocketchat.atlassian.net/browse/CORE-2236)

## Steps to test or reproduce

1. Go to Workspace → Settings → Account

2. enable Accounts_ForgetUserSessionOnWindowClose

3. Save the setting

4. Go to a channel

5. Refresh the page or open a new tab

### Expected Behavior

If refreshing, the user should stay logged in

If opening in a new tab, the user should be able to log back in

### Actual Behavior

The user can’t log in; it gets stuck on the loading page

 on a new tab and had the same issue, only started working again once I disabled the setting

## Further comments

Root cause: https://github.com/RocketChat/Rocket.Chat/pull/40479


[CORE-2236]: https://rocketchat.atlassian.net/browse/CORE-2236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable storage backend to choose between persistent (local) and session storage for user session data.
  * Session handling now follows that setting so sessions can be retained or cleared on window close.
  * Client-side custom scripts are recomputed and reapplied automatically when related script settings change.

* **Tests**
  * E2E tests updated to verify session persistence and cross-tab behavior under the updated setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->