### PR TITLE
fix: Use request's `RelayState` for SAML Single Sign Out

### DIFF
--- a/.changeset/saml-slo-relaystate.md
+++ b/.changeset/saml-slo-relaystate.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes the SAML Single Logout response so the `RelayState` matches the exact value received on the logout request, as required by the SAML specification, instead of using Rocket.Chat's own URL

--- a/apps/meteor/app/meteor-accounts-saml/server/lib/SAML.ts
+++ b/apps/meteor/app/meteor-accounts-saml/server/lib/SAML.ts
@@ -345,7 +345,7 @@ export class SAML {
 					inResponseToId: result.id || '',
 				});
 
-				serviceProvider.logoutResponseToUrl(response, (err, url) => {
+				serviceProvider.logoutResponseToUrl(response, envelope.relayState, (err, url) => {
 					if (err) {
 						SystemLogger.error({ err });
 						return redirect();

--- a/apps/meteor/app/meteor-accounts-saml/server/lib/ServiceProvider.ts
+++ b/apps/meteor/app/meteor-accounts-saml/server/lib/ServiceProvider.ts
@@ -81,7 +81,11 @@ export class SAMLServiceProvider {
 	/*
 		This method will generate the response URL with all the query string params and pass it to the callback
 	*/
-	public logoutResponseToUrl(response: string, callback: (err: string | object | null, url?: string) => void): void {
+	public logoutResponseToUrl(
+		response: string,
+		relayState: string | undefined,
+		callback: (err: string | object | null, url?: string) => void,
+	): void {
 		zlib.deflateRaw(response, (err, buffer) => {
 			if (err) {
 				return callback(err);
@@ -97,12 +101,10 @@ export class SAMLServiceProvider {
 					target += '?';
 				}
 
-				// TBD. We should really include a proper RelayState here
-				const relayState = Meteor.absoluteUrl();
-
+				// The SAML spec requires the response RelayState to exactly match the value received on the request.
 				const samlResponse = this.maybeSignRequest({
 					SAMLResponse: base64,
-					RelayState: relayState,
+					...(relayState !== undefined && { RelayState: relayState }),
 				});
 
 				target += querystring.stringify(samlResponse);

--- a/apps/meteor/tests/e2e/saml.spec.ts
+++ b/apps/meteor/tests/e2e/saml.spec.ts
@@ -322,6 +322,16 @@ test.describe('SAML', () => {
 		});
 	};
 
+	const expectLoggedOutAfterLogoutRequest = async (page: Page) => {
+		await test.step('expect user to be logged out from Rocket.Chat', async () => {
+			// The logout response echoes back the RelayState from the request (per the SAML spec), so the browser
+			// lands on the IdP after SLO instead of returning here; navigate back to confirm the session ended.
+			await page.goto('/home');
+			await expect(page.getByRole('button', { name: 'User menu' })).not.toBeVisible();
+			await expect(poRegistration.btnLoginWithSaml).toBeVisible();
+		});
+	};
+
 	test('Logout - Rocket.Chat only', async ({ page, api }) => {
 		await test.step('Configure logout to only logout from Rocket.Chat', async () => {
 			await expect((await setSettingValueById(api, 'SAML_Custom_Default_logout_behaviour', 'Local')).status()).toBe(200);
@@ -666,11 +676,7 @@ test.describe('SAML', () => {
 
 				await page.goto(`${logoutRequest}&Signature=${logoutRequestSignature}`);
 
-				await test.step('expect user to be logged out from Rocket.Chat', async () => {
-					await expect(page).toHaveURL('/home');
-					await expect(page.getByRole('button', { name: 'User menu' })).not.toBeVisible();
-					await expect(poRegistration.btnLoginWithSaml).toBeVisible();
-				});
+				await expectLoggedOutAfterLogoutRequest(page);
 			});
 		});
 
@@ -685,11 +691,7 @@ test.describe('SAML', () => {
 
 				await page.goto(`${logoutRequest}&Signature=invalid`);
 
-				await test.step('expect user to be logged out from Rocket.Chat', async () => {
-					await expect(page).toHaveURL('/home');
-					await expect(page.getByRole('button', { name: 'User menu' })).not.toBeVisible();
-					await expect(poRegistration.btnLoginWithSaml).toBeVisible();
-				});
+				await expectLoggedOutAfterLogoutRequest(page);
 			});
 
 			test('Ignore Missing Signature on Logout Request', async ({ page }) => {
@@ -698,11 +700,7 @@ test.describe('SAML', () => {
 
 				await page.goto(logoutRequest);
 
-				await test.step('expect user to be logged out from Rocket.Chat', async () => {
-					await expect(page).toHaveURL('/home');
-					await expect(page.getByRole('button', { name: 'User menu' })).not.toBeVisible();
-					await expect(poRegistration.btnLoginWithSaml).toBeVisible();
-				});
+				await expectLoggedOutAfterLogoutRequest(page);
 			});
 		});
 	});

--- a/apps/meteor/tests/unit/app/meteor-accounts-saml/server.tests.ts
+++ b/apps/meteor/tests/unit/app/meteor-accounts-saml/server.tests.ts
@@ -1,3 +1,5 @@
+import zlib from 'node:zlib';
+
 import { isTruthy } from '@rocket.chat/tools';
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
@@ -314,6 +316,19 @@ describe('SAML', () => {
 
 				expect(params.has('RelayState')).to.be.false;
 				expect(params.get('SAMLResponse')).to.be.a('string').that.is.not.empty;
+			});
+
+			it('should target the IdP SLO endpoint with the deflated response and the relay state', async () => {
+				const url = await generateUrl('relay-123');
+				const [target, query] = url.split('?');
+				const params = new URLSearchParams(query);
+
+				expect(target).to.be.equal('[idpSLORedirectURL]');
+				expect([...params.keys()]).to.be.deep.equal(['SAMLResponse', 'RelayState']);
+				expect(params.get('RelayState')).to.be.equal('relay-123');
+
+				const inflated = zlib.inflateRawSync(Buffer.from(params.get('SAMLResponse') ?? '', 'base64')).toString();
+				expect(inflated).to.be.equal('logout-response');
 			});
 		});
 	});

--- a/apps/meteor/tests/unit/app/meteor-accounts-saml/server.tests.ts
+++ b/apps/meteor/tests/unit/app/meteor-accounts-saml/server.tests.ts
@@ -40,17 +40,21 @@ import { LogoutRequestParser } from '../../../../app/meteor-accounts-saml/server
 import { LogoutResponseParser } from '../../../../app/meteor-accounts-saml/server/lib/parsers/LogoutResponse';
 import { ResponseParser } from '../../../../app/meteor-accounts-saml/server/lib/parsers/Response';
 
-const { ServiceProviderMetadata } = proxyquire
-	.noCallThru()
-	.load('../../../../app/meteor-accounts-saml/server/lib/generators/ServiceProviderMetadata', {
-		'meteor/meteor': {
-			Meteor: {
-				absoluteUrl() {
-					return 'http://localhost:3000/';
-				},
+const meteorStub = {
+	'meteor/meteor': {
+		Meteor: {
+			absoluteUrl() {
+				return 'http://localhost:3000/';
 			},
 		},
-	});
+	},
+};
+
+const { ServiceProviderMetadata } = proxyquire
+	.noCallThru()
+	.load('../../../../app/meteor-accounts-saml/server/lib/generators/ServiceProviderMetadata', meteorStub);
+
+const { SAMLServiceProvider } = proxyquire.noCallThru().load('../../../../app/meteor-accounts-saml/server/lib/ServiceProvider', meteorStub);
 
 describe('SAML', () => {
 	describe('[AuthorizeRequest]', () => {
@@ -269,6 +273,46 @@ describe('SAML', () => {
 					expect(err).to.be.equal('Error. Logout not confirmed by IDP');
 					expect(inResponseTo).to.be.null;
 				});
+			});
+		});
+
+		describe('logoutResponseToUrl', () => {
+			const serviceProvider = new SAMLServiceProvider(serviceProviderOptions);
+
+			const generateUrl = (relayState: string | undefined): Promise<string> =>
+				new Promise((resolve, reject) => {
+					serviceProvider.logoutResponseToUrl('logout-response', relayState, (err: unknown, url?: string) => {
+						if (err || !url) {
+							return reject(err ?? new Error('No URL returned'));
+						}
+						resolve(url);
+					});
+				});
+
+			it('should echo back the exact RelayState received on the request', async () => {
+				const relayState = 'idp-shared-session-relay-state';
+				const url = await generateUrl(relayState);
+				const params = new URLSearchParams(url.split('?')[1]);
+
+				expect(url).to.match(/^\[idpSLORedirectURL\]\?/);
+				expect(params.get('SAMLResponse')).to.be.a('string').that.is.not.empty;
+				expect(params.get('RelayState')).to.be.equal(relayState);
+			});
+
+			it('should preserve a RelayState that requires URL encoding', async () => {
+				const relayState = 'https://sp.example.com/return?foo=bar baz&x=1';
+				const url = await generateUrl(relayState);
+				const params = new URLSearchParams(url.split('?')[1]);
+
+				expect(params.get('RelayState')).to.be.equal(relayState);
+			});
+
+			it('should omit RelayState entirely when none was received on the request', async () => {
+				const url = await generateUrl(undefined);
+				const params = new URLSearchParams(url.split('?')[1]);
+
+				expect(params.has('RelayState')).to.be.false;
+				expect(params.get('SAMLResponse')).to.be.a('string').that.is.not.empty;
 			});
 		});
 	});

--- a/apps/meteor/tests/unit/app/meteor-accounts-saml/server.tests.ts
+++ b/apps/meteor/tests/unit/app/meteor-accounts-saml/server.tests.ts
@@ -42,7 +42,8 @@ import { ResponseParser } from '../../../../app/meteor-accounts-saml/server/lib/
 
 const meteorStub = {
 	'meteor/meteor': {
-		Meteor: {
+		'@global': true,
+		'Meteor': {
 			absoluteUrl() {
 				return 'http://localhost:3000/';
 			},


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/CORE-2146

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SAML Single Logout now preserves the exact `RelayState` received in the logout request, improving compatibility with identity providers.
  * Logout redirects now include `RelayState` only when provided, while still returning the SAML response correctly.
* **Tests**
  * Expanded automated coverage for SAML logout redirects, including relay state handling and response encoding.
  * Simplified logout verification checks in end-to-end tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->