### PR TITLE
fix: show faster spotlight results using cached subscriptions

### DIFF
--- a/apps/meteor/client/components/ResultsLiveRegion.tsx
+++ b/apps/meteor/client/components/ResultsLiveRegion.tsx
@@ -1,14 +1,28 @@
 import { VisuallyHidden } from '@react-aria/visually-hidden';
 import { useTranslation } from 'react-i18next';
 
-const ResultsLiveRegion = ({ shouldAnnounce, itemCount }: { shouldAnnounce: boolean; itemCount: number }) => {
+const ResultsLiveRegion = ({
+	shouldAnnounce,
+	itemCount,
+	isLoading = false,
+}: {
+	shouldAnnounce: boolean;
+	itemCount: number;
+	isLoading?: boolean;
+}) => {
 	const { t } = useTranslation();
 
-	if (itemCount === 0) {
-		return <VisuallyHidden role='status'>{shouldAnnounce && t('No_results_found')}</VisuallyHidden>;
-	}
+	const message = (() => {
+		if (isLoading) {
+			return t('Loading');
+		}
+		if (!shouldAnnounce) {
+			return '';
+		}
+		return itemCount === 0 ? t('No_results_found') : t('__count__result_found', { count: itemCount });
+	})();
 
-	return <VisuallyHidden role='status'>{shouldAnnounce && t('__count__result_found', { count: itemCount })}</VisuallyHidden>;
+	return <VisuallyHidden role='status'>{message}</VisuallyHidden>;
 };
 
 export default ResultsLiveRegion;

--- a/apps/meteor/client/navbar/NavBarSearch/NavBarSearchItemSkeleton.tsx
+++ b/apps/meteor/client/navbar/NavBarSearch/NavBarSearchItemSkeleton.tsx
@@ -1,0 +1,20 @@
+import { SidebarV2Item, SidebarV2ItemAvatarWrapper, SidebarV2ItemTitle, Skeleton } from '@rocket.chat/fuselage';
+
+// Placeholder row shown while the server spotlight results are still loading.
+// Decorative only: it has no `role='option'` so keyboard navigation skips it
+// (see useSearchNavigation), and `tabIndex={-1}` + `pointerEvents='none'` keep
+// it out of reach of focus and mouse clicks. Loading is conveyed via aria-busy.
+const NavBarSearchItemSkeleton = () => {
+	return (
+		<SidebarV2Item aria-hidden tabIndex={-1} style={{ pointerEvents: 'none' }}>
+			<SidebarV2ItemAvatarWrapper>
+				<Skeleton variant='rect' width={20} height={20} />
+			</SidebarV2ItemAvatarWrapper>
+			<SidebarV2ItemTitle>
+				<Skeleton />
+			</SidebarV2ItemTitle>
+		</SidebarV2Item>
+	);
+};
+
+export default NavBarSearchItemSkeleton;

--- a/apps/meteor/client/navbar/NavBarSearch/NavBarSearchListbox.tsx
+++ b/apps/meteor/client/navbar/NavBarSearch/NavBarSearchListbox.tsx
@@ -1,5 +1,4 @@
 import type { OverlayTriggerAria } from '@react-aria/overlays';
-import { VisuallyHidden } from '@react-aria/visually-hidden';
 import type { OverlayTriggerState } from '@react-stately/overlays';
 import { Box, Tile } from '@rocket.chat/fuselage';
 import { useStableCallback, useOutsideClick } from '@rocket.chat/fuselage-hooks';
@@ -51,8 +50,7 @@ const NavBarSearchListBox = ({ state, overlayProps }: NavBarSearchListBoxProps) 
 			width='100%'
 			flexDirection='column'
 		>
-			<ResultsLiveRegion shouldAnnounce={!isLoading} itemCount={items.length} />
-			<VisuallyHidden role='status'>{isLoading ? t('Loading') : ''}</VisuallyHidden>
+			<ResultsLiveRegion shouldAnnounce={!isLoading} itemCount={items.length} isLoading={isLoading} />
 			<CustomScrollbars>
 				<div {...overlayProps} role='listbox' aria-label={t('Channels')} aria-busy={isLoading} tabIndex={-1} onKeyDown={handleKeyDown}>
 					{items.length === 0 && !isLoading && <NavBarSearchNoResults />}

--- a/apps/meteor/client/navbar/NavBarSearch/NavBarSearchListbox.tsx
+++ b/apps/meteor/client/navbar/NavBarSearch/NavBarSearchListbox.tsx
@@ -1,7 +1,8 @@
 import type { OverlayTriggerAria } from '@react-aria/overlays';
+import { VisuallyHidden } from '@react-aria/visually-hidden';
 import type { OverlayTriggerState } from '@react-stately/overlays';
-import { Box, Tile } from '@rocket.chat/fuselage';
-import { useDebouncedValue, useStableCallback, useOutsideClick } from '@rocket.chat/fuselage-hooks';
+import { Box, Throbber, Tile } from '@rocket.chat/fuselage';
+import { useStableCallback, useOutsideClick } from '@rocket.chat/fuselage-hooks';
 import { CustomScrollbars } from '@rocket.chat/ui-client';
 import { useRef } from 'react';
 import { useFormContext } from 'react-hook-form';
@@ -28,14 +29,12 @@ const NavBarSearchListBox = ({ state, overlayProps }: NavBarSearchListBoxProps) 
 	const { resetField, watch } = useFormContext();
 	const { filterText } = watch();
 
-	const debouncedFilter = useDebouncedValue(filterText, 500);
-
 	const handleSelect = useStableCallback(() => {
 		state.close();
 		resetField('filterText');
 	});
 
-	const { data: items = [], isLoading } = useSearchItems(debouncedFilter);
+	const { items, isLoading } = useSearchItems(filterText);
 
 	return (
 		<Tile
@@ -52,6 +51,7 @@ const NavBarSearchListBox = ({ state, overlayProps }: NavBarSearchListBoxProps) 
 			flexDirection='column'
 		>
 			<ResultsLiveRegion shouldAnnounce={!isLoading} itemCount={items.length} />
+			<VisuallyHidden role='status'>{isLoading ? t('Loading') : ''}</VisuallyHidden>
 			<CustomScrollbars>
 				<div {...overlayProps} role='listbox' aria-label={t('Channels')} aria-busy={isLoading} tabIndex={-1} onKeyDown={handleKeyDown}>
 					{items.length === 0 && !isLoading && <NavBarSearchNoResults />}
@@ -63,6 +63,11 @@ const NavBarSearchListBox = ({ state, overlayProps }: NavBarSearchListBoxProps) 
 					{items.map((item) => (
 						<NavBarSearchRow key={item._id} room={item} onClick={handleSelect} />
 					))}
+					{isLoading && (
+						<Box pi={12} pbs={8} display='flex' justifyContent='center' role='presentation' aria-hidden>
+							<Throbber />
+						</Box>
+					)}
 				</div>
 			</CustomScrollbars>
 		</Tile>

--- a/apps/meteor/client/navbar/NavBarSearch/NavBarSearchListbox.tsx
+++ b/apps/meteor/client/navbar/NavBarSearch/NavBarSearchListbox.tsx
@@ -1,13 +1,14 @@
 import type { OverlayTriggerAria } from '@react-aria/overlays';
 import { VisuallyHidden } from '@react-aria/visually-hidden';
 import type { OverlayTriggerState } from '@react-stately/overlays';
-import { Box, Throbber, Tile } from '@rocket.chat/fuselage';
+import { Box, Tile } from '@rocket.chat/fuselage';
 import { useStableCallback, useOutsideClick } from '@rocket.chat/fuselage-hooks';
 import { CustomScrollbars } from '@rocket.chat/ui-client';
 import { useRef } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import NavBarSearchItemSkeleton from './NavBarSearchItemSkeleton';
 import NavBarSearchNoResults from './NavBarSearchNoResults';
 import NavBarSearchRow from './NavBarSearchRow';
 import { useSearchItems } from './hooks/useSearchItems';
@@ -63,11 +64,7 @@ const NavBarSearchListBox = ({ state, overlayProps }: NavBarSearchListBoxProps) 
 					{items.map((item) => (
 						<NavBarSearchRow key={item._id} room={item} onClick={handleSelect} />
 					))}
-					{isLoading && (
-						<Box pi={12} pbs={8} display='flex' justifyContent='center' role='presentation' aria-hidden>
-							<Throbber />
-						</Box>
-					)}
+					{isLoading && Array.from({ length: 4 }, (_, index) => <NavBarSearchItemSkeleton key={`skeleton-${index}`} />)}
 				</div>
 			</CustomScrollbars>
 		</Tile>

--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
@@ -72,15 +72,6 @@ export const useSearchItems = (filterText: string): { items: SubscriptionWithRoo
 			const filterUsersUnique = ({ _id }: { _id: string }, index: number, arr: { _id: string }[]): boolean =>
 				index === arr.findIndex((user) => _id === user._id);
 
-			const roomFilter = (room: { t: string; uids?: string[]; _id: string; name?: string }): boolean =>
-				!localRooms.find(
-					(item) =>
-						(room.t === 'd' && room.uids && room.uids.length > 1 && room.uids?.includes(item._id)) ||
-						[item.rid, item._id].includes(room._id),
-				);
-			const usersFilter = (user: { _id: string }): boolean =>
-				!localRooms.find((room) => room.t === 'd' && room.uids && room.uids?.length === 2 && room.uids.includes(user._id));
-
 			const userMap = (user: {
 				_id: string;
 				name: string;
@@ -110,9 +101,11 @@ export const useSearchItems = (filterText: string): { items: SubscriptionWithRoo
 				uids?: string[] | undefined;
 			}[];
 
+			// Local subscriptions are deduped reactively in the merge below (against the *current*
+			// localRooms), so server results aren't filtered against them here.
 			const resultsFromServer: resultsFromServerType = [];
-			resultsFromServer.push(...spotlight.users.filter(filterUsersUnique).filter(usersFilter).map(userMap));
-			resultsFromServer.push(...spotlight.rooms.filter(roomFilter));
+			resultsFromServer.push(...spotlight.users.filter(filterUsersUnique).map(userMap));
+			resultsFromServer.push(...spotlight.rooms);
 
 			return resultsFromServer;
 		},
@@ -132,7 +125,19 @@ export const useSearchItems = (filterText: string): { items: SubscriptionWithRoo
 		const matchesFilter = ({ name, fname }: { name?: string; fname?: string }) =>
 			(name && filterRegex.test(name)) || (fname && filterRegex.test(fname));
 
-		const fromServer = (serverResults ?? []).filter(matchesFilter);
+		// Single source of truth for local/server dedup: drop any server result already present as a
+		// local subscription, checked against the *current* localRooms. The query isn't keyed on
+		// localRooms (to avoid refetching on every subscription change), so subscriptions that load
+		// in after the fetch would otherwise render twice — once from localRooms, once from server.
+		const isLocalDuplicate = (item: { _id: string; t?: string; uids?: string[] }): boolean =>
+			localRooms.some((room) => {
+				const sameRoom = [room.rid, room._id].includes(item._id);
+				const sameGroupDM = item.t === 'd' && !!item.uids && item.uids.length > 1 && item.uids.includes(room._id);
+				const sameDirectDM = item.t === 'd' && room.t === 'd' && !!room.uids && room.uids.length === 2 && room.uids.includes(item._id);
+				return sameRoom || sameGroupDM || sameDirectDM;
+			});
+
+		const fromServer = (serverResults ?? []).filter((item) => matchesFilter(item) && !isLocalDuplicate(item));
 		const exact = fromServer.filter((item) => [item.name, item.fname].includes(name));
 		return Array.from(new Set([...exact, ...localRooms, ...fromServer])) as SubscriptionWithRoom[];
 	}, [serverResults, localRooms, name]);

--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
@@ -55,7 +55,11 @@ export const useSearchItems = (filterText: string): { items: SubscriptionWithRoo
 
 	const getSpotlight = useEndpoint('GET', '/v1/spotlight');
 
-	const { data: serverResults, isFetching } = useQuery({
+	const {
+		data: serverResults,
+		isFetching,
+		isPlaceholderData,
+	} = useQuery({
 		// Keyed on the debounced term only, so typing doesn't refetch on every keystroke.
 		queryKey: ['sidebar/search/spotlight', debouncedName, mention, type],
 
@@ -137,10 +141,18 @@ export const useSearchItems = (filterText: string): { items: SubscriptionWithRoo
 				return sameRoom || sameGroupDM || sameDirectDM;
 			});
 
-		const fromServer = (serverResults ?? []).filter((item) => matchesFilter(item) && !isLocalDuplicate(item));
+		// When local subscriptions already fill the limit the server query is disabled, but React Query
+		// keeps the last results around — ignore them so a full local list isn't padded with stale rows.
+		const candidates = localRooms.length < LIMIT ? (serverResults ?? []) : [];
+		const fromServer = candidates.filter((item) => matchesFilter(item) && !isLocalDuplicate(item));
 		const exact = fromServer.filter((item) => [item.name, item.fname].includes(name));
 		return Array.from(new Set([...exact, ...localRooms, ...fromServer])) as SubscriptionWithRoom[];
 	}, [serverResults, localRooms, name]);
 
-	return { items, isLoading: isFetching };
+	// `isFetching` is also true for silent background revalidations (after staleTime) of results we
+	// already show — only surface loading while there's no usable data for the current term yet, i.e.
+	// the very first fetch (serverResults undefined) or a new term still showing placeholder data.
+	const isLoading = isFetching && (isPlaceholderData || serverResults === undefined);
+
+	return { items, isLoading };
 };

--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
@@ -1,7 +1,8 @@
+import { useDebouncedValue } from '@rocket.chat/fuselage-hooks';
 import { escapeRegExp } from '@rocket.chat/string-helpers';
 import type { SubscriptionWithRoom } from '@rocket.chat/ui-contexts';
 import { useEndpoint, useUserSubscriptions } from '@rocket.chat/ui-contexts';
-import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
 import { getConfig } from '../../../lib/utils/getConfig';
@@ -16,9 +17,9 @@ const options = {
 	limit: LIMIT,
 } as const;
 
-// FIXME: the return type is UTTERLY wrong, but I'm not sure what it should be
-export const useSearchItems = (filterText: string): UseQueryResult<SubscriptionWithRoom[] | undefined, Error> => {
+export const useSearchItems = (filterText: string): { items: SubscriptionWithRoom[]; isLoading: boolean } => {
 	const [, mention, name] = useMemo(() => filterText.match(/(@|#)?(.*)/i) || [], [filterText]);
+
 	const query = useMemo(() => {
 		const filterRegex = new RegExp(escapeRegExp(name), 'i');
 
@@ -30,7 +31,12 @@ export const useSearchItems = (filterText: string): UseQueryResult<SubscriptionW
 		};
 	}, [name, mention]);
 
+	// Local cached subscriptions are matched against the *immediate* filter text so joined
+	// rooms show up instantly, without waiting for the debounce or the server response.
 	const localRooms = useUserSubscriptions(query, options);
+
+	// Only the server spotlight call is debounced — the local results above stay instant.
+	const debouncedName = useDebouncedValue(name, 500);
 
 	const usernamesFromClient = [...localRooms?.map(({ t, name }) => (t === 'd' ? name : null))].filter(Boolean) as string[];
 
@@ -49,16 +55,16 @@ export const useSearchItems = (filterText: string): UseQueryResult<SubscriptionW
 
 	const getSpotlight = useEndpoint('GET', '/v1/spotlight');
 
-	return useQuery({
-		queryKey: ['sidebar/search/spotlight', name, usernamesFromClient, type, localRooms.map(({ _id, name }) => _id + name)],
+	const { data: serverResults, isFetching } = useQuery({
+		// Keyed on the debounced term only, so typing doesn't refetch on every keystroke.
+		queryKey: ['sidebar/search/spotlight', debouncedName, mention, type],
+
+		// When local subscriptions already fill the limit there's nothing more to fetch.
+		enabled: localRooms.length < LIMIT,
 
 		queryFn: async () => {
-			if (localRooms.length === LIMIT) {
-				return localRooms;
-			}
-
 			const spotlight = await getSpotlight({
-				query: name,
+				query: debouncedName,
 				usernames: usernamesFromClient.join(','),
 				type: JSON.stringify(type),
 			});
@@ -108,11 +114,21 @@ export const useSearchItems = (filterText: string): UseQueryResult<SubscriptionW
 			resultsFromServer.push(...spotlight.users.filter(filterUsersUnique).filter(usersFilter).map(userMap));
 			resultsFromServer.push(...spotlight.rooms.filter(roomFilter));
 
-			const exact = resultsFromServer?.filter((item) => [item.name, item.fname].includes(name));
-			return Array.from(new Set([...exact, ...localRooms, ...resultsFromServer]));
+			return resultsFromServer;
 		},
 
 		staleTime: 60_000,
-		placeholderData: (previousData) => previousData ?? localRooms,
+		// Keep the previous server results visible while a new search is in flight.
+		placeholderData: (previousData) => previousData,
 	});
+
+	// Merge reactively (outside the query) so local results render the instant the user types
+	// and server results fold in — deduped — once they arrive.
+	const items = useMemo(() => {
+		const fromServer = serverResults ?? [];
+		const exact = fromServer.filter((item) => [item.name, item.fname].includes(name));
+		return Array.from(new Set([...exact, ...localRooms, ...fromServer])) as SubscriptionWithRoom[];
+	}, [serverResults, localRooms, name]);
+
+	return { items, isLoading: isFetching };
 };

--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
@@ -125,7 +125,14 @@ export const useSearchItems = (filterText: string): { items: SubscriptionWithRoo
 	// Merge reactively (outside the query) so local results render the instant the user types
 	// and server results fold in — deduped — once they arrive.
 	const items = useMemo(() => {
-		const fromServer = serverResults ?? [];
+		// Server results are keyed on the *debounced* term, so while the user is still typing
+		// (or via placeholderData) they may belong to a previous search. Drop the ones that no
+		// longer match the current text so stale, non-matching results aren't rendered.
+		const filterRegex = new RegExp(escapeRegExp(name), 'i');
+		const matchesFilter = ({ name, fname }: { name?: string; fname?: string }) =>
+			(name && filterRegex.test(name)) || (fname && filterRegex.test(fname));
+
+		const fromServer = (serverResults ?? []).filter(matchesFilter);
 		const exact = fromServer.filter((item) => [item.name, item.fname].includes(name));
 		return Array.from(new Set([...exact, ...localRooms, ...fromServer])) as SubscriptionWithRoom[];
 	}, [serverResults, localRooms, name]);


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The navbar search ("spotlight") used to show **instant results from the client-side subscription cache** (the user's joined rooms) while the server `spotlight` request resolved in the background. That fast-feedback behavior had been lost, and there was no visible "still loading" affordance.

Two problems defeated the original UX:

1. **Local results were not instant.** `NavBarSearchListbox` debounced the filter text by 500ms and passed the *debounced* value into `useSearchItems`. Because the local subscription query (`useUserSubscriptions`) lived inside that hook, the cached results were delayed by the full 500ms too.
2. **No visible loading UI.** The listbox only set `aria-busy`; nothing told a sighted user that more results were still arriving.


Video showing the results (bare in mind there is a 5s delay for backend response)


https://github.com/user-attachments/assets/1053c452-709b-436c-91b0-f715bf33cd75





### What changed

- **`useSearchItems`** — the local `useUserSubscriptions` query now runs against the **immediate** filter text, so joined rooms appear instantly. Only the `/v1/spotlight` request is debounced (500ms, keyed on the debounced term). Local + server results are merged **reactively** (in a `useMemo`, outside the query) so cached rooms render the moment the user types and server results fold in — deduped — once they arrive. The hook now returns an explicit `{ items, isLoading }` shape (resolving the previous "return type is UTTERLY wrong" FIXME).
- **`NavBarSearchListbox`** — passes the raw filter text (the hook now owns debouncing) and renders a few **skeleton rows** (`NavBarSearchItemSkeleton`) at the bottom of the list while the server request is in flight, so cached results stay visible above them and the loading state mimics the real result rows.

### Accessibility & i18n

- The skeleton rows are decorative: `aria-hidden`, no `role="option"` (so arrow-key navigation skips them), and `tabIndex={-1}` + `pointer-events: none` (not focusable, not clickable).
- Loading is conveyed non-visually via `aria-busy` on the listbox plus a `role="status"` live region announcing the existing **`Loading`** translation key — no new user-facing strings were added.

## Issue(s)

<!-- link issue if applicable -->

## Steps to test or reproduce

1. Sign in to an account that has joined several channels.
2. Open the navbar search (`Cmd/Ctrl+K`) and type part of a joined channel's name.
4. **Expected:** matching cached subscriptions appear immediately (well under 500ms), with skeleton rows at the bottom of the list.
5. After the server responds, public channels you're not in fold in (deduped against the cached ones) and the skeletons disappear.
6. Type a term that matches nothing locally or remotely → skeletons show during the fetch, then "Try entering a different search term".
7. `#` prefix → channels only; `@` prefix → users/DMs only (existing behavior preserved).



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/40965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated skeleton placeholders and a live “Loading” announcement during navbar search.
* **Bug Fixes**
  * Improved search behavior to avoid stale matches while typing by reconciling local filtering with server results.
  * Enhanced deduping and prioritization of exact matches in the merged results.
  * Adjusted server fetching/loading state handling so results don’t flicker while requests are in flight.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2181]

[ARCH-2181]: https://rocketchat.atlassian.net/browse/ARCH-2181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ