### PR TITLE
feat: ddp-client connection liveness check and forceReopen

### DIFF
--- a/.changeset/fix-ddp-connection-liveness.md
+++ b/.changeset/fix-ddp-connection-liveness.md
@@ -1,0 +1,10 @@
+---
+'@rocket.chat/ddp-client': patch
+---
+
+Adds connection liveness checking to recover from zombie WebSocket sockets (a `connected` socket whose transport is dead, common on mobile NAT timeouts that never fire `onclose`):
+
+- `Connection.probe(timeoutMs?)` — sends a DDP `ping` and resolves `true` if a `pong` arrives in time.
+- `Connection.forceReopen()` — tears down and reconnects, deduplicating concurrent callers via a shared in-flight promise.
+- `Connection.checkAndReopen(probeTimeoutMs?)` — probes when connected, force-reopens when not connected or on a dead probe. Also exposed on `DDPSDK`.
+- `Connection.close()` now severs socket handlers before closing so a dying socket can't deliver late messages or clobber the live connection.

--- a/packages/ddp-client/__tests__/Connection.spec.ts
+++ b/packages/ddp-client/__tests__/Connection.spec.ts
@@ -355,8 +355,9 @@ it('probe resolves true when the server answers the ping with a pong', async () 
 	const probePromise = connection.probe();
 
 	await server.nextMessage.then((message) => {
-		expect(message).toBe('{"msg":"ping"}');
-		server.send('{"msg":"pong"}');
+		const { id } = JSON.parse(message);
+		expect(id).toEqual(expect.any(String));
+		server.send(JSON.stringify({ msg: 'pong', id }));
 	});
 
 	await expect(probePromise).resolves.toBe(true);
@@ -418,8 +419,9 @@ it('checkAndReopen probes and returns true without a forced reopen when alive', 
 	const resultPromise = connection.checkAndReopen();
 
 	await server.nextMessage.then((message) => {
-		expect(message).toBe('{"msg":"ping"}');
-		server.send('{"msg":"pong"}');
+		const { id } = JSON.parse(message);
+		expect(id).toEqual(expect.any(String));
+		server.send(JSON.stringify({ msg: 'pong', id }));
 	});
 
 	await expect(resultPromise).resolves.toBe(true);

--- a/packages/ddp-client/__tests__/Connection.spec.ts
+++ b/packages/ddp-client/__tests__/Connection.spec.ts
@@ -368,11 +368,14 @@ it('probe resolves false when no pong arrives before the timeout', async () => {
 	await handleConnection(server, connection.connect());
 	expect(connection.status).toBe('connected');
 
-	jest.useFakeTimers();
-	const probePromise = connection.probe(100);
-	await jest.advanceTimersByTimeAsync(100);
-	await expect(probePromise).resolves.toBe(false);
-	jest.useRealTimers();
+	try {
+		jest.useFakeTimers();
+		const probePromise = connection.probe(100);
+		await jest.advanceTimersByTimeAsync(100);
+		await expect(probePromise).resolves.toBe(false);
+	} finally {
+		jest.useRealTimers();
+	}
 });
 
 it('forceReopen closes the socket and re-establishes the connection', async () => {

--- a/packages/ddp-client/__tests__/Connection.spec.ts
+++ b/packages/ddp-client/__tests__/Connection.spec.ts
@@ -334,3 +334,126 @@ it('should ignore a stale ws.onclose that fires after the socket has been replac
 	expect(connection.status).toBe(statusBefore);
 	expect((connection as unknown as { retryCount: number }).retryCount).toBe(retryBefore);
 });
+
+// The existing tests above share the `ws://localhost:1234` URL. jest-websocket-mock
+// is backed by `mock-socket`, whose server registry is keyed by URL; leftover closed
+// servers accumulate across tests and can capture a later `new WebSocket(url)`. Run the
+// liveness tests on a separate port so they never bind to a stale server.
+const setupLiveness = (retryOptions: { retryCount: number; retryTime: number } = { retryCount: 0, retryTime: 0 }) => {
+	server = new WS('ws://localhost:4321/websocket');
+	const client = new MinimalDDPClient();
+	const connection = ConnectionImpl.create('ws://localhost:4321', WebSocket, client, retryOptions);
+	return { client, connection };
+};
+
+it('probe resolves true when the server answers the ping with a pong', async () => {
+	const { connection } = setupLiveness();
+
+	await handleConnection(server, connection.connect());
+	expect(connection.status).toBe('connected');
+
+	const probePromise = connection.probe();
+
+	await server.nextMessage.then((message) => {
+		expect(message).toBe('{"msg":"ping"}');
+		server.send('{"msg":"pong"}');
+	});
+
+	await expect(probePromise).resolves.toBe(true);
+});
+
+it('probe resolves false when no pong arrives before the timeout', async () => {
+	const { connection } = setupLiveness();
+
+	await handleConnection(server, connection.connect());
+	expect(connection.status).toBe('connected');
+
+	jest.useFakeTimers();
+	const probePromise = connection.probe(100);
+	await jest.advanceTimersByTimeAsync(100);
+	await expect(probePromise).resolves.toBe(false);
+	jest.useRealTimers();
+});
+
+it('forceReopen closes the socket and re-establishes the connection', async () => {
+	const { connection } = setupLiveness();
+
+	await handleConnection(server, connection.connect());
+	expect(connection.status).toBe('connected');
+
+	const reopened = connection.forceReopen();
+
+	await handleConnection(server, reopened);
+
+	expect(connection.status).toBe('connected');
+	await expect(reopened).resolves.toBe(true);
+	expect((connection as unknown as { reopenInFlight: unknown }).reopenInFlight).toBeNull();
+});
+
+it('forceReopen dedupes concurrent callers onto the in-flight reopen', async () => {
+	const { connection } = setupLiveness();
+
+	await handleConnection(server, connection.connect());
+	expect(connection.status).toBe('connected');
+
+	const first = connection.forceReopen();
+	const second = connection.forceReopen();
+	expect(second).toBe(first);
+
+	await handleConnection(server, first, second);
+
+	await expect(first).resolves.toBe(true);
+	expect((connection as unknown as { reopenInFlight: unknown }).reopenInFlight).toBeNull();
+});
+
+it('checkAndReopen probes and returns true without a forced reopen when alive', async () => {
+	const { connection } = setupLiveness();
+
+	await handleConnection(server, connection.connect());
+	const sessionBefore = connection.session;
+
+	const resultPromise = connection.checkAndReopen();
+
+	await server.nextMessage.then((message) => {
+		expect(message).toBe('{"msg":"ping"}');
+		server.send('{"msg":"pong"}');
+	});
+
+	await expect(resultPromise).resolves.toBe(true);
+	expect(connection.status).toBe('connected');
+	expect(connection.session).toBe(sessionBefore);
+});
+
+it('checkAndReopen force-reopens when the probe reports the connection dead', async () => {
+	const { connection } = setupLiveness();
+
+	await handleConnection(server, connection.connect());
+	expect(connection.status).toBe('connected');
+
+	// Drive the "probe reports dead" branch directly so we don't depend on ping/
+	// pong timing between two in-flight messages.
+	const probeSpy = jest.spyOn(connection, 'probe').mockResolvedValue(false);
+
+	const resultPromise = connection.checkAndReopen();
+
+	await handleConnection(server, resultPromise);
+
+	await expect(resultPromise).resolves.toBe(true);
+	expect(connection.status).toBe('connected');
+	probeSpy.mockRestore();
+});
+
+it('checkAndReopen force-reopens directly when the connection is not connected', async () => {
+	const { connection } = setupLiveness();
+
+	await handleConnection(server, connection.connect());
+	connection.close();
+	expect(connection.status).toBe('closed');
+
+	const resultPromise = connection.checkAndReopen();
+
+	await handleConnection(server, resultPromise);
+
+	await expect(resultPromise).resolves.toBe(true);
+	expect(connection.status).toBe('connected');
+});

--- a/packages/ddp-client/src/Connection.ts
+++ b/packages/ddp-client/src/Connection.ts
@@ -1,6 +1,7 @@
 import { Emitter } from '@rocket.chat/emitter';
 
 import type { DDPClient } from './types/DDPClient';
+import type { RemoveListener } from './types/RemoveListener';
 
 // type Subscription = {
 // 	name: string;
@@ -312,7 +313,7 @@ export class ConnectionImpl
 	probe(timeoutMs = 2000): Promise<boolean> {
 		return new Promise<boolean>((resolve) => {
 			let settled = false;
-			let off: () => void = () => {};
+			let off: RemoveListener | undefined;
 			let timer: ReturnType<typeof setTimeout>;
 
 			const finish = (alive: boolean) => {
@@ -321,7 +322,7 @@ export class ConnectionImpl
 				}
 				settled = true;
 				clearTimeout(timer);
-				off();
+				off?.();
 				resolve(alive);
 			};
 

--- a/packages/ddp-client/src/Connection.ts
+++ b/packages/ddp-client/src/Connection.ts
@@ -101,6 +101,8 @@ export class ConnectionImpl
 
 	private reopenInFlight: Promise<boolean> | null = null;
 
+	private onConnectionOff?: RemoveListener;
+
 	constructor(
 		url: string,
 		private WS: WebSocketConstructor,
@@ -215,7 +217,8 @@ export class ConnectionImpl
 				// If the server is willing to speak the version of the protocol specified in the connect message, it sends back a connected message.
 				// Otherwise the server sends back a failed message with a version of DDP it would rather speak, informed by the connect message's support field, and closes the underlying transport.
 
-				this.client.onConnection((payload) => {
+				this.onConnectionOff?.();
+				this.onConnectionOff = this.client.onConnection((payload) => {
 					if (payload.msg === 'connected') {
 						this.status = 'connected';
 						// Reset the retry budget on successful connection so a future
@@ -293,6 +296,8 @@ export class ConnectionImpl
 
 	close() {
 		this.status = 'closed';
+		this.onConnectionOff?.();
+		this.onConnectionOff = undefined;
 		if (this.ws) {
 			// Sever all handlers before closing so the dying socket cannot deliver
 			// late messages or fire `onclose` on the live connection (e.g. a replaced
@@ -315,6 +320,7 @@ export class ConnectionImpl
 			let settled = false;
 			let off: RemoveListener | undefined;
 			let timer: ReturnType<typeof setTimeout>;
+			const id = Math.random().toString(36).slice(2);
 
 			const finish = (alive: boolean) => {
 				if (settled) {
@@ -328,11 +334,11 @@ export class ConnectionImpl
 
 			timer = setTimeout(() => finish(false), timeoutMs);
 			off = this.client.onMessage((payload) => {
-				if (payload.msg === 'pong') {
+				if (payload.msg === 'pong' && payload.id === id) {
 					finish(true);
 				}
 			});
-			this.client.ping();
+			this.client.ping(id);
 		});
 	}
 

--- a/packages/ddp-client/src/Connection.ts
+++ b/packages/ddp-client/src/Connection.ts
@@ -45,6 +45,26 @@ export interface Connection
 	reconnect(): Promise<boolean>;
 
 	close(): void;
+
+	/**
+	 * Active liveness check: sends a DDP `ping` and resolves `true` if a `pong`
+	 * arrives within `timeoutMs`. Detects zombie sockets that stay `connected`
+	 * while their transport is actually dead (e.g. mobile NAT timeouts that
+	 * never fire `onclose`).
+	 */
+	probe(timeoutMs?: number): Promise<boolean>;
+
+	/**
+	 * Tear down the current socket and reconnect from scratch. Concurrent
+	 * callers share one in-flight promise so parallel calls don't race.
+	 */
+	forceReopen(): Promise<boolean>;
+
+	/**
+	 * Ensure the socket is usable: if not `connected`, force-reopens; if
+	 * `connected`, probes for zombie sockets and force-reopens on a dead probe.
+	 */
+	checkAndReopen(probeTimeoutMs?: number): Promise<boolean>;
 }
 
 interface WebSocketConstructor {
@@ -77,6 +97,8 @@ export class ConnectionImpl
 	private connectPromise?: Promise<boolean>;
 
 	public queue = new Set<string>();
+
+	private reopenInFlight: Promise<boolean> | null = null;
 
 	constructor(
 		url: string,
@@ -270,8 +292,72 @@ export class ConnectionImpl
 
 	close() {
 		this.status = 'closed';
-		this.ws?.close();
+		if (this.ws) {
+			// Sever all handlers before closing so the dying socket cannot deliver
+			// late messages or fire `onclose` on the live connection (e.g. a replaced
+			// socket whose transport is still limping along).
+			try {
+				this.ws.onopen = null;
+				this.ws.onmessage = null;
+				this.ws.onerror = null;
+				this.ws.onclose = null;
+			} catch {
+				// some WebSocket implementations throw on null assignment — safe to ignore
+			}
+			this.ws.close();
+		}
 		this.emitStatus();
+	}
+
+	probe(timeoutMs = 2000): Promise<boolean> {
+		return new Promise<boolean>((resolve) => {
+			let settled = false;
+			let off: () => void = () => {};
+			let timer: ReturnType<typeof setTimeout>;
+
+			const finish = (alive: boolean) => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				clearTimeout(timer);
+				off();
+				resolve(alive);
+			};
+
+			timer = setTimeout(() => finish(false), timeoutMs);
+			off = this.client.onMessage((payload) => {
+				if (payload.msg === 'pong') {
+					finish(true);
+				}
+			});
+			this.client.ping();
+		});
+	}
+
+	forceReopen(): Promise<boolean> {
+		if (this.reopenInFlight) {
+			return this.reopenInFlight;
+		}
+		this.close();
+		const promise = this.reconnect()
+			.then((connected) => Boolean(connected))
+			.catch(() => false);
+		this.reopenInFlight = promise;
+		void promise.finally(() => {
+			if (this.reopenInFlight === promise) {
+				this.reopenInFlight = null;
+			}
+		});
+		return promise;
+	}
+
+	async checkAndReopen(probeTimeoutMs = 2000): Promise<boolean> {
+		if (this.status !== 'connected') {
+			return this.forceReopen();
+		}
+		const alive = await this.probe(probeTimeoutMs);
+		return alive || this.forceReopen();
 	}
 
 	static create(

--- a/packages/ddp-client/src/DDPSDK.ts
+++ b/packages/ddp-client/src/DDPSDK.ts
@@ -40,6 +40,14 @@ export class DDPSDK implements SDK {
 		return this.client.callAsync(method, ...params);
 	}
 
+	/**
+	 * Probe the connection for liveness and force-reopen if the socket is dead
+	 * or zombie. See `Connection.checkAndReopen`.
+	 */
+	checkAndReopen(probeTimeoutMs?: number) {
+		return this.connection.checkAndReopen(probeTimeoutMs);
+	}
+
 	stream(name: string, data: unknown, cb: (...data: PublicationPayloads['fields']['args']) => void) {
 		const [key, args] = Array.isArray(data) ? data : [data];
 		const subscription = this.client.subscribe(`stream-${name}`, key, { useCollection: false, args: [args] });


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Why this is needed

On mobile, a WebSocket can become a **zombie**: the client still reports `status === 'connected'`, but the underlying TCP transport is already dead. Common causes:

- Carrier/NAT bindings silently drop idle connections after a few minutes.
- The OS closes sockets when the app is backgrounded; on wake the socket object looks alive but sends go nowhere.
- These drops frequently **never fire `onclose`**, so the client has no signal that anything is wrong.

**Symptom:** the app looks connected, but method calls and subscriptions silently hang or fail, and the user only recovers by force-killing the app. The existing client only learns about death via `onclose` or the server's own ping timeout — neither is reliable when the drop is silent on the client side.

DDP already has `ping`/`pong`, but it's normally **server-initiated** (server pings, client answers). This PR adds a **client-initiated liveness probe** so the client can detect a dead path itself and recover autonomously.

## Proposed changes

- `Connection.probe(timeoutMs?)` — sends a DDP `ping` and resolves `true` if a `pong` arrives within `timeoutMs`.
- `Connection.forceReopen()` — closes + reconnects, deduplicating concurrent callers via a shared in-flight promise.
- `Connection.checkAndReopen(probeTimeoutMs?)` — probes when `connected`; force-reopens when not connected or on a dead probe. Also exposed on `DDPSDK` (`sdk.checkAndReopen()`).
- `Connection.close()` now severs socket handlers before closing so a dying socket can't deliver late messages or fire `onclose` on the live connection.

## Steps to test or reproduce

- `await sdk.checkAndReopen()` returns `true` when the socket is healthy, and recovers when the transport is dead.
- A zombie socket (no `onclose`, no traffic) is detected by the `pong` timeout and force-reopened.

## Further comments

The methods are **inert until something calls `checkAndReopen()`** — e.g. on app foreground or a `NetInfo` connectivity change in the mobile app. That trigger wiring lives in the mobile repo and is intentionally out of scope here; this PR only provides the capability and makes it reachable on the public `DDPSDK`.

https://rocketchat.atlassian.net/browse/CORE-2282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added connection liveness probing using DDP ping/pong checks.
  * Introduced APIs to force a connection reopen and to automatically check-and-reopen when needed.
  * Exposed the check-and-reopen capability via the DDP SDK.
* **Bug Fixes**
  * Improved recovery from “zombie” WebSocket states where the connection is marked alive but the transport is dead.
  * Hardened connection shutdown and handler detachment to prevent late/stale socket events from affecting active sessions.
  * Deduplicated concurrent forced reopen attempts to reduce race conditions.
* **Tests**
  * Added coverage for liveness probing, reopen behavior, and concurrency handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->