### PR TITLE
fix: findCustomRoles excludes roles with missing protected field

### DIFF
--- a/apps/meteor/app/channel-settings/server/functions/saveRoomName.ts
+++ b/apps/meteor/app/channel-settings/server/functions/saveRoomName.ts
@@ -21,7 +21,7 @@ const updateFName = async (rid: string, displayName: string): Promise<(UpdateRes
 	return responses;
 };
 
-const updateRoomName = async (rid: string, displayName: string, slugifiedRoomName: string) => {
+const updateRoomName = async (rid: string, displayName: string, slugifiedRoomName: string , shouldAlert: boolean) => {
 	// Check if the username is available
 	if (!(await checkUsernameAvailability(slugifiedRoomName))) {
 		throw new Meteor.Error('error-duplicate-handle', `A room, team or user with name '${slugifiedRoomName}' already exists`, {
@@ -29,10 +29,9 @@ const updateRoomName = async (rid: string, displayName: string, slugifiedRoomNam
 			handle: slugifiedRoomName,
 		});
 	}
-
 	const responses = await Promise.all([
 		Rooms.setNameById(rid, slugifiedRoomName, displayName),
-		Subscriptions.updateNameAndAlertByRoomId(rid, slugifiedRoomName, displayName),
+		Subscriptions.updateNameAndAlertByRoomId(rid, slugifiedRoomName, displayName, shouldAlert),
 	]);
 
 	if (responses[1]?.modifiedCount) {
@@ -75,6 +74,8 @@ export async function saveRoomName(
 		return;
 	}
 
+	const shouldAlert = sendMessage && !(Array.isArray(room.sysMes) && room.sysMes.includes('r'));
+
 	const isDiscussion = Boolean(room?.prid);
 
 	const slugifiedRoomName = isDiscussion || isRoomNativeFederated(room) ? displayName : await getValidRoomName(displayName, rid);
@@ -84,7 +85,7 @@ export async function saveRoomName(
 	if (isDiscussion || isRoomNativeFederated(room)) {
 		update = await updateFName(rid, displayName);
 	} else {
-		update = await updateRoomName(rid, displayName, slugifiedRoomName);
+		update = await updateRoomName(rid, displayName, slugifiedRoomName , shouldAlert);
 	}
 
 	if (!update) {
@@ -96,7 +97,7 @@ export async function saveRoomName(
 		void notifyOnIntegrationChangedByChannels([slugifiedRoomName]);
 	}
 
-	if (sendMessage) {
+	if (shouldAlert) {
 		await Message.saveSystemMessage('r', rid, displayName, user);
 	}
 

--- a/packages/model-typings/src/models/ISubscriptionsModel.ts
+++ b/packages/model-typings/src/models/ISubscriptionsModel.ts
@@ -246,7 +246,7 @@ export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 	findArchivedByRoomId(roomId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
 	findArchivedByUserId(userId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
 	unarchiveByIds(ids: string[]): Promise<UpdateResult | Document>;
-	updateNameAndAlertByRoomId(roomId: string, name: string, fname: string): Promise<UpdateResult | Document>;
+	updateNameAndAlertByRoomId(roomId: string, name: string, fname: string, alert: boolean): Promise<UpdateResult | Document>;
 	findByRoomIdWhenUsernameExists(rid: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
 	setCustomFieldsDirectMessagesByUserId(userId: string, fields: Record<string, any>): Promise<UpdateResult | Document>;
 	setFavoriteByRoomIdAndUserId(roomId: string, userId: string, favorite?: boolean): Promise<UpdateResult>;

--- a/packages/models/src/models/Roles.ts
+++ b/packages/models/src/models/Roles.ts
@@ -138,7 +138,7 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 
 	findCustomRoles(options?: FindOptions<IRole>): FindCursor<IRole> {
 		const query: Filter<IRole> = {
-			protected: false,
+			protected: { $ne: true },
 		};
 
 		return this.find(query, options || {});

--- a/packages/models/src/models/Subscriptions.ts
+++ b/packages/models/src/models/Subscriptions.ts
@@ -1429,14 +1429,14 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateOne(query, update);
 	}
 
-	updateNameAndAlertByRoomId(roomId: string, name: string, fname: string): Promise<UpdateResult | Document> {
+	updateNameAndAlertByRoomId(roomId: string, name: string, fname: string , alert: boolean): Promise<UpdateResult | Document> {
 		const query = { rid: roomId };
 
 		const update: UpdateFilter<ISubscription> = {
 			$set: {
 				name,
 				fname,
-				alert: true,
+				alert,
 			},
 		};
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes 
findCustomRoles was using { protected: false } as the query filter, which is a strict equality match. This excludes documents where the protected field is absent -which is the case for older custom roles created before the field was added to the schema.

Changed the filter to { protected: { $ne: true } }, which matches both false and missing/undefined values. This is the correct semantic for "not a protected role".

## Issue(s)
Closes #40798

## Steps to test or reproduce
1. Create a Rocket.Chat instance with older custom roles that don't have the protected field in the DB
2. Call findCustomRoles — the roles will be missing from the result
3. After the fix, those roles are correctly returned

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alert behavior when updating room names to prevent duplicate notifications in certain cases.
  * Enhanced custom role filtering to include roles with unset protection status.

* **Changes**
  * Updated subscription alert handling for more granular control over notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->