### PR TITLE
fix: use relative URLs for avatars to prevent cross-origin canvas errors

### DIFF
--- a/.changeset/fix-avatar-relative-url-cors.md
+++ b/.changeset/fix-avatar-relative-url-cors.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Use relative URLs for avatar images to prevent cross-origin canvas tainted errors when protocols differ (HTTP/HTTPS). Also add `crossOrigin: anonymous` to canvas-based avatar conversion.

--- a/apps/meteor/app/utils/client/getAvatarURL.ts
+++ b/apps/meteor/app/utils/client/getAvatarURL.ts
@@ -2,9 +2,9 @@ import { getURL } from './getURL';
 
 export const getAvatarURL = ({ username, roomId, cache }: { username?: string; roomId?: string; cache?: string }): string | undefined => {
 	if (username) {
-		return getURL(`/avatar/${encodeURIComponent(username)}${cache ? `?etag=${cache}` : ''}`);
+		return getURL(`/avatar/${encodeURIComponent(username)}${cache ? `?etag=${cache}` : ''}`, { cdn: false });
 	}
 	if (roomId) {
-		return getURL(`/avatar/room/${encodeURIComponent(roomId)}${cache ? `?etag=${cache}` : ''}`);
+		return getURL(`/avatar/room/${encodeURIComponent(roomId)}${cache ? `?etag=${cache}` : ''}`, { cdn: false });
 	}
 };

--- a/apps/meteor/client/lib/utils/getAvatarAsPng.ts
+++ b/apps/meteor/client/lib/utils/getAvatarAsPng.ts
@@ -27,6 +27,7 @@ export const getAvatarAsPng = (username: IUser['username'], cb: (dataURL: string
 
 	image.onload = onLoad;
 	image.onerror = onError;
+	image.crossOrigin = 'anonymous';
 	image.src = getUserAvatarURL(username || '') as string;
 
 	return onError;

--- a/apps/meteor/client/providers/AvatarUrlProvider.tsx
+++ b/apps/meteor/client/providers/AvatarUrlProvider.tsx
@@ -17,15 +17,15 @@ const AvatarUrlProvider = ({ children }: AvatarUrlProviderProps) => {
 		function getUserPathAvatar(...args: any): string {
 			if (typeof args[0] === 'string') {
 				const [username, etag] = args;
-				return getURL(`/avatar/${username}${etag ? `?etag=${etag}` : ''}`);
+				return getURL(`/avatar/${username}${etag ? `?etag=${etag}` : ''}`, { cdn: false });
 			}
 			const [params] = args;
 			if ('userId' in params) {
 				const { userId, etag } = params;
-				return getURL(`/avatar/uid/${userId}${etag ? `?etag=${etag}` : ''}`);
+				return getURL(`/avatar/uid/${userId}${etag ? `?etag=${etag}` : ''}`, { cdn: false });
 			}
 			const { username, etag } = params;
-			return getURL(`/avatar/${username}${etag ? `?etag=${etag}` : ''}`);
+			return getURL(`/avatar/${username}${etag ? `?etag=${etag}` : ''}`, { cdn: false });
 		}
 		return {
 			getUserPathAvatar,


### PR DESCRIPTION
## Proposed changes
Avatar URLs were generated as absolute URLs when a CDN prefix was configured (e.g., `http://cdn.example.com/avatar/username`). When the page was served over HTTPS but the avatar URL used HTTP (or vice versa), this caused a cross-origin security error:

```
Uncaught SecurityError: Failed to execute 'toDataURL' on 'HTMLCanvasElement': Tainted canvases may not be exported.
```

### Fix
1. **Relative avatar URLs**: Pass `cdn: false` in `getAvatarURL` and `AvatarUrlProvider` to ensure avatar paths are always relative (same-origin), avoiding cross-origin issues entirely.
2. **CORS-compatible loading**: Add `crossOrigin = 'anonymous'` to the image element in `getAvatarAsPng.ts` (matching the existing pattern in `convertAvatarUrlToPng.ts`).

## Issue(s)
Closes #997
Fixes #942

## Files changed
- `apps/meteor/app/utils/client/getAvatarURL.ts` — Pass `cdn: false` to `getURL`
- `apps/meteor/client/providers/AvatarUrlProvider.tsx` — Pass `cdn: false` to `getURL`
- `apps/meteor/client/lib/utils/getAvatarAsPng.ts` — Add `crossOrigin = 'anonymous'`

## Further comments
This ensures avatar images are always loaded from the same origin, preventing canvas tainted errors when converting avatars to PNG data URLs (used for VoIP avatars and PNG export).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed avatar loading and conversion issues when the app and image server use different protocols.
  * Avatar images now load reliably for canvas-based PNG conversion, preventing failures caused by cross-origin restrictions.
  * Improved avatar URL handling to use relative paths where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->