### PR TITLE
chore(passport-x): declare passport-oauth1 exports for TS7

### DIFF
--- a/packages/passport-x/src/passport-oauth1.d.ts
+++ b/packages/passport-x/src/passport-oauth1.d.ts
@@ -1,23 +1,10 @@
 declare module 'passport-oauth1' {
 	import type { Request } from 'express';
 
-	interface OAuthGetCallback {
-		(err: OAuthError | null, body?: string, res?: { headers: Record<string, string> }): void;
-	}
-
-	interface OAuthError {
-		statusCode?: number;
-		data?: string;
-	}
-
-	interface OAuthClient {
-		get(url: string, token: string, tokenSecret: string, callback: OAuthGetCallback): void;
-	}
-
 	class OAuthStrategy {
 		name: string;
 
-		_oauth: OAuthClient;
+		_oauth: OAuthStrategy.OAuthClient;
 
 		constructor(options: Record<string, unknown>, verify: (...args: unknown[]) => void);
 
@@ -32,10 +19,27 @@ declare module 'passport-oauth1' {
 		redirect(url: string, status?: number): void;
 	}
 
-	class InternalOAuthError extends Error {
-		constructor(message: string, err: unknown);
+	// Merged namespace so the CommonJS `module.exports = Strategy` default and the
+	// `exports.InternalOAuthError` named export coexist under a single `export =`.
+	// TS7 rejects mixing `export =` with `export { ... }`.
+	namespace OAuthStrategy {
+		interface OAuthGetCallback {
+			(err: OAuthError | null, body?: string, res?: { headers: Record<string, string> }): void;
+		}
+
+		interface OAuthError {
+			statusCode?: number;
+			data?: string;
+		}
+
+		interface OAuthClient {
+			get(url: string, token: string, tokenSecret: string, callback: OAuthGetCallback): void;
+		}
+
+		class InternalOAuthError extends Error {
+			constructor(message: string, err: unknown);
+		}
 	}
 
 	export = OAuthStrategy;
-	export { InternalOAuthError, OAuthClient, OAuthError, OAuthGetCallback };
 }


### PR DESCRIPTION
## Summary

Fixes the ambient `passport-oauth1` declaration in `passport-x` so `InternalOAuthError` resolves under TypeScript 7.

## Why

The declaration mixed `export = OAuthStrategy` with a separate `export { InternalOAuthError, ... }`. TS7 rejects that combination, so `import OAuthStrategy, { InternalOAuthError } from 'passport-oauth1'` failed with `TS2305` (no exported member). The runtime module does export it (`exports.InternalOAuthError = ...`).

Move the named members into a `namespace OAuthStrategy` merged with the default class — the canonical way to type a CommonJS module that has both `module.exports = X` and `exports.Y`. Green on both TS5.x and TS7.

Draft — part of the TS7-readiness set.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2244]

[ARCH-2244]: https://rocketchat.atlassian.net/browse/ARCH-2244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected OAuth strategy type definitions for improved compatibility with TypeScript projects.
  * Organized OAuth-related types under the strategy namespace and aligned internal property typing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->