### PR TITLE
fix(admin): handle 'All roles' selection correctly

### DIFF
--- a/apps/meteor/client/views/admin/users/UsersTable/UsersTableFilters.tsx
+++ b/apps/meteor/client/views/admin/users/UsersTable/UsersTableFilters.tsx
@@ -30,6 +30,12 @@ const UsersTableFilters = ({ roleData, setUsersFilters }: UsersTableFiltersProps
 
 	const handleRolesChange = useCallback(
 		(roles: OptionProp[]) => {
+			if (roles.some((role) => role.id === 'all')) {
+				setUsersFilters({ text, roles: [] });
+				setSelectedRoles([]);
+				return;
+			}
+
 			setUsersFilters({ text, roles });
 			setSelectedRoles(roles);
 		},
@@ -45,7 +51,7 @@ const UsersTableFilters = ({ roleData, setUsersFilters }: UsersTableFiltersProps
 			{
 				id: 'all',
 				text: 'All_roles',
-				checked: false,
+				checked: selectedRoles.length === 0,
 			},
 			...(roleData
 				? roleData.roles.map((role) => ({
@@ -55,7 +61,7 @@ const UsersTableFilters = ({ roleData, setUsersFilters }: UsersTableFiltersProps
 					}))
 				: []),
 		],
-		[roleData],
+		[roleData, selectedRoles],
 	);
 
 	const breakpoints = useBreakpoints();

--- a/packages/ui-client/src/components/MultiSelectCustom/MultiSelectCustom.tsx
+++ b/packages/ui-client/src/components/MultiSelectCustom/MultiSelectCustom.tsx
@@ -98,7 +98,7 @@ export const MultiSelectCustom = ({
 		[selectedOptions, setSelectedOptions],
 	);
 
-	const selectedOptionsCount = dropdownOptions.filter((option) => option.hasOwnProperty('checked') && option.checked).length;
+	const selectedOptionsCount = selectedOptions.length;
 	const buttonProps = useButtonPattern(() => toggleCollapsed(!collapsed));
 
 	return (


### PR DESCRIPTION
Fixes #41516.

This PR fixes an issue in **Administration → Workspace → Users** where clicking the **"All roles"** option in the role filter dropdown had no effect.

Previously, selecting **"All roles"** did not clear the active role filters or restore the default filter state. This change updates the role filter logic so that selecting **"All roles"** clears the current role selection, resets the filter state, and updates the UI accordingly.

Additionally, the dropdown header now correctly reflects the current selection state after clearing the filter.

A screen recording demonstrating the fix is attached.

https://github.com/user-attachments/assets/bfb47cb1-5773-46fd-9320-2af3bd7f3f4b

---

## Issue(s)

Fixes #41516

---

## Steps to test or reproduce

1. Go to **Administration → Workspace → Users**.
2. Open the **Role** filter dropdown.
3. Select one or more roles (e.g. Admin or Moderator).
4. Verify the filter label changes to **Roles (N)**.
5. Click **All roles**.
6. Verify:
   - All selected role filters are cleared.
   - The filter label resets to **All roles**.
   - The full user list is displayed again.
   - The **All roles** option reflects the default state correctly.

---

## Further comments

The implementation keeps the role filter state synchronized by treating **"All roles"** as the default (no filter) state rather than an individual role selection. The header count is derived from the current selected roles, ensuring the displayed label remains consistent with the active filter state.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the user role filter so selecting “All roles” clears any previously selected individual roles.
  * Updated the “All roles” checkbox state to correctly reflect when no specific roles are selected.
  * Corrected the multi-select badge/count so it always matches the actual selected options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->