### PR TITLE
fix: add text wrapping to omnichannel transfer comment

### DIFF
--- a/.changeset/fix-omnichannel-comment-wrap.md
+++ b/.changeset/fix-omnichannel-comment-wrap.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes omnichannel transfer comment text not wrapping to multiple lines by adding `white-space: pre-wrap` to the SystemMessage and ContactHistoryMessage components.

--- a/apps/meteor/client/components/message/variants/SystemMessage.tsx
+++ b/apps/meteor/client/components/message/variants/SystemMessage.tsx
@@ -102,7 +102,7 @@ const SystemMessage = ({ message, showUserAvatar, ...props }: SystemMessageProps
 						)}
 					</MessageNameContainer>
 					{messageType && (
-						<MessageSystemBody role='document' aria-roledescription={t('system_message_body')}>
+						<MessageSystemBody role='document' aria-roledescription={t('system_message_body')} style={{ whiteSpace: 'pre-wrap' }}>
 							{messageType.text(t, message)}
 						</MessageSystemBody>
 					)}

--- a/apps/meteor/client/views/omnichannel/contactHistory/MessageList/ContactHistoryMessage.tsx
+++ b/apps/meteor/client/views/omnichannel/contactHistory/MessageList/ContactHistoryMessage.tsx
@@ -71,7 +71,7 @@ const ContactHistoryMessage = ({ message, sequential, isNewDay, showUserAvatar }
 						<MessageSystemName data-username={message.u.username} data-qa-type='username'>
 							@{message.u.username}
 						</MessageSystemName>
-						<MessageSystemBody title={message.msg}>{t('Conversation_closed', { comment: message.msg })}</MessageSystemBody>
+						<MessageSystemBody title={message.msg} style={{ whiteSpace: 'pre-wrap' }}>{t('Conversation_closed', { comment: message.msg })}</MessageSystemBody>
 						<MessageSystemTimestamp title={formatTime(message.ts)}>{formatTime(message.ts)}</MessageSystemTimestamp>
 					</MessageSystemBlock>
 				</MessageSystemContainer>


### PR DESCRIPTION
Fixes #26723

## Description
This PR adds  to the  component to allow omnichannel transfer comments to wrap to multiple lines instead of being truncated.

## Changes
- Added  to  in 
- Added  to  in 

## Testing
1. Transfer an omnichannel conversation to another agent with a long comment
2. Verify that the comment text wraps to multiple lines instead of being truncated

## Related Issues
Fixes #26723

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * System messages now preserve whitespace and line breaks, improving readability.
  * Omnichannel conversation-closed messages in contact history display proper wrapping and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->