### PR TITLE
test: update stale proxyquire mock paths breaking unit test CI

### DIFF
--- a/apps/meteor/server/lib/ldap/Connection.spec.ts
+++ b/apps/meteor/server/lib/ldap/Connection.spec.ts
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 const loggerStub = { debug: sinon.stub(), error: sinon.stub(), info: sinon.stub(), warn: sinon.stub() };
 
 const { LDAPConnection } = proxyquire.noCallThru().load('./Connection', {
-	'../../../app/settings/server': { settings: { get: sinon.stub() } },
+	'../../settings': { settings: { get: sinon.stub() } },
 	'./getLDAPConditionalSetting': { getLDAPConditionalSetting: sinon.stub().returns('') },
 	'./Logger': {
 		logger: loggerStub,

--- a/apps/meteor/tests/unit/server/lib/import/SlackImporter.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/import/SlackImporter.spec.ts
@@ -53,7 +53,7 @@ const { SlackImporter } = proxyquire.noCallThru().load('../../../../../server/li
 		},
 		ImporterWebsocket: { progressUpdated: sinon.stub() },
 	},
-	'../../../../app/lib/server/lib/notifyListener': { notifyOnSettingChanged: sinon.stub() },
+	'../../notifyListener': { notifyOnSettingChanged: sinon.stub() },
 	'../../../../app/mentions/lib/MentionsParser': {
 		MentionsParser: class {
 			getUserMentions() {
@@ -65,8 +65,8 @@ const { SlackImporter } = proxyquire.noCallThru().load('../../../../../server/li
 			}
 		},
 	},
-	'../../../../app/settings/server': { settings: settingsStub },
-	'../../../../app/utils/server/getUserAvatarURL': { getUserAvatarURL: sinon.stub().returns('/avatar/user') },
+	'../../../settings': { settings: settingsStub },
+	'../../utils/getUserAvatarURL': { getUserAvatarURL: sinon.stub().returns('/avatar/user') },
 });
 
 describe('SlackImporter', () => {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The unit test CI stage (`.testunit:server:cov`) has been failing on develop since the backend folder reorganization (Phase 7, 0e7b205e1c) with:

```
server/settings/index.ts:24:0: ERROR: Top-level await is currently not supported with the "cjs" output format
```

Root cause: the reorganization updated the import specifiers inside `server/lib/import/slack/SlackImporter.ts` and `server/lib/ldap/Connection.ts`, but not the proxyquire mock keys in their specs. Since the specs use `proxyquire.noCallThru()`, the now-unmatched keys silently fall back to loading the **real** modules — which pull in the `server/settings` barrel, whose top-level `await initializeSettings(...)` cannot be transformed by tsx in CJS mode. The transform error aborts the entire mocha stage at spec load time (all suites, not just these two).

Fix: point the mock keys at the current import specifiers:

- `SlackImporter.spec.ts`: `app/settings/server` → `../../../settings`, `app/lib/server/lib/notifyListener` → `../../notifyListener`, `app/utils/server/getUserAvatarURL` → `../../utils/getUserAvatarURL`
- `Connection.spec.ts`: `app/settings/server` → `../../settings`

As a bonus, these specs now actually exercise their mocks again instead of real modules.

## Steps to test or reproduce

`yarn testunit` in `apps/meteor` — previously aborted with the top-level-await transform error after the jest stage; now completes with 2059 mocha tests passing.

## Further comments

Found by tracing `Module._load` during the mocha run — the esbuild error surfaces asynchronously without the requiring file, so the offending chain (`spec → real Connection.ts/SlackImporter.ts → server/settings/index.ts`) is invisible in the CI log.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [CORE-2426]

[CORE-2426]: https://rocketchat.atlassian.net/browse/CORE-2426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated test mocks to align with revised internal module locations.
  * Preserved existing LDAP connection and Slack import test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->