### PR TITLE
chore: migrate OAuth services admin DDP methods to REST

### DIFF
--- a/.changeset/ddp-migrate-batch7-oauth-caller.md
+++ b/.changeset/ddp-migrate-batch7-oauth-caller.md
@@ -1,0 +1,11 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Migrated the Admin → OAuth services group page from `useMethod` (DDP) to `useEndpoint` (REST):
+
+- `addOAuthService` → existing `POST /v1/settings.addCustomOAuth`
+- `removeOAuthService` → new `POST /v1/settings.removeCustomOAuth`
+- `refreshOAuthService` → new `POST /v1/settings.refreshOAuthServices`
+
+DDP methods stay registered with deprecation logs pointing at the new routes until 9.0.0.

--- a/.changeset/ddp-migrate-batch7-oauth-caller.md
+++ b/.changeset/ddp-migrate-batch7-oauth-caller.md
@@ -2,7 +2,7 @@
 '@rocket.chat/meteor': patch
 ---
 
-Migrated the Admin → OAuth services group page from `useMethod` (DDP) to `useEndpoint` (REST):
+Migrates the Admin → OAuth services group page from `useMethod` (DDP) to `useEndpoint` (REST):
 
 - `addOAuthService` → existing `POST /v1/settings.addCustomOAuth`
 - `removeOAuthService` → new `POST /v1/settings.removeCustomOAuth`

--- a/.changeset/rest-settings-oauth-admin.md
+++ b/.changeset/rest-settings-oauth-admin.md
@@ -1,0 +1,11 @@
+---
+'@rocket.chat/rest-typings': minor
+'@rocket.chat/meteor': minor
+---
+
+Added two new REST endpoints completing the Custom OAuth admin surface:
+
+- `POST /v1/settings.removeCustomOAuth` body `{ name }` → removes all `Accounts_OAuth_Custom-<Name>-*` setting documents (replaces the deprecated `removeOAuthService` DDP method).
+- `POST /v1/settings.refreshOAuthServices` (no body) → re-reads ServiceConfiguration entries from settings (replaces the deprecated `refreshOAuthService` DDP method).
+
+Both endpoints reuse the `add-oauth-service` permission and `twoFactorRequired` gates that the DDP methods already enforced. `addOAuthService` was already covered by the existing `POST /v1/settings.addCustomOAuth` — its DDP method now also logs a deprecation. The three legacy DDP methods remain registered until 9.0.0.

--- a/.changeset/rest-settings-oauth-admin.md
+++ b/.changeset/rest-settings-oauth-admin.md
@@ -3,7 +3,7 @@
 '@rocket.chat/meteor': minor
 ---
 
-Added two new REST endpoints completing the Custom OAuth admin surface:
+Adds two new REST endpoints completing the Custom OAuth admin surface:
 
 - `POST /v1/settings.removeCustomOAuth` body `{ name }` → removes all `Accounts_OAuth_Custom-<Name>-*` setting documents (replaces the deprecated `removeOAuthService` DDP method).
 - `POST /v1/settings.refreshOAuthServices` (no body) → re-reads ServiceConfiguration entries from settings (replaces the deprecated `refreshOAuthService` DDP method).

--- a/apps/meteor/client/views/admin/settings/groups/OAuthGroupPage/OAuthGroupPage.tsx
+++ b/apps/meteor/client/views/admin/settings/groups/OAuthGroupPage/OAuthGroupPage.tsx
@@ -2,7 +2,7 @@ import type { ISetting } from '@rocket.chat/core-typings';
 import { Button } from '@rocket.chat/fuselage';
 import { capitalize } from '@rocket.chat/string-helpers';
 import { GenericModal } from '@rocket.chat/ui-client';
-import { useToastMessageDispatch, useAbsoluteUrl, useMethod, useTranslation, useSetModal } from '@rocket.chat/ui-contexts';
+import { useToastMessageDispatch, useAbsoluteUrl, useEndpoint, useTranslation, useSetModal } from '@rocket.chat/ui-contexts';
 import DOMPurify from 'dompurify';
 import { memo, useEffect, useState } from 'react';
 
@@ -33,15 +33,15 @@ function OAuthGroupPage({ _id, onClickBack, ...group }: OAuthGroupPageProps) {
 	};
 
 	const dispatchToastMessage = useToastMessageDispatch();
-	const refreshOAuthService = useMethod('refreshOAuthService');
-	const addOAuthService = useMethod('addOAuthService');
-	const removeOAuthService = useMethod('removeOAuthService');
+	const refreshOAuthService = useEndpoint('POST', '/v1/settings.refreshOAuthServices');
+	const addOAuthService = useEndpoint('POST', '/v1/settings.addCustomOAuth');
+	const removeOAuthService = useEndpoint('POST', '/v1/settings.removeCustomOAuth');
 	const setModal = useSetModal();
 
 	const handleRefreshOAuthServicesButtonClick = async (): Promise<void> => {
 		dispatchToastMessage({ type: 'info', message: t('Refreshing') });
 		try {
-			await refreshOAuthService();
+			await refreshOAuthService(undefined);
 			dispatchToastMessage({ type: 'success', message: t('Done') });
 		} catch (error) {
 			dispatchToastMessage({ type: 'error', message: error });
@@ -51,7 +51,7 @@ function OAuthGroupPage({ _id, onClickBack, ...group }: OAuthGroupPageProps) {
 	const handleAddCustomOAuthButtonClick = (): void => {
 		const onConfirm = async (text: string): Promise<void> => {
 			try {
-				await addOAuthService(text);
+				await addOAuthService({ name: text });
 				dispatchToastMessage({ type: 'success', message: t('Custom_OAuth_has_been_added') });
 			} catch (error) {
 				dispatchToastMessage({ type: 'error', message: error });
@@ -71,7 +71,7 @@ function OAuthGroupPage({ _id, onClickBack, ...group }: OAuthGroupPageProps) {
 		(): void => {
 			const handleConfirm = async (): Promise<void> => {
 				try {
-					await removeOAuthService(id);
+					await removeOAuthService({ name: id });
 					dispatchToastMessage({ type: 'success', message: t('Custom_OAuth_has_been_removed') });
 					setSettingSections(settingSections.filter((section) => section !== `Custom OAuth: ${capitalize(id)}`));
 				} catch (error) {

--- a/apps/meteor/server/api/v1/settings.ts
+++ b/apps/meteor/server/api/v1/settings.ts
@@ -28,9 +28,9 @@ import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
 import { notifyOnSettingChanged, notifyOnSettingChangedById } from '../../lib/notifyListener';
 import { SettingValidationError, validateSettingRules } from '../../lib/settingValidationRules';
 import { disableCustomScripts } from '../../lib/shared/disableCustomScripts';
+import { refreshLoginServices } from '../../lib/refreshLoginServices';
 import { addOAuthServiceMethod } from '../../meteor-methods/auth/addOAuthService';
-import { refreshOAuthServiceMethod } from '../../meteor-methods/auth/refreshOAuthService';
-import { removeOAuthServiceMethod } from '../../meteor-methods/auth/removeOAuthService';
+import { removeCustomOAuthSettings } from '../../meteor-methods/auth/removeOAuthService';
 import { SettingsEvents, settings } from '../../settings';
 import { checkSettingValueBounds } from '../../settings/checkSettingValueBonds';
 import { updateAuditedByUser } from '../../settings/lib/auditedSettingUpdates';
@@ -262,6 +262,9 @@ API.v1.post(
 	{
 		authRequired: true,
 		twoFactorRequired: true,
+		permissionsRequired: {
+			POST: { permissions: ['add-oauth-service'], operation: 'hasAll' },
+		},
 		body: addCustomOAuthBodySchema,
 		response: {
 			200: ajv.compile<void>({
@@ -281,7 +284,7 @@ API.v1.post(
 			throw new Meteor.Error('error-name-param-not-provided', 'The parameter "name" is required');
 		}
 
-		await removeOAuthServiceMethod(this.userId, name);
+		await removeCustomOAuthSettings(name);
 
 		return API.v1.success();
 	},
@@ -292,6 +295,9 @@ API.v1.post(
 	{
 		authRequired: true,
 		twoFactorRequired: true,
+		permissionsRequired: {
+			POST: { permissions: ['add-oauth-service'], operation: 'hasAll' },
+		},
 		response: {
 			200: ajv.compile<void>({
 				type: 'object',
@@ -305,7 +311,7 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		await refreshOAuthServiceMethod(this.userId);
+		await refreshLoginServices();
 		return API.v1.success();
 	},
 );

--- a/apps/meteor/server/api/v1/settings.ts
+++ b/apps/meteor/server/api/v1/settings.ts
@@ -29,6 +29,8 @@ import { notifyOnSettingChanged, notifyOnSettingChangedById } from '../../lib/no
 import { SettingValidationError, validateSettingRules } from '../../lib/settingValidationRules';
 import { disableCustomScripts } from '../../lib/shared/disableCustomScripts';
 import { addOAuthServiceMethod } from '../../meteor-methods/auth/addOAuthService';
+import { refreshOAuthServiceMethod } from '../../meteor-methods/auth/refreshOAuthService';
+import { removeOAuthServiceMethod } from '../../meteor-methods/auth/removeOAuthService';
 import { SettingsEvents, settings } from '../../settings';
 import { checkSettingValueBounds } from '../../settings/checkSettingValueBonds';
 import { updateAuditedByUser } from '../../settings/lib/auditedSettingUpdates';
@@ -251,6 +253,59 @@ API.v1.post(
 
 		await addOAuthServiceMethod(this.userId, name);
 
+		return API.v1.success();
+	},
+);
+
+API.v1.post(
+	'settings.removeCustomOAuth',
+	{
+		authRequired: true,
+		twoFactorRequired: true,
+		body: addCustomOAuthBodySchema,
+		response: {
+			200: ajv.compile<void>({
+				type: 'object',
+				properties: { success: { type: 'boolean', enum: [true] } },
+				required: ['success'],
+				additionalProperties: false,
+			}),
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
+		},
+	},
+	async function action() {
+		const { name } = this.bodyParams;
+		if (!name?.trim()) {
+			throw new Meteor.Error('error-name-param-not-provided', 'The parameter "name" is required');
+		}
+
+		await removeOAuthServiceMethod(this.userId, name);
+
+		return API.v1.success();
+	},
+);
+
+API.v1.post(
+	'settings.refreshOAuthServices',
+	{
+		authRequired: true,
+		twoFactorRequired: true,
+		response: {
+			200: ajv.compile<void>({
+				type: 'object',
+				properties: { success: { type: 'boolean', enum: [true] } },
+				required: ['success'],
+				additionalProperties: false,
+			}),
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
+		},
+	},
+	async function action() {
+		await refreshOAuthServiceMethod(this.userId);
 		return API.v1.success();
 	},
 );

--- a/apps/meteor/server/api/v1/settings.ts
+++ b/apps/meteor/server/api/v1/settings.ts
@@ -228,6 +228,9 @@ API.v1.post(
 	{
 		authRequired: true,
 		twoFactorRequired: true,
+		permissionsRequired: {
+			POST: { permissions: ['add-oauth-service'], operation: 'hasAll' },
+		},
 		body: addCustomOAuthBodySchema,
 		response: {
 			200: ajv.compile<void>({
@@ -238,6 +241,7 @@ API.v1.post(
 			}),
 			400: validateBadRequestErrorResponse,
 			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 		},
 	},
 	async function action() {

--- a/apps/meteor/server/api/v1/settings.ts
+++ b/apps/meteor/server/api/v1/settings.ts
@@ -236,12 +236,7 @@ API.v1.post(
 				required: ['success'],
 				additionalProperties: false,
 			}),
-			400: ajv.compile({
-				type: 'object',
-				properties: { success: { type: 'boolean', enum: [false] }, error: { type: 'string' } },
-				required: ['success'],
-				additionalProperties: false,
-			}),
+			400: validateBadRequestErrorResponse,
 			401: validateUnauthorizedErrorResponse,
 		},
 	},

--- a/apps/meteor/server/api/v1/settings.ts
+++ b/apps/meteor/server/api/v1/settings.ts
@@ -26,9 +26,9 @@ import _ from 'underscore';
 
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
 import { notifyOnSettingChanged, notifyOnSettingChangedById } from '../../lib/notifyListener';
+import { refreshLoginServices } from '../../lib/refreshLoginServices';
 import { SettingValidationError, validateSettingRules } from '../../lib/settingValidationRules';
 import { disableCustomScripts } from '../../lib/shared/disableCustomScripts';
-import { refreshLoginServices } from '../../lib/refreshLoginServices';
 import { addOAuthServiceMethod } from '../../meteor-methods/auth/addOAuthService';
 import { removeCustomOAuthSettings } from '../../meteor-methods/auth/removeOAuthService';
 import { SettingsEvents, settings } from '../../settings';

--- a/apps/meteor/server/meteor-methods/auth/addOAuthService.ts
+++ b/apps/meteor/server/meteor-methods/auth/addOAuthService.ts
@@ -2,7 +2,7 @@ import type { ServerMethods } from '@rocket.chat/ddp-client';
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
-import { methodDeprecationLogger } from '../../../app/lib/server/lib/deprecationWarningLogger';
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
 import { addOAuthService } from '../../lib/oauth/addOAuthService';
 

--- a/apps/meteor/server/meteor-methods/auth/addOAuthService.ts
+++ b/apps/meteor/server/meteor-methods/auth/addOAuthService.ts
@@ -2,6 +2,7 @@ import type { ServerMethods } from '@rocket.chat/ddp-client';
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
+import { methodDeprecationLogger } from '../../../app/lib/server/lib/deprecationWarningLogger';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
 import { addOAuthService } from '../../lib/oauth/addOAuthService';
 
@@ -25,6 +26,7 @@ export const addOAuthServiceMethod = async (userId: string, name: string): Promi
 
 Meteor.methods<ServerMethods>({
 	async addOAuthService(name) {
+		methodDeprecationLogger.method('addOAuthService', '9.0.0', '/v1/settings.addCustomOAuth');
 		check(name, String);
 
 		const userId = Meteor.userId();

--- a/apps/meteor/server/meteor-methods/auth/addOAuthService.ts
+++ b/apps/meteor/server/meteor-methods/auth/addOAuthService.ts
@@ -2,8 +2,8 @@ import type { ServerMethods } from '@rocket.chat/ddp-client';
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
-import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { addOAuthService } from '../../lib/oauth/addOAuthService';
 
 declare module '@rocket.chat/ddp-client' {

--- a/apps/meteor/server/meteor-methods/auth/refreshOAuthService.ts
+++ b/apps/meteor/server/meteor-methods/auth/refreshOAuthService.ts
@@ -1,7 +1,7 @@
 import type { ServerMethods } from '@rocket.chat/ddp-client';
 import { Meteor } from 'meteor/meteor';
 
-import { methodDeprecationLogger } from '../../../app/lib/server/lib/deprecationWarningLogger';
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
 import { refreshLoginServices } from '../../lib/refreshLoginServices';
 

--- a/apps/meteor/server/meteor-methods/auth/refreshOAuthService.ts
+++ b/apps/meteor/server/meteor-methods/auth/refreshOAuthService.ts
@@ -1,8 +1,8 @@
 import type { ServerMethods } from '@rocket.chat/ddp-client';
 import { Meteor } from 'meteor/meteor';
 
-import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { refreshLoginServices } from '../../lib/refreshLoginServices';
 
 declare module '@rocket.chat/ddp-client' {

--- a/apps/meteor/server/meteor-methods/auth/refreshOAuthService.ts
+++ b/apps/meteor/server/meteor-methods/auth/refreshOAuthService.ts
@@ -12,17 +12,6 @@ declare module '@rocket.chat/ddp-client' {
 	}
 }
 
-export const refreshOAuthServiceMethod = async (userId: string): Promise<void> => {
-	if ((await hasPermissionAsync(userId, 'add-oauth-service')) !== true) {
-		throw new Meteor.Error('error-action-not-allowed', 'Refresh OAuth Services is not allowed', {
-			method: 'refreshOAuthService',
-			action: 'Refreshing_OAuth_Services',
-		});
-	}
-
-	await refreshLoginServices();
-};
-
 Meteor.methods<ServerMethods>({
 	async refreshOAuthService() {
 		methodDeprecationLogger.method('refreshOAuthService', '9.0.0', '/v1/settings.refreshOAuthServices');
@@ -35,6 +24,13 @@ Meteor.methods<ServerMethods>({
 			});
 		}
 
-		await refreshOAuthServiceMethod(userId);
+		if ((await hasPermissionAsync(userId, 'add-oauth-service')) !== true) {
+			throw new Meteor.Error('error-action-not-allowed', 'Refresh OAuth Services is not allowed', {
+				method: 'refreshOAuthService',
+				action: 'Refreshing_OAuth_Services',
+			});
+		}
+
+		await refreshLoginServices();
 	},
 });

--- a/apps/meteor/server/meteor-methods/auth/refreshOAuthService.ts
+++ b/apps/meteor/server/meteor-methods/auth/refreshOAuthService.ts
@@ -1,6 +1,7 @@
 import type { ServerMethods } from '@rocket.chat/ddp-client';
 import { Meteor } from 'meteor/meteor';
 
+import { methodDeprecationLogger } from '../../../app/lib/server/lib/deprecationWarningLogger';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
 import { refreshLoginServices } from '../../lib/refreshLoginServices';
 
@@ -11,8 +12,21 @@ declare module '@rocket.chat/ddp-client' {
 	}
 }
 
+export const refreshOAuthServiceMethod = async (userId: string): Promise<void> => {
+	if ((await hasPermissionAsync(userId, 'add-oauth-service')) !== true) {
+		throw new Meteor.Error('error-action-not-allowed', 'Refresh OAuth Services is not allowed', {
+			method: 'refreshOAuthService',
+			action: 'Refreshing_OAuth_Services',
+		});
+	}
+
+	await refreshLoginServices();
+};
+
 Meteor.methods<ServerMethods>({
 	async refreshOAuthService() {
+		methodDeprecationLogger.method('refreshOAuthService', '9.0.0', '/v1/settings.refreshOAuthServices');
+
 		const userId = Meteor.userId();
 
 		if (!userId) {
@@ -21,13 +35,6 @@ Meteor.methods<ServerMethods>({
 			});
 		}
 
-		if ((await hasPermissionAsync(userId, 'add-oauth-service')) !== true) {
-			throw new Meteor.Error('error-action-not-allowed', 'Refresh OAuth Services is not allowed', {
-				method: 'refreshOAuthService',
-				action: 'Refreshing_OAuth_Services',
-			});
-		}
-
-		await refreshLoginServices();
+		await refreshOAuthServiceMethod(userId);
 	},
 });

--- a/apps/meteor/server/meteor-methods/auth/removeOAuthService.ts
+++ b/apps/meteor/server/meteor-methods/auth/removeOAuthService.ts
@@ -4,8 +4,9 @@ import { capitalize } from '@rocket.chat/string-helpers';
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
+import { methodDeprecationLogger } from '../../../app/lib/server/lib/deprecationWarningLogger';
+import { notifyOnSettingChangedById } from '../../../app/lib/server/lib/notifyListener';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
-import { notifyOnSettingChangedById } from '../../lib/notifyListener';
 
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -14,8 +15,58 @@ declare module '@rocket.chat/ddp-client' {
 	}
 }
 
+export const removeOAuthServiceMethod = async (userId: string, name: string): Promise<void> => {
+	if ((await hasPermissionAsync(userId, 'add-oauth-service')) !== true) {
+		throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'removeOAuthService' });
+	}
+
+	const normalized = capitalize(name.toLowerCase().replace(/[^a-z0-9_]/g, ''));
+
+	const settingsIds = [
+		`Accounts_OAuth_Custom-${normalized}`,
+		`Accounts_OAuth_Custom-${normalized}-url`,
+		`Accounts_OAuth_Custom-${normalized}-token_path`,
+		`Accounts_OAuth_Custom-${normalized}-identity_path`,
+		`Accounts_OAuth_Custom-${normalized}-authorize_path`,
+		`Accounts_OAuth_Custom-${normalized}-scope`,
+		`Accounts_OAuth_Custom-${normalized}-access_token_param`,
+		`Accounts_OAuth_Custom-${normalized}-token_sent_via`,
+		`Accounts_OAuth_Custom-${normalized}-identity_token_sent_via`,
+		`Accounts_OAuth_Custom-${normalized}-id`,
+		`Accounts_OAuth_Custom-${normalized}-secret`,
+		`Accounts_OAuth_Custom-${normalized}-button_label_text`,
+		`Accounts_OAuth_Custom-${normalized}-button_label_color`,
+		`Accounts_OAuth_Custom-${normalized}-button_color`,
+		`Accounts_OAuth_Custom-${normalized}-login_style`,
+		`Accounts_OAuth_Custom-${normalized}-key_field`,
+		`Accounts_OAuth_Custom-${normalized}-username_field`,
+		`Accounts_OAuth_Custom-${normalized}-email_field`,
+		`Accounts_OAuth_Custom-${normalized}-name_field`,
+		`Accounts_OAuth_Custom-${normalized}-avatar_field`,
+		`Accounts_OAuth_Custom-${normalized}-roles_claim`,
+		`Accounts_OAuth_Custom-${normalized}-merge_roles`,
+		`Accounts_OAuth_Custom-${normalized}-roles_to_sync`,
+		`Accounts_OAuth_Custom-${normalized}-merge_users`,
+		`Accounts_OAuth_Custom-${normalized}-show_button`,
+		`Accounts_OAuth_Custom-${normalized}-groups_claim`,
+		`Accounts_OAuth_Custom-${normalized}-channels_admin`,
+		`Accounts_OAuth_Custom-${normalized}-map_channels`,
+		`Accounts_OAuth_Custom-${normalized}-groups_channel_map`,
+		`Accounts_OAuth_Custom-${normalized}-merge_users_distinct_services`,
+	];
+
+	const promises = settingsIds.map((id) => Settings.removeById(id));
+
+	(await Promise.all(promises)).forEach((value, index) => {
+		if (value?.deletedCount) {
+			void notifyOnSettingChangedById(settingsIds[index], 'removed');
+		}
+	});
+};
+
 Meteor.methods<ServerMethods>({
 	async removeOAuthService(name) {
+		methodDeprecationLogger.method('removeOAuthService', '9.0.0', '/v1/settings.removeCustomOAuth');
 		check(name, String);
 
 		const userId = Meteor.userId();
@@ -26,52 +77,6 @@ Meteor.methods<ServerMethods>({
 			});
 		}
 
-		if ((await hasPermissionAsync(userId, 'add-oauth-service')) !== true) {
-			throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'removeOAuthService' });
-		}
-
-		name = name.toLowerCase().replace(/[^a-z0-9_]/g, '');
-		name = capitalize(name);
-
-		const settingsIds = [
-			`Accounts_OAuth_Custom-${name}`,
-			`Accounts_OAuth_Custom-${name}-url`,
-			`Accounts_OAuth_Custom-${name}-token_path`,
-			`Accounts_OAuth_Custom-${name}-identity_path`,
-			`Accounts_OAuth_Custom-${name}-authorize_path`,
-			`Accounts_OAuth_Custom-${name}-scope`,
-			`Accounts_OAuth_Custom-${name}-access_token_param`,
-			`Accounts_OAuth_Custom-${name}-token_sent_via`,
-			`Accounts_OAuth_Custom-${name}-identity_token_sent_via`,
-			`Accounts_OAuth_Custom-${name}-id`,
-			`Accounts_OAuth_Custom-${name}-secret`,
-			`Accounts_OAuth_Custom-${name}-button_label_text`,
-			`Accounts_OAuth_Custom-${name}-button_label_color`,
-			`Accounts_OAuth_Custom-${name}-button_color`,
-			`Accounts_OAuth_Custom-${name}-login_style`,
-			`Accounts_OAuth_Custom-${name}-key_field`,
-			`Accounts_OAuth_Custom-${name}-username_field`,
-			`Accounts_OAuth_Custom-${name}-email_field`,
-			`Accounts_OAuth_Custom-${name}-name_field`,
-			`Accounts_OAuth_Custom-${name}-avatar_field`,
-			`Accounts_OAuth_Custom-${name}-roles_claim`,
-			`Accounts_OAuth_Custom-${name}-merge_roles`,
-			`Accounts_OAuth_Custom-${name}-roles_to_sync`,
-			`Accounts_OAuth_Custom-${name}-merge_users`,
-			`Accounts_OAuth_Custom-${name}-show_button`,
-			`Accounts_OAuth_Custom-${name}-groups_claim`,
-			`Accounts_OAuth_Custom-${name}-channels_admin`,
-			`Accounts_OAuth_Custom-${name}-map_channels`,
-			`Accounts_OAuth_Custom-${name}-groups_channel_map`,
-			`Accounts_OAuth_Custom-${name}-merge_users_distinct_services`,
-		];
-
-		const promises = settingsIds.map((id) => Settings.removeById(id));
-
-		(await Promise.all(promises)).forEach((value, index) => {
-			if (value?.deletedCount) {
-				void notifyOnSettingChangedById(settingsIds[index], 'removed');
-			}
-		});
+		await removeOAuthServiceMethod(userId, name);
 	},
 });

--- a/apps/meteor/server/meteor-methods/auth/removeOAuthService.ts
+++ b/apps/meteor/server/meteor-methods/auth/removeOAuthService.ts
@@ -4,9 +4,9 @@ import { capitalize } from '@rocket.chat/string-helpers';
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
+import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
 import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { notifyOnSettingChangedById } from '../../lib/notifyListener';
-import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
 
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention

--- a/apps/meteor/server/meteor-methods/auth/removeOAuthService.ts
+++ b/apps/meteor/server/meteor-methods/auth/removeOAuthService.ts
@@ -15,12 +15,12 @@ declare module '@rocket.chat/ddp-client' {
 	}
 }
 
-export const removeOAuthServiceMethod = async (userId: string, name: string): Promise<void> => {
-	if ((await hasPermissionAsync(userId, 'add-oauth-service')) !== true) {
-		throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'removeOAuthService' });
-	}
-
+export const removeCustomOAuthSettings = async (name: string): Promise<void> => {
 	const normalized = capitalize(name.toLowerCase().replace(/[^a-z0-9_]/g, ''));
+
+	if (!normalized) {
+		throw new Meteor.Error('error-invalid-name', 'Invalid OAuth service name', { method: 'removeOAuthService' });
+	}
 
 	const settingsIds = [
 		`Accounts_OAuth_Custom-${normalized}`,
@@ -77,6 +77,10 @@ Meteor.methods<ServerMethods>({
 			});
 		}
 
-		await removeOAuthServiceMethod(userId, name);
+		if ((await hasPermissionAsync(userId, 'add-oauth-service')) !== true) {
+			throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'removeOAuthService' });
+		}
+
+		await removeCustomOAuthSettings(name);
 	},
 });

--- a/apps/meteor/server/meteor-methods/auth/removeOAuthService.ts
+++ b/apps/meteor/server/meteor-methods/auth/removeOAuthService.ts
@@ -4,8 +4,8 @@ import { capitalize } from '@rocket.chat/string-helpers';
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
-import { methodDeprecationLogger } from '../../../app/lib/server/lib/deprecationWarningLogger';
-import { notifyOnSettingChangedById } from '../../../app/lib/server/lib/notifyListener';
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
+import { notifyOnSettingChangedById } from '../../lib/notifyListener';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
 
 declare module '@rocket.chat/ddp-client' {

--- a/apps/meteor/tests/end-to-end/api/settings.ts
+++ b/apps/meteor/tests/end-to-end/api/settings.ts
@@ -704,18 +704,15 @@ describe('[Settings]', () => {
 			it('should fail when the "name" param is not provided', () =>
 				request.post(api('settings.addCustomOAuth')).set(credentials).send({}).expect(400));
 
-			// settings.addCustomOAuth still enforces the permission inside the shared method (no route-level
-			// `permissionsRequired`), so a permission failure surfaces as 400 rather than 403.
 			it('should fail when the user does not have the add-oauth-service permission', async () => {
 				await updatePermission('add-oauth-service', []);
 				await request
 					.post(api('settings.addCustomOAuth'))
 					.set(credentials)
 					.send({ name: oauthName })
-					.expect(400)
 					.expect((res) => {
+						expect(res.status).to.equal(403);
 						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-action-not-allowed');
 					});
 			});
 

--- a/apps/meteor/tests/end-to-end/api/settings.ts
+++ b/apps/meteor/tests/end-to-end/api/settings.ts
@@ -681,4 +681,116 @@ describe('[Settings]', () => {
 			});
 		});
 	});
+
+	describe('Custom OAuth admin endpoints', () => {
+		// `add-oauth-service` is enforced inside the shared method, so a permission failure currently
+		// surfaces as HTTP 400. Once the routes declare `permissionsRequired`, it becomes 403 — the
+		// assertions below accept either so they survive that change.
+		const oauthName = 'apitest';
+		const enableSettingId = 'Accounts_OAuth_Custom-Apitest';
+
+		before(() => updatePermission('add-oauth-service', ['admin']));
+
+		after(async () => {
+			await updatePermission('add-oauth-service', ['admin']);
+			// best-effort cleanup in case a test left the custom service behind
+			await request.post(api('settings.removeCustomOAuth')).set(credentials).send({ name: oauthName });
+		});
+
+		describe('[/settings.addCustomOAuth]', () => {
+			it('should fail when unauthenticated', () => request.post(api('settings.addCustomOAuth')).send({ name: oauthName }).expect(401));
+
+			it('should fail when the "name" param is not provided', () =>
+				request.post(api('settings.addCustomOAuth')).set(credentials).send({}).expect(400));
+
+			it('should fail when the user does not have the add-oauth-service permission', async () => {
+				await updatePermission('add-oauth-service', []);
+				await request
+					.post(api('settings.addCustomOAuth'))
+					.set(credentials)
+					.send({ name: oauthName })
+					.expect((res) => {
+						expect([400, 403]).to.include(res.status);
+						expect(res.body).to.have.property('success', false);
+					});
+				await updatePermission('add-oauth-service', ['admin']);
+			});
+
+			it('should add a custom oauth service', async () => {
+				await request
+					.post(api('settings.addCustomOAuth'))
+					.set(credentials)
+					.send({ name: oauthName })
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('success', true);
+					});
+
+				const value = await getSettingValueById(enableSettingId);
+				expect(value).to.be.a('boolean');
+			});
+		});
+
+		describe('[/settings.refreshOAuthServices]', () => {
+			it('should fail when unauthenticated', () => request.post(api('settings.refreshOAuthServices')).expect(401));
+
+			it('should fail when the user does not have the add-oauth-service permission', async () => {
+				await updatePermission('add-oauth-service', []);
+				await request
+					.post(api('settings.refreshOAuthServices'))
+					.set(credentials)
+					.expect((res) => {
+						expect([400, 403]).to.include(res.status);
+						expect(res.body).to.have.property('success', false);
+					});
+				await updatePermission('add-oauth-service', ['admin']);
+			});
+
+			it('should refresh the oauth services', () =>
+				request
+					.post(api('settings.refreshOAuthServices'))
+					.set(credentials)
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('success', true);
+					}));
+		});
+
+		describe('[/settings.removeCustomOAuth]', () => {
+			it('should fail when unauthenticated', () => request.post(api('settings.removeCustomOAuth')).send({ name: oauthName }).expect(401));
+
+			it('should fail when the "name" param is not provided', () =>
+				request.post(api('settings.removeCustomOAuth')).set(credentials).send({}).expect(400));
+
+			it('should fail when the user does not have the add-oauth-service permission', async () => {
+				await updatePermission('add-oauth-service', []);
+				await request
+					.post(api('settings.removeCustomOAuth'))
+					.set(credentials)
+					.send({ name: oauthName })
+					.expect((res) => {
+						expect([400, 403]).to.include(res.status);
+						expect(res.body).to.have.property('success', false);
+					});
+				await updatePermission('add-oauth-service', ['admin']);
+			});
+
+			it('should remove a custom oauth service', async () => {
+				await request
+					.post(api('settings.removeCustomOAuth'))
+					.set(credentials)
+					.send({ name: oauthName })
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('success', true);
+					});
+
+				// the provider settings should be gone: settings/:_id answers 400 for an unknown id
+				await request.get(`/api/v1/settings/${enableSettingId}`).set(credentials).expect(400);
+			});
+		});
+	});
 });

--- a/apps/meteor/tests/end-to-end/api/settings.ts
+++ b/apps/meteor/tests/end-to-end/api/settings.ts
@@ -1,6 +1,6 @@
 import type { IServerEvents, LoginServiceConfiguration } from '@rocket.chat/core-typings';
 import { expect } from 'chai';
-import { before, describe, it, after } from 'mocha';
+import { before, describe, it, after, afterEach } from 'mocha';
 
 import { getCredentials, api, request, credentials } from '../../data/api-data';
 import { updatePermission, updateSetting, getSettingValueById } from '../../data/permissions.helper';
@@ -688,6 +688,10 @@ describe('[Settings]', () => {
 
 		before(() => updatePermission('add-oauth-service', ['admin']));
 
+		// guarantee the permission is restored even if a permission-denied assertion fails mid-test,
+		// so a failure cannot cascade into the following cases
+		afterEach(() => updatePermission('add-oauth-service', ['admin']));
+
 		after(async () => {
 			await updatePermission('add-oauth-service', ['admin']);
 			// best-effort cleanup in case a test left the custom service behind
@@ -700,17 +704,19 @@ describe('[Settings]', () => {
 			it('should fail when the "name" param is not provided', () =>
 				request.post(api('settings.addCustomOAuth')).set(credentials).send({}).expect(400));
 
+			// settings.addCustomOAuth still enforces the permission inside the shared method (no route-level
+			// `permissionsRequired`), so a permission failure surfaces as 400 rather than 403.
 			it('should fail when the user does not have the add-oauth-service permission', async () => {
 				await updatePermission('add-oauth-service', []);
 				await request
 					.post(api('settings.addCustomOAuth'))
 					.set(credentials)
 					.send({ name: oauthName })
+					.expect(400)
 					.expect((res) => {
-						expect(res.status).to.equal(403);
 						expect(res.body).to.have.property('success', false);
+						expect(res.body.error).to.match(/error-action-not-allowed/);
 					});
-				await updatePermission('add-oauth-service', ['admin']);
 			});
 
 			it('should add a custom oauth service', async () => {
@@ -741,7 +747,6 @@ describe('[Settings]', () => {
 						expect(res.status).to.equal(403);
 						expect(res.body).to.have.property('success', false);
 					});
-				await updatePermission('add-oauth-service', ['admin']);
 			});
 
 			it('should refresh the oauth services', () =>
@@ -781,7 +786,6 @@ describe('[Settings]', () => {
 						expect(res.status).to.equal(403);
 						expect(res.body).to.have.property('success', false);
 					});
-				await updatePermission('add-oauth-service', ['admin']);
 			});
 
 			it('should remove a custom oauth service', async () => {

--- a/apps/meteor/tests/end-to-end/api/settings.ts
+++ b/apps/meteor/tests/end-to-end/api/settings.ts
@@ -683,9 +683,6 @@ describe('[Settings]', () => {
 	});
 
 	describe('Custom OAuth admin endpoints', () => {
-		// `add-oauth-service` is enforced inside the shared method, so a permission failure currently
-		// surfaces as HTTP 400. Once the routes declare `permissionsRequired`, it becomes 403 — the
-		// assertions below accept either so they survive that change.
 		const oauthName = 'apitest';
 		const enableSettingId = 'Accounts_OAuth_Custom-Apitest';
 
@@ -710,7 +707,7 @@ describe('[Settings]', () => {
 					.set(credentials)
 					.send({ name: oauthName })
 					.expect((res) => {
-						expect([400, 403]).to.include(res.status);
+						expect(res.status).to.equal(403);
 						expect(res.body).to.have.property('success', false);
 					});
 				await updatePermission('add-oauth-service', ['admin']);
@@ -741,7 +738,7 @@ describe('[Settings]', () => {
 					.post(api('settings.refreshOAuthServices'))
 					.set(credentials)
 					.expect((res) => {
-						expect([400, 403]).to.include(res.status);
+						expect(res.status).to.equal(403);
 						expect(res.body).to.have.property('success', false);
 					});
 				await updatePermission('add-oauth-service', ['admin']);
@@ -764,6 +761,16 @@ describe('[Settings]', () => {
 			it('should fail when the "name" param is not provided', () =>
 				request.post(api('settings.removeCustomOAuth')).set(credentials).send({}).expect(400));
 
+			it('should fail when the "name" normalizes to an empty string', () =>
+				request
+					.post(api('settings.removeCustomOAuth'))
+					.set(credentials)
+					.send({ name: '!!!' })
+					.expect(400)
+					.expect((res) => {
+						expect(res.body).to.have.property('success', false);
+					}));
+
 			it('should fail when the user does not have the add-oauth-service permission', async () => {
 				await updatePermission('add-oauth-service', []);
 				await request
@@ -771,7 +778,7 @@ describe('[Settings]', () => {
 					.set(credentials)
 					.send({ name: oauthName })
 					.expect((res) => {
-						expect([400, 403]).to.include(res.status);
+						expect(res.status).to.equal(403);
 						expect(res.body).to.have.property('success', false);
 					});
 				await updatePermission('add-oauth-service', ['admin']);

--- a/apps/meteor/tests/end-to-end/api/settings.ts
+++ b/apps/meteor/tests/end-to-end/api/settings.ts
@@ -715,7 +715,7 @@ describe('[Settings]', () => {
 					.expect(400)
 					.expect((res) => {
 						expect(res.body).to.have.property('success', false);
-						expect(res.body.error).to.match(/error-action-not-allowed/);
+						expect(res.body).to.have.property('errorType', 'error-action-not-allowed');
 					});
 			});
 

--- a/packages/rest-typings/src/v1/settings.ts
+++ b/packages/rest-typings/src/v1/settings.ts
@@ -132,6 +132,14 @@ export type SettingsEndpoints = {
 		POST: (params: { name: string }) => void;
 	};
 
+	'/v1/settings.removeCustomOAuth': {
+		POST: (params: { name: string }) => void;
+	};
+
+	'/v1/settings.refreshOAuthServices': {
+		POST: () => void;
+	};
+
 	'/v1/settings': {
 		GET: (params: SettingsGetParams) => {
 			settings: ISetting[];


### PR DESCRIPTION
## Summary

Continues the DDP→REST sweep (#40659, #40711, #40675, #40724, #40728, #40734, #40736). This batch migrates the three OAuth services admin DDP methods that backed the Admin → OAuth settings group. DDP methods stay registered for external SDK/mobile clients with deprecation logs pointing at the new routes.

### Endpoints

| DDP method | REST endpoint | Notes |
|---|---|---|
| `addOAuthService` | `POST /v1/settings.addCustomOAuth` | already exists, DDP now logs deprecation |
| `removeOAuthService` | `POST /v1/settings.removeCustomOAuth` (new) | `add-oauth-service` perm + `twoFactorRequired` |
| `refreshOAuthService` | `POST /v1/settings.refreshOAuthServices` (new) | `add-oauth-service` perm + `twoFactorRequired` |

### Implementation

- `removeOAuthServiceMethod` + `refreshOAuthServiceMethod` extracted from the DDP method files into exported functions, reused by both DDP entrypoints (now thin + deprecation-logged) and the REST handlers.
- Same `add-oauth-service` permission check + `twoFactorRequired` gate as the existing `settings.addCustomOAuth` endpoint.

### Client changes

`OAuthGroupPage.tsx` swapped from three `useMethod` hooks to three `useEndpoint` hooks. `addOAuthService` now sends `{ name }`; `removeOAuthService` now sends `{ name }`.

## Test plan

- [ ] CI green (lint + typecheck)
- [ ] Admin → OAuth → Add custom OAuth → fill name → modal closes, settings group appears
- [ ] Admin → OAuth → Remove custom OAuth (confirm danger modal) → settings group disappears, settings rows deleted
- [ ] Admin → OAuth → Refresh OAuth services → toast OK, login page reflects updated providers
- [ ] Hit endpoints with `curl` and confirm 401/403 without the `add-oauth-service` perm, 2FA prompt without a valid 2FA challenge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added REST API support for removing custom OAuth services.
  - Added REST API support for refreshing OAuth service configurations.
  - Completed the custom OAuth administration workflow with consistent authentication, permission, and two-factor checks.

- **Updates**
  - The OAuth administration page now uses the REST endpoints for adding, removing, and refreshing services.
  - Legacy DDP methods remain available temporarily with deprecation notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2270]

[ARCH-2270]: https://rocketchat.atlassian.net/browse/ARCH-2270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ