### PR TITLE
fix(message-parser): derive ASTNode union from Types registry

### DIFF
--- a/.changeset/astnode-union-completeness.md
+++ b/.changeset/astnode-union-completeness.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/message-parser': patch
+---
+
+Fixed the `ASTNode` union being incomplete: node types emitted by the parser (such as `TIMESTAMP`, `IMAGE`, `ORDERED_LIST`, `KATEX` and others) were missing from the union, which broke type narrowing for valid parser output. `ASTNode` is now derived from the `Types` registry so it always reflects every node type the parser can produce.

--- a/packages/message-parser/src/definitions.ts
+++ b/packages/message-parser/src/definitions.ts
@@ -204,26 +204,7 @@ export type Types = {
 	SPOILER_BLOCK: SpoilerBlock;
 };
 
-export type ASTNode =
-	| BigEmoji
-	| Bold
-	| Spoiler
-	| Paragraph
-	| Plain
-	| Italic
-	| Strike
-	| Code
-	| CodeLine
-	| InlineCode
-	| Heading
-	| Quote
-	| SpoilerBlock
-	| Link
-	| UserMention
-	| ChannelMention
-	| Emoji
-	| Color
-	| Tasks;
+export type ASTNode = Types[keyof Types];
 
 export type TypesKeys = keyof Types;
 


### PR DESCRIPTION
## Proposed changes

The `ASTNode` union in `@rocket.chat/message-parser` was hand-maintained and had drifted out of sync with the parser's `Types` registry: node types emitted at runtime (`TIMESTAMP`, `IMAGE`, `ORDERED_LIST`, `KATEX`, `INLINE_KATEX`, `LINE_BREAK`, `TASK`, `LIST_ITEM`, `UNORDERED_LIST`) were missing from the union, which broke type narrowing for valid parser output via guards such as `isNodeOfType`.

This derives `ASTNode` from the `Types` registry (`Types[keyof Types]`) so the union always reflects every node type the parser can produce and cannot fall out of sync again. `guards.ts` needs no change — `isNodeOfType` is already keyed on `Types`/`TypesKeys`, so the defect was purely the incomplete union.

Includes a changeset for `@rocket.chat/message-parser`.

Closes #39057


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incomplete type definitions in the message parser. The `ASTNode` type now includes all node types supported by the parser, ensuring accurate type representation and improved type safety when working with parsed messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->