### PR TITLE
fix: allow unauthenticated access to users.sendConfirmationEmail

### DIFF
--- a/.changeset/crisp-taxis-pay.md
+++ b/.changeset/crisp-taxis-pay.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes `users.sendConfirmationEmail` rejecting unauthenticated requests, which prevented unverified users from resending their verification email from the login screen

--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -40,6 +40,7 @@ import { regeneratePersonalAccessTokenOfUser } from '../../../../imports/persona
 import { removePersonalAccessTokenOfUser } from '../../../../imports/personal-access-tokens/server/api/methods/removeToken';
 import { UserChangedAuditStore } from '../../../../server/lib/auditServerEvents/userChanged';
 import { i18n } from '../../../../server/lib/i18n';
+import { SystemLogger } from '../../../../server/lib/logger/system';
 import { resetUserE2EEncriptionKey } from '../../../../server/lib/resetUserE2EKey';
 import { registerUser } from '../../../../server/methods/registerUser';
 import { requestDataDownload } from '../../../../server/methods/requestDataDownload';
@@ -1483,7 +1484,7 @@ API.v1
 API.v1.post(
 	'users.sendConfirmationEmail',
 	{
-		authRequired: true,
+		authRequired: false,
 		body: isUsersSendConfirmationEmailParamsPOST,
 		rateLimiterOptions: {
 			numRequestsAllowed: 1,
@@ -1492,16 +1493,11 @@ API.v1.post(
 		response: {
 			200: voidSuccessResponse,
 			400: validateBadRequestErrorResponse,
-			401: validateUnauthorizedErrorResponse,
 		},
 	},
 	async function action() {
-		const { email } = this.bodyParams;
-
-		if (await sendConfirmationEmail(email)) {
-			return API.v1.success();
-		}
-		return API.v1.failure();
+		void sendConfirmationEmail(this.bodyParams.email).catch((err) => SystemLogger.error({ msg: 'sendConfirmationEmail failed', err }));
+		return API.v1.success();
 	},
 );
 

--- a/apps/meteor/server/methods/sendConfirmationEmail.ts
+++ b/apps/meteor/server/methods/sendConfirmationEmail.ts
@@ -1,7 +1,6 @@
 import { Users } from '@rocket.chat/models';
 import { Accounts } from 'meteor/accounts-base';
 import { check } from 'meteor/check';
-import { DDPRateLimiter } from 'meteor/ddp-rate-limiter';
 import { Meteor } from 'meteor/meteor';
 
 export const sendConfirmationEmail = async (to: string): Promise<boolean> => {
@@ -9,14 +8,19 @@ export const sendConfirmationEmail = async (to: string): Promise<boolean> => {
 
 	const email = to.trim();
 
-	const user = await Users.findOneByEmailAddress(email, { projection: { _id: 1 } });
-
+	const user = await Users.findOneByEmailAddress(email, { projection: { emails: 1 } });
 	if (!user) {
 		return false;
 	}
 
+	// Do not re-send a verification mail to an address that is already verified.
+	const target = user.emails?.find((e) => e.address.toLowerCase() === email.toLowerCase() && !e.verified);
+	if (!target) {
+		return false;
+	}
+
 	try {
-		Accounts.sendVerificationEmail(user._id, email);
+		Accounts.sendVerificationEmail(user._id, target.address);
 		return true;
 	} catch (error: any) {
 		throw new Meteor.Error('error-email-send-failed', `Error trying to send email: ${error.message}`, {
@@ -25,15 +29,3 @@ export const sendConfirmationEmail = async (to: string): Promise<boolean> => {
 		});
 	}
 };
-
-DDPRateLimiter.addRule(
-	{
-		type: 'method',
-		name: 'sendConfirmationEmail',
-		userId() {
-			return true;
-		},
-	},
-	5,
-	60000,
-);

--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -3721,44 +3721,23 @@ describe('[Users]', () => {
 	});
 
 	describe('[/users.sendConfirmationEmail]', () => {
-		it('should send email to user (return success), when is a valid email', (done) => {
-			void request
-				.post(api('users.sendConfirmationEmail'))
-				.set(credentials)
-				.send({
-					email: adminEmail,
-				})
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
-		});
-
-		it('should not send email to user(return error), when is a invalid email', (done) => {
-			void request
-				.post(api('users.sendConfirmationEmail'))
-				.set(credentials)
-				.send({
-					email: 'invalidEmail',
-				})
-				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
-		});
-
-		it('should return 401 when not authenticated', async () => {
-			await request
-				.post(api('users.sendConfirmationEmail'))
-				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res: Response) => {
-					expect(res.body).to.have.property('status', 'error');
-				});
+		[
+			{ description: 'authenticated + known email', auth: true, email: adminEmail },
+			{ description: 'unauthenticated + known email', auth: false, email: adminEmail },
+			{ description: 'unauthenticated + unknown email', auth: false, email: 'nobody@example.invalid' },
+		].forEach(({ description, auth, email }) => {
+			it(`should return 200 success for ${description}`, async () => {
+				const req = request.post(api('users.sendConfirmationEmail')).send({ email });
+				if (auth) {
+					req.set(credentials);
+				}
+				await req
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res: Response) => {
+						expect(res.body).to.have.property('success', true);
+					});
+			});
 		});
 
 		it('should return 400 when body is empty', async () => {

--- a/packages/ddp-client/src/types/methods.ts
+++ b/packages/ddp-client/src/types/methods.ts
@@ -1,7 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface ServerMethods {
 	resetPassword(token: string, password: string): { token: string };
-	sendConfirmationEmail(to: string): boolean;
 	checkRegistrationSecretURL(hash: string): boolean;
 }
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

When **Admin -> Accounts -> Require email verification to login** is on, an unverified user is blocked at the login screen and offered a "Send confirmation email" button. That button calls `POST /api/v1/users.sendConfirmationEmail`, which was declared `authRequired: true` - so the unauthenticated user always got `401`, the verification mail was never sent, and the only workaround was for an admin to re-trigger verification by hand.

### Root cause

**`apps/meteor/app/api/server/v1/users.ts`** - the route was added in [#26415](https://github.com/RocketChat/Rocket.Chat/pull/26415) to back the authenticated *Account Profile* page, where `authRequired: true` was correct. When the login screen later started calling the same endpoint, the auth gate was never relaxed. The login-screen flow has therefore never worked end-to-end - latent integration bug, not a regression.

### Solution

1. **Route** - `authRequired: false`, drop `401` from the response schema, handler is fire-and-forget (`void`) and always returns `API.v1.success()`.
2. **`sendConfirmationEmail`** - skip the send if the address is already verified. Function signature and behavior for the other caller (`setEmail.ts`) are preserved.

## Issue(s)

[SUP-1043](https://rocketchat.atlassian.net/browse/SUP-1043)

## Steps to test or reproduce

**Pre-fix:**

1. Register a user with SMTP misconfigured (so the verification mail never goes out).
2. Log out, then enable **Admin -> Accounts -> Require email verification to login**.
3. Attempt login -> click "Send confirmation email" -> request returns `401`. User is stuck.

**Post-fix:**

1. Repeat -> click the button -> request returns `200`, verification mail is dispatched, link verifies the address, retry-login succeeds.
2. Anonymous probes - all three return `200 {"success":true}`:
   ```bash
   curl -X POST .../users.sendConfirmationEmail -d '{"email":"test@example.com"}'        # known unverified -> mail sent
   curl -X POST .../users.sendConfirmationEmail -d '{"email":"verified@x.com"}'          # known verified  -> no mail
   curl -X POST .../users.sendConfirmationEmail -d '{"email":"nobody@nope.invalid"}'     # unknown          -> no mail
   ```

## Further comments

- **Security posture:** the endpoint is brought to parity with `users.forgotPassword` - uniform response shape, per-IP rate limit preserved, mail only goes to the address recorded on the user document.


[SUP-1043]: https://rocketchat.atlassian.net/browse/SUP-1043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email verification resend requests no longer require authentication, so users can request verification emails from the login screen. Resend requests now always return a success response to the requester.

* **Bug Fixes**
  * Verification emails are sent only to an account's unverified address (case-insensitive match), avoiding duplicate or misdirected verification messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->