### PR TITLE
fix: use $ne operator in findCustomRoles to prevent false negatives

### DIFF
--- a/.changeset/fix-missing-protected-roles.md
+++ b/.changeset/fix-missing-protected-roles.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/models': patch
+'@rocket.chat/meteor': patch
+---
+
+Fix custom roles not being found when `protected` is missing. Closes #40798.

--- a/apps/meteor/server/lib/roles/createOrUpdateProtectedRole.ts
+++ b/apps/meteor/server/lib/roles/createOrUpdateProtectedRole.ts
@@ -18,6 +18,8 @@ export const createOrUpdateProtectedRoleAsync = async (
 			roleData.mandatory2fa || role.mandatory2fa,
 		);
 
+		await Roles.updateOne({ _id: roleId, protected: { $ne: true } }, { $set: { protected: true } });
+
 		return;
 	}
 

--- a/apps/meteor/server/lib/roles/createOrUpdateProtectedRole.ts
+++ b/apps/meteor/server/lib/roles/createOrUpdateProtectedRole.ts
@@ -18,8 +18,6 @@ export const createOrUpdateProtectedRoleAsync = async (
 			roleData.mandatory2fa || role.mandatory2fa,
 		);
 
-		await Roles.updateOne({ _id: roleId, protected: { $ne: true } }, { $set: { protected: true } });
-
 		return;
 	}
 

--- a/packages/models/src/models/Roles.ts
+++ b/packages/models/src/models/Roles.ts
@@ -138,7 +138,7 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 
 	findCustomRoles(options?: FindOptions<IRole>): FindCursor<IRole> {
 		const query: Filter<IRole> = {
-			protected: false,
+			protected: { $ne: true },
 		};
 
 		return this.find(query, options || {});
@@ -146,7 +146,7 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 
 	countCustomRoles(options?: CountDocumentsOptions): Promise<number> {
 		const query: Filter<IRole> = {
-			protected: false,
+			protected: { $ne: true },
 		};
 
 		return this.countDocuments(query, options || {});


### PR DESCRIPTION
## Proposed changes

Fixed an issue where custom roles with a missing `protected` field were incorrectly excluded from query results.
fix: include roles with missing protected field in custom role queries
Previously, the query used:

```js
{ protected: false }
```

This only matched documents where `protected` was explicitly set to `false`, causing a false negative for legacy roles where the field was absent.

The query has been updated to:

```js
{ protected: { $ne: true } }
```

This correctly includes both:

* Roles with `protected: false`
* Roles where the `protected` field is missing

The same fix was applied to `countCustomRoles` to ensure consistency between role retrieval and counting operations.

## Issue(s)

Fixes incorrect custom role filtering when the `protected` field is absent.

## Steps to test or reproduce

1. Create a custom role without the `protected` field in the database.
2. Navigate to the Roles management page or invoke the affected API.
3. Observe that the role is not returned when using the previous query (`protected: false`).
4. Apply this change.
5. Verify that the role is now returned correctly.
6. Confirm that roles with `protected: true` remain excluded.
7. Verify that `countCustomRoles` returns the correct count.

## Further comments

This change preserves the intended behavior of excluding protected roles while maintaining compatibility with legacy documents that do not contain the `protected` field.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed custom roles not appearing when their protected status is unspecified.
  * Updated custom role searches and counts to consistently exclude only protected roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->