### PR TITLE
test: fix flaky timeout in channel-management beforeEach navigation

### DIFF
--- a/apps/meteor/tests/e2e/channel-management.spec.ts
+++ b/apps/meteor/tests/e2e/channel-management.spec.ts
@@ -21,16 +21,13 @@ test.describe.serial('channel-management', () => {
 	test.beforeEach(async ({ page }) => {
 		poHomeChannel = new HomeChannel(page);
 
-		// Waiting for the 'load' event can consume most of the test timeout on a busy CI runner,
-		// and the client boot can occasionally get stuck on the loading screen, so wait for the
-		// Home heading with a bounded timeout and recover with a single reload instead of failing
-		await page.goto('/home', { waitUntil: 'domcontentloaded' });
-		try {
+		// The client boot can occasionally get stuck on the loading screen on a busy CI runner,
+		// and only a fresh navigation recovers it, so retry the navigation with a bounded wait
+		// instead of letting a single attempt exhaust the whole test timeout
+		await expect(async () => {
+			await page.goto('/home', { waitUntil: 'domcontentloaded' });
 			await poHomeChannel.waitForHome(15_000);
-		} catch {
-			await page.reload({ waitUntil: 'domcontentloaded' });
-			await poHomeChannel.waitForHome();
-		}
+		}).toPass();
 	});
 
 	test('should navigate on toolbar using arrow keys', async ({ page }) => {

--- a/apps/meteor/tests/e2e/channel-management.spec.ts
+++ b/apps/meteor/tests/e2e/channel-management.spec.ts
@@ -21,9 +21,6 @@ test.describe.serial('channel-management', () => {
 	test.beforeEach(async ({ page }) => {
 		poHomeChannel = new HomeChannel(page);
 
-		// The client boot can occasionally get stuck on the loading screen on a busy CI runner,
-		// and only a fresh navigation recovers it, so retry the navigation with a bounded wait
-		// instead of letting a single attempt exhaust the whole test timeout
 		await expect(async () => {
 			await page.goto('/home', { waitUntil: 'domcontentloaded' });
 			await poHomeChannel.waitForHome(15_000);

--- a/apps/meteor/tests/e2e/channel-management.spec.ts
+++ b/apps/meteor/tests/e2e/channel-management.spec.ts
@@ -24,7 +24,7 @@ test.describe.serial('channel-management', () => {
 		await expect(async () => {
 			await page.goto('/home', { waitUntil: 'domcontentloaded' });
 			await poHomeChannel.waitForHome(15_000);
-		}).toPass();
+		}).toPass({ timeout: 30_000 });
 	});
 
 	test('should navigate on toolbar using arrow keys', async ({ page }) => {

--- a/apps/meteor/tests/e2e/channel-management.spec.ts
+++ b/apps/meteor/tests/e2e/channel-management.spec.ts
@@ -21,8 +21,16 @@ test.describe.serial('channel-management', () => {
 	test.beforeEach(async ({ page }) => {
 		poHomeChannel = new HomeChannel(page);
 
-		await page.goto('/home');
-		await poHomeChannel.waitForHome();
+		// Waiting for the 'load' event can consume most of the test timeout on a busy CI runner,
+		// and the client boot can occasionally get stuck on the loading screen, so wait for the
+		// Home heading with a bounded timeout and recover with a single reload instead of failing
+		await page.goto('/home', { waitUntil: 'domcontentloaded' });
+		try {
+			await poHomeChannel.waitForHome(15_000);
+		} catch {
+			await page.reload({ waitUntil: 'domcontentloaded' });
+			await poHomeChannel.waitForHome();
+		}
 	});
 
 	test('should navigate on toolbar using arrow keys', async ({ page }) => {

--- a/apps/meteor/tests/e2e/page-objects/home-channel.ts
+++ b/apps/meteor/tests/e2e/page-objects/home-channel.ts
@@ -188,8 +188,8 @@ export class HomeChannel {
 		await this.getEmojiByName(emoji).click();
 	}
 
-	async waitForHome(): Promise<void> {
-		await this.homepageHeader.waitFor({ state: 'visible' });
+	async waitForHome(timeout?: number): Promise<void> {
+		await this.homepageHeader.waitFor({ state: 'visible', timeout });
 	}
 
 	async waitForRoomLoad(): Promise<void> {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fixes a flaky timeout in `channel-management.spec.ts` where the suite's shared `beforeEach` hook could consume the entire 60s test timeout before the test body ever started, e.g. in [this run](https://github.com/RocketChat/Rocket.Chat/actions/runs/29372367319/job/87223567263):

```
tests/e2e/channel-management.spec.ts:292:7 › channel-management › cross user tests › should unignore user1 messages
Test timeout of 60000ms exceeded while running "beforeEach" hook.
```

**Diagnosis (from the CI logs):**
- All 18 prior tests in the serial suite passed in 6–15s each, and the server logs show it idle during the hang — the server was healthy.
- The hook does `page.goto('/home')` and then waits for the "Home" heading. The timing shows `goto` spent nearly its full 30s navigation budget waiting for the page `load` event, and the heading then never appeared in the remaining ~28s — the test timeout killed the wait while it was still pending (hence the `Target page, context or browser has been closed` error).

This matches the failure mode already documented in #41319 (`preview-public-channel` flake): on a busy CI runner the client boot is slow or gets stuck on the loading screen, and no amount of waiting recovers it — only a fresh navigation does.

**Changes:**
- Wrap the navigation in `expect(async () => { ... }).toPass()` — Playwright's built-in retry mechanism, already used elsewhere in the e2e suite — so a stuck boot triggers a fresh `goto` attempt instead of a single wait exhausting the whole test timeout.
- Navigate with `waitUntil: 'domcontentloaded'` (same pattern used in `sidebar-menu.spec.ts`), so each attempt doesn't spend its budget waiting for full asset loading — what actually matters is the Home heading, which is waited on explicitly with a bounded 15s timeout per attempt.
- `HomeChannel.waitForHome()` now accepts an optional `timeout` param (backward-compatible for all other callers).

No changeset needed — test-only change.

## Issue(s)

## Steps to test or reproduce

The failure is CI-load dependent and not deterministically reproducible locally. Run the suite to verify no regression:

```
yarn playwright test tests/e2e/channel-management.spec.ts
```

The suite still passes on the happy path (the retry only kicks in when the Home page fails to render within the bounded wait).

## Further comments

Alternatives considered: raising the per-test timeout would hide genuine slow-downs and still fail when the boot is truly stuck; moving `goto` out of `beforeEach` (the #41319 approach) doesn't map here since there are no per-test API mutations racing the boot — every test needs the same fresh navigation; a try/catch with a manual `page.reload()` fallback works but hand-rolls what `toPass()` already expresses declaratively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYTXKLTT79eSBmX2sz1WeE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved channel management e2e reliability with retryable, time-bound setup steps and a more deterministic home-page load condition.
  * Enhanced home-page readiness checks by adding an optional timeout parameter, including a bounded wait during CI to reduce intermittent loading-screen hangs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->