### PR TITLE
fix: server crash when LDAP search filter is invalid

### DIFF
--- a/.changeset/ldap-sync-crash-invalid-filter.md
+++ b/.changeset/ldap-sync-crash-invalid-filter.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes the server crashing during LDAP login or sync when the configured search settings produce an invalid LDAP filter (for example, an empty User Search Field). The operation now fails gracefully with a logged error instead of terminating the process.

--- a/apps/meteor/ee/server/lib/ldap/Manager.ts
+++ b/apps/meteor/ee/server/lib/ldap/Manager.ts
@@ -702,26 +702,28 @@ export class LDAPEEManager extends LDAPManager {
 		return new Promise((resolve, reject) => {
 			let count = 0;
 
-			void ldap.searchAllUsers<IImportUser>({
-				entryCallback: (entry: ldapjs.SearchEntry): IImportUser | undefined => {
-					const data = ldap.extractLdapEntryData(entry);
-					count++;
+			ldap
+				.searchAllUsers<IImportUser>({
+					entryCallback: (entry: ldapjs.SearchEntry): IImportUser | undefined => {
+						const data = ldap.extractLdapEntryData(entry);
+						count++;
 
-					const userData = this.mapUserData(data);
-					converter.addObjectToMemory(userData, { dn: data.dn, username: this.getLdapUsername(data) });
-					return userData;
-				},
-				endCallback: (err: any): void => {
-					if (err) {
-						logger.error({ err });
-						reject(err);
-						return;
-					}
+						const userData = this.mapUserData(data);
+						converter.addObjectToMemory(userData, { dn: data.dn, username: this.getLdapUsername(data) });
+						return userData;
+					},
+					endCallback: (err: any): void => {
+						if (err) {
+							logger.error({ err });
+							reject(err);
+							return;
+						}
 
-					logger.info({ msg: 'LDAP finished loading users. Users added to importer', count });
-					resolve();
-				},
-			});
+						logger.info({ msg: 'LDAP finished loading users. Users added to importer', count });
+						resolve();
+					},
+				})
+				.catch(reject);
 		});
 	}
 

--- a/apps/meteor/server/lib/ldap/Connection.spec.ts
+++ b/apps/meteor/server/lib/ldap/Connection.spec.ts
@@ -25,6 +25,7 @@ describe('LDAPConnection', () => {
 
 		beforeEach(() => {
 			connection = new LDAPConnection();
+			connection.options.userSearchField = 'uid';
 			connection.client = { search: sinon.stub().throws(parseError) };
 		});
 
@@ -51,6 +52,58 @@ describe('LDAPConnection', () => {
 			await connection.searchAllUsers({ endCallback });
 			// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 			expect(endCallback.calledOnceWithExactly(parseError)).to.be.true;
+		});
+	});
+
+	describe('getUserFilter', () => {
+		let connection: any;
+
+		beforeEach(() => {
+			connection = new LDAPConnection();
+		});
+
+		it('should compose the filter for a single search field', () => {
+			connection.options.userSearchField = 'uid';
+			expect(connection.getUserFilter('john')).to.equal('(&(uid=john))');
+		});
+
+		it('should compose an OR filter for multiple search fields', () => {
+			connection.options.userSearchField = 'uid,sAMAccountName';
+			expect(connection.getUserFilter('john')).to.equal('(&(|(uid=john)(sAMAccountName=john)))');
+		});
+
+		it('should trim whitespace and ignore empty segments (e.g. trailing commas)', () => {
+			connection.options.userSearchField = ' uid , sAMAccountName ,';
+			expect(connection.getUserFilter('john')).to.equal('(&(|(uid=john)(sAMAccountName=john)))');
+		});
+
+		it('should include the user search filter when configured', () => {
+			connection.options.userSearchField = 'uid';
+			connection.options.userSearchFilter = '(objectclass=user)';
+			expect(connection.getUserFilter('*')).to.equal('(&(objectclass=user)(uid=*))');
+		});
+
+		it('should throw a configuration error when the search field is empty', () => {
+			connection.options.userSearchField = '';
+			expect(() => connection.getUserFilter('*')).to.throw('LDAP User Search Field is not configured');
+		});
+
+		it('should throw a configuration error when the search field only has empty segments', () => {
+			connection.options.userSearchField = ' , ,';
+			expect(() => connection.getUserFilter('*')).to.throw('LDAP User Search Field is not configured');
+		});
+
+		it('should reject searchAllUsers with the configuration error instead of composing an invalid filter', async () => {
+			connection.options.userSearchField = '';
+			connection.client = { search: sinon.stub() };
+			const endCallback = sinon.stub();
+			const error = await connection.searchAllUsers({ endCallback }).then(
+				() => undefined,
+				(e: unknown) => e,
+			);
+			expect(error).to.be.an('error').with.property('message', 'LDAP User Search Field is not configured');
+			// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+			expect(connection.client.search.called).to.be.false;
 		});
 	});
 });

--- a/apps/meteor/server/lib/ldap/Connection.spec.ts
+++ b/apps/meteor/server/lib/ldap/Connection.spec.ts
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+const loggerStub = { debug: sinon.stub(), error: sinon.stub(), info: sinon.stub(), warn: sinon.stub() };
+
+const { LDAPConnection } = proxyquire.noCallThru().load('./Connection', {
+	'../../../app/settings/server': { settings: { get: sinon.stub() } },
+	'./getLDAPConditionalSetting': { getLDAPConditionalSetting: sinon.stub().returns('') },
+	'./Logger': {
+		logger: loggerStub,
+		connLogger: loggerStub,
+		bindLogger: loggerStub,
+		searchLogger: loggerStub,
+		authLogger: loggerStub,
+		mapLogger: loggerStub,
+	},
+});
+
+describe('LDAPConnection', () => {
+	describe('synchronous errors from client.search (e.g. invalid filters)', () => {
+		const parseError = new Error('invalid attribute name');
+		let connection: any;
+
+		beforeEach(() => {
+			connection = new LDAPConnection();
+			connection.client = { search: sinon.stub().throws(parseError) };
+		});
+
+		it('should reject doCustomSearch with the error', async () => {
+			const error = await connection
+				.doCustomSearch('dc=test', { filter: '(&(=*))' }, () => undefined)
+				.then(
+					() => undefined,
+					(e: unknown) => e,
+				);
+			expect(error).to.equal(parseError);
+		});
+
+		it('should route the error to endCallback on paged searchAllUsers instead of leaking the throw', async () => {
+			const endCallback = sinon.stub();
+			await connection.searchAllUsers({ endCallback });
+			// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+			expect(endCallback.calledOnceWithExactly(parseError)).to.be.true;
+		});
+
+		it('should route the error to endCallback on non-paged searchAllUsers instead of leaking the throw', async () => {
+			connection.options.searchPageSize = 0;
+			const endCallback = sinon.stub();
+			await connection.searchAllUsers({ endCallback });
+			// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+			expect(endCallback.calledOnceWithExactly(parseError)).to.be.true;
+		});
+	});
+});

--- a/apps/meteor/server/lib/ldap/Connection.ts
+++ b/apps/meteor/server/lib/ldap/Connection.ts
@@ -524,8 +524,6 @@ export class LDAPConnection {
 		});
 	}
 
-	// ldapjs parses the filter synchronously and throws on invalid filters (e.g. an empty search field);
-	// route those to the callback so they don't escape as unhandled rejections and crash the process.
 	private clientSearch(baseDN: string, searchOptions: ldapjs.SearchOptions, callback: ldapjs.SearchCallBack): void {
 		try {
 			this.client.search(baseDN, searchOptions, callback);

--- a/apps/meteor/server/lib/ldap/Connection.ts
+++ b/apps/meteor/server/lib/ldap/Connection.ts
@@ -395,11 +395,18 @@ export class LDAPConnection {
 
 		this.addUserFilters(filter, username);
 
-		const usernameFilter = this.options.userSearchField.split(',').map((item) => `(${item}=${username})`);
+		const fields = this.options.userSearchField
+			.split(',')
+			.map((field) => field.trim())
+			.filter(Boolean);
 
-		if (usernameFilter.length === 0) {
-			logger.error('LDAP_LDAP_User_Search_Field not defined');
-		} else if (usernameFilter.length === 1) {
+		if (!fields.length) {
+			throw new Error('LDAP User Search Field is not configured');
+		}
+
+		const usernameFilter = fields.map((field) => `(${field}=${username})`);
+
+		if (usernameFilter.length === 1) {
 			filter.push(`${usernameFilter[0]}`);
 		} else {
 			filter.push(`(|${usernameFilter.join('')})`);

--- a/apps/meteor/server/lib/ldap/Connection.ts
+++ b/apps/meteor/server/lib/ldap/Connection.ts
@@ -349,7 +349,7 @@ export class LDAPConnection {
 		let realEntries = 0;
 
 		return new Promise((resolve, reject) => {
-			this.client.search(baseDN, searchOptions, (err, res: ldapjs.SearchCallbackResponse) => {
+			this.clientSearch(baseDN, searchOptions, (err, res: ldapjs.SearchCallbackResponse) => {
 				if (err) {
 					searchLogger.error({ err });
 					reject(err);
@@ -517,6 +517,16 @@ export class LDAPConnection {
 		});
 	}
 
+	// ldapjs parses the filter synchronously and throws on invalid filters (e.g. an empty search field);
+	// route those to the callback so they don't escape as unhandled rejections and crash the process.
+	private clientSearch(baseDN: string, searchOptions: ldapjs.SearchOptions, callback: ldapjs.SearchCallBack): void {
+		try {
+			this.client.search(baseDN, searchOptions, callback);
+		} catch (err) {
+			callback(err as ldapjs.Error, undefined as unknown as ldapjs.SearchCallbackResponse);
+		}
+	}
+
 	private async doAsyncSearch<T = ldapjs.SearchEntry>(
 		baseDN: string,
 		searchOptions: ldapjs.SearchOptions,
@@ -527,7 +537,7 @@ export class LDAPConnection {
 
 		searchLogger.debug({ msg: 'searchOptions', searchOptions, baseDN });
 
-		this.client.search(baseDN, searchOptions, (err: ldapjs.Error | null, res: ldapjs.SearchCallbackResponse): void => {
+		this.clientSearch(baseDN, searchOptions, (err: ldapjs.Error | null, res: ldapjs.SearchCallbackResponse): void => {
 			if (err) {
 				searchLogger.error({ err });
 				callback(err);
@@ -591,7 +601,7 @@ export class LDAPConnection {
 
 		searchLogger.debug({ msg: 'searchOptions', searchOptions, baseDN });
 
-		this.client.search(baseDN, searchOptions, (err: ldapjs.Error | null, res: ldapjs.SearchCallbackResponse): void => {
+		this.clientSearch(baseDN, searchOptions, (err: ldapjs.Error | null, res: ldapjs.SearchCallbackResponse): void => {
 			if (err) {
 				searchLogger.error({ err });
 				callback(err);


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

ldapjs parses the search filter synchronously inside `client.search` and throws before any callback runs — e.g. `Error: invalid attribute name` when the User Search Field is empty, since `getUserFilter` then composes `(&(objectclass=user)(=*))`. That throw escaped `doAsyncSearch`/`doPagedSearch` as an `UnhandledPromiseRejection` and terminated the whole server process (exit code 1) during LDAP sync or login.

Three layered fixes:

1. **Route synchronous `client.search` throws to the callback error path** (`Connection.ts`): a small `clientSearch` wrapper (try/catch, mirroring the pattern already used in `bindDN`) used by all three call sites (`doCustomSearch`, `doAsyncSearch`, `doPagedSearch`). Covers any malformed filter, not just the empty-field case.
2. **Reject an empty User Search Field with a clear configuration error** (`getUserFilter`): the existing guard was dead code — `''.split(',')` returns `['']`, so the `length === 0` branch was unreachable and an empty field composed the invalid filter `(=*)`. Segments are now trimmed and empty ones dropped (also covers trailing commas like `sAMAccountName,`), and a fully empty field throws `LDAP User Search Field is not configured` before ldapjs is ever called.
3. **Stop discarding the `searchAllUsers` promise in the sync job** (`ee/.../Manager.ts` `importNewUsers`): it was `void`-ed, so any rejection not routed through `endCallback` became an unhandled rejection; it now chains to the surrounding promise's `reject` and lands in `sync()`'s existing try/catch.

Unit tests (`Connection.spec.ts`, new) pin the behavior: sync-throw routing (verified to fail with the leaked throw when the try/catch is removed) and `getUserFilter` composition/trimming/validation.

## Issue(s)
https://rocketchat.atlassian.net/browse/CORE-2407

## Steps to test or reproduce

1. Admin → Users → LDAP: **Server Type** = Active Directory, set Host/Port/Base DN and authentication.
2. Leave **User Search Field** (`LDAP_AD_User_Search_Field`) empty.
3. Enable LDAP and trigger **Sync Now** (`POST /api/v1/ldap.syncNow`).

Before: server logs `UnhandledPromiseRejection: Error: invalid attribute name` and exits. After: sync fails with a logged `LDAP User Search Field is not configured` error and the server keeps running.

Non-AD equivalent: any non-AD server type with `LDAP_User_Search_Field` empty or containing a trailing comma.

## Further comments

An e2e test isn't feasible here: CI has no LDAP server, so `ldap.syncNow`/`ldap.testSearch` fail at connect/bind before ever reaching the filter parse. The unit tests stub the ldapjs client at the exact throw point instead.

All `getUserFilter` callers (`searchByUsername` login/testSearch paths, `searchAllUsers` sync path) already wrap in try/catch or now propagate to one, so the new throw fails only the operation, never the process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed LDAP login and user synchronization crashes caused by invalid or empty user search field settings.
  - LDAP operations now fail gracefully with a logged error instead of terminating the server.
  - Improved handling of LDAP search errors across paged and non-paged searches.
  - LDAP search field configuration is now validated more reliably, including comma-separated fields and optional filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->