### PR TITLE
fix: skip unread alert on room rename when system message is disabled

### DIFF
--- a/apps/meteor/app/channel-settings/server/functions/saveRoomName.ts
+++ b/apps/meteor/app/channel-settings/server/functions/saveRoomName.ts
@@ -21,7 +21,7 @@ const updateFName = async (rid: string, displayName: string): Promise<(UpdateRes
 	return responses;
 };
 
-const updateRoomName = async (rid: string, displayName: string, slugifiedRoomName: string) => {
+const updateRoomName = async (rid: string, displayName: string, slugifiedRoomName: string , shouldAlert: boolean) => {
 	// Check if the username is available
 	if (!(await checkUsernameAvailability(slugifiedRoomName))) {
 		throw new Meteor.Error('error-duplicate-handle', `A room, team or user with name '${slugifiedRoomName}' already exists`, {
@@ -29,10 +29,9 @@ const updateRoomName = async (rid: string, displayName: string, slugifiedRoomNam
 			handle: slugifiedRoomName,
 		});
 	}
-
 	const responses = await Promise.all([
 		Rooms.setNameById(rid, slugifiedRoomName, displayName),
-		Subscriptions.updateNameAndAlertByRoomId(rid, slugifiedRoomName, displayName),
+		Subscriptions.updateNameAndAlertByRoomId(rid, slugifiedRoomName, displayName, shouldAlert),
 	]);
 
 	if (responses[1]?.modifiedCount) {
@@ -75,6 +74,8 @@ export async function saveRoomName(
 		return;
 	}
 
+	const shouldAlert = sendMessage && !(Array.isArray(room.sysMes) && room.sysMes.includes('r'));
+
 	const isDiscussion = Boolean(room?.prid);
 
 	const slugifiedRoomName = isDiscussion || isRoomNativeFederated(room) ? displayName : await getValidRoomName(displayName, rid);
@@ -84,7 +85,7 @@ export async function saveRoomName(
 	if (isDiscussion || isRoomNativeFederated(room)) {
 		update = await updateFName(rid, displayName);
 	} else {
-		update = await updateRoomName(rid, displayName, slugifiedRoomName);
+		update = await updateRoomName(rid, displayName, slugifiedRoomName , shouldAlert);
 	}
 
 	if (!update) {
@@ -96,7 +97,7 @@ export async function saveRoomName(
 		void notifyOnIntegrationChangedByChannels([slugifiedRoomName]);
 	}
 
-	if (sendMessage) {
+	if (shouldAlert) {
 		await Message.saveSystemMessage('r', rid, displayName, user);
 	}
 

--- a/packages/model-typings/src/models/ISubscriptionsModel.ts
+++ b/packages/model-typings/src/models/ISubscriptionsModel.ts
@@ -246,7 +246,7 @@ export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 	findArchivedByRoomId(roomId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
 	findArchivedByUserId(userId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
 	unarchiveByIds(ids: string[]): Promise<UpdateResult | Document>;
-	updateNameAndAlertByRoomId(roomId: string, name: string, fname: string): Promise<UpdateResult | Document>;
+	updateNameAndAlertByRoomId(roomId: string, name: string, fname: string, alert: boolean): Promise<UpdateResult | Document>;
 	findByRoomIdWhenUsernameExists(rid: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
 	setCustomFieldsDirectMessagesByUserId(userId: string, fields: Record<string, any>): Promise<UpdateResult | Document>;
 	setFavoriteByRoomIdAndUserId(roomId: string, userId: string, favorite?: boolean): Promise<UpdateResult>;

--- a/packages/models/src/models/Subscriptions.ts
+++ b/packages/models/src/models/Subscriptions.ts
@@ -1429,14 +1429,14 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateOne(query, update);
 	}
 
-	updateNameAndAlertByRoomId(roomId: string, name: string, fname: string): Promise<UpdateResult | Document> {
+	updateNameAndAlertByRoomId(roomId: string, name: string, fname: string , alert: boolean): Promise<UpdateResult | Document> {
 		const query = { rid: roomId };
 
 		const update: UpdateFilter<ISubscription> = {
 			$set: {
 				name,
 				fname,
-				alert: true,
+				alert,
 			},
 		};
 


### PR DESCRIPTION
#Proposed changes
When a channel is renamed and the "Room name changed" system message type (r) is disabled for that room, the room was still being marked as unread (highlighted in the sidebar) for all members. This created a confusing experience — members would see an unread alert with no visible message explaining why.

Root cause:
updateNameAndAlertByRoomId in SubscriptionsRaw was hardcoding alert: true on all member subscriptions whenever a room was renamed, regardless of whether a system message would actually be posted to explain the change.

Fix:
In saveRoomName.ts, compute shouldAlert by checking if 'r' is present in room.sysMes (the room's hidden system message types). shouldAlert is true only when the system message is not hidden and sendMessage is true.
Pass shouldAlert as a parameter to updateRoomName, which forwards it to updateNameAndAlertByRoomId.
Updated updateNameAndAlertByRoomId in SubscriptionsRaw to accept an alert: boolean parameter instead of hardcoding true.
Updated ISubscriptionsModel interface to match the new signature.

Files changed:
apps/meteor/app/channel-settings/server/functions/saveRoomName.ts
packages/models/src/models/Subscriptions.ts
packages/model-typings/src/models/ISubscriptionsModel.ts


#Issue(s)
Closes #40778

#Steps to test or reproduce

Create a channel with 2 or more users
Go to channel settings → Hide System Messages → disable "Room name changed"
Open a second browser window logged in as another member of the channel
Rename the channel from the first account
Observe the sidebar from the second account

Before fix: Room is highlighted as unread with no new message visible
After fix: Room is not highlighted — no alert is set when system message is disabled

Further comments
The fix intentionally keeps the existing sendMessage parameter behavior intact for callers like SlackBridge that explicitly pass sendMessage = false. The shouldAlert value combines both conditions — it is false if either sendMessage is false OR the room has 'r' in its hidden system messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Room rename notifications now conditionally alert users based on room configuration and system message settings, rather than always alerting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->