### PR TITLE
chore: explicit meteor package imports

### DIFF
--- a/apps/meteor/app/livechat/server/lib/departmentsLib.ts
+++ b/apps/meteor/app/livechat/server/lib/departmentsLib.ts
@@ -2,7 +2,7 @@ import { AppEvents, Apps } from '@rocket.chat/apps';
 import type { LivechatDepartmentDTO, ILivechatDepartment, ILivechatDepartmentAgents, ILivechatAgent } from '@rocket.chat/core-typings';
 import { LivechatDepartment, LivechatDepartmentAgents, LivechatVisitors, LivechatRooms, Users } from '@rocket.chat/models';
 import { isDepartmentCreationAvailable } from '@rocket.chat/omni-core';
-import { check } from 'meteor/check';
+import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
 import { updateDepartmentAgents } from './Helper';

--- a/apps/meteor/app/livechat/server/lib/messages.ts
+++ b/apps/meteor/app/livechat/server/lib/messages.ts
@@ -3,6 +3,8 @@ import * as util from 'node:util';
 
 import type { ILivechatVisitor, AtLeast, IMessage, IUser, IOmnichannelRoomInfo, SelectedAgent } from '@rocket.chat/core-typings';
 import { LivechatDepartment, Messages } from '@rocket.chat/models';
+import { check, Match } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
 
 import type { ILivechatMessage } from './localTypes';
 import { getRoom } from './rooms';

--- a/apps/meteor/app/livechat/server/lib/rooms.ts
+++ b/apps/meteor/app/livechat/server/lib/rooms.ts
@@ -22,6 +22,7 @@ import {
 	ReadReceipts,
 	ReadReceiptsArchive,
 } from '@rocket.chat/models';
+import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
 import { normalizeTransferredByData } from './Helper';

--- a/apps/meteor/app/livechat/server/lib/transfer.ts
+++ b/apps/meteor/app/livechat/server/lib/transfer.ts
@@ -1,6 +1,7 @@
 import { Message } from '@rocket.chat/core-services';
 import type { ILivechatDepartment, ILivechatVisitor, IOmnichannelRoom, TransferData } from '@rocket.chat/core-typings';
 import { Users, LivechatRooms, LivechatVisitors, LivechatDepartment } from '@rocket.chat/models';
+import { check, Match } from 'meteor/check';
 
 import { normalizeTransferredByData } from './Helper';
 import { RoutingManager } from './RoutingManager';

--- a/apps/meteor/app/utils/server/functions/getMongoInfo.ts
+++ b/apps/meteor/app/utils/server/functions/getMongoInfo.ts
@@ -1,4 +1,4 @@
-import { MongoInternals } from 'meteor/mongo';
+import { MongoInternals, type MongoConnection } from 'meteor/mongo';
 
 function getOplogInfo(): { mongo: MongoConnection } {
 	const { mongo } = MongoInternals.defaultRemoteCollectionDriver();

--- a/apps/meteor/client/meteor/login/meteorDeveloperAccount.ts
+++ b/apps/meteor/client/meteor/login/meteorDeveloperAccount.ts
@@ -3,6 +3,7 @@ import { Meteor } from 'meteor/meteor';
 import { MeteorDeveloperAccounts } from 'meteor/meteor-developer-oauth';
 // eslint-disable-next-line import/no-duplicates
 import { OAuth } from 'meteor/oauth';
+import { Random } from 'meteor/random';
 
 import { createOAuthTotpLoginMethod } from './oauth';
 import { overrideLoginMethod } from '../../lib/2fa/overrideLoginMethod';

--- a/apps/meteor/definition/externals/global.d.ts
+++ b/apps/meteor/definition/externals/global.d.ts
@@ -18,6 +18,7 @@ declare global {
 		lastMessageWindow?: Record<string, unknown>;
 		lastMessageWindowHistory?: Record<string, unknown>;
 		favico?: any;
+		ServiceConfiguration?: unknown;
 		__meteor_runtime_config__: {
 			ROOT_URL_PATH_PREFIX: string;
 			ROOT_URL: string;

--- a/apps/meteor/server/api/v1/channels.ts
+++ b/apps/meteor/server/api/v1/channels.ts
@@ -31,6 +31,7 @@ import {
 	isChannelsOnlineProps,
 } from '@rocket.chat/rest-typings';
 import { isTruthy } from '@rocket.chat/tools';
+import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
 import { canAccessRoomAsync } from '../../../app/authorization/server';

--- a/apps/meteor/server/api/v1/omnichannel/room.ts
+++ b/apps/meteor/server/api/v1/omnichannel/room.ts
@@ -27,7 +27,7 @@ import {
 	ajv,
 } from '@rocket.chat/rest-typings';
 import { isPOSTLivechatVisitorDepartmentTransferParams } from '@rocket.chat/rest-typings/src/v1/omnichannel';
-import { check } from 'meteor/check';
+import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
 import { API } from '../..';


### PR DESCRIPTION
## Proposed changes

Convert implicitly-global Meteor symbols into explicit `meteor/*` imports:

- `check`, `Match` from `meteor/check`
- `Meteor` from `meteor/meteor`
- `Random` from `meteor/random`
- `type MongoConnection` from `meteor/mongo`
- `Window.ServiceConfiguration` global type declaration

This is groundwork split out from #40781 (TypeScript 6 upgrade). TS 6 no longer resolves these Meteor symbols as ambient globals, so they must be imported explicitly. Landing this separately keeps the TS-bump PR focused on config/version changes.

No behavior change — imports only.

## Issue(s)

Prep for #40781

## Steps to test or reproduce

`yarn lint` on the changed files — clean (only pre-existing warnings).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation support across live chat, channel, and room workflows to help prevent malformed requests and related errors.
  * Fixed messaging and transfer handling so offline email and transfer history checks work reliably.
  * Updated type definitions for runtime configuration, improving compatibility in environments using service settings.
  * Refined Mongo-related typing and login support for better build and runtime stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [CORE-2401]

[CORE-2401]: https://rocketchat.atlassian.net/browse/CORE-2401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ