### PR TITLE
regression: DM sidebar tooltip shows empty while presence loads

### DIFF
--- a/apps/meteor/client/hooks/useUserStatusTooltip.tsx
+++ b/apps/meteor/client/hooks/useUserStatusTooltip.tsx
@@ -1,4 +1,4 @@
-import { Throbber } from '@rocket.chat/fuselage';
+import { Skeleton } from '@rocket.chat/fuselage';
 import { UserPresenceContext, useTooltipClose, useTooltipOpen, useUserPresence } from '@rocket.chat/ui-contexts';
 import type { MouseEvent } from 'react';
 import { useCallback, useContext, useMemo } from 'react';
@@ -9,7 +9,7 @@ const UserStatusTooltipContent = ({ uid }: { uid: string }) => {
 	const presence = useUserPresence(uid);
 
 	if (!presence) {
-		return <Throbber size='x8' inheritColor />;
+		return <Skeleton width='x200' variant='text' backgroundColor='surface-light' />;
 	}
 
 	return <UserStatusText status={presence.status} statusText={presence.statusText} statusExpiresAt={presence.statusExpiresAt} />;

--- a/apps/meteor/client/hooks/useUserStatusTooltip.tsx
+++ b/apps/meteor/client/hooks/useUserStatusTooltip.tsx
@@ -1,11 +1,22 @@
-import { useTooltipClose, useTooltipOpen, useUserPresence } from '@rocket.chat/ui-contexts';
+import { Throbber } from '@rocket.chat/fuselage';
+import { UserPresenceContext, useTooltipClose, useTooltipOpen, useUserPresence } from '@rocket.chat/ui-contexts';
 import type { MouseEvent } from 'react';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 
 import { UserStatusText } from '../components/UserStatusText';
 
-export function useUserStatusTooltip(uid: string | undefined, title?: string) {
+const UserStatusTooltipContent = ({ uid }: { uid: string }) => {
 	const presence = useUserPresence(uid);
+
+	if (!presence) {
+		return <Throbber size='x8' inheritColor />;
+	}
+
+	return <UserStatusText status={presence.status} statusText={presence.statusText} statusExpiresAt={presence.statusExpiresAt} />;
+};
+
+export function useUserStatusTooltip(uid: string | undefined, title?: string) {
+	const userPresence = useContext(UserPresenceContext);
 
 	const openTooltip = useTooltipOpen();
 	const closeTooltip = useTooltipClose();
@@ -19,11 +30,13 @@ export function useUserStatusTooltip(uid: string | undefined, title?: string) {
 			}
 
 			openTooltip(
-				<UserStatusText status={presence?.status} statusText={presence?.statusText} statusExpiresAt={presence?.statusExpiresAt} />,
+				<UserPresenceContext.Provider value={userPresence}>
+					<UserStatusTooltipContent uid={uid} />
+				</UserPresenceContext.Provider>,
 				target,
 			);
 		},
-		[uid, openTooltip, presence, title],
+		[uid, openTooltip, title, userPresence],
 	);
 
 	return useMemo(() => ({ 'data-tooltip': '', onMouseEnter, 'onMouseLeave': closeTooltip }), [onMouseEnter, closeTooltip]);


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Hovering a DM in the sidebar while the partner's presence was still loading showed an **empty** tooltip. `useUserStatusTooltip` opened the tooltip with a static `<UserStatusText>` snapshot, and while presence was `undefined` that snapshot rendered nothing.

The hook now opens a small self-subscribing component (`UserStatusTooltipContent`) that:
- shows a `Skeleton` while presence is loading, then
- live-updates **in place** to the real status once it resolves (and keeps reflecting later changes while the tooltip stays open).

Since the tooltip renders above `UserPresenceProvider`, the hook bridges `UserPresenceContext` into the tooltip so the content's `useUserPresence` resolves inside the portal. The whole fix is contained in `useUserStatusTooltip.tsx`; no shared components were touched.

Regression introduced by #40469.

## Issue(s)

- [CORE-2359](https://rocketchat.atlassian.net/browse/CORE-2359)

## Steps to test or reproduce

1. Open RC with several DMs in the sidebar.
2. Throttle/slow the network (or block `/v1/users.presence`) so presence loads slowly.
3. Reload, then hover a DM row before its presence resolves.

**Before:** tooltip appears empty, only showing the status after a re-hover.
**After:** tooltip shows a loading spinner, then live-updates to the status (e.g. "Offline") in place — no re-hover.

## Further comments


[CORE-2359]: https://rocketchat.atlassian.net/browse/CORE-2359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the user status tooltip to show a loading state when presence information isn’t available, and automatically display the latest status details once loaded.
  * Made tooltip behavior more consistent by preserving and reusing status data throughout the tooltip content.
  * Tooltip content now stays in sync with the latest available presence, reducing flicker during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->