### PR TITLE
regression: Reply in other channel actions not working if `?msg=` is present in URL

### DIFF
--- a/apps/meteor/client/components/message/toolbar/useReplyInDMAction.spec.ts
+++ b/apps/meteor/client/components/message/toolbar/useReplyInDMAction.spec.ts
@@ -1,0 +1,86 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { renderHook } from '@testing-library/react';
+
+import { useReplyInDMAction } from './useReplyInDMAction';
+import { createFakeMessage, createFakeRoom, createFakeSubscription, createFakeUser } from '../../../../tests/mocks/data';
+import { roomCoordinator } from '../../../lib/rooms/roomCoordinator';
+
+jest.mock('../../../lib/rooms/roomCoordinator', () => ({
+	roomCoordinator: {
+		openRouteLink: jest.fn(),
+	},
+}));
+
+const mockedOpenRouteLink = jest.mocked(roomCoordinator.openRouteLink);
+
+const currentUser = createFakeUser({
+	_id: 'current-user-id',
+	username: 'currentuser',
+});
+
+const messageAuthor = {
+	_id: 'author-user-id',
+	username: 'authoruser',
+	name: 'Author User',
+};
+
+const message = createFakeMessage({
+	_id: 'reply-message-id',
+	u: messageAuthor,
+});
+
+const room = createFakeRoom({
+	_id: 'channel-id',
+	t: 'c',
+	name: 'general',
+});
+
+const subscription = createFakeSubscription({
+	rid: 'channel-id',
+	t: 'c',
+});
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+describe('useReplyInDMAction', () => {
+	it('should not carry over the msg search parameter when opening a direct message', () => {
+		const getSearchParameters = jest.fn().mockReturnValue({
+			msg: 'stale-message-id',
+			layout: 'embedded',
+		});
+
+		const { result } = renderHook(() => useReplyInDMAction(message, { room, subscription }), {
+			wrapper: mockAppRoot().withUser(currentUser).withPermission('create-d').withRouter({ getSearchParameters }).build(),
+		});
+
+		expect(result.current).not.toBeNull();
+
+		result.current?.action({ stopPropagation: jest.fn() } as unknown as UIEvent);
+
+		expect(getSearchParameters).toHaveBeenCalled();
+		expect(mockedOpenRouteLink).toHaveBeenCalledWith(
+			'd',
+			{ name: messageAuthor.username },
+			{
+				layout: 'embedded',
+				reply: 'reply-message-id',
+			},
+		);
+
+		const searchParams = mockedOpenRouteLink.mock.calls[0]?.[2];
+		expect(searchParams).not.toHaveProperty('msg');
+	});
+
+	it('should return null when already in a direct message room', () => {
+		const dmRoom = createFakeRoom({ t: 'd' });
+		const dmSubscription = createFakeSubscription({ t: 'd' });
+
+		const { result } = renderHook(() => useReplyInDMAction(message, { room: dmRoom, subscription: dmSubscription }), {
+			wrapper: mockAppRoot().withUser(currentUser).withPermission('create-d').build(),
+		});
+
+		expect(result.current).toBeNull();
+	});
+});

--- a/apps/meteor/client/components/message/toolbar/useReplyInDMAction.ts
+++ b/apps/meteor/client/components/message/toolbar/useReplyInDMAction.ts
@@ -71,11 +71,12 @@ export const useReplyInDMAction = (
 		context: ['message', 'message-mobile', 'threads', 'federated'],
 		type: 'communication',
 		action() {
+			const { msg: _, ...searchParameters } = router.getSearchParameters();
 			roomCoordinator.openRouteLink(
 				'd',
 				{ name: message.u.username },
 				{
-					...router.getSearchParameters(),
+					...searchParameters,
 					reply: message._id,
 				},
 			);

--- a/apps/meteor/client/lib/chats/flows/replyBroadcast.spec.ts
+++ b/apps/meteor/client/lib/chats/flows/replyBroadcast.spec.ts
@@ -1,0 +1,59 @@
+import { replyBroadcast } from './replyBroadcast';
+import { createFakeMessage } from '../../../../tests/mocks/data';
+import { router } from '../../../providers/RouterProvider';
+import { roomCoordinator } from '../../rooms/roomCoordinator';
+import type { ChatAPI } from '../ChatAPI';
+
+jest.mock('../../rooms/roomCoordinator', () => ({
+	roomCoordinator: {
+		openRouteLink: jest.fn(),
+	},
+}));
+
+jest.mock('../../../providers/RouterProvider', () => ({
+	router: {
+		getSearchParameters: jest.fn(),
+	},
+}));
+
+const mockedOpenRouteLink = jest.mocked(roomCoordinator.openRouteLink);
+const mockedGetSearchParameters = jest.mocked(router.getSearchParameters);
+
+const messageAuthor = {
+	_id: 'author-user-id',
+	username: 'authoruser',
+	name: 'Author User',
+};
+
+const message = createFakeMessage({
+	_id: 'reply-message-id',
+	u: messageAuthor,
+});
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+describe('replyBroadcast', () => {
+	it('should not carry over the msg search parameter when opening a direct message', async () => {
+		mockedGetSearchParameters.mockReturnValue({
+			msg: 'stale-message-id',
+			layout: 'embedded',
+		});
+
+		await replyBroadcast({} as ChatAPI, message);
+
+		expect(mockedGetSearchParameters).toHaveBeenCalled();
+		expect(mockedOpenRouteLink).toHaveBeenCalledWith(
+			'd',
+			{ name: messageAuthor.username },
+			{
+				layout: 'embedded',
+				reply: 'reply-message-id',
+			},
+		);
+
+		const searchParams = mockedOpenRouteLink.mock.calls[0]?.[2];
+		expect(searchParams).not.toHaveProperty('msg');
+	});
+});

--- a/apps/meteor/client/lib/chats/flows/replyBroadcast.ts
+++ b/apps/meteor/client/lib/chats/flows/replyBroadcast.ts
@@ -5,11 +5,12 @@ import { roomCoordinator } from '../../rooms/roomCoordinator';
 import type { ChatAPI } from '../ChatAPI';
 
 export const replyBroadcast = async (_chat: ChatAPI, message: IMessage) => {
+	const { msg: _, ...searchParameters } = router.getSearchParameters();
 	roomCoordinator.openRouteLink(
 		'd',
 		{ name: message.u.username },
 		{
-			...router.getSearchParameters(),
+			...searchParameters,
 			reply: message._id,
 		},
 	);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-2247](https://rocketchat.atlassian.net/browse/CORE-2247)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-2247]: https://rocketchat.atlassian.net/browse/CORE-2247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DM reply navigation now removes stale message query parameters when opening a reply thread, preserving other search params (e.g., layout) so links are clean and navigation is correct.

* **Tests**
  * Added unit tests covering DM reply navigation to verify search-parameter handling and correct route opening.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->