### PR TITLE
ci(codeql): align codeql-action steps to v4.37.1

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         # Override language selection by uncommenting this and choosing your languages
         with:
           languages: javascript
@@ -54,4 +54,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1


### PR DESCRIPTION
## Problem

Every CodeQL run on `develop` fails at Autobuild:

```
##[error]We were unable to automatically build your code. ... Loaded a configuration file for version '4.36.2', but running version '4.37.1'
```

## Cause

`codeql-analysis.yml` had mismatched pins — `autobuild` was bumped to v4.37.1 but `init` and `analyze` stayed on v4.36.2. `init` writes the config for 4.36.2, then autobuild runs 4.37.1 and rejects it.

## Fix

Align all three steps to v4.37.1 (`7188fc363630916deb702c7fdcf4e481b751f97a`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security scanning workflow to use the latest CodeQL Action version.
  * No changes to application functionality or workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->