### PR TITLE
regression: Floating date bubble displaying wrong date

### DIFF
--- a/apps/meteor/client/views/room/MessageList/MessageList.tsx
+++ b/apps/meteor/client/views/room/MessageList/MessageList.tsx
@@ -42,7 +42,7 @@ type MessageListProps = {
 	setUnreadCount: Dispatch<SetStateAction<number>>;
 	setLastMessageDate: Dispatch<SetStateAction<Date | undefined>>;
 	debouncedClearNewMessagesOnScroll: () => void;
-	handleDateScroll: (topMessage: IMessage | undefined) => void;
+	handleDateScroll: (topMessage: IMessage | undefined, offset: number) => void;
 	setShouldJumpToBottom: Dispatch<SetStateAction<boolean>>;
 	debouncedMessageRead: () => void;
 };
@@ -253,7 +253,7 @@ export const MessageList = function MessageList({
 						const handle = virtualizerRef.current;
 						const topMessage = handle ? messages[handle.findItemIndex(handle.scrollOffset) - (canPreview ? 1 : 0)] : undefined;
 						handleTopVisibleMessage(topMessage);
-						handleDateScroll(topMessage);
+						handleDateScroll(topMessage, offset);
 						debouncedMessageRead();
 					}}
 				>

--- a/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.tsx
@@ -195,7 +195,7 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 							isAtBottom.current = offset - handle.scrollSize + handle.viewportSize >= -20;
 
 							const topMessage = items[handle.findItemIndex(handle.scrollOffset)];
-							handleDateScroll(topMessage);
+							handleDateScroll(topMessage, offset);
 						}}
 					>
 						{loading ? (

--- a/apps/meteor/client/views/room/hooks/useDateScroll.ts
+++ b/apps/meteor/client/views/room/hooks/useDateScroll.ts
@@ -62,7 +62,8 @@ export const useDateScroll = (margin = 8): useDateScrollReturn => {
 				// Some dividers might be kept in the DOM if the "new day" message has a file attached
 				// So we check if they are actually visible to avoid showing old dates in the bubble
 				// We also need the parent since it has the actual offset inside the scroll container
-				const parentSafeOffset = divider.parentElement?.offsetTop ? divider.parentElement.offsetTop + DATE_DIVIDER_VISIBILITY_THRESHOLD : 0;
+				const parentOffsetTop = divider.parentElement?.offsetTop;
+				const parentSafeOffset = parentOffsetTop !== undefined ? parentOffsetTop + DATE_DIVIDER_VISIBILITY_THRESHOLD : 0;
 
 				// Sanitize elements
 				if (!divider.dataset.id || parentSafeOffset < offset) {

--- a/apps/meteor/client/views/room/hooks/useDateScroll.ts
+++ b/apps/meteor/client/views/room/hooks/useDateScroll.ts
@@ -7,7 +7,7 @@ import { useRef, useState } from 'react';
 import { useDateListController } from '../providers/DateListProvider';
 
 type useDateScrollReturn = {
-	handleDateScroll: (topMessage: IMessage | undefined) => void;
+	handleDateScroll: (topMessage: IMessage | undefined, offset: number) => void;
 	bubbleRef: MutableRefObject<HTMLElement | null>;
 	listStyle?: ReturnType<typeof css>;
 } & BubbleDateProps;
@@ -18,6 +18,10 @@ export type BubbleDateProps = {
 	showBubble: boolean;
 	bubbleDateStyle?: CSSProperties;
 };
+
+// The threshold in pixels to consider a date divider as "visible" when scrolling.
+// The divider being a few pixels above the top of the viewport is safe, as it is always contained inside a message
+const DATE_DIVIDER_VISIBILITY_THRESHOLD = 100;
 
 export const useDateScroll = (margin = 8): useDateScrollReturn => {
 	const [bubbleDate, setBubbleDate] = useSafely(
@@ -43,7 +47,7 @@ export const useDateScroll = (margin = 8): useDateScrollReturn => {
 	const hideBubbleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	const handleDateScroll = useDebouncedCallback(
-		(topMessage: IMessage | undefined) => {
+		(topMessage: IMessage | undefined, offset: number) => {
 			if (hideBubbleTimeoutRef.current) {
 				clearTimeout(hideBubbleTimeoutRef.current);
 				hideBubbleTimeoutRef.current = null;
@@ -54,12 +58,17 @@ export const useDateScroll = (margin = 8): useDateScrollReturn => {
 			type Matched = [string, HTMLElement | undefined, { [key: string]: string | number }?] | [];
 			// Gets the first non visible message date and sets the bubble date to it
 			let matched: Matched = [...list].reduce<Matched>((ret, divider) => {
+				const { top, height } = divider.getBoundingClientRect();
+				// Some dividers might be kept in the DOM if the "new day" message has a file attached
+				// So we check if they are actually visible to avoid showing old dates in the bubble
+				// We also need the parent since it has the actual offset inside the scroll container
+				const parentSafeOffset = divider.parentElement?.offsetTop ? divider.parentElement.offsetTop + DATE_DIVIDER_VISIBILITY_THRESHOLD : 0;
+
 				// Sanitize elements
-				if (!divider.dataset.id) {
+				if (!divider.dataset.id || parentSafeOffset < offset) {
 					return ret;
 				}
 
-				const { top, height } = divider.getBoundingClientRect();
 				const { id } = divider.dataset;
 
 				// if the bubble if between the divider and the top, position it at the top of the divider


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
This was a tricky one to debug, as there wasn't much context on why it happened. A huge thanks for @cardoso for the work on https://github.com/RocketChat/Rocket.Chat/pull/38200, it allowed debugging using a real server where the issue was found (open.rocket.chat), and if it weren't for that I don't think I'd have been able to patch this.

The issue is as follows:
The message bubble has 2 possibilities for retrieving the date: It can either find a Date Divider (which self-registers by using `DateListProvider`, and get the information from it's dataset, or it relies on the topmost visible message if no divider matches the filtering.

The issue started happening because of a fix requested on the original PR, which required that some messages to be kept on the DOM (Virtualizer's `keepMounted` array prop) in order to avoid files contained inside the message to be downloaded every time it mounted due to scrolling.

The logic on the bubble date gives preference to getting the date from the date dividers, and in doing so relied on the virtualization unmounting the elementing and removing it from the list. Since the date divider is a child of the messages, if the parent message of the divider contained a file, it would never unmount the divider, thus never unregistering from the divider list, and being used as the date source since it would be the "oldest" divider on the list.

In order to fix it we now also check the divider's parent visibility relative to the scroll container. This way any divider that should not be visible will be ignored.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Root cause:  https://github.com/RocketChat/Rocket.Chat/issues/40105
[CORE-2248](https://rocketchat.atlassian.net/browse/CORE-2248)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
This one is tricky. We need to insert messages with old dates in order to reproduce.

- Send ~50 messages with an old date (like 3 days ago)
- Send a single (or more) file message(s) with a newer date (2 days ago) (This message needs to be exactly the next message after the divider, or else it won't break)
- Send a bunch more messages in that same date (just to create some padding)
- Send a bunch of messages (~50 to ensure the older ones are out of the screen) in the current date
- Refresh the room and scroll back until you load the message with the file
- Scroll back down

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-2248]: https://rocketchat.atlassian.net/browse/CORE-2248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date divider visibility and accurate positioning when scrolling through message lists
  * Enhanced scroll offset tracking for more reliable date bubble placement in conversations
  * Refined date divider detection logic to better handle visibility states and filter invisible dividers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat/pull/40739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->