### PR TITLE
refactor(federation): use shared message logger

### DIFF
--- a/ee/packages/federation-matrix/src/events/message.ts
+++ b/ee/packages/federation-matrix/src/events/message.ts
@@ -1,11 +1,10 @@
 import { FederationMatrix, Message } from '@rocket.chat/core-services';
 import { federationSDK } from '@rocket.chat/federation-sdk';
-import { Logger } from '@rocket.chat/logger';
+import { logger } from '../logger';
 import { Users, Rooms, Messages } from '@rocket.chat/models';
 
 import { getThreadMessageId } from '../helpers/getThreadMessageId';
 
-const logger = new Logger('federation-matrix:message');
 
 export function message() {
 	federationSDK.eventEmitterService.on('homeserver.matrix.message', async (event) => {

--- a/ee/packages/federation-matrix/src/helpers/getThreadMessageId.ts
+++ b/ee/packages/federation-matrix/src/helpers/getThreadMessageId.ts
@@ -1,9 +1,6 @@
 import { type EventID } from '@rocket.chat/federation-sdk';
-import { Logger } from '@rocket.chat/logger';
+import { logger } from '../logger';
 import { Messages } from '@rocket.chat/models';
-
-// TODO replace by a reusable logger
-const logger = new Logger('federation-matrix:message');
 
 export async function getThreadMessageId(threadRootEventId: EventID): Promise<{ tmid: string; tshow: boolean } | undefined> {
 	const threadRootMessage = await Messages.findOneByFederationId(threadRootEventId);

--- a/ee/packages/federation-matrix/src/logger.ts
+++ b/ee/packages/federation-matrix/src/logger.ts
@@ -1,0 +1,3 @@
+import { Logger } from '@rocket.chat/logger';
+
+export const logger = new Logger('federation-matrix:message');


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR replaces duplicate `Logger` instances for the `federation-matrix:message` scope with a shared package-level logger.

### Changes made
- Added a shared logger in `ee/packages/federation-matrix/src/logger.ts`
- Updated `events/message.ts` to use the shared logger
- Updated `helpers/getThreadMessageId.ts` to use the shared logger
- Removed the TODO comment from `getThreadMessageId.ts`

This is a refactoring only and does not introduce any behavioral changes.

## Issue(s)

Closes #41452

## Steps to test or reproduce

1. Start the Rocket.Chat development environment.
2. Verify the project builds successfully after the refactor (excluding any unrelated existing build issues).
3. Confirm that logging in the Matrix federation message flow continues to work as before.
4. Ensure no functionality has changed and all existing logger calls behave as expected.

## Further comments

This refactor centralizes the `federation-matrix:message` logger into a reusable package-level module, removing duplicate logger instantiations while preserving the existing logging behavior. The existing `src/api/logger.ts` was intentionally left unchanged since it serves a different logging scope (`FederationMatrixAPI`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal logging consistency across federation message handling.
  * Centralized logging configuration without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->