### PR TITLE
fix(message): Add server-side validation for empty and deleted messages

### DIFF
--- a/.changeset/fix-server-message-validation.md
+++ b/.changeset/fix-server-message-validation.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fix: Added server-side validation to prevent editing soft-deleted messages and bypasses using null bytes.

--- a/apps/meteor/server/lib/messages/updateMessage.ts
+++ b/apps/meteor/server/lib/messages/updateMessage.ts
@@ -25,6 +25,23 @@ export const updateMessage = async function (
 		throw new Error('Invalid message ID.');
 	}
 
+	if (originalMessage.t === 'rm') {
+		throw new Meteor.Error('error-action-not-allowed', 'Message editing not allowed', {
+			method: 'updateMessage',
+			action: 'Message_editing',
+		});
+	}
+
+	if (typeof message.msg === 'string') {
+		message.msg = message.msg.replace(/\0/g, '');
+	}
+
+	if (message.msg !== undefined && !message.msg?.trim() && !originalMessage.attachments?.length && !originalMessage.blocks?.length) {
+		throw new Meteor.Error('error-invalid-message', 'Message cannot be empty', {
+			method: 'updateMessage',
+		});
+	}
+
 	let messageData: IMessage = Object.assign({}, originalMessage, message);
 
 	// For the Rocket.Chat Apps :)

--- a/apps/meteor/server/lib/messages/updateMessage.ts
+++ b/apps/meteor/server/lib/messages/updateMessage.ts
@@ -36,7 +36,7 @@ export const updateMessage = async function (
 		message.msg = message.msg.replace(/\0/g, '');
 	}
 
-	if (message.msg !== undefined && !message.msg?.trim() && !originalMessage.attachments?.length && !originalMessage.blocks?.length) {
+	if (message.msg !== undefined && (typeof message.msg !== 'string' || !message.msg.trim()) && !originalMessage.attachments?.length && !originalMessage.blocks?.length) {
 		throw new Meteor.Error('error-invalid-message', 'Message cannot be empty', {
 			method: 'updateMessage',
 		});

--- a/apps/meteor/server/lib/messages/updateMessage.ts
+++ b/apps/meteor/server/lib/messages/updateMessage.ts
@@ -35,6 +35,9 @@ export const updateMessage = async function (
 	if (typeof message.msg === 'string') {
 		message.msg = message.msg.replace(/\0/g, '');
 	}
+	if (typeof message.attachments?.[0]?.description === 'string') {
+		message.attachments[0].description = message.attachments[0].description.replace(/\0/g, '');
+	}
 
 	if (message.msg !== undefined && (typeof message.msg !== 'string' || !message.msg.trim()) && !originalMessage.attachments?.length && !originalMessage.blocks?.length) {
 		throw new Meteor.Error('error-invalid-message', 'Message cannot be empty', {

--- a/apps/meteor/server/lib/messages/updateMessage.ts
+++ b/apps/meteor/server/lib/messages/updateMessage.ts
@@ -35,8 +35,12 @@ export const updateMessage = async function (
 	if (typeof message.msg === 'string') {
 		message.msg = message.msg.replace(/\0/g, '');
 	}
-	if (typeof message.attachments?.[0]?.description === 'string') {
-		message.attachments[0].description = message.attachments[0].description.replace(/\0/g, '');
+	if (Array.isArray(message.attachments)) {
+		for (const attachment of message.attachments) {
+			if (typeof attachment.description === 'string') {
+				attachment.description = attachment.description.replace(/\0/g, '');
+			}
+		}
 	}
 
 	if (message.msg !== undefined && (typeof message.msg !== 'string' || !message.msg.trim()) && !originalMessage.attachments?.length && !originalMessage.blocks?.length) {
@@ -85,8 +89,12 @@ export const updateMessage = async function (
 	if (typeof messageData.msg === 'string') {
 		messageData.msg = messageData.msg.replace(/\0/g, '');
 	}
-	if (typeof messageData.attachments?.[0]?.description === 'string') {
-		messageData.attachments[0].description = messageData.attachments[0].description.replace(/\0/g, '');
+	if (Array.isArray(messageData.attachments)) {
+		for (const attachment of messageData.attachments) {
+			if (typeof attachment.description === 'string') {
+				attachment.description = attachment.description.replace(/\0/g, '');
+			}
+		}
 	}
 
 	if (messageData.msg !== undefined && (typeof messageData.msg !== 'string' || !messageData.msg.trim()) && !messageData.attachments?.length && !messageData.blocks?.length) {
@@ -110,8 +118,8 @@ export const updateMessage = async function (
 	}
 
 	// do not send $unset if not defined. Can cause exceptions in certain mongo versions.
-	await Messages.updateOne(
-		{ _id },
+	const updateResult = await Messages.updateOne(
+		{ _id, t: { $ne: 'rm' } },
 		{
 			$set: {
 				...editedMessage,
@@ -119,6 +127,13 @@ export const updateMessage = async function (
 			...(!editedMessage.md && { $unset: { md: 1 } }),
 		},
 	);
+
+	if (updateResult.matchedCount === 0) {
+		throw new Meteor.Error('error-action-not-allowed', 'Message editing not allowed', {
+			method: 'updateMessage',
+			action: 'Message_editing',
+		});
+	}
 
 	if (Apps.self?.isLoaded()) {
 		// This returns a promise, but it won't mutate anything about the message

--- a/apps/meteor/server/lib/messages/updateMessage.ts
+++ b/apps/meteor/server/lib/messages/updateMessage.ts
@@ -82,6 +82,19 @@ export const updateMessage = async function (
 
 	messageData = await Message.beforeSave({ message: messageData, room, user, previewUrls, parseUrls });
 
+	if (typeof messageData.msg === 'string') {
+		messageData.msg = messageData.msg.replace(/\0/g, '');
+	}
+	if (typeof messageData.attachments?.[0]?.description === 'string') {
+		messageData.attachments[0].description = messageData.attachments[0].description.replace(/\0/g, '');
+	}
+
+	if (messageData.msg !== undefined && (typeof messageData.msg !== 'string' || !messageData.msg.trim()) && !messageData.attachments?.length && !messageData.blocks?.length) {
+		throw new Meteor.Error('error-invalid-message', 'Message cannot be empty', {
+			method: 'updateMessage',
+		});
+	}
+
 	if (messageData.customFields) {
 		validateCustomMessageFields({
 			customFields: messageData.customFields,

--- a/apps/meteor/server/meteor-methods/messages/sendMessage.ts
+++ b/apps/meteor/server/meteor-methods/messages/sendMessage.ts
@@ -66,7 +66,7 @@ export async function executeSendMessage(
 		message.msg = message.msg.replace(/\0/g, '');
 	}
 
-	if (!message.msg?.trim() && !message.attachments?.length && !message.blocks?.length) {
+	if ((typeof message.msg !== 'string' || !message.msg.trim()) && !message.attachments?.length && !message.blocks?.length) {
 		throw new Meteor.Error('error-invalid-message', 'Message cannot be empty', {
 			method: 'sendMessage',
 		});

--- a/apps/meteor/server/meteor-methods/messages/sendMessage.ts
+++ b/apps/meteor/server/meteor-methods/messages/sendMessage.ts
@@ -62,6 +62,16 @@ export async function executeSendMessage(
 		}
 	}
 
+	if (typeof message.msg === 'string') {
+		message.msg = message.msg.replace(/\0/g, '');
+	}
+
+	if (!message.msg?.trim() && !message.attachments?.length && !message.blocks?.length) {
+		throw new Meteor.Error('error-invalid-message', 'Message cannot be empty', {
+			method: 'sendMessage',
+		});
+	}
+
 	if (message.msg) {
 		if (message.msg.length > (settings.get<number>('Message_MaxAllowedSize') ?? 0)) {
 			throw new Meteor.Error('error-message-size-exceeded', 'Message size exceeds Message_MaxAllowedSize', {

--- a/apps/meteor/server/meteor-methods/messages/updateMessage.ts
+++ b/apps/meteor/server/meteor-methods/messages/updateMessage.ts
@@ -23,22 +23,6 @@ export async function executeUpdateMessage(
 		return;
 	}
 
-	if (originalMessage.t === 'rm') {
-		throw new Meteor.Error('error-action-not-allowed', 'Message editing not allowed', {
-			method: 'updateMessage',
-			action: 'Message_editing',
-		});
-	}
-
-	if (typeof message.msg === 'string') {
-		message.msg = message.msg.replace(/\0/g, '');
-	}
-
-	if (message.msg !== undefined && !message.msg?.trim() && !originalMessage.attachments?.length && !originalMessage.blocks?.length) {
-		throw new Meteor.Error('error-invalid-message', 'Message cannot be empty', {
-			method: 'updateMessage',
-		});
-	}
 
 	Object.entries(message).forEach(([key, value]) => {
 		if (!allowedEditedFields.includes(key) && value !== originalMessage[key as keyof IMessage]) {

--- a/apps/meteor/server/meteor-methods/messages/updateMessage.ts
+++ b/apps/meteor/server/meteor-methods/messages/updateMessage.ts
@@ -23,6 +23,23 @@ export async function executeUpdateMessage(
 		return;
 	}
 
+	if (originalMessage.t === 'rm') {
+		throw new Meteor.Error('error-action-not-allowed', 'Message editing not allowed', {
+			method: 'updateMessage',
+			action: 'Message_editing',
+		});
+	}
+
+	if (typeof message.msg === 'string') {
+		message.msg = message.msg.replace(/\0/g, '');
+	}
+
+	if (message.msg !== undefined && !message.msg?.trim() && !originalMessage.attachments?.length && !originalMessage.blocks?.length) {
+		throw new Meteor.Error('error-invalid-message', 'Message cannot be empty', {
+			method: 'updateMessage',
+		});
+	}
+
 	Object.entries(message).forEach(([key, value]) => {
 		if (!allowedEditedFields.includes(key) && value !== originalMessage[key as keyof IMessage]) {
 			throw new Meteor.Error('error-invalid-update-key', `Cannot update the message ${key}`, {


### PR DESCRIPTION
Fixes #40779

## Description
This PR addresses two missing server-side input validations in the `chat.sendMessage` and `chat.update` API endpoints:
1. **Empty Message Validation Bypass**: Incoming messages containing control characters like null bytes (`\u0000`) are now stripped on the server side. A strict validation ensures that the resulting message is not entirely empty unless it explicitly contains an attachment or UI block.
2. **Post-Deletion Editing**: Prevents authenticated users from editing a message that has already been soft-deleted (`t: 'rm'`). Attempting to edit a deleted message now correctly throws an `error-action-not-allowed`.

## Changes Made:
- Added null-byte sanitation (`.replace(/\0/g, '')`) to `sendMessage.ts` and `updateMessage.ts`.
- Implemented edge-case safe empty-string checks that respect media uploads (`!message.attachments?.length`) and bot integrations (`!message.blocks?.length`).
- Added a `t === 'rm'` status check in `executeUpdateMessage` to throw an error if the user targets a soft-deleted record.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented editing of restricted message types (including soft-deleted variants) to stop unauthorized changes.
  * Added server-side sanitization to remove null-byte (`\0`) characters from message text, including attachment descriptions, closing bypass routes.
  * Rejected effectively empty message sends and edits when only whitespace is provided and no attachments or blocks are present.
* **Chores**
  * Updated the package release note with a patch-level change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->