### PR TITLE
regression: Ephemeral messages not showing on threads

### DIFF
--- a/apps/meteor/client/startup/incomingMessages.ts
+++ b/apps/meteor/client/startup/incomingMessages.ts
@@ -3,6 +3,7 @@ import type { IMessage } from '@rocket.chat/core-typings';
 import { sdk } from '../../app/utils/client/lib/SDKClient';
 import { onLoggedIn } from '../lib/loggedIn';
 import { getUserId } from '../lib/user';
+import { upsertThreadMessageInCache } from '../lib/utils/threadMessageUtils';
 import { Messages } from '../stores';
 
 onLoggedIn(() => {
@@ -11,6 +12,10 @@ onLoggedIn(() => {
 	return sdk.stream('notify-user', [`${getUserId()}/message`], (msg: IMessage) => {
 		msg.u = msg.u || { username: 'rocket.cat' };
 		msg.private = true;
+
+		if (msg.tmid) {
+			upsertThreadMessageInCache(msg, msg.rid, msg.tmid);
+		}
 
 		return Messages.state.store(msg);
 	}).stop;

--- a/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.ts
+++ b/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.ts
@@ -1,5 +1,5 @@
 import { isThreadMessage, type IMessage, type IRoom, type IThreadMainMessage, type IThreadMessage } from '@rocket.chat/core-typings';
-import { useMethod, useStream } from '@rocket.chat/ui-contexts';
+import { useMethod, useStream, useUserId } from '@rocket.chat/ui-contexts';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 
@@ -28,6 +28,8 @@ export const useThreadMessagesQuery = (tmid: IThreadMainMessage['_id'], rid?: IR
 
 	const subscribeToRoomMessages = useStream('room-messages');
 	const subscribeToNotifyRoom = useStream('notify-room');
+	const subscribeToNotifyUser = useStream('notify-user');
+	const uid = useUserId();
 
 	const unprocessedReadMessagesEvent = useRef<{ tmid: string; until: Date } | null>(null);
 
@@ -42,6 +44,17 @@ export const useThreadMessagesQuery = (tmid: IThreadMainMessage['_id'], rid?: IR
 			const processed = await onClientMessageReceived(event);
 			upsertThreadMessageInCache(processed, roomId, tmid, queryClient);
 		});
+
+		const unsubscribeFromUserMessages = uid
+			? subscribeToNotifyUser(`${uid}/message`, async (event) => {
+					if (event.rid !== roomId || event.tmid !== tmid || event._hidden === true) {
+						return;
+					}
+
+					const processed = await onClientMessageReceived(event);
+					upsertThreadMessageInCache(processed, roomId, tmid, queryClient);
+				})
+			: () => undefined;
 
 		const unsubscribeFromDeleteMessage = subscribeToNotifyRoom(`${roomId}/deleteMessage`, (event) => {
 			queryClient.setQueryData<IThreadMessage[]>(currentQueryKey, (old) => {
@@ -94,11 +107,12 @@ export const useThreadMessagesQuery = (tmid: IThreadMainMessage['_id'], rid?: IR
 
 		return () => {
 			unsubscribeFromRoomMessages();
+			unsubscribeFromUserMessages();
 			unsubscribeFromDeleteMessage();
 			unsubscribeFromDeleteMessageBulk();
 			unsubscribeFromMessagesRead();
 		};
-	}, [tmid, roomId, queryClient, subscribeToRoomMessages, subscribeToNotifyRoom]);
+	}, [tmid, roomId, queryClient, subscribeToRoomMessages, subscribeToNotifyRoom, subscribeToNotifyUser, uid]);
 
 	return useQuery({
 		queryKey,

--- a/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.ts
+++ b/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.ts
@@ -1,5 +1,5 @@
 import { isThreadMessage, type IMessage, type IRoom, type IThreadMainMessage, type IThreadMessage } from '@rocket.chat/core-typings';
-import { useMethod, useStream, useUserId } from '@rocket.chat/ui-contexts';
+import { useMethod, useStream } from '@rocket.chat/ui-contexts';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 
@@ -28,8 +28,6 @@ export const useThreadMessagesQuery = (tmid: IThreadMainMessage['_id'], rid?: IR
 
 	const subscribeToRoomMessages = useStream('room-messages');
 	const subscribeToNotifyRoom = useStream('notify-room');
-	const subscribeToNotifyUser = useStream('notify-user');
-	const uid = useUserId();
 
 	const unprocessedReadMessagesEvent = useRef<{ tmid: string; until: Date } | null>(null);
 
@@ -44,17 +42,6 @@ export const useThreadMessagesQuery = (tmid: IThreadMainMessage['_id'], rid?: IR
 			const processed = await onClientMessageReceived(event);
 			upsertThreadMessageInCache(processed, roomId, tmid, queryClient);
 		});
-
-		const unsubscribeFromUserMessages = uid
-			? subscribeToNotifyUser(`${uid}/message`, async (event) => {
-					if (event.rid !== roomId || event.tmid !== tmid || event._hidden === true) {
-						return;
-					}
-
-					const processed = await onClientMessageReceived(event);
-					upsertThreadMessageInCache(processed, roomId, tmid, queryClient);
-				})
-			: () => undefined;
 
 		const unsubscribeFromDeleteMessage = subscribeToNotifyRoom(`${roomId}/deleteMessage`, (event) => {
 			queryClient.setQueryData<IThreadMessage[]>(currentQueryKey, (old) => {
@@ -107,12 +94,11 @@ export const useThreadMessagesQuery = (tmid: IThreadMainMessage['_id'], rid?: IR
 
 		return () => {
 			unsubscribeFromRoomMessages();
-			unsubscribeFromUserMessages();
 			unsubscribeFromDeleteMessage();
 			unsubscribeFromDeleteMessageBulk();
 			unsubscribeFromMessagesRead();
 		};
-	}, [tmid, roomId, queryClient, subscribeToRoomMessages, subscribeToNotifyRoom, subscribeToNotifyUser, uid]);
+	}, [tmid, roomId, queryClient, subscribeToRoomMessages, subscribeToNotifyRoom]);
 
 	return useQuery({
 		queryKey,

--- a/apps/meteor/tests/e2e/message-mentions.spec.ts
+++ b/apps/meteor/tests/e2e/message-mentions.spec.ts
@@ -137,17 +137,17 @@ test.describe.serial('message-mentions', () => {
 			});
 
 			await test.step('show "Do nothing" action', async () => {
-				await expect(adminPage.content.getMessageActionButton(adminPage.content.lastUserMessage, 'Do nothing')).toBeVisible();
+				await expect(adminPage.content.getLastMessageActionButton('Do nothing')).toBeVisible();
 			});
 			await test.step('show "Add them" action', async () => {
-				await expect(adminPage.content.getMessageActionButton(adminPage.content.lastUserMessage, 'Add them')).toBeVisible();
+				await expect(adminPage.content.getLastMessageActionButton('Add them')).toBeVisible();
 			});
 			await test.step('show "Let them know" action', async () => {
-				await expect(adminPage.content.getMessageActionButton(adminPage.content.lastUserMessage, 'Let them know')).toBeVisible();
+				await expect(adminPage.content.getLastMessageActionButton('Let them know')).toBeVisible();
 			});
 
 			await test.step('dismiss', async () => {
-				await adminPage.content.getMessageActionButton(adminPage.content.lastUserMessage, 'Do nothing').click();
+				await adminPage.content.getLastMessageActionButton('Do nothing').click();
 			});
 
 			await test.step('receive second bot message', async () => {
@@ -155,7 +155,7 @@ test.describe.serial('message-mentions', () => {
 				await expect(adminPage.content.lastUserMessage.locator('.rcx-message-block')).toContainText(mentionText);
 			});
 			await test.step('send message to users', async () => {
-				await adminPage.content.getMessageActionButton(adminPage.content.lastUserMessage, 'Let them know').click();
+				await adminPage.content.getLastMessageActionButton('Let them know').click();
 				await expect(adminPage.content.lastUserMessageBody).toContainText(getMentionText(Users.user1.data.username, 3));
 			});
 
@@ -164,7 +164,7 @@ test.describe.serial('message-mentions', () => {
 				await expect(adminPage.content.lastUserMessage.locator('.rcx-message-block')).toContainText(mentionText);
 			});
 			await test.step('add users to room', async () => {
-				await adminPage.content.getMessageActionButton(adminPage.content.lastUserMessage, 'Add them').click();
+				await adminPage.content.getLastMessageActionButton('Add them').click();
 				await expect(adminPage.content.lastSystemMessageBody).toContainText('added');
 			});
 		});
@@ -186,11 +186,9 @@ test.describe.serial('message-mentions', () => {
 			});
 
 			await test.step('show actions inside thread', async () => {
-				const botMessage = adminPage.content.lastUserThreadMessage;
-
-				await expect(adminPage.content.getMessageActionButton(botMessage, 'Do nothing')).toBeVisible();
-				await expect(adminPage.content.getMessageActionButton(botMessage, 'Add them')).toBeVisible();
-				await expect(adminPage.content.getMessageActionButton(botMessage, 'Let them know')).toBeVisible();
+				await expect(adminPage.content.getLastThreadMessageActionButton('Do nothing')).toBeVisible();
+				await expect(adminPage.content.getLastThreadMessageActionButton('Add them')).toBeVisible();
+				await expect(adminPage.content.getLastThreadMessageActionButton('Let them know')).toBeVisible();
 			});
 		});
 
@@ -208,17 +206,17 @@ test.describe.serial('message-mentions', () => {
 				});
 
 				await test.step('show "Do nothing" action', async () => {
-					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Do nothing')).toBeVisible();
+					await expect(userPage.content.getLastMessageActionButton('Do nothing')).toBeVisible();
 				});
 				await test.step('show "Let them know" action', async () => {
-					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Let them know')).toBeVisible();
+					await expect(userPage.content.getLastMessageActionButton('Let them know')).toBeVisible();
 				});
 				await test.step('not show "Add them action', async () => {
-					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Add them')).not.toBeVisible();
+					await expect(userPage.content.getLastMessageActionButton('Add them')).not.toBeVisible();
 				});
 
 				await test.step('dismiss', async () => {
-					await userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Do nothing').click();
+					await userPage.content.getLastMessageActionButton('Do nothing').click();
 				});
 
 				await test.step('receive second bot message', async () => {
@@ -227,7 +225,7 @@ test.describe.serial('message-mentions', () => {
 					await expect(userPage.content.lastUserMessage.locator('.rcx-message-block')).toContainText(mentionText);
 				});
 				await test.step('send message to users', async () => {
-					await userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Let them know').click();
+					await userPage.content.getLastMessageActionButton('Let them know').click();
 					await expect(userPage.content.lastUserMessageBody).toContainText(getMentionText(Users.user2.data.username, 3));
 				});
 			});
@@ -262,17 +260,17 @@ test.describe.serial('message-mentions', () => {
 					await expect(userPage.content.lastUserMessage.locator('.rcx-message-block')).toContainText(mentionText);
 				});
 				await test.step('show "Do nothing" action', async () => {
-					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Do nothing')).toBeVisible();
+					await expect(userPage.content.getLastMessageActionButton('Do nothing')).toBeVisible();
 				});
 				await test.step('show "Add them" action', async () => {
-					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Add them')).toBeVisible();
+					await expect(userPage.content.getLastMessageActionButton('Add them')).toBeVisible();
 				});
 				await test.step('not show "Let them know" action', async () => {
-					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Let them know')).not.toBeVisible();
+					await expect(userPage.content.getLastMessageActionButton('Let them know')).not.toBeVisible();
 				});
 
 				await test.step('dismiss', async () => {
-					await userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Do nothing').click();
+					await userPage.content.getLastMessageActionButton('Do nothing').click();
 				});
 
 				await test.step('receive second bot message', async () => {
@@ -281,7 +279,7 @@ test.describe.serial('message-mentions', () => {
 					await expect(userPage.content.lastUserMessage.locator('.rcx-message-block')).toContainText(mentionText);
 				});
 				await test.step('add users to room', async () => {
-					await userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Add them').click();
+					await userPage.content.getLastMessageActionButton('Add them').click();
 					await expect(userPage.content.lastSystemMessageBody).toContainText('added');
 				});
 			});
@@ -310,13 +308,13 @@ test.describe.serial('message-mentions', () => {
 				});
 
 				await test.step('not show "Do nothing" action', async () => {
-					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Do nothing')).not.toBeVisible();
+					await expect(userPage.content.getLastMessageActionButton('Do nothing')).not.toBeVisible();
 				});
 				await test.step('not show "Add them" action', async () => {
-					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Add them')).not.toBeVisible();
+					await expect(userPage.content.getLastMessageActionButton('Add them')).not.toBeVisible();
 				});
 				await test.step('not show "Let them know" action', async () => {
-					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Let them know')).not.toBeVisible();
+					await expect(userPage.content.getLastMessageActionButton('Let them know')).not.toBeVisible();
 				});
 			});
 		});

--- a/apps/meteor/tests/e2e/message-mentions.spec.ts
+++ b/apps/meteor/tests/e2e/message-mentions.spec.ts
@@ -169,6 +169,23 @@ test.describe.serial('message-mentions', () => {
 			});
 		});
 
+		test('should show non-member mention warning inside threads', async ({ page }) => {
+			const adminPage = new HomeChannel(page);
+			const mentionText = getMentionText(Users.user2.data.username, 1);
+
+			await test.step('open thread', async () => {
+				await adminPage.navbar.openChat(targetChannel);
+				await adminPage.content.sendMessage('thread parent for non-member mention warning');
+				await adminPage.content.openReplyInThread();
+				await adminPage.content.waitForThread();
+			});
+
+			await test.step('receive bot message inside thread', async () => {
+				await adminPage.content.sendMessageInThread(getMentionText(Users.user2.data.username));
+				await expect(adminPage.content.threadMessageListItems.filter({ hasText: mentionText }).first()).toBeVisible();
+			});
+		});
+
 		test.describe(() => {
 			test.use({ storageState: Users.user1.state });
 

--- a/apps/meteor/tests/e2e/message-mentions.spec.ts
+++ b/apps/meteor/tests/e2e/message-mentions.spec.ts
@@ -137,17 +137,17 @@ test.describe.serial('message-mentions', () => {
 			});
 
 			await test.step('show "Do nothing" action', async () => {
-				await expect(adminPage.content.lastUserMessage.locator('button >> text="Do nothing"')).toBeVisible();
+				await expect(adminPage.content.getMessageActionButton(adminPage.content.lastUserMessage, 'Do nothing')).toBeVisible();
 			});
 			await test.step('show "Add them" action', async () => {
-				await expect(adminPage.content.lastUserMessage.locator('button >> text="Add them"')).toBeVisible();
+				await expect(adminPage.content.getMessageActionButton(adminPage.content.lastUserMessage, 'Add them')).toBeVisible();
 			});
 			await test.step('show "Let them know" action', async () => {
-				await expect(adminPage.content.lastUserMessage.locator('button >> text="Let them know"')).toBeVisible();
+				await expect(adminPage.content.getMessageActionButton(adminPage.content.lastUserMessage, 'Let them know')).toBeVisible();
 			});
 
 			await test.step('dismiss', async () => {
-				await adminPage.content.lastUserMessage.locator('button >> text="Do nothing"').click();
+				await adminPage.content.getMessageActionButton(adminPage.content.lastUserMessage, 'Do nothing').click();
 			});
 
 			await test.step('receive second bot message', async () => {
@@ -155,7 +155,7 @@ test.describe.serial('message-mentions', () => {
 				await expect(adminPage.content.lastUserMessage.locator('.rcx-message-block')).toContainText(mentionText);
 			});
 			await test.step('send message to users', async () => {
-				await adminPage.content.lastUserMessage.locator('button >> text="Let them know"').click();
+				await adminPage.content.getMessageActionButton(adminPage.content.lastUserMessage, 'Let them know').click();
 				await expect(adminPage.content.lastUserMessageBody).toContainText(getMentionText(Users.user1.data.username, 3));
 			});
 
@@ -164,7 +164,7 @@ test.describe.serial('message-mentions', () => {
 				await expect(adminPage.content.lastUserMessage.locator('.rcx-message-block')).toContainText(mentionText);
 			});
 			await test.step('add users to room', async () => {
-				await adminPage.content.lastUserMessage.locator('button >> text="Add them"').click();
+				await adminPage.content.getMessageActionButton(adminPage.content.lastUserMessage, 'Add them').click();
 				await expect(adminPage.content.lastSystemMessageBody).toContainText('added');
 			});
 		});
@@ -182,7 +182,15 @@ test.describe.serial('message-mentions', () => {
 
 			await test.step('receive bot message inside thread', async () => {
 				await adminPage.content.sendMessageInThread(getMentionText(Users.user2.data.username));
-				await expect(adminPage.content.threadMessageListItems.filter({ hasText: mentionText }).first()).toBeVisible();
+				await expect(adminPage.content.lastUserThreadMessage).toContainText(mentionText);
+			});
+
+			await test.step('show actions inside thread', async () => {
+				const botMessage = adminPage.content.lastUserThreadMessage;
+
+				await expect(adminPage.content.getMessageActionButton(botMessage, 'Do nothing')).toBeVisible();
+				await expect(adminPage.content.getMessageActionButton(botMessage, 'Add them')).toBeVisible();
+				await expect(adminPage.content.getMessageActionButton(botMessage, 'Let them know')).toBeVisible();
 			});
 		});
 
@@ -200,17 +208,17 @@ test.describe.serial('message-mentions', () => {
 				});
 
 				await test.step('show "Do nothing" action', async () => {
-					await expect(userPage.content.lastUserMessage.locator('button >> text="Do nothing"')).toBeVisible();
+					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Do nothing')).toBeVisible();
 				});
 				await test.step('show "Let them know" action', async () => {
-					await expect(userPage.content.lastUserMessage.locator('button >> text="Let them know"')).toBeVisible();
+					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Let them know')).toBeVisible();
 				});
 				await test.step('not show "Add them action', async () => {
-					await expect(userPage.content.lastUserMessage.locator('button >> text="Add them"')).not.toBeVisible();
+					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Add them')).not.toBeVisible();
 				});
 
 				await test.step('dismiss', async () => {
-					await userPage.content.lastUserMessage.locator('button >> text="Do nothing"').click();
+					await userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Do nothing').click();
 				});
 
 				await test.step('receive second bot message', async () => {
@@ -219,7 +227,7 @@ test.describe.serial('message-mentions', () => {
 					await expect(userPage.content.lastUserMessage.locator('.rcx-message-block')).toContainText(mentionText);
 				});
 				await test.step('send message to users', async () => {
-					await userPage.content.lastUserMessage.locator('button >> text="Let them know"').click();
+					await userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Let them know').click();
 					await expect(userPage.content.lastUserMessageBody).toContainText(getMentionText(Users.user2.data.username, 3));
 				});
 			});
@@ -254,17 +262,17 @@ test.describe.serial('message-mentions', () => {
 					await expect(userPage.content.lastUserMessage.locator('.rcx-message-block')).toContainText(mentionText);
 				});
 				await test.step('show "Do nothing" action', async () => {
-					await expect(userPage.content.lastUserMessage.locator('button >> text="Do nothing"')).toBeVisible();
+					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Do nothing')).toBeVisible();
 				});
 				await test.step('show "Add them" action', async () => {
-					await expect(userPage.content.lastUserMessage.locator('button >> text="Add them"')).toBeVisible();
+					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Add them')).toBeVisible();
 				});
 				await test.step('not show "Let them know" action', async () => {
-					await expect(userPage.content.lastUserMessage.locator('button >> text="Let them know"')).not.toBeVisible();
+					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Let them know')).not.toBeVisible();
 				});
 
 				await test.step('dismiss', async () => {
-					await userPage.content.lastUserMessage.locator('button >> text="Do nothing"').click();
+					await userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Do nothing').click();
 				});
 
 				await test.step('receive second bot message', async () => {
@@ -273,7 +281,7 @@ test.describe.serial('message-mentions', () => {
 					await expect(userPage.content.lastUserMessage.locator('.rcx-message-block')).toContainText(mentionText);
 				});
 				await test.step('add users to room', async () => {
-					await userPage.content.lastUserMessage.locator('button >> text="Add them"').click();
+					await userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Add them').click();
 					await expect(userPage.content.lastSystemMessageBody).toContainText('added');
 				});
 			});
@@ -302,13 +310,13 @@ test.describe.serial('message-mentions', () => {
 				});
 
 				await test.step('not show "Do nothing" action', async () => {
-					await expect(userPage.content.lastUserMessage.locator('button >> text="Do nothing"')).not.toBeVisible();
+					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Do nothing')).not.toBeVisible();
 				});
 				await test.step('not show "Add them" action', async () => {
-					await expect(userPage.content.lastUserMessage.locator('button >> text="Add them"')).not.toBeVisible();
+					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Add them')).not.toBeVisible();
 				});
 				await test.step('not show "Let them know" action', async () => {
-					await expect(userPage.content.lastUserMessage.locator('button >> text="Let them know"')).not.toBeVisible();
+					await expect(userPage.content.getMessageActionButton(userPage.content.lastUserMessage, 'Let them know')).not.toBeVisible();
 				});
 			});
 		});

--- a/apps/meteor/tests/e2e/page-objects/fragments/home-content.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/home-content.ts
@@ -544,8 +544,12 @@ export class HomeContent {
 		return this.page.locator('[role="listitem"][aria-roledescription="message"]', { hasText: text });
 	}
 
-	getMessageActionButton(message: Locator, name: string): Locator {
-		return message.getByRole('button', { name, exact: true });
+	getLastMessageActionButton(name: string): Locator {
+		return this.lastUserMessage.getByRole('button', { name, exact: true });
+	}
+
+	getLastThreadMessageActionButton(name: string): Locator {
+		return this.lastUserThreadMessage.getByRole('button', { name, exact: true });
 	}
 
 	getMessageById(id: string): Locator {

--- a/apps/meteor/tests/e2e/page-objects/fragments/home-content.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/home-content.ts
@@ -544,6 +544,10 @@ export class HomeContent {
 		return this.page.locator('[role="listitem"][aria-roledescription="message"]', { hasText: text });
 	}
 
+	getMessageActionButton(message: Locator, name: string): Locator {
+		return message.getByRole('button', { name, exact: true });
+	}
+
 	getMessageById(id: string): Locator {
 		return this.page.locator(`[role="listitem"][aria-roledescription="message"][id="${id}"]`);
 	}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Fixes non-member mention warnings not appearing inside thread replies.

Fixes ephemeral messages (e.g. non-member mention warnings) not appearing inside thread replies.
The root cause was that the notify-user stream — which delivers user-scoped ephemeral messages — was not feeding into the thread message cache. The fix adds a check in incomingMessages.ts: when an incoming ephemeral message has a tmid, it is forwarded to upsertThreadMessageInCache so it gets inserted into the correct thread, in addition to being stored in the regular message store.

This PR also adds/updates e2e coverage for message mention warnings:

- Adds a thread scenario that mentions a non-member and verifies the warning actions are visible inside the thread.
- Reuses page-object helpers for warning action buttons in regular messages and thread messages.
- Keeps the existing permission-specific warning action assertions for room messages.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-2278](https://rocketchat.atlassian.net/browse/CORE-2278)
Root cause: https://github.com/RocketChat/Rocket.Chat/pull/39859
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Create or open a channel where the target user is not a member.
2. Send a message and open its thread.
3. Send a thread reply mentioning the non-member user.
4. Verify the non-member mention warning appears inside the thread with the expected actions:
   - `Do nothing`
   - `Add them`
   - `Let them know`

Automated coverage: `apps/meteor/tests/e2e/message-mentions.spec.ts` includes the `should show non-member mention warning inside threads` scenario.


## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-2278]: https://rocketchat.atlassian.net/browse/CORE-2278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread message caching for ephemeral incoming messages.

* **Tests**
  * Added test coverage for message mention warnings triggered within thread conversations.
  * Refactored mention warning tests with improved helper utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->