### PR TITLE
ci: send Jira reporter comments as ADF

### DIFF
--- a/apps/meteor/reporters/jira.ts
+++ b/apps/meteor/reporters/jira.ts
@@ -134,6 +134,8 @@ ${this.run_url}
 		const search = await fetch(
 			`${this.url}/rest/api/3/search/jql?${new URLSearchParams({
 				jql: `project = FLAKY AND summary ~ '${payload.name.replace(/[()[\]-]/g, '')}'`,
+				// the /search/jql endpoint returns only issue ids unless fields are requested
+				fields: 'summary',
 			})}`,
 			{
 				method: 'GET',

--- a/apps/meteor/reporters/jira.ts
+++ b/apps/meteor/reporters/jira.ts
@@ -10,6 +10,13 @@ const EMPTY_ADF_DESCRIPTION = {
 	content: [] as const,
 };
 
+/** Jira REST API v3 also expects comment `body` as ADF; plain strings get HTTP 400. */
+const toADF = (text: string) => ({
+	type: 'doc',
+	version: 1,
+	content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+});
+
 class JIRAReporter implements Reporter {
 	private url: string;
 
@@ -58,6 +65,31 @@ class JIRAReporter implements Reporter {
 		const text = await response.text();
 		const preview = text.length > 800 ? `${text.slice(0, 800)}...` : text;
 		throw new Error(`${LOG} ${context}: HTTP ${response.status} ${response.statusText}. Body: ${preview}`);
+	}
+
+	private async postFailureComment(issueKey: string, test: TestCase, run: number) {
+		const { location } = test;
+
+		const commentRes = await fetch(`${this.url}/rest/api/3/issue/${issueKey}/comment`, {
+			method: 'POST',
+			body: JSON.stringify({
+				body: toADF(`Test run ${run} failed
+author: ${this.author}
+PR: ${this.pr}
+https://github.com/RocketChat/Rocket.Chat/blob/${this.headSha}/${location.file.replace(
+					'/home/runner/work/Rocket.Chat/Rocket.Chat',
+					'',
+				)}#L${location.line}:${location.column}
+${this.run_url}
+`),
+			}),
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Basic ${this.apiKey}`,
+			},
+		});
+		await JIRAReporter.ensureJiraOk(commentRes, `comment on ${issueKey}`);
+		console.log(`${LOG} comment posted on ${issueKey} for run ${run}.`);
 	}
 
 	async onTestEnd(test: TestCase, result: TestResult) {
@@ -125,8 +157,6 @@ class JIRAReporter implements Reporter {
 		if (existing) {
 			console.log(`${LOG} exact summary match on ${existing.key}; no new issue will be created (comment / label only).`);
 
-			const { location } = test;
-
 			if (this.pr === 0) {
 				const labelRes = await fetch(`${this.url}/rest/api/3/issue/${existing.key}`, {
 					method: 'PUT',
@@ -148,26 +178,7 @@ class JIRAReporter implements Reporter {
 				console.log(`${LOG} label update OK for ${existing.key}`);
 			}
 
-			const commentRes = await fetch(`${this.url}/rest/api/3/issue/${existing.key}/comment`, {
-				method: 'POST',
-				body: JSON.stringify({
-					body: `Test run ${payload.run} failed
-author: ${this.author}
-PR: ${this.pr}
-https://github.com/RocketChat/Rocket.Chat/blob/${payload.headSha}/${location.file.replace(
-						'/home/runner/work/Rocket.Chat/Rocket.Chat',
-						'',
-					)}#L${location.line}:${location.column}
-${this.run_url}
-`,
-				}),
-				headers: {
-					'Content-Type': 'application/json',
-					'Authorization': `Basic ${this.apiKey}`,
-				},
-			});
-			await JIRAReporter.ensureJiraOk(commentRes, `comment on ${existing.key}`);
-			console.log(`${LOG} comment posted on ${existing.key} for run ${payload.run}.`);
+			await this.postFailureComment(existing.key, test, payload.run);
 			return;
 		}
 
@@ -217,28 +228,7 @@ ${this.run_url}
 
 		console.log(`${LOG} created issue ${issue}.`);
 
-		const { location } = test;
-
-		const commentRes = await fetch(`${this.url}/rest/api/3/issue/${issue}/comment`, {
-			method: 'POST',
-			body: JSON.stringify({
-				body: `Test run ${payload.run} failed
-author: ${this.author}
-PR: ${this.pr}
-https://github.com/RocketChat/Rocket.Chat/blob/${payload.headSha}/${location.file.replace(
-					'/home/runner/work/Rocket.Chat/Rocket.Chat',
-					'',
-				)}#L${location.line}:${location.column}
-${this.run_url}
-`,
-			}),
-			headers: {
-				'Content-Type': 'application/json',
-				'Authorization': `Basic ${this.apiKey}`,
-			},
-		});
-		await JIRAReporter.ensureJiraOk(commentRes, `comment on ${issue}`);
-		console.log(`${LOG} comment posted on ${issue}; done for run ${payload.run}.`);
+		await this.postFailureComment(issue, test, payload.run);
 	}
 }
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The flaky-test Jira reporter has been silently broken — issues stopped getting comments (and often weren't found at all). Two independent regressions:

1. **Search returns no fields** (#40015): the `/rest/api/3/search/jql` endpoint returns only issue ids unless `fields` is requested. The exact-summary match crashed with `TypeError: Cannot read properties of undefined (reading 'summary')` before commenting/labeling (see [this run](https://github.com/RocketChat/Rocket.Chat/actions/runs/29888449243/job/88825511089#step:22:477)). Fixed by requesting `fields=summary`.
2. **Comments rejected** (#37723): the v3 comment endpoint requires the body in Atlassian Document Format and rejects plain strings with HTTP 400. Fixed by wrapping the comment text in an ADF document (same pattern as the description fix in #40171); the two identical comment call sites were deduplicated into a single `postFailureComment` method.

Both failure modes were swallowed by the reporter's catch-all, so CI never failed — the reports just stopped.

Validated against the real Jira instance:
- search with `fields=summary` returns `key` + `fields.summary` (without it, only `{id}`)
- the exact ADF comment payload returns 201 (test comment posted and deleted on FLAKY-1295)

## Issue(s)

## Steps to test or reproduce

## Further comments