### PR TITLE
test: flaky `session-expiration-redirect.spec`

### DIFF
--- a/apps/meteor/tests/e2e/session-expiration-redirect.spec.ts
+++ b/apps/meteor/tests/e2e/session-expiration-redirect.spec.ts
@@ -2,7 +2,7 @@ import { MongoClient } from 'mongodb';
 
 import { URL_MONGODB } from './config/constants';
 import injectInitialData from './fixtures/inject-initial-data';
-import { restoreState, Users } from './fixtures/userStates';
+import { Users } from './fixtures/userStates';
 import { HomeChannel } from './page-objects';
 import { createTargetChannel, deleteChannel } from './utils';
 import { test, expect } from './utils/test';
@@ -25,7 +25,7 @@ test.describe('Session Expiration Redirect', () => {
 	let targetChannel: string;
 
 	test.beforeAll(async ({ api }) => {
-		targetChannel = await createTargetChannel(api, { members: ['user1'] });
+		targetChannel = await createTargetChannel(api, { members: [Users.user1.data.username] });
 	});
 
 	test.afterAll(async ({ api }) => {
@@ -34,11 +34,10 @@ test.describe('Session Expiration Redirect', () => {
 
 	test.beforeEach(async ({ page }) => {
 		poHomeChannel = new HomeChannel(page);
-		await page.goto(`/channel/${targetChannel}`);
+		await poHomeChannel.gotoChannel(targetChannel);
 	});
-	test.afterEach(async ({ page }) => {
+	test.afterEach(async () => {
 		await injectInitialData();
-		await restoreState(page, Users.user1);
 	});
 
 	test('should redirect to login page when server-side token is deleted and user tries to interact', async ({ page }) => {
@@ -60,9 +59,7 @@ test.describe('Session Expiration Redirect', () => {
 		});
 
 		await test.step('should redirect to login page', async () => {
-			const loginForm = page.getByRole('form', { name: 'Login' });
-			await loginForm.waitFor({ state: 'visible', timeout: 20000 });
-			await expect(loginForm).toBeVisible();
+			await expect(page.getByRole('form', { name: 'Login' })).toBeVisible();
 		});
 
 		await test.step('verify localStorage was cleared', async () => {
@@ -90,7 +87,7 @@ test.describe('Session Expiration Redirect', () => {
 		});
 
 		await test.step('expect automatic redirect to login page', async () => {
-			await expect(page.getByRole('form', { name: 'Login' })).toBeVisible({ timeout: 10000 });
+			await expect(page.getByRole('form', { name: 'Login' })).toBeVisible();
 		});
 
 		await test.step('verify localStorage was cleared', async () => {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
There was no assertion waiting for the room to load, so before the app would finish making all requests, the tokens would be removed from the database, causing remaining requests to redirect the user to the login page before the message search button could be clicked.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced session expiration redirect testing with improved setup procedures, refined user targeting logic, optimized navigation patterns, and streamlined assertion mechanisms to increase test reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [FLAKY-2127]

[FLAKY-2127]: https://rocketchat.atlassian.net/browse/FLAKY-2127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ