### PR TITLE
fix: findCustomRoles/countCustomRoles miss roles with unset `protected` field

### DIFF
--- a/.changeset/fix-find-custom-roles-protected-filter.md
+++ b/.changeset/fix-find-custom-roles-protected-filter.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/models': patch
+---
+
+Fixed `findCustomRoles` and `countCustomRoles` missing legacy custom roles that have no `protected` field set. The filter now treats both `protected: false` and a missing/undefined `protected` field as non-protected, restoring expected behavior for instances upgraded from older Rocket.Chat versions.

--- a/packages/models/src/models/Roles.ts
+++ b/packages/models/src/models/Roles.ts
@@ -138,7 +138,7 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 
 	findCustomRoles(options?: FindOptions<IRole>): FindCursor<IRole> {
 		const query: Filter<IRole> = {
-			protected: false,
+			protected: { $ne: true },
 		};
 
 		return this.find(query, options || {});
@@ -146,7 +146,7 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 
 	countCustomRoles(options?: CountDocumentsOptions): Promise<number> {
 		const query: Filter<IRole> = {
-			protected: false,
+			protected: { $ne: true },
 		};
 
 		return this.countDocuments(query, options || {});


### PR DESCRIPTION
## Proposed changes

`findCustomRoles` and `countCustomRoles` in [`packages/models/src/models/Roles.ts`](https://github.com/RocketChat/Rocket.Chat/blob/develop/packages/models/src/models/Roles.ts) currently filter roles with `{ protected: false }`. MongoDB equality comparison against `false` only matches documents where the field is **explicitly** `false` — documents where `protected` is missing/undefined are excluded.

On Rocket.Chat instances upgraded from older versions, custom roles created years ago do not have a `protected` field stored at all. As a result, these legitimate custom roles are silently dropped from both queries, causing false negatives when listing or counting them.

Switching the filter to `{ protected: { $ne: true } }` makes the query match both `false` and missing values, which matches the semantic intent ("all roles that are not protected") and restores correct behavior for legacy databases.

## Issue(s)

Fixes #40798

(Also patches `countCustomRoles`, which has the same bug — not mentioned in the issue but the fix is identical and trivial.)

## Steps to test or reproduce

1. Insert a custom role into the `rocketchat_roles` collection **without** a `protected` field:
   ```js
   db.rocketchat_roles.insertOne({ _id: 'legacy-role', name: 'legacy-role', scope: 'Users' })
   ```
2. Call `Roles.findCustomRoles().toArray()` — before this PR the legacy role is missing; after the PR it appears.
3. Same for `Roles.countCustomRoles()`.

## Further comments

- Two-line behavioral change in a single file plus a changeset.
- No type change (`Filter<IRole>` already permits `{ $ne: T }` operator expressions).
- No tests changed because the existing test suite for `Roles` doesn't cover this query shape; happy to add a unit test if reviewers prefer.
- I'll sign the CLA on the PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed custom role filtering to correctly identify custom roles when the protected attribute is either explicitly disabled or undefined, ensuring consistent behavior across instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->