### PR TITLE
chore: export ConnectionStatus type from @rocket.chat/ddp-client

### DIFF
--- a/.changeset/export-connection-status-type.md
+++ b/.changeset/export-connection-status-type.md
@@ -1,5 +1,0 @@
----
-'@rocket.chat/ddp-client': minor
----
-
-Exports the `ConnectionStatus` type so consumers can reference the connection status union without duplicating it inline.

--- a/.changeset/export-connection-status-type.md
+++ b/.changeset/export-connection-status-type.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/ddp-client': minor
+---
+
+Exports the `ConnectionStatus` type so consumers can reference the connection status union without duplicating it inline.

--- a/packages/ddp-client/src/Connection.ts
+++ b/packages/ddp-client/src/Connection.ts
@@ -22,7 +22,7 @@ type RetryOptions = {
 	retryTime: number;
 };
 
-type ConnectionStatus = 'idle' | 'connecting' | 'connected' | 'failed' | 'closed' | 'disconnected' | 'reconnecting';
+export type ConnectionStatus = 'idle' | 'connecting' | 'connected' | 'failed' | 'closed' | 'disconnected' | 'reconnecting';
 
 export interface Connection
 	extends Emitter<{

--- a/packages/ddp-client/src/index.ts
+++ b/packages/ddp-client/src/index.ts
@@ -6,3 +6,4 @@ export type * from './types/ClientStream';
 export type * from './types/methods';
 export type * from './types/streams';
 export type { SDK } from './types/SDK';
+export type { ConnectionStatus } from './Connection';


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

`ConnectionStatus` was declared as a private `type` inside `packages/ddp-client/src/Connection.ts` and never exported, forcing consumers to repeat the union inline. This PR exports it and re-exports it from the package entry point so it can be imported directly:

```ts
import type { ConnectionStatus } from '@rocket.chat/ddp-client';
```

This gives us a single source of truth for the connection status union.

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/CORE-2447

## Steps to test or reproduce

<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

- Import `ConnectionStatus` from `@rocket.chat/ddp-client` in a consumer and confirm the type resolves.

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Additive public API export only (no behavior change). Follow-up: migrate any inline duplicates of this union to import the exported type.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `ConnectionStatus` type to the public DDP client package exports.
  * External integrations can now import and reuse the connection status type directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->