### PR TITLE
chore(eslint): enable multithread linting and content cache strategy for meteor

### DIFF
--- a/apps/meteor/package.json
+++ b/apps/meteor/package.json
@@ -34,7 +34,7 @@
 		"dev": "NODE_OPTIONS=\"--trace-warnings\" meteor --exclude-archs \"web.browser.legacy, web.cordova\"",
 		"docker:start": "docker-compose up",
 		"dsv": "meteor npm run dev",
-		"eslint": "NODE_OPTIONS=\"--max-old-space-size=8192\" eslint --cache",
+		"eslint": "NODE_OPTIONS=\"--max-old-space-size=8192\" eslint --cache --cache-strategy content --concurrency auto",
 		"eslint:fix": "yarn eslint --fix",
 		"ha": "meteor npm run ha:start",
 		"ha:add": "TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' ts-node .scripts/run-ha.ts instance",


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Speeds up `@rocket.chat/meteor` linting locally and on CI by adding two flags to the `eslint` script:

- `--concurrency auto` (ESLint ≥9.34 multithread linting): full lint of the workspace (5611 files, type-checked) drops from **160s to 74s** locally (14-core machine, 7 workers). `auto` is cache-aware — when ≤50 files need linting it spawns 0 workers and stays serial, so warm-cache runs pay no thread overhead.
- `--cache-strategy content`: the default `metadata` strategy validates cache entries by mtime+size, so the `.eslintcache` restored on CI never validates (fresh checkouts reset all mtimes) and every PR run relints the entire workspace — the lint job currently takes ~7min, dominated by `meteor:lint`. Content hashing makes the restored cache actually work across checkouts, so typical PR runs only lint changed files.

Verified locally: cold run 32s → cached 4.8s → after `touch`-ing every file (simulating a fresh checkout) still 3.5s.

Not touched here: the other workspaces stay single-threaded on purpose — turbo already parallelizes across them, and per-worker TS project service init (~17s) would slow small packages down.

## Issue(s)

## Steps to test or reproduce

1. `cd apps/meteor && yarn eslint .` twice — second run should finish in seconds.
2. `git ls-files '*.ts' | xargs touch` and run again — should still hit the cache.

## Further comments

The CI `.eslintcache` save step only runs on develop pushes (`ci-code-check.yml`); worth confirming after merge that the cache actually gets refreshed so PRs don't restore an increasingly stale cache via the restore-key fallback.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

