### PR TITLE
chore: ignore not-initialized calls when calculating media session state

### DIFF
--- a/packages/media-signaling/src/lib/Call.ts
+++ b/packages/media-signaling/src/lib/Call.ts
@@ -185,7 +185,11 @@ export class ClientMediaCall implements IClientMediaCall {
 
 	private hasRemoteData: boolean;
 
-	private initialized: boolean;
+	private _initialized: boolean;
+
+	public get initialized(): boolean {
+		return this._initialized;
+	}
 
 	private acknowledged: boolean;
 
@@ -296,7 +300,7 @@ export class ClientMediaCall implements IClientMediaCall {
 		this.acceptedRemotely = false;
 		this.endedLocally = false;
 		this.hasRemoteData = false;
-		this.initialized = false;
+		this._initialized = false;
 		this.acknowledged = false;
 		this.contractState = 'proposed';
 		this.serviceStates = new Map();
@@ -340,7 +344,7 @@ export class ClientMediaCall implements IClientMediaCall {
 
 		const wasInitialized = this.initialized;
 
-		this.initialized = true;
+		this._initialized = true;
 		this.acceptedLocally = true;
 		if (this.hasRemoteData) {
 			this.changeContact(contact, { prioritizeExisting: true });
@@ -388,7 +392,7 @@ export class ClientMediaCall implements IClientMediaCall {
 		this.remoteCallId = signal.callId;
 		const wasInitialized = this.initialized;
 
-		this.initialized = true;
+		this._initialized = true;
 		this.hasRemoteData = true;
 		this._service = signal.service;
 		this._role = signal.role;

--- a/packages/media-signaling/src/lib/Session.ts
+++ b/packages/media-signaling/src/lib/Session.ts
@@ -173,7 +173,7 @@ export class MediaSignalingSession extends Emitter<MediaSignalingEvents> {
 		let pendingCall: ClientMediaCall | null = null;
 
 		for (const call of this.knownCalls.values()) {
-			if (call.state === 'hangup' || call.ignored) {
+			if (call.state === 'hangup' || call.ignored || !call.initialized) {
 				continue;
 			}
 			if (skipLocal && !call.confirmed) {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
The client instantiates a Call object whenever a signal is received with a callId it doesn't recognize, but that Call instance only becomes valid once a "new call" signal is received. If the new signal is never received, the call remains there, blocking the media session from initializing new calls.

With this change, calls that have not been initialized yet will be ignored by the session.

This is a bug on the lib, but there's no easy way to trigger this as a bug on the product as a whole.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Derived from [DMV-53](https://rocketchat.atlassian.net/browse/DMV-53)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[DMV-53]: https://rocketchat.atlassian.net/browse/DMV-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed main call selection logic to properly exclude uninitialized calls.

* **Refactor**
  * Improved initialization state tracking for better call lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->