### PR TITLE
fix: Auto-translate not enabled for users who join rooms before setting a language preference

### DIFF
--- a/.changeset/cute-humans-follow.md
+++ b/.changeset/cute-humans-follow.md
@@ -1,0 +1,7 @@
+---
+'@rocket.chat/model-typings': patch
+'@rocket.chat/models': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes auto-translate not activating for users who set their language preference after joining rooms

--- a/apps/meteor/server/methods/saveUserPreferences.ts
+++ b/apps/meteor/server/methods/saveUserPreferences.ts
@@ -224,6 +224,14 @@ export const saveUserPreferences = async (settings: Partial<UserPreferences>, us
 			if (response.modifiedCount) {
 				void notifyOnSubscriptionChangedByAutoTranslateAndUserId(user._id);
 			}
+
+			const workspaceLanguage = rcSettings.get('Language');
+			if (language !== 'default' && language !== workspaceLanguage) {
+				const enableResponse = await Subscriptions.enableAutoTranslateByUserId(user._id, language);
+				if (enableResponse.modifiedCount) {
+					void notifyOnSubscriptionChangedByAutoTranslateAndUserId(user._id);
+				}
+			}
 		}
 	});
 };

--- a/apps/meteor/server/methods/saveUserPreferences.ts
+++ b/apps/meteor/server/methods/saveUserPreferences.ts
@@ -220,17 +220,12 @@ export const saveUserPreferences = async (settings: Partial<UserPreferences>, us
 		}
 
 		if (language && oldLanguage !== language && rcSettings.get('AutoTranslate_AutoEnableOnJoinRoom')) {
-			const response = await Subscriptions.updateAllAutoTranslateLanguagesByUserId(user._id, language);
+			const workspaceLanguage = rcSettings.get('Language');
+			const targetLanguage = language === 'default' || language === workspaceLanguage ? null : language;
+
+			const response = await Subscriptions.setAutoTranslateByUserId(user._id, targetLanguage);
 			if (response.modifiedCount) {
 				void notifyOnSubscriptionChangedByAutoTranslateAndUserId(user._id);
-			}
-
-			const workspaceLanguage = rcSettings.get('Language');
-			if (language !== 'default' && language !== workspaceLanguage) {
-				const enableResponse = await Subscriptions.enableAutoTranslateByUserId(user._id, language);
-				if (enableResponse.modifiedCount) {
-					void notifyOnSubscriptionChangedByAutoTranslateAndUserId(user._id);
-				}
 			}
 		}
 	});

--- a/apps/meteor/tests/end-to-end/api/autotranslate.ts
+++ b/apps/meteor/tests/end-to-end/api/autotranslate.ts
@@ -669,6 +669,96 @@ describe('AutoTranslate', () => {
 				expect(subscription).to.have.property('autoTranslateLanguage', 'es');
 				channelsToRemove.push(newChannel);
 			});
+
+			it('should enable autotranslate on existing subscriptions when user changes from workspace language to a different one', async () => {
+				await setLanguagePref('pt-BR', credA);
+				const newChannel = await createChannel(undefined, credA);
+				channelsToRemove.push(newChannel);
+
+				const subBefore = await getSub(newChannel._id, credA);
+				expect(subBefore).to.not.have.property('autoTranslate');
+				expect(subBefore).to.not.have.property('autoTranslateLanguage');
+
+				await setLanguagePref('en', credA);
+
+				const subAfter = await getSub(newChannel._id, credA);
+				expect(subAfter).to.have.property('autoTranslate', true);
+				expect(subAfter).to.have.property('autoTranslateLanguage', 'en');
+			});
+
+			it("should enable autotranslate on existing subscriptions when user changes from 'default' language to a non-workspace language", async () => {
+				await setLanguagePref('default', credA);
+				const newChannel = await createChannel(undefined, credA);
+				channelsToRemove.push(newChannel);
+
+				const subBefore = await getSub(newChannel._id, credA);
+				expect(subBefore).to.not.have.property('autoTranslate');
+				expect(subBefore).to.not.have.property('autoTranslateLanguage');
+
+				await setLanguagePref('en', credA);
+
+				const subAfter = await getSub(newChannel._id, credA);
+				expect(subAfter).to.have.property('autoTranslate', true);
+				expect(subAfter).to.have.property('autoTranslateLanguage', 'en');
+			});
+
+			it('should disable autotranslate on existing subscriptions when user changes language to default', async () => {
+				await setLanguagePref('en', credA);
+				const newChannel = await createChannel(undefined, credA);
+				channelsToRemove.push(newChannel);
+
+				const subBefore = await getSub(newChannel._id, credA);
+				expect(subBefore).to.have.property('autoTranslate', true);
+
+				await setLanguagePref('default', credA);
+
+				const subAfter = await getSub(newChannel._id, credA);
+				expect(subAfter).to.not.have.property('autoTranslate');
+				expect(subAfter).to.not.have.property('autoTranslateLanguage');
+			});
+
+			it('should disable autotranslate on existing subscriptions when user changes language to the workspace default', async () => {
+				await setLanguagePref('en', credA);
+				const newChannel = await createChannel(undefined, credA);
+				channelsToRemove.push(newChannel);
+
+				const subBefore = await getSub(newChannel._id, credA);
+				expect(subBefore).to.have.property('autoTranslate', true);
+
+				await setLanguagePref('pt-BR', credA);
+
+				const subAfter = await getSub(newChannel._id, credA);
+				expect(subAfter).to.not.have.property('autoTranslate');
+				expect(subAfter).to.not.have.property('autoTranslateLanguage');
+			});
+
+			it('should not re-enable autotranslate for rooms where the user has explicitly opted out', async () => {
+				await updatePermission('auto-translate', ['admin', 'user']);
+
+				await setLanguagePref('en', credA);
+				const newChannel = await createChannel(undefined, credA);
+				channelsToRemove.push(newChannel);
+
+				const subEnabled = await getSub(newChannel._id, credA);
+				expect(subEnabled).to.have.property('autoTranslate', true);
+
+				await request
+					.post(api('autotranslate.saveSettings'))
+					.set(credA)
+					.send({ roomId: newChannel._id, field: 'autoTranslate', value: false, defaultLanguage: 'en' })
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('success', true);
+					});
+
+				const subOptedOut = await getSub(newChannel._id, credA);
+				expect(subOptedOut).to.have.property('autoTranslate', false);
+
+				await setLanguagePref('es', credA);
+
+				const subAfterLangChange = await getSub(newChannel._id, credA);
+				expect(subAfterLangChange).to.have.property('autoTranslate', false);
+			});
 		});
 	});
 });

--- a/packages/model-typings/src/models/ISubscriptionsModel.ts
+++ b/packages/model-typings/src/models/ISubscriptionsModel.ts
@@ -176,8 +176,7 @@ export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 	cachedFindByUserId(userId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
 	updateAutoTranslateById(_id: string, autoTranslate: boolean): Promise<UpdateResult>;
 
-	updateAllAutoTranslateLanguagesByUserId(userId: IUser['_id'], language: string): Promise<UpdateResult | Document>;
-	enableAutoTranslateByUserId(userId: IUser['_id'], language: string): Promise<UpdateResult | Document>;
+	setAutoTranslateByUserId(userId: IUser['_id'], language: string | null): Promise<UpdateResult | Document>;
 	findByAutoTranslateAndUserId(
 		userId: ISubscription['u']['_id'],
 		autoTranslate?: ISubscription['autoTranslate'],

--- a/packages/model-typings/src/models/ISubscriptionsModel.ts
+++ b/packages/model-typings/src/models/ISubscriptionsModel.ts
@@ -177,6 +177,7 @@ export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 	updateAutoTranslateById(_id: string, autoTranslate: boolean): Promise<UpdateResult>;
 
 	updateAllAutoTranslateLanguagesByUserId(userId: IUser['_id'], language: string): Promise<UpdateResult | Document>;
+	enableAutoTranslateByUserId(userId: IUser['_id'], language: string): Promise<UpdateResult | Document>;
 	findByAutoTranslateAndUserId(
 		userId: ISubscription['u']['_id'],
 		autoTranslate?: ISubscription['autoTranslate'],

--- a/packages/models/src/models/Subscriptions.ts
+++ b/packages/models/src/models/Subscriptions.ts
@@ -707,8 +707,8 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			};
 		} else {
 			update = {
-				$unset: {
-					autoTranslate: 1,
+				$set: {
+					autoTranslate: false,
 				},
 			};
 		}
@@ -724,13 +724,20 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 	}
 
 	setAutoTranslateByUserId(userId: IUser['_id'], language: string | null): Promise<UpdateResult | Document> {
-		const query = { 'u._id': userId };
-
 		if (language) {
-			return this.updateMany(query, { $set: { autoTranslate: true, autoTranslateLanguage: language } });
+			return Promise.all([
+				this.updateMany({ 'u._id': userId, 'autoTranslate': true }, { $set: { autoTranslateLanguage: language } }),
+				this.updateMany(
+					{ 'u._id': userId, 'autoTranslate': { $exists: false } },
+					{ $set: { autoTranslate: true, autoTranslateLanguage: language } },
+				),
+			]).then(([updateResult, enableResult]) => ({
+				...updateResult,
+				modifiedCount: updateResult.modifiedCount + enableResult.modifiedCount,
+			}));
 		}
 
-		return this.updateMany(query, { $unset: { autoTranslate: 1, autoTranslateLanguage: 1 } });
+		return this.updateMany({ 'u._id': userId }, { $unset: { autoTranslate: 1, autoTranslateLanguage: 1 } });
 	}
 
 	findByAutoTranslateAndUserId(

--- a/packages/models/src/models/Subscriptions.ts
+++ b/packages/models/src/models/Subscriptions.ts
@@ -738,6 +738,22 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateMany(query, update);
 	}
 
+	enableAutoTranslateByUserId(userId: IUser['_id'], language: string): Promise<UpdateResult | Document> {
+		const query = {
+			'u._id': userId,
+			'autoTranslate': { $ne: true },
+		};
+
+		const update: UpdateFilter<ISubscription> = {
+			$set: {
+				autoTranslate: true,
+				autoTranslateLanguage: language,
+			},
+		};
+
+		return this.updateMany(query, update);
+	}
+
 	findByAutoTranslateAndUserId(
 		userId: ISubscription['u']['_id'],
 		autoTranslate: ISubscription['autoTranslate'] = true,

--- a/packages/models/src/models/Subscriptions.ts
+++ b/packages/models/src/models/Subscriptions.ts
@@ -737,7 +737,7 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			}));
 		}
 
-		return this.updateMany({ 'u._id': userId }, { $unset: { autoTranslate: 1, autoTranslateLanguage: 1 } });
+		return this.updateMany({ 'u._id': userId, 'autoTranslate': true }, { $unset: { autoTranslate: 1, autoTranslateLanguage: 1 } });
 	}
 
 	findByAutoTranslateAndUserId(

--- a/packages/models/src/models/Subscriptions.ts
+++ b/packages/models/src/models/Subscriptions.ts
@@ -723,35 +723,14 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.findOneAndUpdate(query, update, { returnDocument: 'after' });
 	}
 
-	updateAllAutoTranslateLanguagesByUserId(userId: IUser['_id'], language: string): Promise<UpdateResult | Document> {
-		const query = {
-			'u._id': userId,
-			'autoTranslate': true,
-		};
+	setAutoTranslateByUserId(userId: IUser['_id'], language: string | null): Promise<UpdateResult | Document> {
+		const query = { 'u._id': userId };
 
-		const update: UpdateFilter<ISubscription> = {
-			$set: {
-				autoTranslateLanguage: language,
-			},
-		};
+		if (language) {
+			return this.updateMany(query, { $set: { autoTranslate: true, autoTranslateLanguage: language } });
+		}
 
-		return this.updateMany(query, update);
-	}
-
-	enableAutoTranslateByUserId(userId: IUser['_id'], language: string): Promise<UpdateResult | Document> {
-		const query = {
-			'u._id': userId,
-			'autoTranslate': { $ne: true },
-		};
-
-		const update: UpdateFilter<ISubscription> = {
-			$set: {
-				autoTranslate: true,
-				autoTranslateLanguage: language,
-			},
-		};
-
-		return this.updateMany(query, update);
+		return this.updateMany(query, { $unset: { autoTranslate: 1, autoTranslateLanguage: 1 } });
 	}
 
 	findByAutoTranslateAndUserId(


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
[CORE-2297](https://rocketchat.atlassian.net/browse/CORE-2297)
<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

When `AutoTranslate_AutoEnableOnJoinRoom` is enabled, auto-translate is supposed to be automatically configured for users whose language preference differs from the workspace default. However, this only worked at room join time — users who joined rooms before setting a language preference (including users with the default "Default" setting) ended up with subscriptions that never had auto-translate enabled.

Later, when those users set a language preference, the existing sync logic (updateAllAutoTranslateLanguagesByUserId) only updated the autoTranslateLanguage field on subscriptions that already had autoTranslate: true. Since their subscriptions were created without it, nothing changed and auto-translate never activated.

This affects virtually every new user on workspaces with `AutoTranslate_AutoEnableOnJoinRoom` enabled, since "Default" is the out-of-the-box language setting.

**Solution:** 
Added a new `enableAutoTranslateByUserId` method on the Subscriptions model that targets subscriptions where autoTranslate is not yet set, and calls it in `saveUserPreferences` when a user sets a valid non-default language that differs from the workspace default — mirroring the same conditions used in `getSubscriptionAutotranslateDefaultConfig`.

The existing `updateAllAutoTranslateLanguagesByUserId` call is preserved to handle users who already have auto-translate enabled and are just changing their language.



## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

Root Cause
Two separate features introduced in different PRs left a gap:

#30370 introduced `getSubscriptionAutotranslateDefaultConfig` — auto-enables auto-translate at room join time for users with a non-default language
#31417 introduced the language preference sync in saveUserPreferences — but only updated the language on subscriptions that already had `autoTranslate: true`, never enabling it on subscriptions that were created before the user had a language set

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Enable `AutoTranslate_AutoEnableOnJoinRoom` in admin settings
2. Create a user with language set to Default
3. Add the user to a channel
4. Change the user's language preference to Spanish
5. Have another user send a message in the channel

Expected: messages appear translated to Spanish
Actual: messages appear in original language — auto-translate was never enabled on the subscription


## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Users who change their language preference from Default (or any previous value) to a specific language will have auto-translate immediately enabled across all their existing room subscriptions, without needing to leave and rejoin rooms.

If user sets their language to Default, they're saying "use the workspace/browser default" — auto-translate shouldn't be forced on for them.

Note: A migration is recommended to retroactively fix existing users already in the broken state — users who currently have a language preference set but joined rooms before setting it. The fix alone only applies going forward (on the next language preference change), and for users who change the language preference from now on.



[CORE-2297]: https://rocketchat.atlassian.net/browse/CORE-2297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/40992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed auto-translate not activating when users update their language preference after joining rooms. Auto-translate now correctly derives the target language from workspace settings, enables/disables as appropriate when users switch to or from the workspace default and “default,” and respects explicit opt-outs.
* **Tests**
  * Added end-to-end coverage to verify auto-translate subscription behavior for existing room subscriptions across language-change and opt-out scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->