### PR TITLE
regression: setup wizard stuck on 2FA prompt when creating first admin

### DIFF
--- a/apps/meteor/app/2fa/server/code/index.ts
+++ b/apps/meteor/app/2fa/server/code/index.ts
@@ -97,14 +97,17 @@ function isAuthorizedForToken(connection: IMethodConnection, user: IUser, option
 		return true;
 	}
 
-	if (options.disableRememberMe === true) {
-		return false;
+	// Skip 2FA for a freshly registered user who has not set up any 2FA method yet,
+	// until the grace period that starts at registration expires.
+	const rememberPeriodEnd = user.createdAt && getRememberDate(user.createdAt);
+	const isWithinRememberPeriod = rememberPeriodEnd && rememberPeriodEnd >= new Date();
+	const hasNoTwoFactorMethod = getAvailableMethodNames(user).length === 0;
+	if (isWithinRememberPeriod && hasNoTwoFactorMethod) {
+		return true;
 	}
 
-	// remember user right after their registration
-	const rememberAfterRegistration = user.createdAt && getRememberDate(user.createdAt);
-	if (rememberAfterRegistration && rememberAfterRegistration >= new Date()) {
-		return true;
+	if (options.disableRememberMe === true) {
+		return false;
 	}
 
 	if (!tokenObject.twoFactorAuthorizedUntil || !tokenObject.twoFactorAuthorizedHash) {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
On a fresh instance with two-factor authentication enabled (default), the Setup Wizard gets stuck while creating the first admin: completing the admin/organization step pops a "Please enter your password" prompt and the underlying `POST /v1/settings` is rejected with `totp-required`. The brand-new admin has no second factor configured, so the challenge cannot be satisfied and the wizard cannot be completed (cancelling surfaces `totp-cancelled`).

**Root cause.** The wizard's settings save was migrated from the `saveSettings` DDP method to the `POST /v1/settings` REST endpoint. Over DDP the "remember after registration" grace in `isAuthorizedForToken` exempted just-registered users; over REST that grace was no longer reached. #41065 restored login-token resolution over REST (`connection.token` fallback), but the wizard is still blocked because `POST /v1/settings` sets `twoFactorOptions: { disableRememberMe: true }`, which returns early — before the registration grace.

**Fix.** In `isAuthorizedForToken`, the post-registration grace is now evaluated before the `disableRememberMe` guard, tightened so it only applies to users that have **no second factor available** (`getAvailableMethodNames(user).length === 0`). In other words: a user who literally cannot complete any 2FA challenge yet (just registered, no TOTP, unverified email) is not locked out, even on `disableRememberMe` endpoints. `requireSecondFactor` is still checked first and is unaffected, and established users with a configured factor continue to be challenged as before.

> Depends on #41065 (REST login-token resolution) — the grace is only reachable once the token resolves over REST.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-2304](https://rocketchat.atlassian.net/browse/CORE-2304)

[CORE-2304]: https://rocketchat.atlassian.net/browse/CORE-2304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

