### PR TITLE
fix: enforce Accounts_AllowPasswordChange in forgot password flow

### DIFF
--- a/.changeset/fix-password-change-bypass.md
+++ b/.changeset/fix-password-change-bypass.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+fix: enforce Accounts_AllowPasswordChange setting in forgot password flow

--- a/apps/meteor/server/methods/sendForgotPasswordEmail.spec.ts
+++ b/apps/meteor/server/methods/sendForgotPasswordEmail.spec.ts
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+const stubbedSettings = { get: sinon.stub() };
+const stubbedUsers = { findOneByEmailAddress: sinon.stub() };
+const stubbedAccounts = { sendResetPasswordEmail: sinon.stub() };
+
+const { sendForgotPasswordEmail } = proxyquire.noCallThru().load('./sendForgotPasswordEmail', {
+  '../../app/settings/server': { settings: stubbedSettings },
+  '@rocket.chat/models': { Users: stubbedUsers },
+  'meteor/accounts-base': { Accounts: stubbedAccounts },
+  'meteor/check': { check: sinon.stub() },
+  'meteor/meteor': { Meteor: { methods: sinon.stub() } },
+  '../lib/logger/system': { SystemLogger: { error: sinon.stub() } },
+});
+
+describe('sendForgotPasswordEmail()', () => {
+  beforeEach(() => {
+    stubbedSettings.get.reset();
+    stubbedUsers.findOneByEmailAddress.reset();
+    stubbedAccounts.sendResetPasswordEmail.reset();
+  });
+
+  it('returns true when user is not found', async () => {
+    stubbedUsers.findOneByEmailAddress.resolves(undefined);
+    const result = await sendForgotPasswordEmail('notfound@example.com');
+    expect(result).to.be.true;
+    expect(stubbedAccounts.sendResetPasswordEmail.called).to.be.false;
+  });
+
+  it('returns false when Accounts_AllowPasswordChange is false', async () => {
+    stubbedUsers.findOneByEmailAddress.resolves({ _id: 'userId', services: { password: { bcrypt: 'hash' } } });
+    stubbedSettings.get.withArgs('Accounts_AllowPasswordChange').returns(false);
+    const result = await sendForgotPasswordEmail('user@example.com');
+    expect(result).to.be.false;
+    expect(stubbedAccounts.sendResetPasswordEmail.called).to.be.false;
+  });
+
+  it('returns false when user is OAuth-only and Accounts_AllowPasswordChangeForOAuthUsers is false', async () => {
+    stubbedUsers.findOneByEmailAddress.resolves({ _id: 'userId', services: { github: {} } });
+    stubbedSettings.get.withArgs('Accounts_AllowPasswordChange').returns(true);
+    stubbedSettings.get.withArgs('Accounts_AllowPasswordChangeForOAuthUsers').returns(false);
+    const result = await sendForgotPasswordEmail('oauthuser@example.com');
+    expect(result).to.be.false;
+    expect(stubbedAccounts.sendResetPasswordEmail.called).to.be.false;
+  });
+
+  it('sends email and returns true when password change is allowed', async () => {
+    stubbedUsers.findOneByEmailAddress.resolves({ _id: 'userId', services: { password: { bcrypt: 'hash' } } });
+    stubbedSettings.get.withArgs('Accounts_AllowPasswordChange').returns(true);
+    stubbedAccounts.sendResetPasswordEmail.returns(undefined);
+    const result = await sendForgotPasswordEmail('user@example.com');
+    expect(result).to.be.true;
+    expect(stubbedAccounts.sendResetPasswordEmail.calledOnce).to.be.true;
+    expect(stubbedAccounts.sendResetPasswordEmail.calledWith('userId', 'user@example.com')).to.be.true;
+  });
+});

--- a/apps/meteor/server/methods/sendForgotPasswordEmail.ts
+++ b/apps/meteor/server/methods/sendForgotPasswordEmail.ts
@@ -23,6 +23,10 @@ export const sendForgotPasswordEmail = async (to: string): Promise<boolean | und
 		return true;
 	}
 
+	if (!settings.get('Accounts_AllowPasswordChange')) {
+		return false;
+	}
+
 	if (user.services && !user.services.password) {
 		if (!settings.get('Accounts_AllowPasswordChangeForOAuthUsers')) {
 			return false;


### PR DESCRIPTION
## Description

Fixes #9434

When an admin sets **Administration → Accounts → Allow Password Change** to `false`, users were still able to receive a password reset email via the "Forgot Password" flow and effectively change their password, bypassing the restriction.

## Root Cause

`sendForgotPasswordEmail.ts` only guarded against OAuth users (`Accounts_AllowPasswordChangeForOAuthUsers`) but never checked `Accounts_AllowPasswordChange` for regular password-based users.

## Fix

Added an early return in `sendForgotPasswordEmail` when `Accounts_AllowPasswordChange` is `false`, preventing the reset email from being dispatched regardless of the user's authentication method.

## Tests

Added unit tests for `sendForgotPasswordEmail` covering:
- User not found → returns `true` (no email leak)
- `Accounts_AllowPasswordChange = false` → returns `false`, no email sent
- OAuth user + `Accounts_AllowPasswordChangeForOAuthUsers = false` → returns `false`, no email sent
- Normal user with password change allowed → sends email, returns `true`

## Checklist

- [x] PR targets `develop` branch
- [x] Unit tests added
- [x] Changeset added (`patch`)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/40969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the forgot password flow to properly enforce the password change permission setting. Users cannot initiate password reset requests when password changes are disabled by administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->