### PR TITLE
test: add API coverage for users.register settings flows

### DIFF
--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -833,9 +833,11 @@ describe('[Users]', () => {
 	describe('[/users.register]', () => {
 		const email = `email@email${Date.now()}.com`;
 		const username = `myusername${Date.now()}`;
-		let user: IUser;
+		const users: IUser[] = [];
 
-		after(async () => deleteUser(user));
+		after(async () => {
+			await Promise.all(users.map((user) => deleteUser(user)));
+		});
 
 		it('should register new user', (done) => {
 			void request
@@ -853,7 +855,7 @@ describe('[Users]', () => {
 					expect(res.body).to.have.nested.property('user.username', username);
 					expect(res.body).to.have.nested.property('user.active', true);
 					expect(res.body).to.have.nested.property('user.name', 'name');
-					user = res.body.user;
+					users.push(res.body.user);
 				})
 				.end(done);
 		});
@@ -928,6 +930,314 @@ describe('[Users]', () => {
 					expect(res.body).to.have.property('error').and.to.be.equal('Logged in users can not register again.');
 				})
 				.end(done);
+		});
+
+		describe('registration form setting', () => {
+			let previousRegistrationForm: Awaited<ReturnType<typeof getSettingValueById>>;
+
+			beforeEach(async () => {
+				previousRegistrationForm = await getSettingValueById('Accounts_RegistrationForm');
+			});
+
+			afterEach(async () => {
+				await updateSetting('Accounts_RegistrationForm', previousRegistrationForm);
+			});
+
+			it('should reject registration when public registration is disabled', async () => {
+				await updateSetting('Accounts_RegistrationForm', 'Disabled');
+
+				const username = `disabledRegistration_${Date.now()}`;
+				const email = `${username}@rocket.chat`;
+
+				await request
+					.post(api('users.register'))
+					.send({
+						email,
+						name: username,
+						username,
+						pass: 'P@ssw0rd1234.!',
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(400)
+					.expect((res: Response) => {
+						expect(res.body).to.have.property('success', false);
+						expect(res.body).to.have.property('errorType', 'error-user-registration-disabled');
+					});
+
+				const user = await getUserByUsername(username);
+				expect(user).to.be.undefined;
+			});
+		});
+
+		describe('secret URL registration', () => {
+			let previousRegistrationForm: Awaited<ReturnType<typeof getSettingValueById>>;
+			let previousRegistrationFormSecretURL: Awaited<ReturnType<typeof getSettingValueById>>;
+
+			beforeEach(async () => {
+				[previousRegistrationForm, previousRegistrationFormSecretURL] = await Promise.all([
+					getSettingValueById('Accounts_RegistrationForm'),
+					getSettingValueById('Accounts_RegistrationForm_SecretURL'),
+				]);
+			});
+
+			afterEach(async () => {
+				await Promise.all([
+					updateSetting('Accounts_RegistrationForm', previousRegistrationForm),
+					updateSetting('Accounts_RegistrationForm_SecretURL', previousRegistrationFormSecretURL),
+				]);
+			});
+
+			it('should reject registration without a secret when registration is limited to a secret URL', async () => {
+				await Promise.all([
+					updateSetting('Accounts_RegistrationForm', 'Secret URL'),
+					updateSetting('Accounts_RegistrationForm_SecretURL', 'valid-secret'),
+				]);
+
+				const username = `missingSecret_${Date.now()}`;
+				const email = `${username}@rocket.chat`;
+
+				await request
+					.post(api('users.register'))
+					.send({
+						email,
+						name: username,
+						username,
+						pass: 'P@ssw0rd1234.!',
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(400)
+					.expect((res: Response) => {
+						expect(res.body).to.have.property('success', false);
+						expect(res.body).to.have.property('errorType', 'error-user-registration-secret');
+					});
+
+				const user = await getUserByUsername(username);
+				expect(user).to.be.undefined;
+			});
+
+			it('should reject registration with an invalid secret when registration is limited to a secret URL', async () => {
+				await Promise.all([
+					updateSetting('Accounts_RegistrationForm', 'Secret URL'),
+					updateSetting('Accounts_RegistrationForm_SecretURL', 'valid-secret'),
+				]);
+
+				const username = `invalidSecret_${Date.now()}`;
+				const email = `${username}@rocket.chat`;
+
+				await request
+					.post(api('users.register'))
+					.send({
+						email,
+						name: username,
+						username,
+						pass: 'P@ssw0rd1234.!',
+						secret: 'invalid-secret',
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(400)
+					.expect((res: Response) => {
+						expect(res.body).to.have.property('success', false);
+						expect(res.body).to.have.property('errorType', 'error-user-registration-secret');
+					});
+
+				const user = await getUserByUsername(username);
+				expect(user).to.be.undefined;
+			});
+
+			it('should register a user with a valid secret when registration is limited to a secret URL', async () => {
+				await Promise.all([
+					updateSetting('Accounts_RegistrationForm', 'Secret URL'),
+					updateSetting('Accounts_RegistrationForm_SecretURL', 'valid-secret'),
+				]);
+
+				const username = `validSecret_${Date.now()}`;
+				const email = `${username}@rocket.chat`;
+
+				await request
+					.post(api('users.register'))
+					.send({
+						email,
+						name: username,
+						username,
+						pass: 'P@ssw0rd1234.!',
+						secret: 'valid-secret',
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res: Response) => {
+						expect(res.body).to.have.property('success', true);
+						expect(res.body).to.have.nested.property('user.username', username);
+						users.push(res.body.user);
+					});
+			});
+		});
+
+		describe('manual approval', () => {
+			let previousManuallyApproveNewUsers: Awaited<ReturnType<typeof getSettingValueById>>;
+
+			beforeEach(async () => {
+				previousManuallyApproveNewUsers = await getSettingValueById('Accounts_ManuallyApproveNewUsers');
+			});
+
+			afterEach(async () => {
+				await updateSetting('Accounts_ManuallyApproveNewUsers', previousManuallyApproveNewUsers);
+			});
+
+			it('should register an inactive user and persist the reason when manual approval is enabled', async () => {
+				await updateSetting('Accounts_ManuallyApproveNewUsers', true);
+
+				const username = `manualApproval_${Date.now()}`;
+				const email = `${username}@rocket.chat`;
+				const reason = 'I need access to the workspace';
+
+				await request
+					.post(api('users.register'))
+					.send({
+						email,
+						name: username,
+						username,
+						pass: 'P@ssw0rd1234.!',
+						reason,
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res: Response) => {
+						expect(res.body).to.have.property('success', true);
+						expect(res.body).to.have.nested.property('user.username', username);
+						expect(res.body).to.have.nested.property('user.active', false);
+						users.push(res.body.user);
+					});
+
+				const user = await getUserByUsername<IUser>(username);
+				expect(user).to.have.property('reason', reason);
+			});
+		});
+
+		describe('allowed email domains', () => {
+			let previousAllowedDomainsList: Awaited<ReturnType<typeof getSettingValueById>>;
+
+			beforeEach(async () => {
+				previousAllowedDomainsList = await getSettingValueById('Accounts_AllowedDomainsList');
+			});
+
+			afterEach(async () => {
+				await updateSetting('Accounts_AllowedDomainsList', previousAllowedDomainsList);
+			});
+
+			it('should reject registration when the email domain is not allowed', async () => {
+				await updateSetting('Accounts_AllowedDomainsList', 'rocket.chat');
+
+				const username = `invalidDomain_${Date.now()}`;
+				const email = `${username}@example.com`;
+
+				await request
+					.post(api('users.register'))
+					.send({
+						email,
+						name: username,
+						username,
+						pass: 'P@ssw0rd1234.!',
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(400)
+					.expect((res: Response) => {
+						expect(res.body).to.have.property('success', false);
+						expect(res.body).to.have.property('errorType', 'error-invalid-domain');
+					});
+
+				const user = await getUserByUsername(username);
+				expect(user).to.be.undefined;
+			});
+
+			it('should register a user when the email domain is allowed', async () => {
+				await updateSetting('Accounts_AllowedDomainsList', 'rocket.chat');
+
+				const username = `validDomain_${Date.now()}`;
+				const email = `${username}@rocket.chat`;
+
+				await request
+					.post(api('users.register'))
+					.send({
+						email,
+						name: username,
+						username,
+						pass: 'P@ssw0rd1234.!',
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res: Response) => {
+						expect(res.body).to.have.property('success', true);
+						expect(res.body).to.have.nested.property('user.username', username);
+						users.push(res.body.user);
+					});
+			});
+		});
+
+		describe('custom fields', () => {
+			let previousCustomFields: Awaited<ReturnType<typeof getSettingValueById>>;
+
+			beforeEach(async () => {
+				previousCustomFields = await getSettingValueById('Accounts_CustomFields');
+				await setCustomFields({ customFieldText });
+			});
+
+			afterEach(async () => {
+				await updateSetting('Accounts_CustomFields', previousCustomFields);
+			});
+
+			it('should reject registration when a required custom field is empty', async () => {
+				const username = `missingCustomField_${Date.now()}`;
+				const email = `${username}@rocket.chat`;
+
+				await request
+					.post(api('users.register'))
+					.send({
+						email,
+						name: username,
+						username,
+						pass: 'P@ssw0rd1234.!',
+						customFields: {
+							customFieldText: '',
+						},
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(400)
+					.expect((res: Response) => {
+						expect(res.body).to.have.property('success', false);
+						expect(res.body).to.have.property('errorType', 'error-invalid-body');
+						expect(res.body).to.have.nested.property('body.error', 'error-user-registration-custom-field');
+					});
+
+				const user = await getUserByUsername(username);
+				expect(user).to.be.undefined;
+			});
+
+			it('should save valid custom fields when registering a user', async () => {
+				const username = `validCustomField_${Date.now()}`;
+				const email = `${username}@rocket.chat`;
+
+				await request
+					.post(api('users.register'))
+					.send({
+						email,
+						name: username,
+						username,
+						pass: 'P@ssw0rd1234.!',
+						customFields: {
+							customFieldText: 'success',
+						},
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res: Response) => {
+						expect(res.body).to.have.property('success', true);
+						expect(res.body).to.have.nested.property('user.username', username);
+						users.push(res.body.user);
+					});
+
+				const user = await getUserByUsername<IUser>(username);
+				expect(user).to.have.nested.property('customFields.customFieldText', 'success');
+			});
 		});
 
 		it('should return 400 when body is empty', async () => {

--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -846,7 +846,7 @@ describe('[Users]', () => {
 					email,
 					name: 'name',
 					username,
-					pass: 'P@ssw0rd1234.!',
+					pass: password,
 				})
 				.expect('Content-Type', 'application/json')
 				.expect(200)
@@ -867,7 +867,7 @@ describe('[Users]', () => {
 					email,
 					name: 'name',
 					username: 'test$username<>',
-					pass: 'P@ssw0rd1234.!',
+					pass: password,
 				})
 				.expect('Content-Type', 'application/json')
 				.expect(400)
@@ -885,7 +885,7 @@ describe('[Users]', () => {
 					email,
 					name: 'name',
 					username,
-					pass: 'P@ssw0rd1234.!',
+					pass: password,
 				})
 				.expect('Content-Type', 'application/json')
 				.expect(400)
@@ -902,7 +902,7 @@ describe('[Users]', () => {
 					email,
 					name: '</\\name>',
 					username,
-					pass: 'P@ssw0rd1234.!',
+					pass: password,
 				})
 				.expect('Content-Type', 'application/json')
 				.expect(400)
@@ -921,7 +921,7 @@ describe('[Users]', () => {
 					email: `newuser${Date.now()}@email.com`,
 					name: 'New User',
 					username: `newuser${Date.now()}`,
-					pass: 'P@ssw0rd1234.!',
+					pass: password,
 				})
 				.expect('Content-Type', 'application/json')
 				.expect(400)
@@ -955,7 +955,7 @@ describe('[Users]', () => {
 						email,
 						name: username,
 						username,
-						pass: 'P@ssw0rd1234.!',
+						pass: password,
 					})
 					.expect('Content-Type', 'application/json')
 					.expect(400)
@@ -1002,7 +1002,7 @@ describe('[Users]', () => {
 						email,
 						name: username,
 						username,
-						pass: 'P@ssw0rd1234.!',
+						pass: password,
 					})
 					.expect('Content-Type', 'application/json')
 					.expect(400)
@@ -1025,7 +1025,7 @@ describe('[Users]', () => {
 						email,
 						name: username,
 						username,
-						pass: 'P@ssw0rd1234.!',
+						pass: password,
 						secret: 'invalid-secret',
 					})
 					.expect('Content-Type', 'application/json')
@@ -1049,7 +1049,7 @@ describe('[Users]', () => {
 						email,
 						name: username,
 						username,
-						pass: 'P@ssw0rd1234.!',
+						pass: password,
 						secret: 'valid-secret',
 					})
 					.expect('Content-Type', 'application/json')
@@ -1086,7 +1086,7 @@ describe('[Users]', () => {
 						email,
 						name: username,
 						username,
-						pass: 'P@ssw0rd1234.!',
+						pass: password,
 						reason,
 					})
 					.expect('Content-Type', 'application/json')
@@ -1126,7 +1126,7 @@ describe('[Users]', () => {
 						email,
 						name: username,
 						username,
-						pass: 'P@ssw0rd1234.!',
+						pass: password,
 					})
 					.expect('Content-Type', 'application/json')
 					.expect(400)
@@ -1151,7 +1151,7 @@ describe('[Users]', () => {
 						email,
 						name: username,
 						username,
-						pass: 'P@ssw0rd1234.!',
+						pass: password,
 					})
 					.expect('Content-Type', 'application/json')
 					.expect(200)
@@ -1185,7 +1185,7 @@ describe('[Users]', () => {
 						email,
 						name: username,
 						username,
-						pass: 'P@ssw0rd1234.!',
+						pass: password,
 						customFields: {
 							customFieldText: '',
 						},
@@ -1213,7 +1213,7 @@ describe('[Users]', () => {
 						email,
 						name: username,
 						username,
-						pass: 'P@ssw0rd1234.!',
+						pass: password,
 						customFields: {
 							customFieldText: 'success',
 						},

--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -978,6 +978,11 @@ describe('[Users]', () => {
 					getSettingValueById('Accounts_RegistrationForm'),
 					getSettingValueById('Accounts_RegistrationForm_SecretURL'),
 				]);
+
+				await Promise.all([
+					updateSetting('Accounts_RegistrationForm', 'Secret URL'),
+					updateSetting('Accounts_RegistrationForm_SecretURL', 'valid-secret'),
+				]);
 			});
 
 			afterEach(async () => {
@@ -988,11 +993,6 @@ describe('[Users]', () => {
 			});
 
 			it('should reject registration without a secret when registration is limited to a secret URL', async () => {
-				await Promise.all([
-					updateSetting('Accounts_RegistrationForm', 'Secret URL'),
-					updateSetting('Accounts_RegistrationForm_SecretURL', 'valid-secret'),
-				]);
-
 				const username = `missingSecret_${Date.now()}`;
 				const email = `${username}@rocket.chat`;
 
@@ -1016,11 +1016,6 @@ describe('[Users]', () => {
 			});
 
 			it('should reject registration with an invalid secret when registration is limited to a secret URL', async () => {
-				await Promise.all([
-					updateSetting('Accounts_RegistrationForm', 'Secret URL'),
-					updateSetting('Accounts_RegistrationForm_SecretURL', 'valid-secret'),
-				]);
-
 				const username = `invalidSecret_${Date.now()}`;
 				const email = `${username}@rocket.chat`;
 
@@ -1045,11 +1040,6 @@ describe('[Users]', () => {
 			});
 
 			it('should register a user with a valid secret when registration is limited to a secret URL', async () => {
-				await Promise.all([
-					updateSetting('Accounts_RegistrationForm', 'Secret URL'),
-					updateSetting('Accounts_RegistrationForm_SecretURL', 'valid-secret'),
-				]);
-
 				const username = `validSecret_${Date.now()}`;
 				const email = `${username}@rocket.chat`;
 
@@ -1204,6 +1194,7 @@ describe('[Users]', () => {
 					.expect(400)
 					.expect((res: Response) => {
 						expect(res.body).to.have.property('success', false);
+						// TODO: assert error-user-registration-custom-field directly after users.register formats this Meteor.Error correctly
 						expect(res.body).to.have.property('errorType', 'error-invalid-body');
 						expect(res.body).to.have.nested.property('body.error', 'error-user-registration-custom-field');
 					});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Adds API integration test coverage for POST `/api/v1/users.register settings-driven registration` flows in `apps/meteor/tests/end-to-end/api/users.ts.`

| Setting | Coverage |
|---|---|
| `Accounts_RegistrationForm` | Rejects registration when set to `Disabled` |
| `Accounts_RegistrationForm` + `Accounts_RegistrationForm_SecretURL` | Rejects missing/invalid secret; allows registration with valid secret |
| `Accounts_ManuallyApproveNewUsers` | Creates inactive user and persists `reason` |
| `Accounts_AllowedDomainsList` | Rejects disallowed domain; allows whitelisted domain |
| `Accounts_CustomFields` | Rejects empty required field; saves valid custom field values |

Other changes:
- Refactors cleanup from a single `user` to a `users[]` array so all successfully registered test users are deleted in `after`
- Saves and restores settings in `beforeEach`/`afterEach` to avoid polluting other tests

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[QA-116](https://rocketchat.atlassian.net/browse/QA-116)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
**Known limitation — custom field rejection error format:** The empty required custom field test currently asserts `error-invalid-body` (with the underlying `error-user-registration-custom-field` nested in `body.error`). This is because `users.register` passes the raw `Meteor.Error` to `API.v1.failure(e)`, producing a response that fails schema validation in test mode. A TODO is left to assert `error-user-registration-custom-field` directly once the endpoint formats the error consistently with `users.create`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for user registration: disabled signups, secret-URL restricted flows, manual approval (including stored reason), allowed-email-domain enforcement, and custom field validation/persistence.
  * Improved test cleanup to remove all created users after the suite and standardized password usage across registration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[QA-116]: https://rocketchat.atlassian.net/browse/QA-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ