### PR TITLE
fix(message-parser): allow colons in user mentions for matrix federation

### DIFF
--- a/.changeset/petite-jeans-do.md
+++ b/.changeset/petite-jeans-do.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/message-parser': patch
+---
+
+Allow colons in user mentions for matrix federation

--- a/.changeset/petite-jeans-do.md
+++ b/.changeset/petite-jeans-do.md
@@ -2,4 +2,4 @@
 '@rocket.chat/message-parser': patch
 ---
 
-Allow colons in user mentions for matrix federation
+Improve mention parsing to support colons and dots in federated usernames (e.g., `@user:server.org`), and normalize leading-@ handling to avoid duplicate `@` characters during fallback parsing.

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -648,13 +648,13 @@ TildeWithWhitespace = a:$"~"+ w:$Space+ b:$"~"+ { return plain(a + w + b); }
 */
 // Direct form: starts with @, used by dispatch
 UserMentionDirect
-  = "@"+ user:$(UTF8NamesValidation ([:@] UTF8NamesValidation)?) & { return !user.endsWith('__'); } {
+  = "@" user:$(UTF8NamesValidation ([:@.] UTF8NamesValidation)*) & { return !user.endsWith('__'); } {
       return mentionUser(user);
     }
 
 // Full form: includes text@user fallback, used by SlowPath
 UserMention
-  = t:Text "@"+ user:AlphaNumericChar {
+  = t:Text "@" user:AlphaNumericChar {
       return reducePlainTexts([t, plain('@' + user)])[0];
     }
   / UserMentionDirect

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -654,7 +654,7 @@ UserMentionDirect
 
 // Full form: includes text@user fallback, used by SlowPath
 UserMention
-  = t:Text "@" user:AlphaNumericChar {
+  = !"@" t:Text "@" user:AlphaNumericChar {
       return reducePlainTexts([t, plain('@' + user)])[0];
     }
   / UserMentionDirect


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
Fixes an issue where mentions of federated users containing colons (e.g., `@user:domain.com`) were failing to parse properly in the message parser grammar and falling back to plain text (or rendering improperly as `@@user` on mobile).

Updated the `UserMentionDirect` rule in PEG.js grammar (`packages/message-parser/src/grammar.pegjs`) to support `:` (colon) characters alongside `@` and `.` in federated usernames. This allows the parser to generate a proper `mentionUser` AST node for federated mentions.

## Issue(s)
Closes #41522

## Steps to test or reproduce
1. Send a message containing a federated user mention with a domain and colon format, e.g., `@john:matrix.org`.
2. Observe how the message is rendered.
3. **Expected Behavior:** The federated handle is recognized and rendered as a single user mention pill/link instead of falling back to plain text.

## Further comments
The changes were kept strictly within `packages/message-parser` to ensure the grammar cleanly extracts federated handles into AST tokens before rendering without breaking standard user mentions or email-style mentions.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user-mention parsing to better support federation-style identifiers (including dots and colons, e.g., `@user:server.org`).
  * Updated mention rules to accept exactly one leading `@`, preventing repeated `@` characters from being treated as valid mentions.
  * Added a release-note entry reflecting these message-parser mention compatibility enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->