### PR TITLE
refactor(ui-client): Non-standard `useThemeMode`

### DIFF
--- a/apps/meteor/client/sidebar/footer/SidebarFooterDefault.tsx
+++ b/apps/meteor/client/sidebar/footer/SidebarFooterDefault.tsx
@@ -7,7 +7,7 @@ import DOMPurify from 'dompurify';
 import { SidebarFooterWatermark } from './SidebarFooterWatermark';
 
 const SidebarFooterDefault = () => {
-	const [, , theme] = useThemeMode();
+	const theme = useThemeMode();
 	const logo = useSetting(theme === 'dark' ? 'Layout_Sidenav_Footer_Dark' : 'Layout_Sidenav_Footer', '').trim();
 
 	const sidebarFooterStyle = css`

--- a/apps/meteor/client/views/root/AppErrorPage.tsx
+++ b/apps/meteor/client/views/root/AppErrorPage.tsx
@@ -2,7 +2,7 @@ import { Box, PaletteStyleTag, States, StatesAction, StatesActions, StatesIcon, 
 import { useThemeMode } from '@rocket.chat/ui-client';
 
 const AppErrorPage = () => {
-	const [, , theme] = useThemeMode();
+	const theme = useThemeMode();
 
 	return (
 		<>

--- a/apps/meteor/client/views/root/MainLayout/MainLayoutStyleTags.tsx
+++ b/apps/meteor/client/views/root/MainLayout/MainLayoutStyleTags.tsx
@@ -4,7 +4,7 @@ import { useThemeMode } from '@rocket.chat/ui-client';
 import { codeBlock } from '../lib/codeBlockStyles';
 
 export const MainLayoutStyleTags = () => {
-	const [, , theme] = useThemeMode();
+	const theme = useThemeMode();
 
 	return (
 		<>

--- a/packages/ui-client/src/hooks/useThemeMode.spec.ts
+++ b/packages/ui-client/src/hooks/useThemeMode.spec.ts
@@ -1,5 +1,5 @@
 import { mockAppRoot } from '@rocket.chat/mock-providers';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
 import { useThemeMode } from './useThemeMode';
 
@@ -14,120 +14,57 @@ afterEach(() => {
 });
 
 describe('useThemeMode', () => {
-	describe('current theme mode', () => {
-		it('should default to "auto" when no preference is set', () => {
-			mockUseDarkMode.mockReturnValue(false);
+	it('should resolve to "light" when mode is "auto" and system prefers light', () => {
+		mockUseDarkMode.mockReturnValue(false);
 
-			const { result } = renderHook(() => useThemeMode(), {
-				wrapper: mockAppRoot().build(),
-			});
-
-			expect(result.current[0]).toBe('auto');
+		const { result } = renderHook(() => useThemeMode(), {
+			wrapper: mockAppRoot().withUserPreference('themeAppearence', 'auto').build(),
 		});
 
-		it('should return the user preference when set', () => {
-			mockUseDarkMode.mockReturnValue(true);
-
-			const { result } = renderHook(() => useThemeMode(), {
-				wrapper: mockAppRoot().withUserPreference('themeAppearence', 'dark').build(),
-			});
-
-			expect(result.current[0]).toBe('dark');
-		});
+		expect(result.current).toBe('light');
+		expect(mockUseDarkMode).toHaveBeenCalledWith(undefined);
 	});
 
-	describe('resolved theme', () => {
-		it('should resolve to "light" when mode is "auto" and system prefers light', () => {
-			mockUseDarkMode.mockReturnValue(false);
+	it('should resolve to "dark" when mode is "auto" and system prefers dark', () => {
+		mockUseDarkMode.mockReturnValue(true);
 
-			const { result } = renderHook(() => useThemeMode(), {
-				wrapper: mockAppRoot().withUserPreference('themeAppearence', 'auto').build(),
-			});
-
-			expect(result.current[2]).toBe('light');
-			expect(mockUseDarkMode).toHaveBeenCalledWith(undefined);
+		const { result } = renderHook(() => useThemeMode(), {
+			wrapper: mockAppRoot().withUserPreference('themeAppearence', 'auto').build(),
 		});
 
-		it('should resolve to "dark" when mode is "auto" and system prefers dark', () => {
-			mockUseDarkMode.mockReturnValue(true);
-
-			const { result } = renderHook(() => useThemeMode(), {
-				wrapper: mockAppRoot().withUserPreference('themeAppearence', 'auto').build(),
-			});
-
-			expect(result.current[2]).toBe('dark');
-			expect(mockUseDarkMode).toHaveBeenCalledWith(undefined);
-		});
-
-		it('should resolve to "dark" when mode is "dark"', () => {
-			mockUseDarkMode.mockReturnValue(true);
-
-			const { result } = renderHook(() => useThemeMode(), {
-				wrapper: mockAppRoot().withUserPreference('themeAppearence', 'dark').build(),
-			});
-
-			expect(result.current[2]).toBe('dark');
-			expect(mockUseDarkMode).toHaveBeenCalledWith(true);
-		});
-
-		it('should resolve to "light" when mode is "light"', () => {
-			mockUseDarkMode.mockReturnValue(false);
-
-			const { result } = renderHook(() => useThemeMode(), {
-				wrapper: mockAppRoot().withUserPreference('themeAppearence', 'light').build(),
-			});
-
-			expect(result.current[2]).toBe('light');
-			expect(mockUseDarkMode).toHaveBeenCalledWith(false);
-		});
-
-		it('should resolve to "high-contrast" when mode is "high-contrast"', () => {
-			mockUseDarkMode.mockReturnValue(false);
-
-			const { result } = renderHook(() => useThemeMode(), {
-				wrapper: mockAppRoot().withUserPreference('themeAppearence', 'high-contrast').build(),
-			});
-
-			expect(result.current[2]).toBe('high-contrast');
-		});
+		expect(result.current).toBe('dark');
+		expect(mockUseDarkMode).toHaveBeenCalledWith(undefined);
 	});
 
-	describe('setThemeMode', () => {
-		it('should return a function that calls the endpoint for each theme mode', async () => {
-			mockUseDarkMode.mockReturnValue(false);
-			const endpointHandler = jest.fn();
+	it('should resolve to "dark" when mode is "dark"', () => {
+		mockUseDarkMode.mockReturnValue(true);
 
-			const { result } = renderHook(() => useThemeMode(), {
-				wrapper: mockAppRoot().withEndpoint('POST', '/v1/users.setPreferences', endpointHandler).build(),
-			});
-
-			const setTheme = result.current[1];
-
-			await act(async () => {
-				setTheme('dark')();
-			});
-			expect(endpointHandler).toHaveBeenCalledWith({ data: { themeAppearence: 'dark' } });
-
-			endpointHandler.mockClear();
-
-			await act(async () => {
-				setTheme('light')();
-			});
-			expect(endpointHandler).toHaveBeenCalledWith({ data: { themeAppearence: 'light' } });
-
-			endpointHandler.mockClear();
-
-			await act(async () => {
-				setTheme('auto')();
-			});
-			expect(endpointHandler).toHaveBeenCalledWith({ data: { themeAppearence: 'auto' } });
-
-			endpointHandler.mockClear();
-
-			await act(async () => {
-				setTheme('high-contrast')();
-			});
-			expect(endpointHandler).toHaveBeenCalledWith({ data: { themeAppearence: 'high-contrast' } });
+		const { result } = renderHook(() => useThemeMode(), {
+			wrapper: mockAppRoot().withUserPreference('themeAppearence', 'dark').build(),
 		});
+
+		expect(result.current).toBe('dark');
+		expect(mockUseDarkMode).toHaveBeenCalledWith(true);
+	});
+
+	it('should resolve to "light" when mode is "light"', () => {
+		mockUseDarkMode.mockReturnValue(false);
+
+		const { result } = renderHook(() => useThemeMode(), {
+			wrapper: mockAppRoot().withUserPreference('themeAppearence', 'light').build(),
+		});
+
+		expect(result.current).toBe('light');
+		expect(mockUseDarkMode).toHaveBeenCalledWith(false);
+	});
+
+	it('should resolve to "high-contrast" when mode is "high-contrast"', () => {
+		mockUseDarkMode.mockReturnValue(false);
+
+		const { result } = renderHook(() => useThemeMode(), {
+			wrapper: mockAppRoot().withUserPreference('themeAppearence', 'high-contrast').build(),
+		});
+
+		expect(result.current).toBe('high-contrast');
 	});
 });

--- a/packages/ui-client/src/hooks/useThemeMode.ts
+++ b/packages/ui-client/src/hooks/useThemeMode.ts
@@ -27,9 +27,10 @@ export const useThemeMode = (): [
 	);
 
 	const setTheme = useCallback((value: ThemeMode): (() => void) => updaters[value], [updaters]);
+	const isDarkMode = useDarkMode(themeMode === 'auto' ? undefined : themeMode === 'dark');
 
 	const useTheme = () => {
-		if (useDarkMode(themeMode === 'auto' ? undefined : themeMode === 'dark')) {
+		if (isDarkMode) {
 			return 'dark';
 		}
 		if (themeMode === 'high-contrast') {

--- a/packages/ui-client/src/hooks/useThemeMode.ts
+++ b/packages/ui-client/src/hooks/useThemeMode.ts
@@ -1,43 +1,22 @@
-import type { ThemePreference as ThemeMode, Themes } from '@rocket.chat/core-typings';
+import type { ThemePreference as ThemeMode } from '@rocket.chat/core-typings';
 import { useDarkMode } from '@rocket.chat/fuselage-hooks';
-import { useEndpoint, useUserPreference } from '@rocket.chat/ui-contexts';
-import { useCallback, useState } from 'react';
+import { useUserPreference } from '@rocket.chat/ui-contexts';
 
 /**
  * Returns the current option set by the user, the theme mode resolved given the user configuration and OS (if applies) and a function to set it.
  * @param defaultThemeMode The default theme mode to use if the user has not set any.
- * @returns [currentThemeMode, setThemeMode, resolvedThemeMode]
  */
-export const useThemeMode = (): [
-	currentThemeMode: ThemeMode,
-	setThemeMode: (value: ThemeMode) => () => void,
-	resolvedThemeMode: Themes,
-] => {
+export const useThemeMode = () => {
 	const themeMode = useUserPreference<ThemeMode>('themeAppearence') || 'auto';
-
-	const saveUserPreferences = useEndpoint('POST', '/v1/users.setPreferences');
-
-	const [updaters] = useState(
-		(): Record<ThemeMode, () => ReturnType<typeof saveUserPreferences>> => ({
-			'light': () => saveUserPreferences({ data: { themeAppearence: 'light' } }),
-			'dark': () => saveUserPreferences({ data: { themeAppearence: 'dark' } }),
-			'auto': () => saveUserPreferences({ data: { themeAppearence: 'auto' } }),
-			'high-contrast': () => saveUserPreferences({ data: { themeAppearence: 'high-contrast' } }),
-		}),
-	);
-
-	const setTheme = useCallback((value: ThemeMode): (() => void) => updaters[value], [updaters]);
 	const isDarkMode = useDarkMode(themeMode === 'auto' ? undefined : themeMode === 'dark');
 
-	const useTheme = () => {
-		if (isDarkMode) {
-			return 'dark';
-		}
-		if (themeMode === 'high-contrast') {
-			return 'high-contrast';
-		}
-		return 'light';
-	};
+	if (isDarkMode) {
+		return 'dark';
+	}
 
-	return [themeMode, setTheme, useTheme()];
+	if (themeMode === 'high-contrast') {
+		return 'high-contrast';
+	}
+
+	return 'light';
 };

--- a/packages/ui-client/src/hooks/useThemeMode.ts
+++ b/packages/ui-client/src/hooks/useThemeMode.ts
@@ -3,7 +3,7 @@ import { useDarkMode } from '@rocket.chat/fuselage-hooks';
 import { useUserPreference } from '@rocket.chat/ui-contexts';
 
 /**
- * Returns the current option set by the user, the theme mode resolved given the user configuration and OS (if applies) and a function to set it.
+ * Returns the resolved theme string based on the user's theme appearance preference and system dark-mode setting.
  */
 export const useThemeMode = () => {
 	const themeMode = useUserPreference<ThemeMode>('themeAppearence') || 'auto';

--- a/packages/ui-client/src/hooks/useThemeMode.ts
+++ b/packages/ui-client/src/hooks/useThemeMode.ts
@@ -4,7 +4,6 @@ import { useUserPreference } from '@rocket.chat/ui-contexts';
 
 /**
  * Returns the current option set by the user, the theme mode resolved given the user configuration and OS (if applies) and a function to set it.
- * @param defaultThemeMode The default theme mode to use if the user has not set any.
  */
 export const useThemeMode = () => {
 	const themeMode = useUserPreference<ThemeMode>('themeAppearence') || 'auto';

--- a/packages/ui-voip/src/views/usePopoutWindow.ts
+++ b/packages/ui-voip/src/views/usePopoutWindow.ts
@@ -105,7 +105,7 @@ export const usePopoutWindow = (onBeforeUnload: () => void): UsePopoutWindowRetu
 	const { t } = useTranslation();
 	const dispatchToastMessage = useToastMessageDispatch();
 
-	const [, , theme] = useThemeMode();
+	const theme = useThemeMode();
 
 	const openPopoutWindow = useCallback(
 		async (callId: string) => {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
It prevents possible a invalid hook call if `useThemeMode` is modified in the future Additionally, it simplifies the hook according with its usage.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved theme handling across the app so dark and high-contrast modes remain consistent in the sidebar, error page, main layout, and popout window.
  - Theme styling now uses the resolved theme consistently, reducing mismatches between user preference and what’s displayed.

- **Tests**
  - Updated theme-related tests to verify the resolved theme behavior for light, dark, high-contrast, and auto scenarios, including expected system-dark-mode handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2236]

[ARCH-2236]: https://rocketchat.atlassian.net/browse/ARCH-2236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ