### PR TITLE
fix: Remove obsolete offset TODO and fix virtualization typings (#40619)

### DIFF
--- a/.changeset/fix-jump-to-message-types.md
+++ b/.changeset/fix-jump-to-message-types.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+fix: Remove obsolete offset TODO and fix virtualization typings (#40619)

--- a/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.ts
+++ b/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.ts
@@ -3,7 +3,7 @@ import { useEndpoint, useSearchParameter } from '@rocket.chat/ui-contexts';
 import { useQuery } from '@tanstack/react-query';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import { useEffect } from 'react';
-import type { WindowVirtualizerHandle } from 'virtua';
+import type { VirtualizerHandle } from 'virtua';
 
 import { RoomHistoryManager } from '../../../../../app/ui-utils/client';
 import { messagesQueryKeys } from '../../../../lib/queryKeys';
@@ -14,7 +14,7 @@ import { clearHighlightMessage, setHighlightMessage } from '../providers/message
 
 type UseTryToJumpToMessageProps = {
 	rid: string;
-	virtualizerRef: MutableRefObject<WindowVirtualizerHandle | null>;
+	virtualizerRef: MutableRefObject<VirtualizerHandle | null>;
 	setIsJumpingToMessage: Dispatch<SetStateAction<boolean>>;
 	messages: { _id: string }[];
 };
@@ -69,7 +69,6 @@ const useTryToJumpToMessage = ({ rid, virtualizerRef, setIsJumpingToMessage, mes
 		}
 		const messageIndex = messages.indexOf(loadedMessage);
 
-		// TODO: Calculate the offset of the page, for the message to be in the center of the page
 		virtualizerRef.current?.scrollToIndex(messageIndex, {
 			align: 'center',
 		});


### PR DESCRIPTION
## Proposed changes
Removes an obsolete TODO about calculating scroll offsets (virtua's `align: 'center'` handles the viewport centering perfectly).
Also fixes a TypeScript bug where `WindowVirtualizerHandle` was incorrectly expected instead of the actual `VirtualizerHandle`.

## Issue(s)
Closes #40619

## Steps to test or reproduce
1. Go to any room with messages.
2. Search for an old message or click on a permalink deep-link that jumps to an older message.
3. Observe that the message perfectly centers in the view and no TypeScript errors are present in the build.

## Further comments
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deep-link navigation to work correctly with the room’s virtualized message list by correcting the virtualizer reference typing.
  * Ensured message jump, highlighting, and follow-up cleanup continue to function reliably when opening linked messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->