### PR TITLE
chore(ui-voip): Derive "fullscreen" state from document and make it reactive

### DIFF
--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -2589,6 +2589,8 @@
   "Full_Name": "Full Name",
   "Full_log": "Full log",
   "Full_Screen": "Full Screen",
+  "Fullscreen": "Fullscreen",
+  "Fullscreen_failed_to_switch_not_allowed": "Switching to fullscreen was not allowed, please check your browser settings.",
   "Fully_integrated_voip_receive_internal_external_calls_without_switching_between_apps_external_systems": "Fully-integrated Rocket.Chat VoIP allows your team to make and receive internal and external calls without switching between apps or external systems.",
   "Gaming": "Gaming",
   "General": "General",

--- a/packages/ui-voip/src/views/MediaCallPopoutView.tsx
+++ b/packages/ui-voip/src/views/MediaCallPopoutView.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import { ToggleButton, Timer, DevicePicker, ActionButton, useShouldWrapCards, ActionStrip } from '../components';
 import MediaCallCardList from './MediaCallCardList';
+import { useFullscreenToggle } from './useFullscreenToggle';
 import { useMediaCallView } from '../context/MediaCallViewContext';
 
 export type MediaCallPopoutViewProps = {
@@ -13,12 +14,12 @@ export type MediaCallPopoutViewProps = {
 		avatarUrl: string;
 	};
 	onClickClosePopout: () => void;
-	onClickFullscreen: () => void;
-	fullscreen: boolean;
 };
 
-const MediaCallPopoutView = ({ user, onClickClosePopout, onClickFullscreen, fullscreen }: MediaCallPopoutViewProps) => {
+const MediaCallPopoutView = ({ user, onClickClosePopout }: MediaCallPopoutViewProps) => {
 	const { t } = useTranslation();
+
+	const { fullscreen, enabled: fullscreenEnabled, toggleFullscreen: onClickFullscreen } = useFullscreenToggle();
 
 	const {
 		sessionState,
@@ -66,14 +67,16 @@ const MediaCallPopoutView = ({ user, onClickClosePopout, onClickFullscreen, full
 				rightSlot={
 					<ButtonGroup>
 						<ActionButton label={t('Return_to_main_window')} icon='arrow-from-cross-box' onClick={onClickClosePopout} />
-						<ToggleButton
-							label={t('Fullscreen')}
-							titles={[t('Fullscreen'), t('Exit_fullscreen')]}
-							icons={['arrow-expand', 'arrow-collapse']}
-							pressed={fullscreen}
-							onToggle={onClickFullscreen}
-							danger={false}
-						/>
+						{fullscreenEnabled && (
+							<ToggleButton
+								label={t('Fullscreen')}
+								titles={[t('Fullscreen'), t('Exit_fullscreen')]}
+								icons={['arrow-expand', 'arrow-collapse']}
+								pressed={fullscreen}
+								onToggle={onClickFullscreen}
+								danger={false}
+							/>
+						)}
 						<DevicePicker secondary />
 					</ButtonGroup>
 				}

--- a/packages/ui-voip/src/views/MediaCallPopoutWindow.tsx
+++ b/packages/ui-voip/src/views/MediaCallPopoutWindow.tsx
@@ -2,7 +2,7 @@ import { Box, OwnerDocument as FuselageOwnerDocument } from '@rocket.chat/fusela
 import { OwnerDocument as StyledOwnerDocument } from '@rocket.chat/styled';
 import { ModalProvider, ModalRegion, TooltipProvider, useUserDisplayName } from '@rocket.chat/ui-client';
 import { useUser, useUserAvatarPath } from '@rocket.chat/ui-contexts';
-import { useCallback, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import MediaCallPopoutView from './MediaCallPopoutView';
@@ -14,7 +14,6 @@ export type MediaCallPopoutWindowProps = {
 	onClosePopout: () => void;
 };
 const MediaCallPopoutWindow = ({ container, onClosePopout }: MediaCallPopoutWindowProps) => {
-	const [fullscreen, setFullscreen] = useState(false);
 	const [region] = useState(() => Symbol());
 
 	const user = useUser();
@@ -29,23 +28,6 @@ const MediaCallPopoutWindow = ({ container, onClosePopout }: MediaCallPopoutWind
 
 	const { root, ownerDocument } = container;
 
-	const onClickFullscreen = useCallback(() => {
-		const requestFullScreen = async () => {
-			try {
-				if (!fullscreen) {
-					await ownerDocument.documentElement.requestFullscreen();
-					setFullscreen(true);
-				} else {
-					await ownerDocument.exitFullscreen();
-					setFullscreen(false);
-				}
-			} catch (error) {
-				console.error('Error requesting fullscreen', error);
-			}
-		};
-		void requestFullScreen();
-	}, [ownerDocument, fullscreen]);
-
 	const contextValue = useMemo(() => ({ document: ownerDocument }), [ownerDocument]);
 
 	return (
@@ -56,12 +38,7 @@ const MediaCallPopoutWindow = ({ container, onClosePopout }: MediaCallPopoutWind
 						<TooltipProvider ownerDocument={ownerDocument}>
 							{createPortal(
 								<Box width='full' height='full' display='flex' flexDirection='column' justifyContent='space-between'>
-									<MediaCallPopoutView
-										user={ownUser}
-										onClickClosePopout={onClosePopout}
-										onClickFullscreen={onClickFullscreen}
-										fullscreen={fullscreen}
-									/>
+									<MediaCallPopoutView user={ownUser} onClickClosePopout={onClosePopout} />
 									<ModalRegion />
 								</Box>,
 								root,

--- a/packages/ui-voip/src/views/useFullscreenToggle.spec.tsx
+++ b/packages/ui-voip/src/views/useFullscreenToggle.spec.tsx
@@ -1,0 +1,161 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { useFullscreenToggle } from './useFullscreenToggle';
+
+const dispatchToastMessage = jest.fn();
+
+const createWrapper = () =>
+	mockAppRoot()
+		.withTranslations('en', 'core', {
+			Fullscreen_failed_to_switch_not_allowed: 'Switching to fullscreen was not allowed, please check your browser settings.',
+		})
+		.withToastMessageDispatch(dispatchToastMessage)
+		.build();
+
+const setFullscreenElement = (element: Element | null) => {
+	Object.defineProperty(document, 'fullscreenElement', { value: element, writable: true, configurable: true });
+};
+
+const setFullscreenEnabled = (enabled: boolean) => {
+	Object.defineProperty(document, 'fullscreenEnabled', { value: enabled, writable: true, configurable: true });
+};
+
+describe('useFullscreenToggle', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		setFullscreenElement(null);
+		setFullscreenEnabled(true);
+		Object.defineProperty(document, 'exitFullscreen', {
+			value: jest.fn().mockResolvedValue(undefined),
+			writable: true,
+			configurable: true,
+		});
+		Object.defineProperty(document.documentElement, 'requestFullscreen', {
+			value: jest.fn().mockResolvedValue(undefined),
+			writable: true,
+			configurable: true,
+		});
+	});
+
+	it('reflects the initial fullscreen and enabled state from the document', () => {
+		setFullscreenElement(document.body);
+		setFullscreenEnabled(true);
+
+		const { result } = renderHook(() => useFullscreenToggle(), { wrapper: createWrapper() });
+
+		expect(result.current.fullscreen).toBe(true);
+		expect(result.current.enabled).toBe(true);
+	});
+
+	it('reports fullscreen as false when there is no fullscreen element', () => {
+		setFullscreenElement(null);
+
+		const { result } = renderHook(() => useFullscreenToggle(), { wrapper: createWrapper() });
+
+		expect(result.current.fullscreen).toBe(false);
+	});
+
+	it('reports enabled as false when the document does not support fullscreen', () => {
+		setFullscreenEnabled(false);
+
+		const { result } = renderHook(() => useFullscreenToggle(), { wrapper: createWrapper() });
+
+		expect(result.current.enabled).toBe(false);
+	});
+
+	it('updates state when a fullscreenchange event is dispatched', () => {
+		const { result } = renderHook(() => useFullscreenToggle(), { wrapper: createWrapper() });
+
+		expect(result.current.fullscreen).toBe(false);
+
+		act(() => {
+			setFullscreenElement(document.body);
+			document.dispatchEvent(new Event('fullscreenchange'));
+		});
+
+		expect(result.current.fullscreen).toBe(true);
+
+		act(() => {
+			setFullscreenElement(null);
+			document.dispatchEvent(new Event('fullscreenchange'));
+		});
+
+		expect(result.current.fullscreen).toBe(false);
+	});
+
+	it('requests fullscreen on documentElement when not currently fullscreen', async () => {
+		setFullscreenElement(null);
+
+		const { result } = renderHook(() => useFullscreenToggle(), { wrapper: createWrapper() });
+
+		await act(async () => {
+			await result.current.toggleFullscreen();
+		});
+
+		expect(document.documentElement.requestFullscreen).toHaveBeenCalledTimes(1);
+		expect(document.exitFullscreen).not.toHaveBeenCalled();
+	});
+
+	it('exits fullscreen when currently fullscreen', async () => {
+		setFullscreenElement(document.body);
+
+		const { result } = renderHook(() => useFullscreenToggle(), { wrapper: createWrapper() });
+
+		await waitFor(() => expect(result.current.fullscreen).toBe(true));
+
+		await act(async () => {
+			await result.current.toggleFullscreen();
+		});
+
+		expect(document.exitFullscreen).toHaveBeenCalledTimes(1);
+		expect(document.documentElement.requestFullscreen).not.toHaveBeenCalled();
+	});
+
+	it('does nothing when fullscreen is not enabled', async () => {
+		setFullscreenEnabled(false);
+
+		const { result } = renderHook(() => useFullscreenToggle(), { wrapper: createWrapper() });
+
+		await act(async () => {
+			await result.current.toggleFullscreen();
+		});
+
+		expect(document.documentElement.requestFullscreen).not.toHaveBeenCalled();
+		expect(document.exitFullscreen).not.toHaveBeenCalled();
+	});
+
+	it('dispatches an error toast when requestFullscreen rejects', async () => {
+		setFullscreenElement(null);
+		(document.documentElement.requestFullscreen as jest.Mock).mockRejectedValueOnce(new Error('not allowed'));
+
+		const { result } = renderHook(() => useFullscreenToggle(), { wrapper: createWrapper() });
+
+		await act(async () => {
+			await result.current.toggleFullscreen();
+		});
+
+		expect(dispatchToastMessage).toHaveBeenCalledWith({
+			type: 'error',
+			message: 'Switching to fullscreen was not allowed, please check your browser settings.',
+		});
+	});
+
+	it('dispatches an error toast when exitFullscreen rejects', async () => {
+		setFullscreenElement(document.body);
+		(document.exitFullscreen as jest.Mock).mockRejectedValueOnce(new Error('not allowed'));
+
+		const { result } = renderHook(() => useFullscreenToggle(), { wrapper: createWrapper() });
+
+		await waitFor(() => expect(result.current.fullscreen).toBe(true));
+
+		await act(async () => {
+			await result.current.toggleFullscreen();
+		});
+
+		expect(dispatchToastMessage).toHaveBeenCalledWith({
+			type: 'error',
+			message: 'Switching to fullscreen was not allowed, please check your browser settings.',
+		});
+	});
+});

--- a/packages/ui-voip/src/views/useFullscreenToggle.ts
+++ b/packages/ui-voip/src/views/useFullscreenToggle.ts
@@ -1,43 +1,11 @@
 import { useOwnerDocument } from '@rocket.chat/fuselage';
 import { useToastMessageDispatch } from '@rocket.chat/ui-contexts';
-import { useCallback, useMemo, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 type FSResult = {
 	fullscreen: boolean;
 	enabled: boolean;
-};
-
-/**
- * @description
- * Creates subscribe/getSnapshot for use within useSyncExternalStore
- * Tracks if any elements in the passed document are in fullscreen state by listening to `fullscreenchange` event
- */
-const makeFullscreenSubscription = (ownerDocument: Document) => {
-	let result: FSResult = { fullscreen: Boolean(ownerDocument.fullscreenElement), enabled: ownerDocument.fullscreenEnabled };
-
-	const getSnapshot = () => {
-		const fullscreen = Boolean(ownerDocument.fullscreenElement);
-		const enabled = ownerDocument.fullscreenEnabled;
-
-		if (result.fullscreen !== fullscreen || result.enabled !== enabled) {
-			result = { fullscreen, enabled };
-		}
-		return result;
-	};
-
-	const subscribe = (onStoreChange: () => void) => {
-		const onChange = () => {
-			onStoreChange();
-		};
-
-		ownerDocument.addEventListener('fullscreenchange', onChange);
-		return () => {
-			ownerDocument.removeEventListener('fullscreenchange', onChange);
-		};
-	};
-
-	return { subscribe, getSnapshot };
 };
 
 type FullScreenToggleReturn = {
@@ -57,9 +25,24 @@ type FullScreenToggleReturn = {
 export const useFullscreenToggle = (): FullScreenToggleReturn => {
 	const { t } = useTranslation();
 	const { document: ownerDocument } = useOwnerDocument();
-	const { subscribe, getSnapshot } = useMemo(() => makeFullscreenSubscription(ownerDocument), [ownerDocument]);
-	const { fullscreen, enabled } = useSyncExternalStore(subscribe, getSnapshot);
+	const [{ fullscreen, enabled }, setState] = useState<FSResult>(() => ({
+		fullscreen: Boolean(ownerDocument.fullscreenElement),
+		enabled: ownerDocument.fullscreenEnabled,
+	}));
 	const dispatchToastMessage = useToastMessageDispatch();
+
+	useEffect(() => {
+		const onChange = () => {
+			setState({ fullscreen: Boolean(ownerDocument.fullscreenElement), enabled: ownerDocument.fullscreenEnabled });
+		};
+
+		onChange();
+
+		ownerDocument.addEventListener('fullscreenchange', onChange);
+		return () => {
+			ownerDocument.removeEventListener('fullscreenchange', onChange);
+		};
+	}, [ownerDocument]);
 
 	const toggleFullscreen = useCallback(async () => {
 		if (!enabled) {

--- a/packages/ui-voip/src/views/useFullscreenToggle.ts
+++ b/packages/ui-voip/src/views/useFullscreenToggle.ts
@@ -64,9 +64,9 @@ export const useFullscreenToggle = (): FullScreenToggleReturn => {
 		}
 
 		if (fullscreen) {
-			await ownerDocument.documentElement.requestFullscreen();
-		} else {
 			await ownerDocument.exitFullscreen();
+		} else {
+			await ownerDocument.documentElement.requestFullscreen();
 		}
 	}, [ownerDocument, fullscreen, enabled]);
 

--- a/packages/ui-voip/src/views/useFullscreenToggle.ts
+++ b/packages/ui-voip/src/views/useFullscreenToggle.ts
@@ -1,5 +1,7 @@
 import { useOwnerDocument } from '@rocket.chat/fuselage';
+import { useToastMessageDispatch } from '@rocket.chat/ui-contexts';
 import { useCallback, useMemo, useSyncExternalStore } from 'react';
+import { useTranslation } from 'react-i18next';
 
 type FSResult = {
 	fullscreen: boolean;
@@ -25,9 +27,8 @@ const makeFullscreenSubscription = (ownerDocument: Document) => {
 	};
 
 	const subscribe = (onStoreChange: () => void) => {
-		const onChange = (e: any) => {
+		const onChange = () => {
 			onStoreChange();
-			console.log(e);
 		};
 
 		ownerDocument.addEventListener('fullscreenchange', onChange);
@@ -54,21 +55,27 @@ type FullScreenToggleReturn = {
  *  - Caveat: Triggering fullscreen through `F11` or Platform specific window controls is not identifiable. Also, `exitFullscreen` cannot revert this action, so the states returned by this hook might not accurately depict the current window state.
  */
 export const useFullscreenToggle = (): FullScreenToggleReturn => {
+	const { t } = useTranslation();
 	const { document: ownerDocument } = useOwnerDocument();
 	const { subscribe, getSnapshot } = useMemo(() => makeFullscreenSubscription(ownerDocument), [ownerDocument]);
 	const { fullscreen, enabled } = useSyncExternalStore(subscribe, getSnapshot);
+	const dispatchToastMessage = useToastMessageDispatch();
 
 	const toggleFullscreen = useCallback(async () => {
 		if (!enabled) {
 			return;
 		}
 
-		if (fullscreen) {
-			await ownerDocument.exitFullscreen();
-		} else {
-			await ownerDocument.documentElement.requestFullscreen();
+		try {
+			if (fullscreen) {
+				await ownerDocument.exitFullscreen();
+			} else {
+				await ownerDocument.documentElement.requestFullscreen();
+			}
+		} catch (error) {
+			dispatchToastMessage({ type: 'error', message: t('Fullscreen_failed_to_switch_not_allowed') });
 		}
-	}, [ownerDocument, fullscreen, enabled]);
+	}, [ownerDocument, fullscreen, enabled, dispatchToastMessage, t]);
 
 	return {
 		fullscreen,

--- a/packages/ui-voip/src/views/useFullscreenToggle.ts
+++ b/packages/ui-voip/src/views/useFullscreenToggle.ts
@@ -1,0 +1,78 @@
+import { useOwnerDocument } from '@rocket.chat/fuselage';
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+
+type FSResult = {
+	fullscreen: boolean;
+	enabled: boolean;
+};
+
+/**
+ * @description
+ * Creates subscribe/getSnapshot for use within useSyncExternalStore
+ * Tracks if any elements in the passed document are in fullscreen state by listening to `fullscreenchange` event
+ */
+const makeFullscreenSubscription = (ownerDocument: Document) => {
+	let result: FSResult = { fullscreen: Boolean(ownerDocument.fullscreenElement), enabled: ownerDocument.fullscreenEnabled };
+
+	const getSnapshot = () => {
+		const fullscreen = Boolean(ownerDocument.fullscreenElement);
+		const enabled = ownerDocument.fullscreenEnabled;
+
+		if (result.fullscreen !== fullscreen || result.enabled !== enabled) {
+			result = { fullscreen, enabled };
+		}
+		return result;
+	};
+
+	const subscribe = (onStoreChange: () => void) => {
+		const onChange = (e: any) => {
+			onStoreChange();
+			console.log(e);
+		};
+
+		ownerDocument.addEventListener('fullscreenchange', onChange);
+		return () => {
+			ownerDocument.removeEventListener('fullscreenchange', onChange);
+		};
+	};
+
+	return { subscribe, getSnapshot };
+};
+
+type FullScreenToggleReturn = {
+	/** wether any element in the current document (uses OwnerDocument from fuselage) is in fullscreen state */
+	fullscreen: boolean;
+	/** wether requestFullscreen is supported*/
+	enabled: boolean;
+	/** Calls documentElement.requestFullscreen, or document.exitFullscreen if {fullscreen} is false */
+	toggleFullscreen: () => Promise<void>;
+};
+
+/**
+ * @description Hook to transition and track full screen transitioning
+ * 	- Uses {useOwnerDocument} from fuselage, take into consideration wrapped `OwnerDocument` contexts when using to ensure correct behaviour.
+ *  - Caveat: Triggering fullscreen through `F11` or Platform specific window controls is not identifiable. Also, `exitFullscreen` cannot revert this action, so the states returned by this hook might not accurately depict the current window state.
+ */
+export const useFullscreenToggle = (): FullScreenToggleReturn => {
+	const { document: ownerDocument } = useOwnerDocument();
+	const { subscribe, getSnapshot } = useMemo(() => makeFullscreenSubscription(ownerDocument), [ownerDocument]);
+	const { fullscreen, enabled } = useSyncExternalStore(subscribe, getSnapshot);
+
+	const toggleFullscreen = useCallback(async () => {
+		if (!enabled) {
+			return;
+		}
+
+		if (fullscreen) {
+			await ownerDocument.documentElement.requestFullscreen();
+		} else {
+			await ownerDocument.exitFullscreen();
+		}
+	}, [ownerDocument, fullscreen, enabled]);
+
+	return {
+		fullscreen,
+		enabled,
+		toggleFullscreen,
+	};
+};

--- a/packages/ui-voip/src/views/useFullscreenToggle.ts
+++ b/packages/ui-voip/src/views/useFullscreenToggle.ts
@@ -4,20 +4,18 @@ import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 type FSResult = {
-	fullscreen: boolean;
-	enabled: boolean;
-};
-
-type FullScreenToggleReturn = {
 	/** wether any element in the current document (uses OwnerDocument from fuselage) is in fullscreen state */
 	fullscreen: boolean;
 	/** wether requestFullscreen is supported*/
 	enabled: boolean;
+};
+
+type FullScreenToggleReturn = FSResult & {
 	/** Calls documentElement.requestFullscreen, or document.exitFullscreen if {fullscreen} is false */
 	toggleFullscreen: () => Promise<void>;
 };
 
-const getFullscreenState = (ownerDocument: Document): { fullscreen: boolean; enabled: boolean } => {
+const getFullscreenState = (ownerDocument: Document): FSResult => {
 	return { fullscreen: Boolean(ownerDocument.fullscreenElement), enabled: ownerDocument.fullscreenEnabled };
 };
 
@@ -29,10 +27,7 @@ const getFullscreenState = (ownerDocument: Document): { fullscreen: boolean; ena
 export const useFullscreenToggle = (): FullScreenToggleReturn => {
 	const { t } = useTranslation();
 	const { document: ownerDocument } = useOwnerDocument();
-	const [{ fullscreen, enabled }, setState] = useState<FSResult>(() => ({
-		fullscreen: Boolean(ownerDocument.fullscreenElement),
-		enabled: ownerDocument.fullscreenEnabled,
-	}));
+	const [{ fullscreen, enabled }, setState] = useState<FSResult>(() => getFullscreenState(ownerDocument));
 	const dispatchToastMessage = useToastMessageDispatch();
 
 	useEffect(() => {

--- a/packages/ui-voip/src/views/useFullscreenToggle.ts
+++ b/packages/ui-voip/src/views/useFullscreenToggle.ts
@@ -17,6 +17,10 @@ type FullScreenToggleReturn = {
 	toggleFullscreen: () => Promise<void>;
 };
 
+const getFullscreenState = (ownerDocument: Document): { fullscreen: boolean; enabled: boolean } => {
+	return { fullscreen: Boolean(ownerDocument.fullscreenElement), enabled: ownerDocument.fullscreenEnabled };
+};
+
 /**
  * @description Hook to transition and track full screen transitioning
  * 	- Uses {useOwnerDocument} from fuselage, take into consideration wrapped `OwnerDocument` contexts when using to ensure correct behaviour.
@@ -33,10 +37,8 @@ export const useFullscreenToggle = (): FullScreenToggleReturn => {
 
 	useEffect(() => {
 		const onChange = () => {
-			setState({ fullscreen: Boolean(ownerDocument.fullscreenElement), enabled: ownerDocument.fullscreenEnabled });
+			setState(getFullscreenState(ownerDocument));
 		};
-
-		onChange();
 
 		ownerDocument.addEventListener('fullscreenchange', onChange);
 		return () => {
@@ -45,6 +47,7 @@ export const useFullscreenToggle = (): FullScreenToggleReturn => {
 	}, [ownerDocument]);
 
 	const toggleFullscreen = useCallback(async () => {
+		const { fullscreen, enabled } = getFullscreenState(ownerDocument);
 		if (!enabled) {
 			return;
 		}
@@ -58,7 +61,7 @@ export const useFullscreenToggle = (): FullScreenToggleReturn => {
 		} catch (error) {
 			dispatchToastMessage({ type: 'error', message: t('Fullscreen_failed_to_switch_not_allowed') });
 		}
-	}, [ownerDocument, fullscreen, enabled, dispatchToastMessage, t]);
+	}, [ownerDocument, dispatchToastMessage, t]);
 
 	return {
 		fullscreen,


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Use document event "fullscreenchange" to track wether the page is already in fullscreen state. Also hides the button if the feature is not suported by that browser.

This was an attempt to fix an issue where changing the popup to fullscreen by using the system controls (e.g `f11` or clicking on the window controls) would not properly change the state of the button. The issue was not fixed due to limitation on the browser's Fullscreen API.

This PR although improves the current fullscreen logic substantially, does not change any behaviour, so no changeset is needed.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [SSGA-21]

[SSGA-21]: https://rocketchat.atlassian.net/browse/SSGA-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fullscreen controls to media call popouts.
  * Fullscreen availability is detected automatically, with support for entering and exiting fullscreen.
  * Added localized fullscreen labels and an error message when browser settings prevent fullscreen mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->