### PR TITLE
fix: validate UTF8 channel regex setting

### DIFF
--- a/apps/meteor/client/views/admin/settings/SettingsGroupPage/SettingsGroupPage.tsx
+++ b/apps/meteor/client/views/admin/settings/SettingsGroupPage/SettingsGroupPage.tsx
@@ -10,7 +10,18 @@ import { useTranslation } from 'react-i18next';
 
 import type { EditableSetting } from '../../EditableSettingsContext';
 import { useEditableSettingsDispatch, useEditableSettings } from '../../EditableSettingsContext';
+const isValidRegex = (value: unknown): boolean => {
+	if (typeof value !== 'string' || value.trim() === '') {
+		return false;
+	}
 
+	try {
+		new RegExp(`^${value}$`);
+		return true;
+	} catch {
+		return false;
+	}
+};
 type SettingsGroupPageProps = {
 	children: ReactNode;
 	headerButtons?: ReactNode;
@@ -72,10 +83,19 @@ const SettingsGroupPage = ({
 				value: setting.value,
 			};
 		});
-
 		if (changes.length === 0) {
 			return;
 		}
+		const invalidRegexSetting = changes.find(
+			(setting) => setting._id === 'UTF8_Channel_Names_Validation' && !isValidRegex(setting.value),
+		);
+
+		if (invalidRegexSetting) {
+			dispatchToastMessage({ type: 'error', message: 'Invalid regular expression' });
+			return;
+		}
+
+
 
 		try {
 			await dispatch(changes);


### PR DESCRIPTION
Fixes #8849

## What changed
- Validates the UTF8 channel names regex before saving settings.
- Shows an error toast when the regex is invalid.
- Prevents invalid regex values from being saved.

## How tested
- Valid regex `[0-9a-zA-Z-_.]+` saves successfully.
- Invalid regex `[0-9a-zæøåA-ZÆØÅ-_.]+` shows an error toast after clicking **Save changes**.
- Invalid regex is not saved.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for regular-expression settings before saving.
  * Prevented invalid values from being applied and now show an error message when the input is not a valid regex.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->