### PR TITLE
feat(abac): bypass-abac-store-validation permission

### DIFF
--- a/apps/meteor/ee/server/lib/abac/index.ts
+++ b/apps/meteor/ee/server/lib/abac/index.ts
@@ -7,6 +7,7 @@ export const createPermissions = async () => {
 		{ _id: 'manage-abac-admin-room-attributes', roles: ['admin'] },
 		{ _id: 'manage-abac-admin-rooms', roles: ['admin'] },
 		{ _id: 'view-abac-admin-audit', roles: ['admin'] },
+		{ _id: 'bypass-abac-store-validation', roles: [] },
 	];
 
 	for (const permission of permissions) {

--- a/apps/meteor/tests/end-to-end/api/abac.ts
+++ b/apps/meteor/tests/end-to-end/api/abac.ts
@@ -3771,6 +3771,65 @@ const addAbacAttributesToUserDirectly = async (userId: string, abacAttributes: I
 			});
 		});
 
+		describe('bypass-abac-store-validation permission (spec §4.2)', () => {
+			let adminBypass: { user: IUser; creds: Credentials };
+
+			before(async function () {
+				this.timeout(15000);
+				adminBypass = await makeAdmin('bypass');
+				await updatePermission('bypass-abac-store-validation', ['admin']);
+			});
+
+			after(async () => {
+				await mockServerReset();
+				await updatePermission('bypass-abac-store-validation', []);
+				await deleteUser(adminBypass.user);
+			});
+
+			it('skips validateAssignable: assigns a value the admin is not entitled to → 200', async () => {
+				const room = (await createRoom({ type: 'p', name: `vstore-bypass-wg-${Date.now()}` })).body.group;
+
+				await mockServerReset();
+				await seedDefaultMocks();
+				await seedGetEntitlements({ [fqn('clearance', 'secret')]: {} });
+				await seedGetDecisionBulk([{ resourceDecisions: [{ decision: 'DECISION_PERMIT', ephemeralResourceId: room._id }] }]);
+
+				await request
+					.post(`${v1}/abac/rooms/${room._id}/attributes/team`)
+					.set(adminBypass.creds)
+					.send({ values: ['blue'] })
+					.expect(200);
+
+				await deleteRoom({ type: 'p', roomId: room._id });
+			});
+
+			it('skips assertCanModifyRoom: edits an attribute on a room the PDP denies → 200', async () => {
+				await mockServerReset();
+				await seedDefaultMocks();
+				await seedGetEntitlements({ [fqn('clearance', 'secret')]: {} });
+				await seedGetDecisionBulk([{ resourceDecisions: [{ decision: 'DECISION_PERMIT', ephemeralResourceId: '__seed__' }] }]);
+
+				const room = (await createRoom({ type: 'p', name: `vstore-bypass-mod-${Date.now()}` })).body.group;
+				await storeConnection
+					.db()
+					.collection('rocketchat_room')
+					.updateOne({ _id: room._id as any }, { $set: { abacAttributes: [{ key: 'clearance', values: ['secret'] }] } });
+
+				await mockServerReset();
+				await seedDefaultMocks();
+				await seedGetEntitlements({ [fqn('clearance', 'secret')]: {} });
+				await seedGetDecisionBulk([{ resourceDecisions: [{ decision: 'DECISION_DENY', ephemeralResourceId: room._id }] }]);
+
+				await request
+					.post(`${v1}/abac/rooms/${room._id}/attributes/clearance`)
+					.set(adminBypass.creds)
+					.send({ values: ['secret'] })
+					.expect(200);
+
+				await deleteRoom({ type: 'p', roomId: room._id });
+			});
+		});
+
 		describe('hierarchy expansion (spec §3.3)', () => {
 			let room: IRoom;
 			let adminH: { user: IUser; creds: Credentials };

--- a/apps/meteor/tests/end-to-end/api/abac.ts
+++ b/apps/meteor/tests/end-to-end/api/abac.ts
@@ -3821,9 +3821,9 @@ const addAbacAttributesToUserDirectly = async (userId: string, abacAttributes: I
 				await seedGetDecisionBulk([{ resourceDecisions: [{ decision: 'DECISION_DENY', ephemeralResourceId: room._id }] }]);
 
 				await request
-					.post(`${v1}/abac/rooms/${room._id}/attributes/clearance`)
+					.post(`${v1}/abac/rooms/${room._id}/attributes/team`)
 					.set(adminBypass.creds)
-					.send({ values: ['secret'] })
+					.send({ values: ['blue'] })
 					.expect(200);
 
 				await deleteRoom({ type: 'p', roomId: room._id });

--- a/ee/packages/abac/src/index.ts
+++ b/ee/packages/abac/src/index.ts
@@ -1,4 +1,4 @@
-import { api, License, Room, ServiceClass, Settings } from '@rocket.chat/core-services';
+import { api, Authorization, License, Room, ServiceClass, Settings } from '@rocket.chat/core-services';
 import type { AbacActor, IAbacService } from '@rocket.chat/core-services';
 import { AbacAccessOperation, AbacObjectType, isAbacPdpType, isAbacAttributeStoreType } from '@rocket.chat/core-typings';
 import type {
@@ -523,6 +523,20 @@ export class AbacService extends ServiceClass implements IAbacService {
 		void api.broadcast('watch.rooms', { clientAction: 'updated', room });
 	}
 
+	private async enforceCanModifyRoom(store: IAttributeStore, room: Pick<IRoom, '_id' | 'abacAttributes'>, actor: AbacActor): Promise<void> {
+		if (await Authorization.hasPermission(actor._id, 'bypass-abac-store-validation')) {
+			return;
+		}
+		await store.assertCanModifyRoom(room, actor);
+	}
+
+	private async enforceStoreValidation(store: IAttributeStore, attrs: IAbacAttributeDefinition[], actor: AbacActor): Promise<void> {
+		if (await Authorization.hasPermission(actor._id, 'bypass-abac-store-validation')) {
+			return;
+		}
+		await store.validateAssignable(attrs, actor);
+	}
+
 	async setRoomAbacAttributes(rid: string, attributes: Record<string, string[]>, actor: AbacActor): Promise<void> {
 		await this.ensurePdpAvailable();
 		const room = await getAbacRoom(rid);
@@ -535,11 +549,11 @@ export class AbacService extends ServiceClass implements IAbacService {
 			return;
 		}
 
-		await store.assertCanModifyRoom(room, actor);
+		await this.enforceCanModifyRoom(store, room, actor);
 
 		const normalized = validateAndNormalizeAttributes(attributes);
 
-		await store.validateAssignable(normalized, actor);
+		await this.enforceStoreValidation(store, normalized, actor);
 
 		const updated = await Rooms.setAbacAttributesById(rid, normalized);
 		void Audit.objectAttributeChanged({ _id: room._id, name: room.name }, room.abacAttributes || [], normalized, 'updated', actor);
@@ -559,7 +573,7 @@ export class AbacService extends ServiceClass implements IAbacService {
 		const room = await getAbacRoom(rid);
 		const store = await this.resolveAttributeStore();
 
-		await store.assertCanModifyRoom(room, actor);
+		await this.enforceCanModifyRoom(store, room, actor);
 
 		const previous: IAbacAttributeDefinition[] = room.abacAttributes || [];
 
@@ -569,7 +583,7 @@ export class AbacService extends ServiceClass implements IAbacService {
 			throw new AbacInvalidAttributeValuesError();
 		}
 
-		await store.validateAssignable([{ key, values }], actor);
+		await this.enforceStoreValidation(store, [{ key, values }], actor);
 
 		if (isNewKey) {
 			await Rooms.updateSingleAbacAttributeValuesById(rid, key, values);
@@ -619,7 +633,7 @@ export class AbacService extends ServiceClass implements IAbacService {
 		const room = await getAbacRoom(rid);
 		const store = await this.resolveAttributeStore();
 
-		await store.assertCanModifyRoom(room, actor);
+		await this.enforceCanModifyRoom(store, room, actor);
 
 		const previous: IAbacAttributeDefinition[] = room.abacAttributes || [];
 		const exists = previous.some((a) => a.key === key);
@@ -650,9 +664,9 @@ export class AbacService extends ServiceClass implements IAbacService {
 		const room = await getAbacRoom(rid);
 		const store = await this.resolveAttributeStore();
 
-		await store.assertCanModifyRoom(room, actor);
+		await this.enforceCanModifyRoom(store, room, actor);
 
-		await store.validateAssignable([{ key, values }], actor);
+		await this.enforceStoreValidation(store, [{ key, values }], actor);
 
 		const previous: IAbacAttributeDefinition[] = room.abacAttributes || [];
 		if (previous.some((a) => a.key === key)) {
@@ -679,9 +693,9 @@ export class AbacService extends ServiceClass implements IAbacService {
 		const room = await getAbacRoom(rid);
 		const store = await this.resolveAttributeStore();
 
-		await store.assertCanModifyRoom(room, actor);
+		await this.enforceCanModifyRoom(store, room, actor);
 
-		await store.validateAssignable([{ key, values }], actor);
+		await this.enforceStoreValidation(store, [{ key, values }], actor);
 
 		const exists = room?.abacAttributes?.find((a) => a.key === key);
 

--- a/ee/packages/abac/src/service.spec.ts
+++ b/ee/packages/abac/src/service.spec.ts
@@ -5,6 +5,7 @@ import { LocalAttributeStore, VirtruAttributeStore } from './store';
 
 const mockSettingsGet = jest.fn();
 const mockHasModule = jest.fn();
+const mockHasPermission = jest.fn();
 
 jest.mock('./store', () => {
 	const { ensureAttributeDefinitionsExist } = jest.requireActual('./helper');
@@ -119,6 +120,9 @@ jest.mock('@rocket.chat/core-services', () => {
 		},
 		License: {
 			hasModule: (...args: any[]) => mockHasModule(...args),
+		},
+		Authorization: {
+			hasPermission: (...args: any[]) => mockHasPermission(...args),
 		},
 	};
 });
@@ -1080,6 +1084,31 @@ describe('AbacService (unit)', () => {
 
 				expect(store.assertCanModifyRoom).toHaveBeenCalledTimes(1);
 				noMutation();
+			});
+
+			it('skips assertCanModifyRoom and validateAssignable when the actor has the bypass permission', async () => {
+				const store = makeStore();
+				store.assertCanModifyRoom.mockRejectedValue(new Error('should-not-be-called'));
+				store.validateAssignable.mockRejectedValue(new Error('should-not-be-called'));
+				(service as any).attributeStores.local.store = store;
+				mockHasPermission.mockResolvedValue(true);
+
+				await expect(invoke(method)).resolves.toBeUndefined();
+
+				expect(mockHasPermission).toHaveBeenCalledWith(fakeActor._id, 'bypass-abac-store-validation');
+				expect(store.assertCanModifyRoom).not.toHaveBeenCalled();
+				expect(store.validateAssignable).not.toHaveBeenCalled();
+			});
+
+			it('enforces both store guards when the actor lacks the bypass permission', async () => {
+				const store = makeStore();
+				(service as any).attributeStores.local.store = store;
+				mockHasPermission.mockResolvedValue(false);
+
+				await expect(invoke(method)).resolves.toBeUndefined();
+
+				expect(store.assertCanModifyRoom).toHaveBeenCalledTimes(1);
+				expect(store.validateAssignable).toHaveBeenCalledTimes(1);
 			});
 		});
 

--- a/ee/packages/abac/src/user-auto-removal.spec.ts
+++ b/ee/packages/abac/src/user-auto-removal.spec.ts
@@ -23,6 +23,9 @@ jest.mock('@rocket.chat/core-services', () => ({
 	License: {
 		hasModule: async () => true,
 	},
+	Authorization: {
+		hasPermission: async () => false,
+	},
 	MeteorError: class extends Error {},
 	isMeteorError: () => false,
 }));

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -109,6 +109,8 @@
   "manage-abac-admin-rooms_description": "Permission to view rooms and assign or remove ABAC attributes on them",
   "view-abac-admin-audit": "View ABAC audit log",
   "view-abac-admin-audit_description": "Permission to view the ABAC audit log",
+  "bypass-abac-store-validation": "Bypass ABAC store validation",
+  "bypass-abac-store-validation_description": "Permission to save or edit ABAC attributes without validating them against the attribute store",
   "abac_removed_user_from_the_room": "was removed by ABAC",
   "ABAC_No_attributes": "No Attributes",
   "ABAC_No_attributes_description": "Create custom characteristics to determine who can access a room.",


### PR DESCRIPTION
## Summary

Adds a new permission, `bypass-abac-store-validation`, that lets a holder save or edit ABAC room attributes without the attribute store's checks.

When the actor holds the permission, both store guards are skipped on every save/edit/remove path:
- `assertCanModifyRoom` — resource-level "may I modify this room?" auth (PDP decision on the room's current attributes).
- `validateAssignable` — entitlement ownership of the values being assigned.

Seeded with an empty `roles` array, so **nobody holds it by default**.

## Changes
- `apps/meteor/ee/server/lib/abac/index.ts` — seed the permission (`roles: []`).
- `packages/i18n/src/locales/en.i18n.json` — permission label + description.
- `ee/packages/abac/src/index.ts` — `enforceCanModifyRoom` / `enforceStoreValidation` helpers gate both store checks behind the permission; wired into all 5 edit paths (set / update / add / replace / remove).
- Unit tests (`service.spec.ts`, `user-auto-removal.spec.ts`) — bypass-skips-both vs enforce-both across the 4 write methods; added `Authorization` mock.
- API tests (`tests/end-to-end/api/abac.ts`, virtru store) — bypass skips `validateAssignable` (assigns a non-entitled value → 200) and `assertCanModifyRoom` (edits a PDP-denied room → 200).

## Testing
- Unit: 288/288 pass, `tsc` clean, eslint clean.
- API e2e: requires running meteor + virtru mock-server (`IS_EE`-gated); not executed locally.

Targets `feat/abac-virtru-attribute-store`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `bypass-abac-store-validation` permission for modifying ABAC attributes, with localized labels and descriptions.

* **Tests**
  * Added test coverage for ABAC validation bypass functionality, including permission assignment verification and attribute modification scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40738?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->