### PR TITLE
fix: missing "user left" system message after omnichannel room forward

### DIFF
--- a/.changeset/livechat-forward-ul-message.md
+++ b/.changeset/livechat-forward-ul-message.md
@@ -2,4 +2,4 @@
 '@rocket.chat/meteor': patch
 ---
 
-Fixes an issue where the "user left" system message could be missing from an Omnichannel conversation after it was forwarded to another agent or department
+Fixes an issue where the "user left" system message could be added to an Omnichannel conversation only after the forwarding process had already finished, causing it to appear out of order in the conversation history

--- a/.changeset/livechat-forward-ul-message.md
+++ b/.changeset/livechat-forward-ul-message.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes an issue where the "user left" system message could be missing from an Omnichannel conversation after it was forwarded to another agent or department

--- a/apps/meteor/server/lib/omnichannel/RoutingManager.ts
+++ b/apps/meteor/server/lib/omnichannel/RoutingManager.ts
@@ -371,12 +371,11 @@ export const RoutingManager: Routing = {
 	async removeAllRoomSubscriptions(room, ignoreUser) {
 		const { _id: roomId } = room;
 
-		const subscriptions = await Subscriptions.findByRoomId(roomId).toArray();
-		subscriptions?.forEach(({ u }) => {
-			if (ignoreUser && ignoreUser._id === u._id) {
-				return;
+		for await (const { u } of Subscriptions.findByRoomId(roomId, { projection: { u: 1 } })) {
+			if (ignoreUser?._id === u._id) {
+				continue;
 			}
-			void removeAgentFromSubscription(roomId, u);
-		});
+			await removeAgentFromSubscription(roomId, u);
+		}
 	},
 };


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

When an omnichannel room is forwarded (agent, department, or department fallback), `RoutingManager.removeAllRoomSubscriptions` removed each agent subscription with a fire-and-forget `void removeAgentFromSubscription(...)` inside a `forEach`. The `ul` (user left) system message written inside that call was never awaited by any caller, so it raced the rest of the transfer flow: the message could be persisted only after the transfer had already completed and the endpoint had responded. Anything reading the room history right after the transfer — like the `LIVECHAT - rooms livechat/room.forward system messages sent on transfer should be properly generated` API test — could intermittently see 0 `ul` messages, making that test flaky. It also allowed the message to land out of order relative to the transfer system messages.

Changes:
- Await each `removeAgentFromSubscription` call (iterating the cursor directly) so the `ul` message is persisted before the transfer flow returns, and failures surface instead of being swallowed by the floating promise
- Project only `u` from the subscriptions query, which is all the removal needs

## Issue(s)

## Steps to test or reproduce

1. Create two departments with online agents, forward a livechat room from one to the other (`livechat/room.forward`)
2. Fetch the room message history immediately — the previous agent's `ul` system message is now always already present

## Further comments

The fire-and-forget dates back to the Fibers-era JS, where the call was effectively synchronous; the TS conversion added `void` to silence lint, making the race explicit but unhandled. 

 Task: [CORE-2449]

[CORE-2449]: https://rocketchat.atlassian.net/browse/CORE-2449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed conversation forwarding so the “user left” system message appears in the correct order within conversation history.
  - Improved subscription removal handling to ensure agent removals complete reliably during room cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->