### PR TITLE
fix: Update DeepL attachment translation to use new authentication me…

### DIFF
--- a/.changeset/fix-deepl-autotranslate.md
+++ b/.changeset/fix-deepl-autotranslate.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+fix: Update DeepL attachment translation to use new authentication method (#41100)

--- a/apps/meteor/server/lib/autotranslate/deeplTranslate.ts
+++ b/apps/meteor/server/lib/autotranslate/deeplTranslate.ts
@@ -194,10 +194,13 @@ class DeeplAutoTranslate extends AutoTranslate {
 				const result = await fetch(this.apiEndPointUrl, {
 					ignoreSsrfValidation: true,
 					params: {
-						auth_key: this.apiKey,
 						target_lang: language,
 						text: attachment.description || attachment.text || '',
 					},
+					headers: {
+						Authorization: `DeepL-Auth-Key ${this.apiKey}`,
+					},
+					method: 'POST',
 				});
 				if (!result.ok) {
 					throw new Error(result.statusText);


### PR DESCRIPTION
## Proposed changes
Updates the `_translateAttachmentDescriptions` method in DeepL translation to use the `Authorization` header instead of the deprecated `auth_key` query parameter. This resolves the 403 Forbidden errors when translating attachments.

## Issue(s)
Closes #41100

## Steps to test or reproduce
1. Enable Auto Translate, select DeepL as provider, enter a valid DeepL API key.
2. Enable auto-translate in any channel.
3. Post or receive a message with an attachment description in that channel.
4. Verify the attachment text translates without a 403 Forbidden error in the server logs.

## Further comments
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DeepL translation requests for attachment descriptions by sending authentication through the appropriate request header.
  * Updated the request payload to include only the target language and the available description/text content.
  * Preserved existing fallback handling when attachment descriptions or text are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->