### PR TITLE
chore(ci): trim redundant work from CI critical path

### DIFF
--- a/.github/actions/meteor-build/action.yml
+++ b/.github/actions/meteor-build/action.yml
@@ -125,7 +125,7 @@ runs:
         meteor node -v
         git version
 
-    - uses: rharkor/caching-for-turbo@00a0515f175df9fd2e15c4560144ad5fdbebb0c7 # v2.3.13
+    - uses: rharkor/caching-for-turbo@75f8ebf4a43d2c60b23bc2a27082cfea94ffdad9 # v2.5.0
 
     - name: Reset Meteor
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
 
   packages-build:
     name: 📦 Build Packages
-    needs: [release-versions, notify-draft-services]
+    needs: [release-versions]
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Cache build
@@ -271,15 +271,6 @@ jobs:
           name: packages-build
           path: /tmp/RocketChat-packages-build.tar.gz
           retention-days: 5
-
-      - name: Store turbo build
-        if: steps.packages-cache-build.outputs.cache-hit != 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: turbo-build
-          path: .turbo/cache
-          overwrite: true
-          include-hidden-files: true
 
   build:
     name: 📦 Meteor Build (${{ matrix.type }})
@@ -723,17 +714,7 @@ jobs:
           cache-modules: true
           install: true
 
-      - uses: rharkor/caching-for-turbo@75f8ebf4a43d2c60b23bc2a27082cfea94ffdad9 # v2.5.0
-
-      - name: Restore turbo build
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        continue-on-error: true
-        with:
-          name: turbo-build
-          path: .turbo/cache
-
-      - name: Build packages
-        run: yarn build
+      - uses: ./.github/actions/restore-packages
 
       - name: Login to GitHub Container Registry
         if: (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'release' || github.ref == 'refs/heads/develop') && github.actor != 'dependabot[bot]'


### PR DESCRIPTION
Reduce CI resource usage and wall-clock time by cutting redundant work. No test coverage or build outputs change.

## Changes

**1. `packages-build` no longer waits on `notify-draft-services`**
`notify-draft-services` only does real work on `release` events (registers a draft on the cloud). On every PR / `develop` push it was a checkout + skipped step, yet it sat in the critical path blocking `packages-build`. It produces no output that `packages-build` consumes. Dropped from `needs`, so package build starts right after `release-versions`.

**2. `test-federation-matrix` restores the prebuilt packages artifact**
It was running a full `yarn build` on a fresh runner instead of using `restore-packages` (untar the artifact `packages-build` already produced) like every other test job. Swapped to `restore-packages`.

**3. Removed the now-unused `turbo-build` artifact upload**
Only `test-federation-matrix` consumed it (via the turbo cache download it no longer needs). Removing the upload saves artifact storage + upload time on every run.

**4. Aligned `caching-for-turbo` to v2.5.0 in `meteor-build`**
It was pinned to v2.3.13 while every other job used v2.5.0 — different versions namespace their cache separately, so `meteor-build` was missing cache the other jobs populated.

## Impact
- Shorter critical path on every PR/develop run (one fewer job to wait on before builds start).
- No full package rebuild in the federation job.
- Less artifact upload/storage per run.

## Not included (bigger levers, discuss separately)
- Docker matrix still builds arm64 + amd64 for every microservice on PRs, though e2e only consumes amd64 — kept both arches to avoid changing published `pr-*` images.
- `test-ui` / `test-ui-ee` sharding (4 + 5 shards) dominates wall-clock.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

