### PR TITLE
fix: business-hour availability not recomputed when agents are removed from a department

### DIFF
--- a/.changeset/fix-business-hour-agents-availability.md
+++ b/.changeset/fix-business-hour-agents-availability.md
@@ -2,4 +2,4 @@
 '@rocket.chat/meteor': patch
 ---
 
-Fixed agents' business-hour availability not being updated when they are removed from a department linked to a business hour while multiple business hours are enabled. The recomputation step always failed, leaving removed agents available (or unavailable) according to a business hour that no longer applied to them — and, on deployments running with `EXIT_UNHANDLEDPROMISEREJECTION` (or in development/test mode), the unhandled rejection crashed the server process.
+Fixes agents' business-hour availability not being updated when they are removed from a department linked to a business hour while multiple business hours are enabled. The recomputation step always failed, leaving removed agents available (or unavailable) according to a business hour that no longer applied to them — and, on deployments running with `EXIT_UNHANDLEDPROMISEREJECTION` (or in development/test mode), the unhandled rejection crashed the server process.

--- a/.changeset/fix-business-hour-agents-availability.md
+++ b/.changeset/fix-business-hour-agents-availability.md
@@ -2,4 +2,4 @@
 '@rocket.chat/meteor': patch
 ---
 
-Fixed agents' business-hour availability not being updated when they are removed from a department linked to a business hour while multiple business hours are enabled. The recomputation step failed silently, leaving removed agents available (or unavailable) according to a business hour that no longer applied to them.
+Fixed agents' business-hour availability not being updated when they are removed from a department linked to a business hour while multiple business hours are enabled. The recomputation step always failed, leaving removed agents available (or unavailable) according to a business hour that no longer applied to them — and, on deployments running with `EXIT_UNHANDLEDPROMISEREJECTION` (or in development/test mode), the unhandled rejection crashed the server process.

--- a/.changeset/fix-business-hour-agents-availability.md
+++ b/.changeset/fix-business-hour-agents-availability.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed agents' business-hour availability not being updated when they are removed from a department linked to a business hour while multiple business hours are enabled. The recomputation step failed silently, leaving removed agents available (or unavailable) according to a business hour that no longer applied to them.

--- a/apps/meteor/ee/server/models/raw/LivechatDepartment.ts
+++ b/apps/meteor/ee/server/models/raw/LivechatDepartment.ts
@@ -105,32 +105,30 @@ export class LivechatDepartmentEE extends LivechatDepartmentRaw implements ILive
 
 	override findAgentsByBusinessHourId(businessHourId: string): AggregationCursor<{ agentIds: string[] }> {
 		return this.col.aggregate<{ agentIds: string[] }>([
-			[
-				{
-					$match: {
-						businessHourId,
+			{
+				$match: {
+					businessHourId,
+				},
+			},
+			{
+				$lookup: {
+					from: 'rocketchat_livechat_department_agents',
+					localField: '_id',
+					foreignField: 'departmentId',
+					as: 'agents',
+				},
+			},
+			{
+				$unwind: '$agents',
+			},
+			{
+				$group: {
+					_id: null,
+					agentIds: {
+						$addToSet: '$agents.agentId',
 					},
 				},
-				{
-					$lookup: {
-						from: 'rocketchat_livechat_department_agents',
-						localField: '_id',
-						foreignField: 'departmentId',
-						as: 'agents',
-					},
-				},
-				{
-					$unwind: '$agents',
-				},
-				{
-					$group: {
-						_id: null,
-						agentIds: {
-							$addToSet: '$agents.agentId',
-						},
-					},
-				},
-			],
+			},
 		]);
 	}
 }

--- a/apps/meteor/tests/end-to-end/api/livechat/19-business-hours.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/19-business-hours.ts
@@ -25,7 +25,7 @@ import {
 	deleteDepartment,
 } from '../../../data/livechat/department';
 import { createAgent, createManager, makeAgentAvailable } from '../../../data/livechat/rooms';
-import { removeAgent } from '../../../data/livechat/users';
+import { createAnOnlineAgent, removeAgent } from '../../../data/livechat/users';
 import { removePermissionFromAllRoles, restorePermissionToRoles, updateSetting, updateEESetting } from '../../../data/permissions.helper';
 import { password } from '../../../data/user';
 import type { TestUser } from '../../../data/users.helper';
@@ -803,17 +803,41 @@ describe('LIVECHAT - business hours', () => {
 				true,
 			);
 
+			// control agent: belongs only to the first department and is removed in the same request as the
+			// overlapping agent, so both are processed by the same recomputation callback. Observing the control
+			// agent fall back to the default business hour proves that callback ran — only then is asserting the
+			// overlapping agent's unchanged state meaningful (it equals the pre-removal state, so it can't
+			// distinguish "correctly kept" from "callback never ran" on its own)
+			const controlAgent = await createAnOnlineAgent();
 			await addOrRemoveAgentFromDepartment(
 				deptLinkedToCustomBH._id,
 				{
-					agentId: agentLinkedToDept.user._id,
-					username: agentLinkedToDept.user.username || '',
+					agentId: controlAgent.user._id,
+					username: controlAgent.user.username || '',
 				},
-				false,
+				true,
 			);
 
-			// state must not change; give the async callback time to run before asserting
-			await sleep(2000);
+			const overlappingBefore = await waitForAgentBusinessHours(agentLinkedToDept.credentials, [customBusinessHour._id]);
+			expect(overlappingBefore).to.be.an('array').of.length(1);
+			const controlBefore = await waitForAgentBusinessHours(controlAgent.credentials, [customBusinessHour._id]);
+			expect(controlBefore).to.be.an('array').of.length(1);
+
+			await request
+				.post(api(`livechat/department/${deptLinkedToCustomBH._id}/agents`))
+				.set(credentials)
+				.send({
+					upsert: [],
+					remove: [
+						{ agentId: agentLinkedToDept.user._id, username: agentLinkedToDept.user.username || '' },
+						{ agentId: controlAgent.user._id, username: controlAgent.user.username || '' },
+					],
+				})
+				.expect(200);
+
+			const controlOpenBusinessHours = await waitForAgentBusinessHours(controlAgent.credentials, [defaultBusinessHour._id]);
+			expect(controlOpenBusinessHours).to.be.an('array').of.length(1);
+			expect(controlOpenBusinessHours?.[0]).to.be.equal(defaultBusinessHour._id);
 
 			const latestAgent: ILivechatAgent = await getMe(agentLinkedToDept.credentials);
 			expect(latestAgent.openBusinessHours).to.be.an('array').of.length(1);
@@ -821,6 +845,7 @@ describe('LIVECHAT - business hours', () => {
 
 			await deleteDepartment(department._id);
 			await deleteUser(agent.user);
+			await deleteUser(controlAgent.user);
 		});
 
 		afterEach(async () => {

--- a/apps/meteor/tests/end-to-end/api/livechat/19-business-hours.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/19-business-hours.ts
@@ -729,6 +729,109 @@ describe('LIVECHAT - business hours', () => {
 			await deleteUser(agentLinkedToDept.user);
 		});
 	});
+	(IS_EE ? describe : describe.skip)('[EE][BH] On agent removed from department', () => {
+		let defaultBusinessHour: ILivechatBusinessHour;
+		let customBusinessHour: ILivechatBusinessHour;
+		let deptLinkedToCustomBH: ILivechatDepartment;
+		let agentLinkedToDept: Awaited<ReturnType<typeof createDepartmentWithAnOnlineAgent>>['agent'];
+
+		// the business hour recomputation runs on a fire-and-forget callback, so poll until it lands
+		const waitForAgentBusinessHours = async (agentCredentials: Credentials, expected: string[]): Promise<string[] | undefined> => {
+			const matches = (agent: ILivechatAgent) =>
+				JSON.stringify([...(agent.openBusinessHours || [])].sort()) === JSON.stringify([...expected].sort());
+
+			let latestAgent: ILivechatAgent = await getMe(agentCredentials);
+			for (let attempts = 0; attempts < 10 && !matches(latestAgent); attempts++) {
+				await sleep(500);
+				latestAgent = await getMe(agentCredentials);
+			}
+			return latestAgent.openBusinessHours;
+		};
+
+		before(async () => {
+			await updateSetting('Livechat_business_hour_type', LivechatBusinessHourBehaviors.MULTIPLE);
+			// wait for the callbacks to be registered
+			await sleep(1000);
+		});
+
+		beforeEach(async () => {
+			await removeAllCustomBusinessHours();
+
+			defaultBusinessHour = await getDefaultBusinessHour();
+			await openOrCloseBusinessHour(defaultBusinessHour, true);
+
+			const { department, agent } = await createDepartmentWithAnOnlineAgent();
+			deptLinkedToCustomBH = department;
+			agentLinkedToDept = agent;
+
+			customBusinessHour = await createCustomBusinessHour([department._id]);
+			await openOrCloseBusinessHour(customBusinessHour, true);
+		});
+
+		it('upon removing an agent from its only department, the agent should fall back to the default business hour', async () => {
+			const openBusinessHoursBefore = await waitForAgentBusinessHours(agentLinkedToDept.credentials, [customBusinessHour._id]);
+			expect(openBusinessHoursBefore).to.be.an('array').of.length(1);
+			expect(openBusinessHoursBefore?.[0]).to.be.equal(customBusinessHour._id);
+
+			await addOrRemoveAgentFromDepartment(
+				deptLinkedToCustomBH._id,
+				{
+					agentId: agentLinkedToDept.user._id,
+					username: agentLinkedToDept.user.username || '',
+				},
+				false,
+			);
+
+			const openBusinessHours = await waitForAgentBusinessHours(agentLinkedToDept.credentials, [defaultBusinessHour._id]);
+			expect(openBusinessHours).to.be.an('array').of.length(1);
+			expect(openBusinessHours?.[0]).to.be.equal(defaultBusinessHour._id);
+		});
+
+		it('upon removing an agent from one department, the agent should keep the business hour shared with its other department', async () => {
+			// link a second department (with its own agent) to the same business hour and make the first agent overlap
+			const { department, agent } = await createDepartmentWithAnOnlineAgent();
+			await removeAllCustomBusinessHours();
+			customBusinessHour = await createCustomBusinessHour([deptLinkedToCustomBH._id, department._id]);
+			await openOrCloseBusinessHour(customBusinessHour, true);
+
+			await addOrRemoveAgentFromDepartment(
+				department._id,
+				{
+					agentId: agentLinkedToDept.user._id,
+					username: agentLinkedToDept.user.username || '',
+				},
+				true,
+			);
+
+			await addOrRemoveAgentFromDepartment(
+				deptLinkedToCustomBH._id,
+				{
+					agentId: agentLinkedToDept.user._id,
+					username: agentLinkedToDept.user.username || '',
+				},
+				false,
+			);
+
+			// state must not change; give the async callback time to run before asserting
+			await sleep(2000);
+
+			const latestAgent: ILivechatAgent = await getMe(agentLinkedToDept.credentials);
+			expect(latestAgent.openBusinessHours).to.be.an('array').of.length(1);
+			expect(latestAgent?.openBusinessHours?.[0]).to.be.equal(customBusinessHour._id);
+
+			await deleteDepartment(department._id);
+			await deleteUser(agent.user);
+		});
+
+		afterEach(async () => {
+			await deleteDepartment(deptLinkedToCustomBH._id);
+			await deleteUser(agentLinkedToDept.user);
+		});
+
+		after(async () => {
+			await removeAllCustomBusinessHours();
+		});
+	});
 	describe('[CE][BH] On Agent created/removed', () => {
 		let defaultBH: ILivechatBusinessHour;
 		let agent: ILivechatAgent;


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Related to the aggregation audit in #41157 (independent — can merge in any order; rebased onto develop).

`LivechatDepartment.findAgentsByBusinessHourId` (EE) passes its pipeline double-wrapped — `aggregate([[...stages]])` — and MongoDB rejects non-object pipeline elements (`TypeMismatch: Each element of the 'pipeline' array must be an object`, reproduced against a live server). The method has thrown on every invocation since it was introduced in #31468 (2024-01-19).

Its only call path is fire-and-forget: `updateDepartmentAgents` → `callbacks.runAsync('livechat.removeAgentDepartment')` → `MultipleBusinessHoursBehavior.onRemoveAgentFromDepartment` → `handleRemoveAgentsFromDepartments`. `runAsync` schedules callbacks via `setTimeout` with a discarded promise, so the rejection surfaces as an **unhandled promise rejection**. Per `RocketChat.ErrorHandler.ts`, the impact depends on the environment:

- **development / TEST_MODE / `EXIT_UNHANDLEDPROMISEREJECTION` set**: `process.exit(1)` — **removing an agent from a business-hour-linked department crashes the server** (reproduced locally).
- **production default**: logged and swallowed — agent removal succeeds but the removed agents' `openBusinessHours` is never recomputed, leaving their livechat availability stale until an unrelated event refreshes it.

This PR unwraps the pipeline so the recomputation actually executes, and adds two EE e2e tests:

1. Removing an agent from its only department falls back to the default business hour — **fails against the unfixed code** (verified by temporarily reverting the fix: the callback rejected and the dev server exited).
2. Removing an agent from one of two departments sharing the same business hour keeps that business hour open — exercises the `agentIds` set the fixed aggregation returns. A control agent (only in the first department, removed in the same request) must observably fall back to the default business hour first, proving the recomputation ran — the kept-state assertion equals the pre-removal state, so it isn't meaningful on its own.

Both tests poll for the result since the recomputation is asynchronous.

## Issue(s)

## Steps to test or reproduce
1. EE license, enable business hours in **Multiple** mode.
2. Create a custom business hour linked to a department; add an agent to that department.
3. Remove the agent from the department (department edit → save).
4. Before: unhandled `TypeMismatch` rejection (dev/test: server exits; prod: silently skipped bookkeeping, agent keeps stale `openBusinessHours`). After: the agent's business hour closes or falls back to the default business hour.

Or: `IS_EE=true yarn testapi:livechat --grep 'On agent removed from department'`

## Further comments
Requires EE + multiple business hours + a department linked to a business hour — narrow enough that the failure survived 2.5 years.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Livechat business-hours availability so agent status updates correctly after an agent is removed from a department linked to business hours (including when multiple business hours are enabled).
  * Prevented agents from being marked open/closed based on business hours that no longer apply, improving recomputation reliability and overall stability.

* **Tests**
  * Added end-to-end coverage for agent-removal scenarios, including overlapping-department behavior, to ensure cached business-hours availability updates correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [CORE-2378]

[CORE-2378]: https://rocketchat.atlassian.net/browse/CORE-2378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ