### PR TITLE
regression: auto away not triggering in the web client

### DIFF
--- a/apps/meteor/client/lib/userPresence.ts
+++ b/apps/meteor/client/lib/userPresence.ts
@@ -54,6 +54,7 @@ export class UserPresence {
 		switch (newStatus) {
 			case UserStatus.ONLINE:
 				await this.goOnline();
+				this.startTimer();
 				break;
 
 			case UserStatus.AWAY:
@@ -118,9 +119,9 @@ export class UserPresence {
 		}, [RocketChatDesktop]);
 
 		useEffect(() => {
-			if (!user || !connected || isLoggingIn) return;
+			if (!user?._id || !connected || isLoggingIn) return;
 			this.startTimer();
-		}, [connected, isLoggingIn, user]);
+		}, [connected, isLoggingIn, user?._id]);
 
 		useEffect(() => {
 			if (connected) {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

With a normal Idle Time Limit, a web user stays `online` while idle and is never marked away. It only works when the limit is under ~30s, which is why a quick test looks fine.

**Cause.** The idle-timer effect in `apps/meteor/client/lib/userPresence.ts` depends on the whole `user` object, so it restarts the countdown whenever the user document updates. While logged in, the server re-writes the user's status every ~25s (even when it's unchanged), each write pushes a `userData` update, the store hands back a new `user` object, and the effect restarts the countdown — so it never reaches a limit above ~30s.

**Fix.** Key the effect on `user?._id` instead of the object. `_id` is a primitive that's constant for the session, so user-document updates no longer restart the countdown — it only re-arms on login/logout. Activity and connection changes still reset it through their own effects. Desktop is unaffected (OS-level idle detection).

## Issue(s)
- [CORE-2472](https://rocketchat.atlassian.net/browse/CORE-2472)

## Steps to test or reproduce

1. Web client, **Enable Auto Away** on, **Idle Time Limit** = 60s, then reload.
2. Stop interacting and watch the user's status from a second account.
3. Before: stays `online`. After: turns `away` after ~60s.

Verified live: after the fix, 7 status updates arrived over ~2 min, the countdown was restarted 0 times, and the user turned `away`.

## Further comments

The effect has restarted the countdown on every user update since the user-presence relocation (#36704, 7.10.0), but it stayed harmless until #40274 (presence sync engine) started re-writing the status every ~25s even when unchanged (base `findOneAndUpdate` bumps `_updatedAt`, unlike the old raw `updateOne`). This client fix is sufficient to restore auto away. Separate follow-up worth doing: make that presence write a no-op when the status is unchanged, so it stops re-writing/broadcasting every ~25s per connected user.

[CORE-2472]: https://rocketchat.atlassian.net/browse/CORE-2472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic away-status handling during login and connection changes.
  * Ensured the online status timer restarts correctly when returning online.
  * Reduced unnecessary status-effect updates when user information changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->