### PR TITLE
regression: combined emojis displayed as separate emojis and some flags displayed as a black flag

### DIFF
--- a/.changeset/emoji-zwj-tag-sequences.md
+++ b/.changeset/emoji-zwj-tag-sequences.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/message-parser': patch
+---
+
+Fixes an issue in which some combined emojis like 😶‍🌫️, 😮‍💨 and 😵‍💫 were being displayed as two separate emojis, and the flags of some countries like England 🏴󠁧󠁢󠁥󠁮󠁧󠁿, Scotland 🏴󠁧󠁢󠁳󠁣󠁴󠁿 and Wales 🏴󠁧󠁢󠁷󠁬󠁳󠁿 were being displayed as a plain black flag

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -794,11 +794,12 @@ EmoticonBackslash
 
 /* Unicode emojis */
 UnicodeEmoji
-  = UnicodeEmojiEmoticon
+  = UnicodeEmojiTagSequence
   / $(
     (UnicodeEmojiZwjComponent [\u200D])*
     UnicodeEmojiZwjComponent
   )
+  / UnicodeEmojiEmoticon
   / UnicodeEmojiTransportAndMapSymbols
   / UnicodeEmojiMiscellaneousTechnical
   / UnicodeEmojiMiscellaneousSymbols
@@ -810,9 +811,12 @@ UnicodeEmojiEmoticon = $([\uD83D] [\uDE00-\uDE4F])
 UnicodeEmojiSupplementalSymbolsAndPictographs = $([\uD83E] [\uDD00-\uDFFF])
 
 UnicodeEmojiZwjComponent
-  = (UnicodeEmojiSupplementalSymbolsAndPictographs / UnicodeEmojiMiscellaneousSymbolsAndPictographs) UnicodeEmojiMiscellaneousSymbolsAndPictographsFitzpatrickModifiers?
+  = (UnicodeEmojiSupplementalSymbolsAndPictographs / UnicodeEmojiMiscellaneousSymbolsAndPictographs / UnicodeEmojiEmoticon) UnicodeEmojiMiscellaneousSymbolsAndPictographsFitzpatrickModifiers?
   / UnicodeEmojiDingbats
   / UnicodeEmojiMiscellaneousSymbols
+
+/* Emoji tag sequence: Black Flag + tag characters (U+E0020-U+E007E) + Cancel Tag (U+E007F), e.g. England/Scotland/Wales flags */
+UnicodeEmojiTagSequence = $([\uD83C] [\uDFF4] ([\uDB40] [\uDC20-\uDC7E])+ [\uDB40] [\uDC7F])
 
 UnicodeEmojiMiscellaneousSymbolsAndPictographs = $([\uD83C] [\uDF00-\uDFFF] [\uFE00-\uFE0F]?) / $([\uD83D] [\uDC00-\uDDFF] [\uFE00-\uFE0F]?)
 

--- a/packages/message-parser/tests/emoji.test.ts
+++ b/packages/message-parser/tests/emoji.test.ts
@@ -88,6 +88,31 @@ test.each([
 	['🫱🏿‍🫲🏻', [bigEmoji([emojiUnicode('🫱🏿‍🫲🏻')])]], // v14
 	['🫩', [bigEmoji([emojiUnicode('🫩')])]], // v16
 	['🇨🇶', [bigEmoji([emojiUnicode('🇨🇶')])]], // v16
+	// ZWJ sequences anchored by an Emoticon (U+1F600-U+1F64F)
+	['😶‍🌫️', [bigEmoji([emojiUnicode('😶‍🌫️')])]],
+	['😮‍💨', [bigEmoji([emojiUnicode('😮‍💨')])]],
+	['😵‍💫', [bigEmoji([emojiUnicode('😵‍💫')])]],
+	['Hi 😶‍🌫️', [paragraph([plain('Hi '), emojiUnicode('😶‍🌫️')])]],
+	['😶‍🌫️😮‍💨', [bigEmoji([emojiUnicode('😶‍🌫️'), emojiUnicode('😮‍💨')])]],
+	['🙋🏽‍♂️', [bigEmoji([emojiUnicode('🙋🏽‍♂️')])]],
+	['😀', [bigEmoji([emojiUnicode('😀')])]], // standalone emoticon still matches
+	// Emoji tag sequences — England/Scotland/Wales flags
+	['🏴󠁧󠁢󠁥󠁮󠁧󠁿', [bigEmoji([emojiUnicode('🏴󠁧󠁢󠁥󠁮󠁧󠁿')])]],
+	['🏴󠁧󠁢󠁳󠁣󠁴󠁿', [bigEmoji([emojiUnicode('🏴󠁧󠁢󠁳󠁣󠁴󠁿')])]],
+	['🏴󠁧󠁢󠁷󠁬󠁳󠁿', [bigEmoji([emojiUnicode('🏴󠁧󠁢󠁷󠁬󠁳󠁿')])]],
+	['Hi 🏴󠁧󠁢󠁥󠁮󠁧󠁿', [paragraph([plain('Hi '), emojiUnicode('🏴󠁧󠁢󠁥󠁮󠁧󠁿')])]],
+	['🏴', [bigEmoji([emojiUnicode('🏴')])]], // standalone black flag still matches
+	['🏴‍☠️', [bigEmoji([emojiUnicode('🏴‍☠️')])]], // pirate flag (ZWJ, not tag sequence) still matches
+	// Consecutive sequence emojis — each sequence must be consumed whole, without stealing from its neighbor
+	['🏴󠁧󠁢󠁥󠁮󠁧󠁿🏴󠁧󠁢󠁳󠁣󠁴󠁿🏴󠁧󠁢󠁷󠁬󠁳󠁿', [bigEmoji([emojiUnicode('🏴󠁧󠁢󠁥󠁮󠁧󠁿'), emojiUnicode('🏴󠁧󠁢󠁳󠁣󠁴󠁿'), emojiUnicode('🏴󠁧󠁢󠁷󠁬󠁳󠁿')])]],
+	['🏴🏴󠁧󠁢󠁥󠁮󠁧󠁿', [bigEmoji([emojiUnicode('🏴'), emojiUnicode('🏴󠁧󠁢󠁥󠁮󠁧󠁿')])]],
+	['🏴󠁧󠁢󠁥󠁮󠁧󠁿🏴', [bigEmoji([emojiUnicode('🏴󠁧󠁢󠁥󠁮󠁧󠁿'), emojiUnicode('🏴')])]],
+	['😶‍🌫️😮‍💨😵‍💫', [bigEmoji([emojiUnicode('😶‍🌫️'), emojiUnicode('😮‍💨'), emojiUnicode('😵‍💫')])]],
+	['😀😶‍🌫️', [bigEmoji([emojiUnicode('😀'), emojiUnicode('😶‍🌫️')])]],
+	['😶‍🌫️🏴󠁧󠁢󠁥󠁮󠁧󠁿🏴‍☠️', [bigEmoji([emojiUnicode('😶‍🌫️'), emojiUnicode('🏴󠁧󠁢󠁥󠁮󠁧󠁿'), emojiUnicode('🏴‍☠️')])]],
+	// More than 3 emojis: no BigEmoji, plain paragraph of emoji tokens
+	['😶‍🌫️😮‍💨😵‍💫👍', [paragraph([emojiUnicode('😶‍🌫️'), emojiUnicode('😮‍💨'), emojiUnicode('😵‍💫'), emojiUnicode('👍')])]],
+	['England 🏴󠁧󠁢󠁥󠁮󠁧󠁿 and Scotland 🏴󠁧󠁢󠁳󠁣󠁴󠁿', [paragraph([plain('England '), emojiUnicode('🏴󠁧󠁢󠁥󠁮󠁧󠁿'), plain(' and Scotland '), emojiUnicode('🏴󠁧󠁢󠁳󠁣󠁴󠁿')])]],
 ])('parses %p', (input, output) => {
 	expect(parse(input)).toEqual(output);
 });


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

The message parser was splitting multi-codepoint emoji sequences into multiple emojis:

- **ZWJ sequences anchored by a face emoji** (😶‍🌫️, 😮‍💨, 😵‍💫) were displayed as two separate emojis. The grammar tried the standalone emoticon rule before the ZWJ-sequence branch, so the face was matched alone and the remainder of the sequence was left behind. Additionally, the emoticon range was not a valid ZWJ component, so a face could never anchor a sequence even when the branch was reached.
- **Tag-sequence flags** (England 🏴󠁧󠁢󠁥󠁮󠁧󠁿, Scotland 🏴󠁧󠁢󠁳󠁣󠁴󠁿, Wales 🏴󠁧󠁢󠁷󠁬󠁳󠁿) were displayed as a plain black flag. The grammar had no rule for Unicode tag characters, so only the Black Flag base was matched and the invisible tag letters fell through as plain text. This was previously masked by `emojione` shipping its own assets for these flags and was exposed when it was removed (#39411).

Changes in `packages/message-parser/src/grammar.pegjs`:
- Added a new `UnicodeEmojiTagSequence` rule (Black Flag + tag characters + Cancel Tag), tried first so the standalone black flag cannot preempt it.
- Moved the ZWJ-sequence branch ahead of the standalone emoticon rule.
- Added emoticons (with optional skin-tone modifier) as valid ZWJ components.

No existing rule's character ranges were narrowed, so anything that matched before still matches — the only behavioral change is that sequences previously producing two tokens now produce one.

## Issue(s)

[CORE-2311](https://rocketchat.atlassian.net/browse/CORE-2311)
[CORE-2416](https://rocketchat.atlassian.net/browse/CORE-2416)

## Steps to test or reproduce

1. Send a message containing 😶‍🌫️, 😮‍💨 or 😵‍💫 — each should render as a single emoji instead of two.
2. Send a message containing 🏴󠁧󠁢󠁥󠁮󠁧󠁿, 🏴󠁧󠁢󠁳󠁣󠁴󠁿 or 🏴󠁧󠁢󠁷󠁬󠁳󠁿 — the correct flag should render instead of a plain black flag.
3. Verify no regressions: 🏴 (black flag), 🏴‍☠️, 🏳️‍🌈, 👨‍👩‍👧‍👦, 🇺🇸 and standalone emojis like 👍 and 😀 still render as before.

## Further comments

[CORE-2311](https://rocketchat.atlassian.net/browse/CORE-2311) · [CORE-2416](https://rocketchat.atlassian.net/browse/CORE-2416)


[CORE-2311]: https://rocketchat.atlassian.net/browse/CORE-2311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of complex emoji sequences, including combined ZWJ emojis.
  * Corrected display of England, Scotland, and Wales flag emojis.
  * Improved handling of adjacent emoji sequences to prevent incorrect character grouping.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->