### PR TITLE
refactor: migrate omnichannel schedulers to the cron package

### DIFF
--- a/.changeset/omnichannel-schedulers-cron.md
+++ b/.changeset/omnichannel-schedulers-cron.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/meteor': patch
+'@rocket.chat/cron': minor
+---
+
+Unifies the omnichannel job schedulers (auto-close on-hold chats, auto-transfer unanswered chats and queue inactivity monitor) under the cron system, reducing database polling by removing three dedicated scheduler instances

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoCloseOnHoldScheduler.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoCloseOnHoldScheduler.ts
@@ -33,14 +33,18 @@ export class AutoCloseOnHoldSchedulerClass {
 	private async executeJob(roomId: string, comment: string): Promise<void> {
 		this.logger.debug({ msg: 'Executing job for room', roomId });
 
-		const [room, user] = await Promise.all([LivechatRooms.findOneById(roomId), this.getSchedulerUser()]);
-		if (!room || !user) {
-			throw new Error(
-				`Unable to process AutoCloseOnHoldScheduler job because room or user not found for roomId: ${roomId} and userId: rocket.cat`,
-			);
-		}
+		try {
+			const [room, user] = await Promise.all([LivechatRooms.findOneById(roomId), this.getSchedulerUser()]);
+			if (!room || !user) {
+				throw new Error(
+					`Unable to process AutoCloseOnHoldScheduler job because room or user not found for roomId: ${roomId} and userId: rocket.cat`,
+				);
+			}
 
-		await closeRoom({ room, user, comment });
+			await closeRoom({ room, user, comment });
+		} finally {
+			await this.unscheduleRoom(roomId);
+		}
 	}
 
 	private async getSchedulerUser(): Promise<IUser> {

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoCloseOnHoldScheduler.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoCloseOnHoldScheduler.ts
@@ -35,10 +35,9 @@ export class AutoCloseOnHoldSchedulerClass {
 
 		try {
 			const [room, user] = await Promise.all([LivechatRooms.findOneById(roomId), this.getSchedulerUser()]);
-			if (!room || !user) {
-				throw new Error(
-					`Unable to process AutoCloseOnHoldScheduler job because room or user not found for roomId: ${roomId} and userId: rocket.cat`,
-				);
+			if (!room) {
+				this.logger.error({ msg: 'Unable to process auto close on-hold job: room not found', roomId });
+				throw new Error('error-room-not-found');
 			}
 
 			await closeRoom({ room, user, comment });
@@ -51,7 +50,8 @@ export class AutoCloseOnHoldSchedulerClass {
 		if (!this.schedulerUser) {
 			const schedulerUser = await Users.findOneById('rocket.cat');
 			if (!schedulerUser) {
-				throw new Error('Scheduler user not found');
+				this.logger.error({ msg: 'Unable to process auto close on-hold job: scheduler user not found', userId: 'rocket.cat' });
+				throw new Error('error-user-not-found');
 			}
 			this.schedulerUser = schedulerUser;
 		}

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoCloseOnHoldScheduler.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoCloseOnHoldScheduler.ts
@@ -1,10 +1,7 @@
-import { Agenda } from '@rocket.chat/agenda';
 import type { IUser } from '@rocket.chat/core-typings';
+import { cronJobs } from '@rocket.chat/cron';
 import type { MainLogger } from '@rocket.chat/logger';
 import { LivechatRooms, Users } from '@rocket.chat/models';
-import { Meteor } from 'meteor/meteor';
-import { MongoInternals } from 'meteor/mongo';
-import moment from 'moment';
 
 import { schedulerLogger } from './logger';
 import { closeRoom } from '../../../../../app/livechat/server/lib/closeRoom';
@@ -12,11 +9,7 @@ import { closeRoom } from '../../../../../app/livechat/server/lib/closeRoom';
 const SCHEDULER_NAME = 'omnichannel_auto_close_on_hold_scheduler';
 
 export class AutoCloseOnHoldSchedulerClass {
-	scheduler: Agenda;
-
 	schedulerUser: IUser;
-
-	running: boolean;
 
 	logger: MainLogger;
 
@@ -24,50 +17,21 @@ export class AutoCloseOnHoldSchedulerClass {
 		this.logger = schedulerLogger.section('AutoCloseOnHoldScheduler');
 	}
 
-	public async init(): Promise<void> {
-		if (this.running) {
-			return;
-		}
-
-		this.scheduler = new Agenda({
-			mongo: (MongoInternals.defaultRemoteCollectionDriver().mongo as any).client.db(),
-			db: { collection: SCHEDULER_NAME },
-			defaultConcurrency: 1,
-			processEvery: process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api' ? '3 seconds' : '1 minute',
-		});
-
-		await this.scheduler.start();
-		this.running = true;
-		this.logger.info('Service started');
-	}
-
 	public async scheduleRoom(roomId: string, timeout: number, comment: string): Promise<void> {
-		if (!this.running) {
-			throw new Error('AutoCloseOnHoldScheduler is not running');
-		}
-
 		this.logger.debug({ msg: 'Scheduling room to be closed', roomId, timeoutSeconds: timeout });
 		await this.unscheduleRoom(roomId);
 
-		const jobName = `${SCHEDULER_NAME}-${roomId}`;
-		const when = moment(new Date()).add(timeout, 's').toDate();
-
-		this.scheduler.define(jobName, this.executeJob.bind(this));
-		await this.scheduler.schedule(when, jobName, { roomId, comment });
+		const when = new Date(Date.now() + timeout * 1000);
+		await cronJobs.addAtTimestamp(`${SCHEDULER_NAME}-${roomId}`, when, () => this.executeJob(roomId, comment));
 	}
 
 	public async unscheduleRoom(roomId: string): Promise<void> {
-		if (!this.running) {
-			throw new Error('AutoCloseOnHoldScheduler is not running');
-		}
 		this.logger.debug({ msg: 'Unscheduling room', roomId });
-		const jobName = `${SCHEDULER_NAME}-${roomId}`;
-		await this.scheduler.cancel({ name: jobName });
+		await cronJobs.remove(`${SCHEDULER_NAME}-${roomId}`);
 	}
 
-	private async executeJob({ attrs: { data } }: any = {}): Promise<void> {
-		this.logger.debug({ msg: 'Executing job for room', roomId: data.roomId });
-		const { roomId, comment } = data;
+	private async executeJob(roomId: string, comment: string): Promise<void> {
+		this.logger.debug({ msg: 'Executing job for room', roomId });
 
 		const [room, user] = await Promise.all([LivechatRooms.findOneById(roomId), this.getSchedulerUser()]);
 		if (!room || !user) {
@@ -76,13 +40,7 @@ export class AutoCloseOnHoldSchedulerClass {
 			);
 		}
 
-		const payload = {
-			room,
-			user,
-			comment,
-		};
-
-		await closeRoom(payload);
+		await closeRoom({ room, user, comment });
 	}
 
 	private async getSchedulerUser(): Promise<IUser> {
@@ -99,7 +57,3 @@ export class AutoCloseOnHoldSchedulerClass {
 }
 
 export const AutoCloseOnHoldScheduler = new AutoCloseOnHoldSchedulerClass();
-
-Meteor.startup(() => {
-	void AutoCloseOnHoldScheduler.init();
-});

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoCloseOnHoldScheduler.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoCloseOnHoldScheduler.ts
@@ -48,7 +48,7 @@ export class AutoCloseOnHoldSchedulerClass {
 
 	private async getSchedulerUser(): Promise<IUser> {
 		if (!this.schedulerUser) {
-			const schedulerUser = await Users.findOneById('rocket.cat');
+			const schedulerUser = await Users.findOneById('rocket.cat', { projection: { __rooms: 0 } });
 			if (!schedulerUser) {
 				this.logger.error({ msg: 'Unable to process auto close on-hold job: scheduler user not found', userId: 'rocket.cat' });
 				throw new Error('error-user-not-found');

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoTransferChatScheduler.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoTransferChatScheduler.ts
@@ -19,7 +19,7 @@ export class AutoTransferChatSchedulerClass {
 	}
 
 	private async getSchedulerUser(): Promise<IUser & { userType: 'user' }> {
-		const user = await Users.findOneById('rocket.cat');
+		const user = await Users.findOneById('rocket.cat', { projection: { __rooms: 0 } });
 		if (!user) {
 			this.logger.error('Error while transferring room: user not found');
 			throw new Error('error-no-cat');

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoTransferChatScheduler.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoTransferChatScheduler.ts
@@ -9,7 +9,7 @@ import { RoutingManager } from '../../../../../app/livechat/server/lib/RoutingMa
 import { returnRoomAsInquiry } from '../../../../../app/livechat/server/lib/rooms';
 import { settings } from '../../../../../app/settings/server';
 
-const SCHEDULER_NAME = 'omnichannel_scheduler';
+const SCHEDULER_NAME = 'omnichannel_auto_transfer_scheduler';
 
 export class AutoTransferChatSchedulerClass {
 	logger: MainLogger;
@@ -103,10 +103,11 @@ export class AutoTransferChatSchedulerClass {
 	private async executeJob(roomId: string): Promise<void> {
 		try {
 			await this.transferRoom(roomId);
-
-			await Promise.all([LivechatRooms.setAutoTransferredAtById(roomId), this.unscheduleRoom(roomId)]);
+			await LivechatRooms.setAutoTransferredAtById(roomId);
 		} catch (error) {
 			this.logger.error({ msg: 'Error while executing auto-transfer job', schedulerName: SCHEDULER_NAME, roomId, err: error });
+		} finally {
+			await this.unscheduleRoom(roomId);
 		}
 	}
 }

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoTransferChatScheduler.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoTransferChatScheduler.ts
@@ -19,7 +19,7 @@ export class AutoTransferChatSchedulerClass {
 	}
 
 	private async getSchedulerUser(): Promise<IUser & { userType: 'user' }> {
-		const user = await Users.findOneById('rocket.cat', { projection: { __rooms: 0 } });
+		const user = await Users.findOneById('rocket.cat');
 		if (!user) {
 			this.logger.error('Error while transferring room: user not found');
 			throw new Error('error-no-cat');

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoTransferChatScheduler.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoTransferChatScheduler.ts
@@ -55,8 +55,14 @@ export class AutoTransferChatSchedulerClass {
 			open: 1,
 			departmentId: 1,
 		});
-		if (!room?.open || !room?.servedBy?._id) {
-			throw new Error('Room is not open or is not being served by an agent');
+		if (!room) {
+			throw new Error('error-room-not-found');
+		}
+		if (!room.open) {
+			throw new Error('error-room-already-closed');
+		}
+		if (!room.servedBy?._id) {
+			throw new Error('error-room-not-served');
 		}
 
 		const {

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoTransferChatScheduler.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/AutoTransferChatScheduler.ts
@@ -1,9 +1,7 @@
-import { Agenda } from '@rocket.chat/agenda';
 import type { IUser } from '@rocket.chat/core-typings';
+import { cronJobs } from '@rocket.chat/cron';
 import type { MainLogger } from '@rocket.chat/logger';
 import { LivechatRooms, Users } from '@rocket.chat/models';
-import { Meteor } from 'meteor/meteor';
-import { MongoInternals } from 'meteor/mongo';
 
 import { schedulerLogger } from './logger';
 import { forwardRoomToAgent } from '../../../../../app/livechat/server/lib/Helper';
@@ -14,33 +12,10 @@ import { settings } from '../../../../../app/settings/server';
 const SCHEDULER_NAME = 'omnichannel_scheduler';
 
 export class AutoTransferChatSchedulerClass {
-	scheduler: Agenda;
-
-	running: boolean;
-
-	user: IUser;
-
 	logger: MainLogger;
 
 	constructor() {
 		this.logger = schedulerLogger.section('AutoTransferChatScheduler');
-	}
-
-	public async init(): Promise<void> {
-		if (this.running) {
-			return;
-		}
-
-		this.scheduler = new Agenda({
-			mongo: (MongoInternals.defaultRemoteCollectionDriver().mongo as any).client.db(),
-			db: { collection: SCHEDULER_NAME },
-			defaultConcurrency: 1,
-			processEvery: process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api' ? '3 seconds' : '1 minute',
-		});
-
-		await this.scheduler.start();
-		this.running = true;
-		this.logger.info('Service started');
 	}
 
 	private async getSchedulerUser(): Promise<IUser & { userType: 'user' }> {
@@ -59,21 +34,16 @@ export class AutoTransferChatSchedulerClass {
 		this.logger.debug({ msg: 'Scheduling room to be transferred', roomId, timeoutSeconds: timeout });
 		await this.unscheduleRoom(roomId);
 
-		const jobName = `${SCHEDULER_NAME}-${roomId}`;
-		const when = new Date();
-		when.setSeconds(when.getSeconds() + timeout);
-
-		this.scheduler.define(jobName, this.executeJob.bind(this));
-		await this.scheduler.schedule(when, jobName, { roomId });
+		const when = new Date(Date.now() + timeout * 1000);
+		await cronJobs.addAtTimestamp(`${SCHEDULER_NAME}-${roomId}`, when, () => this.executeJob(roomId));
 		await LivechatRooms.setAutoTransferOngoingById(roomId);
 	}
 
 	public async unscheduleRoom(roomId: string): Promise<void> {
 		this.logger.debug({ msg: 'Unscheduling room', roomId });
-		const jobName = `${SCHEDULER_NAME}-${roomId}`;
 
 		await LivechatRooms.unsetAutoTransferOngoingById(roomId);
-		await this.scheduler.cancel({ name: jobName });
+		await cronJobs.remove(`${SCHEDULER_NAME}-${roomId}`);
 	}
 
 	private async transferRoom(roomId: string): Promise<void> {
@@ -130,9 +100,7 @@ export class AutoTransferChatSchedulerClass {
 		});
 	}
 
-	private async executeJob({ attrs: { data } }: any = {}): Promise<void> {
-		const { roomId } = data;
-
+	private async executeJob(roomId: string): Promise<void> {
 		try {
 			await this.transferRoom(roomId);
 
@@ -144,7 +112,3 @@ export class AutoTransferChatSchedulerClass {
 }
 
 export const AutoTransferChatScheduler = new AutoTransferChatSchedulerClass();
-
-Meteor.startup(() => {
-	void AutoTransferChatScheduler.init();
-});

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/QueueInactivityMonitor.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/QueueInactivityMonitor.ts
@@ -55,8 +55,7 @@ export class OmnichannelQueueInactivityMonitorClass {
 
 	async closeRoom(inquiryId: string): Promise<void> {
 		try {
-			// TODO: add projection and maybe use findOneQueued to avoid fetching the whole inquiry
-			const inquiry = await LivechatInquiryRaw.findOneById(inquiryId);
+			const inquiry = await LivechatInquiryRaw.findOneById(inquiryId, { projection: { status: 1, rid: 1 } });
 			if (inquiry?.status !== 'queued') {
 				return;
 			}

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/QueueInactivityMonitor.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/QueueInactivityMonitor.ts
@@ -1,50 +1,25 @@
-import { Agenda } from '@rocket.chat/agenda';
 import type { IUser, IOmnichannelRoom } from '@rocket.chat/core-typings';
+import { cronJobs } from '@rocket.chat/cron';
 import type { MainLogger } from '@rocket.chat/logger';
 import { LivechatRooms, LivechatInquiry as LivechatInquiryRaw, Users } from '@rocket.chat/models';
-import { Meteor } from 'meteor/meteor';
-import { MongoInternals } from 'meteor/mongo';
-import type { Db } from 'mongodb';
 
 import { schedulerLogger } from './logger';
 import { closeRoom } from '../../../../../app/livechat/server/lib/closeRoom';
 import { settings } from '../../../../../app/settings/server';
 import { i18n } from '../../../../../server/lib/i18n';
 
-const SCHEDULER_NAME = 'omnichannel_queue_inactivity_monitor';
-
 export class OmnichannelQueueInactivityMonitorClass {
-	scheduler: Agenda;
-
-	running: boolean;
-
 	logger: MainLogger;
 
 	_name: string;
 
-	user: IUser;
-
 	message: string;
 
-	_db: Db;
-
-	bindedCloseRoom: any;
-
 	constructor() {
-		this._db = MongoInternals.defaultRemoteCollectionDriver().mongo.db;
-		this.running = false;
 		this._name = 'Omnichannel-Queue-Inactivity-Monitor';
 		this.logger = schedulerLogger.section(this._name);
-		this.scheduler = new Agenda({
-			mongo: (MongoInternals.defaultRemoteCollectionDriver().mongo as any).client.db(),
-			db: { collection: SCHEDULER_NAME },
-			defaultConcurrency: 1,
-			processEvery: process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api' ? '3 seconds' : '1 minute',
-		});
-		this.createIndex();
 		const language = settings.get<string>('Language') || 'en';
 		this.message = i18n.t('Closed_automatically_chat_queued_too_long', { lng: language });
-		this.bindedCloseRoom = this.closeRoom.bind(this);
 	}
 
 	private async getRocketCatUser(): Promise<IUser | null> {
@@ -55,48 +30,18 @@ export class OmnichannelQueueInactivityMonitorClass {
 		return `${this._name}-${inquiryId}`;
 	}
 
-	createIndex(): void {
-		void this._db.collection(SCHEDULER_NAME).createIndex(
-			{
-				'data.inquiryId': 1,
-			},
-			{ unique: true },
-		);
-	}
-
-	async start(): Promise<void> {
-		if (this.running) {
-			return;
-		}
-
-		await this.scheduler.start();
-		this.logger.info('Service started');
-		this.running = true;
-	}
-
 	async scheduleInquiry(inquiryId: string, time: Date): Promise<void> {
 		await this.stopInquiry(inquiryId);
 		this.logger.debug({ msg: 'Scheduling automatic close of inquiry', inquiryId, scheduledAt: time });
-		const name = this.getName(inquiryId);
-		this.scheduler.define(name, this.bindedCloseRoom);
-
-		const job = this.scheduler.create(name, { inquiryId });
-		job.schedule(time);
-		job.unique({ 'data.inquiryId': inquiryId });
-		await job.save();
+		await cronJobs.addAtTimestamp(this.getName(inquiryId), time, () => this.closeRoom(inquiryId));
 	}
 
 	async stop(): Promise<void> {
-		if (!this.running) {
-			return;
-		}
-		await this.scheduler.cancel({});
-		this.running = false;
+		await cronJobs.removeByNamePrefix(`${this._name}-`);
 	}
 
 	async stopInquiry(inquiryId: string): Promise<void> {
-		const name = this.getName(inquiryId);
-		await this.scheduler.cancel({ name });
+		await cronJobs.remove(this.getName(inquiryId));
 	}
 
 	async closeRoomAction(room: IOmnichannelRoom): Promise<void> {
@@ -108,8 +53,7 @@ export class OmnichannelQueueInactivityMonitorClass {
 		});
 	}
 
-	async closeRoom({ attrs: { data } }: any = {}): Promise<void> {
-		const { inquiryId } = data;
+	async closeRoom(inquiryId: string): Promise<void> {
 		// TODO: add projection and maybe use findOneQueued to avoid fetching the whole inquiry
 		const inquiry = await LivechatInquiryRaw.findOneById(inquiryId);
 		if (inquiry?.status !== 'queued') {
@@ -128,7 +72,3 @@ export class OmnichannelQueueInactivityMonitorClass {
 }
 
 export const OmnichannelQueueInactivityMonitor = new OmnichannelQueueInactivityMonitorClass();
-
-Meteor.startup(async () => {
-	void OmnichannelQueueInactivityMonitor.start();
-});

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/QueueInactivityMonitor.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/QueueInactivityMonitor.ts
@@ -23,7 +23,7 @@ export class OmnichannelQueueInactivityMonitorClass {
 	}
 
 	private async getRocketCatUser(): Promise<IUser | null> {
-		return Users.findOneById('rocket.cat', { projection: { __rooms: 0 } });
+		return Users.findOneById('rocket.cat');
 	}
 
 	getName(inquiryId: string): string {

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/QueueInactivityMonitor.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/QueueInactivityMonitor.ts
@@ -54,20 +54,24 @@ export class OmnichannelQueueInactivityMonitorClass {
 	}
 
 	async closeRoom(inquiryId: string): Promise<void> {
-		// TODO: add projection and maybe use findOneQueued to avoid fetching the whole inquiry
-		const inquiry = await LivechatInquiryRaw.findOneById(inquiryId);
-		if (inquiry?.status !== 'queued') {
-			return;
-		}
+		try {
+			// TODO: add projection and maybe use findOneQueued to avoid fetching the whole inquiry
+			const inquiry = await LivechatInquiryRaw.findOneById(inquiryId);
+			if (inquiry?.status !== 'queued') {
+				return;
+			}
 
-		const room = await LivechatRooms.findOneById(inquiry.rid);
-		if (!room) {
-			this.logger.error({ msg: 'Unable to find room to close in queue inactivity monitor', inquiryId, roomId: inquiry.rid });
-			return;
-		}
+			const room = await LivechatRooms.findOneById(inquiry.rid);
+			if (!room) {
+				this.logger.error({ msg: 'Unable to find room to close in queue inactivity monitor', inquiryId, roomId: inquiry.rid });
+				return;
+			}
 
-		await Promise.all([this.closeRoomAction(room), this.stopInquiry(inquiryId)]);
-		this.logger.info({ msg: 'Closed room due to queue inactivity', roomId: inquiry.rid, inquiryId });
+			await this.closeRoomAction(room);
+			this.logger.info({ msg: 'Closed room due to queue inactivity', roomId: inquiry.rid, inquiryId });
+		} finally {
+			await this.stopInquiry(inquiryId);
+		}
 	}
 }
 

--- a/apps/meteor/ee/app/livechat-enterprise/server/lib/QueueInactivityMonitor.ts
+++ b/apps/meteor/ee/app/livechat-enterprise/server/lib/QueueInactivityMonitor.ts
@@ -23,7 +23,7 @@ export class OmnichannelQueueInactivityMonitorClass {
 	}
 
 	private async getRocketCatUser(): Promise<IUser | null> {
-		return Users.findOneById('rocket.cat');
+		return Users.findOneById('rocket.cat', { projection: { __rooms: 0 } });
 	}
 
 	getName(inquiryId: string): string {

--- a/apps/meteor/ee/tests/unit/apps/livechat-enterprise/lib/AutoCloseOnHold.tests.ts
+++ b/apps/meteor/ee/tests/unit/apps/livechat-enterprise/lib/AutoCloseOnHold.tests.ts
@@ -19,10 +19,12 @@ const mockUsers = {
 
 const infoStub = sinon.stub();
 const debugStub = sinon.stub();
+const errorStub = sinon.stub();
 const mockLogger = {
 	section: sinon.stub().returns({
 		info: infoStub,
 		debug: debugStub,
+		error: errorStub,
 	}),
 };
 
@@ -100,9 +102,8 @@ describe('AutoCloseOnHoldScheduler', () => {
 			try {
 				await scheduler.executeJob('roomId', 'comment');
 			} catch (e: any) {
-				expect(e.message).to.be.equal(
-					'Unable to process AutoCloseOnHoldScheduler job because room or user not found for roomId: roomId and userId: rocket.cat',
-				);
+				expect(e.message).to.be.equal('error-room-not-found');
+				expect(errorStub.calledWithMatch({ roomId: 'roomId' })).to.be.true;
 			}
 		});
 
@@ -115,7 +116,7 @@ describe('AutoCloseOnHoldScheduler', () => {
 			try {
 				await scheduler.executeJob('roomId', 'comment');
 			} catch (e: any) {
-				expect(e.message).to.be.equal('Scheduler user not found');
+				expect(e.message).to.be.equal('error-user-not-found');
 			}
 		});
 
@@ -153,7 +154,7 @@ describe('AutoCloseOnHoldScheduler', () => {
 			try {
 				await scheduler.getSchedulerUser();
 			} catch (e: any) {
-				expect(e.message).to.be.equal('Scheduler user not found');
+				expect(e.message).to.be.equal('error-user-not-found');
 			}
 		});
 

--- a/apps/meteor/ee/tests/unit/apps/livechat-enterprise/lib/AutoCloseOnHold.tests.ts
+++ b/apps/meteor/ee/tests/unit/apps/livechat-enterprise/lib/AutoCloseOnHold.tests.ts
@@ -7,41 +7,15 @@ import sinon from 'sinon';
 
 chai.use(chaiDateTime);
 
-const mockAgendaConstructor = sinon.stub();
-const mockAgendaStart = sinon.stub();
-const mockAgendaScheduler = sinon.stub();
-const mockAgendaCancel = sinon.stub();
-const mockAgendaDefine = sinon.stub();
+const mockCronAddAtTimestamp = sinon.stub();
+const mockCronRemove = sinon.stub();
 const mockLivechatCloseRoom = sinon.stub();
-const mockMeteorStartup = sinon.stub();
 const mockLivechatRooms = {
 	findOneById: sinon.stub(),
 };
 const mockUsers = {
 	findOneById: sinon.stub(),
 };
-
-class MockAgendaClass {
-	constructor(opts: Record<string, any>) {
-		mockAgendaConstructor(opts);
-	}
-
-	async start() {
-		return mockAgendaStart();
-	}
-
-	async schedule(...args: any) {
-		return mockAgendaScheduler(...args);
-	}
-
-	async cancel(...args: any) {
-		return mockAgendaCancel(...args);
-	}
-
-	async define(...args: any) {
-		return mockAgendaDefine(...args);
-	}
-}
 
 const infoStub = sinon.stub();
 const debugStub = sinon.stub();
@@ -53,15 +27,10 @@ const mockLogger = {
 };
 
 const mocks = {
-	'@rocket.chat/agenda': { Agenda: MockAgendaClass },
-	'meteor/meteor': { Meteor: { startup: mockMeteorStartup } },
-	'meteor/mongo': {
-		MongoInternals: {
-			defaultRemoteCollectionDriver: () => {
-				return {
-					mongo: { client: { db: sinon.stub() } },
-				};
-			},
+	'@rocket.chat/cron': {
+		cronJobs: {
+			addAtTimestamp: mockCronAddAtTimestamp,
+			remove: mockCronRemove,
 		},
 	},
 	'../../../../../app/livechat/server/lib/closeRoom': { closeRoom: mockLivechatCloseRoom },
@@ -77,96 +46,41 @@ const { AutoCloseOnHoldSchedulerClass } = proxyquire
 	.load('../../../../../app/livechat-enterprise/server/lib/AutoCloseOnHoldScheduler', mocks);
 
 describe('AutoCloseOnHoldScheduler', () => {
-	beforeEach(() => {
-		mockMeteorStartup.resetHistory();
-	});
-
 	it('should call logger.section upon instantiating', () => {
 		expect(mockLogger.section.called).to.be.true;
 	});
 
-	describe('init', () => {
-		beforeEach(() => {
-			mockAgendaStart.resetHistory();
-			mockAgendaScheduler.resetHistory();
-		});
-
-		it('should do nothing if scheduler is already running', async () => {
-			const scheduler = new AutoCloseOnHoldSchedulerClass();
-			scheduler.running = true;
-
-			await scheduler.init();
-
-			expect(mockAgendaScheduler.called).to.be.false;
-		});
-
-		it('should succesfully init the scheduler', async () => {
-			const scheduler = new AutoCloseOnHoldSchedulerClass();
-
-			await scheduler.init();
-
-			expect(mockAgendaStart.calledOnce).to.be.true;
-			expect(scheduler.running).to.be.true;
-			expect(infoStub.calledWith('Service started')).to.be.true;
-		});
-	});
-
 	describe('scheduleRoom', () => {
 		beforeEach(() => {
-			mockAgendaCancel.resetHistory();
-			mockAgendaDefine.resetHistory();
-		});
-
-		it('should fail if scheduler has not been init', async () => {
-			const scheduler = new AutoCloseOnHoldSchedulerClass();
-
-			try {
-				await scheduler.scheduleRoom('roomId', 5, 'test comment');
-			} catch (e: any) {
-				expect(e.message).to.equal('AutoCloseOnHoldScheduler is not running');
-			}
+			mockCronAddAtTimestamp.resetHistory();
+			mockCronRemove.resetHistory();
 		});
 
 		it('should schedule a room', async () => {
 			const scheduler = new AutoCloseOnHoldSchedulerClass();
 
-			await scheduler.init();
 			await scheduler.scheduleRoom('roomId', 5, 'test comment');
 
 			const myScheduleTime = moment(new Date()).add(5, 's').toDate();
-			expect(mockAgendaCancel.calledBefore(mockAgendaDefine)).to.be.true;
-			expect(mockAgendaCancel.calledWith({ name: 'omnichannel_auto_close_on_hold_scheduler-roomId' }));
-			expect(mockAgendaDefine.calledWithMatch('omnichannel_auto_close_on_hold_scheduler-roomId'));
-			const funcScheduleTime = mockAgendaScheduler.getCall(0).firstArg;
-
-			expect(funcScheduleTime).to.be.closeToTime(myScheduleTime, 5);
-			expect(mockAgendaScheduler.calledWithMatch('omnichannel_auto_close_on_hold_scheduler-roomId'));
+			expect(mockCronRemove.calledBefore(mockCronAddAtTimestamp)).to.be.true;
+			expect(mockCronRemove.calledWith('omnichannel_auto_close_on_hold_scheduler-roomId')).to.be.true;
+			expect(mockCronAddAtTimestamp.getCall(0).args[0]).to.be.equal('omnichannel_auto_close_on_hold_scheduler-roomId');
+			expect(mockCronAddAtTimestamp.getCall(0).args[1]).to.be.closeToTime(myScheduleTime, 5);
+			expect(mockCronAddAtTimestamp.getCall(0).args[2]).to.be.a('function');
 		});
 	});
 
 	describe('unscheduleRoom', () => {
 		beforeEach(() => {
-			mockAgendaCancel.resetHistory();
+			mockCronRemove.resetHistory();
 		});
 
-		it('should fail if scheduler has not been init', async () => {
+		it('should call .remove to unschedule a room', async () => {
 			const scheduler = new AutoCloseOnHoldSchedulerClass();
-
-			try {
-				await scheduler.unscheduleRoom('roomId');
-			} catch (e: any) {
-				expect(e.message).to.equal('AutoCloseOnHoldScheduler is not running');
-			}
-		});
-
-		it('should call .cancel to unschedule a room', async () => {
-			const scheduler = new AutoCloseOnHoldSchedulerClass();
-
-			await scheduler.init();
 
 			await scheduler.unscheduleRoom('roomId');
 
-			expect(mockAgendaCancel.calledWith({ name: 'omnichannel_auto_close_on_hold_scheduler-roomId' }));
+			expect(mockCronRemove.calledWith('omnichannel_auto_close_on_hold_scheduler-roomId')).to.be.true;
 		});
 	});
 
@@ -184,7 +98,7 @@ describe('AutoCloseOnHoldScheduler', () => {
 			mockUsers.findOneById.returns({ _id: 'rocket.cat' });
 
 			try {
-				await scheduler.executeJob({ attrs: { data: { roomId: 'roomId', comment: 'comment' } } });
+				await scheduler.executeJob('roomId', 'comment');
 			} catch (e: any) {
 				expect(e.message).to.be.equal(
 					'Unable to process AutoCloseOnHoldScheduler job because room or user not found for roomId: roomId and userId: rocket.cat',
@@ -199,7 +113,7 @@ describe('AutoCloseOnHoldScheduler', () => {
 			mockUsers.findOneById.returns(null);
 
 			try {
-				await scheduler.executeJob({ attrs: { data: { roomId: 'roomId', comment: 'comment' } } });
+				await scheduler.executeJob('roomId', 'comment');
 			} catch (e: any) {
 				expect(e.message).to.be.equal('Scheduler user not found');
 			}
@@ -211,7 +125,7 @@ describe('AutoCloseOnHoldScheduler', () => {
 			mockLivechatRooms.findOneById.returns({ _id: 'me' });
 			mockUsers.findOneById.returns({ _id: 'rocket.cat' });
 
-			await scheduler.executeJob({ attrs: { data: { roomId: 'roomId', comment: 'comment' } } });
+			await scheduler.executeJob('roomId', 'comment');
 
 			expect(mockLivechatCloseRoom.calledWithMatch({ room: { _id: 'me' }, user: { _id: 'rocket.cat' }, comment: 'comment' }));
 		});

--- a/apps/meteor/ee/tests/unit/apps/livechat-enterprise/lib/AutoTransferChatsScheduler.tests.ts
+++ b/apps/meteor/ee/tests/unit/apps/livechat-enterprise/lib/AutoTransferChatsScheduler.tests.ts
@@ -7,13 +7,9 @@ import sinon from 'sinon';
 
 chai.use(chaiDateTime);
 
-const mockAgendaConstructor = sinon.stub();
-const mockAgendaStart = sinon.stub();
-const mockAgendaScheduler = sinon.stub();
-const mockAgendaCancel = sinon.stub();
-const mockAgendaDefine = sinon.stub();
+const mockCronAddAtTimestamp = sinon.stub();
+const mockCronRemove = sinon.stub();
 const returnRoomAsInquiryMock = sinon.stub();
-const mockMeteorStartup = sinon.stub();
 const mockLivechatRooms = {
 	findOneById: sinon.stub(),
 	setAutoTransferOngoingById: sinon.stub(),
@@ -23,28 +19,6 @@ const mockLivechatRooms = {
 const mockUsers = {
 	findOneById: sinon.stub(),
 };
-
-class MockAgendaClass {
-	constructor(opts: Record<string, any>) {
-		mockAgendaConstructor(opts);
-	}
-
-	async start() {
-		return mockAgendaStart();
-	}
-
-	async schedule(...args: any) {
-		return mockAgendaScheduler(...args);
-	}
-
-	async cancel(...args: any) {
-		return mockAgendaCancel(...args);
-	}
-
-	async define(...args: any) {
-		return mockAgendaDefine(...args);
-	}
-}
 
 const mockLogger = {
 	section: sinon.stub().returns({
@@ -59,15 +33,10 @@ const routingConfigMock = sinon.stub();
 const getNextAgent = sinon.stub();
 
 const mocks = {
-	'@rocket.chat/agenda': { Agenda: MockAgendaClass },
-	'meteor/meteor': { Meteor: { startup: mockMeteorStartup } },
-	'meteor/mongo': {
-		MongoInternals: {
-			defaultRemoteCollectionDriver: () => {
-				return {
-					mongo: { client: { db: sinon.stub() } },
-				};
-			},
+	'@rocket.chat/cron': {
+		cronJobs: {
+			addAtTimestamp: mockCronAddAtTimestamp,
+			remove: mockCronRemove,
 		},
 	},
 	'../../../../../app/livechat/server/lib/RoutingManager': { RoutingManager: { getConfig: routingConfigMock, getNextAgent } },
@@ -97,54 +66,57 @@ describe('AutoTransferChats', () => {
 	});
 
 	describe('scheduleRoom', () => {
+		beforeEach(() => {
+			mockCronAddAtTimestamp.resetHistory();
+		});
+
 		it('should schedule a room', async () => {
 			const scheduler = new AutoTransferChatSchedulerClass();
-			await scheduler.init();
 			scheduler.unscheduleRoom = sinon.stub();
 
 			const myScheduleTime = moment(new Date()).add(10, 's').toDate();
 			await scheduler.scheduleRoom('roomId', 10);
 
 			expect(scheduler.unscheduleRoom.calledWith('roomId')).to.be.true;
-			expect(mockAgendaDefine.getCall(0).firstArg).to.be.equal('omnichannel_scheduler-roomId');
-			const funcScheduleTime = mockAgendaScheduler.getCall(0).firstArg;
-
-			expect(funcScheduleTime).to.be.closeToTime(myScheduleTime, 5);
+			expect(mockCronAddAtTimestamp.getCall(0).args[0]).to.be.equal('omnichannel_scheduler-roomId');
+			expect(mockCronAddAtTimestamp.getCall(0).args[1]).to.be.closeToTime(myScheduleTime, 5);
+			expect(mockCronAddAtTimestamp.getCall(0).args[2]).to.be.a('function');
 			expect(mockLivechatRooms.setAutoTransferOngoingById.getCall(0).firstArg).to.be.equal('roomId');
 		});
 	});
 
 	describe('unscheduleRoom', () => {
+		beforeEach(() => {
+			mockCronRemove.resetHistory();
+		});
+
 		it('should unschedule a room', async () => {
 			const scheduler = new AutoTransferChatSchedulerClass();
-			await scheduler.init();
 
 			await scheduler.unscheduleRoom('roomId');
 
 			expect(mockLivechatRooms.unsetAutoTransferOngoingById.getCall(0).firstArg).to.be.equal('roomId');
-			expect(mockAgendaCancel.getCall(0).firstArg).to.be.deep.equal({ name: 'omnichannel_scheduler-roomId' });
+			expect(mockCronRemove.getCall(0).firstArg).to.be.equal('omnichannel_scheduler-roomId');
 		});
 	});
 
 	describe('executeJob', () => {
 		it('should execute job', async () => {
 			const scheduler = new AutoTransferChatSchedulerClass();
-			await scheduler.init();
 
 			scheduler.transferRoom = sinon.stub();
 
-			await scheduler.executeJob({ attrs: { data: { roomId: 'roomId' } } });
+			await scheduler.executeJob('roomId');
 
 			expect(scheduler.transferRoom.getCall(0).firstArg).to.be.equal('roomId');
 			expect(mockLivechatRooms.setAutoTransferredAtById.getCall(0).firstArg).to.be.equal('roomId');
 		});
 		it('shouldnt fail even if job fails', async () => {
 			const scheduler = new AutoTransferChatSchedulerClass();
-			await scheduler.init();
 
 			scheduler.transferRoom = sinon.stub().throws('dummy error');
 
-			const r = await scheduler.executeJob({ attrs: { data: { roomId: 'roomId' } } });
+			const r = await scheduler.executeJob('roomId');
 
 			expect(r).to.be.undefined;
 		});
@@ -160,21 +132,18 @@ describe('AutoTransferChats', () => {
 		it('should not transfer undefined rooms', async () => {
 			mockLivechatRooms.findOneById.resolves(undefined);
 			const scheduler = new AutoTransferChatSchedulerClass();
-			await scheduler.init();
 
 			await expect(scheduler.transferRoom('roomId')).to.be.rejectedWith('Room is not open or is not being served by an agent');
 		});
 		it('should not transfer closed rooms', async () => {
 			mockLivechatRooms.findOneById.resolves({ _id: 1 });
 			const scheduler = new AutoTransferChatSchedulerClass();
-			await scheduler.init();
 
 			await expect(scheduler.transferRoom('roomId')).to.be.rejectedWith('Room is not open or is not being served by an agent');
 		});
 		it('should not transfer unserved rooms', async () => {
 			mockLivechatRooms.findOneById.resolves({ _id: 1, open: true });
 			const scheduler = new AutoTransferChatSchedulerClass();
-			await scheduler.init();
 
 			await expect(scheduler.transferRoom('roomId')).to.be.rejectedWith('Room is not open or is not being served by an agent');
 		});
@@ -183,7 +152,6 @@ describe('AutoTransferChats', () => {
 			mockUsers.findOneById.resolves({ _id: 'rocket.cat' });
 			settingsGet.returns(5);
 			const scheduler = new AutoTransferChatSchedulerClass();
-			await scheduler.init();
 
 			await scheduler.transferRoom('roomId');
 
@@ -203,7 +171,6 @@ describe('AutoTransferChats', () => {
 			settingsGet.returns(5);
 
 			const scheduler = new AutoTransferChatSchedulerClass();
-			await scheduler.init();
 
 			const r = await scheduler.transferRoom('roomId');
 
@@ -219,7 +186,6 @@ describe('AutoTransferChats', () => {
 			settingsGet.returns(5);
 
 			const scheduler = new AutoTransferChatSchedulerClass();
-			await scheduler.init();
 
 			await expect(scheduler.transferRoom('roomId')).to.be.rejectedWith('error-no-cat');
 
@@ -235,7 +201,6 @@ describe('AutoTransferChats', () => {
 			settingsGet.returns(5);
 
 			const scheduler = new AutoTransferChatSchedulerClass();
-			await scheduler.init();
 
 			const r = await scheduler.transferRoom('roomId');
 

--- a/apps/meteor/ee/tests/unit/apps/livechat-enterprise/lib/AutoTransferChatsScheduler.tests.ts
+++ b/apps/meteor/ee/tests/unit/apps/livechat-enterprise/lib/AutoTransferChatsScheduler.tests.ts
@@ -133,19 +133,19 @@ describe('AutoTransferChats', () => {
 			mockLivechatRooms.findOneById.resolves(undefined);
 			const scheduler = new AutoTransferChatSchedulerClass();
 
-			await expect(scheduler.transferRoom('roomId')).to.be.rejectedWith('Room is not open or is not being served by an agent');
+			await expect(scheduler.transferRoom('roomId')).to.be.rejectedWith('error-room-not-found');
 		});
 		it('should not transfer closed rooms', async () => {
 			mockLivechatRooms.findOneById.resolves({ _id: 1 });
 			const scheduler = new AutoTransferChatSchedulerClass();
 
-			await expect(scheduler.transferRoom('roomId')).to.be.rejectedWith('Room is not open or is not being served by an agent');
+			await expect(scheduler.transferRoom('roomId')).to.be.rejectedWith('error-room-already-closed');
 		});
 		it('should not transfer unserved rooms', async () => {
 			mockLivechatRooms.findOneById.resolves({ _id: 1, open: true });
 			const scheduler = new AutoTransferChatSchedulerClass();
 
-			await expect(scheduler.transferRoom('roomId')).to.be.rejectedWith('Room is not open or is not being served by an agent');
+			await expect(scheduler.transferRoom('roomId')).to.be.rejectedWith('error-room-not-served');
 		});
 		it('should return a room as inquiry when the routing method is not automatic', async () => {
 			mockLivechatRooms.findOneById.resolves({ _id: 1, open: true, servedBy: { _id: 2 }, departmentId: undefined });

--- a/apps/meteor/ee/tests/unit/apps/livechat-enterprise/lib/AutoTransferChatsScheduler.tests.ts
+++ b/apps/meteor/ee/tests/unit/apps/livechat-enterprise/lib/AutoTransferChatsScheduler.tests.ts
@@ -78,7 +78,7 @@ describe('AutoTransferChats', () => {
 			await scheduler.scheduleRoom('roomId', 10);
 
 			expect(scheduler.unscheduleRoom.calledWith('roomId')).to.be.true;
-			expect(mockCronAddAtTimestamp.getCall(0).args[0]).to.be.equal('omnichannel_scheduler-roomId');
+			expect(mockCronAddAtTimestamp.getCall(0).args[0]).to.be.equal('omnichannel_auto_transfer_scheduler-roomId');
 			expect(mockCronAddAtTimestamp.getCall(0).args[1]).to.be.closeToTime(myScheduleTime, 5);
 			expect(mockCronAddAtTimestamp.getCall(0).args[2]).to.be.a('function');
 			expect(mockLivechatRooms.setAutoTransferOngoingById.getCall(0).firstArg).to.be.equal('roomId');
@@ -96,7 +96,7 @@ describe('AutoTransferChats', () => {
 			await scheduler.unscheduleRoom('roomId');
 
 			expect(mockLivechatRooms.unsetAutoTransferOngoingById.getCall(0).firstArg).to.be.equal('roomId');
-			expect(mockCronRemove.getCall(0).firstArg).to.be.equal('omnichannel_scheduler-roomId');
+			expect(mockCronRemove.getCall(0).firstArg).to.be.equal('omnichannel_auto_transfer_scheduler-roomId');
 		});
 	});
 

--- a/apps/meteor/ee/tests/unit/apps/livechat-enterprise/server/lib/QueueInactivityMonitor.spec.ts
+++ b/apps/meteor/ee/tests/unit/apps/livechat-enterprise/server/lib/QueueInactivityMonitor.spec.ts
@@ -1,18 +1,12 @@
 import { expect } from 'chai';
-import { describe, afterEach, before } from 'mocha';
+import { describe, afterEach, beforeEach } from 'mocha';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
-const AgendaJobStub = {
-	schedule: sinon.stub(),
-	unique: sinon.stub(),
-	save: sinon.stub(),
-};
-const AgendaStub = {
-	start: sinon.stub(),
-	define: sinon.stub(),
-	cancel: sinon.stub(),
-	create: sinon.stub().returns(AgendaJobStub),
+const cronJobsMock = {
+	addAtTimestamp: sinon.stub(),
+	remove: sinon.stub(),
+	removeByNamePrefix: sinon.stub(),
 };
 
 const modelsMock = {
@@ -20,27 +14,14 @@ const modelsMock = {
 	LivechatInquiry: { findOneById: sinon.stub() },
 	Users: { findOneById: sinon.stub() },
 };
-const meteorMock = { Meteor: { startup: sinon.stub() } };
-const createIndexStub = sinon.stub();
-const mongoMock = {
-	MongoInternals: {
-		defaultRemoteCollectionDriver: sinon.stub().returns({
-			mongo: { db: { collection: sinon.stub().returns({ createIndex: createIndexStub }) }, client: { db: sinon.stub() } },
-		}),
-	},
-};
 const livechatMock = { closeRoom: sinon.stub() };
 const settingsMock = { settings: { get: sinon.stub() } };
 
 const { OmnichannelQueueInactivityMonitorClass } = proxyquire
 	.noCallThru()
 	.load('../../../../../../app/livechat-enterprise/server/lib/QueueInactivityMonitor', {
-		'@rocket.chat/agenda': {
-			Agenda: sinon.stub().returns(AgendaStub),
-		},
+		'@rocket.chat/cron': { cronJobs: cronJobsMock },
 		'@rocket.chat/models': modelsMock,
-		'meteor/meteor': meteorMock,
-		'meteor/mongo': mongoMock,
 		'../../../../../app/livechat/server/lib/closeRoom': livechatMock,
 		'../../../../../app/settings/server': settingsMock,
 		'../../../../../server/lib/i18n': { i18n: { t: sinon.stub().returns('Closed automatically') } },
@@ -67,86 +48,44 @@ describe('OmnichannelQueueInactivityMonitorClass', () => {
 		});
 	});
 
-	describe('createIndex', () => {
-		before(() => {
-			createIndexStub.reset();
-		});
-		it('should create index', () => {
-			const qclass = new OmnichannelQueueInactivityMonitorClass();
-			qclass.createIndex();
-			expect(createIndexStub.calledWith(sinon.match({ 'data.inquiryId': 1 }), sinon.match({ unique: true }))).to.be.true;
-		});
-	});
-
-	describe('start', () => {
-		before(() => {
-			AgendaStub.start.reset();
-		});
-		it('should do nothing if its already running', async () => {
-			const qclass = new OmnichannelQueueInactivityMonitorClass();
-			qclass.running = true;
-			await qclass.start();
-			expect(AgendaStub.start.calledOnce).to.be.false;
-		});
-		it('should start scheduler', async () => {
-			const qclass = new OmnichannelQueueInactivityMonitorClass();
-			await qclass.start();
-			expect(AgendaStub.start.calledOnce).to.be.true;
-			expect(qclass.running).to.be.true;
-		});
-	});
-
 	describe('scheduleInquiry', () => {
 		beforeEach(() => {
-			AgendaStub.define.reset();
+			cronJobsMock.addAtTimestamp.reset();
+			cronJobsMock.remove.reset();
 		});
 		it('should schedule inquiry', async () => {
 			const qclass = new OmnichannelQueueInactivityMonitorClass();
 			const now = new Date();
 			await qclass.scheduleInquiry('inquiryId', now);
 
-			expect(AgendaStub.cancel.calledOnce).to.be.true;
-			expect(AgendaStub.cancel.calledBefore(AgendaStub.define)).to.be.true;
-			expect(AgendaStub.define.calledOnce).to.be.true;
-			expect(AgendaJobStub.schedule.calledOnceWith(now)).to.be.true;
-			expect(AgendaJobStub.unique.calledOnceWith(sinon.match({ 'data.inquiryId': 'inquiryId' }))).to.be.true;
+			expect(cronJobsMock.remove.calledOnceWith('Omnichannel-Queue-Inactivity-Monitor-inquiryId')).to.be.true;
+			expect(cronJobsMock.remove.calledBefore(cronJobsMock.addAtTimestamp)).to.be.true;
+			expect(cronJobsMock.addAtTimestamp.calledOnce).to.be.true;
+			expect(cronJobsMock.addAtTimestamp.getCall(0).args[0]).to.be.equal('Omnichannel-Queue-Inactivity-Monitor-inquiryId');
+			expect(cronJobsMock.addAtTimestamp.getCall(0).args[1]).to.be.equal(now);
+			expect(cronJobsMock.addAtTimestamp.getCall(0).args[2]).to.be.a('function');
 		});
 	});
 
 	describe('stop', () => {
 		beforeEach(() => {
-			AgendaStub.cancel.reset();
+			cronJobsMock.removeByNamePrefix.reset();
 		});
-		it('should do nothing if process is already stopped', async () => {
+		it('should cancel all inquiry jobs by prefix', async () => {
 			const qclass = new OmnichannelQueueInactivityMonitorClass();
-			qclass.running = false;
 			await qclass.stop();
-			expect(AgendaStub.cancel.calledOnce).to.be.false;
-		});
-		it('should not call cancel twice if stop is called twice', async () => {
-			const qclass = new OmnichannelQueueInactivityMonitorClass();
-			qclass.running = true;
-			await qclass.stop();
-			await qclass.stop();
-			expect(AgendaStub.cancel.calledOnce).to.be.true;
-		});
-		it('should cancel all inquiries and flag service as not running', async () => {
-			const qclass = new OmnichannelQueueInactivityMonitorClass();
-			qclass.running = true;
-			await qclass.stop();
-			expect(AgendaStub.cancel.calledOnce).to.be.true;
-			expect(qclass.running).to.be.false;
+			expect(cronJobsMock.removeByNamePrefix.calledOnceWith('Omnichannel-Queue-Inactivity-Monitor-')).to.be.true;
 		});
 	});
 
 	describe('stopInquiry', () => {
 		beforeEach(() => {
-			AgendaStub.cancel.reset();
+			cronJobsMock.remove.reset();
 		});
 		it('should cancel inquiry', async () => {
 			const qclass = new OmnichannelQueueInactivityMonitorClass();
 			await qclass.stopInquiry('inquiryId');
-			expect(AgendaStub.cancel.calledOnce).to.be.true;
+			expect(cronJobsMock.remove.calledOnceWith('Omnichannel-Queue-Inactivity-Monitor-inquiryId')).to.be.true;
 		});
 	});
 
@@ -160,7 +99,7 @@ describe('OmnichannelQueueInactivityMonitorClass', () => {
 			const qclass = new OmnichannelQueueInactivityMonitorClass();
 			modelsMock.LivechatInquiry.findOneById.resolves({ status: 'taken' });
 
-			await qclass.closeRoom({ attrs: { data: { inquiryId: 'inquiryId' } } });
+			await qclass.closeRoom('inquiryId');
 			expect(modelsMock.LivechatInquiry.findOneById.calledWith('inquiryId')).to.be.true;
 			expect(livechatMock.closeRoom.notCalled).to.be.true;
 		});
@@ -168,7 +107,7 @@ describe('OmnichannelQueueInactivityMonitorClass', () => {
 			const qclass = new OmnichannelQueueInactivityMonitorClass();
 			modelsMock.LivechatInquiry.findOneById.resolves({ status: 'queued', rid: 'roomId' });
 			modelsMock.LivechatRooms.findOneById.resolves(undefined);
-			await qclass.closeRoom({ attrs: { data: { inquiryId: 'inquiryId' } } });
+			await qclass.closeRoom('inquiryId');
 
 			expect(modelsMock.LivechatInquiry.findOneById.calledWith('inquiryId')).to.be.true;
 			expect(modelsMock.LivechatRooms.findOneById.calledWith('roomId')).to.be.true;
@@ -180,7 +119,7 @@ describe('OmnichannelQueueInactivityMonitorClass', () => {
 			modelsMock.LivechatRooms.findOneById.resolves({ _id: 'roomId' });
 			modelsMock.Users.findOneById.resolves({ _id: 'rocket.cat' });
 
-			await qclass.closeRoom({ attrs: { data: { inquiryId: 'inquiryId' } } });
+			await qclass.closeRoom('inquiryId');
 
 			expect(modelsMock.LivechatInquiry.findOneById.calledWith('inquiryId')).to.be.true;
 			expect(modelsMock.LivechatRooms.findOneById.calledWith('roomId')).to.be.true;

--- a/packages/cron/src/index.ts
+++ b/packages/cron/src/index.ts
@@ -67,7 +67,7 @@ export class AgendaCronJobs {
 			mongo,
 			db: { collection: 'rocketchat_cron' },
 			defaultConcurrency: 1,
-			processEvery: '1 minute',
+			processEvery: process.env.TEST_MODE === 'true' || process.env.TEST_MODE === 'api' ? '3 seconds' : '1 minute',
 		});
 
 		this.scheduler.on('start', (job: Job) => {
@@ -166,8 +166,22 @@ export class AgendaCronJobs {
 			return this.unreserve(name);
 		}
 
-		await this.scheduler.cancel({ name });
-		logger.debug({ msg: `Cron job "${name}" removed`, jobName: name });
+		const removedCount = await this.scheduler.cancel({ name });
+		if (removedCount) {
+			logger.debug({ msg: `Cron job "${name}" removed`, jobName: name });
+		}
+	}
+
+	public async removeByNamePrefix(prefix: string): Promise<void> {
+		if (!this.scheduler) {
+			this.reservedJobs = this.reservedJobs.filter(({ name }) => !name.startsWith(prefix));
+			return;
+		}
+
+		const removedCount = await this.scheduler.cancel({ name: new RegExp(`^${prefix}`) });
+		if (removedCount) {
+			logger.debug({ msg: `Cron jobs with prefix "${prefix}" removed`, prefix, removedCount });
+		}
 	}
 
 	public async has(jobName: string): Promise<boolean> {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The three omnichannel schedulers (`AutoCloseOnHoldScheduler`, `AutoTransferChatScheduler` and `OmnichannelQueueInactivityMonitor`) each ran their own Agenda instance polling a dedicated MongoDB collection. This migrates them to the shared `@rocket.chat/cron` scheduler so all job configs are unified under `rocketchat_cron`, removing three polling loops per server instance.

Follow-up to #32186, which reduced these schedulers' polling frequency and anticipated this migration.

**`@rocket.chat/cron` changes:**
- New `removeByNamePrefix(prefix)` — used by `QueueInactivityMonitor.stop()`, which previously wiped its whole dedicated collection with `cancel({})`; a scoped cancel is required now that the collection is shared
- `processEvery` honors `TEST_MODE` (3s vs 1min), preserving the heartbeat the dedicated instances had (and the omnichannel e2e specs rely on)
- `remove()`/`removeByNamePrefix()` only log when a job was actually deleted (callers issue defensive no-op cancels, e.g. on every room close)

**Scheduler changes:**
- Job data (roomId/comment/inquiryId) is captured in callback closures; jobs were always defined at schedule time, so restart durability is unchanged (pending one-shot jobs never survived restarts before either — queue inactivity re-schedules from queued inquiries at startup, which remains the recovery path)
- Removed per-class `init()`/`start()`/`running` state and `Meteor.startup` blocks — the cron package reserves jobs scheduled before it starts
- Removed the `data.inquiryId` unique index; job-name uniqueness plus cancel-before-schedule covers it

**Left in place on purpose:**
- The legacy collections (`omnichannel_scheduler`, `omnichannel_auto_close_on_hold_scheduler`, `omnichannel_queue_inactivity_monitor`) become stale data; dropping them is deferred to a future major release migration
- `cron_history` has no TTL, and these per-room jobs will add documents on busy omnichannel servers — flagged for a follow-up decision

## Issue(s)
https://rocketchat.atlassian.net/browse/CORE-260
## Steps to test or reproduce

With an EE license:
1. **Queue inactivity**: set `Livechat_max_queue_wait_time` > 0, start a widget chat with no available agents → job `Omnichannel-Queue-Inactivity-Monitor-<inquiryId>` appears in `rocketchat_cron` and the room closes after the timeout. Set the setting to 0 → only jobs with that prefix are removed from `rocketchat_cron`
2. **Auto transfer**: set `Livechat_auto_transfer_chat_timeout` > 0, take a chat and don't reply → chat transfers to another agent (or returns to queue with manual routing)
3. **Auto close on-hold**: set `Livechat_auto_close_on_hold_chats_timeout` > 0, place a chat on hold → room closes after the timeout; resuming before the timeout cancels the job

E2e: `omnichannel-auto-onhold-chat-closing.spec.ts` and `omnichannel-auto-transfer-unanswered-chat.spec.ts` cover these flows (TEST_MODE heartbeat preserved).

## Further comments


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Unified live chat automation scheduling for auto-close on-hold chats, auto-transfer of unanswered chats, and queue inactivity monitoring.
  * Reduced background database polling for these automated workflows.
  * Improved bulk cancellation of scheduled jobs using name-prefix removal.
* **New Features**
  * Added support for removing cron jobs by name prefix.
* **Bug Fixes**
  * Scheduled job removal now reports success only when a job was actually canceled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->