### PR TITLE
fix: trim user search term before building search regex

### DIFF
--- a/apps/meteor/server/api/lib/users.ts
+++ b/apps/meteor/server/api/lib/users.ts
@@ -185,14 +185,31 @@ export async function findPaginatedUsersByStatus({
 		freeSwitchExtension: 1,
 	};
 
-	if (searchTerm?.trim()) {
+	const normalizedSearchTerm = searchTerm?.trim();
+
+	if (normalizedSearchTerm) {
 		match.$or = [
-			...(canSeeAllUserInfo ? [{ 'emails.address': { $regex: escapeRegExp(searchTerm || ''), $options: 'i' } }] : []),
+			...(canSeeAllUserInfo
+				? [
+					{
+						'emails.address': {
+							$regex: escapeRegExp(normalizedSearchTerm),
+							$options: 'i',
+						},
+					},
+				]
+				: []),
 			{
-				username: { $regex: escapeRegExp(searchTerm || ''), $options: 'i' },
+				username: {
+					$regex: escapeRegExp(normalizedSearchTerm),
+					$options: 'i',
+				},
 			},
 			{
-				name: { $regex: escapeRegExp(searchTerm || ''), $options: 'i' },
+				name: {
+					$regex: escapeRegExp(normalizedSearchTerm),
+					$options: 'i',
+				},
 			},
 		];
 	}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR fixes inconsistent whitespace handling in the **Administration → Users** search.

Previously, the search logic checked whether the trimmed search term was non-empty, but it constructed the search regex using the original untrimmed value. As a result, leading or multiple trailing whitespace in the search term prevented valid users from being found.

This change normalizes the search term by trimming leading and trailing whitespace before building the search regex, resulting in consistent and expected search behavior.

**Before**
- ❌ ` preeti` → Not Found
- ❌ `preeti  ` → Not Found

**After**
- ✅ ` preeti` → Found
- ✅ `preeti  ` → Found

_Attached is a screen recording demonstrating the fix._

## Issue(s)

Closes #41530

## Steps to test or reproduce

1. Go to **Administration → Users**.
2. Search for an existing user using the following inputs:
   - `preeti`
   - ` preeti`
   - `preeti `
   - `  preeti`
   - `preeti  `
3. Verify that all of the above return the same user.
4. Search using `pre eti` and verify that it does **not** return the user.

**Fix demonstration:**

https://github.com/user-attachments/assets/44d8839e-5841-494d-af1f-65c776a021bd

## Further comments

The fix is implemented in the backend by trimming the search term before constructing the search regex used by the `users.listByStatus` endpoint. This ensures consistent behavior for all clients consuming the endpoint while keeping the change minimal and localized.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user search by ignoring leading and trailing spaces in search terms.
  * Prevented blank searches from returning unintended broad results.
  * Preserved existing privacy controls for email-based searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->