### PR TITLE
chore(models): remove obsolete notification indexes

### DIFF
--- a/packages/models/src/models/Subscriptions.ts
+++ b/packages/models/src/models/Subscriptions.ts
@@ -46,10 +46,6 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			{ key: { alert: 1 } },
 			{ key: { ts: 1 } },
 			{ key: { ls: 1 } },
-			// TODO: remove these indexes in the next major release (8.0.0) - their only consumers (the per-room notification-preference finders) were removed
-			// { key: { desktopNotifications: 1 }, sparse: true },
-			// { key: { mobilePushNotifications: 1 }, sparse: true },
-			// { key: { emailNotifications: 1 }, sparse: true },
 			{ key: { autoTranslate: 1 }, sparse: true },
 			{ key: { autoTranslateLanguage: 1 }, sparse: true },
 			{ key: { 'userHighlights.0': 1 }, sparse: true },


### PR DESCRIPTION
## Proposed changes

- remove the stale compatibility TODO for the subscription notification-preference indexes
- remove the commented-out `desktopNotifications`, `mobilePushNotifications`, and `emailNotifications` index declarations now that their consumers are gone

Closes #41318

## Changeset

No changeset is required because this is internal comment cleanup only; it does not change runtime behavior or the published package API.

## Testing

- `yarn turbo run build --filter=@rocket.chat/models...`
- `yarn workspace @rocket.chat/models lint` (passes with existing warnings)
- `yarn workspace @rocket.chat/models typecheck`
- `yarn workspace @rocket.chat/models test --runInBand` (2 suites, 16 tests)