### PR TITLE
regression: markdown links break when their URL contains an emoji sho…

### DIFF
--- a/apps/meteor/app/emoji/client/emojiParser.ts
+++ b/apps/meteor/app/emoji/client/emojiParser.ts
@@ -1,5 +1,18 @@
 import { emoji } from './lib';
 
+// Escapes a plain text value into its HTML representation so it can be safely
+// reinserted via innerHTML after emoji rendering (e.g. `<` becomes `&lt;`).
+const escapeHtml = (value: string): string => {
+	const escaper = document.createElement('div');
+	escaper.textContent = value;
+	return escaper.innerHTML;
+};
+
+const renderEmojiPackages = (value: string): string =>
+	Object.entries(emoji.packages)
+		.reverse()
+		.reduce((rendered, [, emojiPackage]) => emojiPackage.render(rendered), value);
+
 /**
  * emojiParser is a function that will replace emojis
  */
@@ -12,23 +25,36 @@ export const emojiParser = (html: string) => {
 	// '<br>' to ' <br> ' for emojis such at line breaks
 	html = html.replace(/<br>/g, ' <br> ');
 
-	html = Object.entries(emoji.packages)
-		.reverse()
-		.reduce((value, [, emojiPackage]) => emojiPackage.render(value), html);
-
 	const checkEmojiOnly = document.createElement('div');
 
 	checkEmojiOnly.innerHTML = html;
 
-	const emojis = Array.from(checkEmojiOnly.querySelectorAll('.emoji:not(:empty)'));
-
-	emojis.forEach((emojiElement) => {
-		const htmlElement = emojiElement.parentElement;
-
-		if (htmlElement && htmlElement.nodeName === 'CODE') {
-			emojiElement.replaceWith(emojiElement.getAttribute('title') ?? '');
-		}
+	// Render emojis only inside text nodes so shortcodes that live in markup
+	// (e.g. a URL containing `:smile:` in an anchor's href) stay untouched.
+	// Emojis inside code blocks are intentionally left as their literal shortcode.
+	const textWalker = document.createTreeWalker(checkEmojiOnly, NodeFilter.SHOW_TEXT, {
+		acceptNode: (node) => (node.parentElement?.closest('code') ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT),
 	});
+
+	const textNodes: Text[] = [];
+	while (textWalker.nextNode()) {
+		textNodes.push(textWalker.currentNode as Text);
+	}
+
+	textNodes.forEach((textNode) => {
+		const escaped = escapeHtml(textNode.nodeValue ?? '');
+		const rendered = renderEmojiPackages(escaped);
+
+		if (rendered === escaped) {
+			return;
+		}
+
+		const fragmentHolder = document.createElement('span');
+		fragmentHolder.innerHTML = rendered;
+		textNode.replaceWith(...Array.from(fragmentHolder.childNodes));
+	});
+
+	const emojis = Array.from(checkEmojiOnly.querySelectorAll('.emoji:not(:empty)'));
 
 	let hasText = false;
 

--- a/apps/meteor/client/components/MarkdownText.spec.tsx
+++ b/apps/meteor/client/components/MarkdownText.spec.tsx
@@ -4,6 +4,7 @@ import dompurify from 'dompurify';
 
 import MarkdownText, { supportedURISchemes } from './MarkdownText';
 import '@testing-library/jest-dom';
+import { emoji } from '../../app/emoji/client/lib';
 import { getMarkdownParserLimit } from '../lib/getMarkdownParserLimit';
 
 jest.mock('../lib/getMarkdownParserLimit');
@@ -547,5 +548,67 @@ describe('parser limit handling', () => {
 		const parsedText = screen.getByText('hi');
 		expect(parsedText).toBeInTheDocument();
 		expect(parsedText.tagName).toBe('STRONG');
+	});
+});
+
+describe('emoji parsing', () => {
+	// Minimal stand-in for the native emoji package that turns the `:smile:`
+	// shortcode into the same markup the real renderer produces.
+	const renderSmile = (text: string): string => text.replace(/:smile:/g, '<span class="emoji" title=":smile:">😄</span>');
+
+	beforeAll(() => {
+		emoji.packages.native = {
+			emojiCategories: [],
+			emojisByCategory: {},
+			toneList: {},
+			render: renderSmile,
+			renderPicker: () => undefined,
+		};
+	});
+
+	afterAll(() => {
+		delete emoji.packages.native;
+	});
+
+	beforeEach(() => {
+		getMarkdownParserLimitMock.mockReturnValue(Infinity);
+	});
+
+	it('should render emoji shortcodes that appear in visible text', () => {
+		const { container } = render(<MarkdownText content='hello :smile:' variant='document' parseEmoji />, {
+			wrapper: mockAppRoot().build(),
+		});
+
+		const emojiElement = container.querySelector('.emoji');
+		expect(emojiElement).toBeInTheDocument();
+		expect(emojiElement).toHaveAttribute('title', ':smile:');
+		expect(emojiElement).toHaveTextContent('😄');
+		expect(container).not.toHaveTextContent(':smile:');
+	});
+
+	it('should not corrupt a link whose href contains an emoji shortcode', () => {
+		render(<MarkdownText content='[docs](https://example.test/:smile:)' variant='document' parseEmoji />, {
+			wrapper: mockAppRoot().build(),
+		});
+
+		const anchorElement = screen.getByText('docs');
+		expect(anchorElement.tagName).toBe('A');
+		// The shortcode inside the href must stay untouched instead of being replaced by an emoji span
+		expect(anchorElement).toHaveAttribute('href', 'https://example.test/:smile:');
+		expect(anchorElement.querySelector('.emoji')).toBeNull();
+	});
+
+	it('should render emoji in text while keeping a shortcode inside an href intact', () => {
+		const { container } = render(<MarkdownText content=':smile: [docs](https://example.test/:smile:)' variant='document' parseEmoji />, {
+			wrapper: mockAppRoot().build(),
+		});
+
+		const anchorElement = screen.getByText('docs');
+		expect(anchorElement).toHaveAttribute('href', 'https://example.test/:smile:');
+		expect(anchorElement.querySelector('.emoji')).toBeNull();
+
+		const emojiElement = container.querySelector('.emoji');
+		expect(emojiElement).toBeInTheDocument();
+		expect(emojiElement).toHaveTextContent('😄');
 	});
 });


### PR DESCRIPTION
…rtcode

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

[CORE-2450](https://rocketchat.atlassian.net/browse/CORE-2450)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-2450]: https://rocketchat.atlassian.net/browse/CORE-2450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emoji shortcode rendering in formatted text by rendering at the text level for more accurate results.
  * Shortcodes inside links and other markup attributes are no longer incorrectly converted into emojis.
  * Shortcodes inside code blocks remain unchanged.
  * Visible emoji shortcodes continue to render correctly in messages and markdown content.
* **Tests**
  * Added coverage for emoji parsing, including mixed-case shortcodes, link attributes, and code-block preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->