### PR TITLE
feat: wait until call signaling is confirmed before playing the "calling" sound effect

### DIFF
--- a/.changeset/sixty-coins-invent.md
+++ b/.changeset/sixty-coins-invent.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/media-signaling': minor
+'@rocket.chat/ui-voip': minor
+---
+
+External calls will now only play the ringing sound effect once the call has been sent out from the server

--- a/packages/media-signaling/src/definition/call/CallEvents.ts
+++ b/packages/media-signaling/src/definition/call/CallEvents.ts
@@ -25,6 +25,8 @@ export type CallEvents = {
 	active: void;
 	/* Triggered when this client puts the call on the ignore list, either because the call was accepted on a different client or because you called `call.ignore()` */
 	hidden: void;
+	/* Triggered when the call has reached the other user and started ringing */
+	ringing: void;
 
 	/* Triggered when the call's state on the server changes to 'hangup' */
 	ended: void;

--- a/packages/media-signaling/src/definition/call/callStates/IDirectMediaCallData.ts
+++ b/packages/media-signaling/src/definition/call/callStates/IDirectMediaCallData.ts
@@ -11,6 +11,7 @@ export interface IDirectMediaCallData {
 	readonly features: readonly CallFeature[];
 	readonly state: CallState;
 	readonly hidden: boolean;
+	readonly ringing: boolean;
 
 	readonly transferredBy: CallContact | null;
 

--- a/packages/media-signaling/src/lib/Call.ts
+++ b/packages/media-signaling/src/lib/Call.ts
@@ -157,6 +157,23 @@ export class ClientMediaCall implements IClientMediaCall {
 		return !this.isPendingAcceptance() && !this.isOver();
 	}
 
+	public get ringing(): boolean {
+		if (this.hidden) {
+			return false;
+		}
+
+		if (this._state !== 'ringing' || !this.hasRemoteData) {
+			return false;
+		}
+
+		if (this.role === 'caller' && this._contact?.type === 'sip') {
+			// On SIP Calls, the caller should start ringing only after the offer is sent to the server
+			return this.sentLocalSdp;
+		}
+
+		return true;
+	}
+
 	public get confirmed(): boolean {
 		return this.hasRemoteData;
 	}
@@ -200,6 +217,8 @@ export class ClientMediaCall implements IClientMediaCall {
 	private remoteCallId: string | null;
 
 	private oldClientState: ClientState;
+
+	private hasFiredRingingEvent: boolean;
 
 	private serviceStates: Map<string, string>;
 
@@ -280,6 +299,7 @@ export class ClientMediaCall implements IClientMediaCall {
 			activeTimestamp: this.activeTimestamp,
 			tempCallId: this.tempCallId,
 			hidden: this.hidden,
+			ringing: this.ringing,
 
 			localParticipant: this.localParticipant,
 			remoteParticipant: this.remoteParticipant,
@@ -321,6 +341,7 @@ export class ClientMediaCall implements IClientMediaCall {
 		this._role = 'callee';
 		this._state = 'none';
 		this.oldClientState = 'none';
+		this.hasFiredRingingEvent = false;
 		this._ignored = false;
 		this._contact = null;
 		this._transferredBy = null;
@@ -467,6 +488,7 @@ export class ClientMediaCall implements IClientMediaCall {
 			}
 			this.emitter.emit('contactUpdate');
 			this.emitter.emit('confirmed');
+			this.updateRingingEvent();
 		}
 
 		await this.processEarlySignals();
@@ -960,6 +982,7 @@ export class ClientMediaCall implements IClientMediaCall {
 		this._state = newState;
 		this.maybeStopWebRTC();
 		this.updateClientState();
+		this.updateRingingEvent();
 
 		this.emitter.emit('stateChange', oldState);
 		this.requestStateReport();
@@ -1002,6 +1025,15 @@ export class ClientMediaCall implements IClientMediaCall {
 		this.requestStateReport();
 		this.oldClientState = clientState;
 		this.emitter.emit('clientStateChange', oldClientState);
+	}
+
+	private updateRingingEvent(): void {
+		if (this.hasFiredRingingEvent || !this.ringing) {
+			return;
+		}
+
+		this.hasFiredRingingEvent = true;
+		this.emitter.emit('ringing');
 	}
 
 	private maybeStopWebRTC(): void {
@@ -1114,6 +1146,7 @@ export class ClientMediaCall implements IClientMediaCall {
 		}
 
 		this.updateClientState();
+		this.updateRingingEvent();
 	}
 
 	protected getLocalStreamIds(): MediaStreamIdentification[] {

--- a/packages/media-signaling/src/lib/Call.ts
+++ b/packages/media-signaling/src/lib/Call.ts
@@ -157,6 +157,23 @@ export class ClientMediaCall implements IClientMediaCall {
 		return !this.isPendingAcceptance() && !this.isOver();
 	}
 
+	public get ringing(): boolean {
+		if (this.hidden) {
+			return false;
+		}
+
+		if (this._state !== 'ringing' || !this.hasRemoteData) {
+			return false;
+		}
+
+		if (this.role === 'caller' && this._contact?.type === 'sip') {
+			// On SIP Calls, the caller should start ringing only after the offer is sent to the server
+			return this.sentLocalSdp;
+		}
+
+		return true;
+	}
+
 	public get confirmed(): boolean {
 		return this.hasRemoteData;
 	}
@@ -200,6 +217,8 @@ export class ClientMediaCall implements IClientMediaCall {
 	private remoteCallId: string | null;
 
 	private oldClientState: ClientState;
+
+	private hasFiredRingingEvent: boolean;
 
 	private serviceStates: Map<string, string>;
 
@@ -278,6 +297,7 @@ export class ClientMediaCall implements IClientMediaCall {
 			activeTimestamp: this.activeTimestamp,
 			tempCallId: this.tempCallId,
 			hidden: this.hidden,
+			ringing: this.ringing,
 
 			localParticipant: this.localParticipant,
 			remoteParticipant: this.remoteParticipant,
@@ -318,6 +338,7 @@ export class ClientMediaCall implements IClientMediaCall {
 		this._role = 'callee';
 		this._state = 'none';
 		this.oldClientState = 'none';
+		this.hasFiredRingingEvent = false;
 		this._ignored = false;
 		this._contact = null;
 		this._transferredBy = null;
@@ -464,6 +485,7 @@ export class ClientMediaCall implements IClientMediaCall {
 			}
 			this.emitter.emit('contactUpdate');
 			this.emitter.emit('confirmed');
+			this.updateRingingEvent();
 		}
 
 		await this.processEarlySignals();
@@ -944,6 +966,7 @@ export class ClientMediaCall implements IClientMediaCall {
 		this._state = newState;
 		this.maybeStopWebRTC();
 		this.updateClientState();
+		this.updateRingingEvent();
 
 		this.emitter.emit('stateChange', oldState);
 		this.requestStateReport();
@@ -986,6 +1009,15 @@ export class ClientMediaCall implements IClientMediaCall {
 		this.requestStateReport();
 		this.oldClientState = clientState;
 		this.emitter.emit('clientStateChange', oldClientState);
+	}
+
+	private updateRingingEvent(): void {
+		if (this.hasFiredRingingEvent || !this.ringing) {
+			return;
+		}
+
+		this.hasFiredRingingEvent = true;
+		this.emitter.emit('ringing');
 	}
 
 	private maybeStopWebRTC(): void {
@@ -1118,6 +1150,7 @@ export class ClientMediaCall implements IClientMediaCall {
 		}
 
 		this.updateClientState();
+		this.updateRingingEvent();
 	}
 
 	protected getLocalStreamIds(): MediaStreamIdentification[] {

--- a/packages/media-signaling/src/lib/Session.ts
+++ b/packages/media-signaling/src/lib/Session.ts
@@ -680,6 +680,7 @@ export class MediaSignalingSession extends Emitter<MediaSignalingEvents> {
 		call.emitter.on('accepting', () => this.onAcceptingCall(call));
 		call.emitter.on('hidden', () => this.onHiddenCall(call));
 		call.emitter.on('active', () => this.onActiveCall(call));
+		call.emitter.on('ringing', () => this.onRingingCall());
 		call.emitter.on('ended', () => this.onEndedCall(call));
 		call.emitter.on('screenShareRequestChange', (requested: boolean) => this.onScreenShareRequestChange(call, requested));
 		call.emitter.on('streamChange', () => this.onSessionStateChange());
@@ -741,6 +742,11 @@ export class MediaSignalingSession extends Emitter<MediaSignalingEvents> {
 	private onActiveCall(_call: ClientMediaCall): void {
 		this.config.logger?.debug('MediaSignalingSession.onActiveCall');
 		this.onSessionStateChange();
+	}
+
+	private onRingingCall(): void {
+		this.config.logger?.debug('MediaSignalingSession.onRingingCall');
+		this.emit('sessionStateChange');
 	}
 
 	private async onScreenShareRequestChange(call: ClientMediaCall, requested: boolean): Promise<void> {

--- a/packages/media-signaling/src/lib/Session.ts
+++ b/packages/media-signaling/src/lib/Session.ts
@@ -679,6 +679,7 @@ export class MediaSignalingSession extends Emitter<MediaSignalingEvents> {
 		call.emitter.on('accepting', () => this.onAcceptingCall(call));
 		call.emitter.on('hidden', () => this.onHiddenCall(call));
 		call.emitter.on('active', () => this.onActiveCall(call));
+		call.emitter.on('ringing', () => this.onRingingCall());
 		call.emitter.on('ended', () => this.onEndedCall(call));
 		call.emitter.on('screenShareRequestChange', (requested: boolean) => this.onScreenShareRequestChange(call, requested));
 		call.emitter.on('streamChange', () => this.onSessionStateChange());
@@ -740,6 +741,11 @@ export class MediaSignalingSession extends Emitter<MediaSignalingEvents> {
 	private onActiveCall(_call: ClientMediaCall): void {
 		this.config.logger?.debug('MediaSignalingSession.onActiveCall');
 		this.onSessionStateChange();
+	}
+
+	private onRingingCall(): void {
+		this.config.logger?.debug('MediaSignalingSession.onRingingCall');
+		this.emit('sessionStateChange');
 	}
 
 	private async onScreenShareRequestChange(call: ClientMediaCall, requested: boolean): Promise<void> {

--- a/packages/ui-voip/src/context/definitions.d.ts
+++ b/packages/ui-voip/src/context/definitions.d.ts
@@ -33,6 +33,7 @@ interface IBaseSession {
 	remoteHeld: boolean;
 	startedAt?: Date;
 	hidden: boolean;
+	ringing?: boolean;
 	supportedFeatures: readonly CallFeature[];
 }
 

--- a/packages/ui-voip/src/context/definitions.d.ts
+++ b/packages/ui-voip/src/context/definitions.d.ts
@@ -31,6 +31,7 @@ interface IBaseSession {
 	remoteHeld: boolean;
 	startedAt?: Date;
 	hidden: boolean;
+	ringing?: boolean;
 	supportedFeatures: readonly CallFeature[];
 }
 

--- a/packages/ui-voip/src/providers/MediaCallViewProvider.tsx
+++ b/packages/ui-voip/src/providers/MediaCallViewProvider.tsx
@@ -60,7 +60,7 @@ const MediaCallViewProvider = ({ children }: MediaCallViewProviderProps) => {
 	}, [audioInput?.id, controls, sessionState.hidden]);
 
 	useCallSounds(
-		sessionState.hidden ? 'none' : sessionState.state,
+		sessionState.hidden || !sessionState.ringing ? 'none' : sessionState.state,
 		useCallback(
 			(callback) => {
 				if (!instance) {

--- a/packages/ui-voip/src/providers/useMediaSession.ts
+++ b/packages/ui-voip/src/providers/useMediaSession.ts
@@ -124,6 +124,7 @@ export const useMediaSession = (instance?: MediaSignalingSession): SessionState 
 				features: supportedFeatures,
 				transferredBy: callTransferredBy,
 				remoteParticipant: { muted: remoteMuted, held: remoteHeld, contact },
+				ringing,
 			} = instanceState;
 
 			const transferredBy = callTransferredBy?.displayName || callTransferredBy?.username || undefined;
@@ -160,6 +161,7 @@ export const useMediaSession = (instance?: MediaSignalingSession): SessionState 
 					callId,
 					startedAt,
 					supportedFeatures,
+					ringing,
 				},
 			});
 		};

--- a/packages/ui-voip/src/providers/useMediaSession.ts
+++ b/packages/ui-voip/src/providers/useMediaSession.ts
@@ -124,6 +124,7 @@ export const useMediaSession = (instance?: MediaSignalingSession): SessionState 
 				features: supportedFeatures,
 				transferredBy: callTransferredBy,
 				remoteParticipant: { muted: remoteMuted, held: remoteHeld, contact },
+				ringing,
 			} = instanceState;
 
 			const transferredBy = callTransferredBy?.displayName || callTransferredBy?.username || undefined;
@@ -144,6 +145,7 @@ export const useMediaSession = (instance?: MediaSignalingSession): SessionState 
 						callId,
 						startedAt,
 						supportedFeatures,
+						ringing,
 					},
 				});
 				return;
@@ -178,6 +180,7 @@ export const useMediaSession = (instance?: MediaSignalingSession): SessionState 
 					callId,
 					startedAt,
 					supportedFeatures,
+					ringing,
 				},
 			});
 		};


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[DMV-85](https://rocketchat.atlassian.net/browse/DMV-85)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



[DMV-85]: https://rocketchat.atlassian.net/browse/DMV-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added ringing status tracking for voice calls.
  - Call sessions now update when a call begins ringing.

- **Bug Fixes**
  - External call ringing sounds now play only after the call reaches the recipient and starts ringing.
  - Prevented call sounds from playing during other non-ringing call states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->