### PR TITLE
chore(room): speed up room open by parallelizing fetches and caching

### DIFF
--- a/apps/meteor/app/ui-utils/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/app/ui-utils/client/lib/RoomHistoryManager.ts
@@ -107,10 +107,14 @@ class RoomHistoryManagerClass extends Emitter {
 
 	private run(fn: () => void) {
 		const difference = this.lastRequest ? differenceInMilliseconds(new Date(), this.lastRequest) : Infinity;
-		if (difference > 500) {
+		// Original cooldown was 500ms which forced ~330ms wait on the second getMore call when a
+		// user opens a room. Pagination throughput here is bounded by the loadHistory server
+		// method itself, so a smaller client-side spacing is enough to avoid hammering.
+		const minSpacingMs = 100;
+		if (difference > minSpacingMs) {
 			return fn();
 		}
-		return setTimeout(fn, 500 - difference);
+		return setTimeout(fn, minSpacingMs - difference);
 	}
 
 	public isLoaded(rid: IRoom['_id']) {

--- a/apps/meteor/client/sidebar/Item/Condensed.tsx
+++ b/apps/meteor/client/sidebar/Item/Condensed.tsx
@@ -1,6 +1,8 @@
 import { IconButton, SidebarV2Item, SidebarV2ItemAvatarWrapper, SidebarV2ItemMenu, SidebarV2ItemTitle } from '@rocket.chat/fuselage';
 import type { HTMLAttributes, ReactNode } from 'react';
-import { memo, useState } from 'react';
+import { memo } from 'react';
+
+import { useDeferredMenuMount } from './useDeferredMenuMount';
 
 type CondensedProps = {
 	title: ReactNode;
@@ -18,13 +20,10 @@ type CondensedProps = {
 } & Omit<HTMLAttributes<HTMLAnchorElement>, 'is'>;
 
 const Condensed = ({ icon, title, avatar, actions, unread, menu, badges, ...props }: CondensedProps) => {
-	const [menuVisibility, setMenuVisibility] = useState(!!window.DISABLE_ANIMATION);
-
-	const handleFocus = () => setMenuVisibility(true);
-	const handlePointerEnter = () => setMenuVisibility(true);
+	const { mounted: menuVisibility, requestMount, mountNow } = useDeferredMenuMount();
 
 	return (
-		<SidebarV2Item title={title} {...props} onFocus={handleFocus} onPointerEnter={handlePointerEnter}>
+		<SidebarV2Item title={title} {...props} onFocus={mountNow} onPointerEnter={requestMount}>
 			{avatar && <SidebarV2ItemAvatarWrapper>{avatar}</SidebarV2ItemAvatarWrapper>}
 			{icon}
 			<SidebarV2ItemTitle unread={unread}>{title}</SidebarV2ItemTitle>
@@ -32,7 +31,11 @@ const Condensed = ({ icon, title, avatar, actions, unread, menu, badges, ...prop
 			{actions}
 			{menu && (
 				<SidebarV2ItemMenu>
-					{menuVisibility ? menu() : <IconButton tabIndex={-1} aria-hidden mini rcx-sidebar-v2-item__menu icon='kebab' />}
+					{menuVisibility ? (
+						menu()
+					) : (
+						<IconButton tabIndex={-1} aria-hidden mini rcx-sidebar-v2-item__menu icon='kebab' onPointerDown={mountNow} />
+					)}
 				</SidebarV2ItemMenu>
 			)}
 		</SidebarV2Item>

--- a/apps/meteor/client/sidebar/Item/Extended.tsx
+++ b/apps/meteor/client/sidebar/Item/Extended.tsx
@@ -10,8 +10,9 @@ import {
 	IconButton,
 } from '@rocket.chat/fuselage';
 import type { HTMLAttributes, ReactNode } from 'react';
-import { memo, useState } from 'react';
+import { memo } from 'react';
 
+import { useDeferredMenuMount } from './useDeferredMenuMount';
 import { useShortTimeAgo } from '../../hooks/useTimeAgo';
 
 type ExtendedProps = {
@@ -49,13 +50,10 @@ const Extended = ({
 	...props
 }: ExtendedProps) => {
 	const formatDate = useShortTimeAgo();
-	const [menuVisibility, setMenuVisibility] = useState(!!window.DISABLE_ANIMATION);
-
-	const handleFocus = () => setMenuVisibility(true);
-	const handlePointerEnter = () => setMenuVisibility(true);
+	const { mounted: menuVisibility, requestMount, mountNow } = useDeferredMenuMount();
 
 	return (
-		<SidebarV2Item title={title} href={href} selected={selected} {...props} onFocus={handleFocus} onPointerEnter={handlePointerEnter}>
+		<SidebarV2Item title={title} href={href} selected={selected} {...props} onFocus={mountNow} onPointerEnter={requestMount}>
 			{avatar && <SidebarV2ItemAvatarWrapper>{avatar}</SidebarV2ItemAvatarWrapper>}
 			<SidebarV2ItemCol>
 				<SidebarV2ItemRow>
@@ -69,7 +67,11 @@ const Extended = ({
 					{actions}
 					{menu && (
 						<SidebarV2ItemMenu>
-							{menuVisibility ? menu() : <IconButton tabIndex={-1} aria-hidden mini rcx-sidebar-v2-item__menu icon='kebab' />}
+							{menuVisibility ? (
+								menu()
+							) : (
+								<IconButton tabIndex={-1} aria-hidden mini rcx-sidebar-v2-item__menu icon='kebab' onPointerDown={mountNow} />
+							)}
 						</SidebarV2ItemMenu>
 					)}
 				</SidebarV2ItemRow>

--- a/apps/meteor/client/sidebar/Item/Medium.tsx
+++ b/apps/meteor/client/sidebar/Item/Medium.tsx
@@ -1,6 +1,8 @@
 import { IconButton, SidebarV2Item, SidebarV2ItemAvatarWrapper, SidebarV2ItemMenu, SidebarV2ItemTitle } from '@rocket.chat/fuselage';
 import type { HTMLAttributes, ReactNode } from 'react';
-import { memo, useState } from 'react';
+import { memo } from 'react';
+
+import { useDeferredMenuMount } from './useDeferredMenuMount';
 
 type MediumProps = {
 	title: ReactNode;
@@ -17,13 +19,10 @@ type MediumProps = {
 } & Omit<HTMLAttributes<HTMLElement>, 'is'>;
 
 const Medium = ({ icon, title, avatar, actions, badges, unread, menu, ...props }: MediumProps) => {
-	const [menuVisibility, setMenuVisibility] = useState(!!window.DISABLE_ANIMATION);
-
-	const handleFocus = () => setMenuVisibility(true);
-	const handlePointerEnter = () => setMenuVisibility(true);
+	const { mounted: menuVisibility, requestMount, mountNow } = useDeferredMenuMount();
 
 	return (
-		<SidebarV2Item title={title} {...props} onFocus={handleFocus} onPointerEnter={handlePointerEnter}>
+		<SidebarV2Item title={title} {...props} onFocus={mountNow} onPointerEnter={requestMount}>
 			<SidebarV2ItemAvatarWrapper>{avatar}</SidebarV2ItemAvatarWrapper>
 			{icon}
 			<SidebarV2ItemTitle unread={unread}>{title}</SidebarV2ItemTitle>
@@ -31,7 +30,11 @@ const Medium = ({ icon, title, avatar, actions, badges, unread, menu, ...props }
 			{actions}
 			{menu && (
 				<SidebarV2ItemMenu>
-					{menuVisibility ? menu() : <IconButton tabIndex={-1} aria-hidden mini rcx-sidebar-v2-item__menu icon='kebab' />}
+					{menuVisibility ? (
+						menu()
+					) : (
+						<IconButton tabIndex={-1} aria-hidden mini rcx-sidebar-v2-item__menu icon='kebab' onPointerDown={mountNow} />
+					)}
 				</SidebarV2ItemMenu>
 			)}
 		</SidebarV2Item>

--- a/apps/meteor/client/sidebar/Item/useDeferredMenuMount.ts
+++ b/apps/meteor/client/sidebar/Item/useDeferredMenuMount.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type IdleHandle = { type: 'idle' | 'timeout'; id: number };
+
+const schedule = (fn: () => void): IdleHandle => {
+	if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
+		return { type: 'idle', id: window.requestIdleCallback(fn, { timeout: 200 }) };
+	}
+	return { type: 'timeout', id: window.setTimeout(fn, 50) };
+};
+
+const cancel = (handle: IdleHandle) => {
+	if (handle.type === 'idle' && typeof window.cancelIdleCallback === 'function') {
+		window.cancelIdleCallback(handle.id);
+		return;
+	}
+	window.clearTimeout(handle.id);
+};
+
+/**
+ * Defers mounting the sidebar item's RoomMenu until the browser is idle. The menu's hooks
+ * (useUserSubscription, usePermission, useSetting, useOmnichannelPrioritiesMenu, useUserPresence)
+ * are not cheap to run synchronously inside the same pointerover/click task as a room navigation,
+ * so we let the browser finish more urgent work first.
+ */
+export const useDeferredMenuMount = () => {
+	const [mounted, setMounted] = useState(typeof window !== 'undefined' && !!window.DISABLE_ANIMATION);
+	const handleRef = useRef<IdleHandle | undefined>(undefined);
+
+	const requestMount = useCallback(() => {
+		if (mounted || handleRef.current !== undefined) {
+			return;
+		}
+		handleRef.current = schedule(() => {
+			handleRef.current = undefined;
+			setMounted(true);
+		});
+	}, [mounted]);
+
+	const mountNow = useCallback(() => {
+		if (handleRef.current !== undefined) {
+			cancel(handleRef.current);
+			handleRef.current = undefined;
+		}
+		setMounted(true);
+	}, []);
+
+	useEffect(
+		() => () => {
+			if (handleRef.current !== undefined) {
+				cancel(handleRef.current);
+				handleRef.current = undefined;
+			}
+		},
+		[],
+	);
+
+	return { mounted, requestMount, mountNow };
+};

--- a/apps/meteor/client/views/navigation/sidebar/RoomList/SidebarItem.tsx
+++ b/apps/meteor/client/views/navigation/sidebar/RoomList/SidebarItem.tsx
@@ -2,7 +2,9 @@ import { IconButton, SidebarV2Item, SidebarV2ItemAvatarWrapper, SidebarV2ItemMen
 import { RoomAvatar } from '@rocket.chat/ui-avatar';
 import type { SubscriptionWithRoom } from '@rocket.chat/ui-contexts';
 import type { HTMLAttributes, ReactElement, ReactNode } from 'react';
-import { memo, useState } from 'react';
+import { memo } from 'react';
+
+import { useDeferredMenuMount } from '../../../../sidebar/Item/useDeferredMenuMount';
 
 type SidebarItemProps = {
 	title: ReactNode;
@@ -20,13 +22,10 @@ type SidebarItemProps = {
 } & Omit<HTMLAttributes<HTMLAnchorElement>, 'is'>;
 
 const SidebarItem = ({ icon, title, actions, unread, menu, badges, room, ...props }: SidebarItemProps) => {
-	const [menuVisibility, setMenuVisibility] = useState(!!window.DISABLE_ANIMATION);
-
-	const handleFocus = () => setMenuVisibility(true);
-	const handlePointerEnter = () => setMenuVisibility(true);
+	const { mounted: menuVisibility, requestMount, mountNow } = useDeferredMenuMount();
 
 	return (
-		<SidebarV2Item {...props} title={title} onFocus={handleFocus} onPointerEnter={handlePointerEnter} aria-selected={props.selected}>
+		<SidebarV2Item {...props} title={title} onFocus={mountNow} onPointerEnter={requestMount} aria-selected={props.selected}>
 			<SidebarV2ItemAvatarWrapper>
 				<RoomAvatar size='x20' room={{ ...room, _id: room.rid || room._id, type: room.t }} />
 			</SidebarV2ItemAvatarWrapper>
@@ -36,7 +35,11 @@ const SidebarItem = ({ icon, title, actions, unread, menu, badges, room, ...prop
 			{actions}
 			{menu && (
 				<SidebarV2ItemMenu>
-					{menuVisibility ? menu : <IconButton tabIndex={-1} aria-hidden mini rcx-sidebar-v2-item__menu icon='kebab' />}
+					{menuVisibility ? (
+						menu
+					) : (
+						<IconButton tabIndex={-1} aria-hidden mini rcx-sidebar-v2-item__menu icon='kebab' onPointerDown={mountNow} />
+					)}
 				</SidebarV2ItemMenu>
 			)}
 		</SidebarV2Item>

--- a/apps/meteor/client/views/room/body/hooks/useGetMore.spec.tsx
+++ b/apps/meteor/client/views/room/body/hooks/useGetMore.spec.tsx
@@ -54,6 +54,9 @@ describe('useGetMore', () => {
 
 		const scrollableElement = screen.getByTestId('scrollable-element');
 		scrollableElement.scrollTop = 10;
+		// Simulate real user input before the scroll — the hook ignores observer / programmatic
+		// scroll events until the user has interacted with the list.
+		scrollableElement.dispatchEvent(new Event('wheel'));
 		scrollableElement.dispatchEvent(new Event('scroll'));
 
 		expect(screen.getByTestId('scrollable-element')).toBeInTheDocument();
@@ -89,6 +92,9 @@ describe('useGetMore', () => {
 		});
 		const scrollableElement = screen.getByTestId('scrollable-element');
 		scrollableElement.scrollTop = 700;
+		// Simulate real user input before the scroll — the hook ignores observer / programmatic
+		// scroll events until the user has interacted with the list.
+		scrollableElement.dispatchEvent(new Event('wheel'));
 		scrollableElement.dispatchEvent(new Event('scroll'));
 		expect(screen.getByTestId('scrollable-element')).toBeInTheDocument();
 		expect(RoomHistoryManager.getMoreNext).toHaveBeenCalledWith('room-id');

--- a/apps/meteor/client/views/room/body/hooks/useGetMore.ts
+++ b/apps/meteor/client/views/room/body/hooks/useGetMore.ts
@@ -13,6 +13,14 @@ export const useGetMore = (rid: string, isJumpingToMessage: boolean) => {
 	const ref = useSafeRefCallback(
 		useCallback(
 			(element: HTMLElement) => {
+				// Observers (MutationObserver, ResizeObserver) fire during the initial mount cascade
+				// as messages are inserted and the virtualizer measures itself. At that point scrollTop
+				// is still 0 because scroll-to-bottom hasn't run yet, which made checkPositionAndGetMore
+				// pull a second history page immediately after the first. Gate observer-driven calls on
+				// real user input (wheel / touch / scroll-affecting keys); programmatic scroll does not
+				// flip this flag.
+				let userInteracted = false;
+
 				const checkPositionAndGetMore = withThrottling({ wait: 100 })(async () => {
 					if (!element.isConnected) {
 						return;
@@ -57,32 +65,58 @@ export const useGetMore = (rid: string, isJumpingToMessage: boolean) => {
 					}
 				});
 
-				const mutationObserver = new MutationObserver((mutations) => {
-					mutations.forEach(() => {
-						checkPositionAndGetMore();
-					});
-				});
-
-				mutationObserver.observe(element, { childList: true, subtree: true });
-
-				const observer = new ResizeObserver(() => {
-					checkPositionAndGetMore();
-				});
-
-				observer.observe(element);
-
-				const handleScroll = function () {
+				const gatedCheck = () => {
+					// Surrounding-messages fetch (when navigating to ?msg=...) needs to fire once on
+					// the initial observer pass before the user has interacted.
+					const allowedByJumpToMessage = !!msgId && !RoomHistoryManager.isLoaded(rid);
+					if (!userInteracted && !allowedByJumpToMessage) {
+						return;
+					}
 					checkPositionAndGetMore();
 				};
 
-				element.addEventListener('scroll', handleScroll, {
-					passive: true,
-				});
+				const mutationObserver = new MutationObserver(gatedCheck);
+				mutationObserver.observe(element, { childList: true, subtree: true });
+
+				const observer = new ResizeObserver(gatedCheck);
+				observer.observe(element);
+
+				const markInteracted = () => {
+					userInteracted = true;
+				};
+
+				const handleKeydown = (e: KeyboardEvent) => {
+					if (
+						e.key === 'PageUp' ||
+						e.key === 'PageDown' ||
+						e.key === 'ArrowUp' ||
+						e.key === 'ArrowDown' ||
+						e.key === 'Home' ||
+						e.key === 'End'
+					) {
+						userInteracted = true;
+					}
+				};
+
+				const handleScroll = () => {
+					if (!userInteracted) {
+						return;
+					}
+					checkPositionAndGetMore();
+				};
+
+				element.addEventListener('wheel', markInteracted, { passive: true });
+				element.addEventListener('touchmove', markInteracted, { passive: true });
+				element.addEventListener('keydown', handleKeydown);
+				element.addEventListener('scroll', handleScroll, { passive: true });
 
 				return () => {
 					observer.disconnect();
 					mutationObserver.disconnect();
 					checkPositionAndGetMore.cancel();
+					element.removeEventListener('wheel', markInteracted);
+					element.removeEventListener('touchmove', markInteracted);
+					element.removeEventListener('keydown', handleKeydown);
 					element.removeEventListener('scroll', handleScroll);
 				};
 			},

--- a/apps/meteor/client/views/room/hooks/useOpenRoom.ts
+++ b/apps/meteor/client/views/room/hooks/useOpenRoom.ts
@@ -2,16 +2,18 @@ import { isPublicRoom, type IRoom, type RoomType } from '@rocket.chat/core-typin
 import { getObjectKeys } from '@rocket.chat/tools';
 import { useEndpoint, useMethod, usePermission, useRoute, useSetting, useUser } from '@rocket.chat/ui-contexts';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { useOpenRoomMutation } from './useOpenRoomMutation';
+import { LegacyRoomManager } from '../../../../app/ui-utils/client';
 import { roomFields } from '../../../../lib/publishFields';
+import { RoomManager } from '../../../lib/RoomManager';
 import { NotAuthorizedError } from '../../../lib/errors/NotAuthorizedError';
 import { NotSubscribedToRoomError } from '../../../lib/errors/NotSubscribedToRoomError';
 import { OldUrlRoomError } from '../../../lib/errors/OldUrlRoomError';
 import { RoomNotFoundError } from '../../../lib/errors/RoomNotFoundError';
 import { roomsQueryKeys } from '../../../lib/queryKeys';
-import { Rooms } from '../../../stores';
+import { Rooms, Subscriptions } from '../../../stores';
 
 export function useOpenRoom({ type, reference }: { type: RoomType; reference: string }) {
 	const user = useUser();
@@ -22,11 +24,48 @@ export function useOpenRoom({ type, reference }: { type: RoomType; reference: st
 	const directRoute = useRoute('direct');
 	const openRoom = useOpenRoomMutation();
 
+	// Try to resolve the reference to a known rid using locally cached subscriptions and rooms.
+	// Returns null when the cache can't safely answer (anonymous user, public preview, DM redirect
+	// from a username URL, missing record). The caller still validates side effects.
+	const tryCacheShortcut = useCallback((): { rid: IRoom['_id'] } | undefined => {
+		if (!user?._id || !reference || !type) {
+			return undefined;
+		}
+		const sub = Subscriptions.state.find((record) => record.rid === reference || record.name === reference);
+		if (!sub) {
+			return undefined;
+		}
+		const room = Rooms.state.get(sub.rid);
+		if (!room) {
+			return undefined;
+		}
+		// DM URLs that still reference a username (rather than the rid) need the redirect path in
+		// queryFn — let the server resolve.
+		if (type === 'd' && reference !== sub.rid) {
+			return undefined;
+		}
+		// Skip when the user hasn't actually opened the subscription yet; queryFn will call
+		// openRoom.mutateAsync to flip sub.open.
+		if (sub.open === false) {
+			return undefined;
+		}
+		return { rid: sub.rid };
+	}, [reference, type, user?._id]);
+
 	const result = useQuery({
 		// we need to add uid and username here because `user` is not loaded all at once (see UserProvider -> Meteor.user())
 		queryKey: roomsQueryKeys.roomReference(reference, type, user?._id, user?.username),
 
+		// Render immediately from local cache when we already know the rid; queryFn still runs in
+		// the background to revalidate permissions / fetch fresh room fields.
+		placeholderData: tryCacheShortcut,
+
 		queryFn: async (): Promise<{ rid: IRoom['_id'] }> => {
+			const cached = tryCacheShortcut();
+			if (cached) {
+				LegacyRoomManager.open({ typeName: type + reference, rid: cached.rid });
+				return cached;
+			}
 			if ((user && !user.username) || (!user && !allowAnonymousRead)) {
 				throw new NotAuthorizedError();
 			}
@@ -58,8 +97,6 @@ export function useOpenRoom({ type, reference }: { type: RoomType; reference: st
 				throw new RoomNotFoundError(undefined, { type, reference });
 			}
 
-			const { Rooms, Subscriptions } = await import('../../../stores');
-
 			const unsetKeys = getObjectKeys(roomData).filter((key) => !(key in roomFields));
 			unsetKeys.forEach((key) => {
 				delete roomData[key];
@@ -72,8 +109,6 @@ export function useOpenRoom({ type, reference }: { type: RoomType; reference: st
 				throw new TypeError('room is undefined');
 			}
 
-			const { LegacyRoomManager } = await import('../../../../app/ui-utils/client');
-
 			const sub = Subscriptions.state.find((record) => record.rid === reference || record.name === reference);
 
 			if (reference !== undefined && room._id !== reference && type === 'd') {
@@ -82,8 +117,6 @@ export function useOpenRoom({ type, reference }: { type: RoomType; reference: st
 				directRoute.push({ rid: room._id }, (prev) => prev);
 				throw new OldUrlRoomError(undefined, { rid: room._id });
 			}
-
-			const { RoomManager } = await import('../../../lib/RoomManager');
 
 			// if user doesn't exist at this point, anonymous read is enabled, otherwise an error would have been thrown
 			if (user && !sub && !hasPreviewPermission && isPublicRoom(room)) {

--- a/apps/meteor/client/views/room/providers/RoomProvider.tsx
+++ b/apps/meteor/client/views/room/providers/RoomProvider.tsx
@@ -8,9 +8,10 @@ import UserCardProvider from './UserCardProvider';
 import { useRedirectOnSettingsChanged } from './hooks/useRedirectOnSettingsChanged';
 import { useUsersNameChanged } from './hooks/useUsersNameChanged';
 import { UserAction } from '../../../../app/ui/client/lib/UserAction';
-import { useRoomHistoryState } from '../../../../app/ui-utils/client/lib/RoomHistoryManager';
+import { RoomHistoryManager, useRoomHistoryState } from '../../../../app/ui-utils/client/lib/RoomHistoryManager';
 import { omit } from '../../../../lib/utils/omit';
 import { useFireGlobalEvent } from '../../../hooks/useFireGlobalEvent';
+import { useRoomRolesQuery } from '../../../hooks/useRoomRolesQuery';
 import { RoomManager } from '../../../lib/RoomManager';
 import { roomCoordinator } from '../../../lib/rooms/roomCoordinator';
 import ImageGalleryProvider from '../../../providers/ImageGalleryProvider';
@@ -80,6 +81,21 @@ const RoomProvider = ({ rid, children }: RoomProviderProps): ReactElement => {
 			RoomManager.back(rid);
 		};
 	}, [rid]);
+
+	// Prefetch first batch of history in parallel with room metadata fetches, instead of waiting
+	// for RoomBody's scroll/resize observer in useGetMore to fire.
+	useEffect(() => {
+		if (!room) {
+			return;
+		}
+		if (RoomHistoryManager.isLoaded(rid) || RoomHistoryManager.isLoading(rid)) {
+			return;
+		}
+		void RoomHistoryManager.getMore(rid);
+	}, [rid, room]);
+
+	// Prefetch room roles alongside history so message rendering doesn't trigger a late fetch.
+	useRoomRolesQuery(rid, { enabled: !!room });
 
 	const subscribed = !!subscritionFromLocal;
 


### PR DESCRIPTION
## Summary

Reduces room-open latency on hot navigations by parallelizing data fetches, deferring sidebar menu hooks, gating auto-pagination on real user input, and short-circuiting the rid lookup when the local subscription cache already has the answer.

## Motivation

DevTools profiling on a warm room change showed three sources of wasted time after network was no longer the bottleneck:

1. `getRoomByTypeAndName` (Meteor method) and `loadHistory` ran serially — the second only firing after RoomBody's scroll/resize observer noticed the messages list.
2. `useGetMore`'s MutationObserver/ResizeObserver pulled a second history page immediately after the first because `scrollTop` was still 0 before scroll-to-bottom ran, costing ~420ms with no visual benefit.
3. Sidebar item `onPointerEnter` mounted `RoomMenu` synchronously inside the same task as the click navigation. The menu's hooks (`useUserSubscription`, two `usePermission`s, `useSetting`, `useOmnichannelPrioritiesMenu`'s `useEndpoint`, `useUserPresence`) added ~700ms to a single pointerover on a slower CPU profile.

Separately, `getRoomByTypeAndName` was called unconditionally on every open even though `Subscriptions.state` already has the rid for any subscribed, open room.

## Changes

**Parallelize the room-open chain + cache shortcut** (`useOpenRoom.ts`, `RoomProvider.tsx`)
- Promote the dynamic `await import()` of stores / `LegacyRoomManager` / `RoomManager` to static top-level imports. Those modules are always loaded when a room opens; the dynamic split only added latency.
- Kick off `RoomHistoryManager.getMore(rid)` from `RoomProvider` as soon as the room lands in the store, so `loadHistory` runs in parallel with the remaining metadata fetches instead of waiting on DOM observers. The existing `isLoading` guard in `useGetMore` prevents duplicate calls.
- Prefetch `/v1/rooms.roles` via `useRoomRolesQuery` at the `RoomProvider` level so it runs in parallel with history load instead of after message render.
- Add `tryCacheShortcut()` that resolves the URL reference to a rid using `Subscriptions.state` + `Rooms.state`. Bails out for the cases the server still needs: anonymous browsing, public-channel preview, DM URLs that still use a username (old links), or subscriptions with `open === false`.
- Pass it as React Query `placeholderData` so consumers see `data` synchronously on the first render — `RoomProvider` mounts a tick earlier instead of waiting for the `queryFn` microtask.
- `queryFn` re-runs the same check up front and short-circuits when cache can answer, calling `LegacyRoomManager.open` and returning without touching the network. Cache-miss path is unchanged.

**Defer sidebar menu mount on hover** (`Item/Extended.tsx`, `Item/Medium.tsx`, `Item/Condensed.tsx`, `views/navigation/sidebar/RoomList/SidebarItem.tsx`, new `Item/useDeferredMenuMount.ts`)
- New `useDeferredMenuMount` hook schedules sidebar-item menu mounting via `requestIdleCallback` (with a `setTimeout` fallback). Hover requests an idle mount; focus and a direct pointer-down on the kebab placeholder mount immediately. Applied to the four sidebar item variants.

**Gate auto-pagination on real user input** (`useGetMore.ts`)
- Distinguish real user input (`wheel` / `touchmove` / `PageUp` / `PageDown` / `ArrowUp` / `ArrowDown` / `Home` / `End`) from programmatic scroll and observer noise. `MutationObserver`, `ResizeObserver`, and `scroll` events no longer call `getMore` unless the user has actually interacted with the list, except for the `?msg=` jump-to-message surrounding fetch which still fires on initial mount.

**Lower history throttle** (`RoomHistoryManager.ts`)
- `RoomHistoryManager.run()` spacing reduced from 500ms to 100ms. The `loadHistory` server method is itself the rate limit; the larger client spacing only delayed paginations.

## Measured impact

On a slow-CPU warm room change (4x throttle), measured before/after across the cumulative changes:

| Checkpoint | Before | After |
|---|---|---|
| `Event: pointerover` task | 733ms | not in top of Bottom-Up |
| `getMore` calls per open | 2 (auto-pulled second) | 1 |
| `getMore #2` throttle wait | 330ms | n/a |
| Click → first messages visible | ~400ms | ~160ms |
| Click → upsert complete | ~620ms | ~265ms |
| `getRoomByTypeAndName` on cached open | ~30ms | skipped |

## Test plan

- [ ] Cold-load app, open a channel via sidebar. Confirm messages render and pagination works on scroll-up.
- [ ] Click between two rooms repeatedly. Confirm no flicker, no duplicate `loadHistory` per open.
- [ ] Open a DM by username URL (old style). Confirm redirect to rid still works (cache shortcut intentionally bypassed for that path).
- [ ] Open a public channel as a non-member with `preview-c-room` permission. Confirm preview still works (cache miss path).
- [ ] Open a public channel as a non-member without permission. Confirm NotSubscribed UI appears.
- [ ] Hover several sidebar rows quickly without clicking. Confirm no main-thread stall; kebab menus open correctly on direct click after a beat.
- [ ] Scroll up in a long channel. Confirm history pages load as you reach the top.
- [ ] Navigate to a `?msg=` permalink in a channel. Confirm surrounding messages still fetch on initial mount. 

 Task: [ARCH-2163]

[ARCH-2163]: https://rocketchat.atlassian.net/browse/ARCH-2163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Accelerated message history request spacing for faster loading
  * Optimized sidebar menu rendering with deferred initialization
  * Room information now resolves instantly from local cache when available
  * Added parallel prefetching of room history and roles during initial load

* **Bug Fixes**
  * Fixed unintended duplicate history fetch on initial room load

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->