### PR TITLE
fix: LDAP users not merging by email during sync

### DIFF
--- a/.changeset/ldap-merge-email-lookup.md
+++ b/.changeset/ldap-merge-email-lookup.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/models': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes LDAP sync failing to merge an existing user matched by email, which caused a `Username already exists` error when the user's username differed from the directory.

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -2438,7 +2438,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 
 	findOneWithoutLDAPByEmailAddress(emailAddress: string, options?: FindOptions<IUser>) {
 		const query = {
-			'email.address': emailAddress.trim().toLowerCase(),
+			'emails.address': emailAddress.trim().toLowerCase(),
 			'services.ldap': {
 				$exists: false,
 			},


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

During LDAP sync, when an existing (non-LDAP) Rocket.Chat user has the same email as a directory entry but a different username, the sync should merge them. It wasn't: the email fallback used during sync never matched, so the sync treated the entry as new and attempted an insert, colliding on the unique username and failing with `Username already exists. [403]`.

This corrects the email lookup so the existing user is found and merged instead of duplicated.

## Issue(s)

Closes: [CORE-1285](https://rocketchat.atlassian.net/browse/CORE-1285)

## Steps to test or reproduce

1. Configure LDAP against a directory; create a local Rocket.Chat user whose email matches a directory user but with a different username.
2. Enable `LDAP_Merge_Existing_Users` and run Sync Now.
3. Expected: the existing user is merged and linked to LDAP (no `Username already exists` error, no duplicate account).

## Further comments

[CORE-1285](https://rocketchat.atlassian.net/browse/CORE-1285)


[CORE-1285]: https://rocketchat.atlassian.net/browse/CORE-1285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ