### PR TITLE
regression: outgoing webhooks fail to match emoji trigger words

### DIFF
--- a/apps/meteor/server/lib/integrations/lib/triggerHandler.ts
+++ b/apps/meteor/server/lib/integrations/lib/triggerHandler.ts
@@ -17,12 +17,18 @@ import _ from 'underscore';
 import type { OutgoingRequestData } from './ScriptEngine';
 import { IsolatedVMScriptEngine } from './isolated-vm/isolated-vm';
 import { updateHistory } from './updateHistory';
+import { shortnameToUnicode } from '../../../../app/emoji-native/lib/shortnameToUnicode';
 import { outgoingEvents } from '../../../../app/integrations/lib/outgoingEvents';
 import { settings } from '../../../settings';
 import { processWebhookMessage } from '../../messages/processWebhookMessage';
 import { notifyOnIntegrationChangedById } from '../../notifyListener';
 import { getRoomByNameOrIdWithOptionToJoin } from '../../rooms/getRoomByNameOrIdWithOptionToJoin';
 import { outgoingLogger } from '../logger';
+
+function getTriggerWordVariants(triggerWord: string): string[] {
+	const unicode = shortnameToUnicode(triggerWord);
+	return unicode !== triggerWord ? [triggerWord, unicode] : [triggerWord];
+}
 
 type Trigger = Record<string, Record<string, any>>;
 
@@ -510,10 +516,11 @@ class RocketChatIntegrationHandler {
 		if (event && outgoingEvents[event].use.triggerWords) {
 			if (trigger.triggerWords && trigger.triggerWords.length > 0) {
 				for (const triggerWord of trigger.triggerWords) {
-					if (!trigger.triggerWordAnywhere && message?.msg.indexOf(triggerWord) === 0) {
+					const variants = getTriggerWordVariants(triggerWord);
+					if (!trigger.triggerWordAnywhere && variants.some((variant) => message?.msg.indexOf(variant) === 0)) {
 						word = triggerWord;
 						break;
-					} else if (trigger.triggerWordAnywhere && message?.msg.includes(triggerWord)) {
+					} else if (trigger.triggerWordAnywhere && variants.some((variant) => message?.msg.includes(variant))) {
 						word = triggerWord;
 						break;
 					}

--- a/apps/meteor/server/lib/integrations/lib/triggerHandler.ts
+++ b/apps/meteor/server/lib/integrations/lib/triggerHandler.ts
@@ -517,7 +517,7 @@ class RocketChatIntegrationHandler {
 			if (trigger.triggerWords && trigger.triggerWords.length > 0) {
 				for (const triggerWord of trigger.triggerWords) {
 					const variants = getTriggerWordVariants(triggerWord);
-					if (!trigger.triggerWordAnywhere && variants.some((variant) => message?.msg.indexOf(variant) === 0)) {
+					if (!trigger.triggerWordAnywhere && variants.some((variant) => message?.msg.startsWith(variant))) {
 						word = triggerWord;
 						break;
 					} else if (trigger.triggerWordAnywhere && variants.some((variant) => message?.msg.includes(variant))) {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

Outgoing webhooks that use an emoji shortcode as their trigger word (for example `:smile:`) stopped firing in 8.7.

The reason: since 8.7 the message composer saves emojis as their native Unicode character (`😄`) instead of the `:smile:` text. The outgoing-webhook matcher compares the configured trigger word against the raw message text, so `:smile:` no longer appeared anywhere in the message and the webhook silently never ran. This worked in 8.6, where the message was stored as `:smile:`.

This change makes the trigger matcher recognize both forms. For each configured trigger word it now also checks the word's native Unicode emoji equivalent, so a `:smile:` trigger matches whether the message contains `:smile:` (e.g. sent via API) or `😄` (sent from the composer). It reuses the same shortcode-to-unicode conversion the message pipeline already uses.

https://github.com/user-attachments/assets/3abc0561-8fa8-4a2c-9333-9bbc3875c142


## Issue(s)

CORE-2469 (no GitHub issue).

## Steps to test or reproduce

1. Create an **incoming** webhook that posts to a channel, e.g. `#emoji-webhook-results`.
2. Create an **outgoing** webhook on another channel `#emoji-webhook-source`: event `Message Sent`, Trigger Words `:smile:`, Word Placement Anywhere `On`, URL set to the incoming webhook's URL.
3. Open `#emoji-webhook-source`, type `hello` and pick the 😄 emoji from the picker/autocomplete, then send it.
4. Expected: the message is forwarded and appears in `#emoji-webhook-results`. (Before this fix, nothing appeared.)

## Further comments

[CORE-2469](https://rocketchat.atlassian.net/browse/CORE-2469)


[CORE-2469]: https://rocketchat.atlassian.net/browse/CORE-2469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trigger-based integrations now recognize Unicode equivalents of configured trigger words.
  * Preserved trigger matching behavior for words appearing at the beginning or anywhere in a message.
  * Recorded trigger data consistently using the configured trigger word.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->