### PR TITLE
feat(desktop): push user roles to the desktop app

### DIFF
--- a/.changeset/desktop-set-user-roles.md
+++ b/.changeset/desktop-set-user-roles.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/desktop-api': minor
+'@rocket.chat/meteor': patch
+---
+
+Added a `setUserRoles` bridge method to the desktop API and pushed the logged-in user's roles to the desktop app. This lets the desktop client restrict supportedVersions messages (such as version-expiration warnings) to specific roles like admins, instead of showing them to every user. The push is reactive to role changes; desktop builds without the bridge method fall back to their own role lookup.

--- a/apps/meteor/client/views/root/AppLayout.tsx
+++ b/apps/meteor/client/views/root/AppLayout.tsx
@@ -18,6 +18,7 @@ import { useCodeHighlight } from './hooks/useCodeHighlight';
 import { useCorsSSLConfig } from './hooks/useCorsSSLConfig';
 import { useDesktopFavicon } from './hooks/useDesktopFavicon';
 import { useDesktopTitle } from './hooks/useDesktopTitle';
+import { useDesktopUserRoles } from './hooks/useDesktopUserRoles';
 import { useEmojiOne } from './hooks/useEmojiOne';
 import { useEscapeKeyStroke } from './hooks/useEscapeKeyStroke';
 import { useGoogleTagManager } from './hooks/useGoogleTagManager';
@@ -73,6 +74,7 @@ const AppLayout = () => {
 	useLoadMissedMessages();
 	useDesktopFavicon();
 	useDesktopTitle();
+	useDesktopUserRoles();
 	useStartupEvent();
 	useIframeCommands();
 

--- a/apps/meteor/client/views/root/hooks/useDesktopUserRoles.ts
+++ b/apps/meteor/client/views/root/hooks/useDesktopUserRoles.ts
@@ -14,8 +14,11 @@ export const useDesktopUserRoles = () => {
 
 	useEffect(() => {
 		if (typeof window === 'undefined') return;
-		// On logout or account switch clear any previously-pushed roles instead of
-		// leaving stale ones cached in the desktop app.
+		// Clear stale roles on logout/account switch by pushing [] when there is no
+		// user, rather than in an effect cleanup: the cleanup runs on every deps
+		// change (including a roles update while staying logged in), which would
+		// push [] and then the new roles, briefly flickering role-targeted UI.
+		// Handling it inline only clears when the user actually goes away.
 		if (!userId) {
 			window.RocketChatDesktop?.setUserRoles?.([]);
 			return;

--- a/apps/meteor/client/views/root/hooks/useDesktopUserRoles.ts
+++ b/apps/meteor/client/views/root/hooks/useDesktopUserRoles.ts
@@ -8,21 +8,16 @@ import { useEffect } from 'react';
  * this bridge is unavailable, so `setUserRoles` is called optionally.
  */
 export const useDesktopUserRoles = () => {
-	const user = useUser();
-	const userId = user?._id;
-	const rolesKey = user?.roles?.join(',');
+	// A single canonical value derived from the reactive user. Logout, login and
+	// account switch all surface as a change to this key, so the effect re-runs
+	// and re-pushes only when the roles actually change — no userId branch and no
+	// effect cleanup (which would fire on every deps change and flicker
+	// role-targeted UI). Logged-out and "logged in with no roles" both resolve to
+	// an empty list, which is the correct signal for the desktop either way.
+	const rolesKey = (useUser()?.roles ?? []).join(',');
 
 	useEffect(() => {
 		if (typeof window === 'undefined') return;
-		// Clear stale roles on logout/account switch by pushing [] when there is no
-		// user, rather than in an effect cleanup: the cleanup runs on every deps
-		// change (including a roles update while staying logged in), which would
-		// push [] and then the new roles, briefly flickering role-targeted UI.
-		// Handling it inline only clears when the user actually goes away.
-		if (!userId) {
-			window.RocketChatDesktop?.setUserRoles?.([]);
-			return;
-		}
 		window.RocketChatDesktop?.setUserRoles?.(rolesKey ? rolesKey.split(',') : []);
-	}, [userId, rolesKey]);
+	}, [rolesKey]);
 };

--- a/apps/meteor/client/views/root/hooks/useDesktopUserRoles.ts
+++ b/apps/meteor/client/views/root/hooks/useDesktopUserRoles.ts
@@ -1,0 +1,20 @@
+import { useUser } from '@rocket.chat/ui-contexts';
+import { useEffect } from 'react';
+
+/**
+ * Pushes the logged-in user's roles to the desktop app so it can decide which
+ * supportedVersions messages to show (e.g. restricting version-expiration
+ * warnings to admins). The desktop app falls back to its own role lookup when
+ * this bridge is unavailable, so `setUserRoles` is called optionally.
+ */
+export const useDesktopUserRoles = () => {
+	const user = useUser();
+	const userId = user?._id;
+	const rolesKey = user?.roles?.join(',');
+
+	useEffect(() => {
+		if (typeof window === 'undefined') return;
+		if (!userId) return;
+		window.RocketChatDesktop?.setUserRoles?.(rolesKey ? rolesKey.split(',') : []);
+	}, [userId, rolesKey]);
+};

--- a/apps/meteor/client/views/root/hooks/useDesktopUserRoles.ts
+++ b/apps/meteor/client/views/root/hooks/useDesktopUserRoles.ts
@@ -14,7 +14,12 @@ export const useDesktopUserRoles = () => {
 
 	useEffect(() => {
 		if (typeof window === 'undefined') return;
-		if (!userId) return;
+		// On logout or account switch clear any previously-pushed roles instead of
+		// leaving stale ones cached in the desktop app.
+		if (!userId) {
+			window.RocketChatDesktop?.setUserRoles?.([]);
+			return;
+		}
 		window.RocketChatDesktop?.setUserRoles?.(rolesKey ? rolesKey.split(',') : []);
 	}, [userId, rolesKey]);
 };

--- a/packages/desktop-api/src/index.ts
+++ b/packages/desktop-api/src/index.ts
@@ -38,6 +38,7 @@ export interface IRocketChatDesktop {
 	setSidebarCustomTheme: (customTheme: string) => void;
 	setTitle: (title: string) => void;
 	setUserLoggedIn: (userLoggedIn: boolean) => void;
+	setUserRoles: (roles: string[]) => void;
 	setUserPresenceDetection: (options: {
 		isAutoAwayEnabled: boolean;
 		idleThreshold: number | null;


### PR DESCRIPTION
Jira: [ARCH-2192](https://rocketchat.atlassian.net/browse/ARCH-2192)

## Proposal

Expose the logged-in user's roles to the desktop app so it can decide which `supportedVersions` messages to show — e.g. restrict version-expiration warnings to admins (the only ones who can act on them) instead of showing them to every user.

## Changes

- **`@rocket.chat/desktop-api`**: add `setUserRoles(roles: string[])` to `IRocketChatDesktop`.
- **meteor client**: new `useDesktopUserRoles` hook that reads the current user's roles via `useUser()` and pushes them through `window.RocketChatDesktop?.setUserRoles?.(...)`. Mounted in `AppLayout` alongside the other `useDesktop*` hooks. The push is reactive — role changes propagate live.

The call is optional (`?.`) so a web client running inside an **older desktop build** without the bridge method keeps working; that desktop falls back to its own role lookup.

## Desktop side

Pairs with the desktop change that consumes this bridge and filters role-targeted `supportedVersions` messages: RocketChat/Rocket.Chat.Electron#3371. The desktop uses a hybrid acquisition — bridge push (this PR) takes precedence, with a `/api/v1/me` REST fallback for clients that predate this change.

## Notes

- `supportedVersions` messages are a shared contract (desktop + mobile, produced by cloud). The role-targeting field (`Message.roles`) is added on the desktop side; this PR provides the role signal the desktop needs.
- Client-side UX, not a security boundary.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic syncing of the logged-in user’s roles to the desktop app, updating reactively as roles change.
  * Introduced a new desktop API bridge method to receive role updates, enabling role-based restrictions for select desktop notifications (including supported-versions related messages).
  * Desktop builds that don’t include the new bridge method continue to work using the existing role lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[ARCH-2192]: https://rocketchat.atlassian.net/browse/ARCH-2192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARCH-2190]: https://rocketchat.atlassian.net/browse/ARCH-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ