### PR TITLE
fix(apps-engine): IUser used wrong federation type definition

### DIFF
--- a/.changeset/old-bats-sniff.md
+++ b/.changeset/old-bats-sniff.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/apps-engine': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes wrong FederationLookup type assigned to IUser in apps. The correct data is there, but the type does not represent it.

--- a/packages/apps-engine/src/definition/federation/FederationUserLookup.ts
+++ b/packages/apps-engine/src/definition/federation/FederationUserLookup.ts
@@ -1,0 +1,5 @@
+export type FederationUserLookup = {
+	version: number;
+	mui: string;
+	origin: string;
+};

--- a/packages/apps-engine/src/definition/federation/index.ts
+++ b/packages/apps-engine/src/definition/federation/index.ts
@@ -1,1 +1,2 @@
 export type * from './FederationLookup';
+export type * from './FederationUserLookup';

--- a/packages/apps-engine/src/definition/users/IUser.ts
+++ b/packages/apps-engine/src/definition/users/IUser.ts
@@ -1,4 +1,4 @@
-import type { FederationLookup } from '../federation';
+import type { FederationUserLookup } from '../federation';
 import type { IUserEmail } from './IUserEmail';
 import type { IUserSettings } from './IUserSettings';
 import type { UserStatusConnection } from './UserStatusConnection';
@@ -28,6 +28,6 @@ export interface IUser {
 	appId?: string;
 	sipExtension?: string;
 	isFederated?: boolean;
-	federation?: FederationLookup;
+	federation?: FederationUserLookup;
 	customFields?: { [key: string]: any };
 }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
The `IUser` defintion published in Apps-Engine version 1.64.0 has the wrong type for the `federation` property: it shares the `FederationLookup` type that `IRoom` uses, but the shape of the properties differ, `IUser.federation` has a `mui` property in core-typings, and `IRoom.federation` has a `mrid` property instead.

Here we're fixing that.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the federation lookup data type associated with user information.
  * Improved type accuracy for federation user details, including version, identifier, and origin fields.

* **Chores**
  * Added patch release notes for the affected application engine and platform packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->