### PR TITLE
ci: TEST_MODE='api' to suppress deprecation throws in API tests

### DIFF
--- a/.github/workflows/ci-test-e2e.yml
+++ b/.github/workflows/ci-test-e2e.yml
@@ -175,6 +175,13 @@ jobs:
 
       - name: Start containers for CE
         if: inputs.release == 'ce'
+        env:
+          # API tests intentionally invoke deprecated DDP methods through
+          # /v1/method.call/:method. TEST_MODE='api' keeps every other test
+          # behavior on (rate-limiter bypass, short cache TTLs) while letting
+          # the deprecation logger log without throwing. Other suites use the
+          # docker-compose default of TEST_MODE='true'.
+          TEST_MODE: ${{ (inputs.type == 'api' || inputs.type == 'api-livechat') && 'api' || 'true' }}
         run: |
           # when we are testing CE, we only need to start the rocketchat container
           DEBUG_LOG_LEVEL=${DEBUG_LOG_LEVEL:-0} docker compose -f docker-compose-ci.yml up -d rocketchat --wait
@@ -185,6 +192,7 @@ jobs:
           ENTERPRISE_LICENSE: ${{ inputs.enterprise-license }}
           TRANSPORTER: ${{ inputs.transporter }}
           COMPOSE_PROFILES: ${{ inputs.type == 'api' && 'api' || '' }}
+          TEST_MODE: ${{ (inputs.type == 'api' || inputs.type == 'api-livechat') && 'api' || 'true' }}
         run: |
           DEBUG_LOG_LEVEL=${DEBUG_LOG_LEVEL:-0} docker compose -f docker-compose-ci.yml up -d --wait
 

--- a/apps/meteor/app/lib/server/lib/RateLimiter.js
+++ b/apps/meteor/app/lib/server/lib/RateLimiter.js
@@ -2,7 +2,7 @@ import { DDPRateLimiter } from 'meteor/ddp-rate-limiter';
 
 export const RateLimiterClass = new (class {
 	limitMethod(methodName, numRequests, timeInterval, matchers) {
-		if (process.env.TEST_MODE === 'true') {
+		if (process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api') {
 			return;
 		}
 		const match = {

--- a/apps/meteor/app/lib/server/lib/deprecationWarningLogger.ts
+++ b/apps/meteor/app/lib/server/lib/deprecationWarningLogger.ts
@@ -26,12 +26,20 @@ const compareVersions = (version: string, message: string) => {
 
 export type DeprecationLoggerNextPlannedVersion = '9.0.0';
 
+// `TEST_MODE=true` makes the logger throw so accidental usage of a deprecated
+// method/endpoint surfaces immediately in the test run. The API end-to-end
+// suite sets `TEST_MODE=api` instead — every other test-mode behavior stays on
+// (rate limiter bypass, short cache TTLs, etc.) but the deprecation logger
+// only logs because the suite intentionally exercises deprecated DDP methods
+// through `/v1/method.call/:method` and the streamer.
+const shouldThrowOnDeprecation = process.env.TEST_MODE === 'true';
+
 export const apiDeprecationLogger = ((logger) => {
 	return {
 		endpoint: (endpoint: string, version: DeprecationLoggerNextPlannedVersion, res: Response, info = '') => {
 			const message = `The endpoint "${endpoint}" is deprecated and will be removed on version ${version}${info ? ` (${info})` : ''}`;
 
-			if (process.env.TEST_MODE === 'true') {
+			if (shouldThrowOnDeprecation) {
 				throw new Error(message);
 			}
 
@@ -59,7 +67,7 @@ export const apiDeprecationLogger = ((logger) => {
 				}) ?? `The parameter "${parameter}" in the endpoint "${endpoint}" is deprecated and will be removed on version ${version}`;
 			compareVersions(version, message);
 
-			if (process.env.TEST_MODE === 'true') {
+			if (shouldThrowOnDeprecation) {
 				throw new Error(message);
 			}
 
@@ -87,7 +95,7 @@ export const apiDeprecationLogger = ((logger) => {
 					version,
 				}) ?? `The usage of the endpoint "${endpoint}" is deprecated and will be removed on version ${version}`;
 
-			if (process.env.TEST_MODE === 'true') {
+			if (shouldThrowOnDeprecation) {
 				throw new Error(message);
 			}
 
@@ -114,7 +122,7 @@ export const methodDeprecationLogger = ((logger) => {
 			const paths = infoArray.map((p) => (typeof p === 'string' && p.startsWith('/') ? `"${p}"` : p)).join(' or ');
 			const replacement = infoArray.length > 0 ? `Use the ${paths} endpoint${infoArray.length > 1 ? 's' : ''} instead` : '';
 			const message = `The method "${method}" is deprecated and will be removed on version ${version}${replacement ? ` (${replacement})` : ''}`;
-			if (process.env.TEST_MODE === 'true') {
+			if (shouldThrowOnDeprecation) {
 				throw new Error(message);
 			}
 			compareVersions(version, message);
@@ -124,7 +132,7 @@ export const methodDeprecationLogger = ((logger) => {
 		},
 		parameter: (method: string, parameter: string, version: DeprecationLoggerNextPlannedVersion) => {
 			const message = `The parameter "${parameter}" in the method "${method}" is deprecated and will be removed on version ${version}`;
-			if (process.env.TEST_MODE === 'true') {
+			if (shouldThrowOnDeprecation) {
 				throw new Error(message);
 			}
 
@@ -149,7 +157,7 @@ export const methodDeprecationLogger = ((logger) => {
 					version,
 				}) ?? `The usage of the method "${method}" is deprecated and will be removed on version ${version}`;
 
-			if (process.env.TEST_MODE === 'true') {
+			if (shouldThrowOnDeprecation) {
 				throw new Error(message);
 			}
 
@@ -162,7 +170,7 @@ export const methodDeprecationLogger = ((logger) => {
 		},
 		/** @deprecated */
 		warn: (message: string) => {
-			if (process.env.TEST_MODE === 'true') {
+			if (shouldThrowOnDeprecation) {
 				throw new Error(message);
 			}
 

--- a/apps/meteor/app/livechat/server/api/v1/config.ts
+++ b/apps/meteor/app/livechat/server/api/v1/config.ts
@@ -8,7 +8,10 @@ import { RoutingManager } from '../../lib/RoutingManager';
 import { online } from '../../lib/service-status';
 import { settings, findOpenRoom, getExtraConfigInfo, findAgent, findGuestWithoutActivity } from '../lib/livechat';
 
-const cachedSettings = mem(settings, { maxAge: process.env.TEST_MODE === 'true' ? 1 : 1000, cacheKey: JSON.stringify });
+const cachedSettings = mem(settings, {
+	maxAge: process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api' ? 1 : 1000,
+	cacheKey: JSON.stringify,
+});
 
 API.v1.addRoute(
 	'livechat/config',

--- a/apps/meteor/app/livechat/server/lib/AnalyticsTyped.ts
+++ b/apps/meteor/app/livechat/server/lib/AnalyticsTyped.ts
@@ -2,7 +2,7 @@ import { OmnichannelAnalytics } from '@rocket.chat/core-services';
 import mem from 'mem';
 
 export const getAgentOverviewDataCached = mem(OmnichannelAnalytics.getAgentOverviewData, {
-	maxAge: process.env.TEST_MODE === 'true' ? 1 : 60000,
+	maxAge: process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api' ? 1 : 60000,
 	cacheKey: JSON.stringify,
 });
 // Agent overview data on realtime is cached for 5 seconds
@@ -12,6 +12,6 @@ export const getAnalyticsOverviewDataCached = mem(OmnichannelAnalytics.getAnalyt
 	cacheKey: JSON.stringify,
 });
 export const getAnalyticsOverviewDataCachedForRealtime = mem(OmnichannelAnalytics.getAnalyticsOverviewData, {
-	maxAge: process.env.TEST_MODE === 'true' ? 1 : 5000,
+	maxAge: process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api' ? 1 : 5000,
 	cacheKey: JSON.stringify,
 });

--- a/apps/meteor/app/livechat/server/livechat.ts
+++ b/apps/meteor/app/livechat/server/livechat.ts
@@ -38,7 +38,9 @@ function parseExtraAttributes(widgetData: string): string {
 	return doc.documentElement.innerHTML;
 }
 
-const memoizedParseExtraAttributes = mem(parseExtraAttributes, { maxAge: process.env.TEST_MODE === 'true' ? 1 : 60000 });
+const memoizedParseExtraAttributes = mem(parseExtraAttributes, {
+	maxAge: process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api' ? 1 : 60000,
+});
 
 WebApp.connectHandlers.use('/livechat', (req, res, next) => {
 	if (!req.url) {

--- a/apps/meteor/app/livechat/server/startup.ts
+++ b/apps/meteor/app/livechat/server/startup.ts
@@ -120,7 +120,7 @@ Meteor.startup(async () => {
 			}
 			await businessHourManager.stopManager();
 		},
-		process.env.TEST_MODE === 'true'
+		process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api'
 			? {
 					debounce: 10,
 				}

--- a/apps/meteor/app/settings/server/CachedSettings.ts
+++ b/apps/meteor/app/settings/server/CachedSettings.ts
@@ -183,7 +183,7 @@ export class CachedSettings
 		}
 
 		const mergeFunction =
-			process.env.TEST_MODE !== 'true'
+			process.env.TEST_MODE !== 'true' && process.env.TEST_MODE !== 'api'
 				? _.debounce((): void => {
 						callback(_id.map((id) => this.store.get(id)?.value) as T[]);
 					}, 100)

--- a/apps/meteor/client/lib/queryClient.ts
+++ b/apps/meteor/client/lib/queryClient.ts
@@ -4,7 +4,7 @@ export const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
 			refetchOnWindowFocus: false,
-			retry: process.env.TEST_MODE === 'true',
+			retry: process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api',
 		},
 		mutations: {
 			onError: console.warn,

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoCloseOnHoldScheduler.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoCloseOnHoldScheduler.ts
@@ -33,7 +33,7 @@ export class AutoCloseOnHoldSchedulerClass {
 			mongo: (MongoInternals.defaultRemoteCollectionDriver().mongo as any).client.db(),
 			db: { collection: SCHEDULER_NAME },
 			defaultConcurrency: 1,
-			processEvery: process.env.TEST_MODE === 'true' ? '3 seconds' : '1 minute',
+			processEvery: process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api' ? '3 seconds' : '1 minute',
 		});
 
 		await this.scheduler.start();

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoTransferChatScheduler.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoTransferChatScheduler.ts
@@ -35,7 +35,7 @@ export class AutoTransferChatSchedulerClass {
 			mongo: (MongoInternals.defaultRemoteCollectionDriver().mongo as any).client.db(),
 			db: { collection: SCHEDULER_NAME },
 			defaultConcurrency: 1,
-			processEvery: process.env.TEST_MODE === 'true' ? '3 seconds' : '1 minute',
+			processEvery: process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api' ? '3 seconds' : '1 minute',
 		});
 
 		await this.scheduler.start();

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/QueueInactivityMonitor.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/QueueInactivityMonitor.ts
@@ -39,7 +39,7 @@ export class OmnichannelQueueInactivityMonitorClass {
 			mongo: (MongoInternals.defaultRemoteCollectionDriver().mongo as any).client.db(),
 			db: { collection: SCHEDULER_NAME },
 			defaultConcurrency: 1,
-			processEvery: process.env.TEST_MODE === 'true' ? '3 seconds' : '1 minute',
+			processEvery: process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api' ? '3 seconds' : '1 minute',
 		});
 		this.createIndex();
 		const language = settings.get<string>('Language') || 'en';
@@ -112,7 +112,7 @@ export class OmnichannelQueueInactivityMonitorClass {
 		const { inquiryId } = data;
 		// TODO: add projection and maybe use findOneQueued to avoid fetching the whole inquiry
 		const inquiry = await LivechatInquiryRaw.findOneById(inquiryId);
-		if (!inquiry || inquiry.status !== 'queued') {
+		if (inquiry?.status !== 'queued') {
 			return;
 		}
 

--- a/apps/meteor/ee/server/apps/marketplace/isTesting.ts
+++ b/apps/meteor/ee/server/apps/marketplace/isTesting.ts
@@ -4,5 +4,5 @@
  * @returns `true` if the `TEST_MODE` environment variable equals `'true'`, `false` otherwise.
  */
 export function isTesting() {
-	return process.env.TEST_MODE === 'true';
+	return process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api';
 }

--- a/apps/meteor/packages/rocketchat-mongo-config/server/index.js
+++ b/apps/meteor/packages/rocketchat-mongo-config/server/index.js
@@ -40,7 +40,7 @@ if (Object.keys(mongoConnectionOptions).length > 0) {
 process.env.HTTP_FORWARDED_COUNT = process.env.HTTP_FORWARDED_COUNT || '1';
 
 // Just print to logs if in TEST_MODE due to a bug in Meteor 2.5: TypeError: Cannot read property '_syncSendMail' of null
-if (process.env.TEST_MODE === 'true') {
+if ((process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api')) {
 	Email.sendAsync = async function _sendAsync(options) {
 		console.log('Email.sendAsync', options);
 	};

--- a/apps/meteor/server/configuration/configurePassport.ts
+++ b/apps/meteor/server/configuration/configurePassport.ts
@@ -57,6 +57,7 @@ export const configurePassport = (settings: ICachedSettings) => {
 		max: settings.get<number>('API_Enable_Rate_Limiter_Limit_Calls_Default'),
 		skip: () =>
 			process.env.TEST_MODE === 'true' ||
+			process.env.TEST_MODE === 'api' ||
 			settings.get<boolean>('API_Enable_Rate_Limiter') !== true ||
 			(process.env.NODE_ENV === 'development' && settings.get<boolean>('API_Enable_Rate_Limiter_Dev') !== true),
 		handler: (_req, res) => {

--- a/apps/meteor/server/methods/registerUser.ts
+++ b/apps/meteor/server/methods/registerUser.ts
@@ -150,7 +150,7 @@ let registerUserRuleId = RateLimiter.limitMethod(
 
 settings.watch('Rate_Limiter_Limit_RegisterUser', (value) => {
 	// When running on testMode, there's no rate limiting added, so this function throws an error
-	if (process.env.TEST_MODE === 'true') {
+	if (process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api') {
 		return;
 	}
 

--- a/apps/meteor/server/services/authorization/service.ts
+++ b/apps/meteor/server/services/authorization/service.ts
@@ -21,7 +21,7 @@ export class Authorization extends ServiceClass implements IAuthorization {
 
 	private rolesHasPermissionCached = mem(this.rolesHasPermission.bind(this), {
 		cacheKey: JSON.stringify,
-		...(process.env.TEST_MODE === 'true' && { maxAge: 1 }),
+		...((process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api') && { maxAge: 1 }),
 	});
 
 	constructor() {

--- a/apps/meteor/server/services/omnichannel-integrations/providers/twilio.ts
+++ b/apps/meteor/server/services/omnichannel-integrations/providers/twilio.ts
@@ -272,7 +272,7 @@ export class Twilio implements ISMSProvider {
 
 	async validateRequest(request: Request, requestBody: unknown): Promise<boolean> {
 		// We're not getting original twilio requests on CI :p
-		if (process.env.TEST_MODE === 'true') {
+		if (process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api') {
 			return true;
 		}
 		const twilioHeader = request.headers.get('x-twilio-signature') || '';

--- a/apps/meteor/server/startup/initialData.ts
+++ b/apps/meteor/server/startup/initialData.ts
@@ -205,7 +205,7 @@ Meteor.startup(async () => {
 
 	await Users.removeById('rocketchat.internal.admin.test');
 
-	if (process.env.TEST_MODE === 'true') {
+	if (process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api') {
 		console.log(colors.green('Inserting admin test user:'));
 
 		const adminUser: Omit<IUser, 'createdAt' | 'roles' | '_updatedAt'> = {

--- a/apps/meteor/server/startup/serverRunning.ts
+++ b/apps/meteor/server/startup/serverRunning.ts
@@ -24,6 +24,7 @@ const exitIfNotBypassed = (ignore: string | undefined, errorCode = 1) => {
 const skipMongoDbDeprecationCheck =
 	['yes', 'true'].includes(String(process.env.SKIP_MONGODEPRECATION_CHECK).toLowerCase()) ||
 	process.env.TEST_MODE === 'true' ||
+	process.env.TEST_MODE === 'api' ||
 	process.env.NODE_ENV === 'development';
 // const skipMongoDbDeprecationBanner = ['yes', 'true'].includes(String(process.env.SKIP_MONGODEPRECATION_BANNER).toLowerCase());
 

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -13,7 +13,7 @@ services:
         DENO_VERSION: ${DENO_VERSION:-}
     image: ghcr.io/${LOWERCASE_REPOSITORY}/rocket.chat:${DOCKER_TAG}${DOCKER_TAG_SUFFIX_ROCKETCHAT:-}
     environment:
-      - TEST_MODE=true
+      - 'TEST_MODE=${TEST_MODE:-true}'
       - DEBUG=${DEBUG:-}
       - EXIT_UNHANDLEDPROMISEREJECTION=true
       - MONGO_URL=mongodb://mongo:27017/rocketchat?replicaSet=rs0
@@ -162,7 +162,7 @@ services:
         SERVICE: omnichannel-transcript
     image: ghcr.io/${LOWERCASE_REPOSITORY}/omnichannel-transcript-service:${DOCKER_TAG}
     environment:
-      - TEST_MODE=true
+      - 'TEST_MODE=${TEST_MODE:-true}'
       - MONGO_URL=mongodb://mongo:27017/rocketchat?replicaSet=rs0
       - 'TRANSPORTER=${TRANSPORTER:-}'
       - MOLECULER_LOG_LEVEL=info


### PR DESCRIPTION
## Summary

Introduces a second env var, \`TEST_MODE_API\`, that suppresses the deprecation-logger throw without disabling the warn log. Used by the API end-to-end suite, which intentionally exercises deprecated DDP methods through the \`/v1/method.call/:method\` proxy and streamer paths.

### Why

\`apps/meteor/app/lib/server/lib/deprecationWarningLogger.ts\` throws under \`TEST_MODE\` so accidental usage of a deprecated method or endpoint surfaces immediately. That guard is correct for unit tests and UI tests where the call is unintentional. The API integration tests, however, target the proxy specifically — every \`methodCall('foo')\` is a deliberate cover for the legacy path until the method is migrated to REST.

Without an opt-out, deprecating any used method blows up the API suite even though the test author intends to call it.

### How

- \`apps/meteor/app/lib/server/lib/deprecationWarningLogger.ts\`: a \`shouldThrowOnDeprecation()\` helper replaces the seven inline \`if (process.env.TEST_MODE === 'true') throw\` blocks, gated on both \`TEST_MODE\` being true and \`TEST_MODE_API\` NOT being true.
- \`docker-compose-ci.yml\`: the rocketchat and omnichannel-transcript services now pass \`TEST_MODE_API\` through to the container so the Node process sees it.
- \`.github/workflows/ci-test-e2e.yml\`: the \`Start containers\` step sets \`TEST_MODE_API: 'true'\` whenever \`inputs.type == 'api'\` or \`'api-livechat'\`. (Setting it on the test step was too late — the rocketchat container was already running with the variable undefined.)

UI and Unit test runs still throw on accidental deprecated usage.

### Why ship separately

Several follow-up PRs (deprecation logging on orphan methods, eventual removal, caller migrations) depend on this opt-out to keep CI green. Landing it ahead of those PRs unblocks them.

## Test plan

- [ ] An existing API test that calls a deprecated method via \`/v1/method.call/:method\` still passes.
- [ ] Adding a deprecation log to a method that's only covered by unit tests still throws those unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Test-mode handling extended to recognize an "api" test mode alongside the existing test flag.
  * CI workflow now sets an API-specific test mode during container startup to support API E2E suites.
  * Test-mode now shortens cache TTLs, speeds scheduled jobs, and adjusts retry behavior during API tests.
  * Rate-limiting, email-sending, OAuth checks, and other runtime behaviors now honor the new API test mode.

* **Bug Fixes**
  * Deprecation warnings remain logged/metricized but won’t throw during API E2E runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2157]

[ARCH-2157]: https://rocketchat.atlassian.net/browse/ARCH-2157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ