### PR TITLE
chore: Align cron job eviction process for abac

### DIFF
--- a/apps/meteor/tests/end-to-end/api/abac.ts
+++ b/apps/meteor/tests/end-to-end/api/abac.ts
@@ -3167,10 +3167,7 @@ const addAbacAttributesToUserDirectly = async (userId: string, abacAttributes: I
 
 			await mockServerReset();
 			await seedDefaultMocks();
-			await seedGetDecisionBulk([
-				{ resourceDecisions: [{ decision: 'DECISION_PERMIT', ephemeralResourceId: room._id }] },
-				{ resourceDecisions: [{ decision: 'DECISION_PERMIT', ephemeralResourceId: room._id }] },
-			]);
+			await seedBulkDecisionByEntity([], 'DECISION_PERMIT');
 
 			await request
 				.post(`/api/v1/abac/rooms/${room._id}/attributes/${attrKey}`)

--- a/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
@@ -414,13 +414,86 @@ describe('VirtruPDP.evaluateUserRooms', () => {
 		expect(result).toEqual([{ user: u, room: rooms[1] }]);
 	});
 
-	it('treats empty resourceDecisions as non-compliant', async () => {
+	it('does not evict on empty resourceDecisions (inconclusive)', async () => {
 		const u = user();
 		const rooms = [{ _id: 'r1', abacAttributes: [{ key: 'k', values: ['v'] }] }];
 		const apiCall = jest.fn().mockResolvedValue({ decisionResponses: [{ resourceDecisions: [] }] });
 		const pdp = new VirtruPDP(mkClient({ apiCall }));
 		const result = await pdp.evaluateUserRooms([{ user: u, rooms }]);
-		expect(result).toEqual([{ user: u, room: rooms[0] }]);
+		expect(result).toEqual([]);
+	});
+
+	it('does not evict on DECISION_UNSPECIFIED (inconclusive)', async () => {
+		const u = user();
+		const rooms = [{ _id: 'r1', abacAttributes: [{ key: 'k', values: ['v'] }] }];
+		const apiCall = jest.fn().mockResolvedValue({
+			decisionResponses: [{ resourceDecisions: [{ ephemeralResourceId: 'r1', decision: 'DECISION_UNSPECIFIED' }] }],
+		});
+		const pdp = new VirtruPDP(mkClient({ apiCall }));
+		const result = await pdp.evaluateUserRooms([{ user: u, rooms }]);
+		expect(result).toEqual([]);
+	});
+
+	it('evicts only explicit DENY among mixed PERMIT/UNSPECIFIED/DENY decisions', async () => {
+		const u = user();
+		const rooms = [
+			{ _id: 'rP', abacAttributes: [{ key: 'k', values: ['v'] }] },
+			{ _id: 'rU', abacAttributes: [{ key: 'k', values: ['v'] }] },
+			{ _id: 'rD', abacAttributes: [{ key: 'k', values: ['v'] }] },
+		];
+		const apiCall = jest.fn().mockResolvedValue({
+			decisionResponses: [
+				{ resourceDecisions: [{ ephemeralResourceId: 'rP', decision: 'DECISION_PERMIT' }] },
+				{ resourceDecisions: [{ ephemeralResourceId: 'rU', decision: 'DECISION_UNSPECIFIED' }] },
+				{ resourceDecisions: [{ ephemeralResourceId: 'rD', decision: 'DECISION_DENY' }] },
+			],
+		});
+		const pdp = new VirtruPDP(mkClient({ apiCall }));
+		const result = await pdp.evaluateUserRooms([{ user: u, rooms }]);
+		expect(result).toEqual([{ user: u, room: rooms[2] }]);
+	});
+
+	it('resolves without evictions when the decision call fails', async () => {
+		const apiCall = jest.fn().mockRejectedValue(new Error('pdp down'));
+		const pdp = new VirtruPDP(mkClient({ apiCall }));
+		const rooms = [{ _id: 'r1', abacAttributes: [{ key: 'k', values: ['v'] }] }];
+		const result = await pdp.evaluateUserRooms([{ user: user(), rooms }]);
+		expect(result).toEqual([]);
+		expect(apiCall).toHaveBeenCalled();
+	});
+
+	it('keeps evictions from successful batches when another batch fails', async () => {
+		const u = user();
+		const total = 201;
+		const rooms = Array.from({ length: total }, (_, i) => ({ _id: `r${i}`, abacAttributes: [{ key: 'k', values: ['v'] }] }));
+		const apiCall = jest.fn().mockImplementation(async (_endpoint, body: any) => {
+			if (body.decisionRequests.some((r: any) => r.resources[0].ephemeralId === 'r0')) {
+				throw new Error('pdp down');
+			}
+			return {
+				decisionResponses: body.decisionRequests.map((r: any) => ({
+					resourceDecisions: [{ ephemeralResourceId: r.resources[0].ephemeralId, decision: 'DECISION_DENY' }],
+				})),
+			};
+		});
+		const pdp = new VirtruPDP(mkClient({ apiCall }));
+		const result = await pdp.evaluateUserRooms([{ user: u, rooms }]);
+		expect(result).toEqual([{ user: u, room: rooms[200] }]);
+		expect(apiCall).toHaveBeenCalledTimes(2);
+	});
+
+	it('skips evictions for a batch whose response count mismatches the request count', async () => {
+		const u = user();
+		const rooms = [
+			{ _id: 'r1', abacAttributes: [{ key: 'k', values: ['v'] }] },
+			{ _id: 'r2', abacAttributes: [{ key: 'k', values: ['v'] }] },
+		];
+		const apiCall = jest.fn().mockResolvedValue({
+			decisionResponses: [{ resourceDecisions: [{ ephemeralResourceId: 'r1', decision: 'DECISION_DENY' }] }],
+		});
+		const pdp = new VirtruPDP(mkClient({ apiCall }));
+		const result = await pdp.evaluateUserRooms([{ user: u, rooms }]);
+		expect(result).toEqual([]);
 	});
 });
 
@@ -461,12 +534,17 @@ describe('VirtruPDP — PDP unreachable (decision call rejects)', () => {
 		expect(apiCall).toHaveBeenCalled();
 	});
 
-	it('evaluateUserRooms rejects when the decision call fails', async () => {
-		const apiCall = pdpDown();
+	it('onSubjectAttributesChanged rejects when response count mismatches request count (positional contract broken)', async () => {
+		const rooms = [
+			{ _id: 'r1', abacAttributes: [{ key: 'k', values: ['v'] }] },
+			{ _id: 'r2', abacAttributes: [{ key: 'k', values: ['v'] }] },
+		];
+		roomsFindPrivateRoomsByIdsWithAbacAttributes.mockReturnValue(cursor(rooms));
+		const apiCall = jest.fn().mockResolvedValue({
+			decisionResponses: [{ resourceDecisions: [{ ephemeralResourceId: 'r1', decision: 'DECISION_PERMIT' }] }],
+		});
 		const pdp = new VirtruPDP(mkClient({ apiCall }));
-		const rooms = [{ _id: 'r1', abacAttributes: [{ key: 'k', values: ['v'] }] }];
-		await expect(pdp.evaluateUserRooms([{ user: user(), rooms } as any])).rejects.toThrow('pdp down');
-		expect(apiCall).toHaveBeenCalled();
+		await expect(pdp.onSubjectAttributesChanged(user({ __rooms: ['r1', 'r2'] }) as any, [])).rejects.toThrow(/mismatch/);
 	});
 });
 

--- a/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
@@ -1,5 +1,6 @@
 import { OnlyCompliantCanBeAddedToRoomError, PdpHealthCheckError } from '../errors';
-import { VirtruPDP } from './VirtruPDP';
+import { collectDenied, VirtruPDP } from './VirtruPDP';
+import type { Decision } from './types';
 
 const serverFetchMock = jest.fn();
 jest.mock('@rocket.chat/server-fetch', () => ({ serverFetch: (...a: unknown[]) => serverFetchMock(...a) }));
@@ -85,6 +86,34 @@ describe('VirtruPDP.isAvailable', () => {
 		const pdp = new VirtruPDP(mkClient({ isAvailable }));
 		expect(await pdp.isAvailable()).toBe(true);
 		expect(isAvailable).toHaveBeenCalled();
+	});
+});
+
+describe('collectDenied', () => {
+	const logContext = (subject: string) => ({ rid: 'r1', userId: subject });
+	const resp = (...decisions: Decision[]) => ({
+		resourceDecisions: decisions.map((decision) => ({ ephemeralResourceId: 'r1', decision })),
+	});
+
+	it('collects subjects with an explicit DENY decision', () => {
+		const responses = [resp('DECISION_DENY'), resp('DECISION_PERMIT'), resp('DECISION_DENY')];
+		expect(collectDenied(responses, ['a', 'b', 'c'], logContext)).toEqual(['a', 'c']);
+	});
+
+	it('skips subjects when every decision is PERMIT', () => {
+		expect(collectDenied([resp('DECISION_PERMIT')], ['a'], logContext)).toEqual([]);
+	});
+
+	it('skips inconclusive subjects (UNSPECIFIED, empty decisions, missing response)', () => {
+		expect(collectDenied([resp('DECISION_UNSPECIFIED'), resp(), undefined], ['a', 'b', 'c'], logContext)).toEqual([]);
+	});
+
+	it('treats a DENY among PERMITs in one response as denied', () => {
+		expect(collectDenied([resp('DECISION_PERMIT', 'DECISION_DENY')], ['a'], logContext)).toEqual(['a']);
+	});
+
+	it('ignores responses without a matching subject', () => {
+		expect(collectDenied([resp('DECISION_DENY'), resp('DECISION_DENY')], ['a'], logContext)).toEqual(['a']);
 	});
 });
 

--- a/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
@@ -90,30 +90,31 @@ describe('VirtruPDP.isAvailable', () => {
 });
 
 describe('getDeniedSubjects', () => {
-	const logContext = (subject: string) => ({ rid: 'r1', userId: subject });
+	const pair = (userId: string) => ({ user: { _id: userId }, room: { _id: 'r1' } });
+	const [a, b, c] = [pair('a'), pair('b'), pair('c')];
 	const resp = (...decisions: Decision[]) => ({
 		resourceDecisions: decisions.map((decision) => ({ ephemeralResourceId: 'r1', decision })),
 	});
 
 	it('collects subjects with an explicit DENY decision', () => {
 		const responses = [resp('DECISION_DENY'), resp('DECISION_PERMIT'), resp('DECISION_DENY')];
-		expect(getDeniedSubjects(responses, ['a', 'b', 'c'], logContext)).toEqual(['a', 'c']);
+		expect(getDeniedSubjects(responses, [a, b, c])).toEqual([a, c]);
 	});
 
 	it('skips subjects when every decision is PERMIT', () => {
-		expect(getDeniedSubjects([resp('DECISION_PERMIT')], ['a'], logContext)).toEqual([]);
+		expect(getDeniedSubjects([resp('DECISION_PERMIT')], [a])).toEqual([]);
 	});
 
 	it('skips inconclusive subjects (UNSPECIFIED, empty decisions, missing response)', () => {
-		expect(getDeniedSubjects([resp('DECISION_UNSPECIFIED'), resp(), undefined], ['a', 'b', 'c'], logContext)).toEqual([]);
+		expect(getDeniedSubjects([resp('DECISION_UNSPECIFIED'), resp(), undefined], [a, b, c])).toEqual([]);
 	});
 
 	it('treats a DENY among PERMITs in one response as denied', () => {
-		expect(getDeniedSubjects([resp('DECISION_PERMIT', 'DECISION_DENY')], ['a'], logContext)).toEqual(['a']);
+		expect(getDeniedSubjects([resp('DECISION_PERMIT', 'DECISION_DENY')], [a])).toEqual([a]);
 	});
 
 	it('ignores responses without a matching subject', () => {
-		expect(getDeniedSubjects([resp('DECISION_DENY'), resp('DECISION_DENY')], ['a'], logContext)).toEqual(['a']);
+		expect(getDeniedSubjects([resp('DECISION_DENY'), resp('DECISION_DENY')], [a])).toEqual([a]);
 	});
 });
 

--- a/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
@@ -1,4 +1,4 @@
-import { OnlyCompliantCanBeAddedToRoomError, PdpHealthCheckError, PdpUnavailableError } from '../errors';
+import { OnlyCompliantCanBeAddedToRoomError, PdpHealthCheckError } from '../errors';
 import { VirtruPDP } from './VirtruPDP';
 
 const serverFetchMock = jest.fn();
@@ -498,7 +498,7 @@ describe('VirtruPDP.evaluateUserRooms', () => {
 		expect(apiCall).toHaveBeenCalled();
 	});
 
-	it('rejects when response count mismatches request count (positional contract broken)', async () => {
+	it('maps responses positionally; a missing trailing response is inconclusive (no evict)', async () => {
 		const u = user();
 		const rooms = [
 			{ _id: 'r1', abacAttributes: [{ key: 'k', values: ['v'] }] },
@@ -508,7 +508,8 @@ describe('VirtruPDP.evaluateUserRooms', () => {
 			decisionResponses: [{ resourceDecisions: [{ ephemeralResourceId: 'r1', decision: 'DECISION_DENY' }] }],
 		});
 		const pdp = new VirtruPDP(mkClient({ apiCall }));
-		await expect(pdp.evaluateUserRooms([{ user: u, rooms }])).rejects.toBeInstanceOf(PdpUnavailableError);
+		const result = await pdp.evaluateUserRooms([{ user: u, rooms }]);
+		expect(result).toEqual([{ user: u, room: rooms[0] }]);
 	});
 });
 
@@ -549,7 +550,7 @@ describe('VirtruPDP — PDP unreachable (decision call rejects)', () => {
 		expect(apiCall).toHaveBeenCalled();
 	});
 
-	it('onSubjectAttributesChanged rejects when response count mismatches request count (positional contract broken)', async () => {
+	it('onSubjectAttributesChanged treats a missing trailing response as non-compliant', async () => {
 		const rooms = [
 			{ _id: 'r1', abacAttributes: [{ key: 'k', values: ['v'] }] },
 			{ _id: 'r2', abacAttributes: [{ key: 'k', values: ['v'] }] },
@@ -559,7 +560,8 @@ describe('VirtruPDP — PDP unreachable (decision call rejects)', () => {
 			decisionResponses: [{ resourceDecisions: [{ ephemeralResourceId: 'r1', decision: 'DECISION_PERMIT' }] }],
 		});
 		const pdp = new VirtruPDP(mkClient({ apiCall }));
-		await expect(pdp.onSubjectAttributesChanged(user({ __rooms: ['r1', 'r2'] }) as any, [])).rejects.toBeInstanceOf(PdpUnavailableError);
+		const result = await pdp.onSubjectAttributesChanged(user({ __rooms: ['r1', 'r2'] }) as any, []);
+		expect(result).toEqual([rooms[1]]);
 	});
 });
 

--- a/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
@@ -1,5 +1,5 @@
 import { OnlyCompliantCanBeAddedToRoomError, PdpHealthCheckError } from '../errors';
-import { collectDenied, VirtruPDP } from './VirtruPDP';
+import { getDeniedSubjects, VirtruPDP } from './VirtruPDP';
 import type { Decision } from './types';
 
 const serverFetchMock = jest.fn();
@@ -89,7 +89,7 @@ describe('VirtruPDP.isAvailable', () => {
 	});
 });
 
-describe('collectDenied', () => {
+describe('getDeniedSubjects', () => {
 	const logContext = (subject: string) => ({ rid: 'r1', userId: subject });
 	const resp = (...decisions: Decision[]) => ({
 		resourceDecisions: decisions.map((decision) => ({ ephemeralResourceId: 'r1', decision })),
@@ -97,23 +97,23 @@ describe('collectDenied', () => {
 
 	it('collects subjects with an explicit DENY decision', () => {
 		const responses = [resp('DECISION_DENY'), resp('DECISION_PERMIT'), resp('DECISION_DENY')];
-		expect(collectDenied(responses, ['a', 'b', 'c'], logContext)).toEqual(['a', 'c']);
+		expect(getDeniedSubjects(responses, ['a', 'b', 'c'], logContext)).toEqual(['a', 'c']);
 	});
 
 	it('skips subjects when every decision is PERMIT', () => {
-		expect(collectDenied([resp('DECISION_PERMIT')], ['a'], logContext)).toEqual([]);
+		expect(getDeniedSubjects([resp('DECISION_PERMIT')], ['a'], logContext)).toEqual([]);
 	});
 
 	it('skips inconclusive subjects (UNSPECIFIED, empty decisions, missing response)', () => {
-		expect(collectDenied([resp('DECISION_UNSPECIFIED'), resp(), undefined], ['a', 'b', 'c'], logContext)).toEqual([]);
+		expect(getDeniedSubjects([resp('DECISION_UNSPECIFIED'), resp(), undefined], ['a', 'b', 'c'], logContext)).toEqual([]);
 	});
 
 	it('treats a DENY among PERMITs in one response as denied', () => {
-		expect(collectDenied([resp('DECISION_PERMIT', 'DECISION_DENY')], ['a'], logContext)).toEqual(['a']);
+		expect(getDeniedSubjects([resp('DECISION_PERMIT', 'DECISION_DENY')], ['a'], logContext)).toEqual(['a']);
 	});
 
 	it('ignores responses without a matching subject', () => {
-		expect(collectDenied([resp('DECISION_DENY'), resp('DECISION_DENY')], ['a'], logContext)).toEqual(['a']);
+		expect(getDeniedSubjects([resp('DECISION_DENY'), resp('DECISION_DENY')], ['a'], logContext)).toEqual(['a']);
 	});
 });
 

--- a/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
@@ -1,4 +1,4 @@
-import { OnlyCompliantCanBeAddedToRoomError, PdpHealthCheckError } from '../errors';
+import { OnlyCompliantCanBeAddedToRoomError, PdpHealthCheckError, PdpUnavailableError } from '../errors';
 import { VirtruPDP } from './VirtruPDP';
 
 const serverFetchMock = jest.fn();
@@ -508,7 +508,7 @@ describe('VirtruPDP.evaluateUserRooms', () => {
 			decisionResponses: [{ resourceDecisions: [{ ephemeralResourceId: 'r1', decision: 'DECISION_DENY' }] }],
 		});
 		const pdp = new VirtruPDP(mkClient({ apiCall }));
-		await expect(pdp.evaluateUserRooms([{ user: u, rooms }])).rejects.toThrow(/mismatch/);
+		await expect(pdp.evaluateUserRooms([{ user: u, rooms }])).rejects.toBeInstanceOf(PdpUnavailableError);
 	});
 });
 
@@ -559,7 +559,7 @@ describe('VirtruPDP — PDP unreachable (decision call rejects)', () => {
 			decisionResponses: [{ resourceDecisions: [{ ephemeralResourceId: 'r1', decision: 'DECISION_PERMIT' }] }],
 		});
 		const pdp = new VirtruPDP(mkClient({ apiCall }));
-		await expect(pdp.onSubjectAttributesChanged(user({ __rooms: ['r1', 'r2'] }) as any, [])).rejects.toThrow(/mismatch/);
+		await expect(pdp.onSubjectAttributesChanged(user({ __rooms: ['r1', 'r2'] }) as any, [])).rejects.toBeInstanceOf(PdpUnavailableError);
 	});
 });
 

--- a/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
@@ -284,13 +284,39 @@ describe('VirtruPDP.onRoomAttributesChanged', () => {
 		expect(result).toEqual([u2]);
 	});
 
-	it('treats empty resourceDecisions as non-compliant', async () => {
+	it('does not evict on empty resourceDecisions (inconclusive)', async () => {
 		const u = user();
 		usersFindActiveByRoomIds.mockReturnValue(asyncIterable([u]));
 		const apiCall = jest.fn().mockResolvedValue({ decisionResponses: [{ resourceDecisions: [] }] });
 		const pdp = new VirtruPDP(mkClient({ apiCall }));
 		const result = await pdp.onRoomAttributesChanged(room, newAttrs);
-		expect(result).toEqual([u]);
+		expect(result).toEqual([]);
+	});
+
+	it('does not evict on DECISION_UNSPECIFIED (inconclusive)', async () => {
+		usersFindActiveByRoomIds.mockReturnValue(asyncIterable([user()]));
+		const apiCall = jest.fn().mockResolvedValue({
+			decisionResponses: [{ resourceDecisions: [{ ephemeralResourceId: 'r1', decision: 'DECISION_UNSPECIFIED' }] }],
+		});
+		const pdp = new VirtruPDP(mkClient({ apiCall }));
+		const result = await pdp.onRoomAttributesChanged(room, newAttrs);
+		expect(result).toEqual([]);
+	});
+
+	it('still evicts entity-keyless users alongside DENY-only filtering of decided users', async () => {
+		const keyless = user({ _id: 'u0', emails: [] });
+		const denied = user({ _id: 'u2', username: 'alice', emails: [{ address: 'a@x.com' }] });
+		const unspecified = user({ _id: 'u3', username: 'carol', emails: [{ address: 'c@x.com' }] });
+		usersFindActiveByRoomIds.mockReturnValue(asyncIterable([keyless, denied, unspecified]));
+		const apiCall = jest.fn().mockResolvedValue({
+			decisionResponses: [
+				{ resourceDecisions: [{ ephemeralResourceId: 'r1', decision: 'DECISION_DENY' }] },
+				{ resourceDecisions: [{ ephemeralResourceId: 'r1', decision: 'DECISION_UNSPECIFIED' }] },
+			],
+		});
+		const pdp = new VirtruPDP(mkClient({ apiCall }));
+		const result = await pdp.onRoomAttributesChanged(room, newAttrs);
+		expect(result).toEqual([keyless, denied]);
 	});
 
 	it('returns only entity-keyless users when ALL users lack entity keys (no API call)', async () => {
@@ -344,6 +370,17 @@ describe('VirtruPDP.onSubjectAttributesChanged', () => {
 		const pdp = new VirtruPDP(mkClient({ apiCall }));
 		const result = await pdp.onSubjectAttributesChanged(user({ __rooms: ['rP', 'rD'] }) as any, []);
 		expect(result).toEqual([rooms[1]]);
+	});
+
+	it('still treats DECISION_UNSPECIFIED as non-compliant (LDAP-driven path cannot yield inconclusive decisions)', async () => {
+		const rooms = [{ _id: 'r1', abacAttributes: [{ key: 'k', values: ['v'] }] }];
+		roomsFindPrivateRoomsByIdsWithAbacAttributes.mockReturnValue(cursor(rooms));
+		const apiCall = jest.fn().mockResolvedValue({
+			decisionResponses: [{ resourceDecisions: [{ ephemeralResourceId: 'r1', decision: 'DECISION_UNSPECIFIED' }] }],
+		});
+		const pdp = new VirtruPDP(mkClient({ apiCall }));
+		const result = await pdp.onSubjectAttributesChanged(user({ __rooms: ['r1'] }) as any, []);
+		expect(result).toEqual(rooms);
 	});
 
 	it('splits >200 rooms into multiple decision batches', async () => {
@@ -453,36 +490,15 @@ describe('VirtruPDP.evaluateUserRooms', () => {
 		expect(result).toEqual([{ user: u, room: rooms[2] }]);
 	});
 
-	it('resolves without evictions when the decision call fails', async () => {
+	it('rejects when the decision call fails (no evictions, sweep retried next run)', async () => {
 		const apiCall = jest.fn().mockRejectedValue(new Error('pdp down'));
 		const pdp = new VirtruPDP(mkClient({ apiCall }));
 		const rooms = [{ _id: 'r1', abacAttributes: [{ key: 'k', values: ['v'] }] }];
-		const result = await pdp.evaluateUserRooms([{ user: user(), rooms }]);
-		expect(result).toEqual([]);
+		await expect(pdp.evaluateUserRooms([{ user: user(), rooms }])).rejects.toThrow('pdp down');
 		expect(apiCall).toHaveBeenCalled();
 	});
 
-	it('keeps evictions from successful batches when another batch fails', async () => {
-		const u = user();
-		const total = 201;
-		const rooms = Array.from({ length: total }, (_, i) => ({ _id: `r${i}`, abacAttributes: [{ key: 'k', values: ['v'] }] }));
-		const apiCall = jest.fn().mockImplementation(async (_endpoint, body: any) => {
-			if (body.decisionRequests.some((r: any) => r.resources[0].ephemeralId === 'r0')) {
-				throw new Error('pdp down');
-			}
-			return {
-				decisionResponses: body.decisionRequests.map((r: any) => ({
-					resourceDecisions: [{ ephemeralResourceId: r.resources[0].ephemeralId, decision: 'DECISION_DENY' }],
-				})),
-			};
-		});
-		const pdp = new VirtruPDP(mkClient({ apiCall }));
-		const result = await pdp.evaluateUserRooms([{ user: u, rooms }]);
-		expect(result).toEqual([{ user: u, room: rooms[200] }]);
-		expect(apiCall).toHaveBeenCalledTimes(2);
-	});
-
-	it('skips evictions for a batch whose response count mismatches the request count', async () => {
+	it('rejects when response count mismatches request count (positional contract broken)', async () => {
 		const u = user();
 		const rooms = [
 			{ _id: 'r1', abacAttributes: [{ key: 'k', values: ['v'] }] },
@@ -492,8 +508,7 @@ describe('VirtruPDP.evaluateUserRooms', () => {
 			decisionResponses: [{ resourceDecisions: [{ ephemeralResourceId: 'r1', decision: 'DECISION_DENY' }] }],
 		});
 		const pdp = new VirtruPDP(mkClient({ apiCall }));
-		const result = await pdp.evaluateUserRooms([{ user: u, rooms }]);
-		expect(result).toEqual([]);
+		await expect(pdp.evaluateUserRooms([{ user: u, rooms }])).rejects.toThrow(/mismatch/);
 	});
 });
 

--- a/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
@@ -497,20 +497,6 @@ describe('VirtruPDP.evaluateUserRooms', () => {
 		await expect(pdp.evaluateUserRooms([{ user: user(), rooms }])).rejects.toThrow('pdp down');
 		expect(apiCall).toHaveBeenCalled();
 	});
-
-	it('maps responses positionally; a missing trailing response is inconclusive (no evict)', async () => {
-		const u = user();
-		const rooms = [
-			{ _id: 'r1', abacAttributes: [{ key: 'k', values: ['v'] }] },
-			{ _id: 'r2', abacAttributes: [{ key: 'k', values: ['v'] }] },
-		];
-		const apiCall = jest.fn().mockResolvedValue({
-			decisionResponses: [{ resourceDecisions: [{ ephemeralResourceId: 'r1', decision: 'DECISION_DENY' }] }],
-		});
-		const pdp = new VirtruPDP(mkClient({ apiCall }));
-		const result = await pdp.evaluateUserRooms([{ user: u, rooms }]);
-		expect(result).toEqual([{ user: u, room: rooms[0] }]);
-	});
 });
 
 describe('VirtruPDP — PDP unreachable (decision call rejects)', () => {
@@ -548,20 +534,6 @@ describe('VirtruPDP — PDP unreachable (decision call rejects)', () => {
 		const pdp = new VirtruPDP(mkClient({ apiCall }));
 		await expect(pdp.onSubjectAttributesChanged(user({ __rooms: ['r1'] }) as any, [])).rejects.toThrow('pdp down');
 		expect(apiCall).toHaveBeenCalled();
-	});
-
-	it('onSubjectAttributesChanged treats a missing trailing response as non-compliant', async () => {
-		const rooms = [
-			{ _id: 'r1', abacAttributes: [{ key: 'k', values: ['v'] }] },
-			{ _id: 'r2', abacAttributes: [{ key: 'k', values: ['v'] }] },
-		];
-		roomsFindPrivateRoomsByIdsWithAbacAttributes.mockReturnValue(cursor(rooms));
-		const apiCall = jest.fn().mockResolvedValue({
-			decisionResponses: [{ resourceDecisions: [{ ephemeralResourceId: 'r1', decision: 'DECISION_PERMIT' }] }],
-		});
-		const pdp = new VirtruPDP(mkClient({ apiCall }));
-		const result = await pdp.onSubjectAttributesChanged(user({ __rooms: ['r1', 'r2'] }) as any, []);
-		expect(result).toEqual([rooms[1]]);
 	});
 });
 

--- a/ee/packages/abac/src/pdp/VirtruPDP.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.ts
@@ -13,8 +13,30 @@ import { buildEntityIdentifier, buildAttributeFqns, getUserEntityKey } from '../
 
 const pdpLogger = logger.section('VirtruPDP');
 
-const hasExplicitDeny = (resp?: { resourceDecisions?: IResourceDecision[] }): boolean =>
-	!!resp?.resourceDecisions?.some((rd) => rd.decision === 'DECISION_DENY');
+export const collectDenied = <T>(
+	responses: Array<{ resourceDecisions?: IResourceDecision[] } | undefined>,
+	subjects: T[],
+	logContext: (subject: T) => { rid: IRoom['_id']; userId: IUser['_id'] },
+): T[] => {
+	const denied: T[] = [];
+
+	responses.forEach((resp, index) => {
+		const subject = subjects[index];
+		if (!subject) {
+			return;
+		}
+		if (resp?.resourceDecisions?.some((rd) => rd.decision === 'DECISION_DENY')) {
+			denied.push(subject);
+			return;
+		}
+		if (resp?.resourceDecisions?.length && resp.resourceDecisions.every((rd) => rd.decision === 'DECISION_PERMIT')) {
+			return;
+		}
+		pdpLogger.warn({ msg: 'Inconclusive PDP decision, eviction skipped', ...logContext(subject) });
+	});
+
+	return denied;
+};
 
 export class VirtruPDP implements IPolicyDecisionPoint {
 	private client: VirtruClient;
@@ -287,19 +309,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 
 		const responses = await this.getDecisionBulk(decisionRequests);
 
-		responses.forEach((resp, index) => {
-			if (!requestUserIndex[index]) {
-				return;
-			}
-			if (hasExplicitDeny(resp)) {
-				nonCompliantUsers.push(requestUserIndex[index]);
-				return;
-			}
-			if (resp?.resourceDecisions?.length && resp.resourceDecisions.every((rd) => rd.decision === 'DECISION_PERMIT')) {
-				return;
-			}
-			pdpLogger.warn({ msg: 'Inconclusive PDP decision, eviction skipped', rid: room._id, userId: requestUserIndex[index]._id });
-		});
+		nonCompliantUsers.push(...collectDenied(responses, requestUserIndex, (user) => ({ rid: room._id, userId: user._id })));
 
 		return nonCompliantUsers;
 	}
@@ -310,7 +320,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 			rooms: AtLeast<IRoom, '_id' | 'abacAttributes'>[];
 		}>,
 	): Promise<Array<{ user: Pick<IUser, '_id' | 'emails' | 'username'>; room: IRoom }>> {
-		const requestIndex: Array<{ user: Pick<IUser, '_id' | 'emails' | 'username'>; room: AtLeast<IRoom, '_id' | 'abacAttributes'> }> = [];
+		const requestIndex: Array<{ user: Pick<IUser, '_id' | 'emails' | 'username'>; room: IRoom }> = [];
 		const allRequests: IGetDecisionBulkRequest[] = [];
 
 		const config = this.client.getConfig();
@@ -327,7 +337,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 			}
 
 			for (const room of rooms) {
-				requestIndex.push({ user, room });
+				requestIndex.push({ user, room: room as IRoom });
 				allRequests.push({
 					entityIdentifier: {
 						entityChain: {
@@ -351,23 +361,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 
 		const responses = await this.getDecisionBulk(allRequests);
 
-		responses.forEach((resp, index) => {
-			if (!requestIndex[index]) {
-				return;
-			}
-			if (hasExplicitDeny(resp)) {
-				nonCompliant.push({ user: requestIndex[index].user, room: requestIndex[index].room as IRoom });
-				return;
-			}
-			if (resp?.resourceDecisions?.length && resp.resourceDecisions.every((rd) => rd.decision === 'DECISION_PERMIT')) {
-				return;
-			}
-			pdpLogger.warn({
-				msg: 'Inconclusive PDP decision, eviction skipped',
-				rid: requestIndex[index].room._id,
-				userId: requestIndex[index].user._id,
-			});
-		});
+		nonCompliant.push(...collectDenied(responses, requestIndex, ({ user, room }) => ({ rid: room._id, userId: user._id })));
 
 		return nonCompliant;
 	}

--- a/ee/packages/abac/src/pdp/VirtruPDP.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.ts
@@ -93,6 +93,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 
 	private async getDecisionBulk(
 		requests: Array<IGetDecisionBulkRequest | null>,
+		{ isolateBatchFailures = false }: { isolateBatchFailures?: boolean } = {},
 	): Promise<Array<{ resourceDecisions?: IResourceDecision[] } | undefined>> {
 		const BATCH_SIZE = 200;
 		const limit = pLimit(4);
@@ -111,13 +112,38 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 						return batch.map(() => undefined);
 					}
 
-					const result = await this.client.apiCall<IGetDecisionBulkResponse>('/authorization.v2.AuthorizationService/GetDecisionBulk', {
-						decisionRequests: validBatch,
-					});
+					let result: IGetDecisionBulkResponse;
+					try {
+						result = await this.client.apiCall<IGetDecisionBulkResponse>('/authorization.v2.AuthorizationService/GetDecisionBulk', {
+							decisionRequests: validBatch,
+						});
+					} catch (err) {
+						if (!isolateBatchFailures) {
+							throw err;
+						}
+						pdpLogger.error({ msg: 'GetDecisionBulk batch failed, skipping its decisions', batch: batchIndex + 1, err });
+						return batch.map(() => undefined);
+					}
 
 					pdpLogger.debug({ msg: 'GetDecisionBulk response', batch: batchIndex + 1, result });
 
 					const responses = result.decisionResponses ?? [];
+					// Decisions carry no entity info, so mapping back to requests is positional; a count
+					// mismatch means the whole batch is unattributable
+					if (responses.length !== validBatch.length) {
+						if (!isolateBatchFailures) {
+							throw new Error(
+								`GetDecisionBulk response count mismatch: expected ${validBatch.length}, received ${responses.length} (batch ${batchIndex + 1})`,
+							);
+						}
+						pdpLogger.error({
+							msg: 'GetDecisionBulk response count mismatch, skipping batch decisions',
+							batch: batchIndex + 1,
+							expected: validBatch.length,
+							received: responses.length,
+						});
+						return batch.map(() => undefined);
+					}
 					let responseIdx = 0;
 					return batch.map((req) => (req ? responses[responseIdx++] : undefined));
 				}),
@@ -339,14 +365,26 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 			return nonCompliant;
 		}
 
-		const responses = await this.getDecisionBulk(allRequests);
+		const responses = await this.getDecisionBulk(allRequests, { isolateBatchFailures: true });
 
+		let inconclusive = 0;
 		responses.forEach((resp, index) => {
-			const permitted = resp?.resourceDecisions?.length && resp.resourceDecisions.every((rd) => rd.decision === 'DECISION_PERMIT');
-			if (!permitted && requestIndex[index]) {
+			if (!requestIndex[index]) {
+				return;
+			}
+			const decisions = resp?.resourceDecisions;
+			if (decisions?.some((rd) => rd.decision === 'DECISION_DENY')) {
 				nonCompliant.push({ user: requestIndex[index].user, room: requestIndex[index].room as IRoom });
+				return;
+			}
+			if (!decisions?.length || decisions.some((rd) => rd.decision !== 'DECISION_PERMIT')) {
+				inconclusive++;
 			}
 		});
+
+		if (inconclusive) {
+			pdpLogger.warn({ msg: 'Inconclusive PDP decisions during membership evaluation, eviction skipped for those pairs', inconclusive });
+		}
 
 		return nonCompliant;
 	}

--- a/ee/packages/abac/src/pdp/VirtruPDP.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.ts
@@ -13,7 +13,7 @@ import { buildEntityIdentifier, buildAttributeFqns, getUserEntityKey } from '../
 
 const pdpLogger = logger.section('VirtruPDP');
 
-export const collectDenied = <T>(
+export const getDeniedSubjects = <T>(
 	responses: Array<{ resourceDecisions?: IResourceDecision[] } | undefined>,
 	subjects: T[],
 	logContext: (subject: T) => { rid: IRoom['_id']; userId: IUser['_id'] },
@@ -309,7 +309,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 
 		const responses = await this.getDecisionBulk(decisionRequests);
 
-		nonCompliantUsers.push(...collectDenied(responses, requestUserIndex, (user) => ({ rid: room._id, userId: user._id })));
+		nonCompliantUsers.push(...getDeniedSubjects(responses, requestUserIndex, (user) => ({ rid: room._id, userId: user._id })));
 
 		return nonCompliantUsers;
 	}
@@ -361,7 +361,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 
 		const responses = await this.getDecisionBulk(allRequests);
 
-		nonCompliant.push(...collectDenied(responses, requestIndex, ({ user, room }) => ({ rid: room._id, userId: user._id })));
+		nonCompliant.push(...getDeniedSubjects(responses, requestIndex, ({ user, room }) => ({ rid: room._id, userId: user._id })));
 
 		return nonCompliant;
 	}

--- a/ee/packages/abac/src/pdp/VirtruPDP.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.ts
@@ -13,8 +13,6 @@ import { buildEntityIdentifier, buildAttributeFqns, getUserEntityKey } from '../
 
 const pdpLogger = logger.section('VirtruPDP');
 
-// Removal requires an explicit DENY, mirroring canAccessObject: inconclusive decisions block
-// access in realtime but must not destroy membership
 const hasExplicitDeny = (resp?: { resourceDecisions?: IResourceDecision[] }): boolean =>
 	!!resp?.resourceDecisions?.some((rd) => rd.decision === 'DECISION_DENY');
 
@@ -123,8 +121,6 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 					pdpLogger.debug({ msg: 'GetDecisionBulk response', batch: batchIndex + 1, result });
 
 					const responses = result.decisionResponses ?? [];
-					// Decisions carry no entity info, so mapping back to requests is positional; a count
-					// mismatch means the whole batch is unattributable
 					if (responses.length !== validBatch.length) {
 						throw new Error(
 							`GetDecisionBulk response count mismatch: expected ${validBatch.length}, received ${responses.length} (batch ${batchIndex + 1})`,
@@ -296,7 +292,6 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 
 		const responses = await this.getDecisionBulk(decisionRequests);
 
-		let inconclusive = 0;
 		responses.forEach((resp, index) => {
 			if (!requestUserIndex[index]) {
 				return;
@@ -305,15 +300,11 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 				nonCompliantUsers.push(requestUserIndex[index]);
 				return;
 			}
-			const permitted = resp?.resourceDecisions?.length && resp.resourceDecisions.every((rd) => rd.decision === 'DECISION_PERMIT');
-			if (!permitted) {
-				inconclusive++;
+			if (resp?.resourceDecisions?.length && resp.resourceDecisions.every((rd) => rd.decision === 'DECISION_PERMIT')) {
+				return;
 			}
+			pdpLogger.warn({ msg: 'Inconclusive PDP decision, eviction skipped', rid: room._id, userId: requestUserIndex[index]._id });
 		});
-
-		if (inconclusive) {
-			pdpLogger.warn({ msg: 'Inconclusive PDP decisions after room attributes change, eviction skipped', rid: room._id, inconclusive });
-		}
 
 		return nonCompliantUsers;
 	}
@@ -365,7 +356,6 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 
 		const responses = await this.getDecisionBulk(allRequests);
 
-		let inconclusive = 0;
 		responses.forEach((resp, index) => {
 			if (!requestIndex[index]) {
 				return;
@@ -374,15 +364,15 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 				nonCompliant.push({ user: requestIndex[index].user, room: requestIndex[index].room as IRoom });
 				return;
 			}
-			const permitted = resp?.resourceDecisions?.length && resp.resourceDecisions.every((rd) => rd.decision === 'DECISION_PERMIT');
-			if (!permitted) {
-				inconclusive++;
+			if (resp?.resourceDecisions?.length && resp.resourceDecisions.every((rd) => rd.decision === 'DECISION_PERMIT')) {
+				return;
 			}
+			pdpLogger.warn({
+				msg: 'Inconclusive PDP decision, eviction skipped',
+				rid: requestIndex[index].room._id,
+				userId: requestIndex[index].user._id,
+			});
 		});
-
-		if (inconclusive) {
-			pdpLogger.warn({ msg: 'Inconclusive PDP decisions during membership evaluation, eviction skipped for those pairs', inconclusive });
-		}
 
 		return nonCompliant;
 	}

--- a/ee/packages/abac/src/pdp/VirtruPDP.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.ts
@@ -4,7 +4,7 @@ import { serverFetch } from '@rocket.chat/server-fetch';
 import { isTruthy } from '@rocket.chat/tools';
 import pLimit from 'p-limit';
 
-import { OnlyCompliantCanBeAddedToRoomError, PdpHealthCheckError } from '../errors';
+import { OnlyCompliantCanBeAddedToRoomError, PdpHealthCheckError, PdpUnavailableError } from '../errors';
 import { logger } from '../logger';
 import type { IPolicyDecisionPoint, IGetDecisionBulkRequest, IGetDecisionBulkResponse, IResourceDecision, ReevaluationUser } from './types';
 import { HEALTH_CHECK_TIMEOUT } from '../clients/virtru/VirtruClient';
@@ -122,9 +122,13 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 
 					const responses = result.decisionResponses ?? [];
 					if (responses.length !== validBatch.length) {
-						throw new Error(
-							`GetDecisionBulk response count mismatch: expected ${validBatch.length}, received ${responses.length} (batch ${batchIndex + 1})`,
-						);
+						pdpLogger.error({
+							msg: 'GetDecisionBulk response count mismatch',
+							batch: batchIndex + 1,
+							expected: validBatch.length,
+							received: responses.length,
+						});
+						throw new PdpUnavailableError();
 					}
 					let responseIdx = 0;
 					return batch.map((req) => (req ? responses[responseIdx++] : undefined));

--- a/ee/packages/abac/src/pdp/VirtruPDP.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.ts
@@ -4,7 +4,7 @@ import { serverFetch } from '@rocket.chat/server-fetch';
 import { isTruthy } from '@rocket.chat/tools';
 import pLimit from 'p-limit';
 
-import { OnlyCompliantCanBeAddedToRoomError, PdpHealthCheckError, PdpUnavailableError } from '../errors';
+import { OnlyCompliantCanBeAddedToRoomError, PdpHealthCheckError } from '../errors';
 import { logger } from '../logger';
 import type { IPolicyDecisionPoint, IGetDecisionBulkRequest, IGetDecisionBulkResponse, IResourceDecision, ReevaluationUser } from './types';
 import { HEALTH_CHECK_TIMEOUT } from '../clients/virtru/VirtruClient';
@@ -121,15 +121,6 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 					pdpLogger.debug({ msg: 'GetDecisionBulk response', batch: batchIndex + 1, result });
 
 					const responses = result.decisionResponses ?? [];
-					if (responses.length !== validBatch.length) {
-						pdpLogger.error({
-							msg: 'GetDecisionBulk response count mismatch',
-							batch: batchIndex + 1,
-							expected: validBatch.length,
-							received: responses.length,
-						});
-						throw new PdpUnavailableError();
-					}
 					let responseIdx = 0;
 					return batch.map((req) => (req ? responses[responseIdx++] : undefined));
 				}),

--- a/ee/packages/abac/src/pdp/VirtruPDP.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.ts
@@ -6,7 +6,14 @@ import pLimit from 'p-limit';
 
 import { OnlyCompliantCanBeAddedToRoomError, PdpHealthCheckError } from '../errors';
 import { logger } from '../logger';
-import type { IPolicyDecisionPoint, IGetDecisionBulkRequest, IGetDecisionBulkResponse, IResourceDecision, ReevaluationUser } from './types';
+import type {
+	IPolicyDecisionPoint,
+	IGetDecisionBulkRequest,
+	IGetDecisionBulkResponse,
+	IResourceDecision,
+	NonCompliantPair,
+	ReevaluationUser,
+} from './types';
 import { HEALTH_CHECK_TIMEOUT } from '../clients/virtru/VirtruClient';
 import type { VirtruClient } from '../clients/virtru/VirtruClient';
 import { buildEntityIdentifier, buildAttributeFqns, getUserEntityKey } from '../clients/virtru/identity';
@@ -319,25 +326,25 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 			user: Pick<IUser, '_id' | 'emails' | 'username'>;
 			rooms: AtLeast<IRoom, '_id' | 'abacAttributes'>[];
 		}>,
-	): Promise<Array<{ user: Pick<IUser, '_id' | 'emails' | 'username'>; room: IRoom }>> {
-		const requestIndex: Array<{ user: Pick<IUser, '_id' | 'emails' | 'username'>; room: IRoom }> = [];
+	): Promise<NonCompliantPair[]> {
+		const requestIndex: NonCompliantPair[] = [];
 		const allRequests: IGetDecisionBulkRequest[] = [];
 
 		const config = this.client.getConfig();
-		const nonCompliant: Array<{ user: Pick<IUser, '_id' | 'emails' | 'username'>; room: IRoom }> = [];
+		const nonCompliant: NonCompliantPair[] = [];
 
 		for (const { user, rooms } of entries) {
 			const entityKey = getUserEntityKey(config.defaultEntityKey, user);
 			if (!entityKey) {
 				pdpLogger.warn({ msg: 'User has no entity key for Virtru PDP evaluation, treating as non-compliant', userId: user._id });
 				for (const room of rooms) {
-					nonCompliant.push({ user, room: room as IRoom });
+					nonCompliant.push({ user, room });
 				}
 				continue;
 			}
 
 			for (const room of rooms) {
-				requestIndex.push({ user, room: room as IRoom });
+				requestIndex.push({ user, room });
 				allRequests.push({
 					entityIdentifier: {
 						entityChain: {
@@ -366,7 +373,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 		return nonCompliant;
 	}
 
-	async reevaluateUsers(users: ReevaluationUser[]): Promise<Array<{ user: Pick<IUser, '_id' | 'emails' | 'username'>; room: IRoom }>> {
+	async reevaluateUsers(users: ReevaluationUser[]): Promise<NonCompliantPair[]> {
 		const roomIds = [...new Set(users.flatMap((u) => u.__rooms ?? []))];
 		if (!roomIds.length) {
 			return [];

--- a/ee/packages/abac/src/pdp/VirtruPDP.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.ts
@@ -20,10 +20,9 @@ import { buildEntityIdentifier, buildAttributeFqns, getUserEntityKey } from '../
 
 const pdpLogger = logger.section('VirtruPDP');
 
-export const getDeniedSubjects = <T>(
+export const getDeniedSubjects = <T extends { user: Pick<IUser, '_id'>; room: Pick<IRoom, '_id'> }>(
 	responses: Array<{ resourceDecisions?: IResourceDecision[] } | undefined>,
 	subjects: T[],
-	logContext: (subject: T) => { rid: IRoom['_id']; userId: IUser['_id'] },
 ): T[] => {
 	const denied: T[] = [];
 
@@ -39,7 +38,7 @@ export const getDeniedSubjects = <T>(
 		if (resp?.resourceDecisions?.length && resp.resourceDecisions.every((rd) => rd.decision === 'DECISION_PERMIT')) {
 			return;
 		}
-		pdpLogger.warn({ msg: 'Inconclusive PDP decision, eviction skipped', ...logContext(subject) });
+		pdpLogger.warn({ msg: 'Inconclusive PDP decision, eviction skipped', rid: subject.room._id, userId: subject.user._id });
 	});
 
 	return denied;
@@ -282,7 +281,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 		const config = this.client.getConfig();
 		const nonCompliantUsers: IUser[] = [];
 		const decisionRequests: IGetDecisionBulkRequest[] = [];
-		const requestUserIndex: IUser[] = [];
+		const requestIndex: Array<{ user: IUser; room: typeof room }> = [];
 		const fqns = buildAttributeFqns(config.attributeNamespace, newAttributes);
 
 		for await (const user of users) {
@@ -293,7 +292,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 				continue;
 			}
 
-			requestUserIndex.push(user);
+			requestIndex.push({ user, room });
 			decisionRequests.push({
 				entityIdentifier: {
 					entityChain: {
@@ -316,7 +315,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 
 		const responses = await this.getDecisionBulk(decisionRequests);
 
-		nonCompliantUsers.push(...getDeniedSubjects(responses, requestUserIndex, (user) => ({ rid: room._id, userId: user._id })));
+		nonCompliantUsers.push(...getDeniedSubjects(responses, requestIndex).map(({ user }) => user));
 
 		return nonCompliantUsers;
 	}
@@ -368,7 +367,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 
 		const responses = await this.getDecisionBulk(allRequests);
 
-		nonCompliant.push(...getDeniedSubjects(responses, requestIndex, ({ user, room }) => ({ rid: room._id, userId: user._id })));
+		nonCompliant.push(...getDeniedSubjects(responses, requestIndex));
 
 		return nonCompliant;
 	}

--- a/ee/packages/abac/src/pdp/VirtruPDP.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.ts
@@ -13,6 +13,11 @@ import { buildEntityIdentifier, buildAttributeFqns, getUserEntityKey } from '../
 
 const pdpLogger = logger.section('VirtruPDP');
 
+// Removal requires an explicit DENY, mirroring canAccessObject: inconclusive decisions block
+// access in realtime but must not destroy membership
+const hasExplicitDeny = (resp?: { resourceDecisions?: IResourceDecision[] }): boolean =>
+	!!resp?.resourceDecisions?.some((rd) => rd.decision === 'DECISION_DENY');
+
 export class VirtruPDP implements IPolicyDecisionPoint {
 	private client: VirtruClient;
 
@@ -93,7 +98,6 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 
 	private async getDecisionBulk(
 		requests: Array<IGetDecisionBulkRequest | null>,
-		{ isolateBatchFailures = false }: { isolateBatchFailures?: boolean } = {},
 	): Promise<Array<{ resourceDecisions?: IResourceDecision[] } | undefined>> {
 		const BATCH_SIZE = 200;
 		const limit = pLimit(4);
@@ -112,18 +116,9 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 						return batch.map(() => undefined);
 					}
 
-					let result: IGetDecisionBulkResponse;
-					try {
-						result = await this.client.apiCall<IGetDecisionBulkResponse>('/authorization.v2.AuthorizationService/GetDecisionBulk', {
-							decisionRequests: validBatch,
-						});
-					} catch (err) {
-						if (!isolateBatchFailures) {
-							throw err;
-						}
-						pdpLogger.error({ msg: 'GetDecisionBulk batch failed, skipping its decisions', batch: batchIndex + 1, err });
-						return batch.map(() => undefined);
-					}
+					const result = await this.client.apiCall<IGetDecisionBulkResponse>('/authorization.v2.AuthorizationService/GetDecisionBulk', {
+						decisionRequests: validBatch,
+					});
 
 					pdpLogger.debug({ msg: 'GetDecisionBulk response', batch: batchIndex + 1, result });
 
@@ -131,18 +126,9 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 					// Decisions carry no entity info, so mapping back to requests is positional; a count
 					// mismatch means the whole batch is unattributable
 					if (responses.length !== validBatch.length) {
-						if (!isolateBatchFailures) {
-							throw new Error(
-								`GetDecisionBulk response count mismatch: expected ${validBatch.length}, received ${responses.length} (batch ${batchIndex + 1})`,
-							);
-						}
-						pdpLogger.error({
-							msg: 'GetDecisionBulk response count mismatch, skipping batch decisions',
-							batch: batchIndex + 1,
-							expected: validBatch.length,
-							received: responses.length,
-						});
-						return batch.map(() => undefined);
+						throw new Error(
+							`GetDecisionBulk response count mismatch: expected ${validBatch.length}, received ${responses.length} (batch ${batchIndex + 1})`,
+						);
 					}
 					let responseIdx = 0;
 					return batch.map((req) => (req ? responses[responseIdx++] : undefined));
@@ -310,12 +296,24 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 
 		const responses = await this.getDecisionBulk(decisionRequests);
 
+		let inconclusive = 0;
 		responses.forEach((resp, index) => {
-			const permitted = resp?.resourceDecisions?.length && resp.resourceDecisions.every((rd) => rd.decision === 'DECISION_PERMIT');
-			if (!permitted && requestUserIndex[index]) {
+			if (!requestUserIndex[index]) {
+				return;
+			}
+			if (hasExplicitDeny(resp)) {
 				nonCompliantUsers.push(requestUserIndex[index]);
+				return;
+			}
+			const permitted = resp?.resourceDecisions?.length && resp.resourceDecisions.every((rd) => rd.decision === 'DECISION_PERMIT');
+			if (!permitted) {
+				inconclusive++;
 			}
 		});
+
+		if (inconclusive) {
+			pdpLogger.warn({ msg: 'Inconclusive PDP decisions after room attributes change, eviction skipped', rid: room._id, inconclusive });
+		}
 
 		return nonCompliantUsers;
 	}
@@ -365,19 +363,19 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 			return nonCompliant;
 		}
 
-		const responses = await this.getDecisionBulk(allRequests, { isolateBatchFailures: true });
+		const responses = await this.getDecisionBulk(allRequests);
 
 		let inconclusive = 0;
 		responses.forEach((resp, index) => {
 			if (!requestIndex[index]) {
 				return;
 			}
-			const decisions = resp?.resourceDecisions;
-			if (decisions?.some((rd) => rd.decision === 'DECISION_DENY')) {
+			if (hasExplicitDeny(resp)) {
 				nonCompliant.push({ user: requestIndex[index].user, room: requestIndex[index].room as IRoom });
 				return;
 			}
-			if (!decisions?.length || decisions.some((rd) => rd.decision !== 'DECISION_PERMIT')) {
+			const permitted = resp?.resourceDecisions?.length && resp.resourceDecisions.every((rd) => rd.decision === 'DECISION_PERMIT');
+			if (!permitted) {
 				inconclusive++;
 			}
 		});

--- a/ee/packages/abac/src/pdp/VirtruPDP.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.ts
@@ -24,24 +24,16 @@ export const getDeniedSubjects = <T extends { user: Pick<IUser, '_id'>; room: Pi
 	responses: Array<{ resourceDecisions?: IResourceDecision[] } | undefined>,
 	subjects: T[],
 ): T[] => {
-	const denied: T[] = [];
-
-	responses.forEach((resp, index) => {
-		const subject = subjects[index];
-		if (!subject) {
-			return;
+	return subjects.filter((subject, index) => {
+		const decisions = responses[index]?.resourceDecisions ?? [];
+		if (decisions.some((rd) => rd.decision === 'DECISION_DENY')) {
+			return true;
 		}
-		if (resp?.resourceDecisions?.some((rd) => rd.decision === 'DECISION_DENY')) {
-			denied.push(subject);
-			return;
+		if (!decisions.length || decisions.some((rd) => rd.decision !== 'DECISION_PERMIT')) {
+			pdpLogger.warn({ msg: 'Inconclusive PDP decision, eviction skipped', rid: subject.room._id, userId: subject.user._id });
 		}
-		if (resp?.resourceDecisions?.length && resp.resourceDecisions.every((rd) => rd.decision === 'DECISION_PERMIT')) {
-			return;
-		}
-		pdpLogger.warn({ msg: 'Inconclusive PDP decision, eviction skipped', rid: subject.room._id, userId: subject.user._id });
+		return false;
 	});
-
-	return denied;
 };
 
 export class VirtruPDP implements IPolicyDecisionPoint {

--- a/ee/packages/abac/src/pdp/types.ts
+++ b/ee/packages/abac/src/pdp/types.ts
@@ -30,6 +30,11 @@ export interface IGetDecisionBulkResponse {
 
 export type ReevaluationUser = Pick<IUser, '_id' | 'emails' | 'username' | '__rooms'>;
 
+export type NonCompliantPair = {
+	user: Pick<IUser, '_id' | 'emails' | 'username'>;
+	room: AtLeast<IRoom, '_id' | 'abacAttributes'>;
+};
+
 export interface IPolicyDecisionPoint {
 	isAvailable(): Promise<boolean>;
 
@@ -54,9 +59,9 @@ export interface IPolicyDecisionPoint {
 			user: Pick<IUser, '_id' | 'emails' | 'username'>;
 			rooms: AtLeast<IRoom, '_id' | 'abacAttributes'>[];
 		}>,
-	): Promise<Array<{ user: Pick<IUser, '_id' | 'emails' | 'username'>; room: IRoom }>>;
+	): Promise<NonCompliantPair[]>;
 
-	reevaluateUsers(users: ReevaluationUser[]): Promise<void | Array<{ user: Pick<IUser, '_id' | 'emails' | 'username'>; room: IRoom }>>;
+	reevaluateUsers(users: ReevaluationUser[]): Promise<void | NonCompliantPair[]>;
 }
 
 export interface IVirtruPDPConfig {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Two of the Virtru PDP eviction paths — the membership sweep (`ABAC_Virtru_PDP_Sync` cron job → `evaluateRoomMembership`, also reachable via the user re-evaluation API) and `onRoomAttributesChanged` — treated *any* decision that wasn't an explicit `DECISION_PERMIT` as non-compliant and removed the user from the room. This included `DECISION_UNSPECIFIED` and empty decision lists, so a degraded or flaky PDP could mass-evict users that the realtime access check (`canAccessObject`) would have merely blocked: the realtime path only removes membership on an explicit `DECISION_DENY`. Eviction is destructive (membership is lost and must be manually restored), so all eviction paths that can see inconclusive decisions now share the realtime posture:

- **Evict only on explicit `DECISION_DENY`** in `evaluateUserRooms` (cron sweep + re-evaluation API) and `onRoomAttributesChanged`. Each inconclusive decision skips eviction and logs a warning with the affected `rid`/`userId`. This fails safe in both directions: no destructive action on PDP noise, and no access without a PERMIT — realtime checks keep blocking the room while decisions are inconclusive, and the periodic sweep re-evaluates the pair on the next run.
- **`onSubjectAttributesChanged` is intentionally unchanged** (still evicts on non-PERMIT): the LDAP-driven subject path cannot yield inconclusive decisions.

Users without a resolvable entity key are still treated as non-compliant and evicted — that's a deterministic local fact, not PDP noise.

Also updates the external-PDP e2e suite to seed the mock server's dynamic permit-all mode instead of a fixed-length canned `GetDecisionBulk` body, so mock responses match the request count regardless of call shape.

## Issue(s)

## Steps to test or reproduce

1. Configure ABAC with the Virtru PDP and a sync interval, add users to a room with ABAC attributes.
2. Make the PDP return `DECISION_UNSPECIFIED` and let the sync job run (or change the room's attributes): users are no longer removed from the room; the log shows an inconclusive-decision warning per affected user/room pair. Room access remains blocked while decisions are inconclusive.
3. Make the PDP return an explicit `DECISION_DENY` for a user and repeat: that user is still removed.

Covered by unit tests in `ee/packages/abac/src/pdp/VirtruPDP.spec.ts` (DENY-only eviction on both paths, mixed-decision handling, entity-keyless handling, failure rejection, and positional response mapping).

## Further comments

Decision-to-request mapping stays positional: the OpenTDF v2 `GetDecisionBulk` contract returns one `decisionResponse` per request, and the responses carry no entity information to match on (`ephemeralResourceId` can't disambiguate multiple users evaluated against the same room). With DENY-only eviction, a hypothetically missing response degrades to an inconclusive (logged, no eviction) rather than a misattributed removal.

Batch-failure isolation inside `GetDecisionBulk` (skipping a failed batch while keeping decisions from the others) was prototyped and dropped: once eviction requires an explicit DENY, a failed call is a no-op retried on the next run, so uniform throw-on-failure semantics across all callers won — smaller change, no silent-skip code path to reason about.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved access control decision handling to only remove user room access when explicitly denied, preventing access loss due to inconclusive or undefined authorization outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

https://rocketchat.atlassian.net/browse/ABAC3-29