### PR TITLE
chore: split composer API and reintroduce RichTextComposerAPI

### DIFF
--- a/apps/meteor/app/ui-message/client/messageBox/createComposerAPI.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/createComposerAPI.ts
@@ -1,14 +1,8 @@
-import type { IMessage } from '@rocket.chat/core-typings';
-import { Emitter } from '@rocket.chat/emitter';
 import type { RefObject } from 'react';
 
+import { createComposerAPICore, triggerEvent, type SetText } from './createComposerAPICore';
 import { limitQuoteChain } from './limitQuoteChain';
-import type { FormattingButton } from './messageBoxFormatting';
-import { formattingButtons } from './messageBoxFormatting';
 import type { ComposerAPI } from '../../../../client/lib/chats/ChatAPI';
-import { createUploadsAPI } from '../../../../client/lib/chats/uploads';
-import { settings } from '../../../../client/lib/settings';
-import { withDebouncing } from '../../../../lib/utils/highOrderFunctions';
 
 export const createComposerAPI = (
 	input: HTMLTextAreaElement,
@@ -18,47 +12,11 @@ export const createComposerAPI = (
 	composerRef: RefObject<HTMLElement | null>,
 	{ rid, tmid }: { rid: string; tmid?: string },
 ): ComposerAPI => {
-	const triggerEvent = (input: HTMLTextAreaElement, evt: string): void => {
-		const event = new Event(evt, { bubbles: true });
-		// TODO: Remove this hack for react to trigger onChange
-		const tracker = (input as any)._valueTracker;
-		if (tracker) {
-			tracker.setValue(new Date().toString());
-		}
-		input.dispatchEvent(event);
+	const focus = (): void => {
+		input.focus();
 	};
 
-	const emitter = new Emitter<{
-		quotedMessagesUpdate: void;
-		editing: void;
-		recording: void;
-		recordingVideo: void;
-		formatting: void;
-		mircophoneDenied: void;
-	}>();
-
-	let _quotedMessages: IMessage[] = [];
-
-	const persist = withDebouncing({ wait: 300 })(() => {
-		persistDraft(input.value);
-	});
-
-	const notifyQuotedMessagesUpdate = (): void => {
-		emitter.emit('quotedMessagesUpdate');
-	};
-
-	const setText = (
-		text: string,
-		{
-			selection,
-			skipFocus,
-		}: {
-			selection?:
-				| { readonly start?: number; readonly end?: number }
-				| ((previous: { readonly start: number; readonly end: number }) => { readonly start?: number; readonly end?: number });
-			skipFocus?: boolean;
-		} = {},
-	): void => {
+	const setText: SetText = (text, { selection, skipFocus } = {}) => {
 		!skipFocus && focus();
 
 		const { selectionStart, selectionEnd } = input;
@@ -86,141 +44,18 @@ export const createComposerAPI = (
 		!skipFocus && focus();
 	};
 
-	const insertText = (text: string): void => {
-		setText(text, {
-			selection: ({ start, end }) => ({
-				start: start + text.length,
-				end: end + text.length,
-			}),
-		});
-	};
+	const core = createComposerAPICore({
+		input,
+		composerRef,
+		room: { rid, tmid },
+		initialValue: initialDraft,
+		save: () => persistDraft(input.value),
+		setText,
+		focus,
+		prepareQuotedMessage: (message) => limitQuoteChain(message, quoteChainLimit),
+	});
 
-	const clear = (): void => {
-		setText('');
-	};
-
-	const focus = (): void => {
-		input.focus();
-	};
-
-	const replyWith = async (text: string): Promise<void> => {
-		if (input) {
-			input.value = text;
-			input.focus();
-		}
-	};
-
-	const quoteMessage = async (message: IMessage): Promise<void> => {
-		_quotedMessages = [..._quotedMessages.filter((_message) => _message._id !== message._id), limitQuoteChain(message, quoteChainLimit)];
-		notifyQuotedMessagesUpdate();
-		input.focus();
-	};
-
-	const dismissQuotedMessage = async (mid: IMessage['_id']): Promise<void> => {
-		_quotedMessages = _quotedMessages.filter((message) => message._id !== mid);
-		notifyQuotedMessagesUpdate();
-	};
-
-	const dismissAllQuotedMessages = async (): Promise<void> => {
-		_quotedMessages = [];
-		notifyQuotedMessagesUpdate();
-	};
-
-	const quotedMessages = {
-		get: () => _quotedMessages,
-		subscribe: (callback: () => void) => emitter.on('quotedMessagesUpdate', callback),
-	};
-
-	const [editing, setEditing] = (() => {
-		let editing = false;
-
-		return [
-			{
-				get: () => editing,
-				subscribe: (callback: () => void) => emitter.on('editing', callback),
-			},
-			(value: boolean) => {
-				editing = value;
-				emitter.emit('editing');
-			},
-		];
-	})();
-
-	const [recording, setRecordingMode] = (() => {
-		let recording = false;
-
-		return [
-			{
-				get: () => recording,
-				subscribe: (callback: () => void) => emitter.on('recording', callback),
-			},
-			(value: boolean) => {
-				recording = value;
-				emitter.emit('recording');
-			},
-		];
-	})();
-
-	const [recordingVideo, setRecordingVideo] = (() => {
-		let recordingVideo = false;
-
-		return [
-			{
-				get: () => recordingVideo,
-				subscribe: (callback: () => void) => emitter.on('recordingVideo', callback),
-			},
-			(value: boolean) => {
-				recordingVideo = value;
-				emitter.emit('recordingVideo');
-			},
-		];
-	})();
-
-	const [isMicrophoneDenied, setIsMicrophoneDenied] = (() => {
-		let isMicrophoneDenied = false;
-
-		return [
-			{
-				get: () => isMicrophoneDenied,
-				subscribe: (callback: () => void) => emitter.on('mircophoneDenied', callback),
-			},
-			(value: boolean) => {
-				isMicrophoneDenied = value;
-				emitter.emit('mircophoneDenied');
-			},
-		];
-	})();
-
-	const setEditingMode = (editing: boolean): void => {
-		setEditing(editing);
-	};
-
-	const [formatters, stopFormatterSubscription] = (() => {
-		let actions: FormattingButton[] = [];
-
-		const recompute = (): void => {
-			actions = formattingButtons.filter(({ condition }) => !condition || condition());
-			emitter.emit('formatting');
-		};
-		recompute();
-		// Coarse-grained: fires on every setting change, but the only condition()
-		// today is Katex_Enabled and the recompute is a cheap zustand read, so the
-		// extra work per unrelated setting change is negligible.
-		const stop = settings.observe('*', recompute);
-
-		return [
-			{
-				get: () => actions,
-				subscribe: (callback: () => void) => emitter.on('formatting', callback),
-			},
-			stop,
-		];
-	})();
-
-	const release = (): void => {
-		input.removeEventListener('input', persist);
-		stopFormatterSubscription();
-	};
+	const { insertText } = core;
 
 	const wrapSelection = (pattern: string): { selectionStart: number; selectionEnd: number; value: string } => {
 		const { selectionEnd = input.value.length, selectionStart = 0 } = input;
@@ -278,14 +113,6 @@ export const createComposerAPI = (
 		};
 	};
 
-	const insertNewLine = (): void => insertText('\n');
-
-	setText(initialDraft, {
-		skipFocus: true,
-	});
-
-	input.addEventListener('input', persist);
-
 	// Gets the text that is connected to the cursor and replaces it with the given text
 	const replaceText = (text: string, selection: { readonly start: number; readonly end: number }): void => {
 		// Selects the text that is connected to the cursor
@@ -306,16 +133,22 @@ export const createComposerAPI = (
 		focus();
 	};
 
-	return {
-		composerRef,
-		replaceText,
-		insertNewLine,
-		blur: () => input.blur(),
+	const replyWith = async (text: string): Promise<void> => {
+		if (input) {
+			input.value = text;
+			input.focus();
+		}
+	};
 
+	return {
+		...core,
+		setText,
+		wrapSelection,
+		replaceText,
+		replyWith,
 		substring: (start: number, end?: number) => {
 			return input.value.substring(start, end);
 		},
-
 		getCursorPosition: () => {
 			return input.selectionStart;
 		},
@@ -329,8 +162,6 @@ export const createComposerAPI = (
 			input.selectionEnd = input.selectionStart;
 			focus();
 		},
-		release,
-		wrapSelection,
 		get text(): string {
 			return input.value;
 		},
@@ -340,25 +171,5 @@ export const createComposerAPI = (
 				end: input.selectionEnd,
 			};
 		},
-
-		editing,
-		setEditingMode,
-		recording,
-		setRecordingMode,
-		recordingVideo,
-		setRecordingVideo,
-		insertText,
-		setText,
-		clear,
-		focus,
-		replyWith,
-		quoteMessage,
-		dismissQuotedMessage,
-		dismissAllQuotedMessages,
-		quotedMessages,
-		formatters,
-		isMicrophoneDenied,
-		setIsMicrophoneDenied,
-		uploads: createUploadsAPI({ rid, tmid }),
 	};
 };

--- a/apps/meteor/app/ui-message/client/messageBox/createComposerAPICore.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/createComposerAPICore.ts
@@ -1,0 +1,253 @@
+import type { IMessage } from '@rocket.chat/core-typings';
+import { Emitter } from '@rocket.chat/emitter';
+import type { RefObject } from 'react';
+
+import type { FormattingButton } from './messageBoxFormatting';
+import { formattingButtons } from './messageBoxFormatting';
+import type { ComposerAPI } from '../../../../client/lib/chats/ChatAPI';
+import { createUploadsAPI } from '../../../../client/lib/chats/uploads';
+import { settings } from '../../../../client/lib/settings';
+import { withDebouncing } from '../../../../lib/utils/highOrderFunctions';
+
+export type SetText = (
+	text: string,
+	options?: {
+		selection?:
+			| { readonly start?: number; readonly end?: number }
+			| ((previous: { readonly start: number; readonly end: number }) => { readonly start?: number; readonly end?: number });
+		skipFocus?: boolean;
+	},
+) => void;
+
+export const triggerEvent = (input: HTMLElement, evt: string): void => {
+	const event = new Event(evt, { bubbles: true });
+	// TODO: Remove this hack for react to trigger onChange
+	const tracker = (input as any)._valueTracker;
+	if (tracker) {
+		tracker.setValue(new Date().toString());
+	}
+	input.dispatchEvent(event);
+};
+
+type ComposerAPICoreParams = {
+	input: HTMLElement;
+	composerRef: RefObject<HTMLElement | null>;
+	room: { rid: string; tmid?: string };
+	initialValue: string;
+	save: () => void;
+	setText: SetText;
+	focus: ComposerAPI['focus'];
+	prepareQuotedMessage?: (message: IMessage) => IMessage;
+};
+
+type ComposerAPICore = Pick<
+	ComposerAPI,
+	| 'release'
+	| 'insertText'
+	| 'insertNewLine'
+	| 'clear'
+	| 'focus'
+	| 'blur'
+	| 'quoteMessage'
+	| 'dismissQuotedMessage'
+	| 'dismissAllQuotedMessages'
+	| 'quotedMessages'
+	| 'setEditingMode'
+	| 'editing'
+	| 'setRecordingMode'
+	| 'recording'
+	| 'setRecordingVideo'
+	| 'recordingVideo'
+	| 'setIsMicrophoneDenied'
+	| 'isMicrophoneDenied'
+	| 'formatters'
+	| 'composerRef'
+	| 'uploads'
+>;
+
+export const createComposerAPICore = ({
+	input,
+	composerRef,
+	room: { rid, tmid },
+	initialValue,
+	save,
+	setText,
+	focus,
+	prepareQuotedMessage = (message) => message,
+}: ComposerAPICoreParams): ComposerAPICore => {
+	const emitter = new Emitter<{
+		quotedMessagesUpdate: void;
+		editing: void;
+		recording: void;
+		recordingVideo: void;
+		formatting: void;
+		mircophoneDenied: void;
+	}>();
+
+	let _quotedMessages: IMessage[] = [];
+
+	const persist = withDebouncing({ wait: 300 })(save);
+
+	const notifyQuotedMessagesUpdate = (): void => {
+		emitter.emit('quotedMessagesUpdate');
+	};
+
+	const insertText = (text: string): void => {
+		setText(text, {
+			selection: ({ start, end }) => ({
+				start: start + text.length,
+				end: end + text.length,
+			}),
+		});
+	};
+
+	const clear = (): void => {
+		setText('');
+	};
+
+	const insertNewLine = (): void => insertText('\n');
+
+	const blur = (): void => input.blur();
+
+	const quoteMessage = async (message: IMessage): Promise<void> => {
+		_quotedMessages = [..._quotedMessages.filter((_message) => _message._id !== message._id), prepareQuotedMessage(message)];
+		notifyQuotedMessagesUpdate();
+		input.focus();
+	};
+
+	const dismissQuotedMessage = async (mid: IMessage['_id']): Promise<void> => {
+		_quotedMessages = _quotedMessages.filter((message) => message._id !== mid);
+		notifyQuotedMessagesUpdate();
+	};
+
+	const dismissAllQuotedMessages = async (): Promise<void> => {
+		_quotedMessages = [];
+		notifyQuotedMessagesUpdate();
+	};
+
+	const quotedMessages = {
+		get: () => _quotedMessages,
+		subscribe: (callback: () => void) => emitter.on('quotedMessagesUpdate', callback),
+	};
+
+	const [editing, setEditing] = (() => {
+		let editing = false;
+
+		return [
+			{
+				get: () => editing,
+				subscribe: (callback: () => void) => emitter.on('editing', callback),
+			},
+			(value: boolean) => {
+				editing = value;
+				emitter.emit('editing');
+			},
+		] as const;
+	})();
+
+	const [recording, setRecordingMode] = (() => {
+		let recording = false;
+
+		return [
+			{
+				get: () => recording,
+				subscribe: (callback: () => void) => emitter.on('recording', callback),
+			},
+			(value: boolean) => {
+				recording = value;
+				emitter.emit('recording');
+			},
+		] as const;
+	})();
+
+	const [recordingVideo, setRecordingVideo] = (() => {
+		let recordingVideo = false;
+
+		return [
+			{
+				get: () => recordingVideo,
+				subscribe: (callback: () => void) => emitter.on('recordingVideo', callback),
+			},
+			(value: boolean) => {
+				recordingVideo = value;
+				emitter.emit('recordingVideo');
+			},
+		] as const;
+	})();
+
+	const [isMicrophoneDenied, setIsMicrophoneDenied] = (() => {
+		let isMicrophoneDenied = false;
+
+		return [
+			{
+				get: () => isMicrophoneDenied,
+				subscribe: (callback: () => void) => emitter.on('mircophoneDenied', callback),
+			},
+			(value: boolean) => {
+				isMicrophoneDenied = value;
+				emitter.emit('mircophoneDenied');
+			},
+		] as const;
+	})();
+
+	const setEditingMode = (editing: boolean): void => {
+		setEditing(editing);
+	};
+
+	const [formatters, stopFormatterSubscription] = (() => {
+		let actions: FormattingButton[] = [];
+
+		const recompute = (): void => {
+			actions = formattingButtons.filter(({ condition }) => !condition || condition());
+			emitter.emit('formatting');
+		};
+		recompute();
+		// Coarse-grained: fires on every setting change, but the only condition()
+		// today is Katex_Enabled and the recompute is a cheap zustand read, so the
+		// extra work per unrelated setting change is negligible.
+		const stop = settings.observe('*', recompute);
+
+		return [
+			{
+				get: () => actions,
+				subscribe: (callback: () => void) => emitter.on('formatting', callback),
+			},
+			stop,
+		] as const;
+	})();
+
+	const release = (): void => {
+		input.removeEventListener('input', persist);
+		stopFormatterSubscription();
+	};
+
+	setText(initialValue, {
+		skipFocus: true,
+	});
+
+	input.addEventListener('input', persist);
+
+	return {
+		release,
+		insertText,
+		insertNewLine,
+		clear,
+		focus,
+		blur,
+		quoteMessage,
+		dismissQuotedMessage,
+		dismissAllQuotedMessages,
+		quotedMessages,
+		setEditingMode,
+		editing,
+		setRecordingMode,
+		recording,
+		setRecordingVideo,
+		recordingVideo,
+		setIsMicrophoneDenied,
+		isMicrophoneDenied,
+		formatters,
+		composerRef,
+		uploads: createUploadsAPI({ rid, tmid }),
+	};
+};

--- a/apps/meteor/app/ui-message/client/messageBox/createRichTextComposerAPI.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/createRichTextComposerAPI.ts
@@ -1,18 +1,12 @@
-import type { IMessage } from '@rocket.chat/core-typings';
-import { Emitter } from '@rocket.chat/emitter';
 import type { Options } from '@rocket.chat/message-parser';
 import { escapeHTML } from '@rocket.chat/string-helpers';
 import { Accounts } from 'meteor/accounts-base';
 import type { RefObject } from 'react';
 
-import type { FormattingButton } from './messageBoxFormatting';
-import { formattingButtons } from './messageBoxFormatting';
+import { createComposerAPICore, triggerEvent, type SetText } from './createComposerAPICore';
 import { resolveComposerBox } from './messageStateHandler';
 import { getSelectionRange, setSelectionRange } from './selectionRange';
 import type { ComposerAPI } from '../../../../client/lib/chats/ChatAPI';
-import { createUploadsAPI } from '../../../../client/lib/chats/uploads';
-import { settings } from '../../../../client/lib/settings';
-import { withDebouncing } from '../../../../lib/utils/highOrderFunctions';
 
 export const createRichTextComposerAPI = (
 	input: HTMLDivElement,
@@ -21,58 +15,11 @@ export const createRichTextComposerAPI = (
 	composerRef: RefObject<HTMLElement | null>,
 	{ rid, tmid }: { rid: string; tmid?: string },
 ): ComposerAPI => {
-	const triggerEvent = (input: HTMLDivElement, evt: string): void => {
-		const event = new Event(evt, { bubbles: true });
-		// TODO: Remove this hack for react to trigger onChange
-		const tracker = (input as any)._valueTracker;
-		if (tracker) {
-			tracker.setValue(new Date().toString());
-		}
-		input.dispatchEvent(event);
+	const focus = (): void => {
+		input.focus();
 	};
 
-	const emitter = new Emitter<{
-		quotedMessagesUpdate: void;
-		editing: void;
-		recording: void;
-		recordingVideo: void;
-		formatting: void;
-		mircophoneDenied: void;
-	}>();
-
-	let _quotedMessages: IMessage[] = [];
-
-	const persist = withDebouncing({ wait: 300 })(() => {
-		// Store the value entirely as HTML with the DOM structure intact
-		if (input.innerHTML !== '<br>') {
-			Accounts.storageLocation.setItem(storageID, input.innerHTML);
-			return;
-		}
-
-		Accounts.storageLocation.removeItem(storageID);
-	});
-
-	const notifyQuotedMessagesUpdate = (): void => {
-		emitter.emit('quotedMessagesUpdate');
-	};
-
-	input.addEventListener('input', persist);
-	input.addEventListener('input', (event: Event) => {
-		resolveComposerBox(event, parseOptions);
-	});
-
-	const setText = (
-		text: string,
-		{
-			selection,
-			skipFocus,
-		}: {
-			selection?:
-				| { readonly start?: number; readonly end?: number }
-				| ((previous: { readonly start: number; readonly end: number }) => { readonly start?: number; readonly end?: number });
-			skipFocus?: boolean;
-		} = {},
-	): void => {
+	const setText: SetText = (text, { selection, skipFocus } = {}) => {
 		!skipFocus && focus();
 
 		// Use innerHTML to set the value in RichTextComposer instead of innerText
@@ -102,138 +49,29 @@ export const createRichTextComposerAPI = (
 		!skipFocus && focus();
 	};
 
-	const insertText = (text: string): void => {
-		setText(text, {
-			selection: ({ start, end }) => ({
-				start: start + text.length,
-				end: end + text.length,
-			}),
-		});
-	};
+	input.addEventListener('input', (event: Event) => {
+		resolveComposerBox(event, parseOptions);
+	});
 
-	const clear = (): void => {
-		setText('');
-	};
+	const core = createComposerAPICore({
+		input,
+		composerRef,
+		room: { rid, tmid },
+		initialValue: Accounts.storageLocation.getItem(storageID) ?? '',
+		save: () => {
+			// Store the value entirely as HTML with the DOM structure intact
+			if (input.innerHTML !== '<br>') {
+				Accounts.storageLocation.setItem(storageID, input.innerHTML);
+				return;
+			}
 
-	const focus = (): void => {
-		input.focus();
-	};
+			Accounts.storageLocation.removeItem(storageID);
+		},
+		setText,
+		focus,
+	});
 
-	const replyWith = async (text: string): Promise<void> => {
-		if (input) {
-			input.innerText = text;
-			input.focus();
-		}
-	};
-
-	const quoteMessage = async (message: IMessage): Promise<void> => {
-		_quotedMessages = [..._quotedMessages.filter((_message) => _message._id !== message._id), message];
-		notifyQuotedMessagesUpdate();
-		input.focus();
-	};
-
-	const dismissQuotedMessage = async (mid: IMessage['_id']): Promise<void> => {
-		_quotedMessages = _quotedMessages.filter((message) => message._id !== mid);
-		notifyQuotedMessagesUpdate();
-	};
-
-	const dismissAllQuotedMessages = async (): Promise<void> => {
-		_quotedMessages = [];
-		notifyQuotedMessagesUpdate();
-	};
-
-	const quotedMessages = {
-		get: () => _quotedMessages,
-		subscribe: (callback: () => void) => emitter.on('quotedMessagesUpdate', callback),
-	};
-
-	const [editing, setEditing] = (() => {
-		let editing = false;
-
-		return [
-			{
-				get: () => editing,
-				subscribe: (callback: () => void) => emitter.on('editing', callback),
-			},
-			(value: boolean) => {
-				editing = value;
-				emitter.emit('editing');
-			},
-		];
-	})();
-
-	const [recording, setRecordingMode] = (() => {
-		let recording = false;
-
-		return [
-			{
-				get: () => recording,
-				subscribe: (callback: () => void) => emitter.on('recording', callback),
-			},
-			(value: boolean) => {
-				recording = value;
-				emitter.emit('recording');
-			},
-		];
-	})();
-
-	const [recordingVideo, setRecordingVideo] = (() => {
-		let recordingVideo = false;
-
-		return [
-			{
-				get: () => recordingVideo,
-				subscribe: (callback: () => void) => emitter.on('recordingVideo', callback),
-			},
-			(value: boolean) => {
-				recordingVideo = value;
-				emitter.emit('recordingVideo');
-			},
-		];
-	})();
-
-	const [isMicrophoneDenied, setIsMicrophoneDenied] = (() => {
-		let isMicrophoneDenied = false;
-
-		return [
-			{
-				get: () => isMicrophoneDenied,
-				subscribe: (callback: () => void) => emitter.on('mircophoneDenied', callback),
-			},
-			(value: boolean) => {
-				isMicrophoneDenied = value;
-				emitter.emit('mircophoneDenied');
-			},
-		];
-	})();
-
-	const setEditingMode = (editing: boolean): void => {
-		setEditing(editing);
-	};
-
-	const [formatters, stopFormatterSubscription] = (() => {
-		let actions: FormattingButton[] = [];
-
-		const recompute = (): void => {
-			actions = formattingButtons.filter(({ condition }) => !condition || condition());
-			emitter.emit('formatting');
-		};
-		recompute();
-		const stop = settings.observe('*', recompute);
-
-		return [
-			{
-				get: () => actions,
-				subscribe: (callback: () => void) => emitter.on('formatting', callback),
-			},
-			stop,
-		];
-	})();
-
-	const release = (): void => {
-		input.removeEventListener('input', persist);
-		stopFormatterSubscription();
-	};
+	const { insertText } = core;
 
 	const wrapSelection = (pattern: string): { selectionStart: number; selectionEnd: number; value: string } => {
 		const { selectionStart, selectionEnd } = getSelectionRange(input);
@@ -299,12 +137,6 @@ export const createRichTextComposerAPI = (
 		return { selectionStart: newStart, selectionEnd: newEnd, value: input.innerText };
 	};
 
-	const insertNewLine = (): void => insertText('\n');
-
-	setText(Accounts.storageLocation.getItem(storageID) ?? '', {
-		skipFocus: true,
-	});
-
 	// Gets the text that is connected to the cursor and replaces it with the given text
 	const replaceText = (text: string, selection: { readonly start: number; readonly end: number }): void => {
 		const { selectionStart, selectionEnd } = getSelectionRange(input);
@@ -347,17 +179,24 @@ export const createRichTextComposerAPI = (
 		triggerEvent(input, 'change');
 	};
 
-	return {
-		replaceText,
-		insertNewLine,
-		blur: () => input.blur(),
+	const replyWith = async (text: string): Promise<void> => {
+		if (input) {
+			input.innerText = text;
+			input.focus();
+		}
+	};
 
+	return {
+		...core,
+		setText,
+		wrapSelection,
+		replaceText,
+		replyWith,
 		substring: (start: number, end?: number) => {
 			// Sanitize the innerText by reducing multiple instances of linebreaks
 			const cleanedInitText = input.innerText.replace(/\n{2,}/g, (match) => '\n'.repeat(match.length - 1));
 			return cleanedInitText.substring(start, end);
 		},
-
 		getCursorPosition: () => {
 			return getSelectionRange(input).selectionStart;
 		},
@@ -370,8 +209,6 @@ export const createRichTextComposerAPI = (
 			focus();
 			setSelectionRange(input, 0, 0);
 		},
-		release,
-		wrapSelection,
 		get text(): string {
 			return input.innerText;
 		},
@@ -382,26 +219,5 @@ export const createRichTextComposerAPI = (
 				end: selectionEnd,
 			};
 		},
-
-		editing,
-		setEditingMode,
-		recording,
-		setRecordingMode,
-		recordingVideo,
-		setRecordingVideo,
-		insertText,
-		setText,
-		clear,
-		focus,
-		replyWith,
-		quoteMessage,
-		dismissQuotedMessage,
-		dismissAllQuotedMessages,
-		quotedMessages,
-		formatters,
-		isMicrophoneDenied,
-		setIsMicrophoneDenied,
-		composerRef,
-		uploads: createUploadsAPI({ rid, tmid }),
 	};
 };


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

[RTC-4](https://rocketchat.atlassian.net/browse/RTC-4)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



[RTC-4]: https://rocketchat.atlassian.net/browse/RTC-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved message composer reliability when editing, inserting, replacing, and formatting text.
  * Enhanced draft persistence while composing messages.
  * Preserved quoting, replying, selection, and rich-text editing workflows across composer modes.
  * Improved handling of text updates so changes are consistently reflected in the composer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->