### PR TITLE
regression: align EmbeddedPreload cache shape with useOpenRoom

### DIFF
--- a/apps/meteor/client/views/root/MainLayout/EmbeddedPreload.tsx
+++ b/apps/meteor/client/views/root/MainLayout/EmbeddedPreload.tsx
@@ -1,12 +1,15 @@
+import { getObjectKeys } from '@rocket.chat/tools';
 import { useEndpoint, useMethod, useRouter, useUserId } from '@rocket.chat/ui-contexts';
 import { useQuery } from '@tanstack/react-query';
 import type { ReactElement, ReactNode } from 'react';
 import { useEffect, useMemo } from 'react';
 
+import { roomFields } from '../../../../lib/publishFields';
 import { RoomsCachedStore, SubscriptionsCachedStore } from '../../../cachedStores';
 import { roomsQueryKeys } from '../../../lib/queryKeys';
 import { roomCoordinator } from '../../../lib/rooms/roomCoordinator';
 import { mapSubscriptionFromApi } from '../../../lib/utils/mapSubscriptionFromApi';
+import { Rooms } from '../../../stores';
 import PageLoading from '../PageLoading';
 import { useMainReady } from '../hooks/useMainReady';
 
@@ -51,12 +54,20 @@ const EmbeddedPreload = ({ children }: { children: ReactNode }): ReactElement =>
 				return null;
 			}
 
+			// Populate Rooms store and return same shape as useOpenRoom so the shared
+			// React Query cache entry is usable when RoomOpenerEmbedded mounts.
+			const unsetKeys = getObjectKeys(roomData).filter((key) => !(key in roomFields));
+			unsetKeys.forEach((key) => {
+				delete roomData[key];
+			});
+			Rooms.state.store(roomData);
+
 			const subResult = await getSubscription({ roomId: roomData._id });
 			if (subResult.subscription) {
 				SubscriptionsCachedStore.upsertSubscription(mapSubscriptionFromApi(subResult.subscription));
 			}
 
-			return subResult;
+			return { rid: roomData._id };
 		},
 		enabled: shouldFetch,
 		retry: false,


### PR DESCRIPTION
## Proposed changes

Alternative to #40714 that fixes the actual cause of the "Room not found" flash in embedded mode instead of papering over it with a render-time ref guard. If this merges, #40714 is no longer needed.

### What is actually happening

`EmbeddedPreload` (added in #40100) registers a `useQuery` with the same key as `useOpenRoom`:

```ts
// EmbeddedPreload.tsx
queryKey: roomsQueryKeys.roomReference(roomParams.reference, roomParams.type, uid ?? undefined)

// useOpenRoom.ts
queryKey: roomsQueryKeys.roomReference(reference, type, user?._id, user?.username)
```

`roomsQueryKeys.roomReference` is defined as:

```ts
roomReference: (reference, type, uid?, username?) => ['rooms', reference, type, uid ?? username]
```

For a logged-in user both observers resolve to the **exact same key** (`uid` wins over `username`). React Query therefore treats them as the same query and serves the preload's cached result to `useOpenRoom` on first mount.

Their `queryFn` implementations, however, return different shapes:

- `EmbeddedPreload` returns the raw `getSubscription` response (no top-level `rid`).
- `useOpenRoom` returns `{ rid: room._id }` and also calls `Rooms.state.store(roomData)`.

Sequence on hard refresh:

1. `EmbeddedPreload` runs, caches `subResult` under the shared key. **`Rooms.state` is never populated.**
2. `RoomOpenerEmbedded` mounts. `useOpenRoom` registers as a new observer for the same key.
3. React Query immediately returns the cached `subResult` with `isSuccess: true`.
4. `RoomOpenerEmbedded` reads `data?.rid` → `undefined` → mounts `<RoomProvider rid={undefined}>`.
5. `RoomProvider` does `Rooms.use((s) => s.get(undefined))` → `undefined` → renders `<RoomNotFound />`. **This is the flash.**
6. The default `staleTime: 0` triggers a background refetch driven by `useOpenRoom`'s `queryFn`. It populates `Rooms.state`, returns `{ rid }`, and the next render finally shows the room.

This was verified locally by instrumenting `Rooms.use.subscribe`, `useOpenRoom`'s queryFn and `RoomProvider`. The instrumentation warning in `RoomProvider` always fires with `rid: undefined`, `hasInState: false`, `storeKeys: []` — i.e. `Rooms.state` is empty at the moment of the flash, then the next `Rooms.set` fires from `useOpenRoom`'s `queryFn`.

### Fix

Make `EmbeddedPreload`'s `queryFn` produce the same data shape `useOpenRoom` produces, and populate `Rooms.state` along the way. The shared cache entry is then immediately usable when `RoomOpenerEmbedded` mounts — no flash, no extra fetches, no extra query keys, no render-time guards in `RoomProvider`.

### Relation to #40714

#40714 hides the symptom with a `loadedRoomId` ref in `RoomProvider` that swaps `<RoomNotFound />` for `<RoomSkeleton />` until a room successfully loads once. It works, but:

- The user still sees a skeleton during the refetch window.
- The underlying cache mismatch stays in the codebase, so any future code that reads `data.rid` from this query key on first mount will hit the same bug.
- A genuine "room not found" now renders an infinite skeleton on first navigation, since `loadedRoomId.current` never matches.

With this PR `RoomProvider` keeps its original control flow and the failure mode is fixed at the source.

## Steps to test or reproduce

1. Sign in as any user.
2. Open `/channel/general?layout=embedded` with DevTools open (the extra JS overhead widens the race so the flash is consistently visible).
3. Hard refresh (Ctrl/Cmd + Shift + R).
4. **Before this PR:** "Room not found" briefly flashes before the room renders.
5. **With this PR:** the room renders directly from the preloaded cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaner room data handling and improved subscription caching during page load: unnecessary room fields are removed before storing, subscriptions are cached more predictably, and the page now loads rooms more reliably and efficiently with reduced stored data and more consistent behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40716?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2239 [Regression] Embedded room routes briefly show "Room not found" before loading the room](https://rocketchat.atlassian.net/browse/CORE-2239)