### PR TITLE
regression: channel route resolving to cached DM with same name

### DIFF
--- a/apps/meteor/client/views/room/hooks/useOpenRoom.spec.ts
+++ b/apps/meteor/client/views/room/hooks/useOpenRoom.spec.ts
@@ -1,0 +1,79 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useOpenRoom } from './useOpenRoom';
+import { createFakeRoom, createFakeSubscription } from '../../../../tests/mocks/data';
+import { Rooms, Subscriptions } from '../../../stores';
+
+jest.mock('../../../../app/ui-utils/client', () => ({
+	LegacyRoomManager: { open: jest.fn(), close: jest.fn() },
+}));
+
+jest.mock('../../../lib/RoomManager', () => ({
+	RoomManager: { opened: null },
+}));
+
+jest.mock('./useOpenRoomMutation', () => ({
+	useOpenRoomMutation: () => ({ mutateAsync: jest.fn() }),
+}));
+
+afterEach(() => {
+	Subscriptions.state.replaceAll([]);
+	Rooms.state.replaceAll([]);
+});
+
+describe('useOpenRoom', () => {
+	describe('type-aware subscription cache lookup', () => {
+		it('resolves /channel/<name> to the channel even when a DM with the same name is cached', async () => {
+			const channelRid = 'channel-rid-abc';
+			const dmRid = 'dm-rid-abc';
+			const sharedName = 'alex';
+
+			// Seed cache: only a DM subscription named 'alex' — no channel subscription
+			Subscriptions.state.store(createFakeSubscription({ t: 'd', name: sharedName, rid: dmRid, open: true }));
+			Rooms.state.store(createFakeRoom({ _id: dmRid, t: 'd' }));
+
+			const channelRoom = createFakeRoom({ _id: channelRid, t: 'c', name: sharedName });
+
+			const { result } = renderHook(() => useOpenRoom({ type: 'c', reference: sharedName }), {
+				wrapper: mockAppRoot()
+					.withJohnDoe()
+					.withPermission('preview-c-room')
+					.withMethod('getRoomByTypeAndName', () => channelRoom as any)
+					.build(),
+			});
+
+			await waitFor(() => expect(result.current.isSuccess).toBe(true));
+			expect(result.current.data?.rid).toBe(channelRid);
+		});
+
+		it('resolves from cache when a channel subscription with a matching name and type is already cached', async () => {
+			const channelRid = 'channel-rid-general';
+			const channelName = 'general';
+
+			Subscriptions.state.store(createFakeSubscription({ t: 'c', name: channelName, rid: channelRid, open: true }));
+			Rooms.state.store(createFakeRoom({ _id: channelRid, t: 'c', name: channelName }));
+
+			const { result } = renderHook(() => useOpenRoom({ type: 'c', reference: channelName }), {
+				wrapper: mockAppRoot().withJohnDoe().build(),
+			});
+
+			await waitFor(() => expect(result.current.isSuccess).toBe(true));
+			expect(result.current.data?.rid).toBe(channelRid);
+		});
+
+		it('resolves a DM from cache when navigating by rid', async () => {
+			const dmRid = 'dm-rid-xyz';
+
+			Subscriptions.state.store(createFakeSubscription({ t: 'd', name: 'bob', rid: dmRid, open: true }));
+			Rooms.state.store(createFakeRoom({ _id: dmRid, t: 'd' }));
+
+			const { result } = renderHook(() => useOpenRoom({ type: 'd', reference: dmRid }), {
+				wrapper: mockAppRoot().withJohnDoe().build(),
+			});
+
+			await waitFor(() => expect(result.current.isSuccess).toBe(true));
+			expect(result.current.data?.rid).toBe(dmRid);
+		});
+	});
+});

--- a/apps/meteor/client/views/room/hooks/useOpenRoom.ts
+++ b/apps/meteor/client/views/room/hooks/useOpenRoom.ts
@@ -31,7 +31,7 @@ export function useOpenRoom({ type, reference }: { type: RoomType; reference: st
 		if (!user?._id || !reference || !type) {
 			return undefined;
 		}
-		const sub = Subscriptions.state.find((record) => record.rid === reference || record.name === reference);
+		const sub = Subscriptions.state.find((record) => record.t === type && (record.rid === reference || record.name === reference));
 		if (!sub) {
 			return undefined;
 		}
@@ -115,7 +115,7 @@ export function useOpenRoom({ type, reference }: { type: RoomType; reference: st
 				throw new TypeError('room is undefined');
 			}
 
-			const sub = Subscriptions.state.find((record) => record.rid === reference || record.name === reference);
+			const sub = Subscriptions.state.find((record) => record.t === type && (record.rid === reference || record.name === reference));
 
 			if (reference !== undefined && room._id !== reference && type === 'd') {
 				// Redirect old url using username to rid


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
[CORE-2316](https://rocketchat.atlassian.net/browse/CORE-2316)
<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

origin:
#40718

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-2316]: https://rocketchat.atlassian.net/browse/CORE-2316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room opening so cached subscriptions now match both the room reference and its type, reducing incorrect room resolution.
  * Fixed navigation behavior for channels and direct messages when similarly named rooms exist.
* **Tests**
  * Added coverage for room lookup behavior across channel and DM cache scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->