### PR TITLE
fix: Move side effect out of useMemo in RoomsTable

### DIFF
--- a/apps/meteor/client/views/admin/rooms/RoomsTable.tsx
+++ b/apps/meteor/client/views/admin/rooms/RoomsTable.tsx
@@ -32,23 +32,17 @@ const RoomsTable = ({ reload }: { reload: MutableRefObject<() => void> }) => {
 	const mediaQuery = useMediaQuery('(min-width: 1024px)');
 
 	const [roomFilters, setRoomFilters] = useState<RoomFilters>({ searchText: '', types: [] });
-
-	const prevRoomFilterText = useRef<string>(roomFilters.searchText);
-
+    
 	const { sortBy, sortDirection, setSort } = useSort<'name' | 't' | 'usersCount' | 'msgs' | 'default' | 'featured' | 'ts'>('name');
 	const { current, itemsPerPage, setItemsPerPage, setCurrent, ...paginationProps } = usePagination();
 	const searchText = useDebouncedValue(roomFilters.searchText, 500);
 
 	const query = useDebouncedValue(
-		useMemo(() => {
-			if (searchText !== prevRoomFilterText.current) {
-				setCurrent(0);
-			}
-			return {
+		useMemo(() => ({
 				filter: searchText || '',
 				sort: `{ "${sortBy}": ${sortDirection === 'asc' ? 1 : -1} }`,
 				count: itemsPerPage,
-				offset: searchText === prevRoomFilterText.current ? current : 0,
+				offset: current,
 				types: (roomFilters.types.length ? [...roomFilters.types.map((roomType) => roomType.id)] : DEFAULT_TYPES) as unknown as (
 					| 'c'
 					| 'd'
@@ -57,8 +51,7 @@ const RoomsTable = ({ reload }: { reload: MutableRefObject<() => void> }) => {
 					| 'discussions'
 					| 'teams'
 				)[],
-			};
-		}, [searchText, sortBy, sortDirection, itemsPerPage, current, roomFilters.types, setCurrent]),
+		}), [searchText, sortBy, sortDirection, itemsPerPage, current, roomFilters.types]),
 		500,
 	);
 
@@ -74,8 +67,8 @@ const RoomsTable = ({ reload }: { reload: MutableRefObject<() => void> }) => {
 	}, [reload, refetch]);
 
 	useEffect(() => {
-		prevRoomFilterText.current = searchText;
-	}, [searchText]);
+        setCurrent(0);
+	}, [searchText, setCurrent]);
 
 	const headers = (
 		<>


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
In `apps/meteor/client/views/admin/rooms/RoomsTable.tsx`, a state setter (`setCurrent(0)`) was being called inside the `useMemo` callback to reset pagination when the search text changed. Calling state setters inside `useMemo` is a side effect during render, which violates React's rendering contract because memos must be pure computations.

This PR moves the pagination reset side effect into a clean `useEffect` watching `searchText`, and simplifies the `useMemo` block to be a pure computation with no side effects.

## Issue(s)
Closes #40589

## Steps to test or reproduce
1. Go to Administration -> Rooms.
2. Type in the search box to filter rooms.
3. Observe that the pagination resets correctly to the first page without triggering React warnings or rendering contract violations in strict mode.

## Further comments
The fix perfectly aligns with standard React patterns for synchronization and respects the pure rendering contract.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/40985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination behavior in the rooms table. The table now correctly resets to the first page when searching, ensuring consistent navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->