### PR TITLE
regression: long DM custom status overlaps room header action icons

### DIFF
--- a/apps/meteor/client/views/room/Header/RoomMemberStatus.tsx
+++ b/apps/meteor/client/views/room/Header/RoomMemberStatus.tsx
@@ -1,5 +1,4 @@
 import type { IRoom } from '@rocket.chat/core-typings';
-import { Box } from '@rocket.chat/fuselage';
 import { useUserId, useUserPresence } from '@rocket.chat/ui-contexts';
 import type { ReactElement } from 'react';
 
@@ -20,11 +19,7 @@ const RoomMemberStatus = ({ room }: RoomMemberStatusProps): ReactElement | null 
 		return null;
 	}
 
-	return (
-		<Box title={expirationText}>
-			<MarkdownText content={presence?.statusText} parseEmoji={true} variant='inline' />
-		</Box>
-	);
+	return <MarkdownText title={expirationText} content={presence?.statusText} parseEmoji={true} variant='inline' withTruncatedText />;
 };
 
 export default RoomMemberStatus;


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

In a DM, a long custom status from the partner overflowed the room header and overlapped the action/options icons.

[#40469](https://github.com/RocketChat/Rocket.Chat/pull/40469) moved the DM partner's status out of `RoomTopic` (which rendered it truncated) into the new `RoomMemberStatus`, which rendered it with no truncation. `RoomMemberStatus` now renders the status as a bare `MarkdownText` with `withTruncatedText` — matching `RoomTopic` — so it clips with an ellipsis within the available header space instead of spilling into the toolbar.

Regression introduced by [#40469](https://github.com/RocketChat/Rocket.Chat/pull/40469).

## Issue(s)

- [CORE-2360](https://rocketchat.atlassian.net/browse/CORE-2360)

## Steps to test or reproduce

1. Open a DM with a user who has a long custom status.
2. Use a normal or narrow desktop viewport.

**Before:** the status overflows horizontally and overlaps the header action icons.
**After:** the status truncates with an ellipsis and stays within the header.

## Further comments

[CORE-2360]: https://rocketchat.atlassian.net/browse/CORE-2360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved member status display by showing truncated text with a full hover title, making long presence/expiration messages easier to read.
  * Simplified the status rendering so the message now appears directly without extra surrounding spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->