### PR TITLE
fix(message-list): scroll latest message to list end

### DIFF
--- a/.changeset/message-list-scroll-end.md
+++ b/.changeset/message-list-scroll-end.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes scrolling to the latest message when opening a room at the bottom of the message list

--- a/apps/meteor/client/views/room/MessageList/MessageList.spec.tsx
+++ b/apps/meteor/client/views/room/MessageList/MessageList.spec.tsx
@@ -177,6 +177,27 @@ describe('MessageList scroll position', () => {
 		expect(mockVirtualizerHandle.scrollToIndex).toHaveBeenCalledWith(2, { align: 'end' });
 	});
 
+	it.each([
+		{ canPreview: true, expectedIndex: 4 },
+		{ canPreview: false, expectedIndex: 3 },
+	])('should keep the latest message at the end when new messages arrive with canPreview=$canPreview', ({ canPreview, expectedIndex }) => {
+		const isAtBottom = { current: false };
+		(RoomManager.getStore as jest.Mock).mockReturnValue({ scroll: undefined, atBottom: false, update: jest.fn() });
+
+		const { rerender } = render(<MessageList {...defaultProps} canPreview={canPreview} isAtBottom={isAtBottom} />, {
+			wrapper: root.build(),
+		});
+
+		mockVirtualizerHandle.scrollToIndex.mockClear();
+		isAtBottom.current = true;
+		mockVirtualizerHandle.scrollSize = 1200;
+		(useMessages as jest.Mock).mockReturnValue([createMessage('message-1'), createMessage('message-2'), createMessage('message-3')]);
+
+		rerender(<MessageList {...defaultProps} canPreview={canPreview} isAtBottom={isAtBottom} />);
+
+		expect(mockVirtualizerHandle.scrollToIndex).toHaveBeenCalledWith(expectedIndex, { align: 'end' });
+	});
+
 	it('should jump to bottom if unreads are present', () => {
 		const store = {
 			scroll: 123,

--- a/apps/meteor/client/views/room/MessageList/MessageList.spec.tsx
+++ b/apps/meteor/client/views/room/MessageList/MessageList.spec.tsx
@@ -151,7 +151,7 @@ describe('MessageList scroll position', () => {
 		expect(mockVirtualizerHandle.scrollToIndex).not.toHaveBeenCalled();
 	});
 
-	it('should jump to bottom if atBottom is true', () => {
+	it('should jump to the end when atBottom is true and the room foreword is visible', () => {
 		const store = {
 			scroll: 123,
 			atBottom: true,
@@ -161,7 +161,20 @@ describe('MessageList scroll position', () => {
 
 		render(<MessageList {...defaultProps} shouldJumpToBottom={true} />, { wrapper: root.build() });
 
-		expect(mockVirtualizerHandle.scrollToIndex).toHaveBeenCalledWith(2, { align: 'center' });
+		expect(mockVirtualizerHandle.scrollToIndex).toHaveBeenCalledWith(3, { align: 'end' });
+	});
+
+	it('should jump to the end when atBottom is true and the room foreword is hidden', () => {
+		const store = {
+			scroll: 123,
+			atBottom: true,
+			update: jest.fn(),
+		};
+		(RoomManager.getStore as jest.Mock).mockReturnValue(store);
+
+		render(<MessageList {...defaultProps} canPreview={false} shouldJumpToBottom={true} />, { wrapper: root.build() });
+
+		expect(mockVirtualizerHandle.scrollToIndex).toHaveBeenCalledWith(2, { align: 'end' });
 	});
 
 	it('should jump to bottom if unreads are present', () => {

--- a/apps/meteor/client/views/room/MessageList/MessageList.tsx
+++ b/apps/meteor/client/views/room/MessageList/MessageList.tsx
@@ -177,7 +177,6 @@ export const MessageList = function MessageList({
 		}
 
 		const handle = virtualizerRef.current;
-		const lastItemIndex = messages.length - 1;
 		if (shouldJumpToBottom === true) {
 			handle?.scrollToIndex(messagesLength, {
 				align: 'end',
@@ -186,7 +185,7 @@ export const MessageList = function MessageList({
 		// If new messages arrive and is at bottom, scroll to keep at bottom.
 		if (isAtBottom.current && lastScrollSizeRef.current !== handle?.scrollSize && !isLoadingMoreMessages) {
 			lastScrollSizeRef.current = handle?.scrollSize ?? 0;
-			handle?.scrollToIndex(lastItemIndex + 1, {
+			handle?.scrollToIndex(messagesLength, {
 				align: 'end',
 			});
 		}

--- a/apps/meteor/client/views/room/MessageList/MessageList.tsx
+++ b/apps/meteor/client/views/room/MessageList/MessageList.tsx
@@ -179,10 +179,8 @@ export const MessageList = function MessageList({
 		const handle = virtualizerRef.current;
 		const lastItemIndex = messages.length - 1;
 		if (shouldJumpToBottom === true) {
-			// When new messages arrive, this effect is triggered, but the latest message is not on the index, so it scrolls to the previous index
-			// TODO: Find if there is a better way to scroll to the latest message
-			handle?.scrollToIndex(lastItemIndex + 1, {
-				align: 'center',
+			handle?.scrollToIndex(messagesLength, {
+				align: 'end',
 			});
 		}
 		// If new messages arrive and is at bottom, scroll to keep at bottom.
@@ -195,6 +193,7 @@ export const MessageList = function MessageList({
 	}, [
 		isAtBottom,
 		messages,
+		messagesLength,
 		shouldJumpToBottom,
 		isJumpingToMessage,
 		isLoadingMoreMessages,


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Scrolls to the actual end of the virtualized message list when restoring a room at the bottom. This accounts for the optional room foreword and uses end alignment instead of the previous center-aligned workaround.

Adds regression coverage for lists with and without the room foreword.

## Issue(s)

Closes #40618

## Steps to test or reproduce

Run:

```sh
corepack yarn workspace @rocket.chat/meteor .testunit:jest client/views/room/MessageList/MessageList.spec.tsx --runInBand
```

## Further comments

Includes a patch changeset for the user-visible fix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed room opening scrolling so the message list reliably jumps to the latest message.
  * Improved “at bottom” scrolling by consistently aligning the newest message at the bottom, with correct behavior depending on whether the foreword is visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->