### PR TITLE
regression: URL preview embeds flicker on new messages/reactions (React 19 regression)

### DIFF
--- a/apps/meteor/client/components/message/content/urlPreviews/OEmbedHtmlPreview.tsx
+++ b/apps/meteor/client/components/message/content/urlPreviews/OEmbedHtmlPreview.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@rocket.chat/fuselage';
 import DOMPurify from 'dompurify';
+import { useMemo } from 'react';
 
 import OEmbedCollapsible from './OEmbedCollapsible';
 import type { OEmbedPreviewMetadata } from './OEmbedPreviewMetadata';
@@ -10,10 +11,14 @@ const purifyOptions = {
 	ALLOW_UNKNOWN_PROTOCOLS: true,
 };
 
-const OEmbedHtmlPreview = ({ html, ...props }: OEmbedPreviewMetadata) => (
-	<OEmbedCollapsible {...props}>
-		{html && <Box withRichContent dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html, purifyOptions) }} />}
-	</OEmbedCollapsible>
-);
+const OEmbedHtmlPreview = ({ html, ...props }: OEmbedPreviewMetadata) => {
+	// Memoize the dangerouslySetInnerHTML object so its identity is stable across
+	// re-renders. React 19 re-applies innerHTML when this object is a new reference
+	// (even with an identical string), which reloads embedded iframes (e.g. YouTube)
+	// on every re-render — visible as a flicker on new messages / reactions.
+	const dangerous = useMemo(() => (html ? { __html: DOMPurify.sanitize(html, purifyOptions) } : undefined), [html]);
+
+	return <OEmbedCollapsible {...props}>{dangerous && <Box withRichContent dangerouslySetInnerHTML={dangerous} />}</OEmbedCollapsible>;
+};
 
 export default OEmbedHtmlPreview;

--- a/apps/meteor/client/contexts/EmojiPickerContext.ts
+++ b/apps/meteor/client/contexts/EmojiPickerContext.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 
 import type { EmojiPickerItem, CategoriesIndexes } from '../../app/emoji/client';
 
@@ -33,11 +33,13 @@ const useEmojiPickerContext = (): EmojiPickerContextValue => {
 	return context;
 };
 
-export const useEmojiPicker = () => ({
-	open: useEmojiPickerContext().open,
-	isOpen: useEmojiPickerContext().isOpen,
-	close: useEmojiPickerContext().close,
-});
+export const useEmojiPicker = () => {
+	const { open, isOpen, close } = useEmojiPickerContext();
+	// Stable identity: consumers (e.g. ChatAPI.emojiPicker) use this as a memo
+	// dependency, so returning a fresh object each render invalidates them and
+	// cascades re-renders across the whole message list.
+	return useMemo(() => ({ open, isOpen, close }), [open, isOpen, close]);
+};
 
 export const usePreviewEmoji = () => ({
 	emojiToPreview: useEmojiPickerContext().emojiToPreview,

--- a/apps/meteor/client/providers/EmojiPickerProvider/EmojiPickerProvider.tsx
+++ b/apps/meteor/client/providers/EmojiPickerProvider/EmojiPickerProvider.tsx
@@ -80,6 +80,8 @@ const EmojiPickerProvider = ({ children }: EmojiPickerProviderProps) => {
 		return setEmojiPicker(<EmojiPicker reference={ref} onClose={() => setEmojiPicker(null)} onPickEmoji={(emoji) => callback(emoji)} />);
 	}, []);
 
+	const close = useCallback(() => setEmojiPicker(null), []);
+
 	const handlePreview = useCallback(
 		(emoji: string, name: string) =>
 			setEmojiToPreview((preview) => {
@@ -96,7 +98,7 @@ const EmojiPickerProvider = ({ children }: EmojiPickerProviderProps) => {
 	const contextValue = useMemo(
 		(): ContextType<typeof EmojiPickerContext> => ({
 			isOpen: emojiPicker !== null,
-			close: () => setEmojiPicker(null),
+			close,
 			open,
 			emojiToPreview,
 			handlePreview,
@@ -117,6 +119,7 @@ const EmojiPickerProvider = ({ children }: EmojiPickerProviderProps) => {
 		[
 			emojiPicker,
 			open,
+			close,
 			emojiToPreview,
 			addRecentEmoji,
 			emojiListByCategory,

--- a/apps/meteor/client/views/room/MessageList/hooks/useKeepMountedMessages.ts
+++ b/apps/meteor/client/views/room/MessageList/hooks/useKeepMountedMessages.ts
@@ -3,7 +3,12 @@ import type { IMessage } from '@rocket.chat/core-typings';
 export const useKeepMountedMessages = (messages: IMessage[], canPreview: boolean = false): number[] => {
 	const offset = canPreview ? 1 : 0;
 	return messages.reduce<number[]>((acc, message, index) => {
-		if (message.files?.length && message.files.length > 0) {
+		// Keep mounted anything with an embed that reloads when re-mounted: file
+		// attachments (audio/video players) and URL previews (e.g. YouTube iframes).
+		// Otherwise virtua recycles them on scroll-to-bottom (new message / reaction
+		// growing a message) and the iframe flickers.
+		const hasUrlPreview = message.urls?.some((url) => Object.keys(url.meta ?? {}).length > 0 || !!url.headers) ?? false;
+		if ((message.files?.length ?? 0) > 0 || hasUrlPreview) {
 			acc.push(index + offset);
 		}
 		return acc;


### PR DESCRIPTION
## Proposed changes (including videos, screenshots)

**Regression (React 19).** URL preview embeds (e.g. YouTube iframes) flicker/reload in the message list whenever a new message or a reaction arrives in the room.

### TL;DR — pre-existing problems made visible by React 19
The underlying inefficiencies already existed and were harmless-looking under React 18. React 19 changed how `dangerouslySetInnerHTML` is applied on update: a re-render with a **new object literal** now re-applies the `innerHTML` even when the string is identical (React 18 special-cased this prop and compared the `__html` string, skipping the write). Re-applying `innerHTML` destroys and recreates the embedded `<iframe>`, so what used to be an invisible wasted re-render now visibly reloads the embed. This PR fixes both the React-19-visible symptom and the latent causes behind it.

The behavior change comes from React DOM's move to commit-phase diffing — facebook/react [#26583](https://github.com/facebook/react/pull/26583) ("Diff properties in the commit phase instead of generating an update payload"). The old `diffProperties` compared `lastProp.__html !== nextProp.__html` (string); the new `updateProperties`/`setProp` compares each prop value by reference (`nextValue === prevValue`) and, for `dangerouslySetInnerHTML`, a fresh `{ __html }` object is never `===` the previous one, so it always writes `domElement.innerHTML`.

### Root cause
**1. Iframe reload on re-render (the React 19 behavior change).** `OEmbedHtmlPreview` passed a fresh `{ __html }` object on every render. Pre-19 this was a no-op (string compare); post-19 the reference compare re-applies `innerHTML` and reloads the iframe.

**2. Re-render storm (pre-existing).** A single reaction / new message re-rendered **every visible message**. Traced to `useEmojiPicker`, which returned a fresh object literal on every call; `ChatAPI` assigns it (`chat.emojiPicker = useEmojiPicker()`) each render, and `MessageListProvider` reads `chat?.emojiPicker` as a `useMemo` dependency. The churning reference rebuilt the `MessageListContext` value on unrelated updates, re-rendering every consumer (`memo` cannot guard against context changes). This wasted work already happened under React 18 — it was just invisible; React 19 turned each of those re-renders into an iframe reload. Confirmed via instrumentation: message object refs were unchanged, and the context value flipped only when the `emojiPicker` dependency changed. After the fix, a reaction re-renders only the changed message (1 vs ~40).

**3. Iframe remount on scroll (pre-existing).** The virtualized list (`virtua`) recycles/remounts items on scroll-to-bottom, and URL-preview messages were not covered by `keepMounted` (only file attachments were). A remount reloads the iframe on any React version — this path was already user-visible before React 19, on scroll.

### Fix
- `OEmbedHtmlPreview`: memoize the `dangerouslySetInnerHTML` object so its identity is stable across re-renders; React 19 then skips re-applying the `innerHTML`.
- `useEmojiPicker` / `EmojiPickerProvider`: memoize the returned object and stabilize `close`, so `chat.emojiPicker` stops churning and `MessageListContext` is no longer rebuilt on every unrelated update — killing the re-render storm at its source.
- `useKeepMountedMessages`: keep URL-preview messages mounted in the virtualized list (same treatment as file attachments), so `virtua` no longer recycles/remounts them on scroll.

## Issue(s)

Latent since the message-list virtualization (#40105) and the emoji-picker/context wiring; surfaced as a visible regression by the React 19 upgrade (#40796). Behavior change: facebook/react [#26583](https://github.com/facebook/react/pull/26583).

## Steps to test or reproduce

1. Open a room containing a YouTube (or other oembed) URL preview, visible in the viewport.
2. Send a new message, or add/remove a reaction on any message.
3. Before: the embed flickers/reloads, and every visible message re-renders. After: the embed stays put; only the changed message re-renders.

## Further comments

Draft — fixes verified locally with render instrumentation (reaction now re-renders 1 message instead of ~40). `MessageListProvider` still re-renders when the list changes (its `children` change), but its context value is now stable, so consumers no longer cascade — a separate, cheap container re-render left out of scope.

[ARCH-2195](https://rocketchat.atlassian.net/browse/ARCH-2195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)


https://rocketchat.atlassian.net/browse/CORE-2402

[ARCH-2195]: https://rocketchat.atlassian.net/browse/ARCH-2195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ