### PR TITLE
fix(admin): synchronize role filter checkbox state with selected roles

### DIFF
--- a/apps/meteor/client/views/admin/users/AdminUserForm.tsx
+++ b/apps/meteor/client/views/admin/users/AdminUserForm.tsx
@@ -8,6 +8,7 @@ import {
 	TextInput,
 	TextAreaInput,
 	MultiSelectFiltered,
+	CheckOption,
 	Box,
 	ToggleSwitch,
 	Icon,
@@ -411,6 +412,9 @@ const AdminUserForm = ({ userData, onReload, context, refetchUserFormData, roleD
 											flexGrow={1}
 											placeholder={t('Select_role')}
 											options={availableRoles}
+											renderItem={({ label, value: optionValue, ...props }) => (
+												<CheckOption {...props} label={label} selected={optionValue ? value?.includes(optionValue) : false} />
+											)}
 										/>
 									)}
 								/>

--- a/apps/meteor/client/views/admin/users/UsersTable/UsersTableFilters.tsx
+++ b/apps/meteor/client/views/admin/users/UsersTable/UsersTableFilters.tsx
@@ -51,11 +51,11 @@ const UsersTableFilters = ({ roleData, setUsersFilters }: UsersTableFiltersProps
 				? roleData.roles.map((role) => ({
 						id: role._id,
 						text: role.description || role.name || role._id,
-						checked: false,
+						checked: selectedRoles.some((selectedRole) => selectedRole.id === role._id),
 					}))
 				: []),
 		],
-		[roleData],
+		[roleData, selectedRoles],
 	);
 
 	const breakpoints = useBreakpoints();


### PR DESCRIPTION
Fixes #41495

## Description

This PR fixes an issue where role selection checkboxes could become out of sync with the current selection while the dropdown remained open.

Previously, the checkbox state was not always recomputed after removing a selected role, causing the corresponding checkbox to remain visually checked until the dropdown was closed and reopened.

The fix derives the checkbox state directly from the current selected values instead of relying on stale option state, ensuring the UI stays synchronized in real time.

## Changes

- Update `UsersTableFilters.tsx` to derive each option's `checked` state from `selectedRoles`.
- Recompute the memoized role options whenever `selectedRoles` changes.
- Update `AdminUserForm.tsx` to render role options using `CheckOption`, with the selected state derived from the current form value.
- Keep the checkbox state synchronized when roles are added or removed while the dropdown remains open.

## Testing

- Open **Administration → Workspace → Users**.
- Verify the **Role filter** updates checkbox state immediately when selecting or deselecting roles.
- Open the **New User** panel.
- Select multiple roles.
- Remove a role using the chip (`×`) while the dropdown remains open.
- Verify the corresponding checkbox is immediately unchecked.
- Verify multiple selections, clearing selections, and reopening the dropdown all behave correctly.

## Screenshots / Video

A screen recording demonstrating the fix has been attached.

https://github.com/user-attachments/assets/2fb4afb2-975b-47a8-983b-bc179a317ed8



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role selection controls in user administration.
  * Role options now correctly display their selected or checked state in both user forms and filters.
  * Filter checkbox states update immediately when role selections change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->