### PR TITLE
feat(e2ee): warn when a DM is not end-to-end encrypted

### DIFF
--- a/.changeset/e2ee-dm-warning-banner.md
+++ b/.changeset/e2ee-dm-warning-banner.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': minor
+---
+
+Added a warning banner in direct message rooms that are not end-to-end encrypted, shown to users who already have E2EE set up on their account. The banner offers a one-click action to enable encryption for that DM, and can be dismissed per room.

--- a/apps/meteor/client/views/room/E2EEWarningBanner/E2EEWarningBanner.tsx
+++ b/apps/meteor/client/views/room/E2EEWarningBanner/E2EEWarningBanner.tsx
@@ -31,16 +31,20 @@ const E2EEWarningBanner = () => {
 				onClose: imperativeModal.close,
 				roomType: getRoomTypeTranslation(room)?.toLowerCase(),
 				onConfirm: async () => {
-					const { success } = await toggleE2E({ rid: room._id, encrypted: true });
-					if (!success) {
-						return;
-					}
+					try {
+						const { success } = await toggleE2E({ rid: room._id, encrypted: true });
+						if (!success) {
+							return;
+						}
 
-					imperativeModal.close();
-					dispatchToastMessage({ type: 'success', message: t('E2E_Encryption_enabled_for_room', { roomName: room.name }) });
+						imperativeModal.close();
+						dispatchToastMessage({ type: 'success', message: t('E2E_Encryption_enabled_for_room', { roomName: room.name }) });
 
-					if (subscription?.autoTranslate) {
-						dispatchToastMessage({ type: 'success', message: t('AutoTranslate_Disabled_for_room', { roomName: room.name }) });
+						if (subscription?.autoTranslate) {
+							dispatchToastMessage({ type: 'success', message: t('AutoTranslate_Disabled_for_room', { roomName: room.name }) });
+						}
+					} catch (error) {
+						dispatchToastMessage({ type: 'error', message: error });
 					}
 				},
 			},

--- a/apps/meteor/client/views/room/E2EEWarningBanner/E2EEWarningBanner.tsx
+++ b/apps/meteor/client/views/room/E2EEWarningBanner/E2EEWarningBanner.tsx
@@ -1,0 +1,66 @@
+import { isRoomFederated } from '@rocket.chat/core-typings';
+import { Banner, Box, Button } from '@rocket.chat/fuselage';
+import { useLocalStorage, useStableCallback } from '@rocket.chat/fuselage-hooks';
+import { imperativeModal } from '@rocket.chat/ui-client';
+import { useSetting, useEndpoint, useToastMessageDispatch } from '@rocket.chat/ui-contexts';
+import { useTranslation } from 'react-i18next';
+
+import { getRoomTypeTranslation } from '../../../lib/getRoomTypeTranslation';
+import { useRoom, useRoomSubscription } from '../contexts/RoomContext';
+import { useE2EEState } from '../hooks/useE2EEState';
+import EnableE2EEModal from '../modals/E2EEModals/EnableE2EEModal';
+
+const E2EEWarningBanner = () => {
+	const { t } = useTranslation();
+	const room = useRoom();
+	const subscription = useRoomSubscription();
+	const e2eEnabled = useSetting('E2E_Enable', false);
+	const e2eeState = useE2EEState();
+	const dispatchToastMessage = useToastMessageDispatch();
+	const toggleE2E = useEndpoint('POST', '/v1/rooms.saveRoomSettings');
+
+	const [dismissed, setDismissed] = useLocalStorage(`e2eeWarningBannerDismissed-${room._id}`, false);
+
+	const isE2EEReady = e2eeState === 'READY' || e2eeState === 'SAVE_PASSWORD';
+	const shouldShow = e2eEnabled && isE2EEReady && room.t === 'd' && !room.encrypted && !isRoomFederated(room) && !dismissed;
+
+	const handleEnableE2EE = useStableCallback(() => {
+		imperativeModal.open({
+			component: EnableE2EEModal,
+			props: {
+				onClose: imperativeModal.close,
+				roomType: getRoomTypeTranslation(room)?.toLowerCase(),
+				onConfirm: async () => {
+					const { success } = await toggleE2E({ rid: room._id, encrypted: true });
+					if (!success) {
+						return;
+					}
+
+					imperativeModal.close();
+					dispatchToastMessage({ type: 'success', message: t('E2E_Encryption_enabled_for_room', { roomName: room.name }) });
+
+					if (subscription?.autoTranslate) {
+						dispatchToastMessage({ type: 'success', message: t('AutoTranslate_Disabled_for_room', { roomName: room.name }) });
+					}
+				},
+			},
+		});
+	});
+
+	if (!shouldShow) {
+		return null;
+	}
+
+	return (
+		<Banner variant='warning' closeable onClose={() => setDismissed(true)}>
+			<Box display='flex' flexDirection='row' alignItems='center' justifyContent='space-between' flexWrap='wrap'>
+				<Box marginInlineEnd={16}>{t('E2EE_not_enabled_for_this_dm_warning')}</Box>
+				<Button small onClick={handleEnableE2EE}>
+					{t('Enable_E2E_encryption')}
+				</Button>
+			</Box>
+		</Banner>
+	);
+};
+
+export default E2EEWarningBanner;

--- a/apps/meteor/client/views/room/E2EEWarningBanner/index.tsx
+++ b/apps/meteor/client/views/room/E2EEWarningBanner/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './E2EEWarningBanner';

--- a/apps/meteor/client/views/room/body/RoomBody.tsx
+++ b/apps/meteor/client/views/room/body/RoomBody.tsx
@@ -12,6 +12,7 @@ import DropTargetOverlay from './DropTargetOverlay';
 import JumpToRecentMessageButton from './JumpToRecentMessageButton';
 import UnreadMessagesIndicator from './UnreadMessagesIndicator';
 import MessageListErrorBoundary from '../MessageList/MessageListErrorBoundary';
+import E2EEWarningBanner from '../E2EEWarningBanner';
 import RoomAnnouncement from '../RoomAnnouncement';
 import UploadProgressIndicator from './UploadProgress';
 import ComposerContainer from '../composer/ComposerContainer';
@@ -161,6 +162,7 @@ const RoomBody = () => {
 	return (
 		<>
 			{!isLayoutEmbedded && room.announcement && <RoomAnnouncement announcement={room.announcement} />}
+			{!isLayoutEmbedded && <E2EEWarningBanner />}
 			<Box key={room._id} className={['main-content-flex', listStyle]}>
 				<section
 					role='presentation'

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -2003,6 +2003,7 @@
   "Duplicated_Email_address_will_be_ignored": "Duplicated email address will be ignored.",
   "Duration": "Duration",
   "E2EE_Composer_Unencrypted_Message": "You're sending an unencrypted message",
+  "E2EE_not_enabled_for_this_dm_warning": "This direct message is not end-to-end encrypted. Anyone with server access could read its content.",
   "E2EE_password_reset": "E2EE password reset",
   "E2EE_alert": "<b>Enabling E2EE affects other functionalities</b> <ul><li> - Encrypted content cannot be found by search</li> <li> - Encrypted content cannot be audited</li> <li> - Bot interactions may not work with encrypted messages</li></ul>",
   "E2E_Allow_Unencrypted_Messages": "Unencrypted messages in encrypted rooms",


### PR DESCRIPTION
## Summary

Closes #41192.

Users who have E2EE set up on their account had no clear indication when a given direct message was not actually encrypted — the only signal was a small key icon in the header, which is easy to miss (as reported in the issue).

This adds a dismissible warning banner, shown above the message list in a DM room when:
- the current user has E2EE configured and ready (same readiness check already used by the "Enable E2E encryption" room action)
- the DM itself is not encrypted (`room.encrypted` is false)

The banner includes a button that opens the existing "Enable encryption" confirmation modal and reuses the same `rooms.saveRoomSettings` toggle already used by the kebab menu action, so enabling behaves identically either way. It can be dismissed per room (stored in local storage), so users who deliberately keep a DM unencrypted aren't nagged repeatedly, per the discussion on the issue.

## Test plan

- [ ] As a user with E2EE set up, open an unencrypted DM and confirm the banner appears
- [ ] Click "Enable E2E encryption" on the banner, confirm in the modal, and verify the DM becomes encrypted and the banner disappears
- [ ] Dismiss the banner, reload, and confirm it stays dismissed for that DM
- [ ] Open a different unencrypted DM and confirm the banner still shows there (dismissal is per-room)
- [ ] Confirm the banner does not show for users without E2EE set up, or in already-encrypted DMs

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end encryption warning banner for direct messages that aren’t encrypted (shown to users with E2EE enabled on their account).
  * Users can enable encryption directly from the banner via a one-click action.
  * Dismissal is saved separately for each direct message conversation.
  * Added user-facing messaging and localization warning about the risks of unencrypted direct messages.
* **Bug Fixes**
  * No bug fixes included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->