### PR TITLE
regression: Prevent inherited properties from being treated as emoji shortcodes

### DIFF
--- a/apps/meteor/app/emoji-native/lib/getEmojiConfig.ts
+++ b/apps/meteor/app/emoji-native/lib/getEmojiConfig.ts
@@ -64,7 +64,7 @@ function renderEmoji(text: string, emojiPackages: EmojiPackages): string {
 			}
 
 			// Fallback to legacy emojione shortcodes for backward compatibility
-			const legacy = Object.hasOwn(legacyEmojioneMap, shortcodeName) ? legacyEmojioneMap[shortcodeName] : undefined;
+			const legacy = legacyEmojioneMap[shortcodeName];
 			if (legacy) {
 				return `<span class="emoji" title="${shortcodeGroup}">${legacy}</span>`;
 			}

--- a/apps/meteor/app/emoji-native/lib/getEmojiConfig.ts
+++ b/apps/meteor/app/emoji-native/lib/getEmojiConfig.ts
@@ -64,7 +64,7 @@ function renderEmoji(text: string, emojiPackages: EmojiPackages): string {
 			}
 
 			// Fallback to legacy emojione shortcodes for backward compatibility
-			const legacy = legacyEmojioneMap[shortcodeName];
+			const legacy = Object.hasOwn(legacyEmojioneMap, shortcodeName) ? legacyEmojioneMap[shortcodeName] : undefined;
 			if (legacy) {
 				return `<span class="emoji" title="${shortcodeGroup}">${legacy}</span>`;
 			}

--- a/apps/meteor/app/emoji-native/lib/legacyEmojioneMap.ts
+++ b/apps/meteor/app/emoji-native/lib/legacyEmojioneMap.ts
@@ -2,7 +2,7 @@
 // These shortcodes existed in emojione but are not in emojibase.
 // They are used to ensure backward compatibility with old stored messages.
 
-export const legacyEmojioneMap: Record<string, string> = {
+const legacyEmojioneMapData: Record<string, string> = {
 	'ac': '🇦🇨',
 	'ad': '🇦🇩',
 	'adult_dark_skin_tone': '🧑🏿',
@@ -1425,3 +1425,5 @@ export const legacyEmojioneMap: Record<string, string> = {
 	'tone4': '🏾',
 	'tone5': '🏿',
 };
+
+export const legacyEmojioneMap: Record<string, string> = Object.assign(Object.create(null), legacyEmojioneMapData);

--- a/apps/meteor/app/emoji-native/lib/shortnameToUnicode.ts
+++ b/apps/meteor/app/emoji-native/lib/shortnameToUnicode.ts
@@ -11,7 +11,7 @@ export function shortnameToUnicode(text: string): string {
 		if (emoji?.unicode) return emoji.unicode;
 
 		// Fallback to legacy emojione shortcodes for backward compatibility
-		const legacy = Object.hasOwn(legacyEmojioneMap, shortcode) ? legacyEmojioneMap[shortcode] : undefined;
+		const legacy = legacyEmojioneMap[shortcode];
 		if (legacy) return legacy;
 
 		return match;

--- a/apps/meteor/tests/unit/app/emoji/emojiNativeParser.spec.ts
+++ b/apps/meteor/tests/unit/app/emoji/emojiNativeParser.spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { getEmojiData } from '../../../../app/emoji-native/lib/generateEmojiData';
+import { getEmojiConfig } from '../../../../app/emoji-native/lib/getEmojiConfig';
 import { shortnameToUnicode } from '../../../../app/emoji-native/lib/shortnameToUnicode';
 
 describe('emoji-native shortcode resolution', () => {
@@ -36,6 +37,19 @@ describe('emoji-native shortcode resolution', () => {
 
 		it('resolves multiple shortcodes within a single string', () => {
 			expect(shortnameToUnicode('hi :thumbsup_tone3: and :regional_indicator_a:')).to.equal('hi 👍🏽 and 🇦');
+		});
+	});
+
+	describe('render', () => {
+		const { render } = getEmojiConfig({ list: {}, packages: {} });
+
+		it('renders a known shortcode as an emoji span', () => {
+			expect(render(':smile:')).to.contain('class="emoji"');
+		});
+
+		it('leaves prototype property names untouched', () => {
+			expect(render(':toString:')).to.equal(':toString:');
+			expect(render('topic :toString: end')).to.equal('topic :toString: end');
 		});
 	});
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Fixes by adding a guard for the lookup with `Object.hasOwn` so only own keys are matched and doesn't match with `Object.prototype`.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Open a channel
- Go to Channel info → Edit
- Set Announcement to - :toString: 
- Save

Check the Announcement
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-2451](https://rocketchat.atlassian.net/browse/CORE-2451)

[CORE-2451]: https://rocketchat.atlassian.net/browse/CORE-2451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed emoji shortcode rendering for names that could conflict with built-in object properties, such as `:toString:`.
  * Preserved correct conversion of recognized legacy emoji shortcodes into emoji characters.

* **Tests**
  * Added coverage confirming valid shortcodes render as emojis while prototype-like names remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->