### PR TITLE
chore: allow parameterless internalError calls

### DIFF
--- a/apps/meteor/app/api/server/ApiClass.ts
+++ b/apps/meteor/app/api/server/ApiClass.ts
@@ -348,6 +348,8 @@ export class APIClass<TBasePath extends string = '', TOperations extends Record<
 
 	public internalError(): InternalError<never>;
 
+	public internalError<T>(msg: T): InternalError<T>;
+
 	public internalError<T>(msg?: T): InternalError<T> {
 		return {
 			statusCode: 500,

--- a/apps/meteor/app/api/server/ApiClass.ts
+++ b/apps/meteor/app/api/server/ApiClass.ts
@@ -346,6 +346,8 @@ export class APIClass<TBasePath extends string = '', TOperations extends Record<
 		};
 	}
 
+	public internalError(): InternalError<never>;
+
 	public internalError<T>(msg?: T): InternalError<T> {
 		return {
 			statusCode: 500,

--- a/apps/meteor/app/api/server/definition.ts
+++ b/apps/meteor/app/api/server/definition.ts
@@ -362,7 +362,7 @@ type Results<TResponse extends TypedOptions['response']> = {
 						: K extends 404
 							? NotFoundResult<InferNon200Result<TResponse[404]>>
 							: K extends ErrorStatusCodes
-								? InternalError<InferNon200Result<TResponse[500]>, K>
+								? InternalError<InferNon200Result<TResponse[K]>, K>
 								: never;
 }[keyof TResponse] & {
 	headers?: Record<string, string>;

--- a/apps/meteor/app/api/server/definition.ts
+++ b/apps/meteor/app/api/server/definition.ts
@@ -362,7 +362,7 @@ type Results<TResponse extends TypedOptions['response']> = {
 						: K extends 404
 							? NotFoundResult<InferNon200Result<TResponse[404]>>
 							: K extends ErrorStatusCodes
-								? InternalError<InferResult<TResponse[500]>, K>
+								? InternalError<InferNon200Result<TResponse[500]>, K>
 								: never;
 }[keyof TResponse] & {
 	headers?: Record<string, string>;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Fixes a TypeScript compilation error (`Type 'unknown' is not assignable to type 'InternalErrorResponse'`) that occurs when calling `API.v1.internalError()` without arguments in endpoints strictly typed with AJV schemas.
There were two underlying typing issues preventing parameterless calls to `internalError` from passing strict AJV schema validations:
1. **Missing Overload:** When `internalError()` was called without arguments, TypeScript inferred the generic `T` as `unknown`.
2. **Incorrect Type Extraction:** In `definition.ts`, `ErrorStatusCodes` (500) was using `InferResult<TResponse[500]>` instead of `InferNon200Result`. This caused the framework to expect the entire response object (`{ success: false, error: string }`) as the generic type instead of just extracting the `error` payload type, unlike how 401, 403, and 404 errors are handled.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-2277 Fix TypeScript compilation error on parameterless API.v1.internalError() calls](https://rocketchat.atlassian.net/browse/CORE-2277)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal error-handling type inference to make server-side error responses more precise and consistent.

---

*Note: These are internal infrastructure improvements with no user-visible changes.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->