### PR TITLE
fix(autotranslate): always remove existing callback before re-registering

### DIFF
--- a/apps/meteor/app/autotranslate/server/autotranslate.ts
+++ b/apps/meteor/app/autotranslate/server/autotranslate.ts
@@ -102,8 +102,9 @@ export class TranslationProviderRegistry {
 	}
 
 	static registerCallbacks(): void {
+		callbacks.remove('afterSaveMessage', 'autotranslate');
+
 		if (!TranslationProviderRegistry.enabled) {
-			callbacks.remove('afterSaveMessage', 'autotranslate');
 			return;
 		}
 


### PR DESCRIPTION
## Proposed changes

When switching AutoTranslate providers while enabled, translations continue using the old provider until the server is restarted.

**Root cause:** In `TranslationProviderRegistry.registerCallbacks()`, the old `afterSaveMessage` callback was only removed when auto-translate was disabled. When the provider changed, `callbacks.add()` was called with the existing id `autotranslate`, but `callbacks.add()` silently returns a removal function instead of replacing when the id already exists. So the old callback (capturing the previous provider in its closure) was never replaced.

**Fix:** Always call `callbacks.remove('afterSaveMessage', 'autotranslate')` before adding the new callback, regardless of whether auto-translate is being enabled or the provider is being changed.

## Issue(s)

Fixes #41197

## Steps to test or reproduce

1. Enable Auto-Translate with the default provider (google-translate)
2. Switch Service Provider to libre-translate (or any other) while Auto-Translate remains enabled
3. Send a message in a channel with auto-translate enabled for a member
4. **Before fix:** Message is translated by the old provider (google-translate)
5. **After fix:** Message is correctly translated by the new provider (libre-translate)

## Further comments

- Changed file: `apps/meteor/app/autotranslate/server/autotranslate.ts`
- Change is minimal: moved `callbacks.remove()` call to always execute before `callbacks.add()`, instead of only when disabling
- This is consistent with how other callback-based systems handle re-registration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate automatic translations that could occur after repeated configuration updates.
  * Improved callback handling when automatic translation is disabled or reconfigured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->