### PR TITLE
test: point oembed API tests at the CI mock-server instead of real providers

### DIFF
--- a/.github/workflows/ci-test-e2e.yml
+++ b/.github/workflows/ci-test-e2e.yml
@@ -191,9 +191,14 @@ jobs:
           # the deprecation logger log without throwing. Other suites use the
           # docker-compose default of TEST_MODE='true'.
           TEST_MODE: ${{ startsWith(inputs.type, 'api') && 'api' || 'true' }}
+          TEST_TYPE: ${{ inputs.type }}
         run: |
-          # when we are testing CE, we only need to start the rocketchat container
-          DEBUG_LOG_LEVEL=${DEBUG_LOG_LEVEL:-0} docker compose -f docker-compose-ci.yml up -d rocketchat --wait
+          # when we are testing CE, we only need to start the rocketchat container (plus mock-server for the api suite)
+          services=(rocketchat)
+          if [ "$TEST_TYPE" == "api" ]; then
+            services+=(mock-server)
+          fi
+          DEBUG_LOG_LEVEL=${DEBUG_LOG_LEVEL:-0} docker compose -f docker-compose-ci.yml up -d "${services[@]}" --wait
 
       - name: Start containers for EE
         if: inputs.release == 'ee'

--- a/apps/meteor/server/services/messages/lib/oembed/providers.ts
+++ b/apps/meteor/server/services/messages/lib/oembed/providers.ts
@@ -103,8 +103,8 @@ providers.registerProvider({
 if (process.env.TEST_MODE) {
 	// resolves the oembed payload from the CI mock-server instead of a real provider — see the oembed suite in tests/end-to-end/api/chat.ts
 	providers.registerProvider({
-		urls: [new RegExp('https?://mock-server\\.local(:\\d+)?/video/\\S+')],
-		endPoint: 'http://mock-server.local:8080/oembed',
+		urls: [new RegExp('https?://mock-server\\.dev(:\\d+)?/video/\\S+')],
+		endPoint: 'http://mock-server.dev:8080/oembed',
 	});
 }
 

--- a/apps/meteor/server/services/messages/lib/oembed/providers.ts
+++ b/apps/meteor/server/services/messages/lib/oembed/providers.ts
@@ -100,6 +100,14 @@ providers.registerProvider({
 	endPoint: 'https://www.loom.com/v1/oembed?format=json',
 });
 
+if (process.env.TEST_MODE) {
+	// resolves the oembed payload from the CI mock-server instead of a real provider — see the oembed suite in tests/end-to-end/api/chat.ts
+	providers.registerProvider({
+		urls: [new RegExp('https?://mock-server\\.local(:\\d+)?/video/\\S+')],
+		endPoint: 'http://mock-server.local:8080/oembed',
+	});
+}
+
 export const beforeGetUrlContent = (data: {
 	urlObj: URL;
 }): {

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -10,6 +10,7 @@ import { sleep } from '../../../lib/utils/sleep';
 import { getCredentials, api, request, credentials, apiUrl } from '../../data/api-data';
 import { followMessage, sendSimpleMessage, deleteMessage } from '../../data/chat.helper';
 import { imgURL } from '../../data/interactions';
+import { mockServerHealthy, mockServerReset, mockServerSet } from '../../data/mock-server.helper';
 import { updatePermission, updateSetting } from '../../data/permissions.helper';
 import { addUserToRoom, createRoom, deleteRoom, getSubscriptionByRoomId } from '../../data/rooms.helper';
 import { password } from '../../data/user';
@@ -1262,14 +1263,56 @@ describe('[Chat]', () => {
 		});
 
 		describe('oembed', () => {
+			// the TEST_MODE oembed provider (server/services/messages/lib/oembed/providers.ts) resolves /video/ URLs through GET /oembed on the mock-server
+			const mockVideoUrl = (id: string) => `http://mock-server.local:8080/video/${id}`;
+			const mockPageUrl = (id: string) => `http://mock-server.local:8080/page/${id}`;
+			const mockOembedEndpoint = { method: 'GET', path: '/oembed' };
+
+			const youtubeOembedResponse = {
+				title: 'Rocket.Chat Demo',
+				author_name: 'Rocket.Chat',
+				author_url: 'https://www.youtube.com/@RocketChatApp',
+				type: 'video',
+				height: 150,
+				width: 200,
+				version: '1.0',
+				provider_name: 'YouTube',
+				provider_url: 'https://www.youtube.com/',
+				thumbnail_height: 360,
+				thumbnail_width: 480,
+				thumbnail_url: 'https://i.ytimg.com/vi/T2v29gK8fP4/hqdefault.jpg',
+				html: '<iframe width="200" height="150" src="https://www.youtube.com/embed/T2v29gK8fP4?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen title="Rocket.Chat Demo"></iframe>',
+			};
+
+			const spotifyOembedResponse = {
+				html: '<iframe style="border-radius: 12px" width="100%" height="152" title="Spotify Embed: Never Gonna Give You Up" frameborder="0" allowfullscreen allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy" src="https://open.spotify.com/embed/track/4cOdK2wGLETKBW3PvgPWqT?utm_source=oembed"></iframe>',
+				iframe_url: 'https://open.spotify.com/embed/track/4cOdK2wGLETKBW3PvgPWqT?utm_source=oembed',
+				width: 456,
+				height: 152,
+				version: '1.0',
+				provider_name: 'Spotify',
+				provider_url: 'https://spotify.com',
+				type: 'rich',
+				title: 'Never Gonna Give You Up',
+				thumbnail_url: 'https://image-cdn-ak.spotifycdn.com/image/ab67616d00001e0215ebbedaacef61af244262a8',
+				thumbnail_width: 300,
+				thumbnail_height: 300,
+			};
+
 			let ytEmbedMsgId: IMessage['_id'];
 			let imgUrlMsgId: IMessage['_id'];
+
+			before(async () => {
+				const healthy = await mockServerHealthy();
+				expect(healthy, 'mock-server is not reachable — ensure it is running').to.be.true;
+				await mockServerReset();
+			});
 
 			before(() =>
 				Promise.all([
 					updateSetting('API_EmbedIgnoredHosts', ''),
-					updateSetting('API_EmbedSafePorts', '80, 443, 3000'),
-					updateSetting('SSRF_Allowlist', '127.0.0.1:3000'),
+					updateSetting('API_EmbedSafePorts', '80, 443, 3000, 8080'),
+					updateSetting('SSRF_Allowlist', '127.0.0.1:3000, mock-server.local'),
 				]),
 			);
 
@@ -1278,14 +1321,16 @@ describe('[Chat]', () => {
 					updateSetting('API_EmbedIgnoredHosts', 'localhost, 127.0.0.1, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16'),
 					updateSetting('API_EmbedSafePorts', '80, 443'),
 					updateSetting('SSRF_Allowlist', ''),
+					mockServerReset(),
 				]),
 			);
 
 			before(async () => {
+				await mockServerSet(mockOembedEndpoint.method, mockOembedEndpoint.path, youtubeOembedResponse);
 				const ytEmbedMsgPayload = {
 					_id: `id-${Date.now()}`,
 					rid: testChannel._id,
-					msg: 'https://www.youtube.com/watch?v=T2v29gK8fP4',
+					msg: mockVideoUrl('embed-max-width'),
 					emoji: ':smirk:',
 				};
 				const ytPostResponse = await request.post(api('chat.sendMessage')).set(credentials).send({ message: ytEmbedMsgPayload });
@@ -1360,7 +1405,7 @@ describe('[Chat]', () => {
 					.send({
 						message: {
 							rid: testChannel._id,
-							msg: 'https://www.youtube.com/watch?v=T2v29gK8fP4',
+							msg: mockVideoUrl('empty-preview-urls'),
 						},
 						previewUrls: [],
 					})
@@ -1389,16 +1434,19 @@ describe('[Chat]', () => {
 			});
 
 			it('should generate previews of chosen URL when the previewUrls array is provided', async () => {
-				let msgId;
+				const chosenUrl = mockPageUrl('chosen-preview');
+				await mockServerSet('GET', '/page/chosen-preview', '<html><head><title>Chosen Preview Page</title></head><body></body></html>');
+
+				let msgId: IMessage['_id'];
 				await request
 					.post(api('chat.sendMessage'))
 					.set(credentials)
 					.send({
 						message: {
 							rid: testChannel._id,
-							msg: 'https://www.youtube.com/watch?v=T2v29gK8fP4 https://www.rocket.chat/',
+							msg: `${mockVideoUrl('not-chosen-preview')} ${chosenUrl}`,
 						},
-						previewUrls: ['https://www.rocket.chat/'],
+						previewUrls: [chosenUrl],
 					})
 					.expect('Content-Type', 'application/json')
 					.expect(200)
@@ -1410,34 +1458,40 @@ describe('[Chat]', () => {
 						msgId = res.body.message._id;
 					});
 
-				// process is async now so wait for a sec
-				await sleep(1000);
+				await retry(
+					'Oembed is generated async thats why the retry is required',
+					async () => {
+						await request
+							.get(api('chat.getMessage'))
+							.set(credentials)
+							.query({
+								msgId,
+							})
+							.expect('Content-Type', 'application/json')
+							.expect(200)
+							.expect((res) => {
+								expect(res.body).to.have.property('message').to.have.property('urls').to.be.an('array').that.has.lengthOf(2);
 
-				await request
-					.get(api('chat.getMessage'))
-					.set(credentials)
-					.query({
-						msgId,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('message').to.have.property('urls').to.be.an('array').that.has.lengthOf(2);
-
-						expect(res.body.message.urls[0]).to.have.property('meta').that.is.an('object').that.is.empty;
-						expect(res.body.message.urls[1]).to.have.property('meta').that.is.an('object').that.is.not.empty;
-					});
+								expect(res.body.message.urls[0]).to.have.property('meta').that.is.an('object').that.is.empty;
+								expect(res.body.message.urls[1]).to.have.property('meta').to.have.property('pageTitle', 'Chosen Preview Page');
+							});
+					},
+					{
+						delayMs: 100,
+						retries: 5,
+					},
+				);
 			});
 
 			it('should not generate previews if the message contains more than five external URL', async () => {
 				let msgId;
 				const urls = [
-					'https://www.youtube.com/watch?v=no050HN4ojo',
-					'https://www.youtube.com/watch?v=9iaSd13mqXA',
-					'https://www.youtube.com/watch?v=MW_qsbgt1KQ',
-					'https://www.youtube.com/watch?v=hLF1XwH5rd4',
-					'https://www.youtube.com/watch?v=Eo-F9hRBbTk',
-					'https://www.youtube.com/watch?v=08ms3W7adFI',
+					mockVideoUrl('over-limit-1'),
+					mockVideoUrl('over-limit-2'),
+					mockVideoUrl('over-limit-3'),
+					mockVideoUrl('over-limit-4'),
+					mockVideoUrl('over-limit-5'),
+					mockVideoUrl('over-limit-6'),
 				];
 				await request
 					.post(api('chat.sendMessage'))
@@ -1472,6 +1526,131 @@ describe('[Chat]', () => {
 							expect(url).to.not.have.property('ignoreParse');
 							expect(url).to.have.property('meta').that.is.an('object').that.is.empty;
 						});
+					});
+			});
+
+			it('should embed the metadata of a rich oembed provider response', async () => {
+				await mockServerSet(mockOembedEndpoint.method, mockOembedEndpoint.path, spotifyOembedResponse);
+				const msg = mockVideoUrl('rich-provider');
+
+				let msgId: IMessage['_id'];
+				await request
+					.post(api('chat.sendMessage'))
+					.set(credentials)
+					.send({ message: { rid: testChannel._id, msg } })
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('success', true);
+						msgId = res.body.message._id;
+					});
+
+				await retry(
+					'Oembed is generated async thats why the retry is required',
+					async () => {
+						await request
+							.get(api('chat.getMessage'))
+							.set(credentials)
+							.query({
+								msgId,
+							})
+							.expect('Content-Type', 'application/json')
+							.expect(200)
+							.expect((res) => {
+								expect(res.body).to.have.property('message').to.have.property('urls').to.be.an('array').that.has.lengthOf(1);
+
+								const { meta } = res.body.message.urls[0];
+								expect(meta).to.have.property('oembedUrl', msg);
+								expect(meta).to.have.property('oembedTitle', 'Never Gonna Give You Up');
+								expect(meta).to.have.property('oembedType', 'rich');
+								expect(meta).to.have.property('oembedProviderName', 'Spotify');
+								expect(meta).to.have.property('oembedThumbnailUrl', spotifyOembedResponse.thumbnail_url);
+								expect(meta).to.have.property('oembedHtml').to.have.string('<iframe style="max-width: 100%;width:400px;height:225px"');
+								expect(meta, 'non-string oembed values must be dropped').to.not.have.any.keys(
+									'oembedWidth',
+									'oembedHeight',
+									'oembedThumbnailWidth',
+									'oembedThumbnailHeight',
+								);
+							});
+					},
+					{
+						delayMs: 100,
+						retries: 5,
+					},
+				);
+			});
+
+			it('should embed only the oembed source url when the provider response has no string values', async () => {
+				await mockServerSet(mockOembedEndpoint.method, mockOembedEndpoint.path, { status: 404, ok: false });
+				const msg = mockVideoUrl('no-string-values');
+
+				let msgId: IMessage['_id'];
+				await request
+					.post(api('chat.sendMessage'))
+					.set(credentials)
+					.send({ message: { rid: testChannel._id, msg } })
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('success', true);
+						msgId = res.body.message._id;
+					});
+
+				await retry(
+					'Oembed is generated async thats why the retry is required',
+					async () => {
+						await request
+							.get(api('chat.getMessage'))
+							.set(credentials)
+							.query({
+								msgId,
+							})
+							.expect('Content-Type', 'application/json')
+							.expect(200)
+							.expect((res) => {
+								expect(res.body).to.have.property('message').to.have.property('urls').to.be.an('array').that.has.lengthOf(1);
+
+								expect(res.body.message.urls[0]).to.have.property('meta').that.deep.equals({ oembedUrl: msg });
+							});
+					},
+					{
+						delayMs: 100,
+						retries: 5,
+					},
+				);
+			});
+
+			it('should not embed metadata when the oembed provider responds with an error', async () => {
+				await mockServerSet(mockOembedEndpoint.method, mockOembedEndpoint.path, {}, 500);
+
+				let msgId;
+				await request
+					.post(api('chat.sendMessage'))
+					.set(credentials)
+					.send({ message: { rid: testChannel._id, msg: mockVideoUrl('error-response') } })
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('success', true);
+						msgId = res.body.message._id;
+					});
+
+				// no observable marker for "processed without meta", so give the async parser time to run before asserting the absence
+				await sleep(500);
+
+				await request
+					.get(api('chat.getMessage'))
+					.set(credentials)
+					.query({
+						msgId,
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('message').to.have.property('urls').to.be.an('array').that.has.lengthOf(1);
+
+						expect(res.body.message.urls[0]).to.have.property('meta').that.is.an('object').that.is.empty;
 					});
 			});
 		});

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -1264,8 +1264,8 @@ describe('[Chat]', () => {
 
 		describe('oembed', () => {
 			// the TEST_MODE oembed provider (server/services/messages/lib/oembed/providers.ts) resolves /video/ URLs through GET /oembed on the mock-server
-			const mockVideoUrl = (id: string) => `http://mock-server.local:8080/video/${id}`;
-			const mockPageUrl = (id: string) => `http://mock-server.local:8080/page/${id}`;
+			const mockVideoUrl = (id: string) => `http://mock-server.dev:8080/video/${id}`;
+			const mockPageUrl = (id: string) => `http://mock-server.dev:8080/page/${id}`;
 			const mockOembedEndpoint = { method: 'GET', path: '/oembed' };
 
 			const youtubeOembedResponse = {
@@ -1312,7 +1312,7 @@ describe('[Chat]', () => {
 				Promise.all([
 					updateSetting('API_EmbedIgnoredHosts', ''),
 					updateSetting('API_EmbedSafePorts', '80, 443, 3000, 8080'),
-					updateSetting('SSRF_Allowlist', '127.0.0.1:3000, mock-server.local'),
+					updateSetting('SSRF_Allowlist', '127.0.0.1:3000, mock-server.dev'),
 				]),
 			);
 

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -5,6 +5,7 @@ import { expect } from 'chai';
 import { after, before, beforeEach, describe, it } from 'mocha';
 import type { Response } from 'supertest';
 
+import { retry } from './helpers/retry';
 import { sleep } from '../../../lib/utils/sleep';
 import { getCredentials, api, request, credentials, apiUrl } from '../../data/api-data';
 import { followMessage, sendSimpleMessage, deleteMessage } from '../../data/chat.helper';
@@ -1354,24 +1355,31 @@ describe('[Chat]', () => {
 			});
 
 			it('should have an iframe oembed with style max-width', async () => {
-				await sleep(oembedProcessingMs);
+				await retry(
+					'Oembed is generated async thats why the retry is required',
+					async () => {
+						await request
+							.get(api('chat.getMessage'))
+							.set(credentials)
+							.query({
+								msgId: ytEmbedMsgId,
+							})
+							.expect('Content-Type', 'application/json')
+							.expect(200)
+							.expect((res) => {
+								expect(res.body).to.have.property('message').to.have.property('urls').to.be.an('array').that.is.not.empty;
 
-				await request
-					.get(api('chat.getMessage'))
-					.set(credentials)
-					.query({
-						msgId: ytEmbedMsgId,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('message').to.have.property('urls').to.be.an('array').that.is.not.empty;
-
-						expect(res.body.message.urls[0])
-							.to.have.property('meta')
-							.to.have.property('oembedHtml')
-							.to.have.string('<iframe style="max-width: 100%;width:400px;height:225px"');
-					});
+								expect(res.body.message.urls[0])
+									.to.have.property('meta')
+									.to.have.property('oembedHtml')
+									.to.have.string('<iframe style="max-width: 100%;width:400px;height:225px"');
+							});
+					},
+					{
+						delayMs: 100,
+						retries: 5,
+					},
+				);
 			});
 
 			it('should embed an image preview if message has an image url', (done) => {

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -5,7 +5,6 @@ import { expect } from 'chai';
 import { after, before, beforeEach, describe, it } from 'mocha';
 import type { Response } from 'supertest';
 
-import { retry } from './helpers/retry';
 import { sleep } from '../../../lib/utils/sleep';
 import { getCredentials, api, request, credentials, apiUrl } from '../../data/api-data';
 import { followMessage, sendSimpleMessage, deleteMessage } from '../../data/chat.helper';
@@ -1267,6 +1266,8 @@ describe('[Chat]', () => {
 			const mockVideoUrl = (id: string) => `http://mock-server.dev:8080/video/${id}`;
 			const mockPageUrl = (id: string) => `http://mock-server.dev:8080/page/${id}`;
 			const mockOembedEndpoint = { method: 'GET', path: '/oembed' };
+			// the whole oembed pipeline runs against the local mock-server, so a fixed wait suffices — exceeding it means a CI perf problem worth surfacing
+			const oembedProcessingMs = 500;
 
 			const youtubeOembedResponse = {
 				title: 'Rocket.Chat Demo',
@@ -1353,31 +1354,24 @@ describe('[Chat]', () => {
 			});
 
 			it('should have an iframe oembed with style max-width', async () => {
-				await retry(
-					'Oembed is generated async thats why the retry is required',
-					async () => {
-						await request
-							.get(api('chat.getMessage'))
-							.set(credentials)
-							.query({
-								msgId: ytEmbedMsgId,
-							})
-							.expect('Content-Type', 'application/json')
-							.expect(200)
-							.expect((res) => {
-								expect(res.body).to.have.property('message').to.have.property('urls').to.be.an('array').that.is.not.empty;
+				await sleep(oembedProcessingMs);
 
-								expect(res.body.message.urls[0])
-									.to.have.property('meta')
-									.to.have.property('oembedHtml')
-									.to.have.string('<iframe style="max-width: 100%;width:400px;height:225px"');
-							});
-					},
-					{
-						delayMs: 100,
-						retries: 5,
-					},
-				);
+				await request
+					.get(api('chat.getMessage'))
+					.set(credentials)
+					.query({
+						msgId: ytEmbedMsgId,
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('message').to.have.property('urls').to.be.an('array').that.is.not.empty;
+
+						expect(res.body.message.urls[0])
+							.to.have.property('meta')
+							.to.have.property('oembedHtml')
+							.to.have.string('<iframe style="max-width: 100%;width:400px;height:225px"');
+					});
 			});
 
 			it('should embed an image preview if message has an image url', (done) => {
@@ -1439,7 +1433,7 @@ describe('[Chat]', () => {
 				const chosenUrl = mockPageUrl('chosen-preview');
 				await mockServerSet('GET', '/page/chosen-preview', '<html><head><title>Chosen Preview Page</title></head><body></body></html>');
 
-				let msgId: IMessage['_id'];
+				let msgId;
 				await request
 					.post(api('chat.sendMessage'))
 					.set(credentials)
@@ -1460,29 +1454,22 @@ describe('[Chat]', () => {
 						msgId = res.body.message._id;
 					});
 
-				await retry(
-					'Oembed is generated async thats why the retry is required',
-					async () => {
-						await request
-							.get(api('chat.getMessage'))
-							.set(credentials)
-							.query({
-								msgId,
-							})
-							.expect('Content-Type', 'application/json')
-							.expect(200)
-							.expect((res) => {
-								expect(res.body).to.have.property('message').to.have.property('urls').to.be.an('array').that.has.lengthOf(2);
+				await sleep(oembedProcessingMs);
 
-								expect(res.body.message.urls[0]).to.have.property('meta').that.is.an('object').that.is.empty;
-								expect(res.body.message.urls[1]).to.have.property('meta').to.have.property('pageTitle', 'Chosen Preview Page');
-							});
-					},
-					{
-						delayMs: 100,
-						retries: 5,
-					},
-				);
+				await request
+					.get(api('chat.getMessage'))
+					.set(credentials)
+					.query({
+						msgId,
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('message').to.have.property('urls').to.be.an('array').that.has.lengthOf(2);
+
+						expect(res.body.message.urls[0]).to.have.property('meta').that.is.an('object').that.is.empty;
+						expect(res.body.message.urls[1]).to.have.property('meta').to.have.property('pageTitle', 'Chosen Preview Page');
+					});
 			});
 
 			it('should not generate previews if the message contains more than five external URL', async () => {
@@ -1535,7 +1522,7 @@ describe('[Chat]', () => {
 				await mockServerSet(mockOembedEndpoint.method, mockOembedEndpoint.path, spotifyOembedResponse);
 				const msg = mockVideoUrl('rich-provider');
 
-				let msgId: IMessage['_id'];
+				let msgId;
 				await request
 					.post(api('chat.sendMessage'))
 					.set(credentials)
@@ -1547,47 +1534,40 @@ describe('[Chat]', () => {
 						msgId = res.body.message._id;
 					});
 
-				await retry(
-					'Oembed is generated async thats why the retry is required',
-					async () => {
-						await request
-							.get(api('chat.getMessage'))
-							.set(credentials)
-							.query({
-								msgId,
-							})
-							.expect('Content-Type', 'application/json')
-							.expect(200)
-							.expect((res) => {
-								expect(res.body).to.have.property('message').to.have.property('urls').to.be.an('array').that.has.lengthOf(1);
+				await sleep(oembedProcessingMs);
 
-								const { meta } = res.body.message.urls[0];
-								expect(meta).to.have.property('oembedUrl', msg);
-								expect(meta).to.have.property('oembedTitle', 'Never Gonna Give You Up');
-								expect(meta).to.have.property('oembedType', 'rich');
-								expect(meta).to.have.property('oembedProviderName', 'Spotify');
-								expect(meta).to.have.property('oembedThumbnailUrl', spotifyOembedResponse.thumbnail_url);
-								expect(meta).to.have.property('oembedHtml').to.have.string('<iframe style="max-width: 100%;width:400px;height:225px"');
-								expect(meta, 'non-string oembed values must be dropped').to.not.have.any.keys(
-									'oembedWidth',
-									'oembedHeight',
-									'oembedThumbnailWidth',
-									'oembedThumbnailHeight',
-								);
-							});
-					},
-					{
-						delayMs: 100,
-						retries: 5,
-					},
-				);
+				await request
+					.get(api('chat.getMessage'))
+					.set(credentials)
+					.query({
+						msgId,
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('message').to.have.property('urls').to.be.an('array').that.has.lengthOf(1);
+
+						const { meta } = res.body.message.urls[0];
+						expect(meta).to.have.property('oembedUrl', msg);
+						expect(meta).to.have.property('oembedTitle', 'Never Gonna Give You Up');
+						expect(meta).to.have.property('oembedType', 'rich');
+						expect(meta).to.have.property('oembedProviderName', 'Spotify');
+						expect(meta).to.have.property('oembedThumbnailUrl', spotifyOembedResponse.thumbnail_url);
+						expect(meta).to.have.property('oembedHtml').to.have.string('<iframe style="max-width: 100%;width:400px;height:225px"');
+						expect(meta, 'non-string oembed values must be dropped').to.not.have.any.keys(
+							'oembedWidth',
+							'oembedHeight',
+							'oembedThumbnailWidth',
+							'oembedThumbnailHeight',
+						);
+					});
 			});
 
 			it('should embed only the oembed source url when the provider response has no string values', async () => {
 				await mockServerSet(mockOembedEndpoint.method, mockOembedEndpoint.path, { status: 404, ok: false });
 				const msg = mockVideoUrl('no-string-values');
 
-				let msgId: IMessage['_id'];
+				let msgId;
 				await request
 					.post(api('chat.sendMessage'))
 					.set(credentials)
@@ -1599,28 +1579,21 @@ describe('[Chat]', () => {
 						msgId = res.body.message._id;
 					});
 
-				await retry(
-					'Oembed is generated async thats why the retry is required',
-					async () => {
-						await request
-							.get(api('chat.getMessage'))
-							.set(credentials)
-							.query({
-								msgId,
-							})
-							.expect('Content-Type', 'application/json')
-							.expect(200)
-							.expect((res) => {
-								expect(res.body).to.have.property('message').to.have.property('urls').to.be.an('array').that.has.lengthOf(1);
+				await sleep(oembedProcessingMs);
 
-								expect(res.body.message.urls[0]).to.have.property('meta').that.deep.equals({ oembedUrl: msg });
-							});
-					},
-					{
-						delayMs: 100,
-						retries: 5,
-					},
-				);
+				await request
+					.get(api('chat.getMessage'))
+					.set(credentials)
+					.query({
+						msgId,
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('message').to.have.property('urls').to.be.an('array').that.has.lengthOf(1);
+
+						expect(res.body.message.urls[0]).to.have.property('meta').that.deep.equals({ oembedUrl: msg });
+					});
 			});
 
 			it('should not embed metadata when the oembed provider responds with an error', async () => {
@@ -1638,8 +1611,7 @@ describe('[Chat]', () => {
 						msgId = res.body.message._id;
 					});
 
-				// no observable marker for "processed without meta", so give the async parser time to run before asserting the absence
-				await sleep(500);
+				await sleep(oembedProcessingMs);
 
 				await request
 					.get(api('chat.getMessage'))

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -1308,6 +1308,9 @@ describe('[Chat]', () => {
 				await mockServerReset();
 			});
 
+			// programmed responses queue per key and an infinite (times: 0) entry never expires, so each test starts from a clean mock
+			afterEach(() => mockServerReset());
+
 			before(() =>
 				Promise.all([
 					updateSetting('API_EmbedIgnoredHosts', ''),
@@ -1321,7 +1324,6 @@ describe('[Chat]', () => {
 					updateSetting('API_EmbedIgnoredHosts', 'localhost, 127.0.0.1, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16'),
 					updateSetting('API_EmbedSafePorts', '80, 443'),
 					updateSetting('SSRF_Allowlist', ''),
-					mockServerReset(),
 				]),
 			);
 

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -229,9 +229,10 @@ services:
       - 4000:8080
     networks:
       default:
-        # single-label hostnames fail server-fetch SSRF domain validation, so oembed tests reach it through this alias
+        # single-label hostnames fail server-fetch SSRF domain validation and message-parser only links TLDs
+        # from its whitelist (.local/.test/.internal are not in it), so oembed tests reach it through this alias
         aliases:
-          - mock-server.local
+          - mock-server.dev
     healthcheck:
       test: ['CMD', '/mock-server', '-healthcheck']
       interval: 2s

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -227,6 +227,11 @@ services:
       - api
     ports:
       - 4000:8080
+    networks:
+      default:
+        # single-label hostnames fail server-fetch SSRF domain validation, so oembed tests reach it through this alias
+        aliases:
+          - mock-server.local
     healthcheck:
       test: ['CMD', '/mock-server', '-healthcheck']
       interval: 2s


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The `chat.sendMessage` oembed API tests fetched real external sites (YouTube's oembed endpoint, rocket.chat) at test time, so slow or failed external fetches flaked the suite — e.g. `should generate previews of chosen URL when the previewUrls array is provided` failing with `expected {} not to be empty` after its fixed 1s sleep.

This points the whole oembed suite at the mock-server already used by the ABAC API tests:

- `providers.ts` registers a `TEST_MODE`-only oembed provider that resolves `http://mock-server.local:8080/video/*` URLs through `GET /oembed` on the mock-server; tests program that endpoint per case with captured real provider payloads (YouTube video, Spotify rich).
- `docker-compose-ci.yml` adds a `mock-server.local` network alias, since single-label hostnames fail `server-fetch` SSRF domain validation.
- The CE api job now also starts `mock-server` (the EE job already does via `COMPOSE_PROFILES=api`).
- The flaky fixed `sleep(1000)` is replaced with the existing `retry` polling helper.

New coverage on top of the converted tests, using real captured oembed responses:

- full metadata of a rich provider response (title/type/provider/thumbnail, `oembedHtml` max-width injection, non-string values dropped)
- provider response with no string values embeds only `oembedUrl`
- provider error response (500) embeds no metadata

Locally verified against the pinned mockserver image: path matching ignores query strings, string bodies work for the generic-page (`pageTitle`) case, and the dotted alias resolves via docker DNS from a peer container.

## Steps to test or reproduce

Run the api E2E suite; the `[Chat] /chat.sendMessage oembed` block no longer performs any external network request.

## Further comments

Test-only change, no changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link previews for supported video and rich-media URLs.
  * Enhanced preview metadata handling, including iframe content and provider responses.
  * Prevented invalid or incomplete metadata from appearing in message previews.
  * Improved behavior when preview providers return errors or when messages contain more than five external URLs.

* **Tests**
  * Expanded end-to-end coverage for chat message previews and link-preview edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [CORE-2457]

[CORE-2457]: https://rocketchat.atlassian.net/browse/CORE-2457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ