### PR TITLE
test: Flaky `rooms-join.spec` timeout on room load

### DIFF
--- a/apps/meteor/tests/e2e/page-objects/home-channel.ts
+++ b/apps/meteor/tests/e2e/page-objects/home-channel.ts
@@ -101,6 +101,11 @@ export class HomeChannel {
 		await this.content.waitForChannel();
 	}
 
+	async gotoPrivateChannel(name: string) {
+		await this.page.goto(`/group/${name}`);
+		await this.content.waitForChannel();
+	}
+
 	get btnContextualbarClose(): Locator {
 		return this.page.locator('[data-qa="ContextualbarActionClose"]');
 	}

--- a/apps/meteor/tests/e2e/rooms-join.spec.ts
+++ b/apps/meteor/tests/e2e/rooms-join.spec.ts
@@ -26,6 +26,8 @@ test.describe.serial('Join rooms', () => {
 
 		test.beforeEach(async ({ page }) => {
 			poHomeChannel = new HomeChannel(page);
+			// poHomeChannel.goToRoom cannot be used here because it waits for specific selectors to ensure the whole room is loaded.
+			// Since the user does not have permission to preview the user, there's never a room to wait for.
 			await page.goto(`/channel/${targetChannel}`);
 		});
 
@@ -44,7 +46,7 @@ test.describe.serial('Join rooms', () => {
 		});
 
 		test('should let a non-member join a public channel', async () => {
-			await expect(poHomeChannel.btnJoinChannel).toBeVisible();
+			await expect(poHomeChannel.btnJoinChannel).toBeVisible({ timeout: 10000 });
 			await poHomeChannel.btnJoinChannel.click();
 			await expect(poHomeChannel.btnJoinChannel).not.toBeVisible();
 			await expect(poHomeChannel.composer.inputMessage).toBeEnabled();
@@ -66,7 +68,7 @@ test.describe.serial('Join rooms', () => {
 
 		test.beforeEach(async ({ page }) => {
 			poHomeChannel = new HomeChannel(page);
-			await page.goto(`/channel/${targetChannel}`);
+			await poHomeChannel.gotoChannel(targetChannel);
 		});
 
 		test.afterEach(async ({ api }) => {
@@ -100,8 +102,8 @@ test.describe.serial('Join rooms', () => {
 			await deleteRoom(api, discussion._id);
 		});
 
-		test('should let a non-member join a discussion', async ({ page }) => {
-			await page.goto(`/channel/${discussion.name}`);
+		test('should let a non-member join a discussion', async () => {
+			await poHomeChannel.gotoChannel(discussion.name);
 
 			await expect(poHomeChannel.composer.btnJoinRoom).toBeVisible();
 
@@ -135,8 +137,8 @@ test.describe.serial('Join rooms', () => {
 			await api.post('/groups.delete', { roomId: group._id });
 		});
 
-		test('should let a parent member join a discussion in a private channel', async ({ page }) => {
-			await page.goto(`/group/${discussion.name}`);
+		test('should let a parent member join a discussion in a private channel', async () => {
+			await poHomeChannel.gotoPrivateChannel(discussion.name);
 
 			await expect(poHomeChannel.composer.btnJoinRoom).toBeVisible();
 			await poHomeChannel.composer.btnJoinRoom.click();


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end room-joining coverage by using shared navigation flows for public and private channels.
  * Added a more reliable wait for channel content to finish loading, reducing flaky visibility checks.
  * Clarified test setup steps for cases where preview rooms are not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->