### PR TITLE
test: stabilize flaky omnichannel and livechat specs

### DIFF
--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-chat-transfers.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-chat-transfers.spec.ts
@@ -180,6 +180,7 @@ test.describe('OC - Chat transfers [Monitor role]', () => {
 			await poOmnichannel.content.forwardChatModal.inputComment.type('any_comment');
 			await expect(poOmnichannel.content.forwardChatModal.btnForward).toBeEnabled();
 			await poOmnichannel.content.forwardChatModal.btnForward.click();
+			await poOmnichannel.content.forwardChatModal.waitForDismissal();
 			// await expect(agentA.poHomeOmnichannel.toastSuccess).toBeVisible();
 		});
 

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-agent-idle-setting.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-agent-idle-setting.spec.ts
@@ -7,7 +7,7 @@ import { Users } from '../fixtures/userStates';
 import { HomeOmnichannel } from '../page-objects';
 import { OmnichannelLiveChat } from '../page-objects/omnichannel';
 import { setSettingValueById } from '../utils';
-import { createAgent } from '../utils/omnichannel/agents';
+import { createAgent, makeAgentAvailable } from '../utils/omnichannel/agents';
 import { test, expect } from '../utils/test';
 
 test.use({ storageState: Users.user1.state });
@@ -41,9 +41,12 @@ test.describe('OC - Routing to Idle Agents', () => {
 
 	test.beforeEach(async ({ page, browser, api }) => {
 		visitor = createFakeVisitor();
+		await expect(await makeAgentAvailable(api, agent.data._id)).toBeOK();
+
 		poHomeOmnichannel = new HomeOmnichannel(page);
 		await poHomeOmnichannel.page.goto('/');
 		await poHomeOmnichannel.waitForHome();
+		await expect(poHomeOmnichannel.navbar.getUserStatusBadge('online')).toBeVisible();
 
 		({ page: livechatPage } = await createAuxContext(browser, Users.user1, '/livechat', false));
 		poLivechat = new OmnichannelLiveChat(livechatPage, api);

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-read-receipts.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-read-receipts.spec.ts
@@ -70,6 +70,7 @@ test.describe('OC - Livechat - Read Receipts', () => {
 			await expect(poHomeOmnichannel.content.lastUserMessage).toBeVisible();
 			await expect(poHomeOmnichannel.content.lastUserMessage).toContainText(testMessage);
 			await markedAsRead;
+			await expect(poHomeOmnichannel.content.lastUserMessage.getByRole('status', { name: 'Message viewed' })).toBeVisible();
 		});
 
 		await test.step('read receipts show both agent and visitor names', async () => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-manager.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-manager.spec.ts
@@ -10,8 +10,7 @@ test.describe.serial('omnichannel-manager', () => {
 	test.beforeEach(async ({ page }) => {
 		poOmnichannelManagers = new OmnichannelManager(page);
 
-		await page.goto('/omnichannel');
-		await poOmnichannelManagers.sidebar.linkManagers.click();
+		await poOmnichannelManagers.goto();
 	});
 
 	test('OC - Manage Managers - Add, Search and Remove', async ({ page }) => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-triggers.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-triggers.spec.ts
@@ -132,6 +132,7 @@ test.describe.serial('OC - Livechat Triggers', () => {
 		});
 
 		await test.step('expect to register visitor', async () => {
+			await expect(poLiveChat.inputName).toBeVisible();
 			await poLiveChat.sendMessage(newVisitor, false);
 		});
 

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-units.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-units.spec.ts
@@ -87,7 +87,7 @@ test.describe('OC - Manage Units', () => {
 
 		await test.step('expect to delete unit', async () => {
 			await poOmnichannelUnits.deleteUnit(unitName);
-			await expect(poOmnichannelUnits.table.findRowByName(unitName)).not.toBeVisible();
+			await expect(poOmnichannelUnits.table.findRowByName(unitName)).toHaveCount(0);
 		});
 	});
 

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-units.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-units.spec.ts
@@ -78,6 +78,7 @@ test.describe('OC - Manage Units', () => {
 			await poOmnichannelUnits.manageUnit.selectVisibility('public');
 			await poOmnichannelUnits.manageUnit.selectDepartment(department.data.name);
 			await poOmnichannelUnits.manageUnit.selectMonitor('user2');
+			await expect(poOmnichannelUnits.manageUnit.findMonitorChipOption('user2')).toBeVisible();
 			await poOmnichannelUnits.manageUnit.btnSave.click();
 			await expect(poOmnichannelUnits.manageUnit.root).not.toBeVisible();
 

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-units.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-units.spec.ts
@@ -60,7 +60,7 @@ test.describe('OC - Manage Units', () => {
 		await poOmnichannelUnits.sidebar.linkUnits.click();
 	});
 
-	test('OC - Manage Units - Create Unit', async ({ page }) => {
+	test('OC - Manage Units - Create Unit', async () => {
 		const unitName = faker.string.uuid();
 
 		await test.step('expect correct form default state', async () => {
@@ -87,7 +87,7 @@ test.describe('OC - Manage Units', () => {
 
 		await test.step('expect to delete unit', async () => {
 			await poOmnichannelUnits.deleteUnit(unitName);
-			await expect(page.locator('h3 >> text="No units yet"')).toBeVisible();
+			await expect(poOmnichannelUnits.table.findRowByName(unitName)).not.toBeVisible();
 		});
 	});
 

--- a/apps/meteor/tests/e2e/page-objects/fragments/home-omnichannel-content.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/home-omnichannel-content.ts
@@ -40,8 +40,9 @@ export class HomeOmnichannelContent extends HomeContent {
 
 	async selectCannedResponse(cannedResponseName: string): Promise<void> {
 		await this.composer.inputMessage.pressSequentially('!');
-		await this.page.locator('[role="menu"][name="ComposerBoxPopup"]').waitFor({ state: 'visible' });
+		const popup = this.composer.boxPopup;
+		await popup.waitFor({ state: 'visible' });
 		await this.composer.inputMessage.pressSequentially(cannedResponseName);
-		await this.page.keyboard.press('Enter');
+		await popup.getByText(cannedResponseName, { exact: true }).click();
 	}
 }

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-manager.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-manager.ts
@@ -21,6 +21,11 @@ export class OmnichannelManager extends OmnichannelAdmin {
 		this.listbox = new Listbox(page);
 	}
 
+	async goto() {
+		await this.page.goto('/omnichannel/managers');
+		await this.btnAddManager.waitFor({ state: 'visible' });
+	}
+
 	get inputUsername(): Locator {
 		return this.page.getByRole('main').getByLabel('Username');
 	}

--- a/apps/meteor/tests/end-to-end/api/livechat/04-dashboards.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/04-dashboards.ts
@@ -12,6 +12,7 @@ import { addOrRemoveAgentFromDepartment, createDepartmentWithAnOnlineAgent, dele
 import {
 	closeOmnichannelRoom,
 	deleteVisitor,
+	makeAgentAvailable,
 	placeRoomOnHold,
 	sendAgentMessage,
 	sendMessage,
@@ -565,6 +566,8 @@ describe('LIVECHAT - dashboards', function () {
 		(IS_EE ? it : it.skip)('should return data with correct values', async () => {
 			const start = moment().subtract(1, 'days').toISOString();
 			const end = moment().toISOString();
+
+			await Promise.all(agents.map((agent) => makeAgentAvailable(agent.credentials)));
 
 			const result = await request
 				.get(api('livechat/analytics/dashboards/charts/agents-status'))


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

This PR focus on stabilizing flaky Omnichannel/API tests by adding explicit waits for the UI/API state each assertion depends on, instead of relying on timing from previous actions.

| Area | Change |
| --- | --- |
| Omnichannel managers | Wait for the manager form to be visible before interacting with it. |
| Livechat read receipts | Wait for the viewed/read receipt state before asserting the read-by dialog content. |
| Omnichannel units | Wait for selected monitor state and unit row removal before continuing assertions. |
| Livechat dashboard API | Reset test agents to `available` before asserting agent status metrics. |
| Agent idle routing | Ensure agent availability state is explicit for routing assertions. |
| Canned responses | Use a more specific popup item locator for selecting canned responses. |
| Livechat triggers | Wait for the livechat registration form input to be visible before filling it. |
| Chat transfers | Wait for the forward modal to close before asserting sidebar ownership changes. |

No screenshots or videos: test-only changes.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[FLAKY-1605](https://rocketchat.atlassian.net/browse/FLAKY-1605)
[FLAKY-1403](https://rocketchat.atlassian.net/browse/FLAKY-1403)
[FLAKY-1829](https://rocketchat.atlassian.net/browse/FLAKY-1829)
[FLAKY-1866](https://rocketchat.atlassian.net/browse/FLAKY-1866)
[FLAKY-1865](https://rocketchat.atlassian.net/browse/FLAKY-1865)
[FLAKY-1603](https://rocketchat.atlassian.net/browse/FLAKY-1603)
[FLAKY-1319](https://rocketchat.atlassian.net/browse/FLAKY-1319)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[FLAKY-1605]: https://rocketchat.atlassian.net/browse/FLAKY-1605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved omnichannel E2E test reliability and coverage across chat transfers, agent idle settings, read receipts, triggers, and units modules.
  * Enhanced test assertions for modal dismissal, agent availability status, and message read receipts.
  * Refactored page object navigation and canned response selection flows for improved test maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->