### PR TITLE
fix: escape HTML in exported data

### DIFF
--- a/.changeset/fast-apes-know.md
+++ b/.changeset/fast-apes-know.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Escapes HTML tags in exported data

--- a/apps/meteor/server/lib/dataExport/exportRoomMessagesToFile.ts
+++ b/apps/meteor/server/lib/dataExport/exportRoomMessagesToFile.ts
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 
 import type { IMessage, IRoom, IUser, MessageAttachment, FileProp, RoomType, IExportOperation } from '@rocket.chat/core-typings';
 import { Messages } from '@rocket.chat/models';
+import { escapeHTML } from '@rocket.chat/string-helpers';
 
 import { settings } from '../../../app/settings/server';
 import { readSecondaryPreferred } from '../../database/readSecondaryPreferred';
@@ -175,9 +176,10 @@ export const exportMessageObject = (type: 'json' | 'html', messageObject: Messag
 
 	const italicTypes: IMessage['t'][] = ['uj', 'ul', 'au', 'r', 'ru', 'wm', 'livechat-close'];
 
-	const message = italicTypes.includes(messageType) ? `<i>${messageObject.msg}</i>` : messageObject.msg;
+	const safeMsg = escapeHTML(messageObject.msg ?? '');
+	const message = italicTypes.includes(messageType) ? `<i>${safeMsg}</i>` : safeMsg;
 
-	file.push(`<p><strong>${messageObject.username}</strong> (${timestamp}):<br/>`);
+	file.push(`<p><strong>${escapeHTML(messageObject.username ?? '')}</strong> (${timestamp}):<br/>`);
 	file.push(message);
 
 	for (const messageFile of messageFiles) {
@@ -187,7 +189,7 @@ export const exportMessageObject = (type: 'json' | 'html', messageObject: Messag
 			const description = attachment?.title || i18n.t('Message_Attachments');
 
 			const assetUrl = `./assets/${messageFile._id}-${messageFile.name}`;
-			const link = `<br/><a href="${assetUrl}">${description}</a>`;
+			const link = `<br/><a href="${escapeHTML(assetUrl)}">${escapeHTML(description)}</a>`;
 			file.push(link);
 		}
 	}
@@ -281,7 +283,14 @@ export const exportRoomMessagesToFile = async function (
 		if (exportOpRoomData.status === 'pending') {
 			exportOpRoomData.status = 'exporting';
 			if (exportType === 'html') {
-				await writeFile(filePath, '<meta http-equiv="content-type" content="text/html; charset=utf-8">', { encoding: 'utf8' });
+				await writeFile(
+					filePath,
+					[
+						'<meta http-equiv="content-type" content="text/html; charset=utf-8">',
+						`<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:;">`,
+					].join('\n'),
+					{ encoding: 'utf8' },
+				);
 			}
 		}
 

--- a/apps/meteor/server/lib/dataExport/processDataDownloads.ts
+++ b/apps/meteor/server/lib/dataExport/processDataDownloads.ts
@@ -4,6 +4,7 @@ import { access, mkdir, rm, writeFile } from 'node:fs/promises';
 
 import type { IExportOperation, IUser, RoomType } from '@rocket.chat/core-typings';
 import { Avatars, ExportOperations, UserDataFiles, Subscriptions } from '@rocket.chat/models';
+import { escapeHTML } from '@rocket.chat/string-helpers';
 import moment from 'moment';
 
 import { FileUpload } from '../../../app/file-upload/server';
@@ -79,15 +80,16 @@ const generateUserFile = async (exportOperation: IExportOperation, userData?: IU
 
 		stream.write('<!DOCTYPE html>\n');
 		stream.write('<meta http-equiv="content-type" content="text/html; charset=utf-8">\n');
+		stream.write(`<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:;">\n`);
 		for (const [key, value] of Object.entries(dataToSave)) {
-			stream.write(`<p><strong>${key}</strong>:`);
+			stream.write(`<p><strong>${escapeHTML(key)}</strong>:`);
 			if (typeof value === 'string') {
-				stream.write(value);
+				stream.write(escapeHTML(value));
 			} else if (Array.isArray(value)) {
 				stream.write('<br/>');
 
 				for (const item of value) {
-					stream.write(`${item}<br/>`);
+					stream.write(`${escapeHTML(String(item))}<br/>`);
 				}
 			}
 

--- a/apps/meteor/server/lib/dataExport/sendViaEmail.ts
+++ b/apps/meteor/server/lib/dataExport/sendViaEmail.ts
@@ -1,5 +1,6 @@
 import type { IMessage, IUser } from '@rocket.chat/core-typings';
 import { Messages, Users } from '@rocket.chat/models';
+import { escapeHTML } from '@rocket.chat/string-helpers';
 import moment from 'moment';
 
 import * as Mailer from '../../../app/mailer/server/api';
@@ -67,9 +68,9 @@ export async function sendViaEmail(
 	)
 		.map((message: IMessage) => {
 			const dateTime = moment(message.ts).locale(lang).format('L LT');
-			return `<p style='margin-bottom: 5px'><b>${
-				message.u.username
-			}</b> <span style='color: #aaa; font-size: 12px'>${dateTime}</span><br/>${Message.parse(message, data.language)}</p>`;
+			return `<p style='margin-bottom: 5px'><b>${escapeHTML(
+				message.u.username ?? '',
+			)}</b> <span style='color: #aaa; font-size: 12px'>${dateTime}</span><br/>${Message.parse(message, data.language)}</p>`;
 		})
 		.join('');
 

--- a/apps/meteor/tests/unit/server/lib/dataExport/exportRoomMessagesToFile.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/dataExport/exportRoomMessagesToFile.spec.ts
@@ -114,6 +114,75 @@ describe('Export - exportMessageObject', () => {
 	});
 });
 
+describe('Export - exportMessageObject HTML escaping (XSS prevention)', () => {
+	const ts = new Date('2020-01-01T00:00:00.000Z');
+
+	it('should escape HTML in the message body when exporting as html', async () => {
+		const result = await exportMessageObject('html', {
+			msg: '<img src=x onerror="alert(1)">',
+			username: 'attacker',
+			ts,
+		});
+
+		expect(result).to.contain('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;');
+		expect(result).to.not.contain('<img src=x');
+	});
+
+	it('should escape HTML in the username when exporting as html', async () => {
+		const result = await exportMessageObject('html', {
+			msg: 'hello',
+			username: '<script>alert(1)</script>',
+			ts,
+		});
+
+		expect(result).to.contain('&lt;script&gt;alert(1)&lt;/script&gt;');
+		expect(result).to.not.contain('<script>');
+	});
+
+	it('should escape HTML inside italicized (system) messages when exporting as html', async () => {
+		const result = await exportMessageObject('html', {
+			msg: '<img src=x onerror=alert(1)>',
+			username: 'attacker',
+			ts,
+			type: 'wm',
+		});
+
+		expect(result).to.contain('<i>&lt;img src=x onerror=alert(1)&gt;</i>');
+		expect(result).to.not.contain('<img src=x');
+	});
+
+	it('should escape HTML in the attachment description and prevent href attribute breakout', async () => {
+		const result = await exportMessageObject(
+			'html',
+			{
+				msg: 'file',
+				username: 'attacker',
+				ts,
+				attachments: [
+					{
+						type: 'file',
+						title: '<img src=x onerror=alert(1)>',
+						title_link: '/file-upload/evil-id/x',
+					},
+				] as any,
+			},
+			[{ _id: 'evil-id', name: '"><img src=x onerror=alert(1)>.png' } as any],
+		);
+
+		expect(result).to.contain('&lt;img src=x');
+		expect(result).to.not.contain('<img src=x');
+		// the crafted filename must not break out of the href="" attribute
+		expect(result).to.not.contain('"><img');
+	});
+
+	it('should not escape plain JSON exports (escaping is html-only)', async () => {
+		const messageObject = { msg: '<b>x</b>', username: 'attacker', ts };
+		const result = await exportMessageObject('json', messageObject);
+
+		expect(result).to.equal(JSON.stringify(messageObject));
+	});
+});
+
 describe('Export - exportRoomMessages', () => {
 	const totalMessages = 10;
 	const userData = {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR hardens Rocket.Chat's HTML data export paths by adding proper output escaping.

Message content, usernames, attachment titles, and uploaded filenames were being written into exported `.html` files without escaping. As a result, any HTML-like characters in that content could be interpreted by the browser when the export was opened, rather than being displayed as text. This affects both the room "Send file via email" export and the "Download My Data" feature, which share the same code path.

This change applies `escapeHTML()` to all user-controlled fields at the output sinks in:

- `exportRoomMessagesToFile.ts`
- `processDataDownloads.ts`
- `sendViaEmail.ts`

It also adds a restrictive CSP meta tag to the generated HTML as an additional layer of hardening.

Escaping is a no-op for normal content and also fixes the display of text such as `a < b`, so there is no behavioral change for legitimate exports.

Also added new tests.

## Issue(s)
https://rocketchat.atlassian.net/browse/VLN-417

## Steps to test or reproduce
N/A

## Further comments
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security in data exports by escaping HTML tags to prevent injection attacks in room messages, user data, and email exports.
  * Enhanced security policies in exported HTML files with stricter Content-Security-Policy restrictions.

* **Tests**
  * Added comprehensive test coverage for HTML escaping and XSS prevention in exported data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->