### PR TITLE
fix: Buttons from emoji picker misbehaving on clicks

### DIFF
--- a/.changeset/fifty-candies-heal.md
+++ b/.changeset/fifty-candies-heal.md
@@ -1,0 +1,7 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+fix: Buttons from emoji picker misbehaving on clicks
+
+An infinite render loop was preventing proper behavior when clicking on the emoji picker buttons. It was fixed by removing the unnecessary state update that was causing the loop and replacing multiple fires of the same mouseover event (when a mouseenter event was the right one to use). There is a chance this pre-existing bug was hidden by React 18's event delegation.

--- a/apps/meteor/client/providers/EmojiPickerProvider/EmojiPickerProvider.spec.tsx
+++ b/apps/meteor/client/providers/EmojiPickerProvider/EmojiPickerProvider.spec.tsx
@@ -1,0 +1,56 @@
+import { renderHook, act } from '@testing-library/react';
+import { useState, type ReactNode } from 'react';
+
+import EmojiPickerProvider from './EmojiPickerProvider';
+import { usePreviewEmoji } from '../../contexts/EmojiPickerContext';
+
+jest.mock('@rocket.chat/fuselage-hooks', () => {
+	const originalModule = jest.requireActual('@rocket.chat/fuselage-hooks');
+
+	return {
+		...originalModule,
+		useDebouncedState: <T,>(initialValue: T) => useState<T>(initialValue),
+		useLocalStorage: <T,>(_: string, initialValue: T) => useState<T>(initialValue),
+		useStableCallback: (callback: (...args: any[]) => unknown) => callback,
+	};
+});
+
+jest.mock('../../../app/emoji/client', () => ({
+	emoji: { packages: { base: { emojisByCategory: { recent: [] } } } },
+	getFrequentEmoji: jest.fn(() => []),
+	createEmojiListByCategorySubscription: jest.fn(() => {
+		const snapshot = [[], {}];
+		return [() => () => undefined, () => snapshot];
+	}),
+}));
+
+jest.mock('../../views/composer/EmojiPicker', () => () => null);
+jest.mock('./useUpdateCustomEmoji', () => ({ useUpdateCustomEmoji: () => undefined }));
+
+const wrapper = ({ children }: { children: ReactNode }) => <EmojiPickerProvider>{children}</EmojiPickerProvider>;
+
+describe('EmojiPickerProvider', () => {
+	it('should keep the same preview reference when receiving the same emoji and name', () => {
+		const { result } = renderHook(() => usePreviewEmoji(), { wrapper });
+
+		act(() => {
+			result.current.handlePreview('image://smile', 'smile');
+		});
+
+		const firstPreview = result.current.emojiToPreview;
+		expect(firstPreview).toEqual({ emoji: 'image://smile', name: 'smile' });
+
+		act(() => {
+			result.current.handlePreview('image://smile', 'smile');
+		});
+
+		expect(result.current.emojiToPreview).toBe(firstPreview);
+
+		act(() => {
+			result.current.handlePreview('image://rocket', 'rocket');
+		});
+
+		expect(result.current.emojiToPreview).toEqual({ emoji: 'image://rocket', name: 'rocket' });
+		expect(result.current.emojiToPreview).not.toBe(firstPreview);
+	});
+});

--- a/apps/meteor/client/providers/EmojiPickerProvider/EmojiPickerProvider.tsx
+++ b/apps/meteor/client/providers/EmojiPickerProvider/EmojiPickerProvider.tsx
@@ -78,7 +78,16 @@ const EmojiPickerProvider = ({ children }: { children: ReactNode }) => {
 		return setEmojiPicker(<EmojiPicker reference={ref} onClose={() => setEmojiPicker(null)} onPickEmoji={(emoji) => callback(emoji)} />);
 	}, []);
 
-	const handlePreview = useCallback((emoji: string, name: string) => setEmojiToPreview({ emoji, name }), [setEmojiToPreview]);
+	const handlePreview = useCallback(
+		(emoji: string, name: string) =>
+			setEmojiToPreview((preview) => {
+				if (preview?.emoji === emoji && preview?.name === name) {
+					return preview;
+				}
+				return { emoji, name };
+			}),
+		[setEmojiToPreview],
+	);
 
 	const handleRemovePreview = useCallback(() => setEmojiToPreview(null), [setEmojiToPreview]);
 

--- a/apps/meteor/client/views/composer/EmojiPicker/EmojiElement.tsx
+++ b/apps/meteor/client/views/composer/EmojiPicker/EmojiElement.tsx
@@ -34,7 +34,7 @@ const EmojiElement = ({ emoji, image, onClick, small = false, ...props }: EmojiE
 			{...(small && { className: emojiSmallClass })}
 			small={small}
 			medium={!small}
-			onMouseOver={() => handlePreview(image, emoji)}
+			onMouseEnter={() => handlePreview(image, emoji)}
 			onMouseLeave={handleRemovePreview}
 			onClick={onClick}
 			data-emoji={emoji}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10830,7 +10830,7 @@ __metadata:
     "@react-aria/toolbar": "*"
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-client": 32.0.0-rc.0
+    "@rocket.chat/ui-client": 32.0.0
     react: "*"
     react-dom: "*"
   languageName: unknown
@@ -11084,7 +11084,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.3.0
-    "@rocket.chat/ui-contexts": 32.0.0-rc.0
+    "@rocket.chat/ui-contexts": 32.0.0
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
It updates emoji preview handling and adjusts event triggers.

An infinite render loop was preventing proper behavior when clicking on the emoji picker buttons. It was fixed by removing the unnecessary state update that was causing the loop and replacing multiple fires of the same mouseover event (when a mouseenter event was the right one to use).

## Issue(s)
- [CORE-2388](https://rocketchat.atlassian.net/browse/CORE-2388)
- [ARCH-2214](https://rocketchat.atlassian.net/browse/ARCH-2214)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
There is a chance this pre-existing bug was hidden by React 18's event delegation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed emoji picker click behavior by preventing an unnecessary state update that could cause unstable re-rendering.
  * Improved emoji hover behavior so previews trigger reliably on mouse entry (instead of repeatedly firing), making hover previews more consistent.
  * Ensured emoji preview state preserves the existing preview when hovering the same emoji again.
* **Tests**
  * Added automated coverage for emoji preview reference stability in the emoji picker provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

[CORE-2388]: https://rocketchat.atlassian.net/browse/CORE-2388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ