### PR TITLE
chore(ui-voip): Improve default popup text

### DIFF
--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -1138,6 +1138,7 @@
   "Call_unavailable_for_federation": "Call is unavailable for Federated rooms",
   "Call_was_not_answered": "Call was not answered",
   "Call_without_mic": "Call without mic",
+  "Call_window": "Call window",
   "Caller": "Caller",
   "Caller_Id": "Caller ID",
   "Calling": "Calling",

--- a/packages/ui-voip/src/generate-landing-view.tsx
+++ b/packages/ui-voip/src/generate-landing-view.tsx
@@ -99,8 +99,8 @@ function LandingView() {
 	return (
 		<div style={containerStyle}>
 			<States>
-				<StatesIcon name='phone-off' />
-				<StatesTitle data-i18n='Call_ended'>Call ended</StatesTitle>
+				<StatesIcon name='phone' />
+				<StatesTitle data-i18n='Call_window'>Call window</StatesTitle>
 				<StatesSubtitle data-i18n='You_can_close_this_window'>You can close this window.</StatesSubtitle>
 			</States>
 		</div>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
This html page is meant to be present when the components unmount but the window is not closed. The current text says "Call ended", but that could not be true, as there are other cases that could leave this window hanging, even though the call has not ended.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [SSGA-22]

[SSGA-22]: https://rocketchat.atlassian.net/browse/SSGA-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the call landing screen with a “Call window” label and matching phone icon.
  * Added English localization for the new call window text.
  * Preserved the existing layout and supporting subtitle for a consistent call experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->