### PR TITLE
chore: TS7 low-risk type fixes (assertions, casts)

### DIFF
--- a/packages/apps-engine/src/definition/api/ApiEndpoint.ts
+++ b/packages/apps-engine/src/definition/api/ApiEndpoint.ts
@@ -9,7 +9,7 @@ export abstract class ApiEndpoint implements IApiEndpoint {
 	 * The last part of the api URL. Example: https://{your-server-address}/api/apps/public/{your-app-id}/{path}
 	 * or https://{your-server-address}/api/apps/private/{your-app-id}/{private-hash}/{path}
 	 */
-	public path: string;
+	public path!: string;
 
 	constructor(public app: IApp) {}
 

--- a/packages/apps/src/server/accessors/DiscussionBuilder.ts
+++ b/packages/apps/src/server/accessors/DiscussionBuilder.ts
@@ -7,7 +7,7 @@ import type { IRoom } from '@rocket.chat/apps-engine/definition/rooms/IRoom';
 import { RoomBuilder } from './RoomBuilder';
 
 export class DiscussionBuilder extends RoomBuilder implements IDiscussionBuilder {
-	public kind: RocketChatAssociationModel.DISCUSSION;
+	public declare kind: RocketChatAssociationModel.DISCUSSION;
 
 	private reply: string;
 

--- a/packages/http-router/src/Router.ts
+++ b/packages/http-router/src/Router.ts
@@ -159,7 +159,7 @@ export class Router<
 			const contentType = request.header('content-type') || '';
 
 			if (contentType.includes('application/json')) {
-				return await request.raw.clone().json();
+				return (await request.raw.clone().json()) as NonNullable<unknown>;
 			}
 
 			if (contentType.includes('application/x-www-form-urlencoded')) {

--- a/packages/jest-presets/src/client/jest-setup.ts
+++ b/packages/jest-presets/src/client/jest-setup.ts
@@ -68,7 +68,7 @@ globalThis.IntersectionObserver = class IntersectionObserver {
 	unobserve() {
 		return null;
 	}
-};
+} as unknown as typeof IntersectionObserver;
 
 globalThis.TextEncoder = TextEncoder as any;
 globalThis.TextDecoder = TextDecoder as any;


### PR DESCRIPTION
## Summary

Small, type-only hardening that TypeScript 7's stricter checker flags:

- `ApiEndpoint.path`: definite-assignment assertion (`path!`) — set externally at endpoint registration, never in the constructor.
- `DiscussionBuilder.kind`: add `declare` to the type-narrowing override — runtime unchanged, the constructor still assigns it.
- `http-router` `parseBodyParams`: cast the `unknown` result of `request.json()` to `NonNullable<unknown>` to match the declared return type.
- `jest-presets` IntersectionObserver mock: cast to `typeof IntersectionObserver`.

No runtime or emit impact; typecheck stays green on the current toolchain.

Draft — part of a set of small, independent TS7-readiness PRs.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2235]

[ARCH-2235]: https://rocketchat.atlassian.net/browse/ARCH-2235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved TypeScript type handling across API endpoints, discussion builders, request body parsing, and client test setup.
  * Preserved existing runtime behavior while improving compatibility with stricter type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->