### PR TITLE
refactor: unify settings validation in REST API

### DIFF
--- a/apps/meteor/server/api/v1/settings.ts
+++ b/apps/meteor/server/api/v1/settings.ts
@@ -23,14 +23,13 @@ import {
 import { Meteor } from 'meteor/meteor';
 import type { FindOptions } from 'mongodb';
 import _ from 'underscore';
-
+import { SettingValidationError } from '../../lib/settingValidationRules';
+import { validateSetting } from '../../settings/validateSetting';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
 import { notifyOnSettingChanged, notifyOnSettingChangedById } from '../../lib/notifyListener';
-import { SettingValidationError, validateSettingRules } from '../../lib/settingValidationRules';
 import { disableCustomScripts } from '../../lib/shared/disableCustomScripts';
 import { addOAuthServiceMethod } from '../../meteor-methods/auth/addOAuthService';
 import { SettingsEvents, settings } from '../../settings';
-import { checkSettingValueBounds } from '../../settings/checkSettingValueBonds';
 import { updateAuditedByUser } from '../../settings/lib/auditedSettingUpdates';
 import { saveSettingsBulk } from '../../settings/lib/saveSettingsBulk';
 import { setValue } from '../../settings/raw';
@@ -390,14 +389,18 @@ API.v1.post(
 
 		if (isSettingsUpdatePropDefault(bodyParams)) {
 			// TODO(next major): unify both validations into one function with a common API error response
-			checkSettingValueBounds(setting, bodyParams.value);
 
 			try {
-				validateSettingRules([{ _id, value: bodyParams.value }]);
+				validateSetting(setting, bodyParams.value);
 			} catch (error) {
 				if (error instanceof SettingValidationError) {
 					return API.v1.failure(error.message, 'error-setting-validation-failed');
 				}
+
+				if (error instanceof Meteor.Error && error.error === 'error-invalid-setting-value') {
+					return API.v1.failure(error.reason ?? error.message, 'error-setting-validation-failed');
+				}
+
 				throw error;
 			}
 

--- a/apps/meteor/server/settings/validateSetting.ts
+++ b/apps/meteor/server/settings/validateSetting.ts
@@ -1,0 +1,9 @@
+import type { ISetting } from '@rocket.chat/core-typings';
+
+import { validateSettingRules } from '../lib/settingValidationRules';
+import { checkSettingValueBounds } from './checkSettingValueBonds';
+
+export const validateSetting = (setting: ISetting, value?: ISetting['value']): void => {
+	checkSettingValueBounds(setting, value);
+	validateSettingRules([{ _id: setting._id, value }]);
+};


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR refactors the settings validation flow by introducing a shared `validateSetting` helper that combines:

- `checkSettingValueBounds`
- `validateSettingRules`

The REST API now uses this helper instead of performing both validations separately, reducing duplicated validation logic while preserving the existing behavior.

Additionally, both bounds validation and rule validation now return a consistent API error response, addressing the existing TODO in `settings.ts`.

## Issue(s)

Related to #41460

## Steps to test or reproduce

1. Start the Rocket.Chat server.
2. Navigate to **Administration → Workspace → Settings**.
3. Update a valid setting and verify it is saved successfully.
4. Enter an invalid value that violates a setting's bounds and verify the API returns the expected validation error.
5. Enter a value that violates a validation rule and verify the API returns the same validation error response.

## Further comments

This is a refactoring change intended to reduce duplicated validation logic in the REST API while keeping the existing validation behavior unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when updating settings through the API.
  * Invalid setting values now return a consistent validation error, including clearer error details when available.
  * Numeric limits and setting-specific validation rules are applied consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->