### PR TITLE
regression(api): implement missing im.leave, dm.leave and dm.blockUser endpoints

### DIFF
--- a/.changeset/im-leave-dm-blockuser-endpoints.md
+++ b/.changeset/im-leave-dm-blockuser-endpoints.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/meteor': patch
+'@rocket.chat/rest-typings': patch
+---
+
+Adds the missing `im.leave`/`dm.leave` and `dm.blockUser` REST endpoints. The `/v1/im.leave` type had been declared and the deprecated `leaveRoom` DDP method pointed clients at it, but no server route implemented it; likewise `im.blockUser` shipped without its `dm.blockUser` alias. All new routes delegate to the same shared server functions as their existing counterparts.

--- a/.changeset/im-leave-dm-blockuser-endpoints.md
+++ b/.changeset/im-leave-dm-blockuser-endpoints.md
@@ -1,6 +1,0 @@
----
-'@rocket.chat/meteor': patch
-'@rocket.chat/rest-typings': patch
----
-
-Adds the missing `im.leave`/`dm.leave` and `dm.blockUser` REST endpoints. The `/v1/im.leave` type had been declared and the deprecated `leaveRoom` DDP method pointed clients at it, but no server route implemented it; likewise `im.blockUser` shipped without its `dm.blockUser` alias. All new routes delegate to the same shared server functions as their existing counterparts.

--- a/apps/meteor/server/api/v1/im.ts
+++ b/apps/meteor/server/api/v1/im.ts
@@ -11,6 +11,7 @@ import {
 	validateBadRequestErrorResponse,
 	isDmBlockUserProps,
 	isDmFileProps,
+	isDmLeaveProps,
 	isDmMemberProps,
 	isDmMessagesProps,
 	isDmCreateProps,
@@ -31,6 +32,7 @@ import { normalizeMessagesForUser } from '../../lib/utils/lib/normalizeMessagesF
 import { createDirectMessage } from '../../meteor-methods/messages/createDirectMessage';
 import { getChannelHistory } from '../../meteor-methods/messages/getChannelHistory';
 import { hideRoomMethod } from '../../meteor-methods/rooms/hideRoom';
+import { leaveRoomMethod } from '../../meteor-methods/rooms/leaveRoom';
 import { saveRoomSettings } from '../../meteor-methods/rooms/saveRoomSettings';
 import { settings } from '../../settings';
 import type { ExtractRoutesFromAPI } from '../ApiClass';
@@ -927,6 +929,35 @@ const dmCreateAction = <Path extends string>(_path: Path): TypedAction<typeof dm
 		});
 	};
 
+const dmLeaveEndpointsProps = {
+	authRequired: true,
+	body: isDmLeaveProps,
+	response: {
+		400: validateBadRequestErrorResponse,
+		401: validateUnauthorizedErrorResponse,
+		200: ajv.compile<void>({
+			type: 'object',
+			properties: {
+				success: { type: 'boolean', enum: [true] },
+			},
+			required: ['success'],
+			additionalProperties: false,
+		}),
+	},
+} as const;
+
+const dmLeaveAction = <Path extends string>(_path: Path): TypedAction<typeof dmLeaveEndpointsProps, Path> =>
+	async function action() {
+		const { room } = await findDirectMessageRoom(
+			'roomId' in this.bodyParams ? { roomId: this.bodyParams.roomId } : { username: this.bodyParams.roomName },
+			this.userId,
+		);
+
+		await leaveRoomMethod(this.user, room._id);
+
+		return API.v1.success();
+	};
+
 const dmBlockUserEndpointsProps = {
 	authRequired: true,
 	body: isDmBlockUserProps,
@@ -990,7 +1021,10 @@ const dmEndpoints = API.v1
 	.get('im.list', dmListEndpointsProps, dmListAction('im.list'))
 	.get('dm.list.everyone', dmListEveryoneEndpointsProps, dmListEveryoneAction('dm.list.everyone'))
 	.get('im.list.everyone', dmListEveryoneEndpointsProps, dmListEveryoneAction('im.list.everyone'))
-	.post('im.blockUser', dmBlockUserEndpointsProps, dmBlockUserAction('im.blockUser'));
+	.post('im.leave', dmLeaveEndpointsProps, dmLeaveAction('im.leave'))
+	.post('dm.leave', dmLeaveEndpointsProps, dmLeaveAction('dm.leave'))
+	.post('im.blockUser', dmBlockUserEndpointsProps, dmBlockUserAction('im.blockUser'))
+	.post('dm.blockUser', dmBlockUserEndpointsProps, dmBlockUserAction('dm.blockUser'));
 
 export type DmEndpoints = ExtractRoutesFromAPI<typeof dmEndpoints>;
 

--- a/packages/rest-typings/src/v1/dm/index.ts
+++ b/packages/rest-typings/src/v1/dm/index.ts
@@ -3,5 +3,6 @@ export type * from './im';
 export * from './DmBlockUserProps';
 export * from './DmCreateProps';
 export * from './DmFileProps';
+export * from './DmLeaveProps';
 export * from './DmMembersProps';
 export * from './DmMessagesProps';


### PR DESCRIPTION
## Summary

Two REST endpoints were declared/referenced but never actually implemented on the server, so calling them 404s despite type-checking fine on the client. This adds them, plus their missing `dm.`/`im.` aliases.

### `im.leave` / `dm.leave` — never implemented

- The `/v1/im.leave` type has been declared in `rest-typings` since the 2022 im/dm TS rewrite (#25521, Ajv schema in #25601), and `DmLeaveProps` alongside it.
- #40704 (*chore: migrate low-friction DDP callers to REST endpoints*) pointed the deprecated `leaveRoom` DDP method at `/v1/im.leave` via `methodDeprecationLogger` — but explicitly deferred the endpoint itself, listing `leaveRoom` under **"Methods skipped (need design work)"**: *"needs per-room-type dispatch (`channels.leave` / `groups.leave` / `im.leave`)"*.
- `channels.leave` and `groups.leave` exist; `im.leave` (and its `dm.leave` alias) never landed. A client calling the advertised replacement endpoint gets a 404.

### `dm.blockUser` — alias missing

- #40724 (*chore: migrate five more client DDP callers to new REST endpoints*) introduced the `im.blockUser` endpoint and `DmBlockUserProps`, but did not register the `dm.blockUser` alias. Every other im/dm endpoint ships both forms.

## Changes

- Register `im.leave` / `dm.leave`, delegating to the shared `leaveRoomMethod` — identical behavior to the deprecated `leaveRoom` DDP method (non-federated DMs still disallow leaving, federated DMs are allowed).
- Register `dm.blockUser`, reusing the existing block-user action.
- Re-export `isDmLeaveProps` from `rest-typings` (`DmLeaveProps` value export was missing from the `dm` barrel).

## Test plan

- [ ] `POST /v1/im.leave` / `POST /v1/dm.leave` on a federated DM removes the caller; on a normal DM returns the same `error-not-allowed` the DDP method returns.
- [ ] `POST /v1/dm.blockUser` `{ roomId, block }` flips the subscription `blocker`/`blocked` flags, matching `im.blockUser`.
- [ ] `rest-typings` builds with `isDmLeaveProps` exported.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

[ARCH-2162](https://rocketchat.atlassian.net/browse/ARCH-2162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)
[ARCH-2177](https://rocketchat.atlassian.net/browse/ARCH-2177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[ARCH-2162]: https://rocketchat.atlassian.net/browse/ARCH-2162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added REST API support for leaving direct message rooms through both `/v1/im.leave` and `/v1/dm.leave`.
  - Endpoints accept a room ID or name and return a successful response when the user leaves.
  - Added REST typing support for the new leave request parameters.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->