### PR TITLE
fix: show reactive status text on user card and user info

### DIFF
--- a/apps/meteor/client/components/UserInfo/UserInfo.stories.tsx
+++ b/apps/meteor/client/components/UserInfo/UserInfo.stories.tsx
@@ -1,9 +1,10 @@
 import { ContextualbarDialog } from '@rocket.chat/ui-client';
 import type { Meta, StoryFn } from '@storybook/react';
 
-import * as Status from '../UserStatus';
 import UserInfo from './UserInfo';
 import { UserCardRole } from '../UserCard';
+import * as Status from '../UserStatus';
+import { UserStatusText } from '../UserStatusText';
 
 export default {
 	component: UserInfo,
@@ -24,10 +25,10 @@ const defaultArgs = {
 	name: 'Guilherme Gazzo',
 	username: 'guilherme.gazzo',
 	nickname: 'gazzo',
-	statusText: '🛴 currently working on User Card',
 	bio: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla tempus, eros convallis vulputate cursus, nisi neque eleifend libero, eget lacinia justo purus nec est. In at sodales ipsum. Sed lacinia quis purus eget pulvinar. Aenean eu pretium nunc, at aliquam magna. Praesent dignissim, tortor sed volutpat mattis, mauris diam pulvinar leo, porta commodo risus est non purus.',
 	email: 'rocketchat@rocket.chat',
 	status: <Status.Offline />,
+	customStatus: <UserStatusText statusText='🛴 currently working on User Card' />,
 	roles: [<UserCardRole key='admin'>admin</UserCardRole>, <UserCardRole key='user'>user</UserCardRole>],
 };
 

--- a/apps/meteor/client/components/UserInfo/UserInfo.tsx
+++ b/apps/meteor/client/components/UserInfo/UserInfo.tsx
@@ -22,7 +22,6 @@ import { useUserCustomFields } from '../../hooks/useUserCustomFields';
 import MarkdownText from '../MarkdownText';
 import UTCClock from '../UTCClock';
 import { UserCardRoles } from '../UserCard';
-import { UserStatusText } from '../UserStatusText';
 import UserInfoABACAttributes from './UserInfoABACAttributes';
 import UserInfoAvatar from './UserInfoAvatar';
 
@@ -38,8 +37,6 @@ type UserInfoDataProps = Serialized<
 		| 'utcOffset'
 		| 'phone'
 		| 'createdAt'
-		| 'statusText'
-		| 'statusExpiresAt'
 		| 'canViewAllInfo'
 		| 'customFields'
 		| 'freeSwitchExtension'
@@ -49,6 +46,7 @@ type UserInfoDataProps = Serialized<
 
 type UserInfoProps = UserInfoDataProps & {
 	status: ReactNode;
+	customStatus?: ReactNode;
 	email?: string;
 	verified?: boolean;
 	actions: ReactNode;
@@ -71,8 +69,7 @@ const UserInfo = ({
 	verified,
 	createdAt,
 	status,
-	statusText,
-	statusExpiresAt,
+	customStatus,
 	customFields,
 	canViewAllInfo,
 	actions,
@@ -103,11 +100,7 @@ const UserInfo = ({
 				<InfoPanelSection>
 					{userDisplayName && <InfoPanelTitle icon={status} title={userDisplayName} />}
 
-					{(statusText || statusExpiresAt) && (
-						<InfoPanelText>
-							<UserStatusText statusText={statusText} statusExpiresAt={statusExpiresAt} />
-						</InfoPanelText>
-					)}
+					{customStatus && <InfoPanelText>{customStatus}</InfoPanelText>}
 				</InfoPanelSection>
 
 				<InfoPanelSection>

--- a/apps/meteor/client/components/UserStatusText/ReactiveUserStatusText.tsx
+++ b/apps/meteor/client/components/UserStatusText/ReactiveUserStatusText.tsx
@@ -1,0 +1,16 @@
+import type { IUser } from '@rocket.chat/core-typings';
+import { useUserPresence } from '@rocket.chat/ui-contexts';
+import { memo } from 'react';
+
+import UserStatusText from './UserStatusText';
+
+type ReactiveUserStatusTextProps = {
+	uid: IUser['_id'];
+};
+
+const ReactiveUserStatusText = ({ uid }: ReactiveUserStatusTextProps) => {
+	const presence = useUserPresence(uid);
+	return <UserStatusText status={presence?.status} statusText={presence?.statusText} statusExpiresAt={presence?.statusExpiresAt} />;
+};
+
+export default memo(ReactiveUserStatusText);

--- a/apps/meteor/client/components/UserStatusText/index.ts
+++ b/apps/meteor/client/components/UserStatusText/index.ts
@@ -1,1 +1,2 @@
 export { default as UserStatusText } from './UserStatusText';
+export { default as ReactiveUserStatusText } from './ReactiveUserStatusText';

--- a/apps/meteor/client/views/admin/users/AdminUserInfoWithData.tsx
+++ b/apps/meteor/client/views/admin/users/AdminUserInfoWithData.tsx
@@ -13,6 +13,7 @@ import { FormSkeleton } from '../../../components/Skeleton';
 import { UserCardRole } from '../../../components/UserCard';
 import { UserInfo } from '../../../components/UserInfo';
 import { UserStatus } from '../../../components/UserStatus';
+import { UserStatusText } from '../../../components/UserStatusText';
 import { getUserEmailVerified } from '../../../lib/utils/getUserEmailVerified';
 
 type AdminUserInfoWithDataProps = {
@@ -60,6 +61,7 @@ const AdminUserInfoWithData = ({ uid, onReload, tab }: AdminUserInfoWithDataProp
 			roles = [],
 			status,
 			statusText,
+			statusExpiresAt,
 			bio,
 			utcOffset,
 			lastLogin,
@@ -88,7 +90,7 @@ const AdminUserInfoWithData = ({ uid, onReload, tab }: AdminUserInfoWithDataProp
 			email: getUserEmailAddress(data.user),
 			createdAt,
 			status: <UserStatus status={status} />,
-			statusText,
+			customStatus: <UserStatusText status={status} statusText={statusText} statusExpiresAt={statusExpiresAt} />,
 			nickname,
 			reason,
 			freeSwitchExtension,

--- a/apps/meteor/client/views/room/UserCard/UserCardWithData.tsx
+++ b/apps/meteor/client/views/room/UserCard/UserCardWithData.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import LocalTime from '../../../components/LocalTime';
 import { UserCard, UserCardAction, UserCardRole, UserCardSkeleton } from '../../../components/UserCard';
 import { ReactiveUserStatus } from '../../../components/UserStatus';
-import { UserStatusText } from '../../../components/UserStatusText';
+import { ReactiveUserStatusText } from '../../../components/UserStatusText';
 import { useUserInfoQuery } from '../../../hooks/useUserInfoQuery';
 import { useMemberExists } from '../../hooks/useMemberExists';
 import { useUserInfoActions } from '../hooks/useUserInfoActions';
@@ -45,9 +45,6 @@ const UserCardWithData = ({ username, rid, onOpenUserInfo, onClose }: UserCardWi
 			_id,
 			name,
 			roles = defaultValue,
-			status,
-			statusText,
-			statusExpiresAt,
 			bio = defaultValue,
 			utcOffset = defaultValue,
 			nickname,
@@ -64,9 +61,7 @@ const UserCardWithData = ({ username, rid, onOpenUserInfo, onClose }: UserCardWi
 			etag: avatarETag,
 			localTime: utcOffset && Number.isInteger(utcOffset) && <LocalTime utcOffset={utcOffset} />,
 			status: _id && <ReactiveUserStatus uid={_id} />,
-			customStatus: (statusText || statusExpiresAt) && (
-				<UserStatusText status={status} statusText={statusText} statusExpiresAt={statusExpiresAt} />
-			),
+			customStatus: _id && <ReactiveUserStatusText uid={_id} />,
 			nickname,
 			freeSwitchExtension,
 		};

--- a/apps/meteor/client/views/room/contextualBar/UserInfo/UserInfoWithData.tsx
+++ b/apps/meteor/client/views/room/contextualBar/UserInfo/UserInfoWithData.tsx
@@ -20,6 +20,7 @@ import { FormSkeleton } from '../../../../components/Skeleton';
 import { UserCardRole } from '../../../../components/UserCard';
 import { UserInfo } from '../../../../components/UserInfo';
 import { ReactiveUserStatus } from '../../../../components/UserStatus';
+import { ReactiveUserStatusText } from '../../../../components/UserStatusText';
 import { usersQueryKeys } from '../../../../lib/queryKeys';
 import { getUserEmailVerified } from '../../../../lib/utils/getUserEmailVerified';
 
@@ -56,8 +57,6 @@ const UserInfoWithData = ({ uid, username, rid, invitationDate, onClose, onClick
 			name,
 			username,
 			roles = [],
-			statusText,
-			statusExpiresAt,
 			bio,
 			utcOffset,
 			lastLogin,
@@ -87,8 +86,7 @@ const UserInfoWithData = ({ uid, username, rid, invitationDate, onClose, onClick
 			utcOffset,
 			createdAt,
 			status: <ReactiveUserStatus uid={_id} />,
-			statusText,
-			statusExpiresAt,
+			customStatus: <ReactiveUserStatusText uid={_id} />,
 			nickname,
 			freeSwitchExtension,
 		};


### PR DESCRIPTION
<!-- fix: show reactive status text on user card and user info -->

## Proposed changes (including videos or screenshots)

Makes the status text on the **user card** and **user info** panels show the user's presence consistently:

- Always renders the status, in the format `[status] - [statusText]` (status alone when there's no custom text), plus the expiration line when set — matching the tooltips.
- The status text is now **reactive**: changing your status from the user menu updates the panels live, no page reload needed.
- Introduces `ReactiveUserStatusText` (mirrors `ReactiveUserStatus`): takes a `uid`, reads `useUserPresence`, and renders `UserStatusText`. Room card and room info use it; the admin panel keeps its existing non-reactive REST data via `UserStatusText`.

## Issue(s)

- [PRES-57](https://rocketchat.atlassian.net/browse/PRES-57)

## Steps to test or reproduce

1. Open a DM/channel and click a user to open the **user card**, then open **user info**.
2. With no custom status, confirm the status label (e.g. `Online`) shows in the custom-message slot.
3. Set a custom status with text and an expiration; confirm `[status] - [statusText]` plus the expiration line.
4. Change your own status from the user menu and confirm the card/info update **without reloading**.

## Further comments

`ReactiveUserStatusText` follows the same behavior and pattern as the existing `ReactiveUserStatus` — a thin wrapper keyed by `uid` that subscribes to `useUserPresence` and renders the presentational component — keeping consistency with the established convention in the codebase.

`UserInfo` stays purely presentational — it receives the dot and the status text as `ReactNode`s, so each call site decides reactive (room) vs REST (admin). Output is covered by the existing `UserInfo` snapshot tests.


[PRES-57]: https://rocketchat.atlassian.net/browse/PRES-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated user status display handling across multiple components to use a new standardized approach.
  * Introduced a reactive user status component for dynamic status rendering.
  * Modified status data flow to use a new prop structure in the UserInfo component, replacing individual status-related fields with a unified custom status element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->