### PR TITLE
fix: Setup wizard forced back into registration on upgrade when Show_Setup_Wizard is env-overridden

### DIFF
--- a/.changeset/setup-wizard-env-override-upgrade.md
+++ b/.changeset/setup-wizard-env-override-upgrade.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes the setup wizard being forced back into the registration step on the first start after an upgrade when `OVERWRITE_SETTING_Show_Setup_Wizard=completed` is set, which affected air-gapped workspaces running offline licenses without cloud registration.

--- a/apps/meteor/app/settings/server/SettingsRegistry.ts
+++ b/apps/meteor/app/settings/server/SettingsRegistry.ts
@@ -84,7 +84,7 @@ export const compareSettings = compareSettingsIgnoringKeys([
 ]);
 
 const hasOverwrittenValueChanged = (stored: ISetting, overwritten: ISetting): boolean =>
-	stored.value !== overwritten.value ||
+	!isEqual(stored.value, overwritten.value) ||
 	stored.valueSource !== overwritten.valueSource ||
 	!isEqual(stored.processEnvValue, overwritten.processEnvValue);
 

--- a/apps/meteor/app/settings/server/SettingsRegistry.ts
+++ b/apps/meteor/app/settings/server/SettingsRegistry.ts
@@ -83,6 +83,11 @@ export const compareSettings = compareSettingsIgnoringKeys([
 	'_updatedAt',
 ]);
 
+const hasOverwrittenValueChanged = (stored: ISetting, overwritten: ISetting): boolean =>
+	stored.value !== overwritten.value ||
+	stored.valueSource !== overwritten.valueSource ||
+	!isEqual(stored.processEnvValue, overwritten.processEnvValue);
+
 export class SettingsRegistry {
 	private model: ISettingsModel;
 
@@ -175,7 +180,7 @@ export class SettingsRegistry {
 		}
 
 		if (settingStored && isOverwritten) {
-			if (settingStored.value !== settingFromCodeOverwritten.value) {
+			if (hasOverwrittenValueChanged(settingStored, settingFromCodeOverwritten)) {
 				const overwrittenKeys = Object.keys(settingFromCodeOverwritten);
 				const removedKeys = Object.keys(settingStored).filter((key) => !['_updatedAt'].includes(key) && !overwrittenKeys.includes(key));
 

--- a/apps/meteor/app/settings/server/functions/overrideGenerator.ts
+++ b/apps/meteor/app/settings/server/functions/overrideGenerator.ts
@@ -40,11 +40,7 @@ export const overrideGenerator =
 		try {
 			const value = convertValue(overwriteValue, setting.type);
 
-			if (
-				compareSettingsValue(value, setting.value, setting.type) &&
-				setting.valueSource === 'processEnvValue' &&
-				compareSettingsValue(value, setting.processEnvValue, setting.type)
-			) {
+			if (compareSettingsValue(value, setting.value, setting.type) && compareSettingsValue(value, setting.processEnvValue, setting.type)) {
 				return setting;
 			}
 

--- a/apps/meteor/app/settings/server/functions/overrideGenerator.ts
+++ b/apps/meteor/app/settings/server/functions/overrideGenerator.ts
@@ -40,7 +40,11 @@ export const overrideGenerator =
 		try {
 			const value = convertValue(overwriteValue, setting.type);
 
-			if (compareSettingsValue(value, setting.value, setting.type)) {
+			if (
+				compareSettingsValue(value, setting.value, setting.type) &&
+				setting.valueSource === 'processEnvValue' &&
+				compareSettingsValue(value, setting.processEnvValue, setting.type)
+			) {
 				return setting;
 			}
 

--- a/apps/meteor/server/startup/cloudRegistration.ts
+++ b/apps/meteor/server/startup/cloudRegistration.ts
@@ -18,7 +18,6 @@ export async function ensureCloudWorkspaceRegistered(): Promise<void> {
 	}
 
 	if (showSetupWizard.valueSource === 'processEnvValue' && showSetupWizard.value === showSetupWizard.processEnvValue) {
-	if (showSetupWizard.valueSource === 'processEnvValue' && showSetupWizard.value === showSetupWizard.processEnvValue) {
 		return;
 	}
 

--- a/apps/meteor/server/startup/cloudRegistration.ts
+++ b/apps/meteor/server/startup/cloudRegistration.ts
@@ -17,8 +17,7 @@ export async function ensureCloudWorkspaceRegistered(): Promise<void> {
 		return;
 	}
 
-	// skip if the value was pinned via env override (e.g. air-gapped deployments) and hasn't
-	// been changed since; forcing the wizard would fight the operator's explicit config
+	if (showSetupWizard.valueSource === 'processEnvValue' && showSetupWizard.value === showSetupWizard.processEnvValue) {
 	if (showSetupWizard.valueSource === 'processEnvValue' && showSetupWizard.value === showSetupWizard.processEnvValue) {
 		return;
 	}

--- a/apps/meteor/server/startup/cloudRegistration.ts
+++ b/apps/meteor/server/startup/cloudRegistration.ts
@@ -1,15 +1,11 @@
 import { Settings } from '@rocket.chat/models';
 
 export async function ensureCloudWorkspaceRegistered(): Promise<void> {
-	// skip if the setting is pinned via env override (e.g. air-gapped deployments); forcing
-	// the wizard would fight the override until the next restart re-applies it
-	if (process.env.OVERWRITE_SETTING_Show_Setup_Wizard) {
-		return;
-	}
-
 	const cloudWorkspaceClientId = await Settings.getValueById('Cloud_Workspace_Client_Id');
 	const cloudWorkspaceClientSecret = await Settings.getValueById('Cloud_Workspace_Client_Secret');
-	const showSetupWizard = await Settings.getValueById('Show_Setup_Wizard');
+	const showSetupWizard = await Settings.findOneById('Show_Setup_Wizard', {
+		projection: { value: 1, valueSource: 1, processEnvValue: 1 },
+	});
 
 	// skip if both fields are already set, which means the workspace is already registered
 	if (!!cloudWorkspaceClientId && !!cloudWorkspaceClientSecret) {
@@ -17,7 +13,13 @@ export async function ensureCloudWorkspaceRegistered(): Promise<void> {
 	}
 
 	// skip if the setup wizard still not completed
-	if (showSetupWizard !== 'completed') {
+	if (showSetupWizard?.value !== 'completed') {
+		return;
+	}
+
+	// skip if the value was pinned via env override (e.g. air-gapped deployments) and hasn't
+	// been changed since; forcing the wizard would fight the operator's explicit config
+	if (showSetupWizard.valueSource === 'processEnvValue' && showSetupWizard.value === showSetupWizard.processEnvValue) {
 		return;
 	}
 

--- a/apps/meteor/server/startup/cloudRegistration.ts
+++ b/apps/meteor/server/startup/cloudRegistration.ts
@@ -1,6 +1,12 @@
 import { Settings } from '@rocket.chat/models';
 
 export async function ensureCloudWorkspaceRegistered(): Promise<void> {
+	// skip if the setting is pinned via env override (e.g. air-gapped deployments); forcing
+	// the wizard would fight the override until the next restart re-applies it
+	if (process.env.OVERWRITE_SETTING_Show_Setup_Wizard) {
+		return;
+	}
+
 	const cloudWorkspaceClientId = await Settings.getValueById('Cloud_Workspace_Client_Id');
 	const cloudWorkspaceClientSecret = await Settings.getValueById('Cloud_Workspace_Client_Secret');
 	const showSetupWizard = await Settings.getValueById('Show_Setup_Wizard');

--- a/apps/meteor/tests/unit/app/settings/server/functions/overrideGenerator.tests.ts
+++ b/apps/meteor/tests/unit/app/settings/server/functions/overrideGenerator.tests.ts
@@ -19,10 +19,26 @@ describe('overrideGenerator', () => {
 		expect(overwritten).to.have.property('valueSource').that.equals('processEnvValue');
 	});
 
-	it('should return the same object since the value didnt change', () => {
+	it('should stamp the env source even when the value didnt change', () => {
 		const overwrite = overrideGenerator(() => 'test');
 
 		const setting = getSettingDefaults({ _id: 'test', value: 'test', type: 'string' });
+		const overwritten = overwrite(setting);
+
+		expect(setting).to.be.not.equal(overwritten);
+		expect(overwritten).to.have.property('value').that.equals('test');
+		expect(overwritten).to.have.property('valueSource').that.equals('processEnvValue');
+		expect(overwritten).to.have.property('processEnvValue').that.equals('test');
+	});
+
+	it('should return the same object when the value and the env stamp are already in place', () => {
+		const overwrite = overrideGenerator(() => 'test');
+
+		const setting = {
+			...getSettingDefaults({ _id: 'test', value: 'test', type: 'string' }),
+			valueSource: 'processEnvValue' as const,
+			processEnvValue: 'test',
+		};
 		const overwritten = overwrite(setting);
 
 		expect(setting).to.be.equal(overwritten);

--- a/apps/meteor/tests/unit/app/settings/server/functions/settings.tests.ts
+++ b/apps/meteor/tests/unit/app/settings/server/functions/settings.tests.ts
@@ -141,6 +141,50 @@ describe('Settings', () => {
 		});
 	});
 
+	it('should stamp the env source when the override equals the stored value', async () => {
+		const addSetting = (registry: SettingsRegistry) =>
+			registry.addGroup('group', async function () {
+				await this.section('section', async function () {
+					await this.add('my_setting_stamped', 0, {
+						type: 'int',
+						sorter: 0,
+					});
+				});
+			});
+
+		const bootRegistry = () => {
+			const settings = new CachedSettings();
+			Settings.settings = settings;
+			for (const _id of ['group', 'my_setting_stamped']) {
+				const stored = Settings.findOne({ _id });
+				if (stored) {
+					settings.set(stored);
+				}
+			}
+			settings.initialized();
+			return new SettingsRegistry({ store: settings, model: Settings as any });
+		};
+
+		await addSetting(bootRegistry());
+
+		expect(Settings.findOne({ _id: 'my_setting_stamped' })).to.include({ value: 0, valueSource: 'packageValue' });
+
+		process.env.OVERWRITE_SETTING_my_setting_stamped = '0';
+
+		await addSetting(bootRegistry());
+
+		expect(Settings).to.have.property('upsertCalls').to.be.equal(1);
+		expect(Settings.findOne({ _id: 'my_setting_stamped' })).to.include({
+			value: 0,
+			processEnvValue: 0,
+			valueSource: 'processEnvValue',
+		});
+
+		await addSetting(bootRegistry());
+
+		expect(Settings).to.have.property('upsertCalls').to.be.equal(1);
+	});
+
 	it('should respect override via environment as boolean', async () => {
 		process.env.OVERWRITE_SETTING_my_setting_bool = 'true';
 

--- a/apps/meteor/tests/unit/server/startup/cloudRegistration.tests.ts
+++ b/apps/meteor/tests/unit/server/startup/cloudRegistration.tests.ts
@@ -1,0 +1,74 @@
+import { expect } from 'chai';
+import { afterEach, beforeEach, describe, it } from 'mocha';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+const models = {
+	Settings: {
+		getValueById: sinon.stub(),
+		updateValueById: sinon.stub(),
+	},
+};
+
+const { ensureCloudWorkspaceRegistered } = proxyquire.noCallThru().load('../../../../server/startup/cloudRegistration', {
+	'@rocket.chat/models': models,
+});
+
+describe('ensureCloudWorkspaceRegistered', () => {
+	const originalEnv = process.env.OVERWRITE_SETTING_Show_Setup_Wizard;
+
+	const stubSettings = (values: Record<string, string | undefined>) => {
+		models.Settings.getValueById.callsFake(async (id: string) => values[id]);
+	};
+
+	beforeEach(() => {
+		delete process.env.OVERWRITE_SETTING_Show_Setup_Wizard;
+		models.Settings.getValueById.reset();
+		models.Settings.updateValueById.reset();
+	});
+
+	afterEach(() => {
+		if (originalEnv === undefined) {
+			delete process.env.OVERWRITE_SETTING_Show_Setup_Wizard;
+		} else {
+			process.env.OVERWRITE_SETTING_Show_Setup_Wizard = originalEnv;
+		}
+	});
+
+	it('should not touch the setting when OVERWRITE_SETTING_Show_Setup_Wizard is set', async () => {
+		process.env.OVERWRITE_SETTING_Show_Setup_Wizard = 'completed';
+		stubSettings({ Show_Setup_Wizard: 'completed' });
+
+		await ensureCloudWorkspaceRegistered();
+
+		expect(models.Settings.updateValueById.called).to.be.false;
+	});
+
+	it('should not touch the setting when the workspace is already registered', async () => {
+		stubSettings({
+			Cloud_Workspace_Client_Id: 'client-id',
+			Cloud_Workspace_Client_Secret: 'client-secret',
+			Show_Setup_Wizard: 'completed',
+		});
+
+		await ensureCloudWorkspaceRegistered();
+
+		expect(models.Settings.updateValueById.called).to.be.false;
+	});
+
+	it('should not touch the setting when the setup wizard is not completed', async () => {
+		stubSettings({ Show_Setup_Wizard: 'in_progress' });
+
+		await ensureCloudWorkspaceRegistered();
+
+		expect(models.Settings.updateValueById.called).to.be.false;
+	});
+
+	it('should flip the setup wizard to in_progress when unregistered, completed and no env override', async () => {
+		stubSettings({ Show_Setup_Wizard: 'completed' });
+
+		await ensureCloudWorkspaceRegistered();
+
+		expect(models.Settings.updateValueById.calledOnceWith('Show_Setup_Wizard', 'in_progress')).to.be.true;
+	});
+});

--- a/apps/meteor/tests/unit/server/startup/cloudRegistration.tests.ts
+++ b/apps/meteor/tests/unit/server/startup/cloudRegistration.tests.ts
@@ -1,11 +1,12 @@
 import { expect } from 'chai';
-import { afterEach, beforeEach, describe, it } from 'mocha';
+import { beforeEach, describe, it } from 'mocha';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
 const models = {
 	Settings: {
 		getValueById: sinon.stub(),
+		findOneById: sinon.stub(),
 		updateValueById: sinon.stub(),
 	},
 };
@@ -15,41 +16,41 @@ const { ensureCloudWorkspaceRegistered } = proxyquire.noCallThru().load('../../.
 });
 
 describe('ensureCloudWorkspaceRegistered', () => {
-	const originalEnv = process.env.OVERWRITE_SETTING_Show_Setup_Wizard;
-
-	const stubSettings = (values: Record<string, string | undefined>) => {
+	const stubSettings = (values: Record<string, string | undefined>, showSetupWizard: Record<string, unknown> | null) => {
 		models.Settings.getValueById.callsFake(async (id: string) => values[id]);
+		models.Settings.findOneById.resolves(showSetupWizard);
 	};
 
 	beforeEach(() => {
-		delete process.env.OVERWRITE_SETTING_Show_Setup_Wizard;
 		models.Settings.getValueById.reset();
+		models.Settings.findOneById.reset();
 		models.Settings.updateValueById.reset();
 	});
 
-	afterEach(() => {
-		if (originalEnv === undefined) {
-			delete process.env.OVERWRITE_SETTING_Show_Setup_Wizard;
-		} else {
-			process.env.OVERWRITE_SETTING_Show_Setup_Wizard = originalEnv;
-		}
-	});
-
-	it('should not touch the setting when OVERWRITE_SETTING_Show_Setup_Wizard is set', async () => {
-		process.env.OVERWRITE_SETTING_Show_Setup_Wizard = 'completed';
-		stubSettings({ Show_Setup_Wizard: 'completed' });
+	it('should not touch the setting when its value was pinned via env override and is unchanged', async () => {
+		stubSettings({}, { value: 'completed', valueSource: 'processEnvValue', processEnvValue: 'completed' });
 
 		await ensureCloudWorkspaceRegistered();
 
 		expect(models.Settings.updateValueById.called).to.be.false;
 	});
 
+	it('should flip the setting when the value diverged from the env override', async () => {
+		stubSettings({}, { value: 'completed', valueSource: 'processEnvValue', processEnvValue: 'pending' });
+
+		await ensureCloudWorkspaceRegistered();
+
+		expect(models.Settings.updateValueById.calledOnceWith('Show_Setup_Wizard', 'in_progress')).to.be.true;
+	});
+
 	it('should not touch the setting when the workspace is already registered', async () => {
-		stubSettings({
-			Cloud_Workspace_Client_Id: 'client-id',
-			Cloud_Workspace_Client_Secret: 'client-secret',
-			Show_Setup_Wizard: 'completed',
-		});
+		stubSettings(
+			{
+				Cloud_Workspace_Client_Id: 'client-id',
+				Cloud_Workspace_Client_Secret: 'client-secret',
+			},
+			{ value: 'completed', valueSource: 'packageValue' },
+		);
 
 		await ensureCloudWorkspaceRegistered();
 
@@ -57,15 +58,15 @@ describe('ensureCloudWorkspaceRegistered', () => {
 	});
 
 	it('should not touch the setting when the setup wizard is not completed', async () => {
-		stubSettings({ Show_Setup_Wizard: 'in_progress' });
+		stubSettings({}, { value: 'in_progress', valueSource: 'packageValue' });
 
 		await ensureCloudWorkspaceRegistered();
 
 		expect(models.Settings.updateValueById.called).to.be.false;
 	});
 
-	it('should flip the setup wizard to in_progress when unregistered, completed and no env override', async () => {
-		stubSettings({ Show_Setup_Wizard: 'completed' });
+	it('should flip the setup wizard to in_progress when unregistered, completed and not env-pinned', async () => {
+		stubSettings({}, { value: 'completed', valueSource: 'packageValue' });
 
 		await ensureCloudWorkspaceRegistered();
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

On the first boot after a version upgrade, `ensureCloudWorkspaceRegistered()` flips `Show_Setup_Wizard` from `completed` to `in_progress` whenever `Cloud_Workspace_Client_Id`/`Cloud_Workspace_Client_Secret` are both empty. Air-gapped workspaces running offline licenses always meet this condition, so admins get redirected into a registration wizard they cannot complete online — even when `OVERWRITE_SETTING_Show_Setup_Wizard=completed` is explicitly set.

The env override is applied during settings init, *before* the version-change callback runs, so the flip wins for the life of that process (it self-heals on the next restart, when the override is re-applied and the version-change callback no longer fires).

### The fix

`ensureCloudWorkspaceRegistered()` now skips the flip when the current value of `Show_Setup_Wizard` was authored by the env override: `valueSource === 'processEnvValue' && value === processEnvValue`. The `value === processEnvValue` part means a value changed *after* the override (by an admin or another process) invalidates the pin naturally, with no reset logic.

For that check to be reliable, two supporting changes in the settings machinery were needed — previously the `processEnvValue` source stamp was only persisted when the override *changed* the stored value, so a setting whose stored value already matched the env var never got stamped:

- `overrideGenerator` now returns a stamped setting even when the env value equals the stored value (if not already stamped).
- `SettingsRegistry.add` now persists the setting when only the source stamp changed (`value` equal, `valueSource`/`processEnvValue` differ). This converges: subsequent boots with the same env produce no writes.

A side effect of the stamping fix is that settings whose env override equals their stored value are now correctly marked as env-sourced (previously they kept `valueSource: 'packageValue'`), which also makes `resetValueById` and any other `valueSource` consumer see the accurate source.

## Issue(s)

[CORE-2377](https://rocketchat.atlassian.net/browse/CORE-2377)

Air-gapped/offline-license workspaces are pushed into the cloud registration step of the setup wizard after every upgrade, despite an explicit config directive to skip it.

## Steps to test or reproduce

1. Run a workspace with no cloud registration (`Cloud_Workspace_Client_Id`/`Cloud_Workspace_Client_Secret` empty) and `OVERWRITE_SETTING_Show_Setup_Wizard=completed`.
2. Simulate an upgrade boot: `db.migrations.updateOne({ _id: 'upgrade' }, { $set: { hash: 'fake' } })`, then restart.
3. Without this fix, `Show_Setup_Wizard` flips to `in_progress` and admins are redirected into the wizard. With the fix, it stays `completed` (and its document now carries `valueSource: 'processEnvValue'`).

Unit tests cover the stamping behavior (`overrideGenerator`, `SettingsRegistry` persistence + cross-boot convergence) and the guard plus the pre-existing behaviors of `ensureCloudWorkspaceRegistered` (registered workspace, wizard not completed, diverged value, and the intended flip when unregistered with no pin).

## Further comments

The bug was verified in a live manual test on both sides: with the guard the setting document receives no write at all on an upgrade boot; without it, it flips within ~300ms of the migration hash update.

Because the pin is persisted state (not a runtime env read), it also protects upgrade boots where the env var is no longer present — the operator's provisioning survives until the value is changed by someone else.


[CORE-2377]: https://rocketchat.atlassian.net/browse/CORE-2377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the setup wizard from reverting to the registration step after upgrades when it was already completed.
  * Refined environment override handling to avoid unnecessary rewrites and repeated updates, including correct detection when env-pinned values match the stored state.
  * Improved setup-wizard startup behavior to respect pinned values and only switch to in-progress when the stored value meaningfully diverges or the wizard completion state changes.
* **Tests**
  * Added/updated unit coverage for setup wizard registration flows and environment override stamping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->