### PR TITLE
fix: switching AutoTranslate service provider silently keeps old provider active

### DIFF
--- a/.changeset/fix-autotranslate-provider-switch.md
+++ b/.changeset/fix-autotranslate-provider-switch.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed AutoTranslate silently continuing to use the previous translation provider after `AutoTranslate_ServiceProvider` was changed while AutoTranslate was enabled, until it was toggled off and on again or the server restarted.

--- a/apps/meteor/app/autotranslate/server/autotranslate.ts
+++ b/apps/meteor/app/autotranslate/server/autotranslate.ts
@@ -112,6 +112,10 @@ export class TranslationProviderRegistry {
 			return;
 		}
 
+		// callbacks.add is a no-op if a callback with this id is already registered, so the
+		// previous provider's callback must be removed first or switching providers has no effect
+		callbacks.remove('afterSaveMessage', 'autotranslate');
+
 		callbacks.add(
 			'afterSaveMessage',
 			(message, { room }) => provider.translateMessage(message, { room }),

--- a/apps/meteor/app/autotranslate/server/autotranslate.ts
+++ b/apps/meteor/app/autotranslate/server/autotranslate.ts
@@ -112,8 +112,6 @@ export class TranslationProviderRegistry {
 			return;
 		}
 
-		// callbacks.add is a no-op if a callback with this id is already registered, so the
-		// previous provider's callback must be removed first or switching providers has no effect
 		callbacks.remove('afterSaveMessage', 'autotranslate');
 
 		callbacks.add(


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`Callbacks.add()` (`apps/meteor/server/lib/callbacks/callbacksBase.ts`) is a no-op if a callback with the given `id` is already registered — it returns early instead of replacing the existing one. `TranslationProviderRegistry.registerCallbacks()` re-adds the `'autotranslate'` `afterSaveMessage` callback whenever `AutoTranslate_ServiceProvider` changes, but because of this no-op behavior, the previous provider's callback (closured over the old provider) stayed registered and active. Messages kept being translated by the old provider until AutoTranslate was toggled off and on again, or the server restarted.

Fixed by removing the existing `'autotranslate'` callback before re-adding it in `registerCallbacks()`, so the new provider is actually bound. Scoped to this call site rather than changing `Callbacks.add()`'s global no-op-on-duplicate-id behavior, since that's shared infrastructure used throughout the app.

## Issue(s)

Closes #41197

## Steps to test or reproduce

1. Set `AutoTranslate_Enabled = true` with the default provider (`google-translate`).
2. Switch `AutoTranslate_ServiceProvider` to another provider (e.g. `libre-translate`), configured correctly.
3. Send a message in a channel where another member has auto-translate enabled — before the fix, it is translated by the old provider; after, by the new one.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AutoTranslate now stops using the previous translation provider after the provider setting is changed, updating more consistently while AutoTranslate is enabled.
  * Switching providers no longer leaves AutoTranslate silently running with the old provider, reducing the need to toggle AutoTranslate off and on or restart.
  * Disabling AutoTranslate now reliably prevents any previously active translation callback behavior from continuing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->