### PR TITLE
ci: enable e2e retries in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -605,7 +605,7 @@ jobs:
       deno-version: ${{ needs.release-versions.outputs.deno-version }}
       lowercase-repo: ${{ needs.release-versions.outputs.lowercase-repo }}
       gh-docker-tag: ${{ needs.release-versions.outputs.gh-docker-tag }}
-      retries: ${{ (github.event_name == 'release' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master') && 2 || 0 }}
+      retries: ${{ (github.event_name == 'release' || github.event_name == 'merge_group' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master') && 2 || 0 }}
     secrets:
       CR_USER: ${{ secrets.CR_USER }}
       CR_PAT: ${{ secrets.CR_PAT }}
@@ -696,7 +696,7 @@ jobs:
       deno-version: ${{ needs.release-versions.outputs.deno-version }}
       lowercase-repo: ${{ needs.release-versions.outputs.lowercase-repo }}
       gh-docker-tag: ${{ needs.release-versions.outputs.gh-docker-tag }}
-      retries: ${{ (github.event_name == 'release' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master') && 2 || 0 }}
+      retries: ${{ (github.event_name == 'release' || github.event_name == 'merge_group' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master') && 2 || 0 }}
     secrets:
       CR_USER: ${{ secrets.CR_USER }}
       CR_PAT: ${{ secrets.CR_PAT }}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

E2E retries are enabled for develop/master/release (`retries: 2`) but merge-queue runs use a `gh-readonly-queue/*` ref, so they never match the branch condition and run with `retries: 0`. A single infra flake evicts the PR from the queue.

Example: [this merge-queue run](https://github.com/RocketChat/Rocket.Chat/actions/runs/29271254427/job/86891848045) failed `administration.spec.ts` because Meteor's `dynamic-import/fetch` for the lazy-loaded admin bundle died mid-stream (`ERR_INCOMPLETE_CHUNKED_ENCODING` in the trace), which makes `React.lazy` reject and the GUI hard-crash ("Application Error" boundary) — the test never had a chance. The same infra flake was previously confirmed on `omnichannel-custom-field` — it can hit any spec that navigates to a lazy-loaded route.

This adds `merge_group` to the retry condition, applying the same `retries: 2` policy that develop and master pushes already use.

No changeset: CI-only change.

## Issue(s)

## Steps to test or reproduce

## Further comments

The underlying GUI crash on transient dynamic-import failure is a real (rare) user-facing issue — a retryable lazy-import wrapper would be the app-level fix, but that's a product change outside the scope of de-flaking CI.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

