### PR TITLE
fix(apps-engine): tighten types for TS7 (exception, uikit responder)

### DIFF
--- a/packages/apps-engine/src/definition/exceptions/AppsEngineException.ts
+++ b/packages/apps-engine/src/definition/exceptions/AppsEngineException.ts
@@ -16,11 +16,8 @@ export class AppsEngineException extends Error {
 
 	public static JSONRPC_ERROR_CODE = -32070;
 
-	public message: string;
-
 	constructor(message?: string) {
-		super();
-		this.message = message;
+		super(message);
 	}
 
 	public getErrorInfo() {

--- a/packages/apps-engine/src/definition/uikit/UIKitInteractionResponder.ts
+++ b/packages/apps-engine/src/definition/uikit/UIKitInteractionResponder.ts
@@ -28,7 +28,7 @@ export class UIKitInteractionResponder {
 
 		return {
 			success: true,
-			...formatModalInteraction(viewData, { appId, triggerId, type: UIKitInteractionType.MODAL_OPEN }),
+			...formatModalInteraction(viewData, { appId, triggerId: triggerId!, type: UIKitInteractionType.MODAL_OPEN }),
 		};
 	}
 
@@ -37,7 +37,7 @@ export class UIKitInteractionResponder {
 
 		return {
 			success: true,
-			...formatModalInteraction(viewData, { appId, triggerId, type: UIKitInteractionType.MODAL_UPDATE }),
+			...formatModalInteraction(viewData, { appId, triggerId: triggerId!, type: UIKitInteractionType.MODAL_UPDATE }),
 		};
 	}
 
@@ -46,7 +46,7 @@ export class UIKitInteractionResponder {
 
 		return {
 			success: true,
-			...formatContextualBarInteraction(viewData, { appId, triggerId, type: UIKitInteractionType.CONTEXTUAL_BAR_OPEN }),
+			...formatContextualBarInteraction(viewData, { appId, triggerId: triggerId!, type: UIKitInteractionType.CONTEXTUAL_BAR_OPEN }),
 		};
 	}
 
@@ -55,7 +55,7 @@ export class UIKitInteractionResponder {
 
 		return {
 			success: true,
-			...formatContextualBarInteraction(viewData, { appId, triggerId, type: UIKitInteractionType.CONTEXTUAL_BAR_UPDATE }),
+			...formatContextualBarInteraction(viewData, { appId, triggerId: triggerId!, type: UIKitInteractionType.CONTEXTUAL_BAR_UPDATE }),
 		};
 	}
 
@@ -64,7 +64,7 @@ export class UIKitInteractionResponder {
 
 		return {
 			appId,
-			triggerId,
+			triggerId: triggerId!,
 			success: false,
 			type: UIKitInteractionType.ERRORS,
 			viewId: errorInteraction.viewId,


### PR DESCRIPTION
## Summary

Type fixes in `apps-engine` that TypeScript 7's checker flags (`TS2322`):

- **`AppsEngineException`** — the class declared `public message: string` but assigned the optional constructor arg (`string | undefined`). Delegate to the `Error` base via `super(message)` (which handles `undefined` natively) and drop the redundant field.
- **`UIKitInteractionResponder`** — `triggerId` is optional on `IUIKitBaseIncomingInteraction`, but a surface (modal / contextual bar / error) interaction always has one. Assert it when forwarding to the interaction formatters.

Type-only; no runtime behavior change. Green on both the current TS5.x toolchain and TS7.

> Complements #41264 (`ApiEndpoint.path`); together they bring `apps-engine` to zero TS7 errors.

Draft — part of the TS7-readiness set.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2243]

[ARCH-2243]: https://rocketchat.atlassian.net/browse/ARCH-2243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error message handling for Apps Engine exceptions, ensuring messages are consistently preserved.
  - Fixed modal and contextual-bar interactions so responses reliably retain the associated interaction trigger.
  - Improved error responses for UI interactions by consistently including the relevant trigger information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->