### PR TITLE
feat: add LibreTranslate message auto-translation provider

### DIFF
--- a/.changeset/libretranslate-autotranslate-provider.md
+++ b/.changeset/libretranslate-autotranslate-provider.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/meteor': minor
+'@rocket.chat/i18n': patch
+---
+
+Added LibreTranslate as a message auto-translation provider, alongside Google, DeepL and Microsoft. LibreTranslate can be self-hosted, enabling fully on-premise / offline message auto-translation. Configure the instance URL (and optional API key) under **Admin → Settings → Message → Auto-Translate → LibreTranslate** and select it as the Service Provider.

--- a/apps/meteor/app/autotranslate/server/index.ts
+++ b/apps/meteor/app/autotranslate/server/index.ts
@@ -10,6 +10,7 @@ import './methods/saveSettings';
 import './methods/translateMessage';
 import './googleTranslate';
 import './deeplTranslate';
+import './libreTranslate';
 import './msTranslate';
 import './methods/getProviderUiMetadata';
 

--- a/apps/meteor/app/autotranslate/server/libreTranslate.ts
+++ b/apps/meteor/app/autotranslate/server/libreTranslate.ts
@@ -2,8 +2,8 @@ import type { IMessage, MessageAttachment, IProviderMetadata, ITranslationResult
 import { serverFetch as fetch } from '@rocket.chat/server-fetch';
 
 import { TranslationProviderRegistry, AutoTranslate } from './autotranslate';
+import { libreLogger } from './logger';
 import { i18n } from '../../../server/lib/i18n';
-import { SystemLogger } from '../../../server/lib/logger/system';
 import { settings } from '../../settings/server';
 
 interface ILibreTranslateLanguage {
@@ -18,7 +18,7 @@ const toLanguageTag = (code: string): string => {
 	try {
 		return new Intl.Locale(code).toString();
 	} catch (err) {
-		SystemLogger.error({ msg: 'Invalid language code returned by LibreTranslate', code, err });
+		libreLogger.error({ msg: 'Invalid language code returned by LibreTranslate', code, err });
 		return code;
 	}
 };
@@ -72,36 +72,32 @@ class LibreTranslateAutoTranslate extends AutoTranslate {
 			return this.supportedLanguages[target];
 		}
 
-		// SECURITY: the URL comes from a setting only an admin can change, so disabling SSRF validation is safe here.
-		const request = await fetch(`${this.apiEndPointUrl}/languages`, {
-			ignoreSsrfValidation: true,
-			timeout: REQUEST_TIMEOUT,
-		});
-		if (!request.ok) {
-			throw new Error('Failed to fetch supported languages');
-		}
-
-		const result = (await request.json()) as ILibreTranslateLanguage[];
-
-		this.supportedLanguages[target || 'en'] = result.map(({ code, name }) => ({
-			language: toLanguageTag(code),
-			name,
-		}));
-		return this.supportedLanguages[target || 'en'];
-	}
-
-	private async _getSupportedLanguagesSafe(): Promise<ISupportedLanguage[]> {
 		try {
-			return await this.getSupportedLanguages('en');
+			// SECURITY: the URL comes from a setting only an admin can change, so disabling SSRF validation is safe here.
+			const request = await fetch(`${this.apiEndPointUrl}/languages`, {
+				ignoreSsrfValidation: true,
+				timeout: REQUEST_TIMEOUT,
+			});
+			if (!request.ok) {
+				throw new Error('Failed to fetch supported languages');
+			}
+
+			const result = (await request.json()) as ILibreTranslateLanguage[];
+
+			this.supportedLanguages[target || 'en'] = result.map(({ code, name }) => ({
+				language: toLanguageTag(code),
+				name,
+			}));
+			return this.supportedLanguages[target || 'en'];
 		} catch (err) {
-			SystemLogger.error({ msg: 'Error fetching supported languages', err });
+			libreLogger.error({ msg: 'Error fetching supported languages', err });
 			return [];
 		}
 	}
 
 	private resolveTargetLanguage(language: string, supportedLanguages: ISupportedLanguage[]): string {
-		if (language.indexOf('-') !== -1 && !supportedLanguages.find((supported) => supported.language === language)) {
-			return language.substr(0, 2);
+		if (language.includes('-') && !supportedLanguages.find((supported) => supported.language === language)) {
+			return language.slice(0, 2);
 		}
 		return language;
 	}
@@ -113,10 +109,8 @@ class LibreTranslateAutoTranslate extends AutoTranslate {
 			source: 'auto',
 			target: targetLanguage,
 			format: 'text',
+			...(this.apiKey && { api_key: this.apiKey }),
 		};
-		if (this.apiKey) {
-			body.api_key = this.apiKey;
-		}
 
 		// SECURITY: the URL comes from a setting only an admin can change, so disabling SSRF validation is safe here.
 		const result = await fetch(`${this.apiEndPointUrl}/translate`, {
@@ -145,7 +139,7 @@ class LibreTranslateAutoTranslate extends AutoTranslate {
 		}
 
 		const msgs = message.msg.split('\n');
-		const supportedLanguages = await this._getSupportedLanguagesSafe();
+		const supportedLanguages = await this.getSupportedLanguages('en');
 		for (const targetLanguage of targetLanguages) {
 			const language = this.resolveTargetLanguage(targetLanguage, supportedLanguages);
 			try {
@@ -154,7 +148,7 @@ class LibreTranslateAutoTranslate extends AutoTranslate {
 					translations[language] = this.deTokenize(Object.assign({}, message, { msg: translatedText }));
 				}
 			} catch (err) {
-				SystemLogger.error({ msg: 'Error translating message', err });
+				libreLogger.error({ msg: 'Error translating message', err });
 			}
 		}
 		return translations;
@@ -166,7 +160,7 @@ class LibreTranslateAutoTranslate extends AutoTranslate {
 			return translations;
 		}
 
-		const supportedLanguages = await this._getSupportedLanguagesSafe();
+		const supportedLanguages = await this.getSupportedLanguages('en');
 		for (const targetLanguage of targetLanguages) {
 			const language = this.resolveTargetLanguage(targetLanguage, supportedLanguages);
 			try {
@@ -175,7 +169,7 @@ class LibreTranslateAutoTranslate extends AutoTranslate {
 					translations[language] = translatedText;
 				}
 			} catch (err) {
-				SystemLogger.error({ msg: 'Error translating message attachment', err });
+				libreLogger.error({ msg: 'Error translating message attachment', err });
 			}
 		}
 		return translations;

--- a/apps/meteor/app/autotranslate/server/libreTranslate.ts
+++ b/apps/meteor/app/autotranslate/server/libreTranslate.ts
@@ -1,0 +1,205 @@
+import type { IMessage, MessageAttachment, IProviderMetadata, ITranslationResult, ISupportedLanguage } from '@rocket.chat/core-typings';
+import { serverFetch as fetch } from '@rocket.chat/server-fetch';
+import _ from 'underscore';
+
+import { TranslationProviderRegistry, AutoTranslate } from './autotranslate';
+import { i18n } from '../../../server/lib/i18n';
+import { SystemLogger } from '../../../server/lib/logger/system';
+import { settings } from '../../settings/server';
+
+interface ILibreTranslateLanguage {
+	code: string;
+	name: string;
+	targets?: string[];
+}
+
+/**
+ * LibreTranslate translation service provider class representation.
+ * Encapsulates the service provider settings and information.
+ * Provides languages supported by the service provider.
+ * Resolves API call to a self-hosted (or hosted) LibreTranslate instance to
+ * resolve the translation request. Enables fully self-hosted / offline
+ * message auto-translation.
+ * @class
+ * @augments AutoTranslate
+ */
+class LibreTranslateAutoTranslate extends AutoTranslate {
+	apiKey: string;
+
+	apiEndPointUrl: string;
+
+	/**
+	 * setup api reference to libretranslate to be used as message translation provider.
+	 * @constructor
+	 */
+	constructor() {
+		super();
+		this.name = 'libre-translate';
+		this.apiEndPointUrl = '';
+		this.apiKey = '';
+
+		// Base URL of the LibreTranslate instance, e.g. http://libretranslate.example:5000
+		settings.watch<string>('AutoTranslate_LibreTranslateAPIURL', (value) => {
+			this.apiEndPointUrl = (value || '').replace(/\/$/, '');
+		});
+
+		// Optional — only required when the instance enforces API keys.
+		settings.watch<string>('AutoTranslate_LibreTranslateAPIKey', (value) => {
+			this.apiKey = value;
+		});
+	}
+
+	/**
+	 * Returns metadata information about the service provider.
+	 * @private implements super abstract method.
+	 * @return {object}
+	 */
+	_getProviderMetadata(): IProviderMetadata {
+		return {
+			name: this.name,
+			displayName: i18n.t('AutoTranslate_LibreTranslate'),
+			settings: this._getSettings(),
+		};
+	}
+
+	/**
+	 * Returns necessary settings information about the translation service provider.
+	 * @private implements super abstract method.
+	 * @return {object}
+	 */
+	_getSettings(): IProviderMetadata['settings'] {
+		return {
+			apiKey: this.apiKey,
+			apiEndPointUrl: this.apiEndPointUrl,
+		};
+	}
+
+	/**
+	 * Returns supported languages for translation by the active service provider.
+	 * Fetches the languages exposed by the configured LibreTranslate instance.
+	 * @private implements super abstract method.
+	 * @param {string} target
+	 * @returns {object} code : value pair
+	 */
+	async getSupportedLanguages(target: string): Promise<ISupportedLanguage[]> {
+		if (!this.apiEndPointUrl) {
+			return [];
+		}
+
+		if (this.supportedLanguages[target]) {
+			return this.supportedLanguages[target];
+		}
+
+		// SECURITY: the URL is a setting set by an admin. It's safe to disable this check.
+		const request = await fetch(`${this.apiEndPointUrl}/languages`, {
+			ignoreSsrfValidation: true,
+		});
+		if (!request.ok) {
+			throw new Error('Failed to fetch supported languages');
+		}
+
+		const result = (await request.json()) as ILibreTranslateLanguage[];
+
+		this.supportedLanguages[target || 'en'] = result.map(({ code, name }) => ({
+			language: new Intl.Locale(code).toString(),
+			name,
+		}));
+		return this.supportedLanguages[target || 'en'];
+	}
+
+	/**
+	 * Send Request REST API call to the service provider.
+	 * `q` is sent as an array of lines; LibreTranslate then returns
+	 * `translatedText` as an array (one entry per input line).
+	 * @private
+	 * @param {string[]} lines
+	 * @param {string} targetLanguage
+	 * @returns {string | null} the joined translated text, or null on failure
+	 */
+	private async _query(lines: string[], targetLanguage: string): Promise<string | null> {
+		const body: Record<string, unknown> = {
+			q: lines,
+			source: 'auto',
+			target: targetLanguage,
+			format: 'text',
+		};
+		if (this.apiKey) {
+			body.api_key = this.apiKey;
+		}
+
+		// SECURITY: the URL is a setting set by an admin. It's safe to disable this check.
+		const result = await fetch(`${this.apiEndPointUrl}/translate`, {
+			method: 'POST',
+			ignoreSsrfValidation: true,
+			headers: { 'Content-Type': 'application/json' },
+			body,
+		});
+
+		if (!result.ok) {
+			throw new Error(result.statusText);
+		}
+
+		const json = (await result.json()) as { translatedText?: string | string[] };
+		if (json.translatedText === undefined) {
+			return null;
+		}
+		return Array.isArray(json.translatedText) ? json.translatedText.join('\n') : json.translatedText;
+	}
+
+	/**
+	 * Send Request REST API call to the service provider.
+	 * Returns translated message for each target language in target languages.
+	 * @private
+	 * @param {object} message
+	 * @param {object} targetLanguages
+	 * @returns {object} translations: Translated messages for each language
+	 */
+	async _translateMessage(message: IMessage, targetLanguages: string[]): Promise<ITranslationResult> {
+		const translations: { [k: string]: string } = {};
+		const msgs = message.msg.split('\n');
+		const supportedLanguages = await this.getSupportedLanguages('en');
+		for (let language of targetLanguages) {
+			if (language.indexOf('-') !== -1 && !_.findWhere(supportedLanguages, { language })) {
+				language = language.substr(0, 2);
+			}
+			try {
+				const translatedText = await this._query(msgs, language);
+				if (translatedText !== null) {
+					translations[language] = this.deTokenize(Object.assign({}, message, { msg: translatedText }));
+				}
+			} catch (err) {
+				SystemLogger.error({ msg: 'Error translating message', err });
+			}
+		}
+		return translations;
+	}
+
+	/**
+	 * Returns translated message attachment description in target languages.
+	 * @private
+	 * @param {object} attachment
+	 * @param {object} targetLanguages
+	 * @returns {object} translated messages for each target language
+	 */
+	async _translateAttachmentDescriptions(attachment: MessageAttachment, targetLanguages: string[]): Promise<ITranslationResult> {
+		const translations: { [k: string]: string } = {};
+		const supportedLanguages = await this.getSupportedLanguages('en');
+		for (let language of targetLanguages) {
+			if (language.indexOf('-') !== -1 && !_.findWhere(supportedLanguages, { language })) {
+				language = language.substr(0, 2);
+			}
+			try {
+				const translatedText = await this._query([attachment.description || attachment.text || ''], language);
+				if (translatedText !== null) {
+					translations[language] = translatedText;
+				}
+			} catch (err) {
+				SystemLogger.error({ msg: 'Error translating message attachment', err });
+			}
+		}
+		return translations;
+	}
+}
+
+// Register LibreTranslate translation provider to the registry.
+TranslationProviderRegistry.registerProvider(new LibreTranslateAutoTranslate());

--- a/apps/meteor/app/autotranslate/server/libreTranslate.ts
+++ b/apps/meteor/app/autotranslate/server/libreTranslate.ts
@@ -1,6 +1,5 @@
 import type { IMessage, MessageAttachment, IProviderMetadata, ITranslationResult, ISupportedLanguage } from '@rocket.chat/core-typings';
 import { serverFetch as fetch } from '@rocket.chat/server-fetch';
-import _ from 'underscore';
 
 import { TranslationProviderRegistry, AutoTranslate } from './autotranslate';
 import { i18n } from '../../../server/lib/i18n';
@@ -13,13 +12,19 @@ interface ILibreTranslateLanguage {
 	targets?: string[];
 }
 
+const REQUEST_TIMEOUT = 10000;
+
+const toLanguageTag = (code: string): string => {
+	try {
+		return new Intl.Locale(code).toString();
+	} catch (err) {
+		SystemLogger.error({ msg: 'Invalid language code returned by LibreTranslate', code, err });
+		return code;
+	}
+};
+
 /**
  * LibreTranslate translation service provider class representation.
- * Encapsulates the service provider settings and information.
- * Provides languages supported by the service provider.
- * Resolves API call to a self-hosted (or hosted) LibreTranslate instance to
- * resolve the translation request. Enables fully self-hosted / offline
- * message auto-translation.
  * @class
  * @augments AutoTranslate
  */
@@ -28,32 +33,21 @@ class LibreTranslateAutoTranslate extends AutoTranslate {
 
 	apiEndPointUrl: string;
 
-	/**
-	 * setup api reference to libretranslate to be used as message translation provider.
-	 * @constructor
-	 */
 	constructor() {
 		super();
 		this.name = 'libre-translate';
 		this.apiEndPointUrl = '';
 		this.apiKey = '';
 
-		// Base URL of the LibreTranslate instance, e.g. http://libretranslate.example:5000
 		settings.watch<string>('AutoTranslate_LibreTranslateAPIURL', (value) => {
 			this.apiEndPointUrl = (value || '').replace(/\/$/, '');
 		});
 
-		// Optional — only required when the instance enforces API keys.
 		settings.watch<string>('AutoTranslate_LibreTranslateAPIKey', (value) => {
 			this.apiKey = value;
 		});
 	}
 
-	/**
-	 * Returns metadata information about the service provider.
-	 * @private implements super abstract method.
-	 * @return {object}
-	 */
 	_getProviderMetadata(): IProviderMetadata {
 		return {
 			name: this.name,
@@ -62,11 +56,6 @@ class LibreTranslateAutoTranslate extends AutoTranslate {
 		};
 	}
 
-	/**
-	 * Returns necessary settings information about the translation service provider.
-	 * @private implements super abstract method.
-	 * @return {object}
-	 */
 	_getSettings(): IProviderMetadata['settings'] {
 		return {
 			apiKey: this.apiKey,
@@ -74,13 +63,6 @@ class LibreTranslateAutoTranslate extends AutoTranslate {
 		};
 	}
 
-	/**
-	 * Returns supported languages for translation by the active service provider.
-	 * Fetches the languages exposed by the configured LibreTranslate instance.
-	 * @private implements super abstract method.
-	 * @param {string} target
-	 * @returns {object} code : value pair
-	 */
 	async getSupportedLanguages(target: string): Promise<ISupportedLanguage[]> {
 		if (!this.apiEndPointUrl) {
 			return [];
@@ -90,9 +72,10 @@ class LibreTranslateAutoTranslate extends AutoTranslate {
 			return this.supportedLanguages[target];
 		}
 
-		// SECURITY: the URL is a setting set by an admin. It's safe to disable this check.
+		// SECURITY: the URL comes from a setting only an admin can change, so disabling SSRF validation is safe here.
 		const request = await fetch(`${this.apiEndPointUrl}/languages`, {
 			ignoreSsrfValidation: true,
+			timeout: REQUEST_TIMEOUT,
 		});
 		if (!request.ok) {
 			throw new Error('Failed to fetch supported languages');
@@ -101,21 +84,29 @@ class LibreTranslateAutoTranslate extends AutoTranslate {
 		const result = (await request.json()) as ILibreTranslateLanguage[];
 
 		this.supportedLanguages[target || 'en'] = result.map(({ code, name }) => ({
-			language: new Intl.Locale(code).toString(),
+			language: toLanguageTag(code),
 			name,
 		}));
 		return this.supportedLanguages[target || 'en'];
 	}
 
-	/**
-	 * Send Request REST API call to the service provider.
-	 * `q` is sent as an array of lines; LibreTranslate then returns
-	 * `translatedText` as an array (one entry per input line).
-	 * @private
-	 * @param {string[]} lines
-	 * @param {string} targetLanguage
-	 * @returns {string | null} the joined translated text, or null on failure
-	 */
+	private async _getSupportedLanguagesSafe(): Promise<ISupportedLanguage[]> {
+		try {
+			return await this.getSupportedLanguages('en');
+		} catch (err) {
+			SystemLogger.error({ msg: 'Error fetching supported languages', err });
+			return [];
+		}
+	}
+
+	private resolveTargetLanguage(language: string, supportedLanguages: ISupportedLanguage[]): string {
+		if (language.indexOf('-') !== -1 && !supportedLanguages.find((supported) => supported.language === language)) {
+			return language.substr(0, 2);
+		}
+		return language;
+	}
+
+	// `q` is sent as an array of lines; LibreTranslate returns `translatedText` as an array (one entry per line).
 	private async _query(lines: string[], targetLanguage: string): Promise<string | null> {
 		const body: Record<string, unknown> = {
 			q: lines,
@@ -127,10 +118,11 @@ class LibreTranslateAutoTranslate extends AutoTranslate {
 			body.api_key = this.apiKey;
 		}
 
-		// SECURITY: the URL is a setting set by an admin. It's safe to disable this check.
+		// SECURITY: the URL comes from a setting only an admin can change, so disabling SSRF validation is safe here.
 		const result = await fetch(`${this.apiEndPointUrl}/translate`, {
 			method: 'POST',
 			ignoreSsrfValidation: true,
+			timeout: REQUEST_TIMEOUT,
 			headers: { 'Content-Type': 'application/json' },
 			body,
 		});
@@ -146,22 +138,16 @@ class LibreTranslateAutoTranslate extends AutoTranslate {
 		return Array.isArray(json.translatedText) ? json.translatedText.join('\n') : json.translatedText;
 	}
 
-	/**
-	 * Send Request REST API call to the service provider.
-	 * Returns translated message for each target language in target languages.
-	 * @private
-	 * @param {object} message
-	 * @param {object} targetLanguages
-	 * @returns {object} translations: Translated messages for each language
-	 */
 	async _translateMessage(message: IMessage, targetLanguages: string[]): Promise<ITranslationResult> {
 		const translations: { [k: string]: string } = {};
+		if (!this.apiEndPointUrl) {
+			return translations;
+		}
+
 		const msgs = message.msg.split('\n');
-		const supportedLanguages = await this.getSupportedLanguages('en');
-		for (let language of targetLanguages) {
-			if (language.indexOf('-') !== -1 && !_.findWhere(supportedLanguages, { language })) {
-				language = language.substr(0, 2);
-			}
+		const supportedLanguages = await this._getSupportedLanguagesSafe();
+		for (const targetLanguage of targetLanguages) {
+			const language = this.resolveTargetLanguage(targetLanguage, supportedLanguages);
 			try {
 				const translatedText = await this._query(msgs, language);
 				if (translatedText !== null) {
@@ -174,20 +160,15 @@ class LibreTranslateAutoTranslate extends AutoTranslate {
 		return translations;
 	}
 
-	/**
-	 * Returns translated message attachment description in target languages.
-	 * @private
-	 * @param {object} attachment
-	 * @param {object} targetLanguages
-	 * @returns {object} translated messages for each target language
-	 */
 	async _translateAttachmentDescriptions(attachment: MessageAttachment, targetLanguages: string[]): Promise<ITranslationResult> {
 		const translations: { [k: string]: string } = {};
-		const supportedLanguages = await this.getSupportedLanguages('en');
-		for (let language of targetLanguages) {
-			if (language.indexOf('-') !== -1 && !_.findWhere(supportedLanguages, { language })) {
-				language = language.substr(0, 2);
-			}
+		if (!this.apiEndPointUrl) {
+			return translations;
+		}
+
+		const supportedLanguages = await this._getSupportedLanguagesSafe();
+		for (const targetLanguage of targetLanguages) {
+			const language = this.resolveTargetLanguage(targetLanguage, supportedLanguages);
 			try {
 				const translatedText = await this._query([attachment.description || attachment.text || ''], language);
 				if (translatedText !== null) {
@@ -201,5 +182,4 @@ class LibreTranslateAutoTranslate extends AutoTranslate {
 	}
 }
 
-// Register LibreTranslate translation provider to the registry.
 TranslationProviderRegistry.registerProvider(new LibreTranslateAutoTranslate());

--- a/apps/meteor/app/autotranslate/server/logger.ts
+++ b/apps/meteor/app/autotranslate/server/logger.ts
@@ -3,3 +3,5 @@ import { Logger } from '@rocket.chat/logger';
 const logger = new Logger('AutoTranslate');
 
 export const msLogger = logger.section('Microsoft');
+
+export const libreLogger = logger.section('LibreTranslate');

--- a/apps/meteor/server/settings/message.ts
+++ b/apps/meteor/server/settings/message.ts
@@ -316,6 +316,10 @@ export const createMessageSettings = () =>
 					key: 'microsoft-translate',
 					i18nLabel: 'AutoTranslate_Microsoft',
 				},
+				{
+					key: 'libre-translate',
+					i18nLabel: 'AutoTranslate_LibreTranslate',
+				},
 			],
 			enableQuery: [{ _id: 'AutoTranslate_Enabled', value: true }],
 			i18nLabel: 'AutoTranslate_ServiceProvider',
@@ -375,6 +379,43 @@ export const createMessageSettings = () =>
 				},
 			],
 		});
+
+		await this.add('AutoTranslate_LibreTranslateAPIURL', '', {
+			type: 'string',
+			group: 'Message',
+			section: 'AutoTranslate_LibreTranslate',
+			public: false,
+			i18nLabel: 'AutoTranslate_LibreTranslate_API_URL',
+			enableQuery: [
+				{
+					_id: 'AutoTranslate_Enabled',
+					value: true,
+				},
+				{
+					_id: 'AutoTranslate_ServiceProvider',
+					value: 'libre-translate',
+				},
+			],
+		});
+
+		await this.add('AutoTranslate_LibreTranslateAPIKey', '', {
+			type: 'string',
+			group: 'Message',
+			section: 'AutoTranslate_LibreTranslate',
+			public: false,
+			i18nLabel: 'AutoTranslate_APIKey',
+			enableQuery: [
+				{
+					_id: 'AutoTranslate_Enabled',
+					value: true,
+				},
+				{
+					_id: 'AutoTranslate_ServiceProvider',
+					value: 'libre-translate',
+				},
+			],
+		});
+
 		await this.add('HexColorPreview_Enabled', true, {
 			type: 'boolean',
 			i18nLabel: 'Enabled',

--- a/apps/meteor/server/settings/message.ts
+++ b/apps/meteor/server/settings/message.ts
@@ -403,6 +403,7 @@ export const createMessageSettings = () =>
 			group: 'Message',
 			section: 'AutoTranslate_LibreTranslate',
 			public: false,
+			secret: true,
 			i18nLabel: 'AutoTranslate_APIKey',
 			enableQuery: [
 				{

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -865,6 +865,8 @@
   "AutoTranslate_Enabled_Description": "Enabling auto-translation will allow people with the `auto-translate` permission to have all messages automatically translated into their selected language. Fees may apply.",
   "AutoTranslate_Enabled_for_room": "Auto-translate enabled for #{{roomName}}",
   "AutoTranslate_Google": "Google",
+  "AutoTranslate_LibreTranslate": "LibreTranslate",
+  "AutoTranslate_LibreTranslate_API_URL": "LibreTranslate API URL",
   "AutoTranslate_Microsoft": "Microsoft",
   "AutoTranslate_Microsoft_API_Key": "Ocp-Apim-Subscription-Key",
   "AutoTranslate_ServiceProvider": "Service Provider",


### PR DESCRIPTION
## Proposed changes

Adds **LibreTranslate** as a message auto-translation provider, alongside the existing Google, DeepL and Microsoft providers.

Unlike the current providers, [LibreTranslate](https://github.com/LibreTranslate/LibreTranslate) is open-source and can be **self-hosted**, which enables fully on-premise / **offline** message auto-translation with no third-party API dependency or per-character cost. This is useful for air-gapped, privacy-sensitive, or cost-constrained deployments.

It integrates through the existing `AutoTranslate` provider abstraction, so it populates the native `translations` message metadata and works with the standard per-user translate toggle — no client changes.

### Implementation
- New provider `libre-translate` (`apps/meteor/app/autotranslate/server/libreTranslate.ts`) extending `AutoTranslate`, registered via `TranslationProviderRegistry`.
- Two new settings under the Auto-Translate section:
  - `AutoTranslate_LibreTranslateAPIURL` — base URL of the LibreTranslate instance (e.g. `http://libretranslate.internal:5000`)
  - `AutoTranslate_LibreTranslateAPIKey` — optional, only when the instance enforces API keys
- Added `libre-translate` to the `AutoTranslate_ServiceProvider` dropdown and the corresponding i18n labels.
- Supported languages are fetched live from the instance's `/languages` endpoint; translation uses `/translate`.

### How to test
1. Run a LibreTranslate instance (e.g. `docker run -p 5000:5000 libretranslate/libretranslate`).
2. Admin → Settings → Message → Auto-Translate: enable Auto-Translate, set **Service Provider** = LibreTranslate, set the **API URL**.
3. In a room, enable Auto-Translate for a user and pick a target language; post a message and confirm it is translated.

Validated end-to-end against a self-hosted LibreTranslate instance (message translated and stored in `message.translations`).

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Further comments
A changeset is included (`@rocket.chat/meteor`: minor, `@rocket.chat/i18n`: patch).

[CORE-2301]
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LibreTranslate as an additional auto-translation service provider alongside Google, DeepL, and Microsoft
  * Enabled admin configuration for LibreTranslate, including support for self-hosted API endpoint URL
  * Added optional API key authentication for LibreTranslate, stored as a secret
  * Added the corresponding Auto-Translate provider and API URL labels to the English UI language pack
* **Bug Fixes**
  * Improved handling of supported language normalization and per-language translation errors during LibreTranslate requests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2301]: https://rocketchat.atlassian.net/browse/CORE-2301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ