### PR TITLE
fix: server crash when re-enabling push notifications

### DIFF
--- a/.changeset/push-reenable-crash.md
+++ b/.changeset/push-reenable-crash.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes a server crash when re-enabling the "Enable Push" setting after it was disabled. Push notifications are now fully reconfigured on re-enable, so settings changed while push was disabled are picked up as well.

--- a/apps/meteor/app/push/server/apn.spec.ts
+++ b/apps/meteor/app/push/server/apn.spec.ts
@@ -136,19 +136,28 @@ describe('shutdownAPN', () => {
 		mocks.ApnProvider.reset();
 	});
 
-	it('should shut down the active provider', () => {
+	it('should shut down the active provider', async () => {
 		const shutdown = sandbox.stub().resolves();
 		mocks.ApnProvider.returns({ shutdown });
 
 		initAPN({ options: buildOptions(), absoluteUrl: 'https://example.com' });
-		shutdownAPN();
+		await shutdownAPN();
 
 		expect(shutdown.calledOnce).to.be.true;
 	});
 
-	it('should not throw when no provider was initialized', () => {
-		shutdownAPN();
+	it('should resolve when no provider was initialized', async () => {
+		await shutdownAPN();
+		await shutdownAPN();
+	});
 
-		expect(() => shutdownAPN()).to.not.throw();
+	it('should not reject when provider shutdown fails', async () => {
+		const shutdown = sandbox.stub().rejects(new Error('shutdown failed'));
+		mocks.ApnProvider.returns({ shutdown });
+
+		initAPN({ options: buildOptions(), absoluteUrl: 'https://example.com' });
+		await shutdownAPN();
+
+		expect(mocks.logger.error.called).to.be.true;
 	});
 });

--- a/apps/meteor/app/push/server/apn.spec.ts
+++ b/apps/meteor/app/push/server/apn.spec.ts
@@ -20,7 +20,7 @@ const apnMock = {
 	'@noCallThru': true,
 };
 
-const { initAPN } = proxyquire.noCallThru().load('./apn', {
+const { initAPN, shutdownAPN } = proxyquire.noCallThru().load('./apn', {
 	'@parse/node-apn': {
 		default: apnMock,
 		...apnMock,
@@ -127,5 +127,28 @@ describe('initAPN', () => {
 				}),
 			).to.not.throw();
 		});
+	});
+});
+
+describe('shutdownAPN', () => {
+	beforeEach(() => {
+		sandbox.resetHistory();
+		mocks.ApnProvider.reset();
+	});
+
+	it('should shut down the active provider', () => {
+		const shutdown = sandbox.stub().resolves();
+		mocks.ApnProvider.returns({ shutdown });
+
+		initAPN({ options: buildOptions(), absoluteUrl: 'https://example.com' });
+		shutdownAPN();
+
+		expect(shutdown.calledOnce).to.be.true;
+	});
+
+	it('should not throw when no provider was initialized', () => {
+		shutdownAPN();
+
+		expect(() => shutdownAPN()).to.not.throw();
 	});
 });

--- a/apps/meteor/app/push/server/apn.ts
+++ b/apps/meteor/app/push/server/apn.ts
@@ -103,6 +103,11 @@ export const sendAPN = ({
 	});
 };
 
+export const shutdownAPN = () => {
+	void apnConnection?.shutdown();
+	apnConnection = undefined;
+};
+
 export const initAPN = ({ options, absoluteUrl }: { options: RequiredField<PushOptions, 'apn'>; absoluteUrl: string }) => {
 	logger.debug('APN configured');
 

--- a/apps/meteor/app/push/server/apn.ts
+++ b/apps/meteor/app/push/server/apn.ts
@@ -103,9 +103,15 @@ export const sendAPN = ({
 	});
 };
 
-export const shutdownAPN = () => {
-	void apnConnection?.shutdown();
+export const shutdownAPN = async () => {
+	const connection = apnConnection;
 	apnConnection = undefined;
+
+	try {
+		await connection?.shutdown();
+	} catch (err) {
+		logger.error({ msg: 'Error shutting down APN connection', err });
+	}
 };
 
 export const initAPN = ({ options, absoluteUrl }: { options: RequiredField<PushOptions, 'apn'>; absoluteUrl: string }) => {

--- a/apps/meteor/app/push/server/push.ts
+++ b/apps/meteor/app/push/server/push.ts
@@ -8,7 +8,7 @@ import { JWT } from 'google-auth-library';
 import { Match, check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
-import { initAPN, sendAPN } from './apn';
+import { initAPN, sendAPN, shutdownAPN } from './apn';
 import type { PushOptions, PendingPushNotification } from './definition';
 import { sendFCM } from './fcm';
 import { logger } from './logger';
@@ -166,6 +166,12 @@ class PushClass {
 		if (this.options.apn) {
 			initAPN({ options: this.options as RequiredField<PushOptions, 'apn'>, absoluteUrl: Meteor.absoluteUrl() });
 		}
+	}
+
+	public unconfigure(): void {
+		logger.info('Push service disabled: shutting down existing connections');
+		shutdownAPN();
+		this.isConfigured = false;
 	}
 
 	private removeToken(token: string): void {

--- a/apps/meteor/app/push/server/push.ts
+++ b/apps/meteor/app/push/server/push.ts
@@ -168,10 +168,10 @@ class PushClass {
 		}
 	}
 
-	public unconfigure(): void {
+	public async unconfigure(): Promise<void> {
 		logger.info('Push service disabled: shutting down existing connections');
-		shutdownAPN();
 		this.isConfigured = false;
+		await shutdownAPN();
 	}
 
 	private removeToken(token: string): void {

--- a/apps/meteor/app/push/server/push.ts
+++ b/apps/meteor/app/push/server/push.ts
@@ -171,7 +171,7 @@ class PushClass {
 	public async unconfigure(): Promise<void> {
 		logger.info('Push service disabled: shutting down existing connections');
 		this.isConfigured = false;
-		await shutdownAPN();
+		return shutdownAPN();
 	}
 
 	private removeToken(token: string): void {

--- a/apps/meteor/server/configuration/pushNotification.ts
+++ b/apps/meteor/server/configuration/pushNotification.ts
@@ -5,6 +5,7 @@ import type { ICachedSettings } from '../../app/settings/server/CachedSettings';
 export async function configurePushNotifications(settings: ICachedSettings): Promise<void> {
 	settings.watch<boolean>('Push_enable', async (enabled) => {
 		if (!enabled) {
+			Push.unconfigure();
 			return;
 		}
 		const gateways =

--- a/apps/meteor/server/configuration/pushNotification.ts
+++ b/apps/meteor/server/configuration/pushNotification.ts
@@ -5,7 +5,7 @@ import type { ICachedSettings } from '../../app/settings/server/CachedSettings';
 export async function configurePushNotifications(settings: ICachedSettings): Promise<void> {
 	settings.watch<boolean>('Push_enable', async (enabled) => {
 		if (!enabled) {
-			Push.unconfigure();
+			await Push.unconfigure();
 			return;
 		}
 		const gateways =


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Toggling the `Push_enable` setting off and back on crashed the server:

```
=== UnHandledPromiseRejection ===
Error: Configure should not be called more than once!
    at PushClass.configure (app/push/server/push.ts)
    at server/configuration/pushNotification.ts
```

The `Push_enable` settings watcher calls `Push.configure()` on every enable, but `configure()` throws by design when called twice. The throw inside the async watcher callback becomes an unhandled promise rejection, which crashes the process when `EXIT_UNHANDLEDPROMISEREJECTION` is set.

Push is now **unconfigured when the setting is disabled**: the APN connection is shut down (`shutdownAPN()`) and the `isConfigured` flag is reset, so re-enabling runs a clean `configure()` again. As a bonus, settings changed while push was disabled (certs, gateway) are picked up on re-enable, and no stale APN connection stays alive while push is disabled. The double-configure guard remains in place to catch genuine programming errors.

## Issue(s)

## Steps to test or reproduce

1. As admin, enable **Push > Enable** (`Push_enable`)
2. Disable it
3. Enable it again
4. Before: server logs `UnHandledPromiseRejection: Configure should not be called more than once!` (and exits when `EXIT_UNHANDLEDPROMISEREJECTION` is set). After: setting toggles cleanly, log line `Push service disabled: shutting down existing connections` appears on disable.

## Further comments

Unit tests added for `shutdownAPN` in `apn.spec.ts`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a server crash that could occur when push notifications were re-enabled after being disabled.
  * Push notification services now shut down cleanly when disabled.
  * Re-enabling push notifications now fully reapplies the latest push settings, including changes made while the feature was disabled.
  * Improved handling of shutdown errors to prevent service interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
https://rocketchat.atlassian.net/browse/CORE-64