### PR TITLE
test: refactor team management permissions

### DIFF
--- a/apps/meteor/tests/e2e/team-management.spec.ts
+++ b/apps/meteor/tests/e2e/team-management.spec.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker';
 import { Users } from './fixtures/userStates';
 import { HomeTeam } from './page-objects';
 import { CreateNewTeamModal, CreateNewChannelModal } from './page-objects/fragments/modals';
-import { createTargetChannel, deleteTeam, isChannelMember } from './utils';
+import { createTargetChannel, deleteTeam, isChannelMember, updatePermissions } from './utils';
 import { expect, test } from './utils/test';
 
 test.use({ storageState: Users.admin.state });
@@ -18,16 +18,14 @@ test.describe('teams-management-permissions', () => {
 	});
 
 	test.afterEach(async ({ api }) => {
-		await api.post('/permissions.update', {
-			permissions: [
-				{ _id: 'create-p', roles: ['admin', 'owner', 'moderator'] },
-				{ _id: 'create-c', roles: ['admin', 'owner', 'moderator'] },
-			],
-		});
+		await updatePermissions(api, [
+			{ _id: 'create-p', roles: ['admin', 'owner', 'moderator'] },
+			{ _id: 'create-c', roles: ['admin', 'owner', 'moderator'] },
+		]);
 	});
 
 	test('should not allow to create public team if user does not have the create-c permission', async ({ page, api }) => {
-		await expect(await api.post('/permissions.update', { permissions: [{ _id: 'create-c', roles: [] }] })).toBeOK();
+		await updatePermissions(api, [{ _id: 'create-c', roles: [] }]);
 		await page.goto('/home');
 		await poHomeTeam.waitForHome();
 
@@ -38,7 +36,7 @@ test.describe('teams-management-permissions', () => {
 	});
 
 	test('should not allow to create private team if user does not have the create-p permission', async ({ page, api }) => {
-		await expect(await api.post('/permissions.update', { permissions: [{ _id: 'create-p', roles: [] }] })).toBeOK();
+		await updatePermissions(api, [{ _id: 'create-p', roles: [] }]);
 		await page.goto('/home');
 		await poHomeTeam.waitForHome();
 
@@ -49,14 +47,10 @@ test.describe('teams-management-permissions', () => {
 	});
 
 	test('should not allow to create team if user does not have both create-p and create-c permissions', async ({ page, api }) => {
-		await expect(
-			await api.post('/permissions.update', {
-				permissions: [
-					{ _id: 'create-p', roles: [] },
-					{ _id: 'create-c', roles: [] },
-				],
-			}),
-		).toBeOK();
+		await updatePermissions(api, [
+			{ _id: 'create-p', roles: [] },
+			{ _id: 'create-c', roles: [] },
+		]);
 		await page.goto('/home');
 		await poHomeTeam.waitForHome();
 
@@ -83,17 +77,16 @@ test.describe.serial('teams-management', () => {
 	});
 
 	test.afterAll(async ({ api }) => {
-		await api.post('/permissions.update', {
-			permissions: [
-				{ _id: 'move-room-to-team', roles: ['admin', 'owner', 'moderator'] },
-				{ _id: 'create-team-channel', roles: ['admin', 'owner', 'moderator'] },
-				{ _id: 'create-team-group', roles: ['admin', 'owner', 'moderator'] },
-				{ _id: 'create-c', roles: ['admin', 'owner', 'moderator'] },
-				{ _id: 'create-p', roles: ['admin', 'owner', 'moderator'] },
-				{ _id: 'delete-team-channel', roles: ['admin', 'owner', 'moderator'] },
-				{ _id: 'delete-team-group', roles: ['admin', 'owner', 'moderator'] },
-			],
-		});
+		await updatePermissions(api, [
+			{ _id: 'move-room-to-team', roles: ['admin', 'owner', 'moderator'] },
+			{ _id: 'create-team-channel', roles: ['admin', 'owner', 'moderator'] },
+			{ _id: 'create-team-group', roles: ['admin', 'owner', 'moderator'] },
+			{ _id: 'create-c', roles: ['admin', 'owner', 'moderator'] },
+			{ _id: 'create-p', roles: ['admin', 'owner', 'moderator'] },
+			{ _id: 'remove-team-channel', roles: ['admin', 'owner', 'moderator'] },
+			{ _id: 'delete-team-channel', roles: ['admin', 'owner', 'moderator'] },
+			{ _id: 'delete-team-group', roles: ['admin', 'owner', 'moderator'] },
+		]);
 	});
 
 	test.beforeEach(async ({ page }) => {
@@ -157,98 +150,92 @@ test.describe.serial('teams-management', () => {
 		await expect(poHomeTeam.content.getSystemMessageByText('set room to read only')).toBeVisible();
 	});
 
-	test('should not allow moving room to team if move-room-to-team permission has not been granted', async ({ api }) => {
-		expect((await api.post('/permissions.update', { permissions: [{ _id: 'move-room-to-team', roles: ['moderator'] }] })).status()).toBe(
-			200,
-		);
+	test.describe('without move-room-to-team permission', () => {
+		test.beforeAll(async ({ api }) => {
+			await updatePermissions(api, [{ _id: 'move-room-to-team', roles: ['moderator'] }]);
+		});
 
-		await poHomeTeam.navbar.openChat(targetTeam);
-		await poHomeTeam.headerToolbar.openTeamChannels();
-		await expect(poHomeTeam.tabs.channels.btnAddExisting).not.toBeVisible();
+		test('should not allow moving room to team if move-room-to-team permission has not been granted', async () => {
+			await poHomeTeam.navbar.openChat(targetTeam);
+			await poHomeTeam.headerToolbar.openTeamChannels();
+			await expect(poHomeTeam.tabs.channels.btnAddExisting).not.toBeVisible();
+		});
 	});
 
-	test('should not allow creating a room in a team if both create-team-channel and create-team-group permissions have not been granted', async ({
-		api,
-	}) => {
-		expect(
-			(
-				await api.post('/permissions.update', {
-					permissions: [
-						{ _id: 'create-team-channel', roles: ['moderator'] },
-						{ _id: 'create-team-group', roles: ['moderator'] },
-					],
-				})
-			).status(),
-		).toBe(200);
+	test.describe('without create-team-channel and create-team-group permissions', () => {
+		test.beforeAll(async ({ api }) => {
+			await updatePermissions(api, [
+				{ _id: 'create-team-channel', roles: ['moderator'] },
+				{ _id: 'create-team-group', roles: ['moderator'] },
+			]);
+		});
 
-		await poHomeTeam.navbar.openChat(targetTeam);
-		await poHomeTeam.headerToolbar.openTeamChannels();
-		await expect(poHomeTeam.tabs.channels.btnCreateNew).not.toBeVisible();
+		test('should not allow creating a room in a team if both create-team-channel and create-team-group permissions have not been granted', async () => {
+			await poHomeTeam.navbar.openChat(targetTeam);
+			await poHomeTeam.headerToolbar.openTeamChannels();
+			await expect(poHomeTeam.tabs.channels.btnCreateNew).not.toBeVisible();
+		});
 	});
 
-	test('should allow creating a channel in a team if user has the create-team-channel permission, but not the create-team-group permission', async ({
-		api,
-	}) => {
-		expect(
-			(
-				await api.post('/permissions.update', {
-					permissions: [
-						{ _id: 'create-team-channel', roles: ['admin'] },
-						{ _id: 'create-team-group', roles: ['moderator'] },
-					],
-				})
-			).status(),
-		).toBe(200);
+	test.describe('with create-team-channel permission only', () => {
+		test.beforeAll(async ({ api }) => {
+			await updatePermissions(api, [
+				{ _id: 'create-team-channel', roles: ['admin'] },
+				{ _id: 'create-team-group', roles: ['moderator'] },
+			]);
+		});
 
-		await poHomeTeam.navbar.openChat(targetTeam);
-		await poHomeTeam.headerToolbar.openTeamChannels();
-		await expect(poHomeTeam.tabs.channels.btnCreateNew).toBeVisible();
-		await poHomeTeam.tabs.channels.btnCreateNew.click();
+		test('should allow creating a channel in a team if user has the create-team-channel permission, but not the create-team-group permission', async () => {
+			await poHomeTeam.navbar.openChat(targetTeam);
+			await poHomeTeam.headerToolbar.openTeamChannels();
+			await expect(poHomeTeam.tabs.channels.btnCreateNew).toBeVisible();
+			await poHomeTeam.tabs.channels.btnCreateNew.click();
 
-		await newChannelModal.inputName.fill(targetChannelNameInTeam);
-		await expect(newChannelModal.checkboxPrivate).not.toBeChecked();
-		await expect(newChannelModal.checkboxPrivate).toBeDisabled();
-		await newChannelModal.btnCreate.click();
+			await newChannelModal.inputName.fill(targetChannelNameInTeam);
+			await expect(newChannelModal.checkboxPrivate).not.toBeChecked();
+			await expect(newChannelModal.checkboxPrivate).toBeDisabled();
+			await newChannelModal.btnCreate.click();
 
-		await expect(poHomeTeam.tabs.channels.channelsList).toContainText(targetChannelNameInTeam);
+			await expect(poHomeTeam.tabs.channels.channelsList).toContainText(targetChannelNameInTeam);
+		});
 	});
 
-	test('should allow creating a group in a team if user has the create-team-group permission, but not the create-team-channel permission', async ({
-		api,
-	}) => {
-		expect(
-			(
-				await api.post('/permissions.update', {
-					permissions: [
-						{ _id: 'create-team-group', roles: ['admin'] },
-						{ _id: 'create-team-channel', roles: ['moderator'] },
-					],
-				})
-			).status(),
-		).toBe(200);
+	test.describe('with create-team-group permission only', () => {
+		test.beforeAll(async ({ api }) => {
+			await updatePermissions(api, [
+				{ _id: 'create-team-group', roles: ['admin'] },
+				{ _id: 'create-team-channel', roles: ['moderator'] },
+			]);
+		});
 
-		await poHomeTeam.navbar.openChat(targetTeam);
-		await poHomeTeam.headerToolbar.openTeamChannels();
-		await expect(poHomeTeam.tabs.channels.btnCreateNew).toBeVisible();
-		await poHomeTeam.tabs.channels.btnCreateNew.click();
+		test('should allow creating a group in a team if user has the create-team-group permission, but not the create-team-channel permission', async () => {
+			await poHomeTeam.navbar.openChat(targetTeam);
+			await poHomeTeam.headerToolbar.openTeamChannels();
+			await expect(poHomeTeam.tabs.channels.btnCreateNew).toBeVisible();
+			await poHomeTeam.tabs.channels.btnCreateNew.click();
 
-		await newChannelModal.inputName.fill(targetGroupNameInTeam);
-		const { checkboxPrivate } = newChannelModal;
-		await expect(checkboxPrivate).toBeChecked();
-		await expect(checkboxPrivate).toBeDisabled();
-		await newChannelModal.btnCreate.click();
+			await newChannelModal.inputName.fill(targetGroupNameInTeam);
+			const { checkboxPrivate } = newChannelModal;
+			await expect(checkboxPrivate).toBeChecked();
+			await expect(checkboxPrivate).toBeDisabled();
+			await newChannelModal.btnCreate.click();
 
-		await expect(poHomeTeam.tabs.channels.channelsList).toContainText(targetGroupNameInTeam);
+			await expect(poHomeTeam.tabs.channels.channelsList).toContainText(targetGroupNameInTeam);
+		});
 	});
 
-	test('should move targetChannel to targetTeam', async ({ api }) => {
-		expect((await api.post('/permissions.update', { permissions: [{ _id: 'move-room-to-team', roles: ['owner'] }] })).status()).toBe(200);
+	test.describe('with move-room-to-team permission', () => {
+		test.beforeAll(async ({ api }) => {
+			await updatePermissions(api, [{ _id: 'move-room-to-team', roles: ['owner'] }]);
+		});
 
-		await poHomeTeam.navbar.openChat(targetTeam);
-		await poHomeTeam.headerToolbar.openTeamChannels();
-		await poHomeTeam.tabs.channels.addExistingChannel(targetChannel);
+		test('should move targetChannel to targetTeam', async () => {
+			await poHomeTeam.navbar.openChat(targetTeam);
+			await poHomeTeam.headerToolbar.openTeamChannels();
+			await poHomeTeam.tabs.channels.addExistingChannel(targetChannel);
 
-		await expect(poHomeTeam.tabs.channels.channelsList).toContainText(targetChannel);
+			await expect(poHomeTeam.tabs.channels.channelsList).toContainText(targetChannel);
+		});
 	});
 
 	test('should access team channel through targetTeam header', async ({ page }) => {
@@ -260,158 +247,172 @@ test.describe.serial('teams-management', () => {
 		await expect(page).toHaveURL(`/group/${targetTeam}`);
 	});
 
-	test('should not allow removing a targetGroup from targetTeam if user does not have the remove-team-channel permission', async ({
-		page,
-		api,
-	}) => {
-		expect((await api.post('/permissions.update', { permissions: [{ _id: 'remove-team-channel', roles: ['moderator'] }] })).status()).toBe(
-			200,
-		);
+	test.describe('without remove-team-channel permission for groups', () => {
+		test.beforeAll(async ({ api }) => {
+			await updatePermissions(api, [{ _id: 'remove-team-channel', roles: ['moderator'] }]);
+		});
 
-		await poHomeTeam.navbar.openChat(targetTeam);
-		await poHomeTeam.headerToolbar.openTeamChannels();
-		await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetGroupNameInTeam);
-		await expect(page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Remove from team' })).not.toBeVisible();
+		test('should not allow removing a targetGroup from targetTeam if user does not have the remove-team-channel permission', async ({
+			page,
+		}) => {
+			await poHomeTeam.navbar.openChat(targetTeam);
+			await poHomeTeam.headerToolbar.openTeamChannels();
+			await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetGroupNameInTeam);
+			await expect(page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Remove from team' })).not.toBeVisible();
+		});
 	});
 
-	test('should allow removing a targetGroup from targetTeam if user has the remove-team-channel permission', async ({ page, api }) => {
-		expect((await api.post('/permissions.update', { permissions: [{ _id: 'remove-team-channel', roles: ['owner'] }] })).status()).toBe(200);
+	test.describe('with remove-team-channel permission for groups', () => {
+		test.beforeAll(async ({ api }) => {
+			await updatePermissions(api, [{ _id: 'remove-team-channel', roles: ['owner'] }]);
+		});
 
-		await poHomeTeam.navbar.openChat(targetTeam);
-		await poHomeTeam.headerToolbar.openTeamChannels();
-		await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetGroupNameInTeam);
-		await expect(page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Remove from team' })).toBeVisible();
-		await page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Remove from team' }).click();
-		await poHomeTeam.tabs.channels.confirmRemoveChannel();
+		test('should allow removing a targetGroup from targetTeam if user has the remove-team-channel permission', async ({ page }) => {
+			await poHomeTeam.navbar.openChat(targetTeam);
+			await poHomeTeam.headerToolbar.openTeamChannels();
+			await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetGroupNameInTeam);
+			await expect(page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Remove from team' })).toBeVisible();
+			await page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Remove from team' }).click();
+			await poHomeTeam.tabs.channels.confirmRemoveChannel();
 
-		await expect(poHomeTeam.tabs.channels.channelsList).not.toContainText(targetGroupNameInTeam);
+			await expect(poHomeTeam.tabs.channels.channelsList).not.toContainText(targetGroupNameInTeam);
+		});
 	});
 
-	test('should not allow deleting a targetGroup from targetTeam if the group owner does not have the delete-team-group permission', async ({
-		page,
-		api,
-	}) => {
-		expect(
-			(
-				await api.post('/permissions.update', {
-					permissions: [
-						{ _id: 'delete-team-group', roles: ['moderator'] },
-						{ _id: 'move-room-to-team', roles: ['owner'] },
-					],
-				})
-			).status(),
-		).toBe(200);
+	test.describe('without delete-team-group permission', () => {
+		test.beforeAll(async ({ api }) => {
+			await updatePermissions(api, [
+				{ _id: 'delete-team-group', roles: ['moderator'] },
+				{ _id: 'move-room-to-team', roles: ['owner'] },
+			]);
+		});
 
-		// re-add channel to team
-		await poHomeTeam.navbar.openChat(targetTeam);
-		await poHomeTeam.headerToolbar.openTeamChannels();
-		await poHomeTeam.tabs.channels.addExistingChannel(targetGroupNameInTeam);
-		await expect(poHomeTeam.tabs.channels.channelsList).toContainText(targetGroupNameInTeam);
+		test('should not allow deleting a targetGroup from targetTeam if the group owner does not have the delete-team-group permission', async ({
+			page,
+		}) => {
+			// re-add channel to team
+			await poHomeTeam.navbar.openChat(targetTeam);
+			await poHomeTeam.headerToolbar.openTeamChannels();
+			await poHomeTeam.tabs.channels.addExistingChannel(targetGroupNameInTeam);
+			await expect(poHomeTeam.tabs.channels.channelsList).toContainText(targetGroupNameInTeam);
 
-		// try to delete group in team
-		await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetGroupNameInTeam);
-		await expect(page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Delete' })).not.toBeVisible();
+			// try to delete group in team
+			await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetGroupNameInTeam);
+			await expect(page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Delete' })).not.toBeVisible();
+		});
 	});
 
-	test('should allow deleting a targetGroup from targetTeam if the group owner also has the delete-team-group permission', async ({
-		page,
-		api,
-	}) => {
-		expect((await api.post('/permissions.update', { permissions: [{ _id: 'delete-team-group', roles: ['owner'] }] })).status()).toBe(200);
+	test.describe('with delete-team-group permission', () => {
+		test.beforeAll(async ({ api }) => {
+			await updatePermissions(api, [{ _id: 'delete-team-group', roles: ['owner'] }]);
+		});
 
-		await poHomeTeam.navbar.openChat(targetTeam);
-		await poHomeTeam.headerToolbar.openTeamChannels();
-		await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetGroupNameInTeam);
-		await expect(page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Delete' })).toBeVisible();
-		await page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Delete' }).click();
-		await poHomeTeam.tabs.channels.confirmDeleteRoom();
+		test('should allow deleting a targetGroup from targetTeam if the group owner also has the delete-team-group permission', async ({
+			page,
+		}) => {
+			await poHomeTeam.navbar.openChat(targetTeam);
+			await poHomeTeam.headerToolbar.openTeamChannels();
+			await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetGroupNameInTeam);
+			await expect(page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Delete' })).toBeVisible();
+			await page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Delete' }).click();
+			await poHomeTeam.tabs.channels.confirmDeleteRoom();
 
-		await poHomeTeam.navbar.openChat(targetTeam);
-		await poHomeTeam.headerToolbar.openTeamChannels();
-		await expect(poHomeTeam.tabs.channels.channelsList).not.toContainText(targetGroupNameInTeam);
+			await poHomeTeam.navbar.openChat(targetTeam);
+			await poHomeTeam.headerToolbar.openTeamChannels();
+			await expect(poHomeTeam.tabs.channels.channelsList).not.toContainText(targetGroupNameInTeam);
+		});
 	});
 
-	test('should not allow removing a targetChannel from targetTeam if user does not have the remove-team-channel permission', async ({
-		page,
-		api,
-	}) => {
-		expect((await api.post('/permissions.update', { permissions: [{ _id: 'remove-team-channel', roles: ['moderator'] }] })).status()).toBe(
-			200,
-		);
+	test.describe('without remove-team-channel permission for channels', () => {
+		test.beforeAll(async ({ api }) => {
+			await updatePermissions(api, [{ _id: 'remove-team-channel', roles: ['moderator'] }]);
+		});
 
-		await poHomeTeam.navbar.openChat(targetTeam);
-		await poHomeTeam.headerToolbar.openTeamChannels();
-		await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetChannelNameInTeam);
-		await expect(page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Remove from team' })).not.toBeVisible();
+		test('should not allow removing a targetChannel from targetTeam if user does not have the remove-team-channel permission', async ({
+			page,
+		}) => {
+			await poHomeTeam.navbar.openChat(targetTeam);
+			await poHomeTeam.headerToolbar.openTeamChannels();
+			await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetChannelNameInTeam);
+			await expect(page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Remove from team' })).not.toBeVisible();
+		});
 	});
 
-	test('should allow removing a targetChannel from targetTeam if user has the remove-team-channel permission', async ({ page, api }) => {
-		expect((await api.post('/permissions.update', { permissions: [{ _id: 'remove-team-channel', roles: ['owner'] }] })).status()).toBe(200);
+	test.describe('with remove-team-channel permission for channels', () => {
+		test.beforeAll(async ({ api }) => {
+			await updatePermissions(api, [{ _id: 'remove-team-channel', roles: ['owner'] }]);
+		});
 
-		await poHomeTeam.navbar.openChat(targetTeam);
-		await poHomeTeam.headerToolbar.openTeamChannels();
-		await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetChannelNameInTeam);
-		await expect(page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Remove from team' })).toBeVisible();
-		await page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Remove from team' }).click();
-		await poHomeTeam.tabs.channels.confirmRemoveChannel();
+		test('should allow removing a targetChannel from targetTeam if user has the remove-team-channel permission', async ({ page }) => {
+			await poHomeTeam.navbar.openChat(targetTeam);
+			await poHomeTeam.headerToolbar.openTeamChannels();
+			await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetChannelNameInTeam);
+			await expect(page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Remove from team' })).toBeVisible();
+			await page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Remove from team' }).click();
+			await poHomeTeam.tabs.channels.confirmRemoveChannel();
 
-		await expect(poHomeTeam.tabs.channels.channelsList).not.toContainText(targetChannelNameInTeam);
+			await expect(poHomeTeam.tabs.channels.channelsList).not.toContainText(targetChannelNameInTeam);
+		});
 	});
 
-	test('should not allow deleting a targetChannel from targetTeam if the channel owner does not have the delete-team-channel permission', async ({
-		page,
-		api,
-	}) => {
-		expect(
-			(
-				await api.post('/permissions.update', {
-					permissions: [
-						{ _id: 'delete-team-channel', roles: ['moderator'] },
-						{ _id: 'move-room-to-team', roles: ['owner'] },
-					],
-				})
-			).status(),
-		).toBe(200);
+	test.describe('without delete-team-channel permission', () => {
+		test.beforeAll(async ({ api }) => {
+			await updatePermissions(api, [
+				{ _id: 'delete-team-channel', roles: ['moderator'] },
+				{ _id: 'move-room-to-team', roles: ['owner'] },
+			]);
+		});
 
-		// re-add channel to team
-		await poHomeTeam.navbar.openChat(targetTeam);
-		await poHomeTeam.headerToolbar.openTeamChannels();
-		await poHomeTeam.tabs.channels.addExistingChannel(targetChannelNameInTeam);
-		await expect(poHomeTeam.tabs.channels.channelsList).toContainText(targetChannelNameInTeam);
+		test('should not allow deleting a targetChannel from targetTeam if the channel owner does not have the delete-team-channel permission', async ({
+			page,
+		}) => {
+			// re-add channel to team
+			await poHomeTeam.navbar.openChat(targetTeam);
+			await poHomeTeam.headerToolbar.openTeamChannels();
+			await poHomeTeam.tabs.channels.addExistingChannel(targetChannelNameInTeam);
+			await expect(poHomeTeam.tabs.channels.channelsList).toContainText(targetChannelNameInTeam);
 
-		// try to delete channel in team
-		await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetChannelNameInTeam);
-		await expect(page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Delete' })).not.toBeVisible();
+			// try to delete channel in team
+			await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetChannelNameInTeam);
+			await expect(page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Delete' })).not.toBeVisible();
+		});
 	});
 
-	test('should allow deleting a targetChannel from targetTeam if the channel owner also has the delete-team-channel permission', async ({
-		page,
-		api,
-	}) => {
-		expect((await api.post('/permissions.update', { permissions: [{ _id: 'delete-team-channel', roles: ['owner'] }] })).status()).toBe(200);
+	test.describe('with delete-team-channel permission', () => {
+		test.beforeAll(async ({ api }) => {
+			await updatePermissions(api, [{ _id: 'delete-team-channel', roles: ['owner'] }]);
+		});
 
-		await poHomeTeam.navbar.openChat(targetTeam);
-		await poHomeTeam.headerToolbar.openTeamChannels();
-		await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetChannelNameInTeam);
-		await expect(page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Delete' })).toBeVisible();
-		await page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Delete' }).click();
-		await poHomeTeam.tabs.channels.confirmDeleteRoom();
+		test('should allow deleting a targetChannel from targetTeam if the channel owner also has the delete-team-channel permission', async ({
+			page,
+		}) => {
+			await poHomeTeam.navbar.openChat(targetTeam);
+			await poHomeTeam.headerToolbar.openTeamChannels();
+			await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetChannelNameInTeam);
+			await expect(page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Delete' })).toBeVisible();
+			await page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Delete' }).click();
+			await poHomeTeam.tabs.channels.confirmDeleteRoom();
 
-		await poHomeTeam.navbar.openChat(targetTeam);
-		await poHomeTeam.headerToolbar.openTeamChannels();
-		await expect(poHomeTeam.tabs.channels.channelsList).not.toContainText(targetChannelNameInTeam);
+			await poHomeTeam.navbar.openChat(targetTeam);
+			await poHomeTeam.headerToolbar.openTeamChannels();
+			await expect(poHomeTeam.tabs.channels.channelsList).not.toContainText(targetChannelNameInTeam);
+		});
 	});
 
-	test('should remove targetChannel from targetTeam', async ({ page, api }) => {
-		expect((await api.post('/permissions.update', { permissions: [{ _id: 'remove-team-channel', roles: ['owner'] }] })).status()).toBe(200);
+	test.describe('with remove-team-channel permission for cleanup', () => {
+		test.beforeAll(async ({ api }) => {
+			await updatePermissions(api, [{ _id: 'remove-team-channel', roles: ['owner'] }]);
+		});
 
-		await poHomeTeam.navbar.openChat(targetTeam);
-		await poHomeTeam.headerToolbar.openTeamChannels();
-		await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetChannel);
-		await page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Remove from team' }).click();
-		await poHomeTeam.tabs.channels.confirmRemoveChannel();
+		test('should remove targetChannel from targetTeam', async ({ page }) => {
+			await poHomeTeam.navbar.openChat(targetTeam);
+			await poHomeTeam.headerToolbar.openTeamChannels();
+			await poHomeTeam.tabs.channels.openChannelOptionMoreActions(targetChannel);
+			await page.getByRole('menu', { exact: true }).getByRole('menuitem', { name: 'Remove from team' }).click();
+			await poHomeTeam.tabs.channels.confirmRemoveChannel();
 
-		await expect(poHomeTeam.tabs.channels.channelsList).not.toBeVisible();
+			await expect(poHomeTeam.tabs.channels.channelsList).not.toBeVisible();
+		});
 	});
 
 	test('should remove user1 from targetTeamNonPrivate', async () => {

--- a/apps/meteor/tests/e2e/utils/index.ts
+++ b/apps/meteor/tests/e2e/utils/index.ts
@@ -2,5 +2,6 @@ export * from './create-target-channel';
 export * from './setSettingValueById';
 export * from './getSettingValueById';
 export * from './getPermissionRoles';
+export * from './updatePermissions';
 export * from './setUserPreferences';
 export * from './updateOwnUserInfo';

--- a/apps/meteor/tests/e2e/utils/updatePermissions.ts
+++ b/apps/meteor/tests/e2e/utils/updatePermissions.ts
@@ -1,0 +1,7 @@
+import { expect, type BaseTest } from './test';
+
+type PermissionUpdate = { _id: string; roles: string[] };
+
+export const updatePermissions = async (api: BaseTest['api'], permissions: PermissionUpdate[]): Promise<void> => {
+	await expect(await api.post('/permissions.update', { permissions })).toBeOK();
+};


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes

Refactors the team management permission E2E coverage to make permission setup clearer and reusable.

- Adds an `updatePermissions` test helper for consistent `/permissions.update` API assertions.
- Groups team permission scenarios by permission state, using scoped setup instead of updating permissions inside each test body.
- Restores all team-related permissions after the suite, including `remove-team-channel`.
- Keeps existing coverage for creating, moving, removing, and deleting team rooms under different permission combinations.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[FLAKY-1817](https://rocketchat.atlassian.net/browse/FLAKY-1817)


## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



[FLAKY-2249]: https://rocketchat.atlassian.net/browse/FLAKY-2249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized team-management end-to-end tests to use a shared permission setup flow.
  * Restructured permission-based scenarios into clearer test groups for easier validation of team, channel, and group actions.
  * Improved coverage around visibility and behavior of menu actions when permissions are present or missing.
* **Chores**
  * Added a reusable test utility for updating permissions across the e2e suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[FLAKY-1817]: https://rocketchat.atlassian.net/browse/FLAKY-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ