### PR TITLE
fix(admin): resolve React hook violation in RoomsTable

### DIFF
--- a/.changeset/fix-rooms-table-react-hook.md
+++ b/.changeset/fix-rooms-table-react-hook.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fix React hook violation in RoomsTable by removing side effects from useMemo

--- a/apps/meteor/client/views/admin/rooms/RoomsTable.tsx
+++ b/apps/meteor/client/views/admin/rooms/RoomsTable.tsx
@@ -41,14 +41,11 @@ const RoomsTable = ({ reload }: { reload: MutableRefObject<() => void> }) => {
 
 	const query = useDebouncedValue(
 		useMemo(() => {
-			if (searchText !== prevRoomFilterText.current) {
-				setCurrent(0);
-			}
 			return {
 				filter: searchText || '',
 				sort: `{ "${sortBy}": ${sortDirection === 'asc' ? 1 : -1} }`,
 				count: itemsPerPage,
-				offset: searchText === prevRoomFilterText.current ? current : 0,
+				offset: current,
 				types: (roomFilters.types.length ? [...roomFilters.types.map((roomType) => roomType.id)] : DEFAULT_TYPES) as unknown as (
 					| 'c'
 					| 'd'
@@ -58,7 +55,7 @@ const RoomsTable = ({ reload }: { reload: MutableRefObject<() => void> }) => {
 					| 'teams'
 				)[],
 			};
-		}, [searchText, sortBy, sortDirection, itemsPerPage, current, roomFilters.types, setCurrent]),
+		}, [searchText, sortBy, sortDirection, itemsPerPage, current, roomFilters.types]),
 		500,
 	);
 
@@ -74,8 +71,9 @@ const RoomsTable = ({ reload }: { reload: MutableRefObject<() => void> }) => {
 	}, [reload, refetch]);
 
 	useEffect(() => {
+		setCurrent(0);
 		prevRoomFilterText.current = searchText;
-	}, [searchText]);
+	}, [searchText, setCurrent]);
 
 	const headers = (
 		<>


### PR DESCRIPTION
## Proposed changes
This fixes an issue in `RoomsTable.tsx` where a state setter (`setCurrent`) was being called inside a `useMemo` callback, violating React's rendering contract. The pagination reset logic has been moved to a `useEffect`, and the `useMemo` query computation has been simplified.

Closes #40589

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination state handling in the rooms table during search operations to ensure proper synchronization and consistent behavior when filtering and navigating rooms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->