### PR TITLE
fix: pagination and projection options silently ignored by model queries

### DIFF
--- a/.changeset/strict-find-options.md
+++ b/.changeset/strict-find-options.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/meteor': patch
+'@rocket.chat/model-typings': patch
+---
+
+Fixes broken pagination on `rooms.bannedUsers` and on omnichannel department listing endpoints, which ignored the `offset` parameter and always returned results from the first page. Also reduces payload over-fetching on several endpoints that unintentionally loaded full documents (`rooms.hide`, private group lookups, direct email replies, omnichannel auto-transfer), and removes the permissive model query typings that allowed these invalid find options to compile unnoticed.

--- a/apps/meteor/ee/server/lib/omnichannel/AutoTransferChatScheduler.ts
+++ b/apps/meteor/ee/server/lib/omnichannel/AutoTransferChatScheduler.ts
@@ -78,13 +78,7 @@ export class AutoTransferChatSchedulerClass {
 
 	private async transferRoom(roomId: string): Promise<void> {
 		this.logger.debug({ msg: 'Transferring room', roomId });
-		const room = await LivechatRooms.findOneById(roomId, {
-			_id: 1,
-			v: 1,
-			servedBy: 1,
-			open: 1,
-			departmentId: 1,
-		});
+		const room = await LivechatRooms.findOneById(roomId);
 		if (!room?.open || !room?.servedBy?._id) {
 			throw new Error('Room is not open or is not being served by an agent');
 		}

--- a/apps/meteor/ee/server/lib/omnichannel/Department.ts
+++ b/apps/meteor/ee/server/lib/omnichannel/Department.ts
@@ -40,7 +40,7 @@ export const findAllDepartmentsByUnit = async (
 		{
 			ancestors: { $in: [unitId] },
 		},
-		{ limit: count, skip: offset },
+		{ limit: count, skip: offset, sort: { name: 1, _id: 1 } },
 	);
 
 	const [departments, total] = await Promise.all([cursor.toArray(), totalCount]);

--- a/apps/meteor/ee/server/lib/omnichannel/Department.ts
+++ b/apps/meteor/ee/server/lib/omnichannel/Department.ts
@@ -24,7 +24,7 @@ export const findAllDepartmentsAvailable = async (
 		query = await applyDepartmentRestrictions(query, uid);
 	}
 
-	const { cursor, totalCount } = LivechatDepartment.findPaginated(query, { limit: count, offset, sort: { name: 1 } });
+	const { cursor, totalCount } = LivechatDepartment.findPaginated(query, { limit: count, skip: offset, sort: { name: 1 } });
 
 	const [departments, total] = await Promise.all([cursor.toArray(), totalCount]);
 
@@ -40,7 +40,7 @@ export const findAllDepartmentsByUnit = async (
 		{
 			ancestors: { $in: [unitId] },
 		},
-		{ limit: count, offset },
+		{ limit: count, skip: offset },
 	);
 
 	const [departments, total] = await Promise.all([cursor.toArray(), totalCount]);

--- a/apps/meteor/server/api/v1/groups.ts
+++ b/apps/meteor/server/api/v1/groups.ts
@@ -106,7 +106,7 @@ async function findPrivateGroupByIdOrName({
 }> {
 	const room = await getRoomFromParams(params);
 
-	const user = await Users.findOneById(userId, { projection: { username: 1, roles: 1 } });
+	const user = await Users.findOneById(userId, { projection: { username: 1, roles: 1, abacAttributes: 1 } });
 
 	if (!room || !user || !(await canAccessRoomAsync(room, user))) {
 		throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');

--- a/apps/meteor/server/api/v1/groups.ts
+++ b/apps/meteor/server/api/v1/groups.ts
@@ -106,7 +106,6 @@ async function findPrivateGroupByIdOrName({
 }> {
 	const room = await getRoomFromParams(params);
 
-	// `roles` is required by the room access validators, which read it straight from the user object
 	const user = await Users.findOneById(userId, { projection: { username: 1, roles: 1 } });
 
 	if (!room || !user || !(await canAccessRoomAsync(room, user))) {

--- a/apps/meteor/server/api/v1/groups.ts
+++ b/apps/meteor/server/api/v1/groups.ts
@@ -106,7 +106,8 @@ async function findPrivateGroupByIdOrName({
 }> {
 	const room = await getRoomFromParams(params);
 
-	const user = await Users.findOneById(userId, { projections: { username: 1 } });
+	// `roles` is required by the room access validators, which read it straight from the user object
+	const user = await Users.findOneById(userId, { projection: { username: 1, roles: 1 } });
 
 	if (!room || !user || !(await canAccessRoomAsync(room, user))) {
 		throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');

--- a/apps/meteor/server/api/v1/omnichannel/lib/customFields.ts
+++ b/apps/meteor/server/api/v1/omnichannel/lib/customFields.ts
@@ -9,7 +9,7 @@ export async function findLivechatCustomFields({
 	pagination: { offset, count, sort },
 }: {
 	text?: string;
-	pagination: { offset: number; count: number; sort: Record<string, number> };
+	pagination: { offset: number; count: number; sort: Record<string, 1 | -1> };
 }): Promise<PaginatedResult<{ customFields: Array<ILivechatCustomField> }>> {
 	const query = {
 		...(text && {

--- a/apps/meteor/server/api/v1/omnichannel/lib/transfer.ts
+++ b/apps/meteor/server/api/v1/omnichannel/lib/transfer.ts
@@ -11,7 +11,7 @@ export async function findLivechatTransferHistory({
 	pagination: { offset, count, sort },
 }: {
 	rid: string;
-	pagination: { offset: number; count: number; sort: Record<string, number> };
+	pagination: { offset: number; count: number; sort: Record<string, 1 | -1> };
 }): Promise<PaginatedResult<{ history: IOmnichannelSystemMessage['transferData'][] }>> {
 	const { cursor, totalCount } = Messages.findPaginated(
 		{ rid, t: 'livechat_transfer_history' },

--- a/apps/meteor/server/api/v1/omnichannel/lib/triggers.ts
+++ b/apps/meteor/server/api/v1/omnichannel/lib/triggers.ts
@@ -5,7 +5,7 @@ import type { PaginatedResult } from '@rocket.chat/rest-typings';
 export async function findTriggers({
 	pagination: { offset, count, sort },
 }: {
-	pagination: { offset: number; count: number; sort: Record<string, number> };
+	pagination: { offset: number; count: number; sort: Record<string, 1 | -1> };
 }): Promise<PaginatedResult<{ triggers: Array<ILivechatTrigger> }>> {
 	const { cursor, totalCount } = LivechatTrigger.findPaginated(
 		{},

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -1301,7 +1301,7 @@ API.v1.post(
 			return API.v1.unauthorized();
 		}
 
-		const user = await Users.findOneById(this.userId, { projections: { _id: 1 } });
+		const user = await Users.findOneById(this.userId, { projection: { _id: 1 } });
 
 		if (!user) {
 			return API.v1.failure('error-invalid-user');
@@ -1706,7 +1706,10 @@ export const roomEndpoints = API.v1
 
 			const { offset, count } = await getPaginationItems(this.queryParams);
 
-			const { cursor, totalCount } = Subscriptions.findPaginated({ rid: roomId, status: 'BANNED' as const }, { offset, count });
+			const { cursor, totalCount } = Subscriptions.findPaginated(
+				{ rid: roomId, status: 'BANNED' as const },
+				{ sort: { ts: 1 }, skip: offset, limit: count, projection: { 'u._id': 1 } },
+			);
 
 			const [bannedSubs, total] = await Promise.all([cursor.toArray(), totalCount]);
 

--- a/apps/meteor/server/lib/notifications/processDirectEmail.ts
+++ b/apps/meteor/server/lib/notifications/processDirectEmail.ts
@@ -50,8 +50,10 @@ export const processDirectEmail = async function (email: ParsedMail): Promise<vo
 	}
 
 	const prevMessage = await Messages.findOneById(mid, {
-		rid: 1,
-		u: 1,
+		projection: {
+			rid: 1,
+			u: 1,
+		},
 	});
 
 	if (!prevMessage) {

--- a/apps/meteor/tests/end-to-end/api/groups.ts
+++ b/apps/meteor/tests/end-to-end/api/groups.ts
@@ -1386,6 +1386,132 @@ describe('[Groups]', () => {
 		});
 	});
 
+	describe('group access as a regular member', () => {
+		let testGroup: IRoom;
+		let member: TestUser<IUser>;
+		let memberCredentials: Credentials;
+		let outsider: TestUser<IUser>;
+		let outsiderCredentials: Credentials;
+		const memberGroupName = `member-access-group-${Date.now()}-${Math.random()}`;
+
+		before(async () => {
+			member = await createUser();
+			memberCredentials = await login(member.username, password);
+			outsider = await createUser();
+			outsiderCredentials = await login(outsider.username, password);
+
+			const result = await createRoom({ type: 'p', name: memberGroupName, members: [member.username] });
+			testGroup = result.body.group;
+		});
+
+		after(async () => {
+			await deleteRoom({ type: 'p', roomId: testGroup._id });
+			await Promise.all([deleteUser(member), deleteUser(outsider)]);
+		});
+
+		it('should return the group info to a regular member', async () => {
+			const res = await request
+				.get(api('groups.info'))
+				.set(memberCredentials)
+				.query({
+					roomId: testGroup._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('group._id', testGroup._id);
+			expect(res.body).to.have.nested.property('group.name', memberGroupName);
+			expect(res.body).to.have.nested.property('group.t', 'p');
+		});
+
+		it('should not return the group info to a non-member', async () => {
+			const res = await request
+				.get(api('groups.info'))
+				.set(outsiderCredentials)
+				.query({
+					roomId: testGroup._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-room-not-found');
+		});
+
+		it('should return the group history to a regular member', async () => {
+			const res = await request
+				.get(api('groups.history'))
+				.set(memberCredentials)
+				.query({
+					roomId: testGroup._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('messages').that.is.an('array');
+		});
+
+		it('should close the group for a regular member', async () => {
+			await request
+				.post(api('groups.close'))
+				.set(memberCredentials)
+				.send({
+					roomId: testGroup._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+				});
+		});
+
+		it('should report the group as already closed on a second close (subscription open flag is read)', async () => {
+			await request
+				.post(api('groups.close'))
+				.set(memberCredentials)
+				.send({
+					roomId: testGroup._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', false);
+					expect(res.body).to.have.property('error', `The private group, ${memberGroupName}, is already closed to the sender`);
+				});
+		});
+
+		it('should open the group back for a regular member', async () => {
+			await request
+				.post(api('groups.open'))
+				.set(memberCredentials)
+				.send({
+					roomId: testGroup._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+				});
+		});
+
+		it('should report the group as already open on a second open (subscription open flag is read)', async () => {
+			await request
+				.post(api('groups.open'))
+				.set(memberCredentials)
+				.send({
+					roomId: testGroup._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', false);
+					expect(res.body).to.have.property('error', `The private group, ${memberGroupName}, is already open for the sender`);
+				});
+		});
+	});
+
 	describe('/groups.list', () => {
 		it('should list the groups the caller is part of', (done) => {
 			void request

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -5073,4 +5073,135 @@ describe('[Rooms]', () => {
 				});
 		});
 	});
+
+	describe('/rooms.bannedUsers', () => {
+		let testChannel: IRoom;
+		let bannedUsers: TestUser<IUser>[];
+		let bannedUserIds: string[];
+
+		before(async () => {
+			const result = await createRoom({ type: 'c', name: `banned-users-list-${Date.now()}-${Math.random()}` });
+			testChannel = result.body.channel;
+
+			bannedUsers = await Promise.all([createUser(), createUser(), createUser()]);
+			bannedUserIds = bannedUsers.map((user) => user._id);
+
+			for (const user of bannedUsers) {
+				await request
+					.post(api('channels.invite'))
+					.set(credentials)
+					.send({
+						roomId: testChannel._id,
+						userId: user._id,
+					})
+					.expect(200);
+
+				await request
+					.post(api('rooms.banUser'))
+					.set(credentials)
+					.send({
+						roomId: testChannel._id,
+						userId: user._id,
+					})
+					.expect(200);
+			}
+		});
+
+		after(async () => {
+			await deleteRoom({ type: 'c', roomId: testChannel._id });
+			await Promise.all(bannedUsers.map((user) => deleteUser(user)));
+		});
+
+		it('should list every banned user of the room with only the projected fields', async () => {
+			const res = await request
+				.get(api('rooms.bannedUsers'))
+				.set(credentials)
+				.query({
+					roomId: testChannel._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('total', bannedUsers.length);
+			expect(res.body).to.have.property('count', bannedUsers.length);
+			expect(res.body).to.have.property('offset', 0);
+			expect(res.body.bannedUsers).to.be.an('array').with.lengthOf(bannedUsers.length);
+			expect(res.body.bannedUsers.map((u: IUser) => u._id)).to.have.members(bannedUserIds);
+
+			res.body.bannedUsers.forEach((user: IUser) => {
+				expect(user).to.have.property('_id').that.is.a('string');
+				expect(user).to.have.property('username').that.is.a('string');
+				expect(Object.keys(user)).to.satisfy(
+					(keys: string[]) => keys.every((key) => ['_id', 'username', 'name'].includes(key)),
+					'response should only contain the projected fields (_id, username, name)',
+				);
+			});
+		});
+
+		it('should limit the number of banned users returned when count is provided', async () => {
+			const res = await request
+				.get(api('rooms.bannedUsers'))
+				.set(credentials)
+				.query({
+					roomId: testChannel._id,
+					count: 2,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('total', bannedUsers.length);
+			expect(res.body).to.have.property('count', 2);
+			expect(res.body).to.have.property('offset', 0);
+			expect(res.body.bannedUsers).to.be.an('array').with.lengthOf(2);
+		});
+
+		it('should skip banned users when offset is provided', async () => {
+			const res = await request
+				.get(api('rooms.bannedUsers'))
+				.set(credentials)
+				.query({
+					roomId: testChannel._id,
+					offset: 2,
+					count: 2,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('total', bannedUsers.length);
+			expect(res.body).to.have.property('offset', 2);
+			expect(res.body.bannedUsers)
+				.to.be.an('array')
+				.with.lengthOf(bannedUsers.length - 2);
+		});
+
+		it('should paginate through all banned users without overlapping results', async () => {
+			const firstPage = await request
+				.get(api('rooms.bannedUsers'))
+				.set(credentials)
+				.query({
+					roomId: testChannel._id,
+					count: 2,
+				})
+				.expect(200);
+
+			const secondPage = await request
+				.get(api('rooms.bannedUsers'))
+				.set(credentials)
+				.query({
+					roomId: testChannel._id,
+					offset: 2,
+					count: 2,
+				})
+				.expect(200);
+
+			const firstPageIds = firstPage.body.bannedUsers.map((u: IUser) => u._id);
+			const secondPageIds = secondPage.body.bannedUsers.map((u: IUser) => u._id);
+
+			expect(firstPageIds.filter((id: string) => secondPageIds.includes(id))).to.be.empty;
+			expect([...firstPageIds, ...secondPageIds]).to.have.members(bannedUserIds);
+		});
+	});
 });

--- a/ee/packages/omni-core-ee/package.json
+++ b/ee/packages/omni-core-ee/package.json
@@ -13,7 +13,8 @@
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
 		"test": "jest",
-		"testunit": "jest"
+		"testunit": "jest",
+		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@rocket.chat/core-services": "workspace:^",

--- a/ee/packages/omni-core-ee/src/outbound-communication/validators/canSendMessage.ts
+++ b/ee/packages/omni-core-ee/src/outbound-communication/validators/canSendMessage.ts
@@ -25,7 +25,9 @@ export async function canSendOutboundMessage(userId: string, agentId?: string, d
 			query = await addQueryRestrictionsToDepartmentsModel(query, userId);
 		}
 
-		const department = await LivechatDepartment.findOne<Pick<ILivechatDepartment, '_id' | 'enabled'>>(query, { _id: 1, enabled: 1 });
+		const department = await LivechatDepartment.findOne<Pick<ILivechatDepartment, '_id' | 'enabled'>>(query, {
+			projection: { _id: 1, enabled: 1 },
+		});
 		if (!department?.enabled) {
 			throw new Error('error-invalid-department');
 		}

--- a/packages/model-typings/src/models/IBaseModel.ts
+++ b/packages/model-typings/src/models/IBaseModel.ts
@@ -60,11 +60,9 @@ export interface IBaseModel<
 
 	findOneById(_id: T['_id'], options?: FindOptions<T> | undefined): Promise<T | null>;
 	findOneById<P extends Document = T>(_id: T['_id'], options?: FindOptions<P>): Promise<P | null>;
-	findOneById(_id: T['_id'], options?: any): Promise<T | null>;
 
 	findOne(query?: Filter<T> | T['_id'], options?: undefined): Promise<T | null>;
-	findOne<P extends Document = T>(query: Filter<T> | T['_id'], options: FindOptions<P extends T ? T : P>): Promise<P | null>;
-	findOne<P>(query: Filter<T> | T['_id'], options?: any): Promise<WithId<T> | WithId<P> | null>;
+	findOne<P extends Document = T>(query: Filter<T> | T['_id'], options?: FindOptions<P extends T ? T : P>): Promise<P | null>;
 
 	find(query?: Filter<T>): FindCursor<ResultFields<T, C>>;
 	find<P extends Document = T>(query: Filter<T>, options: FindOptions<P extends T ? T : P>): FindCursor<P>;
@@ -74,7 +72,6 @@ export interface IBaseModel<
 	): FindCursor<WithId<P>> | FindCursor<WithId<T>>;
 
 	findPaginated<P extends Document = T>(query: Filter<T>, options?: FindOptions<P extends T ? T : P>): FindPaginated<FindCursor<WithId<P>>>;
-	findPaginated(query: Filter<T>, options?: any): FindPaginated<FindCursor<WithId<T>>>;
 
 	update(
 		filter: Filter<T>,

--- a/packages/omni-core/package.json
+++ b/packages/omni-core/package.json
@@ -13,7 +13,8 @@
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
 		"test": "jest",
-		"testunit": "jest"
+		"testunit": "jest",
+		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@rocket.chat/models": "workspace:^",


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`IBaseModel` exposed the `BaseRaw` implementation signatures (`options?: any`) as public overloads for `findOneById`, `findOne` and `findPaginated` (introduced when the interfaces were extracted in #25758 and kept through the mongo v4 typings migration in #25991). Any object literal with invalid `FindOptions` keys failed the excess-property check on the typed overloads and fell through to the `any` overload, compiling silently — and the MongoDB driver ignores unknown options keys at runtime.

This removes the `any` overloads and fixes every latent bug the strict typings surfaced:

- **`rooms.bannedUsers`**: passed `{ offset, count }` to `findPaginated` — pagination was never applied, every banned subscription was fetched with full documents. Now uses `skip`/`limit`, sorts by `ts` for deterministic paging, and projects only `u._id` (the only field read).
- **Omnichannel department listings** (`findAllDepartmentsAvailable`, `findAllDepartmentsByUnit`): used `offset` instead of `skip`, so every page returned the first page.
- **`rooms.hide` and private group lookup**: `projections` typo (instead of `projection`) fetched nearly the whole user document per call. The group lookup keeps `roles` in the projection since the room access validators read it straight from the user object.
- **Direct email replies**: passed a bare projection object as options, fetching the full message document.
- **Livechat auto-transfer scheduler**: passed a bare projection object as options; dropped the options entirely since `returnRoomAsInquiry` reads fields (`onHold`, `lastMessage`) outside the intended projection — full fetch preserves current behavior.
- **Omnichannel pagination helpers** (custom fields, transfer history, triggers): typed `sort` as `Record<string, number>`, which is not assignable to mongo's `Sort`; narrowed to `Record<string, 1 | -1>` (what `parseJsonQuery` returns).

The generic `findOne` overload's `options` parameter is now optional, matching the `BaseRaw` implementation.

## Steps to test or reproduce

1. Ban more users in a channel than the pagination `count` and call `rooms.bannedUsers` with `offset`/`count` — pages now differ instead of always returning the first page.
2. Create more livechat departments than the page size and list them through the omnichannel department endpoints with an offset — paging now advances.
3. Typecheck: `{ projections: ... }`, `{ offset, count }` or bare projection objects passed to `findOneById`/`findOne`/`findPaginated` no longer compile.

## Further comments

Verified with `turbo run typecheck` across all 26 packages depending on `@rocket.chat/model-typings`, plus eslint on the changed files. `BaseRaw`'s own implementation signatures still use `any` internally, which is standard TypeScript overload practice and not externally callable.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [CORE-2427]

[CORE-2427]: https://rocketchat.atlassian.net/browse/CORE-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed pagination where offsets were ignored for banned-user and omnichannel department listings.
  - Corrected projection usage for room hiding and group/private lookups to ensure proper authorization and results.
  - Improved query behavior for omnichannel transfer and direct-email processing to avoid returning unnecessary fields.
  - Tightened sorting and pagination behavior for banned-user listing responses.

- **Tests**
  - Added end-to-end coverage for private-group access, close/reopen behavior, and `/rooms.bannedUsers` pagination/field filtering.

- **Developer Experience**
  - Added unit-test and type-check scripts.
  - Strengthened TypeScript typing for pagination/sort options and model query options to catch invalid inputs earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->