### PR TITLE
chore(deps): patch file-type

### DIFF
--- a/.yarn/patches/file-type-npm-16.5.4-d653e66a40.patch
+++ b/.yarn/patches/file-type-npm-16.5.4-d653e66a40.patch
@@ -1,0 +1,23 @@
+diff --git a/core.js b/core.js
+index d653e66a40..0f5d672dc4 100644
+--- a/core.js
++++ b/core.js
+@@ -1074,6 +1074,7 @@ async function _fromTokenizer(tokenizer) {
+ 		await tokenizer.ignore(30);
+ 		// Search for header should be in first 1KB of file.
+ 		while (tokenizer.position + 24 < tokenizer.fileInfo.size) {
++			const previousPosition = tokenizer.position;
+ 			const header = await readHeader();
+ 			let payload = header.size - 24;
+ 			if (_check(header.id, [0x91, 0x07, 0xDC, 0xB7, 0xB7, 0xA9, 0xCF, 0x11, 0x8E, 0xE6, 0x00, 0xC0, 0x0C, 0x20, 0x53, 0x65])) {
+@@ -1101,6 +1102,10 @@ async function _fromTokenizer(tokenizer) {
+ 			}
+ 
+ 			await tokenizer.ignore(payload);
++
++			if (tokenizer.position <= previousPosition) {
++				break;
++			}
+ 		}
+ 
+ 		// Default to ASF generic extension

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"testunit": "turbo run testunit"
 	},
 	"resolutions": {
+		"file-type@npm:^16.5.4": "patch:file-type@npm%3A16.5.4#~/.yarn/patches/file-type-npm-16.5.4-d653e66a40.patch",
 		"external-editor/tmp": "0.2.7",
 		"@sematext/gc-stats@npm:^1.5.9": "patch:@sematext/gc-stats@npm%3A1.5.9#~/.yarn/patches/@sematext-gc-stats-npm-1.5.9-01e77be4d0.patch",
 		"adm-zip": "0.5.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22100,7 +22100,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"file-type@npm:^16.5.4":
+"file-type@npm:16.5.4":
   version: 16.5.4
   resolution: "file-type@npm:16.5.4"
   dependencies:
@@ -22108,6 +22108,17 @@ __metadata:
     strtok3: "npm:^6.2.4"
     token-types: "npm:^4.1.1"
   checksum: 10/46ced46bb925ab547e0a6d43108a26d043619d234cb0588d7abce7b578dafac142bcfd2e23a6adb0a4faa4b951bd1b14b355134a193362e07cd352f9bf0dc349
+  languageName: node
+  linkType: hard
+
+"file-type@patch:file-type@npm%3A16.5.4#~/.yarn/patches/file-type-npm-16.5.4-d653e66a40.patch":
+  version: 16.5.4
+  resolution: "file-type@patch:file-type@npm%3A16.5.4#~/.yarn/patches/file-type-npm-16.5.4-d653e66a40.patch::version=16.5.4&hash=5b21d2"
+  dependencies:
+    readable-web-to-node-stream: "npm:^3.0.0"
+    strtok3: "npm:^6.2.4"
+    token-types: "npm:^4.1.1"
+  checksum: 10/0d3de7f426954aec727a8a0fb1228a457ee8fa76a53fb7198bb700d31051e551f1a677657e4a770d060b8648c0d8704d0920c7aa131da982548b33575f2d92f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
This PR patches file-type to add a safeguard that prevents a infinite loop reported in CVE-2026-31808. 
Upgrading to `file-type@21.x` was considered but ruled out since it's a breaking major-version bump; patching the pinned version is enough risk mitigation for now. 
It applies a yarn patch (`.yarn/patches/file-type-npm-16.5.4-d653e66a40.patch`) directly to `core.js`, adding a guard that breaks out of the loop whenever the tokenizer's position fails to advance. This mirrors the fix shipped upstream in `file-type@21.3.1`, backported onto the version we currently depend on.
The patch is wired in via a resolutions entry in package.json so it applies to every consumer of `file-type@^16.5.4` in the workspace without per-package changes.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[VLN-456](https://rocketchat.atlassian.net/browse/VLN-456)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[VLN-456]: https://rocketchat.atlassian.net/browse/VLN-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied a package resolution update to use a patched version of a dependency, improving overall stability and reducing risk from a known issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->