### PR TITLE
chore: show Outlook prefix for calendar busy status

### DIFF
--- a/apps/meteor/server/services/calendar/service.ts
+++ b/apps/meteor/server/services/calendar/service.ts
@@ -299,7 +299,7 @@ export class CalendarService extends ServiceClassInternal implements ICalendarSe
 
 		await Presence.setActiveState(uid, {
 			statusDefault: UserStatus.BUSY,
-			statusText: i18n.t('Presence_status_in_a_meeting', { lng }),
+			statusText: i18n.t('Presence_status_outlook_in_a_meeting', { lng }),
 			statusSource: 'external',
 			statusExpiresAt,
 			statusId: this.name,

--- a/apps/meteor/tests/unit/server/services/calendar/service.tests.ts
+++ b/apps/meteor/tests/unit/server/services/calendar/service.tests.ts
@@ -46,7 +46,7 @@ const serviceMocks = {
 	'@rocket.chat/cron': { cronJobs: cronJobsMock },
 	'@rocket.chat/models': { CalendarEvent: CalendarEventMock, Users: UsersMock },
 	'../../../app/utils/server/lib/getUserPreference': { getUserPreference: getUserPreferenceMock },
-	'../../lib/i18n': { i18n: { t: sinon.stub().returns('In a meeting') } },
+	'../../lib/i18n': { i18n: { t: sinon.stub().returns('Outlook: In a meeting') } },
 };
 
 const { CalendarService } = proxyquire.noCallThru().load('../../../../../server/services/calendar/service', serviceMocks);
@@ -495,6 +495,7 @@ describe('CalendarService', () => {
 			expect(state.statusSource).to.equal('external');
 			expect(state.statusExpiresAt.getTime()).to.equal(now + 120 * 60 * 1000);
 			expect(state.statusId).to.equal('calendar');
+			expect(state.statusText).to.equal('Outlook: In a meeting');
 		});
 
 		it('should use the event own endTime when there are no overlapping events', async () => {

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -4266,6 +4266,7 @@
   "Presence_service_cap": "Presence service cap",
   "Presence_status_in_a_meeting": "In a meeting",
   "Presence_status_on_a_call": "On a call",
+  "Presence_status_outlook_in_a_meeting": "Outlook: In a meeting",
   "Preview": "Preview",
   "Previous_image": "Previous image",
   "Previous_month": "Previous Month",


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

When a calendar event sets the user as busy, the status text now reads **`Outlook: In a meeting`** instead of just `In a meeting`, so the source of the status is clear. Combined with the presence status it renders as `[status] - Outlook: In a meeting`.

- Adds a dedicated i18n key `Presence_status_outlook_in_a_meeting` (`"Outlook: In a meeting"`).
- The calendar service uses this key for the busy status text.
- The video-conference busy status keeps using `Presence_status_in_a_meeting` (`"In a meeting"`), so it is unaffected.

## Issue(s)

- [PRES-58](https://rocketchat.atlassian.net/browse/PRES-58)

## Steps to test or reproduce

1. Enable the calendar busy status (`Calendar_BusyStatus_Enabled`).
2. Have a calendar event start for the user.
3. Confirm the user's status text reads `Outlook: In a meeting` (shown as `[status] - Outlook: In a meeting` on the card/info/tooltip).
4. Join a video conference call and confirm its busy status still reads `In a meeting` (no `Outlook:` prefix).

## Further comments

The prefix is scoped to a separate i18n key so the calendar and video-conference busy statuses can diverge without affecting each other.

[PRES-58]: https://rocketchat.atlassian.net/browse/PRES-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated presence status message for Outlook calendar integration to display "Outlook: In a meeting" when busy, providing clearer indication of the calendar source.

* **Tests**
  * Updated unit tests to verify the presence status displays the correct updated message format.

* **Localization**
  * Added English localization string for the new Outlook meeting presence status message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->