### PR TITLE
fix: disable "also send to channel" checkbox when editing thread message

### DIFF
--- a/apps/meteor/client/lib/chats/data.ts
+++ b/apps/meteor/client/lib/chats/data.ts
@@ -187,6 +187,7 @@ export const createDataAPI = ({ rid, tmid }: { rid: IRoom['_id']; tmid: IMessage
 					roomId: message.rid,
 					customFields: message.customFields,
 					text: message.msg,
+					tshow: message.tshow
 				};
 
 		await sdk.rest.post('/v1/chat.update', params);

--- a/apps/meteor/client/lib/chats/data.ts
+++ b/apps/meteor/client/lib/chats/data.ts
@@ -187,7 +187,6 @@ export const createDataAPI = ({ rid, tmid }: { rid: IRoom['_id']; tmid: IMessage
 					roomId: message.rid,
 					customFields: message.customFields,
 					text: message.msg,
-					tshow: message.tshow
 				};
 
 		await sdk.rest.post('/v1/chat.update', params);

--- a/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadChat.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadChat.tsx
@@ -3,7 +3,7 @@ import { isEditedMessage } from '@rocket.chat/core-typings';
 import { Box, CheckBox, Field, FieldLabel, FieldRow } from '@rocket.chat/fuselage';
 import { clientCallbacks, ContextualbarContent } from '@rocket.chat/ui-client';
 import { useMethod, useTranslation, useUserPreference, useRoomToolbox } from '@rocket.chat/ui-contexts';
-import { useState, useEffect, useCallback, useId } from 'react';
+import { useState, useEffect, useCallback, useId  ,useSyncExternalStore} from 'react';
 
 import ThreadMessageList from './ThreadMessageList';
 import MessageListErrorBoundary from '../../../MessageList/MessageListErrorBoundary';
@@ -25,6 +25,10 @@ const ThreadChat = ({ mainMessage }: ThreadChatProps) => {
 	if (!chat) {
 		throw new Error('No ChatContext provided');
 	}
+	const isEditing = useSyncExternalStore(
+    (callback) => chat.composer?.editing.subscribe(callback) ?? (() => undefined),
+    () => chat.composer?.editing.get() ?? false,
+	);
 
 	const sendToChannelPreference = useUserPreference<'always' | 'never' | 'default'>('alsoSendThreadToChannel');
 
@@ -127,6 +131,7 @@ const ThreadChat = ({ mainMessage }: ThreadChatProps) => {
 										checked={sendToChannel}
 										onChange={() => setSendToChannel((checked) => !checked)}
 										name='alsoSendThreadToChannel'
+										disabled={isEditing}
 									/>
 									<FieldLabel mis='x8' htmlFor={sendToChannelID} color='annotation' fontScale='p2'>
 										{t('Also_send_to_channel')}


### PR DESCRIPTION
## Proposed changes
The "Also send to channel" checkbox in the thread composer was visible and 
interactive even when editing an existing message. Since the `tshow` property 
cannot be changed for already-sent messages (changing it would not dispatch 
new notifications and may not be visible in channel history), showing an 
interactive checkbox during edits is misleading.

This PR disables the checkbox when the composer is in editing mode, making 
it clear to users that this property cannot be changed for existing messages.

Implementation: used `useSyncExternalStore` to subscribe to 
`chat.composer.editing` — a reactive `Subscribable<boolean>` — so the 
checkbox disables/enables correctly as the user enters and exits edit mode.

## Issue(s)
Related to #40745 (closed) — fix suggested by maintainer @gabriellsh in #40747

## Steps to test or reproduce
1. Open a thread in Rocket.Chat
2. Hover over a thread message and click the edit button
3. Observe that the "Also send to channel" checkbox is now disabled during editing
4. Submit or cancel the edit — checkbox becomes interactive again

## Further comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "also send to channel" checkbox in thread conversations is now properly disabled while composing or editing a message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->