### PR TITLE
regression: emoji picker hover preview is no longer enlarged

### DIFF
--- a/packages/ui-client/src/components/EmojiPicker/EmojiPickerPreview.tsx
+++ b/packages/ui-client/src/components/EmojiPicker/EmojiPickerPreview.tsx
@@ -8,9 +8,14 @@ export type EmojiPickerPreviewProps = { emoji: string; name: string } & Omit<All
 const EmojiPickerPreview = ({ emoji, name, ...props }: EmojiPickerPreviewProps) => {
 	const previewEmojiClass = css`
 		span {
+			font-size: 2.5rem;
+		}
+		span.emoji--custom {
 			width: 2.5rem;
 			height: 2.5rem;
-			font-size: 2.5rem;
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
 		}
 	`;
 

--- a/packages/ui-client/src/components/EmojiPicker/EmojiPickerPreview.tsx
+++ b/packages/ui-client/src/components/EmojiPicker/EmojiPickerPreview.tsx
@@ -8,7 +8,9 @@ export type EmojiPickerPreviewProps = { emoji: string; name: string } & Omit<All
 const EmojiPickerPreview = ({ emoji, name, ...props }: EmojiPickerPreviewProps) => {
 	const previewEmojiClass = css`
 		span {
-			font-size: 1.375rem;
+			width: 2.5rem;
+			height: 2.5rem;
+			font-size: 2.5rem;
 		}
 	`;
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The emojione → native emoji migration (#39411) translated the preview's `width: 40px; height: 40px` into `font-size: 1.375rem` — the same value as the global `.emoji` rule, so the override became a no-op and the footer preview collapsed to grid-item size. Restores it to `2.5rem` (the original 40px) for both native and custom emojis.

## Issue(s)

- [CORE-2471](https://rocketchat.atlassian.net/browse/CORE-2471)

## Steps to test or reproduce

1. Open the emoji picker
2. Hover a native emoji, then a custom one
3. Both previews should be visibly larger than the grid item

## Further comments

Native emojis are glyphs, sized by `font-size`. Custom emojis are background images pinned by `.emoji--custom` to `width/height: 1.375rem`, so `font-size` alone leaves them grid-sized. On native spans the `width`/`height` are inert (`display: inline`), so one rule covers both.

**rem, not the original px.** `EmojiPickerPreviewArea` resolves `minHeight='x64'` to `4rem`, which is why `40px` fit at a 16px root. At any other root size the container and grid items scale while a hardcoded `40px` would not, shrinking the preview/grid ratio from ~1.8× to ~1.45×.

**One `span` rule, not a `.emoji--custom`-specific one.** Identical rendering, and the class sits on a Box containing only the injected emoji — the name and shortcode are in a sibling Box — so it can't match anything else.

[CORE-2471]: https://rocketchat.atlassian.net/browse/CORE-2471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enlarged the emoji preview for improved visibility and consistency.
  * Updated the preview styling to use a larger, consistent font size.
  * Set explicit width and height for custom emoji to keep sizing uniform and centered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->