### PR TITLE
fix: preserve multi-line text in slash command params

### DIFF
--- a/apps/meteor/client/lib/chats/flows/processSlashCommand.ts
+++ b/apps/meteor/client/lib/chats/flows/processSlashCommand.ts
@@ -10,7 +10,7 @@ import { settings } from '../../settings';
 import type { ChatAPI } from '../ChatAPI';
 
 const parse = (msg: string): { command: string; params: string } | { command: SlashCommand; params: string } | undefined => {
-	const match = msg.match(/^\/([^\s]+)(.*)/);
+	const match = msg.match(/^\/([^\s]+)(.*)/s);
 
 	if (!match) {
 		return undefined;


### PR DESCRIPTION
## Proposed changes

Add the `s` (dotall) flag to the slash command parse regex so that multi-line input is fully captured instead of being truncated at the first newline.

**Before:**
```ts
const match = msg.match(/^\/([^\s]+)(.*)/);
```

**After:**
```ts
const match = msg.match(/^\/([^\s]+)(.*)/s);
```

The `s` flag makes `.` match newline characters (`\n`), allowing the regex to capture the full multi-line text that follows the slash command.

## Why this change?

When a user types a slash command with multi-line text (using Shift+Enter), the client silently discards everything after the first line break. For example:

```
/msg @alice
don't forget the standup
```

Only `@alice` was being sent to the server - the second line was lost without any warning.

The server-side `parseParameters` function already handles multi-line text correctly, so this fix aligns the client behavior with what the server already supports.

## How to test

1. Start the Rocket.Chat dev server (`yarn dsv`)
2. Open the web client at `http://localhost:3000`
3. Type a slash command, e.g., `/msg @username`
4. Press Shift+Enter to add a second line
5. Type additional text on the second line
6. Send the message
7. Verify the full multi-line text reaches the command handler

## Related issue

Closes #41324

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Slash commands now correctly support parameters that span multiple lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->