### PR TITLE
fix: findCustomRoles/countCustomRoles miss roles missing 'protected' field

### DIFF
--- a/.changeset/fix-custom-roles-protected-field.md
+++ b/.changeset/fix-custom-roles-protected-field.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/meteor': patch
+'@rocket.chat/models': patch
+---
+
+Fixed custom roles created before the `protected` field existed being missed by `findCustomRoles`/`countCustomRoles`, which affected the Apps-Engine custom roles list and the `totalCustomRoles` telemetry stat.

--- a/packages/models/src/models/Roles.ts
+++ b/packages/models/src/models/Roles.ts
@@ -137,16 +137,18 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 	}
 
 	findCustomRoles(options?: FindOptions<IRole>): FindCursor<IRole> {
+		// `protected` may be absent on roles created before that field existed, so `false` alone would miss them
 		const query: Filter<IRole> = {
-			protected: false,
+			protected: { $ne: true },
 		};
 
 		return this.find(query, options || {});
 	}
 
 	countCustomRoles(options?: CountDocumentsOptions): Promise<number> {
+		// `protected` may be absent on roles created before that field existed, so `false` alone would miss them
 		const query: Filter<IRole> = {
-			protected: false,
+			protected: { $ne: true },
 		};
 
 		return this.countDocuments(query, options || {});

--- a/packages/models/src/models/Roles.ts
+++ b/packages/models/src/models/Roles.ts
@@ -137,7 +137,6 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 	}
 
 	findCustomRoles(options?: FindOptions<IRole>): FindCursor<IRole> {
-		// `protected` may be absent on roles created before that field existed, so `false` alone would miss them
 		const query: Filter<IRole> = {
 			protected: { $ne: true },
 		};
@@ -146,7 +145,6 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 	}
 
 	countCustomRoles(options?: CountDocumentsOptions): Promise<number> {
-		// `protected` may be absent on roles created before that field existed, so `false` alone would miss them
 		const query: Filter<IRole> = {
 			protected: { $ne: true },
 		};


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

`RolesRaw.findCustomRoles` and `RolesRaw.countCustomRoles` query for `protected: false`, which in MongoDB only matches documents where the field is explicitly `false` - it does not match documents where the field is absent. Custom roles created before the `protected` field existed have no such field at all, so on older/long-running instances they are silently excluded from both queries.

This affects:
- `apps/meteor/app/apps/server/bridges/roles.ts` - Apps-Engine's custom-roles bridge, used by installed Rocket.Chat Apps to enumerate custom roles
- `apps/meteor/app/statistics/server/lib/statistics.ts` - the `totalCustomRoles` telemetry counter

Changed the query to `protected: { $ne: true }`, which correctly matches both `false` and missing/undefined, while still excluding actual protected (built-in) roles.

## Issue(s)

Closes #40798

## Steps to test or reproduce

1. Insert a role document into the `roles` collection without a `protected` field (simulating a pre-existing custom role from before that field was introduced).
2. Call `Roles.findCustomRoles()` / `Roles.countCustomRoles()` - before the fix, the role is excluded; after the fix, it's included.

## Further comments

Small, isolated fix, no behaviour change for roles that already have `protected` set explicitly.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed custom roles not appearing in the custom roles list when the roles were created before a specific protection field existed.
  * Updated custom role counting so legacy roles are included in totals and related usage statistics remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->