### PR TITLE
test(e2e): close leaked browser contexts in omnichannel livechat specs

### DIFF
--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-queue-management-autoselection.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-queue-management-autoselection.spec.ts
@@ -1,3 +1,5 @@
+import type { BrowserContext } from '@playwright/test';
+
 import { createFakeVisitor } from '../../mocks/data';
 import { IS_EE } from '../config/constants';
 import { createAuxContext } from '../fixtures/createAuxContext';
@@ -17,6 +19,7 @@ test.describe('OC - Livechat - Queue Management', () => {
 
 	let poHomeOmnichannel: HomeOmnichannel;
 	let poLiveChat: OmnichannelLiveChat;
+	let liveChatContext: BrowserContext;
 
 	const waitingQueueMessage = 'This is a message from Waiting Queue';
 
@@ -37,8 +40,8 @@ test.describe('OC - Livechat - Queue Management', () => {
 	});
 
 	test.beforeEach(async ({ browser, api }) => {
-		const context = await browser.newContext();
-		const page2 = await context.newPage();
+		liveChatContext = await browser.newContext();
+		const page2 = await liveChatContext.newPage();
 
 		poLiveChat = new OmnichannelLiveChat(page2, api);
 		await poLiveChat.page.goto('/livechat');
@@ -56,19 +59,20 @@ test.describe('OC - Livechat - Queue Management', () => {
 
 	test.describe('OC - Queue Management - Auto Selection', () => {
 		let poLiveChat2: OmnichannelLiveChat;
+		let liveChat2Context: BrowserContext;
 
 		test.beforeEach(async ({ browser, api }) => {
-			const context = await browser.newContext();
-			const page = await context.newPage();
+			liveChat2Context = await browser.newContext();
+			const page = await liveChat2Context.newPage();
 			poLiveChat2 = new OmnichannelLiveChat(page, api);
 			await poLiveChat2.page.goto('/livechat');
 		});
 
 		test.afterEach(async () => {
 			await poLiveChat2.closeChat();
-			await poLiveChat2.page.context().close();
+			await liveChat2Context.close();
 			await poLiveChat.closeChat();
-			await poLiveChat.page.context().close();
+			await liveChatContext.close();
 		});
 
 		test('Update user position on Queue', async () => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-queue-management-autoselection.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-queue-management-autoselection.spec.ts
@@ -66,9 +66,9 @@ test.describe('OC - Livechat - Queue Management', () => {
 
 		test.afterEach(async () => {
 			await poLiveChat2.closeChat();
-			await poLiveChat2.page.close();
+			await poLiveChat2.page.context().close();
 			await poLiveChat.closeChat();
-			await poLiveChat.page.close();
+			await poLiveChat.page.context().close();
 		});
 
 		test('Update user position on Queue', async () => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-queue-management.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-queue-management.spec.ts
@@ -54,7 +54,7 @@ test.describe('OC - Livechat - Queue Management', () => {
 
 	test.afterEach(async () => {
 		await poLiveChat.closeChat();
-		await poLiveChat.page.close();
+		await poLiveChat.page.context().close();
 	});
 
 	test('OC - Queue Management - Waiting Queue Message enabled', async () => {
@@ -82,7 +82,7 @@ test.describe('OC - Livechat - Queue Management', () => {
 
 		test.afterEach(async () => {
 			await poLiveChat2.closeChat();
-			await poLiveChat2.page.close();
+			await poLiveChat2.page.context().close();
 		});
 
 		test('Update user position on Queue', async () => {
@@ -173,7 +173,7 @@ test.describe('OC - Contact Manager Routing', () => {
 
 	test.afterEach(async () => {
 		await poLiveChat.closeChat();
-		await poLiveChat.page.close();
+		await poLiveChat.page.context().close();
 	});
 
 	test('should route inquiry only to the contact manager', async () => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-queue-management.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-queue-management.spec.ts
@@ -1,3 +1,5 @@
+import type { BrowserContext } from '@playwright/test';
+
 import { createFakeVisitor } from '../../mocks/data';
 import { IS_EE } from '../config/constants';
 import { createAuxContext } from '../fixtures/createAuxContext';
@@ -17,6 +19,7 @@ test.describe('OC - Livechat - Queue Management', () => {
 
 	let poHomeOmnichannel: HomeOmnichannel;
 	let poLiveChat: OmnichannelLiveChat;
+	let liveChatContext: BrowserContext;
 
 	const waitingQueueMessage = 'This is a message from Waiting Queue';
 	const queuePosition1 = 'Your spot is #1';
@@ -35,8 +38,8 @@ test.describe('OC - Livechat - Queue Management', () => {
 	});
 
 	test.beforeEach(async ({ browser, api }) => {
-		const context = await browser.newContext();
-		const page2 = await context.newPage();
+		liveChatContext = await browser.newContext();
+		const page2 = await liveChatContext.newPage();
 
 		poLiveChat = new OmnichannelLiveChat(page2, api);
 		await poLiveChat.page.goto('/livechat');
@@ -54,7 +57,7 @@ test.describe('OC - Livechat - Queue Management', () => {
 
 	test.afterEach(async () => {
 		await poLiveChat.closeChat();
-		await poLiveChat.page.context().close();
+		await liveChatContext.close();
 	});
 
 	test('OC - Queue Management - Waiting Queue Message enabled', async () => {
@@ -72,17 +75,18 @@ test.describe('OC - Livechat - Queue Management', () => {
 
 	test.describe('OC - Queue Management - Update Queue Position', () => {
 		let poLiveChat2: OmnichannelLiveChat;
+		let liveChat2Context: BrowserContext;
 
 		test.beforeEach(async ({ browser, api }) => {
-			const context = await browser.newContext();
-			const page = await context.newPage();
+			liveChat2Context = await browser.newContext();
+			const page = await liveChat2Context.newPage();
 			poLiveChat2 = new OmnichannelLiveChat(page, api);
 			await poLiveChat2.page.goto('/livechat');
 		});
 
 		test.afterEach(async () => {
 			await poLiveChat2.closeChat();
-			await poLiveChat2.page.context().close();
+			await liveChat2Context.close();
 		});
 
 		test('Update user position on Queue', async () => {
@@ -125,6 +129,7 @@ test.describe('OC - Contact Manager Routing', () => {
 
 	let poHomeOmnichannel: HomeOmnichannel;
 	let poLiveChat: OmnichannelLiveChat;
+	let liveChatContext: BrowserContext;
 
 	// User2 will be the contact manager
 	let poHomeOmnichannelUser2: HomeOmnichannel;
@@ -152,8 +157,8 @@ test.describe('OC - Contact Manager Routing', () => {
 	});
 
 	test.beforeEach(async ({ browser, api }) => {
-		const context = await browser.newContext();
-		const page = await context.newPage();
+		liveChatContext = await browser.newContext();
+		const page = await liveChatContext.newPage();
 
 		poLiveChat = new OmnichannelLiveChat(page, api);
 		await poLiveChat.page.goto('/livechat');
@@ -173,7 +178,7 @@ test.describe('OC - Contact Manager Routing', () => {
 
 	test.afterEach(async () => {
 		await poLiveChat.closeChat();
-		await poLiveChat.page.context().close();
+		await liveChatContext.close();
 	});
 
 	test('should route inquiry only to the contact manager', async () => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-tab-communication.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-tab-communication.spec.ts
@@ -33,8 +33,8 @@ test.describe('OC - Livechat - Cross Tab Communication', () => {
 	});
 
 	test.afterEach(async () => {
-		await pageLivechat1.page.close();
-		await pageLivechat2.page.close();
+		// Both pages share the same context; closing it disposes both pages and avoids leaking the context
+		await pageLivechat1.page.context().close();
 	});
 
 	test.afterAll(async () => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-tab-communication.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat-tab-communication.spec.ts
@@ -1,3 +1,5 @@
+import type { BrowserContext } from '@playwright/test';
+
 import { createFakeVisitor } from '../../mocks/data';
 import { createAuxContext } from '../fixtures/createAuxContext';
 import { Users } from '../fixtures/userStates';
@@ -9,6 +11,7 @@ import { test, expect } from '../utils/test';
 test.describe('OC - Livechat - Cross Tab Communication', () => {
 	let pageLivechat1: OmnichannelLiveChat;
 	let pageLivechat2: OmnichannelLiveChat;
+	let livechatContext: BrowserContext;
 
 	let poHomeOmnichannel: HomeOmnichannel;
 	let agent: Awaited<ReturnType<typeof createAgent>>;
@@ -21,9 +24,9 @@ test.describe('OC - Livechat - Cross Tab Communication', () => {
 	});
 
 	test.beforeEach(async ({ browser, api }) => {
-		const context = await browser.newContext();
-		const p1 = await context.newPage();
-		const p2 = await context.newPage();
+		livechatContext = await browser.newContext();
+		const p1 = await livechatContext.newPage();
+		const p2 = await livechatContext.newPage();
 
 		pageLivechat1 = new OmnichannelLiveChat(p1, api);
 		pageLivechat2 = new OmnichannelLiveChat(p2, api);
@@ -33,8 +36,8 @@ test.describe('OC - Livechat - Cross Tab Communication', () => {
 	});
 
 	test.afterEach(async () => {
-		// Both pages share the same context; closing it disposes both pages and avoids leaking the context
-		await pageLivechat1.page.context().close();
+		// Both pages share the same context; closing it disposes both pages
+		await livechatContext.close();
 	});
 
 	test.afterAll(async () => {


### PR DESCRIPTION
## Proposed changes

The omnichannel livechat e2e specs `queue-management`, `queue-management-autoselection` and `tab-communication` create browser contexts via `browser.newContext()` but only close the **pages** in teardown. Closing a page does not dispose the context it belongs to, so each test iteration leaks one context.

This replaces `page.close()` with `page.context().close()` in the relevant `afterEach` hooks. Closing the context disposes its pages too, so no separate page close is needed.

Specs that use `createAuxContext` are unaffected — that helper uses `browser.newPage()`, whose owned context is closed when the page closes.

### Changes
- `omnichannel-livechat-queue-management.spec.ts` — 3 teardowns
- `omnichannel-livechat-queue-management-autoselection.spec.ts` — 1 teardown (2 contexts)
- `omnichannel-livechat-tab-communication.spec.ts` — 1 teardown (shared context, both tabs)

## Issue(s)

Browser context leak in omnichannel e2e teardown.

## Steps to test or reproduce

Run the affected specs; contexts are now released between iterations.

## Further comments

Test-only change. No production code touched.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end cleanup for Omnichannel livechat tests by using dedicated Playwright browser contexts per suite/session and closing those contexts during teardown.
  * Queue management now closes each livechat session context, the “Update Queue Position” suite also uses its own context, and tab communication uses one shared context for both livechat pages—improving consistency and reducing leftover state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->