### PR TITLE
regression: quick-reaction emojis rendered larger on message toolbar

### DIFF
--- a/apps/meteor/client/views/composer/EmojiPicker/EmojiElement.tsx
+++ b/apps/meteor/client/views/composer/EmojiPicker/EmojiElement.tsx
@@ -1,3 +1,4 @@
+import { css } from '@rocket.chat/css-in-js';
 import { IconButton } from '@rocket.chat/fuselage';
 import DOMPurify from 'dompurify';
 import type { MouseEvent, AllHTMLAttributes } from 'react';
@@ -11,6 +12,12 @@ export type EmojiElementProps = EmojiItem & { small?: boolean; onClick: (e: Mous
 		'is'
 	>;
 
+const smallEmojiClass = css`
+	.emoji {
+		font-size: 1.125rem;
+	}
+`;
+
 const EmojiElement = ({ emoji, image, onClick, small = false, ...props }: EmojiElementProps) => {
 	const { handlePreview, handleRemovePreview } = usePreviewEmoji();
 
@@ -22,6 +29,7 @@ const EmojiElement = ({ emoji, image, onClick, small = false, ...props }: EmojiE
 
 	return (
 		<IconButton
+			{...(small && { className: smallEmojiClass })}
 			small={small}
 			medium={!small}
 			onMouseEnter={() => handlePreview(image, emoji)}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Since #39411 (native emoji renderer), quick-reaction emojis on the message toolbar render at 1.375rem instead of 1.125rem.

#39411 removed the `small`-variant css-in-js override in `EmojiElement` (`width/height: 1.125rem`) and replaced sprite sizing with a single global rule `.rcx-button .emoji { font-size: 1.375rem }`, which also hits the small IconButtons on the toolbar.

This restores the small-variant sizing in the new font-size scheme, scoped to small icon buttons (`.rcx-button--small-square`), covering custom emojis as well. Emoji picker (medium buttons), message body emojis and reaction pills are unaffected.

<!-- screenshot -->

## Steps to test or reproduce

1. Open any room and send some emojis (👍 ❤️ 😄)
2. Hover a message to show the message toolbar
3. Quick-reaction emojis should render at 1.125rem (18px), matching the toolbar icon size

## Further comments

<img width="357" height="66" alt="image" src="https://github.com/user-attachments/assets/c7549fa2-3e7b-4a3c-bf13-79514b291b2f" />

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

https://rocketchat.atlassian.net/browse/CORE-2461

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved emoji picker display by supporting a smaller emoji size for compact layouts.
  * Preserved existing emoji preview, removal, and sanitization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->