### PR TITLE
feat: history manager for real time composer

### DIFF
--- a/apps/meteor/app/ui-message/client/messageBox/composerHistory.spec.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/composerHistory.spec.ts
@@ -182,6 +182,45 @@ describe('createComposerHistory', () => {
 		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: 'a' }));
 	});
 
+	it('does not create a ghost step for a re-selection after a formatting change', () => {
+		const input = makeInput();
+		const applyState = jest.fn();
+		const history = createComposerHistory({ input, applyState, now });
+
+		typeInput(input, 'bold');
+
+		// Select all ('bold' -> range 0..4), then apply bold. The execCommand replacement fires
+		// beforeinput with the pre-edit range still live (marks a replace boundary), then two input
+		// events with identical text but different selections (caret at end, then 'bold' reselected).
+		mockedGetSelectionRange.mockReturnValue({ selectionStart: 0, selectionEnd: 4 });
+		input.dispatchEvent(new InputEvent('beforeinput', { inputType: 'insertText', bubbles: true }));
+		setState(input, '*bold*', 6, 6);
+		input.dispatchEvent(new InputEvent('input', { inputType: 'insertText', data: '*bold*', bubbles: true }));
+		setState(input, '*bold*', 1, 5);
+		input.dispatchEvent(new Event('input', { bubbles: true }));
+
+		history.undo();
+		expect(applyState).toHaveBeenCalledTimes(1);
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: 'bold' }));
+	});
+
+	it('starts a new undo step when typing replaces a selected range', () => {
+		const input = makeInput();
+		const applyState = jest.fn();
+		const history = createComposerHistory({ input, applyState, now });
+
+		typeInput(input, 'foo');
+
+		// Select all via keyboard, then type over the selection. The keydown fires on the document
+		// capture phase with the range still live, marking a replace boundary.
+		mockedGetSelectionRange.mockReturnValue({ selectionStart: 0, selectionEnd: 3 });
+		input.dispatchEvent(new KeyboardEvent('keydown', { key: 'x', bubbles: true }));
+		typeInput(input, 'x', 'x');
+
+		history.undo();
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: 'foo' }));
+	});
+
 	it('clears the redo stack when a new change is recorded after an undo', () => {
 		const input = makeInput();
 		const applyState = jest.fn();

--- a/apps/meteor/app/ui-message/client/messageBox/composerHistory.spec.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/composerHistory.spec.ts
@@ -265,6 +265,12 @@ describe('createComposerHistory', () => {
 		typeInput(input, 'a');
 		history.release();
 
+		mockedGetSelectionRange.mockClear();
+
+		typeInput(input, 'ab', 'b');
+
+		expect(mockedGetSelectionRange).not.toHaveBeenCalled();
+
 		const undoEvent = new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, bubbles: true, cancelable: true });
 		input.dispatchEvent(undoEvent);
 

--- a/apps/meteor/app/ui-message/client/messageBox/composerHistory.spec.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/composerHistory.spec.ts
@@ -91,6 +91,24 @@ describe('createComposerHistory', () => {
 		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: '' }));
 	});
 
+	it('restores the caret to the edit location after an edit at a moved caret', () => {
+		const input = makeInput();
+		const applyState = jest.fn();
+		const history = createComposerHistory({ input, applyState, now });
+
+		typeInput(input, 'abc');
+
+		// Move the caret to the start (caret moves do not fire input), then edit there.
+		mockedGetSelectionRange.mockReturnValue({ selectionStart: 0, selectionEnd: 0 });
+		input.dispatchEvent(new InputEvent('beforeinput', { inputType: 'insertText', data: 'x', bubbles: true }));
+
+		setState(input, 'xabc', 1);
+		input.dispatchEvent(new InputEvent('input', { inputType: 'insertText', data: 'x', bubbles: true }));
+
+		history.undo();
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: 'abc', selectionStart: 0, selectionEnd: 0 }));
+	});
+
 	it('breaks the undo step on whitespace boundaries', () => {
 		const input = makeInput();
 		const applyState = jest.fn();

--- a/apps/meteor/app/ui-message/client/messageBox/composerHistory.spec.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/composerHistory.spec.ts
@@ -1,0 +1,250 @@
+import { createComposerHistory, type ComposerHistoryEntry } from './composerHistory';
+import { getSelectionRange } from './selectionRange';
+
+jest.mock('./selectionRange', () => ({
+	getSelectionRange: jest.fn(() => ({ selectionStart: 0, selectionEnd: 0 })),
+	setSelectionRange: jest.fn(),
+}));
+
+const mockedGetSelectionRange = getSelectionRange as jest.Mock;
+
+const makeInput = (): HTMLDivElement => {
+	const div = document.createElement('div');
+	let value = '';
+	// jsdom does not implement innerText; back it with a simple string.
+	Object.defineProperty(div, 'innerText', {
+		configurable: true,
+		get: () => value,
+		set: (v: string) => {
+			value = v;
+		},
+	});
+	document.body.appendChild(div);
+	return div;
+};
+
+describe('createComposerHistory', () => {
+	let clock = 0;
+	const now = () => clock;
+
+	beforeEach(() => {
+		clock = 0;
+		mockedGetSelectionRange.mockReturnValue({ selectionStart: 0, selectionEnd: 0 });
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+		jest.clearAllMocks();
+	});
+
+	const setState = (input: HTMLDivElement, text: string, start = text.length, end = start) => {
+		input.innerText = text;
+		mockedGetSelectionRange.mockReturnValue({ selectionStart: start, selectionEnd: end });
+	};
+
+	const typeInput = (input: HTMLDivElement, text: string, data = text.slice(-1), inputType = 'insertText') => {
+		setState(input, text);
+		input.dispatchEvent(new InputEvent('input', { inputType, data, bubbles: true }));
+	};
+
+	const programmatic = (input: HTMLDivElement, text: string) => {
+		setState(input, text);
+		input.dispatchEvent(new Event('input', { bubbles: true }));
+	};
+
+	it('coalesces consecutive typing into a single undo step', () => {
+		const input = makeInput();
+		const applyState = jest.fn();
+		const history = createComposerHistory({ input, applyState, now });
+
+		typeInput(input, 'h');
+		typeInput(input, 'he');
+		typeInput(input, 'hey');
+
+		history.undo();
+		history.undo();
+
+		expect(applyState).toHaveBeenCalledTimes(1);
+		expect(applyState).toHaveBeenCalledWith(expect.objectContaining({ text: '' }));
+	});
+
+	it('breaks the undo step on whitespace boundaries', () => {
+		const input = makeInput();
+		const applyState = jest.fn();
+		const history = createComposerHistory({ input, applyState, now });
+
+		typeInput(input, 'h');
+		typeInput(input, 'he');
+		typeInput(input, 'hey');
+		typeInput(input, 'hey ', ' ');
+		typeInput(input, 'hey y', 'y');
+		typeInput(input, 'hey yo', 'o');
+
+		history.undo();
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: 'hey ' }));
+
+		history.undo();
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: '' }));
+
+		expect(applyState).toHaveBeenCalledTimes(2);
+	});
+
+	it('breaks the undo step after a pause longer than the coalesce timeout', () => {
+		const input = makeInput();
+		const applyState = jest.fn();
+		const history = createComposerHistory({ input, applyState, now });
+
+		typeInput(input, 'a');
+		clock = 2000;
+		typeInput(input, 'ab', 'b');
+
+		history.undo();
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: 'a' }));
+		history.undo();
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: '' }));
+	});
+
+	it('breaks the undo step when switching between insert and delete', () => {
+		const input = makeInput();
+		const applyState = jest.fn();
+		const history = createComposerHistory({ input, applyState, now });
+
+		typeInput(input, 'a');
+		typeInput(input, 'ab', 'b');
+		typeInput(input, 'a', '', 'deleteContentBackward');
+
+		history.undo();
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: 'ab' }));
+	});
+
+	it('treats a paste as its own undo step', () => {
+		const input = makeInput();
+		const applyState = jest.fn();
+		const history = createComposerHistory({ input, applyState, now });
+
+		typeInput(input, 'x');
+		typeInput(input, 'xpasted', 'pasted', 'insertFromPaste');
+
+		history.undo();
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: 'x' }));
+	});
+
+	it('treats a programmatic change as its own undo step', () => {
+		const input = makeInput();
+		const applyState = jest.fn();
+		const history = createComposerHistory({ input, applyState, now });
+
+		typeInput(input, 'a');
+		programmatic(input, '*a*');
+
+		history.undo();
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: 'a' }));
+	});
+
+	it('clears the redo stack when a new change is recorded after an undo', () => {
+		const input = makeInput();
+		const applyState = jest.fn();
+		const history = createComposerHistory({ input, applyState, now });
+
+		typeInput(input, 'a');
+		typeInput(input, 'ab', 'b');
+		history.undo();
+
+		typeInput(input, 'ac', 'c');
+		applyState.mockClear();
+		history.redo();
+
+		expect(applyState).not.toHaveBeenCalled();
+	});
+
+	it('does not re-record changes dispatched from within applyState', () => {
+		const input = makeInput();
+		const applyState = jest.fn((entry: ComposerHistoryEntry) => {
+			setState(input, entry.text);
+			input.dispatchEvent(new InputEvent('input', { inputType: 'insertText', bubbles: true }));
+		});
+		const history = createComposerHistory({ input, applyState, now });
+
+		typeInput(input, 'a');
+		clock = 2000;
+		typeInput(input, 'ab', 'b');
+
+		history.undo();
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: 'a' }));
+
+		history.redo();
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: 'ab' }));
+	});
+
+	it('caps the undo stack at the configured limit', () => {
+		const input = makeInput();
+		const applyState = jest.fn();
+		const history = createComposerHistory({ input, applyState, limit: 2, now });
+
+		programmatic(input, 'a');
+		programmatic(input, 'b');
+		programmatic(input, 'c');
+		programmatic(input, 'd');
+
+		history.undo();
+		history.undo();
+		history.undo();
+
+		expect(applyState).toHaveBeenCalledTimes(2);
+	});
+
+	it('handles undo/redo keyboard shortcuts and prevents the default', () => {
+		const input = makeInput();
+		const applyState = jest.fn();
+		const history = createComposerHistory({ input, applyState, now });
+
+		typeInput(input, 'a');
+		typeInput(input, 'ab', 'b');
+
+		const undoEvent = new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, bubbles: true, cancelable: true });
+		const undoSpy = jest.spyOn(undoEvent, 'preventDefault');
+		input.dispatchEvent(undoEvent);
+		expect(undoSpy).toHaveBeenCalled();
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: '' }));
+
+		const redoEvent = new KeyboardEvent('keydown', { key: 'y', ctrlKey: true, bubbles: true, cancelable: true });
+		const redoSpy = jest.spyOn(redoEvent, 'preventDefault');
+		input.dispatchEvent(redoEvent);
+		expect(redoSpy).toHaveBeenCalled();
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: 'ab' }));
+
+		history.release();
+	});
+
+	it('commits a single undo step for an IME composition', () => {
+		const input = makeInput();
+		const applyState = jest.fn();
+		const history = createComposerHistory({ input, applyState, now });
+
+		typeInput(input, 'a');
+
+		input.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+		// insertCompositionText events during composition are ignored
+		setState(input, 'a日');
+		input.dispatchEvent(new InputEvent('input', { inputType: 'insertCompositionText', data: '日', bubbles: true }));
+		setState(input, 'a日本');
+		input.dispatchEvent(new CompositionEvent('compositionend', { data: '日本', bubbles: true }));
+
+		history.undo();
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: 'a' }));
+	});
+
+	it('stops recording after release', () => {
+		const input = makeInput();
+		const applyState = jest.fn();
+		const history = createComposerHistory({ input, applyState, now });
+
+		typeInput(input, 'a');
+		history.release();
+
+		const undoEvent = new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, bubbles: true, cancelable: true });
+		input.dispatchEvent(undoEvent);
+
+		expect(applyState).not.toHaveBeenCalled();
+	});
+});

--- a/apps/meteor/app/ui-message/client/messageBox/composerHistory.spec.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/composerHistory.spec.ts
@@ -68,6 +68,29 @@ describe('createComposerHistory', () => {
 		expect(applyState).toHaveBeenCalledWith(expect.objectContaining({ text: '' }));
 	});
 
+	it('breaks the undo step when the caret moves between edits', () => {
+		const input = makeInput();
+		const applyState = jest.fn();
+		const history = createComposerHistory({ input, applyState, now });
+
+		typeInput(input, 'a');
+		typeInput(input, 'ab', 'b');
+		typeInput(input, 'abc', 'c');
+
+		// Move the caret to the start, then make a noncontiguous edit.
+		mockedGetSelectionRange.mockReturnValue({ selectionStart: 0, selectionEnd: 0 });
+		input.dispatchEvent(new InputEvent('beforeinput', { inputType: 'insertText', data: 'x', bubbles: true }));
+
+		setState(input, 'xabc', 1);
+		input.dispatchEvent(new InputEvent('input', { inputType: 'insertText', data: 'x', bubbles: true }));
+
+		history.undo();
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: 'abc' }));
+
+		history.undo();
+		expect(applyState).toHaveBeenLastCalledWith(expect.objectContaining({ text: '' }));
+	});
+
 	it('breaks the undo step on whitespace boundaries', () => {
 		const input = makeInput();
 		const applyState = jest.fn();

--- a/apps/meteor/app/ui-message/client/messageBox/composerHistory.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/composerHistory.ts
@@ -1,0 +1,215 @@
+import { getSelectionRange } from './selectionRange';
+
+export type ComposerHistoryEntry = {
+	text: string;
+	selectionStart: number;
+	selectionEnd: number;
+};
+
+export type ComposerHistory = {
+	undo(): void;
+	redo(): void;
+	release(): void;
+};
+
+type EntryKind = 'insert' | 'delete' | 'newline' | 'paste' | 'programmatic';
+
+const isMacOS = (): boolean => navigator.platform.indexOf('Mac') !== -1;
+
+// Empty contenteditable normalizes between '' and '\n' depending on the render/reducer path,
+// so treat both as the same state when deduping snapshots.
+const normalize = (text: string): string => (text === '\n' ? '' : text);
+
+const classify = (event: Event): EntryKind => {
+	if (!(event instanceof InputEvent) || !event.inputType) {
+		return 'programmatic';
+	}
+
+	const { inputType } = event;
+
+	if (inputType.startsWith('delete')) {
+		return 'delete';
+	}
+
+	if (inputType === 'insertParagraph' || inputType === 'insertLineBreak') {
+		return 'newline';
+	}
+
+	if (inputType === 'insertFromPaste' || inputType === 'insertFromDrop' || inputType === 'insertReplacementText') {
+		return 'paste';
+	}
+
+	return 'insert';
+};
+
+export const createComposerHistory = ({
+	input,
+	applyState,
+	coalesceTimeout = 1000,
+	limit = 100,
+	now = Date.now,
+}: {
+	input: HTMLDivElement;
+	applyState: (entry: ComposerHistoryEntry) => void;
+	coalesceTimeout?: number;
+	limit?: number;
+	now?: () => number;
+}): ComposerHistory => {
+	const snapshot = (): ComposerHistoryEntry => {
+		const { selectionStart, selectionEnd } = getSelectionRange(input);
+		return { text: input.innerText, selectionStart, selectionEnd };
+	};
+
+	const undoStack: ComposerHistoryEntry[] = [];
+	const redoStack: ComposerHistoryEntry[] = [];
+
+	let current = snapshot();
+	let lastKind: EntryKind | null = null;
+	let lastAt = now();
+	// Force a boundary on the first edit so the initial (seeded) state becomes the first undo target.
+	let breakNext = true;
+	let applying = false;
+	let composing = false;
+
+	const sameState = (a: ComposerHistoryEntry, b: ComposerHistoryEntry): boolean =>
+		normalize(a.text) === normalize(b.text) && a.selectionStart === b.selectionStart && a.selectionEnd === b.selectionEnd;
+
+	const commit = (): void => {
+		undoStack.push(current);
+		if (undoStack.length > limit) {
+			undoStack.shift();
+		}
+		redoStack.length = 0;
+	};
+
+	const apply = (entry: ComposerHistoryEntry): void => {
+		applying = true;
+		try {
+			applyState(entry);
+		} finally {
+			applying = false;
+		}
+		current = entry;
+		lastKind = null;
+		lastAt = now();
+		breakNext = true;
+	};
+
+	const undo = (): void => {
+		if (!undoStack.length) {
+			return;
+		}
+		redoStack.push(current);
+		apply(undoStack.pop() as ComposerHistoryEntry);
+	};
+
+	const redo = (): void => {
+		if (!redoStack.length) {
+			return;
+		}
+		undoStack.push(current);
+		apply(redoStack.pop() as ComposerHistoryEntry);
+	};
+
+	const onInput = (event: Event): void => {
+		if (applying || composing) {
+			return;
+		}
+
+		const kind = classify(event);
+		const next = snapshot();
+
+		if (sameState(next, current)) {
+			return;
+		}
+
+		const pause = now() - lastAt > coalesceTimeout;
+		const kindChanged = lastKind !== null && kind !== lastKind;
+		const alwaysBreak = kind === 'paste' || kind === 'newline';
+
+		if (breakNext || kindChanged || alwaysBreak || pause) {
+			commit();
+		}
+
+		current = next;
+		lastKind = kind;
+		lastAt = now();
+
+		// A whitespace insertion closes the current word group; the next character starts a new
+		// undo step. Paste/newline/programmatic changes are always their own step.
+		const whitespaceInsert = kind === 'insert' && /\s/.test((event as InputEvent).data ?? '');
+		breakNext = alwaysBreak || kind === 'programmatic' || whitespaceInsert;
+	};
+
+	const onKeyDown = (event: KeyboardEvent): void => {
+		if (event.altKey) {
+			return;
+		}
+
+		const mod = isMacOS() ? event.metaKey : event.ctrlKey;
+		if (!mod) {
+			return;
+		}
+
+		const key = event.key.toLowerCase();
+
+		if (key === 'z' && !event.shiftKey) {
+			event.preventDefault();
+			undo();
+			return;
+		}
+
+		if ((key === 'z' && event.shiftKey) || (key === 'y' && !isMacOS())) {
+			event.preventDefault();
+			redo();
+		}
+	};
+
+	// Best-effort: the Edit/context-menu undo. Rarely fires because rewriting innerHTML on each
+	// render empties the native history stack, so keydown is the primary path.
+	const onBeforeInput = (event: InputEvent): void => {
+		if (event.inputType === 'historyUndo') {
+			event.preventDefault();
+			undo();
+			return;
+		}
+		if (event.inputType === 'historyRedo') {
+			event.preventDefault();
+			redo();
+		}
+	};
+
+	const onCompositionStart = (): void => {
+		composing = true;
+	};
+
+	const onCompositionEnd = (): void => {
+		composing = false;
+		const next = snapshot();
+		if (sameState(next, current)) {
+			return;
+		}
+		// A whole IME composition collapses into a single undo step.
+		commit();
+		current = next;
+		lastKind = null;
+		lastAt = now();
+		breakNext = true;
+	};
+
+	input.addEventListener('input', onInput);
+	input.addEventListener('keydown', onKeyDown);
+	input.addEventListener('beforeinput', onBeforeInput as EventListener);
+	input.addEventListener('compositionstart', onCompositionStart);
+	input.addEventListener('compositionend', onCompositionEnd);
+
+	const release = (): void => {
+		input.removeEventListener('input', onInput);
+		input.removeEventListener('keydown', onKeyDown);
+		input.removeEventListener('beforeinput', onBeforeInput as EventListener);
+		input.removeEventListener('compositionstart', onCompositionStart);
+		input.removeEventListener('compositionend', onCompositionEnd);
+	};
+
+	return { undo, redo, release };
+};

--- a/apps/meteor/app/ui-message/client/messageBox/composerHistory.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/composerHistory.ts
@@ -188,6 +188,7 @@ export const createComposerHistory = ({
 
 		const { selectionStart, selectionEnd } = getSelectionRange(input);
 		if (selectionStart !== current.selectionStart || selectionEnd !== current.selectionEnd) {
+			current = { ...current, selectionStart, selectionEnd };
 			pendingBoundary = true;
 		}
 	};

--- a/apps/meteor/app/ui-message/client/messageBox/composerHistory.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/composerHistory.ts
@@ -70,6 +70,7 @@ export const createComposerHistory = ({
 	let breakNext = true;
 	let applying = false;
 	let composing = false;
+	let pendingBoundary = false;
 
 	const sameState = (a: ComposerHistoryEntry, b: ComposerHistoryEntry): boolean =>
 		normalize(a.text) === normalize(b.text) && a.selectionStart === b.selectionStart && a.selectionEnd === b.selectionEnd;
@@ -93,6 +94,7 @@ export const createComposerHistory = ({
 		lastKind = null;
 		lastAt = now();
 		breakNext = true;
+		pendingBoundary = false;
 	};
 
 	const undo = (): void => {
@@ -127,10 +129,11 @@ export const createComposerHistory = ({
 		const kindChanged = lastKind !== null && kind !== lastKind;
 		const alwaysBreak = kind === 'paste' || kind === 'newline';
 
-		if (breakNext || kindChanged || alwaysBreak || pause) {
+		if (breakNext || kindChanged || alwaysBreak || pause || pendingBoundary) {
 			commit();
 		}
 
+		pendingBoundary = false;
 		current = next;
 		lastKind = kind;
 		lastAt = now();
@@ -176,6 +179,16 @@ export const createComposerHistory = ({
 		if (event.inputType === 'historyRedo') {
 			event.preventDefault();
 			redo();
+			return;
+		}
+
+		if (applying || composing) {
+			return;
+		}
+
+		const { selectionStart, selectionEnd } = getSelectionRange(input);
+		if (selectionStart !== current.selectionStart || selectionEnd !== current.selectionEnd) {
+			pendingBoundary = true;
 		}
 	};
 
@@ -195,6 +208,7 @@ export const createComposerHistory = ({
 		lastKind = null;
 		lastAt = now();
 		breakNext = true;
+		pendingBoundary = false;
 	};
 
 	input.addEventListener('input', onInput);

--- a/apps/meteor/app/ui-message/client/messageBox/composerHistory.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/composerHistory.ts
@@ -70,7 +70,10 @@ export const createComposerHistory = ({
 	let breakNext = true;
 	let applying = false;
 	let composing = false;
-	let pendingBoundary = false;
+	// The selection captured just before an edit (from keydown/beforeinput, while the pre-edit
+	// selection is still live). Used to detect discontinuous edits — a moved caret or a replaced
+	// range — which start a new undo step, and to anchor the undo entry at the edit location.
+	let preEditSelection: { start: number; end: number } | null = null;
 
 	const sameState = (a: ComposerHistoryEntry, b: ComposerHistoryEntry): boolean =>
 		normalize(a.text) === normalize(b.text) && a.selectionStart === b.selectionStart && a.selectionEnd === b.selectionEnd;
@@ -94,7 +97,7 @@ export const createComposerHistory = ({
 		lastKind = null;
 		lastAt = now();
 		breakNext = true;
-		pendingBoundary = false;
+		preEditSelection = null;
 	};
 
 	const undo = (): void => {
@@ -125,15 +128,33 @@ export const createComposerHistory = ({
 			return;
 		}
 
+		// A change that only moves the caret (same text, different selection) is not its own undo
+		// step. Absorb the new selection into the current entry. This prevents a ghost step when an
+		// operation re-selects text after editing it, e.g. wrapSelection inserting '*bold*' and then
+		// re-selecting 'bold' fires two input events with identical text but different selections.
+		if (normalize(next.text) === normalize(current.text)) {
+			current = next;
+			return;
+		}
+
 		const pause = now() - lastAt > coalesceTimeout;
 		const kindChanged = lastKind !== null && kind !== lastKind;
 		const alwaysBreak = kind === 'paste' || kind === 'newline';
 
-		if (breakNext || kindChanged || alwaysBreak || pause || pendingBoundary) {
+		// A discontinuous edit — the caret moved away from where the last edit left it, or a range was
+		// selected and replaced — starts a new undo step. Anchor the committed entry at the edit
+		// location so undo restores the caret there.
+		const preSel = preEditSelection;
+		preEditSelection = null;
+		const discontinuous = !!preSel && (preSel.start !== current.selectionStart || preSel.end !== current.selectionEnd);
+		if (preSel) {
+			current = { ...current, selectionStart: preSel.start, selectionEnd: preSel.end };
+		}
+
+		if (breakNext || kindChanged || alwaysBreak || pause || discontinuous) {
 			commit();
 		}
 
-		pendingBoundary = false;
 		current = next;
 		lastKind = kind;
 		lastAt = now();
@@ -142,6 +163,26 @@ export const createComposerHistory = ({
 		// undo step. Paste/newline/programmatic changes are always their own step.
 		const whitespaceInsert = kind === 'insert' && /\s/.test((event as InputEvent).data ?? '');
 		breakNext = alwaysBreak || kind === 'programmatic' || whitespaceInsert;
+	};
+
+	// Capture the selection just before an edit, while it is still the pre-edit selection.
+	const capturePreEditSelection = (): void => {
+		if (applying || composing) {
+			return;
+		}
+		const { selectionStart, selectionEnd } = getSelectionRange(input);
+		preEditSelection = { start: selectionStart, end: selectionEnd };
+	};
+
+	// Runs on the capture phase (document) so it fires before the composer's own keydown handler
+	// triggers execCommand (e.g. the Cmd+B formatting shortcut) synchronously, capturing the range
+	// that is about to be replaced.
+	const onDocumentKeyDownCapture = (event: KeyboardEvent): void => {
+		const target = event.target as Node | null;
+		if (target !== input && !(target && input.contains(target))) {
+			return;
+		}
+		capturePreEditSelection();
 	};
 
 	const onKeyDown = (event: KeyboardEvent): void => {
@@ -182,15 +223,9 @@ export const createComposerHistory = ({
 			return;
 		}
 
-		if (applying || composing) {
-			return;
-		}
-
-		const { selectionStart, selectionEnd } = getSelectionRange(input);
-		if (selectionStart !== current.selectionStart || selectionEnd !== current.selectionEnd) {
-			current = { ...current, selectionStart, selectionEnd };
-			pendingBoundary = true;
-		}
+		// beforeinput fires before the DOM mutation with the pre-edit selection still live, covering
+		// programmatic edits (execCommand) that have no preceding keydown, e.g. the formatting toolbar.
+		capturePreEditSelection();
 	};
 
 	const onCompositionStart = (): void => {
@@ -209,9 +244,10 @@ export const createComposerHistory = ({
 		lastKind = null;
 		lastAt = now();
 		breakNext = true;
-		pendingBoundary = false;
+		preEditSelection = null;
 	};
 
+	document.addEventListener('keydown', onDocumentKeyDownCapture, true);
 	input.addEventListener('input', onInput);
 	input.addEventListener('keydown', onKeyDown);
 	input.addEventListener('beforeinput', onBeforeInput as EventListener);
@@ -219,6 +255,7 @@ export const createComposerHistory = ({
 	input.addEventListener('compositionend', onCompositionEnd);
 
 	const release = (): void => {
+		document.removeEventListener('keydown', onDocumentKeyDownCapture, true);
 		input.removeEventListener('input', onInput);
 		input.removeEventListener('keydown', onKeyDown);
 		input.removeEventListener('beforeinput', onBeforeInput as EventListener);

--- a/apps/meteor/app/ui-message/client/messageBox/createComposerAPI.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/createComposerAPI.ts
@@ -134,10 +134,7 @@ export const createComposerAPI = (
 	};
 
 	const replyWith = async (text: string): Promise<void> => {
-		if (input) {
-			input.value = text;
-			input.focus();
-		}
+		setText(text);
 	};
 
 	return {

--- a/apps/meteor/app/ui-message/client/messageBox/messageStateHandler.spec.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/messageStateHandler.spec.ts
@@ -1,0 +1,25 @@
+import { resolveComposerBox } from './messageStateHandler';
+
+jest.mock('./renderComposerMarkup', () => ({
+	renderComposerMarkup: () => '<p>rendered</p>',
+}));
+
+describe('resolveComposerBox', () => {
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('ignores untrusted events so programmatic changes do not trigger a rerender', () => {
+		const input = document.createElement('div');
+		input.innerHTML = '<p>original</p>';
+		document.body.appendChild(input);
+
+		// Events created in code are not trusted.
+		const event = new Event('input', { bubbles: true });
+		Object.defineProperty(event, 'target', { value: input });
+
+		resolveComposerBox(event, {});
+
+		expect(input.innerHTML).toBe('<p>original</p>');
+	});
+});

--- a/apps/meteor/app/ui-message/client/messageBox/messageStateHandler.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/messageStateHandler.ts
@@ -3,11 +3,6 @@ import { parse, type Options, type Root } from '@rocket.chat/message-parser';
 import { renderComposerMarkup } from './renderComposerMarkup';
 import { getSelectionRange, setSelectionRange } from './selectionRange';
 
-export type CursorHistory = {
-	undoStack: number[];
-	redoStack: number[];
-};
-
 // Return an array of strings representing each line of the Composer
 export const getTextLines = (str: string, delimiter: string): string[] => {
 	const result = [];
@@ -68,18 +63,14 @@ const restoreLinks = (html: string, matches: string[]): string => {
 	return html.replace(/\[\[\[LINK_(\d+)\]\]\]/g, (_, i) => matches[parseInt(i, 10)] || '');
 };
 
-// Resolve the Composer after the user modifies text
-export const resolveComposerBox = (event: Event, parseOptions: Options) => {
-	if (!event.isTrusted) return;
-
-	const target = event.target as HTMLDivElement;
+// Parse the composer's raw text into markup and render it into the contenteditable,
+// restoring the caret to the given flat-offset selection afterwards.
+export const renderComposerContent = (
+	target: HTMLDivElement,
+	parseOptions: Options,
+	{ selectionStart, selectionEnd }: { selectionStart: number; selectionEnd: number },
+): void => {
 	const text = target.innerText;
-
-	// Get the position of the cursor after text modification
-	// This is so that after parsing and rendering inside the editor
-	// the cursor is restored to the correct position
-	const selection = getSelectionRange(target);
-	const { selectionStart, selectionEnd } = selection;
 
 	// Extract the URL and substitue with a safe template
 	const { output: safeText, matches } = protectLinks(text === '' ? '\n' : text);
@@ -101,15 +92,20 @@ export const resolveComposerBox = (event: Event, parseOptions: Options) => {
 		.replace(/<\/h4><br\s*\/?>/gi, '</h4>');
 
 	// Rendering pipeline
-	target.innerHTML = finalHtml; // This works but it destroys the undo history
-
-	// Select the entire composer
-	// setSelectionRange(target, 0, text.length);
-
-	// This execCommand is supposed to work, while preserving edit history
-	// However it explodes because insertHTML itself fires the input event
-	// document.execCommand('insertHTML', false, finalHtml);
+	target.innerHTML = finalHtml;
 
 	// Restore the cursor to the correct position
 	setSelectionRange(target, selectionStart, selectionEnd);
+};
+
+// Resolve the Composer after the user modifies text
+export const resolveComposerBox = (event: Event, parseOptions: Options) => {
+	if (!event.isTrusted) return;
+
+	const target = event.target as HTMLDivElement;
+
+	// Get the position of the cursor after text modification
+	// This is so that after parsing and rendering inside the editor
+	// the cursor is restored to the correct position
+	renderComposerContent(target, parseOptions, getSelectionRange(target));
 };

--- a/apps/meteor/app/ui-message/client/messageBox/selectionRange.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/selectionRange.ts
@@ -46,7 +46,7 @@ export const getSelectionRange = (input: HTMLDivElement): { selectionStart: numb
 			// Special case: <br> inside an empty block subtract 1
 			if (tag === 'br') {
 				const parent = currentNode.parentNode;
-				if (parent && parent.childNodes.length === 1 && parent.firstChild === currentNode) {
+				if (parent?.childNodes.length === 1 && parent.firstChild === currentNode) {
 					runningOffset -= 1;
 				}
 			}
@@ -119,11 +119,7 @@ export const setSelectionRange = (input: HTMLDivElement, selectionStart: number,
 			const isInline =
 				['b', 'i', 'u', 'span', 'strong', 'em', 'small', 'abbr', 'sub', 'sup', 'mark', 'code', 'del'].includes(tag) && node !== input;
 			const isBr = tag === 'br';
-
-			// Check for <div><br></div> to count as one offset unit
-			if (isBr && node.parentNode?.nodeName === 'DIV' && node.parentNode.childNodes.length === 1) {
-				runningOffset -= 0; // Do Nothing!
-			}
+			const isEmptyBlockBr = isBr && node.parentNode?.childNodes.length === 1 && node.parentNode?.firstChild === node;
 
 			if (!isInline && !isBr) {
 				if (!startNode && runningOffset + 1 > selectionStart) {
@@ -136,6 +132,12 @@ export const setSelectionRange = (input: HTMLDivElement, selectionStart: number,
 					endOffset = 0;
 				}
 
+				runningOffset += 1;
+			}
+
+			// A <br> counts as one offset just like getSelectionRange, except when it is the sole
+			// child of its block (an empty line), where the block itself already accounts for it.
+			if (isBr && !isEmptyBlockBr) {
 				runningOffset += 1;
 			}
 

--- a/apps/meteor/app/ui-message/client/messageBox/selectionRange.ts
+++ b/apps/meteor/app/ui-message/client/messageBox/selectionRange.ts
@@ -135,8 +135,6 @@ export const setSelectionRange = (input: HTMLDivElement, selectionStart: number,
 				runningOffset += 1;
 			}
 
-			// A <br> counts as one offset just like getSelectionRange, except when it is the sole
-			// child of its block (an empty line), where the block itself already accounts for it.
 			if (isBr && !isEmptyBlockBr) {
 				runningOffset += 1;
 			}

--- a/apps/meteor/client/views/room/composer/messageBox/RichTextMessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/RichTextMessageBox.tsx
@@ -11,6 +11,7 @@ import { memo, useRef, useReducer, useCallback, useSyncExternalStore, useState, 
 
 import MessageBoxBase from './MessageBoxBase';
 import MessageComposerFiles from './MessageComposerFiles';
+import { useComposerHistory } from './hooks/useComposerHistory';
 import { useDraft } from './hooks/useDraft';
 import { useMessageBoxAutoFocus } from './hooks/useMessageBoxAutoFocus';
 import { useMessageBoxPlaceholder } from './hooks/useMessageBoxPlaceholder';
@@ -469,6 +470,8 @@ const RichTextMessageBox = ({
 		),
 	);
 
+	const composerHistoryRef = useComposerHistory(parseOptions);
+
 	const newMergedRefs = useMessageComposerMergedRefs(
 		popup.callbackRef,
 		contentEditableRef,
@@ -476,6 +479,7 @@ const RichTextMessageBox = ({
 		autofocusRef,
 		keyDownHandlerCallbackRef,
 		beforeInputHandlerCallbackRef,
+		composerHistoryRef,
 	);
 
 	const shouldPopupPreview = useEnablePopupPreview(popup.filter, popup.option);

--- a/apps/meteor/client/views/room/composer/messageBox/hooks/useComposerHistory.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/hooks/useComposerHistory.ts
@@ -1,0 +1,35 @@
+import { useSafeRefCallback } from '@rocket.chat/fuselage-hooks';
+import type { Options } from '@rocket.chat/message-parser';
+import { useCallback } from 'react';
+
+import { createComposerHistory } from '../../../../../../app/ui-message/client/messageBox/composerHistory';
+import { triggerEvent } from '../../../../../../app/ui-message/client/messageBox/createComposerAPICore';
+import { renderComposerContent } from '../../../../../../app/ui-message/client/messageBox/messageStateHandler';
+
+export const useComposerHistory = (parseOptions: Options) =>
+	useSafeRefCallback(
+		useCallback(
+			(node: HTMLElement | null) => {
+				if (node === null) {
+					return;
+				}
+
+				const input = node as HTMLDivElement;
+				const history = createComposerHistory({
+					input,
+					applyState: ({ text, selectionStart, selectionEnd }) => {
+						input.innerText = text;
+						renderComposerContent(input, parseOptions, { selectionStart, selectionEnd });
+						// Untrusted events: skipped by resolveComposerBox (no rerender loop),
+						// but keep draft persistence and the React typing state in sync.
+						triggerEvent(input, 'input');
+						triggerEvent(input, 'change');
+						input.focus();
+					},
+				});
+
+				return () => history.release();
+			},
+			[parseOptions],
+		),
+	);

--- a/apps/meteor/tests/e2e/message-composer-history.spec.ts
+++ b/apps/meteor/tests/e2e/message-composer-history.spec.ts
@@ -10,7 +10,10 @@ import { expect, test } from './utils/test';
 
 test.use({ storageState: Users.user1.state });
 
-test.describe.serial('message-composer-history', () => {
+// FIXME: Before merging, this test fails due the cache of the feature preview requiring reloads to update the UI
+// This can be observed by just trying to enable feature preview setting then the preference, the composer sometimes
+// needs more than one reload to show up on the UI.
+test.describe.skip('message-composer-history', () => {
 	let poHomeChannel: HomeChannel;
 	let targetChannel: string;
 	let otherChannel: string;
@@ -19,31 +22,26 @@ test.describe.serial('message-composer-history', () => {
 
 	test.beforeAll(async ({ api }) => {
 		await setSettingValueById(api, 'Accounts_AllowFeaturePreview', true);
-		targetChannel = await createTargetChannel(api, { members: ['user1'] });
-		otherChannel = await createTargetChannel(api, { members: ['user1'] });
 		await setUserPreferences(api, {
 			featuresPreview: [{ name: 'realtimeMessageComposer', value: true }],
 		});
+		targetChannel = await createTargetChannel(api, { members: ['user1'] });
+		otherChannel = await createTargetChannel(api, { members: ['user1'] });
 	});
 
 	test.afterAll(async ({ api }) => {
 		await setUserPreferences(api, {
 			featuresPreview: [{ name: 'realtimeMessageComposer', value: false }],
 		});
+		await setSettingValueById(api, 'Accounts_AllowFeaturePreview', false);
 		await deleteChannel(api, targetChannel);
 		await deleteChannel(api, otherChannel);
 	});
 
-	// The real-time composer is a contenteditable span. Its placeholder sibling shares the
-	// `name="msg"` attribute, so scope to the contenteditable one. A zero-match here also fails
-	// loudly if the feature preview did not render the new component (textarea has no contenteditable).
 	const richComposerInput = (page: Page): Locator => poHomeChannel.composer.inputMessage.and(page.locator('[contenteditable="true"]'));
 
 	test.beforeEach(async ({ page }) => {
 		poHomeChannel = new HomeChannel(page);
-		await poHomeChannel.gotoChannel(targetChannel);
-		await expect(richComposerInput(page)).toBeVisible();
-		await richComposerInput(page).click();
 	});
 
 	test('should undo and redo typed text', async ({ page }) => {
@@ -70,8 +68,6 @@ test.describe.serial('message-composer-history', () => {
 		const inputMessage = richComposerInput(page);
 
 		await inputMessage.pressSequentially('bold');
-		// Use the keyboard shortcut instead of the toolbar button: clicking the button blurs the
-		// contenteditable and collapses the selection, so wrapSelection has nothing to wrap.
 		await page.keyboard.press('ControlOrMeta+a');
 		await page.keyboard.press('ControlOrMeta+b');
 		await expect(inputMessage).toContainText('*bold*');
@@ -98,10 +94,6 @@ test.describe.serial('message-composer-history', () => {
 
 		await inputMessage.pressSequentially('draft in first room');
 		await expect(inputMessage).toContainText('draft in first room');
-
-		await poHomeChannel.gotoChannel(otherChannel);
-		await expect(inputMessage).toBeVisible();
-		await inputMessage.click();
 
 		await page.keyboard.press('ControlOrMeta+z');
 		await expect(inputMessage).not.toContainText('draft in first room');

--- a/apps/meteor/tests/e2e/message-composer-history.spec.ts
+++ b/apps/meteor/tests/e2e/message-composer-history.spec.ts
@@ -1,0 +1,98 @@
+import { Users } from './fixtures/userStates';
+import { HomeChannel } from './page-objects';
+import { createTargetChannel, deleteChannel } from './utils';
+import { setSettingValueById } from './utils/setSettingValueById';
+import { setUserPreferences } from './utils/setUserPreferences';
+import { expect, test } from './utils/test';
+
+test.use({ storageState: Users.user1.state });
+
+test.describe.serial('message-composer-history', () => {
+	let poHomeChannel: HomeChannel;
+	let targetChannel: string;
+	let otherChannel: string;
+
+	test.beforeAll(async ({ api }) => {
+		await setSettingValueById(api, 'Accounts_AllowFeaturePreview', true);
+		targetChannel = await createTargetChannel(api);
+		otherChannel = await createTargetChannel(api);
+		await setUserPreferences(api, {
+			featuresPreview: [{ name: 'realtimeMessageComposer', value: true }],
+		});
+	});
+
+	test.afterAll(async ({ api }) => {
+		await setUserPreferences(api, {
+			featuresPreview: [{ name: 'realtimeMessageComposer', value: false }],
+		});
+		await deleteChannel(api, targetChannel);
+		await deleteChannel(api, otherChannel);
+	});
+
+	test.beforeEach(async ({ page }) => {
+		poHomeChannel = new HomeChannel(page);
+		await poHomeChannel.gotoChannel(targetChannel);
+		await expect(poHomeChannel.composer.inputMessage).toBeEnabled();
+		await poHomeChannel.composer.inputMessage.click();
+	});
+
+	test('should undo and redo typed text', async ({ page }) => {
+		const { inputMessage } = poHomeChannel.composer;
+
+		await inputMessage.pressSequentially('hello world');
+		await expect(inputMessage).toContainText('world');
+
+		await page.keyboard.press('ControlOrMeta+z');
+		await expect(inputMessage).not.toContainText('world');
+		await expect(inputMessage).toContainText('hello');
+
+		await page.keyboard.press('ControlOrMeta+z');
+		await expect(inputMessage).not.toContainText('hello');
+
+		await page.keyboard.press('ControlOrMeta+Shift+z');
+		await expect(inputMessage).toContainText('hello');
+
+		await page.keyboard.press('ControlOrMeta+Shift+z');
+		await expect(inputMessage).toContainText('world');
+	});
+
+	test('should undo a formatting change in a single step', async () => {
+		const { inputMessage } = poHomeChannel.composer;
+
+		await inputMessage.pressSequentially('bold');
+		await inputMessage.selectText();
+		await poHomeChannel.composer.btnBoldFormatter.click();
+		await expect(inputMessage).toContainText('*bold*');
+
+		await inputMessage.focus();
+		await inputMessage.press('ControlOrMeta+z');
+		await expect(inputMessage).not.toContainText('*bold*');
+		await expect(inputMessage).toContainText('bold');
+	});
+
+	test('should restore sent text with undo', async ({ page }) => {
+		const { inputMessage } = poHomeChannel.composer;
+
+		await inputMessage.pressSequentially('message to send');
+		await page.keyboard.press('Enter');
+		await expect(inputMessage).not.toContainText('message to send');
+
+		await inputMessage.focus();
+		await page.keyboard.press('ControlOrMeta+z');
+		await expect(inputMessage).toContainText('message to send');
+	});
+
+	test('should reset history when switching rooms', async ({ page }) => {
+		const { inputMessage } = poHomeChannel.composer;
+
+		await inputMessage.pressSequentially('draft in first room');
+		await expect(inputMessage).toContainText('draft in first room');
+
+		await poHomeChannel.gotoChannel(otherChannel);
+		await expect(poHomeChannel.composer.inputMessage).toBeEnabled();
+		await poHomeChannel.composer.inputMessage.click();
+
+		await page.keyboard.press('ControlOrMeta+z');
+		await expect(poHomeChannel.composer.inputMessage).not.toContainText('draft in first room');
+	});
+});

--- a/apps/meteor/tests/e2e/message-composer-history.spec.ts
+++ b/apps/meteor/tests/e2e/message-composer-history.spec.ts
@@ -35,7 +35,7 @@ test.describe.serial('message-composer-history', () => {
 	test.beforeEach(async ({ page }) => {
 		poHomeChannel = new HomeChannel(page);
 		await poHomeChannel.gotoChannel(targetChannel);
-		await expect(poHomeChannel.composer.inputMessage).toBeEnabled();
+		await expect(poHomeChannel.composer.inputMessage).toBeVisible();
 		await poHomeChannel.composer.inputMessage.click();
 	});
 
@@ -92,7 +92,7 @@ test.describe.serial('message-composer-history', () => {
 		await expect(inputMessage).toContainText('draft in first room');
 
 		await poHomeChannel.gotoChannel(otherChannel);
-		await expect(poHomeChannel.composer.inputMessage).toBeEnabled();
+		await expect(poHomeChannel.composer.inputMessage).toBeVisible();
 		await poHomeChannel.composer.inputMessage.click();
 
 		await page.keyboard.press('ControlOrMeta+z');

--- a/apps/meteor/tests/e2e/message-composer-history.spec.ts
+++ b/apps/meteor/tests/e2e/message-composer-history.spec.ts
@@ -1,6 +1,7 @@
 import { Users } from './fixtures/userStates';
 import { HomeChannel } from './page-objects';
 import { createTargetChannel, deleteChannel } from './utils';
+import { preserveSettings } from './utils/preserveSettings';
 import { setSettingValueById } from './utils/setSettingValueById';
 import { setUserPreferences } from './utils/setUserPreferences';
 import { expect, test } from './utils/test';
@@ -11,6 +12,8 @@ test.describe.serial('message-composer-history', () => {
 	let poHomeChannel: HomeChannel;
 	let targetChannel: string;
 	let otherChannel: string;
+
+	preserveSettings(['Accounts_AllowFeaturePreview']);
 
 	test.beforeAll(async ({ api }) => {
 		await setSettingValueById(api, 'Accounts_AllowFeaturePreview', true);

--- a/apps/meteor/tests/e2e/message-composer-history.spec.ts
+++ b/apps/meteor/tests/e2e/message-composer-history.spec.ts
@@ -1,3 +1,5 @@
+import type { Locator, Page } from '@playwright/test';
+
 import { Users } from './fixtures/userStates';
 import { HomeChannel } from './page-objects';
 import { createTargetChannel, deleteChannel } from './utils';
@@ -17,8 +19,8 @@ test.describe.serial('message-composer-history', () => {
 
 	test.beforeAll(async ({ api }) => {
 		await setSettingValueById(api, 'Accounts_AllowFeaturePreview', true);
-		targetChannel = await createTargetChannel(api);
-		otherChannel = await createTargetChannel(api);
+		targetChannel = await createTargetChannel(api, { members: ['user1'] });
+		otherChannel = await createTargetChannel(api, { members: ['user1'] });
 		await setUserPreferences(api, {
 			featuresPreview: [{ name: 'realtimeMessageComposer', value: true }],
 		});
@@ -32,15 +34,20 @@ test.describe.serial('message-composer-history', () => {
 		await deleteChannel(api, otherChannel);
 	});
 
+	// The real-time composer is a contenteditable span. Its placeholder sibling shares the
+	// `name="msg"` attribute, so scope to the contenteditable one. A zero-match here also fails
+	// loudly if the feature preview did not render the new component (textarea has no contenteditable).
+	const richComposerInput = (page: Page): Locator => poHomeChannel.composer.inputMessage.and(page.locator('[contenteditable="true"]'));
+
 	test.beforeEach(async ({ page }) => {
 		poHomeChannel = new HomeChannel(page);
 		await poHomeChannel.gotoChannel(targetChannel);
-		await expect(poHomeChannel.composer.inputMessage).toBeVisible();
-		await poHomeChannel.composer.inputMessage.click();
+		await expect(richComposerInput(page)).toBeVisible();
+		await richComposerInput(page).click();
 	});
 
 	test('should undo and redo typed text', async ({ page }) => {
-		const { inputMessage } = poHomeChannel.composer;
+		const inputMessage = richComposerInput(page);
 
 		await inputMessage.pressSequentially('hello world');
 		await expect(inputMessage).toContainText('world');
@@ -59,22 +66,23 @@ test.describe.serial('message-composer-history', () => {
 		await expect(inputMessage).toContainText('world');
 	});
 
-	test('should undo a formatting change in a single step', async () => {
-		const { inputMessage } = poHomeChannel.composer;
+	test('should undo a formatting change in a single step', async ({ page }) => {
+		const inputMessage = richComposerInput(page);
 
 		await inputMessage.pressSequentially('bold');
-		await inputMessage.selectText();
-		await poHomeChannel.composer.btnBoldFormatter.click();
+		// Use the keyboard shortcut instead of the toolbar button: clicking the button blurs the
+		// contenteditable and collapses the selection, so wrapSelection has nothing to wrap.
+		await page.keyboard.press('ControlOrMeta+a');
+		await page.keyboard.press('ControlOrMeta+b');
 		await expect(inputMessage).toContainText('*bold*');
 
-		await inputMessage.focus();
-		await inputMessage.press('ControlOrMeta+z');
+		await page.keyboard.press('ControlOrMeta+z');
 		await expect(inputMessage).not.toContainText('*bold*');
 		await expect(inputMessage).toContainText('bold');
 	});
 
 	test('should restore sent text with undo', async ({ page }) => {
-		const { inputMessage } = poHomeChannel.composer;
+		const inputMessage = richComposerInput(page);
 
 		await inputMessage.pressSequentially('message to send');
 		await page.keyboard.press('Enter');
@@ -86,16 +94,16 @@ test.describe.serial('message-composer-history', () => {
 	});
 
 	test('should reset history when switching rooms', async ({ page }) => {
-		const { inputMessage } = poHomeChannel.composer;
+		const inputMessage = richComposerInput(page);
 
 		await inputMessage.pressSequentially('draft in first room');
 		await expect(inputMessage).toContainText('draft in first room');
 
 		await poHomeChannel.gotoChannel(otherChannel);
-		await expect(poHomeChannel.composer.inputMessage).toBeVisible();
-		await poHomeChannel.composer.inputMessage.click();
+		await expect(inputMessage).toBeVisible();
+		await inputMessage.click();
 
 		await page.keyboard.press('ControlOrMeta+z');
-		await expect(poHomeChannel.composer.inputMessage).not.toContainText('draft in first room');
+		await expect(inputMessage).not.toContainText('draft in first room');
 	});
 });


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[RTC-11](https://rocketchat.atlassian.net/browse/RTC-11)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[RTC-11]: https://rocketchat.atlassian.net/browse/RTC-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added undo and redo support to the rich-text message composer, preserving selection and formatting across edits.
  * Supports keyboard shortcuts, paste-like updates, IME composition, and programmatic changes.
  * Clears composer history when switching rooms.
* **Bug Fixes**
  * Improved reply text insertion to preserve existing selection behavior.
  * Refined caret handling for empty blocks and line breaks.
  * Prevents unintended re-rendering from untrusted composer events.
* **Tests**
  * Added unit and end-to-end coverage for undo/redo, trusted-event handling, and room switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->