### PR TITLE
feat(message-parser): add GFM table support

### DIFF
--- a/.changeset/gazzodown-render-tables.md
+++ b/.changeset/gazzodown-render-tables.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/gazzodown": minor
+---
+
+Renders GFM tables emitted by the message parser using Fuselage's `Table` components, with per-column alignment. A compact single-row preview of the table header is shown in message previews.

--- a/.changeset/gazzodown-render-tables.md
+++ b/.changeset/gazzodown-render-tables.md
@@ -1,5 +1,0 @@
----
-"@rocket.chat/gazzodown": minor
----
-
-Renders GFM tables emitted by the message parser using Fuselage's `Table` components, with per-column alignment. A compact single-row preview of the table header is shown in message previews.

--- a/.changeset/tame-tables-render.md
+++ b/.changeset/tame-tables-render.md
@@ -1,5 +1,10 @@
 ---
 "@rocket.chat/message-parser": minor
+"@rocket.chat/gazzodown": minor
 ---
 
-Adds support for GFM-style tables in the message parser. Tables require a leading and trailing pipe on every row, support column alignment via the delimiter row (`:---`, `:--:`, `---:`), and allow inline markup inside cells (a literal pipe must be escaped as `\|`). New `TABLE`, `TABLE_ROW`, and `TABLE_CELL` AST nodes are emitted. The `TABLE` node also carries an optional `fallback` — a `[start, end]` offset span into the original source — so renderers without table support can slice the source to show the raw markup instead of dropping it, without duplicating the text into the AST.
+Adds GFM-style table support to the message parser and renders it in gazzodown.
+
+Parser: tables require a leading and trailing pipe on every row, support column alignment via the delimiter row (`:---`, `:--:`, `---:`), and allow inline markup inside cells (a literal pipe must be escaped as `\|`). New `TABLE`, `TABLE_ROW`, and `TABLE_CELL` AST nodes are emitted. The `TABLE` node also carries an optional `fallback` — a `[start, end]` offset span into the original source — so renderers without table support can slice the source to show the raw markup instead of dropping it, without duplicating the text into the AST.
+
+Rendering: gazzodown renders these tables using Fuselage's `Table` components with per-column alignment, and shows a compact single-row preview of the table header in message previews.

--- a/.changeset/tame-tables-render.md
+++ b/.changeset/tame-tables-render.md
@@ -2,4 +2,4 @@
 "@rocket.chat/message-parser": minor
 ---
 
-Adds support for GFM-style tables in the message parser. Tables require a leading and trailing pipe on every row, support column alignment via the delimiter row (`:---`, `:--:`, `---:`), and allow inline markup inside cells (a literal pipe must be escaped as `\|`). New `TABLE`, `TABLE_ROW`, and `TABLE_CELL` AST nodes are emitted. The `TABLE` node also carries an optional `fallback` plain-text node with its raw source, so renderers without table support can degrade to the original markup instead of dropping it.
+Adds support for GFM-style tables in the message parser. Tables require a leading and trailing pipe on every row, support column alignment via the delimiter row (`:---`, `:--:`, `---:`), and allow inline markup inside cells (a literal pipe must be escaped as `\|`). New `TABLE`, `TABLE_ROW`, and `TABLE_CELL` AST nodes are emitted. The `TABLE` node also carries an optional `fallback` — a `[start, end]` offset span into the original source — so renderers without table support can slice the source to show the raw markup instead of dropping it, without duplicating the text into the AST.

--- a/.changeset/tame-tables-render.md
+++ b/.changeset/tame-tables-render.md
@@ -2,4 +2,4 @@
 "@rocket.chat/message-parser": minor
 ---
 
-Adds support for GFM-style tables in the message parser. Tables require a leading and trailing pipe on every row, support column alignment via the delimiter row (`:---`, `:--:`, `---:`), and allow inline markup inside cells (a literal pipe must be escaped as `\|`). New `TABLE`, `TABLE_ROW`, and `TABLE_CELL` AST nodes are emitted.
+Adds support for GFM-style tables in the message parser. Tables require a leading and trailing pipe on every row, support column alignment via the delimiter row (`:---`, `:--:`, `---:`), and allow inline markup inside cells (a literal pipe must be escaped as `\|`). New `TABLE`, `TABLE_ROW`, and `TABLE_CELL` AST nodes are emitted. The `TABLE` node also carries an optional `fallback` plain-text node with its raw source, so renderers without table support can degrade to the original markup instead of dropping it.

--- a/.changeset/tame-tables-render.md
+++ b/.changeset/tame-tables-render.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/message-parser": minor
+---
+
+Adds support for GFM-style tables in the message parser. Tables require a leading and trailing pipe on every row, support column alignment via the delimiter row (`:---`, `:--:`, `---:`), and allow inline markup inside cells (a literal pipe must be escaped as `\|`). New `TABLE`, `TABLE_ROW`, and `TABLE_CELL` AST nodes are emitted.

--- a/packages/gazzodown/src/Markup.stories.tsx
+++ b/packages/gazzodown/src/Markup.stories.tsx
@@ -264,6 +264,18 @@ export const HorizontalRule: StoryObj<typeof Markup> = {
 	},
 };
 
+export const Table: StoryObj<typeof Markup> = {
+	args: {
+		tokens: parse(outdent`
+		| Name | Status | Score |
+		| :--- | :----: | ----: |
+		| Alice | **done** | 9.5 |
+		| Bob | :smile: | 7 |
+		| Carol | [profile](https://rocket.chat) | 12 |
+	`),
+	},
+};
+
 export const Example: StoryObj<{ msg: string }> = {
 	render: ({ msg }) => {
 		const parseOptions: Options = { katex: { dollarSyntax: true, parenthesisSyntax: true }, colors: true, emoticons: true };
@@ -298,6 +310,11 @@ export const Example: StoryObj<{ msg: string }> = {
 		> Cogito ergo sum.
 		> Sit amet, consectetur adipiscing elit.
 		> Donec eget ex euismod, euismod nisi euismod, vulputate nisi.
+
+		| Name | Status | Score |
+		| :--- | :----: | ----: |
+		| Alice | **done** | 9.5 |
+		| Bob | :smile: | 7 |
 
 		\`\`\`
 		const x = 1;

--- a/packages/gazzodown/src/Markup.tsx
+++ b/packages/gazzodown/src/Markup.tsx
@@ -7,6 +7,7 @@ import OrderedListBlock from './blocks/OrderedListBlock';
 import ParagraphBlock from './blocks/ParagraphBlock';
 import QuoteBlock from './blocks/QuoteBlock';
 import SpoilerBlock from './blocks/SpoilerBlock';
+import TableBlock from './blocks/TableBlock';
 import TaskList from './blocks/TaskListBlock';
 import UnorderedListBlock from './blocks/UnorderedListBlock';
 import BigEmojiBlock from './emoji/BigEmojiBlock';
@@ -62,6 +63,9 @@ const Markup = ({ tokens, source }: MarkupProps) => (
 							<KatexBlock code={block.value} />
 						</KatexErrorBoundary>
 					);
+
+				case 'TABLE':
+					return <TableBlock key={index} header={block.value.header} rows={block.value.rows} />;
 
 				case 'LINE_BREAK':
 					return <br key={index} />;

--- a/packages/gazzodown/src/PreviewMarkup.tsx
+++ b/packages/gazzodown/src/PreviewMarkup.tsx
@@ -86,6 +86,18 @@ const PreviewMarkup = ({ tokens, source }: PreviewMarkupProps) => {
 				</KatexErrorBoundary>
 			);
 
+		case 'TABLE':
+			return (
+				<>
+					{firstBlock.value.header.map((cell, index) => (
+						<span key={index}>
+							{index > 0 ? ' | ' : null}
+							<PreviewInlineElements>{cell.value}</PreviewInlineElements>
+						</span>
+					))}
+				</>
+			);
+
 		default: {
 			// Only the `[start, end]` offset form is rendered (sliced from source); the union
 			// keeps the original fallback form too, which we intentionally ignore.

--- a/packages/gazzodown/src/blocks/TableBlock.tsx
+++ b/packages/gazzodown/src/blocks/TableBlock.tsx
@@ -1,0 +1,44 @@
+import { Table, TableBody, TableCell, TableHead, TableRow } from '@rocket.chat/fuselage';
+import type * as MessageParser from '@rocket.chat/message-parser';
+
+import InlineElements from '../elements/InlineElements';
+
+type TableBlockProps = {
+	header: MessageParser.TableCell[];
+	rows: MessageParser.TableRow[];
+};
+
+const alignMap = {
+	left: 'start',
+	center: 'center',
+	right: 'end',
+} as const;
+
+const toAlign = (align: MessageParser.TableCell['align']) => (align ? alignMap[align] : undefined);
+
+const TableBlock = ({ header, rows }: TableBlockProps) => (
+	<Table fixed={false}>
+		<TableHead>
+			<TableRow>
+				{header.map((cell, index) => (
+					<TableCell key={index} align={toAlign(cell.align)}>
+						<InlineElements>{cell.value}</InlineElements>
+					</TableCell>
+				))}
+			</TableRow>
+		</TableHead>
+		<TableBody>
+			{rows.map((row, rowIndex) => (
+				<TableRow key={rowIndex}>
+					{row.value.map((cell, cellIndex) => (
+						<TableCell key={cellIndex} align={toAlign(cell.align)}>
+							<InlineElements>{cell.value}</InlineElements>
+						</TableCell>
+					))}
+				</TableRow>
+			))}
+		</TableBody>
+	</Table>
+);
+
+export default TableBlock;

--- a/packages/gazzodown/src/blocks/TableBlock.tsx
+++ b/packages/gazzodown/src/blocks/TableBlock.tsx
@@ -17,7 +17,7 @@ const alignMap = {
 const toAlign = (align: MessageParser.TableCell['align']) => (align ? alignMap[align] : undefined);
 
 const TableBlock = ({ header, rows }: TableBlockProps) => (
-	<Table fixed={false}>
+	<Table striped fixed={false}>
 		<TableHead>
 			<TableRow>
 				{header.map((cell, index) => (

--- a/packages/gazzodown/src/blocks/TableBlock.tsx
+++ b/packages/gazzodown/src/blocks/TableBlock.tsx
@@ -8,13 +8,20 @@ type TableBlockProps = {
 	rows: MessageParser.TableRow[];
 };
 
-const alignMap = {
-	left: 'start',
-	center: 'center',
-	right: 'end',
-} as const;
-
-const toAlign = (align: MessageParser.TableCell['align']) => (align ? alignMap[align] : undefined);
+// Explicit mapping (not an object lookup) so a crafted AST align like `__proto__`
+// or `toString` can never resolve to an inherited value.
+const toAlign = (align: MessageParser.TableCell['align']): 'start' | 'center' | 'end' | undefined => {
+	switch (align) {
+		case 'left':
+			return 'start';
+		case 'center':
+			return 'center';
+		case 'right':
+			return 'end';
+		default:
+			return undefined;
+	}
+};
 
 const TableBlock = ({ header, rows }: TableBlockProps) => (
 	<Table striped fixed={false}>

--- a/packages/message-parser/README.md
+++ b/packages/message-parser/README.md
@@ -38,6 +38,28 @@ The grammar provides support for markdown, mentions and emojis.
 - URI's
 - mentions users/channels
 - timestamps
+- tables
+
+## Tables
+
+GFM-style tables. A leading and trailing pipe is required on every row.
+Alignment is taken from the delimiter row:
+
+| Marker | Alignment |
+| ------ | --------- |
+| `:---` | left      |
+| `:--:` | center    |
+| `---:` | right     |
+| `---`  | none      |
+
+```
+| Header 1 | Header 2 |
+| -------- | :------: |
+| Cell 1   | Cell 2   |
+```
+
+A literal pipe inside a cell must be escaped as `\|`. Cell content supports
+inline markup (bold, italic, links, emoji, …).
 
 ## Timestamps
 

--- a/packages/message-parser/README.md
+++ b/packages/message-parser/README.md
@@ -52,7 +52,7 @@ Alignment is taken from the delimiter row:
 | `---:` | right     |
 | `---`  | none      |
 
-```
+```md
 | Header 1 | Header 2 |
 | -------- | :------: |
 | Cell 1   | Cell 2   |

--- a/packages/message-parser/src/definitions.ts
+++ b/packages/message-parser/src/definitions.ts
@@ -53,6 +53,8 @@ export type Table = {
 		header: TableCell[];
 		rows: TableRow[];
 	};
+	// Raw source text, rendered verbatim by consumers that don't implement a table renderer
+	fallback?: Plain;
 };
 
 export type Color = {

--- a/packages/message-parser/src/definitions.ts
+++ b/packages/message-parser/src/definitions.ts
@@ -53,8 +53,9 @@ export type Table = {
 		header: TableCell[];
 		rows: TableRow[];
 	};
-	// Raw source text, rendered verbatim by consumers that don't implement a table renderer
-	fallback?: Plain;
+	// New form is a `[start, end]` offset span; the `Plain` form is kept in the
+	// type only to tolerate previously-persisted data at runtime.
+	fallback?: SourceRange | Plain;
 };
 
 export type Color = {

--- a/packages/message-parser/src/definitions.ts
+++ b/packages/message-parser/src/definitions.ts
@@ -34,6 +34,27 @@ export type CodeLine = {
 	value: Plain;
 };
 
+export type TableCellAlignment = 'left' | 'center' | 'right' | undefined;
+
+export type TableCell = {
+	type: 'TABLE_CELL';
+	align: TableCellAlignment;
+	value: Inlines[];
+};
+
+export type TableRow = {
+	type: 'TABLE_ROW';
+	value: TableCell[];
+};
+
+export type Table = {
+	type: 'TABLE';
+	value: {
+		header: TableCell[];
+		rows: TableRow[];
+	};
+};
+
 export type Color = {
 	type: 'COLOR';
 	value: {
@@ -218,6 +239,9 @@ export type Types = {
 	INLINE_KATEX: InlineKaTeX;
 	TIMESTAMP: Timestamp;
 	SPOILER_BLOCK: SpoilerBlock;
+	TABLE: Table;
+	TABLE_ROW: TableRow;
+	TABLE_CELL: TableCell;
 };
 
 export type ASTNode =
@@ -240,7 +264,8 @@ export type ASTNode =
 	| Emoji
 	| Color
 	| Tasks
-	| HorizontalRule;
+	| HorizontalRule
+	| Table;
 
 export type TypesKeys = keyof Types;
 
@@ -271,6 +296,7 @@ export type Blocks =
 	| UnorderedList
 	| LineBreak
 	| KaTeX
-	| HorizontalRule;
+	| HorizontalRule
+	| Table;
 
 export type Root = Array<Paragraph | Blocks> | [BigEmoji];

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -102,7 +102,7 @@ BlockSpoiler = "||" EndOfLine first:(&(! "||") @Paragraph) rest:(&(! "||") @Para
  * the delimiter row: `:---` left, `:--:` center, `---:` right, `---` none.
  * A literal pipe inside a cell must be escaped as `\|`.
  */
-Table = header:TableRowLine aligns:TableDelimiterRow body:TableRowLine* { return table(header, aligns, body, text()); }
+Table = header:TableRowLine aligns:TableDelimiterRow body:TableRowLine* { return table(header, aligns, body, [range().start, range().end]); }
 
 TableRowLine = "|" cells:(@TableCell "|")+ EndOfLine? { return cells; }
 

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -31,6 +31,7 @@
     spoiler,
     spoilerBlock,
     strike,
+    table,
     task,
     tasks,
     unorderedList,
@@ -59,6 +60,7 @@ Blocks
   / BlockSpoiler
   / Code
   / HorizontalRule
+  / Table
   / Heading
   / Tasks
   / OrderedList
@@ -87,6 +89,37 @@ BlockquoteLine
  * ||
  */
 BlockSpoiler = "||" EndOfLine first:(&(! "||") @Paragraph) rest:(&(! "||") @Paragraph)* EndOfLine? "||" { return spoilerBlock([first, ...rest]); }
+
+/**
+ *
+ * Table (GFM)
+ * e.g:
+ * | Header 1 | Header 2 |
+ * | -------- | :------: |
+ * | Cell 1   | Cell 2   |
+ *
+ * v1 requires a leading and trailing pipe on every row. Alignment comes from
+ * the delimiter row: `:---` left, `:--:` center, `---:` right, `---` none.
+ * A literal pipe inside a cell must be escaped as `\|`.
+ */
+Table = header:TableRowLine aligns:TableDelimiterRow body:TableRowLine* { return table(header, aligns, body); }
+
+TableRowLine = "|" cells:(@TableCell "|")+ EndOfLine? { return cells; }
+
+TableCell = items:TableCellItem* { return reducePlainTexts(items); }
+
+TableCellItem
+  = "\\|" { return plain('|'); }
+  / !"|" !EndOfLine @(InlineItemPattern / Any)
+
+TableDelimiterRow = "|" aligns:(@TableDelimiterCell "|")+ EndOfLine? { return aligns; }
+
+TableDelimiterCell = [ \t]* left:":"? "-"+ right:":"? [ \t]* {
+    if (left && right) { return 'center'; }
+    if (right) { return 'right'; }
+    if (left) { return 'left'; }
+    return undefined;
+  }
 
 // <t:1630360800:?{format}>
 // <t:2025-07-22T10:00:00.000Z?:?{format}>

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -102,7 +102,7 @@ BlockSpoiler = "||" EndOfLine first:(&(! "||") @Paragraph) rest:(&(! "||") @Para
  * the delimiter row: `:---` left, `:--:` center, `---:` right, `---` none.
  * A literal pipe inside a cell must be escaped as `\|`.
  */
-Table = header:TableRowLine aligns:TableDelimiterRow body:TableRowLine* { return table(header, aligns, body); }
+Table = header:TableRowLine aligns:TableDelimiterRow body:TableRowLine* { return table(header, aligns, body, text()); }
 
 TableRowLine = "|" cells:(@TableCell "|")+ EndOfLine? { return cells; }
 

--- a/packages/message-parser/src/utils.ts
+++ b/packages/message-parser/src/utils.ts
@@ -182,7 +182,9 @@ export const table = (header: Inlines[][], aligns: Array<TableCell['align']>, ro
 		rows: rows.map(
 			(cells): TableRow => ({
 				type: 'TABLE_ROW',
-				value: cells.map((cell, index) => tableCell(cell, aligns[index])),
+				// Normalize each row to the header's column count: pad missing cells and
+				// drop extras, so ragged GFM rows stay aligned with the header/delimiter.
+				value: header.map((_, index) => tableCell(cells[index] ?? [], aligns[index])),
 			}),
 		),
 	},

--- a/packages/message-parser/src/utils.ts
+++ b/packages/message-parser/src/utils.ts
@@ -19,6 +19,9 @@ import type {
 	Timestamp,
 	SourceRange,
 	HorizontalRule,
+	Table,
+	TableRow,
+	TableCell,
 } from './definitions';
 
 const generate =
@@ -137,6 +140,52 @@ export const listItem = (text: Inlines[], number?: number): ListItem => ({
 	type: 'LIST_ITEM',
 	value: text,
 	...(number !== undefined && { number }),
+});
+
+// GFM trims leading/trailing whitespace of each table cell's content
+const trimCellContent = (value: Inlines[]): Inlines[] => {
+	const result = value.slice();
+
+	const first = result[0];
+	if (first?.type === 'PLAIN_TEXT') {
+		const trimmed = first.value.replace(/^\s+/, '');
+		if (trimmed === '') {
+			result.shift();
+		} else {
+			result[0] = { type: 'PLAIN_TEXT', value: trimmed };
+		}
+	}
+
+	const last = result[result.length - 1];
+	if (last?.type === 'PLAIN_TEXT') {
+		const trimmed = last.value.replace(/\s+$/, '');
+		if (trimmed === '') {
+			result.pop();
+		} else {
+			result[result.length - 1] = { type: 'PLAIN_TEXT', value: trimmed };
+		}
+	}
+
+	return result;
+};
+
+const tableCell = (value: Inlines[], align: TableCell['align']): TableCell => ({
+	type: 'TABLE_CELL',
+	align,
+	value: trimCellContent(value),
+});
+
+export const table = (header: Inlines[][], aligns: Array<TableCell['align']>, rows: Inlines[][][]): Table => ({
+	type: 'TABLE',
+	value: {
+		header: header.map((cell, index) => tableCell(cell, aligns[index])),
+		rows: rows.map(
+			(cells): TableRow => ({
+				type: 'TABLE_ROW',
+				value: cells.map((cell, index) => tableCell(cell, aligns[index])),
+			}),
+		),
+	},
 });
 
 export const mentionUser = (() => {

--- a/packages/message-parser/src/utils.ts
+++ b/packages/message-parser/src/utils.ts
@@ -175,7 +175,7 @@ const tableCell = (value: Inlines[], align: TableCell['align']): TableCell => ({
 	value: trimCellContent(value),
 });
 
-export const table = (header: Inlines[][], aligns: Array<TableCell['align']>, rows: Inlines[][][], source?: string): Table => ({
+export const table = (header: Inlines[][], aligns: Array<TableCell['align']>, rows: Inlines[][][], fallback?: SourceRange): Table => ({
 	type: 'TABLE',
 	value: {
 		header: header.map((cell, index) => tableCell(cell, aligns[index])),
@@ -186,7 +186,7 @@ export const table = (header: Inlines[][], aligns: Array<TableCell['align']>, ro
 			}),
 		),
 	},
-	...(source !== undefined && { fallback: plain(source) }),
+	...(fallback !== undefined && { fallback }),
 });
 
 export const mentionUser = (() => {

--- a/packages/message-parser/src/utils.ts
+++ b/packages/message-parser/src/utils.ts
@@ -175,7 +175,7 @@ const tableCell = (value: Inlines[], align: TableCell['align']): TableCell => ({
 	value: trimCellContent(value),
 });
 
-export const table = (header: Inlines[][], aligns: Array<TableCell['align']>, rows: Inlines[][][]): Table => ({
+export const table = (header: Inlines[][], aligns: Array<TableCell['align']>, rows: Inlines[][][], source?: string): Table => ({
 	type: 'TABLE',
 	value: {
 		header: header.map((cell, index) => tableCell(cell, aligns[index])),
@@ -186,6 +186,7 @@ export const table = (header: Inlines[][], aligns: Array<TableCell['align']>, ro
 			}),
 		),
 	},
+	...(source !== undefined && { fallback: plain(source) }),
 });
 
 export const mentionUser = (() => {

--- a/packages/message-parser/tests/helpers.ts
+++ b/packages/message-parser/tests/helpers.ts
@@ -110,10 +110,10 @@ export const tableRow = (value: unknown[]) => ({
 	value,
 });
 
-export const table = (header: unknown[], rows: unknown[], fallback?: string) => ({
+export const table = (header: unknown[], rows: unknown[], fallback?: [number, number]) => ({
 	type: 'TABLE' as const,
 	value: { header, rows },
-	...(fallback !== undefined ? { fallback: plain(fallback) } : {}),
+	...(fallback !== undefined ? { fallback } : {}),
 });
 
 export const katex = (value: string) => ({

--- a/packages/message-parser/tests/helpers.ts
+++ b/packages/message-parser/tests/helpers.ts
@@ -97,6 +97,24 @@ export const horizontalRule = (fallback?: [number, number]) => ({
 	...(fallback !== undefined ? { fallback } : {}),
 });
 
+type Align = 'left' | 'center' | 'right' | undefined;
+
+export const tableCell = (value: unknown[], align: Align = undefined) => ({
+	type: 'TABLE_CELL' as const,
+	align,
+	value,
+});
+
+export const tableRow = (value: unknown[]) => ({
+	type: 'TABLE_ROW' as const,
+	value,
+});
+
+export const table = (header: unknown[], rows: unknown[]) => ({
+	type: 'TABLE' as const,
+	value: { header, rows },
+});
+
 export const katex = (value: string) => ({
 	type: 'KATEX' as const,
 	value,

--- a/packages/message-parser/tests/helpers.ts
+++ b/packages/message-parser/tests/helpers.ts
@@ -110,9 +110,10 @@ export const tableRow = (value: unknown[]) => ({
 	value,
 });
 
-export const table = (header: unknown[], rows: unknown[]) => ({
+export const table = (header: unknown[], rows: unknown[], fallback?: string) => ({
 	type: 'TABLE' as const,
 	value: { header, rows },
+	...(fallback !== undefined ? { fallback: plain(fallback) } : {}),
 });
 
 export const katex = (value: string) => ({

--- a/packages/message-parser/tests/table.test.ts
+++ b/packages/message-parser/tests/table.test.ts
@@ -68,6 +68,16 @@ test.each([
 	expect(parse(input)).toEqual([table(header, rows, [0, input.length])]);
 });
 
+test('normalizes ragged body rows to the header column count', () => {
+	const input = ['| a | b |', '| - | - |', '| 1 |', '| 1 | 2 | 3 |'].join('\n');
+	const [node] = parse(input) as [ReturnType<typeof table>];
+
+	// every row has exactly 2 cells (header count): short row padded, long row truncated
+	expect(node.value.rows.map((row) => row.value.length)).toEqual([2, 2]);
+	expect(node.value.rows[0].value[1].value).toEqual([]); // padded empty cell
+	expect(node.value.rows[1].value.map((c) => c.value)).toEqual([[plain('1')], [plain('2')]]); // extra 3rd cell dropped
+});
+
 test('exposes the source offsets as fallback for renderers without table support', () => {
 	const input = '| a | b |\n| - | - |\n| 1 | 2 |';
 	const [node] = parse(input) as [ReturnType<typeof table>];

--- a/packages/message-parser/tests/table.test.ts
+++ b/packages/message-parser/tests/table.test.ts
@@ -1,8 +1,8 @@
 import { parse } from '../src';
 import { bold, link, plain, table, tableCell, tableRow } from './helpers';
 
-// `fallback` always equals the exact source the table was parsed from, so each
-// case provides [input, header, rows] and the expected node is built with input.
+// `fallback` is the [start, end] offset span of the table in the source; since
+// each input is exactly the table, that span is [0, input.length].
 test.each([
 	// basic table, no alignment
 	[
@@ -65,13 +65,15 @@ test.each([
 		[tableRow([tableCell([plain('x | y')]), tableCell([plain('z')])])],
 	],
 ])('parses %p', (input, header, rows) => {
-	expect(parse(input)).toEqual([table(header, rows, input)]);
+	expect(parse(input)).toEqual([table(header, rows, [0, input.length])]);
 });
 
-test('exposes the raw source as fallback for renderers without table support', () => {
+test('exposes the source offsets as fallback for renderers without table support', () => {
 	const input = '| a | b |\n| - | - |\n| 1 | 2 |';
 	const [node] = parse(input) as [ReturnType<typeof table>];
-	expect(node.fallback).toEqual(plain(input));
+	expect(node.fallback).toEqual([0, input.length]);
+	// the offsets slice back to the original markup
+	expect(input.slice(node.fallback![0], node.fallback![1])).toBe(input);
 });
 
 test.each([

--- a/packages/message-parser/tests/table.test.ts
+++ b/packages/message-parser/tests/table.test.ts
@@ -1,6 +1,8 @@
 import { parse } from '../src';
 import { bold, link, plain, table, tableCell, tableRow } from './helpers';
 
+// `fallback` always equals the exact source the table was parsed from, so each
+// case provides [input, header, rows] and the expected node is built with input.
 test.each([
 	// basic table, no alignment
 	[
@@ -9,12 +11,8 @@ test.each([
 | -------- | -------- |
 | Cell 1   | Cell 2   |
 `.trim(),
-		[
-			table(
-				[tableCell([plain('Header 1')]), tableCell([plain('Header 2')])],
-				[tableRow([tableCell([plain('Cell 1')]), tableCell([plain('Cell 2')])])],
-			),
-		],
+		[tableCell([plain('Header 1')]), tableCell([plain('Header 2')])],
+		[tableRow([tableCell([plain('Cell 1')]), tableCell([plain('Cell 2')])])],
 	],
 	// alignment markers
 	[
@@ -23,12 +21,8 @@ test.each([
 | :--- | :----: | ----: |
 | a    | b      | c     |
 `.trim(),
-		[
-			table(
-				[tableCell([plain('Left')], 'left'), tableCell([plain('Center')], 'center'), tableCell([plain('Right')], 'right')],
-				[tableRow([tableCell([plain('a')], 'left'), tableCell([plain('b')], 'center'), tableCell([plain('c')], 'right')])],
-			),
-		],
+		[tableCell([plain('Left')], 'left'), tableCell([plain('Center')], 'center'), tableCell([plain('Right')], 'right')],
+		[tableRow([tableCell([plain('a')], 'left'), tableCell([plain('b')], 'center'), tableCell([plain('c')], 'right')])],
 	],
 	// multiple body rows
 	[
@@ -38,7 +32,8 @@ test.each([
 | 1 |
 | 2 |
 `.trim(),
-		[table([tableCell([plain('h')])], [tableRow([tableCell([plain('1')])]), tableRow([tableCell([plain('2')])])])],
+		[tableCell([plain('h')])],
+		[tableRow([tableCell([plain('1')])]), tableRow([tableCell([plain('2')])])],
 	],
 	// header only (no body rows)
 	[
@@ -46,7 +41,8 @@ test.each([
 | a | b |
 | - | - |
 `.trim(),
-		[table([tableCell([plain('a')]), tableCell([plain('b')])], [])],
+		[tableCell([plain('a')]), tableCell([plain('b')])],
+		[],
 	],
 	// inline markup inside cells
 	[
@@ -55,12 +51,8 @@ test.each([
 | ---- | ---- |
 | **bold** | [rc](https://rocket.chat) |
 `.trim(),
-		[
-			table(
-				[tableCell([plain('Name')]), tableCell([plain('Link')])],
-				[tableRow([tableCell([bold([plain('bold')])]), tableCell([link('https://rocket.chat', [plain('rc')])])])],
-			),
-		],
+		[tableCell([plain('Name')]), tableCell([plain('Link')])],
+		[tableRow([tableCell([bold([plain('bold')])]), tableCell([link('https://rocket.chat', [plain('rc')])])])],
 	],
 	// escaped pipe inside a cell stays literal
 	[
@@ -69,10 +61,17 @@ test.each([
 | - | - |
 | x \\| y | z |
 `.trim(),
-		[table([tableCell([plain('a')]), tableCell([plain('b')])], [tableRow([tableCell([plain('x | y')]), tableCell([plain('z')])])])],
+		[tableCell([plain('a')]), tableCell([plain('b')])],
+		[tableRow([tableCell([plain('x | y')]), tableCell([plain('z')])])],
 	],
-])('parses %p', (input, output) => {
-	expect(parse(input)).toEqual(output);
+])('parses %p', (input, header, rows) => {
+	expect(parse(input)).toEqual([table(header, rows, input)]);
+});
+
+test('exposes the raw source as fallback for renderers without table support', () => {
+	const input = '| a | b |\n| - | - |\n| 1 | 2 |';
+	const [node] = parse(input) as [ReturnType<typeof table>];
+	expect(node.fallback).toEqual(plain(input));
 });
 
 test.each([

--- a/packages/message-parser/tests/table.test.ts
+++ b/packages/message-parser/tests/table.test.ts
@@ -1,0 +1,94 @@
+import { parse } from '../src';
+import { bold, link, plain, table, tableCell, tableRow } from './helpers';
+
+test.each([
+	// basic table, no alignment
+	[
+		`
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+`.trim(),
+		[
+			table(
+				[tableCell([plain('Header 1')]), tableCell([plain('Header 2')])],
+				[tableRow([tableCell([plain('Cell 1')]), tableCell([plain('Cell 2')])])],
+			),
+		],
+	],
+	// alignment markers
+	[
+		`
+| Left | Center | Right |
+| :--- | :----: | ----: |
+| a    | b      | c     |
+`.trim(),
+		[
+			table(
+				[tableCell([plain('Left')], 'left'), tableCell([plain('Center')], 'center'), tableCell([plain('Right')], 'right')],
+				[tableRow([tableCell([plain('a')], 'left'), tableCell([plain('b')], 'center'), tableCell([plain('c')], 'right')])],
+			),
+		],
+	],
+	// multiple body rows
+	[
+		`
+| h |
+| - |
+| 1 |
+| 2 |
+`.trim(),
+		[table([tableCell([plain('h')])], [tableRow([tableCell([plain('1')])]), tableRow([tableCell([plain('2')])])])],
+	],
+	// header only (no body rows)
+	[
+		`
+| a | b |
+| - | - |
+`.trim(),
+		[table([tableCell([plain('a')]), tableCell([plain('b')])], [])],
+	],
+	// inline markup inside cells
+	[
+		`
+| Name | Link |
+| ---- | ---- |
+| **bold** | [rc](https://rocket.chat) |
+`.trim(),
+		[
+			table(
+				[tableCell([plain('Name')]), tableCell([plain('Link')])],
+				[tableRow([tableCell([bold([plain('bold')])]), tableCell([link('https://rocket.chat', [plain('rc')])])])],
+			),
+		],
+	],
+	// escaped pipe inside a cell stays literal
+	[
+		`
+| a | b |
+| - | - |
+| x \\| y | z |
+`.trim(),
+		[table([tableCell([plain('a')]), tableCell([plain('b')])], [tableRow([tableCell([plain('x | y')]), tableCell([plain('z')])])])],
+	],
+])('parses %p', (input, output) => {
+	expect(parse(input)).toEqual(output);
+});
+
+test.each([
+	// no delimiter row -> not a table, plain paragraph
+	['| just | text |', [{ type: 'PARAGRAPH', value: [plain('| just | text |')] }]],
+	// missing trailing pipe -> not a table (v1 requires surrounding pipes)
+	[
+		`
+| a | b
+| - | -
+`.trim(),
+		[
+			{ type: 'PARAGRAPH', value: [plain('| a | b')] },
+			{ type: 'PARAGRAPH', value: [plain('| - | -')] },
+		],
+	],
+])('does not parse %p as table', (input, output) => {
+	expect(parse(input)).toEqual(output);
+});

--- a/packages/message-parser/tests/table.test.ts
+++ b/packages/message-parser/tests/table.test.ts
@@ -1,3 +1,4 @@
+import type { Table } from '../src';
 import { parse } from '../src';
 import { bold, link, plain, table, tableCell, tableRow } from './helpers';
 
@@ -70,12 +71,12 @@ test.each([
 
 test('normalizes ragged body rows to the header column count', () => {
 	const input = ['| a | b |', '| - | - |', '| 1 |', '| 1 | 2 | 3 |'].join('\n');
-	const [node] = parse(input) as [ReturnType<typeof table>];
+	const [node] = parse(input) as [Table];
 
 	// every row has exactly 2 cells (header count): short row padded, long row truncated
 	expect(node.value.rows.map((row) => row.value.length)).toEqual([2, 2]);
 	expect(node.value.rows[0].value[1].value).toEqual([]); // padded empty cell
-	expect(node.value.rows[1].value.map((c) => c.value)).toEqual([[plain('1')], [plain('2')]]); // extra 3rd cell dropped
+	expect(node.value.rows[1].value.map((cell) => cell.value)).toEqual([[plain('1')], [plain('2')]]); // extra 3rd cell dropped
 });
 
 test('exposes the source offsets as fallback for renderers without table support', () => {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Adds GFM-style table support across the message parser and the renderer.

### Parser (`@rocket.chat/message-parser`)

The parser now recognizes tables and emits new `TABLE`, `TABLE_ROW`, and `TABLE_CELL` AST nodes:

```
| Header 1 | Header 2 |
| -------- | :------: |
| Cell 1   | Cell 2   |
```

Behavior:
- Column alignment is read from the delimiter row: `:---` (left), `:--:` (center), `---:` (right), `---` (none).
- Inline markup (bold, italic, links, emoji, …) is supported inside cells.
- A leading and trailing pipe is required on every row; rows without surrounding pipes fall back to a paragraph.
- A literal pipe inside a cell must be escaped as `\|`.

AST shape:

```ts
{ type: 'TABLE', value: { header: TableCell[], rows: TableRow[] } }
{ type: 'TABLE_ROW', value: TableCell[] }
{ type: 'TABLE_CELL', align: 'left' | 'center' | 'right' | undefined, value: Inlines[] }
```

### Renderer (`@rocket.chat/gazzodown`)

- Renders the new table nodes using Fuselage's `Table` / `TableHead` / `TableBody` / `TableRow` / `TableCell` components.
- Cell alignment is translated to Fuselage's `start` / `center` / `end`.
- Tables are rendered striped.
- Message previews show a compact single-row rendering of the table header.
- Added a `Table` story (and a table block in the `Example` story) to `Markup.stories.tsx`.

<img width="469" height="494" alt="image" src="https://github.com/user-attachments/assets/366b566d-abed-4a61-918e-6313f0ab4094" />


## Steps to test or reproduce

Parser:

1. `cd packages/message-parser`
2. `yarn jest tests/table.test.ts`

Renderer (visual):

1. `yarn turbo run build --filter=@rocket.chat/gazzodown`
2. `yarn workspace @rocket.chat/gazzodown storybook`
3. Open the `Markup` stories → `Table` / `Example`.

Or paste in a message:

```
| Name | Status | Score |
| :--- | :----: | ----: |
| Alice | **done** | 9.5 |
| Bob | :smile: | 7 |
```

## Further comments

Tables require surrounding pipes in this first iteration to keep the grammar unambiguous against the existing inline `|` (spoiler) syntax.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2196]

[ARCH-2196]: https://rocketchat.atlassian.net/browse/ARCH-2196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GFM-style Markdown table support in the message parser, including per-column alignment, inline formatting within cells, and escaped literal pipes.
  * Tables now render in the message view (including compact header previews), with a new Table rendering component.
  * Added Storybook examples demonstrating table rendering.
* **Bug Fixes**
  * Improved detection of valid table syntax; malformed or incomplete table-like input no longer breaks table rendering and stays as regular content.
* **Documentation**
  * Documented table markup rules in the message-parser README.
* **Tests**
  * Added Jest coverage for table parsing, normalization, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->