### PR TITLE
fix: type custom emoji list entries

### DIFF
--- a/.changeset/gentle-frogs-rest.md
+++ b/.changeset/gentle-frogs-rest.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/meteor": patch
+"@rocket.chat/core-typings": patch
+---
+
+fix: type custom emoji list entries

--- a/apps/meteor/app/emoji-custom/server/lib/uploadEmojiCustom.ts
+++ b/apps/meteor/app/emoji-custom/server/lib/uploadEmojiCustom.ts
@@ -41,11 +41,6 @@ export async function uploadEmojiCustomWithBuffer(
 		throw new Meteor.Error('not_authorized');
 	}
 
-	if (!Array.isArray(emojiData.aliases)) {
-		// delete aliases for notification purposes. here, it is a string or undefined rather than an array
-		delete emojiData.aliases;
-	}
-
 	emojiData.name = limax(emojiData.name, { replacement: '_' });
 
 	const file = await getFile(buffer, emojiData.extension);
@@ -73,7 +68,9 @@ export async function uploadEmojiCustomWithBuffer(
 		ws.on('end', async () => {
 			const etag = Random.hexString(6);
 			await EmojiCustom.setETagByName(emojiData.name, etag);
-			setTimeout(() => api.broadcast('emoji.updateCustom', { ...emojiData, etag }), 500);
+			// aliases may still be a raw comma-separated string here (deprecated method); only broadcast parsed arrays
+			const { aliases, ...restEmojiData } = emojiData;
+			setTimeout(() => api.broadcast('emoji.updateCustom', { ...restEmojiData, ...(Array.isArray(aliases) && { aliases }), etag }), 500);
 			resolve();
 		});
 

--- a/apps/meteor/app/emoji-native/lib/generateEmojiData.ts
+++ b/apps/meteor/app/emoji-native/lib/generateEmojiData.ts
@@ -23,7 +23,7 @@ export type EmojiEntry = {
 	uc_greedy: string;
 	shortnames: string[];
 	category: string;
-	emojiPackage: string;
+	emojiPackage: 'native';
 	unicode: string;
 };
 

--- a/apps/meteor/app/emoji/lib/rocketchat.ts
+++ b/apps/meteor/app/emoji/lib/rocketchat.ts
@@ -1,3 +1,4 @@
+import type { IEmoji } from '@rocket.chat/core-typings';
 import type { TranslationKey } from '@rocket.chat/ui-contexts';
 
 export type EmojiPackage = {
@@ -13,33 +14,48 @@ export type EmojiPackage = {
 	_regexp?: RegExp | null;
 };
 
+/** An emoji provided by a native (unicode) emoji package */
+export type NativeEmojiListEntry = {
+	category: string;
+	emojiPackage: 'native';
+	shortnames: string[];
+	uc_base: string;
+	uc_greedy: string;
+	uc_match: string;
+	uc_output: string;
+	aliases?: string[];
+	aliasOf?: undefined;
+	extension?: undefined;
+	etag?: undefined;
+	unicode?: string;
+};
+
+/** A custom emoji uploaded by an admin; overrides a native emoji with the same name */
+export type CustomEmojiListEntry = IEmoji & {
+	emojiPackage: 'emojiCustom';
+	aliasOf?: undefined;
+	shortnames?: undefined;
+	unicode?: undefined;
+};
+
+/** A shortname that resolves to another emoji */
+export type EmojiAliasListEntry = {
+	emojiPackage: 'emojiCustom';
+	aliasOf: string;
+	extension?: undefined;
+	aliases?: undefined;
+	shortnames?: undefined;
+	etag?: undefined;
+	unicode?: undefined;
+};
+
+export type EmojiListEntry = NativeEmojiListEntry | CustomEmojiListEntry | EmojiAliasListEntry;
+
 export type EmojiPackages = {
 	packages: {
 		[key: string]: EmojiPackage;
 	};
 	list: {
-		[key: keyof NonNullable<EmojiPackages['packages']>]:
-			| {
-					category: string;
-					emojiPackage: string;
-					shortnames: string[];
-					uc_base: string;
-					uc_greedy: string;
-					uc_match: string;
-					uc_output: string;
-					aliases?: string[];
-					aliasOf?: undefined;
-					extension?: string;
-					etag?: string;
-					unicode?: string;
-			  }
-			| {
-					emojiPackage: string;
-					aliasOf: string;
-					extension?: undefined;
-					aliases?: undefined;
-					shortnames?: undefined;
-					etag?: string;
-			  };
+		[key: string]: EmojiListEntry;
 	};
 };

--- a/apps/meteor/client/lib/customEmoji.ts
+++ b/apps/meteor/client/lib/customEmoji.ts
@@ -4,22 +4,13 @@ import { escapeRegExp } from '@rocket.chat/string-helpers';
 import { emoji, removeFromRecent, replaceEmojiInRecent } from '../../app/emoji/client';
 import { getURL } from '../../app/utils/client';
 
-const isSetNotNull = (fn: () => unknown) => {
-	let value;
-	try {
-		value = fn();
-	} catch (e) {
-		value = null;
-	}
-	return value !== null && value !== undefined;
-};
-
 export const updateEmojiCustom = (emojiData: IEmoji) => {
-	const previousExists = isSetNotNull(() => emojiData.previousName);
-	const currentAliases = isSetNotNull(() => emojiData.aliases);
+	const { previousName } = emojiData;
+	const previousExists = previousName !== null && previousName !== undefined;
+	const currentAliases = emojiData.aliases !== null && emojiData.aliases !== undefined;
 
-	if (previousExists && isSetNotNull(() => emoji.list[`:${emojiData.previousName}:`].aliases)) {
-		for (const alias of emoji.list[`:${emojiData.previousName}:`].aliases ?? []) {
+	if (previousExists && emoji.list[`:${previousName}:`]?.aliases != null) {
+		for (const alias of emoji.list[`:${previousName}:`].aliases ?? []) {
 			delete emoji.list[`:${alias}:`];
 			const aliasIndex = emoji.packages.emojiCustom.list?.indexOf(`:${alias}:`) ?? -1;
 			if (aliasIndex !== -1) {
@@ -28,16 +19,16 @@ export const updateEmojiCustom = (emojiData: IEmoji) => {
 		}
 	}
 
-	if (previousExists && emojiData.name !== emojiData.previousName) {
-		const arrayIndex = emoji.packages.emojiCustom.emojisByCategory.rocket.indexOf(emojiData.previousName);
+	if (previousExists && emojiData.name !== previousName) {
+		const arrayIndex = emoji.packages.emojiCustom.emojisByCategory.rocket.indexOf(previousName);
 		if (arrayIndex !== -1) {
 			emoji.packages.emojiCustom.emojisByCategory.rocket.splice(arrayIndex, 1);
 		}
-		const arrayIndexList = emoji.packages.emojiCustom.list?.indexOf(`:${emojiData.previousName}:`) ?? -1;
+		const arrayIndexList = emoji.packages.emojiCustom.list?.indexOf(`:${previousName}:`) ?? -1;
 		if (arrayIndexList !== -1) {
 			emoji.packages.emojiCustom.list?.splice(arrayIndexList, 1);
 		}
-		delete emoji.list[`:${emojiData.previousName}:`];
+		delete emoji.list[`:${previousName}:`];
 	}
 
 	const categoryIndex = emoji.packages.emojiCustom.emojisByCategory.rocket.indexOf(`${emojiData.name}`);
@@ -46,13 +37,12 @@ export const updateEmojiCustom = (emojiData: IEmoji) => {
 		emoji.packages.emojiCustom.list?.push(`:${emojiData.name}:`);
 	}
 	// Don't inherit fields from a native emoji being overridden (e.g. its unicode), or the pick would output the native emoji
-	// TODO: Fix the IEmoji type and standardize the emoji packs types
 	emoji.list[`:${emojiData.name}:`] = {
 		...emojiData,
 		emojiPackage: 'emojiCustom',
-	} as unknown as (typeof emoji.list)[keyof typeof emoji.list];
+	};
 	if (currentAliases) {
-		for (const alias of emojiData.aliases) {
+		for (const alias of emojiData.aliases ?? []) {
 			emoji.packages.emojiCustom.list?.push(`:${alias}:`);
 			emoji.list[`:${alias}:`] = {
 				emojiPackage: 'emojiCustom',
@@ -62,7 +52,7 @@ export const updateEmojiCustom = (emojiData: IEmoji) => {
 	}
 
 	if (previousExists) {
-		replaceEmojiInRecent({ oldEmoji: emojiData.previousName, newEmoji: emojiData.name });
+		replaceEmojiInRecent({ oldEmoji: previousName, newEmoji: emojiData.name });
 	}
 
 	emoji.dispatchUpdate();

--- a/apps/meteor/client/views/root/hooks/loggedIn/useCustomEmoji.ts
+++ b/apps/meteor/client/views/root/hooks/loggedIn/useCustomEmoji.ts
@@ -38,7 +38,7 @@ export const useCustomEmoji = () => {
 				for (const currentEmoji of customEmojis) {
 					emoji.packages.emojiCustom.emojisByCategory.rocket.push(currentEmoji.name);
 					emoji.packages.emojiCustom.list?.push(`:${currentEmoji.name}:`);
-					emoji.list[`:${currentEmoji.name}:`] = { ...currentEmoji, emojiPackage: 'emojiCustom' } as any;
+					emoji.list[`:${currentEmoji.name}:`] = { ...currentEmoji, emojiPackage: 'emojiCustom' };
 					for (const alias of currentEmoji.aliases) {
 						emoji.packages.emojiCustom.list?.push(`:${alias}:`);
 						emoji.list[`:${alias}:`] = {

--- a/packages/core-typings/src/IEmoji.ts
+++ b/packages/core-typings/src/IEmoji.ts
@@ -1,3 +1,12 @@
+/**
+ * Custom emoji data broadcast to clients through the `updateEmojiCustom` and
+ * `deleteEmojiCustom` notifications when a custom emoji changes.
+ */
 export interface IEmoji {
-	[x: string]: any;
+	name: string;
+	extension: string;
+	aliases?: string[];
+	etag?: string;
+	previousName?: string;
+	previousExtension?: string;
 }


### PR DESCRIPTION
## Summary
- Replace the loose `IEmoji` index signature with the custom emoji notification payload shape
- Add explicit native/custom/alias union types for `emoji.list`
- Remove unsafe casts from custom emoji client updates
- Avoid broadcasting deprecated raw alias strings for custom emoji uploads

## Validation
- `yarn turbo run build --filter=@rocket.chat/meteor...`
- `bash apps/meteor/packages/rocketchat-livechat/plugin/build.sh`
- `yarn workspace @rocket.chat/meteor typecheck`

Fixes #41265


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom emoji updates so renamed and alias changes properly clean up prior entries.
  * Prevented invalid alias values from being included in emoji update notifications.
  * Improved robustness when related emoji list entries are missing.

* **Refactor**
  * Strengthened typing for emoji list entries and custom emoji notification payloads, aligning types with actual returned values.
  * Removed unsafe type casts while keeping runtime behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->