### PR TITLE
ci: make Document360 user id configurable via CI secret

### DIFF
--- a/.github/actions/update-version-durability/action.yml
+++ b/.github/actions/update-version-durability/action.yml
@@ -14,6 +14,9 @@ inputs:
   D360_ARTICLE_ID:
     required: true
     description: Document360 Article ID
+  D360_USER_ID:
+    required: true
+    description: Document360 User ID used to fork and publish the article
   PUBLISH:
     required: true
     description: Publish Draft

--- a/.github/actions/update-version-durability/index.js
+++ b/.github/actions/update-version-durability/index.js
@@ -11,6 +11,7 @@ import { Octokit } from '@octokit/rest';
 
 const D360_TOKEN = core.getInput('D360_TOKEN');
 const D360_ARTICLE_ID = core.getInput('D360_ARTICLE_ID');
+const D360_USER_ID = core.getInput('D360_USER_ID');
 const PUBLISH = core.getInput('PUBLISH') === 'true';
 const LTS_VERSIONS = (core.getInput('LTS_VERSIONS') || '7.10').split(',').map((v) => v.trim());
 
@@ -193,11 +194,15 @@ async function generateTable({ owner, repo } = {}) {
 
 		const forkResponse = await requestDocument360('put', `Articles/${D360_ARTICLE_ID}/fork`, {
 			lang_code: "en",
-			user_id: "2511fd00-9558-4826-8d8c-4cc0c110f89c",
+			user_id: D360_USER_ID,
 			version_number: response.data.data.version_number,
 		});
 
 		console.log(forkResponse.data);
+
+		if (!forkResponse.data.success) {
+			throw new Error(`Failed to fork article: ${JSON.stringify(forkResponse.data.errors)}`);
+		}
 	}
 
 	console.log('Updating article');
@@ -211,7 +216,7 @@ async function generateTable({ owner, repo } = {}) {
 		console.log('publishing article', updateResponse.data.data.version_number);
 
 		const forkResponse = await requestDocument360('post', `Articles/${D360_ARTICLE_ID}/en/publish`, {
-			user_id: "2511fd00-9558-4826-8d8c-4cc0c110f89c",
+			user_id: D360_USER_ID,
 			version_number: updateResponse.data.data.version_number,
 			publish_message: 'Update support versions table via GitHub Action',
 		});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1100,3 +1100,4 @@ jobs:
     secrets:
       CI_PAT: ${{ secrets.CI_PAT }}
       D360_TOKEN: ${{ secrets.D360_TOKEN }}
+      D360_USER_ID: ${{ secrets.D360_USER_ID }}

--- a/.github/workflows/update-version-durability.yml
+++ b/.github/workflows/update-version-durability.yml
@@ -12,6 +12,8 @@ on:
         required: true
       D360_TOKEN:
         required: true
+      D360_USER_ID:
+        required: true
 
 jobs:
   update-versions:
@@ -37,4 +39,5 @@ jobs:
           GH_TOKEN: ${{ secrets.CI_PAT }}
           D360_TOKEN: ${{ secrets.D360_TOKEN }}
           D360_ARTICLE_ID: 800f8d52-409d-478d-b560-f82a2c0eb7fb
+          D360_USER_ID: ${{ secrets.D360_USER_ID }}
           PUBLISH: true


### PR DESCRIPTION
## Proposed changes

The `Update Version Durability` CI job crashes with an uncaught `AxiosError: Request failed with status code 400`.

### Root cause
1. The Document360 article is in `status === 3` (published), so editing requires forking a draft first.
2. The fork request used a **hardcoded** `user_id` that no longer exists in the Document360 project. Document360 returns **HTTP 200** with `{ success: false, errors: [{ description: "The user with id '…' does not exist in your project." }] }`.
3. Since axios only throws on status >= 400, the failure was logged but execution continued.
4. The article update `PUT .../en` then returned **400** (article still locked without a draft), throwing an uncaught exception and failing the job.

### Changes
- Read the user id from a new `D360_USER_ID` input instead of hardcoding it (used in both fork and publish requests).
- Fail fast with a clear error when the fork request is unsuccessful, instead of proceeding to a doomed update.
- Wire `D360_USER_ID` through the action, the reusable workflow, and the CI caller as a required secret.

### ⚠️ Required follow-up
Add a repository secret `D360_USER_ID` with a valid Document360 project user id before the next release run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved document-publishing automation: added a required Document360 user ID configuration and stronger validation around fork/publish operations to reduce failures and surface clearer errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->