### PR TITLE
fix: pass tshow param when editing thread messages

### DIFF
--- a/apps/meteor/client/lib/chats/data.ts
+++ b/apps/meteor/client/lib/chats/data.ts
@@ -187,6 +187,7 @@ export const createDataAPI = ({ rid, tmid }: { rid: IRoom['_id']; tmid: IMessage
 					roomId: message.rid,
 					customFields: message.customFields,
 					text: message.msg,
+					tshow: message.tshow
 				};
 
 		await sdk.rest.post('/v1/chat.update', params);


### PR DESCRIPTION
## Proposed changes
When editing a thread message, the `tshow` property was not being passed 
to the API call in `updateMessage`. This meant the "also send to channel" 
checkbox had no effect during message edits — the property was correctly 
set on the message object by `composeMessage`, but dropped before reaching 
the API.

Added `tshow: message.tshow` to the params object in the non-encrypted 
branch of `updateMessage` in `data.ts`.

## Issue(s)
Closes #40745

## Steps to test or reproduce
1. Open a thread in Rocket.Chat
2. Send a thread message with "also send to channel" checked
3. Edit that message
4. Verify the edited message still appears in the main channel



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message update functionality to include enhanced parameter handling for thread visibility, ensuring more consistent and reliable message management across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->