### PR TITLE
fix: validate src URL scheme in slash command composer preview popup

### DIFF
--- a/.changeset/composer-preview-src-validation.md
+++ b/.changeset/composer-preview-src-validation.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Validate `src` URL scheme in the slash command composer preview popup. The `ComposerBoxPopupPreview` component now ignores preview media values that do not resolve to an `http`, `https`, `data`, or `blob` URL, blocking `javascript:` (and other non-media) URIs returned by `/v1/commands.preview`.

--- a/apps/meteor/client/views/room/composer/ComposerBoxPopupPreview.tsx
+++ b/apps/meteor/client/views/room/composer/ComposerBoxPopupPreview.tsx
@@ -9,6 +9,17 @@ import { useChat } from '../contexts/ChatContext';
 
 type ComposerBoxPopupPreviewItem = { _id: string; type: 'image' | 'video' | 'audio' | 'text' | 'other'; value: string; sort?: number };
 
+const SAFE_MEDIA_SCHEMES = new Set(['http:', 'https:', 'data:', 'blob:']);
+
+const safeMediaSrc = (value: string): string | undefined => {
+	try {
+		const { protocol } = new URL(value, window.location.origin);
+		return SAFE_MEDIA_SCHEMES.has(protocol) ? value : undefined;
+	} catch {
+		return undefined;
+	}
+};
+
 type ComposerBoxPopupPreviewProps = ComposerBoxPopupProps<ComposerBoxPopupPreviewItem> & {
 	title?: ReactNode;
 	rid: string;
@@ -119,40 +130,44 @@ const ComposerBoxPopupPreview = forwardRef(function ComposerBoxPopupPreview(
 								.map((_, index) => <Skeleton variant='rect' h='100px' w='120px' m={2} key={index} />)}
 
 						{!isLoading &&
-							itemsFlat.map((item) => (
-								<Box
-									onClick={() => select(item)}
-									role='option'
-									className={['popup-item', item === focused && 'selected'].filter(Boolean).join(' ')}
-									id={`popup-item-${item._id}`}
-									key={item._id}
-									bg={item === focused ? 'selected' : undefined}
-									borderColor={item === focused ? 'highlight' : 'transparent'}
-									tabIndex={item === focused ? 0 : -1}
-									aria-selected={item === focused}
-									m={2}
-									borderWidth='default'
-									borderRadius='x4'
-								>
-									{item.type === 'image' && <img src={item.value} alt={item._id} />}
-									{item.type === 'audio' && (
-										<audio controls>
-											<track kind='captions' />
-											<source src={item.value} />
-											Your browser does not support the audio element.
-										</audio>
-									)}
-									{item.type === 'video' && (
-										<video controls className='inline-video'>
-											<track kind='captions' />
-											<source src={item.value} />
-											Your browser does not support the video element.
-										</video>
-									)}
-									{item.type === 'text' && <Option>{item.value}</Option>}
-									{item.type === 'other' && <code>{item.value}</code>}
-								</Box>
-							))}
+							itemsFlat.map((item) => {
+								const mediaSrc =
+									item.type === 'image' || item.type === 'audio' || item.type === 'video' ? safeMediaSrc(item.value) : undefined;
+								return (
+									<Box
+										onClick={() => select(item)}
+										role='option'
+										className={['popup-item', item === focused && 'selected'].filter(Boolean).join(' ')}
+										id={`popup-item-${item._id}`}
+										key={item._id}
+										bg={item === focused ? 'selected' : undefined}
+										borderColor={item === focused ? 'highlight' : 'transparent'}
+										tabIndex={item === focused ? 0 : -1}
+										aria-selected={item === focused}
+										m={2}
+										borderWidth='default'
+										borderRadius='x4'
+									>
+										{item.type === 'image' && mediaSrc && <img src={mediaSrc} alt={item._id} />}
+										{item.type === 'audio' && mediaSrc && (
+											<audio controls>
+												<track kind='captions' />
+												<source src={mediaSrc} />
+												Your browser does not support the audio element.
+											</audio>
+										)}
+										{item.type === 'video' && mediaSrc && (
+											<video controls className='inline-video'>
+												<track kind='captions' />
+												<source src={mediaSrc} />
+												Your browser does not support the video element.
+											</video>
+										)}
+										{item.type === 'text' && <Option>{item.value}</Option>}
+										{item.type === 'other' && <code>{item.value}</code>}
+									</Box>
+								);
+							})}
 					</Box>
 				</Box>
 			</Tile>


### PR DESCRIPTION
## Summary

\`ComposerBoxPopupPreview\` rendered the \`value\` field from \`/v1/commands.preview\` straight into the \`src\` attribute of \`<img>\`, \`<audio>\`, and \`<video>\` tags. If the endpoint ever returned a \`javascript:\`/\`vbscript:\`/\`file:\` URI, the unsafe value would land in the DOM. Modern browsers do not execute \`javascript:\` from a media \`src\`, but it is still a defense-in-depth gap and a violation of secure coding practice.

## Fix

- Added a scheme allowlist: \`http:\`, \`https:\`, \`data:\`, \`blob:\`.
- \`safeMediaSrc()\` parses the value through \`new URL(value, window.location.origin)\` and returns \`undefined\` for anything outside the allowlist (or unparseable input).
- Each media branch (\`image\`, \`audio\`, \`video\`) now skips render when \`mediaSrc\` is \`undefined\`. Text/other branches keep rendering the value as plain text — no DOM injection vector.

## Origin

Spotted by hacktron during review of #40659. The component predates that PR (Feb 2025 refactor, commit 5f9adcd744f), so a standalone fix.

## Test plan

- [ ] Trigger a slash command with valid \`http(s)\` preview values — popup renders normally.
- [ ] Mock the \`/v1/commands.preview\` response with \`value: 'javascript:alert(1)'\` — preview tile renders empty for that item; no \`src\` attribute hits the DOM.
- [ ] Verify text/other preview types still render their string value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security issue in the composer where invalid URL schemes could be processed as preview media. The preview now validates that media URLs use only standard protocols (http, https, data, or blob), preventing potentially unsafe content from being displayed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->