### PR TITLE
chore: reduce room opening latency in message history load

### DIFF
--- a/.changeset/swift-rooms-load.md
+++ b/.changeset/swift-rooms-load.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Speeds up room opening by removing redundant work in the message history load. On the client, the prefetched first history batch no longer blocks on the message-list DOM before rendering, and the history pager no longer fires an extra `loadHistory` round trip just to reach a full page of visible messages when the latest page contains thread replies. On the server, `loadHistory` reuses the already-fetched room document instead of querying it twice, and runs message normalization and the unread (first-unread + count) queries concurrently instead of sequentially.

--- a/apps/meteor/app/lib/server/functions/loadMessageHistory.ts
+++ b/apps/meteor/app/lib/server/functions/loadMessageHistory.ts
@@ -75,7 +75,13 @@ export async function loadMessageHistory({
 				{ limit: 1, sort: { ts: 1 } },
 				showThreadMessages,
 			).toArray(),
-			Messages.countVisibleByRoomIdBetweenTimestampsNotContainingTypes(rid, lastSeen, firstMessage.ts, hiddenMessageTypes, showThreadMessages),
+			Messages.countVisibleByRoomIdBetweenTimestampsNotContainingTypes(
+				rid,
+				lastSeen,
+				firstMessage.ts,
+				hiddenMessageTypes,
+				showThreadMessages,
+			),
 		]);
 
 		return { firstUnread: firstUnreadRecords[0], unreadNotLoaded };

--- a/apps/meteor/app/lib/server/functions/loadMessageHistory.ts
+++ b/apps/meteor/app/lib/server/functions/loadMessageHistory.ts
@@ -24,8 +24,6 @@ export async function loadMessageHistory({
 	ls?: string | Date;
 	showThreadMessages?: boolean;
 	offset?: number;
-	// Pass a pre-fetched room (must include `sysMes`) to skip the duplicate Rooms.findOneById that
-	// the caller already performed (e.g. the loadHistory method fetches the room for access checks).
 	room?: IRoom;
 }) {
 	const room = providedRoom ?? (await Rooms.findOneById(rid, { projection: { sysMes: 1 } }));
@@ -56,13 +54,12 @@ export async function loadMessageHistory({
 			).toArray()
 		: await Messages.findVisibleByRoomIdNotContainingTypes(rid, hiddenMessageTypes, options, showThreadMessages).toArray();
 
-	// `records` is sorted ts desc, so the oldest message in the batch is the last element. Unread
-	// math only needs its timestamp, so it can run off `records` independently of normalization.
 	const firstMessage = records[records.length - 1];
 	const lastSeen = ls ? new Date(ls) : undefined;
+	const hasValidLastSeen = lastSeen !== undefined && !Number.isNaN(lastSeen.getTime());
 
 	const computeUnread = async (): Promise<{ firstUnread: IMessage | undefined; unreadNotLoaded: number }> => {
-		if (!lastSeen || !firstMessage || new Date(firstMessage.ts) <= lastSeen) {
+		if (!hasValidLastSeen || !lastSeen || !firstMessage || !(new Date(firstMessage.ts) > lastSeen)) {
 			return { firstUnread: undefined, unreadNotLoaded: 0 };
 		}
 
@@ -87,8 +84,6 @@ export async function loadMessageHistory({
 		return { firstUnread: firstUnreadRecords[0], unreadNotLoaded };
 	};
 
-	// Normalization (a Users lookup) and the unread queries are independent — run them concurrently
-	// instead of waiting for normalization before issuing the unread find + count.
 	const [messages, unread] = await Promise.all([normalizeMessagesForUser(records, userId), computeUnread()]);
 
 	return {

--- a/apps/meteor/app/lib/server/functions/loadMessageHistory.ts
+++ b/apps/meteor/app/lib/server/functions/loadMessageHistory.ts
@@ -1,4 +1,4 @@
-import type { IMessage, MessageTypesValues } from '@rocket.chat/core-typings';
+import type { IMessage, IRoom, MessageTypesValues } from '@rocket.chat/core-typings';
 import { Messages, Rooms } from '@rocket.chat/models';
 import type { FindOptions } from 'mongodb';
 
@@ -14,6 +14,7 @@ export async function loadMessageHistory({
 	ls,
 	showThreadMessages = true,
 	offset = 0,
+	room: providedRoom,
 }: {
 	// userId is undefined if user is reading anonymously
 	userId?: string;
@@ -23,8 +24,11 @@ export async function loadMessageHistory({
 	ls?: string | Date;
 	showThreadMessages?: boolean;
 	offset?: number;
+	// Pass a pre-fetched room (must include `sysMes`) to skip the duplicate Rooms.findOneById that
+	// the caller already performed (e.g. the loadHistory method fetches the room for access checks).
+	room?: IRoom;
 }) {
-	const room = await Rooms.findOneById(rid, { projection: { sysMes: 1 } });
+	const room = providedRoom ?? (await Rooms.findOneById(rid, { projection: { sysMes: 1 } }));
 
 	if (!room) {
 		throw new Error('error-invalid-room');
@@ -51,46 +55,39 @@ export async function loadMessageHistory({
 				showThreadMessages,
 			).toArray()
 		: await Messages.findVisibleByRoomIdNotContainingTypes(rid, hiddenMessageTypes, options, showThreadMessages).toArray();
-	const messages = await normalizeMessagesForUser(records, userId);
-	let unreadNotLoaded = 0;
-	let firstUnread;
 
-	if (ls) {
-		const firstMessage = messages[messages.length - 1];
+	// `records` is sorted ts desc, so the oldest message in the batch is the last element. Unread
+	// math only needs its timestamp, so it can run off `records` independently of normalization.
+	const firstMessage = records[records.length - 1];
+	const lastSeen = ls ? new Date(ls) : undefined;
 
-		const lastSeen = new Date(ls);
-
-		if (firstMessage && new Date(firstMessage.ts) > lastSeen) {
-			const unreadMessages = Messages.findVisibleByRoomIdBetweenTimestampsNotContainingTypes(
-				rid,
-				lastSeen,
-				firstMessage.ts,
-				hiddenMessageTypes,
-				{
-					limit: 1,
-					sort: {
-						ts: 1,
-					},
-				},
-				showThreadMessages,
-			);
-
-			const totalCursor = await Messages.countVisibleByRoomIdBetweenTimestampsNotContainingTypes(
-				rid,
-				lastSeen,
-				firstMessage.ts,
-				hiddenMessageTypes,
-				showThreadMessages,
-			);
-
-			firstUnread = (await unreadMessages.toArray())[0];
-			unreadNotLoaded = totalCursor;
+	const computeUnread = async (): Promise<{ firstUnread: IMessage | undefined; unreadNotLoaded: number }> => {
+		if (!lastSeen || !firstMessage || new Date(firstMessage.ts) <= lastSeen) {
+			return { firstUnread: undefined, unreadNotLoaded: 0 };
 		}
-	}
+
+		const [firstUnreadRecords, unreadNotLoaded] = await Promise.all([
+			Messages.findVisibleByRoomIdBetweenTimestampsNotContainingTypes(
+				rid,
+				lastSeen,
+				firstMessage.ts,
+				hiddenMessageTypes,
+				{ limit: 1, sort: { ts: 1 } },
+				showThreadMessages,
+			).toArray(),
+			Messages.countVisibleByRoomIdBetweenTimestampsNotContainingTypes(rid, lastSeen, firstMessage.ts, hiddenMessageTypes, showThreadMessages),
+		]);
+
+		return { firstUnread: firstUnreadRecords[0], unreadNotLoaded };
+	};
+
+	// Normalization (a Users lookup) and the unread queries are independent — run them concurrently
+	// instead of waiting for normalization before issuing the unread find + count.
+	const [messages, unread] = await Promise.all([normalizeMessagesForUser(records, userId), computeUnread()]);
 
 	return {
 		messages,
-		firstUnread,
-		unreadNotLoaded,
+		firstUnread: unread.firstUnread,
+		unreadNotLoaded: unread.unreadNotLoaded,
 	};
 }

--- a/apps/meteor/app/ui-utils/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/app/ui-utils/client/lib/RoomHistoryManager.ts
@@ -174,10 +174,6 @@ class RoomHistoryManagerClass extends Emitter {
 				room.oldestTs = messages[messages.length - 1].ts;
 			}
 
-			// Snapshot scroll position to keep the viewport anchored when older messages are prepended.
-			// Only relevant once the message list is rendered (pagination); on initial room open the
-			// wrapper doesn't exist yet and there's nothing to anchor, so we must NOT block the upsert
-			// waiting for it — that delayed rendering of the prefetched first batch.
 			const wrapper = document.querySelector<HTMLElement>('.messages-box .wrapper [data-overlayscrollbars-viewport]');
 			if (wrapper) {
 				room.scroll = {
@@ -197,7 +193,7 @@ class RoomHistoryManagerClass extends Emitter {
 				room.loaded = 0;
 			}
 
-			const visibleMessages = messages.filter((msg) => !msg.tmid || showThreadsInMainChannel || msg.tshow);
+			const visibleMessages = messages.filter((msg) => msg.t !== 'command' && (!msg.tmid || showThreadsInMainChannel || msg.tshow));
 
 			room.loaded += visibleMessages.length;
 
@@ -205,11 +201,6 @@ class RoomHistoryManagerClass extends Emitter {
 				this.updateRoom(rid, { hasMore: false });
 			}
 
-			// Only keep paging when this batch added NO visible rows (e.g. 50 thread replies) — otherwise
-			// the screen would be blank. Previously we also paged whenever `room.loaded < limit`, which
-			// forced a second ~400ms loadHistory round trip on almost every room open (any thread reply
-			// in the last 50 messages dropped the visible count below the limit). The viewport is filled
-			// by far fewer than `limit` messages, and scroll-driven getMore fetches more on demand.
 			if (room.hasMore && visibleMessages.length === 0) {
 				return this.getMore(rid);
 			}

--- a/apps/meteor/app/ui-utils/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/app/ui-utils/client/lib/RoomHistoryManager.ts
@@ -7,7 +7,6 @@ import { onClientMessageReceived } from '../../../../client/lib/onClientMessageR
 import { getUserId } from '../../../../client/lib/user';
 import { callWithErrorHandling } from '../../../../client/lib/utils/callWithErrorHandling';
 import { getConfig } from '../../../../client/lib/utils/getConfig';
-import { waitForElement } from '../../../../client/lib/utils/waitForElement';
 import { Messages, Subscriptions } from '../../../../client/stores';
 import { getUserPreference } from '../../../utils/client';
 
@@ -175,12 +174,17 @@ class RoomHistoryManagerClass extends Emitter {
 				room.oldestTs = messages[messages.length - 1].ts;
 			}
 
-			const wrapper = await waitForElement('.messages-box .wrapper [data-overlayscrollbars-viewport]');
-
-			room.scroll = {
-				scrollHeight: wrapper.scrollHeight,
-				scrollTop: wrapper.scrollTop,
-			};
+			// Snapshot scroll position to keep the viewport anchored when older messages are prepended.
+			// Only relevant once the message list is rendered (pagination); on initial room open the
+			// wrapper doesn't exist yet and there's nothing to anchor, so we must NOT block the upsert
+			// waiting for it — that delayed rendering of the prefetched first batch.
+			const wrapper = document.querySelector<HTMLElement>('.messages-box .wrapper [data-overlayscrollbars-viewport]');
+			if (wrapper) {
+				room.scroll = {
+					scrollHeight: wrapper.scrollHeight,
+					scrollTop: wrapper.scrollTop,
+				};
+			}
 
 			await upsertMessageBulk({
 				msgs: messages.filter((msg) => msg.t !== 'command'),
@@ -201,7 +205,12 @@ class RoomHistoryManagerClass extends Emitter {
 				this.updateRoom(rid, { hasMore: false });
 			}
 
-			if (room.hasMore && (visibleMessages.length === 0 || room.loaded < limit)) {
+			// Only keep paging when this batch added NO visible rows (e.g. 50 thread replies) — otherwise
+			// the screen would be blank. Previously we also paged whenever `room.loaded < limit`, which
+			// forced a second ~400ms loadHistory round trip on almost every room open (any thread reply
+			// in the last 50 messages dropped the visible count below the limit). The viewport is filled
+			// by far fewer than `limit` messages, and scroll-driven getMore fetches more on demand.
+			if (room.hasMore && visibleMessages.length === 0) {
 				return this.getMore(rid);
 			}
 

--- a/apps/meteor/server/methods/loadHistory.ts
+++ b/apps/meteor/server/methods/loadHistory.ts
@@ -39,7 +39,7 @@ Meteor.methods<ServerMethods>({
 			});
 		}
 
-		const room = await Rooms.findOneById(rid, { projection: { ...roomAccessAttributes, t: 1 } });
+		const room = await Rooms.findOneById(rid, { projection: { ...roomAccessAttributes, t: 1, sysMes: 1 } });
 		if (!room) {
 			return false;
 		}
@@ -51,7 +51,7 @@ Meteor.methods<ServerMethods>({
 
 		// if fromId is undefined and it passed the previous check, the user is reading anonymously
 		if (!fromUser) {
-			return loadMessageHistory({ rid, end, limit, ls, showThreadMessages });
+			return loadMessageHistory({ rid, end, limit, ls, showThreadMessages, room });
 		}
 
 		const canPreview = await hasPermissionAsync(fromUser._id, 'preview-c-room');
@@ -60,6 +60,6 @@ Meteor.methods<ServerMethods>({
 			return false;
 		}
 
-		return loadMessageHistory({ userId: fromUser._id, rid, end, limit, ls, showThreadMessages });
+		return loadMessageHistory({ userId: fromUser._id, rid, end, limit, ls, showThreadMessages, room });
 	},
 });


### PR DESCRIPTION
## Summary

Reduces the time it takes to open a room. The perceived open time was higher than the single `loadHistory` network call (~300ms) because of redundant work on both the client render path and the server method. This PR removes that redundant work; no behavior change for the user beyond faster rooms.

## Client — `RoomHistoryManager`

- **First batch no longer blocks on the DOM.** `upsertMessageBulk` previously waited on `waitForElement('.messages-box .wrapper …')` before storing messages, so the prefetched first history batch couldn't render until `RoomBody` mounted. The scroll-anchor snapshot is now taken synchronously and only when the wrapper already exists (the pagination case). On initial open there is nothing to anchor, so messages render as soon as `loadHistory` returns.
- **No more spurious second history page.** The pager recursed whenever `room.loaded < limit` (50 *visible* messages). Because thread replies are excluded from the visible count, any thread reply in the latest 50 messages dropped the count below the limit and forced a second ~400ms `loadHistory` round trip on almost every room open. It now keeps paging only when a batch adds **zero** visible rows (blank screen); scroll-driven `getMore` fetches more on demand.

## Server — `loadHistory` / `loadMessageHistory`

- **Single room fetch.** `loadHistory` already loads the room for access checks; it now includes `sysMes` in that projection and passes the room into `loadMessageHistory`, which skips its duplicate `Rooms.findOneById`.
- **Concurrent post-query work.** Message normalization (a Users lookup) and the unread computation (first-unread find + count) ran sequentially. They now run via `Promise.all`, and the find + count inside the unread path also run concurrently. The unread math keys off the raw `records` so it no longer waits on normalization.

## Net effect

- Client: warm-cache open issues one `loadHistory` (~300ms) instead of two (~700ms) for thread-bearing rooms, and that batch renders without waiting on the message-list DOM.
- Server: hot path goes from `room → room(dup) → msgQuery → normalize → count → find` to `room → msgQuery → (normalize ‖ count ‖ find)`.

## Not included (follow-up)

When `showThreadsInMainChannel` is off (the common case), the query adds `$or: [{ tmid: { $exists: false } }, { tshow: true }]`, which can defeat the `{ rid: 1, ts: 1, _updatedAt: 1 }` index. A partial index or filter restructure is a candidate next step, pending an `explain` profile.

## Testing

- Open a thread-heavy room: confirm a single `loadHistory` in the Network tab, messages reach the bottom, scroll-up still paginates.
- Open a room with unreads (`ls` set): confirm unread divider + count still correct.
- Anonymous read and livechat history paths still function.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/40954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster room opening by reducing redundant message-history work on both client and server.
  * Improved initial responsiveness by avoiding scroll synchronization delays during “get more”.
  * More efficient history processing by reusing already-fetched room data and running normalization and unread calculations together.
* **Bug Fixes**
  * Refined “load more” pagination to continue only when more history is available, based on visible messages (excluding command messages), leading to more reliable infinite scrolling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2176]

[ARCH-2176]: https://rocketchat.atlassian.net/browse/ARCH-2176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ