### PR TITLE
refactor: sync missed messages via REST chat.syncMessages on reconnect

### DIFF
--- a/.changeset/reconnect-sync-rest-messages.md
+++ b/.changeset/reconnect-sync-rest-messages.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/models': minor
+'@rocket.chat/meteor': minor
+---
+
+Reconnect message synchronization now uses the `chat.syncMessages` REST endpoint instead of the `loadMissedMessages` DDP method, so edits and deletions that happened while the client was offline are reconciled once the connection is restored. Adds a `{ rid: 1, _updatedAt: 1 }` index to the messages collection to keep that query efficient on large rooms and deprecates the `loadMissedMessages` method, planned for removal in 9.0.0.

--- a/apps/meteor/app/ui-utils/client/index.ts
+++ b/apps/meteor/app/ui-utils/client/index.ts
@@ -1,3 +1,3 @@
 export { messageBox } from './lib/messageBox';
 export { LegacyRoomManager } from './lib/LegacyRoomManager';
-export { upsertMessage, RoomHistoryManager } from './lib/RoomHistoryManager';
+export { upsertMessage, upsertMessageBulk, RoomHistoryManager } from './lib/RoomHistoryManager';

--- a/apps/meteor/client/views/root/hooks/useLoadMissedMessages.spec.ts
+++ b/apps/meteor/client/views/root/hooks/useLoadMissedMessages.spec.ts
@@ -1,0 +1,193 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useLoadMissedMessages } from './useLoadMissedMessages';
+import { LegacyRoomManager, upsertMessageBulk } from '../../../../app/ui-utils/client';
+import { Messages, Subscriptions } from '../../../stores';
+
+jest.mock('../../../../app/ui-utils/client', () => ({
+	LegacyRoomManager: {
+		openedRooms: {} as Record<string, { rid?: string }>,
+	},
+	upsertMessageBulk: jest.fn(),
+}));
+
+jest.mock('../../../stores', () => ({
+	Messages: {
+		state: {
+			findFirst: jest.fn(),
+			delete: jest.fn(),
+		},
+	},
+	Subscriptions: {
+		state: {
+			find: jest.fn(),
+		},
+	},
+}));
+
+const mockUseConnectionStatus = jest.fn<{ connected: boolean }, []>();
+
+jest.mock('@rocket.chat/ui-contexts', () => ({
+	...jest.requireActual('@rocket.chat/ui-contexts'),
+	useConnectionStatus: () => mockUseConnectionStatus(),
+}));
+
+const mockedUpsertMessageBulk = jest.mocked(upsertMessageBulk);
+const mockedFindFirst = Messages.state.findFirst as jest.Mock;
+const mockedDelete = Messages.state.delete as jest.Mock;
+const mockedFindSubscription = Subscriptions.state.find as jest.Mock;
+
+const openedRooms = LegacyRoomManager.openedRooms as unknown as Record<string, { rid?: string }>;
+
+const lastLocalMessage = {
+	_id: 'msg-local',
+	rid: 'room-1',
+	_updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+const emptyResult = {
+	result: {
+		updated: [],
+		deleted: [],
+		cursor: { next: null, previous: null },
+	},
+};
+
+beforeEach(() => {
+	jest.clearAllMocks();
+	Object.keys(openedRooms).forEach((key) => delete openedRooms[key]);
+	openedRooms.c__general = { rid: 'room-1' };
+	mockedFindFirst.mockReturnValue(lastLocalMessage);
+	mockedFindSubscription.mockReturnValue(undefined);
+	mockedUpsertMessageBulk.mockResolvedValue(undefined);
+});
+
+const renderWithReconnect = (wrapper: ReturnType<ReturnType<typeof mockAppRoot>['build']>) => {
+	mockUseConnectionStatus.mockReturnValue({ connected: false });
+	const utils = renderHook(() => useLoadMissedMessages(), { wrapper });
+	mockUseConnectionStatus.mockReturnValue({ connected: true });
+	utils.rerender();
+	return utils;
+};
+
+describe('useLoadMissedMessages', () => {
+	it('should not sync while the connection stays online', () => {
+		const syncMessagesSpy = jest.fn(() => emptyResult as any);
+		mockUseConnectionStatus.mockReturnValue({ connected: true });
+
+		const { rerender } = renderHook(() => useLoadMissedMessages(), {
+			wrapper: mockAppRoot().withEndpoint('GET', '/v1/chat.syncMessages', syncMessagesSpy).build(),
+		});
+		rerender();
+
+		expect(syncMessagesSpy).not.toHaveBeenCalled();
+	});
+
+	it('should sync opened rooms on reconnect using the latest local _updatedAt as baseline', async () => {
+		const syncMessagesSpy = jest.fn(() => emptyResult as any);
+
+		renderWithReconnect(mockAppRoot().withEndpoint('GET', '/v1/chat.syncMessages', syncMessagesSpy).build());
+
+		await waitFor(() => {
+			expect(syncMessagesSpy).toHaveBeenCalledWith({
+				roomId: 'room-1',
+				lastUpdate: '2026-01-01T00:00:00.000Z',
+			});
+		});
+	});
+
+	it('should upsert updated messages with dates mapped and delete removed messages', async () => {
+		const syncMessagesSpy = jest.fn(
+			() =>
+				({
+					result: {
+						updated: [
+							{
+								_id: 'msg-edited',
+								rid: 'room-1',
+								msg: 'edited while offline',
+								ts: '2025-12-31T23:00:00.000Z',
+								u: { _id: 'user-1', username: 'john' },
+								_updatedAt: '2026-01-01T01:00:00.000Z',
+							},
+						],
+						deleted: [{ _id: 'msg-deleted', _deletedAt: '2026-01-01T02:00:00.000Z' }],
+						cursor: { next: null, previous: null },
+					},
+				}) as any,
+		);
+		const subscription = { rid: 'room-1' };
+		mockedFindSubscription.mockReturnValue(subscription);
+
+		renderWithReconnect(mockAppRoot().withEndpoint('GET', '/v1/chat.syncMessages', syncMessagesSpy).build());
+
+		await waitFor(() => {
+			expect(mockedUpsertMessageBulk).toHaveBeenCalledWith({
+				msgs: [
+					expect.objectContaining({
+						_id: 'msg-edited',
+						ts: new Date('2025-12-31T23:00:00.000Z'),
+						_updatedAt: new Date('2026-01-01T01:00:00.000Z'),
+					}),
+				],
+				subscription,
+			});
+		});
+
+		expect(mockedDelete).toHaveBeenCalledWith('msg-deleted');
+	});
+
+	it('should apply deletions even when no message was updated', async () => {
+		const syncMessagesSpy = jest.fn(
+			() =>
+				({
+					result: {
+						updated: [],
+						deleted: [{ _id: 'msg-deleted', _deletedAt: '2026-01-01T02:00:00.000Z' }],
+						cursor: { next: null, previous: null },
+					},
+				}) as any,
+		);
+
+		renderWithReconnect(mockAppRoot().withEndpoint('GET', '/v1/chat.syncMessages', syncMessagesSpy).build());
+
+		await waitFor(() => {
+			expect(mockedDelete).toHaveBeenCalledWith('msg-deleted');
+		});
+
+		expect(mockedUpsertMessageBulk).not.toHaveBeenCalled();
+	});
+
+	it('should skip rooms without local messages', () => {
+		mockedFindFirst.mockReturnValue(undefined);
+		const syncMessagesSpy = jest.fn(() => emptyResult as any);
+
+		renderWithReconnect(mockAppRoot().withEndpoint('GET', '/v1/chat.syncMessages', syncMessagesSpy).build());
+
+		expect(syncMessagesSpy).not.toHaveBeenCalled();
+	});
+
+	it('should keep syncing other rooms when one request fails', async () => {
+		openedRooms.c__other = { rid: 'room-2' };
+		const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+		const syncMessagesSpy = jest.fn(({ roomId }: { roomId: string }) => {
+			if (roomId === 'room-1') {
+				throw new Error('network error');
+			}
+			return emptyResult as any;
+		});
+
+		renderWithReconnect(mockAppRoot().withEndpoint('GET', '/v1/chat.syncMessages', syncMessagesSpy).build());
+
+		await waitFor(() => {
+			expect(syncMessagesSpy).toHaveBeenCalledTimes(2);
+		});
+
+		await waitFor(() => {
+			expect(consoleErrorSpy).toHaveBeenCalledWith('Error syncing missed messages:', expect.any(Error));
+		});
+
+		consoleErrorSpy.mockRestore();
+	});
+});

--- a/apps/meteor/client/views/root/hooks/useLoadMissedMessages.spec.ts
+++ b/apps/meteor/client/views/root/hooks/useLoadMissedMessages.spec.ts
@@ -63,6 +63,11 @@ beforeEach(() => {
 	mockedUpsertMessageBulk.mockResolvedValue(undefined);
 });
 
+afterEach(() => {
+	// Restore any spies (e.g. console.error) regardless of test outcome so they don't leak
+	jest.restoreAllMocks();
+});
+
 const renderWithReconnect = (wrapper: ReturnType<ReturnType<typeof mockAppRoot>['build']>) => {
 	mockUseConnectionStatus.mockReturnValue({ connected: false });
 	const utils = renderHook(() => useLoadMissedMessages(), { wrapper });
@@ -219,7 +224,5 @@ describe('useLoadMissedMessages', () => {
 		await waitFor(() => {
 			expect(consoleErrorSpy).toHaveBeenCalledWith('Error syncing missed messages:', expect.any(Error));
 		});
-
-		consoleErrorSpy.mockRestore();
 	});
 });

--- a/apps/meteor/client/views/root/hooks/useLoadMissedMessages.spec.ts
+++ b/apps/meteor/client/views/root/hooks/useLoadMissedMessages.spec.ts
@@ -16,7 +16,7 @@ jest.mock('../../../stores', () => ({
 	Messages: {
 		state: {
 			findFirst: jest.fn(),
-			delete: jest.fn(),
+			remove: jest.fn(),
 		},
 	},
 	Subscriptions: {
@@ -35,7 +35,7 @@ jest.mock('@rocket.chat/ui-contexts', () => ({
 
 const mockedUpsertMessageBulk = jest.mocked(upsertMessageBulk);
 const mockedFindFirst = Messages.state.findFirst as jest.Mock;
-const mockedDelete = Messages.state.delete as jest.Mock;
+const mockedRemove = Messages.state.remove as jest.Mock;
 const mockedFindSubscription = Subscriptions.state.find as jest.Mock;
 
 const openedRooms = LegacyRoomManager.openedRooms as unknown as Record<string, { rid?: string }>;
@@ -97,6 +97,31 @@ describe('useLoadMissedMessages', () => {
 		});
 	});
 
+	it('should only consider non-temp, non-hidden messages that have an _updatedAt as the baseline', async () => {
+		const syncMessagesSpy = jest.fn(() => emptyResult as any);
+
+		renderWithReconnect(mockAppRoot().withEndpoint('GET', '/v1/chat.syncMessages', syncMessagesSpy).build());
+
+		await waitFor(() => {
+			expect(mockedFindFirst).toHaveBeenCalled();
+		});
+
+		const [predicate, comparator] = mockedFindFirst.mock.calls[0];
+
+		expect(predicate({ rid: 'room-1', _hidden: false, temp: false, _updatedAt: new Date() })).toBe(true);
+		// an optimistic message that was acked keeps no _updatedAt: it must be skipped so
+		// the comparator never dereferences undefined
+		expect(predicate({ rid: 'room-1', _hidden: false, temp: false, _updatedAt: undefined })).toBe(false);
+		expect(predicate({ rid: 'room-1', _hidden: false, temp: true, _updatedAt: new Date() })).toBe(false);
+		expect(predicate({ rid: 'room-1', _hidden: true, temp: false, _updatedAt: new Date() })).toBe(false);
+		expect(predicate({ rid: 'room-2', _hidden: false, temp: false, _updatedAt: new Date() })).toBe(false);
+
+		const older = { _updatedAt: new Date('2026-01-01T00:00:00.000Z') };
+		const newer = { _updatedAt: new Date('2026-01-02T00:00:00.000Z') };
+		expect(comparator(newer, older)).toBeLessThan(0);
+		expect(comparator(older, newer)).toBeGreaterThan(0);
+	});
+
 	it('should upsert updated messages with dates mapped and delete removed messages', async () => {
 		const syncMessagesSpy = jest.fn(
 			() =>
@@ -135,7 +160,12 @@ describe('useLoadMissedMessages', () => {
 			});
 		});
 
-		expect(mockedDelete).toHaveBeenCalledWith('msg-deleted');
+		await waitFor(() => {
+			expect(mockedRemove).toHaveBeenCalled();
+		});
+		const removePredicate = mockedRemove.mock.calls[0][0];
+		expect(removePredicate({ _id: 'msg-deleted' })).toBe(true);
+		expect(removePredicate({ _id: 'msg-kept' })).toBe(false);
 	});
 
 	it('should apply deletions even when no message was updated', async () => {
@@ -153,8 +183,10 @@ describe('useLoadMissedMessages', () => {
 		renderWithReconnect(mockAppRoot().withEndpoint('GET', '/v1/chat.syncMessages', syncMessagesSpy).build());
 
 		await waitFor(() => {
-			expect(mockedDelete).toHaveBeenCalledWith('msg-deleted');
+			expect(mockedRemove).toHaveBeenCalled();
 		});
+		const removePredicate = mockedRemove.mock.calls[0][0];
+		expect(removePredicate({ _id: 'msg-deleted' })).toBe(true);
 
 		expect(mockedUpsertMessageBulk).not.toHaveBeenCalled();
 	});

--- a/apps/meteor/client/views/root/hooks/useLoadMissedMessages.ts
+++ b/apps/meteor/client/views/root/hooks/useLoadMissedMessages.ts
@@ -1,19 +1,24 @@
 import type { IRoom } from '@rocket.chat/core-typings';
-import { useConnectionStatus } from '@rocket.chat/ui-contexts';
+import { useConnectionStatus, useEndpoint } from '@rocket.chat/ui-contexts';
 import { useEffect, useRef } from 'react';
 
-import { LegacyRoomManager, upsertMessage } from '../../../../app/ui-utils/client';
-import { callWithErrorHandling } from '../../../lib/utils/callWithErrorHandling';
+import { LegacyRoomManager, upsertMessageBulk } from '../../../../app/ui-utils/client';
+import { mapMessageFromApi } from '../../../lib/utils/mapMessageFromApi';
 import { Messages, Subscriptions } from '../../../stores';
 
+type SyncMessagesEndpoint = ReturnType<typeof useEndpoint<'GET', '/v1/chat.syncMessages'>>;
+
 /**
- * Loads missed messages for a room
- * @param rid - Room ID
+ * Reconciles the messages of a room after a connection loss: everything that
+ * was created, edited, or deleted while offline is fetched and applied to the
+ * local store.
  */
-const loadMissedMessages = async (rid: IRoom['_id']): Promise<void> => {
+const syncMissedMessages = async (rid: IRoom['_id'], syncMessages: SyncMessagesEndpoint): Promise<void> => {
+	// `_updatedAt` (not `ts`) is the sync baseline: the server query returns any
+	// message changed after it, so edits and reactions are not missed
 	const lastMessage = Messages.state.findFirst(
 		(record) => record.rid === rid && record._hidden !== true && !record.temp,
-		(a, b) => b.ts.getTime() - a.ts.getTime(),
+		(a, b) => b._updatedAt.getTime() - a._updatedAt.getTime(),
 	);
 
 	if (!lastMessage) {
@@ -21,37 +26,39 @@ const loadMissedMessages = async (rid: IRoom['_id']): Promise<void> => {
 	}
 
 	try {
-		// TODO(ddp-removal): this should move to `/v1/chat.syncMessages` so reconnect
-		// also reconciles edits/deletions made while offline, but that endpoint queries
-		// by `_updatedAt` (+ trash collection) and is currently too slow for this path.
-		// Evaluate/optimize the query before migrating; for now keep the DDP method.
-		const result = await callWithErrorHandling('loadMissedMessages', rid, lastMessage.ts);
-		if (result) {
+		const { result } = await syncMessages({ roomId: rid, lastUpdate: lastMessage._updatedAt.toISOString() });
+
+		if (result.updated.length > 0) {
 			const subscription = Subscriptions.state.find((record) => record.rid === rid);
-			await Promise.all(Array.from(result).map((msg) => upsertMessage({ msg, subscription })));
+			await upsertMessageBulk({ msgs: result.updated.map((message) => mapMessageFromApi(message)), subscription });
+		}
+
+		for (const { _id } of result.deleted) {
+			Messages.state.delete(_id);
 		}
 	} catch (error) {
-		console.error('Error loading missed messages:', error);
+		console.error('Error syncing missed messages:', error);
 	}
 };
 
 /**
- * React hook that loads missed messages when connection is restored
+ * React hook that synchronizes missed message changes when connection is restored
  */
 export const useLoadMissedMessages = (): void => {
 	const { connected } = useConnectionStatus();
 	const connectionWasOnlineRef = useRef(connected);
+	const syncMessages = useEndpoint('GET', '/v1/chat.syncMessages');
 
 	useEffect(() => {
 		if (connected === true && connectionWasOnlineRef.current === false && LegacyRoomManager.openedRooms) {
 			Object.keys(LegacyRoomManager.openedRooms).forEach((key) => {
 				const value = LegacyRoomManager.openedRooms[key];
 				if (value.rid) {
-					loadMissedMessages(value.rid);
+					syncMissedMessages(value.rid, syncMessages);
 				}
 			});
 		}
 
 		connectionWasOnlineRef.current = connected;
-	}, [connected]);
+	}, [connected, syncMessages]);
 };

--- a/apps/meteor/client/views/root/hooks/useLoadMissedMessages.ts
+++ b/apps/meteor/client/views/root/hooks/useLoadMissedMessages.ts
@@ -1,4 +1,5 @@
 import type { IRoom } from '@rocket.chat/core-typings';
+import type { EndpointFunction } from '@rocket.chat/ui-contexts';
 import { useConnectionStatus, useEndpoint } from '@rocket.chat/ui-contexts';
 import { useEffect, useRef } from 'react';
 
@@ -6,7 +7,7 @@ import { LegacyRoomManager, upsertMessageBulk } from '../../../../app/ui-utils/c
 import { mapMessageFromApi } from '../../../lib/utils/mapMessageFromApi';
 import { Messages, Subscriptions } from '../../../stores';
 
-type SyncMessagesEndpoint = ReturnType<typeof useEndpoint<'GET', '/v1/chat.syncMessages'>>;
+type SyncMessagesEndpoint = EndpointFunction<'GET', '/v1/chat.syncMessages'>;
 
 /**
  * Reconciles the messages of a room after a connection loss: everything that
@@ -14,18 +15,20 @@ type SyncMessagesEndpoint = ReturnType<typeof useEndpoint<'GET', '/v1/chat.syncM
  * local store.
  */
 const syncMissedMessages = async (rid: IRoom['_id'], syncMessages: SyncMessagesEndpoint): Promise<void> => {
-	// `_updatedAt` (not `ts`) is the sync baseline: the server query returns any
-	// message changed after it, so edits and reactions are not missed
-	const lastMessage = Messages.state.findFirst(
-		(record) => record.rid === rid && record._hidden !== true && !record.temp,
-		(a, b) => b._updatedAt.getTime() - a._updatedAt.getTime(),
-	);
-
-	if (!lastMessage) {
-		return;
-	}
-
 	try {
+		// `_updatedAt` (not `ts`) is the sync baseline so edits and reactions are not
+		// missed. Records without `_updatedAt` (an optimistic message awaiting server
+		// confirmation) are skipped: the value is transient and the server copy carries
+		// the real `_updatedAt`.
+		const lastMessage = Messages.state.findFirst(
+			(record) => record.rid === rid && record._hidden !== true && !record.temp && Boolean(record._updatedAt),
+			(a, b) => b._updatedAt.getTime() - a._updatedAt.getTime(),
+		);
+
+		if (!lastMessage) {
+			return;
+		}
+
 		const { result } = await syncMessages({ roomId: rid, lastUpdate: lastMessage._updatedAt.toISOString() });
 
 		if (result.updated.length > 0) {
@@ -33,8 +36,9 @@ const syncMissedMessages = async (rid: IRoom['_id'], syncMessages: SyncMessagesE
 			await upsertMessageBulk({ msgs: result.updated.map((message) => mapMessageFromApi(message)), subscription });
 		}
 
-		for (const { _id } of result.deleted) {
-			Messages.state.delete(_id);
+		if (result.deleted.length > 0) {
+			const deletedIds = new Set(result.deleted.map(({ _id }) => _id));
+			Messages.state.remove((record) => deletedIds.has(record._id));
 		}
 	} catch (error) {
 		console.error('Error syncing missed messages:', error);
@@ -51,8 +55,7 @@ export const useLoadMissedMessages = (): void => {
 
 	useEffect(() => {
 		if (connected === true && connectionWasOnlineRef.current === false && LegacyRoomManager.openedRooms) {
-			Object.keys(LegacyRoomManager.openedRooms).forEach((key) => {
-				const value = LegacyRoomManager.openedRooms[key];
+			Object.values(LegacyRoomManager.openedRooms).forEach((value) => {
 				if (value.rid) {
 					syncMissedMessages(value.rid, syncMessages);
 				}

--- a/apps/meteor/server/methods/loadMissedMessages.ts
+++ b/apps/meteor/server/methods/loadMissedMessages.ts
@@ -5,16 +5,20 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
 import { canAccessRoomIdAsync } from '../../app/authorization/server/functions/canAccessRoom';
+import { methodDeprecationLogger } from '../../app/lib/server/lib/deprecationWarningLogger';
 
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	interface ServerMethods {
+		/** @deprecated Use the `/v1/chat.syncMessages` endpoint instead */
 		loadMissedMessages(rid: IRoom['_id'], ts: Date): Promise<false | IMessage[]>;
 	}
 }
 
 Meteor.methods<ServerMethods>({
 	async loadMissedMessages(rid, start) {
+		methodDeprecationLogger.method('loadMissedMessages', '9.0.0', ['/v1/chat.syncMessages']);
+
 		check(rid, String);
 		check(start, Date);
 

--- a/apps/meteor/server/publications/messages.ts
+++ b/apps/meteor/server/publications/messages.ts
@@ -142,7 +142,10 @@ export function mountPreviousCursor(
 
 export async function handleWithoutPagination(rid: IRoom['_id'], lastUpdate: Date) {
 	const query = { $gt: lastUpdate };
-	const options: FindOptions<IMessage> = { sort: { ts: -1 } };
+	// Sort by `_updatedAt` (the field being filtered) so the `{ rid, _updatedAt }` index serves
+	// the range and the ordering in one pass, avoiding an in-memory sort on large offline syncs.
+	// Consistent with the cursor-paginated path, which also orders by `_updatedAt`.
+	const options: FindOptions<IMessage> = { sort: { _updatedAt: -1 } };
 
 	const [updatedMessages, deletedMessages] = await Promise.all([
 		Messages.findForUpdates(rid, query, options).toArray(),

--- a/apps/meteor/tests/unit/server/publications/messages.spec.ts
+++ b/apps/meteor/tests/unit/server/publications/messages.spec.ts
@@ -213,12 +213,12 @@ describe('handleWithoutPagination', () => {
 			deleted: deletedMessages,
 		});
 
-		sinon.assert.calledWith(messagesMock.findForUpdates, rid, { $gt: lastUpdate }, { sort: { ts: -1 } });
+		sinon.assert.calledWith(messagesMock.findForUpdates, rid, { $gt: lastUpdate }, { sort: { _updatedAt: -1 } });
 		sinon.assert.calledWith(
 			messagesMock.trashFindDeletedAfter,
 			lastUpdate,
 			{ rid },
-			{ projection: { _id: 1, _deletedAt: 1 }, sort: { ts: -1 } },
+			{ projection: { _id: 1, _deletedAt: 1 }, sort: { _updatedAt: -1 } },
 		);
 	});
 

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -46,6 +46,9 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 	protected override modelIndexes(): IndexDescription[] {
 		return [
 			{ key: { rid: 1, ts: 1, _updatedAt: 1 } },
+			// `findForUpdates` (chat.syncMessages) filters by `rid` + `_updatedAt` range only;
+			// the index above cannot bound that scan because `ts` sits between them
+			{ key: { rid: 1, _updatedAt: 1 } },
 			{ key: { ts: 1 } },
 			{ key: { 'u._id': 1 } },
 			{ key: { editedAt: 1 }, sparse: true },


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Migrates reconnect message synchronization from the `loadMissedMessages` DDP method to the `GET /v1/chat.syncMessages` REST endpoint, so edits and deletions made while a client was offline are applied when the connection is restored.

- `useLoadMissedMessages` now sends the latest locally known `_updatedAt` as `lastUpdate`, maps the payload with `mapMessageFromApi`, upserts updated messages through `upsertMessageBulk` (keeps the e2e pending flag handling) and removes deleted messages via `Messages.state.remove`, mirroring the live `deleteMessageBulk` stream handler
- Records still awaiting server confirmation (optimistic messages without an `_updatedAt`) are skipped when choosing the sync baseline
- Adds a `{ rid: 1, _updatedAt: 1 }` index to the messages collection. `findForUpdates` filters by `rid` plus an `_updatedAt` range, which the existing `{ rid: 1, ts: 1, _updatedAt: 1 }` index cannot bound because `ts` sits between the two fields
- No new trash index: `{ rid: 1, __collection__: 1, _deletedAt: 1 }` already exists and serves the deleted side of the query
- Deprecates the `loadMissedMessages` method (removal planned for 9.0.0) instead of removing it, since external clients can still call it through `method.call`
- Adds unit tests for the hook

## Issue(s)

Closes #41079
Closes #41000

## Steps to test or reproduce

1. Open a room, then go offline (devtools network tab)
2. From another user, edit one message, delete another and send a new one in that room
3. Go back online: the edit, the deletion and the new message all appear without reloading

## Further comments

Kept a single `lastUpdate` request per opened room instead of cursor pagination: only currently opened rooms are synced (capped by `maxRoomsOpen`) and the endpoint already supports `type`/`next` cursors if bounded batches become necessary.

Known follow-up, tracked in #41190: the open thread panel and infinite message lists (threads, discussions, omnichannel history) keep their own query caches fed only by live stream events, so they are not reconciled on a DDP-only reconnect. This is a pre-existing gap (the old DDP method also only wrote the message store) and is best solved across all those caches at once.

Lint, typecheck and the jest suite pass locally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Reconnection now syncs missed message changes via the REST-based message sync flow when you come back online, improving recovery of edits and deletions after being offline.

* **Bug Fixes**
  * Missed-message reconciliation is more reliable in large rooms, with improved ordering during offline sync to match the sync cursor.

* **Chores**
  * The older missed-message sync path is now deprecated in favor of the REST-based endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->