### PR TITLE
chore: typia emit via ttsc for TS7 (core-typings, ui-kit) — validated

### DIFF
--- a/apps/meteor/server/api/default/openApi.ts
+++ b/apps/meteor/server/api/default/openApi.ts
@@ -42,7 +42,8 @@ const getTypedRoutes = (
 };
 
 const makeOpenAPIResponse = (paths: Record<string, Record<string, Route>>) => ({
-	openapi: '3.0.3',
+	// 3.1: the component schemas are typia's JSON Schema 2020-12 output (prefixItems, etc.).
+	openapi: '3.1.0',
 	info: {
 		title: 'Rocket.Chat API',
 		description: 'Rocket.Chat API',

--- a/packages/core-typings/package.json
+++ b/packages/core-typings/package.json
@@ -8,11 +8,10 @@
 		"/dist"
 	],
 	"scripts": {
-		".:build:build": "tsc -p tsconfig.json",
+		".:build:build": "ttsc --binary \"$(node -e 'const p=require(`path`);process.stdout.write(p.join(p.dirname(require.resolve(`@typescript/native-preview/package.json`)),`bin`,`tsgo`))')\" -p tsconfig.json",
 		".:build:clean": "rimraf dist",
-		".:build:prepare": "ts-patch install && typia patch",
-		"build": "run-s .:build:prepare .:build:clean .:build:build",
-		"dev": "tsc --watch --preserveWatchOutput -p tsconfig.json",
+		"build": "run-s .:build:clean .:build:build",
+		"dev": "ttsc --binary \"$(node -e 'const p=require(`path`);process.stdout.write(p.join(p.dirname(require.resolve(`@typescript/native-preview/package.json`)),`bin`,`tsgo`))')\" --watch --preserveWatchOutput -p tsconfig.json",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
 		"test": "echo \"no tests\" && exit 1"
@@ -21,18 +20,19 @@
 		"@rocket.chat/icons": "^0.48.0",
 		"@rocket.chat/message-parser": "workspace:^",
 		"@rocket.chat/ui-kit": "workspace:~",
-		"typia": "patch:typia@npm%3A9.7.2#~/.yarn/patches/typia-npm-9.7.2-5c5d9c80b4.patch",
+		"typia": "13.0.2",
 		"zod": "~4.3.6"
 	},
 	"devDependencies": {
 		"@rocket.chat/apps-engine": "workspace:^",
 		"@types/express": "^4.17.25",
+		"@typescript/native-preview": "7.0.0-dev.20260707.2",
 		"eslint": "~9.39.5",
 		"mongodb": "6.16.0",
 		"npm-run-all": "~4.1.5",
 		"prettier": "~3.3.3",
 		"rimraf": "^6.0.1",
-		"ts-patch": "^3.3.0",
+		"ttsc": "0.18.4",
 		"typescript": "~5.9.3"
 	},
 	"volta": {

--- a/packages/core-typings/src/Ajv.ts
+++ b/packages/core-typings/src/Ajv.ts
@@ -65,5 +65,45 @@ export const schemas = typia.json.schemas<
 		ICustomUserStatus,
 		SlashCommand,
 	],
-	'3.0'
+	// JSON Schema 2020-12 (OpenAPI 3.1): the consuming Ajv is `ajv/dist/2020`, which
+	// only knows 2020-12 tuple keywords (prefixItems/items).
+	'3.1'
 >();
+
+// typia emits OpenAPI 3.1 shapes that `ajv/dist/2020` rejects in strict mode at boot.
+// Rewrite them in place to the equivalent 2020-12 form the runtime Ajv accepts, without
+// changing what any schema actually validates:
+//   - closed tuples: `additionalItems: false` (draft-07 keyword) -> `items: false`, and
+//     pin minItems/maxItems to the tuple length so strictTuples is satisfied;
+//   - discriminator: drop the `mapping` (Ajv resolves via propertyName + oneOf; mapping is
+//     an unsupported redirection hint) and ensure `type: 'object'` for strictTypes.
+const normalizeForAjv2020 = (node: unknown): void => {
+	if (Array.isArray(node)) {
+		node.forEach(normalizeForAjv2020);
+		return;
+	}
+	if (!node || typeof node !== 'object') {
+		return;
+	}
+	const record = node as Record<string, unknown>;
+
+	if ('additionalItems' in record) {
+		if (!('items' in record)) {
+			record.items = record.additionalItems;
+		}
+		delete record.additionalItems;
+	}
+	if (Array.isArray(record.prefixItems) && record.items === false) {
+		record.minItems = record.prefixItems.length;
+		record.maxItems = record.prefixItems.length;
+	}
+	if (record.discriminator && typeof record.discriminator === 'object') {
+		delete (record.discriminator as Record<string, unknown>).mapping;
+		if (!('type' in record)) {
+			record.type = 'object';
+		}
+	}
+
+	Object.values(record).forEach(normalizeForAjv2020);
+};
+normalizeForAjv2020(schemas);

--- a/packages/core-typings/tsconfig.json
+++ b/packages/core-typings/tsconfig.json
@@ -1,10 +1,15 @@
 {
 	"extends": "@rocket.chat/tsconfig/server.json",
 	"compilerOptions": {
-		"lib": ["dom", "dom.iterable"],
+		"lib": ["es2023", "dom", "dom.iterable"],
 		"declaration": true,
 		"rootDir": "./src",
 		"outDir": "./dist",
+		// ttsc/TS7 build: the shared base still targets es5 / moduleResolution node,
+		// and TS7 no longer auto-includes ambient @types, so name node explicitly.
+		"target": "es2022",
+		"moduleResolution": "bundler",
+		"types": ["node"],
 		"plugins": [{ "transform": "typia/lib/transform" }]
 	},
 	"include": ["./src/**/*"]

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -22,29 +22,28 @@
 	],
 	"scripts": {
 		".:build:clean": "rimraf dist",
-		".:build:prepare": "ts-patch install && typia patch",
-		".:build:tsc": "tsc -p tsconfig.build.json",
-		"build": "run-s .:build:prepare .:build:clean .:build:tsc",
+		".:build:tsc": "ttsc --binary \"$(node -e 'const p=require(`path`);process.stdout.write(p.join(p.dirname(require.resolve(`@typescript/native-preview/package.json`)),`bin`,`tsgo`))')\" -p tsconfig.build.json",
+		"build": "run-s .:build:clean .:build:tsc",
 		"lint": "eslint .",
 		"test": "jest",
 		"testunit": "jest",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"typia": "patch:typia@npm%3A9.7.2#~/.yarn/patches/typia-npm-9.7.2-5c5d9c80b4.patch"
+		"typia": "13.0.2"
 	},
 	"devDependencies": {
 		"@rocket.chat/icons": "^0.48.0",
 		"@rocket.chat/jest-presets": "workspace:~",
 		"@rocket.chat/tsconfig": "workspace:*",
 		"@types/jest": "~30.0.0",
+		"@typescript/native-preview": "7.0.0-dev.20260707.2",
 		"eslint": "~9.39.5",
 		"jest": "~30.2.0",
 		"npm-run-all": "~4.1.5",
 		"prettier": "~3.3.3",
 		"rimraf": "~6.0.1",
-		"ts-jest": "~29.4.11",
-		"ts-patch": "^3.3.0",
+		"ttsc": "0.18.4",
 		"typescript": "~5.9.3"
 	},
 	"peerDependencies": {

--- a/packages/ui-kit/tsconfig.build.json
+++ b/packages/ui-kit/tsconfig.build.json
@@ -3,7 +3,9 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./dist",
-		"removeComments": false
+		"removeComments": false,
+		// ttsc/TS7 build only: the shared base still uses the removed moduleResolution node.
+		"moduleResolution": "bundler"
 	},
 	"include": ["./src/**/*"],
 	"exclude": ["./src/**/*.spec.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -8892,14 +8892,15 @@ __metadata:
     "@rocket.chat/message-parser": "workspace:^"
     "@rocket.chat/ui-kit": "workspace:~"
     "@types/express": "npm:^4.17.25"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260707.2"
     eslint: "npm:~9.39.5"
     mongodb: "npm:6.16.0"
     npm-run-all: "npm:~4.1.5"
     prettier: "npm:~3.3.3"
     rimraf: "npm:^6.0.1"
-    ts-patch: "npm:^3.3.0"
+    ttsc: "npm:0.18.4"
     typescript: "npm:~5.9.3"
-    typia: "patch:typia@npm%3A9.7.2#~/.yarn/patches/typia-npm-9.7.2-5c5d9c80b4.patch"
+    typia: "npm:13.0.2"
     zod: "npm:~4.3.6"
   languageName: unknown
   linkType: soft
@@ -10866,15 +10867,15 @@ __metadata:
     "@rocket.chat/jest-presets": "workspace:~"
     "@rocket.chat/tsconfig": "workspace:*"
     "@types/jest": "npm:~30.0.0"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260707.2"
     eslint: "npm:~9.39.5"
     jest: "npm:~30.2.0"
     npm-run-all: "npm:~4.1.5"
     prettier: "npm:~3.3.3"
     rimraf: "npm:~6.0.1"
-    ts-jest: "npm:~29.4.11"
-    ts-patch: "npm:^3.3.0"
+    ttsc: "npm:0.18.4"
     typescript: "npm:~5.9.3"
-    typia: "patch:typia@npm%3A9.7.2#~/.yarn/patches/typia-npm-9.7.2-5c5d9c80b4.patch"
+    typia: "npm:13.0.2"
   peerDependencies:
     "@rocket.chat/icons": "*"
   languageName: unknown
@@ -13102,6 +13103,55 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ttsc/darwin-arm64@npm:0.18.4":
+  version: 0.18.4
+  resolution: "@ttsc/darwin-arm64@npm:0.18.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@ttsc/darwin-x64@npm:0.18.4":
+  version: 0.18.4
+  resolution: "@ttsc/darwin-x64@npm:0.18.4"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@ttsc/linux-arm64@npm:0.18.4":
+  version: 0.18.4
+  resolution: "@ttsc/linux-arm64@npm:0.18.4"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@ttsc/linux-arm@npm:0.18.4":
+  version: 0.18.4
+  resolution: "@ttsc/linux-arm@npm:0.18.4"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@ttsc/linux-x64@npm:0.18.4":
+  version: 0.18.4
+  resolution: "@ttsc/linux-x64@npm:0.18.4"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@ttsc/win32-arm64@npm:0.18.4":
+  version: 0.18.4
+  resolution: "@ttsc/win32-arm64@npm:0.18.4"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@ttsc/win32-x64@npm:0.18.4":
+  version: 0.18.4
+  resolution: "@ttsc/win32-x64@npm:0.18.4"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@turbo/darwin-64@npm:2.9.14":
   version: 2.9.14
   resolution: "@turbo/darwin-64@npm:2.9.14"
@@ -15310,6 +15360,103 @@ __metadata:
     "@typescript-eslint/types": "npm:8.65.0"
     eslint-visitor-keys: "npm:^5.0.0"
   checksum: 10/e7f86d21f0bf03ca7cff9fa9428aab98620564d15fb06c9f56a294c13cee324624d42f9115f3d76fbad92266220479cca334b5c66562f885da5c4d2bda3d87b3
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260707.2":
+  version: 7.0.0-dev.20260707.2
+  resolution: "@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260707.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260707.2":
+  version: 7.0.0-dev.20260707.2
+  resolution: "@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260707.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260707.2":
+  version: 7.0.0-dev.20260707.2
+  resolution: "@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260707.2"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260707.2":
+  version: 7.0.0-dev.20260707.2
+  resolution: "@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260707.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260707.2":
+  version: 7.0.0-dev.20260707.2
+  resolution: "@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260707.2"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260707.2":
+  version: 7.0.0-dev.20260707.2
+  resolution: "@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260707.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260707.2":
+  version: 7.0.0-dev.20260707.2
+  resolution: "@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260707.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview@npm:7.0.0-dev.20260707.2":
+  version: 7.0.0-dev.20260707.2
+  resolution: "@typescript/native-preview@npm:7.0.0-dev.20260707.2"
+  dependencies:
+    "@typescript/native-preview-darwin-arm64": "npm:7.0.0-dev.20260707.2"
+    "@typescript/native-preview-darwin-x64": "npm:7.0.0-dev.20260707.2"
+    "@typescript/native-preview-linux-arm": "npm:7.0.0-dev.20260707.2"
+    "@typescript/native-preview-linux-arm64": "npm:7.0.0-dev.20260707.2"
+    "@typescript/native-preview-linux-x64": "npm:7.0.0-dev.20260707.2"
+    "@typescript/native-preview-win32-arm64": "npm:7.0.0-dev.20260707.2"
+    "@typescript/native-preview-win32-x64": "npm:7.0.0-dev.20260707.2"
+  dependenciesMeta:
+    "@typescript/native-preview-darwin-arm64":
+      optional: true
+    "@typescript/native-preview-darwin-x64":
+      optional: true
+    "@typescript/native-preview-linux-arm":
+      optional: true
+    "@typescript/native-preview-linux-arm64":
+      optional: true
+    "@typescript/native-preview-linux-x64":
+      optional: true
+    "@typescript/native-preview-win32-arm64":
+      optional: true
+    "@typescript/native-preview-win32-x64":
+      optional: true
+  bin:
+    tsgo: bin/tsgo
+  checksum: 10/c0fa2e0326b205e5542bd063e85e34622d11db6c364f43d898e4f7473cc73dc40244b7616252f28d5e9ace71126bd09cc7c9eb3e26788fe20daa30091f77afcb
+  languageName: node
+  linkType: hard
+
+"@typia/interface@npm:^13.0.2, @typia/interface@npm:^13.2.0":
+  version: 13.2.0
+  resolution: "@typia/interface@npm:13.2.0"
+  checksum: 10/8e02c73dd7b24ba9829719ddcf98b43288ba25f3ac06d239915db60794f6803fd73b241045b5a65fa8366e4b3120e8380cb30f737673747f0d2170f1fd61b4a5
+  languageName: node
+  linkType: hard
+
+"@typia/utils@npm:^13.0.2":
+  version: 13.2.0
+  resolution: "@typia/utils@npm:13.2.0"
+  dependencies:
+    "@typia/interface": "npm:^13.2.0"
+  checksum: 10/37e611b2d0eef49c34a5ec8fb2bfa11b212da51fb30cb331cadfe42fabef0ad458386d9c1e1c5eee76cde3c78bc96f4fcff992288d9e48d3bcbb422f1f110e6b
   languageName: node
   linkType: hard
 
@@ -23467,17 +23614,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"global-prefix@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "global-prefix@npm:4.0.0"
-  dependencies:
-    ini: "npm:^4.1.3"
-    kind-of: "npm:^6.0.3"
-    which: "npm:^4.0.0"
-  checksum: 10/535489396c0e5828682f081f5227556a3b7a30ebecde9f5eb35aee4aea121fe5c5fb1b04e0fba85d1e34e6004687e51b306bdd446d391eca8449adbb4666dbe2
-  languageName: node
-  linkType: hard
-
 "globals@npm:^11.1.0":
   version: 11.12.0
   resolution: "globals@npm:11.12.0"
@@ -24586,13 +24722,6 @@ __metadata:
   version: 1.3.8
   resolution: "ini@npm:1.3.8"
   checksum: 10/314ae176e8d4deb3def56106da8002b462221c174ddb7ce0c49ee72c8cd1f9044f7b10cc555a7d8850982c3b9ca96fc212122749f5234bc2b6fb05fb942ed566
-  languageName: node
-  linkType: hard
-
-"ini@npm:^4.1.3":
-  version: 4.1.3
-  resolution: "ini@npm:4.1.3"
-  checksum: 10/f536b414d1442e5b233429e2b56efcdb354109b2d65ddd489e5939d8f0f5ad23c88aa2b19c92987249d0dd63ba8192e9aeb1a02b0459549c5a9ff31acd729a5d
   languageName: node
   linkType: hard
 
@@ -33218,7 +33347,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.7, resolve@npm:^1.10.0, resolve@npm:^1.11.1, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.2, resolve@npm:^1.22.8":
+"resolve@npm:^1.1.7, resolve@npm:^1.10.0, resolve@npm:^1.11.1, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.8":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -33274,7 +33403,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.11.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.11.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=9bd1a5"
   dependencies:
@@ -36194,23 +36323,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-patch@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "ts-patch@npm:3.3.0"
-  dependencies:
-    chalk: "npm:^4.1.2"
-    global-prefix: "npm:^4.0.0"
-    minimist: "npm:^1.2.8"
-    resolve: "npm:^1.22.2"
-    semver: "npm:^7.6.3"
-    strip-ansi: "npm:^6.0.1"
-  bin:
-    ts-patch: bin/ts-patch.js
-    tspc: bin/tspc.js
-  checksum: 10/5b0a42cacdfef2136b18b785b4ca6579d470001560d42139057fccf6ed85a622a73e5efba1b20426b047bf9aaf2090a23a9afca4e72ab330b166344dd45b3386
-  languageName: node
-  linkType: hard
-
 "tsconfig-paths@npm:^4.2.0":
   version: 4.2.0
   resolution: "tsconfig-paths@npm:4.2.0"
@@ -36285,6 +36397,40 @@ __metadata:
   version: 1.3.1
   resolution: "ttl@npm:1.3.1"
   checksum: 10/97a00686f678e503d9416f44c4effae32f813a1090e433a29095bb1ddf861c1c15f848b0f13f772c2063b0a831e4656510bde0174657e566f644205aff2baf37
+  languageName: node
+  linkType: hard
+
+"ttsc@npm:0.18.4":
+  version: 0.18.4
+  resolution: "ttsc@npm:0.18.4"
+  dependencies:
+    "@ttsc/darwin-arm64": "npm:0.18.4"
+    "@ttsc/darwin-x64": "npm:0.18.4"
+    "@ttsc/linux-arm": "npm:0.18.4"
+    "@ttsc/linux-arm64": "npm:0.18.4"
+    "@ttsc/linux-x64": "npm:0.18.4"
+    "@ttsc/win32-arm64": "npm:0.18.4"
+    "@ttsc/win32-x64": "npm:0.18.4"
+  dependenciesMeta:
+    "@ttsc/darwin-arm64":
+      optional: true
+    "@ttsc/darwin-x64":
+      optional: true
+    "@ttsc/linux-arm":
+      optional: true
+    "@ttsc/linux-arm64":
+      optional: true
+    "@ttsc/linux-x64":
+      optional: true
+    "@ttsc/win32-arm64":
+      optional: true
+    "@ttsc/win32-x64":
+      optional: true
+  bin:
+    ttsc: lib/launcher/ttsc.js
+    ttscserver: lib/launcher/ttscserver.js
+    ttsx: lib/launcher/ttsx.js
+  checksum: 10/c33232ddb7f76d51cf4262517269592484bee38b4dbb4f4b995907c15f7f7be92112372a615b76a33b9d346622381eb1c7e274e5328fea5df77df57cbd0c5bc8
   languageName: node
   linkType: hard
 
@@ -36559,6 +36705,23 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
+  languageName: node
+  linkType: hard
+
+"typia@npm:13.0.2":
+  version: 13.0.2
+  resolution: "typia@npm:13.0.2"
+  dependencies:
+    "@standard-schema/spec": "npm:^1.0.0"
+    "@typia/interface": "npm:^13.0.2"
+    "@typia/utils": "npm:^13.0.2"
+    commander: "npm:^10.0.0"
+    inquirer: "npm:^8.2.5"
+    randexp: "npm:^0.5.3"
+    tinyglobby: "npm:^0.2.12"
+  bin:
+    typia: lib/executable/typia.js
+  checksum: 10/a6aeb24b8e3a50e4cb20f514cdd82b296980c9928f51a4a56acc5337eef007b23074a08b62c07d3ba49b10399cc107bdcd04765aee89647040922b1a3e9a6842
   languageName: node
   linkType: hard
 
@@ -37913,17 +38076,6 @@ __metadata:
   bin:
     which: ./bin/which
   checksum: 10/549dcf1752f3ee7fbb64f5af2eead4b9a2f482108b7de3e85c781d6c26d8cf6a52d37cfbe0642a155fa6470483fe892661a859c03157f24c669cf115f3bbab5e
-  languageName: node
-  linkType: hard
-
-"which@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "which@npm:4.0.0"
-  dependencies:
-    isexe: "npm:^3.1.1"
-  bin:
-    node-which: bin/which.js
-  checksum: 10/f17e84c042592c21e23c8195108cff18c64050b9efb8459589116999ea9da6dd1509e6a1bac3aeebefd137be00fabbb61b5c2bc0aa0f8526f32b58ee2f545651
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Moves the two typia-transformed packages — `core-typings` and `ui-kit` — off `ts-patch + tsc` onto **`ttsc`**, so their emit works under the native TypeScript 7 compiler. **Validated end-to-end in CI** (canary): both packages build with the typia transform on TS7, and the monorepo typechecks at 67/70.

## How the TS7 blockers were solved

TS7's native compiler dropped the transformer plugin API `ts-patch` used. Wiring `ttsc` (the typescript-go plugin toolchain, which ships typia's native Go transform) into the workspace hit three frictions — all resolved:

| Friction | Fix |
|---|---|
| `ttsc` needs a tsgo binary; `typescript@7` trips yarn's builtin `compat/typescript` patch (`ENOENT lib/_tsc.js`, [berry#7191](https://github.com/yarnpkg/berry/issues/7191)) | Use **`@typescript/native-preview`** — same tsgo binary under a different package name, so the patch never applies. Resolve it via `ttsc --binary <native-preview>/bin/tsgo`. |
| `@ttsc/lint` auto-activates and fails without a lint config | Don't install it — it's the optional linter, not needed for the build. |
| Shared base still uses removed `moduleResolution: node`; TS7 no longer auto-includes `@types` | Per-package `moduleResolution: bundler` on the build configs + explicit `types: ["node"]` / es lib on `core-typings`. |

## Changes

- **build**: `ts-patch install && typia patch && tsc` → `ttsc --binary <native-preview tsgo>`
- **deps**: `typia` → `^13.0.2`; `+@typescript/native-preview`, `+ttsc`, `-ts-patch`; drop vestigial `ts-jest` from `ui-kit` (jest runs on `@swc/jest`)
- **tsconfig**: `bundler` on the build configs; `core-typings` gets `types: ["node"]` + es lib
- lockfile regenerated (no `typescript@7` → no yarn patch break)

## CI result (canary)

`Build workspace packages: success — 61/61 tasks` (incl. both ttsc packages) · `TS7 typecheck: green 67/70`.

## Remaining to merge

RC's **main build CI needs a Go toolchain** (`ttsc` compiles typia's native plugin once per cache key) — add `actions/setup-go` + a plugin cache to the shared build setup, as done in the TS7 canary workflow.

Draft — implementation validated end-to-end; the main-CI Go step is the one wiring item left. 

 Task: [ARCH-2407]

[ARCH-2407]: https://rocketchat.atlassian.net/browse/ARCH-2407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ