### PR TITLE
fix(message-parser): trailing backtick before line end breaks code block

### DIFF
--- a/.changeset/code-fence-trailing-backtick.md
+++ b/.changeset/code-fence-trailing-backtick.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/message-parser": patch
+---
+
+Fixes code fences failing to render when a line inside them ends with an inline-code backtick (e.g. `` - **Node**: `22.22.3` ``). A trailing backtick immediately before a line break could not be consumed as content, causing the whole ```` ``` ```` block to fall back to markdown parsing and split apart. Trailing 1-2 backticks before a line end (or EOF) are now treated as code content.

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -163,8 +163,9 @@ CodeLine
   / "\n" chunk:CodeChunk { return codeLine(chunk); }
   / "\n" !"```" { return codeLine(plain('')); }
 
-// Charclass avoids per-char lookahead; never consume start of "```"
-CodeChunkChar = [^\r\n`] / "`" [^`\r\n] / "`" "`" [^`\r\n]
+// Charclass avoids per-char lookahead; never consume start of "```".
+// Trailing 1-2 backticks before a line end (or EOF) are content, not a fence.
+CodeChunkChar = [^\r\n`] / "`" [^`\r\n] / "`" "`" [^`\r\n] / "`" "`" &("\r" / "\n" / !.) / "`" &("\r" / "\n" / !.)
 CodeChunk = text:$(CodeChunkChar)+ { return plain(text); }
 
 /**

--- a/packages/message-parser/tests/codeFence.test.ts
+++ b/packages/message-parser/tests/codeFence.test.ts
@@ -67,6 +67,26 @@ code
 \`\`\``,
 		[code([codeLine(plain(`# code`)), codeLine(plain(`**code**`))])],
 	],
+	// lines ending in inline code (trailing backtick) must not break the fence
+	[
+		`\`\`\`
+- **Node**: \`22.22.3\`
+- **Apps-Engine**: \`1.64.0\`
+\`\`\``,
+		[code([codeLine(plain('- **Node**: `22.22.3`')), codeLine(plain('- **Apps-Engine**: `1.64.0`'))])],
+	],
+	[
+		`\`\`\`
+foo\`
+\`\`\``,
+		[code([codeLine(plain('foo`'))])],
+	],
+	[
+		`\`\`\`
+foo\`\`
+\`\`\``,
+		[code([codeLine(plain('foo``'))])],
+	],
 ])('parses %p', (input, output) => {
 	expect(parse(input)).toEqual(output);
 });


### PR DESCRIPTION
A line inside a ``` code fence that ends with an inline-code backtick — e.g. `- **Node**: `22.22.3`` — broke the whole block.

## Root cause

`CodeChunkChar` (`grammar.pegjs`) had three alternatives, all requiring a non-backtick, non-newline char **after** the backtick(s):

```
CodeChunkChar = [^\r\n`] / "`" [^`\r\n] / "`" "`" [^`\r\n]
```

A backtick sitting immediately before a `\n` matched none of them → `CodeLine` failed → `CodeLine+` stopped short → the closing ``` never aligned → the entire `Code` rule failed and the parser fell back to markdown, splitting the block into headings/paragraphs/quotes.

This bit real content like release-note summaries, where list lines end in `` `1.64.0` ``.

## Fix

Accept 1-2 trailing backticks before a line end (or EOF) as code content, without ever consuming the 3 backticks of a fence:

```
CodeChunkChar = [^\r\n`] / "`" [^`\r\n] / "`" "`" [^`\r\n] / "`" "`" &("\r" / "\n" / !.) / "`" &("\r" / "\n" / !.)
```

## Tests

Added regression cases in `codeFence.test.ts` (line ending in inline code, lone trailing `` ` ``, trailing ``` `` ```). Full suite: 676 passing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2245]

[ARCH-2245]: https://rocketchat.atlassian.net/browse/ARCH-2245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fenced code blocks containing inline-code markers or trailing backticks.
  * Prevented valid code content from being misinterpreted as the closing fence, preserving the block’s formatting.

* **Tests**
  * Added coverage for single and double trailing backticks and inline backticked text within fenced code blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->