### PR TITLE
fix(composer): resolve memory leaks in audio/video recorders

### DIFF
--- a/.changeset/fix-recorder-memory-leak.md
+++ b/.changeset/fix-recorder-memory-leak.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fix memory leak in VideoMessageRecorder and AudioMessageRecorder by clearing recording interval properly on unmount

--- a/apps/meteor/client/views/composer/AudioMessageRecorder/AudioMessageRecorder.tsx
+++ b/apps/meteor/client/views/composer/AudioMessageRecorder/AudioMessageRecorder.tsx
@@ -22,6 +22,7 @@ const AudioMessageRecorder = ({ rid, isMicrophoneDenied }: AudioMessageRecorderP
 	const [time, setTime] = useState('00:00');
 	const recordingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const [recordingRoomId, setRecordingRoomId] = useState<IRoom['_id'] | null>(null);
+	const isMountedRef = useRef(true);
 
 	const stopRecording = useStableCallback(async () => {
 		if (recordingIntervalRef.current) {
@@ -56,6 +57,9 @@ const AudioMessageRecorder = ({ rid, isMicrophoneDenied }: AudioMessageRecorderP
 
 		try {
 			await audioRecorder.start();
+			if (!isMountedRef.current) {
+				return;
+			}
 			chat?.action.performContinuously('recording');
 			const startTime = new Date();
 			recordingIntervalRef.current = setInterval(() => {
@@ -93,6 +97,7 @@ const AudioMessageRecorder = ({ rid, isMicrophoneDenied }: AudioMessageRecorderP
 		handleRecord();
 
 		return () => {
+			isMountedRef.current = false;
 			if (recordingIntervalRef.current) {
 				clearInterval(recordingIntervalRef.current);
 			}

--- a/apps/meteor/client/views/composer/AudioMessageRecorder/AudioMessageRecorder.tsx
+++ b/apps/meteor/client/views/composer/AudioMessageRecorder/AudioMessageRecorder.tsx
@@ -2,7 +2,7 @@ import type { IRoom } from '@rocket.chat/core-typings';
 import { Box, Icon, Throbber } from '@rocket.chat/fuselage';
 import { useStableCallback } from '@rocket.chat/fuselage-hooks';
 import { MessageComposerAction } from '@rocket.chat/ui-composer';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { AudioRecorder } from '../../../../app/ui/client/lib/recorderjs/AudioRecorder';
@@ -20,14 +20,14 @@ const AudioMessageRecorder = ({ rid, isMicrophoneDenied }: AudioMessageRecorderP
 
 	const [state, setState] = useState<'loading' | 'recording'>('recording');
 	const [time, setTime] = useState('00:00');
-	const [recordingInterval, setRecordingInterval] = useState<ReturnType<typeof setInterval> | null>(null);
+	const recordingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const [recordingRoomId, setRecordingRoomId] = useState<IRoom['_id'] | null>(null);
 
 	const stopRecording = useStableCallback(async () => {
-		if (recordingInterval) {
-			clearInterval(recordingInterval);
+		if (recordingIntervalRef.current) {
+			clearInterval(recordingIntervalRef.current);
 		}
-		setRecordingInterval(null);
+		recordingIntervalRef.current = null;
 		setRecordingRoomId(null);
 
 		setTime('00:00');
@@ -58,15 +58,13 @@ const AudioMessageRecorder = ({ rid, isMicrophoneDenied }: AudioMessageRecorderP
 			await audioRecorder.start();
 			chat?.action.performContinuously('recording');
 			const startTime = new Date();
-			setRecordingInterval(
-				setInterval(() => {
-					const now = new Date();
-					const distance = (now.getTime() - startTime.getTime()) / 1000;
-					const minutes = Math.floor(distance / 60);
-					const seconds = Math.floor(distance % 60);
-					setTime(`${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`);
-				}, 1000),
-			);
+			recordingIntervalRef.current = setInterval(() => {
+				const now = new Date();
+				const distance = (now.getTime() - startTime.getTime()) / 1000;
+				const minutes = Math.floor(distance / 60);
+				const seconds = Math.floor(distance % 60);
+				setTime(`${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`);
+			}, 1000);
 			setRecordingRoomId(rid);
 		} catch (error) {
 			console.log(error);
@@ -95,6 +93,9 @@ const AudioMessageRecorder = ({ rid, isMicrophoneDenied }: AudioMessageRecorderP
 		handleRecord();
 
 		return () => {
+			if (recordingIntervalRef.current) {
+				clearInterval(recordingIntervalRef.current);
+			}
 			handleUnmount();
 		};
 	}, [handleUnmount, handleRecord]);

--- a/apps/meteor/client/views/composer/VideoMessageRecorder/VideoMessageRecorder.tsx
+++ b/apps/meteor/client/views/composer/VideoMessageRecorder/VideoMessageRecorder.tsx
@@ -43,7 +43,7 @@ const VideoMessageRecorder = ({ rid, tmid, reference }: VideoMessageRecorderProp
 
 	const [time, setTime] = useState<string | undefined>('00:00');
 	const [recordingState, setRecordingState] = useState<'idle' | 'loading' | 'recording'>('idle');
-	const [recordingInterval, setRecordingInterval] = useState<ReturnType<typeof setInterval> | null>(null);
+	const recordingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const isRecording = recordingState === 'recording';
 	const cameraStarted = useVideoRecorderCameraStarted();
 	const sendButtonDisabled = !(cameraStarted && !isRecording);
@@ -51,10 +51,10 @@ const VideoMessageRecorder = ({ rid, tmid, reference }: VideoMessageRecorderProp
 	const chat = useChat();
 
 	const stopVideoRecording = async (rid: IRoom['_id'], tmid?: IMessage['_id']) => {
-		if (recordingInterval) {
-			clearInterval(recordingInterval);
+		if (recordingIntervalRef.current) {
+			clearInterval(recordingIntervalRef.current);
 		}
-		setRecordingInterval(null);
+		recordingIntervalRef.current = null;
 		VideoRecorder.stopRecording();
 		UserAction.stop(rid, USER_ACTIVITIES.USER_RECORDING, { tmid });
 		setRecordingState('idle');
@@ -69,15 +69,13 @@ const VideoMessageRecorder = ({ rid, tmid, reference }: VideoMessageRecorderProp
 			UserAction.performContinuously(rid, USER_ACTIVITIES.USER_RECORDING, { tmid });
 			setTime('00:00');
 			const startTime = new Date();
-			setRecordingInterval(
-				setInterval(() => {
-					const now = new Date();
-					const distance = (now.getTime() - startTime.getTime()) / 1000;
-					const minutes = Math.floor(distance / 60);
-					const seconds = Math.floor(distance % 60);
-					setTime(`${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`);
-				}, 1000),
-			);
+			recordingIntervalRef.current = setInterval(() => {
+				const now = new Date();
+				const distance = (now.getTime() - startTime.getTime()) / 1000;
+				const minutes = Math.floor(distance / 60);
+				const seconds = Math.floor(distance % 60);
+				setTime(`${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`);
+			}, 1000);
 		}
 	};
 
@@ -109,6 +107,9 @@ const VideoMessageRecorder = ({ rid, tmid, reference }: VideoMessageRecorderProp
 		VideoRecorder.start(videoRef.current ?? undefined, (success) => (!success ? handleCancel() : undefined));
 
 		return () => {
+			if (recordingIntervalRef.current) {
+				clearInterval(recordingIntervalRef.current);
+			}
 			VideoRecorder.stop();
 		};
 	}, [dispatchToastMessage, handleCancel, t]);

--- a/apps/meteor/client/views/composer/VideoMessageRecorder/VideoMessageRecorder.tsx
+++ b/apps/meteor/client/views/composer/VideoMessageRecorder/VideoMessageRecorder.tsx
@@ -111,8 +111,9 @@ const VideoMessageRecorder = ({ rid, tmid, reference }: VideoMessageRecorderProp
 				clearInterval(recordingIntervalRef.current);
 			}
 			VideoRecorder.stop();
+			UserAction.stop(rid, USER_ACTIVITIES.USER_RECORDING, { tmid });
 		};
-	}, [dispatchToastMessage, handleCancel, t]);
+	}, [dispatchToastMessage, handleCancel, t, rid, tmid]);
 
 	return (
 		<PositionAnimated visible='visible' anchor={reference as RefObject<HTMLElement>} placement='top-end'>


### PR DESCRIPTION
This PR resolves the memory leak described in #40039 where the `setInterval` for recording audio/video messages continues running in the background infinitely if the user quickly navigates away or unmounts the composer. 

The fix stores the interval inside a `useRef` instead of React state and synchronously clears the interval in the `useEffect` cleanup block.

Closes #40039

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where audio message recording timers could continue running after unmount, causing a memory leak.
  * Fixed an issue where video message recording timers could continue running after unmount, causing a memory leak.
  

<!-- end of auto-generated comment: release notes by coderabbit.ai -->