### PR TITLE
test: fix strict mode violation flake in OC manual selection queue test

### DIFF
--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-manual-selection.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-manual-selection.spec.ts
@@ -92,6 +92,8 @@ test.describe('OC - Manual Selection', () => {
 		});
 
 		await test.step('expect chat to be back in queue', async () => {
+			// the returning agent can transiently see the room twice (queued inquiry + not-yet-removed subscription)
+			await expect(poOmnichannel.sidebar.getSidebarItemByName(room.fname)).toHaveCount(1);
 			await expect(poOmnichannel.sidebar.getSidebarItemByName(room.fname)).toBeVisible();
 			await expect(agentB.poHomeOmnichannel.sidebar.getSidebarItemByName(room.fname)).toBeVisible();
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fixes a flake in `omnichannel-manual-selection.spec.ts` ('expect chat to be back in queue' step), seen e.g. in [this run](https://github.com/RocketChat/Rocket.Chat/actions/runs/29346374637/job/87135118391?pr=41345).

When an agent returns a chat to the queue, the server removes the agent's subscription fire-and-forget (`RoutingManager.removeAllRoomSubscriptions`) and then notifies agents of the queued inquiry. The returning agent's client can process the inquiry-queued event before the subscription-removed event, so for a brief window the sidebar renders the same room twice: once from the queued inquiry (`data-unread=true`) and once from the not-yet-removed subscription (`data-unread=false`). The trace's post-failure snapshot confirms the duplicate resolves on its own.

`toBeVisible()` fails immediately (no retry) on a strict mode violation, so even a milliseconds-wide duplicate window fails the test. Asserting `toHaveCount(1)` first polls through the transient 2→1 state while still failing if the duplicate persists or the item never shows up, then the original strict `toBeVisible()` and `click()` run against a settled sidebar.

## Issue(s)

## Steps to test or reproduce

Run `omnichannel-manual-selection.spec.ts`. The race is timing-dependent, so the flake only reproduces when the inquiry-queued event beats the subscription-removed event on the returning agent's client.

## Further comments

A product-side ordering fix (awaiting subscription removal before queueing the inquiry) wouldn't fully close the race either, since the subscription-removal notification itself is dispatched fire-and-forget deeper in the stack — not worth the blast radius for a milliseconds-long cosmetic duplicate.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

[CORE-2443]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that a chat returned to the queue appears only once in the room sidebar.
  * Documented transient duplicate visibility during queue reassignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2443]: https://rocketchat.atlassian.net/browse/CORE-2443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ