### PR TITLE
test: fix race in uikit-interactions e2e by awaiting interaction response

### DIFF
--- a/apps/meteor/tests/e2e/apps/uikit-interactions.spec.ts
+++ b/apps/meteor/tests/e2e/apps/uikit-interactions.spec.ts
@@ -49,12 +49,12 @@ test.describe.serial('Apps > UIKit interactions data', () => {
 		// Send a message with a button via the slash command
 		await poHomeChannel.content.dispatchSlashCommand(`/open-uikit-room-test-modal message ${seed}`);
 
-		const interactionRequest = page.waitForRequest('**/ui.interaction/*');
+		const interactionResponse = page.waitForResponse('**/ui.interaction/*');
 
 		// Wait for the message with the button to appear and click it
 		await page.getByRole('button', { name: 'Click!' }).click();
 
-		await interactionRequest;
+		await interactionResponse;
 
 		// Fetch app logs and validate
 		const logsResult = await getAppLogs(api, appId);
@@ -96,13 +96,13 @@ test.describe.serial('Apps > UIKit interactions data', () => {
 		// has been closed" while the navigation is still in progress.
 		await page.waitForURL(/\/app\//);
 
-		const interactionRequest = page.waitForRequest('**/ui.interaction/*');
+		const interactionResponse = page.waitForResponse('**/ui.interaction/*');
 
 		// Wait for the contextual bar to appear and click the button
 		const surface = page.getByRole('dialog', { name: 'UIKit Room Test Contextual Bar' });
 		await surface.getByRole('button', { name: 'Click!' }).click();
 
-		await interactionRequest;
+		await interactionResponse;
 
 		// Fetch app logs and validate
 		const logsResult = await getAppLogs(api, appId);
@@ -134,13 +134,13 @@ test.describe.serial('Apps > UIKit interactions data', () => {
 		// Open a modal via slash command
 		await poHomeChannel.content.dispatchSlashCommand(`/open-uikit-room-test-modal modal ${seed}`);
 
-		const interactionRequest = page.waitForRequest('**/ui.interaction/*');
+		const interactionResponse = page.waitForResponse('**/ui.interaction/*');
 
 		// Wait for the modal to appear and click the button
 		const surface = page.getByRole('dialog', { name: 'UIKit Room Test Modal' });
 		await surface.getByRole('button', { name: 'Click!' }).click();
 
-		await interactionRequest;
+		await interactionResponse;
 
 		// Fetch app logs and validate
 		const logsResult = await getAppLogs(api, appId);
@@ -173,12 +173,12 @@ test.describe.serial('Apps > UIKit interactions data', () => {
 		// Open a modal via slash command
 		await poHomeChannel.content.dispatchSlashCommand(`/open-uikit-room-test-modal modal ${seed}`);
 
-		const interactionRequest = page.waitForRequest('**/ui.interaction/*');
+		const interactionResponse = page.waitForResponse('**/ui.interaction/*');
 
 		// Wait for the modal and submit it
 		await page.getByLabel('UIKit Room Test Modal').getByRole('button', { name: 'Submit' }).click();
 
-		await interactionRequest;
+		await interactionResponse;
 
 		// Fetch app logs and validate
 		const logsResult = await getAppLogs(api, appId);
@@ -205,12 +205,12 @@ test.describe.serial('Apps > UIKit interactions data', () => {
 		// Wait for the client-side navigation to the contextual bar URL to complete
 		await page.waitForURL(/\/app\//);
 
-		const interactionRequest = page.waitForRequest('**/ui.interaction/*');
+		const interactionResponse = page.waitForResponse('**/ui.interaction/*');
 
 		// Wait for the contextual bar and submit it
 		await page.getByLabel('UIKit Room Test Contextual Bar').getByRole('button', { name: 'Submit' }).click();
 
-		await interactionRequest;
+		await interactionResponse;
 
 		// Fetch app logs and validate
 		const logsResult = await getAppLogs(api, appId);
@@ -235,12 +235,12 @@ test.describe.serial('Apps > UIKit interactions data', () => {
 		// Open a modal via slash command
 		await poHomeChannel.content.dispatchSlashCommand(`/open-uikit-room-test-modal modal ${seed}`);
 
-		const interactionRequest = page.waitForRequest('**/ui.interaction/*');
+		const interactionResponse = page.waitForResponse('**/ui.interaction/*');
 
 		// Wait for the modal and close it (via X button, not submit)
 		await page.getByLabel('UIKit Room Test Modal').getByRole('button', { name: 'Close' }).click();
 
-		await interactionRequest;
+		await interactionResponse;
 
 		// Fetch app logs and validate
 		const logsResult = await getAppLogs(api, appId);
@@ -263,12 +263,12 @@ test.describe.serial('Apps > UIKit interactions data', () => {
 		// Wait for the client-side navigation to the contextual bar URL to complete
 		await page.waitForURL(/\/app\//);
 
-		const interactionRequest = page.waitForRequest('**/ui.interaction/*');
+		const interactionResponse = page.waitForResponse('**/ui.interaction/*');
 
 		// Wait for the contextual bar to appear and close it
 		await page.getByLabel('UIKit Room Test Contextual Bar').getByRole('button', { name: 'Close' }).click();
 
-		await interactionRequest;
+		await interactionResponse;
 
 		// Fetch app logs and validate
 		const logsResult = await getAppLogs(api, appId);


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fixes a flaky failure in `tests/e2e/apps/uikit-interactions.spec.ts` ("Block action handler log not found", e.g. [this merge-queue run](https://github.com/RocketChat/Rocket.Chat/actions/runs/29271254427/job/86891848139)).

The tests used `page.waitForRequest('**/ui.interaction/*')`, which resolves as soon as the browser **sends** the request. `getAppLogs` could then run while the server was still executing the app handler, so the expected log entry wasn't persisted yet.

The `ui.interaction` endpoint only responds after `triggerEvent` completes, and the apps-engine Deno runtime awaits `logStorage.storeEntries` before resolving the handler result — so once the **response** arrives, the log is guaranteed to be in the database. Switching to `page.waitForResponse` removes the race deterministically.

No changeset: test-only change.

## Issue(s)

## Steps to test or reproduce

Run `tests/e2e/apps/uikit-interactions.spec.ts` (EE) — previously flaked under CI load, now deterministic.

## Further comments

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [FLAKY-2381]

[FLAKY-2381]: https://rocketchat.atlassian.net/browse/FLAKY-2381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test synchronization for UIKit interactions by waiting for completed interaction responses.
  * Updated coverage for block actions, view submissions, and view closures across messages, modals, and contextual bars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->