### PR TITLE
regression: fix scroll performance in message list

### DIFF
--- a/apps/meteor/client/views/room/body/hooks/useGetMore.spec.tsx
+++ b/apps/meteor/client/views/room/body/hooks/useGetMore.spec.tsx
@@ -3,7 +3,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
 
 import { useGetMore } from './useGetMore';
-import { getBoundingClientRect } from '../../../../../app/ui/client/views/app/lib/scrolling';
 import { RoomHistoryManager } from '../../../../../app/ui-utils/client';
 
 jest.mock('../../../../../app/ui-utils/client', () => ({
@@ -16,10 +15,6 @@ jest.mock('../../../../../app/ui-utils/client', () => ({
 		getMoreNext: jest.fn(),
 		restoreScroll: jest.fn(),
 	},
-}));
-
-jest.mock('../../../../../app/ui/client/views/app/lib/scrolling', () => ({
-	getBoundingClientRect: jest.fn(),
 }));
 
 const mockGetMore = jest.fn();
@@ -42,18 +37,16 @@ describe('useGetMore', () => {
 		(RoomHistoryManager.hasMoreNext as jest.Mock).mockReturnValue(false);
 		(RoomHistoryManager.getMore as jest.Mock).mockImplementation(mockGetMore);
 
-		(getBoundingClientRect as jest.Mock).mockReturnValue({
-			scrollTop: 10,
-			clientHeight: 100,
-			scrollHeight: 800,
-		});
-
 		render(<Test />, {
 			wrapper: root.build(),
 		});
 
 		const scrollableElement = screen.getByTestId('scrollable-element');
-		scrollableElement.scrollTop = 10;
+		Object.defineProperties(scrollableElement, {
+			scrollTop: { value: 10, writable: true, configurable: true },
+			clientHeight: { value: 100, configurable: true },
+			scrollHeight: { value: 800, configurable: true },
+		});
 		scrollableElement.dispatchEvent(new Event('scroll'));
 
 		expect(screen.getByTestId('scrollable-element')).toBeInTheDocument();
@@ -63,7 +56,7 @@ describe('useGetMore', () => {
 		});
 	});
 
-	it('should call getMoreNext when scrolling near bottom and hasMoreNext is true', () => {
+	it('should call getMoreNext when scrolling near bottom and hasMoreNext is true', async () => {
 		const root = mockAppRoot();
 		(RoomHistoryManager.isLoading as jest.Mock).mockReturnValue(false);
 		(RoomHistoryManager.hasMore as jest.Mock).mockReturnValue(false);
@@ -79,18 +72,20 @@ describe('useGetMore', () => {
 				</div>
 			);
 		};
-		(getBoundingClientRect as jest.Mock).mockReturnValue({
-			scrollTop: 700,
-			clientHeight: 100,
-			scrollHeight: 800,
-		});
 		render(<Test />, {
 			wrapper: root.build(),
 		});
 		const scrollableElement = screen.getByTestId('scrollable-element');
-		scrollableElement.scrollTop = 700;
+		Object.defineProperties(scrollableElement, {
+			scrollTop: { value: 700, writable: true, configurable: true },
+			clientHeight: { value: 100, configurable: true },
+			scrollHeight: { value: 800, configurable: true },
+		});
 		scrollableElement.dispatchEvent(new Event('scroll'));
 		expect(screen.getByTestId('scrollable-element')).toBeInTheDocument();
-		expect(RoomHistoryManager.getMoreNext).toHaveBeenCalledWith('room-id');
+
+		await waitFor(() => {
+			expect(RoomHistoryManager.getMoreNext).toHaveBeenCalledWith('room-id');
+		});
 	});
 });

--- a/apps/meteor/client/views/room/body/hooks/useGetMore.ts
+++ b/apps/meteor/client/views/room/body/hooks/useGetMore.ts
@@ -1,9 +1,7 @@
 import { useSafeRefCallback } from '@rocket.chat/fuselage-hooks';
 import { useSearchParameter } from '@rocket.chat/ui-contexts';
-import { useCallback } from 'react';
-import { flushSync } from 'react-dom';
+import { startTransition, useCallback } from 'react';
 
-import { getBoundingClientRect } from '../../../../../app/ui/client/views/app/lib/scrolling';
 import { RoomHistoryManager } from '../../../../../app/ui-utils/client';
 import { withThrottling } from '../../../../../lib/utils/highOrderFunctions';
 
@@ -13,6 +11,8 @@ export const useGetMore = (rid: string, isJumpingToMessage: boolean) => {
 	const ref = useSafeRefCallback(
 		useCallback(
 			(element: HTMLElement) => {
+				let animationFrameId: number | null = null;
+
 				const checkPositionAndGetMore = withThrottling({ wait: 100 })(async () => {
 					if (!element.isConnected) {
 						return;
@@ -31,7 +31,7 @@ export const useGetMore = (rid: string, isJumpingToMessage: boolean) => {
 						return;
 					}
 
-					const { scrollTop, clientHeight, scrollHeight } = getBoundingClientRect(element);
+					const { scrollTop, clientHeight, scrollHeight } = element;
 
 					const lastScrollTopRef = scrollTop;
 					const height = clientHeight;
@@ -49,7 +49,7 @@ export const useGetMore = (rid: string, isJumpingToMessage: boolean) => {
 							return;
 						}
 
-						flushSync(() => {
+						startTransition(() => {
 							RoomHistoryManager.restoreScroll(rid);
 						});
 					} else if (hasMoreNext === true && Math.ceil(lastScrollTopRef) >= scrollHeight - height) {
@@ -57,22 +57,33 @@ export const useGetMore = (rid: string, isJumpingToMessage: boolean) => {
 					}
 				});
 
+				const scheduleCheckPositionAndGetMore = (): void => {
+					if (animationFrameId !== null) {
+						return;
+					}
+
+					animationFrameId = requestAnimationFrame(() => {
+						animationFrameId = null;
+						checkPositionAndGetMore();
+					});
+				};
+
 				const mutationObserver = new MutationObserver((mutations) => {
 					mutations.forEach(() => {
-						checkPositionAndGetMore();
+						scheduleCheckPositionAndGetMore();
 					});
 				});
 
 				mutationObserver.observe(element, { childList: true, subtree: true });
 
 				const observer = new ResizeObserver(() => {
-					checkPositionAndGetMore();
+					scheduleCheckPositionAndGetMore();
 				});
 
 				observer.observe(element);
 
 				const handleScroll = function () {
-					checkPositionAndGetMore();
+					scheduleCheckPositionAndGetMore();
 				};
 
 				element.addEventListener('scroll', handleScroll, {
@@ -82,6 +93,9 @@ export const useGetMore = (rid: string, isJumpingToMessage: boolean) => {
 				return () => {
 					observer.disconnect();
 					mutationObserver.disconnect();
+					if (animationFrameId !== null) {
+						cancelAnimationFrame(animationFrameId);
+					}
 					checkPositionAndGetMore.cancel();
 					element.removeEventListener('scroll', handleScroll);
 				};

--- a/apps/meteor/client/views/room/hooks/useDateScroll.ts
+++ b/apps/meteor/client/views/room/hooks/useDateScroll.ts
@@ -2,7 +2,7 @@ import type { IMessage } from '@rocket.chat/core-typings';
 import { css } from '@rocket.chat/css-in-js';
 import { useDebouncedCallback, useSafely } from '@rocket.chat/fuselage-hooks';
 import type { CSSProperties, MutableRefObject } from 'react';
-import { useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useDateListController } from '../providers/DateListProvider';
 
@@ -41,8 +41,10 @@ export const useDateScroll = (margin = 8): useDateScrollReturn => {
 	const bubbleRef = useRef<HTMLElement>(null);
 
 	const hideBubbleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const animationFrameRef = useRef<number | null>(null);
+	const topMessageRef = useRef<IMessage | undefined>(undefined);
 
-	const handleDateScroll = useDebouncedCallback(
+	const processDateScroll = useDebouncedCallback(
 		(topMessage: IMessage | undefined) => {
 			if (hideBubbleTimeoutRef.current) {
 				clearTimeout(hideBubbleTimeoutRef.current);
@@ -144,6 +146,38 @@ export const useDateScroll = (margin = 8): useDateScrollReturn => {
 		},
 		5,
 		[list, margin, setBubbleDate],
+	);
+
+	const handleDateScroll = useCallback(
+		(topMessage: IMessage | undefined) => {
+			topMessageRef.current = topMessage;
+
+			if (animationFrameRef.current !== null) {
+				return;
+			}
+
+			animationFrameRef.current = requestAnimationFrame(() => {
+				animationFrameRef.current = null;
+				processDateScroll(topMessageRef.current);
+			});
+		},
+		[processDateScroll],
+	);
+
+	useEffect(
+		() => () => {
+			if (animationFrameRef.current !== null) {
+				cancelAnimationFrame(animationFrameRef.current);
+			}
+
+			processDateScroll.cancel();
+
+			if (hideBubbleTimeoutRef.current) {
+				clearTimeout(hideBubbleTimeoutRef.current);
+				hideBubbleTimeoutRef.current = null;
+			}
+		},
+		[processDateScroll],
 	);
 	// TODO: Make the chip "gliding" work with the new sistem.
 	// const listStyle =


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR improves scroll performance in the room message list by reducing synchronous work in hot paths that run during rapid scrolling.

Main changes:
- Replaced synchronous restore behavior in the message loading flow with transition-based scheduling to avoid blocking the main thread during heavy updates.
- Added requestAnimationFrame scheduling around scroll-triggered checks in the message history loader so multiple scroll, mutation, and resize events are coalesced per frame.
- Reduced layout pressure in the history loader by using direct element scroll metrics in the hot path.
- Added frame-based scheduling to the date bubble scroll handler to limit expensive geometry reads during continuous scrolling.
- Added cleanup for pending animation frames, debounced work, and timeouts to prevent stale work after unmount.
- Updated the related hook tests to reflect async/frame-scheduled behavior.

## Issue(s)

## Steps to test or reproduce

1. Open a room with enough messages to trigger virtualization behavior.
2. Scroll quickly up and down for several seconds.
3. Confirm older/newer messages still load correctly near list boundaries.
4. Confirm scroll restoration behavior still works when loading previous messages.
5. Confirm date bubble behavior is preserved while scrolling.
6. Record a Performance profile in DevTools and compare against baseline:
- Lower time spent in synchronous commit/unmount activity.
- Fewer geometry-read bursts during scroll handling.

## Further comments

This change is intentionally scoped to scheduling and event handling in existing hooks to minimize behavioral risk while targeting the largest observed bottlenecks.  
A potential follow-up is to evaluate additional virtualizer tuning to further reduce large unmount bursts in extreme scroll scenarios.