### PR TITLE
test: scope report-message locator to moderation table

### DIFF
--- a/apps/meteor/tests/e2e/report-message.spec.ts
+++ b/apps/meteor/tests/e2e/report-message.spec.ts
@@ -111,8 +111,9 @@ test.describe.serial('report message', () => {
 			await adminPage.goto('/admin/moderation/messages');
 
 			await expect(adminPage.getByRole('tab', { name: 'Reported messages' })).toBeVisible();
-			await expect(adminPage.getByRole('link', { name: 'user1' })).toBeVisible();
-			await adminPage.getByRole('link', { name: 'user1' }).click();
+			const reportedUserLink = adminPage.getByRole('table').getByRole('link', { name: 'user1' });
+			await expect(reportedUserLink).toBeVisible();
+			await reportedUserLink.click();
 
 			await expect(adminPage.getByText(testMessage)).toBeVisible();
 


### PR DESCRIPTION
## Summary

`tests/e2e/report-message.spec.ts:114` uses `adminPage.getByRole('link', { name: 'user1' })` which matches two elements in strict mode:

1. `<tr role=\"link\">` — the moderation table row
2. `<a title=\"user1\" href=\"/direct/...\">` — the user1 DM entry in the admin sidebar

The DM entry appears when the admin already has a direct conversation with the reported user. When the sidebar finishes rendering before the assertion runs, the locator matches two elements and Playwright fails with:

> `strict mode violation: getByRole('link', { name: 'user1' }) resolved to 2 elements`

## Fix

Scope the locator to the moderation table:

```typescript
const reportedUserLink = adminPage.getByRole('table').getByRole('link', { name: 'user1' });
await expect(reportedUserLink).toBeVisible();
await reportedUserLink.click();
```

## Test plan

- [ ] Run `tests/e2e/report-message.spec.ts:93` locally — passes consistently.
- [ ] CI green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for reported message verification in the moderation console by refining locator strategies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40700?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2161]

[ARCH-2161]: https://rocketchat.atlassian.net/browse/ARCH-2161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ