### PR TITLE
fix: add missing authorization check to fingerprint endpoint

### DIFF
--- a/.changeset/salty-suits-strive.md
+++ b/.changeset/salty-suits-strive.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes missing permission check on the `POST /api/v1/fingerprint` endpoint

--- a/apps/meteor/app/api/server/v1/misc.ts
+++ b/apps/meteor/app/api/server/v1/misc.ts
@@ -11,6 +11,7 @@ import {
 	isMeteorCall,
 	meSuccessResponseSchema,
 	validateUnauthorizedErrorResponse,
+	validateForbiddenErrorResponse,
 	validateBadRequestErrorResponse,
 } from '@rocket.chat/rest-typings';
 import type { MeApiSuccessResponse } from '@rocket.chat/rest-typings';
@@ -795,10 +796,12 @@ API.v1.post(
 	'fingerprint',
 	{
 		authRequired: true,
+		permissionsRequired: ['manage-cloud'],
 		body: isFingerprintProps,
 		response: {
 			200: fingerprintResponseSchema,
 			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 			400: validateBadRequestErrorResponse,
 		},
 	},

--- a/apps/meteor/tests/end-to-end/api/miscellaneous.ts
+++ b/apps/meteor/tests/end-to-end/api/miscellaneous.ts
@@ -686,4 +686,51 @@ describe('miscellaneous', () => {
 				.end(done);
 		});
 	});
+
+	describe('/fingerprint', () => {
+		let unauthorizedUser: TestUser<IUser>;
+		let unauthorizedUserCredentials: Credentials;
+
+		before(async () => {
+			unauthorizedUser = await createUser();
+			unauthorizedUserCredentials = await doLogin(unauthorizedUser.username, password);
+		});
+
+		after(async () => {
+			await deleteUser(unauthorizedUser);
+		});
+
+		it('should return 401 when called without authentication', async () => {
+			const res = await request.post(api('fingerprint')).send({ setDeploymentAs: 'updated-configuration' });
+
+			expect(res.status).to.equal(401);
+			expect(res.body).to.have.property('status', 'error');
+		});
+
+		it('should return 403 when a user without the manage-cloud permission tries to acknowledge a deployment configuration change', async () => {
+			const res = await request
+				.post(api('fingerprint'))
+				.set(unauthorizedUserCredentials)
+				.send({ setDeploymentAs: 'updated-configuration' });
+
+			expect(res.status).to.equal(403);
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
+		});
+
+		it('should return 403 when a user without the manage-cloud permission tries to deregister the workspace as a new workspace', async () => {
+			const res = await request.post(api('fingerprint')).set(unauthorizedUserCredentials).send({ setDeploymentAs: 'new-workspace' });
+
+			expect(res.status).to.equal(403);
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
+		});
+
+		it('should return 200 when a user with the manage-cloud permission acknowledges a deployment configuration change', async () => {
+			const res = await request.post(api('fingerprint')).set(credentials).send({ setDeploymentAs: 'updated-configuration' });
+
+			expect(res.status).to.equal(200);
+			expect(res.body).to.have.property('success', true);
+		});
+	});
 });


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The `POST /api/v1/fingerprint` endpoint was protected by `authRequired: true` but had no `permissionsRequired` check. The endpoint is still actively used as part of the deployment fingerprint change flow.

**Fix:** add `permissionsRequired: ['manage-cloud']` to the endpoint options, matching the authorization pattern used by every other cloud management endpoint in `cloud.ts`. The `manage-cloud` permission is assigned to the `admin` role by default, so the legitimate flow is unaffected.

The `403` response code is also added to the endpoint's response schema, which was missing.

## Issue(s)

[CORE-2238](https://rocketchat.atlassian.net/browse/CORE-2238), [VLN-398](https://rocketchat.atlassian.net/browse/VLN-398?atlOrigin=eyJpIjoiYzQ5YThkMmEyMDJlNGYwNWFhNTQ5MGY5NTljY2RhYzQiLCJwIjoiaiJ9)

## Steps to test or reproduce

**Before the fix:**

1. Call `POST /api/v1/fingerprint` as a user without the `manage-cloud` permission -> returns `200`

**After the fix:**

1. Call `POST /api/v1/fingerprint` as a user without the `manage-cloud` permission -> expect `403 Forbidden`
2. Call `POST /api/v1/fingerprint` as a user with the `manage-cloud` permission -> expect `200`
3. Trigger the fingerprint change modal as an admin (change `Site_Url` setting) -> confirm the modal still works end-to-end

## Further comments

The `manage-cloud` permission was chosen because it is already used by all other cloud management endpoints (`cloud.syncWorkspace`, `cloud.createRegistrationIntent`, `cloud.getRegistrationStatus`, etc.) and is semantically correct for an action that modifies workspace cloud identity.



[CORE-2238]: https://rocketchat.atlassian.net/browse/CORE-2238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[VLN-398]: https://rocketchat.atlassian.net/browse/VLN-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ