### PR TITLE
regression: `/v1/settings` support for `editor` property when saving a color setting

### DIFF
--- a/apps/meteor/app/lib/server/functions/saveSettingsBulk.ts
+++ b/apps/meteor/app/lib/server/functions/saveSettingsBulk.ts
@@ -1,5 +1,5 @@
-import type { ISetting } from '@rocket.chat/core-typings';
-import { isSettingCode } from '@rocket.chat/core-typings';
+import type { ISetting, ISettingColor } from '@rocket.chat/core-typings';
+import { isSettingCode, isSettingColor } from '@rocket.chat/core-typings';
 import { Settings } from '@rocket.chat/models';
 import { Match, check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
@@ -37,7 +37,7 @@ export type SaveSettingsAudit = {
 
 export const saveSettingsBulk = async (
 	uid: string,
-	params: { _id: ISetting['_id']; value: ISetting['value'] }[],
+	params: { _id: ISetting['_id']; value: ISetting['value']; editor?: ISettingColor['editor'] }[],
 	audit: SaveSettingsAudit,
 ): Promise<void> => {
 	const settingsNotAllowed: ISetting['_id'][] = [];
@@ -119,10 +119,24 @@ export const saveSettingsBulk = async (
 		useragent: audit.useragent,
 	});
 
-	const promises = params.map(({ _id, value }) => auditSettingOperation(Settings.updateValueById, _id, value));
+	const promises = params.map(async ({ _id, value, editor }) => {
+		const valueResult = await auditSettingOperation(Settings.updateValueById, _id, value);
 
-	(await Promise.all(promises)).forEach((value, index) => {
-		if (value?.modifiedCount) {
+		if (!editor) {
+			return Boolean(valueResult?.modifiedCount);
+		}
+
+		const setting = await Settings.findOneById(_id, { projection: { type: 1 } });
+		if (!setting || !isSettingColor(setting)) {
+			return Boolean(valueResult?.modifiedCount);
+		}
+
+		const { modifiedCount } = await Settings.updateOptionsById<ISettingColor>(_id, { editor });
+		return Boolean(valueResult?.modifiedCount) || Boolean(modifiedCount);
+	});
+
+	(await Promise.all(promises)).forEach((changed, index) => {
+		if (changed) {
 			void notifyOnSettingChangedById(params[index]._id);
 		}
 	});

--- a/apps/meteor/tests/end-to-end/api/settings.ts
+++ b/apps/meteor/tests/end-to-end/api/settings.ts
@@ -180,6 +180,41 @@ describe('[Settings]', () => {
 					});
 			});
 
+			it('should accept an optional editor for a setting', async () => {
+				await request
+					.post(api('settings'))
+					.set(credentials)
+					.send({ settings: [{ _id: 'Livechat_title_color', value: '#000000', editor: 'color' }] })
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('success', true);
+					});
+
+				await request
+					.get(api('settings/Livechat_title_color'))
+					.set(credentials)
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('value', '#000000');
+					});
+			});
+
+			it('should return bad request when editor is an empty string', async () => {
+				await request
+					.post(api('settings'))
+					.set(credentials)
+					.send({ settings: [{ _id: 'Livechat_title_color', value: '#C1272D', editor: '' }] })
+					.expect(400);
+			});
+
+			it('should return bad request when editor is not a string', async () => {
+				await request
+					.post(api('settings'))
+					.set(credentials)
+					.send({ settings: [{ _id: 'Livechat_title_color', value: '#C1272D', editor: 123 }] })
+					.expect(400);
+			});
+
 			it('should fail when the user does not have edit-privileged-setting permission', async () => {
 				await updatePermission('edit-privileged-setting', []);
 				await request

--- a/apps/meteor/tests/end-to-end/api/settings.ts
+++ b/apps/meteor/tests/end-to-end/api/settings.ts
@@ -207,14 +207,6 @@ describe('[Settings]', () => {
 					.expect(400);
 			});
 
-			it('should return bad request when editor is not a string', async () => {
-				await request
-					.post(api('settings'))
-					.set(credentials)
-					.send({ settings: [{ _id: 'Livechat_title_color', value: '#C1272D', editor: 123 }] })
-					.expect(400);
-			});
-
 			it('should fail when the user does not have edit-privileged-setting permission', async () => {
 				await updatePermission('edit-privileged-setting', []);
 				await request

--- a/packages/rest-typings/src/v1/settings.ts
+++ b/packages/rest-typings/src/v1/settings.ts
@@ -88,7 +88,7 @@ const SettingsGetSchema = {
 export const isSettingsGetParams = ajvQuery.compile<SettingsGetParams>(SettingsGetSchema);
 
 export type SettingsBulkProps = {
-	settings: { _id: ISetting['_id']; value: ISetting['value'] }[];
+	settings: { _id: ISetting['_id']; value: ISetting['value']; editor?: ISettingColor['editor'] }[];
 };
 
 const SettingsBulkSchema = {

--- a/packages/rest-typings/src/v1/settings.ts
+++ b/packages/rest-typings/src/v1/settings.ts
@@ -100,6 +100,7 @@ const SettingsBulkSchema = {
 				type: 'object',
 				properties: {
 					_id: { type: 'string', minLength: 1 },
+					editor: { type: 'string', minLength: 1 },
 					value: {},
 				},
 				required: ['_id', 'value'],

--- a/packages/rest-typings/src/v1/settings.ts
+++ b/packages/rest-typings/src/v1/settings.ts
@@ -100,7 +100,7 @@ const SettingsBulkSchema = {
 				type: 'object',
 				properties: {
 					_id: { type: 'string', minLength: 1 },
-					editor: { type: 'string', minLength: 1 },
+					editor: { type: 'string', enum: ['color', 'expression'] },
 					value: {},
 				},
 				required: ['_id', 'value'],


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/CORE-2314
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk settings updates now support an optional editor mode for eligible color settings, allowing richer updates in one request.
  * The public settings API now accepts and validates the new optional field in bulk update payloads.

* **Bug Fixes**
  * Improved bulk update handling so changes are applied consistently and success is reported only when an actual update occurs.

* **Tests**
  * Added end-to-end coverage for successful and invalid bulk updates using the new optional editor field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->