### PR TITLE
fix: incorrect cursor position after inserting mention

### DIFF
--- a/.changeset/moody-eggs-juggle.md
+++ b/.changeset/moody-eggs-juggle.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes an issue where the cursor jumped to the wrong position after inserting a mention at the start or middle of a message.

--- a/apps/meteor/app/ui-message/client/messageBox/createComposerAPI.spec.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/createComposerAPI.spec.ts
@@ -1,0 +1,61 @@
+import { createComposerAPI } from './createComposerAPI';
+
+jest.mock('../../../../client/lib/chats/uploads', () => ({
+	createUploadsAPI: () => ({}),
+}));
+
+const setupComposer = (initialValue: string, cursor: { start: number; end: number }) => {
+	const input = document.createElement('textarea');
+	document.body.appendChild(input);
+
+	const composer = createComposerAPI(input, jest.fn(), '', Number.MAX_SAFE_INTEGER, { current: null }, { rid: 'GENERAL' });
+
+	input.value = initialValue;
+	input.setSelectionRange(cursor.start, cursor.end);
+
+	return { composer, input };
+};
+
+afterEach(() => {
+	document.body.innerHTML = '';
+});
+
+describe('ChatMessages Composer API - replaceText', () => {
+	it('should place the cursor right after the mention when inserting at the start of the message', () => {
+		const { composer, input } = setupComposer('@jhello', { start: 2, end: 2 });
+
+		composer.replaceText('@john ', { start: 0, end: 2 });
+
+		expect(input.value).toBe('@john hello');
+		expect(input.selectionStart).toBe('@john '.length);
+		expect(input.selectionEnd).toBe('@john '.length);
+	});
+
+	it('should place the cursor right after the mention when inserting in the middle of the message', () => {
+		const { composer, input } = setupComposer('hi @jthere', { start: 5, end: 5 });
+
+		composer.replaceText('@john ', { start: 3, end: 5 });
+
+		expect(input.value).toBe('hi @john there');
+		expect(input.selectionStart).toBe('hi @john '.length);
+		expect(input.selectionEnd).toBe('hi @john '.length);
+	});
+
+	it('should place the cursor right after the mention when inserting at the end of the message', () => {
+		const { composer, input } = setupComposer('hello @j', { start: 8, end: 8 });
+
+		composer.replaceText('@john ', { start: 6, end: 8 });
+
+		expect(input.value).toBe('hello @john ');
+		expect(input.selectionStart).toBe('hello @john '.length);
+		expect(input.selectionEnd).toBe('hello @john '.length);
+	});
+
+	it('should keep the cursor collapsed right after the inserted text', () => {
+		const { composer, input } = setupComposer('@jhello', { start: 2, end: 2 });
+
+		composer.replaceText('@john ', { start: 0, end: 2 });
+
+		expect(input.selectionStart).toBe(input.selectionEnd);
+	});
+});

--- a/apps/meteor/app/ui-message/client/messageBox/createComposerAPI.spec.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/createComposerAPI.spec.ts
@@ -16,11 +16,11 @@ const setupComposer = (initialValue: string, cursor: { start: number; end: numbe
 	return { composer, input };
 };
 
-afterEach(() => {
-	document.body.innerHTML = '';
-});
-
 describe('ChatMessages Composer API - replaceText', () => {
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
 	it('should place the cursor right after the mention when inserting at the start of the message', () => {
 		const { composer, input } = setupComposer('@jhello', { start: 2, end: 2 });
 

--- a/apps/meteor/app/ui-message/client/messageBox/createComposerAPI.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/createComposerAPI.ts
@@ -288,8 +288,6 @@ export const createComposerAPI = (
 
 	// Gets the text that is connected to the cursor and replaces it with the given text
 	const replaceText = (text: string, selection: { readonly start: number; readonly end: number }): void => {
-		const { selectionStart, selectionEnd } = input;
-
 		// Selects the text that is connected to the cursor
 		input.setSelectionRange(selection.start ?? 0, selection.end ?? text.length);
 		const textAreaTxt = input.value;
@@ -298,11 +296,9 @@ export const createComposerAPI = (
 			input.value = textAreaTxt.substring(0, selection.start) + text + textAreaTxt.substring(selection.end);
 		}
 
-		input.selectionStart = selectionStart + text.length;
-		input.selectionEnd = selectionStart + text.length;
-		if (selectionStart !== selectionEnd) {
-			input.selectionStart = selectionStart;
-		}
+		const cursorPosition = (selection.start ?? 0) + text.length;
+		input.selectionStart = cursorPosition;
+		input.selectionEnd = cursorPosition;
 
 		triggerEvent(input, 'input');
 		triggerEvent(input, 'change');


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
When inserting a user/channel mention while the caret is not at the end of the message, the cursor jumped to an incorrect position instead of landing right after the inserted mention, making continued typing and editing awkward.

The root cause was in `replaceText` in `createComposerAPI.ts`: after replacing the partial trigger (e.g. `@j`) with the full mention, the new cursor position was computed from the textarea's live caret position *before* the replacement (`selectionStart`) rather than from where the text was actually inserted (`selection.start`). It also reset the caret back to the original position when a selection existed. This only appeared correct when mentioning at the end of the line, where the overshoot was clamped to the string length.

The cursor is now placed at `selection.start + text.length`, so it always lands immediately after the inserted mention regardless of where in the message it is inserted. Added unit tests for `replaceText` covering insertion at the start, middle, and end of a message.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Open any channel and type a message in the composer
2. Move the cursor to the beginning of the message
3. Type `@` and select a user mention
4. Expected result: the cursor is placed immediately after the inserted mention, and you can continue typing naturally from that position

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-2266](https://rocketchat.atlassian.net/browse/CORE-2266)

[CORE-2266]: https://rocketchat.atlassian.net/browse/CORE-2266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the cursor/selection position in the message composer after inserting or replacing a mention, including when added at the start, middle, or end of the message.
  * Ensured the selection correctly collapses immediately after the inserted mention text.
* **Tests**
  * Added Jest coverage for mention/text replacement in the composer to verify textarea value updates and cursor/selection behavior across common insertion positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->