### PR TITLE
chore(authorization): bound roles-cache key to user id, skip cache when roles are in hand

### DIFF
--- a/apps/meteor/server/services/authorization/service.ts
+++ b/apps/meteor/server/services/authorization/service.ts
@@ -16,7 +16,10 @@ export class Authorization extends ServiceClass implements IAuthorization {
 
 	private getRolesCached = mem(this.getRoles.bind(this), {
 		maxAge: 1000,
-		cacheKey: JSON.stringify,
+		cacheKey: (args: unknown[]) => {
+			const [user, scope] = args as [string | UserWithRoles, IRoom['_id']?];
+			return typeof user === 'string' ? `${user}/${scope ?? ''}` : `${user._id}/${scope ?? ''}/${JSON.stringify(user.roles ?? [])}`;
+		},
 	});
 
 	private rolesHasPermissionCached = mem(this.rolesHasPermission.bind(this), {
@@ -168,8 +171,15 @@ export class Authorization extends ServiceClass implements IAuthorization {
 		return [...userRoles, ...subscriptionsRoles].sort((a, b) => a.localeCompare(b));
 	}
 
+	private async resolveRoles(user: string | UserWithRoles, scope?: IRoom['_id']): Promise<string[]> {
+		if (typeof user !== 'string' && !scope) {
+			return [...(user.roles ?? [])].sort((a, b) => a.localeCompare(b));
+		}
+		return this.getRolesCached(user, scope);
+	}
+
 	private async atLeastOne(user: string | UserWithRoles, permissions: string[] = [], scope?: string): Promise<boolean> {
-		const sortedRoles = await this.getRolesCached(user, scope);
+		const sortedRoles = await this.resolveRoles(user, scope);
 		for await (const permission of permissions) {
 			if (await this.rolesHasPermissionCached(permission, sortedRoles)) {
 				return true;
@@ -180,7 +190,7 @@ export class Authorization extends ServiceClass implements IAuthorization {
 	}
 
 	private async all(user: string | UserWithRoles, permissions: string[] = [], scope?: string): Promise<boolean> {
-		const sortedRoles = await this.getRolesCached(user, scope);
+		const sortedRoles = await this.resolveRoles(user, scope);
 		for await (const permission of permissions) {
 			if (!(await this.rolesHasPermissionCached(permission, sortedRoles))) {
 				return false;


### PR DESCRIPTION
## Why

Follow-up to permission checks accepting a full user object (#41346, #41367, and the `UserWithRoles` change). An automated review flagged that passing `this.user` makes `getRolesCached` stringify the whole authenticated user to build its cache key on every call.

## Changes (`server/services/authorization/service.ts`)

1. **Bound the cache key.** `getRolesCached` used `cacheKey: JSON.stringify`, so a full `IUser` serialized `settings`, `customFields`, `services`, emails, etc. on every check — and string-id vs object callers for the same user produced different keys, never sharing an entry. Now keys on `` `${user._id}/${scope}` `` — small, stable, shared.

2. **Skip the cache when roles are already in hand.** `getRoles` only touches the DB to (a) look up roles for a string id, or (b) fetch subscription roles when a `scope` is given. A user object **without** a scope needs neither — its `roles` are right there. `resolveRoles` short-circuits that (the common REST path): read `user.roles`, sort, return — no memo, no stringify, no DB.

String callers and scoped lookups still use the cache, now with the cheap id-based key.

## Effect

Hot path (object + no scope): was `JSON.stringify(fullUser)` + memo lookup → now a direct array read. Scoped/string paths: same behavior, cheaper key.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
Task: [ARCH-2253](https://rocketchat.atlassian.net/browse/ARCH-2253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)


[ARCH-2253]: https://rocketchat.atlassian.net/browse/ARCH-2253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization role resolution for user-based permission checks.
  * Reduced unnecessary role lookups when scope isn’t provided, returning roles directly when possible.
  * Made cached role results consistent across scoped and unscoped permission evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->