### PR TITLE
fix(meteor): meteor/* type resolution under TS7 (drop packages.d.ts fallback)

### DIFF
--- a/apps/meteor/definition/externals/meteor/npm-mongo.d.ts
+++ b/apps/meteor/definition/externals/meteor/npm-mongo.d.ts
@@ -1,0 +1,4 @@
+declare module 'meteor/npm-mongo' {
+	// The npm-mongo Meteor package re-exports the mongodb driver under this name.
+	export * as NpmModuleMongodb from 'mongodb';
+}

--- a/apps/meteor/definition/externals/meteor/webapp.d.ts
+++ b/apps/meteor/definition/externals/meteor/webapp.d.ts
@@ -1,0 +1,8 @@
+declare module 'meteor/webapp' {
+	import type * as express from 'express';
+
+	namespace WebApp {
+		// Present in Meteor 3's generated types but missing from @types/meteor.
+		const rawHandlers: express.Application;
+	}
+}

--- a/apps/meteor/server/lib/saml/listener.ts
+++ b/apps/meteor/server/lib/saml/listener.ts
@@ -77,7 +77,9 @@ const middleware = async function (req: express.Request, res: ServerResponse, ne
 };
 
 // Listen to incoming SAML http requests
-WebApp.connectHandlers.use(
+// In Meteor 3 connectHandlers is an express app (multi-middleware use), but
+// @types/meteor still types it as connect.Server (1-2 args).
+(WebApp.connectHandlers as unknown as express.Application).use(
 	/^\/_saml/,
 	bodyParser.json(),
 	express.urlencoded({

--- a/apps/meteor/tsconfig.json
+++ b/apps/meteor/tsconfig.json
@@ -22,7 +22,11 @@
 		"paths": {
 			/* Support absolute /imports/* with a leading '/' */
 			"/*": ["*"],
-			"meteor/*": ["./node_modules/@types/meteor/*", ".meteor/local/types/packages.d.ts"],
+			/* No .meteor/local/types/packages.d.ts fallback: its `export =` module
+			   declarations take over the module identity under TS7 and discard the
+			   ambient merges from @types/meteor and definition/externals. Everything
+			   it declared is covered by @types/meteor + definition/externals. */
+			"meteor/*": ["./node_modules/@types/meteor/*"],
 			"swiper/modules/index.mjs": ["./node_modules/swiper/types/modules/index.d.ts"],
 			"swiper/swiper-react.mjs": ["./node_modules/swiper/swiper-react.d.ts"],
 		},


### PR DESCRIPTION
## Summary

Fixes the `meteor/*` module-type resolution that broke under TypeScript 7 (~60 errors: `Accounts._bcryptRounds`, `Accounts.LoginCancelledError`, `DDPRateLimiter._check`, …).

## Root cause

Those Meteor internals are typed by our own ambient augmentations in `apps/meteor/definition/externals/meteor/*.d.ts`, merging with `@types/meteor`. TS7 merges these fine — the problem is the generated `.meteor/local/types/packages.d.ts`, pulled in through the `paths` fallback. It declares every meteor module as:

```ts
declare module 'meteor/accounts-base' {
  import exports = require('package-types/…/accounts-base.d');
  export = exports;
}
```

Under TS7, once that file enters the program, the **`export =` declaration takes over the module identity and the ambient merges are discarded** — all our augmented internals vanish. TS5 resolved the ambient declarations in favor of the merge, which is why this never surfaced before. Verified by isolation: a probe with just the augmentation is green on TS7; adding `packages.d.ts` to the program makes the members disappear.

## Fix

- Remove the `packages.d.ts` fallback from `paths` — a coverage check of every `meteor/*` specifier the app imports showed **everything it declared is already covered** by `@types/meteor` + `definition/externals`, except:
- `meteor/npm-mongo` → new shim re-exporting the `mongodb` driver as `NpmModuleMongodb` (matches the real package),
- `WebApp.rawHandlers` → added to `definition/externals` (present in Meteor 3's generated types, missing from `@types/meteor`).

## Verification

- **TS5 (current toolchain)**: probe covering all three symbol classes (`Accounts._bcryptRounds`, `NpmModuleMongodb.GridFSBucket`, `WebApp.rawHandlers`) — 0 errors, no regression.
- **TS7**: full-app typecheck probe drops **230 → 172**; the Accounts/DDPRateLimiter class goes to zero. The remainder is the Endpoints type-drift (tracked separately as W3) plus a small tail.

Part of the TS7-readiness set (W2).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2283]

[ARCH-2283]: https://rocketchat.atlassian.net/browse/ARCH-2283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript compatibility for Meteor integrations.
  * Corrected type support for MongoDB imports and web application request handlers.
  * Preserved SAML middleware routing while ensuring it works with updated Meteor typings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->