### PR TITLE
regression(core-typings): Optionalize `_updatedAt` field to cloud-related schemas

### DIFF
--- a/apps/meteor/app/cloud/server/functions/syncWorkspace/handleCommsSync.ts
+++ b/apps/meteor/app/cloud/server/functions/syncWorkspace/handleCommsSync.ts
@@ -1,5 +1,5 @@
 import { NPS, Banner } from '@rocket.chat/core-services';
-import type { Cloud, IBanner } from '@rocket.chat/core-typings';
+import type { Cloud, IBanner, Optional } from '@rocket.chat/core-typings';
 
 import { getAndCreateNpsSurvey } from '../../../../../server/services/nps/getAndCreateNpsSurvey';
 
@@ -23,7 +23,7 @@ export const handleNpsOnWorkspaceSync = async (nps: Cloud.NpsSurveyAnnouncement)
 	}
 };
 
-export const handleBannerOnWorkspaceSync = async (banners: IBanner[]) => {
+export const handleBannerOnWorkspaceSync = async (banners: Optional<IBanner, '_updatedAt'>[]) => {
 	for (const banner of banners) {
 		await Banner.create(banner);
 	}

--- a/packages/core-typings/src/cloud/Announcement.ts
+++ b/packages/core-typings/src/cloud/Announcement.ts
@@ -1,9 +1,11 @@
 import * as z from 'zod';
 
 import { IBannerSchema } from '../IBanner';
+import { TimestampSchema } from '../utils';
 
 export const AnnouncementSchema = IBannerSchema.extend({
 	createdBy: z.enum(['cloud', 'system']),
+	_updatedAt: TimestampSchema.optional(),
 	selector: z.object({ roles: z.array(z.string()) }).optional(),
 });
 

--- a/packages/core-typings/src/cloud/WorkspaceSyncPayload.ts
+++ b/packages/core-typings/src/cloud/WorkspaceSyncPayload.ts
@@ -29,7 +29,10 @@ export const WorkspaceSyncPayloadSchema = z.object({
 	/** @deprecated */
 	nps: NpsSurveyAnnouncementSchema.optional().meta({ deprecated: true }),
 	/** @deprecated */
-	banners: z.array(IBannerSchema).optional().meta({ deprecated: true }),
+	banners: z
+		.array(IBannerSchema.extend({ _updatedAt: TimestampSchema.optional() }))
+		.optional()
+		.meta({ deprecated: true }),
 });
 
 export type WorkspaceSyncPayload = z.infer<typeof WorkspaceSyncPayloadSchema>;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
It reverts a schema change affecting cloud-related schemas derived from `IBanner`.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... --> 

 Task: [ARCH-2171]

[ARCH-2171]: https://rocketchat.atlassian.net/browse/ARCH-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Schemas for announcements and workspace banners now include an optional "last updated" timestamp.
  * Workspace sync logic updated to accept banners that may include this optional timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->