### PR TITLE
refactor(ui-voip): extract PeerCardsView from MediaCallRoomSection

### DIFF
--- a/.changeset/extract-peer-cards-view.md
+++ b/.changeset/extract-peer-cards-view.md
@@ -1,5 +1,0 @@
----
-"@rocket.chat/ui-voip": patch
----
-
-Extract the media call peer cards rendering from `MediaCallRoomSection` into a dedicated `PeerCardsView` component. Pure refactor, no behavior change.

--- a/.changeset/extract-peer-cards-view.md
+++ b/.changeset/extract-peer-cards-view.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/ui-voip": patch
+---
+
+Extract the media call peer cards rendering from `MediaCallRoomSection` into a dedicated `PeerCardsView` component. Pure refactor, no behavior change.

--- a/packages/ui-voip/src/views/MediaCallRoomSection/MediaCallRoomSection.tsx
+++ b/packages/ui-voip/src/views/MediaCallRoomSection/MediaCallRoomSection.tsx
@@ -1,16 +1,13 @@
-import { Box, Button, ButtonGroup } from '@rocket.chat/fuselage';
-import { memo, useState } from 'react';
+import { Box, ButtonGroup } from '@rocket.chat/fuselage';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import PeerCardsView from './PeerCardsView';
 import {
 	ToggleButton,
 	Timer,
 	DevicePicker,
 	ActionButton,
-	CardListContainer,
-	CardListSection,
-	PeerCard,
-	StreamCard,
 	useShouldWrapCards,
 	CARD_LIST_SECTION_MAX_HEIGHT,
 	ActionStrip,
@@ -19,7 +16,6 @@ import {
 import { useMediaCallInstance } from '../../context/MediaCallInstanceContext';
 import { useMediaCallView } from '../../context/MediaCallViewContext';
 import useRegisterView from '../../context/useRegisterView';
-import { usePlayMediaStream } from '../../providers/usePlayMediaStream';
 
 type MediaCallRoomSectionProps = {
 	showChat: boolean;
@@ -48,7 +44,6 @@ const getSplitStyles = (showChat?: boolean) => {
 const MediaCallRoomSection = ({ showChat, onToggleChat, user, containerHeight }: MediaCallRoomSectionProps) => {
 	const { t } = useTranslation();
 
-	const [focusedCard, setFocusedCard] = useState<'remote' | 'local' | null>('remote');
 	const {
 		sessionState,
 		onMute,
@@ -58,73 +53,24 @@ const MediaCallRoomSection = ({ showChat, onToggleChat, user, containerHeight }:
 		onToggleScreenSharing,
 		onOpenPopout,
 		onClosePopout,
-		streams: { remoteScreen, localScreen },
+		streams: { localScreen },
 	} = useMediaCallView();
 	const { currentViews } = useMediaCallInstance();
 
 	const isPopout = currentViews.includes('popout');
 
-	const { muted, held, remoteMuted, remoteHeld, peerInfo, connectionState, startedAt } = sessionState;
+	const { muted, held, peerInfo, connectionState, startedAt } = sessionState;
 
 	const shouldWrapCards = useShouldWrapCards(showChat, containerHeight);
 
 	const connecting = connectionState === 'CONNECTING';
 	const reconnecting = connectionState === 'RECONNECTING';
 
-	const [remoteStreamRefCallback] = usePlayMediaStream(remoteScreen?.stream ?? null);
-	const [localStreamRefCallback] = usePlayMediaStream(localScreen?.stream ?? null);
-
 	useRegisterView('room');
-
-	const onClickFocusRemoteCard = () => {
-		setFocusedCard((prev) => (prev === 'remote' ? null : 'remote'));
-	};
-
-	const onClickFocusLocalCard = () => {
-		setFocusedCard((prev) => (prev === 'local' ? null : 'local'));
-	};
 
 	if (!peerInfo || 'number' in peerInfo) {
 		return null;
 	}
-
-	const remoteStreamCard = remoteScreen?.active ? (
-		<StreamCard onClickFocusStream={onClickFocusRemoteCard} focused={focusedCard === 'remote'}>
-			<video
-				preload='metadata'
-				style={{ objectFit: 'contain', height: '100%', width: '100%' }}
-				ref={remoteStreamRefCallback}
-				autoPlay={true}
-				muted={true}
-				playsInline={true}
-			>
-				<track kind='captions' />
-			</video>
-		</StreamCard>
-	) : null;
-
-	const localStreamCard = localScreen?.active ? (
-		<StreamCard
-			own
-			onClickFocusStream={onClickFocusLocalCard}
-			onClickStopSharing={onToggleScreenSharing}
-			focused={focusedCard === 'local'}
-			showStopSharingOnHover
-		>
-			<video
-				preload='metadata'
-				style={{ objectFit: 'contain', height: '100%', width: '100%' }}
-				ref={localStreamRefCallback}
-				autoPlay={true}
-				playsInline={true}
-				muted={true}
-			>
-				<track kind='captions' />
-			</video>
-		</StreamCard>
-	) : null;
-
-	const focusedCardElement = focusedCard === 'remote' ? remoteStreamCard : localStreamCard;
 
 	return (
 		<Box
@@ -138,26 +84,7 @@ const MediaCallRoomSection = ({ showChat, onToggleChat, user, containerHeight }:
 			aria-label={t('Voice_call')}
 			{...getSplitStyles(showChat)}
 		>
-			<CardListSection>
-				{isPopout && (
-					<Box mb={20} p={24} w='full' display='flex' flexDirection='column' justifyContent='space-between' alignItems='center'>
-						<Box is='h1' color='font-default' mbe={40}>
-							{t('Call_open_separate_window')}
-						</Box>
-						<Button onClick={onClosePopout} icon='arrow-from-cross-box' large>
-							{t('Show_call_here')}
-						</Button>
-					</Box>
-				)}
-				{!isPopout && (
-					<CardListContainer focusedCard={focusedCard ? focusedCardElement : undefined} shouldWrapCards={shouldWrapCards}>
-						<PeerCard displayName={user.displayName} avatarUrl={user.avatarUrl} muted={muted} held={held} />
-						<PeerCard displayName={peerInfo.displayName} avatarUrl={peerInfo.avatarUrl} muted={remoteMuted} held={remoteHeld} />
-						{focusedCard !== 'remote' && remoteStreamCard}
-						{focusedCard !== 'local' && localStreamCard}
-					</CardListContainer>
-				)}
-			</CardListSection>
+			<PeerCardsView user={user} shouldWrapCards={shouldWrapCards} />
 			<ActionStrip
 				leftSlot={
 					<Box color='default' alignContent='center' pis={16}>

--- a/packages/ui-voip/src/views/MediaCallRoomSection/PeerCardsView.tsx
+++ b/packages/ui-voip/src/views/MediaCallRoomSection/PeerCardsView.tsx
@@ -1,0 +1,108 @@
+import { Box, Button } from '@rocket.chat/fuselage';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { CardListContainer, CardListSection, PeerCard, StreamCard } from '../../components';
+import { useMediaCallView } from '../../context';
+import { useMediaCallInstance } from '../../context/MediaCallInstanceContext';
+import { usePlayMediaStream } from '../../providers/usePlayMediaStream';
+
+type PeerCardsViewProps = {
+	shouldWrapCards: boolean;
+	user: {
+		displayName: string;
+		avatarUrl: string;
+	};
+};
+
+const PeerCardsView = ({ user, shouldWrapCards }: PeerCardsViewProps) => {
+	const { t } = useTranslation();
+	const [focusedCard, setFocusedCard] = useState<'remote' | 'local' | null>('remote');
+	const {
+		sessionState,
+		onToggleScreenSharing,
+		onClosePopout,
+		streams: { remoteScreen, localScreen },
+	} = useMediaCallView();
+	const { currentViews } = useMediaCallInstance();
+	const isPopout = currentViews.includes('popout');
+	const { muted, held, remoteMuted, remoteHeld, peerInfo } = sessionState;
+
+	const [remoteStreamRefCallback] = usePlayMediaStream(remoteScreen?.stream ?? null);
+	const [localStreamRefCallback] = usePlayMediaStream(localScreen?.stream ?? null);
+
+	const onClickFocusRemoteCard = () => {
+		setFocusedCard((prev) => (prev === 'remote' ? null : 'remote'));
+	};
+
+	const onClickFocusLocalCard = () => {
+		setFocusedCard((prev) => (prev === 'local' ? null : 'local'));
+	};
+
+	if (!peerInfo || 'number' in peerInfo) {
+		return null;
+	}
+
+	const remoteStreamCard = remoteScreen?.active ? (
+		<StreamCard onClickFocusStream={onClickFocusRemoteCard} focused={focusedCard === 'remote'}>
+			<video
+				preload='metadata'
+				style={{ objectFit: 'contain', height: '100%', width: '100%' }}
+				ref={remoteStreamRefCallback}
+				autoPlay={true}
+				muted={true}
+				playsInline={true}
+			>
+				<track kind='captions' />
+			</video>
+		</StreamCard>
+	) : null;
+
+	const localStreamCard = localScreen?.active ? (
+		<StreamCard
+			own
+			onClickFocusStream={onClickFocusLocalCard}
+			onClickStopSharing={onToggleScreenSharing}
+			focused={focusedCard === 'local'}
+			showStopSharingOnHover
+		>
+			<video
+				preload='metadata'
+				style={{ objectFit: 'contain', height: '100%', width: '100%' }}
+				ref={localStreamRefCallback}
+				autoPlay={true}
+				playsInline={true}
+				muted={true}
+			>
+				<track kind='captions' />
+			</video>
+		</StreamCard>
+	) : null;
+
+	const focusedCardElement = focusedCard === 'remote' ? remoteStreamCard : localStreamCard;
+
+	return (
+		<CardListSection>
+			{isPopout && (
+				<Box mb={20} p={24} w='full' display='flex' flexDirection='column' justifyContent='space-between' alignItems='center'>
+					<Box is='h1' color='font-default' mbe={40}>
+						{t('Call_open_separate_window')}
+					</Box>
+					<Button onClick={onClosePopout} icon='arrow-from-cross-box' large>
+						{t('Show_call_here')}
+					</Button>
+				</Box>
+			)}
+			{!isPopout && (
+				<CardListContainer focusedCard={focusedCard ? focusedCardElement : undefined} shouldWrapCards={shouldWrapCards}>
+					<PeerCard displayName={user.displayName} avatarUrl={user.avatarUrl} muted={muted} held={held} />
+					<PeerCard displayName={peerInfo.displayName} avatarUrl={peerInfo.avatarUrl} muted={remoteMuted} held={remoteHeld} />
+					{focusedCard !== 'remote' && remoteStreamCard}
+					{focusedCard !== 'local' && localStreamCard}
+				</CardListContainer>
+			)}
+		</CardListSection>
+	);
+};
+
+export default PeerCardsView;


### PR DESCRIPTION
Pure refactor — extracts the peer cards rendering (cards, screen-share stream cards, focus handling, and the popout "show call here" state) out of `MediaCallRoomSection` into a dedicated `PeerCardsView` component. No behavior change.

This extraction was originally bundled inside the voice-to-video escalation work (#40983, via #40869). Splitting it out as a standalone refactor keeps #40983's diff focused on the new escalation behavior — there `MediaCallRoomSection` now only adds the escalation button/state and the `VideoEscalatedView` swap on top of this component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization of the media call interface for enhanced maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

related to [DMV-17](https://rocketchat.atlassian.net/browse/DMV-17) I

[DMV-17]: https://rocketchat.atlassian.net/browse/DMV-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ