### PR TITLE
docs: add Fuselage design system context (PRODUCT.md + DESIGN.md)

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -2,6 +2,14 @@
   "schemaVersion": 2,
   "generatedAt": "2026-05-26T00:00:00.000Z",
   "title": "Design System: Fuselage",
+  "provenance": {
+    "canonical": "RocketChat/fuselage",
+    "sourceCommit": "faa9feb",
+    "tokenPackage": "@rocket.chat/fuselage-tokens",
+    "consumedVersions": { "@rocket.chat/fuselage": "^0.78.0", "@rocket.chat/fuselage-tokens": "~0.33.2" },
+    "note": "Derived snapshot for tooling/live-preview only. Fuselage owns all values. Component CSS uses literal hex because the Stitch shadow-DOM panel has no Fuselage runtime to resolve --rcx-* vars. Snapshot is from the source tip and may differ from the pinned runtime. Regenerate with /impeccable document on a version bump; never hand-edit.",
+    "regenerate": "/impeccable document"
+  },
   "extensions": {
     "colorMeta": {
       "rocket-blue": {

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,179 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-05-26T00:00:00.000Z",
+  "title": "Design System: Fuselage",
+  "extensions": {
+    "colorMeta": {
+      "rocket-blue": {
+        "role": "primary",
+        "displayName": "Rocket Blue",
+        "canonical": "#156FF5",
+        "darkCounterpart": "#6292DA",
+        "tonalRamp": ["#012247", "#01336B", "#10529E", "#095AD2", "#156FF5", "#549DF9", "#76B7FC", "#D1EBFE", "#E8F2FF"]
+      },
+      "featured-purple": {
+        "role": "secondary",
+        "displayName": "Featured Purple",
+        "canonical": "#5F1477",
+        "darkCounterpart": "#5F1477",
+        "tonalRamp": ["#350B42", "#4A105D", "#5F1477", "#7F1B9F", "#9F22C7", "#CA71E7", "#DCA0EF", "#EDD0F7", "#F9EFFC"]
+      },
+      "danger-red": {
+        "role": "tertiary",
+        "displayName": "Danger Red",
+        "canonical": "#EC0D2A",
+        "darkCounterpart": "#BB3E4E",
+        "tonalRamp": ["#6B0513", "#8B0719", "#BB0B21", "#D40C26", "#EC0D2A", "#F5455C", "#F98F9D", "#FFC1C9", "#FFE9EC"]
+      },
+      "success-green": {
+        "role": "tertiary",
+        "displayName": "Success Green",
+        "canonical": "#1ECB92",
+        "darkCounterpart": "#58AD90",
+        "tonalRamp": ["#0D5940", "#106D4F", "#148660", "#19AC7C", "#1ECB92", "#2DE0A5", "#96F0D2", "#C0F6E4", "#E5FBF4"]
+      },
+      "warning-yellow": {
+        "role": "tertiary",
+        "displayName": "Warning Yellow",
+        "canonical": "#F3BE08",
+        "darkCounterpart": "#C7AA66",
+        "tonalRamp": ["#573D00", "#8E6300", "#AC892F", "#DFAC00", "#F3BE08", "#FFD031", "#FFE383", "#FFECAD", "#FFF8E0"]
+      },
+      "neutral": {
+        "role": "neutral",
+        "displayName": "Tinted Neutral",
+        "canonical": "#2F343D",
+        "darkCounterpart": "#C1C7D0",
+        "tonalRamp": ["#1F2329", "#2F343D", "#6C737A", "#9EA2A8", "#CBCED1", "#D7DBE0", "#E4E7EA", "#F2F3F5", "#F7F8FA"]
+      }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display / Hero", "purpose": "Marketing-scale display, rare inside the app." },
+      "headline": { "displayName": "Headline (h1)", "purpose": "Page titles." },
+      "title": { "displayName": "Title (h2/h3)", "purpose": "Section and subsection headings." },
+      "subtitle": { "displayName": "Subtitle (h4/h5)", "purpose": "Block and dense headings." },
+      "body": { "displayName": "Body (p2)", "purpose": "Default chat-density body text, 14px." },
+      "label": { "displayName": "Caption / Label", "purpose": "Captions, overlines, badge and chip text." },
+      "mono": { "displayName": "Mono", "purpose": "Code, message blocks, technical values." }
+    },
+    "shadows": [
+      { "name": "elevation-1", "value": "0 0 1px 0 rgba(47,52,61,0.08), 0 0 2px 0 rgba(47,52,61,0.12)", "purpose": "Low lift for hovered or single-step raised surfaces (Tile elevation-1)." },
+      { "name": "elevation-2", "value": "0 0 2px 0 rgba(47,52,61,0.08), 0 0 12px 0 rgba(47,52,61,0.12)", "purpose": "Menus, popovers, modals (Tile elevation-2)." },
+      { "name": "elevation-1-dark", "value": "0 0 1px 0 rgba(9,9,9,0.3), 0 0 2px 0 rgba(9,9,9,0.45)", "purpose": "Dark-theme counterpart of elevation-1." }
+    ],
+    "motion": [
+      { "name": "click-animation", "value": "transform 0.2s ease-out", "purpose": "Subtle press feedback on buttons; status buttons excluded." },
+      { "name": "state-transition", "value": "background-color 0.2s ease-out, border-color 0.2s ease-out", "purpose": "Default easing for hover/focus state changes. Respect prefers-reduced-motion." }
+    ],
+    "breakpoints": [
+      { "name": "xs", "value": "0px" },
+      { "name": "sm", "value": "600px" },
+      { "name": "md", "value": "768px" },
+      { "name": "lg", "value": "1024px" },
+      { "name": "xl", "value": "1280px" },
+      { "name": "xxl", "value": "1600px" },
+      { "name": "xxxl", "value": "1920px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The single primary-action button. Rocket Blue fill, white text.",
+      "html": "<button class=\"ds-btn-primary\">Send</button>",
+      "css": ".ds-btn-primary { height: 40px; padding: 0 16px; min-width: 80px; border: none; border-radius: 4px; background: #156FF5; color: #FFFFFF; font-family: Inter, -apple-system, Segoe UI, Roboto, sans-serif; font-size: 14px; font-weight: 500; line-height: 20px; cursor: pointer; transition: background-color 0.2s ease-out, transform 0.2s ease-out; } .ds-btn-primary:hover { background: #095AD2; } .ds-btn-primary:active { background: #10529E; transform: translateY(1px); } .ds-btn-primary:focus-visible { outline: none; box-shadow: 0 0 0 2px #D1EBFE; } .ds-btn-primary:disabled { background: #D1EBFE; cursor: not-allowed; }"
+    },
+    {
+      "name": "Secondary Button",
+      "kind": "button",
+      "refersTo": "button-secondary",
+      "description": "The everyday neutral button. Dark text on a neutral fill.",
+      "html": "<button class=\"ds-btn-secondary\">Cancel</button>",
+      "css": ".ds-btn-secondary { height: 40px; padding: 0 16px; min-width: 80px; border: none; border-radius: 4px; background: #E4E7EA; color: #1F2329; font-family: Inter, sans-serif; font-size: 14px; font-weight: 500; line-height: 20px; cursor: pointer; transition: background-color 0.2s ease-out; } .ds-btn-secondary:hover { background: #CBCED1; } .ds-btn-secondary:active { background: #9EA2A8; } .ds-btn-secondary:focus-visible { outline: none; box-shadow: 0 0 0 2px #D1EBFE; }"
+    },
+    {
+      "name": "Danger Button",
+      "kind": "button",
+      "refersTo": "button-danger",
+      "description": "Destructive confirm only. Danger Red fill, white text.",
+      "html": "<button class=\"ds-btn-danger\">Delete</button>",
+      "css": ".ds-btn-danger { height: 40px; padding: 0 16px; min-width: 80px; border: none; border-radius: 4px; background: #EC0D2A; color: #FFFFFF; font-family: Inter, sans-serif; font-size: 14px; font-weight: 500; line-height: 20px; cursor: pointer; transition: background-color 0.2s ease-out; } .ds-btn-danger:hover { background: #D40C26; } .ds-btn-danger:active { background: #BB0B21; }"
+    },
+    {
+      "name": "Text Input",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "Standard text field. Neutral border, blue focus, full-border error state.",
+      "html": "<input class=\"ds-input\" type=\"text\" placeholder=\"Search messages\" />",
+      "css": ".ds-input { min-width: 144px; padding: 8px 16px; border: 1px solid #CBCED1; border-radius: 4px; background: #FFFFFF; color: #2F343D; font-family: Inter, sans-serif; font-size: 14px; line-height: 20px; transition: border-color 0.2s ease-out, box-shadow 0.2s ease-out; } .ds-input::placeholder { color: #6C737A; } .ds-input:hover { border-color: #9EA2A8; } .ds-input:focus { outline: none; border-color: #156FF5; box-shadow: 0 0 0 2px #D1EBFE; } .ds-input.invalid { border-color: #EC0D2A; box-shadow: 0 0 0 2px #FFC1C9; }"
+    },
+    {
+      "name": "Card",
+      "kind": "card",
+      "refersTo": "card",
+      "description": "Flat-at-rest container. 8px radius, white surface, hover tint when clickable.",
+      "html": "<div class=\"ds-card\"><div class=\"ds-card__title\">Channel settings</div><div class=\"ds-card__body\">Manage members, topic, and permissions.</div></div>",
+      "css": ".ds-card { display: flex; flex-direction: column; gap: 8px; padding: 20px 12px; border-radius: 8px; background: #FFFFFF; color: #2F343D; font-family: Inter, sans-serif; } .ds-card__title { font-size: 16px; font-weight: 700; line-height: 24px; color: #1F2329; } .ds-card__body { font-size: 14px; line-height: 20px; color: #2F343D; }"
+    },
+    {
+      "name": "Tile (elevation-2)",
+      "kind": "card",
+      "refersTo": "tile",
+      "description": "Elevation primitive for menus and popovers. Lift comes from shadow, not standing styling.",
+      "html": "<div class=\"ds-tile\">Popover content</div>",
+      "css": ".ds-tile { padding: 16px; border-radius: 4px; background: #FFFFFF; color: #2F343D; font-family: Inter, sans-serif; font-size: 14px; line-height: 20px; box-shadow: 0 0 2px 0 rgba(47,52,61,0.08), 0 0 12px 0 rgba(47,52,61,0.12); }"
+    },
+    {
+      "name": "Callout (warning)",
+      "kind": "custom",
+      "refersTo": "callout",
+      "description": "Full-bordered status message. Never a side stripe.",
+      "html": "<div class=\"ds-callout\"><svg width=\"20\" height=\"20\" viewBox=\"0 0 24 24\" fill=\"none\"><path d=\"M12 3 1 21h22L12 3Zm0 5 7.5 12h-15L12 8Zm-1 4v3h2v-3h-2Zm0 4v2h2v-2h-2Z\" fill=\"#C7AA66\"/></svg><span>Your trial ends in 3 days.</span></div>",
+      "css": ".ds-callout { display: flex; align-items: center; gap: 8px; padding: 12px; border: 1px solid #C7AA66; border-radius: 4px; background: #FFFFFF; color: #2F343D; font-family: Inter, sans-serif; font-size: 14px; line-height: 20px; }"
+    },
+    {
+      "name": "Chip",
+      "kind": "chip",
+      "refersTo": "chip",
+      "description": "Pill tag/filter. Secondary-button colors, hint text, full radius.",
+      "html": "<button class=\"ds-chip\">design-system <span class=\"ds-chip__x\">x</span></button>",
+      "css": ".ds-chip { display: inline-flex; align-items: center; gap: 4px; height: 24px; padding: 0 8px; border: 1px solid #D7DBE0; border-radius: 9999px; background: #D7DBE0; color: #6C737A; font-family: Inter, sans-serif; font-size: 12px; font-weight: 700; line-height: 16px; cursor: pointer; transition: background-color 0.2s ease-out, border-color 0.2s ease-out; } .ds-chip:hover { background: #CBCED1; border-color: #CBCED1; } .ds-chip:focus-visible { outline: none; border-color: #2F343D; box-shadow: 0 0 0 2px #D1EBFE; } .ds-chip__x { color: #9EA2A8; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Field Manual",
+    "overview": "Fuselage is reference material, not decoration. It reads like a well-kept field manual: every value has a name, every name has a place, and an engineer or designer can look up the right answer instead of guessing it. The identity is the rigor. Token-driven from the ground up, documented in Storybook, predictable in every state, the closest spiritual sibling is GitHub Primer, where accessibility is a gate and the system's discipline is the thing people trust. The surface itself stays quiet so the product can speak: neutral lightly-tinted surfaces carry the room, and saturated color is reserved for meaning, never spent on ambient styling.",
+    "keyCharacteristics": [
+      "Token contract: components consume semantic roles, never raw hex.",
+      "Three themes from one base set: light, high-contrast, dark.",
+      "Flat by default; elevation and color are earned by state or meaning.",
+      "4px spatial grid, enforced at the function level.",
+      "Inter for UI, accessible at AA across all themes."
+    ],
+    "rules": [
+      { "name": "The Token Contract Rule", "body": "Components reference semantic roles (surface.tint, font.default, stroke.light), never raw ramp values. A literal hex inside a component is a defect, not a shortcut.", "section": "colors" },
+      { "name": "The Three-Theme Rule", "body": "Every color decision must resolve correctly in light, high-contrast, and dark. Dark is hand-tuned (its own hex values), never an algorithmic inversion of light.", "section": "colors" },
+      { "name": "The Meaning-Only Color Rule", "body": "Saturated color marks an action, a status, or a featured object. It is never spent on ambient decoration.", "section": "colors" },
+      { "name": "The Weight-Not-Tracking Rule", "body": "Letter-spacing is 0 across the entire scale. Hierarchy comes from size and weight contrast, never from manual tracking.", "section": "typography" },
+      { "name": "The Flat-By-Default Rule", "body": "Surfaces are flat at rest. Shadow appears only as a response to state (hover, focus) or as an explicit elevation level. A resting card with a drop shadow is wrong; raise it with a border or a tint step instead.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do reference semantic tokens (surface.tint, font.default, stroke.light) in every component. A raw hex is a defect.",
+      "Do verify every change in light, high-contrast, and dark before it lands.",
+      "Do keep surfaces flat at rest and raise them with a border or tint step; use elevation-1/elevation-2 only for genuine lift.",
+      "Do size spacing on the 4px grid (none, 1, 2, or multiples of 4); the build rejects anything else.",
+      "Do carry status meaning with paired text/icon, never color alone, and use the matched font-on-* token for contrast.",
+      "Do build hierarchy from size and weight; keep letter-spacing at 0."
+    ],
+    "donts": [
+      "Don't reach for Material/MUI heaviness: no elevation-everywhere, ripple effects, or opinionated motion that fights the host product.",
+      "Don't expose Tailwind-style utility soup as the API; compose components and semantic tokens, not ad-hoc utility stacks.",
+      "Don't let the result read as Bootstrap genericness or any-app-on-the-internet; it must feel like Rocket.Chat.",
+      "Don't ship over-branded, playful flourishes: no decorative gradients, mascots, or trend-chasing that ages fast in an enterprise comms tool.",
+      "Don't use a border-left greater than 1px as a colored accent stripe on cards, list items, or callouts; use a full border or a tint instead.",
+      "Don't spend saturated color on ambient decoration; reserve it for actions, status, and featured objects.",
+      "Don't put a resting drop-shadow on a card. If it looks like a 2014 app, the shadow is too dark and standing where it shouldn't."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,264 @@
+---
+name: Fuselage
+description: Rocket.Chat's open-source design system. Token-driven, three-theme, accessible by gate.
+colors:
+  rocket-blue: "#156FF5"
+  rocket-blue-hover: "#095AD2"
+  rocket-blue-press: "#10529E"
+  featured-purple: "#5F1477"
+  danger-red: "#EC0D2A"
+  success-green: "#1ECB92"
+  warning-yellow: "#F3BE08"
+  surface-light: "#FFFFFF"
+  surface-tint: "#F7F8FA"
+  surface-hover: "#F2F3F5"
+  surface-selected: "#D7DBE0"
+  font-default: "#2F343D"
+  font-titles: "#1F2329"
+  font-hint: "#6C737A"
+  font-on-color: "#FFFFFF"
+  stroke-extra-light: "#EBECEF"
+  stroke-light: "#CBCED1"
+  stroke-medium: "#9EA2A8"
+typography:
+  display:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    fontSize: "48px"
+    fontWeight: 800
+    lineHeight: "64px"
+    letterSpacing: "0"
+  headline:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    fontSize: "32px"
+    fontWeight: 700
+    lineHeight: "40px"
+    letterSpacing: "0"
+  title:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    fontSize: "24px"
+    fontWeight: 700
+    lineHeight: "32px"
+    letterSpacing: "0"
+  subtitle:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    fontSize: "16px"
+    fontWeight: 700
+    lineHeight: "24px"
+    letterSpacing: "0"
+  body:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    fontSize: "14px"
+    fontWeight: 400
+    lineHeight: "20px"
+    letterSpacing: "0"
+  label:
+    fontFamily: "Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    fontSize: "12px"
+    fontWeight: 700
+    lineHeight: "16px"
+    letterSpacing: "0"
+  mono:
+    fontFamily: "Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace"
+    fontSize: "14px"
+    fontWeight: 400
+    lineHeight: "20px"
+    letterSpacing: "0"
+rounded:
+  fine: "2px"
+  medium: "4px"
+  large: "8px"
+  extra-large: "20px"
+  full: "9999px"
+spacing:
+  hairline: "1px"
+  fine: "2px"
+  xs: "4px"
+  sm: "8px"
+  md: "16px"
+  lg: "24px"
+  xl: "32px"
+components:
+  button-primary:
+    backgroundColor: "{colors.rocket-blue}"
+    textColor: "{colors.font-on-color}"
+    typography: "{typography.body}"
+    rounded: "{rounded.medium}"
+    padding: "0 16px"
+    height: "40px"
+  button-primary-hover:
+    backgroundColor: "{colors.rocket-blue-hover}"
+    textColor: "{colors.font-on-color}"
+  button-secondary:
+    backgroundColor: "{colors.surface-selected}"
+    textColor: "{colors.font-titles}"
+    typography: "{typography.body}"
+    rounded: "{rounded.medium}"
+    padding: "0 16px"
+    height: "40px"
+  button-danger:
+    backgroundColor: "{colors.danger-red}"
+    textColor: "{colors.font-on-color}"
+    typography: "{typography.body}"
+    rounded: "{rounded.medium}"
+    height: "40px"
+  input:
+    backgroundColor: "{colors.surface-light}"
+    textColor: "{colors.font-default}"
+    typography: "{typography.body}"
+    rounded: "{rounded.medium}"
+    padding: "8px 16px"
+  card:
+    backgroundColor: "{colors.surface-light}"
+    textColor: "{colors.font-default}"
+    rounded: "{rounded.large}"
+    padding: "20px 12px"
+  tile:
+    backgroundColor: "{colors.surface-light}"
+    textColor: "{colors.font-default}"
+    typography: "{typography.body}"
+    rounded: "{rounded.medium}"
+  callout:
+    backgroundColor: "{colors.surface-light}"
+    textColor: "{colors.font-default}"
+    rounded: "{rounded.medium}"
+    padding: "12px"
+  chip:
+    backgroundColor: "{colors.surface-selected}"
+    textColor: "{colors.font-hint}"
+    typography: "{typography.label}"
+    rounded: "{rounded.full}"
+---
+
+# Design System: Fuselage
+
+## 1. Overview
+
+**Creative North Star: "The Field Manual"**
+
+Fuselage is reference material, not decoration. It reads like a well-kept field manual: every value has a name, every name has a place, and an engineer or designer can look up the right answer instead of guessing it. The identity is the rigor. Token-driven from the ground up, documented in Storybook, predictable in every state. The closest spiritual sibling is GitHub Primer, where accessibility is a gate and the system's discipline is the thing people trust.
+
+The surface itself stays quiet so the product can speak. Neutral, lightly tinted surfaces carry the room; saturated color is reserved for meaning (an action, a status, a featured object), never spent on ambient styling. Density favors legibility: the default body type is 14px with tight line-height, sized for people who read this interface for hours. Nothing competes with the message being sent through Rocket.Chat.
+
+This system explicitly rejects Material/MUI heaviness (elevation everywhere, ripple, opinionated motion), Tailwind-style utility soup as a public API, Bootstrap genericness that reads as any-app-on-the-internet, and over-branded playful kits with gradients and mascots that age fast in an enterprise communications tool.
+
+**Key Characteristics:**
+- Token contract: components consume semantic roles, never raw hex.
+- Three themes from one base set: light, high-contrast, dark.
+- Flat by default; elevation and color are earned by state or meaning.
+- 4px spatial grid, enforced at the function level.
+- Inter for UI, accessible at AA across all themes.
+
+## 2. Colors: The Functional Spectrum
+
+A near-neutral surface field with a small set of saturated colors that only appear when they carry meaning. The same base ramps resolve into three themes; the frontmatter holds the light (default) values, and the sidecar carries each color's full ramp and dark-theme counterpart.
+
+### Primary
+- **Rocket Blue** (`#156FF5`, b500): the single primary-action color. Primary buttons, focus rings, links, info highlights. Darkens to `#095AD2` on hover and `#10529E` on press. The one color a user can trust to mean "this is the actionable thing".
+
+### Secondary
+- **Featured Purple** (`#5F1477`, p700): reserved for featured surfaces and brand-forward moments (featured rooms, promoted UI). Not a general accent; its scarcity is what makes it read as "special".
+
+### Tertiary (status, never used decoratively)
+- **Success Green** (`#1ECB92`, g600): success states, paired with a darker green font on a light green fill.
+- **Warning Yellow** (`#F3BE08`, y600): warnings, paired with deep-yellow text.
+- **Danger Red** (`#EC0D2A`, r500): destructive actions, errors, danger buttons.
+- Service accents (orange `o`, purple `p`) exist for categorical tagging, always shipped as a background plus a matched `font-on-*` text color so contrast holds.
+
+### Neutral
+- **Surface Light** (`#FFFFFF`): primary surface and room background.
+- **Surface Tint** (`#F7F8FA`, n100): subtly raised panels, sidebars, app chrome.
+- **Surface Hover / Selected** (`#F2F3F5` / `#D7DBE0`): interaction feedback on neutral rows.
+- **Font Titles** (`#1F2329`, n900) and **Font Default** (`#2F343D`, n800): titles and body text. Note these are tinted dark-blue-grey, never pure black.
+- **Font Hint** (`#6C737A`, n700): secondary info, annotations, placeholders.
+- **Strokes** (`#EBECEF` extraLight through `#9EA2A8` medium, n250 to n600): borders and dividers, climbing the neutral ramp by emphasis.
+
+### Named Rules
+**The Token Contract Rule.** Components reference semantic roles (`surface.tint`, `font.default`, `stroke.light`), never raw ramp values. A literal hex inside a component is a defect, not a shortcut.
+
+**The Three-Theme Rule.** Every color decision must resolve correctly in light, high-contrast, and dark. Dark is hand-tuned (its own hex values), never an algorithmic inversion of light.
+
+**The Meaning-Only Color Rule.** Saturated color marks an action, a status, or a featured object. It is never spent on ambient decoration. If a screen is mostly neutral with rare color, that is correct.
+
+## 3. Typography
+
+**Display / Body Font:** Inter (with `-apple-system`, `Segoe UI`, `Roboto`, system fallbacks, plus emoji).
+**Mono Font:** Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace (code, message blocks, technical values).
+
+**Character:** One workhorse sans across the whole hierarchy, differentiated by scale and weight rather than by mixing families. The result is calm and uniform, the opposite of an expressive type pairing. Inter's high x-height keeps 12px to 14px text legible at chat density.
+
+### Hierarchy
+- **Display / hero** (800, 48px, 64px line-height): marketing-scale display, rare inside the app.
+- **Headline / h1** (700, 32px, 40px): page titles.
+- **Title / h2 to h3** (700, 24px to 20px, 32px to 28px): section and subsection headings.
+- **Subtitle / h4 to h5** (700, 16px to 14px, 24px to 20px): block and dense headings.
+- **Body / p1 to p2** (400/500/700, 16px or 14px, 24px or 20px): paragraph text. 14px (p2) is the chat default. Cap measure at 65 to 75ch.
+- **Caption / label** (400/700, 12px, 16px) and **micro** (700, 10px, 12px): captions, overlines, badge text.
+
+### Named Rules
+**The Weight-Not-Tracking Rule.** Letter-spacing is 0 across the entire scale. Hierarchy comes from size and weight contrast, never from manual tracking. If two levels look too similar, change weight or size, not spacing.
+
+## 4. Elevation
+
+Flat by default, lifted by state. Surfaces sit flush at rest. Depth is conveyed first by tonal layering (surface tint and hover steps) and by borders; shadow is reserved for genuine elevation (menus, popovers, opt-in raised tiles) and for hover/focus response. There is no ambient drop-shadow on resting cards. Dark theme deepens shadow opacity rather than reusing the light values.
+
+### Shadow Vocabulary
+- **elevation-border** (`#EBECEF` light, `#2F343D` dark): a 1px definition border where a shadow would be too subtle.
+- **elevation-1** (`box-shadow` from `rgba(47,52,61,0.1)` light, `rgba(9,9,9,0.35)` dark): low lift for hovered or single-step raised surfaces (Tile elevation-1).
+- **elevation-2** (composed from `rgba(47,52,61,0.08)` and `rgba(47,52,61,0.12)`; dark `rgba(9,9,9,0.3)` / `0.45`): menus, popovers, modals (Tile elevation-2).
+
+### Named Rules
+**The Flat-By-Default Rule.** Surfaces are flat at rest. Shadow appears only as a response to state (hover, focus) or as an explicit elevation level (`elevation-1`, `elevation-2`). A resting card with a drop shadow is wrong; raise it with a border or a tint step instead.
+
+## 5. Components
+
+The feel across the set is **precise and legible**: tight, instrument-grade defaults optimized for density and scanning, quiet in their resting state.
+
+### Buttons
+- **Shape:** gently squared (4px radius, `rounded.medium`). Fixed 40px height, 16px horizontal padding, body-strong type (14px / 500). A subtle click-animation on press; status buttons excluded.
+- **Primary:** Rocket Blue (`#156FF5`) fill, white text. Hover `#095AD2`, press `#10529E`, disabled `#D1EBFE`.
+- **Secondary:** neutral fill (`#E4E7EA`) climbing to `#CBCED1` hover / `#9EA2A8` press, dark text. The everyday button.
+- **Danger:** Danger Red (`#EC0D2A`) fill, white text, for destructive confirms only.
+- **Ghost / secondary-danger:** transparent or neutral background with colored text; used inline where a filled button would shout.
+
+### Inputs / Fields
+- **Style:** white surface, 1px neutral border, 4px radius (`rounded.medium`), 8px/16px padding, 144px min-width, 14px body text.
+- **Focus:** border shifts to Rocket Blue (`stroke.highlight`) with a soft highlight ring. No glow bloom.
+- **Error:** border and ring shift to error red (`stroke.error`); `:invalid` is styled, not just colored, and pairs with a text message (never color alone).
+
+### Cards / Containers
+- **Corner Style:** rounded (8px radius, `rounded.large`), softer than controls.
+- **Background:** Surface Light (`#FFFFFF`); clickable cards shift to Surface Hover on hover/focus.
+- **Shadow Strategy:** flat at rest per the Flat-By-Default Rule. Use a Tile with `elevation-1`/`elevation-2` when genuine lift is needed.
+- **Internal Padding:** 20px vertical, 12px horizontal, 8px internal gaps; 28px for hero cards.
+
+### Tile
+- **Style:** the elevation primitive. 4px radius, Surface Light, body text, with explicit `elevation-0` (none), `elevation-1`, `elevation-2` levels. Use Tile, not Card, when the only job is to raise content.
+
+### Callout
+- **Style:** full 1px border (never a side stripe), 4px radius, 12px padding, status-colored border and text (info / success / warning / danger) drawn from the `font-on-*` status tokens.
+
+### Chips / Tags
+- **Style:** pill (`rounded.full`), secondary-button background (`#D7DBE0` family), hint-colored text, label type (12px / 700). Hover, active, and focus states track the secondary-button color set; focus adds a dark stroke plus shadow.
+- **Badge:** four severity levels (level-1 to level-4) plus ghost, white text on a saturated fill, for counts and status pips.
+
+### Navigation
+- **Style:** neutral sidebar surface (`surface.sidebar`, n400 light / `#2F343D` dark), body type. Items rest flat; hover uses Surface Hover, the active item uses Surface Selected. Selection is a fill change, not a colored left stripe.
+
+## 6. Do's and Don'ts
+
+### Do:
+- **Do** reference semantic tokens (`surface.tint`, `font.default`, `stroke.light`) in every component. A raw hex is a defect.
+- **Do** verify every change in light, high-contrast, and dark before it lands.
+- **Do** keep surfaces flat at rest and raise them with a border or tint step; use `elevation-1`/`elevation-2` only for genuine lift.
+- **Do** size spacing on the 4px grid (`none`, `1`, `2`, or multiples of 4); the build rejects anything else.
+- **Do** carry status meaning with paired text/icon, never color alone, and use the matched `font-on-*` token for contrast.
+- **Do** build hierarchy from size and weight; keep letter-spacing at 0.
+
+### Don't:
+- **Don't** reach for Material/MUI heaviness: no elevation-everywhere, ripple effects, or opinionated motion that fights the host product.
+- **Don't** expose Tailwind-style utility soup as the API; compose components and semantic tokens, not ad-hoc utility stacks.
+- **Don't** let the result read as Bootstrap genericness or any-app-on-the-internet; it must feel like Rocket.Chat.
+- **Don't** ship over-branded, playful flourishes: no decorative gradients, mascots, or trend-chasing that ages fast in an enterprise comms tool.
+- **Don't** use a `border-left` greater than 1px as a colored accent stripe on cards, list items, or callouts; use a full border or a tint instead.
+- **Don't** spend saturated color on ambient decoration; reserve it for actions, status, and featured objects.
+- **Don't** put a resting drop-shadow on a card. If it looks like a 2014 app, the shadow is too dark and standing where it shouldn't.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,6 +1,6 @@
 ---
 name: Fuselage
-description: Rocket.Chat's open-source design system. Token-driven, three-theme, accessible by gate.
+description: Derived token snapshot of the Fuselage design system (RocketChat/fuselage @ faa9feb). Fuselage is canonical; regenerate, do not hand-edit.
 colors:
   rocket-blue: "#156FF5"
   rocket-blue-hover: "#095AD2"
@@ -135,6 +135,8 @@ components:
 
 **Creative North Star: "The Field Manual"**
 
+> **Source of truth.** Fuselage itself is canonical. It ships semantic tokens (`@rocket.chat/fuselage-tokens`, the `Palette` export, runtime `--rcx-*` CSS variables, the `colors.*` SCSS mixins) and owns every value across light, high-contrast, and dark. **This file is a derived snapshot, not the source.** The frontmatter and sidecar carry literal hex only because the Stitch tooling and live-preview panel cannot resolve Fuselage's runtime tokens; they need static values to render swatches. The prose below references token *names*, never hex, so it cannot drift. Snapshot taken from `RocketChat/fuselage` @ `faa9feb`. This repo consumes `@rocket.chat/fuselage ^0.78.0` / `fuselage-tokens ~0.33.2`; the snapshot is from the source tip and may differ from the pinned runtime. Treat DESIGN.md as a build artifact: regenerate with `/impeccable document` on a version bump, never hand-edit the values.
+
 Fuselage is reference material, not decoration. It reads like a well-kept field manual: every value has a name, every name has a place, and an engineer or designer can look up the right answer instead of guessing it. The identity is the rigor. Token-driven from the ground up, documented in Storybook, predictable in every state. The closest spiritual sibling is GitHub Primer, where accessibility is a gate and the system's discipline is the thing people trust.
 
 The surface itself stays quiet so the product can speak. Neutral, lightly tinted surfaces carry the room; saturated color is reserved for meaning (an action, a status, a featured object), never spent on ambient styling. Density favors legibility: the default body type is 14px with tight line-height, sized for people who read this interface for hours. Nothing competes with the message being sent through Rocket.Chat.
@@ -150,32 +152,33 @@ This system explicitly rejects Material/MUI heaviness (elevation everywhere, rip
 
 ## 2. Colors: The Functional Spectrum
 
-A near-neutral surface field with a small set of saturated colors that only appear when they carry meaning. The same base ramps resolve into three themes; the frontmatter holds the light (default) values, and the sidecar carries each color's full ramp and dark-theme counterpart.
+A near-neutral surface field with a small set of saturated colors that only appear when they carry meaning. The same base ramps resolve into three themes; values are owned by `@rocket.chat/fuselage-tokens` and referenced here by token name. Hex appears once, in the frontmatter, for tooling only.
 
 ### Primary
-- **Rocket Blue** (`#156FF5`, b500): the single primary-action color. Primary buttons, focus rings, links, info highlights. Darkens to `#095AD2` on hover and `#10529E` on press. The one color a user can trust to mean "this is the actionable thing".
+- **Rocket Blue** (ramp `b500`; semantic `button.backgroundPrimaryDefault`, `stroke.highlight`, `font.info`): the single primary-action color. Primary buttons, focus rings, links, info highlights. Darkens through `b600` (hover) and `b700` (press). The one color a user can trust to mean "this is the actionable thing".
 
 ### Secondary
-- **Featured Purple** (`#5F1477`, p700): reserved for featured surfaces and brand-forward moments (featured rooms, promoted UI). Not a general accent; its scarcity is what makes it read as "special".
+- **Featured Purple** (ramp `p700`; semantic `surface.featured`): reserved for featured surfaces and brand-forward moments. Not a general accent; its scarcity is what makes it read as "special".
 
 ### Tertiary (status, never used decoratively)
-- **Success Green** (`#1ECB92`, g600): success states, paired with a darker green font on a light green fill.
-- **Warning Yellow** (`#F3BE08`, y600): warnings, paired with deep-yellow text.
-- **Danger Red** (`#EC0D2A`, r500): destructive actions, errors, danger buttons.
-- Service accents (orange `o`, purple `p`) exist for categorical tagging, always shipped as a background plus a matched `font-on-*` text color so contrast holds.
+- **Success Green** (`g600`; `status.success` + `status.font-on-success`): success states, fill plus a matched darker-green font.
+- **Warning Yellow** (`y600`; `status.warning` + `status.font-on-warning`): warnings, fill plus deep-yellow text.
+- **Danger Red** (`r500`; `status.danger`, `button.backgroundDangerDefault`, `stroke.error`): destructive actions, errors.
+- Service accents (`status.service-1..3`, orange/purple ramps) for categorical tagging, always shipped as a background plus a matched `status.font-on-*` token so contrast holds.
 
 ### Neutral
-- **Surface Light** (`#FFFFFF`): primary surface and room background.
-- **Surface Tint** (`#F7F8FA`, n100): subtly raised panels, sidebars, app chrome.
-- **Surface Hover / Selected** (`#F2F3F5` / `#D7DBE0`): interaction feedback on neutral rows.
-- **Font Titles** (`#1F2329`, n900) and **Font Default** (`#2F343D`, n800): titles and body text. Note these are tinted dark-blue-grey, never pure black.
-- **Font Hint** (`#6C737A`, n700): secondary info, annotations, placeholders.
-- **Strokes** (`#EBECEF` extraLight through `#9EA2A8` medium, n250 to n600): borders and dividers, climbing the neutral ramp by emphasis.
+- **Surface** (`surface.light` / `surface.tint` / `surface.room`): primary surface, raised panels, sidebars, app chrome.
+- **Surface Hover / Selected** (`surface.hover` / `surface.selected`): interaction feedback on neutral rows.
+- **Font** (`font.titlesLabels` for titles, `font.default` for body): note these resolve to tinted dark-blue-greys (`n900` / `n800`), never pure black.
+- **Font Hint** (`font.hint` / `font.secondaryInfo`): secondary info, annotations, placeholders.
+- **Strokes** (`stroke.extraLight` through `stroke.medium`, ramp `n250`..`n600`): borders and dividers, climbing the neutral ramp by emphasis.
 
 ### Named Rules
-**The Token Contract Rule.** Components reference semantic roles (`surface.tint`, `font.default`, `stroke.light`), never raw ramp values. A literal hex inside a component is a defect, not a shortcut.
+**The Token Contract Rule.** Product code references semantic roles (`Palette.surface.tint`, `colors.font(default)`, `var(--rcx-color-font-default)`), never raw ramp values or hex. A literal hex inside a component is a defect, not a shortcut. This document obeys the same rule: prose names tokens, never values.
 
-**The Three-Theme Rule.** Every color decision must resolve correctly in light, high-contrast, and dark. Dark is hand-tuned (its own hex values), never an algorithmic inversion of light.
+**The Derived-Snapshot Rule.** Fuselage owns the values. DESIGN.md's frontmatter is a generated mirror for tooling. On a Fuselage version bump, regenerate with `/impeccable document` against the installed package; never hand-patch a hex here. A value that disagrees with Fuselage is the snapshot being stale, not Fuselage being wrong.
+
+**The Three-Theme Rule.** Every color decision must resolve correctly in light, high-contrast, and dark. Dark is hand-tuned (its own values), never an algorithmic inversion of light.
 
 **The Meaning-Only Color Rule.** Saturated color marks an action, a status, or a featured object. It is never spent on ambient decoration. If a screen is mostly neutral with rare color, that is correct.
 
@@ -184,77 +187,81 @@ A near-neutral surface field with a small set of saturated colors that only appe
 **Display / Body Font:** Inter (with `-apple-system`, `Segoe UI`, `Roboto`, system fallbacks, plus emoji).
 **Mono Font:** Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace (code, message blocks, technical values).
 
-**Character:** One workhorse sans across the whole hierarchy, differentiated by scale and weight rather than by mixing families. The result is calm and uniform, the opposite of an expressive type pairing. Inter's high x-height keeps 12px to 14px text legible at chat density.
+**Character:** One workhorse sans across the whole hierarchy, differentiated by scale and weight rather than by mixing families. The result is calm and uniform, the opposite of an expressive type pairing. Inter's high x-height keeps 12px to 14px text legible at chat density. The scale is a stable structural token set (`fontScales` in `fuselage-tokens`), so sizes are shown inline.
 
 ### Hierarchy
-- **Display / hero** (800, 48px, 64px line-height): marketing-scale display, rare inside the app.
-- **Headline / h1** (700, 32px, 40px): page titles.
-- **Title / h2 to h3** (700, 24px to 20px, 32px to 28px): section and subsection headings.
-- **Subtitle / h4 to h5** (700, 16px to 14px, 24px to 20px): block and dense headings.
-- **Body / p1 to p2** (400/500/700, 16px or 14px, 24px or 20px): paragraph text. 14px (p2) is the chat default. Cap measure at 65 to 75ch.
-- **Caption / label** (400/700, 12px, 16px) and **micro** (700, 10px, 12px): captions, overlines, badge text.
+- **Display** (`hero`: 800, 48px, 64px line-height): marketing-scale display, rare inside the app.
+- **Headline** (`h1`: 700, 32px, 40px): page titles.
+- **Title** (`h2`/`h3`: 700, 24px to 20px, 32px to 28px): section and subsection headings.
+- **Subtitle** (`h4`/`h5`: 700, 16px to 14px, 24px to 20px): block and dense headings.
+- **Body** (`p1`/`p2`: 400/500/700, 16px or 14px, 24px or 20px): paragraph text. `p2` (14px) is the chat default. Cap measure at 65 to 75ch.
+- **Caption / Label** (`c1`/`c2`: 400/700, 12px, 16px) and **Micro** (`micro`: 700, 10px, 12px): captions, overlines, badge text.
 
 ### Named Rules
 **The Weight-Not-Tracking Rule.** Letter-spacing is 0 across the entire scale. Hierarchy comes from size and weight contrast, never from manual tracking. If two levels look too similar, change weight or size, not spacing.
 
 ## 4. Elevation
 
-Flat by default, lifted by state. Surfaces sit flush at rest. Depth is conveyed first by tonal layering (surface tint and hover steps) and by borders; shadow is reserved for genuine elevation (menus, popovers, opt-in raised tiles) and for hover/focus response. There is no ambient drop-shadow on resting cards. Dark theme deepens shadow opacity rather than reusing the light values.
+Flat by default, lifted by state. Surfaces sit flush at rest. Depth is conveyed first by tonal layering (`surface.tint` and `surface.hover` steps) and by borders; shadow is reserved for genuine elevation (menus, popovers, opt-in raised tiles) and for hover/focus response. There is no ambient drop-shadow on resting cards. Dark theme deepens shadow opacity rather than reusing the light values.
 
 ### Shadow Vocabulary
-- **elevation-border** (`#EBECEF` light, `#2F343D` dark): a 1px definition border where a shadow would be too subtle.
-- **elevation-1** (`box-shadow` from `rgba(47,52,61,0.1)` light, `rgba(9,9,9,0.35)` dark): low lift for hovered or single-step raised surfaces (Tile elevation-1).
-- **elevation-2** (composed from `rgba(47,52,61,0.08)` and `rgba(47,52,61,0.12)`; dark `rgba(9,9,9,0.3)` / `0.45`): menus, popovers, modals (Tile elevation-2).
+Drawn from the `shadow.*` and `elevation-*` tokens; the literal box-shadow strings live in the sidecar.
+- **elevation-border** (`shadow.elevation-border`): a 1px definition border where a shadow would be too subtle.
+- **elevation-1** (`shadow.elevation-1`): low lift for hovered or single-step raised surfaces (Tile `elevation-1`).
+- **elevation-2** (`shadow.elevation-2x` + `elevation-2y`): menus, popovers, modals (Tile `elevation-2`).
 
 ### Named Rules
 **The Flat-By-Default Rule.** Surfaces are flat at rest. Shadow appears only as a response to state (hover, focus) or as an explicit elevation level (`elevation-1`, `elevation-2`). A resting card with a drop shadow is wrong; raise it with a border or a tint step instead.
 
 ## 5. Components
 
-The feel across the set is **precise and legible**: tight, instrument-grade defaults optimized for density and scanning, quiet in their resting state.
+The feel across the set is **precise and legible**: tight, instrument-grade defaults optimized for density and scanning, quiet in their resting state. Shapes and sizes below are structural (`lengths.*` tokens); colors are named, not hex'd.
 
 ### Buttons
-- **Shape:** gently squared (4px radius, `rounded.medium`). Fixed 40px height, 16px horizontal padding, body-strong type (14px / 500). A subtle click-animation on press; status buttons excluded.
-- **Primary:** Rocket Blue (`#156FF5`) fill, white text. Hover `#095AD2`, press `#10529E`, disabled `#D1EBFE`.
-- **Secondary:** neutral fill (`#E4E7EA`) climbing to `#CBCED1` hover / `#9EA2A8` press, dark text. The everyday button.
-- **Danger:** Danger Red (`#EC0D2A`) fill, white text, for destructive confirms only.
+- **Shape:** gently squared (`rounded.medium`, 4px). Fixed 40px height, 16px horizontal padding (`lengths.padding`), body-strong type (`p2m`, 14px/500). A subtle click-animation on press; status buttons excluded.
+- **Primary:** `button.backgroundPrimary*` (Rocket Blue) fill, `button.fontOnPrimary` text. Hover/press/disabled track the `Primary` state set.
+- **Secondary:** `button.backgroundSecondary*` (neutral) fill, dark text. The everyday button.
+- **Danger:** `button.backgroundDanger*` (Danger Red) fill, white text, for destructive confirms only.
 - **Ghost / secondary-danger:** transparent or neutral background with colored text; used inline where a filled button would shout.
 
 ### Inputs / Fields
-- **Style:** white surface, 1px neutral border, 4px radius (`rounded.medium`), 8px/16px padding, 144px min-width, 14px body text.
-- **Focus:** border shifts to Rocket Blue (`stroke.highlight`) with a soft highlight ring. No glow bloom.
-- **Error:** border and ring shift to error red (`stroke.error`); `:invalid` is styled, not just colored, and pairs with a text message (never color alone).
+- **Style:** `surface.light` background, 1px `stroke` border, `rounded.medium` (4px), 8px/16px padding, 144px min-width, `p2` (14px) text.
+- **Focus:** border shifts to `stroke.highlight` (Rocket Blue) with a soft highlight ring. No glow bloom.
+- **Error:** border and ring shift to `stroke.error`; `:invalid` is styled, not just colored, and pairs with a text message (never color alone).
 
 ### Cards / Containers
-- **Corner Style:** rounded (8px radius, `rounded.large`), softer than controls.
-- **Background:** Surface Light (`#FFFFFF`); clickable cards shift to Surface Hover on hover/focus.
+- **Corner Style:** `rounded.large` (8px), softer than controls.
+- **Background:** `surface.light`; clickable cards shift to `surface.hover` on hover/focus.
 - **Shadow Strategy:** flat at rest per the Flat-By-Default Rule. Use a Tile with `elevation-1`/`elevation-2` when genuine lift is needed.
-- **Internal Padding:** 20px vertical, 12px horizontal, 8px internal gaps; 28px for hero cards.
+- **Internal Padding:** 20px vertical, 12px horizontal, 8px internal gaps (`lengths.margin`/`padding`); 28px for hero cards.
 
 ### Tile
-- **Style:** the elevation primitive. 4px radius, Surface Light, body text, with explicit `elevation-0` (none), `elevation-1`, `elevation-2` levels. Use Tile, not Card, when the only job is to raise content.
+- **Style:** the elevation primitive. `rounded.medium`, `surface.light`, `p2` text, with explicit `elevation-0` (none), `elevation-1`, `elevation-2` levels. Use Tile, not Card, when the only job is to raise content.
 
 ### Callout
-- **Style:** full 1px border (never a side stripe), 4px radius, 12px padding, status-colored border and text (info / success / warning / danger) drawn from the `font-on-*` status tokens.
+- **Style:** full 1px border (never a side stripe), `rounded.medium`, 12px padding, status-colored border and text (info / success / warning / danger) drawn from the `status.font-on-*` tokens.
 
 ### Chips / Tags
-- **Style:** pill (`rounded.full`), secondary-button background (`#D7DBE0` family), hint-colored text, label type (12px / 700). Hover, active, and focus states track the secondary-button color set; focus adds a dark stroke plus shadow.
-- **Badge:** four severity levels (level-1 to level-4) plus ghost, white text on a saturated fill, for counts and status pips.
+- **Style:** pill (`rounded.full`), `button.backgroundSecondary*` background, `font.secondaryInfo` text, `c2` label type (12px/700). Hover, active, and focus states track the secondary-button color set; focus adds a `stroke.extraDark` border plus shadow.
+- **Badge:** four severity levels (`badge.level-1..4`) plus ghost, `font.pureWhite` text on a saturated fill, for counts and status pips.
 
 ### Navigation
-- **Style:** neutral sidebar surface (`surface.sidebar`, n400 light / `#2F343D` dark), body type. Items rest flat; hover uses Surface Hover, the active item uses Surface Selected. Selection is a fill change, not a colored left stripe.
+- **Style:** `surface.sidebar` background, `p2` type. Items rest flat; hover uses `surface.hover`, the active item uses `surface.selected`. Selection is a fill change, not a colored left stripe.
 
 ## 6. Do's and Don'ts
 
 ### Do:
-- **Do** reference semantic tokens (`surface.tint`, `font.default`, `stroke.light`) in every component. A raw hex is a defect.
+- **Do** consume Fuselage semantic tokens (`Palette.*`, `colors.*` mixins, `var(--rcx-color-*)`) in product code. Fuselage is the source of truth; this file is a reference.
+- **Do** reference semantic roles (`surface.tint`, `font.default`, `stroke.light`) over ramp steps, and ramp steps over hex.
 - **Do** verify every change in light, high-contrast, and dark before it lands.
 - **Do** keep surfaces flat at rest and raise them with a border or tint step; use `elevation-1`/`elevation-2` only for genuine lift.
 - **Do** size spacing on the 4px grid (`none`, `1`, `2`, or multiples of 4); the build rejects anything else.
-- **Do** carry status meaning with paired text/icon, never color alone, and use the matched `font-on-*` token for contrast.
+- **Do** carry status meaning with paired text/icon, never color alone, and use the matched `status.font-on-*` token for contrast.
 - **Do** build hierarchy from size and weight; keep letter-spacing at 0.
+- **Do** regenerate this file with `/impeccable document` when Fuselage bumps; treat its values as a snapshot.
 
 ### Don't:
+- **Don't** hardcode a hex value in product code, or hand-edit the values in this file. If a color is wrong, fix it in Fuselage and regenerate.
 - **Don't** reach for Material/MUI heaviness: no elevation-everywhere, ripple effects, or opinionated motion that fights the host product.
 - **Don't** expose Tailwind-style utility soup as the API; compose components and semantic tokens, not ad-hoc utility stacks.
 - **Don't** let the result read as Bootstrap genericness or any-app-on-the-internet; it must feel like Rocket.Chat.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,49 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Two audiences, served as a single contract:
+
+- **Rocket.Chat core engineers** (primary): internal developers building the main client, admin, EE features, and the embeddable Livechat widget on top of Fuselage. They reach for components and semantic tokens dozens of times a day and expect predictable props, stable APIs, and theming that falls out of the token layer without per-component overrides.
+- **Product designers** (primary): designers consuming tokens and components who need parity between Figma and code. A token or component must mean the same thing in design tooling as it does in the codebase.
+
+Secondary: open-source community contributors and Rocket.Chat App / UiKit developers, who must be able to extend or match the system without reading the maintainers' minds.
+
+## Product Purpose
+
+Fuselage is Rocket.Chat's open-source design system: the single source of truth for the product's UI. It ships React components, semantic design tokens, hooks, and icons that consuming surfaces (the main client, admin, Livechat, UiKit blocks) compose into a consistent interface.
+
+Scope is **library-first**: this document governs the design system as the source of truth, with consuming-app theming (theme wrappers, CSS variables, dynamic CSS) as secondary context for how the system is applied.
+
+Success looks like: an engineer assembles an on-brand, accessible, themeable screen from Fuselage primitives without writing bespoke CSS or fighting the system, and a designer sees the result match their Figma without translation loss.
+
+## Brand Personality
+
+**Neutral and systematic.** Fuselage is invisible scaffolding. Calm, consistent, and out of the way. Components serve the product, never themselves; nothing in the system competes with the content it frames. The voice is that of infrastructure you trust and stop noticing, closer to Radix or Base Web than to a personality-forward kit.
+
+Three words: **systematic, calm, dependable.**
+
+## Anti-references
+
+- **Material / MUI heaviness.** No elevation-everywhere, ripple effects, dense theming configuration, or opinionated motion that fights the host product.
+- **Tailwind-style utility soup.** Utility classes are not the public API. The system exposes components and semantic tokens, not ad-hoc stacks of utility classes.
+- **Bootstrap genericness.** Must not read as an off-the-shelf framework. The result should feel like Rocket.Chat, not like any-app-on-the-internet.
+- **Over-branded / playful kits.** No gradients-for-decoration, mascots, flourishes, or trend-chasing that ages fast in an enterprise communications tool.
+
+Rigor model: **GitHub Primer.** Token-driven, OSS-first, strong contribution documentation, accessibility treated as a gate rather than a backlog item. Match that bar.
+
+## Design Principles
+
+1. **Invisible by design.** The system serves the product. A Fuselage component should never draw attention to itself over the content it frames; the right outcome is that nobody notices the component, only the work it enables.
+2. **Tokens are the contract.** Semantic tokens, not raw values, are the API surface. Theming, dark mode, and density fall out of the token layer, not from per-component overrides. A raw hex or magic number in a component is a bug.
+3. **Accessible or it doesn't ship.** WCAG 2.1 AA is a CI gate, not an aspiration. Keyboard navigation, ARIA semantics, contrast, and reduced-motion are proven per component before it lands.
+4. **One source of truth, two consumers.** Code and Figma stay in parity. A token or component name means the same thing to an engineer and a designer; divergence between the two is a defect in the system, not a translation problem for the user to absorb.
+5. **OSS-legible.** Public APIs are predictable, props are documented, behavior is demonstrated in Storybook. A community contributor can extend the system without insider knowledge.
+
+## Accessibility & Inclusion
+
+**WCAG 2.1 AA, enforced.** AA contrast ratios, full keyboard navigation, correct ARIA roles and states, reduced-motion support, and screen-reader testing are baked into every component and gated in CI. Color is never the sole carrier of meaning. Motion respects `prefers-reduced-motion`. Accessibility regressions block merge.


### PR DESCRIPTION
## Proposed changes

Adds [impeccable](https://impeccable.style/) design context for the **Fuselage** design system so AI agents and contributors generate on-brand, accessible UI.

- **`PRODUCT.md`** — strategic context: register (`product`), users (RC core engineers + product designers), brand personality (neutral/systematic), anti-references, 5 design principles, WCAG 2.1 AA mandate.
- **`DESIGN.md`** — Stitch-format visual spec mined from real `RocketChat/fuselage` source: YAML token frontmatter (colors, typography, spacing, radius, components) + 6 fixed sections. North Star: *The Field Manual*.
- **`.impeccable/design.json`** — machine sidecar: tonal ramps, shadow/motion/breakpoint tokens, drop-in component snippets.

## Notes

- Docs only. No code, no dependency, no runtime change.
- Token values captured from the canonical Fuselage source (`@rocket.chat/fuselage-tokens`, `packages/fuselage/src/styles`).
- No changeset (non-package docs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a full “Fuselage” design system snapshot with concrete token values (colors, typography, spacing, radii) and starter component mappings.
  * Published prescriptive rules: theming (light/contrast/dark), token-contract usage, typography constraints, elevation/shadow vocabulary, and spacing grid.
  * Added component specifications (buttons, inputs, cards, tiles, callouts, chips) with interaction/validation guidance and a do/don’t checklist.
  * Defined audience, brand guidance, and enforced accessibility expectations (WCAG 2.1 AA, keyboard/ARIA, reduced-motion, screen-reader testing).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->