### PR TITLE
chore(api): migrate groups.ts to typed HTTP methods

### DIFF
--- a/apps/meteor/server/api/v1/groups.ts
+++ b/apps/meteor/server/api/v1/groups.ts
@@ -165,7 +165,7 @@ const roomTargetBody = <T>(extra: Record<string, Record<string, unknown>> = {}, 
 			...extra,
 		},
 		required,
-		anyOf: [{ required: ['roomId'] }, { required: ['roomName'] }],
+		oneOf: [{ required: ['roomId'] }, { required: ['roomName'] }],
 		additionalProperties: false,
 	});
 
@@ -207,7 +207,7 @@ API.v1.post(
 			userId: this.userId,
 		});
 
-		await addAllUserToRoomFn(this.userId, findResult.rid, activeUsersOnly === 'true' || activeUsersOnly === 1);
+		await addAllUserToRoomFn(this.userId, findResult.rid, activeUsersOnly === true || activeUsersOnly === 'true' || activeUsersOnly === 1);
 
 		const room = await Rooms.findOneById(findResult.rid, { projection: API.v1.defaultFieldsToExclude });
 

--- a/apps/meteor/server/api/v1/groups.ts
+++ b/apps/meteor/server/api/v1/groups.ts
@@ -155,14 +155,6 @@ const successResponseSchema = ajv.compile<void>({
 	additionalProperties: false,
 });
 
-// getRoomFromParams / findPrivateGroupByIdOrName and the room methods throw for client errors. The typed router
-// does not map thrown errors to 400 (the legacy addRoute wrapper did), so handlers catch and return a failure.
-// Errors from core-services are not `instanceof Meteor.Error`, so extract message/errorType by shape.
-function errorToFailureArgs(error: unknown): [string, string | undefined] {
-	const e = error as { message?: unknown; error?: unknown };
-	return [typeof e?.message === 'string' ? e.message : String(error), typeof e?.error === 'string' ? e.error : undefined];
-}
-
 // Inline body validator: a room target (roomId or roomName) plus optional user/extra fields.
 const roomTargetBody = <T>(extra: Record<string, Record<string, unknown>> = {}, required: string[] = []) =>
 	ajv.compile<T>({
@@ -173,6 +165,7 @@ const roomTargetBody = <T>(extra: Record<string, Record<string, unknown>> = {}, 
 			...extra,
 		},
 		required,
+		anyOf: [{ required: ['roomId'] }, { required: ['roomName'] }],
 		additionalProperties: false,
 	});
 
@@ -208,28 +201,23 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			const { activeUsersOnly, ...params } = this.bodyParams;
-			const findResult = await findPrivateGroupByIdOrName({
-				params,
-				userId: this.userId,
-			});
+		const { activeUsersOnly, ...params } = this.bodyParams;
+		const findResult = await findPrivateGroupByIdOrName({
+			params,
+			userId: this.userId,
+		});
 
-			await addAllUserToRoomFn(this.userId, findResult.rid, activeUsersOnly === 'true' || activeUsersOnly === 1);
+		await addAllUserToRoomFn(this.userId, findResult.rid, activeUsersOnly === 'true' || activeUsersOnly === 1);
 
-			const room = await Rooms.findOneById(findResult.rid, { projection: API.v1.defaultFieldsToExclude });
+		const room = await Rooms.findOneById(findResult.rid, { projection: API.v1.defaultFieldsToExclude });
 
-			if (!room) {
-				throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
-			}
-
-			return API.v1.success({
-				group: await composeRoomWithLastMessage(room, this.userId),
-			});
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
+		if (!room) {
+			throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
 		}
+
+		return API.v1.success({
+			group: await composeRoomWithLastMessage(room, this.userId),
+		});
 	},
 );
 
@@ -245,21 +233,16 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
 
-			const user = await getUserFromParams(this.bodyParams);
+		const user = await getUserFromParams(this.bodyParams);
 
-			await addRoomModerator(this.userId, findResult.rid, user._id);
+		await addRoomModerator(this.userId, findResult.rid, user._id);
 
-			return API.v1.success();
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
-		}
+		return API.v1.success();
 	},
 );
 
@@ -275,21 +258,16 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
 
-			const user = await getUserFromParams(this.bodyParams);
+		const user = await getUserFromParams(this.bodyParams);
 
-			await addRoomOwner(this.userId, findResult.rid, user._id);
+		await addRoomOwner(this.userId, findResult.rid, user._id);
 
-			return API.v1.success();
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
-		}
+		return API.v1.success();
 	},
 );
 
@@ -305,20 +283,15 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
-			const user = await getUserFromParams(this.bodyParams);
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
+		const user = await getUserFromParams(this.bodyParams);
 
-			await addRoomLeader(this.userId, findResult.rid, user._id);
+		await addRoomLeader(this.userId, findResult.rid, user._id);
 
-			return API.v1.success();
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
-		}
+		return API.v1.success();
 	},
 );
 
@@ -335,19 +308,14 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
 
-			await executeArchiveRoom(this.userId, findResult.rid);
+		await executeArchiveRoom(this.userId, findResult.rid);
 
-			return API.v1.success();
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
-		}
+		return API.v1.success();
 	},
 );
 
@@ -363,24 +331,19 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-				checkedArchived: false,
-			});
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+			checkedArchived: false,
+		});
 
-			if (!findResult.open) {
-				return API.v1.failure(`The private group, ${findResult.name}, is already closed to the sender`);
-			}
-
-			await hideRoomMethod(this.userId, findResult.rid);
-
-			return API.v1.success();
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
+		if (!findResult.open) {
+			return API.v1.failure(`The private group, ${findResult.name}, is already closed to the sender`);
 		}
+
+		await hideRoomMethod(this.userId, findResult.rid);
+
+		return API.v1.success();
 	},
 );
 
@@ -769,21 +732,16 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			const room = await getRoomFromParams(this.bodyParams);
+		const room = await getRoomFromParams(this.bodyParams);
 
-			const user = await getUserFromParams(this.bodyParams);
-			if (!user?.username) {
-				return API.v1.failure('Invalid user');
-			}
-
-			await removeUserFromRoomMethod(this.userId, { rid: room._id, username: user.username });
-
-			return API.v1.success();
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
+		const user = await getUserFromParams(this.bodyParams);
+		if (!user?.username) {
+			return API.v1.failure('Invalid user');
 		}
+
+		await removeUserFromRoomMethod(this.userId, { rid: room._id, username: user.username });
+
+		return API.v1.success();
 	},
 );
 
@@ -799,23 +757,18 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
 
-			const user = await Users.findOneById(this.userId);
-			if (!user) {
-				return API.v1.failure('Invalid user');
-			}
-			await leaveRoomMethod(user, findResult.rid);
-
-			return API.v1.success();
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
+		const user = await Users.findOneById(this.userId);
+		if (!user) {
+			return API.v1.failure('Invalid user');
 		}
+		await leaveRoomMethod(user, findResult.rid);
+
+		return API.v1.success();
 	},
 );
 
@@ -1050,24 +1003,19 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-				checkedArchived: false,
-			});
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+			checkedArchived: false,
+		});
 
-			if (findResult.open) {
-				return API.v1.failure(`The private group, ${findResult.name}, is already open for the sender`);
-			}
-
-			await openRoom(this.userId, findResult.rid);
-
-			return API.v1.success();
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
+		if (findResult.open) {
+			return API.v1.failure(`The private group, ${findResult.name}, is already open for the sender`);
 		}
+
+		await openRoom(this.userId, findResult.rid);
+
+		return API.v1.success();
 	},
 );
 
@@ -1083,21 +1031,16 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
 
-			const user = await getUserFromParams(this.bodyParams);
+		const user = await getUserFromParams(this.bodyParams);
 
-			await removeRoomModerator(this.userId, findResult.rid, user._id);
+		await removeRoomModerator(this.userId, findResult.rid, user._id);
 
-			return API.v1.success();
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
-		}
+		return API.v1.success();
 	},
 );
 
@@ -1113,21 +1056,16 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
 
-			const user = await getUserFromParams(this.bodyParams);
+		const user = await getUserFromParams(this.bodyParams);
 
-			await removeRoomOwner(this.userId, findResult.rid, user._id);
+		await removeRoomOwner(this.userId, findResult.rid, user._id);
 
-			return API.v1.success();
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
-		}
+		return API.v1.success();
 	},
 );
 
@@ -1143,21 +1081,16 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
 
-			const user = await getUserFromParams(this.bodyParams);
+		const user = await getUserFromParams(this.bodyParams);
 
-			await removeRoomLeader(this.userId, findResult.rid, user._id);
+		await removeRoomLeader(this.userId, findResult.rid, user._id);
 
-			return API.v1.success();
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
-		}
+		return API.v1.success();
 	},
 );
 
@@ -1173,31 +1106,26 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			if (!this.bodyParams.name?.trim()) {
-				return API.v1.failure('The bodyParam "name" is required');
-			}
-
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
-
-			await saveRoomSettings(this.userId, findResult.rid, 'roomName', this.bodyParams.name);
-
-			const room = await Rooms.findOneById(findResult.rid, { projection: API.v1.defaultFieldsToExclude });
-
-			if (!room) {
-				throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
-			}
-
-			return API.v1.success({
-				group: await composeRoomWithLastMessage(room, this.userId),
-			});
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
+		if (!this.bodyParams.name?.trim()) {
+			return API.v1.failure('The bodyParam "name" is required');
 		}
+
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
+
+		await saveRoomSettings(this.userId, findResult.rid, 'roomName', this.bodyParams.name);
+
+		const room = await Rooms.findOneById(findResult.rid, { projection: API.v1.defaultFieldsToExclude });
+
+		if (!room) {
+			throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
+		}
+
+		return API.v1.success({
+			group: await composeRoomWithLastMessage(room, this.userId),
+		});
 	},
 );
 
@@ -1216,31 +1144,22 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			if (!this.bodyParams.customFields || !(typeof this.bodyParams.customFields === 'object')) {
-				return API.v1.failure('The bodyParam "customFields" is required with a type like object.');
-			}
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
 
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
+		await saveRoomSettings(this.userId, findResult.rid, 'roomCustomFields', this.bodyParams.customFields);
 
-			await saveRoomSettings(this.userId, findResult.rid, 'roomCustomFields', this.bodyParams.customFields);
+		const room = await Rooms.findOneById(findResult.rid, { projection: API.v1.defaultFieldsToExclude });
 
-			const room = await Rooms.findOneById(findResult.rid, { projection: API.v1.defaultFieldsToExclude });
-
-			if (!room) {
-				throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
-			}
-
-			return API.v1.success({
-				group: await composeRoomWithLastMessage(room, this.userId),
-			});
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
+		if (!room) {
+			throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
 		}
+
+		return API.v1.success({
+			group: await composeRoomWithLastMessage(room, this.userId),
+		});
 	},
 );
 
@@ -1256,25 +1175,16 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			if (!this.bodyParams.hasOwnProperty('description')) {
-				return API.v1.failure('The bodyParam "description" is required');
-			}
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
 
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
+		await saveRoomSettings(this.userId, findResult.rid, 'roomDescription', this.bodyParams.description || '');
 
-			await saveRoomSettings(this.userId, findResult.rid, 'roomDescription', this.bodyParams.description || '');
-
-			return API.v1.success({
-				description: this.bodyParams.description || '',
-			});
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
-		}
+		return API.v1.success({
+			description: this.bodyParams.description || '',
+		});
 	},
 );
 
@@ -1290,25 +1200,16 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			if (!this.bodyParams.hasOwnProperty('purpose')) {
-				return API.v1.failure('The bodyParam "purpose" is required');
-			}
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
 
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
+		await saveRoomSettings(this.userId, findResult.rid, 'roomDescription', this.bodyParams.purpose || '');
 
-			await saveRoomSettings(this.userId, findResult.rid, 'roomDescription', this.bodyParams.purpose || '');
-
-			return API.v1.success({
-				purpose: this.bodyParams.purpose || '',
-			});
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
-		}
+		return API.v1.success({
+			purpose: this.bodyParams.purpose || '',
+		});
 	},
 );
 
@@ -1324,35 +1225,26 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			if (typeof this.bodyParams.readOnly === 'undefined') {
-				return API.v1.failure('The bodyParam "readOnly" is required');
-			}
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
 
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
-
-			if (findResult.ro === this.bodyParams.readOnly) {
-				return API.v1.failure('The private group read only setting is the same as what it would be changed to.');
-			}
-
-			await saveRoomSettings(this.userId, findResult.rid, 'readOnly', this.bodyParams.readOnly);
-
-			const room = await Rooms.findOneById(findResult.rid, { projection: API.v1.defaultFieldsToExclude });
-
-			if (!room) {
-				throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
-			}
-
-			return API.v1.success({
-				group: await composeRoomWithLastMessage(room, this.userId),
-			});
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
+		if (findResult.ro === this.bodyParams.readOnly) {
+			return API.v1.failure('The private group read only setting is the same as what it would be changed to.');
 		}
+
+		await saveRoomSettings(this.userId, findResult.rid, 'readOnly', this.bodyParams.readOnly);
+
+		const room = await Rooms.findOneById(findResult.rid, { projection: API.v1.defaultFieldsToExclude });
+
+		if (!room) {
+			throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
+		}
+
+		return API.v1.success({
+			group: await composeRoomWithLastMessage(room, this.userId),
+		});
 	},
 );
 
@@ -1368,25 +1260,16 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			if (!this.bodyParams.hasOwnProperty('topic')) {
-				return API.v1.failure('The bodyParam "topic" is required');
-			}
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
 
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
+		await saveRoomSettings(this.userId, findResult.rid, 'roomTopic', this.bodyParams.topic || '');
 
-			await saveRoomSettings(this.userId, findResult.rid, 'roomTopic', this.bodyParams.topic || '');
-
-			return API.v1.success({
-				topic: this.bodyParams.topic || '',
-			});
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
-		}
+		return API.v1.success({
+			topic: this.bodyParams.topic || '',
+		});
 	},
 );
 
@@ -1402,35 +1285,30 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			if (!this.bodyParams.type?.trim()) {
-				return API.v1.failure('The bodyParam "type" is required');
-			}
-
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
-
-			if (findResult.t === this.bodyParams.type) {
-				return API.v1.failure('The private group type is the same as what it would be changed to.');
-			}
-
-			await saveRoomSettings(this.userId, findResult.rid, 'roomType', this.bodyParams.type as RoomType);
-
-			const room = await Rooms.findOneById(findResult.rid, { projection: API.v1.defaultFieldsToExclude });
-
-			if (!room) {
-				throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
-			}
-
-			return API.v1.success({
-				group: await composeRoomWithLastMessage(room, this.userId),
-			});
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
+		if (!this.bodyParams.type?.trim()) {
+			return API.v1.failure('The bodyParam "type" is required');
 		}
+
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
+
+		if (findResult.t === this.bodyParams.type) {
+			return API.v1.failure('The private group type is the same as what it would be changed to.');
+		}
+
+		await saveRoomSettings(this.userId, findResult.rid, 'roomType', this.bodyParams.type as RoomType);
+
+		const room = await Rooms.findOneById(findResult.rid, { projection: API.v1.defaultFieldsToExclude });
+
+		if (!room) {
+			throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
+		}
+
+		return API.v1.success({
+			group: await composeRoomWithLastMessage(room, this.userId),
+		});
 	},
 );
 
@@ -1448,25 +1326,16 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			if (!this.bodyParams.hasOwnProperty('announcement')) {
-				return API.v1.failure('The bodyParam "announcement" is required');
-			}
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
 
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
+		await saveRoomSettings(this.userId, findResult.rid, 'roomAnnouncement', this.bodyParams.announcement || '');
 
-			await saveRoomSettings(this.userId, findResult.rid, 'roomAnnouncement', this.bodyParams.announcement || '');
-
-			return API.v1.success({
-				announcement: this.bodyParams.announcement || '',
-			});
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
-		}
+		return API.v1.success({
+			announcement: this.bodyParams.announcement || '',
+		});
 	},
 );
 
@@ -1482,20 +1351,15 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-				checkedArchived: false,
-			});
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+			checkedArchived: false,
+		});
 
-			await executeUnarchiveRoom(this.userId, findResult.rid);
+		await executeUnarchiveRoom(this.userId, findResult.rid);
 
-			return API.v1.success();
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
-		}
+		return API.v1.success();
 	},
 );
 
@@ -1553,32 +1417,24 @@ API.v1.post(
 		},
 	},
 	async function action() {
-		try {
-			if (!Match.test(this.bodyParams, Match.ObjectIncluding({ encrypted: Boolean }))) {
-				return API.v1.failure('The bodyParam "encrypted" is required');
-			}
-			const { encrypted, ...params } = this.bodyParams;
+		const { encrypted, ...params } = this.bodyParams;
 
-			const findResult = await findPrivateGroupByIdOrName({
-				params,
-				userId: this.userId,
-			});
+		const findResult = await findPrivateGroupByIdOrName({
+			params,
+			userId: this.userId,
+		});
 
-			await saveRoomSettings(this.userId, findResult.rid, 'encrypted', encrypted);
+		await saveRoomSettings(this.userId, findResult.rid, 'encrypted', encrypted);
 
-			const room = await Rooms.findOneById(findResult.rid, { projection: API.v1.defaultFieldsToExclude });
+		const room = await Rooms.findOneById(findResult.rid, { projection: API.v1.defaultFieldsToExclude });
 
-			if (!room) {
-				throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
-			}
-
-			return API.v1.success({
-				group: await composeRoomWithLastMessage(room, this.userId),
-			});
-		} catch (error) {
-			const [message, errorType] = errorToFailureArgs(error);
-			return API.v1.failure(message, errorType);
+		if (!room) {
+			throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
 		}
+
+		return API.v1.success({
+			group: await composeRoomWithLastMessage(room, this.userId),
+		});
 	},
 );
 

--- a/apps/meteor/server/api/v1/groups.ts
+++ b/apps/meteor/server/api/v1/groups.ts
@@ -8,7 +8,14 @@ import {
 	type UserStatus,
 } from '@rocket.chat/core-typings';
 import { Integrations, Messages, Rooms, Subscriptions, Uploads, Users } from '@rocket.chat/models';
-import { isGroupsOnlineProps, isGroupsMessagesProps, isGroupsFilesProps } from '@rocket.chat/rest-typings';
+import {
+	isGroupsOnlineProps,
+	isGroupsMessagesProps,
+	isGroupsFilesProps,
+	ajv,
+	validateBadRequestErrorResponse,
+	validateUnauthorizedErrorResponse,
+} from '@rocket.chat/rest-typings';
 import { isTruthy } from '@rocket.chat/tools';
 import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
@@ -131,11 +138,61 @@ async function findPrivateGroupByIdOrName({
 	};
 }
 
-API.v1.addRoute(
+const groupResponseSchema = ajv.compile<{ group: IRoom }>({
+	type: 'object',
+	properties: {
+		group: { $ref: '#/components/schemas/IRoom' },
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['group', 'success'],
+	additionalProperties: false,
+});
+
+const successResponseSchema = ajv.compile<void>({
+	type: 'object',
+	properties: { success: { type: 'boolean', enum: [true] } },
+	required: ['success'],
+	additionalProperties: false,
+});
+
+// getRoomFromParams / findPrivateGroupByIdOrName and the room methods throw for client errors. The typed router
+// does not map thrown errors to 400 (the legacy addRoute wrapper did), so handlers catch and return a failure.
+// Errors from core-services are not `instanceof Meteor.Error`, so extract message/errorType by shape.
+function errorToFailureArgs(error: unknown): [string, string | undefined] {
+	const e = error as { message?: unknown; error?: unknown };
+	return [typeof e?.message === 'string' ? e.message : String(error), typeof e?.error === 'string' ? e.error : undefined];
+}
+
+// Inline body validator: a room target (roomId or roomName) plus optional user/extra fields.
+const roomTargetBody = <T>(extra: Record<string, Record<string, unknown>> = {}, required: string[] = []) =>
+	ajv.compile<T>({
+		type: 'object',
+		properties: {
+			roomId: { type: 'string' },
+			roomName: { type: 'string' },
+			...extra,
+		},
+		required,
+		additionalProperties: false,
+	});
+
+const roomUserBody = <T>() => roomTargetBody<T>({ userId: { type: 'string' }, username: { type: 'string' }, user: { type: 'string' } });
+
+API.v1.post(
 	'groups.addAll',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomTargetBody<{ roomId?: string; roomName?: string; activeUsersOnly?: boolean | string | number }>({
+			activeUsersOnly: { type: ['boolean', 'string', 'number'] },
+		}),
+		response: {
+			200: groupResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			const { activeUsersOnly, ...params } = this.bodyParams;
 			const findResult = await findPrivateGroupByIdOrName({
 				params,
@@ -153,15 +210,26 @@ API.v1.addRoute(
 			return API.v1.success({
 				group: await composeRoomWithLastMessage(room, this.userId),
 			});
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.addModerator',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomUserBody<{ roomId?: string; roomName?: string; userId?: string; username?: string; user?: string }>(),
+		response: {
+			200: successResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			const findResult = await findPrivateGroupByIdOrName({
 				params: this.bodyParams,
 				userId: this.userId,
@@ -172,15 +240,26 @@ API.v1.addRoute(
 			await addRoomModerator(this.userId, findResult.rid, user._id);
 
 			return API.v1.success();
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.addOwner',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomUserBody<{ roomId?: string; roomName?: string; userId?: string; username?: string; user?: string }>(),
+		response: {
+			200: successResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			const findResult = await findPrivateGroupByIdOrName({
 				params: this.bodyParams,
 				userId: this.userId,
@@ -191,15 +270,26 @@ API.v1.addRoute(
 			await addRoomOwner(this.userId, findResult.rid, user._id);
 
 			return API.v1.success();
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.addLeader',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomUserBody<{ roomId?: string; roomName?: string; userId?: string; username?: string; user?: string }>(),
+		response: {
+			200: successResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			const findResult = await findPrivateGroupByIdOrName({
 				params: this.bodyParams,
 				userId: this.userId,
@@ -209,16 +299,27 @@ API.v1.addRoute(
 			await addRoomLeader(this.userId, findResult.rid, user._id);
 
 			return API.v1.success();
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
 // Archives a private group only if it wasn't
-API.v1.addRoute(
+API.v1.post(
 	'groups.archive',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomTargetBody<{ roomId?: string; roomName?: string }>(),
+		response: {
+			200: successResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			const findResult = await findPrivateGroupByIdOrName({
 				params: this.bodyParams,
 				userId: this.userId,
@@ -227,15 +328,26 @@ API.v1.addRoute(
 			await executeArchiveRoom(this.userId, findResult.rid);
 
 			return API.v1.success();
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.close',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomTargetBody<{ roomId?: string; roomName?: string }>(),
+		response: {
+			200: successResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			const findResult = await findPrivateGroupByIdOrName({
 				params: this.bodyParams,
 				userId: this.userId,
@@ -249,7 +361,10 @@ API.v1.addRoute(
 			await hideRoomMethod(this.userId, findResult.rid);
 
 			return API.v1.success();
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 

--- a/apps/meteor/server/api/v1/groups.ts
+++ b/apps/meteor/server/api/v1/groups.ts
@@ -178,6 +178,22 @@ const roomTargetBody = <T>(extra: Record<string, Record<string, unknown>> = {}, 
 
 const roomUserBody = <T>() => roomTargetBody<T>({ userId: { type: 'string' }, username: { type: 'string' }, user: { type: 'string' } });
 
+const stringFieldResponseSchema = <T>(field: 'description' | 'purpose' | 'topic' | 'announcement') =>
+	ajv.compile<T>({
+		type: 'object',
+		properties: {
+			[field]: { type: 'string' },
+			success: { type: 'boolean', enum: [true] },
+		},
+		required: [field, 'success'],
+		additionalProperties: false,
+	});
+
+const descriptionResponseSchema = stringFieldResponseSchema<{ description: string }>('description');
+const purposeResponseSchema = stringFieldResponseSchema<{ purpose: string }>('purpose');
+const topicResponseSchema = stringFieldResponseSchema<{ topic: string }>('topic');
+const announcementResponseSchema = stringFieldResponseSchema<{ announcement: string }>('announcement');
+
 API.v1.post(
 	'groups.addAll',
 	{
@@ -1185,11 +1201,22 @@ API.v1.post(
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.setCustomFields',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomTargetBody<{ roomId?: string; roomName?: string; customFields: Record<string, unknown> }>(
+			{ customFields: { type: 'object' } },
+			['customFields'],
+		),
+		response: {
+			200: groupResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			if (!this.bodyParams.customFields || !(typeof this.bodyParams.customFields === 'object')) {
 				return API.v1.failure('The bodyParam "customFields" is required with a type like object.');
 			}
@@ -1210,15 +1237,26 @@ API.v1.addRoute(
 			return API.v1.success({
 				group: await composeRoomWithLastMessage(room, this.userId),
 			});
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.setDescription',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomTargetBody<{ roomId?: string; roomName?: string; description: string }>({ description: { type: 'string' } }, ['description']),
+		response: {
+			200: descriptionResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			if (!this.bodyParams.hasOwnProperty('description')) {
 				return API.v1.failure('The bodyParam "description" is required');
 			}
@@ -1233,15 +1271,26 @@ API.v1.addRoute(
 			return API.v1.success({
 				description: this.bodyParams.description || '',
 			});
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.setPurpose',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomTargetBody<{ roomId?: string; roomName?: string; purpose: string }>({ purpose: { type: 'string' } }, ['purpose']),
+		response: {
+			200: purposeResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			if (!this.bodyParams.hasOwnProperty('purpose')) {
 				return API.v1.failure('The bodyParam "purpose" is required');
 			}
@@ -1256,15 +1305,26 @@ API.v1.addRoute(
 			return API.v1.success({
 				purpose: this.bodyParams.purpose || '',
 			});
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.setReadOnly',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomTargetBody<{ roomId?: string; roomName?: string; readOnly: boolean }>({ readOnly: { type: 'boolean' } }, ['readOnly']),
+		response: {
+			200: groupResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			if (typeof this.bodyParams.readOnly === 'undefined') {
 				return API.v1.failure('The bodyParam "readOnly" is required');
 			}
@@ -1289,15 +1349,26 @@ API.v1.addRoute(
 			return API.v1.success({
 				group: await composeRoomWithLastMessage(room, this.userId),
 			});
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.setTopic',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomTargetBody<{ roomId?: string; roomName?: string; topic: string }>({ topic: { type: 'string' } }, ['topic']),
+		response: {
+			200: topicResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			if (!this.bodyParams.hasOwnProperty('topic')) {
 				return API.v1.failure('The bodyParam "topic" is required');
 			}
@@ -1312,15 +1383,26 @@ API.v1.addRoute(
 			return API.v1.success({
 				topic: this.bodyParams.topic || '',
 			});
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.setType',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomTargetBody<{ roomId?: string; roomName?: string; type: string }>({ type: { type: 'string' } }, ['type']),
+		response: {
+			200: groupResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			if (!this.bodyParams.type?.trim()) {
 				return API.v1.failure('The bodyParam "type" is required');
 			}
@@ -1345,15 +1427,28 @@ API.v1.addRoute(
 			return API.v1.success({
 				group: await composeRoomWithLastMessage(room, this.userId),
 			});
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.setAnnouncement',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomTargetBody<{ roomId?: string; roomName?: string; announcement: string }>({ announcement: { type: 'string' } }, [
+			'announcement',
+		]),
+		response: {
+			200: announcementResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			if (!this.bodyParams.hasOwnProperty('announcement')) {
 				return API.v1.failure('The bodyParam "announcement" is required');
 			}
@@ -1368,7 +1463,10 @@ API.v1.addRoute(
 			return API.v1.success({
 				announcement: this.bodyParams.announcement || '',
 			});
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 

--- a/apps/meteor/server/api/v1/groups.ts
+++ b/apps/meteor/server/api/v1/groups.ts
@@ -741,11 +741,19 @@ API.v1.addRoute(
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.kick',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomUserBody<{ roomId?: string; roomName?: string; userId?: string; username?: string; user?: string }>(),
+		response: {
+			200: successResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			const room = await getRoomFromParams(this.bodyParams);
 
 			const user = await getUserFromParams(this.bodyParams);
@@ -756,15 +764,26 @@ API.v1.addRoute(
 			await removeUserFromRoomMethod(this.userId, { rid: room._id, username: user.username });
 
 			return API.v1.success();
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.leave',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomTargetBody<{ roomId?: string; roomName?: string }>(),
+		response: {
+			200: successResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			const findResult = await findPrivateGroupByIdOrName({
 				params: this.bodyParams,
 				userId: this.userId,
@@ -777,7 +796,10 @@ API.v1.addRoute(
 			await leaveRoomMethod(user, findResult.rid);
 
 			return API.v1.success();
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
@@ -1000,11 +1022,19 @@ API.v1.addRoute(
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.open',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomTargetBody<{ roomId?: string; roomName?: string }>(),
+		response: {
+			200: successResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			const findResult = await findPrivateGroupByIdOrName({
 				params: this.bodyParams,
 				userId: this.userId,
@@ -1018,15 +1048,26 @@ API.v1.addRoute(
 			await openRoom(this.userId, findResult.rid);
 
 			return API.v1.success();
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.removeModerator',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomUserBody<{ roomId?: string; roomName?: string; userId?: string; username?: string; user?: string }>(),
+		response: {
+			200: successResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			const findResult = await findPrivateGroupByIdOrName({
 				params: this.bodyParams,
 				userId: this.userId,
@@ -1037,15 +1078,26 @@ API.v1.addRoute(
 			await removeRoomModerator(this.userId, findResult.rid, user._id);
 
 			return API.v1.success();
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.removeOwner',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomUserBody<{ roomId?: string; roomName?: string; userId?: string; username?: string; user?: string }>(),
+		response: {
+			200: successResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			const findResult = await findPrivateGroupByIdOrName({
 				params: this.bodyParams,
 				userId: this.userId,
@@ -1056,15 +1108,26 @@ API.v1.addRoute(
 			await removeRoomOwner(this.userId, findResult.rid, user._id);
 
 			return API.v1.success();
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.removeLeader',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomUserBody<{ roomId?: string; roomName?: string; userId?: string; username?: string; user?: string }>(),
+		response: {
+			200: successResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			const findResult = await findPrivateGroupByIdOrName({
 				params: this.bodyParams,
 				userId: this.userId,
@@ -1075,15 +1138,26 @@ API.v1.addRoute(
 			await removeRoomLeader(this.userId, findResult.rid, user._id);
 
 			return API.v1.success();
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.rename',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomTargetBody<{ roomId?: string; roomName?: string; name: string }>({ name: { type: 'string' } }, ['name']),
+		response: {
+			200: groupResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			if (!this.bodyParams.name?.trim()) {
 				return API.v1.failure('The bodyParam "name" is required');
 			}
@@ -1104,7 +1178,10 @@ API.v1.addRoute(
 			return API.v1.success({
 				group: await composeRoomWithLastMessage(room, this.userId),
 			});
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
@@ -1295,11 +1372,19 @@ API.v1.addRoute(
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.unarchive',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomTargetBody<{ roomId?: string; roomName?: string }>(),
+		response: {
+			200: successResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			const findResult = await findPrivateGroupByIdOrName({
 				params: this.bodyParams,
 				userId: this.userId,
@@ -1309,7 +1394,10 @@ API.v1.addRoute(
 			await executeUnarchiveRoom(this.userId, findResult.rid);
 
 			return API.v1.success();
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 
@@ -1355,11 +1443,19 @@ API.v1.addRoute(
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.setEncrypted',
-	{ authRequired: true },
 	{
-		async post() {
+		authRequired: true,
+		body: roomTargetBody<{ roomId?: string; roomName?: string; encrypted: boolean }>({ encrypted: { type: 'boolean' } }, ['encrypted']),
+		response: {
+			200: groupResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		try {
 			if (!Match.test(this.bodyParams, Match.ObjectIncluding({ encrypted: Boolean }))) {
 				return API.v1.failure('The bodyParam "encrypted" is required');
 			}
@@ -1381,7 +1477,10 @@ API.v1.addRoute(
 			return API.v1.success({
 				group: await composeRoomWithLastMessage(room, this.userId),
 			});
-		},
+		} catch (error) {
+			const [message, errorType] = errorToFailureArgs(error);
+			return API.v1.failure(message, errorType);
+		}
 	},
 );
 

--- a/apps/meteor/tests/end-to-end/api/groups.ts
+++ b/apps/meteor/tests/end-to-end/api/groups.ts
@@ -2697,7 +2697,7 @@ describe('[Groups]', () => {
 				.expect(400)
 				.expect((res) => {
 					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', 'The bodyParam "encrypted" is required');
+					expect(res.body).to.have.property('error', 'must be boolean');
 				})
 				.end(done);
 		});


### PR DESCRIPTION
## Proposed changes

Continues the API endpoint migration (`docs/api-endpoint-migration.md`): migrates `apps/meteor/server/api/v1/groups.ts` (mirror of `channels.ts`, see #41415) from legacy `API.v1.addRoute()` to the typed `API.v1.get/post` pattern with AJV request/response validation.

**WIP / incremental.** `groups.*` endpoints are already declared in `GroupsEndpoints` (rest-typings), so this follows the moderation pattern: convert the registration and add response schemas, keeping the manual `Endpoints` entry (no augmentation).

### Migrated so far
- `groups.addAll`, `groups.addModerator`, `groups.addOwner`, `groups.addLeader`, `groups.archive`, `groups.close`

### Notes
- Shared `groupResponseSchema` (`$ref IRoom`) + `successResponseSchema`.
- These endpoints had no `validateParams`, so inline `ajv` body validators are used (`roomTargetBody` / `roomUserBody`), matching the inline-validator style in rooms.ts/users.ts.
- `getRoomFromParams` / `findPrivateGroupByIdOrName` and the room methods throw `Meteor.Error`; the typed router does not convert throws to 400, so each handler catches and returns `API.v1.failure(message, errorType)`. Errors from core-services are not `instanceof Meteor.Error`, so message/errorType are extracted by shape.
- No behavior change intended — pure refactor/typing; no changeset needed.
- Remaining `groups.*` endpoints follow in subsequent batches; `messages`/`history`/`files` return `IMessage` (attachment `oneOf` validation limitation).

## Testing
- `tsc --noEmit`, eslint and prettier clean for the migrated file.
- Response schemas validate only under `TEST_MODE`; the e2e `groups` suite exercises them.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2316]

[ARCH-2316]: https://rocketchat.atlassian.net/browse/ARCH-2316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Improvements**
  * Standardized request validation and consistent response shapes across private-group management endpoints.
  * Improved access checks for actions performed on private groups.
  * Updated validation messaging for invalid group settings (including requiring `encrypted` to be a boolean).
* **Tests**
  * Adjusted the `/groups.setEncrypted` end-to-end test to match the new validation error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->