### PR TITLE
refactor: remove unused subscription indexes

### DIFF
--- a/.changeset/four-numbers-repair.md
+++ b/.changeset/four-numbers-repair.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/models": patch
+---
+
+refactor: remove unused subscription indexes

--- a/apps/meteor/server/startup/migrations/index.ts
+++ b/apps/meteor/server/startup/migrations/index.ts
@@ -41,5 +41,6 @@ import './v332';
 import './v333';
 import './v334';
 import './v335';
+import './v336';
 
 export * from './xrun';

--- a/apps/meteor/server/startup/migrations/v336.ts
+++ b/apps/meteor/server/startup/migrations/v336.ts
@@ -1,0 +1,20 @@
+import { Subscriptions } from '@rocket.chat/models';
+
+import { addMigration } from '../../lib/migrations';
+
+addMigration({
+	version: 336,
+	name: 'Remove unused subscription indexes',
+	async up() {
+		try {
+			await Promise.allSettled([
+				Subscriptions.col.dropIndex('desktopNotifications_1'),
+				Subscriptions.col.dropIndex('mobilePushNotifications_1'),
+				Subscriptions.col.dropIndex('emailNotifications_1'),
+			]);
+		} catch (error: unknown) {
+			console.warn('Error dropping redundant subscription indexes, continuing...');
+			console.warn(error);
+		}
+	},
+});

--- a/packages/models/src/models/Subscriptions.ts
+++ b/packages/models/src/models/Subscriptions.ts
@@ -46,10 +46,6 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			{ key: { alert: 1 } },
 			{ key: { ts: 1 } },
 			{ key: { ls: 1 } },
-			// TODO: remove these indexes in the next major release (8.0.0) - their only consumers (the per-room notification-preference finders) were removed
-			// { key: { desktopNotifications: 1 }, sparse: true },
-			// { key: { mobilePushNotifications: 1 }, sparse: true },
-			// { key: { emailNotifications: 1 }, sparse: true },
 			{ key: { autoTranslate: 1 }, sparse: true },
 			{ key: { autoTranslateLanguage: 1 }, sparse: true },
 			{ key: { 'userHighlights.0': 1 }, sparse: true },


### PR DESCRIPTION
Closes #41318. Removes the commented-out subscription indexes from Subscriptions.ts as requested.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed obsolete database index configuration entries for notification subscription fields.
  * Added and registered a new database migration to remove the corresponding unused `Subscriptions` collection indexes; index drop failures are logged but do not block the migration.  
  * Included a patch version update for the affected models package reflecting this database index cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->