### PR TITLE
test: re-enable star message permission e2e test

### DIFF
--- a/apps/meteor/tests/e2e/permissions.spec.ts
+++ b/apps/meteor/tests/e2e/permissions.spec.ts
@@ -100,9 +100,7 @@ test.describe.serial('permissions', () => {
 		});
 	});
 
-	// FIXME: Wrong behavior in Rocket.chat, currently it shows the button
-	// and after a click a "not allowed" alert pops up
-	test.describe.skip('Star message', () => {
+	test.describe.serial('Star message', () => {
 		test.beforeAll(async ({ api }) => {
 			const statusCode = (await api.post('/settings/Message_AllowStarring', { value: false })).status();
 


### PR DESCRIPTION
## Description

Re-enables the E2E test for the "Star message" permission in `permissions.spec.ts`.

The test verifies that when `Message_AllowStarring` is disabled, the "Star Message" option is not visible in the message actions menu.

## Changes

* Re-enabled the existing Star Message permission E2E test.
* No production code changes.
* No changes to application behavior.

## Testing

* Reviewed the test implementation and confirmed it follows the same pattern as the Edit, Delete, and Pin permission tests.
* CI will validate the test in the official Rocket.Chat environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Star message functionality has been re-enabled and is now fully operational after previous issues were resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->