### PR TITLE
regression: archived room links fail to open when user has no subscription

### DIFF
--- a/apps/meteor/app/api/server/v1/rooms.ts
+++ b/apps/meteor/app/api/server/v1/rooms.ts
@@ -535,7 +535,7 @@ API.v1.get(
 		},
 	},
 	async function action() {
-		const room = await findRoomByIdOrName({ params: this.queryParams });
+		const room = await findRoomByIdOrName({ params: this.queryParams, checkedArchived: false });
 		const { fields } = await this.parseJsonQuery();
 
 		if (!room || !(await canAccessRoomAsync(room, { _id: this.userId }))) {

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -1485,7 +1485,8 @@ describe('[Rooms]', () => {
 			let nonMemberCredentials: Credentials;
 
 			before(async () => {
-				publicArchivedChannel = (await createRoom({ type: 'c', name: `rooms.info.archived.c.${Date.now()}-${Math.random()}` })).body.channel;
+				publicArchivedChannel = (await createRoom({ type: 'c', name: `rooms.info.archived.c.${Date.now()}-${Math.random()}` })).body
+					.channel;
 				privateArchivedGroup = (await createRoom({ type: 'p', name: `rooms.info.archived.p.${Date.now()}-${Math.random()}` })).body.group;
 
 				await request.post(api('channels.archive')).set(credentials).send({ roomId: publicArchivedChannel._id }).expect(200);

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -1477,6 +1477,60 @@ describe('[Rooms]', () => {
 					});
 			});
 		});
+
+		describe('with archived rooms', () => {
+			let publicArchivedChannel: IRoom;
+			let privateArchivedGroup: IRoom;
+			let nonMember: TestUser<IUser>;
+			let nonMemberCredentials: Credentials;
+
+			before(async () => {
+				publicArchivedChannel = (await createRoom({ type: 'c', name: `rooms.info.archived.c.${Date.now()}-${Math.random()}` })).body.channel;
+				privateArchivedGroup = (await createRoom({ type: 'p', name: `rooms.info.archived.p.${Date.now()}-${Math.random()}` })).body.group;
+
+				await request.post(api('channels.archive')).set(credentials).send({ roomId: publicArchivedChannel._id }).expect(200);
+				await request.post(api('groups.archive')).set(credentials).send({ roomId: privateArchivedGroup._id }).expect(200);
+
+				nonMember = await createUser({ joinDefaultChannels: false });
+				nonMemberCredentials = await login(nonMember.username, password);
+			});
+
+			after(() =>
+				Promise.all([
+					deleteRoom({ type: 'c', roomId: publicArchivedChannel._id }),
+					deleteRoom({ type: 'p', roomId: privateArchivedGroup._id }),
+					deleteUser(nonMember),
+				]),
+			);
+
+			it('should return an accessible archived public channel to a non-member (reached via link/mention)', async () => {
+				await request
+					.get(api('rooms.info'))
+					.set(nonMemberCredentials)
+					.query({ roomId: publicArchivedChannel._id })
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('success', true);
+						expect(res.body).to.have.property('room').and.to.be.an('object');
+						expect(res.body.room).to.have.property('_id', publicArchivedChannel._id);
+						expect(res.body.room).to.have.property('archived', true);
+					});
+			});
+
+			it('should still reject an archived room the user cannot access (private group, non-member)', async () => {
+				await request
+					.get(api('rooms.info'))
+					.set(nonMemberCredentials)
+					.query({ roomId: privateArchivedGroup._id })
+					.expect('Content-Type', 'application/json')
+					.expect(400)
+					.expect((res) => {
+						expect(res.body).to.have.property('success', false);
+						expect(res.body).to.have.property('error', 'not-allowed');
+					});
+			});
+		});
 	});
 	describe('[/rooms.leave]', () => {
 		let testChannel: IRoom;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

- `rooms.info` API endpoint: Pass `checkedArchive` property as `false` to `findRoomByIdOrName`, avoiding short-circuit when `useGoToRoom` (apps/meteor/client/views/room/hooks/useGoToRoom.ts) calls  `useEndpoint('GET', '/v1/rooms.info');` (It previously used `useMethod('getRoomById');`, change done in https://github.com/RocketChat/Rocket.Chat/pull/40659/). This means that the endpoint response will include archived rooms too.
- Add E2E API tests covering the archived room case for `rooms.info`.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-2317 [Regression] Archived room links fail to open from fresh client state](https://rocketchat.atlassian.net/browse/CORE-2317)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Create a public channel, for example #archived-link-repro
2. Send a message in #general containing #archived-link-repro
3. Archive #archived-link-repro
4. Log in as a normal test user in a fresh/incognito browser session
5. Open #general
6. Click the #archived-link-repro mention

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `rooms.info` now returns information for archived rooms when access is allowed.
  * Archived public channels can be retrieved successfully by non-members.
  * Access checks still prevent users from viewing archived private rooms they can’t access.
* **Tests**
  * Added end-to-end coverage for archived room behavior in `rooms.info`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->