### PR TITLE
fix: unread messages count 40461

### DIFF
--- a/apps/meteor/app/lib/server/lib/notifyUsersOnMessage.ts
+++ b/apps/meteor/app/lib/server/lib/notifyUsersOnMessage.ts
@@ -108,6 +108,11 @@ async function updateUsersSubscriptions(message: IMessage, room: IRoom): Promise
 		onlyRead: !toAll && !toHere && !unreadAllMessages,
 	}).toArray();
 
+	const notifSubs =
+		!toAll && !toHere && !unreadAllMessages
+			? await Subscriptions.findByRoomIdAndNotificationAll(room._id, [message.u._id, ...userIds]).toArray()
+			: [];
+
 	// Give priority to user mentions over group mentions
 	if (userIds.length) {
 		await Subscriptions.incUserMentionsAndUnreadForRoomIdAndUserIds(room._id, userIds, 1, userMentionInc);
@@ -119,6 +124,10 @@ async function updateUsersSubscriptions(message: IMessage, room: IRoom): Promise
 		await Subscriptions.incUnreadForRoomIdExcludingUserIds(room._id, [...userIds, message.u._id], 1);
 	}
 
+	if (!toAll && !toHere && !unreadAllMessages) {
+		await Subscriptions.incUnreadForRoomIdAndNotificationAll(room._id, [message.u._id, ...userIds], 1);
+	}
+
 	// update subscriptions of other members of the room
 	await Promise.all([
 		Subscriptions.setAlertForRoomIdExcludingUserId(message.rid, message.u._id),
@@ -127,7 +136,8 @@ async function updateUsersSubscriptions(message: IMessage, room: IRoom): Promise
 
 	subs.forEach((sub) => {
 		const hasUserMention = userIds.includes(sub.u._id);
-		const shouldIncUnread = hasUserMention || toAll || toHere || unreadAllMessages;
+		const hasAllNotifications = sub.desktopNotifications === 'all' || sub.mobilePushNotifications === 'all';
+		const shouldIncUnread = hasUserMention || toAll || toHere || unreadAllMessages || hasAllNotifications;
 		void notifyOnSubscriptionChanged(
 			{
 				...sub,
@@ -140,6 +150,20 @@ async function updateUsersSubscriptions(message: IMessage, room: IRoom): Promise
 			'updated',
 		);
 	});
+
+	for (const notifSub of notifSubs) {
+		if (!subs.some((s) => s.u._id === notifSub.u._id)) {
+			void notifyOnSubscriptionChanged(
+				{
+					...notifSub,
+					alert: true,
+					open: true,
+					unread: (notifSub.unread || 0) + 1,
+				},
+				'updated',
+			);
+		}
+	}
 
 	// update subscription of the message sender
 	const setAsReadResponse = await Subscriptions.setAsReadByRoomIdAndUserId(message.rid, message.u._id);

--- a/apps/meteor/app/lib/server/lib/notifyUsersOnMessage.ts
+++ b/apps/meteor/app/lib/server/lib/notifyUsersOnMessage.ts
@@ -95,6 +95,15 @@ async function updateUsersSubscriptions(message: IMessage, room: IRoom): Promise
 	const userIds = [...new Set([...mentionIds, ...highlightIds])];
 	const unreadCount = getUnreadSettingCount(room.t);
 	const unreadAllMessages = unreadCount === 'all_messages';
+	console.log('SETTINGS RAW', settings.get('Unread_Count'));
+	console.log('UNREAD CHECK', {
+    roomType: room.t,
+    unreadCount,
+    unreadAllMessages,
+    toAll,
+    toHere,
+    message: message.msg
+});
 
 	const userMentionInc = getUserMentions(room.t, unreadCount as Exclude<UnreadCountType, 'group_mentions_only'>);
 	const groupMentionInc = getGroupMentions(room.t, unreadCount as Exclude<UnreadCountType, 'user_mentions_only'>);

--- a/apps/meteor/app/lib/server/lib/notifyUsersOnMessage.ts
+++ b/apps/meteor/app/lib/server/lib/notifyUsersOnMessage.ts
@@ -95,16 +95,6 @@ async function updateUsersSubscriptions(message: IMessage, room: IRoom): Promise
 	const userIds = [...new Set([...mentionIds, ...highlightIds])];
 	const unreadCount = getUnreadSettingCount(room.t);
 	const unreadAllMessages = unreadCount === 'all_messages';
-	console.log('SETTINGS RAW', settings.get('Unread_Count'));
-	console.log('UNREAD CHECK', {
-    roomType: room.t,
-    unreadCount,
-    unreadAllMessages,
-    toAll,
-    toHere,
-    message: message.msg
-});
-
 	const userMentionInc = getUserMentions(room.t, unreadCount as Exclude<UnreadCountType, 'group_mentions_only'>);
 	const groupMentionInc = getGroupMentions(room.t, unreadCount as Exclude<UnreadCountType, 'user_mentions_only'>);
 

--- a/apps/meteor/client/sidebar/RoomList/RoomList.tsx
+++ b/apps/meteor/client/sidebar/RoomList/RoomList.tsx
@@ -24,6 +24,10 @@ const RoomList = () => {
 
 	const { collapsedGroups, handleClick, handleKeyDown } = useCollapsedGroups();
 	const { groupsCount, groupsList, roomList, groupedUnreadInfo } = useRoomList({ collapsedGroups });
+	console.log('DEBUG SIDEBAR DATA:', {
+    roomList: roomList.map(r => ({ name: r.name, t: r.t, unread: r.unread, alert: r.alert })),
+    groupedUnreadInfo
+});
 	const avatarTemplate = useAvatarTemplate();
 	const sideBarItemTemplate = useTemplateByViewMode();
 	const { ref } = useResizeObserver<HTMLElement>({ debounceDelay: 100 });

--- a/apps/meteor/client/sidebar/RoomList/RoomList.tsx
+++ b/apps/meteor/client/sidebar/RoomList/RoomList.tsx
@@ -24,10 +24,6 @@ const RoomList = () => {
 
 	const { collapsedGroups, handleClick, handleKeyDown } = useCollapsedGroups();
 	const { groupsCount, groupsList, roomList, groupedUnreadInfo } = useRoomList({ collapsedGroups });
-	console.log('DEBUG SIDEBAR DATA:', {
-    roomList: roomList.map(r => ({ name: r.name, t: r.t, unread: r.unread, alert: r.alert })),
-    groupedUnreadInfo
-});
 	const avatarTemplate = useAvatarTemplate();
 	const sideBarItemTemplate = useTemplateByViewMode();
 	const { ref } = useResizeObserver<HTMLElement>({ debounceDelay: 100 });

--- a/apps/meteor/lib/getSubscriptionUnreadData.ts
+++ b/apps/meteor/lib/getSubscriptionUnreadData.ts
@@ -46,7 +46,7 @@ export const getSubscriptionUnreadData = (
 		mentions: userMentions + (tunreadUser?.length || 0),
 		threads: tunread?.length || 0,
 		groupMentions,
-		total: unread + (tunread?.length || 0),
+		total: unread + (tunread?.length || 0) + (alert && !unread ? 1 : 0),
 	};
 
 	const unreadTitle = getUnreadTitle(unreadCount, t);

--- a/packages/model-typings/src/models/ISubscriptionsModel.ts
+++ b/packages/model-typings/src/models/ISubscriptionsModel.ts
@@ -114,6 +114,10 @@ export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 
 	incUnreadForRoomIdExcludingUserIds(roomId: IRoom['_id'], userIds: IUser['_id'][], inc: number): Promise<UpdateResult | Document>;
 
+	findByRoomIdAndNotificationAll(roomId: IRoom['_id'], excludeUserIds: IUser['_id'][]): FindCursor<ISubscription>;
+
+	incUnreadForRoomIdAndNotificationAll(roomId: IRoom['_id'], excludeUserIds: IUser['_id'][], inc: number): Promise<UpdateResult | Document>;
+
 	setAlertForRoomIdExcludingUserId(roomId: IRoom['_id'], userId: IUser['_id']): Promise<UpdateResult | Document>;
 
 	setOpenForRoomIdExcludingUserId(roomId: IRoom['_id'], userId: IUser['_id']): Promise<UpdateResult | Document>;

--- a/packages/models/src/models/Subscriptions.ts
+++ b/packages/models/src/models/Subscriptions.ts
@@ -558,6 +558,43 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateMany(query, update);
 	}
 
+	findByRoomIdAndNotificationAll(roomId: IRoom['_id'], excludeUserIds: IUser['_id'][]): FindCursor<ISubscription> {
+		const query = {
+			'rid': roomId,
+			'u._id': {
+				$nin: excludeUserIds,
+			},
+			$or: [{ desktopNotifications: 'all' as const }, { mobilePushNotifications: 'all' as const }],
+		};
+
+		return this.find(query);
+	}
+
+	incUnreadForRoomIdAndNotificationAll(roomId: IRoom['_id'], excludeUserIds: IUser['_id'][], inc: number): Promise<UpdateResult | Document> {
+		if (inc == null) {
+			inc = 1;
+		}
+		const query = {
+			'rid': roomId,
+			'u._id': {
+				$nin: excludeUserIds,
+			},
+			$or: [{ desktopNotifications: 'all' as const }, { mobilePushNotifications: 'all' as const }],
+		};
+
+		const update = {
+			$set: {
+				alert: true,
+				open: true,
+			},
+			$inc: {
+				unread: inc,
+			},
+		};
+
+		return this.updateMany(query, update);
+	}
+
 	setAlertForRoomIdExcludingUserId(roomId: IRoom['_id'], userId: IUser['_id']): Promise<UpdateResult | Document> {
 		const query = {
 			'rid': roomId,


### PR DESCRIPTION
fix: respect per-user all-message notification preference for channel unread counts

## Proposed changes (including videos or screenshots)

This PR improves channel unread-count behavior by respecting per-user notification preferences for normal channel messages.

Previously:
- DMs correctly showed unread counts.
- Mentions (`@user`, `@all`, `@here`) correctly incremented unread counts.
- Normal channel messages only incremented unread counts when the workspace-level `Unread_Count` setting was configured as `all_messages`.

As a result, users who explicitly enabled:
- Desktop notifications → `All messages`
- Mobile notifications → `All messages`

still did not receive unread count increments for normal channel messages if the workspace unread setting was configured as:
- `user_mentions_only`
- `group_mentions_only`
- `user_and_group_mentions_only`

This PR introduces backend changes so that:
- users who individually configure `All messages` notifications for desktop/mobile
- can still receive unread count increments for normal channel messages
- even when the workspace unread-count policy is more restrictive.

This improves consistency between:
- user notification expectations
- sidebar unread behavior
- notification preferences configured at the room level.

Fixes #40461

## Issue(s)

Fixes #40461

## Steps to test or reproduce

1. Go to:
   - Administration
   - Workspace
   - Settings
   - General
   - Unread Count

2. Set workspace unread behavior to:
   - `User and group mentions only`
   OR
   - `User mentions only`

3. Open a public/private channel.

4. Inside the channel notification settings, enable:
   - Desktop notifications → `All messages`
   - Mobile notifications → `All messages`

5. Send multiple normal messages in the channel without mentions.

### Before this change
- unread count does not increment for normal messages
- sidebar only shows bold/red alert state
<img width="344" height="292" alt="image" src="https://github.com/user-attachments/assets/3755feb4-b565-4bca-9753-67c9392107b1" />


### After this change
- unread count increments correctly
- sidebar unread badge reflects normal channel activity
- behavior becomes consistent with user-level notification preference
<img width="338" height="270" alt="image" src="https://github.com/user-attachments/assets/b913ae54-b6ef-4df5-825d-f93781b6bb2f" />

6. Verify mentions still work correctly:
   - `@user`
   - `@all`
   - `@here`

7. Verify DMs still behave correctly.

## Further comments

This PR adds backend handling for users who explicitly opt into receiving all-message notifications at the room level.

The change ensures that unread counters remain aligned with user-configured notification expectations, even when the workspace-wide unread-count policy is configured for mentions-only behavior.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/40999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

