### PR TITLE
chore(real time composer): refactor messageboxes to use same base and sync feats with develop

### DIFF
--- a/apps/meteor/app/ui-message/client/messageBox/createRichTextComposerAPI.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/createRichTextComposerAPI.ts
@@ -1,16 +1,18 @@
 import type { Options } from '@rocket.chat/message-parser';
 import { escapeHTML } from '@rocket.chat/string-helpers';
-import { Accounts } from 'meteor/accounts-base';
 import type { RefObject } from 'react';
 
 import { createComposerAPICore, triggerEvent, type SetText } from './createComposerAPICore';
+import { limitQuoteChain } from './limitQuoteChain';
 import { resolveComposerBox } from './messageStateHandler';
 import { getSelectionRange, setSelectionRange } from './selectionRange';
 import type { ComposerAPI } from '../../../../client/lib/chats/ChatAPI';
 
 export const createRichTextComposerAPI = (
 	input: HTMLDivElement,
-	storageID: string,
+	persistDraft: (value: string) => void,
+	initialDraft: string,
+	quoteChainLimit: number,
 	parseOptions: Options,
 	composerRef: RefObject<HTMLElement | null>,
 	{ rid, tmid }: { rid: string; tmid?: string },
@@ -49,26 +51,19 @@ export const createRichTextComposerAPI = (
 		!skipFocus && focus();
 	};
 
-	input.addEventListener('input', (event: Event) => {
-		resolveComposerBox(event, parseOptions);
-	});
+	const rerender = (event: Event): void => resolveComposerBox(event, parseOptions);
+
+	input.addEventListener('input', rerender);
 
 	const core = createComposerAPICore({
 		input,
 		composerRef,
 		room: { rid, tmid },
-		initialValue: Accounts.storageLocation.getItem(storageID) ?? '',
-		save: () => {
-			// Store the value entirely as HTML with the DOM structure intact
-			if (input.innerHTML !== '<br>') {
-				Accounts.storageLocation.setItem(storageID, input.innerHTML);
-				return;
-			}
-
-			Accounts.storageLocation.removeItem(storageID);
-		},
+		initialValue: initialDraft,
+		save: () => persistDraft(input.innerText),
 		setText,
 		focus,
+		prepareQuotedMessage: (message) => limitQuoteChain(message, quoteChainLimit),
 	});
 
 	const { insertText } = core;
@@ -188,6 +183,10 @@ export const createRichTextComposerAPI = (
 
 	return {
 		...core,
+		release: () => {
+			core.release();
+			input.removeEventListener('input', rerender);
+		},
 		setText,
 		wrapSelection,
 		replaceText,

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -129,7 +129,7 @@ const MessageBox = ({
 		});
 	});
 
-	const { hasUploads, isUploading, isProcessingUploads } = useFileUpload();
+	const { hasUploads, handleUploadFiles, isUploading, isProcessingUploads } = useFileUpload();
 
 	const handleSendMessage = useStableCallback(() => {
 		if (isUploading || isProcessingUploads) {
@@ -329,7 +329,7 @@ const MessageBox = ({
 
 		if (files.length) {
 			event.preventDefault();
-			onUploadFiles?.(files);
+			(onUploadFiles ?? handleUploadFiles)(files);
 		}
 	});
 

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -129,7 +129,7 @@ const MessageBox = ({
 		});
 	});
 
-	const { hasUploads, handleUploadFiles, isUploading, isProcessingUploads } = useFileUpload();
+	const { hasUploads, isUploading, isProcessingUploads } = useFileUpload();
 
 	const handleSendMessage = useStableCallback(() => {
 		if (isUploading || isProcessingUploads) {

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -9,13 +9,7 @@ import { memo, useRef, useReducer, useCallback, useSyncExternalStore } from 'rea
 
 import MessageBoxBase from './MessageBoxBase';
 import MessageComposerFiles from './MessageComposerFiles';
-import {
-	emptySubscribe,
-	getEmptyFalse,
-	getEmptyArray,
-	handleFormattingShortcut,
-	extractImageFilesFromClipboard,
-} from './messageBoxHelpers';
+import { emptySubscribe, getEmptyFalse, getEmptyArray, handleFormattingShortcut } from './messageBoxHelpers';
 import { handleSelectionWrapping } from './wrapSelection';
 import { emoji } from '../../../../../app/emoji/client';
 import { createComposerAPI } from '../../../../../app/ui-message/client/messageBox/createComposerAPI';
@@ -36,6 +30,7 @@ import { useMessageComposerMergedRefs } from '../hooks/useMessageComposerMergedR
 import { useDraft } from './hooks/useDraft';
 import { useMessageBoxAutoFocus } from './hooks/useMessageBoxAutoFocus';
 import { useMessageBoxPlaceholder } from './hooks/useMessageBoxPlaceholder';
+import { getImageExtensionFromMime } from '../../../../../lib/getImageExtensionFromMime';
 
 const reducer = (_: unknown, event: ChangeEvent<HTMLInputElement>): boolean => {
 	const target = event.target as HTMLInputElement;
@@ -49,6 +44,7 @@ export type MessageBoxProps = {
 	onJoin?: () => Promise<void>;
 	onResize?: () => void;
 	onTyping?: () => void;
+	onUploadFiles?: (files: File[]) => void;
 	onEscape?: () => void;
 	onNavigateToPreviousMessage?: () => void;
 	onNavigateToNextMessage?: () => void;
@@ -65,6 +61,7 @@ const MessageBox = ({
 	onJoin,
 	onNavigateToNextMessage,
 	onNavigateToPreviousMessage,
+	onUploadFiles,
 	onEscape,
 	onTyping,
 	tshow,
@@ -297,11 +294,42 @@ const MessageBox = ({
 	});
 
 	const handlePaste = useStableCallback((event: ClipboardEvent<HTMLTextAreaElement>) => {
-		const files = extractImageFilesFromClipboard(event, format);
+		const { clipboardData } = event;
+
+		if (!clipboardData) {
+			return;
+		}
+
+		const items = Array.from(clipboardData.items);
+
+		if (items.some(({ kind, type }) => kind === 'string' && type === 'text/plain')) {
+			return;
+		}
+
+		const files = items
+			.filter((item) => item.kind === 'file' && item.type.indexOf('image/') !== -1)
+			.map((item) => {
+				const fileItem = item.getAsFile();
+
+				if (!fileItem) {
+					return;
+				}
+
+				const imageExtension = fileItem ? getImageExtensionFromMime(fileItem.type) : undefined;
+
+				const extension = imageExtension ? `.${imageExtension}` : '';
+
+				Object.defineProperty(fileItem, 'name', {
+					writable: true,
+					value: `Clipboard - ${format(new Date())}${extension}`,
+				});
+				return fileItem;
+			})
+			.filter((file): file is File => !!file);
 
 		if (files.length) {
 			event.preventDefault();
-			handleUploadFiles?.(files);
+			onUploadFiles?.(files);
 		}
 	});
 

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -1,47 +1,34 @@
 /* eslint-disable complexity */
 import { isRoomFederated, isRoomNativeFederated, type IMessage, type ISubscription } from '@rocket.chat/core-typings';
 import { useContentBoxSize, useStableCallback, useMediaQuery, useSafeRefCallback } from '@rocket.chat/fuselage-hooks';
-import {
-	MessageComposerAction,
-	MessageComposerToolbarActions,
-	MessageComposer,
-	MessageComposerToolbar,
-	MessageComposerActionsDivider,
-	MessageComposerToolbarSubmit,
-	MessageComposerButton,
-	MessageComposerInputExpandable,
-} from '@rocket.chat/ui-composer';
+import { MessageComposerInputExpandable } from '@rocket.chat/ui-composer';
 import { useTranslation, useUserPreference, useLayout, useSetting } from '@rocket.chat/ui-contexts';
 import { useMutation } from '@tanstack/react-query';
 import type { MouseEvent, ClipboardEvent, ChangeEvent } from 'react';
 import { memo, useRef, useReducer, useCallback, useSyncExternalStore } from 'react';
 
-import MessageBoxActionsToolbar from './MessageBoxActionsToolbar';
-import MessageBoxFormattingToolbar from './MessageBoxFormattingToolbar';
-import MessageBoxHint from './MessageBoxHint';
-import MessageBoxReplies from './MessageBoxReplies';
+import MessageBoxBase from './MessageBoxBase';
 import MessageComposerFiles from './MessageComposerFiles';
+import {
+	emptySubscribe,
+	getEmptyFalse,
+	getEmptyArray,
+	handleFormattingShortcut,
+	extractImageFilesFromClipboard,
+} from './messageBoxHelpers';
 import { handleSelectionWrapping } from './wrapSelection';
 import { emoji } from '../../../../../app/emoji/client';
 import { createComposerAPI } from '../../../../../app/ui-message/client/messageBox/createComposerAPI';
-import type { FormattingButton } from '../../../../../app/ui-message/client/messageBox/messageBoxFormatting';
 import { formattingButtons } from '../../../../../app/ui-message/client/messageBox/messageBoxFormatting';
-import { getImageExtensionFromMime } from '../../../../../lib/getImageExtensionFromMime';
 import { useFormatDateAndTime } from '../../../../hooks/useFormatDateAndTime';
 import { useIsFederationEnabled } from '../../../../hooks/useIsFederationEnabled';
-import type { ComposerAPI } from '../../../../lib/chats/ChatAPI';
 import { roomCoordinator } from '../../../../lib/rooms/roomCoordinator';
 import { keyCodes } from '../../../../lib/utils/keyCodes';
 import { Subscriptions } from '../../../../stores';
-import AudioMessageRecorder from '../../../composer/AudioMessageRecorder';
-import VideoMessageRecorder from '../../../composer/VideoMessageRecorder';
 import { useFileUpload } from '../../body/hooks/useFileUpload';
 import { useChat } from '../../contexts/ChatContext';
 import { useComposerPopupOptions } from '../../contexts/ComposerPopupContext';
 import { useRoom, useRoomSubscription } from '../../contexts/RoomContext';
-import ComposerBoxPopup from '../ComposerBoxPopup';
-import ComposerBoxPopupPreview from '../ComposerBoxPopupPreview';
-import ComposerUserActionIndicator from '../ComposerUserActionIndicator';
 import { useAutoGrow } from '../RoomComposer/hooks/useAutoGrow';
 import { useComposerBoxPopup } from '../hooks/useComposerBoxPopup';
 import { useEnablePopupPreview } from '../hooks/useEnablePopupPreview';
@@ -55,31 +42,6 @@ const reducer = (_: unknown, event: ChangeEvent<HTMLInputElement>): boolean => {
 
 	return Boolean(target.value.trim());
 };
-
-const handleFormattingShortcut = (event: KeyboardEvent, formattingButtons: FormattingButton[], composer: ComposerAPI) => {
-	const isMacOS = navigator.platform.indexOf('Mac') !== -1;
-	const isCmdOrCtrlPressed = (isMacOS && event.metaKey) || (!isMacOS && event.ctrlKey);
-
-	if (!isCmdOrCtrlPressed) {
-		return false;
-	}
-
-	const key = event.key.toLowerCase();
-
-	const formatter = formattingButtons.find((formatter) => 'command' in formatter && formatter.command === key);
-
-	if (!formatter || !('pattern' in formatter)) {
-		return false;
-	}
-
-	composer.wrapSelection(formatter.pattern);
-	return true;
-};
-
-const emptySubscribe = () => () => undefined;
-const getEmptyFalse = () => false;
-const a: any[] = [];
-const getEmptyArray = () => a;
 
 export type MessageBoxProps = {
 	tmid?: IMessage['_id'];
@@ -335,38 +297,7 @@ const MessageBox = ({
 	});
 
 	const handlePaste = useStableCallback((event: ClipboardEvent<HTMLTextAreaElement>) => {
-		const { clipboardData } = event;
-
-		if (!clipboardData) {
-			return;
-		}
-
-		const items = Array.from(clipboardData.items);
-
-		if (items.some(({ kind, type }) => kind === 'string' && type === 'text/plain')) {
-			return;
-		}
-
-		const files = items
-			.filter((item) => item.kind === 'file' && item.type.indexOf('image/') !== -1)
-			.map((item) => {
-				const fileItem = item.getAsFile();
-
-				if (!fileItem) {
-					return;
-				}
-
-				const imageExtension = fileItem ? getImageExtensionFromMime(fileItem.type) : undefined;
-
-				const extension = imageExtension ? `.${imageExtension}` : '';
-
-				Object.defineProperty(fileItem, 'name', {
-					writable: true,
-					value: `Clipboard - ${format(new Date())}${extension}`,
-				});
-				return fileItem;
-			})
-			.filter((file): file is File => !!file);
+		const files = extractImageFilesFromClipboard(event, format);
 
 		if (files.length) {
 			event.preventDefault();
@@ -418,45 +349,33 @@ const MessageBox = ({
 	const shouldPopupPreview = useEnablePopupPreview(popup.filter, popup.option);
 
 	return (
-		<>
-			{chat.composer?.quotedMessages && <MessageBoxReplies />}
-			{shouldPopupPreview && popup.option && (
-				<ComposerBoxPopup
-					select={popup.select}
-					items={popup.items}
-					focused={popup.focused}
-					title={popup.option.title}
-					renderItem={popup.option.renderItem}
-				/>
-			)}
-			{/*
-				SlashCommand Preview popup works in a weird way
-				There is only one trigger for all the commands: "/"
-				After that we need to the slashcommand list and check if the command exists and provide the preview
-				if not the query is `suspend` which means the slashcommand is not found or doesn't have a preview
-			*/}
-			{popup.option?.preview && (
-				<ComposerBoxPopupPreview
-					select={popup.select}
-					items={popup.items as any}
-					focused={popup.focused as any}
-					title={popup.option.title}
-					renderItem={popup.option.renderItem}
-					ref={popup.commandsRef}
-					rid={room._id}
-					tmid={tmid}
-					suspended={popup.suspended}
-				/>
-			)}
-			<MessageBoxHint
-				isEditing={isEditing}
-				e2eEnabled={e2eEnabled}
-				unencryptedMessagesAllowed={unencryptedMessagesAllowed}
-				isMobile={isMobile}
-			/>
-			{isRecordingVideo && <VideoMessageRecorder reference={messageComposerRef} rid={room._id} tmid={tmid} />}
-			<MessageComposer ref={messageComposerRef} variant={isEditing ? 'editing' : undefined}>
-				{isRecordingAudio && <AudioMessageRecorder rid={room._id} isMicrophoneDenied={isMicrophoneDenied} />}
+		<MessageBoxBase
+			rid={room._id}
+			tmid={tmid}
+			composer={chat.composer}
+			messageComposerRef={messageComposerRef}
+			popup={popup}
+			shouldPopupPreview={shouldPopupPreview}
+			isEditing={isEditing}
+			isRecording={isRecording}
+			isRecordingAudio={isRecordingAudio}
+			isRecordingVideo={isRecordingVideo}
+			isMicrophoneDenied={isMicrophoneDenied}
+			formatters={formatters}
+			canSend={canSend}
+			useEmojis={useEmojis}
+			sendEnabled={canSend && !isUploading && !isProcessingUploads && (typing || isEditing || hasUploads)}
+			sendActive={typing || isEditing || hasUploads}
+			inlineSize={sizes.inlineSize}
+			e2eEnabled={e2eEnabled}
+			unencryptedMessagesAllowed={unencryptedMessagesAllowed}
+			isMobile={isMobile}
+			joinPending={joinMutation.isPending}
+			onEmojiClick={handleOpenEmojiPicker}
+			onSend={handleSendMessage}
+			onJoin={onJoin}
+			closeEditing={closeEditing}
+			input={
 				<MessageComposerInputExpandable
 					dimensions={sizes}
 					ref={mergedRefs}
@@ -469,58 +388,9 @@ const MessageBox = ({
 					onPaste={handlePaste}
 					aria-activedescendant={popup.focused ? `popup-item-${popup.focused._id}` : undefined}
 				/>
-				<MessageComposerFiles />
-				<MessageComposerToolbar>
-					<MessageComposerToolbarActions aria-label={t('Message_composer_toolbox_primary_actions')}>
-						<MessageComposerAction
-							icon='emoji'
-							disabled={!useEmojis || isRecording || !canSend}
-							onClick={handleOpenEmojiPicker}
-							title={t('Emoji')}
-						/>
-						<MessageComposerActionsDivider />
-						{chat.composer && formatters.length > 0 && (
-							<MessageBoxFormattingToolbar
-								composer={chat.composer}
-								variant={sizes.inlineSize < 480 ? 'small' : 'large'}
-								items={formatters}
-								disabled={isRecording || !canSend}
-							/>
-						)}
-						<MessageBoxActionsToolbar
-							canSend={canSend}
-							isMicrophoneDenied={isMicrophoneDenied}
-							rid={room._id}
-							tmid={tmid}
-							isRecording={isRecording}
-							variant={sizes.inlineSize < 480 ? 'small' : 'large'}
-							isEditing={isEditing}
-						/>
-					</MessageComposerToolbarActions>
-					<MessageComposerToolbarSubmit>
-						{!canSend && (
-							<MessageComposerButton primary onClick={onJoin} loading={joinMutation.isPending}>
-								{t('Join')}
-							</MessageComposerButton>
-						)}
-						{canSend && (
-							<>
-								{isEditing && <MessageComposerButton onClick={closeEditing}>{t('Cancel')}</MessageComposerButton>}
-								<MessageComposerAction
-									aria-label={t('Send')}
-									icon='send'
-									disabled={!canSend || isUploading || isProcessingUploads || (!typing && !isEditing && !hasUploads)}
-									onClick={handleSendMessage}
-									secondary={typing || isEditing || hasUploads}
-									info={typing || isEditing || hasUploads}
-								/>
-							</>
-						)}
-					</MessageComposerToolbarSubmit>
-				</MessageComposerToolbar>
-			</MessageComposer>
-			<ComposerUserActionIndicator rid={room._id} tmid={tmid} />
-		</>
+			}
+			files={<MessageComposerFiles />}
+		/>
 	);
 };
 

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxBase.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxBase.tsx
@@ -1,0 +1,184 @@
+import type { IMessage, IRoom } from '@rocket.chat/core-typings';
+import {
+	MessageComposerAction,
+	MessageComposerToolbarActions,
+	MessageComposer,
+	MessageComposerToolbar,
+	MessageComposerActionsDivider,
+	MessageComposerToolbarSubmit,
+	MessageComposerButton,
+} from '@rocket.chat/ui-composer';
+import { useTranslation } from '@rocket.chat/ui-contexts';
+import type { MouseEvent, ReactNode, RefObject } from 'react';
+
+import MessageBoxActionsToolbar from './MessageBoxActionsToolbar';
+import MessageBoxFormattingToolbar from './MessageBoxFormattingToolbar';
+import MessageBoxHint from './MessageBoxHint';
+import MessageBoxReplies from './MessageBoxReplies';
+import type { FormattingButton } from '../../../../../app/ui-message/client/messageBox/messageBoxFormatting';
+import type { ComposerAPI } from '../../../../lib/chats/ChatAPI';
+import AudioMessageRecorder from '../../../composer/AudioMessageRecorder';
+import VideoMessageRecorder from '../../../composer/VideoMessageRecorder';
+import ComposerBoxPopup from '../ComposerBoxPopup';
+import ComposerBoxPopupPreview from '../ComposerBoxPopupPreview';
+import ComposerUserActionIndicator from '../ComposerUserActionIndicator';
+import type { useComposerBoxPopup } from '../hooks/useComposerBoxPopup';
+
+type MessageBoxBaseProps = {
+	rid: IRoom['_id'];
+	tmid?: IMessage['_id'];
+	input: ReactNode;
+	hint?: ReactNode;
+	files?: ReactNode;
+	composer?: ComposerAPI;
+	messageComposerRef: RefObject<HTMLElement | null>;
+	popup: ReturnType<typeof useComposerBoxPopup>;
+	shouldPopupPreview?: boolean;
+	isEditing: boolean;
+	isRecording: boolean;
+	isRecordingAudio: boolean;
+	isRecordingVideo: boolean;
+	isMicrophoneDenied: boolean;
+	formatters: FormattingButton[];
+	canSend: boolean;
+	useEmojis?: boolean;
+	sendEnabled: boolean;
+	sendActive: boolean;
+	inlineSize: number;
+	e2eEnabled: boolean;
+	unencryptedMessagesAllowed: boolean;
+	isMobile: boolean;
+	joinPending: boolean;
+	onEmojiClick: (e: MouseEvent<HTMLElement>) => void;
+	onSend: () => void;
+	onJoin?: () => Promise<void>;
+	closeEditing: (event: MouseEvent<HTMLElement>) => void;
+};
+
+const MessageBoxBase = ({
+	rid,
+	tmid,
+	input,
+	hint,
+	files,
+	composer,
+	messageComposerRef,
+	popup,
+	shouldPopupPreview,
+	isEditing,
+	isRecording,
+	isRecordingAudio,
+	isRecordingVideo,
+	isMicrophoneDenied,
+	formatters,
+	canSend,
+	useEmojis,
+	sendEnabled,
+	sendActive,
+	inlineSize,
+	e2eEnabled,
+	unencryptedMessagesAllowed,
+	isMobile,
+	joinPending,
+	onEmojiClick,
+	onSend,
+	onJoin,
+	closeEditing,
+}: MessageBoxBaseProps) => {
+	const t = useTranslation();
+
+	const variant = inlineSize < 480 ? 'small' : 'large';
+
+	return (
+		<>
+			{composer?.quotedMessages && <MessageBoxReplies />}
+			{shouldPopupPreview && popup.option && (
+				<ComposerBoxPopup
+					select={popup.select}
+					items={popup.items}
+					focused={popup.focused}
+					title={popup.option.title}
+					renderItem={popup.option.renderItem}
+				/>
+			)}
+			{/*
+				SlashCommand Preview popup works in a weird way
+				There is only one trigger for all the commands: "/"
+				After that we need to the slashcommand list and check if the command exists and provide the preview
+				if not the query is `suspend` which means the slashcommand is not found or doesn't have a preview
+			*/}
+			{popup.option?.preview && (
+				<ComposerBoxPopupPreview
+					select={popup.select}
+					items={popup.items as any}
+					focused={popup.focused as any}
+					title={popup.option.title}
+					renderItem={popup.option.renderItem}
+					ref={popup.commandsRef}
+					rid={rid}
+					tmid={tmid}
+					suspended={popup.suspended}
+				/>
+			)}
+			{hint}
+			<MessageBoxHint
+				isEditing={isEditing}
+				e2eEnabled={e2eEnabled}
+				unencryptedMessagesAllowed={unencryptedMessagesAllowed}
+				isMobile={isMobile}
+			/>
+			{isRecordingVideo && <VideoMessageRecorder reference={messageComposerRef} rid={rid} tmid={tmid} />}
+			<MessageComposer ref={messageComposerRef} variant={isEditing ? 'editing' : undefined}>
+				{isRecordingAudio && <AudioMessageRecorder rid={rid} isMicrophoneDenied={isMicrophoneDenied} />}
+				{input}
+				{files}
+				<MessageComposerToolbar>
+					<MessageComposerToolbarActions aria-label={t('Message_composer_toolbox_primary_actions')}>
+						<MessageComposerAction
+							icon='emoji'
+							disabled={!useEmojis || isRecording || !canSend}
+							onClick={onEmojiClick}
+							title={t('Emoji')}
+						/>
+						<MessageComposerActionsDivider />
+						{composer && formatters.length > 0 && (
+							<MessageBoxFormattingToolbar composer={composer} variant={variant} items={formatters} disabled={isRecording || !canSend} />
+						)}
+						<MessageBoxActionsToolbar
+							canSend={canSend}
+							isMicrophoneDenied={isMicrophoneDenied}
+							rid={rid}
+							tmid={tmid}
+							isRecording={isRecording}
+							variant={variant}
+							isEditing={isEditing}
+						/>
+					</MessageComposerToolbarActions>
+					<MessageComposerToolbarSubmit>
+						{!canSend && (
+							<MessageComposerButton primary onClick={onJoin} loading={joinPending}>
+								{t('Join')}
+							</MessageComposerButton>
+						)}
+						{canSend && (
+							<>
+								{isEditing && <MessageComposerButton onClick={closeEditing}>{t('Cancel')}</MessageComposerButton>}
+								<MessageComposerAction
+									aria-label={t('Send')}
+									icon='send'
+									disabled={!sendEnabled}
+									onClick={onSend}
+									secondary={sendActive}
+									info={sendActive}
+								/>
+							</>
+						)}
+					</MessageComposerToolbarSubmit>
+				</MessageComposerToolbar>
+			</MessageComposer>
+			<ComposerUserActionIndicator rid={rid} tmid={tmid} />
+		</>
+	);
+};
+
+export default MessageBoxBase;

--- a/apps/meteor/client/views/room/composer/messageBox/RichTextMessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/RichTextMessageBox.tsx
@@ -3,52 +3,37 @@
 import { isRoomFederated, isRoomNativeFederated, type IMessage, type ISubscription } from '@rocket.chat/core-typings';
 import { useContentBoxSize, useSafeRefCallback, useStableCallback } from '@rocket.chat/fuselage-hooks';
 import type { Options } from '@rocket.chat/message-parser';
-import {
-	MessageComposerAction,
-	MessageComposerToolbarActions,
-	MessageComposer,
-	/* MessageComposerInput, */
-	MessageComposerToolbar,
-	MessageComposerActionsDivider,
-	MessageComposerToolbarSubmit,
-	MessageComposerButton,
-	MessageComposerHint,
-	RichTextComposerInputExpandable,
-} from '@rocket.chat/ui-composer';
+import { MessageComposerHint, RichTextComposerInputExpandable } from '@rocket.chat/ui-composer';
 import { useTranslation, useUserPreference, useLayout, useSetting } from '@rocket.chat/ui-contexts';
 import { useMutation } from '@tanstack/react-query';
 import type { ReactElement, FormEvent, MouseEvent, ClipboardEvent } from 'react';
 import { memo, useRef, useReducer, useCallback, useSyncExternalStore, useState, useEffect, useMemo } from 'react';
 
-import MessageBoxActionsToolbar from './MessageBoxActionsToolbar';
-import MessageBoxFormattingToolbar from './MessageBoxFormattingToolbar';
-import MessageBoxHint from './MessageBoxHint';
-import MessageBoxReplies from './MessageBoxReplies';
+import MessageBoxBase from './MessageBoxBase';
 // import { createComposerAPI } from '../../../../../app/ui-message/client/messageBox/createComposerAPI';
 import { useMessageBoxAutoFocus } from './hooks/useMessageBoxAutoFocus';
 import { useMessageBoxPlaceholder } from './hooks/useMessageBoxPlaceholder';
+import {
+	emptySubscribe,
+	getEmptyFalse,
+	getEmptyArray,
+	handleFormattingShortcut,
+	extractImageFilesFromClipboard,
+} from './messageBoxHelpers';
 import { createRichTextComposerAPI } from '../../../../../app/ui-message/client/messageBox/createRichTextComposerAPI';
-import type { FormattingButton } from '../../../../../app/ui-message/client/messageBox/messageBoxFormatting';
 import { formattingButtons } from '../../../../../app/ui-message/client/messageBox/messageBoxFormatting';
 import { getTextLines } from '../../../../../app/ui-message/client/messageBox/messageStateHandler';
 import { getSelectionRange, setSelectionRange } from '../../../../../app/ui-message/client/messageBox/selectionRange';
-import { getImageExtensionFromMime } from '../../../../../lib/getImageExtensionFromMime';
 import { useMessageListKatex, useMessageListShowColors } from '../../../../components/message/list/MessageListContext';
 import { useFormatDateAndTime } from '../../../../hooks/useFormatDateAndTime';
 import { useIsFederationEnabled } from '../../../../hooks/useIsFederationEnabled';
-import type { ComposerAPI } from '../../../../lib/chats/ChatAPI';
 import { roomCoordinator } from '../../../../lib/rooms/roomCoordinator';
 import { keyCodes } from '../../../../lib/utils/keyCodes';
 import { Subscriptions } from '../../../../stores';
-import AudioMessageRecorder from '../../../composer/AudioMessageRecorder';
-import VideoMessageRecorder from '../../../composer/VideoMessageRecorder';
 import { useAutoLinkDomains } from '../../MessageList/hooks/useAutoLinkDomains';
 import { useChat } from '../../contexts/ChatContext';
 import { useComposerPopupOptions } from '../../contexts/ComposerPopupContext';
 import { useRoom } from '../../contexts/RoomContext';
-import ComposerBoxPopup from '../ComposerBoxPopup';
-import ComposerBoxPopupPreview from '../ComposerBoxPopupPreview';
-import ComposerUserActionIndicator from '../ComposerUserActionIndicator';
 import { useComposerBoxPopup } from '../hooks/useComposerBoxPopup';
 import { useEnablePopupPreview } from '../hooks/useEnablePopupPreview';
 import { useMessageComposerMergedRefs } from '../hooks/useMessageComposerMergedRefs';
@@ -80,34 +65,6 @@ const reducer = (_: unknown, event: FormEvent<HTMLElement>): TypingState => {
 		hideplaceholder: Boolean(childNodes.length !== 1 || childNodes[0].nodeName !== 'BR'),
 	};
 };
-
-const handleFormattingShortcut = (event: KeyboardEvent, formattingButtons: FormattingButton[], composer: ComposerAPI) => {
-	const isMacOS = navigator.platform.indexOf('Mac') !== -1;
-	const isCmdOrCtrlPressed = (isMacOS && event.metaKey) || (!isMacOS && event.ctrlKey);
-
-	if (!isCmdOrCtrlPressed) {
-		return false;
-	}
-
-	const key = event.key.toLowerCase();
-
-	const formatter = formattingButtons.find((formatter) => 'command' in formatter && formatter.command === key);
-
-	if (!formatter || !('pattern' in formatter)) {
-		return false;
-	}
-
-	// Prevent Ctrl+B from creating <b></b> and Ctrl+I from creating <i></i>
-	event.preventDefault();
-	composer.wrapSelection(formatter.pattern);
-
-	return true;
-};
-
-const emptySubscribe = () => () => undefined;
-const getEmptyFalse = () => false;
-const a: any[] = [];
-const getEmptyArray = () => a;
 
 type MessageBoxProps = {
 	tmid?: IMessage['_id'];
@@ -326,7 +283,7 @@ const RichTextMessageBox = ({
 			return false;
 		}
 
-		if (chat.composer && handleFormattingShortcut(event, [...formattingButtons], chat.composer)) {
+		if (chat.composer && handleFormattingShortcut(event, [...formattingButtons], chat.composer, true)) {
 			return;
 		}
 
@@ -510,48 +467,38 @@ const RichTextMessageBox = ({
 	const shouldPopupPreview = useEnablePopupPreview(popup.filter, popup.option);
 
 	return (
-		<>
-			{chat.composer?.quotedMessages && <MessageBoxReplies />}
-			{shouldPopupPreview && popup.option && (
-				<ComposerBoxPopup
-					select={popup.select}
-					items={popup.items}
-					focused={popup.focused}
-					title={popup.option.title}
-					renderItem={popup.option.renderItem}
-				/>
-			)}
-			{/*
-				SlashCommand Preview popup works in a weird way
-				There is only one trigger for all the commands: "/"
-				After that we need to the slashcommand list and check if the command exists and provide the preview
-				if not the query is `suspend` which means the slashcommand is not found or doesn't have a preview
-			*/}
-			{popup.option?.preview && (
-				<ComposerBoxPopupPreview
-					select={popup.select}
-					items={popup.items as any}
-					focused={popup.focused as any}
-					title={popup.option.title}
-					renderItem={popup.option.renderItem}
-					ref={popup.commandsRef}
-					rid={room._id}
-					tmid={tmid}
-					suspended={popup.suspended}
-				/>
-			)}
-			<MessageComposerHint icon='flask' helperText=''>
-				Experiment: Real Time Composer
-			</MessageComposerHint>
-			<MessageBoxHint
-				isEditing={isEditing}
-				e2eEnabled={e2eEnabled}
-				unencryptedMessagesAllowed={unencryptedMessagesAllowed}
-				isMobile={isMobile}
-			/>
-			{isRecordingVideo && <VideoMessageRecorder reference={messageComposerRef} rid={room._id} tmid={tmid} />}
-			<MessageComposer ref={messageComposerRef} variant={isEditing ? 'editing' : undefined}>
-				{isRecordingAudio && <AudioMessageRecorder rid={room._id} isMicrophoneDenied={isMicrophoneDenied} />}
+		<MessageBoxBase
+			rid={room._id}
+			tmid={tmid}
+			composer={chat.composer}
+			messageComposerRef={messageComposerRef}
+			popup={popup}
+			shouldPopupPreview={shouldPopupPreview}
+			isEditing={isEditing}
+			isRecording={isRecording}
+			isRecordingAudio={isRecordingAudio}
+			isRecordingVideo={isRecordingVideo}
+			isMicrophoneDenied={isMicrophoneDenied}
+			formatters={formatters}
+			canSend={canSend}
+			useEmojis={useEmojis}
+			sendEnabled={canSend && (typing || isEditing)}
+			sendActive={typing || isEditing}
+			inlineSize={newSizes.inlineSize}
+			e2eEnabled={e2eEnabled}
+			unencryptedMessagesAllowed={unencryptedMessagesAllowed}
+			isMobile={isMobile}
+			joinPending={joinMutation.isPending}
+			onEmojiClick={handleOpenEmojiPicker}
+			onSend={handleSendMessage}
+			onJoin={onJoin}
+			closeEditing={closeEditing}
+			hint={
+				<MessageComposerHint icon='flask' helperText=''>
+					Experiment: Real Time Composer
+				</MessageComposerHint>
+			}
+			input={
 				<RichTextComposerInputExpandable
 					dimensions={newSizes}
 					ref={newMergedRefs}
@@ -567,57 +514,8 @@ const RichTextMessageBox = ({
 					onBlur={setLastCursorPosition}
 					onFocus={getLastCursorPosition}
 				/>
-				<MessageComposerToolbar>
-					<MessageComposerToolbarActions aria-label={t('Message_composer_toolbox_primary_actions')}>
-						<MessageComposerAction
-							icon='emoji'
-							disabled={!useEmojis || isRecording || !canSend}
-							onClick={handleOpenEmojiPicker}
-							title={t('Emoji')}
-						/>
-						<MessageComposerActionsDivider />
-						{chat.composer && formatters.length > 0 && (
-							<MessageBoxFormattingToolbar
-								composer={chat.composer}
-								variant={newSizes.inlineSize < 480 ? 'small' : 'large'}
-								items={formatters}
-								disabled={isRecording || !canSend}
-							/>
-						)}
-						<MessageBoxActionsToolbar
-							canSend={canSend}
-							isEditing={isEditing}
-							isMicrophoneDenied={isMicrophoneDenied}
-							rid={room._id}
-							tmid={tmid}
-							isRecording={isRecording}
-							variant={newSizes.inlineSize < 480 ? 'small' : 'large'}
-						/>
-					</MessageComposerToolbarActions>
-					<MessageComposerToolbarSubmit>
-						{!canSend && (
-							<MessageComposerButton primary onClick={onJoin} loading={joinMutation.isPending}>
-								{t('Join')}
-							</MessageComposerButton>
-						)}
-						{canSend && (
-							<>
-								{isEditing && <MessageComposerButton onClick={closeEditing}>{t('Cancel')}</MessageComposerButton>}
-								<MessageComposerAction
-									aria-label={t('Send')}
-									icon='send'
-									disabled={!canSend || (!typing && !isEditing)}
-									onClick={handleSendMessage}
-									secondary={typing || isEditing}
-									info={typing || isEditing}
-								/>
-							</>
-						)}
-					</MessageComposerToolbarSubmit>
-				</MessageComposerToolbar>
-			</MessageComposer>
-			<ComposerUserActionIndicator rid={room._id} tmid={tmid} />
-		</>
+			}
+		/>
 	);
 };
 

--- a/apps/meteor/client/views/room/composer/messageBox/RichTextMessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/RichTextMessageBox.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable complexity */
 // TODO: CRITICAL fix the race condition between the room composer and thread composer
 import { isRoomFederated, isRoomNativeFederated, type IMessage, type ISubscription } from '@rocket.chat/core-typings';
-import { useContentBoxSize, useSafeRefCallback, useStableCallback } from '@rocket.chat/fuselage-hooks';
+import { useContentBoxSize, useMediaQuery, useSafeRefCallback, useStableCallback } from '@rocket.chat/fuselage-hooks';
 import type { Options } from '@rocket.chat/message-parser';
 import { MessageComposerHint, RichTextComposerInputExpandable } from '@rocket.chat/ui-composer';
 import { useTranslation, useUserPreference, useLayout, useSetting } from '@rocket.chat/ui-contexts';
@@ -10,7 +10,8 @@ import type { ReactElement, FormEvent, MouseEvent, ClipboardEvent } from 'react'
 import { memo, useRef, useReducer, useCallback, useSyncExternalStore, useState, useEffect, useMemo } from 'react';
 
 import MessageBoxBase from './MessageBoxBase';
-// import { createComposerAPI } from '../../../../../app/ui-message/client/messageBox/createComposerAPI';
+import MessageComposerFiles from './MessageComposerFiles';
+import { useDraft } from './hooks/useDraft';
 import { useMessageBoxAutoFocus } from './hooks/useMessageBoxAutoFocus';
 import { useMessageBoxPlaceholder } from './hooks/useMessageBoxPlaceholder';
 import {
@@ -20,6 +21,8 @@ import {
 	handleFormattingShortcut,
 	extractImageFilesFromClipboard,
 } from './messageBoxHelpers';
+import { handleRichTextSelectionWrapping } from './wrapSelection';
+import { emoji } from '../../../../../app/emoji/client';
 import { createRichTextComposerAPI } from '../../../../../app/ui-message/client/messageBox/createRichTextComposerAPI';
 import { formattingButtons } from '../../../../../app/ui-message/client/messageBox/messageBoxFormatting';
 import { getTextLines } from '../../../../../app/ui-message/client/messageBox/messageStateHandler';
@@ -31,9 +34,10 @@ import { roomCoordinator } from '../../../../lib/rooms/roomCoordinator';
 import { keyCodes } from '../../../../lib/utils/keyCodes';
 import { Subscriptions } from '../../../../stores';
 import { useAutoLinkDomains } from '../../MessageList/hooks/useAutoLinkDomains';
+import { useFileUpload } from '../../body/hooks/useFileUpload';
 import { useChat } from '../../contexts/ChatContext';
 import { useComposerPopupOptions } from '../../contexts/ComposerPopupContext';
-import { useRoom } from '../../contexts/RoomContext';
+import { useRoom, useRoomSubscription } from '../../contexts/RoomContext';
 import { useComposerBoxPopup } from '../hooks/useComposerBoxPopup';
 import { useEnablePopupPreview } from '../hooks/useEnablePopupPreview';
 import { useMessageComposerMergedRefs } from '../hooks/useMessageComposerMergedRefs';
@@ -75,7 +79,6 @@ type MessageBoxProps = {
 	onEscape?: () => void;
 	onNavigateToPreviousMessage?: () => void;
 	onNavigateToNextMessage?: () => void;
-	onUploadFiles?: (files: readonly File[]) => void;
 	tshow?: IMessage['tshow'];
 	previewUrls?: string[];
 	subscription?: ISubscription;
@@ -89,7 +92,6 @@ const RichTextMessageBox = ({
 	onJoin,
 	onNavigateToNextMessage,
 	onNavigateToPreviousMessage,
-	onUploadFiles,
 	onEscape,
 	onTyping,
 	tshow,
@@ -102,6 +104,7 @@ const RichTextMessageBox = ({
 	const unencryptedMessagesAllowed = useSetting('E2E_Allow_Unencrypted_Messages', false);
 	const isSlashCommandAllowed = !e2eEnabled || !room.encrypted || unencryptedMessagesAllowed;
 	const composerPlaceholder = useMessageBoxPlaceholder(t('Message'), room);
+	const quoteChainLimit = useSetting('Message_QuoteChainLimit', 2);
 
 	const [stateTyping, setTyping] = useReducer(reducer, { isTyping: false, hideplaceholder: false });
 	const { isTyping: typing, hideplaceholder } = stateTyping;
@@ -155,13 +158,14 @@ const RichTextMessageBox = ({
 
 	const messageComposerRef = useRef<HTMLElement>(null);
 
-	const storageID = `messagebox_${room._id}${tmid ? `-${tmid}` : ''}`;
+	const subscription = useRoomSubscription();
+	const { initialValue, persistLocal, flushDraft } = useDraft(room._id, tmid ? undefined : subscription?.draft, tmid);
 
 	// Update the state of the raw markdown lines when room changes
 	useEffect(() => {
 		const input = contentEditableRef.current as HTMLDivElement;
 		setMdLines(getTextLines(input.innerText, '\n'));
-	}, [storageID]);
+	}, [room._id, tmid]);
 
 	// Get parse options and pass it as prop to the RichTextComposer API
 	const katex = useMessageListKatex();
@@ -187,18 +191,25 @@ const RichTextMessageBox = ({
 	const callbackRef = useCallback(
 		(node: HTMLDivElement) => {
 			if (node === null && chat.composer) {
+				flushDraft();
 				return chat.setComposerAPI();
 			}
 
 			if (chat.composer) {
 				return;
 			}
-			chat.setComposerAPI(createRichTextComposerAPI(node, storageID, parseOptions, messageComposerRef, { rid: room._id, tmid }));
+			chat.setComposerAPI(
+				createRichTextComposerAPI(node, persistLocal, initialValue, quoteChainLimit, parseOptions, messageComposerRef, {
+					rid: room._id,
+					tmid,
+				}),
+			);
 		},
-		[chat, storageID, parseOptions],
+		[chat, flushDraft, initialValue, persistLocal, quoteChainLimit, parseOptions, room._id, tmid],
 	);
 
-	const autofocusRef = useMessageBoxAutoFocus(!isMobile);
+	const isTouchDevice = useMediaQuery('(pointer: coarse)');
+	const autofocusRef = useMessageBoxAutoFocus(!isTouchDevice);
 
 	const useEmojis = useUserPreference<boolean>('useEmojis');
 
@@ -211,10 +222,20 @@ const RichTextMessageBox = ({
 		}
 
 		const ref = messageComposerRef.current as HTMLElement;
-		chat.emojiPicker.open(ref, (emoji: string) => chat.composer?.insertText(` :${emoji}: `));
+		chat.emojiPicker.open(ref, (emojiName: string) => {
+			const emojiEntry = emoji.list[`:${emojiName}:`];
+			const text = emojiEntry && 'unicode' in emojiEntry && emojiEntry.unicode ? ` ${emojiEntry.unicode} ` : ` :${emojiName}: `;
+			chat.composer?.insertText(text);
+		});
 	});
 
+	const { hasUploads, handleUploadFiles, isUploading, isProcessingUploads } = useFileUpload();
+
 	const handleSendMessage = useStableCallback(() => {
+		if (isUploading || isProcessingUploads) {
+			return;
+		}
+
 		const text = chat.composer?.text ?? '';
 		// Sanitize the innerText by reducing multiple instances of linebreaks
 		const cleanedText = text.replace(/\n{2,}/g, (match) => '\n'.repeat((match.length + 1) / 2));
@@ -223,11 +244,12 @@ const RichTextMessageBox = ({
 		setMdLines(['']);
 
 		const isFirefox = typeof navigator !== 'undefined' && /Firefox\/\d+/.test(navigator.userAgent);
+		const isEditingMessage = Boolean(chat.currentEditingMessage.getMID());
 
 		/* TODO: Develop the parser function that will render inside the RichTextComposer component */
 		// This if-else block temporarily solves the problem of editing a message
 		// When a message is being edited, it is a flat text structure without any DOM tree
-		if (chat.currentEditingMessage || isFirefox) {
+		if (isEditingMessage || isFirefox) {
 			onSend?.({
 				value: text,
 				tshow,
@@ -246,21 +268,29 @@ const RichTextMessageBox = ({
 
 	const closeEditing = (event: KeyboardEvent | MouseEvent<HTMLElement>) => {
 		const input = contentEditableRef.current as HTMLDivElement;
+		const mid = chat.currentEditingMessage.getMID();
 
-		if (chat.currentEditingMessage) {
-			event.preventDefault();
-			event.stopPropagation();
-
-			chat.currentEditingMessage.reset().then((reset) => {
-				if (!reset) {
-					chat.currentEditingMessage?.cancel();
-					chat.currentEditingMessage?.stop();
-				}
-				// Sets the cursor position to the end after resetting an edited message
-				setSelectionRange(input, input.innerText.length, input.innerText.length);
-				input.focus();
-			});
+		if (!mid) {
+			return;
 		}
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		chat.currentEditingMessage.reset().then((reset) => {
+			// NOTE: if the message was reset (i.e. content changed), we just update the popup (to re-apply/remove the preview)
+			if (reset) {
+				popup.update();
+			} else {
+				chat.currentEditingMessage.cancel();
+				chat.currentEditingMessage.stop();
+				popup.clear();
+			}
+
+			// Sets the cursor position to the end after resetting an edited message
+			setSelectionRange(input, input.innerText.length, input.innerText.length);
+			input.focus();
+		});
 	};
 
 	const keyboardEventHandler = useStableCallback((event: KeyboardEvent) => {
@@ -397,42 +427,11 @@ const RichTextMessageBox = ({
 	});
 
 	const handlePaste = useStableCallback((event: ClipboardEvent<HTMLDivElement>) => {
-		const { clipboardData } = event;
-
-		if (!clipboardData) {
-			return;
-		}
-
-		const items = Array.from(clipboardData.items);
-
-		if (items.some(({ kind, type }) => kind === 'string' && type === 'text/plain')) {
-			return;
-		}
-
-		const files = items
-			.filter((item) => item.kind === 'file' && item.type.indexOf('image/') !== -1)
-			.map((item) => {
-				const fileItem = item.getAsFile();
-
-				if (!fileItem) {
-					return;
-				}
-
-				const imageExtension = fileItem ? getImageExtensionFromMime(fileItem.type) : undefined;
-
-				const extension = imageExtension ? `.${imageExtension}` : '';
-
-				Object.defineProperty(fileItem, 'name', {
-					writable: true,
-					value: `Clipboard - ${format(new Date())}${extension}`,
-				});
-				return fileItem;
-			})
-			.filter((file): file is File => !!file);
+		const files = extractImageFilesFromClipboard(event, format);
 
 		if (files.length) {
 			event.preventDefault();
-			onUploadFiles?.(files);
+			handleUploadFiles?.(files);
 		}
 	});
 
@@ -453,15 +452,30 @@ const RichTextMessageBox = ({
 		}, []),
 	);
 
-	/* const mergedRefs = useMessageComposerMergedRefs(popup.callbackRef, textareaRef, callbackRef, autofocusRef, keyDownHandlerCallbackRef); */
+	const beforeInputHandlerCallbackRef = useSafeRefCallback(
+		useCallback(
+			(node: HTMLDivElement) => {
+				if (node === null) {
+					return;
+				}
+				const eventHandler = (e: Event) => handleRichTextSelectionWrapping(e as InputEvent, chat);
+				node.addEventListener('beforeinput', eventHandler);
 
-	/* New mergedRefs */
+				return () => {
+					node.removeEventListener('beforeinput', eventHandler);
+				};
+			},
+			[chat],
+		),
+	);
+
 	const newMergedRefs = useMessageComposerMergedRefs(
 		popup.callbackRef,
 		contentEditableRef,
 		callbackRef,
 		autofocusRef,
 		keyDownHandlerCallbackRef,
+		beforeInputHandlerCallbackRef,
 	);
 
 	const shouldPopupPreview = useEnablePopupPreview(popup.filter, popup.option);
@@ -482,8 +496,8 @@ const RichTextMessageBox = ({
 			formatters={formatters}
 			canSend={canSend}
 			useEmojis={useEmojis}
-			sendEnabled={canSend && (typing || isEditing)}
-			sendActive={typing || isEditing}
+			sendEnabled={canSend && !isUploading && !isProcessingUploads && (typing || isEditing || hasUploads)}
+			sendActive={typing || isEditing || hasUploads}
 			inlineSize={newSizes.inlineSize}
 			e2eEnabled={e2eEnabled}
 			unencryptedMessagesAllowed={unencryptedMessagesAllowed}
@@ -504,7 +518,7 @@ const RichTextMessageBox = ({
 					ref={newMergedRefs}
 					aria-label={composerPlaceholder}
 					name='msg'
-					disabled={isRecording || !canSend}
+					disabled={isRecording || !canSend || isProcessingUploads}
 					onInput={setTyping}
 					/* style={textAreaStyle} */
 					placeholder={composerPlaceholder}
@@ -515,6 +529,7 @@ const RichTextMessageBox = ({
 					onFocus={getLastCursorPosition}
 				/>
 			}
+			files={<MessageComposerFiles />}
 		/>
 	);
 };

--- a/apps/meteor/client/views/room/composer/messageBox/messageBoxHelpers.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/messageBoxHelpers.ts
@@ -1,0 +1,75 @@
+import type { ClipboardEvent } from 'react';
+
+import type { FormattingButton } from '../../../../../app/ui-message/client/messageBox/messageBoxFormatting';
+import { getImageExtensionFromMime } from '../../../../../lib/getImageExtensionFromMime';
+import type { ComposerAPI } from '../../../../lib/chats/ChatAPI';
+
+export const emptySubscribe = () => () => undefined;
+export const getEmptyFalse = () => false;
+const a: any[] = [];
+export const getEmptyArray = () => a;
+
+export const handleFormattingShortcut = (
+	event: KeyboardEvent,
+	formattingButtons: FormattingButton[],
+	composer: ComposerAPI,
+	preventDefault = false,
+) => {
+	const isMacOS = navigator.platform.indexOf('Mac') !== -1;
+	const isCmdOrCtrlPressed = (isMacOS && event.metaKey) || (!isMacOS && event.ctrlKey);
+
+	if (!isCmdOrCtrlPressed) {
+		return false;
+	}
+
+	const key = event.key.toLowerCase();
+
+	const formatter = formattingButtons.find((formatter) => 'command' in formatter && formatter.command === key);
+
+	if (!formatter || !('pattern' in formatter)) {
+		return false;
+	}
+
+	if (preventDefault) {
+		// Prevent Ctrl+B from creating <b></b> and Ctrl+I from creating <i></i>
+		event.preventDefault();
+	}
+
+	composer.wrapSelection(formatter.pattern);
+	return true;
+};
+
+export const extractImageFilesFromClipboard = (event: ClipboardEvent<HTMLElement>, format: (date: Date) => string): File[] => {
+	const { clipboardData } = event;
+
+	if (!clipboardData) {
+		return [];
+	}
+
+	const items = Array.from(clipboardData.items);
+
+	if (items.some(({ kind, type }) => kind === 'string' && type === 'text/plain')) {
+		return [];
+	}
+
+	return items
+		.filter((item) => item.kind === 'file' && item.type.indexOf('image/') !== -1)
+		.map((item) => {
+			const fileItem = item.getAsFile();
+
+			if (!fileItem) {
+				return;
+			}
+
+			const imageExtension = fileItem ? getImageExtensionFromMime(fileItem.type) : undefined;
+
+			const extension = imageExtension ? `.${imageExtension}` : '';
+
+			Object.defineProperty(fileItem, 'name', {
+				writable: true,
+				value: `Clipboard - ${format(new Date())}${extension}`,
+			});
+			return fileItem;
+		})
+		.filter((file): file is File => !!file);
+};

--- a/apps/meteor/client/views/room/composer/messageBox/wrapSelection.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/wrapSelection.ts
@@ -1,4 +1,4 @@
-import { getSelectionRange } from '../../../../../app/ui-message/client/messageBox/selectionRange';
+import { getSelectionRange, setSelectionRange } from '../../../../../app/ui-message/client/messageBox/selectionRange';
 import type { ChatAPI } from '../../../../lib/chats/ChatAPI';
 
 const wrapSelectionPatterns: Record<string, string> = {
@@ -96,7 +96,14 @@ export const handleRichTextSelectionWrapping = (event: InputEvent, chat: ChatAPI
 		return false;
 	}
 
-	composer.wrapSelection(pattern);
+	const selection = composer.wrapSelection(pattern);
+	if (event.isComposing) {
+		once(input, 'input', (event) => {
+			input.innerText = selection.value;
+			setSelectionRange(input, selection.selectionStart, selection.selectionEnd);
+			event.preventDefault();
+		});
+	}
 
 	event.preventDefault();
 	return true;

--- a/apps/meteor/client/views/room/composer/messageBox/wrapSelection.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/wrapSelection.ts
@@ -1,3 +1,4 @@
+import { getSelectionRange } from '../../../../../app/ui-message/client/messageBox/selectionRange';
 import type { ChatAPI } from '../../../../lib/chats/ChatAPI';
 
 const wrapSelectionPatterns: Record<string, string> = {
@@ -60,6 +61,42 @@ export const handleSelectionWrapping = (event: InputEvent, chat: ChatAPI): boole
 			event.preventDefault();
 		});
 	}
+
+	event.preventDefault();
+	return true;
+};
+
+// contenteditable divs have no .value/.selectionStart, so selection has to be read via the Selection API
+export const handleRichTextSelectionWrapping = (event: InputEvent, chat: ChatAPI): boolean => {
+	const { composer } = chat;
+	if (!composer) {
+		return false;
+	}
+	const input = event.target as HTMLDivElement;
+	const { selectionStart, selectionEnd } = getSelectionRange(input);
+
+	const testSelection = input.innerText.slice(selectionStart, selectionEnd);
+	// if the selection is the same of the data, return false
+	if (testSelection === event.data) {
+		return false;
+	}
+	if (event.data === chat.composer?.text) {
+		return false;
+	}
+	if (selectionStart === selectionEnd) {
+		return false;
+	}
+
+	const key = event.data;
+	if (!key) {
+		return false;
+	}
+	const pattern = wrapSelectionPatterns[key];
+	if (!pattern) {
+		return false;
+	}
+
+	composer.wrapSelection(pattern);
 
 	event.preventDefault();
 	return true;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

Stops the code duplication at RichTextMessageBox by using a shared base for the message boxes.

Also syncs the realtime composer features with the ones in develop (multiple file uploads)

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[RTC-5](https://rocketchat.atlassian.net/browse/RTC-5)
[RTC-50](https://rocketchat.atlassian.net/browse/RTC-50)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



[RTC-5]: https://rocketchat.atlassian.net/browse/RTC-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drafts now persist consistently across rich-text composer sessions.
  * Clipboard images are extracted and uploaded directly from the composer.
  * Rich-text selection wrapping and keyboard formatting shortcuts are supported.
  * Quoted message chains are automatically limited for cleaner conversations.
* **Bug Fixes**
  * Improved composer teardown and event handling prevents lingering input behavior after closing or switching.
  * Sending is better coordinated with uploads/processing and composer enablement states.
  * Emoji insertion and editing/close flows are more reliable (including caret restoration and popup updates).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->