### PR TITLE
fix: show offline users' custom status text and expiration

### DIFF
--- a/apps/meteor/app/api/server/v1/users.ts
+++ b/apps/meteor/app/api/server/v1/users.ts
@@ -1546,7 +1546,7 @@ API.v1.get(
 
 		if (ids) {
 			return API.v1.success({
-				users: await Users.findNotOfflineByIds(Array.isArray(ids) ? ids : ids.split(','), options).toArray(),
+				users: await Users.findPresenceUsersByIds(Array.isArray(ids) ? ids : ids.split(','), options).toArray(),
 				full: false,
 			});
 		}

--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -1848,6 +1848,34 @@ describe('[Users]', () => {
 					})
 					.end(done);
 			});
+
+			it('should return an offline user that still carries a custom status (vacation text/expiration survives offline)', async () => {
+				const vacationUser = await createUser();
+				const vacationCredentials = await login(vacationUser.username, password);
+				const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+				await request
+					.post(api('users.setStatus'))
+					.set(vacationCredentials)
+					.send({ status: 'offline', message: 'On vacation', expiresAt })
+					.expect(200);
+
+				const res = await request
+					.get(api('users.presence'))
+					.query({ ids: vacationUser._id })
+					.set(credentials)
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				const returned = (res.body.users as IUser[]).find((u) => u._id === vacationUser._id);
+				expect(returned, 'offline user with a custom status must be returned by users.presence').to.not.be.undefined;
+				expect(returned).to.have.property('status', 'offline');
+				expect(returned).to.have.property('statusText', 'On vacation');
+				expect(returned).to.have.property('statusExpiresAt');
+
+				await deleteUser(vacationUser);
+			});
 		});
 	});
 

--- a/ee/packages/presence/src/lib/presenceEngine.spec.ts
+++ b/ee/packages/presence/src/lib/presenceEngine.spec.ts
@@ -48,6 +48,21 @@ describe('processPresence', () => {
 			expect(result.values).toMatchObject({ status: UserStatus.OFFLINE, statusConnection: UserStatus.OFFLINE });
 		});
 
+		test('should not clear a custom status when going OFFLINE (vacation text survives disconnect)', () => {
+			const result = processPresence(
+				user({
+					statusDefault: UserStatus.AWAY,
+					statusSource: 'manual',
+					statusText: 'On vacation',
+					statusExpiresAt: new Date(Date.now() + ONE_HOUR),
+				}),
+				[],
+			);
+			expect(result.values).toEqual({ status: UserStatus.OFFLINE, statusConnection: UserStatus.OFFLINE });
+			expect(result.values).not.toHaveProperty('statusText');
+			expect(result.clear).toBeUndefined();
+		});
+
 		test('should stay OFFLINE when user is invisible (OFFLINE statusDefault with sessions)', () => {
 			const result = processPresence(user({ statusDefault: UserStatus.OFFLINE }), [session(UserStatus.ONLINE)]);
 			expect(result.values).toMatchObject({ status: UserStatus.OFFLINE, statusConnection: UserStatus.ONLINE });

--- a/packages/model-typings/src/models/IUsersModel.ts
+++ b/packages/model-typings/src/models/IUsersModel.ts
@@ -381,7 +381,7 @@ export interface IUsersModel extends IBaseModel<IUser> {
 	findOneActiveById(userId: string, options?: FindOptions<IUser>): Promise<IUser | null>;
 	findOneByIdOrUsername(userId: string, options?: FindOptions<IUser>): Promise<IUser | null>;
 	findOneByRolesAndType<T extends Document = IUser>(roles: IRole['_id'][], type: string, options?: FindOptions<IUser>): Promise<T | null>;
-	findNotOfflineByIds(userIds: string[], options?: FindOptions<IUser>): FindCursor<IUser>;
+	findPresenceUsersByIds(userIds: string[], options?: FindOptions<IUser>): FindCursor<IUser>;
 	findUsersNotOffline(options?: FindOptions<IUser>): FindCursor<IUser>;
 	countUsersNotOffline(options?: FindOptions<IUser>): Promise<number>;
 	findNotIdUpdatedFrom(userId: string, updatedFrom: Date, options?: FindOptions<IUser>): FindCursor<IUser>;

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -2488,12 +2488,14 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOne<T>(query, options);
 	}
 
-	findNotOfflineByIds(users?: IUser['_id'][], options?: FindOptions<IUser>) {
+	findPresenceUsersByIds(users: IUser['_id'][], options?: FindOptions<IUser>) {
 		const query = {
 			_id: { $in: users },
-			status: {
-				$in: [UserStatus.ONLINE, UserStatus.AWAY, UserStatus.BUSY],
-			},
+			$or: [
+				{ status: { $in: [UserStatus.ONLINE, UserStatus.AWAY, UserStatus.BUSY] } },
+				{ statusText: { $exists: true, $ne: '' } },
+				{ statusExpiresAt: { $exists: true } },
+			],
 		};
 		return this.find(query, options);
 	}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

With the new presence engine, a custom status (text + expiration) should stay visible after a user goes offline — e.g. *"On vacation until next week"*. The engine persists it and the live stream already broadcasts it, but it was dropped on the REST cold-load (page reload / first card open), so offline users showed as a plain "Offline" with no message.

**Root cause:** `GET /api/v1/users.presence?ids=<uid>` used `Users.findNotOfflineByIds`, which filtered `status ∈ { online, away, busy }` and excluded every offline user. The client then fell back to `{ status: OFFLINE }` with no `statusText` /`statusExpiresAt`. That filter is a legacy optimization that is wrong now that offline users can keep a displayable custom status.

**Fix:** a dedicated `Users.findByIdsForPresence` backs the `ids` branch, returning online/away/busy users plus offline users that still carry a custom status (`statusText` or `statusExpiresAt`). Silently-offline users are still omitted and inferred offline by the client fallback, keeping the payload optimization. The old `findNotOfflineByIds` (only used here) is removed; bulk/incremental paths unchanged.

## Issue(s)

- [PRES-59](https://rocketchat.atlassian.net/browse/PRES-59)

## Steps to test or reproduce

1. As User A, set a custom status with a message and a future expiration (*Away*, *"On vacation until next week"*, expires in 7 days).
2. Disconnect User A (go offline).
3. As User B, open User A's card/info, or reload the page with it open.

**Expected:** "Offline - On vacation until next week" + expiration, until it expires.
**Before:** plain "Offline", no text/expiration.

## Further comments


[PRES-59]: https://rocketchat.atlassian.net/browse/PRES-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated presence lookups by user ID to include offline users who have a custom status message and/or a status expiry time.
  * Prevented disconnect-triggered offline transitions from clearing an existing manual custom status, preserving consistency in presence data.
* **Tests**
  * Added end-to-end coverage for `users.presence` to verify custom status fields are returned for offline users.
  * Extended presence engine tests to confirm manual offline status text isn’t cleared on disconnect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->