### PR TITLE
test: isolate session expiration e2e users

### DIFF
--- a/apps/meteor/tests/e2e/session-expiration-redirect.spec.ts
+++ b/apps/meteor/tests/e2e/session-expiration-redirect.spec.ts
@@ -1,11 +1,14 @@
+import type { Page } from '@playwright/test';
 import { MongoClient } from 'mongodb';
 
 import { URL_MONGODB } from './config/constants';
-import injectInitialData from './fixtures/inject-initial-data';
-import { Users } from './fixtures/userStates';
+import { createAuxContext } from './fixtures/createAuxContext';
+import type { IUserState } from './fixtures/userStates';
 import { HomeChannel } from './page-objects';
 import { createTargetChannel, deleteChannel } from './utils';
 import { test, expect } from './utils/test';
+import type { ITestUser } from './utils/user-helpers';
+import { createTestUser, loginTestUser } from './utils/user-helpers';
 
 const removeTokensFromdb = async (username: string): Promise<void> => {
 	const connection = await MongoClient.connect(URL_MONGODB);
@@ -18,30 +21,38 @@ const removeTokensFromdb = async (username: string): Promise<void> => {
 	await connection.close();
 };
 
-test.use({ storageState: Users.user1.state });
-
 test.describe('Session Expiration Redirect', () => {
-	let poHomeChannel: HomeChannel;
 	let targetChannel: string;
+	let sessions: { page: Page; poHomeChannel: HomeChannel }[] = [];
+	let expiringUser1: ITestUser;
+	let expiringUser2: ITestUser;
+	let expiringUser1State: IUserState;
+	let expiringUser2State: IUserState;
 
 	test.beforeAll(async ({ api }) => {
-		targetChannel = await createTargetChannel(api, { members: [Users.user1.data.username] });
+		[expiringUser1, expiringUser2] = await Promise.all([createTestUser(api), createTestUser(api)]);
+		[expiringUser1State, expiringUser2State] = await Promise.all([loginTestUser(api, expiringUser1), loginTestUser(api, expiringUser2)]);
+
+		targetChannel = await createTargetChannel(api, { members: [expiringUser1.data.username, expiringUser2.data.username] });
 	});
 
 	test.afterAll(async ({ api }) => {
 		await deleteChannel(api, targetChannel);
+		await Promise.all([expiringUser1?.delete(), expiringUser2?.delete()]);
 	});
 
-	test.beforeEach(async ({ page }) => {
-		poHomeChannel = new HomeChannel(page);
-		await poHomeChannel.gotoChannel(targetChannel);
-	});
 	test.afterEach(async () => {
-		await injectInitialData();
+		await Promise.all(sessions.map(({ page }) => page.close()));
+		sessions = [];
 	});
 
-	test('should redirect to login page when server-side token is deleted and user tries to interact', async ({ page }) => {
+	test('should redirect to login page when server-side token is deleted and user tries to interact', async ({ browser }) => {
+		const { page } = await createAuxContext(browser, expiringUser1State, `/channel/${targetChannel}`);
+		const poHomeChannel = new HomeChannel(page);
+		sessions.push({ page, poHomeChannel });
+
 		await test.step('expect user to be logged in initially', async () => {
+			await poHomeChannel.content.waitForChannel();
 			await expect(page.locator('#main-content')).toBeVisible();
 
 			const userId = await page.evaluate(() => localStorage.getItem('Meteor.userId'));
@@ -51,7 +62,7 @@ test.describe('Session Expiration Redirect', () => {
 		});
 
 		await test.step('delete login tokens from database (simulating server-side expiration)', async () => {
-			await removeTokensFromdb(Users.user1.data.username);
+			await removeTokensFromdb(expiringUser1.data.username);
 		});
 
 		await test.step('open room search messages (without page reload)', async () => {
@@ -73,13 +84,18 @@ test.describe('Session Expiration Redirect', () => {
 		});
 	});
 
-	test('should redirect to login page when trying to send message with expired token', async ({ page }) => {
+	test('should redirect to login page when trying to send message with expired token', async ({ browser }) => {
+		const { page } = await createAuxContext(browser, expiringUser2State, `/channel/${targetChannel}`);
+		const poHomeChannel = new HomeChannel(page);
+		sessions.push({ page, poHomeChannel });
+
 		await test.step('type message', async () => {
+			await poHomeChannel.content.waitForChannel();
 			await poHomeChannel.composer.inputMessage.fill('Test message');
 		});
 
 		await test.step('delete login tokens from database', async () => {
-			await removeTokensFromdb(Users.user1.data.username);
+			await removeTokensFromdb(expiringUser2.data.username);
 		});
 
 		await test.step('try to send a message (should trigger auth error)', async () => {


### PR DESCRIPTION

## Proposed changes

Isolates `session-expiration-redirect.spec.ts` from shared fixture users by creating disposable users for the expired-session scenarios.

The tests now invalidate only users created for this spec, which avoids leaking stale `Users.user1`/`Users.user2` auth state into later E2E tests.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[FLAKY-1910](https://rocketchat.atlassian.net/browse/FLAKY-1910)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

[FLAKY-2212]: https://rocketchat.atlassian.net/browse/FLAKY-2212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FLAKY-1910]: https://rocketchat.atlassian.net/browse/FLAKY-1910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session-expiration behavior in end-to-end coverage so users are redirected to the login screen when their session is no longer valid.
  * Verified that expired sessions are cleared from browser storage after interaction or sending a message, helping prevent stale login states.
  * Added broader multi-user test coverage for channel activity with separate logged-in sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->