### PR TITLE
feat(ui-voip): disabled unsupported call actions in all call views

### DIFF
--- a/.changeset/easy-cycles-judge.md
+++ b/.changeset/easy-cycles-judge.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/ui-voip": patch
+---
+
+Disables unsupported call action buttons (hold, screen-share, transfer) in all voice call views.

--- a/packages/ui-voip/src/views/MediaCallPopoutView.tsx
+++ b/packages/ui-voip/src/views/MediaCallPopoutView.tsx
@@ -30,7 +30,7 @@ const MediaCallPopoutView = ({ user, onClickClosePopout, onClickFullscreen, full
 		streams: { localScreen },
 	} = useMediaCallView();
 
-	const { muted, held, peerInfo, connectionState, startedAt } = sessionState;
+	const { muted, held, peerInfo, connectionState, startedAt, supportedFeatures } = sessionState;
 
 	const { ref, borderBoxSize } = useResizeObserver<HTMLDivElement>();
 
@@ -38,6 +38,10 @@ const MediaCallPopoutView = ({ user, onClickClosePopout, onClickFullscreen, full
 
 	const connecting = connectionState === 'CONNECTING';
 	const reconnecting = connectionState === 'RECONNECTING';
+
+	const holdDisabled = !supportedFeatures.includes('hold');
+	const transferDisabled = !supportedFeatures.includes('transfer');
+	const screenShareDisabled = !supportedFeatures.includes('screen-share');
 
 	if (!peerInfo || 'number' in peerInfo) {
 		return null;
@@ -82,18 +86,26 @@ const MediaCallPopoutView = ({ user, onClickClosePopout, onClickFullscreen, full
 				<ToggleButton
 					label={t('Hold')}
 					icons={['pause-shape-unfilled', 'pause-shape-unfilled']}
-					titles={[t('Hold'), t('Resume')]}
+					titles={[holdDisabled ? t('Call_feature_unsupported') : t('Hold'), t('Resume')]}
 					pressed={held}
+					disabled={connecting || reconnecting || holdDisabled}
 					onToggle={onHold}
 				/>
 				<ToggleButton
 					label={t('Share_screen')}
 					icons={['desktop-arrow-up', 'desktop-cross']}
-					titles={[t('Share_screen'), t('Stop_sharing_screen')]}
+					titles={[screenShareDisabled ? t('Call_feature_unsupported') : t('Share_screen'), t('Stop_sharing_screen')]}
 					pressed={localScreen?.active ?? false}
+					disabled={connecting || reconnecting || screenShareDisabled}
 					onToggle={onToggleScreenSharing}
 				/>
-				<ActionButton disabled={connecting || reconnecting} label={t('Forward')} icon='arrow-forward' onClick={onForward} />
+				<ActionButton
+					disabled={connecting || reconnecting || transferDisabled}
+					label={t('Forward')}
+					title={transferDisabled ? t('Call_feature_unsupported') : t('Forward')}
+					icon='arrow-forward'
+					onClick={onForward}
+				/>
 				<ActionButton label={t('Voice_call__user__hangup', { user: peerInfo.displayName })} icon='phone-off' danger onClick={onEndCall} />
 			</ActionStrip>
 		</Box>

--- a/packages/ui-voip/src/views/MediaCallRoomSection/MediaCallRoomSection.tsx
+++ b/packages/ui-voip/src/views/MediaCallRoomSection/MediaCallRoomSection.tsx
@@ -60,7 +60,7 @@ const MediaCallRoomSection = ({ showChat, onToggleChat, user, containerHeight }:
 
 	const isPopout = currentViews.includes('popout');
 
-	const { muted, held, peerInfo, connectionState, startedAt } = sessionState;
+	const { muted, held, peerInfo, connectionState, startedAt, supportedFeatures } = sessionState;
 
 	const shouldWrapCards = useShouldWrapCards(showChat, containerHeight);
 
@@ -68,6 +68,10 @@ const MediaCallRoomSection = ({ showChat, onToggleChat, user, containerHeight }:
 	const reconnecting = connectionState === 'RECONNECTING';
 
 	useRegisterView('room');
+
+	const holdDisabled = !supportedFeatures.includes('hold');
+	const transferDisabled = !supportedFeatures.includes('transfer');
+	const screenShareDisabled = !supportedFeatures.includes('screen-share');
 
 	if (!peerInfo || 'number' in peerInfo) {
 		return null;
@@ -111,18 +115,27 @@ const MediaCallRoomSection = ({ showChat, onToggleChat, user, containerHeight }:
 				<ToggleButton
 					label={t('Hold')}
 					icons={['pause-shape-unfilled', 'pause-shape-unfilled']}
-					titles={[t('Hold'), t('Resume')]}
+					titles={[holdDisabled ? t('Call_feature_unsupported') : t('Hold'), t('Resume')]}
 					pressed={held}
+					disabled={connecting || reconnecting || holdDisabled}
 					onToggle={onHold}
 				/>
 				<ToggleButton
 					label={t('Share_screen')}
 					icons={['desktop-arrow-up', 'desktop-cross']}
-					titles={[t('Share_screen'), t('Stop_sharing_screen')]}
+					titles={[screenShareDisabled ? t('Call_feature_unsupported') : t('Share_screen'), t('Stop_sharing_screen')]}
 					pressed={localScreen?.active ?? false}
+					disabled={connecting || reconnecting || screenShareDisabled}
 					onToggle={onToggleScreenSharing}
 				/>
-				<ActionButton disabled={connecting || reconnecting} label={t('Forward')} icon='arrow-forward' onClick={onForward} />
+
+				<ActionButton
+					label={t('Forward')}
+					title={transferDisabled ? t('Call_feature_unsupported') : t('Forward')}
+					icon='arrow-forward'
+					disabled={connecting || reconnecting || transferDisabled}
+					onClick={onForward}
+				/>
 				<ActionButton label={t('Voice_call__user__hangup', { user: peerInfo.displayName })} icon='phone-off' danger onClick={onEndCall} />
 			</ActionStrip>
 		</Box>

--- a/packages/ui-voip/src/views/MediaCallWidget/OngoingCallWithScreen.tsx
+++ b/packages/ui-voip/src/views/MediaCallWidget/OngoingCallWithScreen.tsx
@@ -37,7 +37,7 @@ const OngoingCall = () => {
 		widgetPositionTracker,
 		onClosePopout,
 	} = useMediaCallView();
-	const { muted, held, remoteMuted, remoteHeld, peerInfo, connectionState, startedAt } = sessionState;
+	const { muted, held, remoteMuted, remoteHeld, peerInfo, connectionState, startedAt, supportedFeatures } = sessionState;
 	const { currentViews } = useMediaCallInstance();
 	const isPopout = currentViews.includes('popout');
 
@@ -51,6 +51,9 @@ const OngoingCall = () => {
 
 	const connecting = connectionState === 'CONNECTING';
 	const reconnecting = connectionState === 'RECONNECTING';
+
+	const holdDisabled = !supportedFeatures.includes('hold');
+	const transferDisabled = !supportedFeatures.includes('transfer');
 
 	// TODO: Figure out how to ensure this always exist before rendering the component
 	if (!peerInfo) {
@@ -124,8 +127,9 @@ const OngoingCall = () => {
 					<ToggleButton
 						label={t('Hold')}
 						icons={['pause-shape-unfilled', 'pause-shape-unfilled']}
-						titles={[t('Hold'), t('Resume')]}
+						titles={[holdDisabled ? t('Call_feature_unsupported') : t('Hold'), t('Resume')]}
 						pressed={held}
+						disabled={connecting || reconnecting || holdDisabled}
 						onToggle={onHold}
 					/>
 					<ToggleButton
@@ -133,9 +137,16 @@ const OngoingCall = () => {
 						icons={['desktop-arrow-up', 'desktop-cross']}
 						titles={[t('Share_screen'), t('Stop_sharing_screen')]}
 						pressed={localScreen?.active ?? false}
+						disabled={connecting || reconnecting}
 						onToggle={onToggleScreenSharing}
 					/>
-					<ActionButton disabled={connecting || reconnecting} label={t('Forward')} icon='arrow-forward' onClick={onForward} />
+					<ActionButton
+						disabled={connecting || reconnecting || transferDisabled}
+						label={t('Forward')}
+						title={transferDisabled ? t('Call_feature_unsupported') : t('Forward')}
+						icon='arrow-forward'
+						onClick={onForward}
+					/>
 					<ActionButton
 						label={t('Voice_call__user__hangup', { user: 'userId' in peerInfo ? peerInfo.displayName : peerInfo.number })}
 						icon='phone-off'


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
SIP calls do not always support all call features (e.g. hold, transfer, screen share). Previously, buttons for unsupported features were always rendered and enabled — clicking them would either silently fail or produce an error. The fix disables the buttons and shows a tooltip so users have a clear signal that the feature exists but isn't available in the current call.

- Adds handling for unsupported VoIP call features (hold, screen-share, transfer) across all call views — popout, room section, and widget
- Unsupported actions are now shown as disabled with a `Call_feature_unsupported` tooltip instead of being always enabled
- Affects `MediaCallPopoutView`, `MediaCallRoomSection`, and `OngoingCallWithScreen`

## Issue(s)
related to https://rocketchat.atlassian.net/browse/DMV-32

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

