### PR TITLE
refactor: migrate OutlookEventsList to Virtua

### DIFF
--- a/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventsList.spec.tsx
+++ b/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventsList.spec.tsx
@@ -11,7 +11,7 @@ const mockChangeRoute = jest.fn();
 const mockOnClose = jest.fn();
 const mockSyncOutlookCalendar = jest.fn();
 
-const calendarEvents: Serialized<ICalendarEvent>[] = [
+const mockCalendarEvents: Serialized<ICalendarEvent>[] = [
 	{
 		_id: 'calendar-event-1',
 		_updatedAt: '2026-01-01T00:00:00.000Z',
@@ -48,7 +48,7 @@ jest.mock('../hooks/useOutlookCalendarList', () => ({
 		mutate: mockSyncOutlookCalendar,
 	}),
 	useOutlookCalendarListForToday: () => ({
-		data: calendarEvents,
+		data: mockCalendarEvents,
 		isError: false,
 		isPending: false,
 		isSuccess: true,
@@ -140,7 +140,7 @@ it('renders calendar events through PaginatedVirtualList', () => {
 
 	expect(list.tagName.toLowerCase()).toBe('ul');
 	expect(list).toHaveAttribute('data-buffer-size', '25');
-	expect(within(list).getAllByRole('listitem')).toHaveLength(calendarEvents.length);
+	expect(within(list).getAllByRole('listitem')).toHaveLength(mockCalendarEvents.length);
 	expect(within(list).getByText('Planning sync')).toBeInTheDocument();
 	expect(within(list).getByText('Design review')).toBeInTheDocument();
 });

--- a/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventsList.spec.tsx
+++ b/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventsList.spec.tsx
@@ -1,9 +1,8 @@
 import type { ICalendarEvent, Serialized } from '@rocket.chat/core-typings';
 import { mockAppRoot } from '@rocket.chat/mock-providers';
 import { render, screen, within } from '@testing-library/react';
-import type { CSSProperties, HTMLAttributes, ReactNode } from 'react';
-import * as React from 'react';
-import { Children, forwardRef, isValidElement } from 'react';
+import type { CSSProperties, ElementType, HTMLAttributes, ReactNode, Ref } from 'react';
+import { Children, forwardRef, isValidElement, useImperativeHandle } from 'react';
 
 import OutlookEventsList from './OutlookEventsList';
 
@@ -73,19 +72,19 @@ type MockVirtualizerProps = {
 	children: ReactNode;
 	bufferSize?: number;
 	onScroll?: (offset: number) => void;
-	as?: React.ElementType;
-	item?: React.ElementType;
+	as?: ElementType;
+	item?: ElementType;
 	style?: CSSProperties;
 	className?: string;
 };
 
 jest.mock('virtua', () => ({
-	Virtualizer: React.forwardRef(
+	Virtualizer: forwardRef(
 		(
 			{ children, bufferSize, onScroll, as: asRoot = 'div', item: asItem = 'div', style, className }: MockVirtualizerProps,
-			ref: React.Ref<unknown>,
+			ref: Ref<unknown>,
 		) => {
-			React.useImperativeHandle(ref, () => mockVirtualizerHandle);
+			useImperativeHandle(ref, () => mockVirtualizerHandle);
 			const Root = asRoot;
 			const Item = asItem;
 			const wrapped = Children.map(children, (child, index) => {

--- a/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventsList.spec.tsx
+++ b/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventsList.spec.tsx
@@ -5,6 +5,7 @@ import type { CSSProperties, ElementType, HTMLAttributes, ReactNode, Ref } from 
 import { Children, forwardRef, isValidElement, useImperativeHandle } from 'react';
 
 import OutlookEventsList from './OutlookEventsList';
+import { createFakeUser } from '../../../../tests/mocks/data';
 
 const mockChangeRoute = jest.fn();
 const mockOnClose = jest.fn();
@@ -131,7 +132,15 @@ beforeEach(() => {
 it('renders calendar events through PaginatedVirtualList', () => {
 	render(<OutlookEventsList onClose={mockOnClose} changeRoute={mockChangeRoute} />, {
 		wrapper: mockAppRoot()
-			.withUser({ settings: { calendar: { outlook: { Outlook_Url: 'https://outlook.example.com' } } } })
+			.withUser(
+				createFakeUser({
+					settings: {
+						calendar: {
+							outlook: { Enabled: true, Exchange_Url: 'https://exchange.example.com', Outlook_Url: 'https://outlook.example.com' },
+						},
+					},
+				}),
+			)
 			.build(),
 	});
 

--- a/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventsList.spec.tsx
+++ b/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventsList.spec.tsx
@@ -1,0 +1,146 @@
+import type { ICalendarEvent, Serialized } from '@rocket.chat/core-typings';
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { render, screen, within } from '@testing-library/react';
+import type { CSSProperties, HTMLAttributes, ReactNode } from 'react';
+import * as React from 'react';
+import { Children, forwardRef, isValidElement } from 'react';
+
+import OutlookEventsList from './OutlookEventsList';
+
+const mockChangeRoute = jest.fn();
+const mockOnClose = jest.fn();
+const mockSyncOutlookCalendar = jest.fn();
+
+const calendarEvents: Serialized<ICalendarEvent>[] = [
+	{
+		_id: 'calendar-event-1',
+		_updatedAt: '2026-01-01T00:00:00.000Z',
+		startTime: '2026-01-01T10:00:00.000Z',
+		endTime: '2026-01-01T11:00:00.000Z',
+		uid: 'user-id',
+		subject: 'Planning sync',
+		description: 'Project planning',
+		notificationSent: false,
+	},
+	{
+		_id: 'calendar-event-2',
+		_updatedAt: '2026-01-01T00:00:00.000Z',
+		startTime: '2026-01-01T12:00:00.000Z',
+		endTime: '2026-01-01T13:00:00.000Z',
+		uid: 'user-id',
+		subject: 'Design review',
+		description: 'Review design',
+		notificationSent: false,
+	},
+];
+
+jest.mock('../hooks/useOutlookAuthentication', () => ({
+	useOutlookAuthentication: () => ({
+		authEnabled: true,
+		isError: false,
+		error: undefined,
+	}),
+}));
+
+jest.mock('../hooks/useOutlookCalendarList', () => ({
+	useMutationOutlookCalendarSync: () => ({
+		isPending: false,
+		mutate: mockSyncOutlookCalendar,
+	}),
+	useOutlookCalendarListForToday: () => ({
+		data: calendarEvents,
+		isError: false,
+		isPending: false,
+		isSuccess: true,
+	}),
+}));
+
+jest.mock('../../../hooks/useFormatDateAndTime', () => ({
+	useFormatDateAndTime: () => (date: string | Date) => String(date),
+}));
+
+jest.mock('../hooks/useOutlookOpenCall', () => ({
+	useOutlookOpenCall: () => jest.fn(),
+}));
+
+const mockVirtualizerHandle = {
+	scrollOffset: 0,
+	scrollSize: 1000,
+	viewportSize: 300,
+};
+
+type MockVirtualizerProps = {
+	children: ReactNode;
+	bufferSize?: number;
+	onScroll?: (offset: number) => void;
+	as?: React.ElementType;
+	item?: React.ElementType;
+	style?: CSSProperties;
+	className?: string;
+};
+
+jest.mock('virtua', () => ({
+	Virtualizer: React.forwardRef(
+		(
+			{ children, bufferSize, onScroll, as: asRoot = 'div', item: asItem = 'div', style, className }: MockVirtualizerProps,
+			ref: React.Ref<unknown>,
+		) => {
+			React.useImperativeHandle(ref, () => mockVirtualizerHandle);
+			const Root = asRoot;
+			const Item = asItem;
+			const wrapped = Children.map(children, (child, index) => {
+				const key = isValidElement(child) && child.key != null ? String(child.key) : `row-${index}`;
+				return <Item key={key}>{child}</Item>;
+			});
+
+			return (
+				<Root
+					className={className}
+					data-buffer-size={bufferSize}
+					data-testid='outlook-events-virtual-list'
+					style={style ?? { height: '100%' }}
+					onScroll={() => onScroll?.(mockVirtualizerHandle.scrollOffset)}
+				>
+					{wrapped}
+				</Root>
+			);
+		},
+	),
+}));
+
+jest.mock('@rocket.chat/ui-client', () => ({
+	...jest.requireActual('@rocket.chat/ui-client'),
+	CustomVirtuaScrollbars: forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(function CustomVirtuaScrollbars(
+		{ children, ...props },
+		ref,
+	) {
+		// eslint-disable-next-line testing-library/no-node-access
+		const content = isValidElement<{ children?: ReactNode }>(children) && children.type === 'div' ? children.props.children : children;
+
+		return (
+			<div ref={ref} {...props}>
+				{content}
+			</div>
+		);
+	}),
+}));
+
+beforeEach(() => {
+	jest.clearAllMocks();
+});
+
+it('renders calendar events through PaginatedVirtualList', () => {
+	render(<OutlookEventsList onClose={mockOnClose} changeRoute={mockChangeRoute} />, {
+		wrapper: mockAppRoot()
+			.withUser({ settings: { calendar: { outlook: { Outlook_Url: 'https://outlook.example.com' } } } })
+			.build(),
+	});
+
+	const list = screen.getByTestId('outlook-events-virtual-list');
+
+	expect(list.tagName.toLowerCase()).toBe('ul');
+	expect(list).toHaveAttribute('data-buffer-size', '25');
+	expect(within(list).getAllByRole('listitem')).toHaveLength(calendarEvents.length);
+	expect(within(list).getByText('Planning sync')).toBeInTheDocument();
+	expect(within(list).getByText('Design review')).toBeInTheDocument();
+});

--- a/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventsList.tsx
+++ b/apps/meteor/client/views/outlookCalendar/OutlookEventsList/OutlookEventsList.tsx
@@ -1,7 +1,5 @@
 import { Box, States, StatesIcon, StatesTitle, StatesSubtitle, ButtonGroup, Button, Throbber } from '@rocket.chat/fuselage';
-import { useResizeObserver } from '@rocket.chat/fuselage-hooks';
 import {
-	VirtualizedScrollbars,
 	ContextualbarHeader,
 	ContextualbarIcon,
 	ContextualbarTitle,
@@ -11,9 +9,9 @@ import {
 	ContextualbarDialog,
 } from '@rocket.chat/ui-client';
 import { useTranslation, useUser } from '@rocket.chat/ui-contexts';
-import { Virtuoso } from 'react-virtuoso';
 
 import OutlookEventItem from './OutlookEventItem';
+import { PaginatedVirtualList } from '../../../components/PaginatedVirtualList';
 import { getErrorMessage } from '../../../lib/errorHandling';
 import { useOutlookAuthentication } from '../hooks/useOutlookAuthentication';
 import { useMutationOutlookCalendarSync, useOutlookCalendarListForToday } from '../hooks/useOutlookCalendarList';
@@ -35,10 +33,6 @@ const OutlookEventsList = ({ onClose, changeRoute }: OutlookEventsListProps) => 
 
 	const calendarListResult = useOutlookCalendarListForToday();
 
-	const { ref, contentBoxSize: { inlineSize = 378, blockSize = 1 } = {} } = useResizeObserver<HTMLElement>({
-		debounceDelay: 200,
-	});
-
 	const calendarEvents = calendarListResult.data;
 	const total = calendarEvents?.length || 0;
 
@@ -52,7 +46,7 @@ const OutlookEventsList = ({ onClose, changeRoute }: OutlookEventsListProps) => 
 				<ContextualbarClose onClick={onClose} />
 			</ContextualbarHeader>
 			<ContextualbarContent paddingInline={0} color='default'>
-				<Box flexGrow={1} flexShrink={1} overflow='hidden' display='flex' justifyContent='center' ref={ref}>
+				<Box flexGrow={1} flexShrink={1} overflow='hidden' display='flex' justifyContent='center' style={{ minHeight: 0 }}>
 					{calendarListResult.isPending && <Throbber size='x12' />}
 					{calendarListResult.isError && (
 						<States>
@@ -68,18 +62,14 @@ const OutlookEventsList = ({ onClose, changeRoute }: OutlookEventsListProps) => 
 						</States>
 					)}
 					{calendarListResult.isSuccess && calendarListResult.data.length > 0 && (
-						<VirtualizedScrollbars>
-							<Virtuoso
-								style={{
-									height: blockSize,
-									width: inlineSize,
-								}}
+						<Box h='full' w='full' style={{ minHeight: 0 }}>
+							<PaginatedVirtualList
+								items={calendarListResult.data}
 								totalCount={total}
 								overscan={25}
-								data={calendarEvents}
-								itemContent={(_index, calendarData) => <OutlookEventItem {...calendarData} />}
+								renderItem={(calendarData) => <OutlookEventItem {...calendarData} />}
 							/>
-						</VirtualizedScrollbars>
+						</Box>
 					)}
 				</Box>
 			</ContextualbarContent>


### PR DESCRIPTION
## Proposed changes

This PR migrates the Outlook Events list from `react-virtuoso` to the shared `PaginatedVirtualList` while preserving the existing behavior as closely as possible.

### Changes included

- Replaces the direct `react-virtuoso` implementation with the shared `PaginatedVirtualList`.
- Removes the local resize-observer sizing logic.
- Preserves the existing loading, empty, and populated states.
- Preserves event interactions, including opening event details and joining meetings.
- Preserves the existing contextual bar layout and scrollbar behavior.
- Keeps the current row rendering and accessibility behavior while using the shared `ul`/`li` list semantics.
- Adds focused unit tests covering:
  - Shared virtual list rendering
  - `ul`/`li` list semantics
  - Overscan configuration
  - Rendered event rows

This migration is intentionally scoped to replacing the virtualization layer only, avoiding unrelated behavioral or architectural changes.

## Issue(s)

Part of the GSoC Virtua migration effort.

## Steps to test or reproduce

- Open the Outlook Calendar view.
- Verify the events list renders correctly.
- Verify loading, empty, and populated states behave as before.
- Verify clicking an event still opens the event details.
- Verify the Join Meeting action continues to work correctly.
- Verify the footer actions continue to work as expected.

## Further comments

Following the project's migration strategy, this implementation focuses on preserving the existing behavior while replacing only the underlying virtualization library.

The existing `PaginatedVirtualList` is used because `OutlookEventsList` is a flat list that naturally fits the shared abstraction. No shared APIs or component behavior were changed, keeping the migration small, consistent with previous Virtua migrations, and easy to review.

## Verification

- ✅ Targeted ESLint passed.
- ✅ Focused Jest passed.
- ✅ `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Outlook calendar events list rendering in full-height layouts for more reliable display.
  * Updated the events list virtualization to use paginated rendering, providing smoother scrolling and better stability on longer calendars.

* **Tests**
  * Added a Jest/React Testing Library spec that mocks Outlook event data and validates the rendered virtual list structure and expected event subjects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->