### PR TITLE
refactor(authorization): accept a minimal user shape (UserWithRoles) in permission checks

### DIFF
--- a/apps/meteor/server/api/lib/eraseTeam.ts
+++ b/apps/meteor/server/api/lib/eraseTeam.ts
@@ -7,9 +7,9 @@ import { eraseRoom } from '../../lib/eraseRoom';
 import { SystemLogger } from '../../lib/logger/system';
 import { deleteRoom } from '../../lib/rooms/deleteRoom';
 
-type EraseRoomFnType = <T extends AtLeast<IUser, '_id' | 'name' | 'username'>>(rid: string, user: T) => Promise<boolean | void>;
+type EraseRoomFnType = <T extends AtLeast<IUser, '_id' | 'name' | 'username' | 'roles'>>(rid: string, user: T) => Promise<boolean | void>;
 
-export const eraseTeamShared = async <T extends AtLeast<IUser, '_id' | 'name' | 'username'>>(
+export const eraseTeamShared = async <T extends AtLeast<IUser, '_id' | 'name' | 'username' | 'roles'>>(
 	user: T,
 	team: ITeam,
 	roomsToRemove: IRoom['_id'][] = [],

--- a/apps/meteor/server/api/v1/misc.ts
+++ b/apps/meteor/server/api/v1/misc.ts
@@ -467,7 +467,7 @@ API.v1.get(
 		const sortBy = sort ? Object.keys(sort)[0] : undefined;
 		const sortDirection = sort && Object.values(sort)[0] === 1 ? 'asc' : 'desc';
 
-		const user = await Users.findOneById(this.userId, { projection: { __rooms: 1 } });
+		const user = await Users.findOneById(this.userId, { projection: { __rooms: 1, roles: 1 } });
 		const result = await browseChannelsMethod(
 			{
 				...filter,

--- a/apps/meteor/server/bridges/slack/removeChannelLinks.ts
+++ b/apps/meteor/server/bridges/slack/removeChannelLinks.ts
@@ -21,7 +21,7 @@ Meteor.methods<ServerMethods>({
 			});
 		}
 
-		if (!(await hasPermissionAsync(user._id, 'remove-slackbridge-links'))) {
+		if (!(await hasPermissionAsync(user, 'remove-slackbridge-links'))) {
 			throw new Meteor.Error('error-not-authorized', 'Not authorized', {
 				method: 'removeSlackBridgeChannelLinks',
 			});

--- a/apps/meteor/server/lib/authorization/hasPermission.ts
+++ b/apps/meteor/server/lib/authorization/hasPermission.ts
@@ -1,18 +1,19 @@
 import { Authorization } from '@rocket.chat/core-services';
+import type { UserWithRoles } from '@rocket.chat/core-services';
 import type { IUser, IPermission, IRoom } from '@rocket.chat/core-typings';
 
 export const hasAllPermissionAsync = async (
-	user: IUser['_id'] | IUser,
+	user: IUser['_id'] | UserWithRoles,
 	permissions: IPermission['_id'][],
 	scope?: IRoom['_id'],
 ): Promise<boolean> => Authorization.hasAllPermission(user, permissions, scope);
 export const hasPermissionAsync = async (
-	user: IUser['_id'] | IUser,
+	user: IUser['_id'] | UserWithRoles,
 	permissionId: IPermission['_id'],
 	scope?: IRoom['_id'],
 ): Promise<boolean> => Authorization.hasPermission(user, permissionId, scope);
 export const hasAtLeastOnePermissionAsync = async (
-	user: IUser['_id'] | IUser,
+	user: IUser['_id'] | UserWithRoles,
 	permissions: IPermission['_id'][],
 	scope?: IRoom['_id'],
 ): Promise<boolean> => Authorization.hasAtLeastOnePermission(user, permissions, scope);

--- a/apps/meteor/server/lib/eraseRoom.ts
+++ b/apps/meteor/server/lib/eraseRoom.ts
@@ -8,7 +8,7 @@ import { hasPermissionAsync } from './authorization/hasPermission';
 import { deleteRoom } from './rooms/deleteRoom';
 import { roomCoordinator } from './rooms/roomCoordinator';
 
-export async function eraseRoom(roomOrId: string | IRoom, user: AtLeast<IUser, '_id' | 'name' | 'username'>): Promise<void> {
+export async function eraseRoom(roomOrId: string | IRoom, user: AtLeast<IUser, '_id' | 'name' | 'username' | 'roles'>): Promise<void> {
 	const room = typeof roomOrId === 'string' ? await Rooms.findOneById(roomOrId) : roomOrId;
 
 	if (!room) {
@@ -26,7 +26,7 @@ export async function eraseRoom(roomOrId: string | IRoom, user: AtLeast<IUser, '
 	if (
 		!(await roomCoordinator
 			.getRoomDirectives(room.t)
-			?.canBeDeleted((permissionId, rid) => hasPermissionAsync(user._id, permissionId, rid), room))
+			?.canBeDeleted((permissionId, rid) => hasPermissionAsync(user, permissionId, rid), room))
 	) {
 		throw new Meteor.Error('error-not-allowed', 'Not allowed', {
 			method: 'eraseRoom',
@@ -34,7 +34,7 @@ export async function eraseRoom(roomOrId: string | IRoom, user: AtLeast<IUser, '
 	}
 
 	const team = room.teamId && (await Team.getOneById(room.teamId, { projection: { roomId: 1 } }));
-	if (team && !(await hasPermissionAsync(user._id, `delete-team-${room.t === 'c' ? 'channel' : 'group'}`, team.roomId))) {
+	if (team && !(await hasPermissionAsync(user, `delete-team-${room.t === 'c' ? 'channel' : 'group'}`, team.roomId))) {
 		throw new Meteor.Error('error-not-allowed', 'Not allowed', {
 			method: 'eraseRoom',
 		});

--- a/apps/meteor/server/lib/pushConfig.ts
+++ b/apps/meteor/server/lib/pushConfig.ts
@@ -46,7 +46,7 @@ Meteor.methods<ServerMethods>({
 			});
 		}
 
-		if (!(await hasPermissionAsync(user._id, 'test-push-notifications'))) {
+		if (!(await hasPermissionAsync(user, 'test-push-notifications'))) {
 			throw new Meteor.Error('error-not-allowed', 'Not allowed', {
 				method: 'push_test',
 			});

--- a/apps/meteor/server/meteor-methods/messages/loadHistory.ts
+++ b/apps/meteor/server/meteor-methods/messages/loadHistory.ts
@@ -54,7 +54,7 @@ Meteor.methods<ServerMethods>({
 			return loadMessageHistory({ rid, end, limit, ls, showThreadMessages, room });
 		}
 
-		const canPreview = await hasPermissionAsync(fromUser._id, 'preview-c-room');
+		const canPreview = await hasPermissionAsync(fromUser, 'preview-c-room');
 
 		if (room.t === 'c' && !canPreview && !(await Subscriptions.findOneByRoomIdAndUserId(rid, fromUser._id, { projection: { _id: 1 } }))) {
 			return false;

--- a/apps/meteor/server/meteor-methods/rooms/browseChannels.ts
+++ b/apps/meteor/server/meteor-methods/rooms/browseChannels.ts
@@ -46,7 +46,7 @@ const sortUsers = (field: string, direction: 'asc' | 'desc'): Record<string, Sor
 };
 
 const getChannelsAndGroups = async (
-	user: AtLeast<IUser, '_id' | '__rooms'>,
+	user: AtLeast<IUser, '_id' | '__rooms' | 'roles'>,
 	canViewAnon: boolean,
 	searchTerm: string,
 	sort: Record<string, number>,
@@ -55,7 +55,7 @@ const getChannelsAndGroups = async (
 		limit: number;
 	},
 ) => {
-	if ((!user && !canViewAnon) || (user && !(await hasPermissionAsync(user._id, 'view-c-room')))) {
+	if ((!user && !canViewAnon) || (user && !(await hasPermissionAsync(user, 'view-c-room')))) {
 		return;
 	}
 
@@ -120,7 +120,7 @@ const getChannelsCountForTeam = mem((teamId) => Rooms.countByTeamId(teamId), {
 });
 
 const getTeams = async (
-	user: AtLeast<IUser, '_id' | '__rooms'>,
+	user: AtLeast<IUser, '_id' | '__rooms' | 'roles'>,
 	searchTerm: string,
 	sort: Record<string, number>,
 	pagination: {
@@ -248,7 +248,7 @@ const findUsers = async ({
 };
 
 const getUsers = async (
-	user: AtLeast<IUser, '_id' | '__rooms'> | undefined,
+	user: AtLeast<IUser, '_id' | '__rooms' | 'roles'> | undefined,
 	text: string,
 	workspace: string,
 	sort: Record<string, SortDirection>,
@@ -257,11 +257,11 @@ const getUsers = async (
 		limit: number;
 	},
 ) => {
-	if (!user || !(await hasPermissionAsync(user._id, 'view-outside-room')) || !(await hasPermissionAsync(user._id, 'view-d-room'))) {
+	if (!user || !(await hasPermissionAsync(user, 'view-outside-room')) || !(await hasPermissionAsync(user, 'view-d-room'))) {
 		return;
 	}
 
-	const viewFullOtherUserInfo = await hasPermissionAsync(user._id, 'view-full-other-user-info');
+	const viewFullOtherUserInfo = await hasPermissionAsync(user, 'view-full-other-user-info');
 
 	const { total, results } = await findUsers({ text, sort, pagination, workspace, viewFullOtherUserInfo });
 
@@ -300,7 +300,7 @@ export const browseChannelsMethod = async (
 		offset = 0,
 		limit = 10,
 	}: BrowseChannelsParams,
-	user: AtLeast<IUser, '_id' | '__rooms'> | undefined | null,
+	user: AtLeast<IUser, '_id' | '__rooms' | 'roles'> | undefined | null,
 ) => {
 	const searchTerm = trim(escapeRegExp(text));
 

--- a/apps/meteor/server/publications/room/index.ts
+++ b/apps/meteor/server/publications/room/index.ts
@@ -90,7 +90,7 @@ Meteor.methods<ServerMethods>({
 			});
 		}
 
-		if (settings.get('Store_Last_Message') && user && !(await hasPermissionAsync(user._id, 'preview-c-room'))) {
+		if (settings.get('Store_Last_Message') && user && !(await hasPermissionAsync(user, 'preview-c-room'))) {
 			delete room.lastMessage;
 		}
 

--- a/apps/meteor/server/services/authorization/canAccessRoom.ts
+++ b/apps/meteor/server/services/authorization/canAccessRoom.ts
@@ -6,13 +6,13 @@ import { Subscriptions, Rooms, TeamMember, Team, Users } from '@rocket.chat/mode
 
 import { canAccessRoomLivechat } from './canAccessRoomLivechat';
 
-async function canAccessPublicRoom(user?: Partial<IUser>): Promise<boolean> {
+async function canAccessPublicRoom(user?: IUser): Promise<boolean> {
 	if (!user?._id) {
 		const anon = await Settings.get<boolean>('Accounts_AllowAnonymousRead');
 		return !!anon;
 	}
 
-	return Authorization.hasPermission(user._id, 'view-c-room');
+	return Authorization.hasPermission(user, 'view-c-room');
 }
 
 type RoomAccessValidatorConverted = (

--- a/apps/meteor/server/services/authorization/service.ts
+++ b/apps/meteor/server/services/authorization/service.ts
@@ -1,4 +1,4 @@
-import type { IAuthorization, RoomAccessValidator } from '@rocket.chat/core-services';
+import type { IAuthorization, RoomAccessValidator, UserWithRoles } from '@rocket.chat/core-services';
 import { License, ServiceClass } from '@rocket.chat/core-services';
 import type { IUser, IRole, IRoom, ISubscription } from '@rocket.chat/core-typings';
 import { Subscriptions, Rooms, Users, Roles, Permissions } from '@rocket.chat/models';
@@ -56,21 +56,21 @@ export class Authorization extends ServiceClass implements IAuthorization {
 		}
 	}
 
-	async hasAllPermission(userId: string | IUser, permissions: string[], scope?: string): Promise<boolean> {
+	async hasAllPermission(userId: string | UserWithRoles, permissions: string[], scope?: string): Promise<boolean> {
 		if (!userId) {
 			return false;
 		}
 		return this.all(userId, permissions, scope);
 	}
 
-	async hasPermission(userId: string | IUser, permissionId: string, scope?: string): Promise<boolean> {
+	async hasPermission(userId: string | UserWithRoles, permissionId: string, scope?: string): Promise<boolean> {
 		if (!userId) {
 			return false;
 		}
 		return this.all(userId, [permissionId], scope);
 	}
 
-	async hasAtLeastOnePermission(userId: string | IUser, permissions: string[], scope?: string): Promise<boolean> {
+	async hasAtLeastOnePermission(userId: string | UserWithRoles, permissions: string[], scope?: string): Promise<boolean> {
 		if (!userId) {
 			return false;
 		}
@@ -160,7 +160,7 @@ export class Authorization extends ServiceClass implements IAuthorization {
 		return !!result;
 	}
 
-	private async getRoles(user: string | IUser, scope?: IRoom['_id']): Promise<string[]> {
+	private async getRoles(user: string | UserWithRoles, scope?: IRoom['_id']): Promise<string[]> {
 		const { roles: userRoles = [] } = typeof user === 'string' ? (await Users.findOneById(user, { projection: { roles: 1 } })) || {} : user;
 		const { roles: subscriptionsRoles = [] } =
 			(scope &&
@@ -172,7 +172,7 @@ export class Authorization extends ServiceClass implements IAuthorization {
 		return [...userRoles, ...subscriptionsRoles].sort((a, b) => a.localeCompare(b));
 	}
 
-	private async atLeastOne(user: string | IUser, permissions: string[] = [], scope?: string): Promise<boolean> {
+	private async atLeastOne(user: string | UserWithRoles, permissions: string[] = [], scope?: string): Promise<boolean> {
 		const sortedRoles = await this.getRolesCached(user, scope);
 		for await (const permission of permissions) {
 			if (await this.rolesHasPermissionCached(permission, sortedRoles)) {
@@ -183,7 +183,7 @@ export class Authorization extends ServiceClass implements IAuthorization {
 		return false;
 	}
 
-	private async all(user: string | IUser, permissions: string[] = [], scope?: string): Promise<boolean> {
+	private async all(user: string | UserWithRoles, permissions: string[] = [], scope?: string): Promise<boolean> {
 		const sortedRoles = await this.getRolesCached(user, scope);
 		for await (const permission of permissions) {
 			if (!(await this.rolesHasPermissionCached(permission, sortedRoles))) {

--- a/packages/core-services/src/index.ts
+++ b/packages/core-services/src/index.ts
@@ -4,7 +4,7 @@ import type { IAccount, ILoginResult } from './types/IAccount';
 import type { IAnalyticsService } from './types/IAnalyticsService';
 import type { IApiService } from './types/IApiService';
 import type { IAppsEngineService } from './types/IAppsEngineService';
-import type { IAuthorization, RoomAccessValidator } from './types/IAuthorization';
+import type { IAuthorization, RoomAccessValidator, UserWithRoles } from './types/IAuthorization';
 import type { IAuthorizationLivechat } from './types/IAuthorizationLivechat';
 import type { IBannerService } from './types/IBannerService';
 import type { ICalendarService } from './types/ICalendarService';
@@ -138,6 +138,7 @@ export type {
 	NPSVotePayload,
 	ResizeResult,
 	RoomAccessValidator,
+	UserWithRoles,
 	TelemetryEvents,
 	TelemetryMap,
 	VideoConferenceJoinOptions,

--- a/packages/core-services/src/types/IAuthorization.ts
+++ b/packages/core-services/src/types/IAuthorization.ts
@@ -1,5 +1,8 @@
 import type { IRoom, IUser, IRole } from '@rocket.chat/core-typings';
 
+/** Minimal user shape a permission check needs. `getRoles` only reads `_id` and `roles`. */
+export type UserWithRoles = Pick<IUser, '_id' | 'roles'>;
+
 export type RoomAccessValidator = (
 	room?: Pick<IRoom, '_id' | 't' | 'teamId' | 'prid' | 'abacAttributes'>,
 	user?: IUser | Pick<IUser, '_id'>,
@@ -7,9 +10,9 @@ export type RoomAccessValidator = (
 ) => Promise<boolean>;
 
 export interface IAuthorization {
-	hasAllPermission(user: string | IUser, permissions: string[], scope?: string): Promise<boolean>;
-	hasPermission(user: string | IUser, permissionId: string, scope?: string): Promise<boolean>;
-	hasAtLeastOnePermission(user: string | IUser, permissions: string[], scope?: string): Promise<boolean>;
+	hasAllPermission(user: string | UserWithRoles, permissions: string[], scope?: string): Promise<boolean>;
+	hasPermission(user: string | UserWithRoles, permissionId: string, scope?: string): Promise<boolean>;
+	hasAtLeastOnePermission(user: string | UserWithRoles, permissions: string[], scope?: string): Promise<boolean>;
 	canAccessRoom: RoomAccessValidator;
 	canReadRoom: RoomAccessValidator;
 	canAccessRoomId(rid: IRoom['_id'], uid?: IUser['_id']): Promise<boolean>;


### PR DESCRIPTION
## What

Follow-up to accepting `IUser` in permission checks. Adds a minimal named type and migrates the sites that hold a **partial** user projection (which the previous `string | IUser` signature rejected).

## Core change

`getRoles` only ever reads `user._id` and `user.roles`, so requiring a full `IUser` was overkill. New type in `IAuthorization`:

```ts
export type UserWithRoles = Pick<IUser, '_id' | 'roles'>;
```

`Authorization.hasPermission` / `hasAllPermission` / `hasAtLeastOnePermission` and the `hasPermissionAsync` helpers now take `string | UserWithRoles`. Full `IUser` stays compatible, so nothing that already passes a user breaks.

## Migrated sites

- **`Meteor.userAsync()`** (full doc at runtime, only the static type was narrow): `pushConfig`, `removeChannelLinks`, room publications, `loadHistory`.
- **`canAccessRoom`**: pass the user it already re-fetches to a full document.
- **Widened partial param types to carry `roles`, then pass the object**: `canDeleteMessage`, `eraseRoom` (+ the `eraseTeamShared` generic constraints it flows into), `browseChannels`.
- **`browseChannels` REST caller** (`api/v1/misc.ts`) now projects `roles` next to `__rooms`.

Each partial site that now passes an object trades **2 DB lookups for 1** (its own fetch + the check's internal `findOneById` → just its own fetch, widened to include `roles`).

## Left on the string path

`livechat/roomAccessValidator.compatibility` receives `Pick<IUser, '_id'>` from its caller — no roles available, and fetching them would add the lookup this change avoids.

## Verification

Every touched file typechecks clean (serena diagnostics), no `as` casts. `IUser.roles` being required means TS still blocks any rolesless object — the safety gate is intact.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
Task: [ARCH-2248](https://rocketchat.atlassian.net/browse/ARCH-2248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)


[ARCH-2248]: https://rocketchat.atlassian.net/browse/ARCH-2248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Permission checks now use available user role information for more accurate authorization decisions.
  * Channel browsing and directory filtering apply role-aware access controls, including separate checks for viewing users and rooms.
  * Room, team, message-history, push notification, and integration actions now consistently enforce permissions using the authenticated user context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->