### PR TITLE
fix: deduplicate Matrix client requests by txnId

### DIFF
--- a/apps/meteor/server/models.ts
+++ b/apps/meteor/server/models.ts
@@ -18,6 +18,7 @@ import {
 	EmojiCustomRaw,
 	ExportOperationsRaw,
 	FederationKeysRaw,
+	FederationMatrixTransactionsRaw,
 	ImportDataRaw,
 	ImportsModel,
 	InstanceStatusRaw,
@@ -100,6 +101,7 @@ registerModel('IEmailMessageHistoryModel', new EmailMessageHistoryRaw(db));
 registerModel('IEmojiCustomModel', new EmojiCustomRaw(db, trashCollection));
 registerModel('IExportOperationsModel', new ExportOperationsRaw(db));
 registerModel('IFederationKeysModel', new FederationKeysRaw(db));
+registerModel('IFederationMatrixTransactionsModel', new FederationMatrixTransactionsRaw(db));
 registerModel('IImportDataModel', new ImportDataRaw(db));
 registerModel('IImportsModel', new ImportsModel(db));
 registerModel('IInstanceStatusModel', new InstanceStatusRaw(db));

--- a/ee/packages/federation-matrix/src/api/_matrix/client/rooms-messaging.ts
+++ b/ee/packages/federation-matrix/src/api/_matrix/client/rooms-messaging.ts
@@ -3,7 +3,7 @@ import type { IUser } from '@rocket.chat/core-typings';
 import { isUserNativeFederated } from '@rocket.chat/core-typings';
 import type { EventID, FileMessageContent, FileMessageType, PduForType, RoomID, UserID } from '@rocket.chat/federation-sdk';
 import { federationSDK } from '@rocket.chat/federation-sdk';
-import { Rooms, Users } from '@rocket.chat/models';
+import { FederationMatrixTransactions, Rooms, Users } from '@rocket.chat/models';
 import { ajv, ajvQuery } from '@rocket.chat/rest-typings';
 
 import type { ClientRouter } from './_shared';
@@ -150,6 +150,18 @@ export const addRoomsMessagingRoutes = (router: ClientRouter) => {
 				const eventType = c.req.param('eventType');
 				const senderUsername = c.get('impersonatedUserId') as UserID;
 				const body = await c.req.json();
+				const txnId = c.req.param('txnId');
+
+				if (!txnId) {
+					return {
+						statusCode: 400,
+						body: {
+							errcode: 'M_BAD_JSON',
+							error: 'Missing transaction ID',
+						},
+					};
+				}
+				const appService = c.get('appService');
 
 				if (eventType === 'org.matrix.bridge.ping') {
 					try {
@@ -195,6 +207,24 @@ export const addRoomsMessagingRoutes = (router: ClientRouter) => {
 				}
 
 				// TODO: deduplicate by txnId to handle bridge retries
+
+				const existing = await FederationMatrixTransactions.findByTransaction(
+					appService.registration._id,
+					senderUsername,
+					roomId,
+					eventType,
+					txnId,
+				);
+
+				if (existing) {
+					return {
+						statusCode: 200,
+						body: {
+							event_id: existing.eventId,
+						},
+					};
+				}
+
 				try {
 					if (isFileMessage) {
 						const fileContent: FileMessageContent = {
@@ -210,6 +240,16 @@ export const addRoomsMessagingRoutes = (router: ClientRouter) => {
 							event_id: event.eventId,
 						});
 
+						await FederationMatrixTransactions.createTransaction({
+							appServiceId: appService.registration._id,
+							senderId: senderUsername,
+							roomId,
+							eventType,
+							txnId,
+							eventId: event.eventId,
+							createdAt: new Date(),
+						});
+
 						return {
 							statusCode: 200,
 							body: {
@@ -221,6 +261,16 @@ export const addRoomsMessagingRoutes = (router: ClientRouter) => {
 					const event = await federationSDK.sendMessage(roomId, body.body, body.formatted_body ?? body.body, senderUsername);
 
 					await FederationMatrix.saveFederationMessage({ event: event.event as PduForType<'m.room.message'>, event_id: event.eventId });
+
+					await FederationMatrixTransactions.createTransaction({
+						appServiceId: appService.registration._id,
+						senderId: senderUsername,
+						roomId,
+						eventType,
+						txnId,
+						eventId: event.eventId,
+						createdAt: new Date(),
+					});
 
 					return {
 						statusCode: 200,

--- a/packages/core-typings/src/federation/v1/FederationMatrixTransaction.ts
+++ b/packages/core-typings/src/federation/v1/FederationMatrixTransaction.ts
@@ -1,0 +1,11 @@
+import type { IRocketChatRecord } from '../../IRocketChatRecord';
+
+export interface FederationMatrixTransaction extends IRocketChatRecord {
+	appServiceId: string;
+	senderId: string;
+	roomId: string;
+	eventType: string;
+	txnId: string;
+	eventId: string;
+	createdAt: Date;
+}

--- a/packages/core-typings/src/federation/v1/index.ts
+++ b/packages/core-typings/src/federation/v1/index.ts
@@ -2,3 +2,4 @@ export type { FederationKey } from './FederationKey';
 export type { IFederationServer } from './IFederationServer';
 export { eventTypes } from './events';
 export type { IFederationEvent } from './IFederationEvent';
+export type { FederationMatrixTransaction } from './FederationMatrixTransaction';

--- a/packages/model-typings/src/index.ts
+++ b/packages/model-typings/src/index.ts
@@ -14,6 +14,7 @@ export type * from './models/IEmailMessageHistoryModel';
 export type * from './models/IEmojiCustomModel';
 export type * from './models/IExportOperationsModel';
 export type * from './models/IFederationKeysModel';
+export type * from './models/IFederationMatrixTransactionsModel';
 export type * from './models/IInstanceStatusModel';
 export type * from './models/IIntegrationHistoryModel';
 export type * from './models/IIntegrationsModel';

--- a/packages/model-typings/src/models/IFederationMatrixTransactionsModel.ts
+++ b/packages/model-typings/src/models/IFederationMatrixTransactionsModel.ts
@@ -1,0 +1,17 @@
+import type { FederationMatrixTransaction } from '@rocket.chat/core-typings';
+
+import type { IBaseModel } from './IBaseModel';
+
+export interface IFederationMatrixTransactionsModel extends IBaseModel<FederationMatrixTransaction> {
+  findByTransaction(
+    appServiceId: string,
+    senderId: string,
+    roomId: string,
+    eventType: string,
+    txnId: string,
+  ): Promise<FederationMatrixTransaction | null>;
+
+  createTransaction(
+    transaction: Omit<FederationMatrixTransaction, '_id' | '_updatedAt'>,
+  ): Promise<FederationMatrixTransaction>;
+}

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -13,6 +13,7 @@ import type {
 	IEmojiCustomModel,
 	IExportOperationsModel,
 	IFederationKeysModel,
+	IFederationMatrixTransactionsModel,
 	IInstanceStatusModel,
 	IIntegrationHistoryModel,
 	IIntegrationsModel,
@@ -144,6 +145,9 @@ export const EmailMessageHistory = proxify<IEmailMessageHistoryModel>('IEmailMes
 export const EmojiCustom = proxify<IEmojiCustomModel>('IEmojiCustomModel');
 export const ExportOperations = proxify<IExportOperationsModel>('IExportOperationsModel');
 export const FederationKeys = proxify<IFederationKeysModel>('IFederationKeysModel');
+export const FederationMatrixTransactions = proxify<IFederationMatrixTransactionsModel>(
+	'IFederationMatrixTransactionsModel',
+);
 export const ImportData = proxify<IImportDataModel>('IImportDataModel');
 export const Imports = proxify<IImportsModel>('IImportsModel');
 export const InstanceStatus = proxify<IInstanceStatusModel>('IInstanceStatusModel');

--- a/packages/models/src/modelClasses.ts
+++ b/packages/models/src/modelClasses.ts
@@ -15,6 +15,7 @@ export * from './models/EmailMessageHistory';
 export * from './models/EmojiCustom';
 export * from './models/ExportOperations';
 export * from './models/FederationKeys';
+export * from './models/FederationMatrixTransactions';
 export * from './models/ImportData';
 export * from './models/Imports';
 export * from './models/InstanceStatus';

--- a/packages/models/src/models/FederationMatrixTransactions.ts
+++ b/packages/models/src/models/FederationMatrixTransactions.ts
@@ -1,0 +1,58 @@
+import type { FederationMatrixTransaction, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
+import type { IFederationMatrixTransactionsModel } from '@rocket.chat/model-typings';
+import type { Collection, Db, IndexDescription } from 'mongodb';
+
+import { BaseRaw } from './BaseRaw';
+
+export class FederationMatrixTransactionsRaw
+  extends BaseRaw<FederationMatrixTransaction>
+  implements IFederationMatrixTransactionsModel {
+  constructor(db: Db, trash?: Collection<RocketChatRecordDeleted<FederationMatrixTransaction>>) {
+    super(db, 'federation_matrix_transactions', trash);
+  }
+
+  protected override modelIndexes(): IndexDescription[] {
+    return [
+      {
+        key: {
+          appServiceId: 1,
+          senderId: 1,
+          roomId: 1,
+          eventType: 1,
+          txnId: 1,
+        },
+        unique: true,
+      },
+    ];
+  }
+
+  findByTransaction(
+    appServiceId: string,
+    senderId: string,
+    roomId: string,
+    eventType: string,
+    txnId: string,
+  ) {
+    return this.findOne({
+      appServiceId,
+      senderId,
+      roomId,
+      eventType,
+      txnId,
+    });
+  }
+
+  async createTransaction(
+    transaction: Omit<FederationMatrixTransaction, '_id' | '_updatedAt'>,
+  ): Promise<FederationMatrixTransaction> {
+    const { insertedId } = await this.insertOne(transaction);
+
+    const created = await this.findOneById(insertedId);
+
+    if (!created) {
+      throw new Error('Failed to load created FederationMatrixTransaction');
+    }
+
+    return created;
+  }
+}


### PR DESCRIPTION
## Proposed changes

This PR implements transaction deduplication for the Matrix Client API endpoint:

`PUT /_matrix/client/v3/rooms/:roomId/send/:eventType/:txnId`

to handle bridge retries.

### Changes made

- Added a new `FederationMatrixTransaction` type to represent processed Matrix client transactions.
- Added `IFederationMatrixTransactionsModel` and its MongoDB implementation.
- Introduced a unique compound index on:
  - `appServiceId`
  - `senderId`
  - `roomId`
  - `eventType`
  - `txnId`
- Registered the new model in the server.
- Implemented transaction lookup before processing a request.
- If the same `txnId` is received again, the previously generated `event_id` is returned instead of processing the message a second time.
- Successfully processed transactions are stored for future retries.

## Issue(s)

Fixes #41450

## Steps to test or reproduce

1. Configure a Matrix bridge/app service.
2. Send a request to:
   ```
   PUT /_matrix/client/v3/rooms/:roomId/send/:eventType/:txnId
   ```
   with a unique `txnId`.
3. Verify the request succeeds and returns an `event_id`.
4. Send the same request again using the same `txnId`.
5. Verify:
   - The response returns the same `event_id`.
   - No duplicate message is created.
6. Send another request with a different `txnId` and verify a new message is created with a new `event_id`.

## Further comments

This implementation introduces a dedicated persistence model for Matrix client transactions, allowing previously processed transactions to be efficiently identified using a unique compound index. This ensures repeated requests with the same transaction ID return the original `event_id` instead of creating duplicate messages during bridge retries.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable transaction tracking for Matrix message delivery.
  * Repeated message requests now return the original event instead of sending duplicates.
  * Added validation requiring a transaction ID for message requests.
  * Missing transaction IDs now return a clear `400` error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->