### PR TITLE
fix: Sanitize null bytes and control characters on sendMessage

### DIFF
--- a/apps/meteor/app/api/server/v1/chat.ts
+++ b/apps/meteor/app/api/server/v1/chat.ts
@@ -837,6 +837,21 @@ const chatEndpoints = API.v1
 				throw new Error("Cannot send system messages using 'chat.sendMessage'");
 			}
 
+			// Checks for control characters in the message and removes them
+			if (this.bodyParams.message && typeof this.bodyParams.message.msg === 'string') {
+				const range = '\\u0000-\\u001F\\u007F-\\u009F';
+				const controlCharsRegex = new RegExp(`[${range}]`, 'g');
+
+				this.bodyParams.message.msg = this.bodyParams.message.msg.replace(controlCharsRegex, '');
+
+				const hasText = this.bodyParams.message.msg.trim() !== '';
+				const attachmentCount = this.bodyParams.message.attachments ? this.bodyParams.message.attachments.length : 0;
+				const blockCount = this.bodyParams.message.blocks ? this.bodyParams.message.blocks.length : 0;
+				if (!hasText && attachmentCount === 0 && blockCount === 0) {
+					return API.v1.failure('The message text cannot be empty.');
+				}
+			}
+
 			const sent = await applyAirGappedRestrictionsValidation(() =>
 				executeSendMessage(this.user, this.bodyParams.message as Pick<IMessage, 'rid'>, { previewUrls: this.bodyParams.previewUrls }),
 			);

--- a/apps/meteor/app/api/server/v1/chat.ts
+++ b/apps/meteor/app/api/server/v1/chat.ts
@@ -838,11 +838,12 @@ const chatEndpoints = API.v1
 			}
 
 			// Checks for control characters in the message and removes them
-			if (this.bodyParams.message && typeof this.bodyParams.message.msg === 'string') {
-				const range = '\\u0000-\\u001F\\u007F-\\u009F';
-				const controlCharsRegex = new RegExp(`[${range}]`, 'g');
+			if (this.bodyParams.message) {
+				const msg = typeof this.bodyParams.message.msg === 'string' ? this.bodyParams.message.msg : '';
+				// eslint-disable-next-line no-control-regex
+				const controlCharsRegex = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g;
 
-				this.bodyParams.message.msg = this.bodyParams.message.msg.replace(controlCharsRegex, '');
+				this.bodyParams.message.msg = msg.replace(controlCharsRegex, '');
 
 				const hasText = this.bodyParams.message.msg.trim() !== '';
 				const attachmentCount = this.bodyParams.message.attachments ? this.bodyParams.message.attachments.length : 0;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
The PR resolves an issue where the raw, non-printable unicode and nullbytes `\u0000` could be passed through the `chat.sendMessage` REST endpoint or client interface. This bypass was causing the unnecessary ghost messages in the room timeline history without causing the validation error.
This patch intercepts the inbound payload body at the API action layer, scrubs out specified control character strings using a safe Unicode-range RegExp boundary wrapper, and enforces that the remaining message text content isn't empty prior to execution (while safely preserving rich media attachments/layout blocks).

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
#40779 

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Testing the Exploit Block via REST API (After Change)

- Use an API client (like Postman or VS Code REST Client) to send a message using the chat.sendMessage endpoint.

- Include your active X-Auth-Token and X-User-Id in the request headers.

- Send the following raw exploit payload body:
```
{
  "message": {
    "rid": "GENERAL",
    "msg": "\u0000"
  }
}
```
**Expected Result:** The server must reject the message, returning a 400 Bad Request status code with the response:
```
{
  "success": false,
  "error": "The message text cannot be empty."
}
```

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
**After This PR (The Fixed Behavior)**

- When a payload containing control characters hits the chat.sendMessage handler, the backend uses a Unicode-range regular expression to cleanly scrub out all non-printable bytes `(\u0000-\u001F and \u007F-\u009F)`. If the remaining content is stripped down to an empty string (and holds no attachments or layout blocks), the backend immediately blocks execution and handles it with a standardized `400 Bad` Request validation failure error, stating: `"The message text cannot be empty."`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid control characters in message text are now automatically removed before sending.
  * Message text is trimmed; messages that become empty after trimming are rejected unless they include attachments or blocks.
  * Existing system-message handling and rejection rules remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->