### PR TITLE
regression: native emojis bottom-aligned in messages

### DIFF
--- a/apps/meteor/app/theme/client/imports/components/emoji.css
+++ b/apps/meteor/app/theme/client/imports/components/emoji.css
@@ -2,6 +2,7 @@
 .emoji {
 	font-size: 1.375rem;
 	line-height: 1.5rem;
+	vertical-align: middle;
 
 	/* custom emojis */
 	&--custom {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

**Root cause:** the EmojiOne → native emoji migration (#39411) dropped the pre-existing `vertical-align: middle` from `.emoji`.

Native emojis (text glyphs) then fell back to `baseline` — sinking to the bottom of the line and inflating line height (most visible on macOS). This restores that one declaration. Custom emojis, reactions, picker, and autocomplete are unaffected.

## Issue(s)

[CORE-2440](https://rocketchat.atlassian.net/browse/CORE-2440)

## Steps to test or reproduce

1. On macOS, open any room.
2. Send a few separate messages:
   ```
   asd 🙂 ASD
   asd
   asd
   asd 🙂
   asd
   ```
3. Look at the messages that contain an emoji.
   - **Before:** the emoji sits low (aligned to the bottom of the line), making those messages taller and the spacing uneven.
   - **After:** the emoji is vertically centered with the text, and messages have consistent height/spacing.


[CORE-2440]: https://rocketchat.atlassian.net/browse/CORE-2440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved emoji alignment with surrounding text for a more consistent inline appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->