### PR TITLE
ci: speed up merge queue runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ on:
       - '**.md'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  # merge_group runs group by the merge-group ref so a recreated group cancels the stale run;
+  # push/release runs group by run_id on purpose (never cancel a deploy in progress)
+  group: ${{ github.workflow }}-${{ github.head_ref || (github.event_name == 'merge_group' && github.ref) || github.run_id }}
   cancel-in-progress: true
 
 env:
@@ -155,6 +157,7 @@ jobs:
     name: 🚀 Notify external services - draft
     runs-on: ubuntu-24.04-arm
     needs: [release-versions]
+    if: github.event_name == 'release'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -195,7 +198,7 @@ jobs:
 
   packages-build:
     name: 📦 Build Packages
-    needs: [release-versions, notify-draft-services]
+    needs: [release-versions]
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Cache build
@@ -327,12 +330,18 @@ jobs:
         type:
           # if running in a PR build with coverage
           - ${{ (github.event_name != 'release' && github.ref != 'refs/heads/develop') && 'coverage' || 'production' }}
+        exclude:
+          # when images aren't published (merge queue, fork PRs) only amd64 tars are uploaded
+          # as artifacts, so arm64 builds would be discarded — skip them
+          - arch: ${{ (github.event.pull_request.head.repo.full_name != github.repository && github.event_name != 'release' && github.ref != 'refs/heads/develop') && 'arm64' || '' }}
         include:
           # if not, build with coverage for tests
           - arch: amd64
             service: [rocketchat]
             type: coverage
-          - arch: arm64
+          # resolves to amd64 when arm64 is excluded above, matching the entry before this
+          # one instead of re-adding an arm64 job (includes bypass exclude)
+          - arch: ${{ (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'release' || github.ref == 'refs/heads/develop') && 'arm64' || 'amd64' }}
             service: [rocketchat]
             type: coverage
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Three targeted cuts to merge queue CI wall time and wasted runners, based on analysis of run [29336744954](https://github.com/RocketChat/Rocket.Chat/actions/runs/29336744954) (50 min wall):

1. **Concurrency: dedupe merge_group runs by ref.** `github.head_ref` is empty for `merge_group` events, so the concurrency group fell back to `run_id` — unique per run, meaning `cancel-in-progress` never applied. We observed two runs on the same merge-group ref running ~80 min each to completion in parallel. Now merge_group runs group by `github.ref` (the `gh-readonly-queue/...` ref), so a recreated group cancels the stale run. `push`/`release` runs intentionally keep `run_id` grouping — a develop deploy must never be cancelled mid-publish.

2. **Skip arm64 Docker builds when images aren't published.** In merge queue (and fork PRs) `publish-image` is false, and the artifact fallback in `build-docker` only uploads amd64 tars — every arm64 build was discarded after being built. They were also the slowest legs of the docker matrix, delaying e2e start by ~3.5 min. The conditional include resolves to `amd64` in that case so it folds into the existing amd64 coverage entry instead of re-adding an arm64 job (matrix `include` bypasses `exclude`). develop/release/non-fork-PR behavior is unchanged.

3. **Gate `notify-draft-services` to release events.** The job only has release-gated steps but ran (runner spin-up + checkout + no-op) on every event, and sat serially between `release-versions` and `packages-build` — ~40s of critical path on every PR, queue, and develop run. `packages-build` no longer depends on it; nothing consumes its output.

Expected: ~4 min less wall time per merge queue run, 4 fewer runners per queue/fork-PR run, no more duplicate full-pipeline runs on requeue.

## Issue(s)

## Steps to test or reproduce

- `actionlint` passes on the edited workflow.
- Matrix scenarios verified: merge_group/fork PR → amd64-only coverage builds; non-fork PR → unchanged (both arches, coverage); develop push/release → unchanged (both arches production + both coverage rocketchat includes).

## Further comments

Coverage collection during merge_group e2e and the codecov uploads from queue runs were flagged in the same analysis but intentionally left out of this PR to keep it reviewable.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI handling for merge-group events and fork pull requests.
  * Ensured draft service notifications run only for release events.
  * Prevented package builds from being unnecessarily delayed by draft notifications.
  * Updated Docker build coverage for ARM64 and AMD64 targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2271]

[ARCH-2271]: https://rocketchat.atlassian.net/browse/ARCH-2271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ