### PR TITLE
chore: migrate getRoomByTypeAndName DDP method to REST

### DIFF
--- a/.changeset/ddp-migrate-getroombytypeandname.md
+++ b/.changeset/ddp-migrate-getroombytypeandname.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/rest-typings': minor
+'@rocket.chat/meteor': minor
+---
+
+Migrates the `getRoomByTypeAndName` DDP method to REST. Adds `GET /v1/rooms.getByTypeAndName` (query `{ type, name }` → `{ room }`, `authRequired: false` to keep supporting anonymous read). The open-room flow and the embedded preload now use it; the DDP method keeps its registration with a deprecation log pointing at the new route until 9.0.0. The URL scheme is unchanged (still type + name) — this only moves the resolution off DDP.

--- a/apps/meteor/client/lib/utils/mapRoomFromApi.ts
+++ b/apps/meteor/client/lib/utils/mapRoomFromApi.ts
@@ -1,0 +1,13 @@
+import type { IRoom, Serialized } from '@rocket.chat/core-typings';
+
+import { mapMessageFromApi } from './mapMessageFromApi';
+
+// The REST payload serializes Date fields to strings; deserialize the room's date fields
+// (and its nested lastMessage) back to Date so the room can be stored in the Date-typed Rooms state.
+export const mapRoomFromApi = ({ _updatedAt, lm, lastMessage, ...room }: Serialized<IRoom>): IRoom =>
+	({
+		...room,
+		_updatedAt: new Date(_updatedAt),
+		...(lm && { lm: new Date(lm) }),
+		...(lastMessage && { lastMessage: mapMessageFromApi(lastMessage) }),
+	}) as unknown as IRoom;

--- a/apps/meteor/client/views/room/hooks/useOpenRoom.ts
+++ b/apps/meteor/client/views/room/hooks/useOpenRoom.ts
@@ -1,6 +1,6 @@
 import { isPublicRoom, type IRoom, type RoomType } from '@rocket.chat/core-typings';
 import { getObjectKeys } from '@rocket.chat/tools';
-import { useEndpoint, useMethod, usePermission, useRoute, useSetting, useUser } from '@rocket.chat/ui-contexts';
+import { useEndpoint, usePermission, useRoute, useSetting, useUser } from '@rocket.chat/ui-contexts';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect } from 'react';
 
@@ -13,13 +13,14 @@ import { NotSubscribedToRoomError } from '../../../lib/errors/NotSubscribedToRoo
 import { OldUrlRoomError } from '../../../lib/errors/OldUrlRoomError';
 import { RoomNotFoundError } from '../../../lib/errors/RoomNotFoundError';
 import { roomsQueryKeys } from '../../../lib/queryKeys';
+import { mapRoomFromApi } from '../../../lib/utils/mapRoomFromApi';
 import { Rooms, Subscriptions } from '../../../stores';
 
 export function useOpenRoom({ type, reference }: { type: RoomType; reference: string }) {
 	const user = useUser();
 	const hasPreviewPermission = usePermission('preview-c-room');
 	const allowAnonymousRead = useSetting('Accounts_AllowAnonymousRead', true);
-	const getRoomByTypeAndName = useMethod('getRoomByTypeAndName');
+	const getRoomByTypeAndName = useEndpoint('GET', '/v1/rooms.getByTypeAndName');
 	const createDirectMessage = useEndpoint('POST', '/v1/im.create');
 	const directRoute = useRoute('direct');
 	const openRoom = useOpenRoomMutation();
@@ -76,9 +77,14 @@ export function useOpenRoom({ type, reference }: { type: RoomType; reference: st
 
 			let roomData: IRoom;
 			try {
-				roomData = await getRoomByTypeAndName(type, reference);
+				const { room } = await getRoomByTypeAndName({ type, name: reference });
+				roomData = mapRoomFromApi(room);
 			} catch (error) {
-				const errorCode = error && typeof error === 'object' && 'error' in error ? error.error : undefined;
+				// REST surfaces the original Meteor.Error code as `errorType`; DDP used `error`
+				const errorCode =
+					error && typeof error === 'object'
+						? ('errorType' in error && error.errorType) || ('error' in error && error.error) || undefined
+						: undefined;
 
 				// "No permission" means the room exists but the user can't see it — surface the
 				// not-found/no-access screen rather than retrying it as a transient failure.

--- a/apps/meteor/client/views/root/MainLayout/EmbeddedPreload.tsx
+++ b/apps/meteor/client/views/root/MainLayout/EmbeddedPreload.tsx
@@ -1,5 +1,5 @@
 import { getObjectKeys } from '@rocket.chat/tools';
-import { useEndpoint, useMethod, useRouter, useUserId } from '@rocket.chat/ui-contexts';
+import { useEndpoint, useRouter, useUserId } from '@rocket.chat/ui-contexts';
 import { useQuery } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo } from 'react';
@@ -8,6 +8,7 @@ import { roomFields } from '../../../../lib/publishFields';
 import { RoomsCachedStore, SubscriptionsCachedStore } from '../../../cachedStores';
 import { roomsQueryKeys } from '../../../lib/queryKeys';
 import { roomCoordinator } from '../../../lib/rooms/roomCoordinator';
+import { mapRoomFromApi } from '../../../lib/utils/mapRoomFromApi';
 import { mapSubscriptionFromApi } from '../../../lib/utils/mapSubscriptionFromApi';
 import { Rooms } from '../../../stores';
 import PageLoading from '../PageLoading';
@@ -39,7 +40,7 @@ const EmbeddedPreload = ({ children }: EmbeddedPreloadProps) => {
 		return directives.extractOpenRoomParams(router.getRouteParameters());
 	}, [router]);
 
-	const getRoomByTypeAndName = useMethod('getRoomByTypeAndName');
+	const getRoomByTypeAndName = useEndpoint('GET', '/v1/rooms.getByTypeAndName');
 	const getSubscription = useEndpoint('GET', '/v1/subscriptions.getOne');
 
 	const shouldFetch = !!roomParams && !!uid;
@@ -51,7 +52,8 @@ const EmbeddedPreload = ({ children }: EmbeddedPreloadProps) => {
 				return null;
 			}
 
-			const roomData = await getRoomByTypeAndName(roomParams.type, roomParams.reference);
+			const { room } = await getRoomByTypeAndName({ type: roomParams.type, name: roomParams.reference });
+			const roomData = mapRoomFromApi(room);
 			if (!roomData?._id) {
 				return null;
 			}

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -8,6 +8,7 @@ import {
 	isPrivateRoom,
 	isPublicRoom,
 	type IUser,
+	type RoomType,
 } from '@rocket.chat/core-typings';
 import { Messages, Rooms, Users, Uploads, Subscriptions } from '@rocket.chat/models';
 import type { Notifications } from '@rocket.chat/rest-typings';
@@ -75,7 +76,7 @@ import { executeUnarchiveRoom } from '../../meteor-methods/rooms/unarchiveRoom';
 import { unmuteUserInRoom } from '../../meteor-methods/rooms/unmuteUserInRoom';
 import { saveNotificationSettingsMethod } from '../../meteor-methods/users/saveNotificationSettings';
 import type { NotificationFieldType } from '../../meteor-methods/users/saveNotificationSettings';
-import { roomsGetMethod } from '../../publications/room';
+import { getRoomByTypeAndNameMethod, roomsGetMethod } from '../../publications/room';
 import { settings } from '../../settings';
 import type { ExtractRoutesFromAPI } from '../ApiClass';
 import { API } from '../api';
@@ -511,6 +512,44 @@ API.v1.post(
 		});
 
 		return API.v1.success({ _id, count });
+	},
+);
+
+API.v1.get(
+	'rooms.getByTypeAndName',
+	{
+		authRequired: false,
+		rateLimiterOptions: {
+			numRequestsAllowed: 60,
+			intervalTimeInMS: 60000,
+		},
+		query: ajv.compile<{ type: string; name: string }>({
+			type: 'object',
+			properties: {
+				type: { type: 'string', minLength: 1 },
+				name: { type: 'string', minLength: 1 },
+			},
+			required: ['type', 'name'],
+			additionalProperties: false,
+		}),
+		response: {
+			200: ajv.compile<{ room: IRoom }>({
+				type: 'object',
+				properties: {
+					room: { type: 'object' },
+					success: { type: 'boolean', enum: [true] },
+				},
+				required: ['room', 'success'],
+				additionalProperties: false,
+			}),
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		const { type, name } = this.queryParams;
+		const room = await getRoomByTypeAndNameMethod(this.userId ?? null, type as RoomType, name);
+		return API.v1.success({ room });
 	},
 );
 

--- a/apps/meteor/server/publications/room/index.ts
+++ b/apps/meteor/server/publications/room/index.ts
@@ -1,12 +1,13 @@
 import type { IOmnichannelRoom, IRoom, RoomType } from '@rocket.chat/core-typings';
 import type { ServerMethods } from '@rocket.chat/ddp-client';
-import { Rooms } from '@rocket.chat/models';
+import { Rooms, Users } from '@rocket.chat/models';
 import { Meteor } from 'meteor/meteor';
 import _ from 'underscore';
 
 import { roomFields } from '../../../lib/publishFields';
 import { canAccessRoomAsync } from '../../lib/authorization';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { roomCoordinator } from '../../lib/rooms/roomCoordinator';
 import { settings } from '../../settings';
 
@@ -45,55 +46,47 @@ export const roomsGetMethod = async (userId?: string | null, updatedAt?: Date): 
 	return (await Rooms.findBySubscriptionUserId(userId, options)).toArray();
 };
 
+export const getRoomByTypeAndNameMethod = async (userId: string | null, type: RoomType, name: string): Promise<PublicRoom> => {
+	if (!type || !name) {
+		throw new Meteor.Error('error-invalid-room', 'Invalid room', { method: 'getRoomByTypeAndName' });
+	}
+
+	const user = userId ? await Users.findOneById(userId) : null;
+	const isAnonymous = !user?._id;
+
+	if (isAnonymous) {
+		const allowAnon = settings.get('Accounts_AllowAnonymousRead');
+		if (!allowAnon || type !== 'c') {
+			throw new Meteor.Error('error-invalid-user', 'Invalid user', { method: 'getRoomByTypeAndName' });
+		}
+	}
+
+	const roomFind = roomCoordinator.getRoomFind(type);
+
+	const room = roomFind ? await roomFind(name) : await Rooms.findByTypeAndNameOrId(type, name);
+
+	if (!room) {
+		throw new Meteor.Error('error-invalid-room', 'Invalid room', { method: 'getRoomByTypeAndName' });
+	}
+
+	if (user && !(await canAccessRoomAsync(room, user, { includeInvitations: true }))) {
+		throw new Meteor.Error('error-no-permission', 'No permission', { method: 'getRoomByTypeAndName' });
+	}
+
+	if (settings.get('Store_Last_Message') && user && !(await hasPermissionAsync(user, 'preview-c-room'))) {
+		delete room.lastMessage;
+	}
+
+	return roomMap(room);
+};
+
 Meteor.methods<ServerMethods>({
 	async 'rooms/get'(updatedAt) {
 		return roomsGetMethod(Meteor.userId(), updatedAt);
 	},
 
 	async 'getRoomByTypeAndName'(type, name) {
-		if (!type || !name) {
-			throw new Meteor.Error('error-invalid-room', 'Invalid room', {
-				method: 'getRoomByTypeAndName',
-			});
-		}
-
-		const user = await Meteor.userAsync();
-		const isAnonymous = !user?._id;
-
-		if (isAnonymous) {
-			const allowAnon = settings.get('Accounts_AllowAnonymousRead');
-			if (!allowAnon || type !== 'c') {
-				throw new Meteor.Error('error-invalid-user', 'Invalid user', {
-					method: 'getRoomByTypeAndName',
-				});
-			}
-		}
-
-		const roomFind = roomCoordinator.getRoomFind(type);
-
-		const room = roomFind ? await roomFind.call(this, name) : await Rooms.findByTypeAndNameOrId(type, name);
-
-		if (!room) {
-			throw new Meteor.Error('error-invalid-room', 'Invalid room', {
-				method: 'getRoomByTypeAndName',
-			});
-		}
-
-		if (
-			user &&
-			!(await canAccessRoomAsync(room, user, {
-				includeInvitations: true,
-			}))
-		) {
-			throw new Meteor.Error('error-no-permission', 'No permission', {
-				method: 'getRoomByTypeAndName',
-			});
-		}
-
-		if (settings.get('Store_Last_Message') && user && !(await hasPermissionAsync(user, 'preview-c-room'))) {
-			delete room.lastMessage;
-		}
-
-		return roomMap(room);
+		methodDeprecationLogger.method('getRoomByTypeAndName', '9.0.0', '/v1/rooms.getByTypeAndName');
+		return getRoomByTypeAndNameMethod(Meteor.userId(), type, name);
 	},
 });

--- a/packages/rest-typings/src/v1/rooms.ts
+++ b/packages/rest-typings/src/v1/rooms.ts
@@ -915,6 +915,10 @@ export type RoomsEndpoints = {
 		};
 	};
 
+	'/v1/rooms.getByTypeAndName': {
+		GET: (params: { type: string; name: string }) => { room: IRoom };
+	};
+
 	'/v1/rooms.info': {
 		GET: (params: RoomsInfoProps) => {
 			room: IRoom | undefined;


### PR DESCRIPTION
## Proposal (ARCH-2166) — retry of the deferred `getRoomByTypeAndName` migration

Migrates the `getRoomByTypeAndName` DDP method to REST **without** touching the URL scheme (URLs stay `type + name`; this only moves the resolution off DDP — the room-id URL change stays a separate, breaking concern).

### Changes
- Extracts the resolution into a shared `getRoomByTypeAndNameMethod(userId, type, name)` in `publications/room`.
- New `GET /v1/rooms.getByTypeAndName` (query `{ type, name }` → `{ room }`, `authRequired: false` to preserve anonymous read), rate-limited.
- `useOpenRoom` + `EmbeddedPreload` switch to `useEndpoint`.
- DDP method delegates to the shared fn + logs a deprecation pointing at the new route (removed in 9.0.0).

### ⚠️ Draft — needs review / e2e verification
This is the delicate bit that got it deferred from batch4:
- **Serialization:** the REST payload serializes the room's Date fields; the client deserializes via a new `mapRoomFromApi` (`_updatedAt`, `lm`, and `lastMessage` via `mapMessageFromApi`) before `Rooms.state.store`. Confirm all Date-bearing `roomFields` are covered.
- **Error contract:** `useOpenRoom` branches on the error code to drive the not-found / no-access / create-DM flow. It now reads `errorType` (REST) with an `error` (DDP) fallback. Needs e2e coverage of those branches.
- Endpoint name `rooms.getByTypeAndName` is bikesheddable.
- Couldn't fully typecheck locally (worktree lacks generated Meteor types + built rest-typings dist); `rest-typings` source compiles clean — relying on CI.

/jira ARCH-2166

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

