### PR TITLE
test: deflake livechat business-hours and room.forward queue tests

### DIFF
--- a/apps/meteor/tests/end-to-end/api/livechat/00-rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/00-rooms.ts
@@ -1787,10 +1787,12 @@ describe('LIVECHAT - rooms', () => {
 				expect(inquiry).to.have.property('department', targetDepartment._id);
 				expect(inquiry).to.have.property('status', 'queued');
 
+				// the room ends queued (never taken), so close it as the visitor — room.closeByUser rejects a room that is not being served
+				await request.post(api('livechat/room.close')).send({ rid: newRoom._id, token: newVisitor.token }).expect(200);
+
 				await Promise.all([
 					deleteDepartment(initialDepartment._id),
 					deleteDepartment(targetDepartment._id),
-					closeOmnichannelRoom(newRoom._id),
 					deleteVisitor(newVisitor.token),
 					deleteUser(manager),
 					updateSetting('Livechat_waiting_queue', false),

--- a/apps/meteor/tests/end-to-end/api/livechat/00-rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/00-rooms.ts
@@ -664,11 +664,14 @@ describe('LIVECHAT - rooms', () => {
 			expect(body.rooms.some((room: IOmnichannelRoom) => room._id === expectedRoom._id)).to.be.true;
 			expect(body.rooms.some((room: IOmnichannelRoom) => room._id === expectedRoom2._id)).to.be.true;
 
-			await closeOmnichannelRoom(expectedRoom._id);
-			await closeOmnichannelRoom(expectedRoom2._id);
-			await deleteVisitor(expectedVisitor.token);
-			await deleteVisitor(expectedVisitor2.token);
-			await Promise.all([deleteDepartment(department._id), deleteDepartment(department2._id)]);
+			// close both rooms before removing visitors/departments (deleting a department with an open room fails)
+			await Promise.all([closeOmnichannelRoom(expectedRoom._id), closeOmnichannelRoom(expectedRoom2._id)]);
+			await Promise.all([
+				deleteVisitor(expectedVisitor.token),
+				deleteVisitor(expectedVisitor2.token),
+				deleteDepartment(department._id),
+				deleteDepartment(department2._id),
+			]);
 		});
 		(IS_EE ? it : it.skip)('should return only rooms with the given tags', async () => {
 			const tag = await saveTags();

--- a/apps/meteor/tests/end-to-end/api/livechat/19-business-hours.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/19-business-hours.ts
@@ -31,17 +31,7 @@ import { password } from '../../../data/user';
 import type { TestUser } from '../../../data/users.helper';
 import { setUserActiveStatus, createUser, deleteUser, getMe, getUserByUsername, login } from '../../../data/users.helper';
 import { IS_EE } from '../../../e2e/config/constants';
-
-const waitForAgent = async (creds: Credentials, predicate: (agent: ILivechatAgent) => boolean, attempts = 20): Promise<void> => {
-	for (let i = 0; i < attempts; i++) {
-		const current: ILivechatAgent = await getMe(creds);
-		if (predicate(current)) {
-			return;
-		}
-		await sleep(250);
-	}
-	throw new Error('timed out waiting for agent business hours to update');
-};
+import { retry } from '../helpers/retry';
 
 describe('LIVECHAT - business hours', () => {
 	before((done) => getCredentials(done));
@@ -973,9 +963,16 @@ describe('LIVECHAT - business hours', () => {
 		it('should create a new agent and verify if it is assigned to the default business hour which is closed', async () => {
 			await openOrCloseBusinessHour(defaultBH, false);
 
-			// wait for the close to propagate (existing agent loses the BH assignment) before creating the new agent,
-			// otherwise the new agent can be created while the BH still counts as open and comes up available
-			await waitForAgent(agentCredentials, (a) => (a.openBusinessHours?.length ?? 0) === 0);
+			// the BH close recalculates agent statuses asynchronously; wait for it to propagate (existing agent loses the
+			// BH assignment) before creating the new agent, otherwise it is created while the BH still counts as open
+			await retry(
+				'BH close propagation is async, so the existing agent may still be assigned on the first fetch',
+				async () => {
+					const current: ILivechatAgent = await getMe(agentCredentials);
+					expect(current.openBusinessHours ?? []).to.have.lengthOf(0);
+				},
+				{ retries: 20, delayMs: 250 },
+			);
 
 			const newUser: ILivechatAgent = await createUser();
 			const newUserCredentials = await login(newUser.username, password);

--- a/apps/meteor/tests/end-to-end/api/livechat/19-business-hours.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/19-business-hours.ts
@@ -32,6 +32,17 @@ import type { TestUser } from '../../../data/users.helper';
 import { setUserActiveStatus, createUser, deleteUser, getMe, getUserByUsername, login } from '../../../data/users.helper';
 import { IS_EE } from '../../../e2e/config/constants';
 
+const waitForAgent = async (creds: Credentials, predicate: (agent: ILivechatAgent) => boolean, attempts = 20): Promise<void> => {
+	for (let i = 0; i < attempts; i++) {
+		const current: ILivechatAgent = await getMe(creds);
+		if (predicate(current)) {
+			return;
+		}
+		await sleep(250);
+	}
+	throw new Error('timed out waiting for agent business hours to update');
+};
+
 describe('LIVECHAT - business hours', () => {
 	before((done) => getCredentials(done));
 
@@ -961,6 +972,10 @@ describe('LIVECHAT - business hours', () => {
 
 		it('should create a new agent and verify if it is assigned to the default business hour which is closed', async () => {
 			await openOrCloseBusinessHour(defaultBH, false);
+
+			// wait for the close to propagate (existing agent loses the BH assignment) before creating the new agent,
+			// otherwise the new agent can be created while the BH still counts as open and comes up available
+			await waitForAgent(agentCredentials, (a) => (a.openBusinessHours?.length ?? 0) === 0);
 
 			const newUser: ILivechatAgent = await createUser();
 			const newUserCredentials = await login(newUser.username, password);


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Two unrelated flakes in the API Livechat (EE) suite, both surfaced in the merge queue ([run 1](https://github.com/RocketChat/Rocket.Chat/actions/runs/30012069793/job/89225016724), [run 2](https://github.com/RocketChat/Rocket.Chat/actions/runs/30008823193/job/89214612117)) on a PR that only touches thread rendering — i.e. pre-existing flakes, not caused by that PR.

### 1. `19-business-hours.ts` — agent status race

`[CE][BH] On Agent created/removed › ... default business hour which is closed`:

```
AssertionError: expected 'available' to equal 'not-available'
  at 19-business-hours.ts:972
```

Closing the default BH recalculates agent statuses via an async callback. The test closed the BH and immediately created a new agent — when the close had not propagated yet, the agent was created while the BH still counted as open and came up `available`, and nothing re-flips an already-created agent.

Fix: after closing the BH, poll the pre-existing agent until it loses the BH assignment (`openBusinessHours` empty — the same positive signal the next test already asserts) before creating the new agent. Replaces reliance on implicit timing with a bounded poll.

### 2. `00-rooms.ts` — closing a queued room

`livechat/room.forward ... waiting_queue enabled, but department is online, transfer should succeed but it should end queued on target`:

```
Error: expected 200 "OK", got 400 "Bad Request"
  at closeOmnichannelRoom (tests/data/livechat/rooms.ts:428)
  at 00-rooms.ts:1793
```

The test's own scenario leaves the room **queued** (asserts `inquiry.status === 'queued'`). Cleanup then called `closeOmnichannelRoom` → `room.closeByUser`, which rejects a room that is not being served (400). It only passed when the queue processor happened to assign the room to the online target agent before cleanup ran — hence the flake.

Fix: close the room as the visitor (`livechat/room.close` with the visitor token), which is valid for a queued room, then run the rest of the cleanup.

## Issue(s)

## Steps to test or reproduce

```
yarn testapi:livechat --grep "On Agent created/removed"
yarn testapi:livechat --grep "should end queued on target"
```

Both races are load-dependent; the fixes remove the timing assumption rather than reproduce the race.

## Further comments

Test-only, no changeset.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2294]

[ARCH-2294]: https://rocketchat.atlassian.net/browse/ARCH-2294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved live chat end-to-end test cleanup to prevent room/department lifecycle conflicts during teardown.
  * Enhanced business-hours end-to-end tests with retry handling to better account for asynchronous propagation and reduce intermittent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->