### PR TITLE
chore: add PresenceStatusCode type for presence wire format

### DIFF
--- a/apps/meteor/server/modules/listeners/listeners.module.ts
+++ b/apps/meteor/server/modules/listeners/listeners.module.ts
@@ -3,7 +3,7 @@ import type { ISetting as AppsSetting } from '@rocket.chat/apps-engine/definitio
 import type { IServiceClass } from '@rocket.chat/core-services';
 import { EnterpriseSettings } from '@rocket.chat/core-services';
 import { isSettingColor, isSettingEnterprise, UserStatus } from '@rocket.chat/core-typings';
-import type { IUser, IRoom, IRole, VideoConference, ISetting, IOmnichannelRoom } from '@rocket.chat/core-typings';
+import type { IUser, IRoom, IRole, VideoConference, ISetting, IOmnichannelRoom, PresenceStatusCode } from '@rocket.chat/core-typings';
 import { Logger } from '@rocket.chat/logger';
 import type { ServerMediaSignal } from '@rocket.chat/media-signaling';
 import { parse } from '@rocket.chat/message-parser';
@@ -13,7 +13,7 @@ import type { NotificationsModule } from '../notifications/notifications.module'
 
 const isMessageParserDisabled = process.env.DISABLE_MESSAGE_PARSER === 'true';
 
-const STATUS_MAP: Record<UserStatus, 0 | 1 | 2 | 3> = {
+const STATUS_MAP: Record<UserStatus, PresenceStatusCode> = {
 	[UserStatus.OFFLINE]: 0,
 	[UserStatus.ONLINE]: 1,
 	[UserStatus.AWAY]: 2,

--- a/apps/meteor/server/modules/notifications/notifications.module.ts
+++ b/apps/meteor/server/modules/notifications/notifications.module.ts
@@ -1,5 +1,5 @@
 import { Authorization, MediaCall, VideoConf, Settings } from '@rocket.chat/core-services';
-import type { ISubscription, IOmnichannelRoom, IUser, IUserDataEvent } from '@rocket.chat/core-typings';
+import type { ISubscription, IOmnichannelRoom, IUser, IUserDataEvent, PresenceStatusCode } from '@rocket.chat/core-typings';
 import type { StreamerCallbackArgs, StreamKeys, StreamNames } from '@rocket.chat/ddp-client';
 import { Rooms, Subscriptions, Users } from '@rocket.chat/models';
 
@@ -512,7 +512,7 @@ export class NotificationsModule {
 		return this.streamUser.emitWithoutBroadcast(`${userId}/${eventName}`, ...args);
 	}
 
-	sendPresence(uid: string, ...args: [username: string, status?: 0 | 1 | 2 | 3, statusText?: string]): void {
+	sendPresence(uid: string, ...args: [username: string, status?: PresenceStatusCode, statusText?: string]): void {
 		emit(uid, [args]);
 		return this.streamPresence.emitWithoutBroadcast(uid, args);
 	}

--- a/packages/core-typings/src/PresenceStatusCode.ts
+++ b/packages/core-typings/src/PresenceStatusCode.ts
@@ -1,0 +1,1 @@
+export type PresenceStatusCode = 0 | 1 | 2 | 3;

--- a/packages/core-typings/src/index.ts
+++ b/packages/core-typings/src/index.ts
@@ -11,6 +11,7 @@ export type * from './RoomType';
 export type * from './IInvite';
 export type * from './IRocketChatRecord';
 export * from './UserStatus';
+export type * from './PresenceStatusCode';
 export type * from './userAction';
 export * from './IBanner';
 export type * from './IStats';

--- a/packages/ddp-client/src/types/streams.ts
+++ b/packages/ddp-client/src/types/streams.ts
@@ -25,6 +25,7 @@ import type {
 	IWebdavAccount,
 	MessageAttachment,
 	ISession,
+	PresenceStatusCode,
 } from '@rocket.chat/core-typings';
 import type { ServerMediaSignal } from '@rocket.chat/media-signaling';
 import type * as UiKit from '@rocket.chat/ui-kit';
@@ -229,7 +230,7 @@ export interface StreamerEvents {
 				[
 					uid: IUser['_id'],
 					username: IUser['username'],
-					status: 0 | 1 | 2 | 3,
+					status: PresenceStatusCode,
 					statusText: IUser['statusText'],
 					name: IUser['name'],
 					roles: IUser['roles'],
@@ -297,7 +298,7 @@ export interface StreamerEvents {
 		},
 	];
 
-	'user-presence': [{ key: string; args: [[username: string, statusChanged?: 0 | 1 | 2 | 3, statusText?: string]] }];
+	'user-presence': [{ key: string; args: [[username: string, statusChanged?: PresenceStatusCode, statusText?: string]] }];
 
 	// TODO: rename to 'integration-history'
 	'integrationHistory': [


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Adds a named `PresenceStatusCode` type alias in `@rocket.chat/core-typings` for the numeric codes used to broadcast user presence on DDP streams (`0=OFFLINE, 1=ONLINE, 2=AWAY, 3=BUSY`).

Replaces inline `0 | 1 | 2 | 3` unions in 4 places with the named type:
- `apps/meteor/server/modules/listeners/listeners.module.ts` — `STATUS_MAP` value type.
- `apps/meteor/server/modules/notifications/notifications.module.ts` — `sendPresence` signature.
- `packages/ddp-client/src/types/streams.ts` — `user-status` and `user-presence` stream args.

No behavior change. Wire format identical - purely a typing improvement to remove repeated magic-number unions.

Addresses review feedback from [#40274 (comment)](https://github.com/RocketChat/Rocket.Chat/pull/40274#discussion_r3350667917).

## Issue(s)
[PRES-34](https://rocketchat.atlassian.net/browse/PRES-34)

## Further comments
Split out from the presence sync engine PR ([#40274](https://github.com/RocketChat/Rocket.Chat/pull/40274)) to avoid bloating its changed-files surface with cross-cutting edits.

[PRES-34]: https://rocketchat.atlassian.net/browse/PRES-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ