### PR TITLE
fix(search): extend messages text index to include attachment fields

### DIFF
--- a/.changeset/fix-search-attachment-fields.md
+++ b/.changeset/fix-search-attachment-fields.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fix: Message search now includes attachment text fields (text, title, description, pretext, author_name) in the MongoDB text index so searching works on post attachments, not just message body.

--- a/apps/meteor/server/startup/ensureMessagesTextIndex.ts
+++ b/apps/meteor/server/startup/ensureMessagesTextIndex.ts
@@ -96,7 +96,10 @@ export const ensureMessagesTextIndex = async (): Promise<void> => {
 		shape: desiredShape,
 	});
 	try {
-		const name = await Messages.col.createIndex(desiredShape === 'room-scoped' ? { rid: 1, ...TEXT_INDEX_FIELDS } : TEXT_INDEX_FIELDS);
+		const name = await Messages.col.createIndex(
+			desiredShape === 'room-scoped' ? { rid: 1, ...TEXT_INDEX_FIELDS } : TEXT_INDEX_FIELDS,
+			{ name: desiredShape === 'room-scoped' ? 'messages_text_room' : 'messages_text' },
+		);
 		SystemLogger.startup({ msg: 'created messages text index', name, shape: desiredShape });
 	} catch (err) {
 		SystemLogger.error({ msg: 'failed to create messages text index', shape: desiredShape, err });

--- a/apps/meteor/server/startup/ensureMessagesTextIndex.ts
+++ b/apps/meteor/server/startup/ensureMessagesTextIndex.ts
@@ -4,12 +4,29 @@ import { SystemLogger } from '../lib/logger/system';
 
 const { USE_ROOM_SEARCH_INDEX = 'false' } = process.env;
 
+const ATTACHMENT_TEXT_FIELDS = [
+	'attachments.text',
+	'attachments.title',
+	'attachments.description',
+	'attachments.pretext',
+	'attachments.author_name',
+] as const;
+
+const TEXT_INDEX_FIELDS = { msg: 'text' as const, ...Object.fromEntries(ATTACHMENT_TEXT_FIELDS.map((f) => [f, 'text' as const])) };
+
 // MongoDB stores a text index's key with `_fts: 'text'` / `_ftsx: 1` placeholders
 // and tracks the original text fields in `weights`. Classify by looking at the
 // non-placeholder prefix fields plus weights.
 const classifyTextIndex = (idx: { key: Record<string, unknown>; weights?: Record<string, number> }) => {
 	const { weights, key } = idx;
-	if (weights?.msg !== 1 || Object.keys(weights).length !== 1) {
+
+	const expectedWeightKeys = Object.keys(TEXT_INDEX_FIELDS);
+	const actualWeightKeys = Object.keys(weights ?? {});
+
+	if (
+		actualWeightKeys.length !== expectedWeightKeys.length ||
+		!expectedWeightKeys.every((k) => weights?.[k] === 1)
+	) {
 		return 'other';
 	}
 
@@ -79,7 +96,7 @@ export const ensureMessagesTextIndex = async (): Promise<void> => {
 		shape: desiredShape,
 	});
 	try {
-		const name = await Messages.col.createIndex(desiredShape === 'room-scoped' ? { rid: 1, msg: 'text' } : { msg: 'text' });
+		const name = await Messages.col.createIndex(desiredShape === 'room-scoped' ? { rid: 1, ...TEXT_INDEX_FIELDS } : TEXT_INDEX_FIELDS);
 		SystemLogger.startup({ msg: 'created messages text index', name, shape: desiredShape });
 	} catch (err) {
 		SystemLogger.error({ msg: 'failed to create messages text index', shape: desiredShape, err });


### PR DESCRIPTION
## Proposed changes

Renaming a room or using integrations to post with attachments — the attachment content (`title`, `description`, `text`, `pretext`, `author_name`) was never included in MongoDB's text index on the `messages` collection. Only `msg` (message body) was indexed, so searching for terms that appeared only in attachments returned no results.

**Fix:** Extend the text index to cover attachment text fields. On startup, `ensureMessagesTextIndex` detects the old `msg`-only index, drops it, and rebuilds with the new shape automatically.

## Issue
Closes #2938

## Steps to test or reproduce
1. Send a message via an integration (or REST API) with an attachment that has a `title` or `text` field containing a unique search term — but leave the message body empty or with different text
2. Use the search bar to search for the term
3. **Before fix:** no results
4. **After fix:** message with attachment appears in results

## Further comments
- Index rebuild happens automatically on server startup — may take several minutes on large databases (existing startup log warns about this)
- Both `default` and `room-scoped` (`USE_ROOM_SEARCH_INDEX=true`) index shapes are updated
- `classifyTextIndex` updated to match new weight set so stale old index is detected and replaced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Message search now includes attachment content (text, title, description, pretext, and author name), so searches return results contained in attachments as well as message body. This improves relevance and discoverability of attachment content across global and room searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->