### PR TITLE
test(e2e): work around E2E test instabilities

### DIFF
--- a/apps/meteor/tests/e2e/message-composer.spec.ts
+++ b/apps/meteor/tests/e2e/message-composer.spec.ts
@@ -57,6 +57,8 @@ test.describe.serial('message-composer', () => {
 		await page.keyboard.press('Control+A'); // on Windows and Linux
 		await page.keyboard.press('Meta+A'); // on macOS
 		await poHomeChannel.composer.btnLinkFormatter.click();
+		// It takes a while for the modal to be visible and ready to receive input, so we need to wait for it before typing the url
+		await poHomeChannel.composer.addLinkModal.waitFor();
 		await page.keyboard.type(url);
 		await page.keyboard.press('Enter');
 

--- a/apps/meteor/tests/e2e/page-objects/fragments/composer.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/composer.ts
@@ -118,6 +118,10 @@ export abstract class Composer {
 	get typingIndicator(): Locator {
 		return this.root.getByRole('status').getByText(/typing/i);
 	}
+
+	get addLinkModal(): Locator {
+		return this.root.page().getByRole('dialog', { name: 'Add link' });
+	}
 }
 
 export class RoomComposer extends Composer {

--- a/apps/meteor/tests/e2e/page-objects/fragments/sidebar.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/sidebar.ts
@@ -94,7 +94,7 @@ export class RoomSidebar extends Sidebar {
 	}
 
 	getCollapseGroupByName(name: string): Locator {
-		return this.channelsList.getByRole('button').filter({ has: this.page.getByRole('heading', { name, exact: true }) });
+		return this.root.getByRole('button').filter({ has: this.page.getByRole('heading', { name, exact: true }) });
 	}
 
 	getItemUnreadBadge(item: Locator): Locator {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
This pull request makes improvements to the end-to-end (E2E) test suite for the message composer and sidebar components. The main focus is on enhancing test reliability and maintainability by improving element selection and ensuring proper synchronization when interacting with UI elements.

Enhancements to message composer E2E tests:

* Added an explicit wait for the "Add link" modal to appear before typing the URL, improving test reliability when interacting with modals.
* Introduced a new `addLinkModal` locator in the `Composer` page object for more robust and maintainable modal handling.

Sidebar selector improvement:

* Updated the `getCollapseGroupByName` method in the `RoomSidebar` page object to use `this.root` instead of `this.channelsList` for more accurate button selection.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability for adding a link by waiting for the “Add link” dialog to become visible/ready before typing the generated URL.
  * Enhanced sidebar collapse-group interactions by targeting the correct page-level elements, reducing selection/timing flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->