### PR TITLE
chore: Hide `abacAttributes` when `PDP` is not local

### DIFF
--- a/apps/meteor/app/lib/server/functions/getFullUserData.ts
+++ b/apps/meteor/app/lib/server/functions/getFullUserData.ts
@@ -110,6 +110,11 @@ export async function getFullUserDataByUniqueSearchTerm(
 
 	const fields = getFields(canViewAllInfo);
 
+	// When PDP type is not local, Rocket.Chat doesn't manage ABAC attributes, so there's no point in fetching them
+	if (settings.get('ABAC_PDP_Type') !== 'local') {
+		delete fields.abacAttributes;
+	}
+
 	const options = {
 		projection: {
 			...fields,

--- a/apps/meteor/tests/end-to-end/api/abac.ts
+++ b/apps/meteor/tests/end-to-end/api/abac.ts
@@ -3016,6 +3016,8 @@ const addAbacAttributesToUserDirectly = async (userId: string, abacAttributes: I
 	before(async function () {
 		this.timeout(15000);
 
+		connection = await MongoClient.connect(URL_MONGODB);
+
 		const healthy = await mockServerHealthy();
 		expect(healthy, 'mock-server is not reachable — ensure it is running').to.be.true;
 
@@ -3051,6 +3053,8 @@ const addAbacAttributesToUserDirectly = async (userId: string, abacAttributes: I
 		await mockServerReset();
 		await updateSetting('ABAC_PDP_Type', 'local');
 		await updateSetting('ABAC_Enabled', false);
+
+		await connection.close();
 	});
 
 	describe('PERMIT all: users remain when PDP permits everyone', () => {
@@ -3491,6 +3495,27 @@ const addAbacAttributesToUserDirectly = async (userId: string, abacAttributes: I
 				available: false,
 				message: 'ABAC_PDP_Health_IdP_Failed',
 			});
+		});
+	});
+
+	describe('users.info abacAttributes visibility', () => {
+		let userWithAttrs: IUser;
+
+		before(async () => {
+			userWithAttrs = await createUser();
+			await addAbacAttributesToUserDirectly(userWithAttrs._id, [{ key: attrKey, values: ['alpha'] }]);
+		});
+
+		after(async () => {
+			await deleteUser(userWithAttrs);
+		});
+
+		it('omits abacAttributes from /v1/users.info when PDP type is virtru', async () => {
+			const res = await request.get('/api/v1/users.info').set(credentials).query({ userId: userWithAttrs._id }).expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('user');
+			expect(res.body.user).to.not.have.property('abacAttributes');
 		});
 	});
 });


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/ABAC3-19

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
When the PDP is not local, Rocket.Chat doesn't manage the subject attributes, so there's no point in fetching them

Even worse, if there was some stale attributes before the PDP, they could wrongly show on the UI, even though the server wouldn't use them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test coverage validating users.info endpoint behavior with external policy system configuration
  * Established database connection handling for policy system test scenarios

* **Bug Fixes**
  * Improved attribute filtering logic in user data retrieval based on policy system type configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->