### PR TITLE
fix: make email domain validation case-insensitive

### DIFF
--- a/.changeset/email-domain-case-insensitive.md
+++ b/.changeset/email-domain-case-insensitive.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed case-sensitive email domain validation so domains are matched case-insensitively (per RFC 5321) against the configured allowed and blocked domain lists

--- a/apps/meteor/app/authentication/server/startup/index.js
+++ b/apps/meteor/app/authentication/server/startup/index.js
@@ -196,10 +196,11 @@ const validateEmailDomain = (user) => {
 		return true;
 	}
 
-	domainWhiteList = domainWhiteList.split(',').map((domain) => domain.trim());
+	domainWhiteList = domainWhiteList.split(',').map((domain) => domain.trim().toLowerCase());
 
 	if (user.emails && user.emails.length > 0) {
-		const email = user.emails[0].address;
+		// Email domains are case-insensitive (RFC 1035/5321); compare against the allowed-domains list case-insensitively.
+		const email = user.emails[0].address.toLowerCase();
 		const inWhiteList = domainWhiteList.some((domain) => email.match(`@${escapeRegExp(domain)}$`));
 
 		if (!inWhiteList) {
@@ -505,10 +506,11 @@ Accounts.validateNewUser((user) => {
 		return true;
 	}
 
-	domainWhiteList = domainWhiteList.split(',').map((domain) => domain.trim());
+	domainWhiteList = domainWhiteList.split(',').map((domain) => domain.trim().toLowerCase());
 
 	if (user.emails && user.emails.length > 0) {
-		const email = user.emails[0].address;
+		// Email domains are case-insensitive (RFC 1035/5321); compare against the allowed-domains list case-insensitively.
+		const email = user.emails[0].address.toLowerCase();
 		const inWhiteList = domainWhiteList.some((domain) => email.match(`@${escapeRegExp(domain)}$`));
 
 		if (inWhiteList === false) {

--- a/apps/meteor/app/authentication/server/startup/index.js
+++ b/apps/meteor/app/authentication/server/startup/index.js
@@ -199,7 +199,6 @@ const validateEmailDomain = (user) => {
 	domainWhiteList = domainWhiteList.split(',').map((domain) => domain.trim().toLowerCase());
 
 	if (user.emails && user.emails.length > 0) {
-		// Email domains are case-insensitive (RFC 1035/5321); compare against the allowed-domains list case-insensitively.
 		const email = user.emails[0].address.toLowerCase();
 		const inWhiteList = domainWhiteList.some((domain) => email.match(`@${escapeRegExp(domain)}$`));
 

--- a/apps/meteor/app/authentication/server/startup/index.js
+++ b/apps/meteor/app/authentication/server/startup/index.js
@@ -496,30 +496,10 @@ Accounts.validateNewUser((user) => {
 	return true;
 });
 
-Accounts.validateNewUser((user) => {
-	if (user.type === 'visitor') {
-		return true;
-	}
-
-	let domainWhiteList = settings.get('Accounts_AllowedDomainsList');
-	if (_.isEmpty(domainWhiteList?.trim())) {
-		return true;
-	}
-
-	domainWhiteList = domainWhiteList.split(',').map((domain) => domain.trim().toLowerCase());
-
-	if (user.emails && user.emails.length > 0) {
-		// Email domains are case-insensitive (RFC 1035/5321); compare against the allowed-domains list case-insensitively.
-		const email = user.emails[0].address.toLowerCase();
-		const inWhiteList = domainWhiteList.some((domain) => email.match(`@${escapeRegExp(domain)}$`));
-
-		if (inWhiteList === false) {
-			throw new Meteor.Error('error-invalid-domain');
-		}
-	}
-
-	return true;
-});
+// Reuse the shared allowed-domains check (`validateEmailDomain` above) so the logic
+// lives in a single place and cannot drift. This hook also gates OAuth/external
+// account creation.
+Accounts.validateNewUser((user) => validateEmailDomain(user));
 
 Accounts.onLogin(async ({ user }) => {
 	if (!user || !user.services || !user.services.resume || !user.services.resume.loginTokens || !user._id) {

--- a/apps/meteor/app/lib/server/lib/validateEmailDomain.js
+++ b/apps/meteor/app/lib/server/lib/validateEmailDomain.js
@@ -21,7 +21,7 @@ settings.watch('Accounts_BlockedDomainsList', (value) => {
 	emailDomainBlackList = value
 		.split(',')
 		.filter(Boolean)
-		.map((domain) => domain.trim());
+		.map((domain) => domain.trim().toLowerCase());
 });
 settings.watch('Accounts_AllowedDomainsList', (value) => {
 	if (!value) {
@@ -32,7 +32,7 @@ settings.watch('Accounts_AllowedDomainsList', (value) => {
 	emailDomainWhiteList = value
 		.split(',')
 		.filter(Boolean)
-		.map((domain) => domain.trim());
+		.map((domain) => domain.trim().toLowerCase());
 });
 
 export const validateEmailDomain = async function (email) {
@@ -43,7 +43,8 @@ export const validateEmailDomain = async function (email) {
 		});
 	}
 
-	const emailDomain = email.substr(email.lastIndexOf('@') + 1);
+	// Email domains are case-insensitive (RFC 1035/5321), so normalize before comparing against the allow/deny lists.
+	const emailDomain = email.substr(email.lastIndexOf('@') + 1).toLowerCase();
 
 	if (emailDomainWhiteList.length && !emailDomainWhiteList.includes(emailDomain)) {
 		throw new Meteor.Error('error-invalid-domain', 'The email domain is not in whitelist', {

--- a/apps/meteor/app/lib/server/lib/validateEmailDomain.js
+++ b/apps/meteor/app/lib/server/lib/validateEmailDomain.js
@@ -43,8 +43,7 @@ export const validateEmailDomain = async function (email) {
 		});
 	}
 
-	// Email domains are case-insensitive (RFC 1035/5321), so normalize before comparing against the allow/deny lists.
-	const emailDomain = email.substr(email.lastIndexOf('@') + 1).toLowerCase();
+	const emailDomain = email.slice(email.lastIndexOf('@') + 1).toLowerCase();
 
 	if (emailDomainWhiteList.length && !emailDomainWhiteList.includes(emailDomain)) {
 		throw new Meteor.Error('error-invalid-domain', 'The email domain is not in whitelist', {

--- a/apps/meteor/tests/unit/app/lib/server/lib/validateEmailDomain.spec.ts
+++ b/apps/meteor/tests/unit/app/lib/server/lib/validateEmailDomain.spec.ts
@@ -85,6 +85,11 @@ describe('validateEmailDomain', () => {
 			await expectRejectedWith('user@SPAM.com', 'error-email-domain-blacklisted');
 		});
 
+		it('should block when the configured blocked-domain entry is mixed-case', async () => {
+			setBlockedDomains('SPAM.COM');
+			await expectRejectedWith('user@spam.com', 'error-email-domain-blacklisted');
+		});
+
 		it('should block against the default blocked domains list case-insensitively', async () => {
 			getStub.withArgs('Accounts_UseDefaultBlockedDomainsList').returns(true);
 			// A non-empty custom blocked list is required for the default list to be consulted.

--- a/apps/meteor/tests/unit/app/lib/server/lib/validateEmailDomain.spec.ts
+++ b/apps/meteor/tests/unit/app/lib/server/lib/validateEmailDomain.spec.ts
@@ -1,0 +1,95 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+class MeteorError extends Error {
+	error: string;
+
+	reason?: string;
+
+	details?: unknown;
+
+	constructor(error: string, reason?: string, details?: unknown) {
+		super(reason ?? error);
+		this.error = error;
+		this.reason = reason;
+		this.details = details;
+	}
+}
+
+describe('validateEmailDomain', () => {
+	const getStub = sinon.stub();
+	const watchCallbacks: Record<string, (value?: string) => void> = {};
+	const watchStub = sinon.stub().callsFake((setting: string, callback: (value?: string) => void) => {
+		watchCallbacks[setting] = callback;
+	});
+
+	const { validateEmailDomain } = proxyquire.noCallThru().load('../../../../../../app/lib/server/lib/validateEmailDomain', {
+		'../../../settings/server': { settings: { watch: watchStub, get: getStub } },
+		'meteor/meteor': { Meteor: { Error: MeteorError } },
+	});
+
+	const setAllowedDomains = (value?: string) => watchCallbacks.Accounts_AllowedDomainsList(value);
+	const setBlockedDomains = (value?: string) => watchCallbacks.Accounts_BlockedDomainsList(value);
+
+	beforeEach(() => {
+		getStub.reset();
+		// Default every setting to off: no DNS check and no default blocklist.
+		getStub.returns(false);
+		// Reset the in-memory allow/deny lists between tests.
+		setAllowedDomains(undefined);
+		setBlockedDomains(undefined);
+	});
+
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	const expectRejectedWith = async (email: string, expectedError: string) => {
+		let error: MeteorError | undefined;
+		try {
+			await validateEmailDomain(email);
+		} catch (e) {
+			error = e as MeteorError;
+		}
+		expect(error, `expected "${email}" to be rejected`).to.be.instanceOf(MeteorError);
+		expect(error?.error).to.equal(expectedError);
+	};
+
+	describe('allowed domains list', () => {
+		beforeEach(() => {
+			setAllowedDomains('gmail.com');
+		});
+
+		it('should accept an email whose domain matches the allowed list in a different case', async () => {
+			expect(await validateEmailDomain('user@GMAIL.com')).to.be.undefined;
+		});
+
+		it('should accept an email whose domain matches the allowed list exactly', async () => {
+			expect(await validateEmailDomain('user@gmail.com')).to.be.undefined;
+		});
+
+		it('should reject an email whose domain is not in the allowed list, regardless of case', async () => {
+			await expectRejectedWith('user@Yahoo.com', 'error-invalid-domain');
+		});
+
+		it('should match case-insensitively even when the configured list value is mixed-case', async () => {
+			setAllowedDomains('GMail.COM');
+			expect(await validateEmailDomain('user@gmail.com')).to.be.undefined;
+		});
+	});
+
+	describe('blocked domains list', () => {
+		it('should block an email whose domain matches the blocked list in a different case', async () => {
+			setBlockedDomains('spam.com');
+			await expectRejectedWith('user@SPAM.com', 'error-email-domain-blacklisted');
+		});
+
+		it('should block against the default blocked domains list case-insensitively', async () => {
+			getStub.withArgs('Accounts_UseDefaultBlockedDomainsList').returns(true);
+			// A non-empty custom blocked list is required for the default list to be consulted.
+			setBlockedDomains('not-a-default-domain.test');
+			await expectRejectedWith('user@MAILINATOR.com', 'error-email-domain-blacklisted');
+		});
+	});
+});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Email domains are case-insensitive per RFC 1035/5321, but the allowed/blocked domain checks compared the email's domain string **as-is**. As a result, registering or setting an address like `user@GMAIL.com` was rejected when the **Allowed Domains List** contained `gmail.com`, and mixed-case entries in the **Blocked Domains List** were never matched. `user@gmail.com` worked, `user@GMAIL.com` did not.

This normalizes the extracted email domain — and the configured allow/deny list values — to lower case before the comparison. Only the transient value used for comparison is lower-cased; the **stored email address keeps its original casing**.

The bug is fixed in **both** places the check is implemented:

- `apps/meteor/app/lib/server/lib/validateEmailDomain.js` — used by registration, admin user creation and email change.
- `apps/meteor/app/authentication/server/startup/index.js` — the two duplicated allowed-domains checks in the `Accounts.onCreateUser` / `Accounts.validateNewUser` hooks, which also gate OAuth / external account creation.

Added a unit test (`apps/meteor/tests/unit/app/lib/server/lib/validateEmailDomain.spec.ts`) covering the allow-list, block-list and default-block-list paths for mixed-case domains, and a changeset.

## Issue(s)

Closes #40045

## Steps to test or reproduce

1. Admin → Workspace → **Settings → Accounts → Registration** → set **Allowed Domains List** to `gmail.com`.
2. Try to register (or, as an admin, set on an existing user) the email `user@GMAIL.com`.
3. **Before** this change the request is rejected with *"the email domain is not in whitelist"*; **after** it, `user@GMAIL.com` is accepted. `user@gmail.com` continues to work, and a domain that is genuinely not allowed (e.g. `user@Yahoo.com`) is still rejected.

Unit tests (from `apps/meteor`): `yarn .testunit:server` (the new spec lives under `tests/unit/app/lib/server/lib/`).

## Further comments

There are existing open PRs for this issue (#40046, #40049) that only touch `validateEmailDomain.js`. This PR additionally covers the **second, duplicated validation path** in the authentication startup hooks (which also affects OAuth/external account creation) and adds test coverage + a changeset. Happy to coordinate with the maintainers and original authors on the best path to merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated email domain allow/deny validation to be case-insensitive, ensuring mixed-case emails and configured allowed/blocked domains match correctly.

* **Tests**
  * Added unit tests covering case-insensitive matching for both allow and blocked domain lists, including scenarios involving the default blocked-domain list and expected error outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->