### PR TITLE
fix: make user mentions case-insensitive

### DIFF
--- a/apps/meteor/app/mentions/lib/MentionsParser.ts
+++ b/apps/meteor/app/mentions/lib/MentionsParser.ts
@@ -78,7 +78,8 @@ export class MentionsParser {
 				return this.userTemplate({ prefix, className, mention, label: mention, type: 'group' });
 			}
 
-			const filterUser = ({ username, type }: { username?: string; type?: string }) => (!type || type === 'user') && username === mention;
+			const filterUser = ({ username, type }: { username?: string; type?: string }) =>
+				(!type || type === 'user') && username?.toLowerCase() === mention.toLowerCase();
 			const filterTeam = ({ name, type }: { name?: string; type?: string }) => type === 'team' && name === mention;
 
 			const [mentionObj] = (mentions || []).filter((m) => m && (filterUser(m) || filterTeam(m)));
@@ -94,10 +95,10 @@ export class MentionsParser {
 			return this.userTemplate({
 				prefix,
 				className,
-				mention,
+				mention: mentionObj?.username || mention,
 				label,
 				type: mentionObj?.type === 'team' ? 'team' : 'username',
-				title: this.useRealName() ? mention : label,
+				title: this.useRealName() ? mentionObj?.username || mention : label,
 			});
 		});
 

--- a/apps/meteor/server/services/messages/hooks/BeforeSaveMentions.ts
+++ b/apps/meteor/server/services/messages/hooks/BeforeSaveMentions.ts
@@ -12,10 +12,9 @@ class MentionQueries {
 
 		const teams = await Team.listByNames(uniqueUsernames, { projection: { name: 1 } });
 
-		const users = await Users.find<Pick<IUser, '_id' | 'username' | 'name'>>(
-			{ username: { $in: uniqueUsernames } },
-			{ projection: { _id: 1, username: 1, name: 1 } },
-		).toArray();
+		const users = await Users.findByUsernamesIgnoringCase(uniqueUsernames, {
+			projection: { _id: 1, username: 1, name: 1 },
+		}).toArray();
 
 		const taggedUsers = users.map((user) => ({
 			...user,

--- a/apps/meteor/tests/unit/app/mentions/client.tests.js
+++ b/apps/meteor/tests/unit/app/mentions/client.tests.js
@@ -164,6 +164,13 @@ describe('replace methods', () => {
 			expect(result).to.be.equal(`hello <a class="mention-link mention-link--user" data-username="${str2}" title="${str2}">${str2}</a>`);
 		});
 
+		it('should render user mentions case-insensitively', () => {
+			const result = mentionsParser.replaceUsers('hello @Rocket.Cat', message, 'me');
+			expect(result).to.be.equal(
+				'hello <a class="mention-link mention-link--user" data-username="rocket.cat" title="rocket.cat">rocket.cat</a>',
+			);
+		});
+
 		it('should render for unknow/private user "hello @unknow"', () => {
 			const result = mentionsParser.replaceUsers('hello @unknow', message, 'me');
 			expect(result).to.be.equal('hello @unknow');
@@ -195,6 +202,13 @@ describe('replace methods', () => {
 
 		it(`should render for "hello @${str2}"`, () => {
 			const result = mentionsParser.replaceUsers(`hello @${str2}`, message, 'me');
+			expect(result).to.be.equal(
+				`hello <a class="mention-link mention-link--user" data-username="${str2}" title="${str2}">${str2Name}</a>`,
+			);
+		});
+
+		it('should render user mentions case-insensitively', () => {
+			const result = mentionsParser.replaceUsers('hello @Rocket.Cat', message, 'me');
 			expect(result).to.be.equal(
 				`hello <a class="mention-link mention-link--user" data-username="${str2}" title="${str2}">${str2Name}</a>`,
 			);

--- a/apps/meteor/tests/unit/app/mentions/server.tests.js
+++ b/apps/meteor/tests/unit/app/mentions/server.tests.js
@@ -18,7 +18,7 @@ beforeEach(() => {
 					_id: 2,
 					username: 'jon',
 				},
-			].filter((user) => usernames.includes(user.username)), // Meteor.users.find({ username: {$in: _.unique(usernames)}}, { fields: {_id: true, username: true }}).fetch();
+			].filter((user) => usernames.some((username) => username.toLowerCase() === user.username.toLowerCase())), // Meteor.users.find({ username: {$in: _.unique(usernames)}}, { fields: {_id: true, username: true }}).fetch();
 		getChannels(channels) {
 			return [
 				{
@@ -93,6 +93,19 @@ describe('Mention Server', () => {
 			it('should return "rocket.cat"', async () => {
 				const message = {
 					msg: '@rocket.cat',
+				};
+				const expected = [
+					{
+						_id: 1,
+						username: 'rocket.cat',
+					},
+				];
+				const result = await mention.getUsersByMentions(message);
+				expect(expected).to.be.deep.equal(result);
+			});
+			it('should return "rocket.cat" for a differently cased mention', async () => {
+				const message = {
+					msg: '@Rocket.Cat',
 				};
 				const expected = [
 					{


### PR DESCRIPTION
## What was fixed

Closes #13374

Mentions now work even when the typed username uses different casing.

Before this change, if a user’s username was `foo`, typing `@Foo` or `@FOO` would not create a proper mention. This was inconsistent because Rocket.Chat already treats usernames as case-insensitive in other places, like user creation.

## What changed

Updated the message save logic so user mentions are resolved case-insensitively.

Also updated the mention rendering logic so a differently-cased typed mention still gets highlighted correctly and uses the actual stored username.

## Tests added

Added tests for:
- resolving a mixed-case typed mention to the correct existing user
- rendering a mixed-case mention as a normal highlighted mention

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/40948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User mention matching is now case-insensitive, allowing mentions with any capitalization (e.g., `@Rocket.Cat` correctly resolves to `@rocket.cat`). Mention links now use normalized usernames for consistency while preserving display names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->