### PR TITLE
ci: fix Docker image size report showing zero for current

### DIFF
--- a/.github/actions/docker-image-size-tracker/action.yml
+++ b/.github/actions/docker-image-size-tracker/action.yml
@@ -89,10 +89,11 @@ runs:
           # Read only the specified platform architecture
           manifest_file="$service_dir/$PLATFORM/manifest.json"
           if [[ -f "$manifest_file" ]]; then
-            # Docker manifest inspect -v returns SchemaV2Manifest with sizes
-            # Extract config size and layer sizes
-            config_size=$(jq -r '.SchemaV2Manifest.config.size // 0' "$manifest_file")
-            layers_size=$(jq '[.SchemaV2Manifest.layers[]?.size // 0] | add // 0' "$manifest_file")
+            # docker manifest inspect -v puts the manifest under SchemaV2Manifest
+            # (Docker schema2 images) or OCIManifest (OCI images, which buildx
+            # produces by default). Coalesce so both formats are read.
+            config_size=$(jq -r '(.SchemaV2Manifest // .OCIManifest).config.size // 0' "$manifest_file")
+            layers_size=$(jq '[(.SchemaV2Manifest // .OCIManifest).layers[]?.size // 0] | add // 0' "$manifest_file")
             size=$((config_size + layers_size))
 
             echo "  → Found $manifest_file: $size bytes (config: $config_size, layers: $layers_size)"


### PR DESCRIPTION
## Problem

The **Docker Image Size Report** shows `0 B` for every service in the *Current* column while the *Baseline* column stays correct.

## Root cause

The `measure` step in the tracker action reads image sizes only from `.SchemaV2Manifest`:

```sh
config_size=$(jq -r '.SchemaV2Manifest.config.size // 0' "$manifest_file")
layers_size=$(jq '[.SchemaV2Manifest.layers[]?.size // 0] | add // 0' "$manifest_file")
```

The manifests come from `docker manifest inspect -v` (in `build-docker`). When images are pushed with **OCI** media types, verbose inspect populates `.OCIManifest` and leaves `.SchemaV2Manifest` **null** → every service resolves to `0` → the current total is always zero.

The baseline column is unaffected because it parses the raw manifest (`.config` / `.layers`), which is media-type agnostic.

## When it broke (and why it worked before)

It worked until **2026-06-29**. Confirmed from CI logs on `develop`:

| Run | Time (UTC) | dockerd | rocketchat | Total |
|-----|-----------|---------|-----------|-------|
| 28356132826 | 2026-06-29 07:35 | **29.5.3** | 310 MB | **1.44 GB** ✅ |
| 28371945073 | 2026-06-29 12:27 | **29.6.1** | 0 | **0** ❌ |

The GitHub-hosted runner's `setup-docker-action` pulls the "stable" dockerd from the toolcache. Between those two runs the runner bumped dockerd **29.5.3 → 29.6.1**. Sizes moved from `.SchemaV2Manifest` to `.OCIManifest`.

The exact trigger: **dockerd 29.6.0 bundled BuildKit v0.31.0** ([moby/moby#52904](https://github.com/moby/moby/releases/tag/docker-v29.6.0)), and BuildKit v0.31.0 changed the media-type default ([moby/buildkit#6824](https://github.com/moby/buildkit/pull/6824)):

> All image results now default to using OCI media types. Previously this was applied based on whether annotations or attestations were needed. `oci-mediatypes=false` can be used for legacy Docker media types. This change raises the compatibility version of BuildKit v0.31.0 to 30.

So with 29.5.3 (BuildKit ≤ v0.30.x) our `--provenance=false` builds pushed Docker schema2; with 29.6.1 the same builds push OCI. buildx **client** was identical across both runs (v0.35.0) — only the bundled BuildKit in the daemon changed.

An alternative fix would be forcing `oci-mediatypes=false` in the bake command, but reading both keys is more robust (survives a future default flip in either direction).

Not caused by any repo commit:
- The only commit between the good and broken run (`275a6eda0d`, actions/cache bump) does not touch the build.
- `#41083` (06-26, micro-service Docker rework) is not the cause: runs after it still worked, and `rocketchat` — untouched by it — flipped too, proving the change is global (runner-side).

## Fix

Coalesce both keys so Docker schema2 and OCI manifests are both read:

```sh
config_size=$(jq -r '(.SchemaV2Manifest // .OCIManifest).config.size // 0' "$manifest_file")
layers_size=$(jq '[(.SchemaV2Manifest // .OCIManifest).layers[]?.size // 0] | add // 0' "$manifest_file")
```

Media-type-proof regardless of the runner's dockerd version. Verified against a live OCI manifest (non-zero config + layer sizes) and a synthetic schema2 manifest (still correct). 

 Task: [ARCH-2229]

[ARCH-2229]: https://rocketchat.atlassian.net/browse/ARCH-2229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image size tracking so totals now include both Docker Schema V2 and OCI manifest formats.
  * Size calculations are more accurate for images produced by different build outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->