### PR TITLE
chore(client): isolate accounts-base login/logout hooks

### DIFF
--- a/apps/meteor/client/lib/sdk/meteorBackedSdk.ts
+++ b/apps/meteor/client/lib/sdk/meteorBackedSdk.ts
@@ -7,6 +7,20 @@ import { Tracker } from 'meteor/tracker';
 import { parseDDP } from './ddpProtocol';
 import { setStorageBackend } from './storage';
 
+// Wrap an accounts-base onLogin/onLogout hook so it cannot block or abort the
+// (now awaited & sequential, since accounts-base 3.3) hook chain: run it,
+// discard any returned promise so the chain never waits on it, and swallow
+// synchronous throws so later hooks still run.
+const isolateLifecycleHook =
+	(fn: (...args: unknown[]) => unknown) =>
+	(...args: unknown[]): void => {
+		try {
+			void fn(...args);
+		} catch (error) {
+			console.error(error);
+		}
+	};
+
 /**
  * Meteor-backed pass-through DDPSDK used when the SDK transport is OFF.
  *
@@ -243,15 +257,22 @@ const createMeteorBackedAccount = () => {
 		// onEmailVerificationLink/onPageLoadLogin don't expose an unsubscribe at
 		// all — call sites for those are singletons registered at module load,
 		// so a no-op unsubscribe is acceptable.
+		// accounts-base 3.3 (Meteor 3.5) runs onLogin/onLogout hooks sequentially
+		// with `await` (3.2 fired them synchronously, fire-and-forget). A hook that
+		// returns a promise which only settles after login/logout completes now
+		// blocks the whole chain, and a hook that throws aborts every hook after it
+		// — so unrelated cleanup (e.g. E2EE key removal) silently stops running.
+		// Isolate each hook: run its synchronous part immediately, don't propagate
+		// its promise back to the awaited chain, and swallow throws.
 		onLogin: (fn: () => void): (() => void) => {
-			const handle = Accounts.onLogin(fn);
+			const handle = Accounts.onLogin(isolateLifecycleHook(fn));
 			return () => handle.stop();
 		},
 		onLogout: (fn: () => void): (() => void) => {
 			// @types/meteor declares onLogout's return as void, but at runtime it
 			// returns the same `{ stop }` handle as onLogin (Meteor source:
 			// packages/accounts-base/accounts_common.js).
-			const handle = (Accounts.onLogout as unknown as (fn: () => void) => { stop: () => void })(fn);
+			const handle = (Accounts.onLogout as unknown as (fn: () => void) => { stop: () => void })(isolateLifecycleHook(fn));
 			return () => handle.stop();
 		},
 		onEmailVerificationLink: (fn: (token: string) => void): (() => void) => {


### PR DESCRIPTION
## Proposed changes

Precautionary hardening of the SDK adapter that registers `Accounts.onLogin` /
`Accounts.onLogout` hooks (`meteorBackedSdk.ts`).

Today every consumer's lifecycle hook shares one execution pass. This makes each
hook independent:
- run the hook, but **discard any promise it returns** so the caller never waits on it;
- **swallow synchronous throws** so a failing hook doesn't stop the ones after it.

### Why now (runtime-agnostic, but matters for Meteor 3.5)
`accounts-base` 3.3 (bundled with Meteor 3.5) runs these hooks **sequentially with `await`** — 3.2 fired them synchronously, fire-and-forget. Under 3.3:
- a hook whose promise only settles **after** login/logout completes blocks the whole chain (e.g. a login callback that never resolves);
- a **throwing** hook aborts every hook registered after it, so unrelated cleanup (e.g. E2EE key removal on logout) silently stops running.

Landing this on its own keeps it small and reviewable, ahead of the Meteor 3.5 bump.

## Testing
- No behavior change on the current runtime (hooks aren't awaited on 3.2; the Meteor `Hook` class already isolates throws) — purely defensive.
- Validated against Meteor 3.5 in the upgrade branch: fixes login (SAML) hangs and E2EE-after-logout, with the full E2E UI suite green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

