### PR TITLE
regression: missing emojis in picker search

### DIFF
--- a/apps/meteor/app/emoji-native/lib/generateEmojiData.ts
+++ b/apps/meteor/app/emoji-native/lib/generateEmojiData.ts
@@ -17,6 +17,7 @@ const groupToCategory: Record<number, string> = {
 };
 
 export type EmojiEntry = {
+	name: string;
 	uc_base: string;
 	uc_output: string;
 	uc_match: string;
@@ -73,6 +74,7 @@ function buildEmojiData() {
 		const hex = hexFromEmoji(emojiData.emoji);
 
 		const entry: EmojiEntry = {
+			name: primaryShortcode,
 			uc_base: hex,
 			uc_output: hex,
 			uc_match: hex,
@@ -108,6 +110,7 @@ function buildEmojiData() {
 				const skinHex = hexFromEmoji(skin.emoji);
 
 				const skinEntry: EmojiEntry = {
+					name: primaryShortcode,
 					uc_base: skinHex,
 					uc_output: skinHex,
 					uc_match: skinHex,

--- a/apps/meteor/app/emoji/client/helpers.ts
+++ b/apps/meteor/app/emoji/client/helpers.ts
@@ -172,11 +172,11 @@ export const getEmojisBySearchTerm = (
 			continue;
 		}
 
-		const { emojiPackage, shortnames = [] } = emojiObject;
+		const { emojiPackage, shortnames = [], name } = emojiObject;
 		let tone = '';
 		current = current.replace(/:/g, '');
 
-		if (actualTone > 0 && emoji.packages[emojiPackage].toneList.hasOwnProperty(current)) {
+		if (actualTone > 0 && emoji.packages[emojiPackage].toneList.hasOwnProperty(name ?? current)) {
 			tone = `_tone${actualTone}`;
 		}
 

--- a/apps/meteor/app/emoji/client/helpers.ts
+++ b/apps/meteor/app/emoji/client/helpers.ts
@@ -157,57 +157,55 @@ export const getEmojisBySearchTerm = (
 	setRecentEmojis: (emojis: string[]) => void,
 ) => {
 	const emojis = [];
+	const seenEmojis = new Set<(typeof emoji.list)[string]>();
 	const searchRegExp = new RegExp(escapeRegExp(searchTerm.replace(/:/g, '')), 'i');
 
 	for (let current in emoji.list) {
-		if (!emoji.list.hasOwnProperty(current)) {
+		if (!emoji.list.hasOwnProperty(current) || !searchRegExp.test(current)) {
 			continue;
 		}
 
-		if (searchRegExp.test(current)) {
-			const emojiObject = emoji.list[current];
-			const { emojiPackage, shortnames = [] } = emojiObject;
-			let tone = '';
-			current = current.replace(/:/g, '');
-			const alias = shortnames[0] !== undefined ? shortnames[0].replace(/:/g, '') : shortnames[0];
+		const emojiObject = emoji.list[current];
 
-			if (actualTone > 0 && emoji.packages[emojiPackage].toneList.hasOwnProperty(current)) {
-				tone = `_tone${actualTone}`;
-			}
-
-			const mixedTones = current.match(MIXED_TONE_SUFFIX);
-			const categoryName = current.replace(MIXED_TONE_SUFFIX, '');
-			if (mixedTones && !(actualTone > 0 && Number(mixedTones[1]) === actualTone)) {
-				continue;
-			}
-
-			let emojiFound = false;
-
-			for (const key in emoji.packages[emojiPackage].emojisByCategory) {
-				if (emoji.packages[emojiPackage].emojisByCategory.hasOwnProperty(key)) {
-					const contents = emoji.packages[emojiPackage].emojisByCategory[key];
-					const searchValArray = alias !== undefined ? alias.replace(/:/g, '').split('_') : alias;
-					if (contents.indexOf(categoryName) !== -1 || searchValArray?.includes(searchTerm)) {
-						emojiFound = true;
-						break;
-					}
-				}
-			}
-
-			if (emojiFound) {
-				const emojiToRender = `:${current}${tone}:`;
-
-				const actualEmoji = emoji.list[emojiToRender];
-				if (!actualEmoji) {
-					removeFromRecent(emojiToRender, recentEmojis, setRecentEmojis);
-					break;
-				}
-
-				const actualPackage = actualEmoji.emojiPackage;
-
-				emojis.push({ emoji: current, image: emoji.packages[actualPackage].renderPicker(emojiToRender) });
-			}
+		// Skip duplicates (same emoji in different packages)
+		if (seenEmojis.has(emojiObject)) {
+			continue;
 		}
+
+		const { emojiPackage, shortnames = [] } = emojiObject;
+		let tone = '';
+		current = current.replace(/:/g, '');
+
+		if (actualTone > 0 && emoji.packages[emojiPackage].toneList.hasOwnProperty(current)) {
+			tone = `_tone${actualTone}`;
+		}
+
+		const mixedTones = current.match(MIXED_TONE_SUFFIX);
+		const categoryName = current.replace(MIXED_TONE_SUFFIX, '');
+		if (mixedTones && !(actualTone > 0 && Number(mixedTones[1]) === actualTone)) {
+			continue;
+		}
+
+		const isCategoryEmoji = Object.values(emoji.packages[emojiPackage].emojisByCategory).some(
+			(contents) => contents.indexOf(categoryName) !== -1,
+		);
+		if (!isCategoryEmoji && shortnames.length === 0) {
+			continue;
+		}
+
+		const emojiToRender = `:${current}${tone}:`;
+
+		const actualEmoji = emoji.list[emojiToRender];
+		if (!actualEmoji) {
+			removeFromRecent(emojiToRender, recentEmojis, setRecentEmojis);
+			continue;
+		}
+
+		seenEmojis.add(emojiObject);
+
+		const actualPackage = actualEmoji.emojiPackage;
+
+		emojis.push({ emoji: current, image: emoji.packages[actualPackage].renderPicker(emojiToRender) });
 	}
 
 	return emojis;

--- a/apps/meteor/app/emoji/client/helpers.ts
+++ b/apps/meteor/app/emoji/client/helpers.ts
@@ -205,7 +205,7 @@ export const getEmojisBySearchTerm = (
 
 		const actualPackage = actualEmoji.emojiPackage;
 
-		emojis.push({ emoji: current, image: emoji.packages[actualPackage].renderPicker(emojiToRender) });
+		emojis.push({ emoji: `${current}${tone}`, image: emoji.packages[actualPackage].renderPicker(emojiToRender) });
 	}
 
 	return emojis;

--- a/apps/meteor/app/emoji/lib/rocketchat.ts
+++ b/apps/meteor/app/emoji/lib/rocketchat.ts
@@ -20,6 +20,7 @@ export type EmojiPackages = {
 	list: {
 		[key: keyof NonNullable<EmojiPackages['packages']>]:
 			| {
+					name?: string;
 					category: string;
 					emojiPackage: string;
 					shortnames: string[];
@@ -34,6 +35,7 @@ export type EmojiPackages = {
 					unicode?: string;
 			  }
 			| {
+					name?: undefined;
 					emojiPackage: string;
 					aliasOf: string;
 					extension?: undefined;

--- a/apps/meteor/tests/unit/app/emoji/helpers.spec.ts
+++ b/apps/meteor/tests/unit/app/emoji/helpers.spec.ts
@@ -71,6 +71,7 @@ describe('Emoji Client Helpers', () => {
 
 			expect(result).to.exist;
 			expect(result?.image).to.include('👍🏼');
+			expect(result?.emoji).to.equal('thumbsup_tone2');
 		});
 	});
 

--- a/apps/meteor/tests/unit/app/emoji/helpers.spec.ts
+++ b/apps/meteor/tests/unit/app/emoji/helpers.spec.ts
@@ -65,6 +65,13 @@ describe('Emoji Client Helpers', () => {
 		it('excludes skin-tone variants from the results', () => {
 			expect(names('+1').some((name) => /_tone[1-5]/.test(name))).to.be.false;
 		});
+
+		it('applies the selected skin tone when searching by an alias', () => {
+			const result = getEmojisBySearchTerm('thumbsup', 2, [], () => undefined).find(({ image }) => image?.includes('👍'));
+
+			expect(result).to.exist;
+			expect(result?.image).to.include('👍🏼');
+		});
 	});
 
 	describe('updateRecent', () => {

--- a/apps/meteor/tests/unit/app/emoji/helpers.spec.ts
+++ b/apps/meteor/tests/unit/app/emoji/helpers.spec.ts
@@ -1,12 +1,70 @@
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
+import { describe, it, beforeEach, before } from 'mocha';
 
-import { updateRecent, removeFromRecent, replaceEmojiInRecent } from '../../../../app/emoji/client/helpers';
+import { getEmojisBySearchTerm, updateRecent, removeFromRecent, replaceEmojiInRecent } from '../../../../app/emoji/client/helpers';
 import { emoji } from '../../../../app/emoji/client/lib';
+import { getEmojiConfig } from '../../../../app/emoji-native/lib/getEmojiConfig';
+
+const registerNativeEmojis = () => {
+	const config = getEmojiConfig(emoji);
+
+	emoji.packages.native = {
+		emojiCategories: config.emojiCategories as any,
+		emojisByCategory: config.emojisByCategory,
+		toneList: config.toneList,
+		render: config.render,
+		renderPicker: config.renderPicker,
+		sprites: config.sprites,
+	};
+
+	for (const [key, currentEmoji] of Object.entries(config.emojiList)) {
+		currentEmoji.emojiPackage = 'native';
+		emoji.list[key] = currentEmoji as any;
+
+		if (currentEmoji.shortnames) {
+			currentEmoji.shortnames.forEach((shortname: string) => {
+				emoji.list[shortname] = currentEmoji as any;
+			});
+		}
+	}
+};
 
 describe('Emoji Client Helpers', () => {
 	beforeEach(() => {
 		emoji.packages.base.emojisByCategory.recent = [];
+	});
+
+	describe('getEmojisBySearchTerm', () => {
+		before(registerNativeEmojis);
+
+		const search = (term: string) => getEmojisBySearchTerm(term, 0, [], () => undefined);
+		const names = (term: string) => search(term).map((result) => result.emoji);
+		const rendersThumbsUp = (term: string) => search(term).some((result) => result.image?.includes('👍'));
+
+		it('finds an emoji by its primary shortcode', () => {
+			expect(names('+1')).to.include('+1');
+		});
+
+		it('finds an emoji by its first alias (thumbsup -> 👍)', () => {
+			expect(rendersThumbsUp('thumbsup')).to.be.true;
+		});
+
+		it('finds an emoji by a secondary alias (yes -> 👍)', () => {
+			expect(rendersThumbsUp('yes')).to.be.true;
+		});
+
+		it('matches aliases partially (thumb -> thumbsup)', () => {
+			expect(names('thumb')).to.include('thumbsup');
+		});
+
+		it('does not list the same emoji more than once', () => {
+			const images = search('grinning').map((result) => result.image);
+			expect(images.length).to.equal(new Set(images).size);
+		});
+
+		it('excludes skin-tone variants from the results', () => {
+			expect(names('+1').some((name) => /_tone[1-5]/.test(name))).to.be.false;
+		});
 	});
 
 	describe('updateRecent', () => {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-2415](https://rocketchat.atlassian.net/browse/CORE-2415)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-2415]: https://rocketchat.atlassian.net/browse/CORE-2415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emoji search result selection by deduplicating candidates and tightening qualification logic.
  * Enhanced alias handling, including primary/secondary aliases and partial alias matching.
  * Prevented default results from showing skin-tone variant names while still honoring the selected tone.
  * Continued gracefully when an emoji can’t be rendered by moving to the next candidate.

* **Tests**
  * Added unit coverage for the updated emoji search behavior, including deduplication, alias resolution (including partial matches), and tone filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->