### PR TITLE
chore: fix spelling typos in apps-engine comments and messages

### DIFF
--- a/packages/apps-engine/src/definition/uploads/IPreFileUpload.ts
+++ b/packages/apps-engine/src/definition/uploads/IPreFileUpload.ts
@@ -7,7 +7,7 @@ import type { IFileUploadContext } from './IFileUploadContext';
  * register as a handler of the `IPreFileUpload`
  * event
  *
- * This event is triggered prior to an upload succesfully
+ * This event is triggered prior to an upload successfully
  * being saved to the database, but *after* all its contents
  * have been retrieved by Rocket.Chat.
  *

--- a/packages/apps/deno-runtime/lib/accessors/mod.ts
+++ b/packages/apps/deno-runtime/lib/accessors/mod.ts
@@ -66,7 +66,7 @@ export class AppAccessors {
 								return {};
 							}
 
-							// If the prop is inteded to be overriden by the caller
+							// If the prop is intended to be overridden by the caller
 							if (prop in overrides) {
 								return overrides[prop].apply(undefined, params);
 							}

--- a/packages/apps/src/server/AppManager.ts
+++ b/packages/apps/src/server/AppManager.ts
@@ -322,7 +322,7 @@ export class AppManager {
 
 			if (AppStatusUtils.isDisabled(await rl.getStatus())) {
 				// Usually if an App is disabled before it's initialized,
-				// then something (such as an error) occured while
+				// then something (such as an error) occurred while
 				// it was compiled or something similar.
 				// We still have to validate its license, though
 				await rl.validateLicense();

--- a/packages/apps/src/server/bridges/IInternalPersistenceBridge.ts
+++ b/packages/apps/src/server/bridges/IInternalPersistenceBridge.ts
@@ -1,6 +1,6 @@
 export interface IInternalPersistenceBridge {
 	/**
-	 * Purges the App's persistant storage data from the persistent storage.
+	 * Purges the App's persistent storage data from the persistent storage.
 	 * For apps engine's internal use
 	 *
 	 * @argument appId the id of the app's data to remove

--- a/packages/apps/src/server/bridges/PersistenceBridge.ts
+++ b/packages/apps/src/server/bridges/PersistenceBridge.ts
@@ -66,14 +66,14 @@ export abstract class PersistenceBridge extends BaseBridge {
 	}
 
 	/**
-	 * Purges the App's persistant storage data from the persistent storage.
+	 * Purges the App's persistent storage data from the persistent storage.
 	 *
 	 * @argument appId the id of the app's data to remove
 	 */
 	protected abstract purge(appId: string): Promise<void>;
 
 	/**
-	 * Creates a new persistant record with the provided data attached.
+	 * Creates a new persistent record with the provided data attached.
 	 *
 	 * @argument data the data to store in persistent storage
 	 * @argument appId the id of the app which is storing the data

--- a/packages/apps/src/server/errors/CompilerError.ts
+++ b/packages/apps/src/server/errors/CompilerError.ts
@@ -4,6 +4,6 @@ export class CompilerError implements Error {
 	public message: string;
 
 	constructor(detail: string) {
-		this.message = `An error occured while compiling an App: ${detail}`;
+		this.message = `An error occurred while compiling an App: ${detail}`;
 	}
 }

--- a/packages/apps/tests/server/errors/CompilerError.test.ts
+++ b/packages/apps/tests/server/errors/CompilerError.test.ts
@@ -8,6 +8,6 @@ describe('CompilerError', () => {
 		const er = new CompilerError('syntax');
 
 		assert.strictEqual(er.name, 'CompilerError');
-		assert.strictEqual(er.message, 'An error occured while compiling an App: syntax');
+		assert.strictEqual(er.message, 'An error occurred while compiling an App: syntax');
 	});
 });

--- a/packages/media-signaling/src/lib/Call.ts
+++ b/packages/media-signaling/src/lib/Call.ts
@@ -1435,7 +1435,7 @@ export class ClientMediaCall implements IClientMediaCall {
 					break;
 			}
 		} catch (e) {
-			this.config.logger?.error('An error occured while reviewing the webrtc connection state change', e);
+			this.config.logger?.error('An error occurred while reviewing the webrtc connection state change', e);
 		}
 	}
 


### PR DESCRIPTION
Corrects several genuine spelling typos in code comments, JSDoc, and one error message string:

- `occured` → `occurred` (`AppManager.ts`, `CompilerError.ts`, `media-signaling/Call.ts`)
- `overriden` → `overridden` and `inteded` → `intended` (`deno-runtime/lib/accessors/mod.ts` comment)
- `succesfully` → `successfully` (`IPreFileUpload.ts` JSDoc)
- `persistant` → `persistent` (persistence bridge comments)

The `CompilerError` message string change is mirrored in its unit test assertion (`CompilerError.test.ts`) so the test stays in sync. All other changes are comment/JSDoc only — no behavioral impact.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected spelling errors throughout code comments and documentation strings to improve code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->