### PR TITLE
regression: tooltips not reappearing on subsequent hovers

### DIFF
--- a/packages/ui-client/src/providers/TooltipProvider.spec.tsx
+++ b/packages/ui-client/src/providers/TooltipProvider.spec.tsx
@@ -88,3 +88,98 @@ it('should update the tooltip and re-stash the title when it changes while open'
 	expect(anchor).toHaveAttribute('title', '');
 	expect(anchor).toHaveAttribute('data-title', 'World');
 });
+
+describe('click-dismiss while still hovering', () => {
+	it('should keep the title stashed after a click-dismiss while the cursor is still on the anchor', () => {
+		const { anchor } = setup();
+
+		fireEvent.mouseOver(anchor);
+		waitForTooltipDebounce();
+		expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('Hello');
+
+		fireEvent.click(anchor);
+
+		expect(screen.queryByRole('tooltip', { hidden: true })).not.toBeInTheDocument();
+		expect(anchor).toHaveAttribute('title', '');
+		expect(anchor).toHaveAttribute('data-title', 'Hello');
+	});
+
+	it('should restore the title when the cursor leaves after a click-dismiss', () => {
+		const { anchor } = setup();
+
+		fireEvent.mouseOver(anchor);
+		waitForTooltipDebounce();
+		fireEvent.click(anchor);
+
+		fireEvent.mouseLeave(anchor);
+
+		expect(anchor).toHaveAttribute('title', 'Hello');
+		expect(anchor).not.toHaveAttribute('data-title');
+	});
+
+	it('should show the tooltip again after a click-dismiss and mouseleave cycle', () => {
+		const { anchor } = setup();
+
+		fireEvent.mouseOver(anchor);
+		waitForTooltipDebounce();
+		fireEvent.click(anchor);
+		fireEvent.mouseLeave(anchor);
+		act(() => {
+			jest.runOnlyPendingTimers();
+		});
+
+		fireEvent.mouseOver(anchor);
+		waitForTooltipDebounce();
+
+		expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('Hello');
+	});
+});
+
+describe('with a `data-tooltip`-only anchor', () => {
+	const setupDataTooltip = () => {
+		render(
+			<TooltipProvider>
+				<button type='button' data-tooltip='Hello'>
+					anchor
+				</button>
+			</TooltipProvider>,
+		);
+
+		return {
+			anchor: screen.getByRole('button', { name: 'anchor' }),
+		};
+	};
+
+	it('should show the tooltip without ever adding a title attribute', () => {
+		const { anchor } = setupDataTooltip();
+
+		fireEvent.mouseOver(anchor);
+		waitForTooltipDebounce();
+
+		expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('Hello');
+		expect(anchor).not.toHaveAttribute('title');
+		expect(anchor).not.toHaveAttribute('data-title');
+
+		fireEvent.mouseLeave(anchor);
+
+		// the anchor must not gain a native title on close; that would leak the tooltip text to the browser's tooltip
+		expect(screen.queryByRole('tooltip', { hidden: true })).not.toBeInTheDocument();
+		expect(anchor).not.toHaveAttribute('title');
+		expect(anchor).not.toHaveAttribute('data-title');
+	});
+
+	it('should update the tooltip when `data-tooltip` changes while open', async () => {
+		const { anchor } = setupDataTooltip();
+
+		fireEvent.mouseOver(anchor);
+		waitForTooltipDebounce();
+
+		// the MutationObserver callback runs as a microtask, so the update must be flushed asynchronously
+		await act(async () => {
+			anchor.setAttribute('data-tooltip', 'World');
+		});
+
+		expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('World');
+		expect(anchor).not.toHaveAttribute('title');
+	});
+});

--- a/packages/ui-client/src/providers/TooltipProvider.spec.tsx
+++ b/packages/ui-client/src/providers/TooltipProvider.spec.tsx
@@ -1,0 +1,90 @@
+/* eslint-disable testing-library/prefer-user-event */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import TooltipProvider from './TooltipProvider';
+
+beforeEach(() => {
+	jest.useFakeTimers();
+});
+
+afterEach(() => {
+	jest.useRealTimers();
+});
+
+const setup = () => {
+	render(
+		<TooltipProvider>
+			<button type='button' title='Hello'>
+				anchor
+			</button>
+		</TooltipProvider>,
+	);
+
+	return {
+		anchor: screen.getByRole('button', { name: 'anchor' }),
+	};
+};
+
+const waitForTooltipDebounce = () => {
+	act(() => {
+		jest.advanceTimersByTime(300);
+	});
+};
+
+it('should show the tooltip on hover and stash the title attribute', () => {
+	const { anchor } = setup();
+
+	fireEvent.mouseOver(anchor);
+	waitForTooltipDebounce();
+
+	expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('Hello');
+	expect(anchor).toHaveAttribute('title', '');
+	expect(anchor).toHaveAttribute('data-title', 'Hello');
+});
+
+it('should restore the title attribute on unhover without depending on timers', () => {
+	const { anchor } = setup();
+
+	fireEvent.mouseOver(anchor);
+	waitForTooltipDebounce();
+	fireEvent.mouseLeave(anchor);
+
+	// the title must be restored synchronously on unmount, before any timer runs; otherwise a still-attached
+	// MutationObserver can blank it again, permanently suppressing the tooltip for this element
+	expect(screen.queryByRole('tooltip', { hidden: true })).not.toBeInTheDocument();
+	expect(anchor).toHaveAttribute('title', 'Hello');
+	expect(anchor).not.toHaveAttribute('data-title');
+});
+
+it('should show the tooltip again after a full close and reopen cycle', () => {
+	const { anchor } = setup();
+
+	fireEvent.mouseOver(anchor);
+	waitForTooltipDebounce();
+	fireEvent.mouseLeave(anchor);
+	act(() => {
+		jest.runOnlyPendingTimers();
+	});
+	expect(screen.queryByRole('tooltip', { hidden: true })).not.toBeInTheDocument();
+
+	fireEvent.mouseOver(anchor);
+	waitForTooltipDebounce();
+
+	expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('Hello');
+});
+
+it('should update the tooltip and re-stash the title when it changes while open', async () => {
+	const { anchor } = setup();
+
+	fireEvent.mouseOver(anchor);
+	waitForTooltipDebounce();
+
+	// the MutationObserver callback runs as a microtask, so the update must be flushed asynchronously
+	await act(async () => {
+		anchor.setAttribute('title', 'World');
+	});
+
+	expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('World');
+	expect(anchor).toHaveAttribute('title', '');
+	expect(anchor).toHaveAttribute('data-title', 'World');
+});

--- a/packages/ui-client/src/providers/TooltipProvider.spec.tsx
+++ b/packages/ui-client/src/providers/TooltipProvider.spec.tsx
@@ -182,4 +182,22 @@ describe('with a `data-tooltip`-only anchor', () => {
 		expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('World');
 		expect(anchor).not.toHaveAttribute('title');
 	});
+
+	it('should show the tooltip again after a click-dismiss and mouseleave cycle', () => {
+		const { anchor } = setupDataTooltip();
+
+		fireEvent.mouseOver(anchor);
+		waitForTooltipDebounce();
+		fireEvent.click(anchor);
+		fireEvent.mouseLeave(anchor);
+		act(() => {
+			jest.runOnlyPendingTimers();
+		});
+
+		fireEvent.mouseOver(anchor);
+		waitForTooltipDebounce();
+
+		expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('Hello');
+		expect(anchor).not.toHaveAttribute('title');
+	});
 });

--- a/packages/ui-client/src/providers/TooltipProvider.tsx
+++ b/packages/ui-client/src/providers/TooltipProvider.tsx
@@ -1,7 +1,7 @@
 import { useDebouncedState, useMediaQuery } from '@rocket.chat/fuselage-hooks';
 import { TooltipContext } from '@rocket.chat/ui-contexts';
 import type { ReactNode } from 'react';
-import { useEffect, useMemo, useRef, memo, useCallback, useState } from 'react';
+import { useEffect, useMemo, useRef, memo, useState } from 'react';
 
 import { TooltipComponent } from '../components/TooltipComponent';
 
@@ -10,20 +10,27 @@ export type TooltipProviderProps = {
 	ownerDocument?: Document;
 };
 
+const stashAnchorTitle = (anchor: HTMLElement, title: string): void => {
+	anchor.setAttribute('data-title', title);
+	anchor.setAttribute('title', '');
+};
+
+const restoreAnchorTitle = (anchor: HTMLElement): void => {
+	if (!anchor.getAttribute('title')) {
+		anchor.setAttribute('title', anchor.getAttribute('data-title') ?? '');
+		anchor.removeAttribute('data-title');
+	}
+};
+
+const restoreAnchorTitleDeferred = (anchor: HTMLElement): void => {
+	setTimeout(() => restoreAnchorTitle(anchor), 0);
+};
+
 const TooltipProvider = ({ children, ownerDocument = window.document }: TooltipProviderProps) => {
 	const lastAnchor = useRef<HTMLElement>(undefined);
 	const hasHover = !useMediaQuery('(hover: none)');
 
 	const [tooltip, setTooltip] = useDebouncedState<ReactNode>(null, 300);
-
-	const restoreTitle = useCallback((previousAnchor: HTMLElement | undefined): void => {
-		setTimeout(() => {
-			if (previousAnchor && !previousAnchor.getAttribute('title')) {
-				previousAnchor.setAttribute('title', previousAnchor.getAttribute('data-title') ?? '');
-				previousAnchor.removeAttribute('data-title');
-			}
-		}, 0);
-	}, []);
 
 	const contextValue = useMemo(
 		() => ({
@@ -32,7 +39,7 @@ const TooltipProvider = ({ children, ownerDocument = window.document }: TooltipP
 				setTooltip(<TooltipComponent key={new Date().toISOString()} title={tooltip} anchor={anchor} />);
 				lastAnchor.current = anchor;
 				if (previousAnchor) {
-					restoreTitle(previousAnchor);
+					restoreAnchorTitleDeferred(previousAnchor);
 				}
 			},
 			close: (): void => {
@@ -41,7 +48,7 @@ const TooltipProvider = ({ children, ownerDocument = window.document }: TooltipP
 				setTooltip.flush();
 				lastAnchor.current = undefined;
 				if (previousAnchor) {
-					restoreTitle(previousAnchor);
+					restoreAnchorTitleDeferred(previousAnchor);
 				}
 			},
 			dismiss: (): void => {
@@ -49,7 +56,7 @@ const TooltipProvider = ({ children, ownerDocument = window.document }: TooltipP
 				setTooltip.flush();
 			},
 		}),
-		[setTooltip, restoreTitle],
+		[setTooltip],
 	);
 
 	useEffect(() => {
@@ -85,10 +92,7 @@ const TooltipProvider = ({ children, ownerDocument = window.document }: TooltipP
 				const [state, setState] = useState(title);
 				useEffect(() => {
 					const close = (): void => contextValue.close();
-					// store the title in a data attribute
-					anchor.setAttribute('data-title', title);
-					// Removes the title attribute to prevent the browser's tooltip from showing
-					anchor.setAttribute('title', '');
+					stashAnchorTitle(anchor, title);
 
 					anchor.addEventListener('mouseleave', close);
 
@@ -99,11 +103,7 @@ const TooltipProvider = ({ children, ownerDocument = window.document }: TooltipP
 							return;
 						}
 
-						// store the title in a data attribute
-						anchor.setAttribute('data-title', title);
-						// Removes the title attribute to prevent the browser's tooltip from showing
-						anchor.setAttribute('title', '');
-
+						stashAnchorTitle(anchor, title);
 						setState(title);
 					});
 
@@ -114,7 +114,9 @@ const TooltipProvider = ({ children, ownerDocument = window.document }: TooltipP
 
 					return () => {
 						anchor.removeEventListener('mouseleave', close);
+						// the observer must be disconnected before restoring the title, otherwise it would stash it again
 						observer.disconnect();
+						restoreAnchorTitle(anchor);
 					};
 				}, []);
 				return <>{state}</>;

--- a/packages/ui-client/src/providers/TooltipProvider.tsx
+++ b/packages/ui-client/src/providers/TooltipProvider.tsx
@@ -22,10 +22,6 @@ const restoreAnchorTitle = (anchor: HTMLElement): void => {
 	}
 };
 
-const restoreAnchorTitleDeferred = (anchor: HTMLElement): void => {
-	setTimeout(() => restoreAnchorTitle(anchor), 0);
-};
-
 const TooltipProvider = ({ children, ownerDocument = window.document }: TooltipProviderProps) => {
 	const lastAnchor = useRef<HTMLElement>(undefined);
 	const hasHover = !useMediaQuery('(hover: none)');
@@ -35,21 +31,13 @@ const TooltipProvider = ({ children, ownerDocument = window.document }: TooltipP
 	const contextValue = useMemo(
 		() => ({
 			open: (tooltip: ReactNode, anchor: HTMLElement): void => {
-				const previousAnchor = lastAnchor.current;
 				setTooltip(<TooltipComponent key={new Date().toISOString()} title={tooltip} anchor={anchor} />);
 				lastAnchor.current = anchor;
-				if (previousAnchor) {
-					restoreAnchorTitleDeferred(previousAnchor);
-				}
 			},
 			close: (): void => {
-				const previousAnchor = lastAnchor.current;
 				setTooltip(null);
 				setTooltip.flush();
 				lastAnchor.current = undefined;
-				if (previousAnchor) {
-					restoreAnchorTitleDeferred(previousAnchor);
-				}
 			},
 			dismiss: (): void => {
 				setTooltip(null);

--- a/packages/ui-client/src/providers/TooltipProvider.tsx
+++ b/packages/ui-client/src/providers/TooltipProvider.tsx
@@ -51,7 +51,7 @@ const TooltipProvider = ({ children, ownerDocument = window.document }: TooltipP
 				setTooltip(null);
 				setTooltip.flush();
 
-				if (anchor?.hasAttribute('data-title')) {
+				if (anchor) {
 					dismissedAnchor.current = anchor;
 					const restoreOnLeave = (): void => {
 						restoreAnchorTitle(anchor);

--- a/packages/ui-client/src/providers/TooltipProvider.tsx
+++ b/packages/ui-client/src/providers/TooltipProvider.tsx
@@ -11,19 +11,26 @@ export type TooltipProviderProps = {
 };
 
 const stashAnchorTitle = (anchor: HTMLElement, title: string): void => {
+	if (!anchor.hasAttribute('title')) {
+		return;
+	}
 	anchor.setAttribute('data-title', title);
 	anchor.setAttribute('title', '');
 };
 
 const restoreAnchorTitle = (anchor: HTMLElement): void => {
+	if (!anchor.hasAttribute('data-title')) {
+		return;
+	}
 	if (!anchor.getAttribute('title')) {
 		anchor.setAttribute('title', anchor.getAttribute('data-title') ?? '');
-		anchor.removeAttribute('data-title');
 	}
+	anchor.removeAttribute('data-title');
 };
 
 const TooltipProvider = ({ children, ownerDocument = window.document }: TooltipProviderProps) => {
 	const lastAnchor = useRef<HTMLElement>(undefined);
+	const dismissedAnchor = useRef<HTMLElement>(undefined);
 	const hasHover = !useMediaQuery('(hover: none)');
 
 	const [tooltip, setTooltip] = useDebouncedState<ReactNode>(null, 300);
@@ -40,8 +47,23 @@ const TooltipProvider = ({ children, ownerDocument = window.document }: TooltipP
 				lastAnchor.current = undefined;
 			},
 			dismiss: (): void => {
+				const anchor = lastAnchor.current;
 				setTooltip(null);
 				setTooltip.flush();
+
+				if (anchor?.hasAttribute('data-title')) {
+					dismissedAnchor.current = anchor;
+					const restoreOnLeave = (): void => {
+						restoreAnchorTitle(anchor);
+						if (dismissedAnchor.current === anchor) {
+							dismissedAnchor.current = undefined;
+						}
+						if (lastAnchor.current === anchor) {
+							lastAnchor.current = undefined;
+						}
+					};
+					anchor.addEventListener('mouseleave', restoreOnLeave, { once: true });
+				}
 			},
 		}),
 		[setTooltip],
@@ -104,7 +126,9 @@ const TooltipProvider = ({ children, ownerDocument = window.document }: TooltipP
 						anchor.removeEventListener('mouseleave', close);
 						// the observer must be disconnected before restoring the title, otherwise it would stash it again
 						observer.disconnect();
-						restoreAnchorTitle(anchor);
+						if (dismissedAnchor.current !== anchor) {
+							restoreAnchorTitle(anchor);
+						}
 					};
 				}, []);
 				return <>{state}</>;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating translations
  regression: Issues created during development phase
-->

<!-- Checklist
- I have read the Contributing Guide
- I have signed the CLA
- Lint and unit tests pass locally
- I have added tests (if applicable)
- I have added documentation (if applicable)
- Any dependent changes are merged
-->

## Proposed changes (including videos or screenshots)

Tooltips (custom emojis, user avatars in messages, header buttons, etc.) only showed the first time an element was hovered. On any subsequent hover of the same element, the tooltip failed to appear.

`TooltipProvider` suppresses the browser's native tooltip by moving an element's `title` into a `data-title` attribute while its own tooltip is shown, and restores it on close. The restore was deferred via `setTimeout(0)`, while a `MutationObserver` guarding the title was disconnected in the tooltip's effect cleanup. This relied on the effect cleanup running before the deferred restore — an ordering that held under React 18 but flipped with the React 19 upgrade (root scheduling now defers to a microtask). As a result, the still-connected observer re-blanked the title after it was restored, leaving the element with a permanently empty `title` and no tooltip on re-hover.

The fix restores the title synchronously inside the effect cleanup, immediately after the observer is disconnected, removing the reliance on scheduler timing. The stash/restore logic was also extracted into small helpers, and a regression test was added.

## Issue(s)

Closes: CORE-2410

## Steps to test or reproduce

1. Send a custom emoji in a message (or use any element with a hover tooltip, e.g. a user avatar in a message or a header button).
2. Hover over it and confirm the tooltip shows.
3. Move the mouse away.
4. Hover over the same element again.
5. Expected result: the tooltip shows every time you hover, not just the first time.

## Further comments

[CORE-2410](https://rocketchat.atlassian.net/browse/CORE-2410)


[CORE-2410]: https://rocketchat.atlassian.net/browse/CORE-2410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip behavior for anchors using native `title`, with reliable stashing/restoring across hover close-and-reopen and click-dismiss flows.
  * Tooltip text now stays in sync when an anchor’s `title` (or `data-tooltip`) changes while the tooltip is open.
  * Better handling when tooltips are dismissed: native titles remain consistent and restore on subsequent mouseleave.
* **Tests**
  * Expanded Jest + React Testing Library coverage for hover timing, click-dismiss behavior, close-and-reopen, and live tooltip updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [CORE-2463]