### PR TITLE
fix: race condition in E2EE rooms creation causing 'incorrect encryption key' error

### DIFF
--- a/.changeset/four-tigers-clap.md
+++ b/.changeset/four-tigers-clap.md
@@ -1,6 +1,7 @@
 ---
 '@rocket.chat/models': patch
+'@rocket.chat/model-typings': patch
 '@rocket.chat/meteor': patch
 ---
 
-Fixed a race condition that left messages permanently undecryptable ("incorrect encryption key") in rooms created with encryption enabled. When several members opened such a room at the same time, each client could independently generate and distribute a different group key. Establishing the room key is now atomic (first-write-wins) on the server, and a client that loses the race discards its locally generated key and adopts the established one instead of encrypting with a divergent key.
+Fixes a race condition that left messages permanently undecryptable ("incorrect encryption key") in rooms created with encryption enabled. When several members opened such a room at the same time, each client could independently generate and distribute a different group key. Establishing the room key is now atomic (first-write-wins) on the server, and a client that loses the race discards its locally generated key and adopts the established one instead of encrypting with a divergent key.

--- a/.changeset/four-tigers-clap.md
+++ b/.changeset/four-tigers-clap.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/models': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixed a race condition that left messages permanently undecryptable ("incorrect encryption key") in rooms created with encryption enabled. When several members opened such a room at the same time, each client could independently generate and distribute a different group key. Establishing the room key is now atomic (first-write-wins) on the server, and a client that loses the race discards its locally generated key and adopts the established one instead of encrypting with a divergent key.

--- a/apps/meteor/client/lib/e2ee/rocketchat.e2e.room.spec.ts
+++ b/apps/meteor/client/lib/e2ee/rocketchat.e2e.room.spec.ts
@@ -1,0 +1,64 @@
+import * as Aes from './crypto/aes';
+import { E2ERoom } from './rocketchat.e2e.room';
+import { sdk } from '../../../app/utils/client/lib/SDKClient';
+
+jest.mock('./crypto/aes');
+jest.mock('../../../app/utils/client/lib/SDKClient', () => ({
+	sdk: { rest: { post: jest.fn() } },
+}));
+jest.mock('../../../app/utils/client/index', () => ({
+	Info: { version: '8.7.0' },
+}));
+
+class FakeResponse {
+	constructor(
+		private readonly body: unknown,
+		public readonly status = 400,
+	) {}
+
+	clone() {
+		return this;
+	}
+
+	async json() {
+		return this.body;
+	}
+}
+(global as any).Response = FakeResponse;
+
+const makeRoom = () => new E2ERoom('user-1', { _id: 'room-1', t: 'p', encrypted: true } as any);
+
+describe('E2ERoom.createGroupKey', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		(Aes.generate as jest.Mock).mockResolvedValue('group-key');
+		(Aes.exportJwk as jest.Mock).mockResolvedValue({ k: 'jwk' });
+	});
+
+	it('should discard the local key and not distribute it when it loses the race', async () => {
+		(sdk.rest.post as jest.Mock).mockRejectedValueOnce(
+			new (global as any).Response({ success: false, errorType: 'error-room-e2e-key-already-exists' }),
+		);
+
+		const e2eRoom = makeRoom();
+		const result = await e2eRoom.createGroupKey();
+
+		expect(result).toBe(false);
+		expect(e2eRoom.groupSessionKey).toBeNull();
+		expect(e2eRoom.keyID).toBeUndefined();
+		expect(sdk.rest.post).toHaveBeenCalledTimes(1); // only setRoomKeyID was called
+		expect(sdk.rest.post).toHaveBeenCalledWith('/v1/e2e.setRoomKeyID', { rid: e2eRoom.roomId, keyID: expect.anything() });
+	});
+
+	it('should return true and distribute the key when it wins the race', async () => {
+		(sdk.rest.post as jest.Mock).mockResolvedValue({}); // setRoomKeyID + updateGroupKey OK
+		jest.spyOn(E2ERoom.prototype as any, 'encryptGroupKeyForParticipant').mockResolvedValue('mykey');
+		jest.spyOn(E2ERoom.prototype as any, 'encryptKeyForOtherParticipants').mockResolvedValue(undefined);
+
+		const e2eRoom = makeRoom();
+		const result = await e2eRoom.createGroupKey();
+
+		expect(result).toBe(true);
+		expect(e2eRoom.groupSessionKey).not.toBeNull();
+	});
+});

--- a/apps/meteor/client/lib/e2ee/rocketchat.e2e.room.spec.ts
+++ b/apps/meteor/client/lib/e2ee/rocketchat.e2e.room.spec.ts
@@ -35,6 +35,10 @@ describe('E2ERoom.createGroupKey', () => {
 		(Aes.exportJwk as jest.Mock).mockResolvedValue({ k: 'jwk' });
 	});
 
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
 	it('should discard the local key and not distribute it when it loses the race', async () => {
 		(sdk.rest.post as jest.Mock).mockRejectedValueOnce(
 			new (global as any).Response({ success: false, errorType: 'error-room-e2e-key-already-exists' }),
@@ -47,18 +51,31 @@ describe('E2ERoom.createGroupKey', () => {
 		expect(e2eRoom.groupSessionKey).toBeNull();
 		expect(e2eRoom.keyID).toBeUndefined();
 		expect(sdk.rest.post).toHaveBeenCalledTimes(1); // only setRoomKeyID was called
-		expect(sdk.rest.post).toHaveBeenCalledWith('/v1/e2e.setRoomKeyID', { rid: e2eRoom.roomId, keyID: expect.anything() });
+		expect(sdk.rest.post).toHaveBeenCalledWith('/v1/e2e.setRoomKeyID', { rid: e2eRoom.roomId, keyID: expect.any(String) });
 	});
 
 	it('should return true and distribute the key when it wins the race', async () => {
-		(sdk.rest.post as jest.Mock).mockResolvedValue({}); // setRoomKeyID + updateGroupKey OK
+		(sdk.rest.post as jest.Mock).mockResolvedValue({});
 		jest.spyOn(E2ERoom.prototype as any, 'encryptGroupKeyForParticipant').mockResolvedValue('mykey');
-		jest.spyOn(E2ERoom.prototype as any, 'encryptKeyForOtherParticipants').mockResolvedValue(undefined);
+		const encryptForOthersSpy = jest.spyOn(E2ERoom.prototype as any, 'encryptKeyForOtherParticipants').mockResolvedValue(undefined);
 
 		const e2eRoom = makeRoom();
 		const result = await e2eRoom.createGroupKey();
 
 		expect(result).toBe(true);
 		expect(e2eRoom.groupSessionKey).not.toBeNull();
+
+		expect(sdk.rest.post).toHaveBeenCalledWith('/v1/e2e.setRoomKeyID', {
+			rid: e2eRoom.roomId,
+			keyID: expect.any(String),
+		});
+		expect(sdk.rest.post).toHaveBeenCalledWith('/v1/e2e.updateGroupKey', {
+			rid: e2eRoom.roomId,
+			uid: e2eRoom.userId,
+			key: 'mykey',
+		});
+
+		expect(encryptForOthersSpy).toHaveBeenCalledTimes(1);
+		expect(sdk.rest.post).toHaveBeenCalledTimes(2); // both setRoomKeyID and updateGroupKey are called
 	});
 });

--- a/apps/meteor/client/lib/e2ee/rocketchat.e2e.room.ts
+++ b/apps/meteor/client/lib/e2ee/rocketchat.e2e.room.ts
@@ -34,10 +34,7 @@ const log = createLogger('E2E:Room');
 const KEY_ID = Symbol('keyID');
 const PAUSED = Symbol('PAUSED');
 
-const isRoomKeyAlreadyExistsError = async (error: unknown): Promise<boolean> => {
-	if (!(error instanceof Response)) {
-		return false;
-	}
+const isRoomKeyAlreadyExistsError = async (error: Response): Promise<boolean> => {
 	try {
 		const body = await error.clone().json();
 		return body?.errorType === 'error-room-e2e-key-already-exists';
@@ -450,7 +447,7 @@ export class E2ERoom extends Emitter {
 		try {
 			await sdk.rest.post('/v1/e2e.setRoomKeyID', { rid: this.roomId, keyID: this.keyID });
 		} catch (error) {
-			if (await isRoomKeyAlreadyExistsError(error)) {
+			if (error instanceof Response && (await isRoomKeyAlreadyExistsError(error))) {
 				span.info('Room key already established by another member; discarding local key');
 				this.discardGroupKey();
 				return false;

--- a/apps/meteor/client/lib/e2ee/rocketchat.e2e.room.ts
+++ b/apps/meteor/client/lib/e2ee/rocketchat.e2e.room.ts
@@ -34,6 +34,18 @@ const log = createLogger('E2E:Room');
 const KEY_ID = Symbol('keyID');
 const PAUSED = Symbol('PAUSED');
 
+const isRoomKeyAlreadyExistsError = async (error: unknown): Promise<boolean> => {
+	if (!(error instanceof Response)) {
+		return false;
+	}
+	try {
+		const body = await error.clone().json();
+		return body?.errorType === 'error-room-e2e-key-already-exists';
+	} catch {
+		return false;
+	}
+};
+
 type Mutations = { [k in E2ERoomState]?: E2ERoomState[] };
 
 const permitedMutations: Mutations = {
@@ -331,7 +343,12 @@ export class E2ERoom extends Emitter {
 			span.set('room', room);
 			if (!room?.e2eKeyId) {
 				this.setState('CREATING_KEYS');
-				await this.createGroupKey();
+				const created = await this.createGroupKey();
+				if (!created) {
+					// another member won the race
+					this.setState('WAITING_KEYS');
+					return;
+				}
 				this.setState('READY');
 				return;
 			}
@@ -420,10 +437,26 @@ export class E2ERoom extends Emitter {
 		this.keyID = crypto.randomUUID();
 	}
 
-	async createGroupKey() {
+	private discardGroupKey() {
+		this.groupSessionKey = null;
+		this.sessionKeyExportedString = undefined;
+		this.keyID = undefined as unknown as string;
+	}
+
+	async createGroupKey(): Promise<boolean> {
+		const span = log.span('createGroupKey');
 		await this.createNewGroupKey();
 
-		await sdk.rest.post('/v1/e2e.setRoomKeyID', { rid: this.roomId, keyID: this.keyID });
+		try {
+			await sdk.rest.post('/v1/e2e.setRoomKeyID', { rid: this.roomId, keyID: this.keyID });
+		} catch (error) {
+			if (await isRoomKeyAlreadyExistsError(error)) {
+				span.info('Room key already established by another member; discarding local key');
+				this.discardGroupKey();
+				return false;
+			}
+			throw error;
+		}
 		const myKey = await this.encryptGroupKeyForParticipant(e2e.publicKey!);
 		if (myKey) {
 			await sdk.rest.post('/v1/e2e.updateGroupKey', {
@@ -433,6 +466,7 @@ export class E2ERoom extends Emitter {
 			});
 			await this.encryptKeyForOtherParticipants();
 		}
+		return true;
 	}
 
 	async resetRoomKey() {

--- a/apps/meteor/server/meteor-methods/platform/setRoomKeyID.ts
+++ b/apps/meteor/server/meteor-methods/platform/setRoomKeyID.ts
@@ -25,13 +25,13 @@ export const setRoomKeyIDMethod = async (userId: string, rid: IRoom['_id'], keyI
 		throw new Meteor.Error('error-invalid-room', 'Invalid room', { method: 'e2e.setRoomKeyID' });
 	}
 
-	if (room.e2eKeyId) {
+	const { modifiedCount } = await Rooms.setE2eKeyId(room._id, keyID);
+
+	if (modifiedCount === 0) {
 		throw new Meteor.Error('error-room-e2e-key-already-exists', 'E2E Key ID already exists', {
 			method: 'e2e.setRoomKeyID',
 		});
 	}
-
-	await Rooms.setE2eKeyId(room._id, keyID);
 
 	void notifyOnRoomChangedById(room._id);
 };

--- a/apps/meteor/server/meteor-methods/platform/setRoomKeyID.ts
+++ b/apps/meteor/server/meteor-methods/platform/setRoomKeyID.ts
@@ -5,7 +5,7 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
 import { canAccessRoomIdAsync } from '../../lib/authorization/canAccessRoom';
-import { notifyOnRoomChangedById } from '../../lib/notifyListener';
+import { notifyOnRoomChanged } from '../../lib/notifyListener';
 
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -19,21 +19,15 @@ export const setRoomKeyIDMethod = async (userId: string, rid: IRoom['_id'], keyI
 		throw new Meteor.Error('error-invalid-room', 'Invalid room', { method: 'e2e.setRoomKeyID' });
 	}
 
-	const room = await Rooms.findOneById<Pick<IRoom, '_id' | 'e2eKeyId'>>(rid, { projection: { e2eKeyId: 1 } });
+	const room = await Rooms.setE2eKeyId(rid, keyID);
 
 	if (!room) {
-		throw new Meteor.Error('error-invalid-room', 'Invalid room', { method: 'e2e.setRoomKeyID' });
-	}
-
-	const { modifiedCount } = await Rooms.setE2eKeyId(room._id, keyID);
-
-	if (modifiedCount === 0) {
 		throw new Meteor.Error('error-room-e2e-key-already-exists', 'E2E Key ID already exists', {
 			method: 'e2e.setRoomKeyID',
 		});
 	}
 
-	void notifyOnRoomChangedById(room._id);
+	void notifyOnRoomChanged(room);
 };
 
 Meteor.methods<ServerMethods>({

--- a/packages/model-typings/src/models/IRoomsModel.ts
+++ b/packages/model-typings/src/models/IRoomsModel.ts
@@ -193,7 +193,7 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 	setAvatarData(roomId: string, origin: string, etag: string): Promise<UpdateResult>;
 	unsetAvatarData(roomId: string): Promise<UpdateResult>;
 	setSystemMessagesById(roomId: string, systemMessages: IRoom['sysMes']): Promise<UpdateResult>;
-	setE2eKeyId(roomId: string, e2eKeyId: string, options?: FindOptions<IRoom>): Promise<UpdateResult>;
+	setE2eKeyId(roomId: string, e2eKeyId: string, options?: FindOptions<IRoom>): Promise<IRoom | null>;
 	findOneByImportId(importId: string, options?: FindOptions<IRoom>): Promise<IRoom | null>;
 	findOneByNameAndNotId(name: string, rid: string): Promise<IRoom | null>;
 	findOneByIdAndType<T extends Document = IRoom>(roomId: IRoom['_id'], type: IRoom['t'], options?: FindOptions<T>): Promise<T | null>;

--- a/packages/model-typings/src/models/IRoomsModel.ts
+++ b/packages/model-typings/src/models/IRoomsModel.ts
@@ -194,7 +194,11 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 	setAvatarData(roomId: string, origin: string, etag: string): Promise<UpdateResult>;
 	unsetAvatarData(roomId: string): Promise<UpdateResult>;
 	setSystemMessagesById(roomId: string, systemMessages: IRoom['sysMes']): Promise<UpdateResult>;
-	setE2eKeyId(roomId: string, e2eKeyId: string, options?: FindOneAndUpdateOptions): Promise<IRoom | null>;
+	setE2eKeyId(
+		roomId: string,
+		e2eKeyId: string,
+		options?: Omit<FindOneAndUpdateOptions, 'returnDocument' | 'includeResultMetadata' | 'upsert'>,
+	): Promise<IRoom | null>;
 	findOneByImportId(importId: string, options?: FindOptions<IRoom>): Promise<IRoom | null>;
 	findOneByNameAndNotId(name: string, rid: string): Promise<IRoom | null>;
 	findOneByIdAndType<T extends Document = IRoom>(roomId: IRoom['_id'], type: IRoom['t'], options?: FindOptions<T>): Promise<T | null>;

--- a/packages/model-typings/src/models/IRoomsModel.ts
+++ b/packages/model-typings/src/models/IRoomsModel.ts
@@ -18,6 +18,7 @@ import type {
 	UpdateResult,
 	CountDocumentsOptions,
 	WithId,
+	FindOneAndUpdateOptions,
 } from 'mongodb';
 
 import type { Updater } from '../updater';
@@ -193,7 +194,7 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 	setAvatarData(roomId: string, origin: string, etag: string): Promise<UpdateResult>;
 	unsetAvatarData(roomId: string): Promise<UpdateResult>;
 	setSystemMessagesById(roomId: string, systemMessages: IRoom['sysMes']): Promise<UpdateResult>;
-	setE2eKeyId(roomId: string, e2eKeyId: string, options?: FindOptions<IRoom>): Promise<IRoom | null>;
+	setE2eKeyId(roomId: string, e2eKeyId: string, options?: FindOneAndUpdateOptions): Promise<IRoom | null>;
 	findOneByImportId(importId: string, options?: FindOptions<IRoom>): Promise<IRoom | null>;
 	findOneByNameAndNotId(name: string, rid: string): Promise<IRoom | null>;
 	findOneByIdAndType<T extends Document = IRoom>(roomId: IRoom['_id'], type: IRoom['t'], options?: FindOptions<T>): Promise<T | null>;

--- a/packages/models/src/models/Rooms.ts
+++ b/packages/models/src/models/Rooms.ts
@@ -1016,6 +1016,9 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 	setE2eKeyId(_id: IRoom['_id'], e2eKeyId: IRoom['e2eKeyId'], options: UpdateOptions = {}): Promise<UpdateResult> {
 		const query: Filter<IRoom> = {
 			_id,
+			e2eKeyId: {
+				$exists: false,
+			},
 		};
 
 		const update: UpdateFilter<IRoom> = {

--- a/packages/models/src/models/Rooms.ts
+++ b/packages/models/src/models/Rooms.ts
@@ -26,6 +26,7 @@ import type {
 	UpdateResult,
 	WithId,
 	CountDocumentsOptions,
+	FindOneAndUpdateOptions,
 } from 'mongodb';
 
 import { Subscriptions } from '../index';
@@ -1013,7 +1014,7 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.updateOne(query, update);
 	}
 
-	setE2eKeyId(_id: IRoom['_id'], e2eKeyId: IRoom['e2eKeyId'], options: UpdateOptions = {}): Promise<UpdateResult> {
+	setE2eKeyId(_id: IRoom['_id'], e2eKeyId: IRoom['e2eKeyId'], options: FindOneAndUpdateOptions = {}): Promise<IRoom | null> {
 		const query: Filter<IRoom> = {
 			_id,
 			e2eKeyId: {
@@ -1027,7 +1028,7 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			},
 		};
 
-		return this.updateOne(query, update, options);
+		return this.findOneAndUpdate(query, update, { returnDocument: 'after', ...options });
 	}
 
 	findOneByImportId(_id: IRoom['_id'], options: FindOptions<IRoom> = {}): Promise<IRoom | null> {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
There was a race condition occurring when a E2EE room is created with several online users. It happens because  when the room is created, every online added user triggers a request to the `e2e.setRoomKeyID` endpoint concurrently, which isn't atomic (it first reads the room, then checks if it has `e2eKeyId`, and if it doesn't have it, then another roundtrip to the database is performed to add the key). This two-phase behavior caused stale states for users who lost the race.

To address this:
- Added `$exists` condition to the `e2eKeyId` property in the query of the `Rooms.setE2eKeyId` model method. This avoids overwriting the value if another user  already won the race. Also the `Rooms.findOneById` query was removed, since we are already checking for room availability with `canAccessRoomIdAsync`.
- Added frontend handling: in case the user loses the race, it discards the local stored IDs and its state changes to `WAITING_KEYS`.
- Tests: It's difficult to create a test that guarantees that no race condition occur here, therefore I've created a frontend unit test file (`apps/meteor/client/lib/e2ee/rocketchat.e2e.room.spec.ts`) checking the local values are discarded if another user won the race.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[SUP-1067 E2EE: rooms created with encryption enabled at creation leave members' messages undecryptable ("incorrect encryption key")](https://rocketchat.atlassian.net/browse/SUP-1067)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Create at least two more users besides yours in order to reproduce this race condition. All members need to be online (different tabs).
2. Create a private group with "Encrypted" enabled in the creation dialog, adding the online new members at creation.
3. Observe messages from one or more members render the "incorrect encryption key" ephemeral message for everyone.

To reproduce this even more consistently, I'd recommend to have five or more users online concurrently.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a race condition when multiple participants open an encrypted room simultaneously.
  - Ensured only one group key is established for each room.
  - Clients that lose the race now discard their local key and use the server-established key, preventing undecryptable messages.

- **Tests**
  - Added coverage for both winning and losing concurrent key-creation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->