### PR TITLE
chore: declare '*.css' side-effect imports (TS7 compat)

### DIFF
--- a/ee/packages/pdf-worker/src/css.d.ts
+++ b/ee/packages/pdf-worker/src/css.d.ts
@@ -1,0 +1,4 @@
+// TS7 errors on side-effect imports of `.css` (TS2882) without a declaration.
+declare module '*.css' {
+	export = undefined;
+}

--- a/packages/fuselage-ui-kit/src/css.d.ts
+++ b/packages/fuselage-ui-kit/src/css.d.ts
@@ -1,0 +1,4 @@
+// TS7 errors on side-effect imports of `.css` (TS2882) without a declaration.
+declare module '*.css' {
+	export = undefined;
+}

--- a/packages/gazzodown/src/css.d.ts
+++ b/packages/gazzodown/src/css.d.ts
@@ -1,0 +1,4 @@
+// TS7 errors on side-effect imports of `.css` (TS2882) without a declaration.
+declare module '*.css' {
+	export = undefined;
+}

--- a/packages/storybook-config/src/css.d.ts
+++ b/packages/storybook-config/src/css.d.ts
@@ -1,0 +1,4 @@
+// TS7 errors on side-effect imports of `.css` (TS2882) without a declaration.
+declare module '*.css' {
+	export = undefined;
+}

--- a/packages/ui-client/src/css.d.ts
+++ b/packages/ui-client/src/css.d.ts
@@ -1,0 +1,4 @@
+// TS7 errors on side-effect imports of `.css` (TS2882) without a declaration.
+declare module '*.css' {
+	export = undefined;
+}


### PR DESCRIPTION
## Summary

Adds an ambient `declare module '*.css'` to the packages that side-effect-import CSS but don't yet declare it: `gazzodown`, `fuselage-ui-kit`, `storybook-config`, `ui-client`, `pdf-worker`.

## Why

TypeScript 7's native compiler errors (`TS2882`) on side-effect imports like `import './x.css'` when there's no module declaration for the extension. This mirrors the declaration already present in `apps/meteor/client/definitions/css.d.ts`.

No-op on the current TypeScript 5.x toolchain (typecheck stays green); this is forward-compat groundwork for the TS7 migration.

Draft — part of a set of small, independent TS7-readiness PRs.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2232]

[ARCH-2232]: https://rocketchat.atlassian.net/browse/ARCH-2232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved TypeScript errors caused by side-effect CSS imports.
  * Improved compatibility with the latest TypeScript behavior across UI-related packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->