### PR TITLE
chore: add dom lib for WebRTC/DOM globals (TS7 compat)

### DIFF
--- a/ee/packages/media-calls/tsconfig.json
+++ b/ee/packages/media-calls/tsconfig.json
@@ -4,6 +4,7 @@
 		"rootDir": "./src",
 		"outDir": "./dist",
 		"declaration": true,
+		"lib": ["es2023", "dom"],
 	},
 	"include": ["./src/**/*"],
 }

--- a/packages/apps/tsconfig.json
+++ b/packages/apps/tsconfig.json
@@ -4,6 +4,7 @@
 		"declaration": true,
 		"rootDir": "./src",
 		"outDir": "./dist",
+		"lib": ["es2023", "dom"],
 		"strict": false,
 		"noUnusedParameters": false,
 		"noImplicitOverride": false,

--- a/packages/core-typings/src/mediaCalls/IMediaCallNegotiation.ts
+++ b/packages/core-typings/src/mediaCalls/IMediaCallNegotiation.ts
@@ -1,4 +1,5 @@
 import type { IRocketChatRecord } from '../IRocketChatRecord';
+import type { RTCSessionDescriptionInit } from './RTCSessionDescription';
 
 export type MediaCallNegotiationStream = {
 	tag: string;

--- a/packages/core-typings/src/mediaCalls/RTCSessionDescription.ts
+++ b/packages/core-typings/src/mediaCalls/RTCSessionDescription.ts
@@ -1,0 +1,15 @@
+export type RTCSdpType = 'answer' | 'offer' | 'pranswer' | 'rollback';
+
+// Server-side copy of the WebRTC RTCSessionDescriptionInit shape, so packages that
+// don't ship the DOM lib (models, model-typings) can type SDP payloads.
+// TODO: Evaluate a proprietary backend SDP type instead of mirroring the browser RTCSessionDescriptionInit
+// This alias is a hand-maintained copy of the WebRTC/DOM shape, kept only so pure-server
+// packages (models, model-typings) can type SDP payloads without pulling in the whole dom lib.
+// Downsides: it can silently drift from the real browser type, and it carries browser-oriented
+// fields the backend never persists or acts on. A backend-owned SDP type would decouple server
+// typings from the DOM, model only what we actually store/validate, and drop the dom-lib coupling
+// on the media stack (media-signaling and media-calls still rely on the ambient DOM type today).
+export type RTCSessionDescriptionInit = {
+	sdp?: string;
+	type: RTCSdpType;
+};

--- a/packages/core-typings/src/mediaCalls/index.ts
+++ b/packages/core-typings/src/mediaCalls/index.ts
@@ -1,3 +1,4 @@
 export type * from './IMediaCall';
 export type * from './IMediaCallChannel';
 export type * from './IMediaCallNegotiation';
+export type * from './RTCSessionDescription';

--- a/packages/model-typings/src/models/IMediaCallNegotiationsModel.ts
+++ b/packages/model-typings/src/models/IMediaCallNegotiationsModel.ts
@@ -1,4 +1,4 @@
-import type { IMediaCallNegotiation, MediaCallNegotiationStream } from '@rocket.chat/core-typings';
+import type { IMediaCallNegotiation, MediaCallNegotiationStream, RTCSessionDescriptionInit } from '@rocket.chat/core-typings';
 import type { Document, FindOptions, UpdateResult } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';

--- a/packages/models/src/models/MediaCallNegotiations.ts
+++ b/packages/models/src/models/MediaCallNegotiations.ts
@@ -1,4 +1,9 @@
-import type { RocketChatRecordDeleted, IMediaCallNegotiation, MediaCallNegotiationStream } from '@rocket.chat/core-typings';
+import type {
+	RocketChatRecordDeleted,
+	IMediaCallNegotiation,
+	MediaCallNegotiationStream,
+	RTCSessionDescriptionInit,
+} from '@rocket.chat/core-typings';
 import type { IMediaCallNegotiationsModel } from '@rocket.chat/model-typings';
 import type { IndexDescription, Collection, Db, FindOptions, Document, UpdateResult } from 'mongodb';
 


### PR DESCRIPTION
## Summary

Adds `"dom"` to the `lib` of `media-calls`, `apps`, `models` and `model-typings`, which reference DOM/WebRTC globals (`RTCSessionDescriptionInit`, `window`, `MessageEvent`, `ServiceWorker`, ...) but extend the server tsconfig that only ships `es2023`.

## Why

TypeScript 7 flags these globals as missing (`TS2304`/`TS2315`/`TS2339`) because they come from `lib.dom.d.ts`. Type-only change — no runtime or emit impact; typecheck stays green on the current toolchain.

Draft — part of a set of small, independent TS7-readiness PRs.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2233]

[ARCH-2233]: https://rocketchat.atlassian.net/browse/ARCH-2233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved media call TypeScript typings for WebRTC session descriptions, adding platform-independent aliases and a shared session description init shape.
  - Re-exported the new session description types to make them available across related typings.
  - Standardized TypeScript library settings by explicitly enabling `es2023` and `dom` to keep type availability consistent across packages.
  - Updated negotiation typings to reference the new session description init type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->