### PR TITLE
refactor(saml): modernize logout URL generation

### DIFF
--- a/apps/meteor/server/lib/saml/lib/ServiceProvider.ts
+++ b/apps/meteor/server/lib/saml/lib/ServiceProvider.ts
@@ -57,6 +57,26 @@ export class SAMLServiceProvider {
 		};
 	}
 
+	private async buildLogoutResponseUrl(response: string, relayState: string | undefined): Promise<string> {
+		const buffer = await util.promisify(zlib.deflateRaw)(response);
+		const base64 = buffer.toString('base64');
+		let target = this.serviceProviderOptions.idpSLORedirectURL;
+
+		if (target.indexOf('?') > 0) {
+			target += '&';
+		} else {
+			target += '?';
+		}
+
+		// The SAML spec requires the response RelayState to exactly match the value received on the request.
+		const samlResponse = this.maybeSignRequest({
+			SAMLResponse: base64,
+			...(relayState !== undefined && { RelayState: relayState }),
+		});
+
+		return target + querystring.stringify(samlResponse);
+	}
+
 	public generateAuthorizeRequest(credentialToken: string): string {
 		const identifiedRequest = AuthorizeRequest.generate(this.serviceProviderOptions, credentialToken);
 		return identifiedRequest.request;
@@ -86,34 +106,9 @@ export class SAMLServiceProvider {
 		relayState: string | undefined,
 		callback: (err: string | object | null, url?: string) => void,
 	): void {
-		zlib.deflateRaw(response, (err, buffer) => {
-			if (err) {
-				return callback(err);
-			}
-
-			try {
-				const base64 = buffer.toString('base64');
-				let target = this.serviceProviderOptions.idpSLORedirectURL;
-
-				if (target.indexOf('?') > 0) {
-					target += '&';
-				} else {
-					target += '?';
-				}
-
-				// The SAML spec requires the response RelayState to exactly match the value received on the request.
-				const samlResponse = this.maybeSignRequest({
-					SAMLResponse: base64,
-					...(relayState !== undefined && { RelayState: relayState }),
-				});
-
-				target += querystring.stringify(samlResponse);
-
-				return callback(null, target);
-			} catch (error) {
-				return callback(error instanceof Error ? error : String(error));
-			}
-		});
+		void this.buildLogoutResponseUrl(response, relayState)
+			.then((url) => callback(null, url))
+			.catch((error) => callback(error instanceof Error ? error : String(error)));
 	}
 
 	/*

--- a/apps/meteor/tests/unit/server/lib/saml/server.tests.ts
+++ b/apps/meteor/tests/unit/server/lib/saml/server.tests.ts
@@ -332,6 +332,55 @@ describe('SAML', () => {
 				const inflated = zlib.inflateRawSync(Buffer.from(params.get('SAMLResponse') ?? '', 'base64')).toString();
 				expect(inflated).to.be.equal('logout-response');
 			});
+
+			it('should report compression errors through the callback', async () => {
+				const compressionError = new Error('compression failed');
+				const deflateRaw = sinon.stub().callsFake((_response: string, callback: (error: Error) => void) => callback(compressionError));
+				const { SAMLServiceProvider: FailingSAMLServiceProvider } = proxyquire
+					.noCallThru()
+					.load('../../../../../server/lib/saml/lib/ServiceProvider', {
+						...meteorStub,
+						'node:zlib': { default: { deflateRaw }, __esModule: true },
+					});
+				const failingServiceProvider = new FailingSAMLServiceProvider(serviceProviderOptions);
+
+				await new Promise<void>((resolve, reject) => {
+					failingServiceProvider.logoutResponseToUrl('logout-response', undefined, (err: unknown, url?: string) => {
+						try {
+							expect(err).to.equal(compressionError);
+							expect(url).to.be.undefined;
+							resolve();
+						} catch (error) {
+							reject(error);
+						}
+					});
+				});
+			});
+
+			it('should report errors thrown by the success callback', async () => {
+				const callbackError = new Error('callback failed');
+				let callbackCalls = 0;
+
+				await new Promise<void>((resolve, reject) => {
+					serviceProvider.logoutResponseToUrl('logout-response', undefined, (err: unknown, url?: string) => {
+						callbackCalls += 1;
+
+						if (callbackCalls === 1) {
+							expect(err).to.be.null;
+							expect(url).to.be.a('string');
+							throw callbackError;
+						}
+
+						try {
+							expect(err).to.equal(callbackError);
+							expect(url).to.be.undefined;
+							resolve();
+						} catch (error) {
+							reject(error);
+						}
+					});
+				});
+			});
 		});
 	});
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

- use Promise-based deflate and async/await internally for SAML logout response URLs
- preserve the public callback API, URL output, RelayState handling, and callback error behavior
- add regression coverage for compression and callback-thrown errors

## Issue(s)

Closes #38741

## Steps to test or reproduce

Run:

`yarn workspace @rocket.chat/meteor .testunit:server --grep "logoutResponseToUrl"`

## Further comments

No changeset: behavior-preserving internal refactor.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

