### PR TITLE
regression: emoji avatars overlap message content and render undersized

### DIFF
--- a/apps/meteor/app/theme/client/imports/components/emoji.css
+++ b/apps/meteor/app/theme/client/imports/components/emoji.css
@@ -9,6 +9,7 @@
 		width: 1.375rem;
 		overflow: hidden;
 		position: relative;
+		white-space: nowrap;
 		text-indent: 100%;
 		vertical-align: bottom;
 		display: inline-block;

--- a/packages/ui-avatar/src/components/MessageAvatar.tsx
+++ b/packages/ui-avatar/src/components/MessageAvatar.tsx
@@ -12,8 +12,15 @@ export type MessageAvatarProps = {
 } & Omit<HTMLAttributes<HTMLElement>, 'is'>;
 
 const styleMessageAvatar = css`
+	overflow: hidden;
+	min-width: 0;
 	font-size: 2.25rem;
 	line-height: 1;
+
+	.emoji {
+		font-size: inherit;
+		line-height: inherit;
+	}
 `;
 
 const MessageAvatar = ({ emoji, avatarUrl, username, size = 'x36', ...props }: MessageAvatarProps) => {

--- a/packages/ui-avatar/src/components/MessageAvatar.tsx
+++ b/packages/ui-avatar/src/components/MessageAvatar.tsx
@@ -11,20 +11,33 @@ export type MessageAvatarProps = {
 	size?: ComponentProps<typeof UserAvatar>['size'];
 } & Omit<HTMLAttributes<HTMLElement>, 'is'>;
 
-const styleMessageAvatar = css`
-	overflow: hidden;
-	min-width: 0;
-	font-size: 2.25rem;
-	line-height: 1;
+const DEFAULT_EMOJI_FONT_SIZE = '2.25rem';
 
-	.emoji {
-		font-size: inherit;
-		line-height: inherit;
-	}
-`;
+const getEmojiFontSize = (size: ComponentProps<typeof UserAvatar>['size']): string => {
+	const px = Number(size?.slice(1));
+	return Number.isFinite(px) && px > 0 ? `${px / 16}rem` : DEFAULT_EMOJI_FONT_SIZE;
+};
 
 const MessageAvatar = ({ emoji, avatarUrl, username, size = 'x36', ...props }: MessageAvatarProps) => {
 	if (emoji) {
+		const styleMessageAvatar = css`
+			overflow: hidden;
+			min-width: 0;
+			font-size: ${getEmojiFontSize(size)};
+			line-height: 1;
+
+			.emoji {
+				font-size: inherit;
+				line-height: inherit;
+			}
+
+			.emoji:not(.emoji--custom) {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+			}
+		`;
+
 		return (
 			<AvatarContainer size={size} {...props}>
 				<Box className={styleMessageAvatar}>{emoji}</Box>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

PR #39411 (emojione → native emoji migration) introduced two regressions in how **emoji avatars** render on messages — the avatar used by incoming webhooks/bots that set an emoji instead of an avatar image:

1. **Custom (image) emoji avatars overlapped the message.** The emoji-hiding CSS lost `white-space: nowrap`, so the hidden `:shortcode:` text wrapped into view. Combined with the new avatar `<Box>` wrapper (a flex item that shrink-wrapped to the hidden text's width), the avatar blew out well past 36px, showed the shortcode name, and overlapped the username/message content.
2. **Native (unicode) emoji avatars rendered undersized.** The base `.emoji { font-size: 1.375rem }` overrode the avatar box's `2.25rem`, so native emoji rendered at ~22px inside a 36px avatar instead of filling it.

Fixes (all scoped to the message avatar; inline message emojis, reactions, and the emoji picker are untouched):
- `apps/meteor/app/theme/client/imports/components/emoji.css`: restore `white-space: nowrap` on `.emoji--custom` so the hidden shortcode stays clipped.
- `packages/ui-avatar/src/components/MessageAvatar.tsx`: add `min-width: 0; overflow: hidden;` to the avatar box so the hidden shortcode can't drive its width, and `.emoji { font-size: inherit; line-height: inherit; }` so native emoji fill the avatar.
<img width="558" height="665" alt="Screenshot 2026-07-22 at 8 31 21 PM" src="https://github.com/user-attachments/assets/2d68bcea-a5b8-46d1-b19a-edace2c329cb" />

## Issue(s)

[CORE-2454](https://rocketchat.atlassian.net/browse/CORE-2454)

## Steps to test or reproduce

1. Workspace → Integrations → Incoming → New; fill required fields, leave Avatar URL empty.
2. Set Emoji to a **custom** emoji (e.g. `:ghost1:`), save, copy the webhook URL, and post a message through it.
3. Repeat with a **native** emoji (e.g. `:ghost:`).
4. Expected: the emoji is centered and fills the 36px avatar, the message content sits beside it with no overlap, and no shortcode text is shown.

## Further comments

[CORE-2454](https://rocketchat.atlassian.net/browse/CORE-2454)


[CORE-2454]: https://rocketchat.atlassian.net/browse/CORE-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented custom emoji from wrapping to keep them visually consistent.
  * Updated message avatar emoji rendering to be size-aware, improving scaling across different avatar sizes.
  * Tightened avatar emoji layout (including overflow handling and typography) so emoji display aligns with surrounding avatar text without layout glitches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->