### PR TITLE
fix(apps-engine/deno): use std mkdtemp for ephemeral files

### DIFF
--- a/packages/apps/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/packages/apps/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -17,10 +17,6 @@ function getDenoConfigPath(): string {
 	return require.resolve('../../../../deno-runtime/deno.jsonc');
 }
 
-function getDenoEphemeralConfigPath(): string {
-	return fs.mkdtempSync("deno-runtimeXXXXX");
-}
-
 /**
  * Generates a runtime deno.jsonc at `<tempDir>/deno_runtime.jsonc` by reading
  * the static config and injecting the resolved absolute path for
@@ -71,7 +67,7 @@ export class DenoRuntimeSubprocessController extends BaseRuntimeSubprocessContro
 		this.denoDir = process.env.DENO_DIR ?? path.join(this.packagePath, '.deno-cache');
 
 		this.denoRuntimePath = path.join(this.tempFilePath, 'deno-runtime', 'main.ts');
-		this.denoEphemeralConfigPath = path.join(getDenoEphemeralConfigPath(), path.basename(this.denoConfigPath).replace('.jsonc', '.runtime.jsonc'));
+		this.denoEphemeralConfigPath = path.join(this.tempFilePath, path.basename(this.denoConfigPath).replace('.jsonc', '.runtime.jsonc'));
 
 		/**
 		 * Deno 2.x refuses to run scripts inside the node_modules, so we create a symlink to the deno runtime files in the temp directory

--- a/packages/apps/src/server/runtime/deno/AppsEngineDenoRuntime.ts
+++ b/packages/apps/src/server/runtime/deno/AppsEngineDenoRuntime.ts
@@ -17,6 +17,10 @@ function getDenoConfigPath(): string {
 	return require.resolve('../../../../deno-runtime/deno.jsonc');
 }
 
+function getDenoEphemeralConfigPath(): string {
+	return fs.mkdtempSync("deno-runtimeXXXXX");
+}
+
 /**
  * Generates a runtime deno.jsonc at `<tempDir>/deno_runtime.jsonc` by reading
  * the static config and injecting the resolved absolute path for
@@ -67,7 +71,7 @@ export class DenoRuntimeSubprocessController extends BaseRuntimeSubprocessContro
 		this.denoDir = process.env.DENO_DIR ?? path.join(this.packagePath, '.deno-cache');
 
 		this.denoRuntimePath = path.join(this.tempFilePath, 'deno-runtime', 'main.ts');
-		this.denoEphemeralConfigPath = this.denoConfigPath.replace('.jsonc', '.runtime.jsonc');
+		this.denoEphemeralConfigPath = path.join(getDenoEphemeralConfigPath(), path.basename(this.denoConfigPath).replace('.jsonc', '.runtime.jsonc'));
 
 		/**
 		 * Deno 2.x refuses to run scripts inside the node_modules, so we create a symlink to the deno runtime files in the temp directory


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
CORE-2428

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

this will respect posix `TMPDIR` environment variable. app shouldn't write to /app/bundle at runtime. it breaks change in runtime uid changes. separating where data is written to, we can bind an emptyDir at TMPDIR and call it a day

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Deno runtime configuration generation to write the ephemeral runtime config into an isolated temporary directory rather than alongside the static config.
  * Reduces the likelihood of filename/location collisions by deriving the runtime config path from the original config’s basename, improving reliability for concurrent runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->