### PR TITLE
chore: use @rocket.chat/logger in presence service

### DIFF
--- a/ee/packages/presence/package.json
+++ b/ee/packages/presence/package.json
@@ -18,6 +18,7 @@
 	"dependencies": {
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
+		"@rocket.chat/logger": "workspace:^",
 		"@rocket.chat/models": "workspace:^",
 		"mongodb": "6.16.0"
 	},

--- a/ee/packages/presence/src/Presence.ts
+++ b/ee/packages/presence/src/Presence.ts
@@ -4,11 +4,14 @@ import type { IPresence, IBrokerNode } from '@rocket.chat/core-services';
 import { License, ServiceClass, Settings } from '@rocket.chat/core-services';
 import type { IUser } from '@rocket.chat/core-typings';
 import { UserStatus } from '@rocket.chat/core-typings';
+import { Logger } from '@rocket.chat/logger';
 import { Users, UsersSessions } from '@rocket.chat/models';
 
 import { PresenceReaper } from './lib/PresenceReaper';
 import { normalizeStatusText } from './lib/normalizeStatusText';
 import { type ClaimUpdate, processPresence } from './lib/presenceEngine';
+
+const logger = new Logger('Presence');
 
 const MAX_CONNECTIONS = 200;
 const MAX_TIMEOUT_DELAY_MS = 2 ** 31 - 1;
@@ -146,7 +149,7 @@ export class Presence extends ServiceClass implements IPresence {
 		const delay = Math.min(Math.max(next.statusExpiresAt.getTime() - Date.now(), 0), MAX_TIMEOUT_DELAY_MS);
 		this.expirationTimeout = setTimeout(() => {
 			this.expirationTimeout = undefined;
-			this.handleExpirationJob().catch((err) => console.error('[Presence] Error handling status expiration:', err));
+			this.handleExpirationJob().catch((err) => logger.error({ msg: 'Error handling status expiration', err }));
 		}, delay);
 	}
 
@@ -161,14 +164,15 @@ export class Presence extends ServiceClass implements IPresence {
 		const rejected = results.filter((result) => result.status === 'rejected');
 
 		if (fulfilled.length > 0) {
-			console.debug(`[PresenceReaper] Successfully updated presence for ${fulfilled.length} users.`);
+			logger.debug({ msg: 'Successfully updated presence for users', count: fulfilled.length });
 		}
 
 		if (rejected.length > 0) {
-			console.error(
-				`[PresenceReaper] Failed to update presence for ${rejected.length} users:`,
-				rejected.map(({ reason }) => reason),
-			);
+			logger.error({
+				msg: 'Failed to update presence for users',
+				count: rejected.length,
+				reasons: rejected.map(({ reason }): unknown => reason),
+			});
 		}
 	}
 

--- a/ee/packages/presence/src/lib/PresenceReaper.ts
+++ b/ee/packages/presence/src/lib/PresenceReaper.ts
@@ -1,8 +1,11 @@
 import { setInterval } from 'node:timers';
 
 import type { IUserSession } from '@rocket.chat/core-typings';
+import { Logger } from '@rocket.chat/logger';
 import { UsersSessions } from '@rocket.chat/models';
 import type { AnyBulkWriteOperation } from 'mongodb';
+
+const logger = new Logger('PresenceReaper');
 
 type ReaperPlan = {
 	userId: string;
@@ -48,7 +51,7 @@ export class PresenceReaper {
 
 		// Run every 1 minute
 		this.intervalId = setInterval(() => {
-			this.run().catch((err) => console.error('[PresenceReaper] Error:', err));
+			this.run().catch((err) => logger.error({ msg: 'Error running presence reaper', err }));
 		}, 60 * 1000);
 	}
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Replace the raw `console.*` calls in `@rocket.chat/presence` (`Presence.ts`, `PresenceReaper.ts`) with structured `@rocket.chat/logger` instances.

## Issue(s)
- [PRES-33](https://rocketchat.atlassian.net/browse/PRES-33)

## Steps to test or reproduce

## Further comments

Logging-only migration, no behavior change. No Dockerfile edit needed — `@rocket.chat/logger` is already a dependency of presence-service and copied into its build.


[PRES-33]: https://rocketchat.atlassian.net/browse/PRES-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved logging infrastructure in the presence service by integrating a dedicated logger instead of standard console outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->