### PR TITLE
regression: Setup Wizard prompts for 2FA/password between steps

### DIFF
--- a/.changeset/setup-wizard-2fa-prompt.md
+++ b/.changeset/setup-wizard-2fa-prompt.md
@@ -1,0 +1,7 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed the Setup Wizard incorrectly prompting for a password/2FA confirmation between steps on a fresh installation.
+
+The post-registration grace window that skips two-factor checks right after a user is created was being short-circuited by the `disableRememberMe` option (set by `POST /v1/settings`, which the wizard calls between steps). The grace-window check now runs before the `disableRememberMe` early-return, so a freshly registered admin can complete the wizard without intermediate verifications, while sensitive endpoints that set `disableRememberMe` (reset TOTP, reset E2E key, disable 2FA email) keep requiring a fresh confirmation outside that short window.

--- a/.changeset/setup-wizard-2fa-prompt.md
+++ b/.changeset/setup-wizard-2fa-prompt.md
@@ -1,7 +1,0 @@
----
-'@rocket.chat/meteor': patch
----
-
-Fixed the Setup Wizard incorrectly prompting for a password/2FA confirmation between steps on a fresh installation.
-
-The post-registration grace window that skips two-factor checks right after a user is created was being short-circuited by the `disableRememberMe` option (set by `POST /v1/settings`, which the wizard calls between steps). The grace-window check now runs before the `disableRememberMe` early-return, so a freshly registered admin can complete the wizard without intermediate verifications, while sensitive endpoints that set `disableRememberMe` (reset TOTP, reset E2E key, disable 2FA email) keep requiring a fresh confirmation outside that short window.

--- a/apps/meteor/app/2fa/server/code/checkCodeForUser.spec.ts
+++ b/apps/meteor/app/2fa/server/code/checkCodeForUser.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { afterEach, beforeEach, describe, it } from 'mocha';
+import { before, after, beforeEach, describe, it } from 'mocha';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
@@ -105,14 +105,10 @@ const connection = {
 describe('checkCodeForUser - post-registration grace window', () => {
 	let originalTestMode: string | undefined;
 
-	beforeEach(() => {
+	before(() => {
 		originalTestMode = process.env.TEST_MODE;
 		delete process.env.TEST_MODE;
 
-		totpEnabled.reset();
-		totpEnabled.returns(false);
-
-		settingsGet.reset();
 		settingsGet.callsFake((key: string) => {
 			switch (key) {
 				case 'Accounts_TwoFactorAuthentication_Enabled':
@@ -127,12 +123,17 @@ describe('checkCodeForUser - post-registration grace window', () => {
 		});
 	});
 
-	afterEach(() => {
+	after(() => {
 		if (originalTestMode === undefined) {
 			delete process.env.TEST_MODE;
 		} else {
 			process.env.TEST_MODE = originalTestMode;
 		}
+	});
+
+	beforeEach(() => {
+		totpEnabled.reset();
+		totpEnabled.returns(false);
 	});
 
 	it('should not prompt a freshly registered user even when disableRememberMe is set (Setup Wizard regression)', async () => {

--- a/apps/meteor/app/2fa/server/code/checkCodeForUser.spec.ts
+++ b/apps/meteor/app/2fa/server/code/checkCodeForUser.spec.ts
@@ -4,6 +4,7 @@ import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
 const settingsGet = sinon.stub();
+const totpEnabled = sinon.stub().returns(false);
 
 class MeteorError extends Error {
 	error: string;
@@ -22,7 +23,11 @@ class TOTPCheck {
 	name = 'totp';
 
 	isEnabled(): boolean {
-		return false;
+		return totpEnabled();
+	}
+
+	async processInvalidCode(): Promise<{ codeGenerated: boolean }> {
+		return { codeGenerated: false };
 	}
 }
 
@@ -54,7 +59,7 @@ class PasswordCheckFallback {
 	}
 }
 
-const { checkCodeForUser } = proxyquire.noCallThru().load('./index', {
+const { checkCodeForUser, getFingerprintFromConnection } = proxyquire.noCallThru().load('./index', {
 	'@rocket.chat/models': {
 		Users: {
 			findOneById: async () => null,
@@ -104,6 +109,9 @@ describe('checkCodeForUser - post-registration grace window', () => {
 		originalTestMode = process.env.TEST_MODE;
 		delete process.env.TEST_MODE;
 
+		totpEnabled.reset();
+		totpEnabled.returns(false);
+
 		settingsGet.reset();
 		settingsGet.callsFake((key: string) => {
 			switch (key) {
@@ -139,6 +147,19 @@ describe('checkCodeForUser - post-registration grace window', () => {
 		expect(result).to.be.equal(true);
 	});
 
+	it('should still prompt a freshly registered user who already has a 2FA method configured', async () => {
+		totpEnabled.returns(true);
+		const user = buildUser(new Date());
+
+		await expect(
+			checkCodeForUser({
+				user,
+				options: { disableRememberMe: true },
+				connection,
+			}),
+		).to.be.rejectedWith('TOTP Required');
+	});
+
 	it('should still prompt when the post-registration grace window has expired and disableRememberMe is set', async () => {
 		const user = buildUser(new Date(Date.now() - (REMEMBER_FOR_SECONDS + 60) * 1000));
 
@@ -157,7 +178,7 @@ describe('checkCodeForUser - post-registration grace window', () => {
 		user.services.resume.loginTokens[0] = {
 			hashedToken: 'token-hash',
 			twoFactorAuthorizedUntil: new Date(Date.now() + 60 * 1000),
-			twoFactorAuthorizedHash: 'whatever',
+			twoFactorAuthorizedHash: getFingerprintFromConnection(connection),
 		} as (typeof user.services.resume.loginTokens)[number];
 
 		await expect(

--- a/apps/meteor/app/2fa/server/code/checkCodeForUser.spec.ts
+++ b/apps/meteor/app/2fa/server/code/checkCodeForUser.spec.ts
@@ -1,0 +1,171 @@
+import { expect } from 'chai';
+import { afterEach, beforeEach, describe, it } from 'mocha';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+const settingsGet = sinon.stub();
+
+class MeteorError extends Error {
+	error: string;
+
+	details?: unknown;
+
+	constructor(error: string, reason?: string, details?: unknown) {
+		super(reason ?? error);
+		this.error = error;
+		this.details = details;
+	}
+}
+
+// Disabled second-factor methods so the password fallback is the only candidate.
+class TOTPCheck {
+	name = 'totp';
+
+	isEnabled(): boolean {
+		return false;
+	}
+}
+
+class EmailCheck {
+	name = 'email';
+
+	isEnabled(): boolean {
+		return false;
+	}
+}
+
+class PasswordCheckFallback {
+	name = 'password';
+
+	isEnabled(): boolean {
+		return true;
+	}
+
+	async verify(): Promise<boolean> {
+		return false;
+	}
+
+	async processInvalidCode(): Promise<{ codeGenerated: boolean }> {
+		return { codeGenerated: false };
+	}
+
+	async maxFaildedAttemtpsReached(): Promise<boolean> {
+		return false;
+	}
+}
+
+const { checkCodeForUser } = proxyquire.noCallThru().load('./index', {
+	'@rocket.chat/models': {
+		Users: {
+			findOneById: async () => null,
+			setTwoFactorAuthorizationHashAndUntilForUserIdAndToken: async () => undefined,
+		},
+	},
+	'meteor/accounts-base': {
+		Accounts: {
+			_getLoginToken: () => 'token-hash',
+		},
+	},
+	'meteor/meteor': {
+		Meteor: { Error: MeteorError },
+	},
+	'./TOTPCheck': { TOTPCheck },
+	'./EmailCheck': { EmailCheck },
+	'./PasswordCheckFallback': { PasswordCheckFallback },
+	'../../../lib/server/functions/getModifiedHttpHeaders': {
+		normalizeHeaders: (headers: unknown) => headers,
+	},
+	'../../../settings/server': {
+		settings: { get: settingsGet },
+	},
+});
+
+const REMEMBER_FOR_SECONDS = 1800;
+
+const buildUser = (createdAt: Date) => ({
+	_id: 'user-id',
+	createdAt,
+	services: {
+		password: { bcrypt: 'hashed' },
+		resume: { loginTokens: [{ hashedToken: 'token-hash' }] },
+	},
+});
+
+const connection = {
+	id: 'connection-id',
+	httpHeaders: { 'user-agent': 'agent' },
+	clientAddress: '127.0.0.1',
+};
+
+describe('checkCodeForUser - post-registration grace window', () => {
+	let originalTestMode: string | undefined;
+
+	beforeEach(() => {
+		originalTestMode = process.env.TEST_MODE;
+		delete process.env.TEST_MODE;
+
+		settingsGet.reset();
+		settingsGet.callsFake((key: string) => {
+			switch (key) {
+				case 'Accounts_TwoFactorAuthentication_Enabled':
+					return true;
+				case 'Accounts_TwoFactorAuthentication_RememberFor':
+					return REMEMBER_FOR_SECONDS;
+				case 'Accounts_TwoFactorAuthentication_Enforce_Password_Fallback':
+					return true;
+				default:
+					return false;
+			}
+		});
+	});
+
+	afterEach(() => {
+		if (originalTestMode === undefined) {
+			delete process.env.TEST_MODE;
+		} else {
+			process.env.TEST_MODE = originalTestMode;
+		}
+	});
+
+	it('should not prompt a freshly registered user even when disableRememberMe is set (Setup Wizard regression)', async () => {
+		const user = buildUser(new Date());
+
+		const result = await checkCodeForUser({
+			user,
+			options: { disableRememberMe: true },
+			connection,
+		});
+
+		expect(result).to.be.equal(true);
+	});
+
+	it('should still prompt when the post-registration grace window has expired and disableRememberMe is set', async () => {
+		const user = buildUser(new Date(Date.now() - (REMEMBER_FOR_SECONDS + 60) * 1000));
+
+		await expect(
+			checkCodeForUser({
+				user,
+				options: { disableRememberMe: true },
+				connection,
+			}),
+		).to.be.rejectedWith('TOTP Required');
+	});
+
+	it('should ignore a remembered authorization when disableRememberMe is set and grace window expired', async () => {
+		const user = buildUser(new Date(Date.now() - (REMEMBER_FOR_SECONDS + 60) * 1000));
+		// A previously remembered 2FA authorization that is still valid in time.
+		user.services.resume.loginTokens[0] = {
+			hashedToken: 'token-hash',
+			twoFactorAuthorizedUntil: new Date(Date.now() + 60 * 1000),
+			twoFactorAuthorizedHash: 'whatever',
+		} as (typeof user.services.resume.loginTokens)[number];
+
+		await expect(
+			checkCodeForUser({
+				user,
+				options: { disableRememberMe: true },
+				connection,
+			}),
+		).to.be.rejectedWith('TOTP Required');
+	});
+});

--- a/apps/meteor/app/2fa/server/code/index.ts
+++ b/apps/meteor/app/2fa/server/code/index.ts
@@ -54,7 +54,7 @@ export async function getUserForCheck(userId: string): Promise<IUser | null> {
 	});
 }
 
-function getFingerprintFromConnection(connection: IMethodConnection): string {
+export function getFingerprintFromConnection(connection: IMethodConnection): string {
 	const data = JSON.stringify({
 		userAgent: connection.httpHeaders['user-agent'],
 		clientAddress: connection.clientAddress,

--- a/apps/meteor/app/2fa/server/code/index.ts
+++ b/apps/meteor/app/2fa/server/code/index.ts
@@ -97,14 +97,15 @@ function isAuthorizedForToken(connection: IMethodConnection, user: IUser, option
 		return true;
 	}
 
-	if (options.disableRememberMe === true) {
-		return false;
-	}
-
-	// remember user right after their registration
+	// remember user right after their registration, even when remember-me is disabled
+	// (e.g. the Setup Wizard saving settings between steps before any 2FA is configured)
 	const rememberAfterRegistration = user.createdAt && getRememberDate(user.createdAt);
 	if (rememberAfterRegistration && rememberAfterRegistration >= new Date()) {
 		return true;
+	}
+
+	if (options.disableRememberMe === true) {
+		return false;
 	}
 
 	if (!tokenObject.twoFactorAuthorizedUntil || !tokenObject.twoFactorAuthorizedHash) {

--- a/apps/meteor/app/2fa/server/code/index.ts
+++ b/apps/meteor/app/2fa/server/code/index.ts
@@ -97,10 +97,13 @@ function isAuthorizedForToken(connection: IMethodConnection, user: IUser, option
 		return true;
 	}
 
-	// remember user right after their registration, even when remember-me is disabled
+	// Skip 2FA for a freshly registered user who has not set up any 2FA method yet,
+	// until the grace period that starts at registration expires.
 	// (e.g. the Setup Wizard saving settings between steps before any 2FA is configured)
-	const rememberAfterRegistration = user.createdAt && getRememberDate(user.createdAt);
-	if (rememberAfterRegistration && rememberAfterRegistration >= new Date()) {
+	const rememberPeriodEnd = user.createdAt && getRememberDate(user.createdAt);
+	const isWithinRememberPeriod = rememberPeriodEnd && rememberPeriodEnd >= new Date();
+	const hasNoTwoFactorMethod = getAvailableMethodNames(user).length === 0;
+	if (isWithinRememberPeriod && hasNoTwoFactorMethod) {
 		return true;
 	}
 


### PR DESCRIPTION
## Proposed changes

### Problem

A regression in `8.6.0`: the initial Setup Wizard prompts for a password/2FA confirmation between each step (email, password, organization info, etc.) on a clean database. This did not happen in `8.5.1`.

### Root cause

The Setup Wizard saves settings between steps through the `SettingsProvider`, which was migrated to call `POST /v1/settings`. That endpoint passes `twoFactorOptions: { disableRememberMe: true }`.

In `isAuthorizedForToken` (`apps/meteor/app/2fa/server/code/index.ts`) the `disableRememberMe === true` early-return runs **before** the post-registration grace window check (`getRememberDate(user.createdAt)`). That grace window exists precisely for first-time setup, where the freshly created admin has no second factor configured yet — but `disableRememberMe` was defeating it, so every settings save fell through to the password fallback prompt.

The legacy `saveSettings` Meteor method used in `8.5.1` did not set `disableRememberMe`, so the grace window applied and no prompt appeared.

### Fix

Move the post-registration grace-window check **above** the `disableRememberMe` early-return. The grace window represents the "first-time setup" special case and is conceptually independent of the remember-me token mechanism.

This keeps the intent of `disableRememberMe` on the genuinely sensitive endpoints (`users.resetTOTP`, `users.resetE2EKey`, `users.2fa.disableEmail`): outside the short post-registration window they still require a fresh confirmation every time, and the long-lived remember-me authorization is still ignored for them.

### Tests

- Adds `app/2fa/server/code/checkCodeForUser.spec.ts` covering:
  - freshly registered user is not prompted even with `disableRememberMe` (the regression),
  - prompt still required once the grace window expires,
  - a remembered authorization is still ignored when `disableRememberMe` is set and the grace window has expired.
- Wires `app/2fa/server/**/*.spec.ts` into the unit test config (these specs, including the existing `EmailCheck.spec.ts`, were not being picked up by any runner).

### How to test manually

1. Reset the database (`meteor reset` / drop the DB).
2. Run the workspace and go through the Setup Wizard.
3. Advance between steps — no password/2FA prompt should appear.

[CORE-2310]: https://rocketchat.atlassian.net/browse/CORE-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CORE-2304](https://rocketchat.atlassian.net/browse/CORE-2304)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted newly registered account “remember me” handling: authorization during the post-registration grace window now only applies when the user has **no enabled 2FA methods**, regardless of “disable remember me”.
  - Users with active 2FA still must complete verification during/after the grace period.
  - Once the grace window expires, any previously remembered sign-in state no longer bypasses 2FA and requires TOTP (“TOTP Required”).

- **Tests**
  - Added a test suite covering grace-period behavior and “disable remember me” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->