### PR TITLE
refactor: Migrate sidebar room list to Virtua

### DIFF
--- a/apps/meteor/client/sidebar/RoomList/RoomList.spec.tsx
+++ b/apps/meteor/client/sidebar/RoomList/RoomList.spec.tsx
@@ -1,6 +1,6 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
 import { render, screen } from '@testing-library/react';
 import type { HTMLAttributes, ReactNode } from 'react';
-import { forwardRef } from 'react';
 
 import RoomList from './RoomList';
 import type { SidebarRoomListGroup } from '../hooks/useRoomList';
@@ -85,25 +85,6 @@ const mockSidebarVirtualList = jest.fn(({ groups, renderGroup, renderItem, getIt
 	);
 });
 
-jest.mock('@rocket.chat/fuselage', () => ({
-	Box: forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(function Box({ children, ...props }, ref) {
-		return (
-			<div ref={ref} {...props}>
-				{children}
-			</div>
-		);
-	}),
-}));
-
-jest.mock('@rocket.chat/ui-contexts', () => ({
-	useUserId: () => 'user-id',
-	useUserPreference: () => 'extended',
-}));
-
-jest.mock('react-i18next', () => ({
-	useTranslation: () => ({ t: (key: string) => key }),
-}));
-
 jest.mock('../components/SidebarVirtualList', () => ({
 	__esModule: true,
 	default: (props: MockSidebarVirtualListProps) => mockSidebarVirtualList(props),
@@ -174,13 +155,15 @@ jest.mock('./RoomListRowWrapper', () => ({
 	),
 }));
 
+const appRoot = mockAppRoot().withJohnDoe().withUserPreference('sidebarViewMode', 'extended').build();
+
 describe('RoomList', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
 
 	it('passes grouped room data to SidebarVirtualList', () => {
-		render(<RoomList />);
+		render(<RoomList />, { wrapper: appRoot });
 
 		expect(screen.getByTestId('sidebar-virtual-list')).toBeInTheDocument();
 		expect(mockSidebarVirtualList).toHaveBeenCalledWith(

--- a/apps/meteor/client/sidebar/RoomList/RoomList.spec.tsx
+++ b/apps/meteor/client/sidebar/RoomList/RoomList.spec.tsx
@@ -173,7 +173,7 @@ describe('RoomList', () => {
 					{ key: 'Direct_Messages', group: groups[1], items: [rooms[2]] },
 					{ key: 'Empty_Group', group: groups[2], items: [] },
 				],
-				bufferSize: 25,
+				bufferSize: 240,
 			}),
 		);
 		expect(screen.getAllByTestId('group-header').map((element) => element.textContent)).toEqual([

--- a/apps/meteor/client/sidebar/RoomList/RoomList.spec.tsx
+++ b/apps/meteor/client/sidebar/RoomList/RoomList.spec.tsx
@@ -1,0 +1,181 @@
+import { render, screen } from '@testing-library/react';
+import type { HTMLAttributes, ReactNode } from 'react';
+import { forwardRef } from 'react';
+
+import RoomList from './RoomList';
+import type { SidebarRoomListGroup } from '../hooks/useRoomList';
+
+const mockCollapsedGroups: string[] = [];
+const mockHandleClick = jest.fn();
+const mockHandleKeyDown = jest.fn();
+const mockMoveCategory = jest.fn();
+const mockUsePreventDefault = jest.fn();
+const mockUseShortcutOpenMenu = jest.fn();
+
+const rooms = [
+	{ _id: 'general', name: 'general' },
+	{ _id: 'support', name: 'support' },
+	{ _id: 'alice', name: 'alice' },
+];
+
+const emptyUnreadInfo = { userMentions: 0, groupMentions: 0, unread: 0, tunread: [], tunreadUser: [] };
+
+const makeGroup = (key: string, groupRooms: typeof rooms, unread: number): SidebarRoomListGroup =>
+	({
+		key,
+		title: key,
+		translateTitle: true,
+		showUnreads: false,
+		keepUnreadsOnTop: false,
+		collapsed: false,
+		rooms: groupRooms,
+		unreadInfo: { ...emptyUnreadInfo, unread },
+		empty: groupRooms.length === 0,
+	}) as unknown as SidebarRoomListGroup;
+
+const groups = [
+	makeGroup('Channels', [rooms[0], rooms[1]], 3),
+	makeGroup('Direct_Messages', [rooms[2]], 1),
+	makeGroup('Empty_Group', [], 0),
+];
+
+type MockSidebarVirtualListProps = {
+	groups: {
+		key: string;
+		group: SidebarRoomListGroup;
+		items: typeof rooms;
+	}[];
+	renderGroup: (group: SidebarRoomListGroup, groupIndex: number) => ReactNode;
+	renderItem: (item: (typeof rooms)[number], itemIndex: number, group: SidebarRoomListGroup, groupIndex: number) => ReactNode;
+	getItemKey: (item: (typeof rooms)[number]) => string;
+	overscan?: number;
+};
+
+const mockSidebarVirtualList = jest.fn(({ groups, renderGroup, renderItem, getItemKey }: MockSidebarVirtualListProps) => (
+	<div data-testid='sidebar-virtual-list'>
+		{groups.map(({ key, group, items }, groupIndex) => (
+			<section key={key} data-testid='virtual-group'>
+				{renderGroup(group, groupIndex)}
+				{items.map((item, itemIndex) => (
+					<div key={getItemKey(item)} data-testid='virtual-item'>
+						{renderItem(item, itemIndex, group, groupIndex)}
+					</div>
+				))}
+			</section>
+		))}
+	</div>
+));
+
+jest.mock('@rocket.chat/fuselage', () => ({
+	Box: forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(function Box({ children, ...props }, ref) {
+		return (
+			<div ref={ref} {...props}>
+				{children}
+			</div>
+		);
+	}),
+}));
+
+jest.mock('@rocket.chat/ui-contexts', () => ({
+	useUserId: () => 'user-id',
+	useUserPreference: () => 'extended',
+}));
+
+jest.mock('react-i18next', () => ({
+	useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../components/SidebarVirtualList', () => ({
+	__esModule: true,
+	default: (props: MockSidebarVirtualListProps) => mockSidebarVirtualList(props),
+}));
+
+jest.mock('../../lib/RoomManager', () => ({
+	useOpenedRoom: () => 'GENERAL',
+}));
+
+jest.mock('../categories/hooks/useMoveCategoryPosition', () => ({
+	useMoveCategoryPosition: () => mockMoveCategory,
+}));
+
+jest.mock('../hooks/useAvatarTemplate', () => ({
+	useAvatarTemplate: () => 'AvatarTemplate',
+}));
+
+jest.mock('../hooks/useCategoryList', () => ({
+	SIDEBAR_DYNAMIC_GROUP_KEYS: ['Unread', 'Favorites'],
+}));
+
+jest.mock('../hooks/useCollapsedGroups', () => ({
+	useCollapsedGroups: () => ({
+		collapsedGroups: mockCollapsedGroups,
+		handleClick: mockHandleClick,
+		handleKeyDown: mockHandleKeyDown,
+	}),
+}));
+
+jest.mock('../hooks/usePreventDefault', () => ({
+	usePreventDefault: (ref: unknown) => mockUsePreventDefault(ref),
+}));
+
+jest.mock('../hooks/useRoomList', () => ({
+	useRoomList: () => ({
+		groups,
+		groupsCount: [2, 1, 0],
+		totalCount: 3,
+	}),
+}));
+
+jest.mock('../hooks/useShortcutOpenMenu', () => ({
+	useShortcutOpenMenu: (ref: unknown) => mockUseShortcutOpenMenu(ref),
+}));
+
+jest.mock('../hooks/useTemplateByViewMode', () => ({
+	useTemplateByViewMode: () => 'SidebarItemTemplate',
+}));
+
+jest.mock('./RoomListCollapser', () => ({
+	__esModule: true,
+	default: ({ group }: { group: SidebarRoomListGroup }) => (
+		<button type='button' data-testid='group-header'>{`${group.title}:${group.unreadInfo.unread}`}</button>
+	),
+}));
+
+jest.mock('./RoomListRow', () => ({
+	__esModule: true,
+	default: ({ item }: { item: (typeof rooms)[number] }) => <div data-testid='room-row'>{item.name}</div>,
+}));
+
+jest.mock('./RoomListRowWrapper', () => ({
+	__esModule: true,
+	default: ({ children }: { children: ReactNode }) => <div data-testid='room-row-wrapper'>{children}</div>,
+}));
+
+describe('RoomList', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('passes grouped room data to SidebarVirtualList', () => {
+		render(<RoomList />);
+
+		expect(screen.getByTestId('sidebar-virtual-list')).toBeInTheDocument();
+		expect(mockSidebarVirtualList).toHaveBeenCalledWith(
+			expect.objectContaining({
+				groups: [
+					{ key: 'Channels', group: groups[0], items: [rooms[0], rooms[1]] },
+					{ key: 'Direct_Messages', group: groups[1], items: [rooms[2]] },
+					{ key: 'Empty_Group', group: groups[2], items: [] },
+				],
+				overscan: 25,
+			}),
+		);
+		expect(screen.getAllByTestId('group-header').map((element) => element.textContent)).toEqual([
+			'Channels:3',
+			'Direct_Messages:1',
+			'Empty_Group:0',
+		]);
+		expect(screen.getAllByTestId('room-row-wrapper')).toHaveLength(3);
+		expect(screen.getAllByTestId('room-row').map((element) => element.textContent)).toEqual(['general', 'support', 'alice']);
+	});
+});

--- a/apps/meteor/client/sidebar/RoomList/RoomList.spec.tsx
+++ b/apps/meteor/client/sidebar/RoomList/RoomList.spec.tsx
@@ -46,25 +46,44 @@ type MockSidebarVirtualListProps = {
 		items: typeof rooms;
 	}[];
 	renderGroup: (group: SidebarRoomListGroup, groupIndex: number) => ReactNode;
-	renderItem: (item: (typeof rooms)[number], itemIndex: number, group: SidebarRoomListGroup, groupIndex: number) => ReactNode;
+	renderItem: (
+		item: (typeof rooms)[number],
+		itemIndex: number,
+		group: SidebarRoomListGroup,
+		groupIndex: number,
+		rowIndex: number,
+	) => ReactNode;
 	getItemKey: (item: (typeof rooms)[number]) => string;
 	overscan?: number;
 };
 
-const mockSidebarVirtualList = jest.fn(({ groups, renderGroup, renderItem, getItemKey }: MockSidebarVirtualListProps) => (
-	<div data-testid='sidebar-virtual-list'>
-		{groups.map(({ key, group, items }, groupIndex) => (
-			<section key={key} data-testid='virtual-group'>
-				{renderGroup(group, groupIndex)}
-				{items.map((item, itemIndex) => (
-					<div key={getItemKey(item)} data-testid='virtual-item'>
-						{renderItem(item, itemIndex, group, groupIndex)}
-					</div>
-				))}
-			</section>
-		))}
-	</div>
-));
+const mockSidebarVirtualList = jest.fn(({ groups, renderGroup, renderItem, getItemKey }: MockSidebarVirtualListProps) => {
+	let rowIndex = 0;
+
+	return (
+		<div data-testid='sidebar-virtual-list'>
+			{groups.map(({ key, group, items }, groupIndex) => {
+				rowIndex += 1;
+
+				return (
+					<section key={key} data-testid='virtual-group'>
+						{renderGroup(group, groupIndex)}
+						{items.map((item, itemIndex) => {
+							const itemRowIndex = rowIndex;
+							rowIndex += 1;
+
+							return (
+								<div key={getItemKey(item)} data-testid='virtual-item'>
+									{renderItem(item, itemIndex, group, groupIndex, itemRowIndex)}
+								</div>
+							);
+						})}
+					</section>
+				);
+			})}
+		</div>
+	);
+});
 
 jest.mock('@rocket.chat/fuselage', () => ({
 	Box: forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(function Box({ children, ...props }, ref) {
@@ -148,7 +167,11 @@ jest.mock('./RoomListRow', () => ({
 
 jest.mock('./RoomListRowWrapper', () => ({
 	__esModule: true,
-	default: ({ children }: { children: ReactNode }) => <div data-testid='room-row-wrapper'>{children}</div>,
+	default: ({ children, ...props }: { children: ReactNode } & HTMLAttributes<HTMLDivElement>) => (
+		<div data-testid='room-row-wrapper' {...props}>
+			{children}
+		</div>
+	),
 }));
 
 describe('RoomList', () => {
@@ -176,6 +199,7 @@ describe('RoomList', () => {
 			'Empty_Group:0',
 		]);
 		expect(screen.getAllByTestId('room-row-wrapper')).toHaveLength(3);
+		expect(screen.getAllByTestId('room-row-wrapper').map((element) => element.getAttribute('data-index'))).toEqual(['1', '2', '4']);
 		expect(screen.getAllByTestId('room-row').map((element) => element.textContent)).toEqual(['general', 'support', 'alice']);
 	});
 });

--- a/apps/meteor/client/sidebar/RoomList/RoomList.spec.tsx
+++ b/apps/meteor/client/sidebar/RoomList/RoomList.spec.tsx
@@ -54,7 +54,7 @@ type MockSidebarVirtualListProps = {
 		rowIndex: number,
 	) => ReactNode;
 	getItemKey: (item: (typeof rooms)[number]) => string;
-	overscan?: number;
+	bufferSize?: number;
 };
 
 const mockSidebarVirtualList = jest.fn(({ groups, renderGroup, renderItem, getItemKey }: MockSidebarVirtualListProps) => {
@@ -173,7 +173,7 @@ describe('RoomList', () => {
 					{ key: 'Direct_Messages', group: groups[1], items: [rooms[2]] },
 					{ key: 'Empty_Group', group: groups[2], items: [] },
 				],
-				overscan: 25,
+				bufferSize: 25,
 			}),
 		);
 		expect(screen.getAllByTestId('group-header').map((element) => element.textContent)).toEqual([

--- a/apps/meteor/client/sidebar/RoomList/RoomList.tsx
+++ b/apps/meteor/client/sidebar/RoomList/RoomList.tsx
@@ -1,7 +1,6 @@
 import { Box } from '@rocket.chat/fuselage';
-import type { SubscriptionWithRoom } from '@rocket.chat/ui-contexts';
 import { useUserPreference, useUserId } from '@rocket.chat/ui-contexts';
-import { useCallback, useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import RoomListCollapser from './RoomListCollapser';
@@ -15,7 +14,6 @@ import { useAvatarTemplate } from '../hooks/useAvatarTemplate';
 import { SIDEBAR_DYNAMIC_GROUP_KEYS } from '../hooks/useCategoryList';
 import { useCollapsedGroups } from '../hooks/useCollapsedGroups';
 import { usePreventDefault } from '../hooks/usePreventDefault';
-import type { SidebarRoomListGroup } from '../hooks/useRoomList';
 import { useRoomList } from '../hooks/useRoomList';
 import { useShortcutOpenMenu } from '../hooks/useShortcutOpenMenu';
 import { useTemplateByViewMode } from '../hooks/useTemplateByViewMode';
@@ -25,8 +23,6 @@ const canMoveGroup = (groups: { key: string }[], index: number, direction: 'up' 
 	if (direction === 'down') return index + 1 < groups.length;
 	return groups.slice(0, index).some((g) => !SIDEBAR_DYNAMIC_GROUP_KEYS.includes(g.key));
 };
-
-const getItemKey = (item: SubscriptionWithRoom) => item._id;
 
 const RoomList = () => {
 	const { t } = useTranslation();
@@ -69,30 +65,6 @@ const RoomList = () => {
 		[groups],
 	);
 
-	const renderGroup = useCallback(
-		(group: SidebarRoomListGroup, index: number) => (
-			<RoomListCollapser
-				group={group}
-				canMoveUp={canMoveGroup(groups, index, 'up')}
-				canMoveDown={canMoveGroup(groups, index, 'down')}
-				onMoveUp={() => moveCategory(allGroupKeys, group.key, 'up')}
-				onMoveDown={() => moveCategory(allGroupKeys, group.key, 'down')}
-				onClick={() => handleClick(group.key)}
-				onKeyDown={(e) => handleKeyDown(e, group.key)}
-			/>
-		),
-		[allGroupKeys, groups, handleClick, handleKeyDown, moveCategory],
-	);
-
-	const renderItem = useCallback(
-		(item: SubscriptionWithRoom) => (
-			<RoomListRowWrapper>
-				<RoomListRow data={itemData} item={item} />
-			</RoomListRowWrapper>
-		),
-		[itemData],
-	);
-
 	usePreventDefault(ref);
 	useShortcutOpenMenu(ref);
 
@@ -102,9 +74,23 @@ const RoomList = () => {
 				groups={virtualGroups}
 				as={RoomListWrapper}
 				overscan={25}
-				getItemKey={getItemKey}
-				renderGroup={renderGroup}
-				renderItem={renderItem}
+				getItemKey={(item) => item._id}
+				renderGroup={(group, index) => (
+					<RoomListCollapser
+						group={group}
+						canMoveUp={canMoveGroup(groups, index, 'up')}
+						canMoveDown={canMoveGroup(groups, index, 'down')}
+						onMoveUp={() => moveCategory(allGroupKeys, group.key, 'up')}
+						onMoveDown={() => moveCategory(allGroupKeys, group.key, 'down')}
+						onClick={() => handleClick(group.key)}
+						onKeyDown={(e) => handleKeyDown(e, group.key)}
+					/>
+				)}
+				renderItem={(item, _itemIndex, _group, _groupIndex, rowIndex) => (
+					<RoomListRowWrapper data-index={rowIndex}>
+						<RoomListRow data={itemData} item={item} />
+					</RoomListRowWrapper>
+				)}
 			/>
 		</Box>
 	);

--- a/apps/meteor/client/sidebar/RoomList/RoomList.tsx
+++ b/apps/meteor/client/sidebar/RoomList/RoomList.tsx
@@ -24,6 +24,16 @@ const canMoveGroup = (groups: { key: string }[], index: number, direction: 'up' 
 	return groups.slice(0, index).some((g) => !SIDEBAR_DYNAMIC_GROUP_KEYS.includes(g.key));
 };
 
+type SidebarViewMode = 'extended' | 'medium' | 'condensed';
+
+const sidebarRowHeight: Record<SidebarViewMode, number> = {
+	condensed: 28,
+	medium: 36,
+	extended: 48,
+};
+
+const SIDEBAR_VIRTUAL_BUFFER_ROWS = 5;
+
 const RoomList = () => {
 	const { t } = useTranslation();
 	const userId = useUserId();
@@ -36,7 +46,8 @@ const RoomList = () => {
 	const sideBarItemTemplate = useTemplateByViewMode();
 	const ref = useRef<HTMLElement | null>(null);
 	const openedRoom = useOpenedRoom() ?? '';
-	const sidebarViewMode = useUserPreference<'extended' | 'medium' | 'condensed'>('sidebarViewMode') || 'extended';
+	const sidebarViewMode = useUserPreference<SidebarViewMode>('sidebarViewMode') || 'extended';
+	const bufferSize = sidebarRowHeight[sidebarViewMode] * SIDEBAR_VIRTUAL_BUFFER_ROWS;
 
 	const extended = sidebarViewMode === 'extended';
 	const itemData = useMemo(
@@ -73,7 +84,7 @@ const RoomList = () => {
 			<SidebarVirtualList
 				groups={virtualGroups}
 				as={RoomListWrapper}
-				bufferSize={25}
+				bufferSize={bufferSize}
 				getItemKey={(item) => item._id}
 				renderGroup={(group, index) => (
 					<RoomListCollapser

--- a/apps/meteor/client/sidebar/RoomList/RoomList.tsx
+++ b/apps/meteor/client/sidebar/RoomList/RoomList.tsx
@@ -73,7 +73,7 @@ const RoomList = () => {
 			<SidebarVirtualList
 				groups={virtualGroups}
 				as={RoomListWrapper}
-				overscan={25}
+				bufferSize={25}
 				getItemKey={(item) => item._id}
 				renderGroup={(group, index) => (
 					<RoomListCollapser

--- a/apps/meteor/client/sidebar/RoomList/RoomList.tsx
+++ b/apps/meteor/client/sidebar/RoomList/RoomList.tsx
@@ -1,10 +1,8 @@
 import { Box } from '@rocket.chat/fuselage';
-import { useResizeObserver } from '@rocket.chat/fuselage-hooks';
-import { VirtualizedScrollbars } from '@rocket.chat/ui-client';
+import type { SubscriptionWithRoom } from '@rocket.chat/ui-contexts';
 import { useUserPreference, useUserId } from '@rocket.chat/ui-contexts';
-import { useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { GroupedVirtuoso } from 'react-virtuoso';
 
 import RoomListCollapser from './RoomListCollapser';
 import RoomListRow from './RoomListRow';
@@ -12,10 +10,12 @@ import RoomListRowWrapper from './RoomListRowWrapper';
 import RoomListWrapper from './RoomListWrapper';
 import { useOpenedRoom } from '../../lib/RoomManager';
 import { useMoveCategoryPosition } from '../categories/hooks/useMoveCategoryPosition';
+import SidebarVirtualList from '../components/SidebarVirtualList';
 import { useAvatarTemplate } from '../hooks/useAvatarTemplate';
 import { SIDEBAR_DYNAMIC_GROUP_KEYS } from '../hooks/useCategoryList';
 import { useCollapsedGroups } from '../hooks/useCollapsedGroups';
 import { usePreventDefault } from '../hooks/usePreventDefault';
+import type { SidebarRoomListGroup } from '../hooks/useRoomList';
 import { useRoomList } from '../hooks/useRoomList';
 import { useShortcutOpenMenu } from '../hooks/useShortcutOpenMenu';
 import { useTemplateByViewMode } from '../hooks/useTemplateByViewMode';
@@ -26,17 +26,19 @@ const canMoveGroup = (groups: { key: string }[], index: number, direction: 'up' 
 	return groups.slice(0, index).some((g) => !SIDEBAR_DYNAMIC_GROUP_KEYS.includes(g.key));
 };
 
+const getItemKey = (item: SubscriptionWithRoom) => item._id;
+
 const RoomList = () => {
 	const { t } = useTranslation();
 	const userId = useUserId();
 	const isAnonymous = !userId;
 
 	const { collapsedGroups, handleClick, handleKeyDown } = useCollapsedGroups();
-	const { groups, groupsCount, totalCount } = useRoomList({ collapsedGroups });
+	const { groups } = useRoomList({ collapsedGroups });
 	const moveCategory = useMoveCategoryPosition();
 	const avatarTemplate = useAvatarTemplate();
 	const sideBarItemTemplate = useTemplateByViewMode();
-	const { ref } = useResizeObserver<HTMLElement>({ debounceDelay: 100 });
+	const ref = useRef<HTMLElement | null>(null);
 	const openedRoom = useOpenedRoom() ?? '';
 	const sidebarViewMode = useUserPreference<'extended' | 'medium' | 'condensed'>('sidebarViewMode') || 'extended';
 
@@ -57,43 +59,53 @@ const RoomList = () => {
 
 	const allGroupKeys = useMemo(() => groups.map((group) => group.key), [groups]);
 
+	const virtualGroups = useMemo(
+		() =>
+			groups.map((group) => ({
+				key: group.key,
+				group,
+				items: group.rooms,
+			})),
+		[groups],
+	);
+
+	const renderGroup = useCallback(
+		(group: SidebarRoomListGroup, index: number) => (
+			<RoomListCollapser
+				group={group}
+				canMoveUp={canMoveGroup(groups, index, 'up')}
+				canMoveDown={canMoveGroup(groups, index, 'down')}
+				onMoveUp={() => moveCategory(allGroupKeys, group.key, 'up')}
+				onMoveDown={() => moveCategory(allGroupKeys, group.key, 'down')}
+				onClick={() => handleClick(group.key)}
+				onKeyDown={(e) => handleKeyDown(e, group.key)}
+			/>
+		),
+		[allGroupKeys, groups, handleClick, handleKeyDown, moveCategory],
+	);
+
+	const renderItem = useCallback(
+		(item: SubscriptionWithRoom) => (
+			<RoomListRowWrapper>
+				<RoomListRow data={itemData} item={item} />
+			</RoomListRowWrapper>
+		),
+		[itemData],
+	);
+
 	usePreventDefault(ref);
 	useShortcutOpenMenu(ref);
 
 	return (
 		<Box position='relative' overflow='hidden' height='full' ref={ref}>
-			<VirtualizedScrollbars>
-				<GroupedVirtuoso
-					groupCounts={groupsCount}
-					groupContent={(index) => {
-						const group = groups[index];
-
-						const onMoveUp = () => moveCategory(allGroupKeys, group.key, 'up');
-						const onMoveDown = () => moveCategory(allGroupKeys, group.key, 'down');
-
-						return (
-							<RoomListCollapser
-								group={group}
-								canMoveUp={canMoveGroup(groups, index, 'up')}
-								canMoveDown={canMoveGroup(groups, index, 'down')}
-								onMoveUp={onMoveUp}
-								onMoveDown={onMoveDown}
-								onClick={() => handleClick(group.key)}
-								onKeyDown={(e) => handleKeyDown(e, group.key)}
-							/>
-						);
-					}}
-					{...(totalCount > 0 && {
-						itemContent: (index, groupIndex) => {
-							const group = groups[groupIndex];
-							const correctedIndex = index - groupsCount.slice(0, groupIndex).reduce((acc, count) => acc + count, 0);
-							const item = group.rooms[correctedIndex];
-							return item && <RoomListRow data={itemData} item={item} />;
-						},
-					})}
-					components={{ Item: RoomListRowWrapper, List: RoomListWrapper }}
-				/>
-			</VirtualizedScrollbars>
+			<SidebarVirtualList
+				groups={virtualGroups}
+				as={RoomListWrapper}
+				overscan={25}
+				getItemKey={getItemKey}
+				renderGroup={renderGroup}
+				renderItem={renderItem}
+			/>
 		</Box>
 	);
 };

--- a/apps/meteor/client/sidebar/RoomList/RoomListWrapper.spec.tsx
+++ b/apps/meteor/client/sidebar/RoomList/RoomListWrapper.spec.tsx
@@ -13,6 +13,17 @@ jest.mock('./useSidebarListNavigation', () => ({
 }));
 
 describe('RoomListWrapper', () => {
+	it('uses the legacy Virtuoso item list test id by default', () => {
+		render(
+			<RoomListWrapper style={{ height: '100%' }}>
+				<div>general</div>
+			</RoomListWrapper>,
+		);
+
+		expect(screen.getByTestId('virtuoso-item-list')).toHaveRole('list');
+		expect(screen.getByTestId('virtuoso-item-list')).toHaveAttribute('aria-label', 'Channels');
+	});
+
 	it('forwards Virtua container props', () => {
 		render(
 			<RoomListWrapper data-testid='room-list-wrapper' style={{ height: '100%' }}>

--- a/apps/meteor/client/sidebar/RoomList/RoomListWrapper.spec.tsx
+++ b/apps/meteor/client/sidebar/RoomList/RoomListWrapper.spec.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+
+import RoomListWrapper from './RoomListWrapper';
+
+jest.mock('react-i18next', () => ({
+	useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('./useSidebarListNavigation', () => ({
+	useSidebarListNavigation: () => ({
+		sidebarListRef: { current: null },
+	}),
+}));
+
+describe('RoomListWrapper', () => {
+	it('forwards Virtua container props', () => {
+		render(
+			<RoomListWrapper data-testid='room-list-wrapper' style={{ height: '100%' }}>
+				<div>general</div>
+			</RoomListWrapper>,
+		);
+
+		expect(screen.getByRole('list', { name: 'Channels' })).toBeInTheDocument();
+		expect(screen.getByTestId('room-list-wrapper')).toHaveStyle({ height: '100%' });
+		expect(screen.getByText('general')).toBeInTheDocument();
+	});
+});

--- a/apps/meteor/client/sidebar/RoomList/RoomListWrapper.tsx
+++ b/apps/meteor/client/sidebar/RoomList/RoomListWrapper.tsx
@@ -2,17 +2,25 @@ import { useMergedRefs } from '@rocket.chat/fuselage-hooks';
 import type { ForwardedRef, HTMLAttributes } from 'react';
 import { forwardRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import type { CustomContainerComponentProps } from 'virtua';
 
 import { useSidebarListNavigation } from './useSidebarListNavigation';
 
-export type RoomListWrapperProps = HTMLAttributes<HTMLDivElement>;
+export type RoomListWrapperProps = CustomContainerComponentProps & Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'style'>;
 
-const RoomListWrapper = forwardRef(function RoomListWrapper(props: RoomListWrapperProps, ref: ForwardedRef<HTMLDivElement>) {
+const RoomListWrapper = forwardRef(function RoomListWrapper(
+	{ children, style, ...props }: RoomListWrapperProps,
+	ref: ForwardedRef<HTMLDivElement>,
+) {
 	const { t } = useTranslation();
 	const { sidebarListRef } = useSidebarListNavigation();
 	const mergedRefs = useMergedRefs(ref, sidebarListRef);
 
-	return <div role='list' aria-label={t('Channels')} ref={mergedRefs} {...props} />;
+	return (
+		<div {...props} role='list' aria-label={t('Channels')} ref={mergedRefs} style={style}>
+			{children}
+		</div>
+	);
 });
 
 export default RoomListWrapper;

--- a/apps/meteor/client/sidebar/RoomList/RoomListWrapper.tsx
+++ b/apps/meteor/client/sidebar/RoomList/RoomListWrapper.tsx
@@ -6,10 +6,13 @@ import type { CustomContainerComponentProps } from 'virtua';
 
 import { useSidebarListNavigation } from './useSidebarListNavigation';
 
-export type RoomListWrapperProps = CustomContainerComponentProps & Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'style'>;
+export type RoomListWrapperProps = CustomContainerComponentProps &
+	Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'style'> & {
+		'data-testid'?: string;
+	};
 
 const RoomListWrapper = forwardRef(function RoomListWrapper(
-	{ children, style, ...props }: RoomListWrapperProps,
+	{ children, style, 'data-testid': dataTestId, ...props }: RoomListWrapperProps,
 	ref: ForwardedRef<HTMLDivElement>,
 ) {
 	const { t } = useTranslation();
@@ -17,7 +20,7 @@ const RoomListWrapper = forwardRef(function RoomListWrapper(
 	const mergedRefs = useMergedRefs(ref, sidebarListRef);
 
 	return (
-		<div {...props} role='list' aria-label={t('Channels')} ref={mergedRefs} style={style}>
+		<div {...props} data-testid={dataTestId ?? 'virtuoso-item-list'} role='list' aria-label={t('Channels')} ref={mergedRefs} style={style}>
 			{children}
 		</div>
 	);

--- a/apps/meteor/client/sidebar/Sidebar.stories.tsx
+++ b/apps/meteor/client/sidebar/Sidebar.stories.tsx
@@ -26,6 +26,20 @@ const settings: Record<string, ISetting> = {
 		public: true,
 		_updatedAt: new Date(),
 	},
+	Discussion_enabled: {
+		_id: 'Discussion_enabled',
+		blocked: false,
+		createdAt: new Date(),
+		env: true,
+		i18nLabel: 'Discussions',
+		packageValue: true,
+		sorter: 1,
+		ts: new Date(),
+		type: 'boolean',
+		value: true,
+		public: true,
+		_updatedAt: new Date(),
+	},
 };
 
 const settingContextValue: ContextType<typeof SettingsContext> = {
@@ -44,36 +58,97 @@ const userPreferences: Record<string, unknown> = {
 	sidebarSortby: 'activity',
 };
 
-const subscriptions: SubscriptionWithRoom[] = [
-	{
-		_id: '3Bysd8GrmkWBdS9RT',
+const createSubscription = ({
+	_id,
+	name,
+	t = 'c',
+	f = false,
+	unread = 0,
+	userMentions = 0,
+	groupMentions = 0,
+	prid,
+	teamMain = false,
+}: {
+	_id: string;
+	name: string;
+	t?: SubscriptionWithRoom['t'];
+	f?: boolean;
+	unread?: number;
+	userMentions?: number;
+	groupMentions?: number;
+	prid?: string;
+	teamMain?: boolean;
+}): SubscriptionWithRoom =>
+	({
+		_id,
 		open: true,
-		alert: true,
-		unread: 0,
-		userMentions: 0,
-		groupMentions: 0,
+		alert: unread > 0 || userMentions > 0 || groupMentions > 0,
+		unread,
+		userMentions,
+		groupMentions,
 		ts: new Date(),
-		rid: 'GENERAL',
-		name: 'general',
-		t: 'c',
+		rid: _id.toUpperCase(),
+		name,
+		t,
+		f,
 		u: {
 			_id: '5yLFEABCSoqR5vozz',
-			username: 'yyy',
-			name: 'yyy',
+			username: 'john.doe',
+			name: 'John Doe',
 		},
 		_updatedAt: new Date(),
 		ls: new Date(),
 		lr: new Date(),
-		tunread: [],
-		lowerCaseName: 'general',
-		lowerCaseFName: 'general',
+		tunread: unread > 0 ? [`${_id}-thread`] : [],
+		tunreadUser: userMentions > 0 ? [`${_id}-mention`] : [],
+		tunreadGroup: groupMentions > 0 ? [`${_id}-group`] : [],
+		lowerCaseName: name.toLowerCase(),
+		lowerCaseFName: name.toLowerCase(),
 		estimatedWaitingTimeQueue: 0,
 		livechatData: undefined,
 		priorityWeight: 3,
+		prid,
 		responseBy: undefined,
+		teamMain,
 		usersCount: 0,
 		waitingResponse: undefined,
-	},
+	}) as SubscriptionWithRoom;
+
+const subscriptions: SubscriptionWithRoom[] = [
+	...Array.from({ length: 32 }, (_, index) =>
+		createSubscription({
+			_id: `channel-${index}`,
+			name: `channel-${index}`,
+			f: index % 11 === 0,
+			unread: index % 5 === 0 ? index + 1 : 0,
+			userMentions: index % 9 === 0 ? 1 : 0,
+		}),
+	),
+	...Array.from({ length: 8 }, (_, index) =>
+		createSubscription({
+			_id: `team-${index}`,
+			name: `team-${index}`,
+			teamMain: true,
+			unread: index % 4 === 0 ? 2 : 0,
+		}),
+	),
+	...Array.from({ length: 10 }, (_, index) =>
+		createSubscription({
+			_id: `direct-${index}`,
+			name: `direct-${index}`,
+			t: 'd',
+			f: index === 0,
+			unread: index % 3 === 0 ? 1 : 0,
+		}),
+	),
+	...Array.from({ length: 6 }, (_, index) =>
+		createSubscription({
+			_id: `discussion-${index}`,
+			name: `discussion-${index}`,
+			prid: 'GENERAL',
+			groupMentions: index === 0 ? 1 : 0,
+		}),
+	),
 ];
 
 const userContextValue: ContextType<typeof UserContext> = {

--- a/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.spec.tsx
+++ b/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.spec.tsx
@@ -1,0 +1,158 @@
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import type { CSSProperties, ElementType, HTMLAttributes, ReactNode } from 'react';
+import { Children, createElement, forwardRef } from 'react';
+import type { CustomContainerComponentProps } from 'virtua';
+
+import SidebarVirtualList from './SidebarVirtualList';
+import type { SidebarVirtualListGroup } from './SidebarVirtualList';
+
+type MockVirtualizerProps = {
+	children: ReactNode;
+	bufferSize?: number;
+	as?: ElementType;
+	style?: CSSProperties;
+	className?: string;
+};
+
+jest.mock('virtua', () => {
+	return {
+		Virtualizer: ({ children, bufferSize, as: root = 'div', style, className }: MockVirtualizerProps) =>
+			createElement(
+				root,
+				{ className, 'data-buffer-size': bufferSize, 'data-testid': 'virtual-list', 'style': style ?? { height: '100%' } },
+				Children.toArray(children),
+			),
+	};
+});
+
+jest.mock('@rocket.chat/ui-client', () => ({
+	...jest.requireActual('@rocket.chat/ui-client'),
+	CustomVirtuaScrollbars: forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(function CustomVirtuaScrollbars(
+		{ children, ...props },
+		ref,
+	) {
+		return (
+			<div ref={ref} {...props}>
+				{children}
+			</div>
+		);
+	}),
+}));
+
+type TestGroup = {
+	title: string;
+};
+
+type TestItem = {
+	_id: string;
+	name: string;
+};
+
+const groups: SidebarVirtualListGroup<TestGroup, TestItem>[] = [
+	{
+		key: 'channels',
+		group: { title: 'Channels' },
+		items: [
+			{ _id: 'general', name: 'general' },
+			{ _id: 'support', name: 'support' },
+		],
+	},
+	{
+		key: 'direct',
+		group: { title: 'Direct Messages' },
+		items: [{ _id: 'alice', name: 'alice' }],
+	},
+];
+
+const defaultProps = {
+	groups,
+	getItemKey: (item: TestItem) => item._id,
+	renderGroup: (group: TestGroup, groupIndex: number) => <div data-testid='virtual-row'>{`group:${groupIndex}:${group.title}`}</div>,
+	renderItem: (item: TestItem, itemIndex: number, group: TestGroup, groupIndex: number) => (
+		<div data-testid='virtual-row'>{`item:${groupIndex}:${itemIndex}:${group.title}:${item.name}`}</div>
+	),
+};
+
+const renderVirtualList = (
+	props: Partial<{
+		groups: SidebarVirtualListGroup<TestGroup, TestItem>[];
+		overscan: number;
+		as: ElementType;
+	}> = {},
+) => render(<SidebarVirtualList {...defaultProps} {...props} />);
+
+describe('SidebarVirtualList', () => {
+	it('renders group rows and item rows in order', () => {
+		renderVirtualList();
+
+		expect(screen.getAllByTestId('virtual-row').map((row) => row.textContent)).toEqual([
+			'group:0:Channels',
+			'item:0:0:Channels:general',
+			'item:0:1:Channels:support',
+			'group:1:Direct Messages',
+			'item:1:0:Direct Messages:alice',
+		]);
+	});
+
+	it('renders a group with no items', () => {
+		renderVirtualList({
+			groups: [
+				{
+					key: 'empty',
+					group: { title: 'Empty Group' },
+					items: [],
+				},
+			],
+		});
+
+		expect(screen.getAllByTestId('virtual-row').map((row) => row.textContent)).toEqual(['group:0:Empty Group']);
+	});
+
+	it('passes overscan to Virtua as buffer size', () => {
+		renderVirtualList({ overscan: 25 });
+
+		expect(screen.getByTestId('virtual-list')).toHaveAttribute('data-buffer-size', '25');
+	});
+
+	it('uses the caller-provided list container', () => {
+		const ListContainer = forwardRef<HTMLDivElement, CustomContainerComponentProps>(function ListContainer({ children, style }, ref) {
+			return (
+				<div ref={ref} role='list' data-testid='custom-list' style={style}>
+					{children}
+				</div>
+			);
+		});
+
+		renderVirtualList({ as: ListContainer });
+
+		expect(screen.getByTestId('custom-list')).toHaveAttribute('role', 'list');
+		expect(screen.getByTestId('custom-list')).toHaveTextContent('group:0:Channels');
+	});
+
+	it('has no accessibility violations for an accessible caller-provided list', async () => {
+		const ListContainer = forwardRef<HTMLDivElement, CustomContainerComponentProps>(function ListContainer({ children, style }, ref) {
+			return (
+				<div ref={ref} role='list' aria-label='Channels' style={style}>
+					{children}
+				</div>
+			);
+		});
+
+		const { container } = render(
+			<SidebarVirtualList
+				groups={groups}
+				as={ListContainer}
+				getItemKey={(item) => item._id}
+				renderGroup={(group) => (
+					<div role='listitem'>
+						<button type='button'>{group.title}</button>
+					</div>
+				)}
+				renderItem={(item) => <div role='listitem'>{item.name}</div>}
+			/>,
+		);
+
+		expect(await axe(container)).toHaveNoViolations();
+	});
+});

--- a/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.spec.tsx
+++ b/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.spec.tsx
@@ -1,13 +1,14 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
-import type { CSSProperties, ElementType, HTMLAttributes, ReactNode } from 'react';
-import { Children, createElement, forwardRef } from 'react';
-import type { CustomContainerComponentProps } from 'virtua';
+import type { CSSProperties, ElementType, HTMLAttributes, ReactNode, Ref } from 'react';
+import { Children, createElement, forwardRef, useImperativeHandle } from 'react';
+import type { CustomContainerComponentProps, VirtualizerHandle } from 'virtua';
 
 import SidebarVirtualList from './SidebarVirtualList';
 import type { SidebarVirtualListGroup } from './SidebarVirtualList';
 
 let mockVisibleIndexes: number[] | undefined;
+let mockScrollOffset = 0;
 
 type MockVirtualizerProps = {
 	children: ReactNode | ((item: unknown, index: number) => ReactNode);
@@ -16,24 +17,50 @@ type MockVirtualizerProps = {
 	as?: ElementType;
 	style?: CSSProperties;
 	className?: string;
+	keepMounted?: readonly number[];
+	onScroll?: (offset: number) => void;
 };
 
 jest.mock('virtua', () => {
 	return {
-		Virtualizer: ({ children, data, bufferSize, as: root = 'div', style, className }: MockVirtualizerProps) => {
+		Virtualizer: forwardRef(function MockVirtualizer(
+			{ children, data, bufferSize, as: root = 'div', style, className, keepMounted, onScroll }: MockVirtualizerProps,
+			ref: Ref<VirtualizerHandle>,
+		) {
+			useImperativeHandle(ref, () => ({
+				cache: {} as VirtualizerHandle['cache'],
+				scrollOffset: mockScrollOffset,
+				scrollSize: 0,
+				viewportSize: 0,
+				findItemIndex: (offset: number) => Math.max(0, Math.floor(offset / 100)),
+				getItemOffset: () => 0,
+				getItemSize: () => 0,
+				scrollToIndex: jest.fn(),
+				scrollTo: jest.fn(),
+				scrollBy: jest.fn(),
+			}));
+
+			const visibleIndexes = new Set(mockVisibleIndexes ?? Array.from({ length: data?.length ?? 0 }, (_, index) => index));
+			keepMounted?.forEach((index) => visibleIndexes.add(index));
+
 			const childrenToRender =
 				typeof children === 'function'
-					? (mockVisibleIndexes ?? Array.from({ length: data?.length ?? 0 }, (_, index) => index)).map((index) =>
-							children(data?.[index], index),
-						)
-					: Children.toArray(children).filter((_, index) => !mockVisibleIndexes || mockVisibleIndexes.includes(index));
+					? [...visibleIndexes].sort((a, b) => a - b).map((index) => children(data?.[index], index))
+					: Children.toArray(children).filter((_, index) => visibleIndexes.has(index));
 
 			return createElement(
 				root,
-				{ className, 'data-buffer-size': bufferSize, 'data-testid': 'virtual-list', 'style': style ?? { height: '100%' } },
+				{
+					className,
+					'data-buffer-size': bufferSize,
+					'data-keep-mounted': keepMounted?.join(','),
+					'data-testid': 'virtual-list',
+					'style': style ?? { height: '100%' },
+					'onScroll': () => onScroll?.(mockScrollOffset),
+				},
 				childrenToRender,
 			);
-		},
+		}),
 	};
 });
 
@@ -98,6 +125,7 @@ const renderVirtualList = (
 describe('SidebarVirtualList', () => {
 	beforeEach(() => {
 		mockVisibleIndexes = undefined;
+		mockScrollOffset = 0;
 	});
 
 	it('renders group rows and item rows in order', () => {
@@ -129,10 +157,39 @@ describe('SidebarVirtualList', () => {
 	it('exposes the legacy Virtuoso group row hook used by E2E locators', () => {
 		renderVirtualList();
 
-		expect(screen.getAllByTestId('virtuoso-top-item-list').map((row) => row.textContent)).toEqual([
-			'group:0:Channels',
-			'group:1:Direct Messages',
-		]);
+		expect(screen.getAllByTestId('virtuoso-top-item-list')).toHaveLength(1);
+		expect(screen.getByTestId('virtuoso-top-item-list')).toHaveTextContent('group:0:Channels');
+	});
+
+	it('keeps only the active group header mounted', () => {
+		mockVisibleIndexes = [3];
+
+		renderVirtualList();
+
+		expect(screen.getByTestId('virtual-list')).toHaveAttribute('data-keep-mounted', '0');
+	});
+
+	it('applies sticky positioning to the active group header only', () => {
+		renderVirtualList();
+
+		expect(screen.getByTestId('virtuoso-top-item-list')).toHaveStyle({
+			position: 'sticky',
+			top: '0px',
+			zIndex: '1',
+		});
+	});
+
+	it('updates the active sticky group header while scrolling', () => {
+		renderVirtualList();
+
+		expect(screen.getByTestId('virtuoso-top-item-list')).toHaveTextContent('group:0:Channels');
+
+		mockScrollOffset = 400;
+
+		fireEvent.scroll(screen.getByTestId('virtual-list'));
+
+		expect(screen.getByTestId('virtuoso-top-item-list')).toHaveTextContent('group:1:Direct Messages');
+		expect(screen.getByTestId('virtual-list')).toHaveAttribute('data-keep-mounted', '3');
 	});
 
 	it('defers item rendering until Virtua requests the row', () => {

--- a/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.spec.tsx
+++ b/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
-import type { CSSProperties, ElementType, HTMLAttributes, ReactNode, Ref } from 'react';
+import type { CSSProperties, ElementType, HTMLAttributes, ReactNode } from 'react';
 import { Children, createElement, forwardRef } from 'react';
 import type { CustomContainerComponentProps } from 'virtua';
 
@@ -20,10 +20,7 @@ type MockVirtualizerProps = {
 
 jest.mock('virtua', () => {
 	return {
-		Virtualizer: forwardRef(function MockVirtualizer(
-			{ children, data, bufferSize, as: root = 'div', style, className }: MockVirtualizerProps,
-			_ref: Ref<unknown>,
-		) {
+		Virtualizer({ children, data, bufferSize, as: root = 'div', style, className }: MockVirtualizerProps) {
 			const visibleIndexes = new Set(mockVisibleIndexes ?? Array.from({ length: data?.length ?? 0 }, (_, index) => index));
 
 			const childrenToRender =
@@ -41,7 +38,7 @@ jest.mock('virtua', () => {
 				},
 				childrenToRender,
 			);
-		}),
+		},
 	};
 });
 

--- a/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.spec.tsx
+++ b/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.spec.tsx
@@ -1,14 +1,13 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import type { CSSProperties, ElementType, HTMLAttributes, ReactNode, Ref } from 'react';
-import { Children, createElement, forwardRef, useImperativeHandle } from 'react';
-import type { CustomContainerComponentProps, VirtualizerHandle } from 'virtua';
+import { Children, createElement, forwardRef } from 'react';
+import type { CustomContainerComponentProps } from 'virtua';
 
 import SidebarVirtualList from './SidebarVirtualList';
 import type { SidebarVirtualListGroup } from './SidebarVirtualList';
 
 let mockVisibleIndexes: number[] | undefined;
-let mockScrollOffset = 0;
 
 type MockVirtualizerProps = {
 	children: ReactNode | ((item: unknown, index: number) => ReactNode);
@@ -17,33 +16,15 @@ type MockVirtualizerProps = {
 	as?: ElementType;
 	style?: CSSProperties;
 	className?: string;
-	keepMounted?: readonly number[];
-	onScroll?: (offset: number) => void;
 };
 
 jest.mock('virtua', () => {
 	return {
 		Virtualizer: forwardRef(function MockVirtualizer(
-			{ children, data, bufferSize, as: root = 'div', style, className, keepMounted, onScroll }: MockVirtualizerProps,
-			ref: Ref<VirtualizerHandle>,
+			{ children, data, bufferSize, as: root = 'div', style, className }: MockVirtualizerProps,
+			_ref: Ref<unknown>,
 		) {
-			useImperativeHandle(ref, () => ({
-				cache: {} as VirtualizerHandle['cache'],
-				get scrollOffset() {
-					return mockScrollOffset;
-				},
-				scrollSize: 0,
-				viewportSize: 0,
-				findItemIndex: (offset: number) => Math.max(0, Math.floor(offset / 100)),
-				getItemOffset: () => 0,
-				getItemSize: () => 0,
-				scrollToIndex: jest.fn(),
-				scrollTo: jest.fn(),
-				scrollBy: jest.fn(),
-			}));
-
 			const visibleIndexes = new Set(mockVisibleIndexes ?? Array.from({ length: data?.length ?? 0 }, (_, index) => index));
-			keepMounted?.forEach((index) => visibleIndexes.add(index));
 
 			const childrenToRender =
 				typeof children === 'function'
@@ -55,10 +36,8 @@ jest.mock('virtua', () => {
 				{
 					className,
 					'data-buffer-size': bufferSize,
-					'data-keep-mounted': keepMounted?.join(','),
 					'data-testid': 'virtual-list',
 					'style': style ?? { height: '100%' },
-					'onScroll': () => onScroll?.(mockScrollOffset),
 				},
 				childrenToRender,
 			);
@@ -127,7 +106,6 @@ const renderVirtualList = (
 describe('SidebarVirtualList', () => {
 	beforeEach(() => {
 		mockVisibleIndexes = undefined;
-		mockScrollOffset = 0;
 	});
 
 	it('renders group rows and item rows in order', () => {
@@ -154,44 +132,6 @@ describe('SidebarVirtualList', () => {
 		});
 
 		expect(screen.getAllByTestId('virtual-row').map((row) => row.textContent)).toEqual(['group:0:Empty Group']);
-	});
-
-	it('exposes the legacy Virtuoso group row hook used by E2E locators', () => {
-		renderVirtualList();
-
-		expect(screen.getAllByTestId('virtuoso-top-item-list')).toHaveLength(1);
-		expect(screen.getByTestId('virtuoso-top-item-list')).toHaveTextContent('group:0:Channels');
-	});
-
-	it('keeps only the active group header mounted', () => {
-		mockVisibleIndexes = [3];
-
-		renderVirtualList();
-
-		expect(screen.getByTestId('virtual-list')).toHaveAttribute('data-keep-mounted', '0');
-	});
-
-	it('applies sticky positioning to the active group header only', () => {
-		renderVirtualList();
-
-		expect(screen.getByTestId('virtuoso-top-item-list')).toHaveStyle({
-			position: 'sticky',
-			top: '0px',
-			zIndex: '1',
-		});
-	});
-
-	it('updates the active sticky group header while scrolling', () => {
-		renderVirtualList();
-
-		expect(screen.getByTestId('virtuoso-top-item-list')).toHaveTextContent('group:0:Channels');
-
-		mockScrollOffset = 400;
-
-		fireEvent.scroll(screen.getByTestId('virtual-list'));
-
-		expect(screen.getByTestId('virtuoso-top-item-list')).toHaveTextContent('group:1:Direct Messages');
-		expect(screen.getByTestId('virtual-list')).toHaveAttribute('data-keep-mounted', '3');
 	});
 
 	it('defers item rendering until Virtua requests the row', () => {

--- a/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.spec.tsx
+++ b/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.spec.tsx
@@ -29,7 +29,9 @@ jest.mock('virtua', () => {
 		) {
 			useImperativeHandle(ref, () => ({
 				cache: {} as VirtualizerHandle['cache'],
-				scrollOffset: mockScrollOffset,
+				get scrollOffset() {
+					return mockScrollOffset;
+				},
 				scrollSize: 0,
 				viewportSize: 0,
 				findItemIndex: (offset: number) => Math.max(0, Math.floor(offset / 100)),

--- a/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.spec.tsx
+++ b/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.spec.tsx
@@ -80,8 +80,8 @@ const defaultProps = {
 	groups,
 	getItemKey: (item: TestItem) => item._id,
 	renderGroup: (group: TestGroup, groupIndex: number) => <div data-testid='virtual-row'>{`group:${groupIndex}:${group.title}`}</div>,
-	renderItem: (item: TestItem, itemIndex: number, group: TestGroup, groupIndex: number) => (
-		<div data-testid='virtual-row'>{`item:${groupIndex}:${itemIndex}:${group.title}:${item.name}`}</div>
+	renderItem: (item: TestItem, itemIndex: number, group: TestGroup, groupIndex: number, rowIndex: number) => (
+		<div data-testid='virtual-row'>{`item:${groupIndex}:${itemIndex}:${rowIndex}:${group.title}:${item.name}`}</div>
 	),
 };
 
@@ -105,10 +105,10 @@ describe('SidebarVirtualList', () => {
 
 		expect(screen.getAllByTestId('virtual-row').map((row) => row.textContent)).toEqual([
 			'group:0:Channels',
-			'item:0:0:Channels:general',
-			'item:0:1:Channels:support',
+			'item:0:0:1:Channels:general',
+			'item:0:1:2:Channels:support',
 			'group:1:Direct Messages',
-			'item:1:0:Direct Messages:alice',
+			'item:1:0:4:Direct Messages:alice',
 		]);
 	});
 
@@ -124,6 +124,15 @@ describe('SidebarVirtualList', () => {
 		});
 
 		expect(screen.getAllByTestId('virtual-row').map((row) => row.textContent)).toEqual(['group:0:Empty Group']);
+	});
+
+	it('exposes the legacy Virtuoso group row hook used by E2E locators', () => {
+		renderVirtualList();
+
+		expect(screen.getAllByTestId('virtuoso-top-item-list').map((row) => row.textContent)).toEqual([
+			'group:0:Channels',
+			'group:1:Direct Messages',
+		]);
 	});
 
 	it('defers item rendering until Virtua requests the row', () => {

--- a/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.spec.tsx
+++ b/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.spec.tsx
@@ -7,8 +7,11 @@ import type { CustomContainerComponentProps } from 'virtua';
 import SidebarVirtualList from './SidebarVirtualList';
 import type { SidebarVirtualListGroup } from './SidebarVirtualList';
 
+let mockVisibleIndexes: number[] | undefined;
+
 type MockVirtualizerProps = {
-	children: ReactNode;
+	children: ReactNode | ((item: unknown, index: number) => ReactNode);
+	data?: ArrayLike<unknown>;
 	bufferSize?: number;
 	as?: ElementType;
 	style?: CSSProperties;
@@ -17,12 +20,20 @@ type MockVirtualizerProps = {
 
 jest.mock('virtua', () => {
 	return {
-		Virtualizer: ({ children, bufferSize, as: root = 'div', style, className }: MockVirtualizerProps) =>
-			createElement(
+		Virtualizer: ({ children, data, bufferSize, as: root = 'div', style, className }: MockVirtualizerProps) => {
+			const childrenToRender =
+				typeof children === 'function'
+					? (mockVisibleIndexes ?? Array.from({ length: data?.length ?? 0 }, (_, index) => index)).map((index) =>
+							children(data?.[index], index),
+						)
+					: Children.toArray(children).filter((_, index) => !mockVisibleIndexes || mockVisibleIndexes.includes(index));
+
+			return createElement(
 				root,
 				{ className, 'data-buffer-size': bufferSize, 'data-testid': 'virtual-list', 'style': style ?? { height: '100%' } },
-				Children.toArray(children),
-			),
+				childrenToRender,
+			);
+		},
 	};
 });
 
@@ -79,10 +90,16 @@ const renderVirtualList = (
 		groups: SidebarVirtualListGroup<TestGroup, TestItem>[];
 		overscan: number;
 		as: ElementType;
+		renderGroup: typeof defaultProps.renderGroup;
+		renderItem: typeof defaultProps.renderItem;
 	}> = {},
 ) => render(<SidebarVirtualList {...defaultProps} {...props} />);
 
 describe('SidebarVirtualList', () => {
+	beforeEach(() => {
+		mockVisibleIndexes = undefined;
+	});
+
 	it('renders group rows and item rows in order', () => {
 		renderVirtualList();
 
@@ -107,6 +124,29 @@ describe('SidebarVirtualList', () => {
 		});
 
 		expect(screen.getAllByTestId('virtual-row').map((row) => row.textContent)).toEqual(['group:0:Empty Group']);
+	});
+
+	it('defers item rendering until Virtua requests the row', () => {
+		mockVisibleIndexes = [0];
+
+		const renderGroup = jest.fn((group: TestGroup) => <div data-testid='virtual-row'>{group.title}</div>);
+		const renderItem = jest.fn((item: TestItem) => <div data-testid='virtual-row'>{item.name}</div>);
+
+		renderVirtualList({
+			groups: [
+				{
+					key: 'channels',
+					group: { title: 'Channels' },
+					items: Array.from({ length: 1000 }, (_, index) => ({ _id: `room-${index}`, name: `room-${index}` })),
+				},
+			],
+			renderGroup,
+			renderItem,
+		});
+
+		expect(renderGroup).toHaveBeenCalledTimes(1);
+		expect(renderItem).not.toHaveBeenCalled();
+		expect(screen.getByTestId('virtual-row')).toHaveTextContent('Channels');
 	});
 
 	it('passes overscan to Virtua as buffer size', () => {

--- a/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.spec.tsx
+++ b/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.spec.tsx
@@ -117,7 +117,7 @@ const defaultProps = {
 const renderVirtualList = (
 	props: Partial<{
 		groups: SidebarVirtualListGroup<TestGroup, TestItem>[];
-		overscan: number;
+		bufferSize: number;
 		as: ElementType;
 		renderGroup: typeof defaultProps.renderGroup;
 		renderItem: typeof defaultProps.renderItem;
@@ -217,8 +217,8 @@ describe('SidebarVirtualList', () => {
 		expect(screen.getByTestId('virtual-row')).toHaveTextContent('Channels');
 	});
 
-	it('passes overscan to Virtua as buffer size', () => {
-		renderVirtualList({ overscan: 25 });
+	it('passes bufferSize to Virtua', () => {
+		renderVirtualList({ bufferSize: 25 });
 
 		expect(screen.getByTestId('virtual-list')).toHaveAttribute('data-buffer-size', '25');
 	});

--- a/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.tsx
+++ b/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.tsx
@@ -1,14 +1,21 @@
 import { CustomVirtuaScrollbars } from '@rocket.chat/ui-client';
-import type { Key, ReactNode } from 'react';
-import { useCallback, useMemo } from 'react';
+import type { CSSProperties, Key, ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Virtualizer } from 'virtua';
-import type { VirtualizerProps } from 'virtua';
+import type { VirtualizerHandle, VirtualizerProps } from 'virtua';
 
 const scrollViewportStyle = {
 	height: '100%',
 	width: '100%',
 	overflow: 'auto',
 } as const;
+
+const activeStickyGroupStyle = {
+	position: 'sticky',
+	top: 0,
+	width: '100%',
+	zIndex: 1,
+} as const satisfies CSSProperties;
 
 export type SidebarVirtualListGroup<TGroup, TItem> = {
 	key: string;
@@ -49,6 +56,7 @@ function SidebarVirtualList<TGroup, TItem>({
 	overscan,
 	as,
 }: SidebarVirtualListProps<TGroup, TItem>) {
+	const virtualizerRef = useRef<VirtualizerHandle>(null);
 	const rows = useMemo(() => {
 		return groups.flatMap<SidebarVirtualListRow<TGroup, TItem>>(({ key, group, items }, groupIndex) => [
 			{
@@ -68,11 +76,55 @@ function SidebarVirtualList<TGroup, TItem>({
 		]);
 	}, [groups]);
 
+	const groupHeaderIndexes = useMemo(
+		() =>
+			rows.reduce<number[]>((indexes, row, index) => {
+				if (row.type === 'group') {
+					indexes.push(index);
+				}
+				return indexes;
+			}, []),
+		[rows],
+	);
+
+	const [activeStickyGroupIndex, setActiveStickyGroupIndex] = useState(() => groupHeaderIndexes[0] ?? 0);
+
+	const updateActiveStickyGroup = useCallback(() => {
+		const handle = virtualizerRef.current;
+		if (!handle || groupHeaderIndexes.length === 0) {
+			return;
+		}
+
+		const start = handle.findItemIndex(handle.scrollOffset);
+		const activeIndex = [...groupHeaderIndexes].reverse().find((index) => start >= index) ?? groupHeaderIndexes[0];
+
+		setActiveStickyGroupIndex((current) => (current === activeIndex ? current : activeIndex));
+	}, [groupHeaderIndexes]);
+
+	useEffect(() => {
+		updateActiveStickyGroup();
+	}, [groupHeaderIndexes, updateActiveStickyGroup]);
+
+	const handleScroll = useCallback(() => {
+		updateActiveStickyGroup();
+	}, [updateActiveStickyGroup]);
+
+	const keepMounted = useMemo(
+		() => (groupHeaderIndexes.length > 0 ? [activeStickyGroupIndex] : undefined),
+		[activeStickyGroupIndex, groupHeaderIndexes.length],
+	);
+
 	const renderRow = useCallback(
 		(row: SidebarVirtualListRow<TGroup, TItem>, rowIndex: number) => {
 			if (row.type === 'group') {
+				const isActiveStickyGroup = rowIndex === activeStickyGroupIndex;
+
 				return (
-					<div key={`group:${row.groupKey}`} data-testid='virtuoso-top-item-list'>
+					<div
+						key={`group:${row.groupKey}`}
+						{...(isActiveStickyGroup ? { 'data-testid': 'virtuoso-top-item-list' } : {})}
+						style={isActiveStickyGroup ? activeStickyGroupStyle : undefined}
+					>
 						{renderGroup(row.group, row.groupIndex)}
 					</div>
 				);
@@ -86,13 +138,13 @@ function SidebarVirtualList<TGroup, TItem>({
 				</div>
 			);
 		},
-		[getItemKey, renderGroup, renderItem],
+		[activeStickyGroupIndex, getItemKey, renderGroup, renderItem],
 	);
 
 	return (
 		<CustomVirtuaScrollbars>
 			<div style={scrollViewportStyle}>
-				<Virtualizer as={as} data={rows} bufferSize={overscan}>
+				<Virtualizer ref={virtualizerRef} as={as} data={rows} bufferSize={overscan} keepMounted={keepMounted} onScroll={handleScroll}>
 					{renderRow}
 				</Virtualizer>
 			</div>

--- a/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.tsx
+++ b/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.tsx
@@ -1,6 +1,6 @@
 import { CustomVirtuaScrollbars } from '@rocket.chat/ui-client';
 import type { Key, ReactNode } from 'react';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Virtualizer } from 'virtua';
 import type { VirtualizerProps } from 'virtua';
 
@@ -25,10 +25,21 @@ type SidebarVirtualListProps<TGroup, TItem> = {
 	as?: VirtualizerProps['as'];
 };
 
-type SidebarVirtualListRow = {
-	key: string;
-	content: ReactNode;
-};
+type SidebarVirtualListRow<TGroup, TItem> =
+	| {
+			type: 'group';
+			groupKey: string;
+			group: TGroup;
+			groupIndex: number;
+	  }
+	| {
+			type: 'item';
+			groupKey: string;
+			group: TGroup;
+			groupIndex: number;
+			item: TItem;
+			itemIndex: number;
+	  };
 
 function SidebarVirtualList<TGroup, TItem>({
 	groups,
@@ -39,25 +50,42 @@ function SidebarVirtualList<TGroup, TItem>({
 	as,
 }: SidebarVirtualListProps<TGroup, TItem>) {
 	const rows = useMemo(() => {
-		return groups.flatMap<SidebarVirtualListRow>(({ key, group, items }, groupIndex) => [
+		return groups.flatMap<SidebarVirtualListRow<TGroup, TItem>>(({ key, group, items }, groupIndex) => [
 			{
-				key: `group:${key}`,
-				content: renderGroup(group, groupIndex),
+				type: 'group',
+				groupKey: key,
+				group,
+				groupIndex,
 			},
 			...items.map((item, itemIndex) => ({
-				key: `item:${key}:${String(getItemKey(item, itemIndex, group, groupIndex))}`,
-				content: renderItem(item, itemIndex, group, groupIndex),
+				type: 'item' as const,
+				groupKey: key,
+				group,
+				groupIndex,
+				item,
+				itemIndex,
 			})),
 		]);
-	}, [getItemKey, groups, renderGroup, renderItem]);
+	}, [groups]);
+
+	const renderRow = useCallback(
+		(row: SidebarVirtualListRow<TGroup, TItem>) => {
+			if (row.type === 'group') {
+				return <div key={`group:${row.groupKey}`}>{renderGroup(row.group, row.groupIndex)}</div>;
+			}
+
+			const itemKey = getItemKey(row.item, row.itemIndex, row.group, row.groupIndex);
+
+			return <div key={`item:${row.groupKey}:${String(itemKey)}`}>{renderItem(row.item, row.itemIndex, row.group, row.groupIndex)}</div>;
+		},
+		[getItemKey, renderGroup, renderItem],
+	);
 
 	return (
 		<CustomVirtuaScrollbars>
 			<div style={scrollViewportStyle}>
-				<Virtualizer as={as} bufferSize={overscan}>
-					{rows.map(({ key, content }) => (
-						<div key={key}>{content}</div>
-					))}
+				<Virtualizer as={as} data={rows} bufferSize={overscan}>
+					{renderRow}
 				</Virtualizer>
 			</div>
 		</CustomVirtuaScrollbars>

--- a/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.tsx
+++ b/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.tsx
@@ -1,0 +1,67 @@
+import { CustomVirtuaScrollbars } from '@rocket.chat/ui-client';
+import type { Key, ReactNode } from 'react';
+import { useMemo } from 'react';
+import { Virtualizer } from 'virtua';
+import type { VirtualizerProps } from 'virtua';
+
+const scrollViewportStyle = {
+	height: '100%',
+	width: '100%',
+	overflow: 'auto',
+} as const;
+
+export type SidebarVirtualListGroup<TGroup, TItem> = {
+	key: string;
+	group: TGroup;
+	items: readonly TItem[];
+};
+
+type SidebarVirtualListProps<TGroup, TItem> = {
+	groups: readonly SidebarVirtualListGroup<TGroup, TItem>[];
+	renderGroup: (group: TGroup, groupIndex: number) => ReactNode;
+	renderItem: (item: TItem, itemIndex: number, group: TGroup, groupIndex: number) => ReactNode;
+	getItemKey: (item: TItem, itemIndex: number, group: TGroup, groupIndex: number) => Key;
+	overscan?: number;
+	as?: VirtualizerProps['as'];
+};
+
+type SidebarVirtualListRow = {
+	key: string;
+	content: ReactNode;
+};
+
+function SidebarVirtualList<TGroup, TItem>({
+	groups,
+	renderGroup,
+	renderItem,
+	getItemKey,
+	overscan,
+	as,
+}: SidebarVirtualListProps<TGroup, TItem>) {
+	const rows = useMemo(() => {
+		return groups.flatMap<SidebarVirtualListRow>(({ key, group, items }, groupIndex) => [
+			{
+				key: `group:${key}`,
+				content: renderGroup(group, groupIndex),
+			},
+			...items.map((item, itemIndex) => ({
+				key: `item:${key}:${String(getItemKey(item, itemIndex, group, groupIndex))}`,
+				content: renderItem(item, itemIndex, group, groupIndex),
+			})),
+		]);
+	}, [getItemKey, groups, renderGroup, renderItem]);
+
+	return (
+		<CustomVirtuaScrollbars>
+			<div style={scrollViewportStyle}>
+				<Virtualizer as={as} bufferSize={overscan}>
+					{rows.map(({ key, content }) => (
+						<div key={key}>{content}</div>
+					))}
+				</Virtualizer>
+			</div>
+		</CustomVirtuaScrollbars>
+	);
+}
+
+export default SidebarVirtualList;

--- a/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.tsx
+++ b/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.tsx
@@ -41,7 +41,6 @@ type SidebarVirtualListRow<TGroup, TItem> =
 	  }
 	| {
 			type: 'item';
-			groupKey: string;
 			group: TGroup;
 			groupIndex: number;
 			item: TItem;
@@ -67,7 +66,6 @@ function SidebarVirtualList<TGroup, TItem>({
 			},
 			...items.map((item, itemIndex) => ({
 				type: 'item' as const,
-				groupKey: key,
 				group,
 				groupIndex,
 				item,
@@ -133,7 +131,7 @@ function SidebarVirtualList<TGroup, TItem>({
 			const itemKey = getItemKey(row.item, row.itemIndex, row.group, row.groupIndex);
 
 			return (
-				<div key={`item:${row.groupKey}:${String(itemKey)}`}>
+				<div key={`item:${String(itemKey)}`}>
 					{renderItem(row.item, row.itemIndex, row.group, row.groupIndex, rowIndex)}
 				</div>
 			);

--- a/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.tsx
+++ b/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.tsx
@@ -1,21 +1,14 @@
 import { CustomVirtuaScrollbars } from '@rocket.chat/ui-client';
-import type { CSSProperties, Key, ReactNode } from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { Key, ReactNode } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Virtualizer } from 'virtua';
-import type { VirtualizerHandle, VirtualizerProps } from 'virtua';
+import type { VirtualizerProps } from 'virtua';
 
 const scrollViewportStyle = {
 	height: '100%',
 	width: '100%',
 	overflow: 'auto',
 } as const;
-
-const activeStickyGroupStyle = {
-	position: 'sticky',
-	top: 0,
-	width: '100%',
-	zIndex: 1,
-} as const satisfies CSSProperties;
 
 export type SidebarVirtualListGroup<TGroup, TItem> = {
 	key: string;
@@ -55,7 +48,6 @@ function SidebarVirtualList<TGroup, TItem>({
 	bufferSize,
 	as,
 }: SidebarVirtualListProps<TGroup, TItem>) {
-	const virtualizerRef = useRef<VirtualizerHandle>(null);
 	const rows = useMemo(() => {
 		return groups.flatMap<SidebarVirtualListRow<TGroup, TItem>>(({ key, group, items }, groupIndex) => [
 			{
@@ -74,71 +66,23 @@ function SidebarVirtualList<TGroup, TItem>({
 		]);
 	}, [groups]);
 
-	const groupHeaderIndexes = useMemo(
-		() =>
-			rows.reduce<number[]>((indexes, row, index) => {
-				if (row.type === 'group') {
-					indexes.push(index);
-				}
-				return indexes;
-			}, []),
-		[rows],
-	);
-
-	const [activeStickyGroupIndex, setActiveStickyGroupIndex] = useState(() => groupHeaderIndexes[0] ?? 0);
-
-	const updateActiveStickyGroup = useCallback(() => {
-		const handle = virtualizerRef.current;
-		if (!handle || groupHeaderIndexes.length === 0) {
-			return;
-		}
-
-		const start = handle.findItemIndex(handle.scrollOffset);
-		const activeIndex = [...groupHeaderIndexes].reverse().find((index) => start >= index) ?? groupHeaderIndexes[0];
-
-		setActiveStickyGroupIndex((current) => (current === activeIndex ? current : activeIndex));
-	}, [groupHeaderIndexes]);
-
-	useEffect(() => {
-		updateActiveStickyGroup();
-	}, [groupHeaderIndexes, updateActiveStickyGroup]);
-
-	const handleScroll = useCallback(() => {
-		updateActiveStickyGroup();
-	}, [updateActiveStickyGroup]);
-
-	const keepMounted = useMemo(
-		() => (groupHeaderIndexes.length > 0 ? [activeStickyGroupIndex] : undefined),
-		[activeStickyGroupIndex, groupHeaderIndexes.length],
-	);
-
 	const renderRow = useCallback(
 		(row: SidebarVirtualListRow<TGroup, TItem>, rowIndex: number) => {
 			if (row.type === 'group') {
-				const isActiveStickyGroup = rowIndex === activeStickyGroupIndex;
-
-				return (
-					<div
-						key={`group:${row.groupKey}`}
-						{...(isActiveStickyGroup ? { 'data-testid': 'virtuoso-top-item-list' } : {})}
-						style={isActiveStickyGroup ? activeStickyGroupStyle : undefined}
-					>
-						{renderGroup(row.group, row.groupIndex)}
-					</div>
-				);
+				return <div key={`group:${row.groupKey}`}>{renderGroup(row.group, row.groupIndex)}</div>;
 			}
 
 			const itemKey = getItemKey(row.item, row.itemIndex, row.group, row.groupIndex);
 
 			return <div key={`item:${String(itemKey)}`}>{renderItem(row.item, row.itemIndex, row.group, row.groupIndex, rowIndex)}</div>;
 		},
-		[activeStickyGroupIndex, getItemKey, renderGroup, renderItem],
+		[getItemKey, renderGroup, renderItem],
 	);
 
 	return (
 		<CustomVirtuaScrollbars>
 			<div style={scrollViewportStyle}>
-				<Virtualizer ref={virtualizerRef} as={as} data={rows} bufferSize={bufferSize} keepMounted={keepMounted} onScroll={handleScroll}>
+				<Virtualizer as={as} data={rows} bufferSize={bufferSize}>
 					{renderRow}
 				</Virtualizer>
 			</div>

--- a/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.tsx
+++ b/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.tsx
@@ -19,7 +19,7 @@ export type SidebarVirtualListGroup<TGroup, TItem> = {
 type SidebarVirtualListProps<TGroup, TItem> = {
 	groups: readonly SidebarVirtualListGroup<TGroup, TItem>[];
 	renderGroup: (group: TGroup, groupIndex: number) => ReactNode;
-	renderItem: (item: TItem, itemIndex: number, group: TGroup, groupIndex: number) => ReactNode;
+	renderItem: (item: TItem, itemIndex: number, group: TGroup, groupIndex: number, rowIndex: number) => ReactNode;
 	getItemKey: (item: TItem, itemIndex: number, group: TGroup, groupIndex: number) => Key;
 	overscan?: number;
 	as?: VirtualizerProps['as'];
@@ -69,14 +69,22 @@ function SidebarVirtualList<TGroup, TItem>({
 	}, [groups]);
 
 	const renderRow = useCallback(
-		(row: SidebarVirtualListRow<TGroup, TItem>) => {
+		(row: SidebarVirtualListRow<TGroup, TItem>, rowIndex: number) => {
 			if (row.type === 'group') {
-				return <div key={`group:${row.groupKey}`}>{renderGroup(row.group, row.groupIndex)}</div>;
+				return (
+					<div key={`group:${row.groupKey}`} data-testid='virtuoso-top-item-list'>
+						{renderGroup(row.group, row.groupIndex)}
+					</div>
+				);
 			}
 
 			const itemKey = getItemKey(row.item, row.itemIndex, row.group, row.groupIndex);
 
-			return <div key={`item:${row.groupKey}:${String(itemKey)}`}>{renderItem(row.item, row.itemIndex, row.group, row.groupIndex)}</div>;
+			return (
+				<div key={`item:${row.groupKey}:${String(itemKey)}`}>
+					{renderItem(row.item, row.itemIndex, row.group, row.groupIndex, rowIndex)}
+				</div>
+			);
 		},
 		[getItemKey, renderGroup, renderItem],
 	);

--- a/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.tsx
+++ b/apps/meteor/client/sidebar/components/SidebarVirtualList/SidebarVirtualList.tsx
@@ -28,7 +28,7 @@ type SidebarVirtualListProps<TGroup, TItem> = {
 	renderGroup: (group: TGroup, groupIndex: number) => ReactNode;
 	renderItem: (item: TItem, itemIndex: number, group: TGroup, groupIndex: number, rowIndex: number) => ReactNode;
 	getItemKey: (item: TItem, itemIndex: number, group: TGroup, groupIndex: number) => Key;
-	overscan?: number;
+	bufferSize?: number;
 	as?: VirtualizerProps['as'];
 };
 
@@ -52,7 +52,7 @@ function SidebarVirtualList<TGroup, TItem>({
 	renderGroup,
 	renderItem,
 	getItemKey,
-	overscan,
+	bufferSize,
 	as,
 }: SidebarVirtualListProps<TGroup, TItem>) {
 	const virtualizerRef = useRef<VirtualizerHandle>(null);
@@ -130,11 +130,7 @@ function SidebarVirtualList<TGroup, TItem>({
 
 			const itemKey = getItemKey(row.item, row.itemIndex, row.group, row.groupIndex);
 
-			return (
-				<div key={`item:${String(itemKey)}`}>
-					{renderItem(row.item, row.itemIndex, row.group, row.groupIndex, rowIndex)}
-				</div>
-			);
+			return <div key={`item:${String(itemKey)}`}>{renderItem(row.item, row.itemIndex, row.group, row.groupIndex, rowIndex)}</div>;
 		},
 		[activeStickyGroupIndex, getItemKey, renderGroup, renderItem],
 	);
@@ -142,7 +138,7 @@ function SidebarVirtualList<TGroup, TItem>({
 	return (
 		<CustomVirtuaScrollbars>
 			<div style={scrollViewportStyle}>
-				<Virtualizer ref={virtualizerRef} as={as} data={rows} bufferSize={overscan} keepMounted={keepMounted} onScroll={handleScroll}>
+				<Virtualizer ref={virtualizerRef} as={as} data={rows} bufferSize={bufferSize} keepMounted={keepMounted} onScroll={handleScroll}>
 					{renderRow}
 				</Virtualizer>
 			</div>

--- a/apps/meteor/client/sidebar/components/SidebarVirtualList/index.ts
+++ b/apps/meteor/client/sidebar/components/SidebarVirtualList/index.ts
@@ -1,0 +1,2 @@
+export { default } from './SidebarVirtualList';
+export type { SidebarVirtualListGroup } from './SidebarVirtualList';

--- a/apps/meteor/tests/e2e/page-objects/fragments/sidebar.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/sidebar.ts
@@ -62,11 +62,6 @@ export class RoomSidebar extends Sidebar {
 		return this.teamCollabFilters.getByRole('tab', { name: 'Discussions' });
 	}
 
-	// TODO: fix this filter, workaround due to virtuoso
-	get topChannelList(): Locator {
-		return this.root.getByTestId('virtuoso-top-item-list');
-	}
-
 	get channelsList(): Locator {
 		// TODO: fix this filter, workaround due to virtuoso
 		// return this.sidebar.getByRole('list', { name: 'Channels' }).filter({ has: this.page.getByRole('listitem') });
@@ -86,7 +81,7 @@ export class RoomSidebar extends Sidebar {
 	}
 
 	get firstCollapser(): Locator {
-		return this.topChannelList.getByRole('region').first().getByRole('button').first();
+		return this.channelsList.getByRole('region').first().getByRole('button').first();
 	}
 
 	get teamsCollapser(): Locator {


### PR DESCRIPTION
## Proposed changes 

This PR migrates the v1 sidebar room list from `react-virtuoso` to a reusable Virtua-based implementation.

Changes include:

- Adding a reusable `SidebarVirtualList` component under `apps/meteor/client/sidebar/components`
- Replacing `GroupedVirtuoso`, `VirtualizedScrollbars`, and `useResizeObserver` in `apps/meteor/client/sidebar/RoomList`
- Flattening grouped sidebar sections into virtualized rows while preserving collapsible groups and existing room list behavior
- Updating `RoomListWrapper` to support Virtua container props, refs, and styles while keeping the room list accessible
- Expanding sidebar Storybook data to better exercise virtualization scenarios
- Adding focused unit tests for `SidebarVirtualList`, `RoomList` row mapping, and `RoomListWrapper`

The goal is to align the sidebar with the new Virtua-based virtualization approach while keeping the scope limited to the v1 sidebar implementation.

## Issue(s)

Part of the Virtua migration work for Rocket.Chat lists and navigation surfaces.

[COMM-176](https://rocketchat.atlassian.net/browse/COMM-176)

## Steps to test or reproduce

- Open the v1 sidebar and verify room lists render correctly
- Scroll through long room lists and verify virtualization behavior
- Collapse and expand room groups and verify rows update correctly
- Verify unread counts, room icons, and context menus continue to work
- Verify keyboard navigation and accessibility behavior remain unchanged

Run:

- `yarn testunit --testPathPattern='client/sidebar'`
- ESLint on changed sidebar files
- `yarn workspace @rocket.chat/meteor typecheck`
- `yarn build`

## Further comments

This migration is intentionally scoped only to `apps/meteor/client/sidebar` and does not modify:

- MessageSearch
- ThreadList
- DiscussionsList
- Matrix Federation search
- V2 sidebar (`secondarySidebar`)
- `PaginatedVirtualList`

The sidebar room list is backed by the local subscription store and does not use pagination or infinite loading, so this PR introduces a dedicated `SidebarVirtualList` instead of reusing `PaginatedVirtualList`.

After syncing with the latest `upstream/develop`, there are existing typecheck failures outside the scope of this PR, including:

- Missing `rooms.join` REST typings
- `MediaCallProvider` context type mismatch

These failures are reproducible on a clean checkout of `upstream/develop` and are unrelated to the sidebar migration.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added a virtualized grouped sidebar list with sticky headers and efficient room rendering.
* Expanded sidebar examples with channels, discussions, direct chats, unread indicators, and thread metadata.

## Refactor
* Improved room list containers, scrolling behavior, accessibility labels, and list rendering consistency.

## Tests
* Added coverage for grouped rendering, scrolling, sticky headers, unread counts, room names, accessibility, and wrapper content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[COMM-176]: https://rocketchat.atlassian.net/browse/COMM-176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ