### PR TITLE
test: fix race condition in business hours toggle e2e test

### DIFF
--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-business-hours.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-business-hours.spec.ts
@@ -136,8 +136,6 @@ test.describe('OC - Business Hours', () => {
 		await poOmnichannelBusinessHours.sidebar.linkBusinessHours.click();
 
 		await test.step('expect to disable business hours', async () => {
-			await poOmnichannelBusinessHours.sidebar.linkBusinessHours.click();
-
 			await poOmnichannelBusinessHours.search(BHName);
 			await poOmnichannelBusinessHours.table.findRowByName(BHName).click();
 
@@ -145,11 +143,10 @@ test.describe('OC - Business Hours', () => {
 			await expect(poOmnichannelBusinessHours.getCheckboxByLabel('Enabled')).not.toBeChecked();
 
 			await poOmnichannelBusinessHours.btnSave.click();
+			await expect(poOmnichannelBusinessHours.btnSave).not.toBeVisible();
 		});
 
 		await test.step('expect to enable business hours', async () => {
-			await poOmnichannelBusinessHours.sidebar.linkBusinessHours.click();
-
 			await poOmnichannelBusinessHours.search(BHName);
 			await poOmnichannelBusinessHours.table.findRowByName(BHName).click();
 
@@ -157,6 +154,7 @@ test.describe('OC - Business Hours', () => {
 			await expect(poOmnichannelBusinessHours.getCheckboxByLabel('Enabled')).toBeChecked();
 
 			await poOmnichannelBusinessHours.btnSave.click();
+			await expect(poOmnichannelBusinessHours.btnSave).not.toBeVisible();
 		});
 
 		await test.step('expect delete business hours', async () => {


### PR DESCRIPTION
The save handler navigates back to the list only after the POST resolves. The test re-opened the edit form before that pending navigation landed, which then closed the form and timed out waiting for the Enabled checkbox. Wait for the edit form to close after saving and drop the redundant sidebar clicks that widened the race window.

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for business hours toggling by verifying the Save button disappears after saving changes in both disable and enable flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [FLAKY-2281]

[FLAKY-2281]: https://rocketchat.atlassian.net/browse/FLAKY-2281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ