### PR TITLE
fix(ui-voip): Sync voice call UI state on mount in useMediaSession

### DIFF
--- a/.changeset/wise-years-shout.md
+++ b/.changeset/wise-years-shout.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/ui-voip": patch
+---
+
+Fixes voice call UI not reflecting active call state when a new view mounted while a call was already active (e.g. opening the popout window)

--- a/packages/ui-voip/src/providers/useMediaSession.ts
+++ b/packages/ui-voip/src/providers/useMediaSession.ts
@@ -230,6 +230,8 @@ export const useMediaSession = (instance?: MediaSignalingSession): MediaSessionS
 
 		const offCbs = [instance.on('sessionStateChange', updateSessionState), instance.on('hiddenCall', updateSessionState)];
 
+		updateSessionState();
+
 		return () => {
 			offCbs.forEach((offCb) => offCb());
 		};


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`useMediaSession` subscribed to `sessionStateChange` events but never read the current session state on mount, relying on a side effect of the old `setDeviceId` reference-equality bug to trigger an initial sync. 
After `e626fb9` fixed `setDeviceId` to use value-based comparison, that accidental sync no longer fires, leaving the hook stuck at the default closed state when a `MediaCallViewProvider` mounts with an already-active call.

Calling `updateSessionState()` immediately after subscribing ensures the hook reads the real session state on mount, fixing the popout opening in the ended state, `MediaCallRoomSection` not rendering, and call actions not reflecting live state.

## Issue(s)
[CORE-2306](https://rocketchat.atlassian.net/browse/CORE-2306)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-2306]: https://rocketchat.atlassian.net/browse/CORE-2306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed voice call UI state so it correctly reflects an already-active call when opening new views/windows during an ongoing session.
* Improved reliability of audio input handling during voice calls by better detecting when the selected device changes, reducing failures when switching contexts (e.g., moving between rooms right as a call starts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->