### PR TITLE
Revert "refactor: Remove unused `description` from attachments render" (#40067)

### DIFF
--- a/apps/meteor/app/autotranslate/client/lib/autotranslate.ts
+++ b/apps/meteor/app/autotranslate/client/lib/autotranslate.ts
@@ -69,6 +69,16 @@ export const AutoTranslate = {
 					}
 				}
 
+				if (attachment.description && attachment.translations && attachment.translations[language]) {
+					attachment.translations.original = attachment.description;
+
+					if (autoTranslateShowInverse) {
+						attachment.description = attachment.translations.original;
+					} else {
+						attachment.description = attachment.translations[language];
+					}
+				}
+
 				if (attachment.attachments && attachment.attachments.length > 0) {
 					// @ts-expect-error - not sure what to do with this
 					attachment.attachments = this.translateAttachments(attachment.attachments, language);

--- a/apps/meteor/app/autotranslate/server/autotranslate.ts
+++ b/apps/meteor/app/autotranslate/server/autotranslate.ts
@@ -320,7 +320,7 @@ export abstract class AutoTranslate {
 		if (message.attachments && message.attachments.length > 0) {
 			setImmediate(async () => {
 				for (const [index, attachment] of message.attachments?.entries() ?? []) {
-					if (attachment.text) {
+					if (attachment.description || attachment.text) {
 						// Removes the initial link `[ ](quoterl)` from quote message before translation
 						const translatedText = attachment?.text?.replace(/\[(.*?)\]\(.*?\)/g, '$1') || attachment?.text;
 						const attachmentMessage = { ...attachment, text: translatedText };

--- a/apps/meteor/app/autotranslate/server/deeplTranslate.ts
+++ b/apps/meteor/app/autotranslate/server/deeplTranslate.ts
@@ -196,7 +196,7 @@ class DeeplAutoTranslate extends AutoTranslate {
 					params: {
 						auth_key: this.apiKey,
 						target_lang: language,
-						text: attachment.text || '',
+						text: attachment.description || attachment.text || '',
 					},
 				});
 				if (!result.ok) {

--- a/apps/meteor/app/autotranslate/server/googleTranslate.ts
+++ b/apps/meteor/app/autotranslate/server/googleTranslate.ts
@@ -195,7 +195,7 @@ class GoogleAutoTranslate extends AutoTranslate {
 						key: this.apiKey,
 						target: language,
 						format: 'text',
-						q: attachment.text || '',
+						q: attachment.description || attachment.text || '',
 					},
 				});
 				if (!result.ok) {

--- a/apps/meteor/app/autotranslate/server/msTranslate.ts
+++ b/apps/meteor/app/autotranslate/server/msTranslate.ts
@@ -192,7 +192,7 @@ class MsAutoTranslate extends AutoTranslate {
 			return this._translate(
 				[
 					{
-						Text: attachment.text || '',
+						Text: attachment.description || attachment.text || '',
 					},
 				],
 				targetLanguages,

--- a/apps/meteor/app/lib/server/functions/notifications/email.js
+++ b/apps/meteor/app/lib/server/functions/notifications/email.js
@@ -77,8 +77,13 @@ export async function getEmailContent({ message, user, room }) {
 	}
 
 	if (hasFiles) {
-		const fileParts = files.map((file) => {
-			return escapeHTML(file.name);
+		const attachments = message.attachments || [];
+		const fileParts = files.map((file, index) => {
+			let part = escapeHTML(file.name);
+			if (attachments[index]?.description) {
+				part += `<br/><br/>${escapeHTML(attachments[index].description)}`;
+			}
+			return part;
 		});
 		contentParts.push(fileParts.join('<br/><br/>'));
 	}

--- a/apps/meteor/app/lib/server/lib/sendNotificationsOnMessage.ts
+++ b/apps/meteor/app/lib/server/lib/sendNotificationsOnMessage.ts
@@ -195,6 +195,8 @@ export const sendNotification = async ({
 		const firstAttachment = message.attachments?.length && message.attachments.shift();
 
 		if (firstAttachment) {
+			firstAttachment.description =
+				typeof firstAttachment.description === 'string' ? emojione.shortnameToUnicode(firstAttachment.description) : undefined;
 			firstAttachment.text = typeof firstAttachment.text === 'string' ? emojione.shortnameToUnicode(firstAttachment.text) : undefined;
 		}
 

--- a/apps/meteor/app/lib/server/methods/updateMessage.ts
+++ b/apps/meteor/app/lib/server/methods/updateMessage.ts
@@ -34,7 +34,7 @@ export async function executeUpdateMessage(
 	// IF the message has custom fields, always update
 	// Ideally, we'll compare the custom fields to check for change, but since we don't know the shape of
 	// custom fields, as it's user defined, we're gonna update
-	const msgText = originalMessage.msg;
+	const msgText = originalMessage?.attachments?.[0]?.description ?? originalMessage.msg;
 	if (msgText === message.msg && !previewUrls && !message.customFields) {
 		return;
 	}
@@ -85,6 +85,13 @@ export async function executeUpdateMessage(
 		throw new Meteor.Error('error-invalid-user', 'Invalid user', { method: 'updateMessage' });
 	}
 	await canSendMessageAsync(message.rid, { uid: user._id, username: user.username ?? undefined, ...user });
+
+	// It is possible to have an empty array as the attachments property, so ensure both things exist
+	if (originalMessage.attachments && originalMessage.attachments.length > 0 && originalMessage.attachments[0].description !== undefined) {
+		originalMessage.attachments[0].description = message.msg;
+		message.attachments = originalMessage.attachments;
+		message.msg = originalMessage.msg;
+	}
 
 	message.u = originalMessage.u;
 

--- a/apps/meteor/app/livechat/server/lib/sendTranscript.ts
+++ b/apps/meteor/app/livechat/server/lib/sendTranscript.ts
@@ -108,7 +108,7 @@ export async function sendTranscript({
 
 		const messageType = MessageTypes.getType(message);
 
-		const messageContent = messageType?.system
+		let messageContent = messageType?.system
 			? DOMPurify.sanitize(`
 				<i>${messageType.text(i18n.cloneInstance({ interpolation: { escapeValue: false } }).t, message)}}</i>`)
 			: escapeHtml(message.msg);
@@ -116,6 +116,9 @@ export async function sendTranscript({
 		let filesHTML = '';
 
 		if (message.attachments && message.attachments?.length > 0) {
+			messageContent = message.attachments[0].description || '';
+			escapeHtml(messageContent);
+
 			for await (const attachment of message.attachments) {
 				if (!isFileAttachment(attachment)) {
 					continue;

--- a/apps/meteor/app/slackbridge/server/RocketAdapter.ts
+++ b/apps/meteor/app/slackbridge/server/RocketAdapter.ts
@@ -203,11 +203,14 @@ export default class RocketAdapter {
 
 		if (rocketMessage.file.name) {
 			let fileName = rocketMessage.file.name;
-			const text = rocketMessage.msg;
+			let text = rocketMessage.msg;
 
 			const attachment = this.getMessageAttachment(rocketMessage);
 			if (attachment) {
 				fileName = Meteor.absoluteUrl(attachment.title_link);
+				if (!text) {
+					text = attachment.description;
+				}
 			}
 
 			await slack.postMessage(slack.getSlackChannel(rocketMessage.rid), { ...rocketMessage, msg: `${text} ${fileName}` });

--- a/apps/meteor/app/ui/client/lib/ChatMessages.ts
+++ b/apps/meteor/app/ui/client/lib/ChatMessages.ts
@@ -120,7 +120,7 @@ export class ChatMessages implements ChatAPI {
 		},
 		editMessage: async (message: IMessage, { cursorAtStart = false }: { cursorAtStart?: boolean } = {}) => {
 			this.composer?.uploads.clear();
-			const text = (await this.data.getDraft(message._id)) || message.msg;
+			const text = (await this.data.getDraft(message._id)) || message.attachments?.[0]?.description || message.msg;
 
 			await this.currentEditingMessage.stop();
 

--- a/apps/meteor/client/components/message/content/attachments/file/AudioAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/AudioAttachment.tsx
@@ -4,13 +4,17 @@ import { useMediaUrl } from '@rocket.chat/ui-contexts';
 import { useMemo } from 'react';
 
 import { useReloadOnError } from './hooks/useReloadOnError';
+import MarkdownText from '../../../../MarkdownText';
 import MessageCollapsible from '../../../MessageCollapsible';
+import MessageContentBody from '../../../MessageContentBody';
 
 const AudioAttachment = ({
 	title,
 	audio_url: url,
 	audio_type: type,
 	audio_size: size,
+	description,
+	descriptionMd,
 	title_link: link,
 	title_link_download: hasDownload,
 	collapsed,
@@ -21,6 +25,7 @@ const AudioAttachment = ({
 
 	return (
 		<>
+			{descriptionMd ? <MessageContentBody md={descriptionMd} /> : <MarkdownText parseEmoji content={description} />}
 			<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
 				<AudioPlayer src={src} type={type} ref={mediaRef} />
 			</MessageCollapsible>

--- a/apps/meteor/client/components/message/content/attachments/file/GenericFileAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/GenericFileAttachment.tsx
@@ -13,7 +13,9 @@ import { useTranslation } from 'react-i18next';
 
 import { getFileExtension } from '../../../../../../lib/utils/getFileExtension';
 import { forAttachmentDownload, registerDownloadForUid } from '../../../../../hooks/useDownloadFromServiceWorker';
+import MarkdownText from '../../../../MarkdownText';
 import MessageCollapsible from '../../../MessageCollapsible';
+import MessageContentBody from '../../../MessageContentBody';
 import AttachmentSize from '../structure/AttachmentSize';
 import { useOpenEncryptedPdf } from './hooks/useOpenEncryptedPdf';
 
@@ -23,6 +25,8 @@ type GenericFileAttachmentProps = MessageAttachmentBase;
 
 const GenericFileAttachment = ({
 	title,
+	description,
+	descriptionMd,
 	title_link: link,
 	title_link_download: hasDownload,
 	size,
@@ -81,6 +85,7 @@ const GenericFileAttachment = ({
 
 	return (
 		<>
+			{descriptionMd ? <MessageContentBody md={descriptionMd} /> : <MarkdownText parseEmoji content={description} />}
 			<MessageCollapsible title={title} hasDownload={hasDownload} link={link} isCollapsed={collapsed}>
 				<MessageGenericPreview style={{ maxWidth: 368, width: '100%' }}>
 					<MessageGenericPreviewContent

--- a/apps/meteor/client/components/message/content/attachments/file/ImageAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/ImageAttachment.tsx
@@ -2,7 +2,9 @@ import type { ImageAttachmentProps } from '@rocket.chat/core-typings';
 import { useMediaUrl } from '@rocket.chat/ui-contexts';
 
 import { useLoadImage } from './hooks/useLoadImage';
+import MarkdownText from '../../../../MarkdownText';
 import MessageCollapsible from '../../../MessageCollapsible';
+import MessageContentBody from '../../../MessageContentBody';
 import AttachmentImage from '../structure/AttachmentImage';
 
 const ImageAttachment = ({
@@ -16,6 +18,7 @@ const ImageAttachment = ({
 		height: 368,
 	},
 	description,
+	descriptionMd,
 	title_link: link,
 	title_link_download: hasDownload,
 	collapsed,
@@ -25,6 +28,7 @@ const ImageAttachment = ({
 
 	return (
 		<>
+			{descriptionMd ? <MessageContentBody md={descriptionMd} /> : <MarkdownText parseEmoji content={description} />}
 			<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
 				<AttachmentImage
 					{...imageDimensions}

--- a/apps/meteor/client/components/message/content/attachments/file/VideoAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/VideoAttachment.tsx
@@ -5,13 +5,17 @@ import { useMemo } from 'react';
 
 import { useReloadOnError } from './hooks/useReloadOnError';
 import { userAgentMIMETypeFallback } from '../../../../../lib/utils/userAgentMIMETypeFallback';
+import MarkdownText from '../../../../MarkdownText';
 import MessageCollapsible from '../../../MessageCollapsible';
+import MessageContentBody from '../../../MessageContentBody';
 
 const VideoAttachment = ({
 	title,
 	video_url: url,
 	video_type: type,
 	video_size: size,
+	description,
+	descriptionMd,
 	title_link: link,
 	title_link_download: hasDownload,
 	collapsed,
@@ -22,6 +26,7 @@ const VideoAttachment = ({
 
 	return (
 		<>
+			{descriptionMd ? <MessageContentBody md={descriptionMd} /> : <MarkdownText parseEmoji content={description} />}
 			<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
 				<MessageGenericPreview style={{ maxWidth: 368, width: '100%' }}>
 					<Box is='video' controls preload='metadata' ref={mediaRef}>

--- a/apps/meteor/client/components/message/toolbar/useCopyAction.ts
+++ b/apps/meteor/client/components/message/toolbar/useCopyAction.ts
@@ -6,8 +6,8 @@ import type { MessageActionConfig } from '../../../../app/ui-utils/client/lib/Me
 
 const getMainMessageText = (message: IMessage): IMessage => {
 	const newMessage = { ...message };
-	newMessage.msg = newMessage.msg || newMessage.attachments?.[0]?.title || '';
-	newMessage.md = newMessage.md || undefined;
+	newMessage.msg = newMessage.msg || newMessage.attachments?.[0]?.description || newMessage.attachments?.[0]?.title || '';
+	newMessage.md = newMessage.md || newMessage.attachments?.[0]?.descriptionMd || undefined;
 	return { ...newMessage };
 };
 

--- a/apps/meteor/client/components/message/toolbar/useReportMessageAction.tsx
+++ b/apps/meteor/client/components/message/toolbar/useReportMessageAction.tsx
@@ -7,8 +7,8 @@ import ReportMessageModal from '../../../views/room/modals/ReportMessageModal';
 
 const getMainMessageText = (message: IMessage): IMessage => {
 	const newMessage = { ...message };
-	newMessage.msg = newMessage.msg || newMessage.attachments?.[0]?.title || '';
-	newMessage.md = newMessage.md || undefined;
+	newMessage.msg = newMessage.msg || newMessage.attachments?.[0]?.description || newMessage.attachments?.[0]?.title || '';
+	newMessage.md = newMessage.md || newMessage.attachments?.[0]?.descriptionMd || undefined;
 	return { ...newMessage };
 };
 

--- a/apps/meteor/client/hooks/useDecryptedMessage.spec.ts
+++ b/apps/meteor/client/hooks/useDecryptedMessage.spec.ts
@@ -53,7 +53,7 @@ describe('useDecryptedMessage', () => {
 	it('should handle E2EE messages with attachments', async () => {
 		(isE2EEMessage as jest.MockedFunction<typeof isE2EEMessage>).mockReturnValue(true);
 		(e2e.decryptMessage as jest.Mock).mockResolvedValue({
-			attachments: [{ title: 'Attachment title' }],
+			attachments: [{ description: 'Attachment description' }],
 		});
 		const message = { msg: 'Encrypted message with attachment' };
 
@@ -63,6 +63,7 @@ describe('useDecryptedMessage', () => {
 			expect(result.current).toBe('E2E_message_encrypted_placeholder');
 		});
 
+		expect(result.current).toBe('Attachment description');
 		expect(e2e.decryptMessage).toHaveBeenCalledWith(message);
 	});
 

--- a/apps/meteor/client/hooks/useDecryptedMessage.ts
+++ b/apps/meteor/client/hooks/useDecryptedMessage.ts
@@ -18,11 +18,14 @@ export const useDecryptedMessage = (message: IMessage): string => {
 		e2e.decryptMessage(message).then((decryptedMsg) => {
 			if (decryptedMsg.msg) {
 				setDecryptedMessage(decryptedMsg.msg);
-				return;
 			}
 
-			if (decryptedMsg.attachments && decryptedMsg.attachments.length > 0) {
-				setDecryptedMessage(t('Message_with_attachment'));
+			if (decryptedMsg.attachments && decryptedMsg.attachments?.length > 0) {
+				if (decryptedMsg.attachments[0].description) {
+					setDecryptedMessage(decryptedMsg.attachments[0].description);
+				} else {
+					setDecryptedMessage(t('Message_with_attachment'));
+				}
 			}
 		});
 	}, [message, t, setDecryptedMessage]);

--- a/apps/meteor/client/lib/normalizeThreadMessage.tsx
+++ b/apps/meteor/client/lib/normalizeThreadMessage.tsx
@@ -24,7 +24,11 @@ export function normalizeThreadMessage({ ...message }: Readonly<Pick<IMessage, '
 	}
 
 	if (message.attachments) {
-		const attachment = message.attachments.find((attachment) => attachment.title);
+		const attachment = message.attachments.find((attachment) => attachment.title || attachment.description);
+
+		if (attachment?.description) {
+			return <>{attachment.description}</>;
+		}
 
 		if (attachment?.title) {
 			return <>{attachment.title}</>;

--- a/apps/meteor/client/lib/parseMessageTextToAstMarkdown.spec.ts
+++ b/apps/meteor/client/lib/parseMessageTextToAstMarkdown.spec.ts
@@ -182,6 +182,47 @@ describe('parseMessageTextToAstMarkdown', () => {
 				...translatedMessage,
 				attachments: [
 					{
+						description: 'description',
+						translations: {
+							en: 'description translated',
+						},
+					},
+				],
+			};
+			const attachmentTranslatedMessageParsed = {
+				...translatedMessage,
+				md: translatedMessageParsed,
+				attachments: [
+					{
+						description: 'description',
+						translations: {
+							en: 'description translated',
+						},
+						md: [
+							{
+								type: 'PARAGRAPH',
+								value: [
+									{
+										type: 'PLAIN_TEXT',
+										value: 'description translated',
+									},
+								],
+							},
+						],
+					},
+				],
+			};
+
+			expect(parseMessageTextToAstMarkdown(attachmentTranslatedMessage, parseOptions, enabledAutoTranslatedOptions)).toStrictEqual(
+				attachmentTranslatedMessageParsed,
+			);
+		});
+
+		it('should return correct attachment quote translated parsed md when translate is active', () => {
+			const attachmentTranslatedMessage = {
+				...translatedMessage,
+				attachments: [
+					{
 						text: 'text',
 						translations: {
 							en: 'text translated',
@@ -337,7 +378,7 @@ describe('parseMessageAttachments', () => {
 
 	const attachmentMessage = [
 		{
-			text: 'message **bold** _italic_ and ~strike~',
+			description: 'message **bold** _italic_ and ~strike~',
 			md: messageParserTokenMessage,
 		},
 	];
@@ -359,7 +400,66 @@ describe('parseMessageAttachments', () => {
 				autoTranslateLanguage: 'en',
 			};
 
-			it('should return correct attachment text parsed md when translate is active and auto translate language is undefined', () => {
+			it('should return correct attachment description translated parsed md when translate is active', () => {
+				const descriptionAttachment = [
+					{
+						...attachmentMessage[0],
+						description: 'attachment not translated',
+						translationProvider: 'provider',
+						translations: {
+							en: 'attachment translated',
+						},
+					},
+				];
+				const descriptionAttachmentParsed: Root = [
+					{
+						type: 'PARAGRAPH',
+						value: [
+							{
+								type: 'PLAIN_TEXT',
+								value: 'attachment translated',
+							},
+						],
+					},
+				];
+
+				expect(parseMessageAttachments(descriptionAttachment, parseOptions, enabledAutoTranslatedOptions)[0].md).toStrictEqual(
+					descriptionAttachmentParsed,
+				);
+			});
+
+			it('should return correct attachment description parsed md when translate is active and auto translate language is undefined', () => {
+				const descriptionAttachment = [
+					{
+						...attachmentMessage[0],
+						description: 'attachment not translated',
+						translationProvider: 'provider',
+						translations: {
+							en: 'attachment translated',
+						},
+					},
+				];
+				const descriptionAttachmentParsed: Root = [
+					{
+						type: 'PARAGRAPH',
+						value: [
+							{
+								type: 'PLAIN_TEXT',
+								value: 'attachment not translated',
+							},
+						],
+					},
+				];
+
+				expect(
+					parseMessageAttachments(descriptionAttachment, parseOptions, {
+						...enabledAutoTranslatedOptions,
+						autoTranslateLanguage: undefined,
+					})[0].md,
+				).toStrictEqual(descriptionAttachmentParsed);
+			});
+
+			it('should return correct attachment text translated parsed md when translate is active', () => {
 				const textAttachment = [
 					{
 						...attachmentMessage[0],
@@ -376,18 +476,15 @@ describe('parseMessageAttachments', () => {
 						value: [
 							{
 								type: 'PLAIN_TEXT',
-								value: 'attachment not translated',
+								value: 'attachment translated',
 							},
 						],
 					},
 				];
 
-				expect(
-					parseMessageAttachments(textAttachment, parseOptions, {
-						...enabledAutoTranslatedOptions,
-						autoTranslateLanguage: undefined,
-					})[0].md,
-				).toStrictEqual(textAttachmentParsed);
+				expect(parseMessageAttachments(textAttachment, parseOptions, enabledAutoTranslatedOptions)[0].md).toStrictEqual(
+					textAttachmentParsed,
+				);
 			});
 
 			it('should return correct attachment text translated parsed md when translate is active and has multiple texts', () => {

--- a/apps/meteor/client/lib/parseMessageTextToAstMarkdown.ts
+++ b/apps/meteor/client/lib/parseMessageTextToAstMarkdown.ts
@@ -1,5 +1,12 @@
 import type { IMessage, ITranslatedMessage, MessageAttachment } from '@rocket.chat/core-typings';
-import { isE2EEMessage, isQuoteAttachment, isTranslatedAttachment, isTranslatedMessage } from '@rocket.chat/core-typings';
+import {
+	isFileAttachment,
+	isE2EEMessage,
+	isQuoteAttachment,
+	isTranslatedAttachment,
+	isTranslatedMessage,
+	isEncryptedMessageAttachment,
+} from '@rocket.chat/core-typings';
 import type { Options, Root } from '@rocket.chat/message-parser';
 import { parse } from '@rocket.chat/message-parser';
 
@@ -51,7 +58,7 @@ export const parseMessageAttachment = <T extends MessageAttachment>(
 	autoTranslateOptions: { autoTranslateLanguage?: string; translated: boolean },
 ): T => {
 	const { translated, autoTranslateLanguage } = autoTranslateOptions;
-	if (!attachment.text) {
+	if (!attachment.text && !attachment.description) {
 		return attachment;
 	}
 
@@ -62,7 +69,15 @@ export const parseMessageAttachment = <T extends MessageAttachment>(
 	const text =
 		(isTranslatedAttachment(attachment) && autoTranslateLanguage && attachment?.translations?.[autoTranslateLanguage]) ||
 		attachment.text ||
+		attachment.description ||
 		'';
+
+	if (isFileAttachment(attachment) && attachment.description) {
+		attachment.descriptionMd =
+			translated || isEncryptedMessageAttachment(attachment)
+				? textToMessageToken(text, parseOptions)
+				: (attachment.descriptionMd ?? textToMessageToken(text, parseOptions));
+	}
 
 	return {
 		...attachment,

--- a/apps/meteor/client/lib/utils/normalizeMessagePreview/normalizeMessagePreview.spec.ts
+++ b/apps/meteor/client/lib/utils/normalizeMessagePreview/normalizeMessagePreview.spec.ts
@@ -48,7 +48,7 @@ describe('normalizeMessagePreview', () => {
 	});
 
 	describe('when message has attachments', () => {
-		it('should return attachment title when description is available', () => {
+		it('should return attachment description when available', () => {
 			const message = createFakeMessageWithAttachment({
 				msg: '',
 				attachments: [
@@ -60,10 +60,10 @@ describe('normalizeMessagePreview', () => {
 			});
 			const result = normalizeMessagePreview(message, mockT);
 
-			expect(result).toBe('Attachment title');
+			expect(result).toBe('Attachment description');
 		});
 
-		it('should return attachment title when message is not provided', () => {
+		it('should return attachment title when description is not available', () => {
 			const message = createFakeMessageWithAttachment({
 				msg: '',
 				attachments: [
@@ -112,7 +112,7 @@ describe('normalizeMessagePreview', () => {
 			expect(result).toBe('Second attachment title');
 		});
 
-		it('should find first attachment title', () => {
+		it('should find first attachment description', () => {
 			const message = createFakeMessageWithAttachment({
 				msg: '',
 				attachments: [
@@ -129,7 +129,21 @@ describe('normalizeMessagePreview', () => {
 			});
 			const result = normalizeMessagePreview(message, mockT);
 
-			expect(result).toBe('Third attachment title');
+			expect(result).toBe('Second attachment description');
+		});
+
+		it('should escape HTML in attachment description', () => {
+			const message = createFakeMessageWithAttachment({
+				msg: '',
+				attachments: [
+					{
+						description: '<script>alert("xss")</script>',
+					},
+				],
+			});
+			const result = normalizeMessagePreview(message, mockT);
+
+			expect(result).toBe('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
 		});
 
 		it('should escape HTML in attachment title', () => {

--- a/apps/meteor/client/lib/utils/normalizeMessagePreview/normalizeMessagePreview.ts
+++ b/apps/meteor/client/lib/utils/normalizeMessagePreview/normalizeMessagePreview.ts
@@ -11,7 +11,11 @@ export const normalizeMessagePreview = (message: IMessage, t: TFunction): string
 	}
 
 	if (message.attachments) {
-		const attachment = message.attachments.find((attachment) => attachment.title);
+		const attachment = message.attachments.find((attachment) => attachment.title || attachment.description);
+
+		if (attachment?.description) {
+			return escapeHTML(attachment.description);
+		}
 
 		if (attachment?.title) {
 			return escapeHTML(attachment.title);

--- a/apps/meteor/client/views/room/MessageList/hooks/useMessageBody.tsx
+++ b/apps/meteor/client/views/room/MessageList/hooks/useMessageBody.tsx
@@ -31,7 +31,11 @@ export const useMessageBody = (message: IMessage | undefined): string | Root => 
 		}
 
 		if (message.attachments) {
-			const attachment = message.attachments.find((attachment) => attachment.title);
+			const attachment = message.attachments.find((attachment) => attachment.title || attachment.description);
+
+			if (attachment?.description) {
+				return attachment.description;
+			}
 
 			if (attachment?.title) {
 				return attachment.title;

--- a/apps/meteor/client/views/room/contextualBar/ExportMessages/useDownloadExportMutation.ts
+++ b/apps/meteor/client/views/room/contextualBar/ExportMessages/useDownloadExportMutation.ts
@@ -39,6 +39,7 @@ export const useDownloadExportMutation = () => {
 							...('image_type' in attachment && { image_type: attachment.image_type }),
 							...('image_size' in attachment && { image_size: attachment.image_size }),
 							...('type' in attachment && { type: attachment.type }),
+							description: attachment.description,
 						})) ?? [],
 				}),
 			);

--- a/apps/meteor/client/views/room/contextualBar/ExportMessages/useExportMessagesAsPDFMutation.tsx
+++ b/apps/meteor/client/views/room/contextualBar/ExportMessages/useExportMessagesAsPDFMutation.tsx
@@ -116,6 +116,7 @@ export const useExportMessagesAsPDFMutation = () => {
 										<Text style={message.tmid ? pdfStyles.threadMessage : pdfStyles.message}>{parseMessage(message)}</Text>
 										{message.attachments?.map((attachment: MessageAttachmentDefault, index) => (
 											<View key={index}>
+												{attachment.description && <Text style={pdfStyles.message}>{attachment.description}</Text>}
 												{attachment.image_url && <Image src={attachment.title_link} style={attachment.image_dimensions} />}
 												<Text style={pdfStyles.message}>{attachment.title}</Text>
 											</View>

--- a/apps/meteor/client/views/room/contextualBar/Threads/hooks/useNormalizedThreadTitleHtml.ts
+++ b/apps/meteor/client/views/room/contextualBar/Threads/hooks/useNormalizedThreadTitleHtml.ts
@@ -33,7 +33,11 @@ export const useNormalizedThreadTitleHtml = (mainMessage: IThreadMainMessage) =>
 		}
 
 		if (message.attachments) {
-			const attachment = message.attachments.find((attachment) => attachment.title);
+			const attachment = message.attachments.find((attachment) => attachment.title || attachment.description);
+
+			if (attachment?.description) {
+				return escapeHTML(attachment.description);
+			}
 
 			if (attachment?.title) {
 				return escapeHTML(attachment.title);

--- a/apps/meteor/server/features/EmailInbox/EmailInbox_Outgoing.ts
+++ b/apps/meteor/server/features/EmailInbox/EmailInbox_Outgoing.ts
@@ -142,7 +142,11 @@ slashCommands.add({
 			return;
 		}
 
-		const emailText = message?.msg || '';
+		const emailText =
+			message?.attachments
+				?.map((a) => a.description)
+				.filter(Boolean)
+				.join('\n\n') || '';
 
 		void sendEmail(
 			inbox,

--- a/apps/meteor/server/services/messages/hooks/BeforeSaveMarkdownParser.ts
+++ b/apps/meteor/server/services/messages/hooks/BeforeSaveMarkdownParser.ts
@@ -38,6 +38,10 @@ export class BeforeSaveMarkdownParser {
 			if (message.msg) {
 				message.md = parse(message.msg, config);
 			}
+
+			if (message.attachments?.[0]?.description) {
+				message.attachments[0].descriptionMd = parse(message.attachments[0].description, config);
+			}
 		} catch (e) {
 			console.error(e); // errors logged while the parser is at experimental stage
 		}

--- a/apps/meteor/tests/unit/server/services/messages/hooks/BeforeSaveJumpToMessage.tests.ts
+++ b/apps/meteor/tests/unit/server/services/messages/hooks/BeforeSaveJumpToMessage.tests.ts
@@ -500,6 +500,17 @@ describe('Create attachments for message URLs', () => {
 											image_size: 68016,
 											type: 'file',
 											description: 'chained 3 - file',
+											descriptionMd: [
+												{
+													type: 'PARAGRAPH',
+													value: [
+														{
+															type: 'PLAIN_TEXT',
+															value: 'chained 3 - file',
+														},
+													],
+												},
+											],
 										},
 									],
 								},

--- a/apps/meteor/tests/unit/server/services/messages/hooks/BeforeSaveMarkdownParser.tests.ts
+++ b/apps/meteor/tests/unit/server/services/messages/hooks/BeforeSaveMarkdownParser.tests.ts
@@ -82,4 +82,29 @@ describe('Markdown parser', () => {
 
 		expect(message).to.have.property('md');
 	});
+
+	it('should parse markdown on the first attachment only', async () => {
+		const markdownParser = new BeforeSaveMarkdownParser(true);
+
+		const message = await markdownParser.parseMarkdown({
+			message: createMessage('hey', {
+				attachments: [
+					{
+						description: 'hey ho',
+					},
+					{
+						description: 'lets go',
+					},
+				],
+			}),
+			config: {},
+		});
+
+		expect(message).to.have.property('md');
+
+		const [attachment1, attachment2] = message.attachments || [];
+
+		expect(attachment1).to.have.property('descriptionMd');
+		expect(attachment2).to.not.have.property('descriptionMd');
+	});
 });

--- a/ee/packages/omnichannel-services/src/OmnichannelTranscript.ts
+++ b/ee/packages/omnichannel-services/src/OmnichannelTranscript.ts
@@ -312,7 +312,9 @@ export class OmnichannelTranscript extends ServiceClass implements IOmnichannelT
 				}
 			}
 
-			const msg = message.msg || '';
+			// When you send a file message, the things you type in the modal are not "msg", they're in "description" of the attachment
+			// So, we'll fetch the the msg, if empty, go for the first description on an attachment, if empty, empty string
+			const msg = message.msg || message.attachments.find((attachment) => attachment.description)?.description || '';
 			// Remove nulls from final array
 			messagesData.push({
 				msg,

--- a/packages/core-typings/src/IMessage/MessageAttachment/MessageAttachmentBase.ts
+++ b/packages/core-typings/src/IMessage/MessageAttachment/MessageAttachmentBase.ts
@@ -7,6 +7,7 @@ export type MessageAttachmentBase = {
 	collapsed?: boolean;
 	/** description isn't being used on client for non-image attachments, we're keeping it for backward compatibility */
 	description?: string;
+	descriptionMd?: Root;
 	text?: string;
 	md?: Root;
 	size?: number;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
This reverts PR #40067 (merge commit `9760d84`), restoring the `description` / `descriptionMd` handling in attachment rendering.

### Why

PR #40067 removed the `description` field from the attachments render path on the assumption it was unused. That removal regressed attachment description rendering (and autotranslate of attachment descriptions), so we are reverting it to restore previous behavior.

### Changes

- Restores the `description` block in autotranslate client lib.
- Restores `descriptionMd` plumbing across attachment components (Image/Audio/Video/GenericFile) and related message/preview/export helpers.
- Restores `description` on `MessageAttachmentBase` typing.
- Restores the associated changeset and unit tests.

Conflicts in `autotranslate.ts` and `ImageAttachment.tsx` (from changes landed on `develop` after #40067 merged) were resolved by keeping the restored `description`/`descriptionMd` logic.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Closes #40663

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attachment descriptions now support automatic translation across all translation providers
  * Attachment descriptions display in messages, emails, PDF and JSON exports, and live chat transcripts
  * Users can edit and preview attachment descriptions inline with messages

* **Tests**
  * Added test coverage for attachment description handling in message parsing and markdown processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[SUP-1039]

[SUP-1039]: https://rocketchat.atlassian.net/browse/SUP-1039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ