### PR TITLE
fix: allow admin users to clean DM room history via REST API

### DIFF
--- a/.changeset/fix-clean-history-dm-access.md
+++ b/.changeset/fix-clean-history-dm-access.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fix `rooms.cleanHistory` API and method rejecting admin users from cleaning DM room history when they have the `clean-channel-history` permission.

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -491,7 +491,12 @@ API.v1.post(
 		const room = await findRoomByIdOrName({ params: this.bodyParams });
 		const { _id } = room;
 
-		if (!room || !(await canAccessRoomAsync(room, { _id: this.userId }))) {
+		if (!room) {
+			return API.v1.failure('User does not have access to the room [error-not-allowed]', 'error-not-allowed');
+		}
+
+		const hasAccess = await canAccessRoomAsync(room, { _id: this.userId });
+		if (!hasAccess && !(await hasPermissionAsync(this.userId, 'clean-channel-history', _id))) {
 			return API.v1.failure('User does not have access to the room [error-not-allowed]', 'error-not-allowed');
 		}
 

--- a/apps/meteor/server/meteor-methods/rooms/cleanRoomHistory.ts
+++ b/apps/meteor/server/meteor-methods/rooms/cleanRoomHistory.ts
@@ -47,7 +47,12 @@ export const cleanRoomHistoryMethod = async (
 
 	const room = await findRoomByIdOrName({ params: { roomId } });
 
-	if (!room || !(await canAccessRoomAsync(room, { _id: userId }))) {
+	if (!room) {
+		throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'cleanRoomHistory' });
+	}
+
+	const hasAccess = await canAccessRoomAsync(room, { _id: userId });
+	if (!hasAccess && !(await hasPermissionAsync(userId, 'clean-channel-history', roomId))) {
 		throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'cleanRoomHistory' });
 	}
 


### PR DESCRIPTION
## Proposed changes
The `rooms.cleanHistory` REST endpoint and `cleanRoomHistory` method both check `canAccessRoomAsync` before allowing the operation. For DM rooms, this check requires the user to be a subscribed participant — with no admin bypass. Admin users who aren't DM participants get rejected with `error-not-allowed`, even though they hold the `clean-channel-history` permission.

This is a regression: the method already checks `hasPermissionAsync(userId, 'clean-channel-history', roomId)` independently, but the earlier `canAccessRoomAsync` gate blocks execution before that permission check runs.

**Fix:** When `canAccessRoomAsync` denies access, fall back to checking `clean-channel-history` permission. If the user has it, allow the operation.

## Issue(s)
Closes #35329

## Steps to test or reproduce
1. As an admin user, call `POST /api/v1/cleanHistory` on a DM room you are not a participant of
2. Before: returns `error-not-allowed`
3. After: succeeds (admin has `clean-channel-history` permission)

## Further comments
- Modified both the REST endpoint (`apps/meteor/server/api/v1/rooms.ts`) and the Meteor method (`apps/meteor/server/meteor-methods/rooms/cleanRoomHistory.ts`) for consistency

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Administrators with the `clean-channel-history` permission can now clean direct-message history, even when standard room access checks would otherwise deny the action.
  - Improved room validation distinguishes missing rooms from insufficient access permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->