### PR TITLE
fix: update deno-runtime symlink handling to handle package relocation

### DIFF
--- a/packages/apps/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/packages/apps/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -186,10 +186,20 @@ export class DenoRuntimeSubprocessController extends EventEmitter implements IRu
 		 * Deno 2.x refuses to run scripts inside the node_modules, so we create a symlink to the deno runtime files in the temp directory
 		 * The temp directory is the same we are given by the host to store temporary upload files
 		 */
+		const symlinkSource = path.dirname(this.denoRuntimePath);
+		const symlinkTarget = path.dirname(this.denoConfigPath);
+
 		try {
-			fs.symlinkSync(path.dirname(this.denoConfigPath), path.dirname(this.denoRuntimePath), 'dir');
+			const existingTarget = fs.readlinkSync(symlinkSource);
+			if (existingTarget !== symlinkTarget) {
+				fs.unlinkSync(symlinkSource);
+				fs.symlinkSync(symlinkTarget, symlinkSource, 'dir');
+			}
 		} catch (reason: unknown) {
-			if ((reason as NodeJS.ErrnoException).code !== 'EEXIST') {
+			const err = reason as NodeJS.ErrnoException;
+			if (err.code === 'ENOENT') {
+				fs.symlinkSync(symlinkTarget, symlinkSource, 'dir');
+			} else if (err.code !== 'EEXIST') {
 				throw reason;
 			}
 		}

--- a/packages/apps/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/packages/apps/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -199,6 +199,9 @@ export class DenoRuntimeSubprocessController extends EventEmitter implements IRu
 			const err = reason as NodeJS.ErrnoException;
 			if (err.code === 'ENOENT') {
 				fs.symlinkSync(symlinkTarget, symlinkSource, 'dir');
+			} else if (err.code === 'EINVAL' || err.code === 'EISDIR' || err.code === 'UNKNOWN') {
+				fs.rmSync(symlinkSource, { recursive: true, force: true });
+				fs.symlinkSync(symlinkTarget, symlinkSource, 'dir');
 			} else if (err.code !== 'EEXIST') {
 				throw reason;
 			}


### PR DESCRIPTION
Fixes #40944

When upgrading Rocket.Chat, users reported that the Jitsi app could no longer be enabled. The root cause was a stale symlink at `/tmp/apps-engine-temp/deno-runtime` that continued to point to an outdated location after the upgrade.

In Rocket.Chat 8.5.0, the `deno-runtime` directory was moved from `@rocket.chat/apps-engine` to `@rocket.chat/apps`. However, the existing symlink logic only handled the case where the symlink did not exist. If a symlink was already present from a previous installation, the code would simply keep it without verifying whether it pointed to the correct target.

This change improves the symlink handling logic by validating the target of an existing symlink. If the symlink points to an outdated location, it is removed and recreated with the correct target. If no symlink exists, a new one is created as before.

With this fix, upgrades and restarts automatically recover from stale symlinks, eliminating the need for manual cleanup while preserving the existing behavior for fresh installations.

Closes #40944

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/40951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of Deno runtime initialization through improved symlink management that avoids unnecessary recreation and handles edge cases more robustly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->