### PR TITLE
fix: workspace crashing when invalid regular expression is used on message search query

### DIFF
--- a/.changeset/eighty-onions-deny.md
+++ b/.changeset/eighty-onions-deny.md
@@ -2,4 +2,4 @@
 '@rocket.chat/meteor': patch
 ---
 
-Fixes error handling on message search
+Fixes error handling when using invalid regular expressions on message search

--- a/.changeset/eighty-onions-deny.md
+++ b/.changeset/eighty-onions-deny.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes error handling on message search

--- a/apps/meteor/server/lib/parseMessageSearchQuery.ts
+++ b/apps/meteor/server/lib/parseMessageSearchQuery.ts
@@ -251,7 +251,8 @@ class MessageSearchQueryParser {
 		if (/^\/.+\/[imxs]*$/.test(text)) {
 			const r = text.split('/');
 
-			new RegExp(r[1], r[2]);
+			// We remove the 'x' flag that JS does not support but Mongo does
+			new RegExp(r[1], r[2].replace(/x/g, ''));
 
 			this.query.msg = {
 				$regex: r[1],

--- a/apps/meteor/server/lib/parseMessageSearchQuery.ts
+++ b/apps/meteor/server/lib/parseMessageSearchQuery.ts
@@ -250,11 +250,16 @@ class MessageSearchQueryParser {
 
 		if (/^\/.+\/[imxs]*$/.test(text)) {
 			const r = text.split('/');
+
+			new RegExp(r[1], r[2]);
+
 			this.query.msg = {
 				$regex: r[1],
 				$options: r[2],
 			};
 		} else if (this.forceRegex) {
+			new RegExp(text, 'i');
+
 			this.query.msg = {
 				$regex: text,
 				$options: 'i',

--- a/apps/meteor/server/methods/messageSearch.ts
+++ b/apps/meteor/server/methods/messageSearch.ts
@@ -87,12 +87,17 @@ export const messageSearch = async function (
 			},
 		};
 	} catch (error: unknown) {
-		SystemLogger.error({ msg: 'Error while finding messages', error });
-		return {
-			message: {
-				docs: [],
-			},
-		};
+		if (error instanceof Error) {
+			const mongoError = error as Error & { code: number };
+
+			if (mongoError.code === 51091) {
+				SystemLogger.debug({ msg: 'Invalid regex gracefully caught at DB level', text });
+				return { message: { docs: [] } };
+			}
+		}
+
+		SystemLogger.error({ msg: 'Critical error while finding messages', error });
+		throw error;
 	}
 };
 

--- a/apps/meteor/server/methods/messageSearch.ts
+++ b/apps/meteor/server/methods/messageSearch.ts
@@ -9,6 +9,7 @@ import { methodDeprecationLogger } from '../../app/lib/server/lib/deprecationWar
 import type { IRawSearchResult } from '../../app/search/server/model/ISearchResult';
 import { settings } from '../../app/settings/server';
 import { readSecondaryPreferred } from '../database/readSecondaryPreferred';
+import { SystemLogger } from '../lib/logger/system';
 import { parseMessageSearchQuery } from '../lib/parseMessageSearchQuery';
 
 declare module '@rocket.chat/ddp-client' {
@@ -75,15 +76,24 @@ export const messageSearch = async function (
 		};
 	}
 
-	return {
-		message: {
-			docs: await Messages.find(query, {
-				// @ts-expect-error col.s.db is not typed
-				readPreference: readSecondaryPreferred(Messages.col.s.db),
-				...options,
-			}).toArray(),
-		},
-	};
+	try {
+		return {
+			message: {
+				docs: await Messages.find(query, {
+					// @ts-expect-error col.s.db is not typed
+					readPreference: readSecondaryPreferred(Messages.col.s.db),
+					...options,
+				}).toArray(),
+			},
+		};
+	} catch (error: unknown) {
+		SystemLogger.error({ msg: 'Error while finding messages', error });
+		return {
+			message: {
+				docs: [],
+			},
+		};
+	}
 };
 
 Meteor.methods<ServerMethods>({

--- a/apps/meteor/server/methods/messageSearch.ts
+++ b/apps/meteor/server/methods/messageSearch.ts
@@ -90,15 +90,20 @@ export const messageSearch = async function (
 		};
 	}
 
-	return {
-		message: {
-			docs: await Messages.find(query, {
-				// @ts-expect-error col.s.db is not typed
-				readPreference: readSecondaryPreferred(Messages.col.s.db),
-				...options,
-			}).toArray(),
-		},
-	};
+	try {
+		return {
+			message: {
+				docs: await Messages.find(query, {
+					// @ts-expect-error col.s.db is not typed
+					readPreference: readSecondaryPreferred(Messages.col.s.db),
+					...options,
+				}).toArray(),
+			},
+		};
+	} catch (error) {
+		logger.error({ msg: 'Error while finding messages', error });
+		throw new Error('error-while-finding-messages', { cause: error });
+	}
 };
 
 Meteor.methods<ServerMethods>({

--- a/apps/meteor/server/methods/messageSearch.ts
+++ b/apps/meteor/server/methods/messageSearch.ts
@@ -58,11 +58,10 @@ export const messageSearch = async function (
 			forceRegex: settings.get('Message_AlwaysSearchRegExp'),
 		});
 	} catch (error: unknown) {
+		logger.error({ msg: 'Error while parsing message search query', error });
 		if (error instanceof SyntaxError) {
-			logger.debug({ msg: 'Invalid regex gracefully caught' });
 			return { message: { docs: [] } };
 		}
-		logger.error({ msg: 'Critical error while parsing message search query', error });
 		throw error;
 	}
 

--- a/apps/meteor/server/methods/messageSearch.ts
+++ b/apps/meteor/server/methods/messageSearch.ts
@@ -1,5 +1,6 @@
 import type { ISubscription } from '@rocket.chat/core-typings';
 import type { ServerMethods } from '@rocket.chat/ddp-client';
+import { Logger } from '@rocket.chat/logger';
 import { Messages, Subscriptions, Users } from '@rocket.chat/models';
 import { Match, check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
@@ -9,8 +10,9 @@ import { methodDeprecationLogger } from '../../app/lib/server/lib/deprecationWar
 import type { IRawSearchResult } from '../../app/search/server/model/ISearchResult';
 import { settings } from '../../app/settings/server';
 import { readSecondaryPreferred } from '../database/readSecondaryPreferred';
-import { SystemLogger } from '../lib/logger/system';
 import { parseMessageSearchQuery } from '../lib/parseMessageSearchQuery';
+
+const logger = new Logger('MessageSearch');
 
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -46,12 +48,25 @@ export const messageSearch = async function (
 
 	const user = (await Users.findOneById(userId)) || undefined;
 
-	const { query, options } = parseMessageSearchQuery(text, {
-		user,
-		offset,
-		limit,
-		forceRegex: settings.get('Message_AlwaysSearchRegExp'),
-	});
+	let parsedQuery: ReturnType<typeof parseMessageSearchQuery>;
+
+	try {
+		parsedQuery = parseMessageSearchQuery(text, {
+			user,
+			offset,
+			limit,
+			forceRegex: settings.get('Message_AlwaysSearchRegExp'),
+		});
+	} catch (error: unknown) {
+		if (error instanceof SyntaxError) {
+			logger.debug({ msg: 'Invalid regex gracefully caught' });
+			return { message: { docs: [] } };
+		}
+		logger.error({ msg: 'Critical error while parsing message search query', error });
+		throw error;
+	}
+
+	const { query, options } = parsedQuery;
 
 	if (Object.keys(query).length === 0) {
 		return {
@@ -76,29 +91,15 @@ export const messageSearch = async function (
 		};
 	}
 
-	try {
-		return {
-			message: {
-				docs: await Messages.find(query, {
-					// @ts-expect-error col.s.db is not typed
-					readPreference: readSecondaryPreferred(Messages.col.s.db),
-					...options,
-				}).toArray(),
-			},
-		};
-	} catch (error: unknown) {
-		if (error instanceof Error) {
-			const mongoError = error as Error & { code: number };
-
-			if (mongoError.code === 51091) {
-				SystemLogger.debug({ msg: 'Invalid regex gracefully caught at DB level', text });
-				return { message: { docs: [] } };
-			}
-		}
-
-		SystemLogger.error({ msg: 'Critical error while finding messages', error });
-		throw error;
-	}
+	return {
+		message: {
+			docs: await Messages.find(query, {
+				// @ts-expect-error col.s.db is not typed
+				readPreference: readSecondaryPreferred(Messages.col.s.db),
+				...options,
+			}).toArray(),
+		},
+	};
 };
 
 Meteor.methods<ServerMethods>({

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -2616,13 +2616,45 @@ describe('[Chat]', () => {
 				.end(done);
 		});
 
-		it('should return an empty array of messages with status 200 if the regexp is invalid', async () => {
+		it('should return an empty array of messages with status 200 if the regexp starts with an invalid quantifier', async () => {
 			await request
 				.get(api('chat.search'))
 				.set(credentials)
 				.query({
 					roomId: testChannel._id,
 					searchText: '/*test/',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('messages').and.to.be.deep.equal([]);
+				});
+		});
+
+		it('should return an empty array of messages with status 200 if the regexp has an unclosed parenthesis', async () => {
+			await request
+				.get(api('chat.search'))
+				.set(credentials)
+				.query({
+					roomId: testChannel._id,
+					searchText: '/(test/',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('messages').and.to.be.deep.equal([]);
+				});
+		});
+
+		it('should return an empty array of messages with status 200 if the regexp has an unclosed character class', async () => {
+			await request
+				.get(api('chat.search'))
+				.set(credentials)
+				.query({
+					roomId: testChannel._id,
+					searchText: '/[a-z/',
 				})
 				.expect('Content-Type', 'application/json')
 				.expect(200)

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -2614,6 +2614,23 @@ describe('[Chat]', () => {
 				})
 				.end(done);
 		});
+
+		it('should return an empty array of messages with status 200 if the regexp is invalid', (done) => {
+			void request
+				.get(api('chat.search'))
+				.set(credentials)
+				.query({
+					roomId: testChannel._id,
+					searchText: '/*test/',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('messages').and.to.be.deep.equal([]);
+				})
+				.end(done);
+		});
 	});
 
 	describe('[/chat.react]', () => {

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -2539,6 +2539,7 @@ describe('[Chat]', () => {
 			await sendMessage('msg1');
 			await sendMessage('msg1');
 			await sendMessage('msg1');
+			await sendMessage('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!');
 		});
 
 		it('should return a list of messages when execute successfully', (done) => {
@@ -2615,8 +2616,8 @@ describe('[Chat]', () => {
 				.end(done);
 		});
 
-		it('should return an empty array of messages with status 200 if the regexp is invalid', (done) => {
-			void request
+		it('should return an empty array of messages with status 200 if the regexp is invalid', async () => {
+			await request
 				.get(api('chat.search'))
 				.set(credentials)
 				.query({
@@ -2628,8 +2629,23 @@ describe('[Chat]', () => {
 				.expect((res) => {
 					expect(res.body).to.have.property('success', true);
 					expect(res.body).to.have.property('messages').and.to.be.deep.equal([]);
+				});
+		});
+
+		it('should not cause catastrophic backtracking when using a malicious regexp', async () => {
+			await request
+				.get(api('chat.search'))
+				.set(credentials)
+				.query({
+					roomId: testChannel._id,
+					searchText: '/(a+)+$/',
 				})
-				.end(done);
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('messages').and.to.be.deep.equal([]);
+				});
 		});
 	});
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
 When users wrap searches in slashes (/.../), or if the `Message_AlwaysSearchRegExp` setting is enabled, the parser sends the raw, unescaped string directly to MongoDB as a $regex query. MongoDB rightfully rejects syntax that starts with a quantifier (like ?test or *test) and throws a MongoServerError. 
 
My proposed solution is to check regular expressions are valid wrapping the `parseMessageSearchQuery` method within a try-catch and capture `SyntaxError` thrown by `new RegExp()`.  Also an API test is added to avoid the regression.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[SUP-1049 Bug with regex expressions on global search](https://rocketchat.atlassian.net/browse/SUP-1049)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1- Open any room.
2- Click on 'Search Messages' from the room toolbar (the button with this icon  🔍).
3- Type `/*test/`

**Without this PR**: The workspace crashes due to the Mongo server unhandled error.
**With this PR**: The 'invalid regexp' error is caught by the try-catch and an error is logged in console.
 
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Message search no longer errors on invalid regex-like patterns; such queries return an empty result set instead of failing.
  * Adjustments to regex-style and forced-regex handling may affect which messages match in edge cases.

* **Tests**
  * Added end-to-end test verifying invalid search patterns return success with no messages.

* **Chores**
  * Added a release entry documenting the patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->