### PR TITLE
test: deflake read-receipts-thread viewed-in-thread test

### DIFF
--- a/apps/meteor/tests/e2e/read-receipts-thread.spec.ts
+++ b/apps/meteor/tests/e2e/read-receipts-thread.spec.ts
@@ -50,6 +50,9 @@ test.describe.serial('read-receipts-thread', () => {
 		await auxContext.poHomeChannel.navbar.openChat(targetChannel);
 		await auxContext.poHomeChannel.content.openReplyInThread();
 
+		// the read receipt only flips once user1 has actually read the reply, so wait for it to render on their side first
+		await expect(auxContext.poHomeChannel.content.lastUserThreadMessage).toContainText('first thread reply');
+
 		await expect(poHomeChannel.content.lastUserThreadMessage.getByRole('status', { name: 'Message viewed' })).toBeVisible();
 	});
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fixes a flaky timeout in `read-receipts-thread.spec.ts` ([failing run](https://github.com/RocketChat/Rocket.Chat/actions/runs/30065094302/job/89395840989), on an unrelated audit-DDP PR):

```
read-receipts-thread › should show read receipt as viewed in thread when both users have the thread open
Error: Timed out 5000ms waiting for expect(locator).toBeVisible()
Locator: ...thread message...last().getByRole('status', { name: 'Message viewed' })
  at read-receipts-thread.spec.ts:53
```

**Diagnosis:** the receipt flips to *viewed* only once user1 has actually read the reply. The failing test opened user1's thread and then **immediately** asserted the viewed status on the sender, without waiting for the reply to render on user1's side — so when user1's thread had not finished loading the message yet, user1 had not "read" it, the receipt never flipped, and the assertion timed out. The sibling test at line 56 (which passes) already waits for the aux user to see the content before asserting the receipt; this test did not.

**Fix:** wait for user1 to actually see the reply (`lastUserThreadMessage` contains `first thread reply`) before asserting the viewed receipt on the sender — mirroring the passing sibling test.

Confirmed unrelated to the PR whose run surfaced it: that PR (#40736) touches only `audit` files — no read-receipt, notification, subscription, or streamer code — so read-receipt behavior is unchanged from develop; this is a pre-existing flake.

## Issue(s)

## Steps to test or reproduce

```
yarn playwright test tests/e2e/read-receipts-thread.spec.ts
```

Cross-user/cross-context timing race; the fix removes the assumption that the receipt is pushed to the sender before the reader has loaded the message. Test-only, no changeset.

## Further comments


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2296]

[ARCH-2296]: https://rocketchat.atlassian.net/browse/ARCH-2296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by waiting for thread content to finish rendering before validating read-receipt visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->