### PR TITLE
regression: opening a contextual bar changes message list scroll position

### DIFF
--- a/apps/meteor/client/views/room/layout/RoomLayout.tsx
+++ b/apps/meteor/client/views/room/layout/RoomLayout.tsx
@@ -39,6 +39,7 @@ const RoomLayout = ({ header, body, footer, aside, ...props }: RoomLayoutProps):
 
 	const contextualbarPosition = breakpoints.includes('md') ? 'relative' : 'absolute';
 	const contextualbarSize = breakpoints.includes('sm') ? (breakpoints.includes('xl') ? '38%' : '380px') : '100%';
+	const hideBody = aside && contextualbarSize === '100%';
 
 	const layout = useLayout();
 
@@ -59,7 +60,7 @@ const RoomLayout = ({ header, body, footer, aside, ...props }: RoomLayoutProps):
 			<Box h='full' w='full' display='flex' flexDirection='column' bg='room' {...props} ref={ref}>
 				<Suspense fallback={<HeaderSkeleton />}>{header}</Suspense>
 				<Box display='flex' flexGrow={1} overflow='hidden' height='full' position='relative'>
-					<Box display='flex' flexDirection='column' flexGrow={1} minWidth={0}>
+					<Box display={hideBody ? 'none' : 'flex'} flexDirection='column' flexGrow={1} minWidth={0}>
 						<Box is='div' display='flex' flexDirection='column' flexGrow={1} maxHeight='100%'>
 							<Suspense fallback={null}>{body}</Suspense>
 						</Box>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
The way the contextual bar is handled makes the body of the room assume a width of 0. This breaks Virtua somehow, but upon digging their issues, this one stood out https://github.com/inokawa/virtua/issues/225. By changing the body's display to "none" when it's hidden, the issue seises to exist.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-2225](https://rocketchat.atlassian.net/browse/CORE-2225)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-2249]: https://rocketchat.atlassian.net/browse/CORE-2249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CORE-2225]: https://rocketchat.atlassian.net/browse/CORE-2225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved room layout behavior to properly hide the main content area when the side panel expands to full width, preventing display conflicts and overlapping UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->