### PR TITLE
test: fix flaky omnichannel status toggle assertion in navbar page object

### DIFF
--- a/apps/meteor/tests/e2e/page-objects/fragments/navbar.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/navbar.ts
@@ -305,19 +305,14 @@ export class Navbar {
 			online = 'Turn off answer chats',
 		}
 
+		const expectedTitle = status === 'offline' ? StatusTitleMap.offline : StatusTitleMap.online;
+
 		const currentStatus = await toggleButton.getAttribute('title');
-		if (status === 'offline') {
-			if (currentStatus === StatusTitleMap.online) {
-				await toggleButton.click();
-			}
-		} else if (currentStatus === StatusTitleMap.offline) {
+		if (currentStatus !== expectedTitle) {
 			await toggleButton.click();
 		}
 
-		await this.root.waitForTimeout(500);
-
-		const newStatus = await this.btnSwitchOmnichannelStatus.getAttribute('title');
-		expect(newStatus).toBe(status === 'offline' ? StatusTitleMap.offline : StatusTitleMap.online);
+		await expect(toggleButton).toHaveAttribute('title', expectedTitle);
 	}
 
 	getUserStatusBadge(status: 'online' | 'away' | 'busy' | 'offline'): Locator {

--- a/apps/meteor/tests/e2e/page-objects/fragments/navbar.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/navbar.ts
@@ -296,16 +296,10 @@ export class Navbar {
 	}
 
 	async switchOmnichannelStatus(status: 'offline' | 'online') {
-		// button has a id of "omnichannel-status-toggle"
 		const toggleButton = this.btnSwitchOmnichannelStatus;
 		await expect(toggleButton).toBeVisible();
 
-		enum StatusTitleMap {
-			offline = 'Turn on answer chats',
-			online = 'Turn off answer chats',
-		}
-
-		const expectedTitle = status === 'offline' ? StatusTitleMap.offline : StatusTitleMap.online;
+		const expectedTitle = status === 'offline' ? 'Turn on answer chats' : 'Turn off answer chats';
 
 		const currentStatus = await toggleButton.getAttribute('title');
 		if (currentStatus !== expectedTitle) {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fixes a flaky e2e failure in `OC - Livechat API - onOfflineFormSubmit` (and any other test using `Navbar.switchOmnichannelStatus`):

```
Expected: "Turn on answer chats"
Received: "Turn off answer chats"
    at page-objects/fragments/navbar.ts:320
```

The `switchOmnichannelStatus` helper clicked the omnichannel status toggle, waited a fixed 500ms, and then asserted the button's `title` attribute with a one-shot `getAttribute` read. The title only flips after the `POST /v1/livechat/agent.status` round-trip completes and the reactive `useOmnichannelAgentAvailable` state propagates back to the UI — so on slow CI runs the 500ms was not enough and the assertion failed with the stale title.

This PR replaces the fixed timeout + one-shot read with Playwright's auto-retrying `expect(toggleButton).toHaveAttribute('title', expectedTitle)`, which polls until the title reflects the requested status (or the assertion timeout is reached). It also collapses the duplicated click-decision branches into a single `currentStatus !== expectedTitle` check.

Example failing run: https://github.com/RocketChat/Rocket.Chat/actions/runs/29293507301/job/86963590521

## Issue(s)

## Steps to test or reproduce

Run the omnichannel livechat API e2e suite:

```
yarn test:e2e tests/e2e/omnichannel/omnichannel-livechat-api.spec.ts
```

The `onOfflineFormSubmit` test should pass consistently, including under CI load where the agent status change takes longer than 500ms to reflect in the navbar.

## Further comments

Test-only change (page object fragment); no runtime code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJaU41dJvN6gcWdRrZCv5p

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJaU41dJvN6gcWdRrZCv5p)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability for changing omnichannel availability status.
  * Simplified the status-toggle interaction to click only when the current state differs from the expected one, and verify the resulting status directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [FLAKY-2383]

[FLAKY-2383]: https://rocketchat.atlassian.net/browse/FLAKY-2383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ