### PR TITLE
chore(perf): quick wins on hot paths without behavior changes

### DIFF
--- a/.changeset/perf-quick-wins.md
+++ b/.changeset/perf-quick-wins.md
@@ -1,0 +1,9 @@
+---
+'@rocket.chat/random': patch
+'@rocket.chat/i18n': patch
+'@rocket.chat/license': patch
+'@rocket.chat/ui-client': patch
+'@rocket.chat/meteor': patch
+---
+
+Improves performance of several hot code paths without changing behavior: generates random IDs with a single `crypto.randomBytes` call instead of one per character, caches constant regular expressions used by the markdown/mention/autotranslate parsers instead of recompiling them for every message, skips the channel-mention database query for messages without channel mentions, deduplicates the room member count query when a message contains both `@all` and `@here`, and replaces linear array scans and spread-accumulators with Map/Set lookups in API response shaping (files, DM members, directory search and team listing).

--- a/apps/meteor/app/markdown/lib/parser/filtered/filtered.js
+++ b/apps/meteor/app/markdown/lib/parser/filtered/filtered.js
@@ -1,3 +1,7 @@
+import { getFilteredLinkRegexes } from '../linkRegexes';
+
+const inlineCodeRegex = /`([^`\r\n]+)\`/gm;
+
 /**
  * Filter markdown tags in message
  * Use case: notifications
@@ -10,21 +14,19 @@ export const filtered = (
 	},
 ) => {
 	const schemes = (options.supportSchemesForLink || 'http,https').split(',').join('|');
+	const linkRegexes = getFilteredLinkRegexes(schemes);
 
 	// Remove block code backticks
 	message = message.replace(/```/g, '');
 
 	// Remove inline code backticks
-	message = message.replace(new RegExp(/`([^`\r\n]+)\`/gm), (match) => match.substr(1, match.length - 2));
+	message = message.replace(inlineCodeRegex, (match) => match.substr(1, match.length - 2));
 
 	// Filter [text](url), ![alt_text](image_url)
-	message = message.replace(new RegExp(`!?\\[([^\\]]+)\\]\\((?:${schemes}):\\/\\/[^\\)]+\\)`, 'gm'), (match, title) => title);
+	message = message.replace(linkRegexes.link, (match, title) => title);
 
 	// Filter <http://link|Text>
-	message = message.replace(
-		new RegExp(`(?:<|&lt;)(?:${schemes}):\\/\\/[^\\|]+\\|(.+?)(?=>|&gt;)(?:>|&gt;)`, 'gm'),
-		(match, title) => title,
-	);
+	message = message.replace(linkRegexes.pipedLink, (match, title) => title);
 
 	// Filter headings
 	message = message.replace(

--- a/apps/meteor/app/markdown/lib/parser/linkRegexes.js
+++ b/apps/meteor/app/markdown/lib/parser/linkRegexes.js
@@ -1,0 +1,20 @@
+import mem from 'mem';
+
+// The link regexes only vary with the configured URL schemes, which come from
+// a setting that rarely changes; cache the compiled regexes per schemes value
+// instead of recompiling them for every message.
+//
+// The two parsers intentionally use different patterns: `filtered` only strips
+// markup (no URL capture, URLs may contain `)` escapes) while `original`
+// renders it (captures the URL, splits image from link).
+
+export const getMarkdownLinkRegexes = mem((schemes) => ({
+	image: new RegExp(`!\\[([^\\]]+)\\]\\(((?:${schemes}):\\/\\/[^\\s]+)\\)`, 'gm'),
+	link: new RegExp(`\\[([^\\]]+)\\]\\(((?:${schemes}):\\/\\/[^\\s]+)\\)`, 'gm'),
+	pipedLink: new RegExp(`(?:<|&lt;)((?:${schemes}):\\/\\/[^\\|]+)\\|(.+?)(?=>|&gt;)(?:>|&gt;)`, 'gm'),
+}));
+
+export const getFilteredLinkRegexes = mem((schemes) => ({
+	link: new RegExp(`!?\\[([^\\]]+)\\]\\((?:${schemes}):\\/\\/[^\\)]+\\)`, 'gm'),
+	pipedLink: new RegExp(`(?:<|&lt;)(?:${schemes}):\\/\\/[^\\|]+\\|(.+?)(?=>|&gt;)(?:>|&gt;)`, 'gm'),
+}));

--- a/apps/meteor/app/markdown/lib/parser/original/markdown.js
+++ b/apps/meteor/app/markdown/lib/parser/original/markdown.js
@@ -1,4 +1,5 @@
 import { addAsToken, isToken, validateAllowedTokens } from './token';
+import { getMarkdownLinkRegexes } from '../linkRegexes';
 
 const validateUrl = (url, message) => {
 	// Don't render markdown inside links
@@ -31,7 +32,11 @@ const getTextWrapper = (marker, tagName) => (textPrepend, wrappedText, textAppen
 
 const getRegexReplacer = (replaceFunction, getRegex) => (marker, tagName) => {
 	const wrapper = getTextWrapper(marker, tagName);
-	return (msg) => msg.replace(getRegex(marker), (...args) => replaceFunction(wrapper, ...args));
+	// The regex only depends on the marker, so build it once when the parser is
+	// created instead of on every message. Safe with /g because
+	// String.prototype.replace resets lastIndex on each call.
+	const regex = getRegex(marker);
+	return (msg) => msg.replace(regex, (...args) => replaceFunction(wrapper, ...args));
 };
 
 const getParserWithCustomMarker = getRegexReplacer(
@@ -68,6 +73,7 @@ const parseNotEscaped = (message, { supportSchemesForLink, headers, rootUrl }) =
 	}
 
 	const schemes = (supportSchemesForLink || '').split(',').join('|');
+	const linkRegexes = getMarkdownLinkRegexes(schemes);
 
 	if (headers) {
 		// Support # Text for h1
@@ -130,7 +136,7 @@ const parseNotEscaped = (message, { supportSchemesForLink, headers, rootUrl }) =
 	msg = msg.replace(/<\/blockquote>\n<blockquote/gm, '</blockquote><blockquote');
 
 	// Support ![alt text](http://image url)
-	msg = msg.replace(new RegExp(`!\\[([^\\]]+)\\]\\(((?:${schemes}):\\/\\/[^\\s]+)\\)`, 'gm'), (match, title, url) => {
+	msg = msg.replace(linkRegexes.image, (match, title, url) => {
 		if (!validateUrl(url, message)) {
 			return match;
 		}
@@ -148,7 +154,7 @@ const parseNotEscaped = (message, { supportSchemesForLink, headers, rootUrl }) =
 	});
 
 	// Support [Text](http://link)
-	msg = msg.replace(new RegExp(`\\[([^\\]]+)\\]\\(((?:${schemes}):\\/\\/[^\\s]+)\\)`, 'gm'), (match, title, url) => {
+	msg = msg.replace(linkRegexes.link, (match, title, url) => {
 		if (!validateUrl(url, message)) {
 			return match;
 		}
@@ -168,7 +174,7 @@ const parseNotEscaped = (message, { supportSchemesForLink, headers, rootUrl }) =
 	});
 
 	// Support <http://link|Text>
-	msg = msg.replace(new RegExp(`(?:<|&lt;)((?:${schemes}):\\\/\\\/[^\\|]+)\\|(.+?)(?=>|&gt;)(?:>|&gt;)`, 'gm'), (match, url, title) => {
+	msg = msg.replace(linkRegexes.pipedLink, (match, url, title) => {
 		if (!validateUrl(url, message)) {
 			return match;
 		}

--- a/apps/meteor/app/mentions/lib/MentionsParser.ts
+++ b/apps/meteor/app/mentions/lib/MentionsParser.ts
@@ -47,12 +47,34 @@ export class MentionsParser {
 		this.roomTemplate = roomTemplate;
 	}
 
-	get userMentionRegex() {
-		return new RegExp(`(^|\\s|>)@(${this.pattern()}(@(${this.pattern()}))?(:([0-9a-zA-Z-_.]+))?)`, 'gm');
+	// The mention regexes only depend on the configured pattern (a setting that
+	// rarely changes), but these getters are hit multiple times per message;
+	// cache the compiled regexes and rebuild only when the pattern changes.
+	// Sharing the instances is safe because they're only used with
+	// String.prototype.replace/match, which reset lastIndex on each call.
+	private cachedPattern: string | undefined;
+
+	private cachedUserMentionRegex: RegExp | undefined;
+
+	private cachedChannelMentionRegex: RegExp | undefined;
+
+	private updateRegexCache() {
+		const pattern = this.pattern();
+		if (pattern !== this.cachedPattern || !this.cachedUserMentionRegex || !this.cachedChannelMentionRegex) {
+			this.cachedPattern = pattern;
+			this.cachedUserMentionRegex = new RegExp(`(^|\\s|>)@(${pattern}(@(${pattern}))?(:([0-9a-zA-Z-_.]+))?)`, 'gm');
+			this.cachedChannelMentionRegex = new RegExp(`(^|\\s|>)#(${pattern}(@(${pattern}))?)`, 'gm');
+		}
 	}
 
-	get channelMentionRegex() {
-		return new RegExp(`(^|\\s|>)#(${this.pattern()}(@(${this.pattern()}))?)`, 'gm');
+	get userMentionRegex(): RegExp {
+		this.updateRegexCache();
+		return this.cachedUserMentionRegex as RegExp;
+	}
+
+	get channelMentionRegex(): RegExp {
+		this.updateRegexCache();
+		return this.cachedChannelMentionRegex as RegExp;
 	}
 
 	replaceUsers = (msg: string, { mentions, temp }: IMessage, me: string) =>
@@ -103,18 +125,14 @@ export class MentionsParser {
 
 	replaceChannels = (msg: string, { temp, channels }: IMessage) =>
 		msg.replace(/&#39;/g, "'").replace(this.channelMentionRegex, (match, prefix, mention) => {
-			if (
-				!temp &&
-				!channels?.find((c) => {
-					return c.name === mention;
-				})
-			) {
-				return match;
-			}
-
 			const channel = channels?.find(({ name }) => {
 				return name === mention;
 			});
+
+			if (!temp && !channel) {
+				return match;
+			}
+
 			const reference = channel ? channel._id : mention;
 			return this.roomTemplate({ prefix, reference, channel, mention });
 		});

--- a/apps/meteor/server/api/lib/addUserToFileObj.ts
+++ b/apps/meteor/server/api/lib/addUserToFileObj.ts
@@ -7,9 +7,10 @@ export async function addUserToFileObj(files: IUpload[]): Promise<(IUpload & { u
 	const uids = files.map(({ userId }) => userId).filter(isString);
 
 	const users = await Users.findByIds(uids, { projection: { name: 1, username: 1 } }).toArray();
+	const usersById = new Map(users.map((user) => [user._id, user]));
 
 	return files.map((file) => {
-		const user = users.find(({ _id: userId }) => file.userId && userId === file.userId);
+		const user = file.userId ? usersById.get(file.userId) : undefined;
 		if (!user) {
 			return file;
 		}

--- a/apps/meteor/server/api/v1/im.ts
+++ b/apps/meteor/server/api/v1/im.ts
@@ -590,8 +590,10 @@ const dmMembersAction = <Path extends string>(_path: Path): TypedAction<typeof d
 			{ projection: { u: 1, status: 1, ts: 1, roles: 1 } },
 		).toArray();
 
+		const subsByUserId = new Map(subs.map((sub) => [sub.u._id, sub]));
+
 		const membersWithSubscriptionInfo = members.map((member) => {
-			const sub = subs.find((sub) => sub.u._id === member._id);
+			const sub = subsByUserId.get(member._id);
 
 			const { u: _u, ...subscription } = sub || {};
 

--- a/apps/meteor/server/lib/autotranslate/autotranslate.ts
+++ b/apps/meteor/server/lib/autotranslate/autotranslate.ts
@@ -19,6 +19,14 @@ import { notifyOnMessageChange } from '../notifyListener';
 
 const translationLogger = new Logger('AutoTranslate');
 
+// Constant tokenizer patterns, compiled once instead of on every message.
+// Safe to share with /g flags because String.prototype.replace resets
+// lastIndex on each call.
+const urlSchemes = 'http,https';
+const markdownLinkRegex = new RegExp(`(!?\\[)([^\\]]+)(\\]\\((?:${urlSchemes}):\\/\\/[^\\)]+\\))`, 'gm');
+const pipedLinkRegex = new RegExp(`((?:<|&lt;)(?:${urlSchemes}):\\/\\/[^\\|]+\\|)(.+?)(?=>|&gt;)((?:>|&gt;))`, 'gm');
+const wrappedParagraphRegex = new RegExp('^\\s*<p>|</p>\\s*$', 'gm');
+
 const Providers = Symbol('Providers');
 const Provider = Symbol('Provider');
 
@@ -179,47 +187,39 @@ export abstract class AutoTranslate {
 	tokenizeURLs(message: IMessage): IMessage {
 		let count = message.tokens?.length || 0;
 
-		const schemes = 'http,https';
-
 		// Support ![alt text](http://image url) and [text](http://link)
-		message.msg = message.msg.replace(
-			new RegExp(`(!?\\[)([^\\]]+)(\\]\\((?:${schemes}):\\/\\/[^\\)]+\\))`, 'gm'),
-			(_match, pre, text, post) => {
-				const pretoken = `<i class=notranslate>{${count++}}</i>`;
-				message.tokens?.push({
-					token: pretoken,
-					text: pre,
-				});
+		message.msg = message.msg.replace(markdownLinkRegex, (_match, pre, text, post) => {
+			const pretoken = `<i class=notranslate>{${count++}}</i>`;
+			message.tokens?.push({
+				token: pretoken,
+				text: pre,
+			});
 
-				const posttoken = `<i class=notranslate>{${count++}}</i>`;
-				message.tokens?.push({
-					token: posttoken,
-					text: post,
-				});
+			const posttoken = `<i class=notranslate>{${count++}}</i>`;
+			message.tokens?.push({
+				token: posttoken,
+				text: post,
+			});
 
-				return pretoken + text + posttoken;
-			},
-		);
+			return pretoken + text + posttoken;
+		});
 
 		// Support <http://link|Text>
-		message.msg = message.msg.replace(
-			new RegExp(`((?:<|&lt;)(?:${schemes}):\\/\\/[^\\|]+\\|)(.+?)(?=>|&gt;)((?:>|&gt;))`, 'gm'),
-			(_match, pre, text, post) => {
-				const pretoken = `<i class=notranslate>{${count++}}</i>`;
-				message.tokens?.push({
-					token: pretoken,
-					text: pre,
-				});
+		message.msg = message.msg.replace(pipedLinkRegex, (_match, pre, text, post) => {
+			const pretoken = `<i class=notranslate>{${count++}}</i>`;
+			message.tokens?.push({
+				token: pretoken,
+				text: pre,
+			});
 
-				const posttoken = `<i class=notranslate>{${count++}}</i>`;
-				message.tokens?.push({
-					token: posttoken,
-					text: post,
-				});
+			const posttoken = `<i class=notranslate>{${count++}}</i>`;
+			message.tokens?.push({
+				token: posttoken,
+				text: post,
+			});
 
-				return pretoken + text + posttoken;
-			},
-		);
+			return pretoken + text + posttoken;
+		});
 
 		return message;
 	}
@@ -230,8 +230,7 @@ export abstract class AutoTranslate {
 		message = Markdown.parseMessageNotEscaped(message);
 
 		// Some parsers (e. g. Marked) wrap the complete message in a <p> - this is unnecessary and should be ignored with respect to translations
-		const regexWrappedParagraph = new RegExp('^\\s*<p>|</p>\\s*$', 'gm');
-		message.msg = message.msg.replace(regexWrappedParagraph, '');
+		message.msg = message.msg.replace(wrappedParagraphRegex, '');
 
 		for (const [tokenIndex, value] of message.tokens?.entries() ?? []) {
 			const { token } = value;

--- a/apps/meteor/server/lib/messages/parseUrlsInMessage.ts
+++ b/apps/meteor/server/lib/messages/parseUrlsInMessage.ts
@@ -5,13 +5,16 @@ import { getMessageUrlRegex } from '../../../lib/getMessageUrlRegex';
 import { settings } from '../../settings';
 import { Markdown } from '../messaging/markdown';
 
-const prepareUrl = (url: string, previewUrls: string[] | undefined) => ({
+const prepareUrl = (url: string, previewUrls: string[] | undefined, siteUrl: string) => ({
 	url,
 	meta: {},
-	...(previewUrls && !previewUrls.includes(url) && !url.includes(settings.get('Site_Url')) && { ignoreParse: true }),
+	...(previewUrls && !previewUrls.includes(url) && !url.includes(siteUrl) && { ignoreParse: true }),
 });
 
-const prepareUrls = (urls: string[], previewUrls?: string[]) => [...new Set(urls)].map((url) => prepareUrl(url, previewUrls));
+const prepareUrls = (urls: string[], previewUrls?: string[]) => {
+	const siteUrl = settings.get<string>('Site_Url');
+	return [...new Set(urls)].map((url) => prepareUrl(url, previewUrls, siteUrl));
+};
 
 export const parseUrlsInMessage = (
 	message: AtLeast<IMessage, 'msg' | 'md'> & {

--- a/apps/meteor/server/lib/messaging/mentions/Mentions.ts
+++ b/apps/meteor/server/lib/messaging/mentions/Mentions.ts
@@ -76,10 +76,9 @@ export class MentionsServer extends MentionsParser {
 				userMentions.add(mention);
 				continue;
 			}
-			const messageMaxAll = this.messageMaxAll();
-			if (messageMaxAll > 0) {
+			if (this.messageMaxAll() > 0) {
 				totalChannelMembers ??= await this.getTotalChannelMembers(rid);
-				if (totalChannelMembers > messageMaxAll) {
+				if (totalChannelMembers > this.messageMaxAll()) {
 					await this.onMaxRoomMembersExceeded({ sender, rid });
 					continue;
 				}

--- a/apps/meteor/server/lib/messaging/mentions/Mentions.ts
+++ b/apps/meteor/server/lib/messaging/mentions/Mentions.ts
@@ -59,6 +59,10 @@ export class MentionsServer extends MentionsParser {
 		const mentionsAll: { _id: string; username: string }[] = [];
 		const userMentions = new Set<string>();
 
+		// A message may mention both @all and @here; fetch the member count at
+		// most once per message instead of once per mention.
+		let totalChannelMembers: number | undefined;
+
 		for (const m of mentions) {
 			let mention: string;
 			if (m.includes(':')) {
@@ -72,9 +76,13 @@ export class MentionsServer extends MentionsParser {
 				userMentions.add(mention);
 				continue;
 			}
-			if (this.messageMaxAll() > 0 && (await this.getTotalChannelMembers(rid)) > this.messageMaxAll()) {
-				await this.onMaxRoomMembersExceeded({ sender, rid });
-				continue;
+			const messageMaxAll = this.messageMaxAll();
+			if (messageMaxAll > 0) {
+				totalChannelMembers ??= await this.getTotalChannelMembers(rid);
+				if (totalChannelMembers > messageMaxAll) {
+					await this.onMaxRoomMembersExceeded({ sender, rid });
+					continue;
+				}
 			}
 			mentionsAll.push({
 				_id: mention,
@@ -96,6 +104,12 @@ export class MentionsServer extends MentionsParser {
 	}
 
 	async convertMentionsToChannels(channels: string[]): Promise<Pick<IRoom, '_id' | 'name' | 'fname' | 'federated'>[]> {
+		// Most messages don't mention any channel; skip the (empty) database
+		// query entirely in that case. An empty $in matches nothing anyway.
+		if (channels.length === 0) {
+			return [];
+		}
+
 		return this.getChannels(channels.map((c) => (c.startsWith('#') ? c.substring(1) : c)));
 	}
 

--- a/apps/meteor/server/meteor-methods/rooms/browseChannels.ts
+++ b/apps/meteor/server/meteor-methods/rooms/browseChannels.ts
@@ -97,10 +97,11 @@ const getChannelsAndGroups = async (
 
 	const teamIds = result.map(({ teamId }) => teamId).filter(isTruthy);
 	const teamsMains = await Team.listByIds([...new Set(teamIds)], { projection: { _id: 1, name: 1 } });
+	const teamsById = new Map(teamsMains.map((team) => [team._id, team]));
 
 	const results = result.map((room) => {
 		if (room.teamId) {
-			const team = teamsMains.find((mainRoom) => mainRoom._id === room.teamId);
+			const team = teamsById.get(room.teamId);
 			if (team) {
 				return { ...room, belongsTo: team.name };
 			}

--- a/apps/meteor/server/services/messages/service.ts
+++ b/apps/meteor/server/services/messages/service.ts
@@ -292,12 +292,8 @@ export class MessageService extends ServiceClassInternal implements IMessageServ
 	}
 
 	private getMarkdownConfig() {
-		const customDomains = settings.get<string>('Message_CustomDomain_AutoLink')
-			? settings
-					.get<string>('Message_CustomDomain_AutoLink')
-					.split(',')
-					.map((domain) => domain.trim())
-			: [];
+		const customDomainAutoLink = settings.get<string>('Message_CustomDomain_AutoLink');
+		const customDomains = customDomainAutoLink ? customDomainAutoLink.split(',').map((domain) => domain.trim()) : [];
 
 		return {
 			colors: settings.get<boolean>('HexColorPreview_Enabled'),

--- a/apps/meteor/server/services/team/service.ts
+++ b/apps/meteor/server/services/team/service.ts
@@ -177,21 +177,22 @@ export class TeamService extends ServiceClassInternal implements ITeamService {
 				projection: { _id: 1 },
 			}).toArray();
 			const publicTeamIds = publicTeams.map(({ _id }) => _id);
-			const privateTeamIds = unfilteredTeamIds.filter((teamId) => !publicTeamIds.includes(teamId));
+			const publicTeamIdsSet = new Set(publicTeamIds);
+			const privateTeamIds = unfilteredTeamIds.filter((teamId) => !publicTeamIdsSet.has(teamId));
 
 			const privateTeams = await TeamMember.findByUserIdAndTeamIds(callerId, privateTeamIds, {
 				projection: { teamId: 1 },
 			}).toArray();
-			const visibleTeamIds = privateTeams.map(({ teamId }) => teamId).concat(publicTeamIds);
-			teamIds = unfilteredTeamIds.filter((teamId) => visibleTeamIds.includes(teamId));
+			const visibleTeamIds = new Set(privateTeams.map(({ teamId }) => teamId).concat(publicTeamIds));
+			teamIds = unfilteredTeamIds.filter((teamId) => visibleTeamIds.has(teamId));
 		}
 
-		const ownedTeams = unfilteredTeams.filter(({ roles = [] }) => roles.includes('owner')).map(({ teamId }) => teamId);
+		const ownedTeams = new Set(unfilteredTeams.filter(({ roles = [] }) => roles.includes('owner')).map(({ teamId }) => teamId));
 
 		const results = await Team.findByIds(teamIds).toArray();
 		return results.map((team) => ({
 			...team,
-			isOwner: ownedTeams.includes(team._id),
+			isOwner: ownedTeams.has(team._id),
 		}));
 	}
 

--- a/apps/meteor/server/settings/SettingsRegistry.ts
+++ b/apps/meteor/server/settings/SettingsRegistry.ts
@@ -293,7 +293,7 @@ export class SettingsRegistry {
 			{
 				$set: settingProps,
 				...(removedKeys?.length && {
-					$unset: removedKeys.reduce((unset, key) => ({ ...unset, [key]: 1 }), {}),
+					$unset: Object.fromEntries(removedKeys.map((key) => [key, 1])),
 				}),
 			},
 			{ upsert: true },

--- a/ee/packages/license/src/v2/convertToV3.ts
+++ b/ee/packages/license/src/v2/convertToV3.ts
@@ -51,8 +51,7 @@ export const convertToV3 = (v2: ILicenseV2): ILicenseV3 => {
 		grantedModules: [
 			...new Set(
 				['outbound-messaging', 'teams-voip', 'contact-id-verification', 'hide-watermark', ...v2.modules]
-					.map((licenseModule) => (isBundle(licenseModule) ? getBundleModules(licenseModule) : [licenseModule]))
-					.reduce((prev, curr) => [...prev, ...curr], [])
+					.flatMap((licenseModule) => (isBundle(licenseModule) ? getBundleModules(licenseModule) : [licenseModule]))
 					.map((licenseModule) => ({ module: licenseModule as InternalModuleName })),
 			),
 		],

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -107,7 +107,7 @@ export const extractTranslationNamespaces = (source: Record<string, string>): Re
 export const extractTranslationKeys = (source: Record<string, string>, namespaces: string | string[] = []): { [key: string]: any } => {
 	const all = extractTranslationNamespaces(source);
 	return Array.isArray(namespaces)
-		? (namespaces as TranslationNamespace[]).reduce((result, namespace) => ({ ...result, ...all[namespace] }), {})
+		? (namespaces as TranslationNamespace[]).reduce((result, namespace) => Object.assign(result, all[namespace]), {})
 		: all[namespaces as TranslationNamespace];
 };
 

--- a/packages/random/src/NodeRandomGenerator.ts
+++ b/packages/random/src/NodeRandomGenerator.ts
@@ -42,7 +42,7 @@ export class NodeRandomGenerator extends RandomGenerator {
 		let result = '';
 		for (let i = 0; i < count; i++) {
 			const fraction = bytes.readUInt32BE(i * 4) * 2.3283064365386963e-10; // 2^-32
-			result += alphabet[Math.floor(fraction * alphabet.length)];
+			result += alphabet.charAt(Math.floor(fraction * alphabet.length));
 		}
 		return result;
 	}

--- a/packages/random/src/NodeRandomGenerator.ts
+++ b/packages/random/src/NodeRandomGenerator.ts
@@ -23,19 +23,39 @@ export class NodeRandomGenerator extends RandomGenerator {
 	 */
 	override hexString(digits: number) {
 		const numBytes = Math.ceil(digits / 2);
-		let bytes;
-		// Try to get cryptographically strong randomness. Fall back to
-		// non-cryptographically strong if not available.
-		try {
-			bytes = crypto.randomBytes(numBytes);
-		} catch (e) {
-			// XXX should re-throw any error except insufficient entropy
-			bytes = crypto.pseudoRandomBytes(numBytes);
-		}
+		const bytes = this.randomBytes(numBytes);
 		const result = bytes.toString('hex');
 		// If the number of digits is odd, we'll have generated an extra 4 bits
 		// of randomness, so we need to trim the last digit.
 		return result.substring(0, digits);
+	}
+
+	override _randomString(charsCount: number, alphabet: string) {
+		// Generate all the randomness in a single call instead of one
+		// crypto.randomBytes() call per character. Each character consumes 4
+		// bytes read as a big-endian uint32, matching what fraction() would
+		// have produced, so the output distribution is unchanged.
+		// Normalized like the base-class loop: NaN/negative counts yield an
+		// empty string, fractional counts round up.
+		const count = Number.isNaN(charsCount) ? 0 : Math.max(0, Math.ceil(charsCount));
+		const bytes = this.randomBytes(count * 4);
+		let result = '';
+		for (let i = 0; i < count; i++) {
+			const fraction = bytes.readUInt32BE(i * 4) * 2.3283064365386963e-10; // 2^-32
+			result += alphabet[Math.floor(fraction * alphabet.length)];
+		}
+		return result;
+	}
+
+	private randomBytes(numBytes: number): Buffer {
+		// Try to get cryptographically strong randomness. Fall back to
+		// non-cryptographically strong if not available.
+		try {
+			return crypto.randomBytes(numBytes);
+		} catch (e) {
+			// XXX should re-throw any error except insufficient entropy
+			return crypto.pseudoRandomBytes(numBytes);
+		}
 	}
 
 	/**

--- a/packages/ui-client/src/components/GenericMenu/GenericMenu.tsx
+++ b/packages/ui-client/src/components/GenericMenu/GenericMenu.tsx
@@ -36,7 +36,7 @@ const GenericMenu = ({ title, icon = 'menu', disabled, onAction, callbackAction,
 	const sections = 'sections' in props && props.sections;
 	const items = 'items' in props && props.items;
 
-	const itemsList = sections ? sections.reduce((acc, { items }) => [...acc, ...items], [] as GenericMenuItemProps[]) : items || [];
+	const itemsList = sections ? sections.flatMap(({ items }) => items) : items || [];
 
 	const disabledKeys = itemsList.filter(({ disabled }) => disabled).map(({ id }) => id);
 	const handleAction = useHandleMenuAction(itemsList || [], callbackAction);


### PR DESCRIPTION
- Random.id/secret (server): generate all randomness with a single
  crypto.randomBytes call instead of one per character (~15x faster,
  identical output distribution)
- Markdown original/filtered parsers: hoist constant regexes and cache
  the schemes-derived link regexes instead of recompiling per message
- MentionsParser: cache user/channel mention regexes keyed on the
  configured pattern; avoid a duplicate channels.find per mention
- AutoTranslate tokenizers: compile constant regexes once at module load
- MentionsServer: skip the empty channel-mention DB query on messages
  with no channel mentions; fetch the room member count at most once per
  message when handling @all/@here
- API response shaping: replace O(n*m) Array.find/includes scans with
  Map/Set lookups (channels/groups/im files, im.members, browseChannels,
  Team.findBySubscribedUserIds)
- Replace quadratic reduce+spread accumulators with Object.assign,
  Object.fromEntries and flatMap (i18n namespace merge, license v2->v3
  conversion, settings $unset build, GenericMenu items)
- Avoid repeated settings.get calls in parseUrlsInMessage and
  getMarkdownConfig

## Micro-benchmarks

Old vs. new implementation (Node, Apple Silicon):

| Change | Old | New | Gain |
|---|---|---|---|
| `Random.id()` — 1 `randomBytes` call vs 17 | 12.4µs/op | 0.8µs/op | **15.7x** |
| MentionsParser regex caching | 515ns/op | 364ns/op | 1.4x |
| markdown `filtered()` regex caching | 490ns/op | 280ns/op | 1.7x |
| AutoTranslate tokenizer regexes | 339ns/op | 184ns/op | 1.8x |
| `im.members` shaping (100×100) — Map vs `find` | 12.3µs/op | 3.3µs/op | 3.7x |
| Team listing (200 ids) — Set vs `includes` | 13.8µs/op | 2.8µs/op | 4.8x |
| i18n namespace merge (10×200 keys) | 1087µs/op | 132µs/op | **8.2x** |
| settings `$unset` build (30 keys) | 6.3µs/op | 1.8µs/op | 3.5x |
| flatMap vs reduce+spread (150 items) | 1.8µs/op | 1.3µs/op | 1.4x |

`Random.id` is the hottest path (message IDs, uploads, session tokens),
and the i18n namespace merge was quadratic. Regex caching wins are small
per-op but apply several times per message. An equivalent Map lookup for
LDAP role sync benched as a wash at realistic sizes (60 roles) and was
dropped from this PR. Not benchable offline: the skipped channel-mention
DB query, the memoized `@all`/`@here` member-count query, and the
`settings.get` hoists — those avoid I/O or cache hits and need a live
server to measure.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ETnjqyMsf3b8LAeQ8fYCbG

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness across messaging, mentions, channel browsing, translation, Markdown processing, and menu rendering.
  * Reduced unnecessary database queries, repeated lookups, and repeated pattern processing.
  * Accelerated random ID generation and other frequently used operations.
* **Bug Fixes**
  * Preserved existing Markdown, mention, URL parsing, settings, and license conversion behavior while improving processing efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [CORE-2618]

[CORE-2618]: https://rocketchat.atlassian.net/browse/CORE-2618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ