### PR TITLE
fix: dates showing one day earlier for users in negative UTC-offset

### DIFF
--- a/.changeset/swift-ants-appear.md
+++ b/.changeset/swift-ants-appear.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes dates showing one day earlier for users in negative UTC-offset timezones

--- a/apps/meteor/client/lib/utils/dateFormat.spec.ts
+++ b/apps/meteor/client/lib/utils/dateFormat.spec.ts
@@ -1,5 +1,5 @@
 /**
- * @jest-environment <rootDir>/tests/environments/timezone.js
+ * @jest-environment <rootDir>/tests/environments/timezone.ts
  * @jest-environment-options {"timezone": "America/Argentina/Buenos_Aires"}
  */
 import { formatDate, momentFormatToDateFns, toDate } from './dateFormat';

--- a/apps/meteor/client/lib/utils/dateFormat.spec.ts
+++ b/apps/meteor/client/lib/utils/dateFormat.spec.ts
@@ -1,4 +1,8 @@
-import { formatDate, momentFormatToDateFns } from './dateFormat';
+/**
+ * @jest-environment <rootDir>/tests/environments/timezone.js
+ * @jest-environment-options {"timezone": "America/Argentina/Buenos_Aires"}
+ */
+import { formatDate, momentFormatToDateFns, toDate } from './dateFormat';
 
 describe('momentFormatToDateFns', () => {
 	it('maps locale tokens', () => {
@@ -139,5 +143,30 @@ describe('formatDate', () => {
 		// option is wired through.
 		expect(() => formatDate(sample, 'gggg')).not.toThrow();
 		expect(formatDate(sample, 'gggg')).toMatch(/^\d{4}$/);
+	});
+});
+
+describe('toDate', () => {
+	it('parses a bare yyyy-MM-dd string at LOCAL midnight (not UTC midnight)', () => {
+		const d = toDate('2026-07-02');
+		// Pre-fix `new Date('2026-07-02')` (UTC midnight) is the previous day / 21:00 here.
+		expect(d.getFullYear()).toBe(2026);
+		expect(d.getMonth()).toBe(6); // July (0-indexed)
+		expect(d.getDate()).toBe(2);
+		expect(d.getHours()).toBe(0);
+	});
+
+	it('keeps full ISO datetimes as instants (UTC preserved)', () => {
+		expect(toDate('2026-07-02T15:30:00.000Z').toISOString()).toBe('2026-07-02T15:30:00.000Z');
+	});
+
+	it('returns Date objects unchanged', () => {
+		const d = new Date();
+		expect(toDate(d)).toBe(d);
+	});
+
+	it('accepts epoch milliseconds', () => {
+		const ms = Date.UTC(2026, 6, 2, 12);
+		expect(toDate(ms).getTime()).toBe(ms);
 	});
 });

--- a/apps/meteor/client/lib/utils/dateFormat.ts
+++ b/apps/meteor/client/lib/utils/dateFormat.ts
@@ -192,7 +192,7 @@ const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
  * previous day in negative-offset timezones (e.g. UTC-3 shows "Jul 1"). Full ISO
  * datetimes, numbers and Date objects keep their original instant semantics.
  */
-const toDate = (date: DateInput): Date => {
+export const toDate = (date: DateInput): Date => {
 	if (date instanceof Date) {
 		return date;
 	}

--- a/apps/meteor/client/lib/utils/dateFormat.ts
+++ b/apps/meteor/client/lib/utils/dateFormat.ts
@@ -1,4 +1,4 @@
-import { format, formatDistanceToNow, formatDuration, intervalToDuration, differenceInCalendarDays } from 'date-fns';
+import { format, formatDistanceToNow, formatDuration, intervalToDuration, differenceInCalendarDays, parse } from 'date-fns';
 import type { Locale } from 'date-fns';
 
 export type DateInput = string | Date | number;
@@ -181,6 +181,27 @@ export const momentFormatToDateFns = (momentFormat: string): string => {
 	return out;
 };
 
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Normalize a date input to a Date.
+ *
+ * Calendar-date-only strings (`yyyy-MM-dd`, e.g. produced by an `<input type="date">`)
+ * are parsed in LOCAL time, the way Moment.js did before the date-fns migration.
+ * `new Date('2026-07-02')` instead parses as UTC midnight, which renders as the
+ * previous day in negative-offset timezones (e.g. UTC-3 shows "Jul 1"). Full ISO
+ * datetimes, numbers and Date objects keep their original instant semantics.
+ */
+const toDate = (date: DateInput): Date => {
+	if (date instanceof Date) {
+		return date;
+	}
+	if (typeof date === 'string' && DATE_ONLY_RE.test(date)) {
+		return parse(date, 'yyyy-MM-dd', new Date());
+	}
+	return new Date(date);
+};
+
 const safeFormat = (d: Date, momentFormat: string, locale?: Locale): string => {
 	const options = {
 		...(locale && { locale }),
@@ -195,8 +216,7 @@ const safeFormat = (d: Date, momentFormat: string, locale?: Locale): string => {
 };
 
 export const formatDate = (date: DateInput, formatStr: string, locale?: Locale): string => {
-	const d = typeof date === 'object' && date instanceof Date ? date : new Date(date);
-	return safeFormat(d, formatStr, locale);
+	return safeFormat(toDate(date), formatStr, locale);
 };
 
 export const formatTimeAgo = (
@@ -211,7 +231,7 @@ export const formatTimeAgo = (
 	},
 	locale?: Locale,
 ): string => {
-	const d = typeof date === 'object' && date instanceof Date ? date : new Date(date);
+	const d = toDate(date);
 	const now = new Date();
 	const diffDays = differenceInCalendarDays(now, d);
 
@@ -233,8 +253,7 @@ export const formatTimeAgo = (
 };
 
 export const formatFromNow = (date: DateInput, addSuffix: boolean, locale?: Locale): string => {
-	const d = typeof date === 'object' && date instanceof Date ? date : new Date(date);
-	return formatDistanceToNow(d, { addSuffix, locale });
+	return formatDistanceToNow(toDate(date), { addSuffix, locale });
 };
 
 export const formatDurationMs = (timeMs: number, locale?: Locale): string => {

--- a/apps/meteor/client/views/admin/engagementDashboard/users/NewUsersSection.tsx
+++ b/apps/meteor/client/views/admin/engagementDashboard/users/NewUsersSection.tsx
@@ -38,7 +38,7 @@ const NewUsersSection = ({ timezone }: NewUsersSectionProps) => {
 		const endDate = new Date(data.end);
 		const daysCount = differenceInDays(endDate, startDate) + 1;
 		const values = Array.from({ length: daysCount }, (_, i) => ({
-			date: format(addDays(startDate, i), 'yyyy-MM-dd'),
+			date: addDays(startDate, i).toISOString(),
 			newUsers: 0,
 		}));
 		for (const { day, users } of data.days) {

--- a/apps/meteor/tests/environments/timezone.ts
+++ b/apps/meteor/tests/environments/timezone.ts
@@ -1,0 +1,25 @@
+import type { JestEnvironmentConfig, EnvironmentContext } from '@jest/environment';
+import JSDOMEnvironment from 'jest-environment-jsdom';
+
+// Pins the test's timezone.
+// the (jsdom) environment and the timezone gets locked in; a beforeAll() is too late.
+module.exports = class TimezoneEnvironment extends JSDOMEnvironment {
+	private previousTZ: string | undefined;
+
+	constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
+		const { timezone = 'UTC' } = config.projectConfig.testEnvironmentOptions as { timezone?: string };
+		const previousTZ: string | undefined = process.env.TZ;
+		process.env.TZ = timezone;
+		super(config, context);
+		this.previousTZ = previousTZ;
+	}
+
+	override async teardown(): Promise<void> {
+		if (this.previousTZ === undefined) {
+			delete process.env.TZ;
+		} else {
+			process.env.TZ = this.previousTZ;
+		}
+		await super.teardown();
+	}
+};


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
- Parse `yyyy-MM-dd` calendar dates (e.g. from `type=date` inputs) with date-fns `parse` method (local midnight) instead of `new Date` (UTC midnight), which shifted the day back in negative offset timezones. Datetimes/Dates/numbers are unchanged.
- Added JSDom test environment to reuse it across different test suites which will need a specific timezone in the future + unit tests for the new `toDate` function. For reference: https://jestjs.io/docs/test-environment
- Small change in `NewUsersSection.tsx`, why? While checking places where `formatDate` with `YYYY-MM-DD` format was being called to check nothing breaks, I saw that the "New users" chart in `Workspace -> Engagement -> Users` had an offset of one day in the labels. The `NewUsersSection` chart builds a string key per bar and then re-parses it in the axis and tooltip. Under Moment both ends used moment(...), and Moment parses a bare `YYYY-MM-DD` string as local midnight, so the key round-tripped correctly. The `moment → date-fns` migration (https://github.com/RocketChat/Rocket.Chat/pull/40076) replaced moment(date) with new Date(date) at the re-parse points. But `new Date('YYYY-MM-DD')` parses as UTC midnight (per the JS spec), not local. In negative UTC offsets that lands on the previous day, that's the off-by-one.

The sibling MessagesSentSection was immune because its key is .toISOString() (a full instant with Z), and new Date(iso) === moment(iso). Only the YYYY-MM-DD key was ambiguous, so only NewUsersSection broke.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[SUP-1070 UI bug: Contact Center date conversion error](https://rocketchat.atlassian.net/browse/SUP-1070)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1- Set a negative UTC-offset timezone (e.g, UTC-3). If you are from Brazil or Argentina, you shouldn't need this step.
2- Go to Omnichannel Contact Center -> Open 'Filters' -> Set a date in `From` and `To`.
3- Observe how the displayed dates in the chips is one day earlier.
 
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date/time displays showing one day early for negative UTC-offset timezones.
  * Date-only (`YYYY-MM-DD`) inputs are interpreted as local dates, while full timestamps preserve the exact instant.
  * Improved admin dashboard day tooltips by indexing with ISO timestamps.
* **Tests**
  * Added a Jest environment to pin the test timezone and expanded coverage for date parsing/conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->