### PR TITLE
chore: auto detect screen share based on video direction

### DIFF
--- a/packages/media-signaling/src/lib/services/webrtc/Processor.ts
+++ b/packages/media-signaling/src/lib/services/webrtc/Processor.ts
@@ -7,7 +7,7 @@ import { MediaStreamManager } from '../../media/MediaStreamManager';
 import { getExternalWaiter, type PromiseWaiterData } from '../../utils/getExternalWaiter';
 
 const DATA_CHANNEL_LABEL = 'rocket.chat';
-type P2PCommand = 'mute' | 'unmute' | 'end' | 'screen-share.start' | 'screen-share.stop';
+type P2PCommand = 'mute' | 'unmute' | 'end';
 
 export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 	public readonly emitter: Emitter<WebRTCProcessorEvents>;
@@ -94,8 +94,6 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 
 		this.screenVideoTrack = newVideoTrack;
 		await this.loadScreenVideoTrack();
-
-		this.updateDirectionForVideoTrackChanged();
 	}
 
 	public async createOffer({ iceRestart }: { iceRestart?: boolean }): Promise<RTCSessionDescriptionInit> {
@@ -477,7 +475,7 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 
 		channel.onopen = (_event) => {
 			this.config.logger?.debug('Data Channel Open', channel.label);
-			if (!this._dataChannel || this._dataChannel.readyState !== 'open') {
+			if (this._dataChannel?.readyState !== 'open') {
 				this._dataChannel = channel;
 			}
 
@@ -528,7 +526,7 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 	}
 
 	private isValidCommand(command: string): command is P2PCommand {
-		return ['mute', 'unmute', 'end', 'screen-share.start', 'screen-share.stop'].includes(command);
+		return ['mute', 'unmute', 'end'].includes(command);
 	}
 
 	private getCommandFromDataChannelMessage(message: string): P2PCommand | null {
@@ -555,12 +553,6 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 				break;
 			case 'end':
 				this._dataChannelEnded = true;
-				break;
-			case 'screen-share.start':
-				this.streams.screenShareRemote.setActive(true);
-				break;
-			case 'screen-share.stop':
-				this.streams.screenShareRemote.setActive(false);
 				break;
 		}
 	}
@@ -598,14 +590,11 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 		this.updateAudioDirectionAfterNegotiation();
 		this.updateVideoDirectionAfterNegotiation();
 		this.updateRemoteHeld();
+		this.updateRemoteScreenShare();
 	}
 
 	private updateRemoteHeld(): void {
-		if (this.stopped) {
-			return;
-		}
-
-		if (['closed', 'failed', 'new'].includes(this.peer.connectionState)) {
+		if (!this.isActiveConnection()) {
 			return;
 		}
 
@@ -626,6 +615,30 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 		}
 
 		this.setRemoteHeld(anyTransceiverNotSending);
+	}
+
+	private updateRemoteScreenShare(): void {
+		if (!this.isActiveConnection()) {
+			return;
+		}
+
+		const transceivers = this.getTransceivers('video');
+		for (const transceiver of transceivers) {
+			if (!transceiver.currentDirection || transceiver.currentDirection === 'stopped') {
+				continue;
+			}
+
+			if (transceiver.currentDirection.includes('recv')) {
+				this.config.logger?.debug(`Video Transceiver is receiving; enabling screen-share`);
+				this.streams.screenShareRemote.setActive(true);
+				return;
+			}
+		}
+
+		if (this.streams.screenShareRemote.active) {
+			this.config.logger?.debug(`No video Transceiver is receiving, disabling screen-share`);
+			this.streams.screenShareRemote.setActive(false);
+		}
 	}
 
 	private registerPeerEvents() {
@@ -668,6 +681,10 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 
 	private canRenegotiate(): boolean {
 		return !this.stopped && this.peer.signalingState === 'stable';
+	}
+
+	private isActiveConnection(): boolean {
+		return !this.stopped && !['new', 'closed', 'failed'].includes(this.peer.connectionState);
 	}
 
 	private onIceCandidate(event: RTCPeerConnectionIceEvent) {
@@ -760,11 +777,7 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 
 		this.streams.screenShareLocal.setActive(Boolean(this.screenVideoTrack));
 
-		if (this.screenVideoTrack) {
-			this.sendP2PCommand('screen-share.start');
-		} else {
-			this.sendP2PCommand('screen-share.stop');
-		}
+		this.updateDirectionForVideoTrackChanged();
 	}
 
 	private onIceGatheringComplete() {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
The current screen share implementation relies on a data channel to notify the other side that the screen share has started/stopped. This PR removes that dependency on the data channel and makes both sides of the call auto detect when screen sharing is enabled or not based on the state of video exchange in the connection.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Derived from [DMV-44](https://rocketchat.atlassian.net/browse/DMV-44)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Also solves this flaky test:
https://github.com/RocketChat/Rocket.Chat/actions/runs/29510595480/job/87668479725


[DMV-44]: https://rocketchat.atlassian.net/browse/DMV-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen-sharing state synchronization during WebRTC negotiations.
  * Reduced unnecessary peer-to-peer commands for screen sharing, improving connection reliability.
  * Improved handling of remote screen-share status and active connection state.
  * Simplified data-channel readiness handling for more consistent call behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->