### PR TITLE
chore: Upgrade fuselage packages

### DIFF
--- a/apps/meteor/package.json
+++ b/apps/meteor/package.json
@@ -107,7 +107,7 @@
 		"@rocket.chat/favicon": "workspace:^",
 		"@rocket.chat/federation-matrix": "workspace:^",
 		"@rocket.chat/federation-sdk": "0.6.3",
-		"@rocket.chat/fuselage": "~0.80.0",
+		"@rocket.chat/fuselage": "^0.81.0",
 		"@rocket.chat/fuselage-forms": "~1.4.0",
 		"@rocket.chat/fuselage-hooks": "~0.42.0",
 		"@rocket.chat/fuselage-toastbar": "~0.36.0",

--- a/apps/uikit-playground/package.json
+++ b/apps/uikit-playground/package.json
@@ -18,7 +18,7 @@
 		"@lezer/highlight": "^1.2.3",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/css-in-js": "^0.32.0",
-		"@rocket.chat/fuselage": "~0.80.0",
+		"@rocket.chat/fuselage": "^0.81.0",
 		"@rocket.chat/fuselage-hooks": "~0.42.0",
 		"@rocket.chat/fuselage-toastbar": "~0.36.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",

--- a/packages/fuselage-ui-kit/package.json
+++ b/packages/fuselage-ui-kit/package.json
@@ -46,7 +46,7 @@
 		"@rocket.chat/apps-engine": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/emitter": "^0.32.0",
-		"@rocket.chat/fuselage": "~0.80.0",
+		"@rocket.chat/fuselage": "^0.81.0",
 		"@rocket.chat/fuselage-hooks": "~0.42.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/icons": "^0.48.0",

--- a/packages/gazzodown/package.json
+++ b/packages/gazzodown/package.json
@@ -31,7 +31,7 @@
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/css-in-js": "^0.32.0",
 		"@rocket.chat/emitter": "^0.32.0",
-		"@rocket.chat/fuselage": "~0.80.0",
+		"@rocket.chat/fuselage": "^0.81.0",
 		"@rocket.chat/fuselage-hooks": "~0.42.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/icons": "^0.48.0",

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -33,7 +33,7 @@
 		"webpack": "~5.104.1"
 	},
 	"devDependencies": {
-		"@rocket.chat/fuselage": "~0.80.0",
+		"@rocket.chat/fuselage": "^0.81.0",
 		"@rocket.chat/icons": "^0.48.0",
 		"@rocket.chat/tsconfig": "workspace:*",
 		"@storybook/react": "^9.1.13",

--- a/packages/ui-avatar/package.json
+++ b/packages/ui-avatar/package.json
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@rocket.chat/core-typings": "workspace:~",
 		"@rocket.chat/emitter": "^0.32.0",
-		"@rocket.chat/fuselage": "~0.80.0",
+		"@rocket.chat/fuselage": "^0.81.0",
 		"@rocket.chat/fuselage-hooks": "~0.42.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/icons": "^0.48.0",

--- a/packages/ui-client/package.json
+++ b/packages/ui-client/package.json
@@ -26,7 +26,7 @@
 		"@rocket.chat/core-typings": "workspace:~",
 		"@rocket.chat/css-in-js": "^0.32.0",
 		"@rocket.chat/emitter": "^0.32.0",
-		"@rocket.chat/fuselage": "~0.80.0",
+		"@rocket.chat/fuselage": "^0.81.0",
 		"@rocket.chat/fuselage-hooks": "~0.42.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/icons": "^0.48.0",

--- a/packages/ui-composer/package.json
+++ b/packages/ui-composer/package.json
@@ -22,7 +22,7 @@
 	"devDependencies": {
 		"@react-aria/toolbar": "^3.0.0-nightly.5042",
 		"@rocket.chat/emitter": "^0.32.0",
-		"@rocket.chat/fuselage": "~0.80.0",
+		"@rocket.chat/fuselage": "^0.81.0",
 		"@rocket.chat/fuselage-hooks": "~0.42.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/icons": "^0.48.0",

--- a/packages/ui-contexts/package.json
+++ b/packages/ui-contexts/package.json
@@ -23,7 +23,7 @@
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/ddp-client": "workspace:~",
 		"@rocket.chat/emitter": "^0.32.0",
-		"@rocket.chat/fuselage": "~0.80.0",
+		"@rocket.chat/fuselage": "^0.81.0",
 		"@rocket.chat/fuselage-hooks": "~0.42.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/i18n": "workspace:~",

--- a/packages/ui-video-conf/package.json
+++ b/packages/ui-video-conf/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {
 		"@rocket.chat/css-in-js": "^0.32.0",
-		"@rocket.chat/fuselage": "~0.80.0",
+		"@rocket.chat/fuselage": "^0.81.0",
 		"@rocket.chat/fuselage-hooks": "~0.42.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/icons": "^0.48.0",

--- a/packages/ui-voip/package.json
+++ b/packages/ui-voip/package.json
@@ -31,7 +31,7 @@
 		"@react-spectrum/test-utils": "~1.0.0-alpha.8",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/css-in-js": "^0.32.0",
-		"@rocket.chat/fuselage": "~0.80.0",
+		"@rocket.chat/fuselage": "^0.81.0",
 		"@rocket.chat/fuselage-hooks": "~0.42.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/fuselage-ui-kit": "workspace:^",

--- a/packages/web-ui-registration/package.json
+++ b/packages/web-ui-registration/package.json
@@ -23,7 +23,7 @@
 		"@rocket.chat/core-typings": "workspace:~",
 		"@rocket.chat/css-in-js": "^0.32.0",
 		"@rocket.chat/emitter": "^0.32.0",
-		"@rocket.chat/fuselage": "~0.80.0",
+		"@rocket.chat/fuselage": "^0.81.0",
 		"@rocket.chat/fuselage-hooks": "~0.42.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/i18n": "workspace:~",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9259,7 +9259,7 @@ __metadata:
     "@rocket.chat/apps-engine": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/emitter": "npm:^0.32.0"
-    "@rocket.chat/fuselage": "npm:~0.80.0"
+    "@rocket.chat/fuselage": "npm:^0.81.0"
     "@rocket.chat/fuselage-hooks": "npm:~0.42.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/gazzodown": "workspace:^"
@@ -9314,9 +9314,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rocket.chat/fuselage@npm:~0.80.0":
-  version: 0.80.0
-  resolution: "@rocket.chat/fuselage@npm:0.80.0"
+"@rocket.chat/fuselage@npm:^0.81.0":
+  version: 0.81.0
+  resolution: "@rocket.chat/fuselage@npm:0.81.0"
   dependencies:
     "@rocket.chat/css-in-js": "npm:^0.32.0"
     "@rocket.chat/css-supports": "npm:^0.31.25"
@@ -9333,7 +9333,7 @@ __metadata:
     react: "*"
     react-dom: "*"
     react-virtuoso: "*"
-  checksum: 10/1026ad667a843fa018ba4cd01055bad8070cfb7ca8c86eff551a0364c0c0d4343f2b1b40326660202d0364033b9d26e0f2d5fc27eca7730b4d7a7d5a7ff057de
+  checksum: 10/cffda6847ee6d3734c74ba3525b5a80622d617fa1df4ce402ed8c758ea987a1bda9a3314b7f1e796bdc7f597e55dcb3b9b4a3acc8ba2b1902c8326763526ab95
   languageName: node
   linkType: hard
 
@@ -9344,7 +9344,7 @@ __metadata:
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/css-in-js": "npm:^0.32.0"
     "@rocket.chat/emitter": "npm:^0.32.0"
-    "@rocket.chat/fuselage": "npm:~0.80.0"
+    "@rocket.chat/fuselage": "npm:^0.81.0"
     "@rocket.chat/fuselage-hooks": "npm:~0.42.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/icons": "npm:^0.48.0"
@@ -9789,7 +9789,7 @@ __metadata:
     "@rocket.chat/favicon": "workspace:^"
     "@rocket.chat/federation-matrix": "workspace:^"
     "@rocket.chat/federation-sdk": "npm:0.6.3"
-    "@rocket.chat/fuselage": "npm:~0.80.0"
+    "@rocket.chat/fuselage": "npm:^0.81.0"
     "@rocket.chat/fuselage-forms": "npm:~1.4.0"
     "@rocket.chat/fuselage-hooks": "npm:~0.42.0"
     "@rocket.chat/fuselage-toastbar": "npm:~0.36.0"
@@ -10675,7 +10675,7 @@ __metadata:
   resolution: "@rocket.chat/storybook-config@workspace:packages/storybook-config"
   dependencies:
     "@rocket.chat/emitter": "npm:^0.32.0"
-    "@rocket.chat/fuselage": "npm:~0.80.0"
+    "@rocket.chat/fuselage": "npm:^0.81.0"
     "@rocket.chat/fuselage-hooks": "npm:~0.42.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/icons": "npm:^0.48.0"
@@ -10770,7 +10770,7 @@ __metadata:
   dependencies:
     "@rocket.chat/core-typings": "workspace:~"
     "@rocket.chat/emitter": "npm:^0.32.0"
-    "@rocket.chat/fuselage": "npm:~0.80.0"
+    "@rocket.chat/fuselage": "npm:^0.81.0"
     "@rocket.chat/fuselage-hooks": "npm:~0.42.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/icons": "npm:^0.48.0"
@@ -10797,7 +10797,7 @@ __metadata:
     "@rocket.chat/core-typings": "workspace:~"
     "@rocket.chat/css-in-js": "npm:^0.32.0"
     "@rocket.chat/emitter": "npm:^0.32.0"
-    "@rocket.chat/fuselage": "npm:~0.80.0"
+    "@rocket.chat/fuselage": "npm:^0.81.0"
     "@rocket.chat/fuselage-hooks": "npm:~0.42.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/icons": "npm:^0.48.0"
@@ -10854,7 +10854,7 @@ __metadata:
   dependencies:
     "@react-aria/toolbar": "npm:^3.0.0-nightly.5042"
     "@rocket.chat/emitter": "npm:^0.32.0"
-    "@rocket.chat/fuselage": "npm:~0.80.0"
+    "@rocket.chat/fuselage": "npm:^0.81.0"
     "@rocket.chat/fuselage-hooks": "npm:~0.42.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/icons": "npm:^0.48.0"
@@ -10894,7 +10894,7 @@ __metadata:
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/ddp-client": "workspace:~"
     "@rocket.chat/emitter": "npm:^0.32.0"
-    "@rocket.chat/fuselage": "npm:~0.80.0"
+    "@rocket.chat/fuselage": "npm:^0.81.0"
     "@rocket.chat/fuselage-hooks": "npm:~0.42.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/i18n": "workspace:~"
@@ -10953,7 +10953,7 @@ __metadata:
   dependencies:
     "@rocket.chat/css-in-js": "npm:^0.32.0"
     "@rocket.chat/emitter": "npm:^0.32.0"
-    "@rocket.chat/fuselage": "npm:~0.80.0"
+    "@rocket.chat/fuselage": "npm:^0.81.0"
     "@rocket.chat/fuselage-hooks": "npm:~0.42.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/icons": "npm:^0.48.0"
@@ -11000,7 +11000,7 @@ __metadata:
     "@rocket.chat/css-in-js": "npm:^0.32.0"
     "@rocket.chat/desktop-api": "workspace:^"
     "@rocket.chat/emitter": "npm:^0.32.0"
-    "@rocket.chat/fuselage": "npm:~0.80.0"
+    "@rocket.chat/fuselage": "npm:^0.81.0"
     "@rocket.chat/fuselage-hooks": "npm:~0.42.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/fuselage-ui-kit": "workspace:^"
@@ -11066,7 +11066,7 @@ __metadata:
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/css-in-js": "npm:^0.32.0"
     "@rocket.chat/emitter": "npm:^0.32.0"
-    "@rocket.chat/fuselage": "npm:~0.80.0"
+    "@rocket.chat/fuselage": "npm:^0.81.0"
     "@rocket.chat/fuselage-hooks": "npm:~0.42.0"
     "@rocket.chat/fuselage-toastbar": "npm:~0.36.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
@@ -11104,7 +11104,7 @@ __metadata:
     "@rocket.chat/core-typings": "workspace:~"
     "@rocket.chat/css-in-js": "npm:^0.32.0"
     "@rocket.chat/emitter": "npm:^0.32.0"
-    "@rocket.chat/fuselage": "npm:~0.80.0"
+    "@rocket.chat/fuselage": "npm:^0.81.0"
     "@rocket.chat/fuselage-hooks": "npm:~0.42.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/i18n": "workspace:~"


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Release changes:
[@rocket.chat/fuselage@0.81.0](https://github.com/RocketChat/fuselage/releases/tag/%40rocket.chat%2Ffuselage%400.81.0)

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[ARCH-2202]

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a shared UI dependency across several apps and packages to a newer compatible version.
  * This helps keep the product stack current and supports ongoing stability and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ARCH-2202]: https://rocketchat.atlassian.net/browse/ARCH-2202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ