### PR TITLE
test: fix flaky timeout in preview-public-channel spec

### DIFF
--- a/apps/meteor/tests/e2e/preview-public-channel.spec.ts
+++ b/apps/meteor/tests/e2e/preview-public-channel.spec.ts
@@ -13,11 +13,11 @@ test.describe('Preview public channel', () => {
 	let targetChannel: string;
 	let targetChannelMessage: string;
 
+	// Each test navigates to /home by itself after its API setup is done, otherwise the API mutations
+	// can race the client boot (initial cached stores sync) and leave the UI stuck on the loading screen
 	test.beforeEach(async ({ page }) => {
 		poHomeChannel = new HomeChannel(page);
 		poDirectory = new Directory(page);
-
-		await page.goto('/home');
 	});
 
 	test.beforeAll(async ({ api }) => {
@@ -35,16 +35,20 @@ test.describe('Preview public channel', () => {
 	test.describe('User', () => {
 		test.use({ storageState: Users.user1.state });
 
-		test('should let user preview public rooms messages', async () => {
+		test('should let user preview public rooms messages', async ({ page }) => {
+			await page.goto('/home');
+
 			await poHomeChannel.navbar.btnDirectory.click();
 			await poDirectory.openChannel(targetChannel);
 
 			await expect(poHomeChannel.content.lastUserMessageBody).toContainText(targetChannelMessage);
 		});
 
-		test('should let user view direct rooms', async ({ api }) => {
+		test('should let user view direct rooms', async ({ api, page }) => {
 			await api.post('/permissions.update', { permissions: [{ _id: 'preview-c-room', roles: ['admin'] }] });
 			await createDirectMessage(api);
+
+			await page.goto('/home');
 
 			await poHomeChannel.navbar.openChat(Users.user2.data.username);
 
@@ -52,8 +56,10 @@ test.describe('Preview public channel', () => {
 			await expect(poHomeChannel.composer.inputMessage).toBeEnabled();
 		});
 
-		test('should not let user role preview public rooms', async ({ api }) => {
+		test('should not let user role preview public rooms', async ({ api, page }) => {
 			await api.post('/permissions.update', { permissions: [{ _id: 'preview-c-room', roles: ['admin'] }] });
+
+			await page.goto('/home');
 
 			await poHomeChannel.navbar.btnDirectory.click();
 			await poDirectory.openChannel(targetChannel);
@@ -69,6 +75,9 @@ test.describe('Preview public channel', () => {
 
 		test('should prevent user from join the room', async ({ api, page }) => {
 			await api.post('/permissions.update', { permissions: [{ _id: 'preview-c-room', roles: ['admin', 'user', 'anonymous'] }] });
+
+			await page.goto('/home');
+
 			await poHomeChannel.navbar.btnDirectory.click();
 			await poDirectory.openChannel(targetChannel);
 
@@ -85,6 +94,8 @@ test.describe('Preview public channel', () => {
 
 		test('should prevent user from join the room without preview permission', async ({ api, page }) => {
 			await api.post('/permissions.update', { permissions: [{ _id: 'preview-c-room', roles: ['admin'] }] });
+
+			await page.goto('/home');
 
 			await poHomeChannel.navbar.btnDirectory.click();
 			await poDirectory.openChannel(targetChannel);


### PR DESCRIPTION
The shared beforeEach navigated to /home and the tests then immediately
fired admin API mutations (permissions.update, dm.create) while the
client was still performing its initial boot (cached stores sync, which
gates the whole UI behind the loading screen via useMainReady). When the
mutations raced that sync, the app could get stuck loading and the
navbar search combobox never rendered, timing out the test:

  locator.fill: waiting for getByRole('search').getByRole('combobox')

Move the /home navigation into each test, after its API setup, so the
client always boots against a settled server state instead of racing
the mutations.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AeMr1suzJzyLmrKceYxDkr

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test navigation reliability by ensuring each scenario explicitly loads the home page before interacting with the application.
  * Reduced potential race conditions during public channel preview testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [FLAKY-2377]

[FLAKY-2377]: https://rocketchat.atlassian.net/browse/FLAKY-2377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ