### PR TITLE
chore: use @rocket.chat/cron for presence status expiration in microservices

### DIFF
--- a/ee/apps/presence-service/package.json
+++ b/ee/apps/presence-service/package.json
@@ -21,6 +21,7 @@
 	"dependencies": {
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
+		"@rocket.chat/cron": "workspace:^",
 		"@rocket.chat/emitter": "^0.33.0",
 		"@rocket.chat/logger": "workspace:^",
 		"@rocket.chat/model-typings": "workspace:^",

--- a/ee/apps/presence-service/src/service.ts
+++ b/ee/apps/presence-service/src/service.ts
@@ -1,4 +1,5 @@
 import { api, getConnection, getTrashCollection } from '@rocket.chat/core-services';
+import { cronJobs } from '@rocket.chat/cron';
 import { registerServiceModels } from '@rocket.chat/models';
 import { startBroker } from '@rocket.chat/network-broker';
 import { startTracing } from '@rocket.chat/tracing';
@@ -12,6 +13,8 @@ void (async () => {
 	startTracing({ service: 'presence-service', db: client });
 
 	registerServiceModels(db, await getTrashCollection());
+
+	await cronJobs.start(db);
 
 	api.setBroker(startBroker());
 

--- a/ee/packages/presence/package.json
+++ b/ee/packages/presence/package.json
@@ -18,6 +18,7 @@
 	"dependencies": {
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
+		"@rocket.chat/cron": "workspace:^",
 		"@rocket.chat/logger": "workspace:^",
 		"@rocket.chat/models": "workspace:^",
 		"mongodb": "6.16.0"

--- a/ee/packages/presence/src/Presence.ts
+++ b/ee/packages/presence/src/Presence.ts
@@ -4,6 +4,7 @@ import type { IPresence, IBrokerNode } from '@rocket.chat/core-services';
 import { License, ServiceClass, Settings } from '@rocket.chat/core-services';
 import type { IUser } from '@rocket.chat/core-typings';
 import { UserStatus } from '@rocket.chat/core-typings';
+import { cronJobs } from '@rocket.chat/cron';
 import { Logger } from '@rocket.chat/logger';
 import { Users, UsersSessions } from '@rocket.chat/models';
 
@@ -14,7 +15,7 @@ import { type ClaimUpdate, processPresence } from './lib/presenceEngine';
 const logger = new Logger('Presence');
 
 const MAX_CONNECTIONS = 200;
-const MAX_TIMEOUT_DELAY_MS = 2 ** 31 - 1;
+const STATUS_EXPIRATION_JOB = 'presence-status-expiration';
 
 type PresenceUser = Pick<
 	IUser,
@@ -50,8 +51,6 @@ export class Presence extends ServiceClass implements IPresence {
 	private peakConnections = 0;
 
 	private reaper: PresenceReaper;
-
-	private expirationTimeout?: NodeJS.Timeout;
 
 	private expirationScheduleToken?: symbol;
 
@@ -129,8 +128,6 @@ export class Presence extends ServiceClass implements IPresence {
 	}
 
 	private async processExpiredStatuses(): Promise<void> {
-		// TODO: in MS mode every instance runs this independently.
-		// Add a job-level lock to avoid redundant cross-instance reads.
 		const expiredCursor = Users.findExpiredStatuses();
 		for await (const user of expiredCursor) {
 			await this.updateUserPresence(user, { type: 'endActive' });
@@ -143,27 +140,22 @@ export class Presence extends ServiceClass implements IPresence {
 
 		const next = await Users.findNextStatusExpiration();
 
-		// A newer reschedule replaced our token while we awaited the lookup; let it arm the timer.
+		// A newer reschedule superseded this token during the lookup; let it win.
 		if (this.expirationScheduleToken !== token) {
 			return;
 		}
 
-		clearTimeout(this.expirationTimeout);
-		this.expirationTimeout = undefined;
+		// addAtTimestamp adds a new job document each call, so cancel the previous one first —
+		// otherwise every reschedule leaves a duplicate job behind.
+		await cronJobs.remove(STATUS_EXPIRATION_JOB);
 
 		if (!next?.statusExpiresAt) {
 			return;
 		}
 
-		// Node coerces any setTimeout delay > 2^31-1 ms (~24.8 days) to 1ms, firing on the next tick.
-		// See https://nodejs.org/api/timers.html#settimeoutcallback-delay-args
-		// "When delay is larger than 2147483647 [...] the delay will be set to 1".
-		// Cap at the limit so far-future expirations reschedule on each wake instead of misfiring immediately.
-		const delay = Math.min(Math.max(next.statusExpiresAt.getTime() - Date.now(), 0), MAX_TIMEOUT_DELAY_MS);
-		this.expirationTimeout = setTimeout(() => {
-			this.expirationTimeout = undefined;
-			this.handleExpirationJob().catch((err) => logger.error({ msg: 'Error handling status expiration', err }));
-		}, delay);
+		await cronJobs.addAtTimestamp(STATUS_EXPIRATION_JOB, next.statusExpiresAt, () =>
+			this.handleExpirationJob().catch((err) => logger.error({ msg: 'Error handling status expiration', err })),
+		);
 	}
 
 	private async handleExpirationJob(): Promise<void> {
@@ -192,8 +184,7 @@ export class Presence extends ServiceClass implements IPresence {
 	override async stopped(): Promise<void> {
 		this.reaper.stop();
 		this.expirationScheduleToken = undefined;
-		clearTimeout(this.expirationTimeout);
-		this.expirationTimeout = undefined;
+		await cronJobs.remove(STATUS_EXPIRATION_JOB);
 		clearTimeout(this.lostConTimeout);
 	}
 

--- a/ee/packages/presence/src/Presence.ts
+++ b/ee/packages/presence/src/Presence.ts
@@ -153,9 +153,7 @@ export class Presence extends ServiceClass implements IPresence {
 			return;
 		}
 
-		await cronJobs.addAtTimestamp(STATUS_EXPIRATION_JOB, next.statusExpiresAt, () =>
-			this.handleExpirationJob().catch((err) => logger.error({ msg: 'Error handling status expiration', err })),
-		);
+		await cronJobs.addAtTimestamp(STATUS_EXPIRATION_JOB, next.statusExpiresAt, () => this.handleExpirationJob());
 	}
 
 	private async handleExpirationJob(): Promise<void> {

--- a/ee/packages/presence/src/Presence.ts
+++ b/ee/packages/presence/src/Presence.ts
@@ -145,8 +145,6 @@ export class Presence extends ServiceClass implements IPresence {
 			return;
 		}
 
-		// addAtTimestamp adds a new job document each call, so cancel the previous one first —
-		// otherwise every reschedule leaves a duplicate job behind.
 		await cronJobs.remove(STATUS_EXPIRATION_JOB);
 
 		if (!next?.statusExpiresAt) {

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -108,6 +108,7 @@ import {
 	AbacAttributesRaw,
 	ServerEventsRaw,
 	SamlUsedAssertionsRaw,
+	CronHistoryRaw,
 } from './modelClasses';
 import { proxify, registerModel } from './proxify';
 
@@ -245,4 +246,5 @@ export function registerServiceModels(db: Db, trash?: Collection<RocketChatRecor
 	registerModel('IAbacAttributesModel', () => new AbacAttributesRaw(db));
 	registerModel('IServerEventsModel', () => new ServerEventsRaw(db));
 	registerModel('ISamlUsedAssertionsModel', () => new SamlUsedAssertionsRaw(db));
+	registerModel('ICronHistoryModel', () => new CronHistoryRaw(db));
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10458,6 +10458,7 @@ __metadata:
   dependencies:
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
+    "@rocket.chat/cron": "workspace:^"
     "@rocket.chat/emitter": "npm:^0.33.0"
     "@rocket.chat/logger": "workspace:^"
     "@rocket.chat/model-typings": "workspace:^"
@@ -10493,6 +10494,7 @@ __metadata:
     "@rocket.chat/apps-engine": "workspace:^"
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
+    "@rocket.chat/cron": "workspace:^"
     "@rocket.chat/logger": "workspace:^"
     "@rocket.chat/models": "workspace:^"
     "@rocket.chat/rest-typings": "workspace:^"


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Move presence status expiration off a hand-rolled `setTimeout` and onto `@rocket.chat/cron`, plus the wiring cron needs to run in a microservice:

- Register `ICronHistoryModel` in `registerServiceModels` (services never did, so cron's `CronHistory` write threw).
- `cronJobs.start(db)` in the presence-service entrypoint.
- `setTimeout` → `cronJobs.addAtTimestamp` — so one instance runs each expiration (agenda locks the job in Mongo), instead of every presence instance running its own timer and reverting independently.

## Issue(s)

- [PRES-32](https://rocketchat.atlassian.net/browse/PRES-32)

## Steps to test or reproduce

1. Run in microservices mode (`yarn ms`).
2. `POST /api/v1/users.setStatus` with `status: "busy"` and a short `expiresAt`.
3. `rocketchat_cron` gets a `presence-status-expiration` job at that time; after it fires the status reverts and `rocketchat_cron_history` gets a run row.

## Further comments
[PRES-32]: https://rocketchat.atlassian.net/browse/PRES-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Presence updates now use a shared scheduled-job system, improving how status expirations are handled across instances.
  * The presence service now starts its scheduling subsystem automatically during startup.

* **Bug Fixes**
  * Reduced the risk of missed or duplicated presence expiration handling by replacing local timers with centralized job scheduling.
  * Improved cleanup when presence-related jobs are stopped or rescheduled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->