### PR TITLE
chore(apps): swap default runtime backend from deno to node

### DIFF
--- a/.changeset/apps-engine-runtime-default-node.md
+++ b/.changeset/apps-engine-runtime-default-node.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/apps': minor
+'@rocket.chat/meteor': minor
+---
+
+Changes the default apps-engine runtime backend from `deno` to `node`. The previous behavior can be restored by setting the environment variable `APPS_ENGINE_RUNTIME_BACKEND='deno'`

--- a/.github/workflows/ci-test-e2e.yml
+++ b/.github/workflows/ci-test-e2e.yml
@@ -207,7 +207,7 @@ jobs:
           TRANSPORTER: ${{ inputs.transporter }}
           COMPOSE_PROFILES: ${{ inputs.type == 'api' && 'api' || '' }}
           TEST_MODE: ${{ startsWith(inputs.type, 'api') && 'api' || 'true' }}
-          APPS_ENGINE_RUNTIME_BACKEND: ${{ inputs.type == 'api-apps-node' && 'node' || '' }}
+          APPS_ENGINE_RUNTIME_BACKEND: ${{ inputs.type == 'api-apps-deno' && 'deno' || '' }}
           FIPS_OVERRIDE: ${{ inputs.fips && '-f docker-compose-ci.fips.yml' || '' }}
         run: |
           read -r -a fips_override <<< "$FIPS_OVERRIDE"
@@ -247,8 +247,8 @@ jobs:
           exit "${s:-0}"
 
       # This step should be temporary, only here until we remove the deno-runtime
-      - name: E2E Test API (apps + node-runtime)
-        if: (inputs.type == 'api-apps-node' && inputs.release == 'ee')
+      - name: E2E Test API (apps + deno-runtime)
+        if: (inputs.type == 'api-apps-deno' && inputs.release == 'ee')
         working-directory: ./apps/meteor
         env:
           WEBHOOK_TEST_URL: 'http://httpbin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -711,13 +711,13 @@ jobs:
       CR_PAT: ${{ secrets.CR_PAT }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  test-api-apps-node-ee:
-    name: 🔨 Test API Apps (node-runtime - EE)
+  test-api-apps-deno-ee:
+    name: 🔨 Test API Apps (deno-runtime - EE)
     needs: [checks, build-gh-docker-publish, release-versions]
 
     uses: ./.github/workflows/ci-test-e2e.yml
     with:
-      type: api-apps-node
+      type: api-apps-deno
       release: ee
       transporter: 'nats://nats:4222'
       enterprise-license: ${{ needs.release-versions.outputs.enterprise-license }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -985,7 +985,7 @@ jobs:
   tests-done:
     name: ✅ Tests Done
     runs-on: ubuntu-24.04-arm
-    needs: [test-guard, checks, test-unit, test-api, test-ui, test-api-ee, test-ui-ee, test-api-livechat, test-api-livechat-ee, test-api-apps-node-ee, test-api-fips, test-api-livechat-fips, test-ui-fips, test-federation-matrix]
+    needs: [test-guard, checks, test-unit, test-api, test-ui, test-api-ee, test-ui-ee, test-api-livechat, test-api-livechat-ee, test-api-apps-deno-ee, test-api-fips, test-api-livechat-fips, test-ui-fips, test-federation-matrix]
     if: always() && needs.test-guard.outputs.skip-tests != 'true'
     steps:
       - name: Test finish aggregation
@@ -1022,7 +1022,7 @@ jobs:
             exit 1
           fi
 
-          if [[ '${{ needs.test-api-apps-node-ee.result }}' != 'success' ]]; then
+          if [[ '${{ needs.test-api-apps-deno-ee.result }}' != 'success' ]]; then
             exit 1
           fi
 

--- a/packages/apps/src/server/managers/AppRuntimeManager.ts
+++ b/packages/apps/src/server/managers/AppRuntimeManager.ts
@@ -19,7 +19,7 @@ export type ExecRequestOptions = {
 	timeout?: number;
 };
 
-const { APPS_ENGINE_RUNTIME_BACKEND = 'deno' } = process.env;
+const { APPS_ENGINE_RUNTIME_BACKEND = 'node' } = process.env;
 
 export const nodeRuntimeFactory = (manager: AppManager, appPackage: IParseAppPackageResult, storageItem: IAppStorageItem) =>
 	new NodeRuntimeSubprocessController(manager, appPackage, storageItem);
@@ -27,7 +27,7 @@ export const nodeRuntimeFactory = (manager: AppManager, appPackage: IParseAppPac
 export const denoRuntimeFactory = (manager: AppManager, appPackage: IParseAppPackageResult, storageItem: IAppStorageItem) =>
 	new DenoRuntimeSubprocessController(manager, appPackage, storageItem);
 
-const defaultRuntimeFactory = APPS_ENGINE_RUNTIME_BACKEND === 'node' ? nodeRuntimeFactory : denoRuntimeFactory;
+const defaultRuntimeFactory = APPS_ENGINE_RUNTIME_BACKEND === 'deno' ? denoRuntimeFactory : nodeRuntimeFactory;
 
 export class AppRuntimeManager {
 	private readonly subprocesses: Record<string, IRuntimeController> = {};


### PR DESCRIPTION
- **feat(apps-engine): default runtime backend to node**
- **ci: repurpose dedicated apps runtime job to test deno instead of node**

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The default Apps runtime backend is now Node.js.
  * Deno is still supported by setting `APPS_ENGINE_RUNTIME_BACKEND='deno'`.
* **Bug Fixes**
  * Updated runtime selection so the configured backend is consistently honored.
* **Tests**
  * CI and E2E coverage was updated to run the Apps-based API tests against the Deno runtime when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->