### PR TITLE
fix: update custom roles queries to include missing protected fields

### DIFF
--- a/packages/models/src/models/Roles.ts
+++ b/packages/models/src/models/Roles.ts
@@ -138,7 +138,7 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 
 	findCustomRoles(options?: FindOptions<IRole>): FindCursor<IRole> {
 		const query: Filter<IRole> = {
-			protected: false,
+			protected: { $ne: true },
 		};
 
 		return this.find(query, options || {});
@@ -146,7 +146,7 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 
 	countCustomRoles(options?: CountDocumentsOptions): Promise<number> {
 		const query: Filter<IRole> = {
-			protected: false,
+			protected: { $ne: true },
 		};
 
 		return this.countDocuments(query, options || {});


### PR DESCRIPTION
## Proposed changes 

Fix an issue where custom roles created in older Rocket.Chat versions are not displayed in the **Administration → Permissions → Custom Roles** panel.

The root cause is that legacy role documents may not contain the `protected` field. The existing query uses a strict filter:

```ts
{ protected: false }
```

This excludes documents where the field is missing, causing them to not appear in query results.

MongoDB’s `$ne` operator matches documents where the field is not equal to a specified value, including documents where the field does not exist.  
By updating the query to use `{ protected: { $ne: true } }`, both explicitly unprotected roles (`false`) and legacy roles without the field are correctly returned.

### Changes:
- Updated `findCustomRoles` query:
  - `protected: false` → `protected: { $ne: true }`
- Updated `countCustomRoles` to use the same filter to ensure consistency between results and pagination

---

## Issue(s)

Closes #40798

---

## Steps to test or reproduce

1. Create a custom role from:
   **Administration → Permissions → Custom Roles**

2. Remove the `protected` field manually:
   ```js
   db.roles.updateOne(
     { name: "your-custom-role" },
     { $unset: { protected: "" } }
   )
   ```

3. Before this fix:
   - The role does not appear in the Custom Roles list

4. After this fix:
   - The role appears correctly in the UI

---

## Further comments

- This change ensures backward compatibility with legacy role documents without requiring a database migration.
- Existing behavior remains unchanged for roles where `protected: true`.
- Verified that protected roles (`protected: true`) are still excluded as expected.
- The query logic is now aligned with MongoDB behavior for missing fields and non-equality comparisons.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/40937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed custom role filtering logic to correctly identify roles without an explicit protection status as custom roles, improving the accuracy of role discovery and filtering throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->