### PR TITLE
test: Remove virtual flag from CodeMirror spec mocks to fix flaky suite

### DIFF
--- a/apps/meteor/client/views/admin/settings/Setting/inputs/CodeMirror/CodeMirror.spec.tsx
+++ b/apps/meteor/client/views/admin/settings/Setting/inputs/CodeMirror/CodeMirror.spec.tsx
@@ -20,13 +20,13 @@ jest.mock('codemirror', () => ({
 	default: { fromTextArea: (...args: unknown[]) => fromTextArea(...(args as [])) },
 }));
 
-jest.mock('codemirror/addon/edit/matchbrackets', () => ({}), { virtual: true });
-jest.mock('codemirror/addon/edit/closebrackets', () => ({}), { virtual: true });
-jest.mock('codemirror/addon/edit/matchtags', () => ({}), { virtual: true });
-jest.mock('codemirror/addon/edit/trailingspace', () => ({}), { virtual: true });
-jest.mock('codemirror/addon/search/match-highlighter', () => ({}), { virtual: true });
-jest.mock('codemirror/lib/codemirror.css', () => ({}), { virtual: true });
-jest.mock('../../../../../../../app/ui/client/lib/codeMirror/codeMirror', () => ({}), { virtual: true });
+jest.mock('codemirror/addon/edit/matchbrackets', () => ({}));
+jest.mock('codemirror/addon/edit/closebrackets', () => ({}));
+jest.mock('codemirror/addon/edit/matchtags', () => ({}));
+jest.mock('codemirror/addon/edit/trailingspace', () => ({}));
+jest.mock('codemirror/addon/search/match-highlighter', () => ({}));
+jest.mock('codemirror/lib/codemirror.css', () => ({}));
+jest.mock('../../../../../../../app/ui/client/lib/codeMirror/codeMirror', () => ({}));
 
 const flushAsync = () => act(() => Promise.resolve());
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`CodeMirror.spec.tsx` intermittently fails in full `testunit` runs with all 6 of its tests reporting:

```
CodeMirror initialization failed: TypeError: CodeMirror.registerHelper is not a function
    at codemirror/addon/fold/brace-fold.js:72
```

The spec registers its module mocks with `{ virtual: true }`, but every mocked module exists on disk — virtual mocks are meant for modules that don't. Virtual mocks can be keyed by the raw specifier string instead of the resolved file path, and the spec and the `CodeMirror` component reach the same file (`app/ui/client/lib/codeMirror/codeMirror`) through different relative specifiers. When that keying misses, the component's dynamic import loads the real `codeMirror.ts`, whose first addon (`brace-fold`) requires `codemirror/lib/codemirror` — the exact file the `'codemirror'` mock is registered against (it is the package main). The mock only defines `fromTextArea`, so `registerHelper` is undefined and the component's memoized `Promise.all` rejects, failing every test in the suite at once.

Dropping `{ virtual: true }` registers the mocks against the resolved absolute paths, so both the spec's and the component's specifiers hit the mocks deterministically.

## Issue(s)

## Steps to test or reproduce

- `yarn workspace @rocket.chat/meteor .testunit:jest` — the client project passes consistently (verified with two consecutive full runs, 258/258 suites) with no `CodeMirror initialization failed` errors in `CodeMirror.spec.tsx`.

## Further comments

Unrelated to this flake, `CodeSettingInput.spec.tsx` logs `act(...)` warnings because the CodeMirror component resolves its lazy import after the test's render; that is cosmetic noise and could be addressed separately by awaiting the editor initialization in that spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CodeMirror test mocks to use standard module resolution.
  * Improved test environment alignment with the editor’s loaded modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2258]

[ARCH-2258]: https://rocketchat.atlassian.net/browse/ARCH-2258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ