### PR TITLE
fix: Encrypted toggle ignored when creating a discussion

### DIFF
--- a/.changeset/fix-create-discussion-encrypted-flag.md
+++ b/.changeset/fix-create-discussion-encrypted-flag.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed the **Encrypted** toggle being ignored when creating a discussion from an unencrypted parent room. The `encrypted` flag selected in the Create Discussion dialog was not sent to the API, so the discussion was created unencrypted even though the user explicitly enabled encryption.

--- a/apps/meteor/client/components/CreateDiscussion/CreateDiscussion.spec.tsx
+++ b/apps/meteor/client/components/CreateDiscussion/CreateDiscussion.spec.tsx
@@ -63,6 +63,54 @@ describe('CreateDiscussion', () => {
 		expect(results).toHaveNoViolations();
 	});
 
+	describe('Encrypted flag submission', () => {
+		it('should send encrypted: true to the API when the encrypted toggle is enabled for an unencrypted parent room', async () => {
+			const createDiscussionEndpoint = jest.fn().mockReturnValue({
+				success: true,
+				discussion: {
+					...createFakeRoom({ _id: 'discussion-id', t: 'p' as const, prid: room2._id }),
+					rid: 'discussion-id',
+				} as any,
+			});
+
+			const appRootWithSpy = mockAppRoot()
+				.withEndpoint('POST', '/v1/rooms.createDiscussion', createDiscussionEndpoint)
+				.withEndpoint('GET', '/v1/rooms.autocomplete.channelAndPrivate', () => ({ items: [room1, room2] }) as any)
+				.withTranslations('en', 'core', {
+					Encrypted: 'Encrypted',
+					Name: 'Name',
+					Create: 'Create',
+					Discussion_target_channel: 'Parent channel or team',
+				})
+				.build();
+
+			render(<CreateDiscussion onClose={jest.fn()} />, { wrapper: appRootWithSpy });
+
+			const parentRoomSelect = screen.getByRole('textbox', { name: 'Parent channel or team' });
+			await userEvent.click(parentRoomSelect);
+			await waitFor(() => {
+				expect(screen.getByText('Unencrypted Room 2')).toBeInTheDocument();
+			});
+			await userEvent.click(screen.getByText('Unencrypted Room 2'));
+
+			await userEvent.type(screen.getByLabelText('Name'), 'My secret discussion');
+
+			await userEvent.click(screen.getByRole('checkbox', { name: 'Encrypted' }));
+
+			await userEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+			await waitFor(() => {
+				expect(createDiscussionEndpoint).toHaveBeenCalledWith(
+					expect.objectContaining({
+						prid: room2._id,
+						t_name: 'My secret discussion',
+						encrypted: true,
+					}),
+				);
+			});
+		});
+	});
+
 	describe('Encrypted parent room behavior', () => {
 		it('should disable encrypted toggle and first message field when parent room is encrypted', () => {
 			render(<CreateDiscussion onClose={jest.fn()} encryptedParentRoom={true} />, { wrapper: appRoot });

--- a/apps/meteor/client/components/CreateDiscussion/CreateDiscussion.spec.tsx
+++ b/apps/meteor/client/components/CreateDiscussion/CreateDiscussion.spec.tsx
@@ -109,6 +109,52 @@ describe('CreateDiscussion', () => {
 				);
 			});
 		});
+
+		it('should send encrypted: false to the API when the encrypted toggle is left off for an unencrypted parent room', async () => {
+			const createDiscussionEndpoint = jest.fn().mockReturnValue({
+				success: true,
+				discussion: {
+					...createFakeRoom({ _id: 'discussion-id', t: 'p' as const, prid: room2._id }),
+					rid: 'discussion-id',
+				} as any,
+			});
+
+			const appRootWithSpy = mockAppRoot()
+				.withEndpoint('POST', '/v1/rooms.createDiscussion', createDiscussionEndpoint)
+				.withEndpoint('GET', '/v1/rooms.autocomplete.channelAndPrivate', () => ({ items: [room1, room2] }) as any)
+				.withTranslations('en', 'core', {
+					Encrypted: 'Encrypted',
+					Name: 'Name',
+					Create: 'Create',
+					Discussion_target_channel: 'Parent channel or team',
+				})
+				.build();
+
+			render(<CreateDiscussion onClose={jest.fn()} />, { wrapper: appRootWithSpy });
+
+			const parentRoomSelect = screen.getByRole('textbox', { name: 'Parent channel or team' });
+			await userEvent.click(parentRoomSelect);
+			await waitFor(() => {
+				expect(screen.getByText('Unencrypted Room 2')).toBeInTheDocument();
+			});
+			await userEvent.click(screen.getByText('Unencrypted Room 2'));
+
+			await userEvent.type(screen.getByLabelText('Name'), 'My public discussion');
+
+			// leave the encrypted toggle off
+
+			await userEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+			await waitFor(() => {
+				expect(createDiscussionEndpoint).toHaveBeenCalledWith(
+					expect.objectContaining({
+						prid: room2._id,
+						t_name: 'My public discussion',
+						encrypted: false,
+					}),
+				);
+			});
+		});
 	});
 
 	describe('Encrypted parent room behavior', () => {

--- a/apps/meteor/client/components/CreateDiscussion/CreateDiscussion.tsx
+++ b/apps/meteor/client/components/CreateDiscussion/CreateDiscussion.tsx
@@ -96,6 +96,7 @@ const CreateDiscussion = ({
 			prid: defaultParentRoom || parentRoom,
 			t_name: name,
 			users: usernames,
+			encrypted,
 			reply: encrypted ? undefined : firstMessage,
 			topic,
 			...(parentMessageId && { pmid: parentMessageId }),


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

  The **Encrypted** toggle in the Create Discussion dialog was destructured in `handleCreate` but never included in the
  `rooms.createDiscussion` payload. As a result, discussions created from an unencrypted parent room were always created
  unencrypted, regardless of the toggle state.

  This passes the selected `encrypted` value to the endpoint, which — along with the REST schema
  (`RoomsCreateDiscussionProps` / `RoomsCreateDiscussionSchema`) and the server-side `createDiscussion` handler —
  already accepts and honors it. No API or schema changes were required; only the client payload was missing the field.

  A regression test was added to `CreateDiscussion.spec.tsx` that enables the encrypted toggle on an unencrypted parent
  room and asserts the `rooms.createDiscussion` endpoint is called with `encrypted: true`.

  ## Issue(s)

  Closes #39443

  ## Steps to test or reproduce

  1. Have (or create) an **unencrypted** channel.
  2. Create a discussion inside it and enable the **Encrypted** toggle.
  3. Create the discussion and open it.

  - **Before:** the discussion is created unencrypted despite the toggle being on.
  - **After:** the discussion is created encrypted, matching the toggle.

  ## Further comments

  This is a one-line client fix — the only missing piece was forwarding the already-supported `encrypted` flag from the
  form to the endpoint. The accompanying test guards against the field being dropped from the payload again.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the **Encrypted** toggle in the Create Discussion flow to properly include the user’s encryption selection when creating from an unencrypted parent room, ensuring the discussion is created with the intended encrypted state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->