### PR TITLE
fix: Restore Away to quick status menu

### DIFF
--- a/.changeset/ready-taxis-join.md
+++ b/.changeset/ready-taxis-join.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Restores Away as a selectable preset in the quick status menu, custom status modal, and account profile page.

--- a/apps/meteor/client/components/UserStatusMenu.tsx
+++ b/apps/meteor/client/components/UserStatusMenu.tsx
@@ -37,21 +37,16 @@ const UserStatusMenu = ({
 
 		const statuses: Array<[value: UserStatusType, label: ReactNode]> = [
 			[UserStatusType.ONLINE, renderOption(UserStatusType.ONLINE, t('Online'))],
+			[UserStatusType.AWAY, renderOption(UserStatusType.AWAY, t('Away'))],
 			[UserStatusType.BUSY, renderOption(UserStatusType.BUSY, t('Busy'))],
 		];
-
-		// Away is no longer manually selectable, but surface it if the user is currently on it
-		// (e.g., set in a previous version or auto-applied by the server) so they can switch off.
-		if (status === UserStatusType.AWAY) {
-			statuses.push([UserStatusType.AWAY, renderOption(UserStatusType.AWAY, t('Away'))]);
-		}
 
 		if (allowInvisibleStatus) {
 			statuses.push([UserStatusType.OFFLINE, renderOption(UserStatusType.OFFLINE, t('Offline'))]);
 		}
 
 		return statuses;
-	}, [t, allowInvisibleStatus, status]);
+	}, [t, allowInvisibleStatus]);
 
 	const [cursor, handleKeyDown, handleKeyUp, reset, [visible, hide, show]] = useCursor(-1, options, ([selected], [, hide]) => {
 		setStatus(selected);

--- a/apps/meteor/client/lib/getUserInitialStatus.ts
+++ b/apps/meteor/client/lib/getUserInitialStatus.ts
@@ -15,8 +15,7 @@ export const getUserStatusInitialValues = (user: IUser | null, initialStatusText
 
 	return {
 		statusText: user?.statusText ?? initialStatusText ?? '',
-		statusType:
-			user?.status === UserStatusType.AWAY ? (user?.statusDefault ?? UserStatusType.ONLINE) : (user?.status ?? UserStatusType.ONLINE),
+		statusType: user?.status ?? UserStatusType.ONLINE,
 		statusDuration: initialExpiration ? 'custom' : '',
 		statusCustomDate: initialDate.toLocaleDateString('en-CA'),
 		statusCustomTime: initialDate.toTimeString().slice(0, 5),

--- a/apps/meteor/client/navbar/NavBarSettingsToolbar/UserMenu/hooks/useStatusItems.tsx
+++ b/apps/meteor/client/navbar/NavBarSettingsToolbar/UserMenu/hooks/useStatusItems.tsx
@@ -130,7 +130,6 @@ export const useStatusItems = (user?: IUser): GenericMenuItemProps[] => {
 			});
 		}
 
-		// Presets: Online / Away / Busy / Offline.
 		const isPresetSelected = (statusType: UserStatusEnum): boolean =>
 			!user?.statusText && !customStatusExpiration && user?.status === statusType;
 		const presetItems = (statuses ?? [])

--- a/apps/meteor/client/navbar/NavBarSettingsToolbar/UserMenu/hooks/useStatusItems.tsx
+++ b/apps/meteor/client/navbar/NavBarSettingsToolbar/UserMenu/hooks/useStatusItems.tsx
@@ -1,5 +1,4 @@
-import type { ICustomUserStatus, IUser } from '@rocket.chat/core-typings';
-import { UserStatus as UserStatusEnum } from '@rocket.chat/core-typings';
+import type { ICustomUserStatus, IUser, UserStatus as UserStatusEnum } from '@rocket.chat/core-typings';
 import { Box, Icon, RadioButton } from '@rocket.chat/fuselage';
 import type { GenericMenuItemProps } from '@rocket.chat/ui-client';
 import { clientCallbacks } from '@rocket.chat/ui-client';
@@ -131,12 +130,11 @@ export const useStatusItems = (user?: IUser): GenericMenuItemProps[] => {
 			});
 		}
 
-		// Presets: filter to Online / Busy / Offline. Keep Away only if user is currently on Away (legacy).
+		// Presets: Online / Away / Busy / Offline.
 		const isPresetSelected = (statusType: UserStatusEnum): boolean =>
 			!user?.statusText && !customStatusExpiration && user?.status === statusType;
 		const presetItems = (statuses ?? [])
 			.filter((s) => userStatuses.isValidType(s.id))
-			.filter((s) => s.statusType !== UserStatusEnum.AWAY || isPresetSelected(UserStatusEnum.AWAY))
 			.map(
 				(status): GenericMenuItemProps => ({
 					id: status.id,


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Restores **Away** as a manually selectable preset in the quick status menu, the custom status modal, and the account profile page.

Away had been hidden (shown only when the user was already on it) when presence and status text were still treated as one thing. Now that they're separated, Away is a valid standalone presence state again — independent of any custom status text.

The change removes the two filters that hid Away (`UserStatusMenu.tsx`, shared by the modal + profile; and `useStatusItems.tsx` for the navbar) and restores the original order Online → Away → Busy → Offline. No backend change needed: `away` is already accepted by `users.setStatus` and preserved by the presence engine.

## Issue(s)

- [CORE-2430](https://rocketchat.atlassian.net/browse/CORE-2430)

## Steps to test or reproduce

1. Open the user menu (avatar) → **Away** appears as a preset; selecting it sets your status to Away.
2. Open **Custom Status** modal → the status picker offers Away.
3. Go to **My Account → Profile** → the status picker offers Away.

## Further comments


[CORE-2430]: https://rocketchat.atlassian.net/browse/CORE-2430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored “Away” as a selectable preset in the quick status menu.
  * Made “Away” available in the custom status modal and account profile page.
  * Improved consistency of available status options across the application by ensuring “Away” is included appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->