### PR TITLE
chore: type fixes extracted from TS 6 upgrade branch

### DIFF
--- a/apps/meteor/client/views/room/MessageList/providers/MessageListProvider.tsx
+++ b/apps/meteor/client/views/room/MessageList/providers/MessageListProvider.tsx
@@ -64,7 +64,7 @@ const MessageListProvider = ({ children, attachmentDimension }: MessageListProvi
 
 	const chat = useChat();
 
-	const context: MessageListContextValue = useMemo(
+	const context: MessageListContextValue = useMemo<MessageListContextValue>(
 		() => ({
 			showColors,
 			useUserHasReacted: username

--- a/apps/meteor/ee/app/canned-responses/server/methods/saveCannedResponse.ts
+++ b/apps/meteor/ee/app/canned-responses/server/methods/saveCannedResponse.ts
@@ -90,6 +90,7 @@ export const saveCannedResponse = async (
 
 		result = await CannedResponse.updateCannedResponse(_id, {
 			...responseData,
+			tags: responseData.tags ?? [],
 			...(cannedResponse.scope === 'user' && { userId: cannedResponse.userId }),
 			createdBy: cannedResponse.createdBy,
 		});
@@ -98,6 +99,7 @@ export const saveCannedResponse = async (
 
 		const data = {
 			...responseData,
+			tags: responseData.tags ?? [],
 			...(responseData.scope === 'user' && { userId: user?._id }),
 			createdBy: { _id: user?._id || '', username: user?.username || '' },
 			_createdAt: new Date(),

--- a/packages/http-router/src/Router.ts
+++ b/packages/http-router/src/Router.ts
@@ -159,7 +159,7 @@ export class Router<
 			const contentType = request.header('content-type') || '';
 
 			if (contentType.includes('application/json')) {
-				return await request.raw.clone().json();
+				return (await request.raw.clone().json()) as NonNullable<unknown>;
 			}
 
 			if (contentType.includes('application/x-www-form-urlencoded')) {

--- a/packages/jest-presets/src/client/jest-setup.ts
+++ b/packages/jest-presets/src/client/jest-setup.ts
@@ -46,27 +46,29 @@ Object.defineProperty(global.navigator, 'serviceWorker', {
 	},
 });
 
-globalThis.IntersectionObserver = class IntersectionObserver {
-	root = null;
+globalThis.IntersectionObserver = class implements IntersectionObserver {
+	readonly root: Document | Element | null = null;
 
-	rootMargin = '';
+	readonly rootMargin: string = '';
 
-	thresholds = [];
+	readonly scrollMargin: string = '';
 
-	disconnect() {
-		return null;
+	readonly thresholds: ReadonlyArray<number> = [];
+
+	disconnect(): void {
+		// no-op mock
 	}
 
-	observe() {
-		return null;
+	observe(): void {
+		// no-op mock
 	}
 
-	takeRecords() {
+	takeRecords(): IntersectionObserverEntry[] {
 		return [];
 	}
 
-	unobserve() {
-		return null;
+	unobserve(): void {
+		// no-op mock
 	}
 };
 

--- a/packages/ui-client/src/components/Wizard/index.ts
+++ b/packages/ui-client/src/components/Wizard/index.ts
@@ -11,4 +11,3 @@ export * from './lib/StepNode';
 export * from './WizardContext';
 export * from './useWizardContext';
 export * from './useWizard';
-export * from './mocks/createMockWizardApi';


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Extracts standalone type fixes from #40781 so the TS 6 upgrade PR shrinks:

- `MessageListProvider.tsx`: explicit `useMemo<MessageListContextValue>` type argument
- `saveCannedResponse.ts`: default `tags` to `[]` on both update and insert paths
- `http-router` `Router.ts`: cast parsed JSON body to `NonNullable<unknown>`
- `jest-presets` client setup: `IntersectionObserver` mock now `implements IntersectionObserver` (typed members, adds `scrollMargin`)
- `ui-client` Wizard barrel: drop `createMockWizardApi` export (test-only mock, consumed via relative imports)

## Issue(s)

## Steps to test or reproduce

`yarn turbo run build --filter='@rocket.chat/meteor^...'` then `yarn workspace @rocket.chat/meteor typecheck` — both pass.

## Further comments

Same changes as in #40781; no behavior change except canned responses always persisting a `tags` array.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

