### PR TITLE
test(unit): fix flaky mongo connection test

### DIFF
--- a/packages/ddp-client/__tests__/Connection.spec.ts
+++ b/packages/ddp-client/__tests__/Connection.spec.ts
@@ -111,7 +111,15 @@ it('should handle reconnecting', async () => {
 		server,
 		jest.advanceTimersByTimeAsync(200),
 		new Promise((resolve) => connection.once('reconnecting', () => resolve(undefined))),
-		new Promise((resolve) => connection.once('connection', (data) => resolve(data))),
+		new Promise((resolve) => {
+			const handler = (status: string) => {
+				if (status === 'connected') {
+					connection.off('connection', handler);
+					resolve(status);
+				}
+			};
+			connection.on('connection', handler);
+		}),
 	);
 
 	expect(connection.status).toBe('connected');
@@ -268,7 +276,15 @@ it('should reset retryCount on a successful connection so subsequent drops can r
 		server,
 		jest.advanceTimersByTimeAsync(200),
 		new Promise((resolve) => connection.once('reconnecting', () => resolve(undefined))),
-		new Promise((resolve) => connection.once('connection', (data) => resolve(data))),
+		new Promise((resolve) => {
+			const handler = (status: string) => {
+				if (status === 'connected') {
+					connection.off('connection', handler);
+					resolve(status);
+				}
+			};
+			connection.on('connection', handler);
+		}),
 	);
 	jest.useRealTimers();
 	expect(connection.status).toBe('connected');
@@ -286,7 +302,15 @@ it('should reset retryCount on a successful connection so subsequent drops can r
 		server,
 		jest.advanceTimersByTimeAsync(200),
 		new Promise((resolve) => connection.once('reconnecting', () => resolve(undefined))),
-		new Promise((resolve) => connection.once('connection', (data) => resolve(data))),
+		new Promise((resolve) => {
+			const handler = (status: string) => {
+				if (status === 'connected') {
+					connection.off('connection', handler);
+					resolve(status);
+				}
+			};
+			connection.on('connection', handler);
+		}),
 	);
 	jest.useRealTimers();
 	expect(connection.status).toBe('connected');
@@ -316,7 +340,15 @@ it('should ignore a stale ws.onclose that fires after the socket has been replac
 		server,
 		jest.advanceTimersByTimeAsync(200),
 		new Promise((resolve) => connection.once('reconnecting', () => resolve(undefined))),
-		new Promise((resolve) => connection.once('connection', (data) => resolve(data))),
+		new Promise((resolve) => {
+			const handler = (status: string) => {
+				if (status === 'connected') {
+					connection.off('connection', handler);
+					resolve(status);
+				}
+			};
+			connection.on('connection', handler);
+		}),
 	);
 
 	expect(connection.status).toBe('connected');


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
**Problem**

`Connection.spec.ts` had a flaky reconnect test (`should reset retryCount on a successful connection…`) that intermittently failed in CI with `Expected: "connected" / Received: "connecting"`.

The reconnect helper blocks waited on `connection.once('connection', …)`, but the `'connection'` event fires on **every** status transition. During a reconnect the sequence is `reconnecting → connecting → connected`, so `once` resolved on the very first emission (`'reconnecting'`) — two transitions early. That let `handleConnection` resolve before the handshake finished, so the synchronous `expect(connection.status).toBe('connected')` on the next line raced the message delivery. It passed on fast/idle machines and lost under CI load.

**Fix**

Replaced the `once('connection', …)` waiters with a value-gated `on('connection', …)` listener that only resolves once status actually reaches `'connected'`, then detaches itself. Applied to all four reconnect blocks in the spec. This keeps the same observation channel and leaves every assertion unchanged — it only stops resolving on the intermediate `'reconnecting'` state.

No production code changed; this is purely a test-synchronization fix.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reconnect test reliability by waiting specifically for confirmed connected states.
  * Updated coverage for retry-budget resets and stale socket closure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2292]

[ARCH-2292]: https://rocketchat.atlassian.net/browse/ARCH-2292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ