### PR TITLE
fix: newer license in env not applied

### DIFF
--- a/.changeset/fix-license-env-precedence.md
+++ b/.changeset/fix-license-env-precedence.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/meteor': patch
+'@rocket.chat/license': patch
+---
+
+Fixes the license provided via the `ROCKETCHAT_LICENSE` environment variable not being applied when it is newer than the one persisted in the workspace.

--- a/apps/meteor/ee/server/lib/license/startup.ts
+++ b/apps/meteor/ee/server/lib/license/startup.ts
@@ -17,7 +17,7 @@ const applyStartupLicense = async (): Promise<void> => {
 	// so the startup license is never left pending behind the Site_Url watcher.
 	await License.setWorkspaceUrl(settings.get<string>('Site_Url'));
 
-	await applyNewestLicense(settings.get<string>('Enterprise_License') ?? '', process.env.ROCKETCHAT_LICENSE ?? '');
+	await applyNewestLicense(License, settings.get<string>('Enterprise_License') ?? '', process.env.ROCKETCHAT_LICENSE ?? '');
 };
 
 export const startLicense = async () => {

--- a/apps/meteor/ee/server/lib/license/startup.ts
+++ b/apps/meteor/ee/server/lib/license/startup.ts
@@ -1,6 +1,6 @@
 import { api } from '@rocket.chat/core-services';
 import type { LicenseLimitKind } from '@rocket.chat/core-typings';
-import { applyLicense, applyLicenseOrRemove, License } from '@rocket.chat/license';
+import { applyLicense, applyLicenseOrRemove, applyNewestLicense, License } from '@rocket.chat/license';
 import { Subscriptions, Users, Settings, LivechatContacts } from '@rocket.chat/models';
 import { wrapExceptions } from '@rocket.chat/tools';
 import moment from 'moment';
@@ -11,6 +11,14 @@ import { syncWorkspace } from '../../../../server/lib/cloud/syncWorkspace';
 import { SystemLogger } from '../../../../server/lib/logger/system';
 import { notifyOnSettingChangedById } from '../../../../server/lib/notifyListener';
 import { settings } from '../../../../server/settings';
+
+const applyStartupLicense = async (): Promise<void> => {
+	// Licenses can't be validated before the workspace URL is known; set it explicitly
+	// so the startup license is never left pending behind the Site_Url watcher.
+	await License.setWorkspaceUrl(settings.get<string>('Site_Url'));
+
+	await applyNewestLicense(settings.get<string>('Enterprise_License') ?? '', process.env.ROCKETCHAT_LICENSE ?? '');
+};
 
 export const startLicense = async () => {
 	settings.watch<string>('Site_Url', (value) => {
@@ -119,12 +127,7 @@ export const startLicense = async () => {
 		// When settings are loaded, apply the current license if there is one.
 		settings.onReady(async () => {
 			import('./airGappedRestrictions');
-			if (!(await applyLicense(settings.get<string>('Enterprise_License') ?? '', false))) {
-				// License from the envvar is always treated as new, because it would have been saved on the setting if it was already in use.
-				if (process.env.ROCKETCHAT_LICENSE && !License.hasValidLicense()) {
-					await applyLicense(process.env.ROCKETCHAT_LICENSE, true);
-				}
-			}
+			await applyStartupLicense();
 
 			License.onInstall(() => {
 				if (License.hasOfflineLicense()) {

--- a/ee/packages/license/__tests__/applyNewestLicense.spec.ts
+++ b/ee/packages/license/__tests__/applyNewestLicense.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment node
+ */
+
+import { MockedLicenseBuilder, getReadyLicenseManager } from './MockedLicenseBuilder';
+import { applyNewestLicense } from '../src/applyLicense';
+
+const OLDER = new Date('2026-01-01T00:00:00.000Z');
+const NEWER = new Date('2026-06-01T00:00:00.000Z');
+
+describe('applyNewestLicense', () => {
+	it('should apply the provided license when it is newer than the stored one', async () => {
+		const manager = await getReadyLicenseManager();
+		const stored = await new MockedLicenseBuilder().withCreatedAt(OLDER).withGrantedModules(['auditing']).sign();
+		const provided = await new MockedLicenseBuilder().withCreatedAt(NEWER).withGrantedModules(['livechat-enterprise']).sign();
+
+		await expect(applyNewestLicense(stored, provided, manager)).resolves.toBe(true);
+
+		expect(manager.hasValidLicense()).toBe(true);
+		expect(manager.hasModule('livechat-enterprise')).toBe(true);
+		expect(manager.hasModule('auditing')).toBe(false);
+	});
+
+	it('should apply the stored license when it is newer than the provided one', async () => {
+		const manager = await getReadyLicenseManager();
+		const stored = await new MockedLicenseBuilder().withCreatedAt(NEWER).withGrantedModules(['auditing']).sign();
+		const provided = await new MockedLicenseBuilder().withCreatedAt(OLDER).withGrantedModules(['livechat-enterprise']).sign();
+
+		await expect(applyNewestLicense(stored, provided, manager)).resolves.toBe(true);
+
+		expect(manager.hasModule('auditing')).toBe(true);
+		expect(manager.hasModule('livechat-enterprise')).toBe(false);
+	});
+
+	it('should apply the provided license when there is no stored license', async () => {
+		const manager = await getReadyLicenseManager();
+		const provided = await new MockedLicenseBuilder().withCreatedAt(OLDER).withGrantedModules(['livechat-enterprise']).sign();
+
+		await expect(applyNewestLicense('', provided, manager)).resolves.toBe(true);
+
+		expect(manager.hasModule('livechat-enterprise')).toBe(true);
+	});
+
+	it('should fall back to the provided license when the newer stored one fails to apply', async () => {
+		const manager = await getReadyLicenseManager();
+		const stored = await new MockedLicenseBuilder().withCreatedAt(NEWER).withExpiredDate().withGrantedModules(['auditing']).sign();
+		const provided = await new MockedLicenseBuilder().withCreatedAt(OLDER).withGrantedModules(['livechat-enterprise']).sign();
+
+		await expect(applyNewestLicense(stored, provided, manager)).resolves.toBe(true);
+
+		expect(manager.hasModule('livechat-enterprise')).toBe(true);
+	});
+
+	it('should fall back to the stored license when the newer provided one is corrupted', async () => {
+		const manager = await getReadyLicenseManager();
+		const stored = await new MockedLicenseBuilder().withCreatedAt(OLDER).withGrantedModules(['auditing']).sign();
+		const provided = `${await new MockedLicenseBuilder().withCreatedAt(NEWER).sign()}corrupted`;
+
+		await expect(applyNewestLicense(stored, provided, manager)).resolves.toBe(true);
+
+		expect(manager.hasModule('auditing')).toBe(true);
+	});
+
+	it('should return false when neither license is provided', async () => {
+		const manager = await getReadyLicenseManager();
+
+		await expect(applyNewestLicense('', '', manager)).resolves.toBe(false);
+
+		expect(manager.hasValidLicense()).toBe(false);
+	});
+});

--- a/ee/packages/license/__tests__/applyNewestLicense.spec.ts
+++ b/ee/packages/license/__tests__/applyNewestLicense.spec.ts
@@ -14,9 +14,25 @@ describe('applyNewestLicense', () => {
 		const stored = await new MockedLicenseBuilder().withCreatedAt(OLDER).withGrantedModules(['auditing']).sign();
 		const provided = await new MockedLicenseBuilder().withCreatedAt(NEWER).withGrantedModules(['livechat-enterprise']).sign();
 
-		await expect(applyNewestLicense(stored, provided, manager)).resolves.toBe(true);
+		await expect(applyNewestLicense(manager, stored, provided)).resolves.toBe(true);
 
 		expect(manager.hasValidLicense()).toBe(true);
+		expect(manager.hasModule('livechat-enterprise')).toBe(true);
+		expect(manager.hasModule('auditing')).toBe(false);
+	});
+
+	it('should apply the dated provided license when the stored one has no issue date', async () => {
+		const manager = await getReadyLicenseManager();
+
+		// V2 licenses carry no signature-verified issue date, so they must sort as the oldest
+		const storedBuilder = new MockedLicenseBuilder().withGrantedModules(['auditing']);
+		storedBuilder.information.createdAt = 'not-a-date';
+		const stored = await storedBuilder.sign();
+
+		const provided = await new MockedLicenseBuilder().withCreatedAt(NEWER).withGrantedModules(['livechat-enterprise']).sign();
+
+		await expect(applyNewestLicense(manager, stored, provided)).resolves.toBe(true);
+
 		expect(manager.hasModule('livechat-enterprise')).toBe(true);
 		expect(manager.hasModule('auditing')).toBe(false);
 	});
@@ -26,7 +42,7 @@ describe('applyNewestLicense', () => {
 		const stored = await new MockedLicenseBuilder().withCreatedAt(NEWER).withGrantedModules(['auditing']).sign();
 		const provided = await new MockedLicenseBuilder().withCreatedAt(OLDER).withGrantedModules(['livechat-enterprise']).sign();
 
-		await expect(applyNewestLicense(stored, provided, manager)).resolves.toBe(true);
+		await expect(applyNewestLicense(manager, stored, provided)).resolves.toBe(true);
 
 		expect(manager.hasModule('auditing')).toBe(true);
 		expect(manager.hasModule('livechat-enterprise')).toBe(false);
@@ -36,7 +52,7 @@ describe('applyNewestLicense', () => {
 		const manager = await getReadyLicenseManager();
 		const provided = await new MockedLicenseBuilder().withCreatedAt(OLDER).withGrantedModules(['livechat-enterprise']).sign();
 
-		await expect(applyNewestLicense('', provided, manager)).resolves.toBe(true);
+		await expect(applyNewestLicense(manager, '', provided)).resolves.toBe(true);
 
 		expect(manager.hasModule('livechat-enterprise')).toBe(true);
 	});
@@ -46,7 +62,7 @@ describe('applyNewestLicense', () => {
 		const stored = await new MockedLicenseBuilder().withCreatedAt(NEWER).withExpiredDate().withGrantedModules(['auditing']).sign();
 		const provided = await new MockedLicenseBuilder().withCreatedAt(OLDER).withGrantedModules(['livechat-enterprise']).sign();
 
-		await expect(applyNewestLicense(stored, provided, manager)).resolves.toBe(true);
+		await expect(applyNewestLicense(manager, stored, provided)).resolves.toBe(true);
 
 		expect(manager.hasModule('livechat-enterprise')).toBe(true);
 	});
@@ -56,7 +72,7 @@ describe('applyNewestLicense', () => {
 		const stored = await new MockedLicenseBuilder().withCreatedAt(OLDER).withGrantedModules(['auditing']).sign();
 		const provided = `${await new MockedLicenseBuilder().withCreatedAt(NEWER).sign()}corrupted`;
 
-		await expect(applyNewestLicense(stored, provided, manager)).resolves.toBe(true);
+		await expect(applyNewestLicense(manager, stored, provided)).resolves.toBe(true);
 
 		expect(manager.hasModule('auditing')).toBe(true);
 	});
@@ -64,7 +80,7 @@ describe('applyNewestLicense', () => {
 	it('should return false when neither license is provided', async () => {
 		const manager = await getReadyLicenseManager();
 
-		await expect(applyNewestLicense('', '', manager)).resolves.toBe(false);
+		await expect(applyNewestLicense(manager, '', '')).resolves.toBe(false);
 
 		expect(manager.hasValidLicense()).toBe(false);
 	});

--- a/ee/packages/license/__tests__/getLicenseCreatedAt.spec.ts
+++ b/ee/packages/license/__tests__/getLicenseCreatedAt.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment node
+ */
+
+import { MockedLicenseBuilder } from './MockedLicenseBuilder';
+import { getLicenseCreatedAt } from '../src/getLicenseCreatedAt';
+
+describe('getLicenseCreatedAt', () => {
+	it('should return the createdAt of a signed V3 license', async () => {
+		const createdAt = new Date('2026-01-02T03:04:05.000Z');
+		const encrypted = await new MockedLicenseBuilder().withCreatedAt(createdAt).sign();
+
+		await expect(getLicenseCreatedAt(encrypted)).resolves.toEqual(createdAt);
+	});
+
+	it('should return undefined for an empty license string', async () => {
+		await expect(getLicenseCreatedAt('')).resolves.toBeUndefined();
+		await expect(getLicenseCreatedAt('   ')).resolves.toBeUndefined();
+	});
+
+	it('should return undefined for a non-V3 license string', async () => {
+		await expect(getLicenseCreatedAt('not-a-license')).resolves.toBeUndefined();
+	});
+
+	it('should return undefined for a V3 license with a broken signature', async () => {
+		const encrypted = await new MockedLicenseBuilder().sign();
+
+		await expect(getLicenseCreatedAt(`${encrypted}corrupted`)).resolves.toBeUndefined();
+	});
+});

--- a/ee/packages/license/src/MockedLicenseBuilder.ts
+++ b/ee/packages/license/src/MockedLicenseBuilder.ts
@@ -115,6 +115,11 @@ export class MockedLicenseBuilder {
 		};
 	}
 
+	public withCreatedAt(date: Date): this {
+		this.information.createdAt = date.toISOString();
+		return this;
+	}
+
 	public withExpiredDate(): this {
 		// expired 1 minute ago
 		const date = new Date();

--- a/ee/packages/license/src/applyLicense.ts
+++ b/ee/packages/license/src/applyLicense.ts
@@ -1,37 +1,80 @@
+import { getLicenseCreatedAt } from './getLicenseCreatedAt';
+import type { LicenseImp } from './licenseImp';
 import { License } from './licenseImp';
 
-export const applyLicense = async (license: string, isNewLicense: boolean): Promise<boolean> => {
+export const applyLicense = async (license: string, isNewLicense: boolean, manager: LicenseImp = License): Promise<boolean> => {
 	const enterpriseLicense = (license ?? '').trim();
 	if (!enterpriseLicense) {
 		return false;
 	}
 
-	if (enterpriseLicense === License.encryptedLicense) {
+	if (enterpriseLicense === manager.encryptedLicense) {
 		return false;
 	}
 
 	try {
-		return License.setLicense(enterpriseLicense, isNewLicense);
+		return manager.setLicense(enterpriseLicense, isNewLicense);
 	} catch {
 		return false;
 	}
 };
 
-export const applyLicenseOrRemove = async (license: string, isNewLicense: boolean): Promise<boolean> => {
+export const applyLicenseOrRemove = async (license: string, isNewLicense: boolean, manager: LicenseImp = License): Promise<boolean> => {
 	const enterpriseLicense = (license ?? '').trim();
 	if (!enterpriseLicense) {
-		License.remove();
+		manager.remove();
 		return false;
 	}
 
-	if (enterpriseLicense === License.encryptedLicense) {
+	if (enterpriseLicense === manager.encryptedLicense) {
 		return false;
 	}
 
 	try {
-		return License.setLicense(enterpriseLicense, isNewLicense);
+		return manager.setLicense(enterpriseLicense, isNewLicense);
 	} catch {
-		License.remove();
+		manager.remove();
 		return false;
 	}
+};
+
+/**
+ * Applies whichever of the two licenses was issued most recently, falling back to
+ * the other one when the newest doesn't result in a valid license (note that
+ * `setLicense` reports success even for licenses applied in an invalid/expired
+ * state, so validity — not the apply result — drives the fallback).
+ *
+ * `storedLicense` is the license already known to the workspace (applied as not
+ * new); `providedLicense` is externally supplied, e.g. through an environment
+ * variable (applied as new). Issue dates come from signature-verified payloads
+ * only — licenses without one (V2, invalid or empty strings) sort as oldest, so
+ * two undated licenses keep the traditional stored-first order.
+ *
+ * Returns whether the workspace ended up with a valid license.
+ */
+export const applyNewestLicense = async (
+	storedLicense: string,
+	providedLicense: string,
+	manager: LicenseImp = License,
+): Promise<boolean> => {
+	const [storedCreatedAt, providedCreatedAt] = await Promise.all([
+		getLicenseCreatedAt(storedLicense),
+		getLicenseCreatedAt(providedLicense),
+	]);
+
+	const providedIsNewer = !!providedCreatedAt && (!storedCreatedAt || providedCreatedAt > storedCreatedAt);
+
+	const [first, second] = providedIsNewer
+		? [() => applyLicense(providedLicense, true, manager), () => applyLicense(storedLicense, false, manager)]
+		: [() => applyLicense(storedLicense, false, manager), () => applyLicense(providedLicense, true, manager)];
+
+	await first();
+
+	if (manager.hasValidLicense()) {
+		return true;
+	}
+
+	await second();
+
+	return manager.hasValidLicense();
 };

--- a/ee/packages/license/src/applyLicense.ts
+++ b/ee/packages/license/src/applyLicense.ts
@@ -39,42 +39,35 @@ export const applyLicenseOrRemove = async (license: string, isNewLicense: boolea
 };
 
 /**
- * Applies whichever of the two licenses was issued most recently, falling back to
- * the other one when the newest doesn't result in a valid license (note that
+ * Applies the most recently issued of the given licenses, falling back to the
+ * next one whenever the newest doesn't result in a valid license (note that
  * `setLicense` reports success even for licenses applied in an invalid/expired
  * state, so validity — not the apply result — drives the fallback).
  *
- * `storedLicense` is the license already known to the workspace (applied as not
- * new); `providedLicense` is externally supplied, e.g. through an environment
+ * The first license is the one already known to the workspace (applied as not
+ * new); the others are externally supplied, e.g. through an environment
  * variable (applied as new). Issue dates come from signature-verified payloads
- * only — licenses without one (V2, invalid or empty strings) sort as oldest, so
- * two undated licenses keep the traditional stored-first order.
+ * only — licenses without one (V2, invalid or empty strings) sort as oldest,
+ * preserving the given order among themselves.
  *
  * Returns whether the workspace ended up with a valid license.
  */
-export const applyNewestLicense = async (
-	storedLicense: string,
-	providedLicense: string,
-	manager: LicenseImp = License,
-): Promise<boolean> => {
-	const [storedCreatedAt, providedCreatedAt] = await Promise.all([
-		getLicenseCreatedAt(storedLicense),
-		getLicenseCreatedAt(providedLicense),
-	]);
+export const applyNewestLicense = async (manager: LicenseImp = License, ...licenses: Array<string>): Promise<boolean> => {
+	const candidates = licenses
+		.map((license, index) => ({ license: (license ?? '').trim(), isNewLicense: index > 0 }))
+		.filter(({ license }) => license);
 
-	const providedIsNewer = !!providedCreatedAt && (!storedCreatedAt || providedCreatedAt > storedCreatedAt);
+	const sortedLicenses = (
+		await Promise.all(candidates.map(async (candidate) => ({ ...candidate, createdAt: await getLicenseCreatedAt(candidate.license) })))
+	).sort((a, b) => (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0));
 
-	const [first, second] = providedIsNewer
-		? [() => applyLicense(providedLicense, true, manager), () => applyLicense(storedLicense, false, manager)]
-		: [() => applyLicense(storedLicense, false, manager), () => applyLicense(providedLicense, true, manager)];
+	for (const { license, isNewLicense } of sortedLicenses) {
+		await applyLicense(license, isNewLicense, manager);
 
-	await first();
-
-	if (manager.hasValidLicense()) {
-		return true;
+		if (manager.hasValidLicense()) {
+			return true;
+		}
 	}
-
-	await second();
 
 	return manager.hasValidLicense();
 };

--- a/ee/packages/license/src/getLicenseCreatedAt.ts
+++ b/ee/packages/license/src/getLicenseCreatedAt.ts
@@ -1,0 +1,29 @@
+import type { ILicenseV3 } from '@rocket.chat/core-typings';
+
+import { decrypt } from './token';
+
+/**
+ * Returns the signature-verified `information.createdAt` of an encrypted license,
+ * without applying it.
+ *
+ * Returns `undefined` when the string is empty or invalid, or when the license
+ * carries no issue date (V2 licenses) — callers ordering licenses by age should
+ * treat those as the oldest.
+ */
+export async function getLicenseCreatedAt(encryptedLicense: string): Promise<Date | undefined> {
+	const license = (encryptedLicense ?? '').trim();
+
+	if (!license.startsWith('RCV3_')) {
+		return undefined;
+	}
+
+	try {
+		const decrypted: ILicenseV3 = JSON.parse(await decrypt(license));
+
+		const createdAt = new Date(decrypted.information.createdAt);
+
+		return Number.isNaN(createdAt.getTime()) ? undefined : createdAt;
+	} catch {
+		return undefined;
+	}
+}

--- a/ee/packages/license/src/index.ts
+++ b/ee/packages/license/src/index.ts
@@ -3,4 +3,5 @@ export * from './licenseImp';
 export * from './license';
 export * from './MockedLicenseBuilder';
 export * from './applyLicense';
+export * from './getLicenseCreatedAt';
 export * from './AirGappedRestriction';


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [CORE-2441]

[CORE-2441]: https://rocketchat.atlassian.net/browse/CORE-2441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup licensing now applies the newest valid license, including licenses provided via the `ROCKETCHAT_LICENSE` environment variable.
  * Workspace URL is set before license validation runs.
  * If the selected license is missing, invalid, expired, or corrupted, the system safely falls back to another available license.

* **Tests**
  * Added coverage for extracting license creation dates, newest-license selection, fallback behavior, and handling corrupted/empty license inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->