### PR TITLE
refactor: Revamp admin settings — card-based layout with section navigation

### DIFF
--- a/.changeset/admin-settings-card-layout.md
+++ b/.changeset/admin-settings-card-layout.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': minor
+---
+
+Refreshes the look of every admin settings group. The shared settings template now renders each section as a card with an in-page section navigation ("Settings in …") on the right, instead of a single accordion. All existing setting groups, sections, names, and descriptions are preserved — this is a presentational refactor of the settings rendering components, so it applies uniformly across the admin without reorganizing any settings.

--- a/apps/meteor/client/views/admin/settings/SettingsGroupPage/SettingsGroupPage.tsx
+++ b/apps/meteor/client/views/admin/settings/SettingsGroupPage/SettingsGroupPage.tsx
@@ -1,5 +1,5 @@
 import type { ISetting, ISettingColor } from '@rocket.chat/core-typings';
-import { Accordion, Box, Button, ButtonGroup } from '@rocket.chat/fuselage';
+import { Box, Button, ButtonGroup } from '@rocket.chat/fuselage';
 import { useStableCallback } from '@rocket.chat/fuselage-hooks';
 import { Page, PageHeader, PageScrollableContentWithShadow, PageFooter } from '@rocket.chat/ui-client';
 import type { TranslationKey } from '@rocket.chat/ui-contexts';
@@ -8,6 +8,8 @@ import type { ReactNode, MouseEvent, SubmitEvent } from 'react';
 import { useMemo, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import SettingsSectionNav from './SettingsSectionNav';
+import type { SettingsSectionNavItem } from './SettingsSectionNav';
 import type { EditableSetting } from '../../EditableSettingsContext';
 import { useEditableSettingsDispatch, useEditableSettings } from '../../EditableSettingsContext';
 
@@ -19,6 +21,7 @@ export type SettingsGroupPageProps = {
 	i18nLabel: string;
 	i18nDescription?: string;
 	tabs?: ReactNode;
+	navItems?: SettingsSectionNavItem[];
 	isCustom?: boolean;
 };
 
@@ -30,6 +33,7 @@ const SettingsGroupPage = ({
 	i18nLabel,
 	i18nDescription = undefined,
 	tabs = undefined,
+	navItems = undefined,
 	isCustom = false,
 }: SettingsGroupPageProps) => {
 	const { t, i18n } = useTranslation();
@@ -146,17 +150,24 @@ const SettingsGroupPage = ({
 			{isCustom ? (
 				children
 			) : (
-				<PageScrollableContentWithShadow>
-					<Box marginBlock='none' marginInline='auto' width='full' maxWidth='x580'>
-						{i18nDescription && isTranslationKey(i18nDescription) && i18n.exists(i18nDescription) && (
-							<Box is='p' color='hint' fontScale='p2'>
-								{t(i18nDescription)}
-							</Box>
-						)}
+				<Box display='flex' flexDirection='row' flexGrow={1} minHeight={0} overflow='hidden'>
+					<Box display='flex' flexDirection='column' flexGrow={1} minWidth={0}>
+						<PageScrollableContentWithShadow>
+							<Box marginBlock='none' marginInline='auto' width='full' maxWidth='x600' pbe={24}>
+								{i18nDescription && isTranslationKey(i18nDescription) && i18n.exists(i18nDescription) && (
+									<Box is='p' color='hint' fontScale='p2' mbe={24}>
+										{t(i18nDescription)}
+									</Box>
+								)}
 
-						<Accordion>{children}</Accordion>
+								{children}
+							</Box>
+						</PageScrollableContentWithShadow>
 					</Box>
-				</PageScrollableContentWithShadow>
+					{navItems && navItems.length > 1 && (
+						<SettingsSectionNav groupLabel={isTranslationKey(i18nLabel) ? t(i18nLabel) : i18nLabel} items={navItems} />
+					)}
+				</Box>
 			)}
 			<PageFooter isDirty={!(changedEditableSettings.length === 0)}>
 				<ButtonGroup>

--- a/apps/meteor/client/views/admin/settings/SettingsGroupPage/SettingsGroupPageSkeleton.tsx
+++ b/apps/meteor/client/views/admin/settings/SettingsGroupPage/SettingsGroupPageSkeleton.tsx
@@ -1,4 +1,4 @@
-import { Accordion, Box, Skeleton } from '@rocket.chat/fuselage';
+import { Box, Skeleton } from '@rocket.chat/fuselage';
 import { Page, PageHeader, PageContent } from '@rocket.chat/ui-client';
 import { useMemo } from 'react';
 
@@ -8,15 +8,13 @@ const SettingsGroupPageSkeleton = () => (
 	<Page>
 		<PageHeader title={<Skeleton style={{ width: '20rem' }} />} />
 		<PageContent>
-			<Box style={useMemo(() => ({ margin: '0 auto', width: '100%', maxWidth: '590px' }), [])}>
-				<Box is='p' color='hint' fontScale='p2'>
+			<Box style={useMemo(() => ({ margin: '0 auto', width: '100%', maxWidth: '600px' }), [])}>
+				<Box is='p' color='hint' fontScale='p2' mbe={24}>
 					<Skeleton />
 					<Skeleton />
 					<Skeleton width='75%' />
 				</Box>
-				<Accordion>
-					<SettingsSectionSkeleton />
-				</Accordion>
+				<SettingsSectionSkeleton />
 			</Box>
 		</PageContent>
 	</Page>

--- a/apps/meteor/client/views/admin/settings/SettingsGroupPage/SettingsSectionNav.tsx
+++ b/apps/meteor/client/views/admin/settings/SettingsGroupPage/SettingsSectionNav.tsx
@@ -1,0 +1,70 @@
+import { Box } from '@rocket.chat/fuselage';
+import type { MouseEvent } from 'react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export type SettingsSectionNavItem = {
+	id: string;
+	label: string;
+};
+
+type SettingsSectionNavProps = {
+	groupLabel: string;
+	items: SettingsSectionNavItem[];
+};
+
+const SettingsSectionNav = ({ groupLabel, items }: SettingsSectionNavProps) => {
+	const { t } = useTranslation();
+	const [activeId, setActiveId] = useState(items[0]?.id);
+
+	useEffect(() => {
+		setActiveId((current) => (items.some((item) => item.id === current) ? current : items[0]?.id));
+	}, [items]);
+
+	const handleClick = (event: MouseEvent<HTMLAnchorElement>, id: string): void => {
+		event.preventDefault();
+		setActiveId(id);
+		document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+	};
+
+	return (
+		<Box
+			is='nav'
+			width='x240'
+			flexShrink={0}
+			pi={24}
+			pbs={24}
+			display='flex'
+			flexDirection='column'
+			overflowY='auto'
+			borderInlineStartWidth='default'
+			borderInlineStartColor='light'
+		>
+			<Box is='h3' mbe={16} color='hint' fontScale='micro' textTransform='uppercase'>
+				{t('Settings_in_group', { group: groupLabel })}
+			</Box>
+			{items.map(({ id, label }) => {
+				const isActive = id === activeId;
+				return (
+					<Box
+						key={id}
+						is='a'
+						href={`#${id}`}
+						onClick={(event: MouseEvent<HTMLAnchorElement>) => handleClick(event, id)}
+						pb={8}
+						pis={12}
+						mbe={4}
+						fontScale='p2'
+						color={isActive ? 'info' : 'hint'}
+						fontWeight={isActive ? 700 : 400}
+						style={{ cursor: 'pointer', textDecoration: 'none' }}
+					>
+						{label}
+					</Box>
+				);
+			})}
+		</Box>
+	);
+};
+
+export default SettingsSectionNav;

--- a/apps/meteor/client/views/admin/settings/SettingsSection/SettingsSection.tsx
+++ b/apps/meteor/client/views/admin/settings/SettingsSection/SettingsSection.tsx
@@ -1,5 +1,5 @@
 import { isSetting, isSettingColor } from '@rocket.chat/core-typings';
-import { AccordionItem, Box, Button, FieldGroup } from '@rocket.chat/fuselage';
+import { Box, Button, FieldGroup } from '@rocket.chat/fuselage';
 import { useStableCallback } from '@rocket.chat/fuselage-hooks';
 import type { TranslationKey } from '@rocket.chat/ui-contexts';
 import type { ReactNode } from 'react';
@@ -14,12 +14,12 @@ export type SettingsSectionProps = {
 	hasReset?: boolean;
 	sectionName: string;
 	currentTab?: string;
-	solo: boolean;
+	id?: string;
 	help?: ReactNode;
 	children?: ReactNode;
 };
 
-function SettingsSection({ groupId, hasReset = true, sectionName, currentTab, solo, help, children }: SettingsSectionProps) {
+function SettingsSection({ groupId, hasReset = true, sectionName, currentTab, id, help, children }: SettingsSectionProps) {
 	const { t } = useTranslation();
 
 	const editableSettings = useEditableSettings(
@@ -71,29 +71,47 @@ function SettingsSection({ groupId, hasReset = true, sectionName, currentTab, so
 	};
 
 	return (
-		<AccordionItem
-			data-qa-section={sectionName}
-			noncollapsible={solo || !sectionName}
-			title={sectionName && t(sectionName as TranslationKey)}
-		>
-			{help && (
-				<Box is='p' color='hint' fontScale='p2'>
-					{help}
+		<Box is='section' data-qa-section={sectionName} id={id} mbe={24}>
+			{sectionName && (
+				<Box is='h2' fontScale='h4' mbe={12}>
+					{t(sectionName as TranslationKey)}
 				</Box>
 			)}
-			<FieldGroup>
-				{editableSettings.map(
-					(setting) => isSetting(setting) && <Setting key={setting._id} settingId={setting._id} sectionChanged={changed} />,
+			<Box
+				p={24}
+				borderWidth='default'
+				borderColor='light'
+				borderRadius='x8'
+				backgroundColor='surface-light'
+				display='flex'
+				flexDirection='column'
+			>
+				{help && (
+					<Box is='p' color='hint' fontScale='p2' mbe={16}>
+						{help}
+					</Box>
 				)}
+				<FieldGroup>
+					{editableSettings.map(
+						(setting) => isSetting(setting) && <Setting key={setting._id} settingId={setting._id} sectionChanged={changed} />,
+					)}
 
-				{children}
-			</FieldGroup>
-			{hasReset && canReset && (
-				<Button secondary danger marginBlockStart={16} data-section={sectionName} onClick={handleResetSectionClick}>
-					{t('Reset_section_settings')}
-				</Button>
-			)}
-		</AccordionItem>
+					{children}
+				</FieldGroup>
+				{hasReset && canReset && (
+					<Button
+						secondary
+						danger
+						marginBlockStart={16}
+						alignSelf='flex-start'
+						data-section={sectionName}
+						onClick={handleResetSectionClick}
+					>
+						{t('Reset_section_settings')}
+					</Button>
+				)}
+			</Box>
+		</Box>
 	);
 }
 

--- a/apps/meteor/client/views/admin/settings/SettingsSection/SettingsSectionSkeleton.tsx
+++ b/apps/meteor/client/views/admin/settings/SettingsSection/SettingsSectionSkeleton.tsx
@@ -1,20 +1,21 @@
-import { AccordionItem, Box, FieldGroup, Skeleton } from '@rocket.chat/fuselage';
+import { Box, FieldGroup, Skeleton } from '@rocket.chat/fuselage';
 
 import SettingSkeleton from '../Setting/SettingSkeleton';
 
 function SettingsSectionSkeleton() {
 	return (
-		<AccordionItem noncollapsible title={<Skeleton />}>
-			<Box is='p' color='hint' fontScale='p2'>
+		<Box is='section' mbe={24}>
+			<Box mbe={12} width='x160'>
 				<Skeleton />
 			</Box>
-
-			<FieldGroup>
-				{Array.from({ length: 10 }).map((_, i) => (
-					<SettingSkeleton key={i} />
-				))}
-			</FieldGroup>
-		</AccordionItem>
+			<Box p={24} borderWidth='default' borderColor='light' borderRadius='x8' backgroundColor='surface-light'>
+				<FieldGroup>
+					{Array.from({ length: 10 }).map((_, i) => (
+						<SettingSkeleton key={i} />
+					))}
+				</FieldGroup>
+			</Box>
+		</Box>
 	);
 }
 

--- a/apps/meteor/client/views/admin/settings/groups/GenericGroupPage.tsx
+++ b/apps/meteor/client/views/admin/settings/groups/GenericGroupPage.tsx
@@ -1,6 +1,9 @@
+import type { TranslationKey } from '@rocket.chat/ui-contexts';
 import type { ReactNode } from 'react';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 
+import { getSettingsSectionAnchorId } from './getSettingsSectionAnchorId';
 import SettingsGroupPage from '../SettingsGroupPage';
 import Section from '../SettingsSection';
 
@@ -16,12 +19,27 @@ export type GenericGroupPageProps = {
 };
 
 function GenericGroupPage({ _id, i18nLabel, sections, tabs, currentTab, hasReset, onClickBack, ...props }: GenericGroupPageProps) {
-	const solo = sections.length === 1;
+	const { t } = useTranslation();
+
+	const navItems = useMemo(
+		() =>
+			sections
+				.filter(Boolean)
+				.map((sectionName) => ({ id: getSettingsSectionAnchorId(_id, sectionName), label: t(sectionName as TranslationKey) })),
+		[sections, _id, t],
+	);
 
 	return (
-		<SettingsGroupPage _id={_id} i18nLabel={i18nLabel} onClickBack={onClickBack} tabs={tabs} {...props}>
+		<SettingsGroupPage _id={_id} i18nLabel={i18nLabel} onClickBack={onClickBack} tabs={tabs} navItems={navItems} {...props}>
 			{sections.map((sectionName) => (
-				<Section key={sectionName || ''} hasReset={hasReset} groupId={_id} sectionName={sectionName} currentTab={currentTab} solo={solo} />
+				<Section
+					key={sectionName || ''}
+					id={getSettingsSectionAnchorId(_id, sectionName)}
+					hasReset={hasReset}
+					groupId={_id}
+					sectionName={sectionName}
+					currentTab={currentTab}
+				/>
 			))}
 		</SettingsGroupPage>
 	);

--- a/apps/meteor/client/views/admin/settings/groups/OAuthGroupPage/OAuthGroupPage.tsx
+++ b/apps/meteor/client/views/admin/settings/groups/OAuthGroupPage/OAuthGroupPage.tsx
@@ -4,13 +4,14 @@ import { capitalize } from '@rocket.chat/string-helpers';
 import { GenericModal } from '@rocket.chat/ui-client';
 import { useToastMessageDispatch, useAbsoluteUrl, useMethod, useTranslation, useSetModal } from '@rocket.chat/ui-contexts';
 import DOMPurify from 'dompurify';
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 
 import CreateOAuthModal from './CreateOAuthModal';
 import { strRight } from '../../../../../../lib/utils/stringUtils';
 import { useEditableSettingsGroupSections } from '../../../EditableSettingsContext';
 import SettingsGroupPage from '../../SettingsGroupPage';
 import SettingsSection from '../../SettingsSection';
+import { getSettingsSectionAnchorId } from '../getSettingsSectionAnchorId';
 
 export type OAuthGroupPageProps = ISetting & {
 	onClickBack?: () => void;
@@ -18,10 +19,15 @@ export type OAuthGroupPageProps = ISetting & {
 
 function OAuthGroupPage({ _id, onClickBack, ...group }: OAuthGroupPageProps) {
 	const sections = useEditableSettingsGroupSections(_id);
-	const solo = sections.length === 1;
 	const t = useTranslation();
 
 	const [settingSections, setSettingSections] = useState(sections);
+
+	const navItems = useMemo(
+		() =>
+			settingSections.filter(Boolean).map((sectionName) => ({ id: getSettingsSectionAnchorId(_id, sectionName), label: t(sectionName) })),
+		[settingSections, _id, t],
+	);
 
 	const sectionIsCustomOAuth = (sectionName: string): string | boolean => sectionName && /^Custom OAuth:\s.+/.test(sectionName);
 
@@ -98,6 +104,7 @@ function OAuthGroupPage({ _id, onClickBack, ...group }: OAuthGroupPageProps) {
 			_id={_id}
 			{...group}
 			onClickBack={onClickBack}
+			navItems={navItems}
 			headerButtons={
 				<>
 					<Button onClick={handleRefreshOAuthServicesButtonClick}>{t('Refresh_oauth_services')}</Button>
@@ -114,6 +121,7 @@ function OAuthGroupPage({ _id, onClickBack, ...group }: OAuthGroupPageProps) {
 					return (
 						<SettingsSection
 							key={sectionName}
+							id={getSettingsSectionAnchorId(_id, sectionName)}
 							groupId={_id}
 							help={
 								<span
@@ -123,7 +131,6 @@ function OAuthGroupPage({ _id, onClickBack, ...group }: OAuthGroupPageProps) {
 								/>
 							}
 							sectionName={sectionName}
-							solo={solo}
 						>
 							<div className='submit'>
 								<Button secondary danger onClick={handleRemoveCustomOAuthButtonClick}>
@@ -134,7 +141,9 @@ function OAuthGroupPage({ _id, onClickBack, ...group }: OAuthGroupPageProps) {
 					);
 				}
 
-				return <SettingsSection key={sectionName} groupId={_id} sectionName={sectionName} solo={solo} />;
+				return (
+					<SettingsSection key={sectionName} id={getSettingsSectionAnchorId(_id, sectionName)} groupId={_id} sectionName={sectionName} />
+				);
 			})}
 		</SettingsGroupPage>
 	);

--- a/apps/meteor/client/views/admin/settings/groups/getSettingsSectionAnchorId.ts
+++ b/apps/meteor/client/views/admin/settings/groups/getSettingsSectionAnchorId.ts
@@ -1,0 +1,7 @@
+/**
+ * Builds a stable DOM id for a settings section so the in-page section
+ * navigation can scroll to it. Section names may be empty (top-level
+ * settings) or contain spaces/special characters.
+ */
+export const getSettingsSectionAnchorId = (groupId: string, sectionName: string): string =>
+	`settings-${groupId}-${(sectionName || 'general').replace(/[^A-Za-z0-9]+/g, '-').toLowerCase()}`;

--- a/apps/meteor/tests/e2e/administration-settings.spec.ts
+++ b/apps/meteor/tests/e2e/administration-settings.spec.ts
@@ -76,8 +76,6 @@ test.describe.parallel('administration-settings', () => {
 		test.afterAll(async ({ api }) => setSettingValueById(api, 'theme-custom-css', ''));
 
 		test('should display the code mirror correctly', async ({ page, api }) => {
-			await poAdminSettings.getAccordionBtnByName('Custom CSS').click();
-
 			await test.step('should render only one code mirror element', async () => {
 				const codeMirrorParent = page.getByRole('code');
 				await expect(codeMirrorParent.locator('.CodeMirror')).toHaveCount(1);

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -5002,6 +5002,7 @@
   "Setting": "Setting",
   "Setting_change": "Setting change",
   "Settings": "Settings",
+  "Settings_in_group": "Settings in {{group}}",
   "Settings_updated": "Settings updated",
   "Setup_SMTP": "Set up SMTP",
   "Setup_Wizard": "Setup Wizard",


### PR DESCRIPTION
## Proposed changes

Refreshes the look of **every** admin settings group by refactoring the shared settings-rendering **template components** — not by reorganizing settings. All existing groups, sections, names, and descriptions are preserved; this is a presentational refactor that applies uniformly across the admin.

Based on the design mockup (Accounts page), generalized to the whole settings template.

### What changed

- **`SettingsSection`** — renders each section as a **titled card** (bordered, padded, surface background) instead of an accordion item. The title stays an `<h2>` so existing selectors keep working; `data-qa-section` is preserved.
- **`SettingsGroupPage`** — replaces the single `<Accordion>` with a **two-column layout**: stacked section cards on the left and an in-page **"Settings in {group}"** section navigation on the right that scroll-jumps to each section.
- **`GenericGroupPage` / `OAuthGroupPage`** — compute stable section anchor ids and the nav item list; a shared `getSettingsSectionAnchorId` helper keeps the anchors and nav in sync.
- **Skeletons** updated to match the card layout (last `Accordion` usage removed).
- One new i18n key: `Settings_in_group` ("Settings in {{group}}") for the nav header.

Because the change lives in the generic renderer, it applies to **all** groups automatically (Accounts, Message, Layout, OAuth, LDAP, Assets, Omnichannel, …). No settings were moved, renamed, or re-described.

### Behavior notes

- Sections are now **always expanded** (cards) rather than collapsible; the right-side nav replaces expand/collapse as the way to move between sections.
- Save / Cancel / per-section Reset and the editable-settings dirty tracking are unchanged.
- Dropped an obsolete accordion-expand click from the Layout settings e2e (`administration-settings.spec.ts`), since the "Custom CSS" section is always visible now.

## Verification

- `tsc --noEmit` (meteor app): **0 errors**.
- ESLint: clean on all changed files.
- Reviewed e2e selectors that touched settings sections (`data-qa-section` h2 lookups, omnichannel `group()` clicks) — still valid.
- ⚠️ Visual/interaction QA in a running workspace is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned admin settings pages with card-based sections.
  * Added in-page navigation for quickly moving between settings sections.
  * Added smooth scrolling and active-section highlighting.
  * Preserved existing setting groups, names, descriptions, and controls.

* **Bug Fixes**
  * Improved settings page loading placeholders to match the updated layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->