### PR TITLE
feat(apps-engine): expose `isFederated` field  in room  and user objects to apps

### DIFF
--- a/.changeset/true-cooks-lick.md
+++ b/.changeset/true-cooks-lick.md
@@ -3,4 +3,4 @@
 '@rocket.chat/meteor': minor
 ---
 
-Exposes the `isFederated` and `federation` fields for room objects in apps
+Exposes the `isFederated` and `federation` fields for room and user objects in apps

--- a/.changeset/true-cooks-lick.md
+++ b/.changeset/true-cooks-lick.md
@@ -3,4 +3,4 @@
 '@rocket.chat/meteor': minor
 ---
 
-Exposes the `isFederated` field for room objects in apps
+Exposes the `isFederated` and `federation` fields for room objects in apps

--- a/.changeset/true-cooks-lick.md
+++ b/.changeset/true-cooks-lick.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/apps-engine': minor
+'@rocket.chat/meteor': minor
+---
+
+Exposes the `isFederated` field for room objects in apps

--- a/apps/meteor/app/apps/server/bridges/rooms.ts
+++ b/apps/meteor/app/apps/server/bridges/rooms.ts
@@ -37,6 +37,7 @@ const rawRoomProjection: FindOptions<ICoreRoom>['projection'] = {
 	prid: 1,
 	teamId: 1,
 	teamMain: 1,
+	federated: 1,
 	livechatData: 1,
 	waitingResponse: 1,
 	open: 1,

--- a/apps/meteor/app/apps/server/bridges/rooms.ts
+++ b/apps/meteor/app/apps/server/bridges/rooms.ts
@@ -38,6 +38,7 @@ const rawRoomProjection: FindOptions<ICoreRoom>['projection'] = {
 	teamId: 1,
 	teamMain: 1,
 	federated: 1,
+	federation: 1,
 	livechatData: 1,
 	waitingResponse: 1,
 	open: 1,

--- a/apps/meteor/app/apps/server/converters/rooms.js
+++ b/apps/meteor/app/apps/server/converters/rooms.js
@@ -60,6 +60,7 @@ export class AppRoomsConverter {
 			departmentId: 'departmentId',
 			parentRoomId: 'prid',
 			isFederated: 'federated',
+			federation: 'federation',
 			visitor: (data) => {
 				const { v } = data;
 				if (!v) {
@@ -263,6 +264,7 @@ export class AppRoomsConverter {
 			...(room.customFields && { customFields: room.customFields }),
 			...(room.livechatData && { livechatData: room.livechatData }),
 			...(typeof room.isFederated !== 'undefined' && { federated: room.isFederated }),
+			...(typeof room.federation !== 'undefined' && { federation: room.federation }),
 			...(typeof room.parentRoom !== 'undefined' && { prid: room.parentRoom.id }),
 			...(contactId && { contactId }),
 			...(room._USERNAMES && { _USERNAMES: room._USERNAMES }),
@@ -307,6 +309,7 @@ export class AppRoomsConverter {
 			teamId: 'teamId',
 			isTeamMain: 'teamMain',
 			isFederated: 'federated',
+			federation: 'federation',
 			isDefault: (room) => {
 				const result = !!room.default;
 				delete room.default;

--- a/apps/meteor/app/apps/server/converters/rooms.js
+++ b/apps/meteor/app/apps/server/converters/rooms.js
@@ -59,6 +59,7 @@ export class AppRoomsConverter {
 			contactId: 'contactId',
 			departmentId: 'departmentId',
 			parentRoomId: 'prid',
+			isFederated: 'federated',
 			visitor: (data) => {
 				const { v } = data;
 				if (!v) {
@@ -261,6 +262,7 @@ export class AppRoomsConverter {
 			...(room.lastModifiedAt && { lm: room.lastModifiedAt }),
 			...(room.customFields && { customFields: room.customFields }),
 			...(room.livechatData && { livechatData: room.livechatData }),
+			...(typeof room.isFederated !== 'undefined' && { federated: room.isFederated }),
 			...(typeof room.parentRoom !== 'undefined' && { prid: room.parentRoom.id }),
 			...(contactId && { contactId }),
 			...(room._USERNAMES && { _USERNAMES: room._USERNAMES }),
@@ -304,6 +306,7 @@ export class AppRoomsConverter {
 			closer: 'closer',
 			teamId: 'teamId',
 			isTeamMain: 'teamMain',
+			isFederated: 'federated',
 			isDefault: (room) => {
 				const result = !!room.default;
 				delete room.default;

--- a/apps/meteor/app/apps/server/converters/users.js
+++ b/apps/meteor/app/apps/server/converters/users.js
@@ -45,6 +45,8 @@ export class AppUsersConverter {
 			lastLoginAt: user.lastLogin,
 			appId: user.appId,
 			customFields: user.customFields,
+			isFederated: user.federated,
+			federation: user.federation,
 			sipExtension: user.freeSwitchExtension,
 			settings: {
 				preferences: {
@@ -75,6 +77,8 @@ export class AppUsersConverter {
 			_updatedAt: user.updatedAt,
 			lastLogin: user.lastLoginAt,
 			appId: user.appId,
+			federated: user.isFederated,
+			federation: user.federation,
 			freeSwitchExtension: user.sipExtension,
 		});
 	}

--- a/packages/apps-engine/src/definition/federation/FederationLookup.ts
+++ b/packages/apps-engine/src/definition/federation/FederationLookup.ts
@@ -1,0 +1,5 @@
+export type FederationLookup = {
+	version: number;
+	mrid: string;
+	origin: string;
+};

--- a/packages/apps-engine/src/definition/federation/index.ts
+++ b/packages/apps-engine/src/definition/federation/index.ts
@@ -1,0 +1,1 @@
+export type * from './FederationLookup';

--- a/packages/apps-engine/src/definition/rooms/IRoom.ts
+++ b/packages/apps-engine/src/definition/rooms/IRoom.ts
@@ -27,6 +27,11 @@ export interface IRoom {
 	parentRoom?: IRoom;
 	livechatData?: { [key: string]: any };
 	isFederated?: boolean;
+	federation?: {
+		version: number;
+		mrid: string;
+		origin: string;
+	};
 
 	abacAttributes?: IAbacAttributeDefinition[];
 }

--- a/packages/apps-engine/src/definition/rooms/IRoom.ts
+++ b/packages/apps-engine/src/definition/rooms/IRoom.ts
@@ -1,4 +1,5 @@
 import type { IAbacAttributeDefinition } from '../abac/AbacAttributes';
+import type { FederationLookup } from '../federation';
 import type { IUser } from '../users';
 import type { RoomType } from './RoomType';
 
@@ -27,11 +28,7 @@ export interface IRoom {
 	parentRoom?: IRoom;
 	livechatData?: { [key: string]: any };
 	isFederated?: boolean;
-	federation?: {
-		version: number;
-		mrid: string;
-		origin: string;
-	};
+	federation?: FederationLookup;
 
 	abacAttributes?: IAbacAttributeDefinition[];
 }

--- a/packages/apps-engine/src/definition/rooms/IRoom.ts
+++ b/packages/apps-engine/src/definition/rooms/IRoom.ts
@@ -26,6 +26,7 @@ export interface IRoom {
 	customFields?: { [key: string]: any };
 	parentRoom?: IRoom;
 	livechatData?: { [key: string]: any };
+	isFederated?: boolean;
 
 	abacAttributes?: IAbacAttributeDefinition[];
 }

--- a/packages/apps-engine/src/definition/rooms/IRoomRaw.ts
+++ b/packages/apps-engine/src/definition/rooms/IRoomRaw.ts
@@ -1,7 +1,7 @@
 import type { IVisitor } from '../livechat';
+import type { RoomType } from './RoomType';
 import type { IOmnichannelSource, IVisitorChannelInfo } from '../livechat/ILivechatRoom';
 import type { IUserLookup } from '../users';
-import type { RoomType } from './RoomType';
 
 /**
  * A lightweight representation of a room without resolving relational data.
@@ -40,4 +40,5 @@ export interface IRoomRaw {
 	visitor?: Pick<IVisitor, 'id' | 'token' | 'username' | 'name' | 'status' | 'activity'> & IVisitorChannelInfo;
 	departmentId?: string;
 	contactId?: string;
+	isFederated?: boolean;
 }

--- a/packages/apps-engine/src/definition/rooms/IRoomRaw.ts
+++ b/packages/apps-engine/src/definition/rooms/IRoomRaw.ts
@@ -1,5 +1,6 @@
 import type { IVisitor } from '../livechat';
 import type { RoomType } from './RoomType';
+import type { FederationLookup } from '../federation';
 import type { IOmnichannelSource, IVisitorChannelInfo } from '../livechat/ILivechatRoom';
 import type { IUserLookup } from '../users';
 
@@ -41,9 +42,5 @@ export interface IRoomRaw {
 	departmentId?: string;
 	contactId?: string;
 	isFederated?: boolean;
-	federation?: {
-		version: number;
-		mrid: string;
-		origin: string;
-	};
+	federation?: FederationLookup;
 }

--- a/packages/apps-engine/src/definition/rooms/IRoomRaw.ts
+++ b/packages/apps-engine/src/definition/rooms/IRoomRaw.ts
@@ -41,4 +41,9 @@ export interface IRoomRaw {
 	departmentId?: string;
 	contactId?: string;
 	isFederated?: boolean;
+	federation?: {
+		version: number;
+		mrid: string;
+		origin: string;
+	};
 }

--- a/packages/apps-engine/src/definition/users/IUser.ts
+++ b/packages/apps-engine/src/definition/users/IUser.ts
@@ -1,3 +1,4 @@
+import type { FederationLookup } from '../federation';
 import type { IUserEmail } from './IUserEmail';
 import type { IUserSettings } from './IUserSettings';
 import type { UserStatusConnection } from './UserStatusConnection';
@@ -22,5 +23,7 @@ export interface IUser {
 	settings?: IUserSettings;
 	appId?: string;
 	sipExtension?: string;
+	isFederated?: boolean;
+	federation?: FederationLookup;
 	customFields?: { [key: string]: any };
 }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[DMV-11]
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[DMV-11]: https://rocketchat.atlassian.net/browse/DMV-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apps can now read/write optional federation metadata on room records, including `isFederated` and `federation` (version, mrid, origin).
  * Apps can now read/write the same optional federation metadata on user records.
  * Added a federation lookup type to support the `federation` field.
* **Documentation**
  * Documented that room and user objects expose both `isFederated` and `federation`.
* **Chores**
  * Bumped related apps engine and platform packages to minor versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->