### PR TITLE
chore(streamer): defensively guard against a null session socket

### DIFF
--- a/apps/meteor/server/modules/streamer/streamer.module.ts
+++ b/apps/meteor/server/modules/streamer/streamer.module.ts
@@ -13,7 +13,9 @@ class StreamerCentralClass<N extends keyof StreamerEvents> extends EventEmitter 
 	}
 }
 
-type ActivePublication = IPublication & { _session: NonNullable<IPublication['_session']> };
+type ActivePublication = IPublication & {
+	_session: NonNullable<IPublication['_session']> & { socket: NonNullable<NonNullable<IPublication['_session']>['socket']> };
+};
 
 export const StreamerCentral = new StreamerCentralClass();
 
@@ -294,7 +296,9 @@ export abstract class Streamer<N extends keyof StreamerEvents> extends EventEmit
 	}
 
 	static isPublicationActive(publication: IPublication): publication is ActivePublication {
-		return !publication._isDeactivated();
+		// After Meteor 3.5 the socket can become null independently of session deactivation
+		// (e.g. right after a disconnection), so "active" must also mean the socket is still there.
+		return !publication._isDeactivated() && publication._session?.socket != null;
 	}
 
 	async sendToManySubscriptions(

--- a/apps/meteor/server/modules/streamer/types.ts
+++ b/apps/meteor/server/modules/streamer/types.ts
@@ -10,7 +10,7 @@ export interface IPublication {
 		userId: string | undefined;
 		socket: {
 			send: (payload: string) => void;
-		};
+		} | null;
 	} | null;
 	client: {
 		meteorClient: boolean;


### PR DESCRIPTION
## Proposed changes

Precautionary hardening of the streamer's active-publication check.

A publication's session socket can end up `null` **independently** of session
deactivation — e.g. right after a client disconnects, and now more easily after
any `await` in an emit handler. `Streamer.isPublicationActive()` only checked
`_isDeactivated()`, so a call site guarded by it could still reach
`_session.socket.send(...)` on a null socket and throw:

```
TypeError: Cannot read properties of null (reading 'send')
    at Stream.roomEvent (server/modules/notifications/notifications.module.ts:418)
```

This fires on `rooms-changed` / presence emits during normal activity (login,
room changes). The type previously claimed `socket` was always present, which
hid the possibility at compile time.

### Changes
- `streamer/types.ts`: mark `_session.socket` as nullable (reflects reality).
- `streamer/streamer.module.ts`: `isPublicationActive()` now also requires a live
  socket, and `ActivePublication` narrows `socket` to non-null. Every guarded send
  site (`notifications.module.ts`, `Presence.ts`) is therefore safe with no
  per-site changes.

### Why now
We hit this while validating a newer Node/Meteor runtime, where the socket goes
null more readily. The fix is runtime-agnostic and defensive — it only tightens
an existing guard, so it is safe to land on `develop` on its own ahead of that work.

## Testing
- Existing streamer/notification behaviour unchanged for live sockets.
- Removes the null-socket crash path on `rooms-changed` / presence emits.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2242]

[ARCH-2242]: https://rocketchat.atlassian.net/browse/ARCH-2242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved publication activity detection to correctly handle disconnected sessions.
  * Prevented inactive publications with missing session sockets from being treated as active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->