### PR TITLE
chore: Replace some `SidebarV1` components in favor of `SidebarV2`

### DIFF
--- a/apps/meteor/client/components/Sidebar/Sidebar.tsx
+++ b/apps/meteor/client/components/Sidebar/Sidebar.tsx
@@ -1,10 +1,10 @@
-import { Sidebar as FuselageSidebar } from '@rocket.chat/fuselage';
+import { SidebarV2 as FuselageSidebar } from '@rocket.chat/fuselage';
 import type { ComponentPropsWithoutRef } from 'react';
 
 export type SidebarProps = ComponentPropsWithoutRef<typeof FuselageSidebar>;
 
 const Sidebar = (props: SidebarProps) => (
-	<FuselageSidebar {...props} role='navigation' display='flex' flexDirection='column' height='full' />
-);
+		<FuselageSidebar {...props} />
+	);
 
 export default Sidebar;

--- a/apps/meteor/client/components/Sidebar/Sidebar.tsx
+++ b/apps/meteor/client/components/Sidebar/Sidebar.tsx
@@ -3,8 +3,6 @@ import type { ComponentPropsWithoutRef } from 'react';
 
 export type SidebarProps = ComponentPropsWithoutRef<typeof FuselageSidebar>;
 
-const Sidebar = (props: SidebarProps) => (
-		<FuselageSidebar {...props} />
-	);
+const Sidebar = (props: SidebarProps) => <FuselageSidebar {...props} />;
 
 export default Sidebar;

--- a/apps/meteor/client/components/Sidebar/SidebarGenericItem.tsx
+++ b/apps/meteor/client/components/Sidebar/SidebarGenericItem.tsx
@@ -1,19 +1,17 @@
-import { Box, SidebarItem } from '@rocket.chat/fuselage';
+import { Box, SidebarV2Item } from '@rocket.chat/fuselage';
 import type { ReactNode } from 'react';
 import { memo } from 'react';
 
 export type SidebarGenericItemProps = {
 	href?: string;
 	active?: boolean;
-	featured?: boolean;
 	children: ReactNode;
 	externalUrl?: boolean;
 };
 
 const SidebarGenericItem = ({ href, active, externalUrl, children, ...props }: SidebarGenericItemProps) => (
-	<SidebarItem
+	<SidebarV2Item
 		selected={active}
-		clickable
 		is='a'
 		href={href}
 		{...(externalUrl && { target: '_blank', rel: 'noopener noreferrer' })}
@@ -22,7 +20,7 @@ const SidebarGenericItem = ({ href, active, externalUrl, children, ...props }: S
 		<Box display='flex' flexDirection='row' alignItems='center' paddingBlock={8} width='100%'>
 			{children}
 		</Box>
-	</SidebarItem>
+	</SidebarV2Item>
 );
 
 export default memo(SidebarGenericItem);

--- a/apps/meteor/client/components/Sidebar/SidebarGenericItem.tsx
+++ b/apps/meteor/client/components/Sidebar/SidebarGenericItem.tsx
@@ -10,13 +10,7 @@ export type SidebarGenericItemProps = {
 };
 
 const SidebarGenericItem = ({ href, active, externalUrl, children, ...props }: SidebarGenericItemProps) => (
-	<SidebarV2Item
-		selected={active}
-		is='a'
-		href={href}
-		{...(externalUrl && { target: '_blank', rel: 'noopener noreferrer' })}
-		{...props}
-	>
+	<SidebarV2Item selected={active} is='a' href={href} {...(externalUrl && { target: '_blank', rel: 'noopener noreferrer' })} {...props}>
 		<Box display='flex' flexDirection='row' alignItems='center' paddingBlock={8} width='100%'>
 			{children}
 		</Box>

--- a/apps/meteor/client/sidebar/footer/SidebarFooterDefault.tsx
+++ b/apps/meteor/client/sidebar/footer/SidebarFooterDefault.tsx
@@ -1,5 +1,5 @@
 import { css } from '@rocket.chat/css-in-js';
-import { Box, SidebarDivider, Palette, SidebarFooter as Footer } from '@rocket.chat/fuselage';
+import { Box, SidebarV2Divider, Palette, SidebarV2Footer as Footer } from '@rocket.chat/fuselage';
 import { useThemeMode } from '@rocket.chat/ui-client';
 import { useSetting } from '@rocket.chat/ui-contexts';
 import DOMPurify from 'dompurify';
@@ -23,11 +23,9 @@ const SidebarFooterDefault = () => {
 
 	return (
 		<Footer>
-			<SidebarDivider />
+			<SidebarV2Divider />
 			<Box
-				is='footer'
 				paddingBlock={12}
-				paddingInline={16}
 				height='x48'
 				width='auto'
 				className={sidebarFooterStyle}

--- a/apps/meteor/client/sidebar/footer/SidebarFooterWatermark.tsx
+++ b/apps/meteor/client/sidebar/footer/SidebarFooterWatermark.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@rocket.chat/fuselage';
+import { Box, SidebarV2FooterContent as FooterContent } from '@rocket.chat/fuselage';
 import { useLicense, useLicenseName } from '@rocket.chat/ui-client';
 import { useTranslation } from 'react-i18next';
 
@@ -26,15 +26,15 @@ export const SidebarFooterWatermark = () => {
 	}
 
 	return (
-		<Box paddingInline={16} paddingBlockEnd={8}>
+		<FooterContent paddingBlockEnd={8}>
 			<Box is='a' href={links.rocketChat} target='_blank' rel='noopener noreferrer'>
-				<Box fontScale='micro' color='hint' paddingBlockEnd={4}>
+				<Box color='hint' paddingBlockEnd={4}>
 					{t('Powered_by_RocketChat')}
 				</Box>
-				<Box fontScale='micro' color='pure-white' paddingBlockEnd={4}>
+				<Box color='pure-white' paddingBlockEnd={4}>
 					{licenseName.data}
 				</Box>
 			</Box>
-		</Box>
+		</FooterContent>
 	);
 };


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-2455](https://rocketchat.atlassian.net/browse/CORE-2455)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



[CORE-2455]: https://rocketchat.atlassian.net/browse/CORE-2455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the sidebar layout and visual presentation using the refreshed sidebar components.
  * Refined sidebar footer spacing, dividers, and branding display.
  * Improved watermark and footer content alignment.

* **Bug Fixes**
  * Preserved correct behavior for external sidebar links, including opening them securely in a new tab.
  * Maintained license loading and error-state handling in the footer watermark.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->