### PR TITLE
fix: use $ne operator in findCustomRoles to include roles without protected field

### DIFF
--- a/packages/models/src/models/Roles.ts
+++ b/packages/models/src/models/Roles.ts
@@ -128,7 +128,7 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 
 	findCustomRoles(options?: FindOptions<IRole>): FindCursor<IRole> {
 		const query: Filter<IRole> = {
-			protected: false,
+			protected: { $ne: true },
 		};
 
 		return this.find(query, options || {});
@@ -136,7 +136,7 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 
 	countCustomRoles(options?: CountDocumentsOptions): Promise<number> {
 		const query: Filter<IRole> = {
-			protected: false,
+			protected: { $ne: true },
 		};
 
 		return this.countDocuments(query, options || {});


### PR DESCRIPTION
## Description

This PR fixes a bug in `findCustomRoles` and `countCustomRoles` methods in `packages/models/src/models/Roles.ts` where roles without the `protected` field were being excluded from results.

### Problem
The original query used `protected: false` which only matches documents where the `protected` field exists and is explicitly `false`. It does NOT match documents where the `protected` field is missing/undefined.

This causes issues on older Rocket.Chat instances where custom roles were created before the `protected` field was added to the schema. These roles are invisible to `findCustomRoles` and `countCustomRoles`.

### Solution
Changed the query from `protected: false` to `protected: { $ne: true }` which:
1. Matches documents where `protected` is `false`
2. Matches documents where `protected` is `undefined`/missing
3. Only excludes documents where `protected` is explicitly `true`

This is consistent with how MongoDB's `$ne` operator works and handles the edge case of missing fields properly.

## Related Issue
Closes #40798

## Changes
- `packages/models/src/models/Roles.ts`: Updated `findCustomRoles` and `countCustomRoles` query filters

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom role filtering to include roles without an explicitly defined protected status, while continuing to exclude protected roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->