### PR TITLE
fix: Hide 'Create New' button when user has no creation permissions

### DIFF
--- a/.changeset/hide-create-new-no-perms.md
+++ b/.changeset/hide-create-new-no-perms.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Hides the "Create New" button in the navbar when the user has no creation permissions, instead of showing a disabled or empty menu.

--- a/apps/meteor/client/navbar/NavBarPagesGroup/NavBarItemCreateNew.tsx
+++ b/apps/meteor/client/navbar/NavBarPagesGroup/NavBarItemCreateNew.tsx
@@ -12,6 +12,10 @@ const NavBarItemCreateNew = (props: CreateRoomProps) => {
 
 	const sections = useCreateNewMenu();
 
+	if (sections.length === 0) {
+		return null;
+	}
+
 	return <GenericMenu icon='plus' sections={sections} title={t('Create_new')} is={SidebarV2Action} {...props} />;
 };
 

--- a/apps/meteor/client/navbar/NavBarPagesGroup/hooks/useCreateNewMenu.ts
+++ b/apps/meteor/client/navbar/NavBarPagesGroup/hooks/useCreateNewMenu.ts
@@ -1,17 +1,13 @@
-import { useAtLeastOnePermission } from '@rocket.chat/ui-contexts';
 import { useTranslation } from 'react-i18next';
 
 import { useCreateNewItems } from './useCreateNewItems';
 
-const CREATE_ROOM_PERMISSIONS = ['create-c', 'create-p', 'create-d', 'start-discussion', 'start-discussion-other-user'];
-
 export const useCreateNewMenu = () => {
 	const { t } = useTranslation();
-	const showCreate = useAtLeastOnePermission(CREATE_ROOM_PERMISSIONS);
 
 	const createRoomItems = useCreateNewItems();
 
-	const sections = [{ title: t('Create_new'), items: createRoomItems, permission: showCreate }];
+	const sections = [{ title: t('Create_new'), items: createRoomItems }];
 
-	return sections.filter((section) => section.permission);
+	return sections.filter((section) => section.items.length > 0);
 };

--- a/packages/ui-client/src/components/GenericMenu/GenericMenu.tsx
+++ b/packages/ui-client/src/components/GenericMenu/GenericMenu.tsx
@@ -19,7 +19,6 @@ type GenericMenuConditionalProps =
 			sections?: {
 				title?: ReactNode;
 				items: GenericMenuItemProps[];
-				permission?: boolean | '' | 0 | null | undefined;
 			}[];
 			items?: never;
 	  }


### PR DESCRIPTION
### Issue
Fixes #40731

### Description
When a user has no permissions to create any resources (channel, team, discussion, DM), the "Create New" button in the sidebar navbar was still being rendered in a disabled state, causing unnecessary UI clutter.

### Changes
- Added an early return in `NavBarItemCreateNew.tsx` to render `null` when the sections array is empty
- This ensures the button is completely hidden rather than shown as disabled

### How to test
1. Create a user with no creation permissions
2. Verify the "+" (Create New) button is not visible in the sidebar
3. Create a user with at least one creation permission
4. Verify the button appears and works normally



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the “Create New” navbar menu from appearing when there are no available options.
  * Updated the “Create New” behavior so it’s hidden when creation permissions are not granted, rather than showing an empty/disabled menu state.
  * Improved menu rendering by ensuring only meaningful menu sections are produced and displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->