### PR TITLE
fix: thread panel not scrolling to bottom after sending a reply

### DIFF
--- a/.changeset/old-cities-enjoy.md
+++ b/.changeset/old-cities-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+fixes issue that caused threads to sometimes not scroll when sending messages

--- a/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.tsx
@@ -75,6 +75,7 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 
 	const virtualizerRef = useRef<VirtualizerHandle | null>(null);
 	const isAtBottom = useRef<boolean | null>(null);
+	const prevItemsLengthRef = useRef(0);
 
 	const { keepAtBottomRef, setKeepAtBottom } = useKeepAtBottom(isAtBottom);
 	const messagesLength = messages.length;
@@ -109,6 +110,7 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 
 	useEffect(() => {
 		lastThreadJumpKeyRef.current = undefined;
+		prevItemsLengthRef.current = 0;
 	}, [mainMessage._id]);
 
 	useEffect(() => {
@@ -120,15 +122,31 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 			setShouldJumpToBottom(false);
 			return;
 		}
+
+		// Scroll to bottom when current user's optimistic (temp) message is appended.
+		// Fires before server confirmation, giving immediate scroll feedback.
+		const prev = prevItemsLengthRef.current;
+		prevItemsLengthRef.current = items.length;
+		if (items.length > prev && uid) {
+			const lastItem = items.at(-1);
+			if (lastItem?.temp && lastItem.u._id === uid) {
+				setShouldJumpToBottom(true);
+			}
+		}
+
 		if (isAtBottom.current === true && lastScrollSizeRef.current !== handle?.scrollSize) {
 			lastScrollSizeRef.current = handle?.scrollSize ?? 0;
 			setShouldJumpToBottom(true);
 		}
 		if (shouldJumpToBottom) {
+			// Optimistically mark as at-bottom before the scroll executes (rAF).
+			// This ensures the ResizeObserver in useKeepAtBottom re-scrolls if
+			// quote/attachment content grows between now and when Virtua fires the scroll.
+			isAtBottom.current = true;
 			handle.scrollToIndex(items.length, { align: 'end' });
 			setShouldJumpToBottom(false);
 		}
-	}, [loading, items.length, msgJumpParam, threadMsgTargetIndex, shouldJumpToBottom, setShouldJumpToBottom]);
+	}, [items, loading, msgJumpParam, threadMsgTargetIndex, shouldJumpToBottom, setShouldJumpToBottom, uid]);
 
 	useEffect(() => {
 		if (threadMsgTargetIndex < 0 || !msgJumpParam) {


### PR DESCRIPTION
## Proposed changes

Tries to fix the intermittent issue of sometimes threads not scrolling when the user is sending them. Adjusted the scroll to work with the existing optimistic message sent system (grey messages that appear before the server returns if the message was sent or not)

**Two root causes fixed:**

### 1. Optimistic scroll trigger

Previously the scroll was only triggered via `streamNewMessage`, which fires after the server confirms the message (network round-trip). Added detection of the current user's optimistic (`temp`) message being appended to `items` — triggers `setShouldJumpToBottom(true)` immediately, before server confirmation.

### 2. Race condition with quote/attachment content growth

`scrollToIndex` is queued in Virtua and executes on the next animation frame (rAF). If the message contains a quoted message or attachment, the content can grow between the queue time and execution:

- ResizeObserver fires **during browser layout phase** (before rAF)
- At that point `isAtBottom.current` is still `false` (scroll hasn't executed yet)
- `useKeepAtBottom` ignores the resize → content grows → scroll lands at wrong position

Fix: optimistically set `isAtBottom.current = true` before calling `scrollToIndex`. The ResizeObserver now sees `isAtBottom = true`, queues a corrective `scrollToIndex`, and since ResizeObserver fires before rAF, the corrective scroll overwrites the original — Virtua lands at the actual bottom.

## Issue(s)

[CORE-2289](https://rocketchat.atlassian.net/browse/CORE-2289)

## Steps to test or reproduce

1. Open a channel with an existing thread that has several messages
2. Open the thread panel
3. Scroll up within the thread so the latest messages are not visible
4. Type and send a reply (optionally quote a message)
5. **Before:** (intermittent) thread stays at current scroll position
6. **After:** thread panel scrolls to bottom showing the sent reply


[CORE-2289]: https://rocketchat.atlassian.net/browse/CORE-2289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where threads did not automatically scroll to the bottom when sending messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->