### PR TITLE
fix: filter spotlight exact-match users against exclusion list

### DIFF
--- a/.changeset/fix-spotlight-exact-match-exclusion.md
+++ b/.changeset/fix-spotlight-exact-match-exclusion.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fix spotlight search exact-match branches bypassing the username exclusion list, so excluded users no longer appear in search results.

--- a/apps/meteor/server/lib/spotlight.js
+++ b/apps/meteor/server/lib/spotlight.js
@@ -230,16 +230,12 @@ export class Spotlight {
 		};
 
 		// Exact match for username only
-		// TODO: these exact-match branches push the user without filtering against `usernames`
-		// (the exclusion list), so an exact username query bypasses the exclusion that the
-		// findByActiveUsersExcept paths below honor. Evaluate filtering exactMatch against
-		// `usernames` here so the exclusion applies uniformly.
 		if (rid && canListInsiders) {
 			const exactMatch = await Users.findOneByUsernameAndRoomIgnoringCase(text, rid, {
 				projection: options.projection,
 				readPreference: options.readPreference,
 			});
-			if (exactMatch) {
+			if (exactMatch && !usernames.includes(exactMatch.username)) {
 				users.push(exactMatch);
 				this.processLimitAndUsernames(options, usernames, users);
 			}
@@ -250,7 +246,7 @@ export class Spotlight {
 				projection: options.projection,
 				readPreference: options.readPreference,
 			});
-			if (exactMatch) {
+			if (exactMatch && !usernames.includes(exactMatch.username)) {
 				users.push(this.mapOutsiders(exactMatch));
 				this.processLimitAndUsernames(options, usernames, users);
 			}


### PR DESCRIPTION
## Proposed changes
The spotlight search has two exact-match code paths (insider and outsider) that push the matched user directly into results without checking the `usernames` exclusion list. The other search methods (`_searchInsiderUsers`, `_searchOutsiderUsers`, `_searchConnectedUsers`) all pass `usernames` to `findByActiveUsersExcept` which filters them out, but the exact-match branches bypass this entirely.

This means excluded users can still appear in search results when their username matches the query exactly.

## Issue(s)
Closes #40961

## Steps to test or reproduce
1. Open a channel and mention a user (they get added to the exclusion list)
2. Search for that exact username in the spotlight
3. The excluded user still appears in results

## Further comments
Added `!usernames.includes(exactMatch.username)` guard to both exact-match branches (lines 238 and 250) and removed the TODO comment.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Spotlight search to consistently exclude usernames on the exclusion list, including exact matches.
  - Prevented excluded users from appearing in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->