### PR TITLE
fix: Screen share failing to start while call negotiation is in progress

### DIFF
--- a/.changeset/voice-call-renegotiation-deferral.md
+++ b/.changeset/voice-call-renegotiation-deferral.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/media-signaling': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixed screen sharing silently failing to start when initiated right after the voice call was connected. The renegotiation request could be discarded while the connection was still being negotiated, leaving the presenter with a share that never reached the other participant; it is now sent once the ongoing negotiation completes.

--- a/apps/meteor/tests/e2e/voice-calls-ee.spec.ts
+++ b/apps/meteor/tests/e2e/voice-calls-ee.spec.ts
@@ -7,6 +7,22 @@ import { HomeChannel } from './page-objects';
 import { setSettingValueById } from './utils';
 import { expect, test } from './utils/test';
 
+// If a test fails mid-call, the call stays active server-side and poisons every test that
+// tries to start a new call with the same users, so always hang up leftover calls.
+const endLeftoverCalls = async (sessions: { page: Page }[]) => {
+	for (const { page } of sessions) {
+		if (page.isClosed()) {
+			continue;
+		}
+
+		const btnEndCall = page.getByRole('button', { name: /^End call/ }).first();
+		if (await btnEndCall.isVisible()) {
+			await btnEndCall.click();
+			await expect(btnEndCall).not.toBeVisible();
+		}
+	}
+};
+
 test.describe('Internal Voice Calls - Enterprise Edition', () => {
 	test.skip(!IS_EE, 'Enterprise Edition Only');
 	let sessions: { page: Page; poHomeChannel: HomeChannel }[];
@@ -30,6 +46,8 @@ test.describe('Internal Voice Calls - Enterprise Edition', () => {
 		await setSettingValueById(api, 'VoIP_TeamCollab_Screen_Sharing_Enabled', true);
 		await Promise.all([...sessions.map(({ page }) => page.close())]);
 	});
+
+	test.afterEach(() => endLeftoverCalls(sessions));
 
 	test('should initiate voice call from direct message', async () => {
 		const [user1, user2] = sessions;
@@ -177,6 +195,8 @@ test.describe('Internal Voice Calls - In-room view - Enterprise Edition', () => 
 	test.afterAll(async () => {
 		await Promise.all([...sessions.map(({ page }) => page.close())]);
 	});
+
+	test.afterEach(() => endLeftoverCalls(sessions));
 
 	test('should show in-room view when navigating to peer DM during call', async () => {
 		const [user1, user2] = sessions;
@@ -340,6 +360,8 @@ test.describe('Internal Voice Calls - Popout view - Enterprise Edition', () => {
 	test.afterAll(async () => {
 		await Promise.all([...sessions.map(({ page }) => page.close())]);
 	});
+
+	test.afterEach(() => endLeftoverCalls(sessions));
 
 	test('should show popout view', async () => {
 		const [user1, user2] = sessions;

--- a/packages/media-signaling/jest.config.ts
+++ b/packages/media-signaling/jest.config.ts
@@ -1,0 +1,6 @@
+import server from '@rocket.chat/jest-presets/server';
+import type { Config } from 'jest';
+
+export default {
+	preset: server.preset,
+} satisfies Config;

--- a/packages/media-signaling/package.json
+++ b/packages/media-signaling/package.json
@@ -26,7 +26,8 @@
 		"dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
-		"test": "jest"
+		"test": "jest",
+		"testunit": "jest"
 	},
 	"dependencies": {
 		"@rocket.chat/emitter": "^0.33.0",

--- a/packages/media-signaling/src/lib/NegotiationManager.spec.ts
+++ b/packages/media-signaling/src/lib/NegotiationManager.spec.ts
@@ -1,0 +1,92 @@
+import { Emitter } from '@rocket.chat/emitter';
+
+import { NegotiationManager } from './NegotiationManager';
+import type { IClientMediaCall, IWebRTCProcessor } from '../definition';
+
+const flushMicrotasks = () => new Promise(process.nextTick);
+
+const createWebRTCProcessorMock = () =>
+	({
+		emitter: new Emitter(),
+		createOffer: jest.fn().mockResolvedValue({ type: 'offer', sdp: 'offer-sdp' }),
+		createAnswer: jest.fn().mockResolvedValue({ type: 'answer', sdp: 'answer-sdp' }),
+		setLocalDescription: jest.fn().mockResolvedValue(undefined),
+		setRemoteDescription: jest.fn().mockResolvedValue(undefined),
+		getLocalDescription: jest.fn().mockReturnValue({ type: 'offer', sdp: 'offer-sdp' }),
+		waitForIceGathering: jest.fn().mockResolvedValue(undefined),
+		streams: {
+			hasAllRequiredTracks: jest.fn().mockReturnValue(true),
+		},
+	}) as unknown as IWebRTCProcessor;
+
+const createCallMock = () =>
+	({
+		state: 'active',
+		hidden: false,
+		localParticipant: { role: 'caller' },
+	}) as unknown as IClientMediaCall;
+
+describe('NegotiationManager', () => {
+	it('emits negotiation-needed immediately when no negotiation is in progress', async () => {
+		const manager = new NegotiationManager(createCallMock(), {});
+		const webrtcProcessor = createWebRTCProcessorMock();
+		manager.setWebRTCProcessor(webrtcProcessor);
+
+		const onNegotiationNeeded = jest.fn();
+		manager.emitter.on('negotiation-needed', onNegotiationNeeded);
+
+		await manager.addNegotiation('n1');
+		await manager.setRemoteDescription('n1', { type: 'answer', sdp: 'answer-sdp' });
+		await flushMicrotasks();
+
+		webrtcProcessor.emitter.emit('negotiationNeeded');
+
+		expect(onNegotiationNeeded).toHaveBeenCalledTimes(1);
+		expect(onNegotiationNeeded).toHaveBeenCalledWith({ oldNegotiationId: 'n1' });
+	});
+
+	it('defers negotiation-needed while a negotiation is waiting for an answer and emits it once the negotiation ends', async () => {
+		const manager = new NegotiationManager(createCallMock(), {});
+		const webrtcProcessor = createWebRTCProcessorMock();
+		manager.setWebRTCProcessor(webrtcProcessor);
+
+		const onNegotiationNeeded = jest.fn();
+		manager.emitter.on('negotiation-needed', onNegotiationNeeded);
+
+		// local negotiation stays active until the remote answer arrives
+		await manager.addNegotiation('n1');
+		await flushMicrotasks();
+
+		webrtcProcessor.emitter.emit('negotiationNeeded');
+		expect(onNegotiationNeeded).not.toHaveBeenCalled();
+
+		await manager.setRemoteDescription('n1', { type: 'answer', sdp: 'answer-sdp' });
+		await flushMicrotasks();
+
+		expect(onNegotiationNeeded).toHaveBeenCalledTimes(1);
+		expect(onNegotiationNeeded).toHaveBeenCalledWith({ oldNegotiationId: 'n1' });
+	});
+
+	it('does not emit a deferred negotiation-needed when a queued negotiation already fulfills it', async () => {
+		const manager = new NegotiationManager(createCallMock(), {});
+		const webrtcProcessor = createWebRTCProcessorMock();
+		manager.setWebRTCProcessor(webrtcProcessor);
+
+		const onNegotiationNeeded = jest.fn();
+		manager.emitter.on('negotiation-needed', onNegotiationNeeded);
+
+		await manager.addNegotiation('n1');
+		await flushMicrotasks();
+
+		webrtcProcessor.emitter.emit('negotiationNeeded');
+
+		// a new local negotiation requested by the server fulfills the deferred need
+		await manager.setRemoteDescription('n1', { type: 'answer', sdp: 'answer-sdp' });
+		await manager.addNegotiation('n2');
+		await flushMicrotasks();
+		await manager.setRemoteDescription('n2', { type: 'answer', sdp: 'answer-sdp' });
+		await flushMicrotasks();
+
+		expect(onNegotiationNeeded).not.toHaveBeenCalled();
+	});
+});

--- a/packages/media-signaling/src/lib/NegotiationManager.ts
+++ b/packages/media-signaling/src/lib/NegotiationManager.ts
@@ -36,6 +36,9 @@ export class NegotiationManager {
 	/** id of the newest negotiation that has finished processing */
 	protected highestFinishedNegotiationId: string | null;
 
+	/** whether a negotiation-needed event was deferred because a negotiation was already in progress */
+	protected deferredNegotiationNeeded: boolean;
+
 	constructor(
 		protected readonly call: IClientMediaCall,
 		protected readonly config: NegotiationManagerConfig,
@@ -49,6 +52,7 @@ export class NegotiationManager {
 		this.highestNegotiationId = null;
 		this.highestKnownNegotiationId = null;
 		this.highestFinishedNegotiationId = null;
+		this.deferredNegotiationNeeded = false;
 
 		this.emitter = new Emitter();
 	}
@@ -137,6 +141,10 @@ export class NegotiationManager {
 
 		const nextNegotiation = this.getNextInQueue();
 		if (!nextNegotiation) {
+			if (this.deferredNegotiationNeeded) {
+				this.deferredNegotiationNeeded = false;
+				this.onWebRTCNegotiationNeeded();
+			}
 			return;
 		}
 
@@ -201,6 +209,11 @@ export class NegotiationManager {
 		this.currentNegotiation = negotiation;
 		this.highestProcessedSequence = negotiation.sequence;
 		this.highestNegotiationId = negotiation.negotiationId;
+
+		// A local negotiation builds its offer from the current stream state, so it fulfills any deferred need
+		if (negotiation.isLocal) {
+			this.deferredNegotiationNeeded = false;
+		}
 
 		negotiation.emitter.on('ended', () => {
 			if (this.currentNegotiation !== negotiation) {
@@ -280,6 +293,13 @@ export class NegotiationManager {
 
 		// If we already have a queued negotiation that would fulfill this need, then don't do anything
 		if (this.isFulfillingNegotiationQueued()) {
+			return;
+		}
+
+		// The server rejects renegotiation requests from the offerer of a negotiation that is still waiting
+		// for an answer, so defer the request until the current negotiation is done.
+		if (this.currentNegotiation) {
+			this.deferredNegotiationNeeded = true;
 			return;
 		}
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Starting a screen share right after a voice call connects can silently fail: the client emits `negotiation-needed` while its own initial negotiation is still waiting for an answer, and the server discards that request (`CallSignalProcessor` logs `Invalid state for renegotiation request`). Since the client never retries, the share track is never negotiated — the remote participant never receives the video and the presenter's share rolls back.

This is also the root cause of the flaky `voice-calls-ee.spec.ts` › `Screen sharing` e2e test (the in-room variant clicks Share ~100ms after accepting the call, so under CI load it races the initial negotiation; the popout variant rarely fails because opening the popouts gives the negotiation time to complete).

Changes:
- `NegotiationManager` now defers the `negotiation-needed` event while a negotiation is in flight and re-evaluates it once the negotiation queue drains. A local negotiation processed in the meantime consumes the deferred need, since its offer is built from the current stream state — avoiding a spurious extra renegotiation.
- Added jest specs for `NegotiationManager` covering the deferral sequence (this is the package's first test suite, so it includes a `jest.config.ts`).
- The voice-calls e2e suites now hang up leftover calls in `afterEach`, so a test failing mid-call no longer poisons the subsequent tests with an already-active call (this cascade is what turned one flake into two failures in CI).

## Issue(s)

## Steps to test or reproduce

1. Start a voice call between two users.
2. As the caller, start a screen share immediately after the callee accepts (before the initial negotiation gets its answer — easiest to hit on a slow connection or under CPU load).
3. Without this fix, the share silently never reaches the other participant; with it, the renegotiation is sent once the initial negotiation completes and the share appears for both users.

Observed in CI: https://github.com/RocketChat/Rocket.Chat/actions/runs/29510595480/job/87668479725

## Further comments

The server-side state machine was left untouched: rejecting an offerer's renegotiation request while its negotiation is unanswered is a defensible rule — the client is the one with enough context to defer and retry.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

