### PR TITLE
test: use gotoChannel when possible

### DIFF
--- a/apps/meteor/tests/e2e/README.md
+++ b/apps/meteor/tests/e2e/README.md
@@ -243,6 +243,26 @@ Do **not** apply when:
 - Suite covers auth, 2FA, or session lifecycle — the browser state is the subject.
 - Suite has more than ~15 tests: the debug cost of shared state outgrows the speed win (see "Big test files should not be `.serial`" above).
 
+### Pattern 3 — navigate to a known room by URL, not by search
+
+When a test already knows the room it needs (a channel created via API, `general`, etc.), open it directly with `poHomeChannel.gotoChannel(name)` instead of `page.goto('/home')` + `navbar.openChat(name)`.
+
+```ts
+// ❌ fragile — three independent things must align before the combobox `fill` resolves
+await page.goto('/home');
+await poHomeChannel.navbar.openChat(targetChannel);
+
+// ✅ deterministic — navigate straight to the room, then wait for it to be ready
+await poHomeChannel.gotoChannel(targetChannel);
+```
+
+Why: searching the navbar couples the navigation to (1) the app shell hydrating, (2) the **search index** having picked up the room — a real lag for a channel created moments earlier via API — and (3) the listbox rendering and the option becoming clickable. Any one stalling makes `searchInput.fill` hang until the test timeout, surfacing as the misleading `Target page, context or browser has been closed`. `gotoChannel` loads `/channel/<name>` and then `waitForChannel()` (main region, heading, message list, `aria-busy` cleared), so it has a proper readiness wait without the search dependency.
+
+Do **not** apply when:
+- The navbar search is the actual subject of the test.
+- Navigating to a **DM** (`/direct/<username>`) or a **discussion** — `gotoChannel` builds a `/channel/` URL only.
+- Reaching a channel the user is **not a member of** — the direct URL hits a different preview/join flow; verify the behavior before switching.
+
 ## API helpers for state seeding
 
 Prefer these helpers in `beforeAll` / `beforeEach` and in setup `test.step`s. All live under `apps/meteor/tests/e2e/utils/`.
@@ -296,8 +316,7 @@ test.describe.serial('Feature X', () => {
         page = await context.newPage();
         poHomeChannel = new HomeChannel(page);
 
-        await page.goto('/home');
-        await poHomeChannel.navbar.openChat(targetChannel);
+        await poHomeChannel.gotoChannel(targetChannel);
     });
 
     test.afterAll(async ({ api }) => {
@@ -332,6 +351,7 @@ Recipe for a single spec. Keep PRs to at most 5 files so reviews stay tractable.
 - `poHomeChannel.content.sendMessage(...)` used inside `beforeEach` or `beforeAll` — that is setup, should be `sendMessage(api, ...)`.
 - Opening meatball menus or modals purely to create a discussion, thread, or DM as a setup step.
 - `test.describe.serial` combined with `beforeEach(async ({ page }) => { await page.goto(...) })` — the context should be shared in `beforeAll`.
+- `page.goto('/home')` + `navbar.openChat(name)` to reach a room the test already knows — use `poHomeChannel.gotoChannel(name)` (see Pattern 3). Searching a just-created channel races the search index and hangs until timeout.
 - New non-serial suites whose tests still each carry >3s of UI setup.
 - Inline `api.post('/im.create', …)` / `api.post('/chat.sendMessage', …)` in a spec instead of extending the helpers in `utils/`.
 

--- a/apps/meteor/tests/e2e/embedded-layout.spec.ts
+++ b/apps/meteor/tests/e2e/embedded-layout.spec.ts
@@ -31,8 +31,7 @@ test.describe('embedded-layout', () => {
 
 	test.describe('Layout elements visibility', () => {
 		test('should hide primary navigation elements in embedded layout', async ({ page }) => {
-			await page.goto('/home');
-			await poHomeChannel.navbar.openChat(targetChannelId);
+			await poHomeChannel.gotoChannel(targetChannelId);
 			await expect(poHomeChannel.roomHeaderToolbar).toBeVisible();
 
 			await page.goto(embeddedLayoutURL(page.url()));
@@ -50,8 +49,7 @@ test.describe('embedded-layout', () => {
 			});
 
 			test('should show room header toolbar as top navbar when setting enabled', async ({ page }) => {
-				await page.goto('/home');
-				await poHomeChannel.navbar.openChat(targetChannelId);
+				await poHomeChannel.gotoChannel(targetChannelId);
 				await page.goto(embeddedLayoutURL(page.url()));
 
 				await expect(poHomeChannel.roomHeaderToolbar).toBeVisible();
@@ -61,8 +59,7 @@ test.describe('embedded-layout', () => {
 
 	test.describe('Channel member functionality', () => {
 		test('should hide join button and enable messaging for members', async ({ page }) => {
-			await page.goto('/home');
-			await poHomeChannel.navbar.openChat(targetChannelId);
+			await poHomeChannel.gotoChannel(targetChannelId);
 			await page.goto(embeddedLayoutURL(page.url()));
 
 			await expect(poHomeChannel.composer.inputMessage).toBeVisible();
@@ -71,8 +68,7 @@ test.describe('embedded-layout', () => {
 		});
 
 		test('should allow sending and receiving messages', async ({ page }) => {
-			await page.goto('/home');
-			await poHomeChannel.navbar.openChat(targetChannelId);
+			await poHomeChannel.gotoChannel(targetChannelId);
 			await page.goto(embeddedLayoutURL(page.url()));
 
 			const testMessage = `Embedded test message ${Date.now()}`;
@@ -81,8 +77,7 @@ test.describe('embedded-layout', () => {
 		});
 
 		test('should preserve message composer functionality', async ({ page }) => {
-			await page.goto('/home');
-			await poHomeChannel.navbar.openChat(targetChannelId);
+			await poHomeChannel.gotoChannel(targetChannelId);
 			await page.goto(embeddedLayoutURL(page.url()));
 
 			await expect(poHomeChannel.composer.inputMessage).toBeVisible();

--- a/apps/meteor/tests/e2e/file-upload.spec.ts
+++ b/apps/meteor/tests/e2e/file-upload.spec.ts
@@ -24,8 +24,7 @@ test.describe.serial('file-upload', () => {
 	test.beforeEach(async ({ page }) => {
 		poHomeChannel = new HomeChannel(page);
 
-		await page.goto('/home');
-		await poHomeChannel.navbar.openChat(targetChannel);
+		await poHomeChannel.gotoChannel(targetChannel);
 	});
 
 	test.afterAll(async ({ api }) => {
@@ -132,7 +131,7 @@ test.describe.serial('file-upload', () => {
 
 	test('should upload file in composer after recording video message', async ({ context }) => {
 		await context.grantPermissions(['camera', 'microphone']);
-		await poHomeChannel.navbar.openChat(targetChannel);
+		await poHomeChannel.gotoChannel(targetChannel);
 
 		await test.step('should be able to record a video with text content in composer ', async () => {
 			await poHomeChannel.composer.inputMessage.fill('this is a message with video message');
@@ -235,8 +234,7 @@ test.describe('file-upload-not-member', () => {
 	test.beforeEach(async ({ page }) => {
 		poHomeChannel = new HomeChannel(page);
 
-		await page.goto('/home');
-		await poHomeChannel.navbar.openChat(targetChannel);
+		await poHomeChannel.gotoChannel(targetChannel);
 	});
 
 	test.afterAll(async ({ api }) => {

--- a/apps/meteor/tests/e2e/image-upload.spec.ts
+++ b/apps/meteor/tests/e2e/image-upload.spec.ts
@@ -19,8 +19,7 @@ test.describe('image-upload', () => {
 
 	test.beforeEach(async ({ page }) => {
 		poHomeChannel = new HomeChannel(page);
-		await page.goto('/home');
-		await poHomeChannel.navbar.openChat(targetChannel);
+		await poHomeChannel.gotoChannel(targetChannel);
 	});
 
 	test.afterAll(async ({ api }) => {

--- a/apps/meteor/tests/e2e/quote-attachment.spec.ts
+++ b/apps/meteor/tests/e2e/quote-attachment.spec.ts
@@ -18,8 +18,7 @@ test.describe.parallel('Quote Attachment', () => {
 
 	test.beforeEach(async ({ page }) => {
 		poHomeChannel = new HomeChannel(page);
-		await page.goto('/home');
-		await poHomeChannel.navbar.openChat(targetChannel);
+		await poHomeChannel.gotoChannel(targetChannel);
 	});
 
 	test.afterAll(async ({ api }) => {

--- a/apps/meteor/tests/e2e/quote-messages.spec.ts
+++ b/apps/meteor/tests/e2e/quote-messages.spec.ts
@@ -32,8 +32,7 @@ test.describe.serial('Quote Messages', () => {
 		page = await context.newPage();
 		poHomeChannel = new HomeChannel(page);
 
-		await page.goto('/home');
-		await poHomeChannel.navbar.openChat(targetChannel);
+		await poHomeChannel.gotoChannel(targetChannel);
 	});
 
 	test.afterAll(async ({ api }) => {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Using `gotoChannel` is more reliable and can fix some flaky tests out there.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated end-to-end testing guidance with a recommended, more reliable way to open a known room.
  * Added clearer do’s and don’ts for navigating to rooms in test flows.

* **Tests**
  * Standardized several automated tests to use the same room-navigation approach.

* **Bug Fixes**
  * Improved test stability by avoiding a navigation pattern that could race with loading and cause hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2277]

[ARCH-2277]: https://rocketchat.atlassian.net/browse/ARCH-2277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ