### PR TITLE
fix: own account showing twice in navbar room search when searching by username

### DIFF
--- a/.changeset/breezy-moons-search.md
+++ b/.changeset/breezy-moons-search.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes own account showing twice in navbar room search when searching by username

--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.spec.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.spec.ts
@@ -1,46 +1,30 @@
 import { mockAppRoot } from '@rocket.chat/mock-providers';
-import { useUserSubscriptions, useEndpoint } from '@rocket.chat/ui-contexts';
+import type { SubscriptionWithRoom } from '@rocket.chat/ui-contexts';
 import { renderHook, waitFor } from '@testing-library/react';
 
 import { useSearchItems } from './useSearchItems';
 
-jest.mock('@rocket.chat/ui-contexts', () => {
-	const original = jest.requireActual('@rocket.chat/ui-contexts');
-	return {
-		...original,
-		useUserSubscriptions: jest.fn(),
-		useEndpoint: jest.fn(),
-	};
-});
-
 describe('useSearchItems', () => {
-	let getSpotlightMock: jest.Mock;
-
-	beforeEach(() => {
-		getSpotlightMock = jest.fn();
-		jest.mocked(useEndpoint).mockReturnValue(getSpotlightMock);
-		jest.clearAllMocks();
-	});
-
 	it('should deduplicate a user if they already exist in local subscriptions as a self-DM', async () => {
 		const myUserName = 'rocketchat.internal.admin.test';
 		const myUserId = 'user_id_456';
 
-		jest.mocked(useUserSubscriptions).mockReturnValue([
-			{
-				_id: 'local_room_123',
-				t: 'd',
-				name: myUserName,
-				uids: [myUserId],
-			},
-		]);
+		const wrapper = mockAppRoot()
+			.withSubscriptions([
+				{
+					_id: 'local_room_123',
+					t: 'd',
+					name: myUserName,
+					uids: [myUserId],
+				} as unknown as SubscriptionWithRoom,
+			])
+			.withEndpoint('GET', '/v1/spotlight', () => ({
+				users: [{ _id: myUserId, username: myUserName, name: 'Rocket Chat Test' }],
+				rooms: [],
+			}))
+			.build();
 
-		getSpotlightMock.mockResolvedValueOnce({
-			users: [{ _id: myUserId, username: myUserName, name: 'Rocket Chat Test' }],
-			rooms: [],
-		});
-
-		const { result } = renderHook(() => useSearchItems(myUserName), { wrapper: mockAppRoot().build() });
+		const { result } = renderHook(() => useSearchItems(myUserName), { wrapper });
 
 		expect(result.current.items).toHaveLength(1);
 		expect(result.current.items[0]._id).toBe('local_room_123');
@@ -55,14 +39,15 @@ describe('useSearchItems', () => {
 	});
 
 	it('should append users from the server if they are NOT duplicates', async () => {
-		jest.mocked(useUserSubscriptions).mockReturnValue([{ _id: 'local_room_123', t: 'd', name: 'general' }]);
+		const wrapper = mockAppRoot()
+			.withSubscriptions([{ _id: 'local_room_123', t: 'd', name: 'general' } as unknown as SubscriptionWithRoom])
+			.withEndpoint('GET', '/v1/spotlight', () => ({
+				users: [{ _id: 'user_id_456', username: 'john.doe', name: 'John Doe' }],
+				rooms: [],
+			}))
+			.build();
 
-		getSpotlightMock.mockResolvedValueOnce({
-			users: [{ _id: 'user_id_456', username: 'john.doe', name: 'John Doe' }],
-			rooms: [],
-		});
-
-		const { result } = renderHook(() => useSearchItems('jo'), { wrapper: mockAppRoot().build() });
+		const { result } = renderHook(() => useSearchItems('jo'), { wrapper });
 
 		await waitFor(() => {
 			expect(result.current.isLoading).toBe(false);

--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.spec.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.spec.ts
@@ -1,36 +1,32 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
 import { useUserSubscriptions, useEndpoint } from '@rocket.chat/ui-contexts';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import type { ReactNode } from 'react';
 
 import { useSearchItems } from './useSearchItems';
 
-jest.mock('@rocket.chat/ui-contexts', () => ({
-	useUserSubscriptions: jest.fn(),
-	useEndpoint: jest.fn(),
-}));
+jest.mock('@rocket.chat/ui-contexts', () => {
+	const original = jest.requireActual('@rocket.chat/ui-contexts');
+	return {
+		...original,
+		useUserSubscriptions: jest.fn(),
+		useEndpoint: jest.fn(),
+	};
+});
 
 describe('useSearchItems', () => {
-	let queryClient: QueryClient;
 	let getSpotlightMock: jest.Mock;
 
 	beforeEach(() => {
-		queryClient = new QueryClient({
-			defaultOptions: { queries: { retry: false } },
-		});
-
 		getSpotlightMock = jest.fn();
-		(useEndpoint as jest.Mock).mockReturnValue(getSpotlightMock);
+		jest.mocked(useEndpoint).mockReturnValue(getSpotlightMock);
 		jest.clearAllMocks();
 	});
-
-	const wrapper = ({ children }: { children: ReactNode }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 
 	it('should deduplicate a user if they already exist in local subscriptions as a self-DM', async () => {
 		const myUserName = 'rocketchat.internal.admin.test';
 		const myUserId = 'user_id_456';
 
-		(useUserSubscriptions as jest.Mock).mockReturnValue([
+		jest.mocked(useUserSubscriptions).mockReturnValue([
 			{
 				_id: 'local_room_123',
 				t: 'd',
@@ -44,7 +40,7 @@ describe('useSearchItems', () => {
 			rooms: [],
 		});
 
-		const { result } = renderHook(() => useSearchItems(myUserName), { wrapper });
+		const { result } = renderHook(() => useSearchItems(myUserName), { wrapper: mockAppRoot().build() });
 
 		expect(result.current.items).toHaveLength(1);
 		expect(result.current.items[0]._id).toBe('local_room_123');
@@ -59,14 +55,14 @@ describe('useSearchItems', () => {
 	});
 
 	it('should append users from the server if they are NOT duplicates', async () => {
-		(useUserSubscriptions as jest.Mock).mockReturnValue([{ _id: 'local_room_123', t: 'd', name: 'general' }]);
+		jest.mocked(useUserSubscriptions).mockReturnValue([{ _id: 'local_room_123', t: 'd', name: 'general' }]);
 
 		getSpotlightMock.mockResolvedValueOnce({
 			users: [{ _id: 'user_id_456', username: 'john.doe', name: 'John Doe' }],
 			rooms: [],
 		});
 
-		const { result } = renderHook(() => useSearchItems('jo'), { wrapper });
+		const { result } = renderHook(() => useSearchItems('jo'), { wrapper: mockAppRoot().build() });
 
 		await waitFor(() => {
 			expect(result.current.isLoading).toBe(false);

--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.spec.tsx
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.spec.tsx
@@ -1,0 +1,76 @@
+import { useUserSubscriptions, useEndpoint } from '@rocket.chat/ui-contexts';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { useSearchItems } from './useSearchItems';
+
+jest.mock('@rocket.chat/ui-contexts', () => ({
+	useUserSubscriptions: jest.fn(),
+	useEndpoint: jest.fn(),
+}));
+
+describe('useSearchItems', () => {
+	let queryClient: QueryClient;
+	let getSpotlightMock: jest.Mock;
+
+	beforeEach(() => {
+		queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+
+		getSpotlightMock = jest.fn();
+		(useEndpoint as jest.Mock).mockReturnValue(getSpotlightMock);
+		jest.clearAllMocks();
+	});
+
+	const wrapper = ({ children }: { children: ReactNode }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+
+	it('should deduplicate a user if they already exist in local subscriptions as a self-DM', async () => {
+		const myUserName = 'rocketchat.internal.admin.test';
+		const myUserId = 'user_id_456';
+
+		(useUserSubscriptions as jest.Mock).mockReturnValue([
+			{
+				_id: 'local_room_123',
+				t: 'd',
+				name: myUserName,
+				uids: [myUserId],
+			},
+		]);
+
+		getSpotlightMock.mockResolvedValueOnce({
+			users: [{ _id: myUserId, username: myUserName, name: 'Rocket Chat Test' }],
+			rooms: [],
+		});
+
+		const { result } = renderHook(() => useSearchItems(myUserName), { wrapper });
+
+		expect(result.current.items).toHaveLength(1);
+		expect(result.current.items[0]._id).toBe('local_room_123');
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		expect(result.current.items).toHaveLength(1);
+		expect(result.current.items[0]._id).toBe('local_room_123');
+		expect(result.current.items[0].name).toBe(myUserName);
+	});
+
+	it('should append users from the server if they are NOT duplicates', async () => {
+		(useUserSubscriptions as jest.Mock).mockReturnValue([{ _id: 'local_room_123', t: 'd', name: 'general' }]);
+
+		getSpotlightMock.mockResolvedValueOnce({
+			users: [{ _id: 'user_id_456', username: 'john.doe', name: 'John Doe' }],
+			rooms: [],
+		});
+
+		const { result } = renderHook(() => useSearchItems('jo'), { wrapper });
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+			expect(result.current.items).toHaveLength(2);
+		});
+	});
+});

--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
@@ -138,7 +138,8 @@ export const useSearchItems = (filterText: string): { items: SubscriptionWithRoo
 				const sameRoom = [room.rid, room._id].includes(item._id);
 				const sameGroupDM = item.t === 'd' && !!item.uids && item.uids.length > 1 && item.uids.includes(room._id);
 				const sameDirectDM = item.t === 'd' && room.t === 'd' && !!room.uids && room.uids.length === 2 && room.uids.includes(item._id);
-				return sameRoom || sameGroupDM || sameDirectDM;
+				const sameUserDM = item.t === 'd' && room.t === 'd' && item.name === room.name;
+				return sameRoom || sameGroupDM || sameDirectDM || sameUserDM;
 			});
 
 		// When local subscriptions already fill the limit the server query is disabled, but React Query

--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
@@ -133,7 +133,7 @@ export const useSearchItems = (filterText: string): { items: SubscriptionWithRoo
 		// local subscription, checked against the *current* localRooms. The query isn't keyed on
 		// localRooms (to avoid refetching on every subscription change), so subscriptions that load
 		// in after the fetch would otherwise render twice — once from localRooms, once from server.
-		const isLocalDuplicate = (item: { _id: string; t?: string; uids?: string[], name: string }): boolean =>
+		const isLocalDuplicate = (item: { _id: string; t?: string; uids?: string[]; name: string }): boolean =>
 			localRooms.some((room) => {
 				const sameRoom = [room.rid, room._id].includes(item._id);
 				const sameGroupDM = item.t === 'd' && !!item.uids && item.uids.length > 1 && item.uids.includes(room._id);

--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
@@ -133,7 +133,7 @@ export const useSearchItems = (filterText: string): { items: SubscriptionWithRoo
 		// local subscription, checked against the *current* localRooms. The query isn't keyed on
 		// localRooms (to avoid refetching on every subscription change), so subscriptions that load
 		// in after the fetch would otherwise render twice — once from localRooms, once from server.
-		const isLocalDuplicate = (item: { _id: string; t?: string; uids?: string[] }): boolean =>
+		const isLocalDuplicate = (item: { _id: string; t?: string; uids?: string[], name: string }): boolean =>
 			localRooms.some((room) => {
 				const sameRoom = [room.rid, room._id].includes(item._id);
 				const sameGroupDM = item.t === 'd' && !!item.uids && item.uids.length > 1 && item.uids.includes(room._id);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Filter out own DMs from local rooms. Previously we were only removing duplicate of DMs with only two members (`room.uids.length === 2` condition in `sameDirectDM`).
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[SUP-1069 Own account shows twice in navbar user search when searching by username (self DM duplicate)](https://rocketchat.atlassian.net/browse/SUP-1069)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Log in as any user.
2. Create a DM with yourself.
3. Open the navbar search.
4. Search for your own **username** (not display name).
5. Your account is listed twice in the dropdown.
6. Open either entry: both open the same direct message with yourself.
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed navbar room search so your own account no longer appears twice when searching by username.
  - Improved navbar search result merging by better deduplicating direct-message results representing the same DM user.

- **Tests**
  - Added Jest coverage for the navbar search hook to verify both deduped (duplicate DM user) and appended (non-duplicate) results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->