### PR TITLE
regression: private room access denial shows delayed generic error

### DIFF
--- a/apps/meteor/client/views/room/hooks/useOpenRoom.spec.ts
+++ b/apps/meteor/client/views/room/hooks/useOpenRoom.spec.ts
@@ -3,6 +3,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 
 import { useOpenRoom } from './useOpenRoom';
 import { createFakeRoom, createFakeSubscription } from '../../../../tests/mocks/data';
+import { RoomNotFoundError } from '../../../lib/errors/RoomNotFoundError';
 import { Rooms, Subscriptions } from '../../../stores';
 
 jest.mock('../../../../app/ui-utils/client', () => ({
@@ -74,6 +75,62 @@ describe('useOpenRoom', () => {
 
 			await waitFor(() => expect(result.current.isSuccess).toBe(true));
 			expect(result.current.data?.rid).toBe(dmRid);
+		});
+	});
+
+	describe('error classification', () => {
+		it('maps error-no-permission to RoomNotFoundError without retrying (regression for #40991)', async () => {
+			const getRoomByTypeAndName = jest.fn().mockImplementation(() => {
+				throw Object.assign(new Error('No permission'), { error: 'error-no-permission' });
+			});
+
+			const { result } = renderHook(() => useOpenRoom({ type: 'p', reference: 'private-channel' }), {
+				wrapper: mockAppRoot().withJohnDoe().withMethod('getRoomByTypeAndName', getRoomByTypeAndName).build(),
+			});
+
+			await waitFor(() => expect(result.current.isError).toBe(true));
+			expect(result.current.error).toBeInstanceOf(RoomNotFoundError);
+			expect(getRoomByTypeAndName).toHaveBeenCalledTimes(1);
+		});
+
+		it('maps error-invalid-room to RoomNotFoundError without retrying for non-DM rooms', async () => {
+			const getRoomByTypeAndName = jest.fn().mockImplementation(() => {
+				throw Object.assign(new Error('Invalid room'), { error: 'error-invalid-room' });
+			});
+
+			const { result } = renderHook(() => useOpenRoom({ type: 'c', reference: 'missing-channel' }), {
+				wrapper: mockAppRoot().withJohnDoe().withMethod('getRoomByTypeAndName', getRoomByTypeAndName).build(),
+			});
+
+			await waitFor(() => expect(result.current.isError).toBe(true));
+			expect(result.current.error).toBeInstanceOf(RoomNotFoundError);
+			expect(getRoomByTypeAndName).toHaveBeenCalledTimes(1);
+		});
+
+		it('retries unclassified transient errors and recovers on a later attempt', async () => {
+			const channelRid = 'channel-rid-transient';
+			const channelName = 'flaky-channel';
+			const channelRoom = createFakeRoom({ _id: channelRid, t: 'c', name: channelName });
+
+			const getRoomByTypeAndName = jest
+				.fn()
+				.mockImplementationOnce(() => {
+					throw new Error('network down');
+				})
+				.mockImplementation(() => channelRoom);
+
+			const { result } = renderHook(() => useOpenRoom({ type: 'c', reference: channelName }), {
+				wrapper: mockAppRoot()
+					.withJohnDoe()
+					.withPermission('preview-c-room')
+					.withMethod('getRoomByTypeAndName', getRoomByTypeAndName)
+					.build(),
+			});
+
+			// Backoff is Math.min(1000 * 2 ** attempt, 5000); first retry fires after ~1s.
+			await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 3000 });
+			expect(result.current.data?.rid).toBe(channelRid);
+			expect(getRoomByTypeAndName).toHaveBeenCalledTimes(2);
 		});
 	});
 });

--- a/apps/meteor/client/views/room/hooks/useOpenRoom.ts
+++ b/apps/meteor/client/views/room/hooks/useOpenRoom.ts
@@ -78,9 +78,15 @@ export function useOpenRoom({ type, reference }: { type: RoomType; reference: st
 			try {
 				roomData = await getRoomByTypeAndName(type, reference);
 			} catch (error) {
-				const isDefinitivelyNotFound = error && typeof error === 'object' && 'error' in error && error.error === 'error-invalid-room';
+				const errorCode = error && typeof error === 'object' && 'error' in error ? error.error : undefined;
 
-				if (!isDefinitivelyNotFound) {
+				// "No permission" means the room exists but the user can't see it — surface the
+				// not-found/no-access screen rather than retrying it as a transient failure.
+				if (errorCode === 'error-no-permission') {
+					throw new RoomNotFoundError(undefined, { type, reference });
+				}
+
+				if (errorCode !== 'error-invalid-room') {
 					throw error;
 				}
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Opening a private room the current user cannot access was retrying the server call 4× (with exponential backoff up to 12s total) and then rendering a generic error screen with the raw `"No permission"` message, instead of the room-not-found/no-access screen shown in 8.5.1.

## Issue(s)

[CORE-2356](https://rocketchat.atlassian.net/browse/CORE-2356)

## Steps to test or reproduce

1. Log in as User A, create a private channel `private-channel`. Do **not** add User B.
2. Log in as User B.
3. Open `/group/private-channel` directly in the browser.

**Expected (and now actual):** the room-not-found/no-access screen renders immediately, matching 8.5.1.
**Before this PR:** ~12s of retries, then a generic Error layout with the raw `"No permission"` message.

## Further comments

Unit tests in `useOpenRoom.spec.ts` cover the three relevant paths:

- `error-no-permission` → `RoomNotFoundError`, method called exactly once (regression check — fails on the pre-fix code with a 1s retry delay before failing).
- `error-invalid-room` on a non-DM → `RoomNotFoundError`, method called exactly once (PR #40991 behavior preserved).
- Generic transient `Error` → retried, succeeds on the second attempt (PR #40991 retry behavior preserved).

[CORE-2356]: https://rocketchat.atlassian.net/browse/CORE-2356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room opening behavior so “access denied” and invalid room lookups are treated as not found, preventing unexpected failures.
  * Refined error handling to retry transient room-lookup issues and successfully open the room once the lookup succeeds.
* **Tests**
  * Expanded coverage for room-opening error classification and retry behavior, including verification of call counts and final room results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->