### PR TITLE
chore: remove unused ip+loginAt index from Sessions model

### DIFF
--- a/packages/models/src/models/Sessions.ts
+++ b/packages/models/src/models/Sessions.ts
@@ -992,8 +992,6 @@ export class SessionsRaw extends BaseRaw<ISession> implements ISessionsModel {
 			{ key: { createdAt: -1 } },
 			{ key: { loginAt: -1 } },
 			{ key: { searchTerm: 1 }, partialFilterExpression: { searchTerm: { $exists: true } }, background: true },
-			// TODO: remove this index in the next major release (8.0.0) - its only consumer (findLastLoginByIp) was removed
-			// { key: { ip: 1, loginAt: -1 } },
 			{ key: { userId: 1, sessionId: 1 } },
 			{ key: { type: 1, year: 1, month: 1, day: 1 } },
 			{ key: { sessionId: 1, instanceId: 1, year: 1, month: 1, day: 1 } },


### PR DESCRIPTION
## Proposed changes

Removes the commented-out `{ ip: 1, loginAt: -1 }` index definition (and its
TODO) from `packages/models/src/models/Sessions.ts`. This index's only
consumer, `findLastLoginByIp`, was removed in #40849, so the index has been
dead code since then. This PR completes the cleanup the original TODO asked
for.

## Issue(s)

Fixes #41317

## Steps to test or reproduce

1. Checked out this branch and ran `yarn dev`.
2. Confirmed the server starts cleanly with no errors referencing the
   removed index or `Sessions.ts`.
3. Searched the codebase for any remaining references to
   `findLastLoginByIp` or the `{ ip: 1, loginAt: -1 }` index — none found.

## Further comments

Checked #40849 (the PR that removed `findLastLoginByIp`) — it did not
include a migration for dropping this index, so this cleanup follows the
same and doesn't add one either.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an obsolete database index configuration.
  * No user-facing functionality or session behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->