### PR TITLE
fix: import Slack files as attachments instead of raw URLs

### DIFF
--- a/.changeset/deep-ways-poke.md
+++ b/.changeset/deep-ways-poke.md
@@ -1,0 +1,7 @@
+---
+'@rocket.chat/core-typings': patch
+'@rocket.chat/models': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes the Slack importer storing shared files as raw URLs in the message body. Imported file messages now stay hidden until "Download Pending Files" button fetches them, then display as native attachments with image previews. Failed downloads (e.g. invalidated export links) are no longer silently saved as the file's content — they are counted as errors and can be retried.

--- a/apps/meteor/server/lib/import/classes/converters/MessageConverter.ts
+++ b/apps/meteor/server/lib/import/classes/converters/MessageConverter.ts
@@ -104,6 +104,7 @@ export class MessageConverter extends RecordConverter<IImportMessageRecord> {
 			mentions,
 			channels,
 			_importFile: data._importFile,
+			_hidden: data._hidden,
 			url: data.url,
 			attachments: data.attachments,
 			bot: data.bot,

--- a/apps/meteor/server/lib/import/pending-files/PendingFileImporter.ts
+++ b/apps/meteor/server/lib/import/pending-files/PendingFileImporter.ts
@@ -3,10 +3,11 @@ import https from 'node:https';
 
 import { api } from '@rocket.chat/core-services';
 import type { IImport, MessageAttachment, IUpload, IImporterShortSelection } from '@rocket.chat/core-typings';
-import { Messages } from '@rocket.chat/models';
+import { Messages, Users } from '@rocket.chat/models';
 import { Random } from '@rocket.chat/random';
 
 import { Importer, ProgressStep } from '..';
+import { parseFileIntoMessageAttachments } from '../../../meteor-methods/messages/sendFileMessage';
 import { FileUpload } from '../../media/file-upload';
 import type { ConverterOptions } from '../classes/ImportDataConverter';
 import type { ImporterProgress } from '../classes/ImporterProgress';
@@ -79,6 +80,12 @@ export class PendingFileImporter extends Importer {
 			currentSize -= details.size;
 		};
 
+		const failFile = async (details: { size: number }) => {
+			await this.addCountError(1);
+			count--;
+			currentSize -= details.size;
+		};
+
 		const logError = this.logger.error.bind(this.logger);
 
 		try {
@@ -107,7 +114,6 @@ export class PendingFileImporter extends Importer {
 						rid: message.rid,
 					};
 
-					const requestModule = /https/i.test(url) ? https : http;
 					const fileStore = FileUpload.getStore('Uploads');
 
 					nextSize = details.size;
@@ -116,41 +122,25 @@ export class PendingFileImporter extends Importer {
 					currentSize += nextSize;
 					downloadedFileIds.push(_importFile.id);
 
-					requestModule.get(url, (res) => {
-						const contentType = res.headers['content-type'];
-						if (!details.type && contentType) {
-							details.type = contentType;
-						}
+					void this.downloadFile(url, details)
+						.then(async (rawData) => {
+							// Bypass the fileStore filters
+							const file = await fileStore._doInsert(details, rawData);
 
-						const rawData: Uint8Array[] = [];
-						res.on('data', (chunk) => {
-							rawData.push(chunk);
+							const rocketChatUrl = FileUpload.getPath(`${file._id}/${encodeURI(file.name || '')}`);
+							const user = await Users.findOneById(message.u._id);
+							const attachment = user
+								? (await parseFileIntoMessageAttachments(file, message.rid, user)).attachments[0]
+								: this.getMessageAttachment(file, rocketChatUrl);
 
-							// Update progress more often on large files
-							this.reportProgress();
-						});
-						res.on('error', async (err) => {
+							await Messages.setImportFileRocketChatAttachment(_importFile.id, rocketChatUrl, attachment);
 							await completeFile(details);
-							logError({ err });
+							importedRoomIds.add(message.rid);
+						})
+						.catch(async (err) => {
+							logError({ msg: 'Failed to download pending file', url, err });
+							await failFile(details);
 						});
-
-						res.on('end', async () => {
-							try {
-								// Bypass the fileStore filters
-								const file = await fileStore._doInsert(details, Buffer.concat(rawData));
-
-								const url = FileUpload.getPath(`${file._id}/${encodeURI(file.name || '')}`);
-								const attachment = this.getMessageAttachment(file, url);
-
-								await Messages.setImportFileRocketChatAttachment(_importFile.id, url, attachment);
-								await completeFile(details);
-								importedRoomIds.add(message.rid);
-							} catch (err) {
-								await completeFile(details);
-								logError({ err });
-							}
-						});
-					});
 				} catch (err) {
 					this.logger.error({ err });
 				}
@@ -170,6 +160,39 @@ export class PendingFileImporter extends Importer {
 
 		await super.updateProgress(ProgressStep.DONE);
 		return this.getProgress();
+	}
+
+	private downloadFile(url: string, details: { type?: string }): Promise<Buffer> {
+		return new Promise((resolve, reject) => {
+			const requestModule = /https/i.test(url) ? https : http;
+
+			requestModule
+				.get(url, (res) => {
+					res.on('error', reject);
+
+					if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
+						// Error responses (e.g. a redirect to a login page) would otherwise be saved as the file's content.
+						res.resume(); // discard the body and free the socket
+						reject(new Error(`Unexpected response status ${res.statusCode}`));
+						return;
+					}
+
+					const contentType = res.headers['content-type'];
+					if (!details.type && contentType) {
+						details.type = contentType;
+					}
+
+					const rawData: Uint8Array[] = [];
+					res.on('data', (chunk) => {
+						rawData.push(chunk);
+
+						// Update progress more often on large files
+						this.reportProgress();
+					});
+					res.on('end', () => resolve(Buffer.concat(rawData)));
+				})
+				.on('error', reject);
+		});
 	}
 
 	getMessageAttachment(file: IUpload, url: string): MessageAttachment {

--- a/apps/meteor/server/lib/import/slack/SlackImporter.ts
+++ b/apps/meteor/server/lib/import/slack/SlackImporter.ts
@@ -496,7 +496,8 @@ export class SlackImporter extends Importer {
 						_id: fileId,
 						rid: newMessage.rid,
 						ts: newMessage.ts,
-						msg: message.file.url_private_download || '',
+						msg: '',
+						_hidden: true,
 						_importFile: this.convertSlackFileToPendingFile(message.file),
 						u: {
 							_id: newMessage.u._id,
@@ -568,7 +569,8 @@ export class SlackImporter extends Importer {
 						_id: fileId,
 						rid: slackChannelId,
 						ts: newMessage.ts,
-						msg: file.url_private_download || '',
+						msg: '',
+						_hidden: true,
 						_importFile: this.convertSlackFileToPendingFile(file),
 						u: {
 							_id: this._replaceSlackUserId(message.user),

--- a/apps/meteor/tests/unit/server/lib/import/PendingFileImporter.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/import/PendingFileImporter.spec.ts
@@ -1,0 +1,357 @@
+import { EventEmitter } from 'events';
+
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+class MockIncomingMessage extends EventEmitter {
+	statusCode: number;
+
+	headers: Record<string, string>;
+
+	constructor(statusCode: number, headers: Record<string, string> = {}) {
+		super();
+		this.statusCode = statusCode;
+		this.headers = headers;
+	}
+
+	resume() {
+		// no-op
+	}
+}
+
+class MockClientRequest extends EventEmitter {
+	// no-op
+}
+
+const createMockHttpModule = (responseFactory: () => MockIncomingMessage, errorOnConnect = false) => ({
+	get: (_url: string, callback: (res: MockIncomingMessage) => void) => {
+		const req = new MockClientRequest();
+
+		if (errorOnConnect) {
+			setImmediate(() => req.emit('error', new Error('Connection refused')));
+		} else {
+			setImmediate(() => {
+				const res = responseFactory();
+				callback(res);
+			});
+		}
+
+		return req;
+	},
+});
+
+const createPendingFileImporter = (httpMock: ReturnType<typeof createMockHttpModule>) => {
+	const { PendingFileImporter } = proxyquire.noCallThru().load('../../../../../server/lib/import/pending-files/PendingFileImporter', {
+		'node:http': httpMock,
+		'node:https': httpMock,
+		'@rocket.chat/core-services': { api: { broadcast: sinon.stub() } },
+		'@rocket.chat/models': {
+			Messages: {
+				countAllImportedMessagesWithFilesToDownload: sinon.stub().resolves(0),
+				findAllImportedMessagesWithFilesToDownload: sinon.stub().returns([]),
+				setImportFileRocketChatAttachment: sinon.stub().resolves(),
+			},
+			Users: {
+				findOneById: sinon.stub().resolves(null),
+			},
+		},
+		'@rocket.chat/random': { Random: { id: () => 'random-id' } },
+		'../../media/file-upload': { FileUpload: { getStore: sinon.stub(), getPath: sinon.stub() } },
+		'../../../meteor-methods/messages/sendFileMessage': { parseFileIntoMessageAttachments: sinon.stub() },
+		'..': {
+			Importer: class MockImporter {
+				logger = { debug: sinon.stub(), error: sinon.stub(), info: sinon.stub() };
+
+				progress = { count: { total: 0 } };
+
+				reportProgress() {
+					// no-op
+				}
+
+				async updateProgress() {
+					// no-op
+				}
+
+				async updateRecord() {
+					// no-op
+				}
+
+				async addCountCompleted() {
+					// no-op
+				}
+
+				async addCountError() {
+					// no-op
+				}
+
+				getProgress() {
+					return this.progress;
+				}
+
+				isCursorNotFoundError() {
+					return false;
+				}
+			},
+			ProgressStep: {
+				PREPARING_STARTED: 'preparing_started',
+				IMPORTING_FILES: 'importing_files',
+				DONE: 'done',
+				ERROR: 'error',
+			},
+		},
+	});
+
+	const info = { key: 'pending-files', name: 'Pending Files' };
+	const importRecord = { _id: 'test-import' };
+
+	return new PendingFileImporter(info, importRecord, {});
+};
+
+describe('PendingFileImporter', () => {
+	describe('downloadFile', () => {
+		it('should resolve with buffer on successful 200 response', async () => {
+			const responseData = Buffer.from('file content');
+			const httpMock = createMockHttpModule(() => {
+				const res = new MockIncomingMessage(200, { 'content-type': 'image/png' });
+				setImmediate(() => {
+					res.emit('data', responseData);
+					res.emit('end');
+				});
+				return res;
+			});
+
+			const importer = createPendingFileImporter(httpMock);
+			const details: { type?: string } = {};
+
+			// Access private method through the instance
+			const result = await (importer as any).downloadFile('https://example.com/file.png', details);
+
+			expect(result).to.deep.equal(responseData);
+			expect(details.type).to.equal('image/png');
+		});
+
+		it('should reject on non-2xx status codes (e.g., 302 redirect)', async () => {
+			const httpMock = createMockHttpModule(() => {
+				const res = new MockIncomingMessage(302, { location: 'https://example.com/login' });
+				return res;
+			});
+
+			const importer = createPendingFileImporter(httpMock);
+			const details: { type?: string } = {};
+
+			try {
+				await (importer as any).downloadFile('https://example.com/file.png', details);
+				expect.fail('Should have thrown an error');
+			} catch (err: any) {
+				expect(err.message).to.include('Unexpected response status 302');
+			}
+		});
+
+		it('should reject on 404 status code', async () => {
+			const httpMock = createMockHttpModule(() => {
+				const res = new MockIncomingMessage(404);
+				return res;
+			});
+
+			const importer = createPendingFileImporter(httpMock);
+			const details: { type?: string } = {};
+
+			try {
+				await (importer as any).downloadFile('https://example.com/file.png', details);
+				expect.fail('Should have thrown an error');
+			} catch (err: any) {
+				expect(err.message).to.include('Unexpected response status 404');
+			}
+		});
+
+		it('should reject on 500 server error', async () => {
+			const httpMock = createMockHttpModule(() => {
+				const res = new MockIncomingMessage(500);
+				return res;
+			});
+
+			const importer = createPendingFileImporter(httpMock);
+			const details: { type?: string } = {};
+
+			try {
+				await (importer as any).downloadFile('https://example.com/file.png', details);
+				expect.fail('Should have thrown an error');
+			} catch (err: any) {
+				expect(err.message).to.include('Unexpected response status 500');
+			}
+		});
+
+		it('should reject on connection errors', async () => {
+			const httpMock = createMockHttpModule(
+				() => new MockIncomingMessage(200),
+				true, // errorOnConnect
+			);
+
+			const importer = createPendingFileImporter(httpMock);
+			const details: { type?: string } = {};
+
+			try {
+				await (importer as any).downloadFile('https://example.com/file.png', details);
+				expect.fail('Should have thrown an error');
+			} catch (err: any) {
+				expect(err.message).to.equal('Connection refused');
+			}
+		});
+
+		it('should reject on stream errors during download', async () => {
+			const httpMock = createMockHttpModule(() => {
+				const res = new MockIncomingMessage(200, { 'content-type': 'image/png' });
+				setImmediate(() => {
+					res.emit('data', Buffer.from('partial'));
+					res.emit('error', new Error('Stream error'));
+				});
+				return res;
+			});
+
+			const importer = createPendingFileImporter(httpMock);
+			const details: { type?: string } = {};
+
+			try {
+				await (importer as any).downloadFile('https://example.com/file.png', details);
+				expect.fail('Should have thrown an error');
+			} catch (err: any) {
+				expect(err.message).to.equal('Stream error');
+			}
+		});
+
+		it('should not set content-type if details already has a type', async () => {
+			const responseData = Buffer.from('file content');
+			const httpMock = createMockHttpModule(() => {
+				const res = new MockIncomingMessage(200, { 'content-type': 'text/html' });
+				setImmediate(() => {
+					res.emit('data', responseData);
+					res.emit('end');
+				});
+				return res;
+			});
+
+			const importer = createPendingFileImporter(httpMock);
+			const details: { type?: string } = { type: 'image/png' };
+
+			await (importer as any).downloadFile('https://example.com/file.png', details);
+
+			expect(details.type).to.equal('image/png');
+		});
+
+		it('should handle responses with undefined statusCode', async () => {
+			const httpMock = createMockHttpModule(() => {
+				const res = new MockIncomingMessage(undefined as any);
+				return res;
+			});
+
+			const importer = createPendingFileImporter(httpMock);
+			const details: { type?: string } = {};
+
+			try {
+				await (importer as any).downloadFile('https://example.com/file.png', details);
+				expect.fail('Should have thrown an error');
+			} catch (err: any) {
+				expect(err.message).to.include('Unexpected response status');
+			}
+		});
+
+		it('should accept status code 201', async () => {
+			const responseData = Buffer.from('created');
+			const httpMock = createMockHttpModule(() => {
+				const res = new MockIncomingMessage(201);
+				setImmediate(() => {
+					res.emit('data', responseData);
+					res.emit('end');
+				});
+				return res;
+			});
+
+			const importer = createPendingFileImporter(httpMock);
+			const details: { type?: string } = {};
+
+			const result = await (importer as any).downloadFile('https://example.com/file.png', details);
+			expect(result).to.deep.equal(responseData);
+		});
+	});
+
+	describe('getMessageAttachment', () => {
+		let importer: any;
+
+		beforeEach(() => {
+			const httpMock = createMockHttpModule(() => new MockIncomingMessage(200));
+			importer = createPendingFileImporter(httpMock);
+		});
+
+		it('should create image attachment for image types', () => {
+			const file = { _id: 'file-1', name: 'image.png', type: 'image/png', size: 1024 };
+			const url = '/file-upload/file-1/image.png';
+
+			const attachment = importer.getMessageAttachment(file, url);
+
+			expect(attachment).to.deep.equal({
+				title: 'image.png',
+				title_link: url,
+				image_url: url,
+				image_type: 'image/png',
+				image_size: 1024,
+				image_dimensions: undefined,
+			});
+		});
+
+		it('should create audio attachment for audio types', () => {
+			const file = { _id: 'file-1', name: 'audio.mp3', type: 'audio/mpeg', size: 2048 };
+			const url = '/file-upload/file-1/audio.mp3';
+
+			const attachment = importer.getMessageAttachment(file, url);
+
+			expect(attachment).to.deep.equal({
+				title: 'audio.mp3',
+				title_link: url,
+				audio_url: url,
+				audio_type: 'audio/mpeg',
+				audio_size: 2048,
+			});
+		});
+
+		it('should create video attachment for video types', () => {
+			const file = { _id: 'file-1', name: 'video.mp4', type: 'video/mp4', size: 4096 };
+			const url = '/file-upload/file-1/video.mp4';
+
+			const attachment = importer.getMessageAttachment(file, url);
+
+			expect(attachment).to.deep.equal({
+				title: 'video.mp4',
+				title_link: url,
+				video_url: url,
+				video_type: 'video/mp4',
+				video_size: 4096,
+			});
+		});
+
+		it('should create generic attachment for other types', () => {
+			const file = { _id: 'file-1', name: 'doc.pdf', type: 'application/pdf', size: 8192 };
+			const url = '/file-upload/file-1/doc.pdf';
+
+			const attachment = importer.getMessageAttachment(file, url);
+
+			expect(attachment).to.deep.equal({
+				title: 'doc.pdf',
+				title_link: url,
+			});
+		});
+
+		it('should create generic attachment for files without type', () => {
+			const file = { _id: 'file-1', name: 'unknown', size: 512 };
+			const url = '/file-upload/file-1/unknown';
+
+			const attachment = importer.getMessageAttachment(file, url);
+
+			expect(attachment).to.deep.equal({
+				title: 'unknown',
+				title_link: url,
+			});
+		});
+	});
+});

--- a/apps/meteor/tests/unit/server/lib/import/SlackImporter.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/import/SlackImporter.spec.ts
@@ -1,0 +1,298 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+const addMessageStub = sinon.stub().resolves();
+const settingsStub = { get: sinon.stub() };
+
+const { SlackImporter } = proxyquire.noCallThru().load('../../../../../server/lib/import/slack/SlackImporter', {
+	'@rocket.chat/models': {
+		'Messages': { find: sinon.stub().returns({ toArray: () => [] }) },
+		'Settings': { findOneById: sinon.stub().resolves(null) },
+		'ImportData': {},
+		'@global': true,
+	},
+	'..': {
+		Importer: class MockImporter {
+			logger = { debug: sinon.stub(), error: sinon.stub(), info: sinon.stub(), warn: sinon.stub() };
+
+			progress = { count: { total: 0 } };
+
+			converter = {
+				addMessage: addMessageStub,
+				addUser: sinon.stub().resolves(),
+				addChannel: sinon.stub().resolves(),
+			};
+
+			_useUpsert = false;
+
+			reportProgress() {
+				// no-op
+			}
+
+			async updateProgress() {
+				// no-op
+			}
+
+			async updateRecord() {
+				// no-op
+			}
+
+			getProgress() {
+				return this.progress;
+			}
+		},
+		ProgressStep: {
+			PREPARING_STARTED: 'preparing_started',
+			IMPORTING_USERS: 'importing_users',
+			IMPORTING_CHANNELS: 'importing_channels',
+			IMPORTING_MESSAGES: 'importing_messages',
+			DONE: 'done',
+			ERROR: 'error',
+		},
+		ImporterWebsocket: { progressUpdated: sinon.stub() },
+	},
+	'../../../../app/lib/server/lib/notifyListener': { notifyOnSettingChanged: sinon.stub() },
+	'../../../../app/mentions/lib/MentionsParser': {
+		MentionsParser: class {
+			getUserMentions() {
+				return [];
+			}
+
+			getChannelMentions() {
+				return [];
+			}
+		},
+	},
+	'../../../../app/settings/server': { settings: settingsStub },
+	'../../../../app/utils/server/getUserAvatarURL': { getUserAvatarURL: sinon.stub().returns('/avatar/user') },
+});
+
+describe('SlackImporter', () => {
+	let importer: any;
+
+	beforeEach(() => {
+		addMessageStub.reset();
+		settingsStub.get.reset();
+
+		const info = { key: 'slack', name: 'Slack' };
+		const importRecord = { _id: 'test-import' };
+		importer = new SlackImporter(info, importRecord, {});
+	});
+
+	describe('processMessageSubType - file_share', () => {
+		it('should create hidden file message with empty msg for file_share subtype', async () => {
+			const message = {
+				type: 'message',
+				subtype: 'file_share',
+				ts: '1234567890.000001',
+				user: 'U12345',
+				file: {
+					id: 'F12345',
+					name: 'test.png',
+					url_private_download: 'https://files.slack.com/files/F12345/test.png?token=xoxe-123',
+					size: 1024,
+					is_external: false,
+				},
+			};
+
+			const slackChannelId = 'C12345';
+			const newMessage = {
+				_id: 'slack-C12345-1234567890-000001',
+				rid: slackChannelId,
+				ts: new Date(1234567890000),
+				msg: '',
+				u: { _id: 'U12345' },
+			};
+
+			await importer.processMessageSubType(message, slackChannelId, newMessage, {});
+
+			expect(addMessageStub.calledOnce).to.be.true;
+
+			const fileMessage = addMessageStub.firstCall.args[0];
+			expect(fileMessage._hidden).to.equal(true);
+			expect(fileMessage.msg).to.equal('');
+			expect(fileMessage._importFile).to.exist;
+			expect(fileMessage._importFile.downloadUrl).to.equal('https://files.slack.com/files/F12345/test.png?token=xoxe-123');
+		});
+
+		it('should not create file message if file has no download URL', async () => {
+			const message = {
+				type: 'message',
+				subtype: 'file_share',
+				ts: '1234567890.000001',
+				user: 'U12345',
+				file: {
+					id: 'F12345',
+					name: 'test.png',
+					size: 1024,
+				},
+			};
+
+			const slackChannelId = 'C12345';
+			const newMessage = {
+				_id: 'slack-C12345-1234567890-000001',
+				rid: slackChannelId,
+				ts: new Date(1234567890000),
+				msg: '',
+				u: { _id: 'U12345' },
+			};
+
+			await importer.processMessageSubType(message, slackChannelId, newMessage, {});
+
+			expect(addMessageStub.called).to.be.false;
+		});
+
+		it('should include thread message id if file is shared in a thread', async () => {
+			const message = {
+				type: 'message',
+				subtype: 'file_share',
+				ts: '1234567890.000002',
+				thread_ts: '1234567890.000001',
+				user: 'U12345',
+				file: {
+					id: 'F12345',
+					name: 'test.png',
+					url_private_download: 'https://files.slack.com/files/F12345/test.png',
+					size: 1024,
+				},
+			};
+
+			const slackChannelId = 'C12345';
+			const newMessage = {
+				_id: 'slack-C12345-1234567890-000002',
+				rid: slackChannelId,
+				ts: new Date(1234567890000),
+				msg: '',
+				u: { _id: 'U12345' },
+			};
+
+			await importer.processMessageSubType(message, slackChannelId, newMessage, {});
+
+			expect(addMessageStub.calledOnce).to.be.true;
+
+			const fileMessage = addMessageStub.firstCall.args[0];
+			expect(fileMessage.tmid).to.equal('slack-C12345-1234567890-000001');
+			expect(fileMessage._hidden).to.equal(true);
+		});
+	});
+
+	describe('prepareMessageObject - messages with files', () => {
+		it('should create hidden file messages for messages with files array', async () => {
+			const message = {
+				type: 'message',
+				ts: '1234567890.000001',
+				user: 'U12345',
+				text: 'Check out these files',
+				files: [
+					{
+						id: 'F12345',
+						name: 'image1.png',
+						url_private_download: 'https://files.slack.com/files/F12345/image1.png',
+						size: 1024,
+					},
+					{
+						id: 'F12346',
+						name: 'image2.png',
+						url_private_download: 'https://files.slack.com/files/F12346/image2.png',
+						size: 2048,
+					},
+				],
+			};
+
+			const slackChannelId = 'C12345';
+
+			await importer.prepareMessageObject(message, {}, slackChannelId);
+
+			const fileMessages = addMessageStub.getCalls().filter((call: any) => call.args[0]._importFile);
+			expect(fileMessages.length).to.equal(2);
+
+			fileMessages.forEach((call: any) => {
+				const fileMessage = call.args[0];
+				expect(fileMessage._hidden).to.equal(true);
+				expect(fileMessage.msg).to.equal('');
+				expect(fileMessage._importFile).to.exist;
+			});
+		});
+
+		it('should create unique file message IDs for multiple files', async () => {
+			const message = {
+				type: 'message',
+				ts: '1234567890.000001',
+				user: 'U12345',
+				text: 'Multiple files',
+				files: [
+					{ id: 'F1', name: 'file1.png', url_private_download: 'https://files.slack.com/F1', size: 100 },
+					{ id: 'F2', name: 'file2.png', url_private_download: 'https://files.slack.com/F2', size: 200 },
+				],
+			};
+
+			await importer.prepareMessageObject(message, {}, 'C12345');
+
+			const fileMessages = addMessageStub.getCalls().filter((call: any) => call.args[0]._importFile);
+			const ids = fileMessages.map((call: any) => call.args[0]._id);
+
+			expect(ids[0]).to.include('-file1');
+			expect(ids[1]).to.include('-file2');
+			expect(ids[0]).to.not.equal(ids[1]);
+		});
+	});
+
+	describe('convertSlackFileToPendingFile', () => {
+		it('should convert Slack file to pending file format', () => {
+			const slackFile = {
+				id: 'F12345',
+				name: 'document.pdf',
+				url_private_download: 'https://files.slack.com/files/F12345/document.pdf?token=xoxe-abc',
+				size: 4096,
+				is_external: false,
+				mimetype: 'application/pdf',
+			};
+
+			const pendingFile = importer.convertSlackFileToPendingFile(slackFile);
+
+			expect(pendingFile.id).to.equal('F12345');
+			expect(pendingFile.name).to.equal('document.pdf');
+			expect(pendingFile.downloadUrl).to.equal('https://files.slack.com/files/F12345/document.pdf?token=xoxe-abc');
+			expect(pendingFile.size).to.equal(4096);
+			expect(pendingFile.external).to.equal(false);
+			expect(pendingFile.source).to.equal('slack');
+			expect(pendingFile.original).to.deep.include(slackFile);
+		});
+
+		it('should handle external files', () => {
+			const slackFile = {
+				id: 'F99999',
+				name: 'external.pdf',
+				url_private_download: 'https://external.com/file.pdf',
+				size: 1000,
+				is_external: true,
+			};
+
+			const pendingFile = importer.convertSlackFileToPendingFile(slackFile);
+
+			expect(pendingFile.external).to.equal(true);
+		});
+	});
+
+	describe('makeSlackMessageId', () => {
+		it('should generate base message ID without file index', () => {
+			const id = importer.makeSlackMessageId('C12345', '1234567890.000001');
+
+			expect(id).to.equal('slack-C12345-1234567890-000001');
+		});
+
+		it('should generate message ID with file index', () => {
+			const id = importer.makeSlackMessageId('C12345', '1234567890.000001', '1');
+
+			expect(id).to.equal('slack-C12345-1234567890-000001-file1');
+		});
+
+		it('should replace dots with dashes in timestamp', () => {
+			const id = importer.makeSlackMessageId('CHANNEL', '123.456.789');
+
+			expect(id).to.equal('slack-CHANNEL-123-456-789');
+		});
+	});
+});

--- a/apps/meteor/tests/unit/server/lib/import/messageConverter.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/import/messageConverter.spec.ts
@@ -103,6 +103,55 @@ describe('Message Converter', () => {
 		});
 
 		// #TODO: Validate all message attributes
+
+		it('should include _hidden field when present', async () => {
+			const converter = new MessageConverter({ workInMemory: true });
+
+			const hiddenMessage = {
+				...messageToImport,
+				_hidden: true,
+			};
+
+			const converted = await converter.buildMessageObject(hiddenMessage, 'general', { _id: 'rocket.cat', username: 'rocket.cat' });
+
+			expect(converted).to.have.property('_hidden', true);
+		});
+
+		it('should include _importFile field when present', async () => {
+			const converter = new MessageConverter({ workInMemory: true });
+
+			const importFile = {
+				id: 'F12345',
+				name: 'test.png',
+				downloadUrl: 'https://files.slack.com/F12345/test.png',
+				size: 1024,
+				source: 'slack',
+			};
+
+			const fileMessage = {
+				...messageToImport,
+				_hidden: true,
+				msg: '',
+				_importFile: importFile,
+			};
+
+			const converted = await converter.buildMessageObject(fileMessage, 'general', { _id: 'rocket.cat', username: 'rocket.cat' });
+
+			expect(converted).to.have.property('_hidden', true);
+			expect(converted).to.have.property('msg', '');
+			expect(converted).to.have.property('_importFile').that.deep.includes({
+				id: 'F12345',
+				name: 'test.png',
+			});
+		});
+
+		it('should not include _hidden field when not present or false', async () => {
+			const converter = new MessageConverter({ workInMemory: true });
+
+			const converted = await converter.buildMessageObject(messageToImport, 'general', { _id: 'rocket.cat', username: 'rocket.cat' });
+
+			expect(converted).to.not.have.property('_hidden');
+		});
 	});
 
 	describe('callbacks', () => {

--- a/packages/core-typings/src/import/IImportMessage.ts
+++ b/packages/core-typings/src/import/IImportMessage.ts
@@ -48,4 +48,5 @@ export interface IImportMessage {
 
 	url?: string;
 	_importFile?: IImportPendingFile;
+	_hidden?: boolean;
 }

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -610,6 +610,7 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 
 		return this.updateMany(query, {
 			$set: {
+				'_hidden': false,
 				'_importFile.rocketChatUrl': rocketChatUrl,
 				'_importFile.downloaded': true,
 			},


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

When importing a Slack workspace export, shared files were left as **raw `files.slack.com` URLs in the message body** instead of proper attachments. A Slack export contains no file bytes — only links with a self-authenticating token — and the *Download Pending Files* pass already downloads them correctly, but:

1. The importer wrote `url_private_download` into `msg` and never cleared it — files rendered as links even after a successful download.
2. The download worker never checked the HTTP status — an invalidated link (token revoked in Slack / source deleted) returns a `302` to an HTML page, which was **silently saved as the file** and marked downloaded.
3. Failures were mis-accounted: stream errors counted as *completed*, and connection errors had no handler at all — an unhandled `'error'` event, which crashes the process.

**Changes** — imported file messages now follow a simple lifecycle:

1. **On import** — `SlackImporter` creates each file message **hidden** (`_hidden: true`, empty `msg`): it exists in the database, with the download URL kept in `_importFile.downloadUrl`, but nothing is displayed in the room yet.
2. **When the download succeeds** — `PendingFileImporter` stores the upload, builds a native attachment (reusing `parseFileIntoMessageAttachments`, so images get real thumbnails/previews), and sets `_hidden: false` — the message is revealed and displays as a normal file message.
3. **When the download fails** — the message simply stays hidden and pending, and the failure is counted as an **error** (previously it was counted as *completed*). Nothing broken ever appears in the room, and re-running *Download Pending Files* retries it.

Supporting changes: `_hidden` threaded through `IImportMessage`/`MessageConverter`; the download itself extracted into a promise-based `downloadFile()` helper that rejects non-2xx responses (an invalidated link is discarded instead of saved as an HTML file) and connection/stream errors (previously an unhandled `'error'` event — a process crash), keeping the pre-existing chunked download and progress reporting.

## Issue(s)

- [CORE-2044](https://rocketchat.atlassian.net/browse/CORE-2044)

## Steps to test or reproduce

Verified end-to-end with a real Slack workspace: files/videos/images shared in channels, workspace exported, zip imported into Rocket.Chat.

**Happy path:**
1. Share files/videos/images in a Slack workspace and generate a workspace export (`.zip`).
2. Import it via **Manage > Workspace > Import > Slack**, then click **Download Pending Files** (required — file messages stay hidden until it runs).
3. Open the channel (join it — file access can be restricted to room members): files render inline with previews, no raw URLs. In the DB: `msg: ''`, `_hidden: false`, attachment with `image_url`/`video_url`, `_importFile.downloaded: true`.

<img width="871" height="953" alt="image" src="https://github.com/user-attachments/assets/6f9b836c-bb46-48db-b247-5814145cc982" />

**Failure path (revoked token):**
1. Revoke the export's access on Slack's admin page (or corrupt every `token=xoxe-...` in the export JSON and re-zip).
2. Reset the previous import:
   ```js
   db.rocketchat_message.deleteMany({ _id: /^slack-/ })
   db.rocketchat_uploads.deleteMany({ message_id: /^slack-/ })
   db.rocketchat_import_data.deleteMany({})
   db.rocketchat_import.deleteMany({})
   ```
3. Re-import and click **Download Pending Files**.
4. Expected: text messages import normally, but **the files don't appear at all** — no broken attachments, no raw URLs, no empty lines (see screenshot). No `text/html` upload is saved; downloads are reported as **errors** and stay pending, so retrying with a fresh export recovers them. Previously this silently stored the HTML page as the file and reported success.

<img width="882" height="427" alt="image" src="https://github.com/user-attachments/assets/6b1e12ed-b102-42fa-b1e4-bf6142e6dbbe" />

## Further comments

**Follow-ups identified (not in this PR):**
- **Auto-start the download when the import finishes** + a Slack note on the import screen — the manual, unexplained *Download Pending Files* step is what confused the original reporter (prototype works; separate PR).
- **Docs update** — [Import from Slack](https://docs.rocket.chat/docs/import-from-slack) currently doesn't cover file handling at all. It must explain:
  - a Slack export contains **links only** (no file bytes), and *Download Pending Files* is a **required step** to fetch them;
  - **how Slack handles these links**: every file URL in an export embeds a self-authenticating token, which the workspace admin can **revoke and resume from Slack's admin panel**. The token has **no automatic expiry** — links stay valid for as long as they are live, i.e. until the admin revokes them or the source file/channel/workspace is deleted;
  - because of that — and **contrary to what the task refinement suggested** — **no Slack API token or authentication support is needed** in the importer: the export URLs authenticate themselves.


[CORE-2044]: https://rocketchat.atlassian.net/browse/CORE-2044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack imports for shared files.
  * Imported file messages remain hidden until files are downloaded.
  * Downloaded files now appear as native attachments, including image previews.
  * Failed downloads are recorded correctly and marked for retry instead of being saved as invalid file content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->