### PR TITLE
fix: Video attachment controls not clickable on Chromium 150

### DIFF
--- a/apps/meteor/client/components/message/content/attachments/file/VideoAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/VideoAttachment.tsx
@@ -29,7 +29,7 @@ const VideoAttachment = ({
 			{descriptionMd ? <MessageContentBody md={descriptionMd} /> : <MarkdownText parseEmoji content={description} />}
 			<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
 				<MessageGenericPreview style={{ maxWidth: 368, width: '100%' }}>
-					<Box is='video' controls preload='metadata' ref={mediaRef}>
+					<Box is='video' controls preload='metadata' ref={mediaRef} position='relative'>
 						<source src={getURL(url)} type={userAgentMIMETypeFallback(type)} />
 					</Box>
 				</MessageGenericPreview>


### PR DESCRIPTION
<!-- Suggested title: fix: Video attachment controls not clickable on Chromium 150 (CSS containment) -->

## Proposed changes (including videos or screenshots)

**Problem:** on Chromium 150 (Chrome & Brave), videos in messages can't be played — the video is fully **visible**, but the native controls don't respond to hover or click.

**Root cause:** a Chromium 150 hit-test/paint bug triggered by **CSS containment**. Our virtualized message list (react-virtuoso) wraps rows in `contain`. Inside that scope, a `<video controls>` **paints on top** (you see it) but **hit-tests behind** its parent card — so `document.elementFromPoint()` at the video returns the card `<div>`, and clicks/hover never reach the controls. Confirmed with a pure-HTML repro (no React/Rocket.Chat) and bisected to Chromium CL [`b629d9b` "Paint replaced normal-flow stacking contexts inline"](https://chromium.googlesource.com/chromium/src/+/b629d9bab3c38336a3048d5471fd115f5131e09c), which reworked how `<video>`'s self-painting layer paints/hit-tests but didn't handle ancestors with paint `contain`. Unaffected on Chromium ≤148.

**Fix:** give the video `position: relative` — moves it into the positioned-paint phase, where paint and hit-test agree again. One line, no `z-index`.

```diff
- <Box is='video' controls preload='metadata' ref={mediaRef}>
+ <Box is='video' controls preload='metadata' ref={mediaRef} position='relative'>
```

## Issue(s)

- Upstream Chromium bug: https://issues.chromium.org/issues/532229489
- [CORE-2395](https://rocketchat.atlassian.net/browse/CORE-2395)

## Steps to test or reproduce

1. On Chromium 150 (Chrome/Brave), open a message with a video attachment and click play.
   - Before: the video shows but the controls don't respond (no hover, no play).
   - After: controls respond and the video plays.
2. Chromium ≤148: unaffected.

Console check: `elementFromPoint` at the video's center should return the `<video>`, not the card `<div>`.

## Further comments

This is an upstream Chromium regression (CL above), but **we fix it on our side because we can't wait on Chromium's timeline** — there's no ETA for the upstream fix, and even after it lands it takes weeks/months to reach Chrome/Brave/Edge users, while 150 already breaks playback today.

> **Glossary:** "hit-testing" = which element the browser thinks is under the pointer, i.e. who gets the click. (Took me a while to learn that's the official name. 🙂)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video attachment display by ensuring the video container is positioned correctly, helping the player render more reliably in messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2395]: https://rocketchat.atlassian.net/browse/CORE-2395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ