### PR TITLE
fix: Iframe support for passport OAuth

### DIFF
--- a/apps/meteor/client/views/root/hooks/useIframeCommands.ts
+++ b/apps/meteor/client/views/root/hooks/useIframeCommands.ts
@@ -17,6 +17,7 @@ export const useIframeCommands = () => {
 	const loginWithToken = useLoginWithToken();
 	const loginWithCustomOauth = useLoginWithCustomOauth();
 	const { logout } = useContext(UserContext);
+	const enableNewOAuthFlow = useSetting('Accounts_OAuth_Use_Modern_Flow', true);
 
 	useEffect(() => {
 		if (!iframeReceiveEnabled) {
@@ -50,6 +51,21 @@ export const useIframeCommands = () => {
 			},
 
 			'call-custom-oauth-login'(data: { service: string; redirectUrl?: string | null }, event: MessageEvent) {
+				if (enableNewOAuthFlow) {
+					const url = new URL(window.location.href);
+					const queryParams = url.searchParams;
+					const loginClient = queryParams.get('loginClient');
+
+					const redirectUrl = new URL(`/oauth/${data.service}`, window.location.origin);
+
+					if (loginClient) {
+						redirectUrl.searchParams.set('loginClient', loginClient);
+					}
+
+					window.location.href = redirectUrl.toString();
+					return;
+				}
+
 				const customOAuthCallback = (response: unknown) => {
 					event.source?.postMessage(
 						{

--- a/apps/meteor/client/views/root/hooks/useIframeCommands.ts
+++ b/apps/meteor/client/views/root/hooks/useIframeCommands.ts
@@ -17,7 +17,7 @@ export const useIframeCommands = () => {
 	const loginWithToken = useLoginWithToken();
 	const loginWithCustomOauth = useLoginWithCustomOauth();
 	const { logout } = useContext(UserContext);
-	const enableNewOAuthFlow = useSetting('Accounts_OAuth_Use_Modern_Flow', true);
+	const enableModernOAuthFlow = useSetting('Accounts_OAuth_Use_Modern_Flow', true);
 
 	useEffect(() => {
 		if (!iframeReceiveEnabled) {
@@ -51,7 +51,7 @@ export const useIframeCommands = () => {
 			},
 
 			'call-custom-oauth-login'(data: { service: string; redirectUrl?: string | null }, event: MessageEvent) {
-				if (enableNewOAuthFlow) {
+				if (enableModernOAuthFlow) {
 					const url = new URL(window.location.href);
 					const queryParams = url.searchParams;
 					const loginClient = queryParams.get('loginClient');
@@ -133,5 +133,5 @@ export const useIframeCommands = () => {
 		return () => {
 			window.removeEventListener('message', messageListener);
 		};
-	}, [iframeReceiveEnabled, iframeReceiveOrigin, loginWithToken, loginWithCustomOauth, logout, enableNewOAuthFlow]);
+	}, [iframeReceiveEnabled, iframeReceiveOrigin, loginWithToken, loginWithCustomOauth, logout, enableModernOAuthFlow]);
 };

--- a/apps/meteor/client/views/root/hooks/useIframeCommands.ts
+++ b/apps/meteor/client/views/root/hooks/useIframeCommands.ts
@@ -133,5 +133,5 @@ export const useIframeCommands = () => {
 		return () => {
 			window.removeEventListener('message', messageListener);
 		};
-	}, [iframeReceiveEnabled, iframeReceiveOrigin, loginWithToken, loginWithCustomOauth, logout]);
+	}, [iframeReceiveEnabled, iframeReceiveOrigin, loginWithToken, loginWithCustomOauth, logout, enableNewOAuthFlow]);
 };

--- a/apps/meteor/client/views/root/hooks/useIframeCommands.ts
+++ b/apps/meteor/client/views/root/hooks/useIframeCommands.ts
@@ -81,7 +81,7 @@ export const useIframeCommands = () => {
 					data.redirectUrl = null;
 				}
 
-				if (typeof data.service === 'string' && window.ServiceConfiguration) {
+				if (window.ServiceConfiguration) {
 					const customOauth = loginServices.getLoginService(data.service);
 
 					if (customOauth) {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[PRM-52](https://rocketchat.atlassian.net/browse/PRM-52)

[PRM-52]: https://rocketchat.atlassian.net/browse/PRM-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/40949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a modern custom OAuth login flow behind the `Accounts_OAuth_Use_Modern_Flow` setting. When enabled, initiating custom OAuth now uses a redirect-based approach to start authentication and, when available, preserves the current `loginClient` parameter for smoother handoffs. When disabled, the existing legacy custom OAuth flow remains the default to keep current behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->