### PR TITLE
refactor(authorization): forward only { _id, roles } from hasPermission wrappers

### DIFF
--- a/apps/meteor/server/lib/authorization/hasPermission.ts
+++ b/apps/meteor/server/lib/authorization/hasPermission.ts
@@ -2,18 +2,23 @@ import { Authorization } from '@rocket.chat/core-services';
 import type { UserWithRoles } from '@rocket.chat/core-services';
 import type { IUser, IPermission, IRoom } from '@rocket.chat/core-typings';
 
+// Forward only the fields the permission check needs, so a full user document
+// (with services, e2e keys, etc.) isn't serialized to the authorization service.
+const toSubject = (user: IUser['_id'] | UserWithRoles): IUser['_id'] | UserWithRoles =>
+	typeof user === 'string' ? user : { _id: user._id, roles: user.roles };
+
 export const hasAllPermissionAsync = async (
 	user: IUser['_id'] | UserWithRoles,
 	permissions: IPermission['_id'][],
 	scope?: IRoom['_id'],
-): Promise<boolean> => Authorization.hasAllPermission(user, permissions, scope);
+): Promise<boolean> => Authorization.hasAllPermission(toSubject(user), permissions, scope);
 export const hasPermissionAsync = async (
 	user: IUser['_id'] | UserWithRoles,
 	permissionId: IPermission['_id'],
 	scope?: IRoom['_id'],
-): Promise<boolean> => Authorization.hasPermission(user, permissionId, scope);
+): Promise<boolean> => Authorization.hasPermission(toSubject(user), permissionId, scope);
 export const hasAtLeastOnePermissionAsync = async (
 	user: IUser['_id'] | UserWithRoles,
 	permissions: IPermission['_id'][],
 	scope?: IRoom['_id'],
-): Promise<boolean> => Authorization.hasAtLeastOnePermission(user, permissions, scope);
+): Promise<boolean> => Authorization.hasAtLeastOnePermission(toSubject(user), permissions, scope);


### PR DESCRIPTION
## Why

Follow-up to the permission-check migration (#41346, #41367) — the systemic part of the P2 review finding. The `hasPermissionAsync` family accepts a full user object so callers can skip an internal `Users.findOneById`, but only `_id` and `roles` are ever consumed by the check. Passing the whole `IUser` means credential-bearing fields (`services`, `e2e.private_key`, custom fields, settings…) are serialized to the authorization service whenever it runs out of process (e.g. `ee/apps/authorization-service`).

## Change

`server/lib/authorization/hasPermission.ts`: normalize object inputs to a minimal `{ _id, roles }` subject before calling `Authorization.*`. String ids pass through unchanged. Behavior-preserving — the check already reads only `_id`/`roles`.

```ts
const toSubject = (user) => (typeof user === 'string' ? user : { _id: user._id, roles: user.roles });
```

## Effect

- No credential fields cross the service boundary; only id + roles.
- Bounds the serialized payload on every wrapper-based permission check.
- Complements the merged cache-key fix (#41371), which bounded the roles-cache key.

Direct `Authorization.hasPermission` callers outside these wrappers (already minimal: FederationMatrix passes `{ _id, roles }`; room/service and canAccessRoom pass an id) are unaffected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2260]

[ARCH-2260]: https://rocketchat.atlassian.net/browse/ARCH-2260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission checks by using only the account identity and applicable roles when evaluating access.
  * Reduced unnecessary account data passed during authorization, resulting in more consistent and focused access decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->