### PR TITLE
docs: add Zenith to deploy options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ We support different methods of deployment for different needs. Choose your meth
 
 - Looking for a custom cloud-hosted solution without handling infrastructure? Check out our premium, dedicated [cloud hosting options](https://docs.rocket.chat/docs/rocketchat-cloud-hosting-service-level-agreement-sla) that adapt to your needs.
 
+- One-click managed hosting is available [via Zenith](https://zenith.hosting/host/rocket-chat), with storage, backups and email handled for you.
+
 - Interested in decentralized communication? Enable [federation](https://docs.rocket.chat/docs/rocketchat-native-federation) to securely communicate and share resources across a federated network.
 
 # 📱 Desktop and mobile apps


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Rocket.Chat to our marketplace, so this PR adds a small managed-hosting entry in the Deploy section (links to https://zenith.hosting/host/rocket-chat).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

## Issue(s)

## Steps to test or reproduce

view the rendered README Deploy section

## Further comments

No LLMs were involved.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the deployment section with an additional hosting option.
  * Added a new bullet promoting one-click managed hosting, including a direct link for quick access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
