### PR TITLE
regression: reject past expiresAt dates when setting a status

### DIFF
--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -1942,7 +1942,7 @@ API.v1
 				intervalTimeInMS: 60000,
 			},
 			body: ajv.compile<{
-				status?: UserStatus;
+				status?: Exclude<UserStatus, UserStatus.DISABLED>;
 				message?: string;
 				expiresAt?: string;
 				userId?: string;
@@ -1999,13 +1999,6 @@ API.v1
 
 			if (!user) {
 				return API.v1.forbidden();
-			}
-
-			const validStatus = ['online', 'away', 'offline', 'busy'];
-			if (this.bodyParams.status && !validStatus.includes(this.bodyParams.status)) {
-				throw new Meteor.Error('error-invalid-status', 'Valid status types include online, away, offline, and busy.', {
-					method: 'users.setStatus',
-				});
 			}
 
 			const { status, message, expiresAt } = this.bodyParams;

--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -2010,6 +2010,12 @@ API.v1
 				});
 			}
 
+			if (statusExpiresAt && statusExpiresAt.getTime() <= Date.now()) {
+				throw new Meteor.Error('error-invalid-date', 'expiresAt must be a future date', {
+					method: 'users.setStatus',
+				});
+			}
+
 			// If status is missing (message-only update), keep the user's chosen status (statusDefault),
 			// not the computed status — otherwise a transient auto-away/offline gets pinned as a manual claim.
 			const effectiveStatus = status || user.statusDefault || ('online' as UserStatus);

--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -5830,6 +5830,23 @@ describe('[Users]', () => {
 			expect(new Date(status.statusExpiresAt!).getTime()).to.be.closeTo(new Date(expiresAt).getTime(), 2000);
 		});
 
+		it('should reject a past expiresAt date', async () => {
+			await request
+				.post(api('users.setStatus'))
+				.set(credentials)
+				.send({
+					status: 'busy',
+					expiresAt: '2020-01-01T00:00:00.000Z',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', false);
+					expect(res.body.errorType).to.be.equal('error-invalid-date');
+					expect(res.body.error).to.be.equal('expiresAt must be a future date [error-invalid-date]');
+				});
+		});
+
 		it('should not return statusExpiresAt when expiresAt is not set', async () => {
 			await request
 				.post(api('users.setStatus'))

--- a/ee/packages/presence/src/Presence.spec.ts
+++ b/ee/packages/presence/src/Presence.spec.ts
@@ -118,6 +118,32 @@ describe('Presence class', () => {
 				undefined,
 			);
 		});
+
+		it('should reject a past statusExpiresAt', async () => {
+			await expect(
+				presence.setActiveState('u1', {
+					statusDefault: UserStatus.BUSY,
+					statusSource: 'manual',
+					statusText: 'Focus',
+					statusExpiresAt: new Date(Date.now() - 3600_000),
+				}),
+			).rejects.toThrow('statusExpiresAt must be a future date');
+
+			expect(updatePresenceMock).not.toHaveBeenCalled();
+		});
+
+		it('should reject an invalid statusExpiresAt', async () => {
+			await expect(
+				presence.setActiveState('u1', {
+					statusDefault: UserStatus.BUSY,
+					statusSource: 'manual',
+					statusText: 'Focus',
+					statusExpiresAt: new Date('not a date'),
+				}),
+			).rejects.toThrow('statusExpiresAt must be a future date');
+
+			expect(updatePresenceMock).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('endActiveState', () => {

--- a/ee/packages/presence/src/Presence.ts
+++ b/ee/packages/presence/src/Presence.ts
@@ -316,6 +316,13 @@ export class Presence extends ServiceClass implements IPresence {
 		userId: string,
 		newState: Pick<IUser, 'statusDefault' | 'statusSource' | 'statusText' | 'statusExpiresAt'>,
 	): Promise<boolean> {
+		if (newState.statusExpiresAt) {
+			const expiresAt = new Date(newState.statusExpiresAt).getTime();
+			if (Number.isNaN(expiresAt) || expiresAt <= Date.now()) {
+				throw new Error('statusExpiresAt must be a future date');
+			}
+		}
+
 		return this.updatePresenceAndReschedule(userId, {
 			type: 'setActive',
 			newState: {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`users.setStatus` accepted any valid `expiresAt`, including past dates — a status that's already expired the moment it's applied and never reschedules correctly.

This rejects past (and invalid) expirations at two layers:

- **API** (`users.setStatus`): rejects `expiresAt <= now` with `error-invalid-date` ("expiresAt must be a future date"). NaN is already caught by the existing invalid-date-string check.
- **Service** (`Presence.setActiveState`): throws on a `NaN` or past `statusExpiresAt` before dispatching, covering callers that bypass the REST endpoint.

Also removes a dead `validStatus` array check that duplicated schema-level validation, and tightens the body type to `Exclude<UserStatus, UserStatus.DISABLED>`.

## Issue(s)

- [PRES-44](https://rocketchat.atlassian.net/browse/PRES-44)
- [PRES-54](https://rocketchat.atlassian.net/browse/PRES-54)

## Steps to test or reproduce

1. `POST /api/v1/users.setStatus` with `{ "status": "busy", "expiresAt": "2020-01-01T00:00:00.000Z" }`.
2. Expect `400`, `errorType: "error-invalid-date"`, error `expiresAt must be a future date [error-invalid-date]`.
3. A future `expiresAt` still succeeds and returns `statusExpiresAt`.

Covered by tests in `apps/meteor/tests/end-to-end/api/users.ts` and `ee/packages/presence/src/Presence.spec.ts`.


[PRES-44]: https://rocketchat.atlassian.net/browse/PRES-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PRES-54]: https://rocketchat.atlassian.net/browse/PRES-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent setting status expiration dates to the past; expiration dates must be in the future.
  * Removed support for `DISABLED` status value in status update requests.

* **Tests**
  * Added test coverage for status expiration date validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->