### PR TITLE
chore: make screen share not rely on bundles from previous negotiations

### DIFF
--- a/packages/media-signaling/src/lib/services/webrtc/Processor.ts
+++ b/packages/media-signaling/src/lib/services/webrtc/Processor.ts
@@ -272,9 +272,21 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 	}
 
 	public async waitForIceGathering(): Promise<void> {
-		if (this.stopped || this.peer.iceGatheringState === 'complete') {
+		if (this.stopped) {
 			return;
 		}
+
+		if (this.peer.iceGatheringState === 'complete') {
+			// If the peer state is 'complete', wait long enough for a macrotask to complete to ensure this state is not outdated
+			await new Promise((resolve) => {
+				setTimeout(resolve, 1);
+			});
+
+			if (this.peer.iceGatheringState === 'complete') {
+				return;
+			}
+		}
+
 		this.config.logger?.debug('MediaCallWebRTCProcessor.waitForIceGathering');
 		await this.initialization;
 

--- a/packages/media-signaling/src/lib/services/webrtc/Processor.ts
+++ b/packages/media-signaling/src/lib/services/webrtc/Processor.ts
@@ -282,7 +282,7 @@ export class MediaCallWebRTCProcessor implements IWebRTCProcessor {
 				setTimeout(resolve, 1);
 			});
 
-			if (this.peer.iceGatheringState === 'complete') {
+			if (this.stopped || this.peer.iceGatheringState === 'complete') {
 				return;
 			}
 		}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
When the rocket.chat client starts a WebRTC negotiation, it waits for the ICE Gathering process to complete before sending the offer to the remote peer. 
When screen share is initiated, this waiting process gets skipped because the previous ICE Gathering has already completed but the new one has not yet started.
This PR changes the skip condition to ensure it waits for at least one macrotask whenever it gets called to ensure the current ice gathering state isn't just outdated.

Screen share works today because the ICE gathering isn't really needed on renegotiations within the same bundle - but we are not controlling the bundle explicitly so that could easily break at any time.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Derived from [DMV-44](https://rocketchat.atlassian.net/browse/DMV-44)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[DMV-44]: https://rocketchat.atlassian.net/browse/DMV-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebRTC connection handling by refining detection of ICE gathering completion.
  * The call now stops immediately when a stop request is active.
  * When ICE reports “complete,” the system performs a brief re-check to avoid acting on short-lived or transient state.
  * Helps reduce occasional media call instability related to changing ICE status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->