### PR TITLE
regression: fix message list scroll jump when closing fullscreen video

### DIFF
--- a/apps/meteor/client/views/room/MessageList/MessageList.tsx
+++ b/apps/meteor/client/views/room/MessageList/MessageList.tsx
@@ -14,6 +14,7 @@ import { useRoomSubscription } from '../contexts/RoomContext';
 import { useFirstUnreadMessageId } from '../hooks/useFirstUnreadMessageId';
 import { SelectedMessagesProvider } from '../providers/SelectedMessagesProvider';
 import { useMessages } from './hooks/useMessages';
+import { useScrollAnchor } from './hooks/useScrollAnchor';
 import useTryToJumpToMessage from './hooks/useTryToJumpToMessage';
 import { isMessageSequential } from './lib/isMessageSequential';
 import MessageListProvider from './providers/MessageListProvider';
@@ -85,6 +86,9 @@ export const MessageList = function MessageList({
 
 	const handlePrepend = useCallback(
 		(offset: number) => {
+			if (!isRoomInitialized.current) {
+				return;
+			}
 			// If the offset is less than 200, it means the user is reaching the top of the list,
 			// so the prepend need to be enabled for smooth scrolling,
 			// if the prepend is enabled when a new message is added, the list will misalign.
@@ -187,6 +191,12 @@ export const MessageList = function MessageList({
 
 	const storeScrollPosition = useStoreScrollPosition({ rid, isAtBottom, virtualizerRef });
 
+	const { updateTopAnchor } = useScrollAnchor({
+		virtualizerRef,
+		suppress: isJumpingToMessage,
+		pinToBottom: shouldJumpToBottom,
+	});
+
 	const subscription = useRoomSubscription();
 	const showUserAvatar = !!useUserPreference<boolean>('displayAvatars');
 	const messageGroupingPeriod = useSetting('Message_GroupingPeriod', 300);
@@ -250,8 +260,8 @@ export const MessageList = function MessageList({
 						storeScrollPosition();
 						debouncedClearNewMessagesOnScroll();
 
-						const handle = virtualizerRef.current;
-						const topMessage = handle ? messages[handle.findItemIndex(handle.scrollOffset) - (canPreview ? 1 : 0)] : undefined;
+						const topItemIndex = updateTopAnchor();
+						const topMessage = messages[topItemIndex - (canPreview ? 1 : 0)];
 						handleTopVisibleMessage(topMessage);
 						handleDateScroll(topMessage, offset);
 						debouncedMessageRead();

--- a/apps/meteor/client/views/room/MessageList/hooks/useScrollAnchor.spec.ts
+++ b/apps/meteor/client/views/room/MessageList/hooks/useScrollAnchor.spec.ts
@@ -1,0 +1,155 @@
+import { act, renderHook } from '@testing-library/react';
+import type { MutableRefObject } from 'react';
+import type { VirtualizerHandle } from 'virtua';
+
+import { useScrollAnchor } from './useScrollAnchor';
+
+describe('useScrollAnchor', () => {
+	describe('hook integration', () => {
+		type MockHandle = {
+			scrollOffset: number;
+			scrollSize: number;
+			viewportSize: number;
+			findItemIndex: jest.Mock;
+			getItemOffset: jest.Mock;
+			scrollTo: jest.Mock;
+			scrollToIndex: jest.Mock;
+		};
+
+		const makeHandle = (over: Partial<MockHandle> = {}): MockHandle => ({
+			scrollOffset: 700,
+			scrollSize: 1000,
+			viewportSize: 300,
+			findItemIndex: jest.fn(() => 7),
+			getItemOffset: jest.fn(() => 700),
+			scrollTo: jest.fn(),
+			scrollToIndex: jest.fn(),
+			...over,
+		});
+
+		const refTo = (h: MockHandle): MutableRefObject<VirtualizerHandle | null> => ({ current: h as unknown as VirtualizerHandle });
+
+		// Step the rAF loop one tick at a time; the next rAF the tick re-schedules
+		// stays queued for the following call.
+		const tick = () => act(() => jest.advanceTimersToNextTimer(1));
+
+		beforeEach(() => {
+			jest.useFakeTimers();
+		});
+
+		afterEach(() => {
+			jest.useRealTimers();
+		});
+
+		it('captures at-bottom on a settled frame and pins to bottom on a scrollSize change', () => {
+			const handle = makeHandle({ scrollOffset: 700, scrollSize: 1000, viewportSize: 300 });
+			renderHook(() => useScrollAnchor({ virtualizerRef: refTo(handle), suppress: false }));
+
+			tick();
+			tick();
+			handle.scrollSize = 1500;
+			tick();
+
+			expect(handle.scrollToIndex).toHaveBeenCalledWith(7, { align: 'end' });
+		});
+
+		it('pins to bottom on a viewport-height change even when scrollSize is unchanged', () => {
+			// A pure height resize changes viewportSize but not scrollSize; the restore must
+			// still fire, or the newest message drifts below the fold.
+			const handle = makeHandle({ scrollOffset: 700, scrollSize: 1000, viewportSize: 300 });
+			renderHook(() => useScrollAnchor({ virtualizerRef: refTo(handle), suppress: false }));
+
+			tick();
+			tick();
+			handle.viewportSize = 200;
+			tick();
+
+			expect(handle.scrollToIndex).toHaveBeenCalledWith(7, { align: 'end' });
+		});
+
+		it('pins to bottom on a change when pinToBottom is set, even if not at bottom', () => {
+			// e.g. just sent a message (shouldJumpToBottom): a late-loading video grows while
+			// the user is being scrolled to the bottom; we must follow it down, not top-anchor.
+			const handle = makeHandle({ scrollOffset: 200, scrollSize: 1000, viewportSize: 300 });
+			renderHook(() => useScrollAnchor({ virtualizerRef: refTo(handle), suppress: false, pinToBottom: true }));
+
+			tick();
+			tick();
+			handle.scrollSize = 1500;
+			tick();
+
+			expect(handle.scrollToIndex).toHaveBeenCalledWith(7, { align: 'end' });
+		});
+
+		it('captures not-at-bottom on a settled frame and restores the top anchor on a change', () => {
+			const handle = makeHandle({ scrollOffset: 723.5, scrollSize: 5000, viewportSize: 300, getItemOffset: jest.fn(() => 700) });
+			const { result } = renderHook(() => useScrollAnchor({ virtualizerRef: refTo(handle), suppress: false }));
+
+			act(() => {
+				result.current.updateTopAnchor();
+			});
+
+			tick();
+			tick();
+			handle.scrollSize = 5100;
+			tick();
+
+			expect(handle.scrollToIndex).toHaveBeenCalledWith(7, { align: 'start', offset: 23.5 });
+		});
+
+		it('freezes at-bottom through a change instead of recomputing from mid-change geometry', () => {
+			// A resize re-wraps content and grows scrollSize before scrollTop
+			// follows, so live geometry reads "not at bottom" exactly when it changes. The
+			// captured (settled) at-bottom must be held through the change so we still pin.
+			const handle = makeHandle({ scrollOffset: 200, scrollSize: 1000, viewportSize: 300 });
+			renderHook(() => useScrollAnchor({ virtualizerRef: refTo(handle), suppress: false }));
+
+			tick();
+			tick();
+			handle.scrollOffset = 700;
+			tick();
+
+			handle.scrollSize = 1500;
+			tick();
+
+			expect(handle.scrollToIndex).toHaveBeenCalledWith(7, { align: 'end' });
+		});
+
+		it('skips the decision while suppress is true and resumes when it flips false', () => {
+			const handle = makeHandle({ scrollOffset: 700, scrollSize: 1000, viewportSize: 300 });
+			const virtualizerRef = refTo(handle);
+			const { rerender } = renderHook(({ suppress }) => useScrollAnchor({ virtualizerRef, suppress }), {
+				initialProps: { suppress: true },
+			});
+
+			tick();
+			tick();
+			handle.scrollSize = 1500;
+			tick();
+
+			expect(handle.scrollToIndex).not.toHaveBeenCalled();
+
+			rerender({ suppress: false });
+			handle.scrollSize = 1800;
+			tick();
+
+			expect(handle.scrollToIndex).toHaveBeenCalledWith(7, { align: 'end' });
+		});
+
+		it('cancels the rAF loop on unmount', () => {
+			const handle = makeHandle();
+			const { unmount } = renderHook(() => useScrollAnchor({ virtualizerRef: refTo(handle), suppress: false }));
+
+			tick();
+			unmount();
+
+			handle.scrollSize = 9999;
+			act(() => {
+				jest.runOnlyPendingTimers();
+			});
+
+			expect(handle.scrollTo).not.toHaveBeenCalled();
+			expect(handle.scrollToIndex).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/apps/meteor/client/views/room/MessageList/hooks/useScrollAnchor.ts
+++ b/apps/meteor/client/views/room/MessageList/hooks/useScrollAnchor.ts
@@ -1,0 +1,79 @@
+import type { MutableRefObject } from 'react';
+import { useEffect, useRef } from 'react';
+import type { VirtualizerHandle } from 'virtua';
+
+type UseScrollAnchorProps = {
+	virtualizerRef: MutableRefObject<VirtualizerHandle | null>;
+	suppress: boolean;
+	pinToBottom?: boolean;
+};
+
+/**
+ * Virtua-aware scroll anchoring: on a content- or viewport-size change, pins to the
+ * bottom if the user was there, else holds the top-visible item. At-bottom is captured
+ * only on settled frames — virtua's sizes swing mid-resize and would falsely read "at
+ * bottom". Callers must call `updateTopAnchor` from `onScroll`.
+ *
+ * This specifically fixes the case where a video exits native browser fullscreen:
+ * the browser applies/removes :fullscreen CSS (position: fixed; width/height: 100%),
+ * causing the item's ResizeObserver to fire and virtua to adjust scroll incorrectly.
+ */
+export const useScrollAnchor = ({ virtualizerRef, suppress, pinToBottom = false }: UseScrollAnchorProps) => {
+	const topAnchorRef = useRef<{ index: number; subOffset: number }>({ index: 0, subOffset: 0 });
+	const wasAtBottomRef = useRef<boolean | null>(null);
+	const suppressRef = useRef(suppress);
+	suppressRef.current = suppress;
+	const pinToBottomRef = useRef(pinToBottom);
+	pinToBottomRef.current = pinToBottom;
+
+	useEffect(() => {
+		let lastScrollSize: number | null = null;
+		let lastViewportSize: number | null = null;
+		let rafId: number;
+
+		const tick = () => {
+			const handle = virtualizerRef.current;
+			if (handle) {
+				if (lastScrollSize !== null) {
+					const changed = handle.scrollSize !== lastScrollSize || handle.viewportSize !== lastViewportSize;
+					if (!changed) {
+						wasAtBottomRef.current = handle.scrollOffset >= Math.floor(handle.scrollSize - handle.viewportSize);
+					} else if (!suppressRef.current) {
+						if (pinToBottomRef.current || wasAtBottomRef.current === true) {
+							handle.scrollToIndex(Math.max(0, handle.findItemIndex(handle.scrollSize)), { align: 'end' });
+						} else if (wasAtBottomRef.current === false) {
+							const { index, subOffset } = topAnchorRef.current;
+							handle.scrollToIndex(index, { align: 'start', offset: subOffset });
+						}
+					}
+				}
+
+				lastScrollSize = handle.scrollSize;
+				lastViewportSize = handle.viewportSize;
+			}
+			rafId = requestAnimationFrame(tick);
+		};
+
+		rafId = requestAnimationFrame(tick);
+
+		return () => cancelAnimationFrame(rafId);
+	}, [virtualizerRef]);
+
+	const updateTopAnchor = (): number => {
+		const handle = virtualizerRef.current;
+		if (!handle) {
+			return 0;
+		}
+		const index = handle.findItemIndex(handle.scrollOffset);
+		if (index < 0) {
+			return 0;
+		}
+		topAnchorRef.current = {
+			index,
+			subOffset: handle.scrollOffset - handle.getItemOffset(index),
+		};
+		return index;
+	};
+
+	return { updateTopAnchor };
+};


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

When a `<video>` message is opened in native browser fullscreen and then closed, the message list scrolls upward unexpectedly. Reproducible consistently on Web and Desktop (Electron).

**Root cause:** 8.5.0 virtualized the message list with `virtua`'s `VList`, which replaces the browser's native CSS scroll anchoring. When a video enters/exits native fullscreen the browser applies/removes `:fullscreen` CSS (`position: fixed; width: 100%; height: 100%`), changing the element's layout dimensions. VList's `ResizeObserver` detects this and adjusts `scrollTop` to maintain its internal state — causing the list to scroll upward when the video shrinks back to its in-list size.

**Fix:** Port `useScrollAnchor` from `develop` (commits `f9a16db`, `43b3919`, `1f54cad`, `dabccf9`) to `release-8.5.0`. The hook runs a `requestAnimationFrame` loop that:

- Captures the "at-bottom" state only on **settled frames** (sizes stable between ticks), avoiding false reads mid-resize
- On a `scrollSize` or `viewportSize` change: pins to the last item if the user was at the bottom, otherwise restores the previously top-visible item by `index + subOffset`
- Starts with `wasAtBottom = null` so it takes **no action before the first settled frame**, preventing clobbering of the stored scroll position when switching back to a channel
- Is suppressed during jump-to-message to avoid fighting the imperative scroll

Also includes the `handlePrepend` initialization guard from `dabccf9` to prevent premature `isPrepend` flag activation before the room is fully initialized.

7 unit tests cover: at-bottom pinning, viewport resize, `pinToBottom` prop, top-anchor restore, the frozen-at-bottom regression case, `suppress` toggle, and rAF cleanup on unmount.

## Issue(s)

<!-- add issue reference if available -->

## Steps to test or reproduce

1. Open a room that has a video message
2. Note your current scroll position (ideally mid-list, not at the very bottom)
3. Click the video's native fullscreen button
4. Exit fullscreen (Escape or the browser's exit button)
5. **Before:** message list scrolls up to an incorrect position
6. **After:** message list stays exactly where it was

Also verify no regressions:
- Scroll position is restored when switching back to a channel you had scrolled mid-way
- New messages at the bottom still auto-scroll when you are at the bottom
- Loading older messages (scrolling to the top) does not jump the list
- Jump-to-message links still scroll to the correct message

## Further comments

This is a direct backport of the scroll anchor work already merged into `develop`. The `develop` branch carries additional scroll-restoration improvements (`8d3445c`, `dabccf9`) that go beyond this fix and are intentionally left out to keep the release change minimal.