### PR TITLE
chore(eslint): Replace eslint-plugin-import with eslint-plugin-import-x

### DIFF
--- a/apps/meteor/.scripts/run-ha.ts
+++ b/apps/meteor/.scripts/run-ha.ts
@@ -56,7 +56,7 @@ async function runMain(config: IConfig): Promise<void> {
 
 async function runInstance(config: IConfig): Promise<void> {
 	// Desctructuring the unused variables allows us to omit them in the `mainConfig`
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+
 	const { customEnv, parentEnv, ...mainConfig } = config;
 
 	const env = {

--- a/apps/meteor/.scripts/version.js
+++ b/apps/meteor/.scripts/version.js
@@ -3,7 +3,7 @@ const path = require('path');
 let pkgJson = {};
 
 try {
-	// eslint-disable-next-line import/no-dynamic-require
+	// eslint-disable-next-line import-x/no-dynamic-require
 	pkgJson = require(path.resolve(process.cwd(), './package.json'));
 } catch (err) {
 	console.error('no root package.json found');

--- a/apps/meteor/app/utils/client/getURL.ts
+++ b/apps/meteor/app/utils/client/getURL.ts
@@ -3,7 +3,7 @@ import { getURLWithoutSettings } from '../lib/getURL';
 import { Info } from '../rocketchat.info';
 
 export const getURL = function (
-	path: string, // eslint-disable-next-line @typescript-eslint/naming-convention
+	path: string,
 	params: {
 		cdn?: boolean;
 		full?: boolean;

--- a/apps/meteor/app/utils/lib/getURL.ts
+++ b/apps/meteor/app/utils/lib/getURL.ts
@@ -37,7 +37,7 @@ function getCloudUrl(
 
 export const _getURL = (
 	path: string,
-	// eslint-disable-next-line @typescript-eslint/naming-convention
+
 	{ cdn, full, cloud, cloud_route, cloud_params, _cdn_prefix, _root_url_path_prefix, _site_url }: Record<string, any>,
 	deeplinkUrl?: string,
 ): string => {
@@ -76,7 +76,7 @@ export const _getURL = (
 
 export const getURLWithoutSettings = (
 	path: string,
-	// eslint-disable-next-line @typescript-eslint/naming-convention
+
 	{
 		cdn = true,
 		full = false,

--- a/apps/meteor/client/components/GenericUpsellModal/GenericUpsellModal.spec.tsx
+++ b/apps/meteor/client/components/GenericUpsellModal/GenericUpsellModal.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { mockAppRoot } from '@rocket.chat/mock-providers';
 import { composeStories } from '@storybook/react';
 import { render, screen } from '@testing-library/react';

--- a/apps/meteor/client/definitions/global.d.ts
+++ b/apps/meteor/client/definitions/global.d.ts
@@ -1,7 +1,6 @@
 import type { IRocketChatDesktop } from '@rocket.chat/desktop-api';
 
 declare global {
-	// eslint-disable-next-line @typescript-eslint/naming-convention
 	interface Window {
 		RocketChatDesktop?: IRocketChatDesktop;
 
@@ -70,7 +69,6 @@ declare global {
 		addStream(stream: MediaStream): void;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/naming-convention
 	interface MediaTrackConstraints {
 		/** @deprecated */
 		mozMediaSource?: string;

--- a/apps/meteor/client/meteor/login/facebook.ts
+++ b/apps/meteor/client/meteor/login/facebook.ts
@@ -1,9 +1,9 @@
 import type { FacebookOAuthConfiguration } from '@rocket.chat/core-typings';
 import { Random } from '@rocket.chat/random';
-// eslint-disable-next-line import/no-duplicates
+// eslint-disable-next-line import-x/no-duplicates
 import { Facebook } from 'meteor/facebook-oauth';
 import { Meteor } from 'meteor/meteor';
-// eslint-disable-next-line import/no-duplicates
+// eslint-disable-next-line import-x/no-duplicates
 import { OAuth } from 'meteor/oauth';
 
 import { createOAuthTotpLoginMethod } from './oauth';

--- a/apps/meteor/client/meteor/login/google.ts
+++ b/apps/meteor/client/meteor/login/google.ts
@@ -1,9 +1,9 @@
 import { Random } from '@rocket.chat/random';
 import { Accounts } from 'meteor/accounts-base';
-// eslint-disable-next-line import/no-duplicates
+// eslint-disable-next-line import-x/no-duplicates
 import { Google } from 'meteor/google-oauth';
 import { Meteor } from 'meteor/meteor';
-// eslint-disable-next-line import/no-duplicates
+// eslint-disable-next-line import-x/no-duplicates
 import { OAuth } from 'meteor/oauth';
 
 import { createOAuthTotpLoginMethod } from './oauth';

--- a/apps/meteor/client/meteor/login/meteorDeveloperAccount.ts
+++ b/apps/meteor/client/meteor/login/meteorDeveloperAccount.ts
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
-// eslint-disable-next-line import/no-duplicates
+// eslint-disable-next-line import-x/no-duplicates
 import { MeteorDeveloperAccounts } from 'meteor/meteor-developer-oauth';
-// eslint-disable-next-line import/no-duplicates
+// eslint-disable-next-line import-x/no-duplicates
 import { OAuth } from 'meteor/oauth';
 import { Random } from 'meteor/random';
 

--- a/apps/meteor/client/meteor/login/twitter.ts
+++ b/apps/meteor/client/meteor/login/twitter.ts
@@ -1,9 +1,9 @@
 import type { TwitterOAuthConfiguration } from '@rocket.chat/core-typings';
 import { Random } from '@rocket.chat/random';
 import { Meteor } from 'meteor/meteor';
-// eslint-disable-next-line import/no-duplicates
+// eslint-disable-next-line import-x/no-duplicates
 import { OAuth } from 'meteor/oauth';
-// eslint-disable-next-line import/no-duplicates
+// eslint-disable-next-line import-x/no-duplicates
 import { Twitter } from 'meteor/twitter-oauth';
 
 import { createOAuthTotpLoginMethod } from './oauth';

--- a/apps/meteor/client/views/admin/ABAC/ABACAttributesTab/AttributesForm.spec.tsx
+++ b/apps/meteor/client/views/admin/ABAC/ABACAttributesTab/AttributesForm.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { mockAppRoot } from '@rocket.chat/mock-providers';
 import { composeStories } from '@storybook/react';
 import { render, screen, waitFor } from '@testing-library/react';

--- a/apps/meteor/client/views/admin/engagementDashboard/channels/useChannelsList.ts
+++ b/apps/meteor/client/views/admin/engagementDashboard/channels/useChannelsList.ts
@@ -10,7 +10,6 @@ type UseChannelsListOptions = {
 	count: number;
 };
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const useChannelsList = ({ period, offset, count }: UseChannelsListOptions) => {
 	const getChannelsList = useEndpoint('GET', '/v1/engagement-dashboard/channels/list');
 

--- a/apps/meteor/client/views/admin/engagementDashboard/messages/useMessageOrigins.ts
+++ b/apps/meteor/client/views/admin/engagementDashboard/messages/useMessageOrigins.ts
@@ -6,7 +6,6 @@ import { getPeriodRange } from '../../../../components/dashboards/periods';
 
 type UseMessageOriginsOptions = { period: Period['key'] };
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const useMessageOrigins = ({ period }: UseMessageOriginsOptions) => {
 	const getMessageOrigins = useEndpoint('GET', '/v1/engagement-dashboard/messages/origin');
 

--- a/apps/meteor/client/views/admin/engagementDashboard/messages/useMessagesSent.ts
+++ b/apps/meteor/client/views/admin/engagementDashboard/messages/useMessagesSent.ts
@@ -6,7 +6,6 @@ import { getPeriodRange } from '../../../../components/dashboards/periods';
 
 type UseMessagesSentOptions = { period: Period['key']; utc: boolean };
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const useMessagesSent = ({ period, utc }: UseMessagesSentOptions) => {
 	const getMessagesSent = useEndpoint('GET', '/v1/engagement-dashboard/messages/messages-sent');
 

--- a/apps/meteor/client/views/admin/engagementDashboard/messages/useTopFivePopularChannels.ts
+++ b/apps/meteor/client/views/admin/engagementDashboard/messages/useTopFivePopularChannels.ts
@@ -6,7 +6,6 @@ import { getPeriodRange } from '../../../../components/dashboards/periods';
 
 type UseTopFivePopularChannelsOptions = { period: Period['key'] };
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const useTopFivePopularChannels = ({ period }: UseTopFivePopularChannelsOptions) => {
 	const getTopFivePopularChannels = useEndpoint('GET', '/v1/engagement-dashboard/messages/top-five-popular-channels');
 

--- a/apps/meteor/client/views/admin/engagementDashboard/users/useActiveUsers.ts
+++ b/apps/meteor/client/views/admin/engagementDashboard/users/useActiveUsers.ts
@@ -5,7 +5,6 @@ import { getPeriodRange } from '../../../../components/dashboards/periods';
 
 type UseActiveUsersOptions = { utc: boolean };
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const useActiveUsers = ({ utc }: UseActiveUsersOptions) => {
 	const getActiveUsers = useEndpoint('GET', '/v1/engagement-dashboard/users/active-users');
 

--- a/apps/meteor/client/views/admin/engagementDashboard/users/useUsersByTimeOfTheDay.ts
+++ b/apps/meteor/client/views/admin/engagementDashboard/users/useUsersByTimeOfTheDay.ts
@@ -6,7 +6,6 @@ import { getPeriodRange } from '../../../../components/dashboards/periods';
 
 type UseUsersByTimeOfTheDayOptions = { period: Period['key']; utc: boolean };
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const useUsersByTimeOfTheDay = ({ period, utc }: UseUsersByTimeOfTheDayOptions) => {
 	const getUsersByTimeOfTheDay = useEndpoint('GET', '/v1/engagement-dashboard/users/users-by-time-of-the-day-in-a-week');
 

--- a/apps/meteor/client/views/e2e/EnterE2EPasswordModal/EnterE2EPasswordModal.spec.tsx
+++ b/apps/meteor/client/views/e2e/EnterE2EPasswordModal/EnterE2EPasswordModal.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { mockAppRoot } from '@rocket.chat/mock-providers';
 import { composeStories } from '@storybook/react';
 import { render, screen } from '@testing-library/react';

--- a/apps/meteor/client/views/navigation/sidebar/RoomList/SidebarItemWithData.tsx
+++ b/apps/meteor/client/views/navigation/sidebar/RoomList/SidebarItemWithData.tsx
@@ -96,7 +96,6 @@ function safeDateNotEqualCheck(a: Date | string | undefined, b: Date | string | 
 
 const keys: (keyof RoomListRowProps)[] = ['id', 'style', 't', 'videoConfActions'];
 
-// eslint-disable-next-line react/no-multi-comp
 export default memo(SidebarItemWithData, (prevProps, nextProps) => {
 	if (keys.some((key) => prevProps[key] !== nextProps[key])) {
 		return false;

--- a/apps/meteor/client/views/omnichannel/components/outboundMessage/components/OutboundMessageWizard/steps/MessageStep.spec.tsx
+++ b/apps/meteor/client/views/omnichannel/components/outboundMessage/components/OutboundMessageWizard/steps/MessageStep.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { mockAppRoot } from '@rocket.chat/mock-providers';
 import { WizardContext, StepsLinkedList } from '@rocket.chat/ui-client';
 import { composeStories } from '@storybook/react';

--- a/apps/meteor/client/views/omnichannel/components/outboundMessage/components/OutboundMessageWizard/steps/RecipientStep.spec.tsx
+++ b/apps/meteor/client/views/omnichannel/components/outboundMessage/components/OutboundMessageWizard/steps/RecipientStep.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { mockAppRoot } from '@rocket.chat/mock-providers';
 import { WizardContext, StepsLinkedList } from '@rocket.chat/ui-client';
 import { composeStories } from '@storybook/react';

--- a/apps/meteor/client/views/omnichannel/components/outboundMessage/components/OutboundMessageWizard/steps/RepliesStep.spec.tsx
+++ b/apps/meteor/client/views/omnichannel/components/outboundMessage/components/OutboundMessageWizard/steps/RepliesStep.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { mockAppRoot } from '@rocket.chat/mock-providers';
 import { WizardContext, StepsLinkedList } from '@rocket.chat/ui-client';
 import { composeStories } from '@storybook/react';

--- a/apps/meteor/ee/server/cron/readReceiptsArchive.ts
+++ b/apps/meteor/ee/server/cron/readReceiptsArchive.ts
@@ -21,13 +21,12 @@ export async function archiveOldReadReceipts(): Promise<void> {
 	let batchNumber = 0;
 	let hasMore = true;
 
-	// eslint-disable-next-line no-await-in-loop
 	while (hasMore) {
 		batchNumber++;
 		logger.info({ msg: 'Processing batch', batchNumber });
 
 		// Find receipts older than the retention period, limited by batch size
-		// eslint-disable-next-line no-await-in-loop
+
 		const oldReceipts = await ReadReceipts.findOlderThan(cutoffDate).limit(batchSize).toArray();
 
 		if (oldReceipts.length === 0) {
@@ -43,7 +42,6 @@ export async function archiveOldReadReceipts(): Promise<void> {
 		try {
 			// Insert receipts into archive collection (using insertMany with ordered: false to continue on duplicate key errors)
 			try {
-				// eslint-disable-next-line no-await-in-loop
 				await ReadReceiptsArchive.insertMany(oldReceipts, { ordered: false });
 				logger.info({ msg: 'Successfully archived read receipts', count: oldReceipts.length, batchNumber });
 			} catch (error: unknown) {
@@ -71,13 +69,13 @@ export async function archiveOldReadReceipts(): Promise<void> {
 			}
 
 			// Mark messages as having archived receipts
-			// eslint-disable-next-line no-await-in-loop
+
 			const updateResult = await Messages.setReceiptsArchivedById(messageIds, true);
 			logger.info({ msg: 'Marked messages as having archived receipts', modifiedCount: updateResult.modifiedCount, batchNumber });
 
 			// Delete old receipts from hot storage for this batch
 			const receiptIds = oldReceipts.map((receipt) => receipt._id);
-			// eslint-disable-next-line no-await-in-loop
+
 			const deleteResult = await ReadReceipts.removeByIds(receiptIds);
 			logger.info({ msg: 'Deleted old receipts from hot storage', deletedCount: deleteResult.deletedCount, batchNumber });
 
@@ -86,7 +84,7 @@ export async function archiveOldReadReceipts(): Promise<void> {
 			// If we processed a full batch, there might be more, so wait and continue
 			if (oldReceipts.length === batchSize) {
 				logger.info({ msg: 'Batch complete, waiting before next batch', batchNumber, delayMs: BATCH_DELAY_MS });
-				// eslint-disable-next-line no-await-in-loop
+
 				await sleep(BATCH_DELAY_MS);
 			} else {
 				// This was the last batch (partial batch)

--- a/apps/meteor/ee/server/lib/omnichannel/debounceByParams.ts
+++ b/apps/meteor/ee/server/lib/omnichannel/debounceByParams.ts
@@ -9,10 +9,7 @@ interface IMemoizeDebouncedFunction<F extends (...args: any[]) => any> {
 // Debounce `func` based on passed parameters
 // ref: https://github.com/lodash/lodash/issues/2403#issuecomment-816137402
 export function memoizeDebounce<F extends (...args: any[]) => any>(func: F, wait = 0, options: any = {}): IMemoizeDebouncedFunction<F> {
-	const debounceMemo = mem(
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		(..._args: Parameters<F>) => debounce(func, wait, options),
-	);
+	const debounceMemo = mem((..._args: Parameters<F>) => debounce(func, wait, options));
 
 	function wrappedFunction(this: IMemoizeDebouncedFunction<F>, ...args: Parameters<F>): ReturnType<F> | undefined {
 		return debounceMemo(...args)(...args);

--- a/apps/meteor/server/api/ApiClass.ts
+++ b/apps/meteor/server/api/ApiClass.ts
@@ -10,11 +10,11 @@ import { wrapExceptions } from '@rocket.chat/tools';
 import type { ValidateFunction } from 'ajv';
 import { Accounts } from 'meteor/accounts-base';
 import { DDP } from 'meteor/ddp';
-// eslint-disable-next-line import/no-duplicates
+// eslint-disable-next-line import-x/no-duplicates
 import { DDPCommon } from 'meteor/ddp-common';
 import { Meteor } from 'meteor/meteor';
 import type { RateLimiterOptionsToCheck } from 'meteor/rate-limit';
-// eslint-disable-next-line import/no-duplicates
+// eslint-disable-next-line import-x/no-duplicates
 import { RateLimiter } from 'meteor/rate-limit';
 import _ from 'underscore';
 

--- a/apps/meteor/server/api/lib/isValidQuery.ts
+++ b/apps/meteor/server/api/lib/isValidQuery.ts
@@ -15,7 +15,6 @@ export const isValidQuery: {
 			throw new Error('query must be an object');
 		}
 
-		// eslint-disable-next-line @typescript-eslint/no-use-before-define
 		return verifyQuery(query, allowedAttributes, allowedOperations);
 	},
 	{

--- a/apps/meteor/server/bridges/slack/slackbridge.ts
+++ b/apps/meteor/server/bridges/slack/slackbridge.ts
@@ -1,6 +1,6 @@
 // This is a JS File that was renamed to TS so it won't lose its git history when converted to TS
 // TODO: Remove the following lint/ts instructions when the file gets properly converted
-/* eslint-disable @typescript-eslint/no-floating-promises */
+
 /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 import { debounce } from 'lodash';

--- a/apps/meteor/server/lib/error-handler/RocketChat.ErrorHandler.ts
+++ b/apps/meteor/server/lib/error-handler/RocketChat.ErrorHandler.ts
@@ -68,7 +68,6 @@ Meteor.startup(async () => {
 	});
 });
 
-// eslint-disable-next-line @typescript-eslint/no-this-alias
 const originalMeteorDebug = Meteor._debug;
 
 Meteor._debug = function (message, stack, ...args) {

--- a/apps/meteor/server/lib/i18n.ts
+++ b/apps/meteor/server/lib/i18n.ts
@@ -88,7 +88,7 @@ void i18n.init({
 			language,
 			extractTranslationNamespaces(
 				// TODO: commonjs is terrible but we don't have esm build yet
-				// eslint-disable-next-line @typescript-eslint/no-var-requires, import-x/no-dynamic-require
+				// eslint-disable-next-line import-x/no-dynamic-require
 				require(`@rocket.chat/i18n/dist/resources/${language}.i18n.json`) as unknown as Record<string, string>,
 			),
 		]),

--- a/apps/meteor/server/lib/i18n.ts
+++ b/apps/meteor/server/lib/i18n.ts
@@ -88,7 +88,7 @@ void i18n.init({
 			language,
 			extractTranslationNamespaces(
 				// TODO: commonjs is terrible but we don't have esm build yet
-				// eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require
+				// eslint-disable-next-line @typescript-eslint/no-var-requires, import-x/no-dynamic-require
 				require(`@rocket.chat/i18n/dist/resources/${language}.i18n.json`) as unknown as Record<string, string>,
 			),
 		]),

--- a/apps/meteor/server/lib/media/file-upload/lib/FileUpload.ts
+++ b/apps/meteor/server/lib/media/file-upload/lib/FileUpload.ts
@@ -457,7 +457,7 @@ export const FileUpload = {
 		}
 
 		const { query } = URL.parse(url, true);
-		// eslint-disable-next-line @typescript-eslint/naming-convention
+
 		let { rc_uid, rc_token } = query as Record<string, string | undefined>;
 
 		if (!rc_uid && headers.cookie) {
@@ -482,7 +482,7 @@ export const FileUpload = {
 		}
 
 		const { query } = URL.parse(url, true);
-		// eslint-disable-next-line @typescript-eslint/naming-convention
+
 		let { rc_uid, rc_token, rc_rid, rc_room_type } = query as Record<string, string | undefined>;
 		const { token } = query;
 
@@ -699,7 +699,6 @@ export const FileUpload = {
 				return;
 			}
 
-			// eslint-disable-next-line prettier/prettier
 			const headersToProxy = ['age', 'cache-control', 'content-length', 'content-type', 'date', 'expired', 'last-modified'];
 
 			headersToProxy.forEach((header) => {

--- a/apps/meteor/server/lib/messages/isTheLastMessage.ts
+++ b/apps/meteor/server/lib/messages/isTheLastMessage.ts
@@ -2,6 +2,5 @@ import type { IMessage, IRoom, AtLeast } from '@rocket.chat/core-typings';
 
 import { settings } from '../../settings';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const isTheLastMessage = (room: AtLeast<IRoom, 'lastMessage'>, message: Pick<IMessage, '_id'>) =>
 	settings.get('Store_Last_Message') && (!room.lastMessage || room.lastMessage._id === message._id);

--- a/apps/meteor/server/lib/rooms/updateGroupDMsName.ts
+++ b/apps/meteor/server/lib/rooms/updateGroupDMsName.ts
@@ -57,7 +57,6 @@ export const updateGroupDMsName = async (
 
 	const rooms = Rooms.findGroupDMsByUids([userThatChangedName._id], { projection: { uids: 1 }, session });
 
-	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 	const getMembers = (uids: string[]) => uids.map((uid) => users.get(uid)).filter(isNotUndefined);
 
 	// loop rooms to update the subscriptions from them all

--- a/apps/meteor/server/lib/utils/getURL.ts
+++ b/apps/meteor/server/lib/utils/getURL.ts
@@ -2,7 +2,7 @@ import { getURLWithoutSettings } from '../../../app/utils/lib/getURL';
 import { settings } from '../../settings';
 
 export const getURL = function (
-	path: string, // eslint-disable-next-line @typescript-eslint/naming-convention
+	path: string,
 	params: {
 		cdn?: boolean;
 		full?: boolean;

--- a/apps/meteor/server/services/import/service.spec.ts
+++ b/apps/meteor/server/services/import/service.spec.ts
@@ -57,7 +57,7 @@ jest.mock('../user/lib/getNewUserRoles', () => ({
 	getNewUserRoles: (...args: unknown[]) => mockGetNewUserRoles(...args),
 }));
 
-// eslint-disable-next-line import/first
+// eslint-disable-next-line import-x/first
 import { ImportService } from './service';
 
 const createMockOperation = (overrides?: Partial<IImport>): IImport => ({

--- a/apps/meteor/server/services/omnichannel-analytics/service.ts
+++ b/apps/meteor/server/services/omnichannel-analytics/service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable new-cap */
 import { ServiceClassInternal } from '@rocket.chat/core-services';
 import type {
 	AgentOverviewDataOptions,

--- a/apps/meteor/server/settings/SettingsRegistry.ts
+++ b/apps/meteor/server/settings/SettingsRegistry.ts
@@ -213,7 +213,6 @@ export class SettingsRegistry {
 	 */
 	async addGroup(_id: string, cb?: addGroupCallback): Promise<void>;
 
-	// eslint-disable-next-line no-dupe-class-members
 	async addGroup(_id: string, groupOptions: ISettingAddGroupOptions | addGroupCallback = {}, cb?: addGroupCallback): Promise<void> {
 		if (!_id || (groupOptions instanceof Function && cb)) {
 			throw new Error('Invalid arguments');

--- a/apps/meteor/server/settings/functions/settings.mocks.ts
+++ b/apps/meteor/server/settings/functions/settings.mocks.ts
@@ -41,7 +41,7 @@ class SettingsClass {
 
 	insertOne(doc: any): void {
 		this.data.set(doc._id, doc);
-		// eslint-disable-next-line @typescript-eslint/no-var-requires
+
 		this.settings.set(doc);
 		this.insertCalls++;
 	}
@@ -77,13 +77,13 @@ class SettingsClass {
 				this.data.set(query._id, data);
 
 				// Can't import before the mock command on end of this file!
-				// eslint-disable-next-line @typescript-eslint/no-var-requires
+
 				this.settings.set(data);
 			}, this.delay);
 		} else {
 			this.data.set(query._id, data);
 			// Can't import before the mock command on end of this file!
-			// eslint-disable-next-line @typescript-eslint/no-var-requires
+
 			this.settings.set(data);
 		}
 
@@ -98,7 +98,7 @@ class SettingsClass {
 	updateValueById(id: string, value: any): void {
 		this.data.set(id, { ...this.data.get(id), value });
 		// Can't import before the mock command on end of this file!
-		// eslint-disable-next-line @typescript-eslint/no-var-requires
+
 		if (this.delay) {
 			setTimeout(() => {
 				this.settings.set(this.data.get(id) as ISetting);

--- a/apps/meteor/server/settings/startup.ts
+++ b/apps/meteor/server/settings/startup.ts
@@ -3,7 +3,6 @@ import type { Settings } from '@rocket.chat/models';
 
 import type { ICachedSettings } from './CachedSettings';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export async function initializeSettings({ model, settings }: { model: typeof Settings; settings: ICachedSettings }): Promise<void> {
 	await model.find().forEach((record: ISetting) => {
 		settings.set(record);

--- a/apps/meteor/server/ufs/ufs-server.ts
+++ b/apps/meteor/server/ufs/ufs-server.ts
@@ -168,7 +168,6 @@ WebApp.connectHandlers.use(async (req, res, next) => {
 
 						if (
 							(file.modifiedAt instanceof Date && file.modifiedAt > modifiedSince) ||
-							// eslint-disable-next-line no-mixed-operators
 							(file.uploadedAt instanceof Date && file.uploadedAt > modifiedSince)
 						) {
 							res.writeHead(304); // Not Modified

--- a/apps/meteor/server/ufs/ufs-store.ts
+++ b/apps/meteor/server/ufs/ufs-store.ts
@@ -240,7 +240,6 @@ export class Store {
 
 	generateToken(pattern?: string) {
 		return (pattern || 'xyxyxyxyxy').replace(/[xy]/g, (c) => {
-			// eslint-disable-next-line no-mixed-operators
 			const r = (Math.random() * 16) | 0;
 			const v = c === 'x' ? r : (r & 0x3) | 0x8;
 			const s = v.toString(16);

--- a/apps/meteor/tests/e2e/e2e-encryption/e2ee-legacy-format.spec.ts
+++ b/apps/meteor/tests/e2e/e2e-encryption/e2ee-legacy-format.spec.ts
@@ -72,7 +72,7 @@ test.describe('E2EE Legacy Format', () => {
 
 		await page.evaluate(
 			async ({ rid, kid, encryptedKey }) => {
-				// eslint-disable-next-line import/no-unresolved, import/no-absolute-path
+				// eslint-disable-next-line import-x/no-unresolved, import-x/no-absolute-path
 				const { e2e } = require('/client/lib/e2ee/rocketchat.e2e.ts') as typeof import('../../../client/lib/e2ee/rocketchat.e2e');
 				const room = await e2e.getInstanceByRoomId(rid);
 				await room?.importGroupKey(kid + encryptedKey);

--- a/apps/meteor/tests/e2e/e2e-encryption/e2ee-legacy-format.spec.ts
+++ b/apps/meteor/tests/e2e/e2e-encryption/e2ee-legacy-format.spec.ts
@@ -72,7 +72,7 @@ test.describe('E2EE Legacy Format', () => {
 
 		await page.evaluate(
 			async ({ rid, kid, encryptedKey }) => {
-				// eslint-disable-next-line import-x/no-unresolved, import-x/no-absolute-path
+				// eslint-disable-next-line import-x/no-absolute-path
 				const { e2e } = require('/client/lib/e2ee/rocketchat.e2e.ts') as typeof import('../../../client/lib/e2ee/rocketchat.e2e');
 				const room = await e2e.getInstanceByRoomId(rid);
 				await room?.importGroupKey(kid + encryptedKey);

--- a/apps/meteor/tests/e2e/page-objects/login.ts
+++ b/apps/meteor/tests/e2e/page-objects/login.ts
@@ -46,7 +46,7 @@ export class LoginPage {
 			items.forEach(({ name, value }) => {
 				window.localStorage.setItem(name, value);
 			});
-			// eslint-disable-next-line @typescript-eslint/no-var-requires
+
 			require('meteor/accounts-base').Accounts._pollStoredLoginToken();
 		}, localStorageItems);
 

--- a/apps/meteor/tests/unit/server/services/omnichannel-analytics/AgentData.tests.ts
+++ b/apps/meteor/tests/unit/server/services/omnichannel-analytics/AgentData.tests.ts
@@ -70,7 +70,7 @@ describe('AgentData Analytics', () => {
 
 			try {
 				// @ts-expect-error - test
-				// eslint-disable-next-line prettier/prettier, no-return-await
+
 				await agentOverview.callAction('invalid', moment(), moment());
 			} catch (e) {
 				expect(e).to.be.instanceOf(Error);

--- a/ee/apps/omnichannel-transcript/src/i18n.ts
+++ b/ee/apps/omnichannel-transcript/src/i18n.ts
@@ -16,7 +16,7 @@ void i18n.init({
 			language,
 			extractTranslationNamespaces(
 				// TODO: commonjs is terrible but we don't have esm build yet
-				// eslint-disable-next-line @typescript-eslint/no-var-requires, import-x/no-dynamic-require
+				// eslint-disable-next-line import-x/no-dynamic-require
 				require(`@rocket.chat/i18n/dist/resources/${language}.i18n.json`) as unknown as Record<string, string>,
 			),
 		]),

--- a/ee/apps/omnichannel-transcript/src/i18n.ts
+++ b/ee/apps/omnichannel-transcript/src/i18n.ts
@@ -16,7 +16,7 @@ void i18n.init({
 			language,
 			extractTranslationNamespaces(
 				// TODO: commonjs is terrible but we don't have esm build yet
-				// eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require
+				// eslint-disable-next-line @typescript-eslint/no-var-requires, import-x/no-dynamic-require
 				require(`@rocket.chat/i18n/dist/resources/${language}.i18n.json`) as unknown as Record<string, string>,
 			),
 		]),

--- a/ee/packages/license/src/licenseImp.ts
+++ b/ee/packages/license/src/licenseImp.ts
@@ -26,7 +26,6 @@ import { getTags } from './tags';
 import { getCurrentValueForLicenseLimit, setLicenseLimitCounter } from './validation/getCurrentValueForLicenseLimit';
 import { validateFormat } from './validation/validateFormat';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export class LicenseImp extends LicenseManager {
 	constructor() {
 		super();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,11 +29,11 @@ export default [
 			'you-dont-need-lodash-underscore': youDontNeedLodashUnderscorePlugin,
 		},
 		settings: {
-			'import/ignore': ['meteor/.+'],
+			'import-x/ignore': ['meteor/.+'],
 		},
 		rules: {
-			'import/named': 'error',
-			'import/no-unresolved': [
+			'import-x/named': 'error',
+			'import-x/no-unresolved': [
 				'error',
 				{
 					commonjs: true,
@@ -249,8 +249,8 @@ export default [
 		},
 		rules: {
 			'@typescript-eslint/no-floating-promises': 'error',
-			'import/named': 'error',
-			'import/order': [
+			'import-x/named': 'error',
+			'import-x/order': [
 				'error',
 				{
 					'newlines-between': 'always',
@@ -470,7 +470,7 @@ export default [
 	{
 		files: ['ee/packages/federation-matrix/src/api/.well-known/server.ts'],
 		rules: {
-			'import/order': 'warn',
+			'import-x/order': 'warn',
 		},
 	},
 ];

--- a/package.json
+++ b/package.json
@@ -132,7 +132,6 @@
 		"create-hmac/sha.js": "2.4.12",
 		"@typescript-eslint/typescript-estree/minimatch": "10.2.5",
 		"depcheck/minimatch": "7.4.9",
-		"eslint-plugin-import/minimatch": "3.1.5",
 		"eslint-plugin-jsx-a11y/minimatch": "3.1.5",
 		"eslint-plugin-react/minimatch": "3.1.5",
 		"fork-ts-checker-webpack-plugin/minimatch": "3.1.5",

--- a/packages/apps/node-runtime/src/lib/require.ts
+++ b/packages/apps/node-runtime/src/lib/require.ts
@@ -32,6 +32,6 @@ export const sandboxRequire = (module: string) => {
 	}
 
 	// This is THE purpose of this function, we can't escape a dinamyc require call
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-return, import/no-dynamic-require, @typescript-eslint/no-require-imports
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-return, import-x/no-dynamic-require, @typescript-eslint/no-require-imports
 	return require(normalized);
 };

--- a/packages/cas-validate/src/validate.ts
+++ b/packages/cas-validate/src/validate.ts
@@ -7,7 +7,6 @@ import type { Cheerio, CheerioAPI } from 'cheerio';
 import { load } from 'cheerio';
 
 export type CasOptions = {
-	// eslint-disable-next-line @typescript-eslint/naming-convention
 	base_url: string;
 	service?: string;
 	version: 1.0 | 2.0;
@@ -16,7 +15,7 @@ export type CasOptions = {
 export type CasCallbackExtendedData = {
 	username?: string;
 	attributes?: Record<string, string[]>;
-	// eslint-disable-next-line @typescript-eslint/naming-convention
+
 	PGTIOU?: string;
 	ticket?: string;
 	proxies?: string[];
@@ -268,7 +267,7 @@ export function validate(options: CasOptions, ticket: string, callback: CasCallb
 					callback(undefined, true, username, {
 						username,
 						attributes,
-						// eslint-disable-next-line @typescript-eslint/naming-convention
+
 						PGTIOU: pgtIOU,
 						ticket,
 						proxies,

--- a/packages/ddp-client/src/types/methods.ts
+++ b/packages/ddp-client/src/types/methods.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export interface ServerMethods {
 	resetPassword(token: string, password: string): { token: string };
 	checkRegistrationSecretURL(hash: string): boolean;

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,7 +1,8 @@
 import eslint from '@eslint/js';
 import { defineConfig } from 'eslint/config';
+import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
 import antiTrojanSourcePlugin from 'eslint-plugin-anti-trojan-source';
-import importPlugin from 'eslint-plugin-import';
+import importXPlugin, { createNodeResolver } from 'eslint-plugin-import-x';
 import jestPlugin from 'eslint-plugin-jest';
 import jsxA11yPlugin from 'eslint-plugin-jsx-a11y';
 import prettierPluginRecommended from 'eslint-plugin-prettier/recommended';
@@ -32,8 +33,8 @@ export default defineConfig(
 			},
 		},
 	},
-	importPlugin.flatConfigs.recommended,
-	importPlugin.flatConfigs.typescript,
+	importXPlugin.flatConfigs.recommended,
+	importXPlugin.flatConfigs.typescript,
 	jsxA11yPlugin.flatConfigs.recommended,
 	{
 		name: 'rocket.chat/jsx-a11y',
@@ -337,28 +338,29 @@ export default defineConfig(
 	{
 		name: 'rocket.chat/import',
 		settings: {
-			'import/resolver': {
-				node: true,
-				typescript: true,
-			},
+			// The node resolver must run first (the TypeScript resolver would otherwise resolve
+			// packages like node-fetch to their `@types/*` declarations), and `exportsFields: []`
+			// keeps the old eslint-import-resolver-node behavior of ignoring package `exports`
+			// maps (required for deep imports like `csv-parse/lib/sync` and `swiper/modules/*.css`).
+			'import-x/resolver-next': [createNodeResolver({ exportsFields: [] }), createTypeScriptImportResolver()],
 		},
 		rules: {
-			'import/no-unresolved': [
+			'import-x/no-unresolved': [
 				'error',
 				{
 					commonjs: true,
 					caseSensitive: true,
 				},
 			],
-			'import/named': 'off',
-			'import/default': 'off',
-			'import/namespace': 'off',
-			'import/export': 'error',
-			'import/no-named-as-default': 'off',
-			'import/no-named-as-default-member': 'off',
-			'import/first': 'error',
-			'import/no-duplicates': 'error',
-			'import/order': [
+			'import-x/named': 'off',
+			'import-x/default': 'off',
+			'import-x/namespace': 'off',
+			'import-x/export': 'error',
+			'import-x/no-named-as-default': 'off',
+			'import-x/no-named-as-default-member': 'off',
+			'import-x/first': 'error',
+			'import-x/no-duplicates': 'error',
+			'import-x/order': [
 				'error',
 				{
 					'newlines-between': 'always',
@@ -368,12 +370,12 @@ export default defineConfig(
 					},
 				},
 			],
-			'import/newline-after-import': 'error',
-			'import/no-absolute-path': 'error',
-			'import/no-dynamic-require': 'error',
-			'import/no-self-import': 'error',
-			'import/no-cycle': 'off',
-			'import/no-useless-path-segments': 'error',
+			'import-x/newline-after-import': 'error',
+			'import-x/no-absolute-path': 'error',
+			'import-x/no-dynamic-require': 'error',
+			'import-x/no-self-import': 'error',
+			'import-x/no-cycle': 'off',
+			'import-x/no-useless-path-segments': 'error',
 		},
 	},
 	{

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -24,7 +24,7 @@
 		"eslint-config-prettier": "~10.1.8",
 		"eslint-import-resolver-typescript": "~4.4.4",
 		"eslint-plugin-anti-trojan-source": "~1.1.2",
-		"eslint-plugin-import": "~2.32.0",
+		"eslint-plugin-import-x": "~4.17.1",
 		"eslint-plugin-jest": "~29.15.2",
 		"eslint-plugin-jsx-a11y": "~6.10.2",
 		"eslint-plugin-prettier": "~5.5.5",

--- a/packages/mock-providers/src/MockedAppRootBuilder.tsx
+++ b/packages/mock-providers/src/MockedAppRootBuilder.tsx
@@ -60,7 +60,6 @@ type Mutable<T> = {
 	-readonly [P in keyof T]: T[P];
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 // interface MockedAppRootEvents extends Record<`stream-${StreamNames}-${StreamKeys<StreamNames>}`, any> {
 // 	'update-modal': void;
 // }

--- a/packages/ui-client/src/methods.d.ts
+++ b/packages/ui-client/src/methods.d.ts
@@ -2,7 +2,6 @@ import '@rocket.chat/ddp-client';
 import type { ISetting } from '@rocket.chat/core-typings';
 
 declare module '@rocket.chat/ddp-client' {
-	// eslint-disable-next-line @typescript-eslint/naming-convention
 	interface ServerMethods {
 		getSetupWizardParameters(): Promise<{
 			settings: ISetting[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -9083,7 +9083,7 @@ __metadata:
     eslint-config-prettier: "npm:~10.1.8"
     eslint-import-resolver-typescript: "npm:~4.4.4"
     eslint-plugin-anti-trojan-source: "npm:~1.1.2"
-    eslint-plugin-import: "npm:~2.32.0"
+    eslint-plugin-import-x: "npm:~4.17.1"
     eslint-plugin-jest: "npm:~29.15.2"
     eslint-plugin-jsx-a11y: "npm:~6.10.2"
     eslint-plugin-prettier: "npm:~5.5.5"
@@ -11246,13 +11246,6 @@ __metadata:
   version: 1.0.1
   resolution: "@rolldown/pluginutils@npm:1.0.1"
   checksum: 10/4e95cf9ce23d75e5aa03ea0249cd86f7d1e21f83fbf6f8520e4edd8a251ba1b82c4ba9bc13cd24b6c4661daec6225b06e6d35c64c604e731b230b2a49af47d05
-  languageName: node
-  linkType: hard
-
-"@rtsao/scc@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@rtsao/scc@npm:1.1.0"
-  checksum: 10/17d04adf404e04c1e61391ed97bca5117d4c2767a76ae3e879390d6dec7b317fcae68afbf9e98badee075d0b64fa60f287729c4942021b4d19cd01db77385c01
   languageName: node
   linkType: hard
 
@@ -14138,13 +14131,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json5@npm:^0.0.29":
-  version: 0.0.29
-  resolution: "@types/json5@npm:0.0.29"
-  checksum: 10/4e5aed58cabb2bbf6f725da13421aa50a49abb6bc17bfab6c31b8774b073fa7b50d557c61f961a09a85f6056151190f8ac95f13f5b48136ba5841f7d4484ec56
-  languageName: node
-  linkType: hard
-
 "@types/jsonwebtoken@npm:^8.3.7":
   version: 8.5.9
   resolution: "@types/jsonwebtoken@npm:8.5.9"
@@ -15159,6 +15145,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/types@npm:^8.56.0":
+  version: 8.63.0
+  resolution: "@typescript-eslint/types@npm:8.63.0"
+  checksum: 10/f72eb114970cae0da8e53f68cd8dca1b51ac410f4438141a2851655fa07aacb3090e24a2ae53462cf0970e4d5b52cabf9693aa6f07abdff5c210874806427e5b
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/typescript-estree@npm:8.56.1":
   version: 8.56.1
   resolution: "@typescript-eslint/typescript-estree@npm:8.56.1"
@@ -15217,10 +15210,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@unrs/resolver-binding-android-arm-eabi@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-android-arm-eabi@npm:1.12.2"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@unrs/resolver-binding-android-arm-eabi@npm:1.9.0":
   version: 1.9.0
   resolution: "@unrs/resolver-binding-android-arm-eabi@npm:1.9.0"
   conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@unrs/resolver-binding-android-arm64@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-android-arm64@npm:1.12.2"
+  conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -15231,10 +15238,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@unrs/resolver-binding-darwin-arm64@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-darwin-arm64@npm:1.12.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@unrs/resolver-binding-darwin-arm64@npm:1.9.0":
   version: 1.9.0
   resolution: "@unrs/resolver-binding-darwin-arm64@npm:1.9.0"
   conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@unrs/resolver-binding-darwin-x64@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-darwin-x64@npm:1.12.2"
+  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -15245,6 +15266,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@unrs/resolver-binding-freebsd-x64@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-freebsd-x64@npm:1.12.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@unrs/resolver-binding-freebsd-x64@npm:1.9.0":
   version: 1.9.0
   resolution: "@unrs/resolver-binding-freebsd-x64@npm:1.9.0"
@@ -15252,9 +15280,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@unrs/resolver-binding-linux-arm-gnueabihf@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-linux-arm-gnueabihf@npm:1.12.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@unrs/resolver-binding-linux-arm-gnueabihf@npm:1.9.0":
   version: 1.9.0
   resolution: "@unrs/resolver-binding-linux-arm-gnueabihf@npm:1.9.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@unrs/resolver-binding-linux-arm-musleabihf@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-linux-arm-musleabihf@npm:1.12.2"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -15266,10 +15308,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@unrs/resolver-binding-linux-arm64-gnu@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-linux-arm64-gnu@npm:1.12.2"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@unrs/resolver-binding-linux-arm64-gnu@npm:1.9.0":
   version: 1.9.0
   resolution: "@unrs/resolver-binding-linux-arm64-gnu@npm:1.9.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@unrs/resolver-binding-linux-arm64-musl@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-linux-arm64-musl@npm:1.12.2"
+  conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
@@ -15280,10 +15336,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@unrs/resolver-binding-linux-loong64-gnu@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-linux-loong64-gnu@npm:1.12.2"
+  conditions: os=linux & cpu=loong64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@unrs/resolver-binding-linux-loong64-musl@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-linux-loong64-musl@npm:1.12.2"
+  conditions: os=linux & cpu=loong64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@unrs/resolver-binding-linux-ppc64-gnu@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-linux-ppc64-gnu@npm:1.12.2"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@unrs/resolver-binding-linux-ppc64-gnu@npm:1.9.0":
   version: 1.9.0
   resolution: "@unrs/resolver-binding-linux-ppc64-gnu@npm:1.9.0"
   conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@unrs/resolver-binding-linux-riscv64-gnu@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-linux-riscv64-gnu@npm:1.12.2"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -15294,10 +15378,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@unrs/resolver-binding-linux-riscv64-musl@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-linux-riscv64-musl@npm:1.12.2"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@unrs/resolver-binding-linux-riscv64-musl@npm:1.9.0":
   version: 1.9.0
   resolution: "@unrs/resolver-binding-linux-riscv64-musl@npm:1.9.0"
   conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@unrs/resolver-binding-linux-s390x-gnu@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-linux-s390x-gnu@npm:1.12.2"
+  conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
@@ -15308,6 +15406,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@unrs/resolver-binding-linux-x64-gnu@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-linux-x64-gnu@npm:1.12.2"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@unrs/resolver-binding-linux-x64-gnu@npm:1.9.0":
   version: 1.9.0
   resolution: "@unrs/resolver-binding-linux-x64-gnu@npm:1.9.0"
@@ -15315,10 +15420,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@unrs/resolver-binding-linux-x64-musl@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-linux-x64-musl@npm:1.12.2"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@unrs/resolver-binding-linux-x64-musl@npm:1.9.0":
   version: 1.9.0
   resolution: "@unrs/resolver-binding-linux-x64-musl@npm:1.9.0"
   conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@unrs/resolver-binding-openharmony-arm64@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-openharmony-arm64@npm:1.12.2"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@unrs/resolver-binding-wasm32-wasi@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-wasm32-wasi@npm:1.12.2"
+  dependencies:
+    "@emnapi/core": "npm:1.10.0"
+    "@emnapi/runtime": "npm:1.10.0"
+    "@napi-rs/wasm-runtime": "npm:^1.1.4"
+  conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
@@ -15331,6 +15461,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@unrs/resolver-binding-win32-arm64-msvc@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-win32-arm64-msvc@npm:1.12.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@unrs/resolver-binding-win32-arm64-msvc@npm:1.9.0":
   version: 1.9.0
   resolution: "@unrs/resolver-binding-win32-arm64-msvc@npm:1.9.0"
@@ -15338,10 +15475,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@unrs/resolver-binding-win32-ia32-msvc@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-win32-ia32-msvc@npm:1.12.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@unrs/resolver-binding-win32-ia32-msvc@npm:1.9.0":
   version: 1.9.0
   resolution: "@unrs/resolver-binding-win32-ia32-msvc@npm:1.9.0"
   conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@unrs/resolver-binding-win32-x64-msvc@npm:1.12.2":
+  version: 1.12.2
+  resolution: "@unrs/resolver-binding-win32-x64-msvc@npm:1.12.2"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -16230,22 +16381,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-includes@npm:^3.1.9":
-  version: 3.1.9
-  resolution: "array-includes@npm:3.1.9"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.4"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.24.0"
-    es-object-atoms: "npm:^1.1.1"
-    get-intrinsic: "npm:^1.3.0"
-    is-string: "npm:^1.1.1"
-    math-intrinsics: "npm:^1.1.0"
-  checksum: 10/8bfe9a58df74f326b4a76b04ee05c13d871759e888b4ee8f013145297cf5eb3c02cfa216067ebdaac5d74eb9763ac5cad77cdf2773b8ab475833701e032173aa
-  languageName: node
-  linkType: hard
-
 "array-timsort@npm:^1.0.3":
   version: 1.0.3
   resolution: "array-timsort@npm:1.0.3"
@@ -16297,21 +16432,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.findlastindex@npm:^1.2.6":
-  version: 1.2.6
-  resolution: "array.prototype.findlastindex@npm:1.2.6"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.4"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.9"
-    es-errors: "npm:^1.3.0"
-    es-object-atoms: "npm:^1.1.1"
-    es-shim-unscopables: "npm:^1.1.0"
-  checksum: 10/5ddb6420e820bef6ddfdcc08ce780d0fd5e627e97457919c27e32359916de5a11ce12f7c55073555e503856618eaaa70845d6ca11dcba724766f38eb1c22f7a2
-  languageName: node
-  linkType: hard
-
 "array.prototype.flat@npm:^1.3.1":
   version: 1.3.2
   resolution: "array.prototype.flat@npm:1.3.2"
@@ -16321,18 +16441,6 @@ __metadata:
     es-abstract: "npm:^1.22.1"
     es-shim-unscopables: "npm:^1.0.0"
   checksum: 10/d9d2f6f27584de92ec7995bc931103e6de722cd2498bdbfc4cba814fc3e52f056050a93be883018811f7c0a35875f5056584a0e940603a5e5934f0279896aebe
-  languageName: node
-  linkType: hard
-
-"array.prototype.flat@npm:^1.3.3":
-  version: 1.3.3
-  resolution: "array.prototype.flat@npm:1.3.3"
-  dependencies:
-    call-bind: "npm:^1.0.8"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.5"
-    es-shim-unscopables: "npm:^1.0.2"
-  checksum: 10/f9b992fa0775d8f7c97abc91eb7f7b2f0ed8430dd9aeb9fdc2967ac4760cdd7fc2ef7ead6528fef40c7261e4d790e117808ce0d3e7e89e91514d4963a531cd01
   languageName: node
   linkType: hard
 
@@ -18569,6 +18677,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"comment-parser@npm:^1.4.1":
+  version: 1.4.7
+  resolution: "comment-parser@npm:1.4.7"
+  checksum: 10/7c102b7ff0b7321f1c09f21f62c8a75996dd7522750bac06d68d125c9e039d30d30a9e248c9e0172c81f4bf61a46b72780db97f79f1e0dfff8cd9fe6edaa515f
+  languageName: node
+  linkType: hard
+
 "commondir@npm:^1.0.1":
   version: 1.0.1
   resolution: "commondir@npm:1.0.1"
@@ -20755,7 +20870,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.17.5, es-abstract@npm:^1.24.0, es-abstract@npm:^1.24.1":
+"es-abstract@npm:^1.17.5, es-abstract@npm:^1.24.1":
   version: 1.24.1
   resolution: "es-abstract@npm:1.24.1"
   dependencies:
@@ -20982,15 +21097,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-shim-unscopables@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "es-shim-unscopables@npm:1.1.0"
-  dependencies:
-    hasown: "npm:^2.0.2"
-  checksum: 10/c351f586c30bbabc62355be49564b2435468b52c3532b8a1663672e3d10dc300197e69c247869dd173e56d86423ab95fc0c10b0939cdae597094e0fdca078cba
-  languageName: node
-  linkType: hard
-
 "es-to-primitive@npm:^1.3.0":
   version: 1.3.0
   resolution: "es-to-primitive@npm:1.3.0"
@@ -21169,7 +21275,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-context@npm:^0.1.8":
+"eslint-import-context@npm:^0.1.8, eslint-import-context@npm:^0.1.9":
   version: 0.1.9
   resolution: "eslint-import-context@npm:0.1.9"
   dependencies:
@@ -21181,17 +21287,6 @@ __metadata:
     unrs-resolver:
       optional: true
   checksum: 10/f0778126bb3aae57c8c68946c71c4418927e9d39f72099b799d9c47a3b5712d6c9166b63ee8be58a020961dcc9216df09c856b825336af375ccbbdeedfc82a99
-  languageName: node
-  linkType: hard
-
-"eslint-import-resolver-node@npm:^0.3.9":
-  version: 0.3.9
-  resolution: "eslint-import-resolver-node@npm:0.3.9"
-  dependencies:
-    debug: "npm:^3.2.7"
-    is-core-module: "npm:^2.13.0"
-    resolve: "npm:^1.22.4"
-  checksum: 10/d52e08e1d96cf630957272e4f2644dcfb531e49dcfd1edd2e07e43369eb2ec7a7d4423d417beee613201206ff2efa4eb9a582b5825ee28802fc7c71fcd53ca83
   languageName: node
   linkType: hard
 
@@ -21219,18 +21314,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-module-utils@npm:^2.12.1":
-  version: 2.12.1
-  resolution: "eslint-module-utils@npm:2.12.1"
-  dependencies:
-    debug: "npm:^3.2.7"
-  peerDependenciesMeta:
-    eslint:
-      optional: true
-  checksum: 10/bd25d6610ec3abaa50e8f1beb0119541562bbb8dd02c035c7e887976fe1e0c5dd8175f4607ca8d86d1146df24d52a071bd3d1dd329f6902bd58df805a8ca16d3
-  languageName: node
-  linkType: hard
-
 "eslint-plugin-anti-trojan-source@npm:~1.1.2":
   version: 1.1.2
   resolution: "eslint-plugin-anti-trojan-source@npm:1.1.2"
@@ -21240,32 +21323,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:~2.32.0":
-  version: 2.32.0
-  resolution: "eslint-plugin-import@npm:2.32.0"
+"eslint-plugin-import-x@npm:~4.17.1":
+  version: 4.17.1
+  resolution: "eslint-plugin-import-x@npm:4.17.1"
   dependencies:
-    "@rtsao/scc": "npm:^1.1.0"
-    array-includes: "npm:^3.1.9"
-    array.prototype.findlastindex: "npm:^1.2.6"
-    array.prototype.flat: "npm:^1.3.3"
-    array.prototype.flatmap: "npm:^1.3.3"
-    debug: "npm:^3.2.7"
-    doctrine: "npm:^2.1.0"
-    eslint-import-resolver-node: "npm:^0.3.9"
-    eslint-module-utils: "npm:^2.12.1"
-    hasown: "npm:^2.0.2"
-    is-core-module: "npm:^2.16.1"
+    "@typescript-eslint/types": "npm:^8.56.0"
+    comment-parser: "npm:^1.4.1"
+    debug: "npm:^4.4.1"
+    eslint-import-context: "npm:^0.1.9"
     is-glob: "npm:^4.0.3"
-    minimatch: "npm:^3.1.2"
-    object.fromentries: "npm:^2.0.8"
-    object.groupby: "npm:^1.0.3"
-    object.values: "npm:^1.2.1"
-    semver: "npm:^6.3.1"
-    string.prototype.trimend: "npm:^1.0.9"
-    tsconfig-paths: "npm:^3.15.0"
+    minimatch: "npm:^9.0.3 || ^10.1.2"
+    semver: "npm:^7.7.2"
+    stable-hash-x: "npm:^0.2.0"
+    unrs-resolver: "npm:^1.9.2"
   peerDependencies:
-    eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
-  checksum: 10/1bacf4967e9ebf99e12176a795f0d6d3a87d1c9a030c2207f27b267e10d96a1220be2647504c7fc13ab543cdf13ffef4b8f5620e0447032dba4ff0d3922f7c9e
+    "@typescript-eslint/utils": ^8.56.0
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    eslint-import-resolver-node: "*"
+  peerDependenciesMeta:
+    "@typescript-eslint/utils":
+      optional: true
+    eslint-import-resolver-node:
+      optional: true
+  checksum: 10/1cb95284765cf0ff937f7ab44cf965278939c25dedc72ac41d00d954f4c0bd607bcaffacdeb22a3796aa8f2775c63dd25f818c7f897f061f2339035826cbaf5c
   languageName: node
   linkType: hard
 
@@ -26412,17 +26492,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "json5@npm:1.0.2"
-  dependencies:
-    minimist: "npm:^1.2.0"
-  bin:
-    json5: lib/cli.js
-  checksum: 10/a78d812dbbd5642c4f637dd130954acfd231b074965871c3e28a5bbd571f099d623ecf9161f1960c4ddf68e0cc98dee8bebfdb94a71ad4551f85a1afc94b63f6
-  languageName: node
-  linkType: hard
-
 "json5@npm:^2.1.2, json5@npm:^2.2.2, json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
@@ -28050,7 +28119,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:10.2.5, minimatch@npm:^10.1.1, minimatch@npm:^10.2.5":
+"minimatch@npm:10.2.5, minimatch@npm:^10.1.1, minimatch@npm:^10.2.5, minimatch@npm:^9.0.3 || ^10.1.2":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
   dependencies:
@@ -28613,6 +28682,15 @@ __metadata:
   bin:
     napi-postinstall: lib/cli.js
   checksum: 10/286785f884b872102fb284847ecc693101f70126b1fc7a97e19293929ce7f08802b41f89398015cce0797070ea3ce6871939a3c1e693c04cf594f7939dbe8cfb
+  languageName: node
+  linkType: hard
+
+"napi-postinstall@npm:^0.3.4":
+  version: 0.3.4
+  resolution: "napi-postinstall@npm:0.3.4"
+  bin:
+    napi-postinstall: lib/cli.js
+  checksum: 10/5541381508f9e1051ff3518701c7130ebac779abb3a1ffe9391fcc3cab4cc0569b0ba0952357db3f6b12909c3bb508359a7a60261ffd795feebbdab967175832
   languageName: node
   linkType: hard
 
@@ -29210,17 +29288,6 @@ __metadata:
     es-abstract: "npm:^1.23.2"
     es-object-atoms: "npm:^1.0.0"
   checksum: 10/5b2e80f7af1778b885e3d06aeb335dcc86965e39464671adb7167ab06ac3b0f5dd2e637a90d8ebd7426d69c6f135a4753ba3dd7d0fe2a7030cf718dcb910fd92
-  languageName: node
-  linkType: hard
-
-"object.groupby@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "object.groupby@npm:1.0.3"
-  dependencies:
-    call-bind: "npm:^1.0.7"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.2"
-  checksum: 10/44cb86dd2c660434be65f7585c54b62f0425b0c96b5c948d2756be253ef06737da7e68d7106e35506ce4a44d16aa85a413d11c5034eb7ce5579ec28752eb42d0
   languageName: node
   linkType: hard
 
@@ -32775,7 +32842,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.7, resolve@npm:^1.10.0, resolve@npm:^1.11.1, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.2, resolve@npm:^1.22.4, resolve@npm:^1.22.8":
+"resolve@npm:^1.1.7, resolve@npm:^1.10.0, resolve@npm:^1.11.1, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.2, resolve@npm:^1.22.8":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -32831,7 +32898,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.11.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.11.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:
@@ -35750,18 +35817,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfig-paths@npm:^3.15.0":
-  version: 3.15.0
-  resolution: "tsconfig-paths@npm:3.15.0"
-  dependencies:
-    "@types/json5": "npm:^0.0.29"
-    json5: "npm:^1.0.2"
-    minimist: "npm:^1.2.6"
-    strip-bom: "npm:^3.0.0"
-  checksum: 10/2041beaedc6c271fc3bedd12e0da0cc553e65d030d4ff26044b771fac5752d0460944c0b5e680f670c2868c95c664a256cec960ae528888db6ded83524e33a14
-  languageName: node
-  linkType: hard
-
 "tsconfig-paths@npm:^4.2.0":
   version: 4.2.0
   resolution: "tsconfig-paths@npm:4.2.0"
@@ -36454,6 +36509,82 @@ __metadata:
     "@unrs/resolver-binding-win32-x64-msvc":
       optional: true
   checksum: 10/49c149b71dfc22b7e134ea1ee317b564e3498ceb3512b6267fe3fdb52a5fbe8b5a5b4b5f3027a30b0a3ad0a4844f33d4ea8b87253c05209602456c5de1150ba7
+  languageName: node
+  linkType: hard
+
+"unrs-resolver@npm:^1.9.2":
+  version: 1.12.2
+  resolution: "unrs-resolver@npm:1.12.2"
+  dependencies:
+    "@unrs/resolver-binding-android-arm-eabi": "npm:1.12.2"
+    "@unrs/resolver-binding-android-arm64": "npm:1.12.2"
+    "@unrs/resolver-binding-darwin-arm64": "npm:1.12.2"
+    "@unrs/resolver-binding-darwin-x64": "npm:1.12.2"
+    "@unrs/resolver-binding-freebsd-x64": "npm:1.12.2"
+    "@unrs/resolver-binding-linux-arm-gnueabihf": "npm:1.12.2"
+    "@unrs/resolver-binding-linux-arm-musleabihf": "npm:1.12.2"
+    "@unrs/resolver-binding-linux-arm64-gnu": "npm:1.12.2"
+    "@unrs/resolver-binding-linux-arm64-musl": "npm:1.12.2"
+    "@unrs/resolver-binding-linux-loong64-gnu": "npm:1.12.2"
+    "@unrs/resolver-binding-linux-loong64-musl": "npm:1.12.2"
+    "@unrs/resolver-binding-linux-ppc64-gnu": "npm:1.12.2"
+    "@unrs/resolver-binding-linux-riscv64-gnu": "npm:1.12.2"
+    "@unrs/resolver-binding-linux-riscv64-musl": "npm:1.12.2"
+    "@unrs/resolver-binding-linux-s390x-gnu": "npm:1.12.2"
+    "@unrs/resolver-binding-linux-x64-gnu": "npm:1.12.2"
+    "@unrs/resolver-binding-linux-x64-musl": "npm:1.12.2"
+    "@unrs/resolver-binding-openharmony-arm64": "npm:1.12.2"
+    "@unrs/resolver-binding-wasm32-wasi": "npm:1.12.2"
+    "@unrs/resolver-binding-win32-arm64-msvc": "npm:1.12.2"
+    "@unrs/resolver-binding-win32-ia32-msvc": "npm:1.12.2"
+    "@unrs/resolver-binding-win32-x64-msvc": "npm:1.12.2"
+    napi-postinstall: "npm:^0.3.4"
+  dependenciesMeta:
+    "@unrs/resolver-binding-android-arm-eabi":
+      optional: true
+    "@unrs/resolver-binding-android-arm64":
+      optional: true
+    "@unrs/resolver-binding-darwin-arm64":
+      optional: true
+    "@unrs/resolver-binding-darwin-x64":
+      optional: true
+    "@unrs/resolver-binding-freebsd-x64":
+      optional: true
+    "@unrs/resolver-binding-linux-arm-gnueabihf":
+      optional: true
+    "@unrs/resolver-binding-linux-arm-musleabihf":
+      optional: true
+    "@unrs/resolver-binding-linux-arm64-gnu":
+      optional: true
+    "@unrs/resolver-binding-linux-arm64-musl":
+      optional: true
+    "@unrs/resolver-binding-linux-loong64-gnu":
+      optional: true
+    "@unrs/resolver-binding-linux-loong64-musl":
+      optional: true
+    "@unrs/resolver-binding-linux-ppc64-gnu":
+      optional: true
+    "@unrs/resolver-binding-linux-riscv64-gnu":
+      optional: true
+    "@unrs/resolver-binding-linux-riscv64-musl":
+      optional: true
+    "@unrs/resolver-binding-linux-s390x-gnu":
+      optional: true
+    "@unrs/resolver-binding-linux-x64-gnu":
+      optional: true
+    "@unrs/resolver-binding-linux-x64-musl":
+      optional: true
+    "@unrs/resolver-binding-openharmony-arm64":
+      optional: true
+    "@unrs/resolver-binding-wasm32-wasi":
+      optional: true
+    "@unrs/resolver-binding-win32-arm64-msvc":
+      optional: true
+    "@unrs/resolver-binding-win32-ia32-msvc":
+      optional: true
+    "@unrs/resolver-binding-win32-x64-msvc":
+      optional: true
+  checksum: 10/ef2fc38e7a7c5e0cad9a5fb3a70abead3c8073955b444908f35a55f54ced1c08433324220810b04d9ef5adeff62982ade136793dcde8297505ca3556ee0bbb82
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Replaces `eslint-plugin-import` (~2.32.0) with its actively maintained fork [`eslint-plugin-import-x`](https://github.com/un-ts/eslint-plugin-import-x) (~4.17.1) across the monorepo, keeping the effective rule set identical.

**`@rocket.chat/eslint-config`**
- All `import/*` rules and settings renamed to `import-x/*` with the same severities and options, including the overrides in the root `eslint.config.mjs` and every inline disable directive.
- Module resolution now uses the modern `import-x/resolver-next` API with an explicit chain: a node resolver first (with `exportsFields: []` to keep the old `eslint-import-resolver-node` behavior of ignoring package `exports` maps — required for deep imports like `csv-parse/lib/sync` and `swiper/modules/*.css`), then the TypeScript resolver. The order matters: the TS resolver alone would resolve packages like `node-fetch` to their `@types/*` declarations and produce false `import-x/named` errors.
- Dropped the now-dead `eslint-plugin-import/minimatch` yarn resolution (import-x already uses minimatch 9/10).

**Unused directive cleanup**
- With `reportUnusedDisableDirectives` already enabled, wiped all stale `eslint-disable` directives repo-wide via `eslint --fix --fix-type directive`, run per workspace so resolution context matches how turbo lints (notably `meteor/*` imports only resolve from within `apps/meteor`). 42 files touched, removals only — no behavioral autofixes were applied.

Rule parity was verified by diffing `eslint --print-config` output before/after, and by injecting deliberate violations (import order, duplicated imports, statement-before-import, missing group separation) in files across `apps/meteor`, `packages/*`, `ee/packages/*`, and `ee/apps/*` — every one was reported as an `import-x/*` error.

No changeset: developer tooling only, no end-user impact.

## Issue(s)

## Steps to test or reproduce

- Run `yarn lint` — all 71 tasks pass with no errors and no unused-directive warnings.
- Scramble any import block (reorder, duplicate, remove group blank line) in any workspace and run that workspace's `yarn lint` — the violation is reported as an `import-x/*` error.

## Further comments

`eslint-plugin-import` has slow release cadence and lacks first-class flat-config/ESLint 9 support; import-x is the community fork adopted by most of the ecosystem, with the same rule implementations and active maintenance. The resolver configuration is the only place where behavior could have drifted, hence the explicit node-first chain documented inline in `packages/eslint-config/index.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code-quality configuration and linting rules for more consistent import validation.
  * Removed outdated lint exceptions across application, server, and shared code.
  * Simplified select lint-related code patterns without changing runtime behavior.

* **Tests**
  * Cleaned up lint directives in automated test files while preserving existing test coverage and assertions.

* **Impact**
  * No user-facing features, workflows, or application behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2256]

[ARCH-2256]: https://rocketchat.atlassian.net/browse/ARCH-2256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ