### PR TITLE
regression: keep E2EE password banner after closing modal

### DIFF
--- a/apps/meteor/client/lib/e2ee/rocketchat.e2e.spec.ts
+++ b/apps/meteor/client/lib/e2ee/rocketchat.e2e.spec.ts
@@ -1,5 +1,6 @@
 import { imperativeModal } from '@rocket.chat/ui-client';
 
+import * as banners from '../banners';
 import { e2e } from './rocketchat.e2e';
 import { dispatchToastMessage } from '../toast';
 
@@ -22,6 +23,11 @@ jest.mock('../toast', () => ({
 	dispatchToastMessage: jest.fn(),
 }));
 
+jest.mock('../banners', () => ({
+	closeById: jest.fn(),
+	open: jest.fn(),
+}));
+
 describe('E2E password modal', () => {
 	const getModalProps = () => (imperativeModal.open as jest.Mock).mock.calls.at(-1)?.[0].props;
 
@@ -31,30 +37,25 @@ describe('E2E password modal', () => {
 	});
 
 	it('keeps the E2EE alert open when the modal header close button is used', () => {
-		const closeAlertSpy = jest.spyOn(e2e, 'closeAlert');
-
 		e2e.openEnterE2EEPasswordModal(jest.fn());
 
 		getModalProps().onClose();
 
 		expect(imperativeModal.close).toHaveBeenCalledTimes(1);
-		expect(closeAlertSpy).not.toHaveBeenCalled();
+		expect(banners.closeById).not.toHaveBeenCalled();
 	});
 
 	it('dismisses the E2EE alert when the user explicitly cancels entering the password', () => {
-		const closeAlertSpy = jest.spyOn(e2e, 'closeAlert');
-
 		e2e.openEnterE2EEPasswordModal(jest.fn());
 
 		getModalProps().onCancel();
 
 		expect(dispatchToastMessage).toHaveBeenCalledWith({ type: 'info', message: 'End_To_End_Encryption_Not_Enabled' });
 		expect(imperativeModal.close).toHaveBeenCalledTimes(1);
-		expect(closeAlertSpy).toHaveBeenCalledTimes(1);
+		expect(banners.closeById).toHaveBeenCalledWith('e2e');
 	});
 
 	it('dismisses the E2EE alert after the password is entered successfully', async () => {
-		const closeAlertSpy = jest.spyOn(e2e, 'closeAlert');
 		const onEnterE2EEPassword = jest.fn().mockResolvedValue(undefined);
 
 		e2e.openEnterE2EEPasswordModal(onEnterE2EEPassword);
@@ -64,6 +65,6 @@ describe('E2E password modal', () => {
 		expect(onEnterE2EEPassword).toHaveBeenCalledWith('password');
 		expect(dispatchToastMessage).toHaveBeenCalledWith({ type: 'success', message: 'E2E_encryption_enabled' });
 		expect(imperativeModal.close).toHaveBeenCalledTimes(1);
-		expect(closeAlertSpy).toHaveBeenCalledTimes(1);
+		expect(banners.closeById).toHaveBeenCalledWith('e2e');
 	});
 });

--- a/apps/meteor/client/lib/e2ee/rocketchat.e2e.spec.ts
+++ b/apps/meteor/client/lib/e2ee/rocketchat.e2e.spec.ts
@@ -1,0 +1,69 @@
+import { imperativeModal } from '@rocket.chat/ui-client';
+
+import { e2e } from './rocketchat.e2e';
+import { dispatchToastMessage } from '../toast';
+
+jest.mock('@rocket.chat/ui-client', () => ({
+	imperativeModal: {
+		open: jest.fn(),
+		close: jest.fn(),
+	},
+}));
+
+jest.mock('../../../app/utils/client', () => ({
+	getUserAvatarURL: jest.fn(),
+}));
+
+jest.mock('../../../app/utils/lib/i18n', () => ({
+	t: (key: string) => key,
+}));
+
+jest.mock('../toast', () => ({
+	dispatchToastMessage: jest.fn(),
+}));
+
+describe('E2E password modal', () => {
+	const getModalProps = () => (imperativeModal.open as jest.Mock).mock.calls.at(-1)?.[0].props;
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+		jest.clearAllMocks();
+	});
+
+	it('keeps the E2EE alert open when the modal header close button is used', () => {
+		const closeAlertSpy = jest.spyOn(e2e, 'closeAlert');
+
+		e2e.openEnterE2EEPasswordModal(jest.fn());
+
+		getModalProps().onClose();
+
+		expect(imperativeModal.close).toHaveBeenCalledTimes(1);
+		expect(closeAlertSpy).not.toHaveBeenCalled();
+	});
+
+	it('dismisses the E2EE alert when the user explicitly cancels entering the password', () => {
+		const closeAlertSpy = jest.spyOn(e2e, 'closeAlert');
+
+		e2e.openEnterE2EEPasswordModal(jest.fn());
+
+		getModalProps().onCancel();
+
+		expect(dispatchToastMessage).toHaveBeenCalledWith({ type: 'info', message: 'End_To_End_Encryption_Not_Enabled' });
+		expect(imperativeModal.close).toHaveBeenCalledTimes(1);
+		expect(closeAlertSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('dismisses the E2EE alert after the password is entered successfully', async () => {
+		const closeAlertSpy = jest.spyOn(e2e, 'closeAlert');
+		const onEnterE2EEPassword = jest.fn().mockResolvedValue(undefined);
+
+		e2e.openEnterE2EEPasswordModal(onEnterE2EEPassword);
+
+		await getModalProps().onConfirm('password');
+
+		expect(onEnterE2EEPassword).toHaveBeenCalledWith('password');
+		expect(dispatchToastMessage).toHaveBeenCalledWith({ type: 'success', message: 'E2E_encryption_enabled' });
+		expect(imperativeModal.close).toHaveBeenCalledTimes(1);
+		expect(closeAlertSpy).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/meteor/client/lib/e2ee/rocketchat.e2e.ts
+++ b/apps/meteor/client/lib/e2ee/rocketchat.e2e.ts
@@ -524,6 +524,9 @@ class E2E extends Emitter {
 
 	openEnterE2EEPasswordModal(onEnterE2EEPassword: (password: string) => Promise<void>) {
 		const close = () => {
+			imperativeModal.close();
+		};
+		const dismiss = () => {
 			this.closeAlert();
 			imperativeModal.close();
 		};
@@ -534,12 +537,12 @@ class E2E extends Emitter {
 				onCancel: () => {
 					failedToDecodeKey = false;
 					dispatchToastMessage({ type: 'info', message: t('End_To_End_Encryption_Not_Enabled') });
-					close();
+					dismiss();
 				},
 				onConfirm: async (password) => {
 					await onEnterE2EEPassword(password);
 					dispatchToastMessage({ type: 'success', message: t('E2E_encryption_enabled') });
-					close();
+					dismiss();
 				},
 			},
 		});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
This PR fixes the E2EE password modal behavior so closing the modal with the header close button only closes the modal and keeps the “Enter E2EE password” banner visible.

Previously, closing the modal used the same flow as dismissing/canceling it, which also closed the banner. 

Now the flows are separated:
  - Header close button: closes only the modal
  - “Do it later”: closes the modal and dismisses the banner
  - Successful password entry: closes the modal and dismisses the banner

  Unit tests were added to cover these three behaviors.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-2245](https://rocketchat.atlassian.net/browse/CORE-2245)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
 1. Enable E2EE.
  2. Set up/save the E2EE password for a user.
  3. Log out and log back in.
  4. Click the “Enter E2EE password” banner.
  5. Close the modal using the header close button.
  6. Verify the banner remains visible.
  7. Open the modal again and click “Do it later”.
  8. Verify the banner is dismissed.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-2245]: https://rocketchat.atlassian.net/browse/CORE-2245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for end-to-end encryption password modal interactions.

* **Bug Fixes**
  * Improved modal dismissal behavior to properly clear related notifications when canceling or confirming password entry in the encryption setup flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->