### PR TITLE
regression: custom sound record breaks when validation error on update

### DIFF
--- a/apps/meteor/app/api/server/v1/custom-sounds.ts
+++ b/apps/meteor/app/api/server/v1/custom-sounds.ts
@@ -259,6 +259,13 @@ const customSoundsEndpoints = API.v1
 				: soundToUpdate.extension;
 
 			try {
+				await insertOrUpdateSound({
+					_id: fields._id,
+					name: fields.name,
+					extension: nextExtension,
+					previousName: soundToUpdate.name,
+					previousExtension: soundToUpdate.extension,
+				});
 				if (fileBuffer) {
 					await uploadCustomSound(fileBuffer, computedMimeType, {
 						_id: fields._id,
@@ -267,13 +274,6 @@ const customSoundsEndpoints = API.v1
 						extension: nextExtension,
 					});
 				}
-				await insertOrUpdateSound({
-					_id: fields._id,
-					name: fields.name,
-					extension: nextExtension,
-					previousName: soundToUpdate.name,
-					previousExtension: soundToUpdate.extension,
-				});
 				return API.v1.success({});
 			} catch (error) {
 				SystemLogger.error({ error });

--- a/apps/meteor/tests/end-to-end/api/custom-sounds.ts
+++ b/apps/meteor/tests/end-to-end/api/custom-sounds.ts
@@ -375,12 +375,8 @@ describe('[CustomSounds]', () => {
 			});
 
 			after(async () => {
-				if (soundAId) {
-					await deleteCustomSound(soundAId);
-				}
-				if (soundBId) {
-					await deleteCustomSound(soundBId);
-				}
+				await deleteCustomSound(soundAId);
+				await deleteCustomSound(soundBId);
 			});
 
 			it('should not mutate the underlying file or metadata if the update fails validation (e.g., name collision)', async () => {

--- a/apps/meteor/tests/end-to-end/api/custom-sounds.ts
+++ b/apps/meteor/tests/end-to-end/api/custom-sounds.ts
@@ -361,6 +361,59 @@ describe('[CustomSounds]', () => {
 					.expect(403);
 			});
 		});
+
+		describe('mutating file on failed validation', () => {
+			let soundAId: string;
+			let soundBId: string;
+			const soundAName = `sound-a-${randomUUID()}`;
+			const soundBName = `sound-b-${randomUUID()}`;
+
+			before(async () => {
+				soundAId = await createCustomSound(soundAName, mockWavAudioPath);
+				soundBId = await createCustomSound(soundBName, mockMp3AudioPath);
+			});
+
+			after(async () => {
+				if (soundAId) {
+					await deleteCustomSound(soundAId);
+				}
+				if (soundBId) {
+					await deleteCustomSound(soundBId);
+				}
+			});
+
+			it('should not mutate the underlying file or metadata if the update fails validation (e.g., name collision)', async () => {
+				await request
+					.post(api('custom-sounds.update'))
+					.set(credentials)
+					.attach('sound', mockMp3AudioPath)
+					.field('_id', soundAId)
+					.field('name', soundBName)
+					.expect(400)
+					.expect((res) => {
+						expect(res.body).to.have.property('success', false);
+						expect(res.body).to.have.property('error', 'The custom sound name is already in use [Custom_Sound_Error_Name_Already_In_Use]');
+					});
+
+				await request
+					.get(api('custom-sounds.getOne'))
+					.set(credentials)
+					.query({ _id: soundAId })
+					.expect(200)
+					.expect((res) => {
+						expect(res.body.sound).to.have.property('name', soundAName);
+						expect(res.body.sound).to.have.property('extension', 'wav');
+					});
+
+				await request
+					.get(`/custom-sounds/${soundAId}.wav`)
+					.set(credentials)
+					.expect(200)
+					.expect((res) => {
+						expect(res.headers).to.have.property('content-type', 'audio/wav');
+					});
+			});
+		});
 	});
 
 	describe('[/custom-sounds.list]', () => {

--- a/apps/meteor/tests/end-to-end/api/custom-sounds.ts
+++ b/apps/meteor/tests/end-to-end/api/custom-sounds.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import fs from 'fs';
 import path from 'path';
 
 import type { Credentials } from '@rocket.chat/api-client';
@@ -405,13 +406,19 @@ describe('[CustomSounds]', () => {
 						expect(res.body.sound).to.have.property('extension', 'wav');
 					});
 
+				const originalWavBuffer = fs.readFileSync(mockWavAudioPath);
+
 				await request
 					.get(`/custom-sounds/${soundAId}.wav`)
 					.set(credentials)
 					.expect(200)
 					.expect((res) => {
 						expect(res.headers).to.have.property('content-type', 'audio/wav');
+						expect(Buffer.isBuffer(res.body)).to.be.true;
+						expect(originalWavBuffer.equals(res.body)).to.be.true;
 					});
+
+				await request.get(`/custom-sounds/${soundAId}.mp3`).set(credentials).expect(404);
 			});
 		});
 	});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
When an admin tried to update a custom sound but provided an invalid name (e.g., a name already in use), the update would correctly throw a 400 validation error, but the underlying audio file would break.

- **Swapped execution order**: We now invoke `insertOrUpdateSound` first. If the payload fails validation (e.g., duplicate name), the error is thrown immediately, and the execution stops before any file manipulation occurs.

- **Added Regression Test**: Added an isolated integration test within the test suite to simulate a failed update (name collision with a different file extension) and assert that neither the database metadata nor the underlying file is mutated.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-2243 [Regression] Failed custom-sound rename can break the sound file](https://rocketchat.atlassian.net/browse/CORE-2243)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
**Preconditions**: Have two custom sounds, for example sound-a.mp3 and sound-b.mp3

1. Go to Workspace → Sounds
2. Open sound-a
3. Attach a replacement file with a different extension than the current one.
     e.g: replace the current .mp3 with an .wav
4. Change the name of sound-a to fail the validation
     e.g: change it “sound-b”
5. Save
6. Close it
7. Click to hear the sound-a

**Expected Behavior**: The update should fail and leave sound-a unchanged and still play
**Wrong Behavior**: The update fails, and when you click to hear the sound-a it doesn’t play anymore. If the new file uses a different extension, the database still points to the old extension, and the sound becomes broken.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents uploaded sound files from replacing existing sounds when an update fails validation, ensuring original files, names and served audio formats remain unchanged.
* **Tests**
  * Added end-to-end test coverage to verify failed sound updates do not alter stored audio content or served endpoints (including content-type and byte-for-byte checks).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->