### PR TITLE
fix: Automatically reload client if permanently stuck in reconnect lo…

### DIFF
--- a/.changeset/fix-reconnect-loop.md
+++ b/.changeset/fix-reconnect-loop.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+fix: Automatically reload client if permanently stuck in reconnect loop (#41405)

--- a/apps/meteor/client/providers/ServerProvider.tsx
+++ b/apps/meteor/client/providers/ServerProvider.tsx
@@ -13,7 +13,7 @@ import type { UploadResult, ServerContextValue } from '@rocket.chat/ui-contexts'
 import { ServerContext } from '@rocket.chat/ui-contexts';
 import { Meteor } from 'meteor/meteor';
 import { compile } from 'path-to-regexp';
-import { useMemo, useSyncExternalStore, type ReactNode } from 'react';
+import { useMemo, useSyncExternalStore, useEffect, type ReactNode } from 'react';
 
 import { sdk } from '../../app/utils/client/lib/SDKClient';
 import { Info as info } from '../../app/utils/rocketchat.info';
@@ -178,6 +178,12 @@ export type ServerProviderProps = { children?: ReactNode };
 
 const ServerProvider = ({ children }: ServerProviderProps) => {
 	const { connected, status, retryCount, retryTime } = useSyncExternalStore(subscribeStatus, getStatusSnapshot);
+
+	useEffect(() => {
+		if (retryCount && retryCount >= 30 && navigator.onLine) {
+			window.location.reload();
+		}
+	}, [retryCount]);
 
 	const value = useMemo(
 		(): ServerContextValue => ({


### PR DESCRIPTION
## Proposed changes
When the client is permanently stuck in a SockJS reconnect loop despite having internet connectivity (e.g. `retryCount >= 30` and `navigator.onLine === true`), we now automatically trigger a reload. This robustly recreates the entire connection stream and recovers the client from the corrupted state without requiring user intervention (CTRL+R).

## Issue(s)
Closes #41405

## Steps to test or reproduce
1. Start Rocket.Chat Desktop on Windows 11.
2. Connect it normally to a Rocket.Chat workspace.
3. Make the Rocket.Chat server temporarily unavailable (e.g. stop the stack).
4. Wait 60-90 seconds.
5. Start the server again.
6. The client should automatically recover. If it gets stuck in the corrupted state where `retryCount` exceeds 30, it will automatically reload the renderer and recover the connection successfully.

## Further comments
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically reloads the page after repeated connection retries when the browser is online, helping recover from cases where the app gets stuck in a reconnect loop.
  * Improves end-user resilience by restoring the app without requiring manual refresh after prolonged reconnect attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->