### PR TITLE
fix: livechat tags.save rejected by response validation on edit (+ e2e deflakes and Playwright GitHub annotations)

### DIFF
--- a/.changeset/tags-save-updatedat.md
+++ b/.changeset/tags-save-updatedat.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixed saving a livechat tag failing with "Invalid response" — the model mutated its return value with `_updatedAt`, which the endpoint response schema rejects

--- a/apps/meteor/ee/server/models/raw/LivechatTag.ts
+++ b/apps/meteor/ee/server/models/raw/LivechatTag.ts
@@ -37,7 +37,8 @@ export class LivechatTagRaw extends BaseRaw<ILivechatTag> implements ILivechatTa
 			_id = (await this.insertOne(record)).insertedId;
 		}
 
-		return Object.assign(record, { _id });
+		// updateOne/insertOne mutate `record` by injecting `_updatedAt` (setUpdatedAt), so rebuild the declared shape
+		return { _id, name, description, numDepartments: departments.length, departments };
 	}
 
 	// REMOVE

--- a/apps/meteor/playwright.config.ts
+++ b/apps/meteor/playwright.config.ts
@@ -22,6 +22,7 @@ export default {
 	outputDir: 'tests/e2e/.playwright',
 	reporter: [
 		['list'],
+		process.env.GITHUB_ACTIONS === 'true' && ['github'],
 		process.env.REPORTER_ROCKETCHAT_REPORT === 'true' && [
 			'./reporters/rocketchat.ts',
 			{

--- a/apps/meteor/tests/e2e/e2e-encryption/e2ee-file-encryption.spec.ts
+++ b/apps/meteor/tests/e2e/e2e-encryption/e2ee-file-encryption.spec.ts
@@ -1,5 +1,6 @@
 import { Users } from '../fixtures/userStates';
 import { HomeChannel } from '../page-objects';
+import { EncryptedRoomPage } from '../page-objects/encrypted-room';
 import { createTargetGroupAndReturnFullRoom } from '../utils';
 import { preserveSettings } from '../utils/preserveSettings';
 import { test, expect } from '../utils/test';
@@ -50,6 +51,8 @@ test.describe('E2EE File Encryption', () => {
 		await page.goto(`/group/${group.name}`);
 		await page.locator('#main-content').waitFor();
 		await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toBeVisible();
+		// wait for the room key to be ready, otherwise messages are sent unencrypted (E2E_Allow_Unencrypted_Messages is on)
+		await expect(new EncryptedRoomPage(page).encryptionNotReadyIndicator).not.toBeVisible();
 	});
 
 	test.afterEach(async ({ api }) => {

--- a/apps/meteor/tests/e2e/e2e-encryption/e2ee-file-encryption.spec.ts
+++ b/apps/meteor/tests/e2e/e2e-encryption/e2ee-file-encryption.spec.ts
@@ -1,6 +1,5 @@
 import { Users } from '../fixtures/userStates';
 import { HomeChannel } from '../page-objects';
-import { EncryptedRoomPage } from '../page-objects/encrypted-room';
 import { createTargetGroupAndReturnFullRoom } from '../utils';
 import { preserveSettings } from '../utils/preserveSettings';
 import { test, expect } from '../utils/test';
@@ -51,8 +50,18 @@ test.describe('E2EE File Encryption', () => {
 		await page.goto(`/group/${group.name}`);
 		await page.locator('#main-content').waitFor();
 		await expect(poHomeChannel.content.encryptedRoomHeaderIcon).toBeVisible();
-		// wait for the room key to be ready, otherwise messages are sent unencrypted (E2E_Allow_Unencrypted_Messages is on)
-		await expect(new EncryptedRoomPage(page).encryptionNotReadyIndicator).not.toBeVisible();
+		await expect
+			.poll(
+				() =>
+					page.evaluate(async (rid) => {
+						// eslint-disable-next-line import-x/no-absolute-path
+						const { e2e } = require('/client/lib/e2ee/rocketchat.e2e.ts') as typeof import('../../../client/lib/e2ee/rocketchat.e2e');
+						const room = await e2e.getInstanceByRoomId(rid);
+						return room?.getState();
+					}, group._id),
+				{ message: 'expect room encryption key to be ready before sending messages' },
+			)
+			.toBe('READY');
 	});
 
 	test.afterEach(async ({ api }) => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-agents.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-agents.spec.ts
@@ -81,7 +81,6 @@ test.describe.serial('OC - Manage Agents', () => {
 		await test.step('expect update "user1" information', async () => {
 			await poOmnichannelAgents.editAgent.selectStatus('Not Available');
 			await poOmnichannelAgents.editAgent.selectDepartment(department.data.name);
-			// wait for dismissal, otherwise the contextual bar closing after save can detach the reopened panel
 			await poOmnichannelAgents.editAgent.save();
 		});
 

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-agents.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-agents.spec.ts
@@ -81,7 +81,8 @@ test.describe.serial('OC - Manage Agents', () => {
 		await test.step('expect update "user1" information', async () => {
 			await poOmnichannelAgents.editAgent.selectStatus('Not Available');
 			await poOmnichannelAgents.editAgent.selectDepartment(department.data.name);
-			await poOmnichannelAgents.editAgent.btnSave.click();
+			// wait for dismissal, otherwise the contextual bar closing after save can detach the reopened panel
+			await poOmnichannelAgents.editAgent.save();
 		});
 
 		await test.step('expect removing "user1" via sidebar', async () => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-business-hours.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-business-hours.spec.ts
@@ -94,7 +94,6 @@ test.describe('OC - Business Hours', () => {
 			await poOmnichannelBusinessHours.table.findRowByName(BHName).click();
 			await poOmnichannelBusinessHours.selectDepartment(department2.data.name);
 			await poOmnichannelBusinessHours.btnSave.click();
-			// wait for the form to be dismissed, otherwise the navigation after save can detach the reopened form
 			await expect(poOmnichannelBusinessHours.btnSave).not.toBeVisible();
 		});
 

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-business-hours.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-business-hours.spec.ts
@@ -94,6 +94,8 @@ test.describe('OC - Business Hours', () => {
 			await poOmnichannelBusinessHours.table.findRowByName(BHName).click();
 			await poOmnichannelBusinessHours.selectDepartment(department2.data.name);
 			await poOmnichannelBusinessHours.btnSave.click();
+			// wait for the form to be dismissed, otherwise the navigation after save can detach the reopened form
+			await expect(poOmnichannelBusinessHours.btnSave).not.toBeVisible();
 		});
 
 		await test.step('expect department to be in the chosen departments list', async () => {
@@ -108,6 +110,7 @@ test.describe('OC - Business Hours', () => {
 			await poOmnichannelBusinessHours.table.findRowByName(BHName).click();
 			await poOmnichannelBusinessHours.selectDepartment(department2.data.name);
 			await poOmnichannelBusinessHours.btnSave.click();
+			await expect(poOmnichannelBusinessHours.btnSave).not.toBeVisible();
 		});
 
 		await test.step('expect department to not be in the chosen departments list', async () => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-tags.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-tags.spec.ts
@@ -97,7 +97,6 @@ test.describe('OC - Manage Tags', () => {
 			await poOmnichannelTags.table.findRowByName(tag.name).click();
 			await expect(poOmnichannelTags.editTag.root).toBeVisible();
 			await poOmnichannelTags.editTag.selectDepartment(department2.data.name);
-			// wait for dismissal, otherwise the contextual bar closing after save can detach the reopened panel
 			await poOmnichannelTags.editTag.save();
 		});
 

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-tags.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-tags.spec.ts
@@ -97,7 +97,8 @@ test.describe('OC - Manage Tags', () => {
 			await poOmnichannelTags.table.findRowByName(tag.name).click();
 			await expect(poOmnichannelTags.editTag.root).toBeVisible();
 			await poOmnichannelTags.editTag.selectDepartment(department2.data.name);
-			await poOmnichannelTags.editTag.btnSave.click();
+			// wait for dismissal, otherwise the contextual bar closing after save can detach the reopened panel
+			await poOmnichannelTags.editTag.save();
 		});
 
 		await test.step('expect department to be in the chosen departments list', async () => {
@@ -113,7 +114,7 @@ test.describe('OC - Manage Tags', () => {
 			await poOmnichannelTags.table.findRowByName(tag.name).click();
 			await expect(poOmnichannelTags.editTag.root).toBeVisible();
 			await poOmnichannelTags.editTag.selectDepartment(department2.data.name);
-			await poOmnichannelTags.editTag.btnSave.click();
+			await poOmnichannelTags.editTag.save();
 		});
 
 		await test.step('expect department to not be in the chosen departments list', async () => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-tags.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-tags.spec.ts
@@ -97,6 +97,7 @@ test.describe('OC - Manage Tags', () => {
 			await poOmnichannelTags.table.findRowByName(tag.name).click();
 			await expect(poOmnichannelTags.editTag.root).toBeVisible();
 			await poOmnichannelTags.editTag.selectDepartment(department2.data.name);
+			await expect(poOmnichannelTags.editTag.findSelectedDepartment(department2.data.name)).toBeVisible();
 			await poOmnichannelTags.editTag.save();
 		});
 
@@ -113,6 +114,7 @@ test.describe('OC - Manage Tags', () => {
 			await poOmnichannelTags.table.findRowByName(tag.name).click();
 			await expect(poOmnichannelTags.editTag.root).toBeVisible();
 			await poOmnichannelTags.editTag.selectDepartment(department2.data.name);
+			await expect(poOmnichannelTags.editTag.findSelectedDepartment(department2.data.name)).not.toBeVisible();
 			await poOmnichannelTags.editTag.save();
 		});
 

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-tags.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-tags.ts
@@ -22,6 +22,10 @@ class OmnichannelEditTagFlexTab extends FlexTab {
 		await this.inputDepartments.fill(name);
 		await this.listbox.selectOption(name);
 	}
+
+	findSelectedDepartment(name: string) {
+		return this.root.getByLabel('Departments').getByRole('option', { name });
+	}
 }
 
 class OmnichannelTagsTable extends Table {

--- a/apps/meteor/tests/e2e/threads.spec.ts
+++ b/apps/meteor/tests/e2e/threads.spec.ts
@@ -54,7 +54,9 @@ test.describe.serial('Threads', () => {
 			await test.step('open threads contextual bar when clicked on thread preview', async () => {
 				await poHomeChannel.content.lastThreadMessagePreviewText.click();
 				await expect(page).toHaveURL(/.*thread/);
-				await expect(poHomeChannel.content.lastUserThreadMessage).toContainText('This is a thread message also sent in channel');
+				await expect(poHomeChannel.content.lastUserThreadMessage).toContainText('This is a thread message also sent in channel', {
+					timeout: 15_000,
+				});
 			});
 			await expect(page).not.toHaveURL(/[?&]msg=/);
 
@@ -64,7 +66,9 @@ test.describe.serial('Threads', () => {
 		test('expect not to close thread contextual bar when performing some action', async ({ page }) => {
 			await poHomeChannel.content.lastThreadMessagePreviewText.click();
 			await expect(page).toHaveURL(/.*thread/);
-			await expect(poHomeChannel.content.lastUserThreadMessage).toContainText('This is a thread message also sent in channel');
+			await expect(poHomeChannel.content.lastUserThreadMessage).toContainText('This is a thread message also sent in channel', {
+				timeout: 15_000,
+			});
 
 			await poHomeChannel.content.openLastThreadMessageMenu();
 			await page.locator('role=menuitem[name="Copy text"]').click();

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -2764,7 +2764,6 @@ describe('[Rooms]', () => {
 			]),
 		);
 
-		// renaming a user propagates to subscriptions asynchronously, so poll instead of relying on a fixed delay
 		const expectSubscriptionFieldToEqual = async (field: 'name' | 'fname', expected: string) => {
 			for (let attempt = 0; ; attempt++) {
 				const { body } = await request.get(api('subscriptions.getOne')).set(credentials).query({ roomId });

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -2764,6 +2764,18 @@ describe('[Rooms]', () => {
 			]),
 		);
 
+		// renaming a user propagates to subscriptions asynchronously, so poll instead of relying on a fixed delay
+		const expectSubscriptionFieldToEqual = async (field: 'name' | 'fname', expected: string) => {
+			for (let attempt = 0; ; attempt++) {
+				const { body } = await request.get(api('subscriptions.getOne')).set(credentials).query({ roomId });
+				if (body.subscription?.[field] === expected || attempt >= 20) {
+					expect(body.subscription?.[field]).to.equal(expected);
+					return;
+				}
+				await sleep(250);
+			}
+		};
+
 		it('should update group name if user changes username', async () => {
 			await updateSetting('UI_Use_Real_Name', false);
 			await request
@@ -2776,18 +2788,7 @@ describe('[Rooms]', () => {
 					},
 				});
 
-			// need to wait for the username update finish
-			await sleep(300);
-
-			await request
-				.get(api('subscriptions.getOne'))
-				.set(credentials)
-				.query({ roomId })
-				.send()
-				.expect((res) => {
-					const { subscription } = res.body;
-					expect(subscription.name).to.equal(`changed.username.${testUser.username},${testUser2.username}`);
-				});
+			await expectSubscriptionFieldToEqual('name', `changed.username.${testUser.username},${testUser2.username}`);
 		});
 
 		describe('use real name', () => {
@@ -2810,18 +2811,7 @@ describe('[Rooms]', () => {
 						},
 					});
 
-				// need to wait for the name update finish
-				await sleep(300);
-
-				await request
-					.get(api('subscriptions.getOne'))
-					.set(credentials)
-					.query({ roomId })
-					.send()
-					.expect((res) => {
-						const { subscription } = res.body;
-						expect(subscription.fname).to.equal(`changed.name.${testUser.username}, ${testUser2.name}`);
-					});
+				await expectSubscriptionFieldToEqual('fname', `changed.name.${testUser.username}, ${testUser2.name}`);
 			});
 		});
 	});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fixes flaky patterns spotted in recent CI runs.

### 1. Omnichannel UI: save → reopen contextual bar race

Saving via the contextual bar closes it **asynchronously** once the save request resolves. Tests that clicked `btnSave` and immediately searched/reopened the panel could have the freshly reopened panel detached by the delayed close, making the next click retry until the test times out.

Example failure ([CI run](https://github.com/RocketChat/Rocket.Chat/actions/runs/29792793924/job/88520249076)):

```
OC - Manage Agents [CE]- Edit and Remove › expect removing "user1" via sidebar
Test timeout of 60000ms exceeded.
locator.click: ... element was detached from the DOM, retrying
```

- `omnichannel-agents.spec.ts`: use `editAgent.save()` (click + `waitForDismissal`) instead of raw `btnSave.click()` before reopening the agent info panel — same race already documented and worked around in the "Manage departments" test in this file.
- `omnichannel-tags.spec.ts`: same, via `editTag.save()`.
- `omnichannel-business-hours.spec.ts`: no FlexTab here, so assert `btnSave` is gone after saving — same guard already used by the "Toggle BH active status" test in this file.

All remaining `btnSave.click()` call sites were audited: they are followed by assertions that implicitly wait for the save to take effect, so no race window.

### 2. Rooms API: username rename propagation ([failure on this PR's run](https://github.com/RocketChat/Rocket.Chat/actions/runs/29872754828/job/88778780315?pr=41504#step:19:3334))

`update group dms name` tests waited a fixed `sleep(300)` for the rename to propagate to DM subscription names, which is not enough on slower runners (failed on FIPS). Replaced with a poll on `subscriptions.getOne` (up to ~5s).

### 3. E2EE file encryption: message sent before room key is ready ([failure on this PR's run](https://github.com/RocketChat/Rocket.Chat/actions/runs/29872754828/job/88778780401?pr=41504#step:22:406))

With `E2E_Allow_Unencrypted_Messages` on, sending right after opening a freshly created encrypted room can go out unencrypted if the room key is still being set up — the key icon assertion then fails. Added the same `encryptionNotReadyIndicator` guard the encryption-decryption spec already uses to the file-encryption spec's `beforeEach`.

### 4. Threads: first assertion after opening the thread panel ([failure on another run](https://github.com/RocketChat/Rocket.Chat/actions/runs/29920984517/job/88929200376#step:22:376))

Opening the thread contextual bar fetches the thread messages; on coverage-instrumented runners this can exceed the default 5s expect timeout while the panel still shows its loading state (confirmed via the run's trace screenshot). Extended the first content assertion to 15s in both tests of the `hideFlexTab` describe.

### 5. CI: Playwright `github` reporter

Enabled conditionally (`GITHUB_ACTIONS === 'true'`), so failed tests become check-run annotations — visible in the PR diff and queryable via `gh api repos/.../check-runs/<job_id>/annotations` — instead of requiring log archaeology.

### 6. Product bug: `livechat/tags.save` always failed response validation on edit ([failure on this PR's run](https://github.com/RocketChat/Rocket.Chat/actions/runs/29926910061/job/88950005493#step:22:438))

The dismissal wait added in item 1 exposed a real bug: `BaseRaw.updateOne`/`insertOne` mutate the update object via `setUpdatedAt`, so `LivechatTag.createOrUpdateTag` returned its local record with an injected `_updatedAt`. The `tags.save` response schema declares `additionalProperties: false` (its type intentionally omits `_updatedAt`), so every tag edit returned `error-invalid-body` 400 while the write itself succeeded — the UI kept the contextual bar open with an error toast, and the old test flow passed without ever saving anything (trace evidence: request payload correct, response 400 with the saved tag embedded in the error body).

Fixed by rebuilding the declared return shape in `createOrUpdateTag` instead of returning the mutated record. Changeset added.

## Issue(s)

## Steps to test or reproduce

Run the affected specs; the races are timing-dependent (reproduce under CI load):

```
yarn test:e2e tests/e2e/omnichannel/omnichannel-agents.spec.ts tests/e2e/omnichannel/omnichannel-tags.spec.ts tests/e2e/omnichannel/omnichannel-business-hours.spec.ts tests/e2e/e2e-encryption/e2ee-file-encryption.spec.ts
```

## Further comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end reliability for omnichannel “Edit and Remove” flows by persisting edits through the save action and tightening post-save assertions.
  * Updated business-hours and tag-department scenarios to confirm the edit form dismisses and selection state updates before proceeding.
  * Strengthened end-to-end encryption coverage by waiting for room encryption readiness before validating messages and files.
  * Reduced flakiness in API room direct-message rename tests by polling for subscription updates instead of fixed delays.
  * Added a page-object helper to verify the currently selected department during tag editing.
* **Chores / Configuration**
  * Enabled the GitHub test reporter automatically when running in GitHub Actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2291]

[ARCH-2291]: https://rocketchat.atlassian.net/browse/ARCH-2291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ