### PR TITLE
regression: timed status sometimes never reverts after expiring

### DIFF
--- a/ee/packages/presence/src/Presence.ts
+++ b/ee/packages/presence/src/Presence.ts
@@ -131,10 +131,11 @@ export class Presence extends ServiceClass implements IPresence {
 	}
 
 	private async setupNextExpiration(): Promise<void> {
+		const next = await Users.findNextStatusExpiration();
+
 		clearTimeout(this.expirationTimeout);
 		this.expirationTimeout = undefined;
 
-		const next = await Users.findNextStatusExpiration();
 		if (!next?.statusExpiresAt) {
 			return;
 		}

--- a/ee/packages/presence/src/Presence.ts
+++ b/ee/packages/presence/src/Presence.ts
@@ -48,6 +48,8 @@ export class Presence extends ServiceClass implements IPresence {
 
 	private expirationTimeout?: NodeJS.Timeout;
 
+	private expirationScheduleToken?: symbol;
+
 	constructor() {
 		super();
 
@@ -131,7 +133,15 @@ export class Presence extends ServiceClass implements IPresence {
 	}
 
 	private async setupNextExpiration(): Promise<void> {
+		const token = Symbol();
+		this.expirationScheduleToken = token;
+
 		const next = await Users.findNextStatusExpiration();
+
+		// A newer reschedule replaced our token while we awaited the lookup; let it arm the timer.
+		if (this.expirationScheduleToken !== token) {
+			return;
+		}
 
 		clearTimeout(this.expirationTimeout);
 		this.expirationTimeout = undefined;

--- a/ee/packages/presence/src/Presence.ts
+++ b/ee/packages/presence/src/Presence.ts
@@ -185,7 +185,9 @@ export class Presence extends ServiceClass implements IPresence {
 
 	override async stopped(): Promise<void> {
 		this.reaper.stop();
+		this.expirationScheduleToken = undefined;
 		clearTimeout(this.expirationTimeout);
+		this.expirationTimeout = undefined;
 		clearTimeout(this.lostConTimeout);
 	}
 

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -1133,7 +1133,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 
 	findNextStatusExpiration() {
 		return this.findOne<Pick<IUser, '_id' | 'statusExpiresAt'>>(
-			{ statusExpiresAt: { $gte: new Date() } },
+			{ statusExpiresAt: { $exists: true } },
 			{ projection: { _id: 1, statusExpiresAt: 1 }, sort: { statusExpiresAt: 1 } },
 		);
 	}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

A temporary status with an expiration (e.g. Busy "until 14:32") could intermittently **never revert** — it stayed stuck until the user changed status again or the server restarted.

Status expiry runs off a single in-memory timer rescheduled on every status change. Concurrent reschedules raced over that timer: a slow, stale lookup could resolve last and wipe out a newer call's timer, leaving the expiration unscheduled. A status that then went overdue with no timer was invisible to the scheduler.

Fix (keeps the precise on-time timer):

- **`Presence.ts`** — guard the reschedule with a per-call token: each call stamps a unique `Symbol` before its lookup and bails if a newer call replaced it, so a stale lookup can't clear the newer timer. Calls stay independent (no serialization). Shutdown invalidates the token so an in-flight reschedule can't re-arm the timer after the service stops.
- **`Users.ts`** — `findNextStatusExpiration` now returns the soonest expiry *including overdue ones* (`{$exists: true}`), so a missed expiry self-heals on the next scheduling pass.

The revert logic (`endActive`) was already correct — only the scheduling was broken.

## Issue(s)

- [PRES-56](https://rocketchat.atlassian.net/browse/PRES-56)

## Steps to test or reproduce

1. Set Busy with a short expiration (with or without a message).
2. Wait past the expiration → it reverts to online and clears text/expiration.
3. Set the status repeatedly around the expiry boundary — still reverts reliably.

## Further comments

[PRES-56]: https://rocketchat.atlassian.net/browse/PRES-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved reliability of user status expiration scheduling by preventing outdated timers from being re-armed during async race conditions.
  * Adjusted how the next upcoming status expiration is selected, ensuring the system consistently finds the correct expiration timestamp and processes expirations more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
