### PR TITLE
fix: trim directory user search term before building regex

### DIFF
--- a/apps/meteor/server/api/lib/users.ts
+++ b/apps/meteor/server/api/lib/users.ts
@@ -185,14 +185,31 @@ export async function findPaginatedUsersByStatus({
 		freeSwitchExtension: 1,
 	};
 
-	if (searchTerm?.trim()) {
+	const normalizedSearchTerm = searchTerm?.trim();
+
+	if (normalizedSearchTerm) {
 		match.$or = [
-			...(canSeeAllUserInfo ? [{ 'emails.address': { $regex: escapeRegExp(searchTerm || ''), $options: 'i' } }] : []),
+			...(canSeeAllUserInfo
+				? [
+					{
+						'emails.address': {
+							$regex: escapeRegExp(normalizedSearchTerm),
+							$options: 'i',
+						},
+					},
+				]
+				: []),
 			{
-				username: { $regex: escapeRegExp(searchTerm || ''), $options: 'i' },
+				username: {
+					$regex: escapeRegExp(normalizedSearchTerm),
+					$options: 'i',
+				},
 			},
 			{
-				name: { $regex: escapeRegExp(searchTerm || ''), $options: 'i' },
+				name: {
+					$regex: escapeRegExp(normalizedSearchTerm),
+					$options: 'i',
+				},
 			},
 		];
 	}

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -350,6 +350,8 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			exceptions = [exceptions];
 		}
 
+		const normalizedSearchTerm = searchTerm.trim();
+
 		const termRegex = new RegExp((startsWith ? '^' : '') + escapeRegExp(searchTerm) + (endsWith ? '$' : ''), 'i');
 
 		const orStmt = (searchFields || []).reduce(
@@ -369,7 +371,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 						...(exceptions.length > 0 && { $nin: exceptions }),
 					},
 					// if the search term is empty, don't need to have the $or statement (because it would be an empty regex)
-					...(searchTerm && orStmt.length > 0 && { $or: orStmt }),
+					...(normalizedSearchTerm && orStmt.length > 0 && { $or: orStmt }),
 				},
 				...extraQuery,
 			],
@@ -396,7 +398,9 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			exceptions = [exceptions];
 		}
 
-		const termRegex = new RegExp((startsWith ? '^' : '') + escapeRegExp(searchTerm) + (endsWith ? '$' : ''), 'i');
+		const normalizedSearchTerm = searchTerm.trim();
+
+		const termRegex = new RegExp((startsWith ? '^' : '') + escapeRegExp(normalizedSearchTerm) + (endsWith ? '$' : ''), 'i');
 
 		const orStmt = (searchFields || []).reduce(
 			(acc, el) => {
@@ -415,7 +419,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 						...(exceptions.length > 0 && { $nin: exceptions }),
 					},
 					// if the search term is empty, don't need to have the $or statement (because it would be an empty regex)
-					...(searchTerm && orStmt.length > 0 && { $or: orStmt }),
+					...(normalizedSearchTerm  && orStmt.length > 0 && { $or: orStmt }),
 				},
 				...extraQuery,
 			],


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR fixes an issue where **Directory → Users** search did not ignore leading or trailing whitespace in the search term.

Previously, leading or trailing whitespace became part of the generated regular expression, causing valid users not to appear in the search results. This change normalizes the search term before building the regex and before determining whether a search filter should be applied, ensuring consistent search behavior.

### After fix

https://github.com/user-attachments/assets/fc14c222-7d60-429e-a0c6-07bc50dce2e7

## Issue(s)

Closes #41545

## Steps to test or reproduce

1. Open **Directory** → **Users**.
2. Search using the following inputs:
   - `preeti`
   - ` preeti`
   - `preeti `
   - `  preeti`
   - `preeti  `
   - `pre eti`
3. Verify the results:
   - `preeti` → ✅ Found
   - ` preeti` → ✅ Found
   - `preeti ` → ✅ Found
   - `  preeti` → ✅ Found
   - `preeti  ` → ✅ Found
   - `pre eti` → ❌ Not Found

## Further comments

The fix normalizes the search term in the shared user search helper before constructing the regular expression. This prevents leading and trailing whitespace from affecting user search while preserving the existing behavior for searches containing internal whitespace.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user search by ignoring leading and trailing spaces in search terms.
  * Prevented empty or whitespace-only searches from producing unnecessary search conditions.
  * Applied consistent whitespace handling across user status and active-user searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->