### PR TITLE
regression: custom OAuth client secret logged in plaintext at debug level

### DIFF
--- a/apps/meteor/server/lib/auth-providers/custom-oauth/custom_oauth_server.js
+++ b/apps/meteor/server/lib/auth-providers/custom-oauth/custom_oauth_server.js
@@ -18,7 +18,7 @@ import { notifyOnUserChange } from '../../notifyListener';
 import { saveUserIdentity } from '../../users/saveUserIdentity';
 import { registerAccessTokenService } from '../oauth/oauth';
 
-const logger = new Logger('CustomOAuth');
+const logger = new Logger('CustomOAuth', { redact: ['options.clientSecret'] });
 
 const Services = {};
 const BeforeUpdateOrCreateUserFromExternalService = [];


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Since #40721, the `options` object passed to the `CustomOAuth` constructor includes `clientSecret`, and the `Init CustomOAuth` debug log wrote it to the logs in plaintext on startup and on every provider reconfiguration when log level is set to debug.

Adds pino `redact` for `options.clientSecret` on the `CustomOAuth` logger, so the secret is replaced with `[Redacted]` in any log entry from this logger. Covers all providers routed through this constructor (admin-configured custom OAuth plus GitLab, Drupal, WordPress, Dolphin, GitHub Enterprise, LinkedIn, Nextcloud).

Verified at runtime:

```json
"options":{"clientId":"id","clientSecret":"[Redacted]"}
```

## Issue(s)

## Steps to test or reproduce

1. Admin > Settings > Logs > Log Level: `2 - Errors, Information and Debug`
2. Configure and enable a custom OAuth provider
3. Restart the server and check the `Init CustomOAuth` log entry: `clientSecret` shows `[Redacted]`
4. Change any setting of the provider and confirm the reconfiguration log is redacted as well

## Further comments

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
https://rocketchat.atlassian.net/browse/CORE-2460


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive OAuth client secrets are now automatically redacted from server logs, reducing the risk of credential exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->