### PR TITLE
test: fix omnichannel-takeChat flake by waiting for agent availability

### DIFF
--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-takeChat.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-takeChat.spec.ts
@@ -5,7 +5,7 @@ import { createAuxContext } from '../fixtures/createAuxContext';
 import { Users } from '../fixtures/userStates';
 import { HomeOmnichannel } from '../page-objects';
 import { OmnichannelLiveChat } from '../page-objects/omnichannel';
-import { expectUserStatus } from '../utils/expectUserStatus';
+import { expectPollUserStatus } from '../utils/expectPollUserStatus';
 import { test, expect } from '../utils/test';
 
 test.describe('omnichannel-takeChat', () => {
@@ -46,7 +46,7 @@ test.describe('omnichannel-takeChat', () => {
 
 	test.beforeEach('start a new livechat chat', async ({ page, api }) => {
 		await agent.poHomeChannel.navbar.changeUserStatus('online');
-		await expectUserStatus(api, 'user1', 'online');
+		await expectPollUserStatus(api, 'user1', 'online');
 
 		newVisitor = createFakeVisitor();
 
@@ -71,7 +71,7 @@ test.describe('omnichannel-takeChat', () => {
 
 	test('When agent is offline should not take the chat', async ({ api }) => {
 		await agent.poHomeChannel.navbar.changeUserStatus('offline');
-		await expectUserStatus(api, 'user1', 'offline');
+		await expectPollUserStatus(api, 'user1', 'offline');
 
 		await sendLivechatMessage();
 

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-takeChat.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-takeChat.spec.ts
@@ -5,13 +5,8 @@ import { createAuxContext } from '../fixtures/createAuxContext';
 import { Users } from '../fixtures/userStates';
 import { HomeOmnichannel } from '../page-objects';
 import { OmnichannelLiveChat } from '../page-objects/omnichannel';
-import { getUserInfo } from '../utils/getUserInfo';
-import type { BaseTest } from '../utils/test';
+import { expectUserStatus } from '../utils/expectUserStatus';
 import { test, expect } from '../utils/test';
-
-const expectAgentStatus = async (api: BaseTest['api'], status: 'online' | 'offline') => {
-	await expect.poll(async () => (await getUserInfo(api, 'user1'))?.status).toBe(status);
-};
 
 test.describe('omnichannel-takeChat', () => {
 	let poLiveChat: OmnichannelLiveChat;
@@ -51,7 +46,7 @@ test.describe('omnichannel-takeChat', () => {
 
 	test.beforeEach('start a new livechat chat', async ({ page, api }) => {
 		await agent.poHomeChannel.navbar.changeUserStatus('online');
-		await expectAgentStatus(api, 'online');
+		await expectUserStatus(api, 'user1', 'online');
 
 		newVisitor = createFakeVisitor();
 
@@ -76,7 +71,7 @@ test.describe('omnichannel-takeChat', () => {
 
 	test('When agent is offline should not take the chat', async ({ api }) => {
 		await agent.poHomeChannel.navbar.changeUserStatus('offline');
-		await expectAgentStatus(api, 'offline');
+		await expectUserStatus(api, 'user1', 'offline');
 
 		await sendLivechatMessage();
 

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-takeChat.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-takeChat.spec.ts
@@ -5,7 +5,12 @@ import { createAuxContext } from '../fixtures/createAuxContext';
 import { Users } from '../fixtures/userStates';
 import { HomeOmnichannel } from '../page-objects';
 import { OmnichannelLiveChat } from '../page-objects/omnichannel';
+import type { BaseTest } from '../utils/test';
 import { test, expect } from '../utils/test';
+
+const expectAgentsAvailability = async (api: BaseTest['api'], online: boolean) => {
+	await expect.poll(async () => (await (await api.get('/livechat/config')).json()).config.online).toBe(online);
+};
 
 test.describe('omnichannel-takeChat', () => {
 	let poLiveChat: OmnichannelLiveChat;
@@ -45,6 +50,7 @@ test.describe('omnichannel-takeChat', () => {
 
 	test.beforeEach('start a new livechat chat', async ({ page, api }) => {
 		await agent.poHomeChannel.navbar.changeUserStatus('online');
+		await expectAgentsAvailability(api, true);
 
 		newVisitor = createFakeVisitor();
 
@@ -67,8 +73,9 @@ test.describe('omnichannel-takeChat', () => {
 		await expect(agent.poHomeChannel.composer.inputMessage).toBeVisible();
 	});
 
-	test('When agent is offline should not take the chat', async () => {
+	test('When agent is offline should not take the chat', async ({ api }) => {
 		await agent.poHomeChannel.navbar.changeUserStatus('offline');
+		await expectAgentsAvailability(api, false);
 
 		await sendLivechatMessage();
 

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-takeChat.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-takeChat.spec.ts
@@ -5,11 +5,12 @@ import { createAuxContext } from '../fixtures/createAuxContext';
 import { Users } from '../fixtures/userStates';
 import { HomeOmnichannel } from '../page-objects';
 import { OmnichannelLiveChat } from '../page-objects/omnichannel';
+import { getUserInfo } from '../utils/getUserInfo';
 import type { BaseTest } from '../utils/test';
 import { test, expect } from '../utils/test';
 
-const expectAgentsAvailability = async (api: BaseTest['api'], online: boolean) => {
-	await expect.poll(async () => (await (await api.get('/livechat/config')).json()).config.online).toBe(online);
+const expectAgentStatus = async (api: BaseTest['api'], status: 'online' | 'offline') => {
+	await expect.poll(async () => (await getUserInfo(api, 'user1'))?.status).toBe(status);
 };
 
 test.describe('omnichannel-takeChat', () => {
@@ -50,7 +51,7 @@ test.describe('omnichannel-takeChat', () => {
 
 	test.beforeEach('start a new livechat chat', async ({ page, api }) => {
 		await agent.poHomeChannel.navbar.changeUserStatus('online');
-		await expectAgentsAvailability(api, true);
+		await expectAgentStatus(api, 'online');
 
 		newVisitor = createFakeVisitor();
 
@@ -75,7 +76,7 @@ test.describe('omnichannel-takeChat', () => {
 
 	test('When agent is offline should not take the chat', async ({ api }) => {
 		await agent.poHomeChannel.navbar.changeUserStatus('offline');
-		await expectAgentsAvailability(api, false);
+		await expectAgentStatus(api, 'offline');
 
 		await sendLivechatMessage();
 

--- a/apps/meteor/tests/e2e/utils/expectPollUserStatus.ts
+++ b/apps/meteor/tests/e2e/utils/expectPollUserStatus.ts
@@ -2,6 +2,6 @@ import { getUserInfo } from './getUserInfo';
 import type { BaseTest } from './test';
 import { expect } from './test';
 
-export const expectUserStatus = async (api: BaseTest['api'], username: string, status: 'online' | 'offline' | 'away' | 'busy') => {
+export const expectPollUserStatus = async (api: BaseTest['api'], username: string, status: 'online' | 'offline' | 'away' | 'busy') => {
 	await expect.poll(async () => (await getUserInfo(api, username))?.status).toBe(status);
 };

--- a/apps/meteor/tests/e2e/utils/expectUserStatus.ts
+++ b/apps/meteor/tests/e2e/utils/expectUserStatus.ts
@@ -1,0 +1,7 @@
+import { getUserInfo } from './getUserInfo';
+import type { BaseTest } from './test';
+import { expect } from './test';
+
+export const expectUserStatus = async (api: BaseTest['api'], username: string, status: 'online' | 'offline' | 'away' | 'busy') => {
+	await expect.poll(async () => (await getUserInfo(api, username))?.status).toBe(status);
+};


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`omnichannel-takeChat.spec.ts` flakes in CI (e.g. merge-queue run https://github.com/RocketChat/Rocket.Chat/actions/runs/28836457296): the tests change the agent's user status via the UI (`changeUserStatus`) and immediately have the visitor start a chat. The status click resolves before the server-side presence/availability propagates, so `QueueManager.requestRoom` still rejects with `no-agent-online`, no room is created, and the sidebar item wait times out.

The failure trace confirms it — the widget's room-creation request returned:

```
{"success":false,"error":"Sorry, no online agents [no-agent-online]"}
```

This adds a poll on `GET /livechat/config` → `config.online` (the same `online()` check `requestRoom` uses) after each status change, so the visitor only starts the chat once the server actually agrees on the agent's availability. Applied to `beforeEach` (online) and to the offline test (which has the symmetric race).

## Issue(s)

## Steps to test or reproduce

Run `omnichannel-takeChat.spec.ts` — availability races no longer depend on presence propagation timing.

## Further comments


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end chat coverage by waiting for agent status changes to sync before continuing test steps.
  * Added a reusable test helper to verify user status updates such as online, offline, away, and busy.
  * Reduced flakiness in live chat scenarios by making status-based assertions more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [FLAKY-2292]

[FLAKY-2292]: https://rocketchat.atlassian.net/browse/FLAKY-2292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ