### PR TITLE
fix: escape special characters in file search

### DIFF
--- a/apps/meteor/server/api/v1/channels.ts
+++ b/apps/meteor/server/api/v1/channels.ts
@@ -9,6 +9,7 @@ import {
 	type UserStatus,
 } from '@rocket.chat/core-typings';
 import { Integrations, Messages, Rooms, Subscriptions, Uploads, Users } from '@rocket.chat/models';
+import { escapeRegExp } from '@rocket.chat/string-helpers';
 import {
 	isChannelsAddAllProps,
 	isChannelsArchiveProps,
@@ -815,6 +816,7 @@ API.v1.addRoute(
 	{
 		async get() {
 			const { typeGroup, name, roomId, roomName, onlyConfirmed } = this.queryParams;
+			const searchName = name?.trim();
 
 			const findResult = await findChannelByIdOrName({
 				params: {
@@ -834,7 +836,12 @@ API.v1.addRoute(
 			const filter = {
 				rid: findResult._id,
 				...query,
-				...(name ? { name: { $regex: name || '', $options: 'i' } } : {}),
+				...(searchName && {
+					name: {
+						$regex: escapeRegExp(searchName),
+						$options: 'i',
+					},
+				}),
 				...(typeGroup ? { typeGroup } : {}),
 				...(onlyConfirmed && { expiresAt: { $exists: false } }),
 			};

--- a/apps/meteor/server/api/v1/groups.ts
+++ b/apps/meteor/server/api/v1/groups.ts
@@ -9,6 +9,7 @@ import {
 } from '@rocket.chat/core-typings';
 import { Integrations, Messages, Rooms, Subscriptions, Uploads, Users } from '@rocket.chat/models';
 import { isGroupsOnlineProps, isGroupsMessagesProps, isGroupsFilesProps } from '@rocket.chat/rest-typings';
+import { escapeRegExp } from '@rocket.chat/string-helpers';
 import { isTruthy } from '@rocket.chat/tools';
 import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
@@ -399,6 +400,7 @@ API.v1.addRoute(
 	{
 		async get() {
 			const { typeGroup, name, roomId, roomName, onlyConfirmed } = this.queryParams;
+			const searchName = name?.trim();
 
 			const findResult = await findPrivateGroupByIdOrName({
 				params: roomId ? { roomId } : { roomName },
@@ -412,7 +414,12 @@ API.v1.addRoute(
 			const filter = {
 				...query,
 				rid: findResult.rid,
-				...(name ? { name: { $regex: name || '', $options: 'i' } } : {}),
+				...(searchName && {
+					name: {
+						$regex: escapeRegExp(searchName),
+						$options: 'i',
+					},
+				}),
 				...(typeGroup ? { typeGroup } : {}),
 				...(onlyConfirmed && { expiresAt: { $exists: false } }),
 			};

--- a/apps/meteor/server/api/v1/im.ts
+++ b/apps/meteor/server/api/v1/im.ts
@@ -20,6 +20,7 @@ import {
 import { Match, check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import type { FindOptions } from 'mongodb';
+import { escapeRegExp } from '@rocket.chat/string-helpers';
 
 import { canAccessRoomIdAsync } from '../../lib/authorization/canAccessRoom';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
@@ -464,6 +465,7 @@ const dmFilesAction = <Path extends string>(_path: Path): TypedAction<typeof dmF
 		}
 
 		const { typeGroup, name, roomId, username, onlyConfirmed } = this.queryParams;
+		const searchName = name?.trim();
 
 		const { offset, count } = await getPaginationItems(this.queryParams);
 		const { sort, fields, query } = await this.parseJsonQuery();
@@ -478,7 +480,12 @@ const dmFilesAction = <Path extends string>(_path: Path): TypedAction<typeof dmF
 		const filter = {
 			...query,
 			rid: room._id,
-			...(name ? { name: { $regex: name || '', $options: 'i' } } : {}),
+			...(searchName && {
+				name: {
+					$regex: escapeRegExp(searchName),
+					$options: 'i',
+				},
+			}),
 			...(typeGroup ? { typeGroup } : {}),
 			...(onlyConfirmed && { expiresAt: { $exists: false } }),
 		};

--- a/apps/meteor/tests/data/uploads.helper.ts
+++ b/apps/meteor/tests/data/uploads.helper.ts
@@ -332,6 +332,63 @@ export async function testFileUploads(
 
 		after(() => Promise.all([deleteUser(anotherUser), deleteRoom({ type: roomType, roomId: extraRoom._id })]));
 
+		it('should properly filter files with regex special characters and trimmed whitespace', async () => {
+			let fileId: string;
+			const fileName = 'file(1).txt';
+
+			await request
+				.post(api(`rooms.media/${testRoom._id}`))
+				.set(credentials)
+				.attach('file', imgURL, { filename: fileName })
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res: Response) => {
+					expect(res.body).to.have.property('success', true);
+					fileId = res.body.file._id;
+				});
+
+			await request
+				.post(api(`rooms.mediaConfirm/${testRoom._id}/${fileId}`))
+				.set(credentials)
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			await request
+				.get(api(filesEndpoint))
+				.set(credentials)
+				.query({
+					roomId: testRoom._id,
+					name: 'file(1)',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res: Response) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('files').and.to.be.an('array').with.lengthOf(1);
+
+					const { files } = res.body;
+
+					expect(files[0].name).to.equal(fileName);
+				});
+
+			await request
+				.get(api(filesEndpoint))
+				.set(credentials)
+				.query({
+					roomId: testRoom._id,
+					name: '  file(1)  ',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res: Response) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('files').and.to.be.an('array').with.lengthOf(1);
+
+					const { files } = res.body;
+
+					expect(files[0].name).to.equal(fileName);
+				});
+		});
 		it('should not allow to confirm a file from another user', async function () {
 			if (roomType === 'd') {
 				this.skip();


### PR DESCRIPTION
## Summary

This PR fixes file search when the search term contains regex special characters (e.g. `(`, `)`) and when it contains leading/trailing whitespace.

### Changes
- Escape regex special characters using `escapeRegExp` before constructing the MongoDB `$regex`.
- Trim the search term before applying the filter.
- Add an API regression test covering:
  - filenames containing regex special characters (`file(1).txt`)
  - searches with leading/trailing whitespace

Fixes #41536

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-name searches across channels, groups, and direct messages.
  * Searches now handle special characters safely and ignore leading or trailing whitespace.
  * Empty search terms no longer apply an unnecessary name filter.

* **Tests**
  * Added coverage for file names containing regex-special characters and searches with extra whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->