### PR TITLE
refactor(gazzodown,livechat): Problematic import

### DIFF
--- a/packages/gazzodown/src/elements/LinkSpan.tsx
+++ b/packages/gazzodown/src/elements/LinkSpan.tsx
@@ -1,5 +1,5 @@
 import type * as MessageParser from '@rocket.chat/message-parser';
-import { getBaseURI, isExternal } from '@rocket.chat/ui-client/dist/helpers/getBaseURI';
+import { getBaseURI, isExternal } from '@rocket.chat/ui-client';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/packages/livechat/package.json
+++ b/packages/livechat/package.json
@@ -44,6 +44,7 @@
 		"mem": "^8.1.1",
 		"path-to-regexp": "^6.3.0",
 		"preact": "~10.25.4",
+		"preact-render-to-string": "~6.7.0",
 		"preact-router": "^4.1.2",
 		"query-string": "^7.1.3",
 		"react-hook-form": "~7.54.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9591,6 +9591,7 @@ __metadata:
     postcss-scss: "npm:^4.0.9"
     postcss-selector-not: "npm:^8.0.1"
     preact: "npm:~10.25.4"
+    preact-render-to-string: "npm:~6.7.0"
     preact-router: "npm:^4.1.2"
     query-string: "npm:^7.1.3"
     react: "npm:~19.2.7"
@@ -31203,6 +31204,15 @@ __metadata:
   version: 2.2.0
   resolution: "postis@npm:2.2.0"
   checksum: 10/f7a872ad65a80b52f58b5217f917b6fc35dbd503019374cf813207c30e85b4fdf38e275a7faf1a393af554e258321bcda58b3b60c4a13c22d6c70527e16ba730
+  languageName: node
+  linkType: hard
+
+"preact-render-to-string@npm:~6.7.0":
+  version: 6.7.0
+  resolution: "preact-render-to-string@npm:6.7.0"
+  peerDependencies:
+    preact: ">=10 || >= 11.0.0-0"
+  checksum: 10/1596656221c36458b759b51b95cbf8b97a67da5c8f69e3a7d75ac1c1c0b3f7399f35e0b51c3772cf5e1b8f1d70c4e2da263e2732a11715b72e86a207bcd6abbd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Deep-importing from @rocket.chat/ui-client/dist breaks when the package is resolved from source (e.g. by bundler aliases); the helper is already re-exported from the package index.

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This is the cheaper and dirtier counterpart of #41352.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link handling reliability by updating how link utilities are accessed.
* **Chores**
  * Added required rendering support for the Livechat package.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2280]

[ARCH-2280]: https://rocketchat.atlassian.net/browse/ARCH-2280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ