### PR TITLE
chore: presence sync engine findings

### DIFF
--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -1982,12 +1982,6 @@ API.v1
 				),
 			);
 
-			if (!settings.get('Accounts_AllowUserStatusMessageChange')) {
-				throw new Meteor.Error('error-not-allowed', 'Change status is not allowed', {
-					method: 'users.setStatus',
-				});
-			}
-
 			const user = await (async () => {
 				if (isUserFromParams(this.bodyParams, this.userId, this.user)) {
 					return Users.findOneById(this.userId);
@@ -2009,6 +2003,12 @@ API.v1
 			}
 
 			const { status, message, expiresAt } = this.bodyParams;
+
+			if (message && !settings.get('Accounts_AllowUserStatusMessageChange')) {
+				throw new Meteor.Error('error-not-allowed', 'Change status is not allowed', {
+					method: 'users.setStatus',
+				});
+			}
 
 			const statusExpiresAt = expiresAt ? new Date(expiresAt) : undefined;
 			if (statusExpiresAt && Number.isNaN(statusExpiresAt.getTime())) {

--- a/apps/meteor/client/components/UserInfo/UserInfo.tsx
+++ b/apps/meteor/client/components/UserInfo/UserInfo.tsx
@@ -103,7 +103,7 @@ const UserInfo = ({
 				<InfoPanelSection>
 					{userDisplayName && <InfoPanelTitle icon={status} title={userDisplayName} />}
 
-					{statusText && (
+					{(statusText || statusExpiresAt) && (
 						<InfoPanelText>
 							<UserStatusText statusText={statusText} statusExpiresAt={statusExpiresAt} />
 						</InfoPanelText>

--- a/apps/meteor/client/navbar/NavBarSettingsToolbar/UserMenu/hooks/useStatusItems.tsx
+++ b/apps/meteor/client/navbar/NavBarSettingsToolbar/UserMenu/hooks/useStatusItems.tsx
@@ -142,7 +142,20 @@ export const useStatusItems = (user?: IUser): GenericMenuItemProps[] => {
 				}),
 			);
 
-		return [...items, ...presetItems];
+		// Admin-defined custom statuses
+		const customItems = (statuses ?? [])
+			.filter((s) => !userStatuses.isValidType(s.id))
+			.map(
+				(status): GenericMenuItemProps => ({
+					id: status.id,
+					status: <UserStatus status={status.statusType} />,
+					content: <MarkdownText content={status.localizeName ? t(status.name) : status.name} parseEmoji variant='inline' />,
+					addon: <RadioButton checked={user?.statusText === status.name} readOnly />,
+					onClick: () => setStatusMutation.mutate(status),
+				}),
+			);
+
+		return [...items, ...presetItems, ...customItems];
 	}, [
 		presenceDisabled,
 		allowUserStatusMessageChange,

--- a/apps/meteor/client/navbar/NavBarSettingsToolbar/UserMenu/hooks/useStatusItems.tsx
+++ b/apps/meteor/client/navbar/NavBarSettingsToolbar/UserMenu/hooks/useStatusItems.tsx
@@ -50,18 +50,21 @@ export const useStatusItems = (user?: IUser): GenericMenuItemProps[] => {
 
 	const { t } = useTranslation();
 
+	const presenceDisabled = useSetting('Presence_broadcast_disabled', false);
+	const allowUserStatusMessageChange = useSetting('Accounts_AllowUserStatusMessageChange', true);
+
 	const fireGlobalStatusEvent = useFireGlobalEvent('user-status-manually-set');
 	const setStatus = useEndpoint('POST', '/v1/users.setStatus');
 	const setStatusMutation = useMutation({
 		mutationFn: async (status: UserStatusDescriptor) => {
-			void setStatus({ status: status.statusType, message: userStatuses.isValidType(status.id) ? '' : status.name });
+			void setStatus({
+				status: status.statusType,
+				...(allowUserStatusMessageChange && { message: userStatuses.isValidType(status.id) ? '' : status.name }),
+			});
 			void clientCallbacks.run('userStatusManuallySet', status);
 			await fireGlobalStatusEvent.mutateAsync(status);
 		},
 	});
-
-	const presenceDisabled = useSetting('Presence_broadcast_disabled', false);
-	const allowUserStatusMessageChange = useSetting('Accounts_AllowUserStatusMessageChange', true);
 
 	const { data: statuses } = useQuery({
 		queryKey: ['user-statuses'],
@@ -77,7 +80,7 @@ export const useStatusItems = (user?: IUser): GenericMenuItemProps[] => {
 	const customStatusExpiration = useExpirationText(user?.statusExpiresAt);
 
 	return useMemo<GenericMenuItemProps[]>(() => {
-		if (presenceDisabled || !allowUserStatusMessageChange) {
+		if (presenceDisabled) {
 			return [
 				{
 					id: 'presence-disabled',
@@ -118,13 +121,15 @@ export const useStatusItems = (user?: IUser): GenericMenuItemProps[] => {
 			});
 		}
 
-		// Always: "Custom..." action - opens the edit modal.
-		items.push({
-			id: 'custom-status-edit',
-			icon: 'edit',
-			content: t('Custom_Status'),
-			onClick: handleCustomStatus,
-		});
+		// "Custom..." action opens the edit modal
+		if (allowUserStatusMessageChange) {
+			items.push({
+				id: 'custom-status-edit',
+				icon: 'edit',
+				content: t('Custom_Status'),
+				onClick: handleCustomStatus,
+			});
+		}
 
 		// Presets: filter to Online / Busy / Offline. Keep Away only if user is currently on Away (legacy).
 		const isPresetSelected = (statusType: UserStatusEnum): boolean =>
@@ -143,17 +148,19 @@ export const useStatusItems = (user?: IUser): GenericMenuItemProps[] => {
 			);
 
 		// Admin-defined custom statuses
-		const customItems = (statuses ?? [])
-			.filter((s) => !userStatuses.isValidType(s.id))
-			.map(
-				(status): GenericMenuItemProps => ({
-					id: status.id,
-					status: <UserStatus status={status.statusType} />,
-					content: <MarkdownText content={status.localizeName ? t(status.name) : status.name} parseEmoji variant='inline' />,
-					addon: <RadioButton checked={user?.statusText === status.name} readOnly />,
-					onClick: () => setStatusMutation.mutate(status),
-				}),
-			);
+		const customItems = allowUserStatusMessageChange
+			? (statuses ?? [])
+					.filter((s) => !userStatuses.isValidType(s.id))
+					.map(
+						(status): GenericMenuItemProps => ({
+							id: status.id,
+							status: <UserStatus status={status.statusType} />,
+							content: <MarkdownText content={status.localizeName ? t(status.name) : status.name} parseEmoji variant='inline' />,
+							addon: <RadioButton checked={user?.statusText === status.name} readOnly />,
+							onClick: () => setStatusMutation.mutate(status),
+						}),
+					)
+			: [];
 
 		return [...items, ...presetItems, ...customItems];
 	}, [

--- a/apps/meteor/client/views/account/profile/AccountProfileForm.tsx
+++ b/apps/meteor/client/views/account/profile/AccountProfileForm.tsx
@@ -168,14 +168,6 @@ const AccountProfileForm = (props: AllHTMLAttributes<HTMLFormElement>) => {
 			dirtyFields.statusCustomTime;
 
 		try {
-			if (statusDirty) {
-				await setUserStatus({
-					status: statusType,
-					...(allowUserStatusMessageChange && { message: statusText }),
-					...(allowUserStatusMessageChange && expiresAt && { expiresAt: expiresAt.toISOString() }),
-				});
-			}
-
 			await updateOwnBasicInfo({
 				data: {
 					name,
@@ -186,6 +178,14 @@ const AccountProfileForm = (props: AllHTMLAttributes<HTMLFormElement>) => {
 				},
 				customFields,
 			});
+
+			if (statusDirty) {
+				await setUserStatus({
+					status: statusType,
+					...(allowUserStatusMessageChange && { message: statusText }),
+					...(allowUserStatusMessageChange && expiresAt && { expiresAt: expiresAt.toISOString() }),
+				});
+			}
 
 			await updateAvatar();
 			dispatchToastMessage({ type: 'success', message: t('Profile_saved_successfully') });

--- a/apps/meteor/client/views/account/profile/AccountProfileForm.tsx
+++ b/apps/meteor/client/views/account/profile/AccountProfileForm.tsx
@@ -168,11 +168,11 @@ const AccountProfileForm = (props: AllHTMLAttributes<HTMLFormElement>) => {
 			dirtyFields.statusCustomTime;
 
 		try {
-			if (allowUserStatusMessageChange && statusDirty) {
+			if (statusDirty) {
 				await setUserStatus({
-					message: statusText,
 					status: statusType,
-					...(expiresAt && { expiresAt: expiresAt.toISOString() }),
+					...(allowUserStatusMessageChange && { message: statusText }),
+					...(allowUserStatusMessageChange && expiresAt && { expiresAt: expiresAt.toISOString() }),
 				});
 			}
 
@@ -322,6 +322,7 @@ const AccountProfileForm = (props: AllHTMLAttributes<HTMLFormElement>) => {
 										<InputBox
 											aria-label={t('Status_expiration_date')}
 											type='date'
+											disabled={!allowUserStatusMessageChange}
 											flexGrow={1}
 											value={value}
 											onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -339,6 +340,7 @@ const AccountProfileForm = (props: AllHTMLAttributes<HTMLFormElement>) => {
 										<InputBox
 											aria-label={t('Status_expiration_time')}
 											type='time'
+											disabled={!allowUserStatusMessageChange}
 											flexGrow={1}
 											value={value}
 											onChange={(e: ChangeEvent<HTMLInputElement>) => {

--- a/apps/meteor/client/views/account/profile/AccountProfileForm.tsx
+++ b/apps/meteor/client/views/account/profile/AccountProfileForm.tsx
@@ -148,7 +148,7 @@ const AccountProfileForm = (props: AllHTMLAttributes<HTMLFormElement>) => {
 			customDate: statusCustomDate,
 			customTime: statusCustomTime,
 		});
-		if (allowUserStatusMessageChange && (statusCustomDate || statusCustomTime)) {
+		if (allowUserStatusMessageChange && statusDuration === 'custom') {
 			if (!statusCustomDate || !statusCustomTime || !expiresAt) {
 				setError('statusDuration', { message: t('Status_choose_date_and_time') });
 				return;

--- a/apps/meteor/client/views/room/UserCard/UserCardWithData.tsx
+++ b/apps/meteor/client/views/room/UserCard/UserCardWithData.tsx
@@ -64,7 +64,9 @@ const UserCardWithData = ({ username, rid, onOpenUserInfo, onClose }: UserCardWi
 			etag: avatarETag,
 			localTime: utcOffset && Number.isInteger(utcOffset) && <LocalTime utcOffset={utcOffset} />,
 			status: _id && <ReactiveUserStatus uid={_id} />,
-			customStatus: statusText && <UserStatusText status={status} statusText={statusText} statusExpiresAt={statusExpiresAt} />,
+			customStatus: (statusText || statusExpiresAt) && (
+				<UserStatusText status={status} statusText={statusText} statusExpiresAt={statusExpiresAt} />
+			),
 			nickname,
 			freeSwitchExtension,
 		};

--- a/apps/meteor/server/services/media-call/service.ts
+++ b/apps/meteor/server/services/media-call/service.ts
@@ -370,13 +370,15 @@ export class MediaCallService extends ServiceClassInternal implements IMediaCall
 	}
 
 	private async setPresenceForUsers(uids: IUser['_id'][], callId: IMediaCall['_id']): Promise<void> {
+		const users = await Users.findByIds<Pick<IUser, '_id' | 'language'>>(uids, { projection: { language: 1 } }).toArray();
+		const languageByUid = new Map(users.map((user) => [user._id, user.language]));
+
 		await Promise.all(
 			uids.map(async (uid) => {
 				try {
-					const user = await Users.findOneById(uid, { projection: { language: 1 } });
 					await Presence.setActiveState(uid, {
 						statusDefault: UserStatus.BUSY,
-						statusText: i18n.t('Presence_status_on_a_call', { lng: this.getLanguageForUser(user?.language) }),
+						statusText: i18n.t('Presence_status_on_a_call', { lng: this.getLanguageForUser(languageByUid.get(uid)) }),
 						statusSource: 'internal',
 						statusId: callId,
 					});

--- a/apps/meteor/tests/data/utils.ts
+++ b/apps/meteor/tests/data/utils.ts
@@ -4,6 +4,18 @@ import { expect } from 'chai';
 
 import { api, request, type PathWithoutPrefix } from './api-data';
 
+export function withTimeout<T>(fn: (signal: AbortSignal) => Promise<T>, ms: number): Promise<T> {
+	const controller = new AbortController();
+
+	const timeoutId = setTimeout(() => {
+		controller.abort();
+	}, ms);
+
+	return fn(controller.signal).finally(() => {
+		clearTimeout(timeoutId);
+	});
+}
+
 export const pagination = <TPath extends PathWithoutPrefix<Path>>(
 	apiEndpoint: TPath,
 	credentials: Credentials,

--- a/apps/meteor/tests/end-to-end/api/calendar.ts
+++ b/apps/meteor/tests/end-to-end/api/calendar.ts
@@ -8,6 +8,7 @@ import { sleep } from '../../../lib/utils/sleep';
 import { getCredentials, api, request, credentials } from '../../data/api-data';
 import { password } from '../../data/user';
 import { createUser, deleteUser, login } from '../../data/users.helper';
+import { withTimeout } from '../../data/utils';
 import { IS_EE } from '../../e2e/config/constants';
 
 describe('[Calendar Events]', () => {
@@ -672,20 +673,20 @@ describe('[Calendar Events]', () => {
 		});
 
 		// claim apply/clear land asynchronously, so poll instead of asserting on a fixed sleep
-		const waitForStatusSource = async (
+		const waitForStatusSource = (
 			predicate: (source: string | undefined) => boolean,
 			{ timeout = 15000, interval = 500 } = {},
-		): Promise<string | undefined> => {
-			const deadline = Date.now() + timeout;
-			for (;;) {
-				const res = await request.get('/api/v1/users.getStatus').set(userCredentials).expect(200);
-				const source = res.body.statusSource;
-				if (predicate(source) || Date.now() >= deadline) {
-					return source;
+		): Promise<string | undefined> =>
+			withTimeout(async (signal) => {
+				for (;;) {
+					const res = await request.get('/api/v1/users.getStatus').set(userCredentials).expect(200);
+					const source = res.body.statusSource;
+					if (predicate(source) || signal.aborted) {
+						return source;
+					}
+					await sleep(interval);
 				}
-				await sleep(interval);
-			}
-		};
+			}, timeout);
 
 		it('should apply a calendar (external) claim for an in-progress event and clear it when removed', async () => {
 			const now = new Date();

--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -5658,7 +5658,7 @@ describe('[Users]', () => {
 					.set(credentials)
 					.send({
 						status: 'busy',
-						message: '',
+						message: 'test',
 					})
 					.expect('Content-Type', 'application/json')
 					.expect(400)


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Follow-up fixes and cleanups for the presence sync / custom status work. Each commit maps to a Jira ticket.

**Custom status & expiration UI**

- **[PRES-53] apply status only after profile update succeeds** — In `AccountProfileForm`, `setUserStatus` ran before `updateOwnBasicInfo`, so a failing profile save still applied the status. Reordered so the status call runs only after the basic-info update resolves.
- **[PRES-55] disable custom statuses when `Accounts_AllowUserStatusMessageChange` is false** — The setting blocked the entire `users.setStatus` endpoint. Now it only blocks status *message* changes: preset statuses (online/away/busy/offline) still work, while the "Custom..." action, admin-defined custom statuses, and the expiration date/time fields are hidden/disabled. Existing e2e adjusted accordingly.
- **[PRES-52] show timed status expiration when message is empty** — `UserInfo` and `UserCard` only rendered the status row when `statusText` was present, hiding the expiration on a message-less timed status. Now they render when either `statusText` or `statusExpiresAt` is set.
- **[PRES-50] profile save blocked by hidden status expiration fields** — Custom date/time validation fired on leftover field values even when the duration wasn't "custom", blocking save. Gated the validation on `statusDuration === 'custom'`.
- **[PRES-48] restore admin-defined custom statuses in user menu** — Admin-defined custom statuses had stopped appearing in the user status menu; re-added them to the menu items.

**Presence service & tests**

- **[PRES-46] batch-fetch user languages in media-call `setPresenceForUsers`** — Replaced a per-user `findOneById` inside the loop with a single `findByIds` projected to `language`, keyed by uid.
- **[PRES-45] use `withTimeout` helper for status polling in calendar e2e** — Extracted a reusable `AbortSignal`-based `withTimeout` helper and used it for the status-source polling loop.

## Issue(s)

- [PRES-53](https://rocketchat.atlassian.net/browse/PRES-53)
- [PRES-55](https://rocketchat.atlassian.net/browse/PRES-55)
- [PRES-52](https://rocketchat.atlassian.net/browse/PRES-52)
- [PRES-50](https://rocketchat.atlassian.net/browse/PRES-50)
- [PRES-48](https://rocketchat.atlassian.net/browse/PRES-48)
- [PRES-46](https://rocketchat.atlassian.net/browse/PRES-46)
- [PRES-45](https://rocketchat.atlassian.net/browse/PRES-45)

## Steps to test or reproduce

- **PRES-53**: With an invalid profile field, save — status must not change when the save fails.
- **PRES-55**: Set `Accounts_AllowUserStatusMessageChange` off — presets still settable; custom status action, admin custom statuses, and expiration fields are unavailable.
- **PRES-52**: Set a timed status with an empty message — the expiration still shows in UserInfo and UserCard.
- **PRES-50**: Open the profile form with a non-custom duration and save — no spurious "choose date and time" error.
- **PRES-48**: Define a custom status in admin — it appears in the user status menu.

## Further comments


[PRES-53]: https://rocketchat.atlassian.net/browse/PRES-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PRES-55]: https://rocketchat.atlassian.net/browse/PRES-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PRES-52]: https://rocketchat.atlassian.net/browse/PRES-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PRES-50]: https://rocketchat.atlassian.net/browse/PRES-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom status items can now be selected when enabled by administrator.

* **Improvements**
  * Status information now displays when either text or expiration date is present.
  * Status message change enforcement refined to apply only when messages are modified.
  * Optimized performance for status update operations through improved data lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->