### PR TITLE
docs(accounts): enhance Accounts_SearchFields setting documentation

### DIFF
--- a/.changeset/fix-accounts-search-fields-documentation.md
+++ b/.changeset/fix-accounts-search-fields-documentation.md
@@ -1,0 +1,9 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+docs(accounts): enhance Accounts_SearchFields setting documentation
+
+Added descriptive label and help text to Accounts_SearchFields setting with examples of searchable fields including nested fields like `emails.address` and custom fields.
+
+Closes #17203

--- a/apps/meteor/server/settings/accounts.ts
+++ b/apps/meteor/server/settings/accounts.ts
@@ -266,6 +266,8 @@ export const createAccountSettings = () =>
 		});
 		await this.add('Accounts_SearchFields', 'username, name, bio, nickname', {
 			type: 'string',
+			i18nLabel: 'Accounts_SearchFields',
+			i18nDescription: 'Accounts_SearchFields_Description',
 		});
 		await this.add('Accounts_Directory_DefaultView', 'channels', {
 			type: 'select',

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -414,6 +414,7 @@
   "Accounts_RoomAvatarExternalProviderUrl": "Room Avatar External Provider URL",
   "Accounts_RoomAvatarExternalProviderUrl_Description": "Example: `https://acme.com/api/v1/{roomId}`",
   "Accounts_SearchFields": "Fields to Consider in Search",
+  "Accounts_SearchFields_Description": "Comma-separated list of user fields to search. Examples: `username`, `name`, `bio`, `nickname`, `emails.address`, `status`, `statusText`, `language`, `customFields.fieldName`",
   "Accounts_Send_Email_When_Activating": "Send email to user when user is activated",
   "Accounts_Send_Email_When_Deactivating": "Send email to user when user is deactivated",
   "Accounts_SetDefaultAvatar": "Set Default Avatar",


### PR DESCRIPTION
## Proposed changes

Added descriptive label and help text to `Accounts_SearchFields` setting explaining available search fields with examples including nested fields like `emails.address` and custom field references.

## Issue(s)

Closes #17203

## Steps to test or reproduce

1. Go to Administration → Accounts → Settings
2. Find "Fields to Consider in Search" 
3. Hover over the setting → help text displays examples of valid searchable fields
4. Examples shown: `username`, `name`, `bio`, `nickname`, `emails.address`, `status`, `statusText`, `language`, `customFields.fieldName`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/40945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for account search field settings with improved help text describing supported searchable fields, including built-in and custom field examples.

* **Localization**
  * Added English localization support for account search field configuration descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->