### PR TITLE
refactor: rendering of call history contact information

### DIFF
--- a/apps/meteor/client/views/mediaCallHistory/CallHistoryPage.tsx
+++ b/apps/meteor/client/views/mediaCallHistory/CallHistoryPage.tsx
@@ -1,9 +1,10 @@
+import type { CallHistoryItem, Serialized } from '@rocket.chat/core-typings';
 import { Pagination } from '@rocket.chat/fuselage';
 import { useDebouncedValue } from '@rocket.chat/fuselage-hooks';
 import { useSort, usePagination, GenericTableLoadingRow } from '@rocket.chat/ui-client';
 import { useEndpoint, useRouteParameter, useRouter } from '@rocket.chat/ui-contexts';
-import { MediaCallHistoryTable, isCallHistoryUnknownContact, isCallHistoryTableInternalContact } from '@rocket.chat/ui-voip';
-import type { CallHistoryTableInternalContact, CallHistoryUnknownContact, CallHistoryTableExternalContact } from '@rocket.chat/ui-voip';
+import { MediaCallHistoryTable, isCallHistoryUnknownContact, isCallHistoryInternalContact } from '@rocket.chat/ui-voip';
+import type { CallHistoryContact } from '@rocket.chat/ui-voip';
 import { useQuery } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -14,6 +15,7 @@ import CallHistoryRowExternalUser from './CallHistoryRowExternalUser';
 import CallHistoryRowInternalUser from './CallHistoryRowInternalUser';
 import CallHistoryRowUnknownUser from './CallHistoryRowUnknownUser';
 import MediaCallHistoryContextualbar from './MediaCallHistoryContextualbar';
+import { getExternalContact } from './MediaCallHistoryExternal';
 import GenericNoResults from '../../components/GenericNoResults';
 import UserInfoWithData from '../room/contextualBar/UserInfo/UserInfoWithData';
 
@@ -41,6 +43,18 @@ const getStateFilter = <T extends string[]>(states: T): T | [...T, 'error'] | un
 		return [...states, 'error'];
 	}
 	return states;
+};
+
+const getContact = (item: Serialized<CallHistoryItem>): CallHistoryContact => {
+	if (item.external) {
+		return getExternalContact(item);
+	}
+
+	if (!item.contactUsername || !item.contactName) {
+		return { unknown: true };
+	}
+
+	return { _id: item.contactId, username: item.contactUsername, name: item.contactName };
 };
 
 type DetailsTab = {
@@ -130,33 +144,11 @@ const CallHistoryPage = () => {
 
 	const tableData = useMemo(() => {
 		return data?.items.map((item) => {
-			if (item.external) {
-				return {
-					_id: item._id,
-					contact: item.contactExtension
-						? ({ number: item.contactExtension } as CallHistoryTableExternalContact)
-						: ({ unknown: true } as CallHistoryUnknownContact),
-					type: item.direction,
-					status: item.state,
-					timestamp: item.ts,
-					duration: item.duration,
-				};
-			}
-			if (!item.contactUsername || !item.contactName) {
-				return {
-					_id: item._id,
-					contact: { unknown: true } as CallHistoryUnknownContact,
-					type: item.direction,
-					status: item.state,
-					timestamp: item.ts,
-					duration: item.duration,
-				};
-			}
 			return {
 				_id: item._id,
-				rid: item.rid,
-				contact: { _id: item.contactId, username: item.contactUsername, name: item.contactName } as CallHistoryTableInternalContact,
-				messageId: item.messageId,
+				...('rid' in item && { rid: item.rid }),
+				contact: getContact(item),
+				...('messageId' in item && { messageId: item.messageId }),
 				type: item.direction,
 				status: item.state,
 				timestamp: item.ts,
@@ -216,7 +208,7 @@ const CallHistoryPage = () => {
 						if (isCallHistoryUnknownContact(item.contact)) {
 							return <CallHistoryRowUnknownUser key={item._id} {...item} contact={item.contact} onClick={() => onClickRow('', item._id)} />;
 						}
-						if (isCallHistoryTableInternalContact(item.contact)) {
+						if (isCallHistoryInternalContact(item.contact)) {
 							return (
 								<CallHistoryRowInternalUser
 									key={item._id}

--- a/apps/meteor/client/views/mediaCallHistory/CallHistoryRowExternalUser.tsx
+++ b/apps/meteor/client/views/mediaCallHistory/CallHistoryRowExternalUser.tsx
@@ -1,10 +1,10 @@
 import { GenericMenu } from '@rocket.chat/ui-client';
-import type { CallHistoryTableExternalContact, CallHistoryTableRowProps } from '@rocket.chat/ui-voip';
+import type { CallHistoryExternalContact, CallHistoryTableRowProps } from '@rocket.chat/ui-voip';
 import { CallHistoryTableRow, usePeekMediaSessionState, useWidgetExternalControls } from '@rocket.chat/ui-voip';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-type CallHistoryRowExternalUserProps = Omit<CallHistoryTableRowProps<CallHistoryTableExternalContact>, 'onClick' | 'menu'> & {
+type CallHistoryRowExternalUserProps = Omit<CallHistoryTableRowProps<CallHistoryExternalContact>, 'onClick' | 'menu'> & {
 	onClick: (historyId: string) => void;
 };
 

--- a/apps/meteor/client/views/mediaCallHistory/CallHistoryRowInternalUser.tsx
+++ b/apps/meteor/client/views/mediaCallHistory/CallHistoryRowInternalUser.tsx
@@ -1,14 +1,14 @@
 import type { Keys as IconName } from '@rocket.chat/icons';
 import { GenericMenu } from '@rocket.chat/ui-client';
 import { CallHistoryTableRow, usePeekMediaSessionState } from '@rocket.chat/ui-voip';
-import type { CallHistoryTableRowProps, CallHistoryTableInternalContact, PeekMediaSessionStateReturn } from '@rocket.chat/ui-voip';
+import type { CallHistoryTableRowProps, CallHistoryInternalContact, PeekMediaSessionStateReturn } from '@rocket.chat/ui-voip';
 import type { TFunction } from 'i18next';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useMediaCallInternalHistoryActions } from './useMediaCallInternalHistoryActions';
 
-type CallHistoryRowInternalUserProps = Omit<CallHistoryTableRowProps<CallHistoryTableInternalContact>, 'onClick' | 'menu'> & {
+type CallHistoryRowInternalUserProps = Omit<CallHistoryTableRowProps<CallHistoryInternalContact>, 'onClick' | 'menu'> & {
 	messageId?: string;
 	rid: string;
 	onClickUserInfo?: (userId: string, rid: string) => void;

--- a/apps/meteor/client/views/mediaCallHistory/MediaCallHistoryExternal.tsx
+++ b/apps/meteor/client/views/mediaCallHistory/MediaCallHistoryExternal.tsx
@@ -1,10 +1,16 @@
-import type { CallHistoryItem, IExternalMediaCallHistoryItem, IMediaCall, Serialized } from '@rocket.chat/core-typings';
-import { CallHistoryContextualBar, useWidgetExternalControls, usePeekMediaSessionState } from '@rocket.chat/ui-voip';
+import type { CallHistoryItem, IInternalMediaCallHistoryItem, IMediaCall, Serialized } from '@rocket.chat/core-typings';
+import {
+	CallHistoryContextualBar,
+	useWidgetExternalControls,
+	usePeekMediaSessionState,
+	type CallHistoryExternalContact,
+	type CallHistoryUnknownContact,
+} from '@rocket.chat/ui-voip';
 import { useMemo } from 'react';
 
 type ExternalCallEndpointData = Serialized<{
-	item: IExternalMediaCallHistoryItem;
-	call: IMediaCall;
+	item: Exclude<CallHistoryItem, IInternalMediaCallHistoryItem>;
+	call?: IMediaCall;
 }>;
 
 type MediaCallHistoryExternalProps = {
@@ -12,21 +18,25 @@ type MediaCallHistoryExternalProps = {
 	onClose: () => void;
 };
 
-const getContact = (item: ExternalCallEndpointData['item']) => {
-	return {
-		number: item.contactExtension,
-	};
+export const getExternalContact = (item: ExternalCallEndpointData['item']): CallHistoryExternalContact | CallHistoryUnknownContact => {
+	if (item.type === 'media-call') {
+		return {
+			number: item.contactExtension,
+		};
+	}
+
+	return { unknown: true };
 };
 
 export const isExternalCallHistoryItem = (data: { item: Serialized<CallHistoryItem> }): data is ExternalCallEndpointData => {
-	return 'external' in data.item && data.item.external;
+	return data.item.type !== 'media-call' || data.item.external;
 };
 
 const MediaCallHistoryExternal = ({ data, onClose }: MediaCallHistoryExternalProps) => {
-	const contact = useMemo(() => getContact(data.item), [data]);
+	const contact = useMemo(() => getExternalContact(data.item), [data]);
 	const historyData = useMemo(() => {
 		return {
-			callId: data.call._id,
+			callId: data.item.callId,
 			direction: data.item.direction,
 			duration: data.item.duration,
 			startedAt: new Date(data.item.ts),

--- a/apps/meteor/client/views/mediaCallHistory/MediaCallHistoryInternal.tsx
+++ b/apps/meteor/client/views/mediaCallHistory/MediaCallHistoryInternal.tsx
@@ -1,5 +1,5 @@
 import type { CallHistoryItem, IInternalMediaCallHistoryItem, IMediaCall, Serialized } from '@rocket.chat/core-typings';
-import { CallHistoryContextualBar } from '@rocket.chat/ui-voip';
+import { CallHistoryContextualBar, type CallHistoryInternalContact } from '@rocket.chat/ui-voip';
 import { useMemo } from 'react';
 
 import { useMediaCallInternalHistoryActions } from './useMediaCallInternalHistoryActions';
@@ -18,10 +18,10 @@ type MediaCallHistoryInternalProps = {
 };
 
 export const isInternalCallHistoryItem = (data: { item: Serialized<CallHistoryItem> }): data is InternalCallEndpointData => {
-	return 'external' in data.item && !data.item.external;
+	return data.item.type === 'media-call' && !data.item.external;
 };
 
-const getContact = (item: InternalCallEndpointData['item'], call: InternalCallEndpointData['call']) => {
+const getContact = (item: InternalCallEndpointData['item'], call: InternalCallEndpointData['call']): CallHistoryInternalContact => {
 	const { caller, callee } = call ?? {};
 	const contact = caller?.id === item.contactId ? caller : callee;
 	const { id, sipExtension, username, displayName, ...rest } = contact;

--- a/apps/meteor/client/views/mediaCallHistory/MediaCallHistoryInternal.tsx
+++ b/apps/meteor/client/views/mediaCallHistory/MediaCallHistoryInternal.tsx
@@ -24,7 +24,7 @@ export const isInternalCallHistoryItem = (data: { item: Serialized<CallHistoryIt
 const getContact = (item: InternalCallEndpointData['item'], call: InternalCallEndpointData['call']): CallHistoryInternalContact => {
 	const { caller, callee } = call ?? {};
 	const contact = caller?.id === item.contactId ? caller : callee;
-	const { id, sipExtension, username, displayName, ...rest } = contact;
+	const { id, sipExtension, username, displayName, ...rest } = contact ?? {};
 	return {
 		...rest,
 		_id: id,

--- a/apps/meteor/client/views/mediaCallHistory/useMediaCallInternalHistoryActions.ts
+++ b/apps/meteor/client/views/mediaCallHistory/useMediaCallInternalHistoryActions.ts
@@ -1,20 +1,11 @@
 import { useEffectEvent } from '@rocket.chat/fuselage-hooks';
 import { useGoToDirectMessage } from '@rocket.chat/ui-client';
 import { useRouter, useUserAvatarPath } from '@rocket.chat/ui-contexts';
-import { useWidgetExternalControls, usePeekMediaSessionState } from '@rocket.chat/ui-voip';
+import { useWidgetExternalControls, usePeekMediaSessionState, type CallHistoryInternalContact } from '@rocket.chat/ui-voip';
 import { useMemo } from 'react';
 
-export type InternalCallHistoryContact = {
-	_id: string;
-	name?: string;
-	username: string;
-	displayName?: string;
-	voiceCallExtension?: string;
-	avatarUrl?: string;
-};
-
 type UseMediaCallInternalHistoryActionsBaseOptions = {
-	contact: InternalCallHistoryContact;
+	contact: CallHistoryInternalContact;
 	messageId?: string;
 	openRoomId?: string;
 	messageRoomId?: string;

--- a/packages/ui-voip/src/components/CallHistoryExternalUser.tsx
+++ b/packages/ui-voip/src/components/CallHistoryExternalUser.tsx
@@ -1,11 +1,13 @@
 import { Box, Icon, FramedIcon } from '@rocket.chat/fuselage';
 
+import type { CallHistoryExternalContact } from '../definitions';
+
 type CallHistoryExternalUserProps = {
-	number: string;
+	contact: CallHistoryExternalContact;
 	showIcon?: boolean;
 };
 
-const CallHistoryExternalUser = ({ number, showIcon = true }: CallHistoryExternalUserProps) => {
+const CallHistoryExternalUser = ({ contact: { number }, showIcon = true }: CallHistoryExternalUserProps) => {
 	return (
 		<Box display='flex' flexDirection='row' alignItems='center'>
 			<Box mie={8}>

--- a/packages/ui-voip/src/components/CallHistoryInternalUser.tsx
+++ b/packages/ui-voip/src/components/CallHistoryInternalUser.tsx
@@ -3,13 +3,13 @@ import { useUserDisplayName } from '@rocket.chat/ui-client';
 import { useUserAvatarPath, useUserPresence, useUserCard } from '@rocket.chat/ui-contexts';
 import { useMemo } from 'react';
 
+import type { CallHistoryInternalContact } from '../definitions';
+
 type CallHistoryInternalUserProps = {
-	username: string;
-	name?: string;
-	_id: string;
+	contact: CallHistoryInternalContact;
 };
 
-const CallHistoryInternalUser = ({ username, name, _id }: CallHistoryInternalUserProps) => {
+const CallHistoryInternalUser = ({ contact: { username, name, _id } }: CallHistoryInternalUserProps) => {
 	const getUserAvatarPath = useUserAvatarPath();
 
 	const avatarUrl = useMemo(() => {

--- a/packages/ui-voip/src/components/CallHistoryUnknownUser.tsx
+++ b/packages/ui-voip/src/components/CallHistoryUnknownUser.tsx
@@ -1,7 +1,7 @@
 import { Box, FramedIcon } from '@rocket.chat/fuselage';
 import { useTranslation } from 'react-i18next';
 
-const CallHistoryTableUnknownContact = () => {
+const CallHistoryUnknownUser = () => {
 	const { t } = useTranslation();
 	return (
 		<Box display='flex' flexDirection='row' alignItems='center'>
@@ -13,4 +13,4 @@ const CallHistoryTableUnknownContact = () => {
 	);
 };
 
-export default CallHistoryTableUnknownContact;
+export default CallHistoryUnknownUser;

--- a/packages/ui-voip/src/components/CallHistoryUser.tsx
+++ b/packages/ui-voip/src/components/CallHistoryUser.tsx
@@ -1,0 +1,22 @@
+import CallHistoryExternalUser from './CallHistoryExternalUser';
+import CallHistoryInternalUser from './CallHistoryInternalUser';
+import CallHistoryUnknownUser from './CallHistoryUnknownUser';
+import { isCallHistoryExternalContact, isCallHistoryInternalContact, type CallHistoryContact } from '../definitions';
+
+type CallHistoryUserProps = {
+	contact: CallHistoryContact;
+};
+
+const CallHistoryUser = ({ contact }: CallHistoryUserProps) => {
+	if (isCallHistoryInternalContact(contact)) {
+		return <CallHistoryInternalUser contact={contact} />;
+	}
+
+	if (isCallHistoryExternalContact(contact)) {
+		return <CallHistoryExternalUser showIcon={false} contact={contact} />;
+	}
+
+	return <CallHistoryUnknownUser />;
+};
+
+export default CallHistoryUser;

--- a/packages/ui-voip/src/definitions/callHistoryContacts.ts
+++ b/packages/ui-voip/src/definitions/callHistoryContacts.ts
@@ -1,0 +1,30 @@
+export type CallHistoryExternalContact = {
+	number: string;
+};
+
+export type CallHistoryInternalContact = {
+	_id: string;
+	name?: string;
+	username: string;
+	displayName?: string;
+	voiceCallExtension?: string;
+	avatarUrl?: string;
+};
+
+export type CallHistoryUnknownContact = {
+	unknown: true;
+};
+
+export type CallHistoryContact = CallHistoryInternalContact | CallHistoryExternalContact | CallHistoryUnknownContact;
+
+export const isCallHistoryUnknownContact = (contact: CallHistoryContact): contact is CallHistoryUnknownContact => {
+	return 'unknown' in contact && contact.unknown;
+};
+
+export const isCallHistoryInternalContact = (contact: CallHistoryContact): contact is CallHistoryInternalContact => {
+	return '_id' in contact && Boolean(contact._id);
+};
+
+export const isCallHistoryExternalContact = (contact: CallHistoryContact): contact is CallHistoryExternalContact => {
+	return !isCallHistoryUnknownContact(contact) && !isCallHistoryInternalContact(contact);
+};

--- a/packages/ui-voip/src/definitions/index.ts
+++ b/packages/ui-voip/src/definitions/index.ts
@@ -1,1 +1,2 @@
+export * from './callHistoryContacts';
 export type * from './IceServer';

--- a/packages/ui-voip/src/index.ts
+++ b/packages/ui-voip/src/index.ts
@@ -12,7 +12,8 @@ export type { PeerInfo } from './context';
 export { useMediaCallAction, useMediaCallOpenRoomTracker } from './hooks';
 
 export { CallHistoryContextualBar, MediaCallRoomActivity } from './views';
-export type { InternalCallHistoryContact, ExternalCallHistoryContact, CallHistoryData } from './views';
+export type { CallHistoryData } from './views';
+export * from './definitions/callHistoryContacts';
 
 export { getHistoryMessagePayload } from './ui-kit/getHistoryMessagePayload';
 

--- a/packages/ui-voip/src/views/CallHistoryContextualbar/CallHistoryContextualbar.tsx
+++ b/packages/ui-voip/src/views/CallHistoryContextualbar/CallHistoryContextualbar.tsx
@@ -17,20 +17,10 @@ import { useTranslation } from 'react-i18next';
 import type { HistoryActionCallbacks } from './CallHistoryActions';
 import CallHistoryActions from './CallHistoryActions';
 import { useFullStartDate } from './useFullStartDate';
-import { CallHistoryExternalUser, CallHistoryInternalUser } from '../../components';
+import CallHistoryUser from '../../components/CallHistoryUser';
 import { usePeekMediaSessionState } from '../../context/usePeekMediaSessionState';
+import { isCallHistoryInternalContact, type CallHistoryContact } from '../../definitions';
 import { getHistoryMessagePayload } from '../../ui-kit/getHistoryMessagePayload';
-
-export type InternalCallHistoryContact = {
-	_id: string;
-	name?: string;
-	username: string;
-	voiceCallExtension?: string;
-};
-
-export type ExternalCallHistoryContact = {
-	number: string;
-};
 
 export type CallHistoryData = {
 	callId: string;
@@ -44,14 +34,8 @@ export type CallHistoryData = {
 type CallHistoryContextualBarProps = {
 	onClose: () => void;
 	actions: HistoryActionCallbacks;
-	contact: InternalCallHistoryContact | ExternalCallHistoryContact;
+	contact: CallHistoryContact;
 	data: CallHistoryData;
-};
-
-const isInternalCallHistoryContact = (
-	contact: InternalCallHistoryContact | ExternalCallHistoryContact,
-): contact is InternalCallHistoryContact => {
-	return '_id' in contact;
 };
 
 const contextValue = {
@@ -78,11 +62,7 @@ const CallHistoryContextualBar = ({ onClose, actions, contact, data }: CallHisto
 			<ContextualbarScrollableContent>
 				<InfoPanel>
 					<InfoPanelSection fontScale='p1b'>
-						{isInternalCallHistoryContact(contact) ? (
-							<CallHistoryInternalUser username={contact.username} name={contact.name} _id={contact._id} />
-						) : (
-							<CallHistoryExternalUser number={contact.number} />
-						)}
+						<CallHistoryUser contact={contact} />
 					</InfoPanelSection>
 					<InfoPanelSection>
 						<Box display='flex' flexDirection='row' alignItems='center' fontScale='p1b'>
@@ -102,7 +82,7 @@ const CallHistoryContextualBar = ({ onClose, actions, contact, data }: CallHisto
 						<InfoPanelLabel>{t('Call_ID')}</InfoPanelLabel>
 						<InfoPanelText>{callId}</InfoPanelText>
 					</InfoPanelSection>
-					{isInternalCallHistoryContact(contact) && contact.voiceCallExtension && (
+					{isCallHistoryInternalContact(contact) && contact.voiceCallExtension && (
 						<InfoPanelSection>
 							<InfoPanelLabel>{t('Voice_call_extension')}</InfoPanelLabel>
 							<InfoPanelText>{contact.voiceCallExtension}</InfoPanelText>
@@ -112,7 +92,7 @@ const CallHistoryContextualBar = ({ onClose, actions, contact, data }: CallHisto
 			</ContextualbarScrollableContent>
 			<ContextualbarFooter>
 				<ButtonGroup stretch>
-					{isInternalCallHistoryContact(contact) && directMessage && (
+					{isCallHistoryInternalContact(contact) && directMessage && (
 						<Button onClick={directMessage}>
 							<Icon name='balloon' size='x20' mie='x4' />
 							{t('Direct_message')}

--- a/packages/ui-voip/src/views/CallHistoryContextualbar/__snapshots__/CallHistoryContextualbar.spec.tsx.snap
+++ b/packages/ui-voip/src/views/CallHistoryContextualbar/__snapshots__/CallHistoryContextualbar.spec.tsx.snap
@@ -472,16 +472,6 @@ exports[`renders ExternalContact without crashing 1`] = `
                         </i>
                       </div>
                       <div
-                        class="rcx-box rcx-box--full rcx-css-1rtu0k9"
-                      >
-                        <i
-                          aria-hidden="true"
-                          class="rcx-box rcx-box--full rcx-icon--name-phone rcx-icon rcx-css-1bepdyv"
-                        >
-                          
-                        </i>
-                      </div>
-                      <div
                         class="rcx-box rcx-box--full"
                       >
                         1234567890

--- a/packages/ui-voip/src/views/CallHistoryContextualbar/index.ts
+++ b/packages/ui-voip/src/views/CallHistoryContextualbar/index.ts
@@ -1,2 +1,2 @@
 export { default as CallHistoryContextualBar } from './CallHistoryContextualbar';
-export type { InternalCallHistoryContact, ExternalCallHistoryContact, CallHistoryData } from './CallHistoryContextualbar';
+export type { CallHistoryData } from './CallHistoryContextualbar';

--- a/packages/ui-voip/src/views/MediaCallHistoryTable/CallHistoryTableRow.tsx
+++ b/packages/ui-voip/src/views/MediaCallHistoryTable/CallHistoryTableRow.tsx
@@ -6,31 +6,20 @@ import type { ReactNode } from 'react';
 
 import CallHistoryTableDirection from './CallHistoryTableDirection';
 import CallHistoryTableStatus from './CallHistoryTableStatus';
-import CallHistoryTableUnknownContact from './CallHistoryTableUnknownContact';
-import { CallHistoryExternalUser, CallHistoryInternalUser } from '../../components';
+import CallHistoryUser from '../../components/CallHistoryUser';
+import type {
+	CallHistoryContact,
+	CallHistoryExternalContact,
+	CallHistoryInternalContact,
+	CallHistoryUnknownContact,
+} from '../../definitions';
 
-export type CallHistoryTableExternalContact = {
-	number: string;
-};
-
-export type CallHistoryTableInternalContact = {
+export type CallHistoryTableRowProps<T extends CallHistoryContact> = {
 	_id: string;
-	username?: string;
-	name?: string;
-};
-
-export type CallHistoryUnknownContact = {
-	unknown: true;
-};
-
-type CallHistoryTableRowContact = CallHistoryTableInternalContact | CallHistoryTableExternalContact | CallHistoryUnknownContact;
-
-export type CallHistoryTableRowProps<T extends CallHistoryTableRowContact> = {
-	_id: string;
-	contact: T extends CallHistoryTableInternalContact
-		? CallHistoryTableInternalContact
-		: T extends CallHistoryTableExternalContact
-			? CallHistoryTableExternalContact
+	contact: T extends CallHistoryInternalContact
+		? CallHistoryInternalContact
+		: T extends CallHistoryExternalContact
+			? CallHistoryExternalContact
 			: CallHistoryUnknownContact;
 	type: 'outbound' | 'inbound';
 	status: CallHistoryItemState;
@@ -40,19 +29,7 @@ export type CallHistoryTableRowProps<T extends CallHistoryTableRowContact> = {
 	menu: ReactNode;
 };
 
-export const isCallHistoryTableExternalContact = (contact: CallHistoryTableRowContact): contact is CallHistoryTableExternalContact => {
-	return 'number' in contact;
-};
-
-export const isCallHistoryUnknownContact = (contact: CallHistoryTableRowContact): contact is CallHistoryUnknownContact => {
-	return 'unknown' in contact;
-};
-
-export const isCallHistoryTableInternalContact = (contact: CallHistoryTableRowContact): contact is CallHistoryTableInternalContact => {
-	return '_id' in contact && ('username' in contact || 'name' in contact);
-};
-
-const CallHistoryTableRow = <T extends CallHistoryTableRowContact>({
+const CallHistoryTableRow = <T extends CallHistoryContact>({
 	_id,
 	contact,
 	type,
@@ -66,11 +43,7 @@ const CallHistoryTableRow = <T extends CallHistoryTableRowContact>({
 	return (
 		<GenericTableRow key={_id} onClick={onClick} tabIndex={0} role='link' action>
 			<GenericTableCell>
-				{isCallHistoryTableExternalContact(contact) && <CallHistoryExternalUser showIcon={false} number={contact.number} />}
-				{isCallHistoryTableInternalContact(contact) && (
-					<CallHistoryInternalUser username={contact.username ?? ''} name={contact.name} _id={contact._id} />
-				)}
-				{isCallHistoryUnknownContact(contact) && <CallHistoryTableUnknownContact />}
+				<CallHistoryUser contact={contact} />
 			</GenericTableCell>
 			<GenericTableCell>
 				<CallHistoryTableDirection direction={type} />

--- a/packages/ui-voip/src/views/MediaCallHistoryTable/MediaCallHistoryTable.stories.tsx
+++ b/packages/ui-voip/src/views/MediaCallHistoryTable/MediaCallHistoryTable.stories.tsx
@@ -3,14 +3,10 @@ import { GenericMenu, useSort } from '@rocket.chat/ui-client';
 import { action } from '@storybook/addon-actions';
 import type { Meta, StoryFn } from '@storybook/react';
 
-import type {
-	CallHistoryTableExternalContact,
-	CallHistoryTableInternalContact,
-	CallHistoryTableRowProps,
-	CallHistoryUnknownContact,
-} from './CallHistoryTableRow';
+import type { CallHistoryTableRowProps } from './CallHistoryTableRow';
 import CallHistoryTableRow from './CallHistoryTableRow';
 import MediaCallHistoryTable from './MediaCallHistoryTable';
+import type { CallHistoryContact, CallHistoryInternalContact } from '../../definitions';
 
 const mockedContexts = mockAppRoot()
 	.withTranslations('en', 'core', {
@@ -65,7 +61,7 @@ const getDate = (index: number) => {
 	return new Date(date.setMonth(date.getMonth() - 2));
 };
 
-const getContact = (index: number): CallHistoryTableInternalContact | CallHistoryTableExternalContact | CallHistoryUnknownContact => {
+const getContact = (index: number): CallHistoryContact => {
 	if (index % 3 === 0) {
 		return {
 			_id: `user_${index}`,
@@ -84,9 +80,9 @@ const getContact = (index: number): CallHistoryTableInternalContact | CallHistor
 };
 
 const results = Array.from({ length: 100 }).map(
-	(_, index): CallHistoryTableRowProps<CallHistoryTableInternalContact> => ({
+	(_, index): CallHistoryTableRowProps<CallHistoryInternalContact> => ({
 		_id: `call_${index}`,
-		contact: getContact(index) as CallHistoryTableInternalContact,
+		contact: getContact(index) as CallHistoryInternalContact,
 		type: index % 2 ? 'outbound' : 'inbound',
 		status: getStatus(index),
 		duration: index % 2 ? 120 : 0,


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Reorganizes how the call history views handle rendering of contact information

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Derived from [DMV-7](https://rocketchat.atlassian.net/browse/DMV-7)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[DMV-7]: https://rocketchat.atlassian.net/browse/DMV-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified contact handling and rendering for call history entries, resulting in more consistent display across internal, external, and unknown callers.
  * Improved handling of external/unnamed callers so they appear as "unknown" when name/username are missing.
  * Contact actions and row options preserved but now routed through the shared contact renderer for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->