### PR TITLE
feat(apps): IPreFileMessageConfirm event + server-initiated UIKit surfaces

### DIFF
--- a/.changeset/server-initiated-surfaces.md
+++ b/.changeset/server-initiated-surfaces.md
@@ -1,0 +1,11 @@
+---
+'@rocket.chat/apps-engine': minor
+'@rocket.chat/ui-kit': minor
+'@rocket.chat/meteor': minor
+---
+
+Added a new `IPreFileMessageConfirm` app event and an `openServerInitiatedView` UI accessor.
+
+`IPreFileMessageConfirm` fires when a file *message* is about to be posted (the send stage), unlike `IPreFileUpload` which fires at the blob-upload/attach stage. Returning `false` cancels the send.
+
+`openServerInitiatedView(view, user)` lets an app open a UIKit modal/contextual bar in response to a server-side event, without a user-initiated `triggerId`. It is gated by a new opt-in `ui.server-initiated-view` permission; the server flags the interaction `serverInitiated` and the client renders it through a dedicated typed channel, leaving the existing triggerId validation flow untouched.

--- a/apps/meteor/app/ui-message/client/ActionManager.ts
+++ b/apps/meteor/app/ui-message/client/ActionManager.ts
@@ -140,6 +140,18 @@ export class ActionManager implements IActionManager {
 
 		const appId = this.invalidateTriggerId(triggerId);
 		if (!appId) {
+			// Surfaces opened by an app in response to a server-side event carry no
+			// client-minted triggerId. They are trusted via the explicit `serverInitiated`
+			// flag (the server gates them behind the `ui.server-initiated-view` permission),
+			// and only open modal / contextual bar surfaces are accepted here.
+			if (interaction.type === 'modal.open' && interaction.serverInitiated) {
+				this.openModal(interaction.view);
+				return interaction.type;
+			}
+			if (interaction.type === 'contextual_bar.open' && interaction.serverInitiated) {
+				this.openContextualBar(interaction.view);
+				return interaction.type;
+			}
 			return;
 		}
 

--- a/apps/meteor/server/meteor-methods/messages/sendFileMessage.ts
+++ b/apps/meteor/server/meteor-methods/messages/sendFileMessage.ts
@@ -1,3 +1,4 @@
+import { Apps, AppEvents } from '@rocket.chat/apps';
 import type {
 	MessageAttachment,
 	FileAttachmentProps,
@@ -232,6 +233,16 @@ export const sendFileMessage = async (
 	data.file = files[0];
 	data.files = files;
 	data.attachments = attachments;
+
+	// App IPreFileMessageConfirm hook: fires at the SEND stage (unlike IPreFileUpload,
+	// which fires at the blob-upload/attach stage). Returning false cancels the post.
+	const fileMessageConfirmed = await Apps.self?.triggerEvent(AppEvents.IPreFileMessageConfirm, {
+		file: { name: file.name || '', size: file.size || 0, type: file.type || '', rid: roomId, userId },
+		messageText: data.msg ?? '',
+	});
+	if (fileMessageConfirmed === false) {
+		throw new Meteor.Error('error-app-prevented', 'File message send was cancelled by an app', { method: 'sendFileMessage' });
+	}
 
 	const msg = await executeSendMessage(userId, data);
 

--- a/packages/apps-engine/src/definition/accessors/IUIController.ts
+++ b/packages/apps-engine/src/definition/accessors/IUIController.ts
@@ -26,5 +26,13 @@ export interface IUIController {
 	updateContextualBarView(view: IUIKitContextualBarViewParam, context: IUIKitInteractionParam, user: IUser): Promise<void>;
 	setViewError(errorInteraction: IUIKitErrorInteractionParam, context: IUIKitInteractionParam, user: IUser): Promise<void>;
 	openSurfaceView(view: IUIKitSurfaceViewParam, context: IUIKitInteractionParam, user: IUser): Promise<void>;
+	/**
+	 * Open a UIKit surface for a user in response to a server-side event, without a
+	 * user-initiated triggerId. Requires the `ui.server-initiated-view` permission.
+	 * The framework mints and registers a server interaction token; the client renders
+	 * it through the dedicated server-initiated channel. Only modal / contextual bar
+	 * surfaces are permitted. `view.id` is chosen by the app to correlate the submit.
+	 */
+	openServerInitiatedView(view: IUIKitSurfaceViewParam, user: IUser): Promise<void>;
 	updateSurfaceView(view: IUIKitSurfaceViewParam, context: IUIKitInteractionParam, user: IUser): Promise<void>;
 }

--- a/packages/apps-engine/src/definition/metadata/AppInterface.ts
+++ b/packages/apps-engine/src/definition/metadata/AppInterface.ts
@@ -53,6 +53,7 @@ export enum AppInterface {
 	IPostLivechatDepartmentDisabled = 'IPostLivechatDepartmentDisabled',
 	// FileUpload
 	IPreFileUpload = 'IPreFileUpload',
+	IPreFileMessageConfirm = 'IPreFileMessageConfirm',
 	// Email
 	IPreEmailSent = 'IPreEmailSent',
 	IPostUserCreated = 'IPostUserCreated',

--- a/packages/apps-engine/src/definition/metadata/AppMethod.ts
+++ b/packages/apps-engine/src/definition/metadata/AppMethod.ts
@@ -98,6 +98,7 @@ export enum AppMethod {
 	EXECUTE_POST_LIVECHAT_DEPARTMENT_REMOVED = 'executePostLivechatDepartmentRemoved',
 	// FileUpload
 	EXECUTE_PRE_FILE_UPLOAD = 'executePreFileUpload',
+	EXECUTE_PRE_FILE_MESSAGE_CONFIRM = 'executePreFileMessageConfirm',
 	// Email
 	EXECUTE_PRE_EMAIL_SENT = 'executePreEmailSent',
 	// User

--- a/packages/apps-engine/src/definition/metadata/AppPermissions.ts
+++ b/packages/apps-engine/src/definition/metadata/AppPermissions.ts
@@ -31,6 +31,7 @@ export const AppPermissions = {
 	'ui': {
 		interaction: { name: 'ui.interact' },
 		registerButtons: { name: 'ui.registerButtons' },
+		serverInitiatedView: { name: 'ui.server-initiated-view' },
 	},
 	'setting': {
 		read: { name: 'server-setting.read', hiddenSettings: [] } as IReadSettingPermission,

--- a/packages/apps-engine/src/definition/uikit/IUIKitInteractionType.ts
+++ b/packages/apps-engine/src/definition/uikit/IUIKitInteractionType.ts
@@ -18,6 +18,12 @@ export interface IUIKitInteraction {
 	type: UIKitInteractionType;
 	triggerId: string;
 	appId: string;
+	/**
+	 * Set when the surface was opened by the server in response to an app event
+	 * (no user-initiated triggerId). The client renders these through a dedicated
+	 * channel instead of validating triggerId. See `IUIController.openServerInitiatedView`.
+	 */
+	serverInitiated?: boolean;
 }
 
 export interface IUIKitErrorInteraction extends IUIKitInteraction {

--- a/packages/apps-engine/src/definition/uploads/IFileMessageConfirmContext.ts
+++ b/packages/apps-engine/src/definition/uploads/IFileMessageConfirmContext.ts
@@ -1,0 +1,10 @@
+import type { IUploadDetails } from './IUploadDetails';
+
+/**
+ * Context handed to an `IPreFileMessageConfirm` handler: the file whose message
+ * is about to be posted, and the accompanying message text (caption), if any.
+ */
+export interface IFileMessageConfirmContext {
+	file: IUploadDetails;
+	messageText: string;
+}

--- a/packages/apps-engine/src/definition/uploads/IPreFileMessageConfirm.ts
+++ b/packages/apps-engine/src/definition/uploads/IPreFileMessageConfirm.ts
@@ -1,0 +1,24 @@
+import type { IHttp, IModify, IPersistence, IRead } from '../accessors';
+import { AppMethod } from '../metadata';
+import type { IFileMessageConfirmContext } from './IFileMessageConfirmContext';
+
+/**
+ * Event interface that allows an app to register as a handler of the
+ * `IPreFileMessageConfirm` event.
+ *
+ * Unlike `IPreFileUpload` (which fires when the file *blob* is uploaded, at
+ * attach time), this event fires when the file *message* is about to be posted
+ * (at send time). It lets an app confirm or cancel the send — e.g. by opening
+ * a server-initiated modal and awaiting the user's choice.
+ *
+ * @returns `true` to allow the message to be posted, `false` to cancel it.
+ */
+export interface IPreFileMessageConfirm {
+	[AppMethod.EXECUTE_PRE_FILE_MESSAGE_CONFIRM](
+		context: IFileMessageConfirmContext,
+		read: IRead,
+		http: IHttp,
+		persis: IPersistence,
+		modify: IModify,
+	): Promise<boolean>;
+}

--- a/packages/apps-engine/src/definition/uploads/index.ts
+++ b/packages/apps-engine/src/definition/uploads/index.ts
@@ -1,7 +1,9 @@
+import type { IFileMessageConfirmContext } from './IFileMessageConfirmContext';
 import type { IFileUploadContext } from './IFileUploadContext';
+import type { IPreFileMessageConfirm } from './IPreFileMessageConfirm';
 import type { IPreFileUpload } from './IPreFileUpload';
 import type { IUpload } from './IUpload';
 import { StoreType } from './StoreType';
 
-export type { IFileUploadContext, IPreFileUpload, IUpload };
+export type { IFileMessageConfirmContext, IFileUploadContext, IPreFileMessageConfirm, IPreFileUpload, IUpload };
 export { StoreType };

--- a/packages/apps/src/server/accessors/UIController.ts
+++ b/packages/apps/src/server/accessors/UIController.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import type { IUIController } from '@rocket.chat/apps-engine/definition/accessors';
 import type {
 	IUIKitErrorInteractionParam,
@@ -79,6 +81,33 @@ export class UIController implements IUIController {
 			case UIKitSurfaceType.MODAL:
 				return this.openModal(viewWithIds, context, user, true);
 		}
+	}
+
+	public openServerInitiatedView(view: IUIKitSurfaceViewParam, user: IUser): Promise<void> {
+		const blocks = UIHelper.assignIds(view.blocks, this.appId);
+		const viewWithIds = { ...view, blocks };
+
+		// A server-minted token stands in for the (absent) user triggerId. The client
+		// trusts these via the explicit `serverInitiated` flag + the app permission,
+		// not by validating the token against a client-minted map.
+		const interactionContext = { triggerId: randomUUID(), appId: this.appId };
+
+		let interaction;
+		switch (view.type) {
+			case UIKitSurfaceType.MODAL:
+				interaction = formatModalInteraction(viewWithIds, { ...interactionContext, type: UIKitInteractionType.MODAL_OPEN });
+				break;
+			case UIKitSurfaceType.CONTEXTUAL_BAR:
+				interaction = formatContextualBarInteraction(viewWithIds, {
+					...interactionContext,
+					type: UIKitInteractionType.CONTEXTUAL_BAR_OPEN,
+				});
+				break;
+			default:
+				throw new Error('A server-initiated view must be a modal or contextual bar surface');
+		}
+
+		return this.uiInteractionBridge.doNotifyUserServerInitiated(user, { ...interaction, serverInitiated: true }, this.appId);
 	}
 
 	public setViewError(errorInteraction: IUIKitErrorInteractionParam, context: IUIKitInteractionParam, user: IUser) {

--- a/packages/apps/src/server/bridges/UiInteractionBridge.ts
+++ b/packages/apps/src/server/bridges/UiInteractionBridge.ts
@@ -13,7 +13,28 @@ export abstract class UiInteractionBridge extends BaseBridge {
 		}
 	}
 
+	public async doNotifyUserServerInitiated(user: IUser, interaction: IUIKitInteraction, appId: string): Promise<void> {
+		if (this.hasServerInitiatedViewPermission(appId)) {
+			return this.notifyUser(user, interaction, appId);
+		}
+	}
+
 	protected abstract notifyUser(user: IUser, interaction: IUIKitInteraction, appId: string): Promise<void>;
+
+	private hasServerInitiatedViewPermission(appId: string): boolean {
+		if (AppPermissionManager.hasPermission(appId, AppPermissions.ui.serverInitiatedView)) {
+			return true;
+		}
+
+		AppPermissionManager.notifyAboutError(
+			new PermissionDeniedError({
+				appId,
+				missingPermissions: [AppPermissions.ui.serverInitiatedView],
+			}),
+		);
+
+		return false;
+	}
 
 	private hasInteractionPermission(appId: string): boolean {
 		if (AppPermissionManager.hasPermission(appId, AppPermissions.ui.interaction)) {

--- a/packages/apps/src/server/managers/AppListenerManager.ts
+++ b/packages/apps/src/server/managers/AppListenerManager.ts
@@ -28,6 +28,7 @@ import type {
 	IUIKitLivechatBlockIncomingInteraction,
 	IUIKitLivechatIncomingInteraction,
 } from '@rocket.chat/apps-engine/definition/uikit/livechat';
+import type { IFileMessageConfirmContext } from '@rocket.chat/apps-engine/definition/uploads/IFileMessageConfirmContext';
 import type { IFileUploadInternalContext } from '@rocket.chat/apps-engine/definition/uploads/IFileUploadContext';
 import type { IUser, IUserContext, IUserStatusContext, IUserUpdateContext } from '@rocket.chat/apps-engine/definition/users';
 
@@ -212,6 +213,10 @@ export interface IListenerExecutor {
 	[AppInterface.IPreFileUpload]: {
 		args: [IFileUploadInternalContext];
 		result: void;
+	};
+	[AppInterface.IPreFileMessageConfirm]: {
+		args: [IFileMessageConfirmContext];
+		result: boolean;
 	};
 	// Email
 	[AppInterface.IPreEmailSent]: {
@@ -454,6 +459,8 @@ export class AppListenerManager {
 			// FileUpload
 			case AppInterface.IPreFileUpload:
 				return this.executePreFileUpload(data as IFileUploadInternalContext);
+			case AppInterface.IPreFileMessageConfirm:
+				return this.executePreFileMessageConfirm(data as IFileMessageConfirmContext);
 			// Email
 			case AppInterface.IPreEmailSent:
 				return this.executePreEmailSent(data as IPreEmailSentContext);
@@ -1181,6 +1188,21 @@ export class AppListenerManager {
 
 			await app.call(AppMethod.EXECUTE_PRE_FILE_UPLOAD, data);
 		}
+	}
+
+	private async executePreFileMessageConfirm(data: IFileMessageConfirmContext): Promise<boolean> {
+		for (const appId of this.listeners.get(AppInterface.IPreFileMessageConfirm)) {
+			const app = this.manager.getOneById(appId);
+
+			const confirmed = (await app.call(AppMethod.EXECUTE_PRE_FILE_MESSAGE_CONFIRM, data)) as boolean;
+
+			// Any app that declines cancels the send.
+			if (confirmed === false) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	private async executePreEmailSent(data: IPreEmailSentContext): Promise<IEmailDescriptor> {

--- a/packages/ui-kit/src/interactions/ServerInteraction.ts
+++ b/packages/ui-kit/src/interactions/ServerInteraction.ts
@@ -9,6 +9,7 @@ type OpenModalServerInteraction = {
 	triggerId: string;
 	appId: string;
 	view: ModalView;
+	serverInitiated?: boolean;
 };
 
 type UpdateModalServerInteraction = {
@@ -49,6 +50,7 @@ type OpenContextualBarServerInteraction = {
 	triggerId: string;
 	appId: string;
 	view: ContextualBarView;
+	serverInitiated?: boolean;
 };
 
 type UpdateContextualBarServerInteraction = {


### PR DESCRIPTION
## Proposal

Apps can only open a UIKit surface (modal / contextual bar) in response to a **user interaction** that produced a client-minted `triggerId` (button click, slash command, action). Server-side app events — file uploads, message events, scheduled jobs — have no `triggerId`, so an app **cannot** open a modal from them.

Concretely, an app cannot show a "confirm this upload?" modal when a file is sent, because the send isn't a triggerId-bearing interaction.

This PR adds two pieces to enable that, in a way that keeps the existing triggerId protection intact.

## What's added

**1. `IPreFileMessageConfirm` app event.** Fires when a file *message* is about to be posted (the send stage), unlike `IPreFileUpload` which fires at the blob-upload/attach stage. Returning `false` cancels the send. Fired from `sendFileMessage` before `executeSendMessage`.

**2. `IUIController.openServerInitiatedView(view, user)`.** Opens a modal / contextual bar for a user in response to a server-side event, with no user `triggerId`. It is gated by a new **opt-in** `ui.server-initiated-view` permission. The server mints a token and flags the interaction `serverInitiated: true`; the client renders these through a dedicated, typed branch in `ActionManager` — not by validating the token against the client-minted map, and not by any string-matching hack. The existing triggerId flow is byte-for-byte unchanged.

An event handler can `await` the user's choice: the Deno app runtime dispatches RPCs concurrently, so the parked handler and the modal-submit run in the same isolate without deadlocking (bounded under `APPS_ENGINE_RUNTIME_TIMEOUT`).

## Backward compatibility

- New permission is opt-in; existing apps are unaffected.
- New accessor is additive; `openModalView` / `openSurfaceView` are untouched.
- The client change is a new typed `serverInitiated` branch that only runs for interactions with no valid triggerId **and** the flag set; `Random.id()` never contains a `:`, so no existing interaction shape collides.
- No changes to `IMessage` or existing event signatures.

## Status / honesty

This is a **proposal + working proof-of-concept**, opened as a draft for design feedback. It was implemented and verified end-to-end against the `8.5.0` release (both the confirm and cancel paths), then ported onto `develop` — CI here is the first compile check on `develop`. **It does not yet include automated tests**, and a couple of areas deserve maintainer input before it's merge-ready:

- The `serverInitiated` client-trust model (is the opt-in permission + typed channel the right boundary, or should there be an explicit per-open confirmation / rate limit?).
- The interactive `await`-a-submit pattern inside an event handler.
- Permission granting UX for a new opt-in permission (a raw private-app upload doesn't grant it without the `permissions` field).

Happy to add tests, docs, and iterate on the design based on feedback.
