### PR TITLE
chore: type shim for csv-parse/lib/sync (TS7 compat)

### DIFF
--- a/apps/meteor/definition/externals/csv-parse.d.ts
+++ b/apps/meteor/definition/externals/csv-parse.d.ts
@@ -1,0 +1,8 @@
+// The Meteor bundler resolves npm requires by physical path and doesn't support
+// package `exports` subpaths, so runtime code must keep importing the real file
+// 'csv-parse/lib/sync'. That path isn't in csv-parse's exports map, which newer
+// TypeScript resolution modes enforce — bridge the types to the exports-declared
+// entry point.
+declare module 'csv-parse/lib/sync' {
+	export * from 'csv-parse/sync';
+}


### PR DESCRIPTION
## Summary

Type-only shim so the CSV importers typecheck under TypeScript 7 — **reworked after CI caught a runtime crash in the first approach.**

## What happened

The original PR switched the imports from `csv-parse/lib/sync` to the exports-declared `csv-parse/sync`. Typecheck and plain-node resolution were green, but the **production Meteor bundle crashed at boot** (`Error: Cannot find module 'csv-parse/sync'`, [run 29833170912](https://github.com/RocketChat/Rocket.Chat/actions/runs/29833170912)) — the Meteor bundler resolves npm requires by **physical path** and doesn't support package `exports` subpaths. The legacy `csv-parse/lib/sync` specifier exists precisely because of that.

## Fix

Keep the runtime specifier untouched and bridge only the types, following the existing `definition/externals` pattern:

```ts
declare module 'csv-parse/lib/sync' {
	export * from 'csv-parse/sync';
}
```

`csv-parse/lib/sync` isn't in the package's exports map (which TS7's resolution enforces), while `csv-parse/sync` carries a proper `types` condition — so the ambient declaration satisfies TS7 without changing what the bundler loads.

## Verification

- TS7 probe (bundler resolution): import of `csv-parse/lib/sync` + shim → **0 errors**
- TS5 (current toolchain): **0 errors**
- **Zero source/runtime changes** — production bundle identical to develop

Part of the TS7-readiness set. Also supersedes the old branch content (the importer files moved to `server/lib/import/` in the backend restructure; branch rebuilt on current develop).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when importing CSV parsing functionality, preventing related TypeScript resolution issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2286]

[ARCH-2286]: https://rocketchat.atlassian.net/browse/ARCH-2286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ