### PR TITLE
fix: invalidate React Query cache on DDP reconnection

### DIFF
--- a/.changeset/reconnect-thread-sync-invalidation.md
+++ b/.changeset/reconnect-thread-sync-invalidation.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixes React Query cache not being invalidated on DDP reconnection, causing open thread panels and infinite message lists to not refresh with missed messages after a reconnect.

--- a/apps/meteor/client/views/root/hooks/useLoadMissedMessages.ts
+++ b/apps/meteor/client/views/root/hooks/useLoadMissedMessages.ts
@@ -1,8 +1,10 @@
 import type { IRoom } from '@rocket.chat/core-typings';
 import { useConnectionStatus } from '@rocket.chat/ui-contexts';
+import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 
 import { LegacyRoomManager, upsertMessage } from '../../../../app/ui-utils/client';
+import { roomsQueryKeys } from '../../../lib/queryKeys';
 import { callWithErrorHandling } from '../../../lib/utils/callWithErrorHandling';
 import { Messages, Subscriptions } from '../../../stores';
 
@@ -41,6 +43,7 @@ const loadMissedMessages = async (rid: IRoom['_id']): Promise<void> => {
 export const useLoadMissedMessages = (): void => {
 	const { connected } = useConnectionStatus();
 	const connectionWasOnlineRef = useRef(connected);
+	const queryClient = useQueryClient();
 
 	useEffect(() => {
 		if (connected === true && connectionWasOnlineRef.current === false && LegacyRoomManager.openedRooms) {
@@ -48,10 +51,11 @@ export const useLoadMissedMessages = (): void => {
 				const value = LegacyRoomManager.openedRooms[key];
 				if (value.rid) {
 					loadMissedMessages(value.rid);
+					queryClient.invalidateQueries({ queryKey: roomsQueryKeys.room(value.rid) });
 				}
 			});
 		}
 
 		connectionWasOnlineRef.current = connected;
-	}, [connected]);
+	}, [connected, queryClient]);
 };


### PR DESCRIPTION
## Description

Fixes issue #41190: Open thread panels and infinite message lists do not refresh with missed messages after a DDP-only reconnection.

### Root cause

On DDP reconnection, the  hook correctly calls  to sync new messages into the Dexie/Memory cache. However, React Query caches (used by thread panels via  and infinite message lists via ) are never invalidated, so the UI does not refetch to display the newly synced messages.

### Fix

After calling  for each opened room on reconnect, invalidate all React Query caches under `roomsQueryKeys.room(rid)`. This single invalidation covers thread messages, discussion messages, infinite message lists, pinned/starred messages, and all other room-scoped queries — since they are all nested children of `roomsQueryKeys.room(rid)`.

### Changes

- `apps/meteor/client/views/root/hooks/useLoadMissedMessages.ts`: Add `queryClient.invalidateQueries({ queryKey: roomsQueryKeys.room(rid) })` per opened room in the reconnect effect.

Closes #41190

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message lists and open thread panels not refreshing after reconnecting.
  * Missed messages now appear automatically when the connection is restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->