### PR TITLE
fix: hide voice-call icon for users without a phone extension

### DIFF
--- a/.changeset/dmv-62-phone-icon-no-extension.md
+++ b/.changeset/dmv-62-phone-icon-no-extension.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixed the voice-call phone icon being shown in direct messages with users that have no phone extension assigned. When internal calls are routed through SIP, the call action is now only offered if the other user has an extension; with SIP routing disabled the action keeps showing as before.

--- a/apps/meteor/client/hooks/roomActions/useMediaCallRoomAction.spec.tsx
+++ b/apps/meteor/client/hooks/roomActions/useMediaCallRoomAction.spec.tsx
@@ -2,7 +2,7 @@ import type { IUser, IRoom } from '@rocket.chat/core-typings';
 import { mockAppRoot } from '@rocket.chat/mock-providers';
 import type { SubscriptionWithRoom } from '@rocket.chat/ui-contexts';
 import { useMediaCallAction } from '@rocket.chat/ui-voip';
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 import { useMediaCallRoomAction } from './useMediaCallRoomAction';
 import FakeRoomProvider from '../../../tests/mocks/client/FakeRoomProvider';
@@ -19,11 +19,14 @@ jest.mock('@rocket.chat/ui-voip', () => ({
 
 const getUserInfoMocked = jest.fn().mockResolvedValue({ user: createFakeUser({ _id: 'peer-uid', username: 'peer-username' }) });
 
-const appRoot = (overrides: { user?: IUser | null; room?: IRoom; subscription?: SubscriptionWithRoom } = {}) => {
+const appRoot = (
+	overrides: { user?: IUser | null; room?: IRoom; subscription?: SubscriptionWithRoom; settings?: Record<string, unknown> } = {},
+) => {
 	const {
 		user = createFakeUser({ _id: 'own-uid', username: 'own-username' }),
 		room = createFakeRoom({ uids: ['own-uid', 'peer-uid'] }),
 		subscription = createFakeSubscription(),
+		settings = {},
 	} = overrides;
 
 	const root = mockAppRoot()
@@ -34,6 +37,10 @@ const appRoot = (overrides: { user?: IUser | null; room?: IRoom; subscription?: 
 				{children}
 			</FakeRoomProvider>
 		));
+
+	for (const [key, value] of Object.entries(settings)) {
+		root.withSetting(key as any, value as any);
+	}
 
 	if (user !== null) {
 		root.withUser(user);
@@ -142,5 +149,42 @@ describe('useMediaCallRoomAction', () => {
 		// Test the action trigger
 		act(() => result.current?.action?.());
 		expect(actionMock).toHaveBeenCalled();
+	});
+
+	describe('SIP routing for internal calls (DMV-62)', () => {
+		const SIP_ROUTING_SETTING = 'VoIP_TeamCollab_SIP_Integration_For_Internal_Calls';
+
+		it('should return undefined when SIP routing is enabled and the peer has no extension', async () => {
+			getUserInfoMocked.mockResolvedValue({ user: createFakeUser({ _id: 'peer-uid', username: 'peer-username' }) });
+
+			const { result } = renderHook(() => useMediaCallRoomAction(), {
+				wrapper: appRoot({ settings: { [SIP_ROUTING_SETTING]: true } }),
+			});
+
+			// The peer never gains an extension, so the action must stay hidden.
+			await waitFor(() => expect(result.current).toBeUndefined());
+		});
+
+		it('should return the action when SIP routing is enabled and the peer has an extension', async () => {
+			getUserInfoMocked.mockResolvedValue({
+				user: createFakeUser({ _id: 'peer-uid', username: 'peer-username', freeSwitchExtension: '1001' }),
+			});
+
+			const { result } = renderHook(() => useMediaCallRoomAction(), {
+				wrapper: appRoot({ settings: { [SIP_ROUTING_SETTING]: true } }),
+			});
+
+			await waitFor(() => expect(result.current).toMatchObject({ id: 'start-voice-call', icon: 'phone' }));
+		});
+
+		it('should return the action when SIP routing is disabled even if the peer has no extension', async () => {
+			getUserInfoMocked.mockResolvedValue({ user: createFakeUser({ _id: 'peer-uid', username: 'peer-username' }) });
+
+			const { result } = renderHook(() => useMediaCallRoomAction(), {
+				wrapper: appRoot({ settings: { [SIP_ROUTING_SETTING]: false } }),
+			});
+
+			await waitFor(() => expect(result.current).toMatchObject({ id: 'start-voice-call', icon: 'phone' }));
+		});
 	});
 });

--- a/apps/meteor/client/hooks/roomActions/useMediaCallRoomAction.spec.tsx
+++ b/apps/meteor/client/hooks/roomActions/useMediaCallRoomAction.spec.tsx
@@ -10,7 +10,7 @@ import { createFakeRoom, createFakeSubscription, createFakeUser } from '../../..
 
 jest.mock('@rocket.chat/ui-contexts', () => ({
 	...jest.requireActual('@rocket.chat/ui-contexts'),
-	useUserAvatarPath: jest.fn((_args: any) => 'avatar-url'),
+	useUserAvatarPath: jest.fn(() => (_args: any) => 'avatar-url'),
 }));
 
 jest.mock('@rocket.chat/ui-voip', () => ({

--- a/apps/meteor/client/hooks/roomActions/useMediaCallRoomAction.ts
+++ b/apps/meteor/client/hooks/roomActions/useMediaCallRoomAction.ts
@@ -1,5 +1,5 @@
 import { isRoomFederated } from '@rocket.chat/core-typings';
-import { useUserAvatarPath, useUserId } from '@rocket.chat/ui-contexts';
+import { useSetting, useUserAvatarPath, useUserId } from '@rocket.chat/ui-contexts';
 import type { TranslationKey, RoomToolboxActionConfig } from '@rocket.chat/ui-contexts';
 import type { PeerInfo } from '@rocket.chat/ui-voip';
 import { useMediaCallAction } from '@rocket.chat/ui-voip';
@@ -36,6 +36,12 @@ export const useMediaCallRoomAction = () => {
 
 	const { data } = useUserInfoQuery({ userId: peerId as string }, { enabled: !!peerId });
 
+	// When internal calls are routed through SIP, the callee is only reachable if they
+	// have a phone extension assigned. Without SIP routing the call is peer-to-peer and
+	// no extension is required.
+	const routeInternalCallsViaSip = useSetting('VoIP_TeamCollab_SIP_Integration_For_Internal_Calls', false);
+	const peerHasExtension = Boolean(data?.user?.freeSwitchExtension);
+
 	const peerInfo = useMemo<PeerInfo | undefined>(() => {
 		if (!data?.user?._id) {
 			return undefined;
@@ -59,6 +65,11 @@ export const useMediaCallRoomAction = () => {
 			return undefined;
 		}
 
+		// DMV-62: don't offer the call when SIP routing is required but the peer has no extension.
+		if (routeInternalCallsViaSip && !peerHasExtension) {
+			return undefined;
+		}
+
 		const { action, title, icon } = callAction;
 
 		return {
@@ -69,5 +80,5 @@ export const useMediaCallRoomAction = () => {
 			action: () => action(),
 			groups: ['direct'] as const,
 		};
-	}, [peerId, callAction, blocked, federated]);
+	}, [peerId, callAction, blocked, federated, routeInternalCallsViaSip, peerHasExtension]);
 };

--- a/apps/meteor/client/hooks/roomActions/useMediaCallRoomAction.ts
+++ b/apps/meteor/client/hooks/roomActions/useMediaCallRoomAction.ts
@@ -1,5 +1,5 @@
 import { isRoomFederated } from '@rocket.chat/core-typings';
-import { useUserAvatarPath, useUserId } from '@rocket.chat/ui-contexts';
+import { useSetting, useUserAvatarPath, useUserId } from '@rocket.chat/ui-contexts';
 import type { TranslationKey, RoomToolboxActionConfig } from '@rocket.chat/ui-contexts';
 import type { PeerInfo } from '@rocket.chat/ui-voip';
 import { useMediaCallAction } from '@rocket.chat/ui-voip';
@@ -36,6 +36,13 @@ export const useMediaCallRoomAction = () => {
 
 	const { data } = useUserInfoQuery({ userId: peerId as string }, { enabled: !!peerId });
 
+	// When internal calls are routed through SIP, the callee is only reachable if they
+	// have a phone extension assigned. Without SIP routing the call is peer-to-peer and
+	// no extension is required.
+	const sipEnabled = useSetting('VoIP_TeamCollab_SIP_Integration_Enabled', false);
+	const routeInternalCallsViaSip = useSetting('VoIP_TeamCollab_SIP_Integration_For_Internal_Calls', false);
+	const peerHasExtension = Boolean(data?.user?.freeSwitchExtension);
+
 	const peerInfo = useMemo<PeerInfo | undefined>(() => {
 		if (!data?.user?._id) {
 			return undefined;
@@ -59,6 +66,11 @@ export const useMediaCallRoomAction = () => {
 			return undefined;
 		}
 
+		// don't offer the call when SIP routing is required but the peer has no extension.
+		if (sipEnabled && routeInternalCallsViaSip && !peerHasExtension) {
+			return undefined;
+		}
+
 		const { action, title, icon } = callAction;
 
 		return {
@@ -69,5 +81,5 @@ export const useMediaCallRoomAction = () => {
 			action: () => action(),
 			groups: ['direct'] as const,
 		};
-	}, [peerId, callAction, blocked, federated]);
+	}, [peerId, callAction, blocked, federated, sipEnabled, routeInternalCallsViaSip, peerHasExtension]);
 };


### PR DESCRIPTION
## Proposed changes

In a direct message the voice-call icon was shown for any user, even one **without a phone extension**. Clicking it opened the call widget for an instant and then hid it, since the call could not be placed (DMV-62).

When internal calls are routed through SIP (`VoIP_TeamCollab_SIP_Integration_For_Internal_Calls`), the callee can only be reached if they have a `freeSwitchExtension` assigned, so `useMediaCallRoomAction` now gates the action on it. With SIP routing disabled, internal calls are peer-to-peer and need no extension, so the action keeps showing as before.

Visibility rule:
`permission AND ( (SIP routing enabled AND peer has extension) OR SIP routing disabled )`

## Issue(s)

DMV-62

## How to test the changes

1. Enable `VoIP_TeamCollab_SIP_Integration_For_Internal_Calls`.
2. Open a DM with a user that has **no** extension assigned → the phone icon must not appear.
3. Assign an extension to that user → the phone icon appears.
4. Disable the setting → the phone icon appears regardless of extension.

## Further comments

- Covered by unit tests in `useMediaCallRoomAction.spec.tsx` (SIP-routing × extension matrix).
- `freeSwitchExtension` is already returned by `users.info` (`DefaultUserInfo`), reused from the existing `useUserInfoQuery`.
DMV-62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Voice-call actions are now hidden in direct messages when SIP routing for internal calls is enabled and the other participant has no phone extension.
  * Call actions remain available when the participant has an extension or when SIP routing for internal calls is disabled.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->