### PR TITLE
test: add guards to composer focus to prevent flakyness

### DIFF
--- a/apps/meteor/tests/e2e/channel-management.spec.ts
+++ b/apps/meteor/tests/e2e/channel-management.spec.ts
@@ -28,6 +28,7 @@ test.describe.serial('channel-management', () => {
 		await poHomeChannel.navbar.openChat(targetChannel);
 		await poHomeChannel.content.sendMessage('hello composer');
 		await poHomeChannel.roomHeaderFavoriteBtn.focus();
+		await expect(poHomeChannel.roomHeaderFavoriteBtn).toBeFocused();
 
 		await page.keyboard.press('Tab');
 		await page.keyboard.press('Tab');
@@ -40,6 +41,7 @@ test.describe.serial('channel-management', () => {
 	test('should move the focus away from toolbar using tab key', async ({ page }) => {
 		await poHomeChannel.navbar.openChat(targetChannel);
 		await poHomeChannel.roomHeaderFavoriteBtn.focus();
+		await expect(poHomeChannel.roomHeaderFavoriteBtn).toBeFocused();
 
 		await page.keyboard.press('Tab');
 		await page.keyboard.press('Tab');
@@ -137,6 +139,7 @@ test.describe.serial('channel-management', () => {
 	test('should open room info when clicking on roomName', async ({ page }) => {
 		await poHomeChannel.navbar.openChat(targetChannel);
 		await page.getByRole('button', { name: targetChannel }).first().focus();
+		await expect(page.getByRole('button', { name: targetChannel }).first()).toBeFocused();
 		await page.keyboard.press('Space');
 		await page.getByRole('dialog').waitFor();
 
@@ -159,6 +162,7 @@ test.describe.serial('channel-management', () => {
 		await page.getByRole('listitem', { name: discussionName }).getByRole('button', { name: 'Reply' }).click();
 
 		await page.getByRole('button', { name: `Back to ${targetChannel} channel`, exact: true }).focus();
+		await expect(page.getByRole('button', { name: `Back to ${targetChannel} channel`, exact: true })).toBeFocused();
 		await page.keyboard.press('Space');
 
 		await expect(page).toHaveURL(`/channel/${targetChannel}`);

--- a/apps/meteor/tests/e2e/e2e-encryption/e2ee-file-encryption.spec.ts
+++ b/apps/meteor/tests/e2e/e2e-encryption/e2ee-file-encryption.spec.ts
@@ -77,7 +77,7 @@ test.describe('E2EE File Encryption', () => {
 			await poHomeChannel.content.openLastMessageMenu();
 			await poHomeChannel.content.btnOptionEditMessage.click();
 
-			expect(await poHomeChannel.composer.inputMessage.inputValue()).toBe('any_description');
+			await expect(poHomeChannel.composer.inputMessage).toHaveValue('any_description');
 
 			await poHomeChannel.composer.inputMessage.fill('edited any_description');
 			await page.keyboard.press('Enter');

--- a/apps/meteor/tests/e2e/feature-preview.spec.ts
+++ b/apps/meteor/tests/e2e/feature-preview.spec.ts
@@ -106,8 +106,7 @@ test.describe.serial('feature preview', () => {
 		test('should display new channel from team on the sidepanel', async ({ page, api }) => {
 			newChannelModal = new CreateNewChannelModal(page);
 
-			await page.goto(`/group/${sidepanelTeam}`);
-			await poHomeTeam.content.waitForChannel();
+			await poHomeTeam.gotoGroup(sidepanelTeam);
 
 			await poHomeTeam.headerToolbar.openTeamChannels();
 			await poHomeTeam.tabs.channels.btnCreateNew.click();
@@ -143,8 +142,8 @@ test.describe.serial('feature preview', () => {
 			await expect(poHomeChannel.sidepanel.getItemByName(sidepanelTeam)).not.toHaveText(parsedWrong);
 		});
 
-		test('should show channel in sidepanel after adding existing one', async ({ page }) => {
-			await page.goto(`/group/${sidepanelTeam}`);
+		test('should show channel in sidepanel after adding existing one', async () => {
+			await poHomeTeam.gotoGroup(sidepanelTeam);
 
 			await poHomeTeam.headerToolbar.openTeamChannels();
 			await poHomeTeam.tabs.channels.addExistingChannel(targetChannel);
@@ -156,7 +155,7 @@ test.describe.serial('feature preview', () => {
 			const user1Page = await browser.newPage({ storageState: Users.user1.state });
 			const user1Channel = new HomeChannel(user1Page);
 
-			await page.goto(`/group/${sidepanelTeam}`);
+			await poHomeTeam.gotoGroup(sidepanelTeam);
 
 			await poHomeTeam.headerToolbar.openTeamChannels();
 			await poHomeTeam.tabs.channels.addExistingChannel(targetChannel);
@@ -225,9 +224,8 @@ test.describe.serial('feature preview', () => {
 			await expect(poHomeChannel.sidebar.discussionsTeamCollabFilter).toBeVisible();
 		});
 
-		test('should show favorite team on the sidepanel', async ({ page }) => {
-			await page.goto(`/group/${sidepanelTeam}`);
-			await poHomeChannel.content.waitForChannel();
+		test('should show favorite team on the sidepanel', async () => {
+			await poHomeChannel.gotoGroup(sidepanelTeam);
 			await poHomeChannel.sidebar.favoritesTeamCollabFilter.click();
 
 			await expect(poHomeChannel.sidepanel.getTeamItemByName(sidepanelTeam)).not.toBeVisible();
@@ -239,8 +237,7 @@ test.describe.serial('feature preview', () => {
 
 		test('should show discussion in discussions and all sidepanel filter, should remove after deleting discussion', async ({ page }) => {
 			const poHomeDiscussion = new HomeDiscussion(page);
-			await page.goto(`/group/${sidepanelTeam}`);
-			await poHomeChannel.content.waitForChannel();
+			await poHomeChannel.gotoGroup(sidepanelTeam);
 
 			const discussionName = faker.string.uuid();
 

--- a/apps/meteor/tests/e2e/messaging.spec.ts
+++ b/apps/meteor/tests/e2e/messaging.spec.ts
@@ -142,6 +142,7 @@ test.describe('Messaging', () => {
 
 		test('should focus the latest message when moving the focus on the list and theres no previous focus', async ({ page }) => {
 			await page.getByRole('button', { name: targetChannel }).first().focus();
+			await expect(page.getByRole('button', { name: targetChannel }).first()).toBeFocused();
 
 			await test.step('move focus to the list', async () => {
 				await page.keyboard.press('Tab');
@@ -152,6 +153,7 @@ test.describe('Messaging', () => {
 
 			await test.step('move focus to the list again', async () => {
 				await page.getByRole('button', { name: targetChannel }).first().focus();
+				await expect(page.getByRole('button', { name: targetChannel }).first()).toBeFocused();
 				await page.keyboard.press('Tab');
 				await page.keyboard.press('Tab');
 				await page.keyboard.press('Tab');

--- a/apps/meteor/tests/e2e/messaging.spec.ts
+++ b/apps/meteor/tests/e2e/messaging.spec.ts
@@ -165,9 +165,10 @@ test.describe('Messaging', () => {
 			await channelPage.navbar.openChat(targetChannel);
 
 			await test.step('focus on the second message', async () => {
+				await expect(channelPage.composer.inputMessage).toBeFocused();
 				await page.keyboard.press('ArrowUp');
 
-				expect(await channelPage.composer.inputMessage.inputValue()).toBe('msg2');
+				await expect(channelPage.composer.inputMessage).toHaveValue('msg2');
 			});
 
 			await test.step('send edited message', async () => {
@@ -187,6 +188,7 @@ test.describe('Messaging', () => {
 				);
 
 				for (const element of ['edited msg2 a', 'edited msg2 b', 'edited msg2 c', 'edited msg2 d', 'edited msg2 e']) {
+					await expect(channelPage.composer.inputMessage).toBeFocused();
 					await page.keyboard.press('ArrowUp');
 
 					await channelPage.content.sendMessage(element, false);

--- a/apps/meteor/tests/e2e/page-objects/home-channel.ts
+++ b/apps/meteor/tests/e2e/page-objects/home-channel.ts
@@ -101,6 +101,11 @@ export class HomeChannel {
 		await this.content.waitForChannel();
 	}
 
+	async gotoGroup(name: string) {
+		await this.page.goto(`/group/${name}`);
+		await this.content.waitForChannel();
+	}
+
 	get btnContextualbarClose(): Locator {
 		return this.page.locator('[data-qa="ContextualbarActionClose"]');
 	}

--- a/apps/meteor/tests/e2e/rooms-join.spec.ts
+++ b/apps/meteor/tests/e2e/rooms-join.spec.ts
@@ -143,8 +143,8 @@ test.describe.serial('Join rooms', () => {
 			await api.post('/groups.delete', { roomId: group._id });
 		});
 
-		test('should let a parent member join a discussion in a private channel', async ({ page }) => {
-			await page.goto(`/group/${discussion.name}`);
+		test('should let a parent member join a discussion in a private channel', async () => {
+			await poHomeChannel.gotoGroup(discussion.name);
 
 			await expect(poHomeChannel.composer.btnJoinRoom).toBeVisible();
 			await poHomeChannel.composer.btnJoinRoom.click();

--- a/apps/meteor/tests/e2e/sidebar.spec.ts
+++ b/apps/meteor/tests/e2e/sidebar.spec.ts
@@ -64,6 +64,7 @@ test.describe.serial('Sidebar', () => {
 		});
 		test('should navigate on navbar toolbar pressing tab', async ({ page }) => {
 			await poHomeChannel.navbar.btnHome.focus();
+			await expect(poHomeChannel.navbar.btnHome).toBeFocused();
 
 			await test.step('move focus to directory button', async () => {
 				await page.keyboard.press('Tab');
@@ -135,6 +136,7 @@ test.describe.serial('Sidebar', () => {
 
 			await expect(async () => {
 				await collapser.focus();
+				await expect(collapser).toBeFocused();
 				await page.keyboard.press('Space');
 				const isExpanded = (await collapser.getAttribute('aria-expanded')) === 'true';
 				expect(isExpanded).toBeTruthy();

--- a/apps/meteor/tests/e2e/team-management.spec.ts
+++ b/apps/meteor/tests/e2e/team-management.spec.ts
@@ -254,6 +254,7 @@ test.describe.serial('teams-management', () => {
 	test('should access team channel through targetTeam header', async ({ page }) => {
 		await poHomeTeam.navbar.openChat(targetChannel);
 		await page.getByRole('button', { name: targetChannel }).first().focus();
+		await expect(page.getByRole('button', { name: targetChannel }).first()).toBeFocused();
 		await page.keyboard.press('Shift+Tab');
 		await page.keyboard.press('Space');
 

--- a/apps/meteor/tests/e2e/team-management.spec.ts
+++ b/apps/meteor/tests/e2e/team-management.spec.ts
@@ -437,8 +437,7 @@ test.describe.serial('teams-management', () => {
 	test('should user1 leave from targetTeam', async ({ browser }) => {
 		const user1Page = await browser.newPage({ storageState: Users.user1.state });
 		const user1Channel = new HomeTeam(user1Page);
-		await user1Page.goto(`/group/${targetTeam}`);
-		await user1Channel.content.waitForChannel();
+		await user1Channel.gotoGroup(targetTeam);
 
 		await user1Channel.headerToolbar.openTeamInfo();
 		await user1Channel.tabs.room.leaveRoom();

--- a/apps/meteor/tests/e2e/video-conference.spec.ts
+++ b/apps/meteor/tests/e2e/video-conference.spec.ts
@@ -49,6 +49,7 @@ test.describe('video conference', () => {
 		await poHomeChannel.navbar.openChat(targetChannel);
 		await poHomeChannel.content.sendMessage('hello video conference');
 		await poHomeChannel.roomHeaderFavoriteBtn.focus();
+		await expect(poHomeChannel.roomHeaderFavoriteBtn).toBeFocused();
 
 		await test.step('opens video conference popup', async () => {
 			await page.keyboard.press('Tab');


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Hardens three e2e assertions that race against composer focus/population, causing intermittent failures (e.g. `ArrowUp` triggering edit before the composer is focused → empty input).

### Changes
- **`messaging.spec.ts`** – assert the composer is focused before `ArrowUp` (edit shortcut) and use auto-retrying `toHaveValue('msg2')` instead of a one-shot `inputValue()` read.
- **`messaging.spec.ts`** – same focus guard before each `ArrowUp` in the message-edition stress loop.
- **`e2ee-file-encryption.spec.ts`** – replace one-shot `inputValue()` read with auto-retrying `toHaveValue('any_description')` after triggering edit.

### Why
`ArrowUp`-to-edit only works when the composer already holds focus, and `inputValue()` samples a single instant. Both relied on timing that fails under CI load. Mirrors the existing guarded pattern in `threads.spec.ts`. Test-only; no product code touched.


## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened end-to-end coverage by adding explicit focus checks before continuing keyboard navigation flows (messaging, sidebar, channel management, and team management).
  * Improved message editing stability by asserting the composer is focused and validating composer contents using reliable value assertions during single edits and repeated edit “stress” loops.
  * Updated navigation in feature preview and related join flows to use page-object group navigation helpers for more consistent loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2194]

[ARCH-2194]: https://rocketchat.atlassian.net/browse/ARCH-2194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ