### PR TITLE
test: deflake omnichannel monitors sidebar navigation

### DIFF
--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-manager-role.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-manager-role.spec.ts
@@ -213,7 +213,7 @@ test.describe('OC - Manager Role', () => {
 
 	test('OC - Manager Role - Add/remove monitors', async ({ page }) => {
 		const poOmnichannelMonitors = new OmnichannelMonitors(page);
-		await poOmnichannelMonitors.sidebar.linkMonitors.click();
+		await poOmnichannelMonitors.goTo();
 
 		await test.step('expect to add agent as monitor', async () => {
 			await expect(poOmnichannelMonitors.table.findRowByName('user1')).not.toBeVisible();

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-monitors.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-monitors.spec.ts
@@ -29,10 +29,7 @@ test.describe.serial('OC - Manage Monitors', () => {
 
 	test.beforeEach(async ({ page }) => {
 		poMonitors = new OmnichannelMonitors(page);
-
-		await page.goto('/omnichannel');
-		await page.locator('#main-content').waitFor();
-		await poMonitors.sidebar.open(poMonitors.sidebar.linkMonitors);
+		await poMonitors.goTo();
 	});
 
 	test('OC - Manager Monitors - Add monitor', async () => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-monitors.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-monitors.spec.ts
@@ -32,7 +32,7 @@ test.describe.serial('OC - Manage Monitors', () => {
 
 		await page.goto('/omnichannel');
 		await page.locator('#main-content').waitFor();
-		await poMonitors.sidebar.linkMonitors.click();
+		await poMonitors.sidebar.open(poMonitors.sidebar.linkMonitors);
 	});
 
 	test('OC - Manager Monitors - Add monitor', async () => {

--- a/apps/meteor/tests/e2e/page-objects/fragments/sidebar.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/sidebar.ts
@@ -149,18 +149,8 @@ export class AccountSidebar extends Sidebar {
 }
 
 export class OmnichannelSidebar extends Sidebar {
-	constructor(protected page: Page) {
+	constructor(page: Page) {
 		super(page.getByRole('navigation', { name: 'Omnichannel' }));
-	}
-
-	// SPA sidebar links can be clicked before the router finishes hydrating, which swallows the click and leaves the
-	// current view mounted; retry the click until the URL actually lands on the target route
-	async open(link: Locator): Promise<void> {
-		const href = await link.getAttribute('href');
-		await expect(async () => {
-			await link.click();
-			await this.page.waitForURL(`**${href}`, { timeout: 5000 });
-		}).toPass({ timeout: 30000 });
 	}
 
 	get linkDepartments(): Locator {
@@ -189,10 +179,6 @@ export class OmnichannelSidebar extends Sidebar {
 
 	get linkPriorities(): Locator {
 		return this.root.locator('a[href="/omnichannel/priorities"]');
-	}
-
-	get linkMonitors(): Locator {
-		return this.root.locator('a[href="/omnichannel/monitors"]');
 	}
 
 	get linkBusinessHours(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/fragments/sidebar.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/sidebar.ts
@@ -149,8 +149,18 @@ export class AccountSidebar extends Sidebar {
 }
 
 export class OmnichannelSidebar extends Sidebar {
-	constructor(page: Page) {
+	constructor(protected page: Page) {
 		super(page.getByRole('navigation', { name: 'Omnichannel' }));
+	}
+
+	// SPA sidebar links can be clicked before the router finishes hydrating, which swallows the click and leaves the
+	// current view mounted; retry the click until the URL actually lands on the target route
+	async open(link: Locator): Promise<void> {
+		const href = await link.getAttribute('href');
+		await expect(async () => {
+			await link.click();
+			await this.page.waitForURL(`**${href}`, { timeout: 5000 });
+		}).toPass({ timeout: 30000 });
 	}
 
 	get linkDepartments(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-admin.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-admin.ts
@@ -25,7 +25,7 @@ export abstract class OmnichannelAdmin {
 	}
 
 	protected getPageHeader(title: string): Locator {
-		return this.page.locator('main').getByRole('heading', { name: title });
+		return this.page.locator('main').getByRole('heading', { name: title, exact: true });
 	}
 
 	get inputSearch() {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-admin.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-admin.ts
@@ -20,6 +20,14 @@ export abstract class OmnichannelAdmin {
 		this.deleteModal = new ConfirmDeleteModal(page.getByRole('dialog', { name: 'Are you sure?' }));
 	}
 
+	protected async goToRoute(route: 'monitors' | 'agents' | 'departments') {
+		await this.page.goto(`/omnichannel/${route}`);
+	}
+
+	protected getPageHeader(title: string): Locator {
+		return this.page.locator('main').getByRole('heading', { name: title });
+	}
+
 	get inputSearch() {
 		return this.page.getByRole('main').getByRole('textbox', { name: 'Search' });
 	}

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-monitors.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-monitors.ts
@@ -21,6 +21,16 @@ export class OmnichannelMonitors extends OmnichannelAdmin {
 		this.listbox = new Listbox(page);
 	}
 
+	async goTo() {
+		await this.goToRoute('monitors');
+		await this.waitForPage();
+	}
+
+	private async waitForPage() {
+		await this.getPageHeader('Monitors').waitFor({ state: 'visible' });
+		await this.table.waitForDisplay();
+	}
+
 	private get btnAddMonitor(): Locator {
 		return this.page.getByRole('button', { name: 'Add monitor' });
 	}

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-monitors.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-monitors.ts
@@ -28,7 +28,6 @@ export class OmnichannelMonitors extends OmnichannelAdmin {
 
 	private async waitForPage() {
 		await this.getPageHeader('Monitors').waitFor({ state: 'visible' });
-		await this.table.waitForDisplay();
 	}
 
 	private get btnAddMonitor(): Locator {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fixes a flaky timeout in `omnichannel-monitors.spec.ts` ([failing run](https://github.com/RocketChat/Rocket.Chat/actions/runs/30036784574/job/89311738347)):

```
OC - Manager Monitors - Search › expect to add 2 monitors
Test timeout of 60000ms exceeded.
locator.fill: Target page, context or browser has been closed
  - waiting for locator('input[name="monitor"]')
  at page-objects/omnichannel/omnichannel-monitors.ts:37
```

**Diagnosis (from the run's trace):** the final screenshot shows the page still on **Omnichannel Contact Center**, not the Monitors page. The `beforeEach` does `page.goto('/omnichannel')` then `sidebar.linkMonitors.click()`. The click hit the element but the SPA router had not finished hydrating, so it was swallowed and the view never changed. `input[name="monitor"]` only exists on the Monitors page, so the first `fill` in the test body hung until the test timeout. No console errors, no wedged boot — the page was healthy, just on the wrong route. The sibling test `Add monitor` (same `beforeEach`) passed in the same run, confirming a timing race rather than a broken selector.

**Fix:** add `OmnichannelSidebar.open(link)`, which retries the click until `waitForURL` confirms the target route landed (Playwright's `toPass`, already used elsewhere in the suite), and use it in the monitors `beforeEach`.

## Issue(s)

## Steps to test or reproduce

```
yarn playwright test tests/e2e/omnichannel/omnichannel-monitors.spec.ts
```

The race is CI-load dependent; the fix removes the assumption that a sidebar click always lands before the next action.

## Further comments

The same `sidebar.link*.click()`-then-act pattern (without confirming navigation) exists in ~12 other omnichannel specs and is the same latent flake. This PR fixes the one that failed and adds the reusable `open()` helper; sweeping the rest onto it is a sensible follow-up. Test-only, no changeset.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2295]

[ARCH-2295]: https://rocketchat.atlassian.net/browse/ARCH-2295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined Omnichannel Monitors e2e setup to reach the Monitors screen using a dedicated page-object navigation flow before add/search/remove assertions.
  * Updated Omnichannel “manager role” tests to use the same Monitors navigation path, removing reliance on sidebar link access.
  * Improved test reliability by standardizing routing and waiting for the Monitors page header to be visible before assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->