### PR TITLE
refactor: migrate TeamsChannels to PaginatedVirtualList

### DIFF
--- a/apps/meteor/client/views/teams/contextualBar/channels/TeamsChannelItem.tsx
+++ b/apps/meteor/client/views/teams/contextualBar/channels/TeamsChannelItem.tsx
@@ -53,7 +53,7 @@ const TeamsChannelItem = ({ room, mainRoom, onClickView, reload }: TeamsChannelI
 	}
 
 	return (
-		<Option id={room._id} data-rid={room._id} {...handleMenuEvent} onClick={() => onClickView(room)}>
+		<Option is='div' id={room._id} data-rid={room._id} {...handleMenuEvent} onClick={() => onClickView(room)}>
 			<OptionAvatar>
 				<RoomAvatar room={room} size='x28' />
 			</OptionAvatar>

--- a/apps/meteor/client/views/teams/contextualBar/channels/TeamsChannels.spec.tsx
+++ b/apps/meteor/client/views/teams/contextualBar/channels/TeamsChannels.spec.tsx
@@ -1,7 +1,10 @@
-/* eslint-disable testing-library/no-container */
 /* eslint-disable testing-library/no-node-access */
 import { mockAppRoot } from '@rocket.chat/mock-providers';
-import { render, waitFor } from '@testing-library/react';
+import type { UseInfiniteQueryResult } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import type { CSSProperties, HTMLAttributes, ReactNode } from 'react';
+import * as React from 'react';
+import { Children, forwardRef, isValidElement } from 'react';
 
 import TeamsChannels from './TeamsChannels';
 import { createFakeRoom } from '../../../../../tests/mocks/data';
@@ -9,13 +12,92 @@ import { createFakeRoom } from '../../../../../tests/mocks/data';
 jest.mock('../../../../lib/rooms/roomCoordinator', () => ({
 	roomCoordinator: {
 		getRouteLink: () => undefined,
+		getRoomName: (_type: string, room: { name?: string }) => room.name,
 	},
+}));
+
+const mockVirtualizerHandle = {
+	scrollOffset: 0,
+	scrollSize: 1000,
+	viewportSize: 300,
+};
+
+type MockVirtualizerProps = {
+	children: ReactNode;
+	bufferSize?: number;
+	onScroll?: (offset: number) => void;
+	as?: React.ElementType;
+	item?: React.ElementType;
+	style?: CSSProperties;
+	className?: string;
+};
+
+jest.mock('virtua', () => {
+	return {
+		Virtualizer: React.forwardRef(
+			(
+				{ children, bufferSize, onScroll, as: asRoot = 'div', item: asItem = 'div', style, className }: MockVirtualizerProps,
+				ref: React.Ref<unknown>,
+			) => {
+				React.useImperativeHandle(ref, () => mockVirtualizerHandle);
+				const Root = asRoot;
+				const Item = asItem;
+				const wrapped = Children.map(children, (child, index) => {
+					const key = isValidElement(child) && child.key != null ? String(child.key) : `row-${index}`;
+					return <Item key={key}>{child}</Item>;
+				});
+
+				return (
+					<Root
+						className={className}
+						data-buffer-size={bufferSize}
+						data-testid='teams-channels-virtual-list'
+						style={style ?? { height: '100%' }}
+						onScroll={() => onScroll?.(mockVirtualizerHandle.scrollOffset)}
+					>
+						{wrapped}
+					</Root>
+				);
+			},
+		),
+	};
+});
+
+jest.mock('@rocket.chat/ui-client', () => ({
+	...jest.requireActual('@rocket.chat/ui-client'),
+	CustomVirtuaScrollbars: forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(function CustomVirtuaScrollbars(
+		{ children, ...props },
+		ref,
+	) {
+		const content = isValidElement<{ children?: ReactNode }>(children) && children.type === 'div' ? children.props.children : children;
+
+		return (
+			<div ref={ref} {...props}>
+				{content}
+			</div>
+		);
+	}),
 }));
 
 const mainRoom = createFakeRoom({ name: 'Main Room' });
 const fakeRooms = Array.from({ length: 10 }, (_, index) => createFakeRoom({ t: 'c', name: `Fake Room ${index}` }));
 
+const createLoadMoreItems = () =>
+	jest.fn(async () => {
+		return {} as Awaited<ReturnType<UseInfiniteQueryResult['fetchNextPage']>>;
+	}) satisfies jest.MockedFunction<UseInfiniteQueryResult['fetchNextPage']>;
+
+const advanceDebouncedScroll = async () => {
+	await act(async () => {
+		await jest.advanceTimersByTimeAsync(300);
+	});
+};
+
 beforeEach(() => {
+	mockVirtualizerHandle.scrollOffset = 0;
+	mockVirtualizerHandle.scrollSize = 1000;
+	mockVirtualizerHandle.viewportSize = 300;
+
 	Object.defineProperty(window, 'getComputedStyle', {
 		value: () => {
 			return {
@@ -26,14 +108,17 @@ beforeEach(() => {
 	});
 });
 
-// TODO: Replace this with the storybook & snapshot
-it('should render scrollbars', async () => {
-	const { container } = render(
+afterEach(() => {
+	jest.useRealTimers();
+});
+
+it('renders channels inside the paginated virtual list', () => {
+	render(
 		<TeamsChannels
 			text=''
 			type='all'
 			reload={() => undefined}
-			loadMoreItems={() => undefined}
+			loadMoreItems={createLoadMoreItems()}
 			setText={() => undefined}
 			setType={() => undefined}
 			onClickClose={() => undefined}
@@ -50,9 +135,43 @@ it('should render scrollbars', async () => {
 		},
 	);
 
-	await waitFor(() => {
-		expect(container.querySelector('[data-overlayscrollbars]')).toBeInTheDocument();
-	});
+	const list = screen.getByTestId('teams-channels-virtual-list');
 
-	expect(container.querySelector('[data-overlayscrollbars]')).toBeInTheDocument();
+	expect(list.tagName.toLowerCase()).toBe('ul');
+	expect(within(list).getAllByRole('listitem')).toHaveLength(fakeRooms.length);
+	expect(within(list).getByText('Fake Room 0')).toBeInTheDocument();
+});
+
+it('wires end reached to load more items', async () => {
+	jest.useFakeTimers();
+	const loadMoreItems = createLoadMoreItems();
+
+	render(
+		<TeamsChannels
+			text=''
+			type='all'
+			reload={() => undefined}
+			loadMoreItems={loadMoreItems}
+			setText={() => undefined}
+			setType={() => undefined}
+			onClickClose={() => undefined}
+			onClickAddExisting={() => undefined}
+			onClickView={() => undefined}
+			onClickCreateNew={() => undefined}
+			total={fakeRooms.length + 1}
+			loading={false}
+			mainRoom={mainRoom}
+			channels={fakeRooms}
+		/>,
+		{
+			wrapper: mockAppRoot().build(),
+		},
+	);
+	expect(loadMoreItems).not.toHaveBeenCalled();
+
+	mockVirtualizerHandle.scrollOffset = 700;
+	fireEvent.scroll(screen.getByTestId('teams-channels-virtual-list'));
+	await advanceDebouncedScroll();
+
+	expect(loadMoreItems).toHaveBeenCalledTimes(1);
 });

--- a/apps/meteor/client/views/teams/contextualBar/channels/TeamsChannels.tsx
+++ b/apps/meteor/client/views/teams/contextualBar/channels/TeamsChannels.tsx
@@ -1,9 +1,8 @@
 import type { IRoom } from '@rocket.chat/core-typings';
 import type { SelectOption } from '@rocket.chat/fuselage';
 import { Box, Icon, TextInput, Select, Throbber, ButtonGroup, Button } from '@rocket.chat/fuselage';
-import { useStableCallback, useAutoFocus, useDebouncedCallback } from '@rocket.chat/fuselage-hooks';
+import { useAutoFocus } from '@rocket.chat/fuselage-hooks';
 import {
-	VirtualizedScrollbars,
 	ContextualbarHeader,
 	ContextualbarIcon,
 	ContextualbarTitle,
@@ -14,13 +13,13 @@ import {
 	ContextualbarSection,
 	ContextualbarDialog,
 } from '@rocket.chat/ui-client';
+import type { UseInfiniteQueryResult } from '@tanstack/react-query';
 import type { ChangeEvent, Dispatch, SetStateAction, SyntheticEvent } from 'react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Virtuoso } from 'react-virtuoso';
 
 import TeamsChannelItem from './TeamsChannelItem';
-import InfiniteListAnchor from '../../../../components/InfiniteListAnchor';
+import { PaginatedVirtualList } from '../../../../components/PaginatedVirtualList';
 
 type TeamsChannelsProps = {
 	loading: boolean;
@@ -34,7 +33,7 @@ type TeamsChannelsProps = {
 	onClickAddExisting: false | ((e: SyntheticEvent) => void);
 	onClickCreateNew: false | ((e: SyntheticEvent) => void);
 	total: number;
-	loadMoreItems: () => void;
+	loadMoreItems: UseInfiniteQueryResult['fetchNextPage'];
 	onClickView: (room: IRoom) => void;
 	reload: () => void;
 };
@@ -64,20 +63,6 @@ const TeamsChannels = ({
 			['autoJoin', t('Team_Auto-join')],
 		],
 		[t],
-	);
-
-	const lm = useStableCallback(() => !loading && loadMoreItems());
-
-	const loadMoreChannels = useDebouncedCallback(
-		() => {
-			if (channels.length >= total) {
-				return;
-			}
-
-			lm();
-		},
-		300,
-		[lm, channels],
 	);
 
 	return (
@@ -111,18 +96,16 @@ const TeamsChannels = ({
 								{t('Total')}: {total}
 							</Box>
 						</Box>
-						<Box w='full' h='full' role='list' overflow='hidden' flexShrink={1}>
-							<VirtualizedScrollbars>
-								<Virtuoso
+						<Box w='full' h='full' overflow='hidden' flexShrink={1}>
+							<Box h='full' w='full' style={{ minHeight: 0 }}>
+								<PaginatedVirtualList
+									items={channels}
 									totalCount={total}
-									data={channels}
-									// eslint-disable-next-line react/no-multi-comp
-									components={{ Footer: () => <InfiniteListAnchor loadMore={loadMoreChannels} /> }}
-									itemContent={(index, data) => (
-										<TeamsChannelItem onClickView={onClickView} room={data} mainRoom={mainRoom} reload={reload} key={index} />
-									)}
+									overscan={25}
+									onEndReached={loading ? undefined : loadMoreItems}
+									renderItem={(data) => <TeamsChannelItem onClickView={onClickView} room={data} mainRoom={mainRoom} reload={reload} />}
 								/>
-							</VirtualizedScrollbars>
+							</Box>
 						</Box>
 					</>
 				)}

--- a/apps/meteor/client/views/teams/contextualBar/channels/TeamsChannels.tsx
+++ b/apps/meteor/client/views/teams/contextualBar/channels/TeamsChannels.tsx
@@ -102,7 +102,7 @@ const TeamsChannels = ({
 									items={channels}
 									totalCount={total}
 									overscan={25}
-									onEndReached={loading ? undefined : loadMoreItems}
+									onEndReached={loadMoreItems}
 									renderItem={(data) => <TeamsChannelItem onClickView={onClickView} room={data} mainRoom={mainRoom} reload={reload} />}
 								/>
 							</Box>


### PR DESCRIPTION
## Proposed changes 

This PR migrates the Team Channels contextual bar list from `react-virtuoso` to the shared `PaginatedVirtualList` while preserving the existing behavior.

### Changes
- Replaced the `react-virtuoso` implementation in `TeamsChannels` with `PaginatedVirtualList`.
- Preserved the existing loading, empty, search, filter, and pagination behavior.
- Preserved channel actions, permissions, and navigation.
- Updated `TeamsChannelItem` to render as a `div` so the shared virtual list owns the `ul > li` structure.
- Updated the unit tests to cover the Virtua-backed implementation and pagination wiring.

This migration is limited to the virtualization layer and does not modify data fetching, backend APIs, or component behavior.

## Issue(s)

Part of the GSoC 2026 Virtual List migration project.

## Steps to test or reproduce

1. Open a Team and navigate to the **Channels** tab.
2. Verify:
   - Loading state
   - Empty state
   - Search and filter behavior
   - Infinite scrolling loads additional channels
   - Channel navigation works correctly
   - Channel actions and permissions remain unchanged
3. Run the focused tests:
   ```bash
   yarn workspace @rocket.chat/meteor run .testunit:jest client/views/teams/contextualBar/channels/TeamsChannels.spec.tsx --runInBand
   ```
4. Run ESLint:
   ```bash
   yarn workspace @rocket.chat/meteor run eslint client/views/teams/contextualBar/channels/TeamsChannels.tsx client/views/teams/contextualBar/channels/TeamsChannelItem.tsx client/views/teams/contextualBar/channels/TeamsChannels.spec.tsx
   ```

## Further comments

This migration follows the existing Virtua migration pattern by using the shared `PaginatedVirtualList` without introducing new abstractions or modifying shared components. The goal is to preserve the existing user experience while replacing the underlying virtualization library.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team channel lists now load more items more reliably as you scroll.
  * Channel lists have been updated to use a smoother virtualized rendering experience.

* **Bug Fixes**
  * Improved list rendering so channels display correctly in the team context panel.
  * Reduced extra loading triggers when reaching the end of the list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->