### PR TITLE
chore: use public preact JSX import in livechat (TS7 compat)

### DIFF
--- a/packages/livechat/src/components/Alert/index.tsx
+++ b/packages/livechat/src/components/Alert/index.tsx
@@ -1,6 +1,5 @@
-import type { ComponentChildren } from 'preact';
+import type { ComponentChildren, JSX as JSXInternal } from 'preact';
 import { useCallback, useEffect } from 'preact/hooks';
-import type { JSXInternal } from 'preact/src/jsx';
 import { useTranslation } from 'react-i18next';
 
 import styles from './styles.scss';

--- a/packages/livechat/src/components/Button/index.tsx
+++ b/packages/livechat/src/components/Button/index.tsx
@@ -1,6 +1,5 @@
-import type { ComponentChildren } from 'preact';
+import type { ComponentChildren, JSX as JSXInternal } from 'preact';
 import type { CSSProperties } from 'preact/compat';
-import type { JSXInternal } from 'preact/src/jsx';
 import { useTranslation } from 'react-i18next';
 
 import styles from './styles.scss';

--- a/packages/livechat/src/components/Form/DateInput/index.tsx
+++ b/packages/livechat/src/components/Form/DateInput/index.tsx
@@ -1,6 +1,5 @@
-import type { Ref } from 'preact';
+import type { Ref, JSX as JSXInternal } from 'preact';
 import { memo, type TargetedEvent } from 'preact/compat';
-import type { JSXInternal } from 'preact/src/jsx';
 
 import styles from './styles.scss';
 import { createClassName } from '../../../helpers/createClassName';

--- a/packages/livechat/src/components/Form/FormField/index.tsx
+++ b/packages/livechat/src/components/Form/FormField/index.tsx
@@ -1,6 +1,5 @@
-import type { ComponentChildren } from 'preact';
 import { cloneElement } from 'preact';
-import type { JSXInternal } from 'preact/src/jsx';
+import type { ComponentChildren, JSX as JSXInternal } from 'preact';
 
 import styles from './styles.scss';
 import { createClassName } from '../../../helpers/createClassName';

--- a/packages/livechat/src/components/Form/HookFormExample/stories.tsx
+++ b/packages/livechat/src/components/Form/HookFormExample/stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryFn } from '@storybook/preact';
-import type { ComponentProps } from 'preact';
-import type { JSXInternal } from 'preact/src/jsx';
+import type { ComponentProps, JSX as JSXInternal } from 'preact';
 import { Controller, useForm } from 'react-hook-form';
 import { action } from 'storybook/actions';
 

--- a/packages/livechat/src/components/Form/MultilineTextInput/index.tsx
+++ b/packages/livechat/src/components/Form/MultilineTextInput/index.tsx
@@ -1,6 +1,5 @@
-import type { Ref } from 'preact';
+import type { Ref, JSX as JSXInternal } from 'preact';
 import type { TargetedEvent } from 'preact/compat';
-import type { JSXInternal } from 'preact/src/jsx';
 
 import styles from './styles.scss';
 import { createClassName } from '../../../helpers/createClassName';

--- a/packages/livechat/src/components/Form/PasswordInput/index.tsx
+++ b/packages/livechat/src/components/Form/PasswordInput/index.tsx
@@ -1,6 +1,5 @@
-import type { Ref } from 'preact';
+import type { Ref, JSX as JSXInternal } from 'preact';
 import type { TargetedEvent } from 'preact/compat';
-import type { JSXInternal } from 'preact/src/jsx';
 
 import styles from './styles.scss';
 import { createClassName } from '../../../helpers/createClassName';

--- a/packages/livechat/src/components/Form/SelectInput/index.tsx
+++ b/packages/livechat/src/components/Form/SelectInput/index.tsx
@@ -1,6 +1,5 @@
-import type { ComponentChild, Ref } from 'preact';
+import type { ComponentChild, Ref, JSX as JSXInternal } from 'preact';
 import type { TargetedEvent } from 'preact/compat';
-import type { JSXInternal } from 'preact/src/jsx';
 
 import styles from './styles.scss';
 import { createClassName } from '../../../helpers/createClassName';

--- a/packages/livechat/src/components/Form/TextInput/index.tsx
+++ b/packages/livechat/src/components/Form/TextInput/index.tsx
@@ -1,6 +1,5 @@
-import type { Ref } from 'preact';
+import type { Ref, JSX as JSXInternal } from 'preact';
 import type { TargetedEvent } from 'preact/compat';
-import type { JSXInternal } from 'preact/src/jsx';
 
 import styles from './styles.scss';
 import { createClassName } from '../../../helpers/createClassName';

--- a/packages/livechat/src/components/Form/index.tsx
+++ b/packages/livechat/src/components/Form/index.tsx
@@ -1,6 +1,5 @@
 import i18next from 'i18next';
-import type { ComponentChildren } from 'preact';
-import type { JSXInternal } from 'preact/src/jsx';
+import type { ComponentChildren, JSX as JSXInternal } from 'preact';
 
 export type FormProps = {
 	onSubmit?: JSXInternal.GenericEventHandler<HTMLFormElement>;

--- a/packages/livechat/src/components/Header/Header.tsx
+++ b/packages/livechat/src/components/Header/Header.tsx
@@ -1,6 +1,5 @@
-import type { ComponentChildren, Ref } from 'preact';
+import type { ComponentChildren, Ref, JSX as JSXInternal } from 'preact';
 import type { MouseEventHandler } from 'preact/compat';
-import type { JSXInternal } from 'preact/src/jsx';
 
 import styles from './styles.scss';
 import type { Theme } from '../../Theme';

--- a/packages/livechat/src/components/Messages/MessageText/index.tsx
+++ b/packages/livechat/src/components/Messages/MessageText/index.tsx
@@ -1,5 +1,5 @@
+import type { JSX as JSXInternal } from 'preact';
 import { memo } from 'preact/compat';
-import type { JSXInternal } from 'preact/src/jsx';
 
 import styles from './styles.scss';
 import { createClassName } from '../../../helpers/createClassName';

--- a/packages/livechat/src/routes/LeaveMessage/index.tsx
+++ b/packages/livechat/src/routes/LeaveMessage/index.tsx
@@ -1,5 +1,5 @@
+import type { JSX as JSXInternal } from 'preact';
 import { useContext, useRef } from 'preact/hooks';
-import type { JSXInternal } from 'preact/src/jsx';
 import type { FieldValues, SubmitHandler } from 'react-hook-form';
 import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';

--- a/packages/livechat/src/routes/Register/index.tsx
+++ b/packages/livechat/src/routes/Register/index.tsx
@@ -1,5 +1,5 @@
+import type { JSX as JSXInternal } from 'preact';
 import { useContext, useEffect, useMemo, useRef } from 'preact/hooks';
-import type { JSXInternal } from 'preact/src/jsx';
 import { route } from 'preact-router';
 import type { FieldValues, SubmitHandler } from 'react-hook-form';
 import { Controller, useForm } from 'react-hook-form';


### PR DESCRIPTION
## Summary

Replaces `import type { JSXInternal } from 'preact/src/jsx'` with `import type { JSX as JSXInternal } from 'preact'` across livechat components.

## Why

The internal `preact/src/jsx` path isn't reachable under `bundler`/TypeScript 7 module resolution (it's not in preact's package exports). preact re-exports `JSXInternal` as `JSX` from its public entry (`export import JSX = JSXInternal`), so the aliased import is type-identical — all `JSXInternal.*` usages stay unchanged. Using the public API is correct regardless of the TS7 migration; typecheck and lint stay green.

Draft — part of a set of small, independent TS7-readiness PRs.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2234]

[ARCH-2234]: https://rocketchat.atlassian.net/browse/ARCH-2234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized internal type imports across live chat components and routes.
  - Improved compatibility by using the supported public interface for JSX and related type definitions.
  - No changes to visible functionality, component behavior, or event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->