### PR TITLE
regression: jump to message behaving erratically

### DIFF
--- a/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.ts
+++ b/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.ts
@@ -9,6 +9,7 @@ import { RoomHistoryManager } from '../../../../../app/ui-utils/client';
 import { messagesQueryKeys } from '../../../../lib/queryKeys';
 import { mapMessageFromApi } from '../../../../lib/utils/mapMessageFromApi';
 import { setMessageJumpQueryStringParameter } from '../../../../lib/utils/setMessageJumpQueryStringParameter';
+import { useRoomMessages } from '../../contexts/RoomContext';
 import { clearHighlightMessage, setHighlightMessage } from '../providers/messageHighlightSubscription';
 
 type UseTryToJumpToMessageProps = {
@@ -20,6 +21,8 @@ type UseTryToJumpToMessageProps = {
 
 const useTryToJumpToMessage = ({ rid, virtualizerRef, setIsJumpingToMessage, messages }: UseTryToJumpToMessageProps) => {
 	const messageJumpParam = useSearchParameter('msg');
+
+	const { isLoadingMoreMessages } = useRoomMessages();
 
 	const getMessage = useEndpoint('GET', '/v1/chat.getMessage');
 
@@ -47,25 +50,23 @@ const useTryToJumpToMessage = ({ rid, virtualizerRef, setIsJumpingToMessage, mes
 			setIsJumpingToMessage(false);
 			return;
 		}
-
 		if (!virtualizerRef.current) {
 			return;
 		}
-
 		setIsJumpingToMessage(true);
 
-		if (RoomHistoryManager.isLoading(rid) || messages.length === 0) {
+		if (isLoadingMoreMessages || messages.length === 0) {
 			return;
 		}
-
 		const loadedMessage = messages.find((message) => message._id === messageJumpParam);
 		if (!loadedMessage) {
-			if (message) {
+			// Do not load surrounding messages for thread messages that have a tshow: true
+			// as these are previews on the main list and will be handled by useTryToJumpToThreadMessage
+			if (message && (!isThreadMessage(message) || isThreadMainMessage(message))) {
 				RoomHistoryManager.getSurroundingChannelMessages(message);
 			}
 			return;
 		}
-
 		const messageIndex = messages.indexOf(loadedMessage);
 
 		// TODO: Calculate the offset of the page, for the message to be in the center of the page
@@ -83,7 +84,7 @@ const useTryToJumpToMessage = ({ rid, virtualizerRef, setIsJumpingToMessage, mes
 			setIsJumpingToMessage(false);
 			setMessageJumpQueryStringParameter(null);
 		}, 500);
-	}, [messageJumpParam, virtualizerRef, setIsJumpingToMessage, rid, messages, message]);
+	}, [messageJumpParam, virtualizerRef, setIsJumpingToMessage, rid, messages, message, isLoadingMoreMessages]);
 };
 
 export default useTryToJumpToMessage;

--- a/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToThreadMessage.spec.ts
+++ b/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToThreadMessage.spec.ts
@@ -2,14 +2,11 @@ import { mockAppRoot } from '@rocket.chat/mock-providers';
 import { renderHook, waitFor } from '@testing-library/react';
 
 import useTryToJumpToThreadMessage from './useTryToJumpToThreadMessage';
-import { RoomHistoryManager } from '../../../../../app/ui-utils/client';
+import { RoomManager } from '../../../../lib/RoomManager';
+import { useGoToRoom } from '../../hooks/useGoToRoom';
 
-jest.mock('../../../../../app/ui-utils/client', () => ({
-	RoomHistoryManager: {
-		getSurroundingMessages: jest.fn().mockResolvedValue(undefined),
-		isLoaded: jest.fn().mockReturnValue(false),
-		getMore: jest.fn().mockResolvedValue(undefined),
-	},
+jest.mock('../../hooks/useGoToRoom', () => ({
+	useGoToRoom: jest.fn(),
 }));
 
 jest.mock('../../../../lib/RoomManager', () => ({
@@ -39,15 +36,21 @@ jest.mock('../../../../stores', () => ({
 	},
 }));
 
-const mockedRoomHistoryManager = jest.mocked(RoomHistoryManager);
+const mockedUseGoToRoom = jest.mocked(useGoToRoom);
+const mockedGoToRoom = jest.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+	mockedUseGoToRoom.mockReturnValue(mockedGoToRoom);
+});
 
 afterEach(() => {
 	jest.clearAllMocks();
+	(RoomManager as { opened: string | undefined }).opened = undefined;
 });
 
 describe('useTryToJumpToThreadMessage', () => {
 	describe('early return when msg param is absent or jumpContext is jumpToUnread', () => {
-		it('should not navigate or load messages when msg search parameter is absent', () => {
+		it('should not navigate when msg search parameter is absent', () => {
 			const endpointSpy = jest.fn();
 
 			renderHook(() => useTryToJumpToThreadMessage(), {
@@ -55,11 +58,10 @@ describe('useTryToJumpToThreadMessage', () => {
 			});
 
 			expect(endpointSpy).not.toHaveBeenCalled();
-			expect(mockedRoomHistoryManager.getSurroundingMessages).not.toHaveBeenCalled();
-			expect(mockedRoomHistoryManager.getMore).not.toHaveBeenCalled();
+			expect(mockedGoToRoom).not.toHaveBeenCalled();
 		});
 
-		it('should not navigate or load messages when jumpContext is jumpToUnread', async () => {
+		it('should not navigate when jumpContext is jumpToUnread', async () => {
 			const threadMessage = {
 				_id: 'msg-1',
 				rid: 'room-1',
@@ -86,16 +88,13 @@ describe('useTryToJumpToThreadMessage', () => {
 
 			await waitFor(async () => {
 				await new Promise((resolve) => setTimeout(resolve, 300));
-				expect(mockedRoomHistoryManager.getMore).not.toHaveBeenCalled();
+				expect(mockedGoToRoom).not.toHaveBeenCalled();
 			});
-
-			expect(mockedRoomHistoryManager.getSurroundingMessages).not.toHaveBeenCalled();
-			expect(mockedRoomHistoryManager.getMore).not.toHaveBeenCalled();
 		});
 	});
 
 	describe('when jumpContext is absent', () => {
-		it('should load more messages when jumpContext is null', async () => {
+		it('should open the thread when jumpContext is null', async () => {
 			const threadMessage = {
 				_id: 'msg-1',
 				rid: 'room-1',
@@ -105,8 +104,6 @@ describe('useTryToJumpToThreadMessage', () => {
 				msg: 'Thread reply',
 				_updatedAt: new Date('2024-01-01T00:00:00Z').toISOString(),
 			};
-
-			mockedRoomHistoryManager.isLoaded.mockReturnValue(false);
 
 			const endpointSpy = jest.fn().mockResolvedValue({ message: threadMessage });
 
@@ -123,10 +120,11 @@ describe('useTryToJumpToThreadMessage', () => {
 			});
 
 			await waitFor(() => {
-				expect(mockedRoomHistoryManager.getMore).toHaveBeenCalledWith('room-1');
+				expect(mockedGoToRoom).toHaveBeenCalledWith('room-1', {
+					routeParamsOverrides: { tab: 'thread', context: 'parent-msg-1' },
+					replace: false,
+				});
 			});
-
-			expect(mockedRoomHistoryManager.getSurroundingMessages).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToThreadMessage.ts
+++ b/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToThreadMessage.ts
@@ -3,7 +3,6 @@ import { useEndpoint, useRouteParameter, useSearchParameter } from '@rocket.chat
 import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
-import { RoomHistoryManager } from '../../../../../app/ui-utils/client';
 import { RoomManager } from '../../../../lib/RoomManager';
 import { messagesQueryKeys } from '../../../../lib/queryKeys';
 import { mapMessageFromApi } from '../../../../lib/utils/mapMessageFromApi';
@@ -40,7 +39,6 @@ const useTryToJumpToThreadMessage = (): void => {
 		if (!isThreadMessage(message) && !isThreadMainMessage(message)) {
 			return;
 		}
-
 		if (tab === 'thread' && (context === message.tmid || context === message._id)) {
 			return;
 		}
@@ -50,12 +48,6 @@ const useTryToJumpToThreadMessage = (): void => {
 				routeParamsOverrides: { tab: 'thread', context: message.tmid || message._id },
 				replace: RoomManager.opened === message.rid,
 			});
-
-			if (message.tcount) {
-				await RoomHistoryManager.getSurroundingMessages(message);
-			} else if (!RoomHistoryManager.isLoaded(message.rid)) {
-				await RoomHistoryManager.getMore(message.rid);
-			}
 		})();
 	}, [messageJumpParam, message, goToRoom, tab, context, messageJumpContext]);
 };

--- a/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.tsx
@@ -80,13 +80,13 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 	const messagesLength = messages.length;
 	useEffect(() => {
 		setKeepAtBottom(() => {
-			if (virtualizerRef.current) {
+			if (virtualizerRef.current && !msgJumpParam) {
 				virtualizerRef.current.scrollToIndex(messagesLength + 1, {
 					align: 'end',
 				});
 			}
 		});
-	}, [messagesLength, setKeepAtBottom]);
+	}, [messagesLength, setKeepAtBottom, msgJumpParam]);
 
 	const mergedRefs = useMergedRefsV2(messageListRef, keepAtBottomRef);
 
@@ -160,13 +160,9 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 				setMessageJumpQueryStringParameter(null);
 			}
 		};
-		const timeoutId = setTimeout(() => {
+		setTimeout(() => {
 			clearMsgJumpParam();
 		}, 500);
-		return () => {
-			clearMsgJumpParam();
-			clearTimeout(timeoutId);
-		};
 	}, [msgJumpParam, messages, mainMessage._id]);
 
 	useEffect(() => {


### PR DESCRIPTION
fix: jump to message behaving erratically

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-2293](https://rocketchat.atlassian.net/browse/CORE-2293)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-2293]: https://rocketchat.atlassian.net/browse/CORE-2293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/40953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “jump to message/thread” reliability with added loading/reference guards and refined surrounding-message loading (including special handling for thread preview cases).
  * Updated thread list auto-scroll behavior to avoid unintended scrolling when a message-jump query parameter is present.
* **Tests**
  * Revised thread navigation test mocks and expectations to match the updated jump flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->