### PR TITLE
chore(spotlight): parallelize searches and slim connected-users pipeline

### DIFF
--- a/.changeset/spotlight-perf.md
+++ b/.changeset/spotlight-perf.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/meteor': patch
+'@rocket.chat/models': patch
+---
+
+Improved `/v1/spotlight` search performance: results return faster, and room searches now read from secondary database replicas when available, reducing load on the primary.

--- a/apps/meteor/server/lib/spotlight.js
+++ b/apps/meteor/server/lib/spotlight.js
@@ -39,6 +39,7 @@ export class Spotlight {
 			sort: {
 				name: 1,
 			},
+			readPreference: readSecondaryPreferred(Rooms.col.s.db),
 		};
 
 		if (userId == null) {
@@ -55,12 +56,15 @@ export class Spotlight {
 
 		const searchableRoomTypeIds = roomCoordinator.searchableRoomTypes();
 
-		const roomIds = (
-			await SubscriptionsRaw.findByUserIdAndTypes(userId, searchableRoomTypeIds, {
+		const [subscriptions, exactRoom] = await Promise.all([
+			SubscriptionsRaw.findByUserIdAndTypes(userId, searchableRoomTypeIds, {
 				projection: { rid: 1 },
-			}).toArray()
-		).map((s) => s.rid);
-		const exactRoom = await Rooms.findOneByNameAndType(text, searchableRoomTypeIds, roomOptions, includeFederatedRooms);
+				readPreference: roomOptions.readPreference,
+			}).toArray(),
+			Rooms.findOneByNameAndType(text, searchableRoomTypeIds, roomOptions, includeFederatedRooms),
+		]);
+
+		const roomIds = subscriptions.map((s) => s.rid);
 		if (exactRoom) {
 			roomIds.push(exactRoom.rid);
 		}

--- a/apps/meteor/server/publications/spotlight.ts
+++ b/apps/meteor/server/publications/spotlight.ts
@@ -61,10 +61,12 @@ export const spotlightMethod = async ({
 		text = text.slice(1);
 	}
 
-	return {
-		users: type.users ? await spotlight.searchUsers({ userId, rid, text, usernames, mentions }) : [],
-		rooms: type.rooms ? await spotlight.searchRooms({ userId, text, includeFederatedRooms }) : [],
-	};
+	const [users, rooms] = await Promise.all([
+		type.users ? spotlight.searchUsers({ userId, rid, text, usernames, mentions }) : [],
+		type.rooms ? spotlight.searchRooms({ userId, text, includeFederatedRooms }) : [],
+	]);
+
+	return { users, rooms };
 };
 
 Meteor.methods<ServerMethods>({

--- a/packages/models/src/models/Subscriptions.ts
+++ b/packages/models/src/models/Subscriptions.ts
@@ -457,7 +457,12 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 							let: {
 								rid: '$_id',
 							},
-							pipeline: [{ $match: { '$expr': { $eq: ['$rid', '$$rid'] }, 'u._id': { $ne: userId } } }],
+							// Only `u._id` is read downstream (next $group); projecting it away keeps the
+							// $unwind/$group volume tiny instead of carrying full subscription documents.
+							pipeline: [
+								{ $match: { '$expr': { $eq: ['$rid', '$$rid'] }, 'u._id': { $ne: userId } } },
+								{ $project: { '_id': 0, 'u._id': 1 } },
+							],
 						},
 					},
 					// Unwind the subscription so we have a separate document for each
@@ -494,6 +499,8 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 										...(searchTerm && orStatement.length > 0 && { $or: orStatement }),
 									},
 								},
+								// Only these fields are read by the final $group; avoid hauling full user documents.
+								{ $project: { name: 1, username: 1, nickname: 1, status: 1, statusText: 1, avatarETag: 1 } },
 							],
 						},
 					},


### PR DESCRIPTION
## Proposed changes

Performance pass over the `/spotlight` endpoint (`apps/meteor/app/api/server/v1/misc.ts` → `spotlightMethod` → `Spotlight`). All changes are **result-preserving** — the same users/rooms come back, in the same order; only how the work is executed changes.

### What changed

**1. Parallelize user + room search** (`server/publications/spotlight.ts`)
`spotlightMethod` awaited `searchUsers` then `searchRooms` sequentially. They are independent, so they now run together via `Promise.all`. End-to-end latency becomes `max(users, rooms)` instead of the sum.

**2. Parallelize room prelim queries** (`server/lib/spotlight.js`)
In `searchRooms`, the subscribed-room-ids fetch and the exact-room lookup were sequential and independent — now run concurrently. Same `roomIds` / `exactRoom` flow, no semantic change.

**3. Secondary read preference for room queries** (`server/lib/spotlight.js`)
User searches already read from `secondaryPreferred`; room queries did not. Added `readSecondaryPreferred(Rooms.col.s.db)` so room reads also offload to replicas.

**4. Slim the connected-users aggregation** (`packages/models/src/models/Subscriptions.ts`)
`findConnectedUsersExcept` was carrying **full** documents through its blocking stages:
- The self-`$lookup` on subscriptions pulled entire subscription docs (notification prefs, roles, settings…) for every shared-room membership, then `$unwind` + `$group` over all of them — even though only `subscription.u._id` is read downstream. This is the stage that explodes for members of large rooms.
- The user `$lookup` loaded entire user docs when only 6 fields are projected at the end.

Both `$lookup` sub-pipelines now `$project` down to exactly the fields read downstream, so far less data flows through `$unwind`/`$group`. Output is identical (verified: nothing downstream reads a dropped field; scores unchanged).

### Why

Spotlight fires per keystroke from navbar autocomplete with no caching, so its per-call cost matters. These changes cut wall-clock latency and memory/IO pressure with no behavior change and minimal, low-risk diffs.

### Out of scope (follow-ups)

- The dominant cost remains the unanchored case-insensitive `/text/i` regex on users/rooms, which forces a collection scan and cannot use any index (including on MongoDB 8.0). The real fix is a normalized lowercase field + anchored prefix index — tracked separately as it needs a migration.
- A short-TTL autocomplete cache to absorb keystroke bursts.

## Testing

- `eslint` clean on all changed files.
- Aggregation changes are projection-only and preserve the documented return shape; no existing spec covers `findConnectedUsersExcept`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Issue
https://rocketchat.atlassian.net/browse/CORE-2362

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved `/v1/spotlight` search responsiveness by running user and room lookups concurrently.
  * Enhanced room search query efficiency by using a more suitable Mongo read strategy and reducing work in the room-search flow.
  * Optimized connected-user retrieval to carry less data through the aggregation pipeline, improving speed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Your favorite part, perf

# Spotlight endpoint load test — develop vs chore/spotlight

**Date:** 2026-07-02
**Change under test:** `1db19988c5` — perf(spotlight): parallelize searches and slim connected-users pipeline

## Setup

- Local dev server (`meteor`), Rocket.Chat 8.7.0-develop, single-node MongoDB at `localhost:3001`
- `chore/spotlight` rebased onto develop tip before measuring, so the branches differ by exactly the perf commit
- Load: k6 (`k6-spotlight.js`), `constant-arrival-rate` executor — fixed 25 req/s for 60s (~1500 requests per run), identical load on both branches
- Requests: `GET /api/v1/spotlight?query=<term>` authenticated as `testerio`; 13 query terms rotated (short prefixes, usernames, room names, no-match); every 4th request adds `rid=GENERAL` to exercise the connected-users aggregation
- 15s warm-up run before each measured run; 0 failed requests on both sides

## Results (http_req_duration)

| metric | develop | chore/spotlight | delta |
|--------|---------|-----------------|-------|
| med    | 29.2ms  | 26.7ms          | −8.5% |
| avg    | 30.2ms  | 27.3ms          | −9.5% |
| p90    | 34.9ms  | 29.8ms          | −14.5% |
| p95    | 37.3ms  | 31.1ms          | −16.7% |
| max    | 101.3ms | 85.3ms          | −15.8% |

Improvement across all percentiles, largest in the tail — consistent with running the users and rooms searches concurrently (latency becomes max of the two queries instead of their sum).

Raw k6 summaries: `spotlight-develop.json`, `spotlight-pr.json`.

## Dataset

| collection | count |
|------------|-------|
| rooms (total) | 5,869 |
| — public channels (`c`) | 5,575 |
| — private groups (`p`) | 273 |
| — livechat (`l`) | 13 |
| — DMs (`d`) | 8 |
| users (total) | 1,065 |
| — active | 20 (19 users + 1 bot) |
| — inactive | 1,045 |
| subscriptions | 43,367 |

## Caveats

- Single 60s run per branch on a laptop; treat deltas as directional, not precise
- Single-node MongoDB: the `readPreference: secondaryPreferred` change is a no-op locally — production replica sets should see additional primary offload beyond what's measured here
- Small dataset relative to production; absolute latencies will differ, but the parallelization win scales with per-query cost

https://gist.github.com/KevLehman/2f44614fff4040a352a954c4c0281121.js