### PR TITLE
fix: grant actions:read permission to CI e2e test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,6 +557,9 @@ jobs:
   test-api:
     name: 🔨 Test API (CE)
     needs: [checks, build-gh-docker-publish, release-versions]
+    permissions:
+      actions: read
+      contents: read
 
     uses: ./.github/workflows/ci-test-e2e.yml
     with:
@@ -574,6 +577,9 @@ jobs:
   test-api-livechat:
     name: 🔨 Test API Livechat (CE)
     needs: [checks, build-gh-docker-publish, release-versions]
+    permissions:
+      actions: read
+      contents: read
 
     uses: ./.github/workflows/ci-test-e2e.yml
     with:
@@ -591,6 +597,9 @@ jobs:
   test-ui:
     name: 🔨 Test UI (CE)
     needs: [checks, build-gh-docker-publish, release-versions]
+    permissions:
+      actions: read
+      contents: read
 
     uses: ./.github/workflows/ci-test-e2e.yml
     with:
@@ -617,6 +626,9 @@ jobs:
   test-api-ee:
     name: 🔨 Test API (EE)
     needs: [checks, build-gh-docker-publish, release-versions]
+    permissions:
+      actions: read
+      contents: read
 
     uses: ./.github/workflows/ci-test-e2e.yml
     with:
@@ -638,6 +650,9 @@ jobs:
   test-api-livechat-ee:
     name: 🔨 Test API Livechat (EE)
     needs: [checks, build-gh-docker-publish, release-versions]
+    permissions:
+      actions: read
+      contents: read
 
     uses: ./.github/workflows/ci-test-e2e.yml
     with:
@@ -659,6 +674,9 @@ jobs:
   test-ui-ee:
     name: 🔨 Test UI (EE)
     needs: [checks, build-gh-docker-publish, release-versions]
+    permissions:
+      actions: read
+      contents: read
 
     uses: ./.github/workflows/ci-test-e2e.yml
     with:


### PR DESCRIPTION
## Summary
- #40687 applied least-privilege GitHub Actions permissions, scoping `ci.yml`'s `GITHUB_TOKEN` to `contents: read` at the workflow level.
- `ci-test-e2e.yml` (called by `ci.yml` via `uses:`) requires `actions: read` at the job level (needed by `actions/download-artifact`), which exceeds the caller's granted permissions.
- A reusable workflow cannot be granted more permissions than its caller allows, so GitHub rejects the entire run at startup — this broke `CI` on every push/PR since the merge (e.g. https://github.com/RocketChat/Rocket.Chat/actions/runs/28599899385, `startup_failure`, 0 jobs scheduled).

## Fix
Add `actions: read` (alongside `contents: read`) at the job level in `ci.yml` for the six jobs that call `ci-test-e2e.yml` (`test-api`, `test-api-livechat`, `test-ui`, `test-api-ee`, `test-api-livechat-ee`, `test-ui-ee`), scoped only to those jobs rather than widening the workflow-level default.

## Test plan
- [ ] Confirm the `CI` workflow schedules jobs (no `startup_failure`) on this PR
- [ ] Confirm `test-api`, `test-api-livechat`, `test-ui`, `test-api-ee`, `test-api-livechat-ee`, `test-ui-ee` run and pass

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated test workflow permissions to be more restrictive for several end-to-end test jobs.
  * No user-facing functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->