### PR TITLE
regression: device logout showing success feedback when request fails

### DIFF
--- a/apps/meteor/client/hooks/useDeviceLogout.spec.tsx
+++ b/apps/meteor/client/hooks/useDeviceLogout.spec.tsx
@@ -1,0 +1,173 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { QueryClient } from '@tanstack/react-query';
+import { act, renderHook, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { useDeviceLogout } from './useDeviceLogout';
+
+const SESSION_ID = 'session-id';
+
+type Endpoint = '/v1/sessions/logout' | '/v1/sessions/logout.me';
+
+const setup = ({
+	isCurrentSession,
+	endpoint,
+	shouldFail = false,
+	openContextualBar = false,
+}: {
+	isCurrentSession?: boolean;
+	endpoint: Endpoint;
+	shouldFail?: boolean;
+	openContextualBar?: boolean;
+}) => {
+	const dispatchToastMessage = jest.fn();
+	const logout = jest.fn(() => Promise.resolve());
+	const navigate = jest.fn();
+	const logoutEndpoint = jest.fn(() => {
+		if (shouldFail) {
+			throw new Error('logout failed');
+		}
+		return { sessionId: SESSION_ID };
+	});
+
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries');
+
+	let builder = mockAppRoot()
+		.withQueryClient(queryClient)
+		.withEndpoint('POST', endpoint, logoutEndpoint)
+		.withRouter({ navigate })
+		.withToastMessageDispatch(dispatchToastMessage)
+		.withLogout(logout);
+
+	// `isContextualBarOpen` is derived from the `id` route param matching the session id.
+	if (openContextualBar) {
+		builder = builder.withRouteParameter('id', SESSION_ID);
+	}
+
+	const { result } = renderHook(() => useDeviceLogout(SESSION_ID, endpoint, isCurrentSession), { wrapper: builder.build() });
+
+	return { result, dispatchToastMessage, logout, navigate, logoutEndpoint, invalidateQueries };
+};
+
+const openModalAndConfirm = async (openLogoutModal: () => void) => {
+	act(() => {
+		openLogoutModal();
+	});
+
+	const confirmButton = screen.getByRole('button', { name: 'Logout_Device' });
+	await userEvent.click(confirmButton);
+};
+
+describe('useDeviceLogout', () => {
+	it('should open a confirmation modal when the returned callback is invoked', () => {
+		const { result } = setup({ endpoint: '/v1/sessions/logout' });
+
+		expect(screen.queryByRole('button', { name: 'Logout_Device' })).not.toBeInTheDocument();
+
+		act(() => {
+			result.current();
+		});
+
+		expect(screen.getByRole('button', { name: 'Logout_Device' })).toBeInTheDocument();
+	});
+
+	describe('for another session', () => {
+		it('should log the device out, show a success toast and close the modal on success', async () => {
+			const { result, dispatchToastMessage, logout, invalidateQueries } = setup({ endpoint: '/v1/sessions/logout' });
+
+			openModalAndConfirm(result.current);
+
+			await waitFor(() => {
+				expect(dispatchToastMessage).toHaveBeenCalledWith({ type: 'success', message: 'Device_Logged_Out' });
+			});
+			expect(invalidateQueries).toHaveBeenCalled();
+			expect(logout).not.toHaveBeenCalled();
+
+			await waitFor(() => {
+				expect(screen.queryByRole('button', { name: 'Logout_Device' })).not.toBeInTheDocument();
+			});
+		});
+
+		it('should call the endpoint with the session id', async () => {
+			const { result, logoutEndpoint } = setup({ endpoint: '/v1/sessions/logout' });
+
+			openModalAndConfirm(result.current);
+
+			await waitFor(() => {
+				expect(logoutEndpoint).toHaveBeenCalledWith({ sessionId: SESSION_ID });
+			});
+		});
+
+		it('should close the contextual bar when it is open for the logged out session', async () => {
+			const { result, navigate } = setup({ endpoint: '/v1/sessions/logout', openContextualBar: true });
+
+			openModalAndConfirm(result.current);
+
+			await waitFor(() => {
+				expect(navigate).toHaveBeenCalledWith(expect.objectContaining({ name: 'device-management', params: {} }), expect.anything());
+			});
+		});
+
+		it('should show an error toast and close the modal on failure, without a success toast', async () => {
+			const { result, dispatchToastMessage, logout, invalidateQueries } = setup({
+				endpoint: '/v1/sessions/logout',
+				shouldFail: true,
+			});
+
+			openModalAndConfirm(result.current);
+
+			await waitFor(() => {
+				expect(dispatchToastMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+			});
+			expect(dispatchToastMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+			expect(invalidateQueries).not.toHaveBeenCalled();
+			expect(logout).not.toHaveBeenCalled();
+
+			await waitFor(() => {
+				expect(screen.queryByRole('button', { name: 'Logout_Device' })).not.toBeInTheDocument();
+			});
+		});
+	});
+
+	describe('for the current session', () => {
+		it('should log the user out and close the modal on success, without any toast', async () => {
+			const { result, dispatchToastMessage, logout } = setup({
+				endpoint: '/v1/sessions/logout.me',
+				isCurrentSession: true,
+			});
+
+			openModalAndConfirm(result.current);
+
+			await waitFor(() => {
+				expect(logout).toHaveBeenCalledTimes(1);
+			});
+			expect(dispatchToastMessage).not.toHaveBeenCalled();
+
+			await waitFor(() => {
+				expect(screen.queryByRole('button', { name: 'Logout_Device' })).not.toBeInTheDocument();
+			});
+		});
+
+		it('should still log the user out and close the modal on failure, without any toast', async () => {
+			const { result, dispatchToastMessage, logout } = setup({
+				endpoint: '/v1/sessions/logout.me',
+				isCurrentSession: true,
+				shouldFail: true,
+			});
+
+			openModalAndConfirm(result.current);
+
+			await waitFor(() => {
+				expect(logout).toHaveBeenCalledTimes(1);
+			});
+			expect(dispatchToastMessage).not.toHaveBeenCalled();
+
+			await waitFor(() => {
+				expect(screen.queryByRole('button', { name: 'Logout_Device' })).not.toBeInTheDocument();
+			});
+		});
+	});
+});

--- a/apps/meteor/client/hooks/useDeviceLogout.spec.tsx
+++ b/apps/meteor/client/hooks/useDeviceLogout.spec.tsx
@@ -78,7 +78,7 @@ describe('useDeviceLogout', () => {
 		it('should log the device out, show a success toast and close the modal on success', async () => {
 			const { result, dispatchToastMessage, logout, invalidateQueries } = setup({ endpoint: '/v1/sessions/logout' });
 
-			openModalAndConfirm(result.current);
+			await openModalAndConfirm(result.current);
 
 			await waitFor(() => {
 				expect(dispatchToastMessage).toHaveBeenCalledWith({ type: 'success', message: 'Device_Logged_Out' });
@@ -94,7 +94,7 @@ describe('useDeviceLogout', () => {
 		it('should call the endpoint with the session id', async () => {
 			const { result, logoutEndpoint } = setup({ endpoint: '/v1/sessions/logout' });
 
-			openModalAndConfirm(result.current);
+			await openModalAndConfirm(result.current);
 
 			await waitFor(() => {
 				expect(logoutEndpoint).toHaveBeenCalledWith({ sessionId: SESSION_ID });
@@ -104,7 +104,7 @@ describe('useDeviceLogout', () => {
 		it('should close the contextual bar when it is open for the logged out session', async () => {
 			const { result, navigate } = setup({ endpoint: '/v1/sessions/logout', openContextualBar: true });
 
-			openModalAndConfirm(result.current);
+			await openModalAndConfirm(result.current);
 
 			await waitFor(() => {
 				expect(navigate).toHaveBeenCalledWith(expect.objectContaining({ name: 'device-management', params: {} }), expect.anything());
@@ -117,7 +117,7 @@ describe('useDeviceLogout', () => {
 				shouldFail: true,
 			});
 
-			openModalAndConfirm(result.current);
+			await openModalAndConfirm(result.current);
 
 			await waitFor(() => {
 				expect(dispatchToastMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
@@ -139,7 +139,7 @@ describe('useDeviceLogout', () => {
 				isCurrentSession: true,
 			});
 
-			openModalAndConfirm(result.current);
+			await openModalAndConfirm(result.current);
 
 			await waitFor(() => {
 				expect(logout).toHaveBeenCalledTimes(1);
@@ -158,7 +158,7 @@ describe('useDeviceLogout', () => {
 				shouldFail: true,
 			});
 
-			openModalAndConfirm(result.current);
+			await openModalAndConfirm(result.current);
 
 			await waitFor(() => {
 				expect(logout).toHaveBeenCalledTimes(1);

--- a/apps/meteor/client/hooks/useDeviceLogout.tsx
+++ b/apps/meteor/client/hooks/useDeviceLogout.tsx
@@ -26,29 +26,25 @@ export const useDeviceLogout = (
 
 	const { mutate: logoutDevice } = useMutation({
 		mutationFn: logoutEndpoint,
-		onSettled: () => {
-			if (isCurrentSession) {
-				setModal(null);
-				logout();
-			}
-		},
 		onSuccess: () => {
-			if (isCurrentSession) {
-				return;
-			}
+			if (isCurrentSession) return;
+
 			queryClient.invalidateQueries({ queryKey: deviceManagementQueryKeys.all });
 			if (isContextualBarOpen) {
 				handleCloseContextualBar();
 			}
 			dispatchToastMessage({ type: 'success', message: t('Device_Logged_Out') });
-			setModal(null);
 		},
 		onError: (error) => {
-			if (isCurrentSession) {
-				return;
-			}
+			if (isCurrentSession) return;
 			dispatchToastMessage({ type: 'error', message: error });
+		},
+		onSettled: () => {
 			setModal(null);
+
+			if (isCurrentSession) {
+				logout();
+			}
 		},
 		throwOnError: false,
 	});

--- a/apps/meteor/client/hooks/useDeviceLogout.tsx
+++ b/apps/meteor/client/hooks/useDeviceLogout.tsx
@@ -26,7 +26,6 @@ export const useDeviceLogout = (
 
 	const { mutate: logoutDevice } = useMutation({
 		mutationFn: logoutEndpoint,
-		// logging out the current session terminates it mid-request, so an error is expected there
 		onSettled: () => {
 			if (isCurrentSession) {
 				setModal(null);

--- a/apps/meteor/client/hooks/useDeviceLogout.tsx
+++ b/apps/meteor/client/hooks/useDeviceLogout.tsx
@@ -26,18 +26,30 @@ export const useDeviceLogout = (
 
 	const { mutate: logoutDevice } = useMutation({
 		mutationFn: logoutEndpoint,
+		// logging out the current session terminates it mid-request, so an error is expected there
 		onSettled: () => {
 			if (isCurrentSession) {
 				setModal(null);
 				logout();
-			} else {
-				queryClient.invalidateQueries({ queryKey: deviceManagementQueryKeys.all });
-				if (isContextualBarOpen) {
-					handleCloseContextualBar();
-				}
-				dispatchToastMessage({ type: 'success', message: t('Device_Logged_Out') });
-				setModal(null);
 			}
+		},
+		onSuccess: () => {
+			if (isCurrentSession) {
+				return;
+			}
+			queryClient.invalidateQueries({ queryKey: deviceManagementQueryKeys.all });
+			if (isContextualBarOpen) {
+				handleCloseContextualBar();
+			}
+			dispatchToastMessage({ type: 'success', message: t('Device_Logged_Out') });
+			setModal(null);
+		},
+		onError: (error) => {
+			if (isCurrentSession) {
+				return;
+			}
+			dispatchToastMessage({ type: 'error', message: error });
+			setModal(null);
 		},
 		throwOnError: false,
 	});

--- a/packages/mock-providers/src/MockedAppRootBuilder.tsx
+++ b/packages/mock-providers/src/MockedAppRootBuilder.tsx
@@ -30,6 +30,7 @@ import type {
 	ServerContextValue,
 	SettingsContextQuery,
 	SubscriptionWithRoom,
+	ToastMessagesContextValue,
 	TranslationKey,
 } from '@rocket.chat/ui-contexts';
 import {
@@ -43,6 +44,7 @@ import {
 	ModalContext,
 	UserPresenceContext,
 	AuthenticationContext,
+	ToastMessagesContext,
 } from '@rocket.chat/ui-contexts';
 import type { VideoConfPopupPayload } from '@rocket.chat/ui-video-conf';
 import { VideoConfContext } from '@rocket.chat/ui-video-conf';
@@ -163,6 +165,10 @@ export class MockedAppRootBuilder {
 		], // apply query and option
 		user: null,
 		userId: undefined,
+	};
+
+	private toastMessages: ToastMessagesContextValue = {
+		dispatch: () => undefined,
 	};
 
 	private userPresence: ContextType<typeof UserPresenceContext> = {
@@ -452,6 +458,18 @@ export class MockedAppRootBuilder {
 		return this;
 	}
 
+	withLogout(logout: ContextType<typeof UserContext>['logout']): this {
+		this.user = { ...this.user, logout };
+
+		return this;
+	}
+
+	withToastMessageDispatch(dispatch: ToastMessagesContextValue['dispatch']): this {
+		this.toastMessages = { ...this.toastMessages, dispatch };
+
+		return this;
+	}
+
 	withUsers(users: IUser[]): this {
 		users.forEach((user) => {
 			this.userPresence.queryUserData = (_uid) => ({ subscribe: () => () => undefined, get: () => user });
@@ -699,6 +717,7 @@ export class MockedAppRootBuilder {
 			wrappers,
 			deviceContext,
 			authentication,
+			toastMessages,
 		} = this;
 
 		const reduceTranslation = (translation?: ContextType<typeof TranslationContext>): ContextType<typeof TranslationContext> => {
@@ -767,62 +786,62 @@ export class MockedAppRootBuilder {
 								<I18nextProvider i18n={i18n}>
 									<TranslationContext.Provider value={translation}>
 										{/* <SessionProvider>
-												<TooltipProvider>
-														<ToastMessagesProvider>
-																<LayoutProvider>
-																		<AvatarUrlProvider>
-																				<CustomSoundProvider> */}
-										<UserContext.Provider value={user}>
-											<AuthenticationContext.Provider value={authentication}>
-												<MockedDeviceContext {...deviceContext}>
-													<ModalContext.Provider value={modal}>
-														<AuthorizationContext.Provider value={authorization}>
-															{/* <EmojiPickerProvider>
+												<TooltipProvider> */}
+										<ToastMessagesContext.Provider value={toastMessages}>
+											{/* <LayoutProvider>
+																	<AvatarUrlProvider>
+																			<CustomSoundProvider> */}
+											<UserContext.Provider value={user}>
+												<AuthenticationContext.Provider value={authentication}>
+													<MockedDeviceContext {...deviceContext}>
+														<ModalContext.Provider value={modal}>
+															<AuthorizationContext.Provider value={authorization}>
+																{/* <EmojiPickerProvider>
 																<OmnichannelRoomIconProvider>
 																	*/}
-															<UserPresenceContext.Provider value={userPresence}>
-																<ActionManagerContext.Provider
-																	value={{
-																		generateTriggerId: () => '',
-																		emitInteraction: () => Promise.reject(new Error('not implemented')),
-																		getInteractionPayloadByViewId: () => undefined,
-																		handleServerInteraction: () => undefined,
-																		off: () => undefined,
-																		on: () => undefined,
-																		openView: () => undefined,
-																		disposeView: () => undefined,
-																		notifyBusy: () => undefined,
-																		notifyIdle: () => undefined,
-																	}}
-																>
-																	<VideoConfContext.Provider value={videoConf}>
-																		{/* <CallProvider>
+																<UserPresenceContext.Provider value={userPresence}>
+																	<ActionManagerContext.Provider
+																		value={{
+																			generateTriggerId: () => '',
+																			emitInteraction: () => Promise.reject(new Error('not implemented')),
+																			getInteractionPayloadByViewId: () => undefined,
+																			handleServerInteraction: () => undefined,
+																			off: () => undefined,
+																			on: () => undefined,
+																			openView: () => undefined,
+																			disposeView: () => undefined,
+																			notifyBusy: () => undefined,
+																			notifyIdle: () => undefined,
+																		}}
+																	>
+																		<VideoConfContext.Provider value={videoConf}>
+																			{/* <CallProvider>
 																		<OmnichannelProvider> */}
-																		{wrappers.reduce<ReactNode>(
-																			(children, wrapper) => wrapper(children),
-																			<>
-																				{children}
-																				{modal.currentModal.component}
-																			</>,
-																		)}
-																		{/* </OmnichannelProvider>
+																			{wrappers.reduce<ReactNode>(
+																				(children, wrapper) => wrapper(children),
+																				<>
+																					{children}
+																					{modal.currentModal.component}
+																				</>,
+																			)}
+																			{/* </OmnichannelProvider>
 																	</CallProvider> */}
-																	</VideoConfContext.Provider>
-																</ActionManagerContext.Provider>
-															</UserPresenceContext.Provider>
-															{/*
+																		</VideoConfContext.Provider>
+																	</ActionManagerContext.Provider>
+																</UserPresenceContext.Provider>
+																{/*
 																</OmnichannelRoomIconProvider>
 															</EmojiPickerProvider>*/}
-														</AuthorizationContext.Provider>
-													</ModalContext.Provider>
-												</MockedDeviceContext>
-											</AuthenticationContext.Provider>
-										</UserContext.Provider>
-										{/* 					</CustomSoundProvider>
-																</AvatarUrlProvider>
-															</LayoutProvider>
-														</ToastMessagesProvider>
-													</TooltipProvider>
+															</AuthorizationContext.Provider>
+														</ModalContext.Provider>
+													</MockedDeviceContext>
+												</AuthenticationContext.Provider>
+											</UserContext.Provider>
+											{/* 					</CustomSoundProvider>
+																	</AvatarUrlProvider>
+																</LayoutProvider> */}
+										</ToastMessagesContext.Provider>
+										{/* 	</TooltipProvider>
 												</SessionProvider> */}
 									</TranslationContext.Provider>
 								</I18nextProvider>


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

When logging out a device fails (e.g. network offline, server error), the UI still showed the "Device logged out" success toast, closed the confirmation modal, and invalidated the sessions query — while the session remained active on the server. Both `POST /v1/sessions/logout.me` (account) and `POST /v1/sessions/logout` (admin) flows were affected.

#40351 moved all mutation feedback into `onSettled`, which runs on both success and error, so the success path executed regardless of the request outcome. It also dropped the error toast that `useEndpointMutation` previously provided.

This splits the handling: success UI runs in `onSuccess`, an error toast is dispatched in `onError`, and the current-session flow (where an error is expected because the session is terminated mid-request) stays in `onSettled`, preserving the fix from #40351.

## Issue(s)

[CORE-2459](https://rocketchat.atlassian.net/browse/CORE-2459)

## Steps to test or reproduce

1. Open **Account → Device Management** with another active session listed
2. Initiate logout for that session
3. Block the `POST /v1/sessions/logout.me` request (e.g. go offline / block via devtools)
4. Click **Log out device**
5. An error toast is shown instead of the success one; same for **Admin → Device Management**

## Further comments

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


[CORE-2459]: https://rocketchat.atlassian.net/browse/CORE-2459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined device logout handling to better distinguish between the current session and other sessions.
  * Other-session logouts now show the correct success/error toast, close the confirmation modal, close the contextual bar, and refresh device-management data on success.
  * Current-session logouts now consistently dismiss the modal and perform logout without toast notifications.
  * Improved error toast-bar message formatting with a default fallback.
* **Tests**
  * Expanded hook tests to verify toast, navigation, modal, and data-refresh behavior for current vs. other sessions.
* **Chores**
  * Enhanced the mock app builder to support toast message dispatch in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->