### PR TITLE
regression: native emoji rendered as corrupted characters in omnichannel PDF transcript

### DIFF
--- a/ee/packages/pdf-worker/src/templates/ChatTranscript/markup/emoji.spec.ts
+++ b/ee/packages/pdf-worker/src/templates/ChatTranscript/markup/emoji.spec.ts
@@ -1,0 +1,19 @@
+import { unicodeToShortname } from './emoji';
+
+describe('unicodeToShortname', () => {
+	it('converts emoji without variation selector to shortname', () => {
+		expect(unicodeToShortname('\u{1F44D}')).toBe(':+1:');
+	});
+
+	it('converts emoji with variation selector to shortname', () => {
+		expect(unicodeToShortname('\u{1F44D}\u{FE0F}')).toBe(':+1:');
+	});
+
+	it('converts skin tone emoji to shortname', () => {
+		expect(unicodeToShortname('\u{1F44D}\u{1F3FD}')).toBe(':+1_tone3:');
+	});
+
+	it('returns the input unchanged when no shortname exists', () => {
+		expect(unicodeToShortname('not an emoji')).toBe('not an emoji');
+	});
+});

--- a/ee/packages/pdf-worker/src/templates/ChatTranscript/markup/emoji.ts
+++ b/ee/packages/pdf-worker/src/templates/ChatTranscript/markup/emoji.ts
@@ -13,17 +13,19 @@ const firstShortcode = (hexcode: string): string | undefined => {
 	return Array.isArray(entry) ? entry[0] : entry;
 };
 
+const stripVariationSelectors = (unicode: string): string => unicode.replace(/\p{Variation_Selector}/gu, '');
+
 const buildMap = (): Map<string, string> => {
 	const map = new Map<string, string>();
 	for (const emoji of data as EmojibaseEntry[]) {
 		const code = firstShortcode(emoji.hexcode);
 		if (code) {
-			map.set(emoji.emoji, `:${code}:`);
+			map.set(stripVariationSelectors(emoji.emoji), `:${code}:`);
 		}
 		for (const skin of emoji.skins ?? []) {
 			const skinCode = firstShortcode(skin.hexcode);
 			if (skinCode) {
-				map.set(skin.emoji, `:${skinCode}:`);
+				map.set(stripVariationSelectors(skin.emoji), `:${skinCode}:`);
 			}
 		}
 	}
@@ -34,5 +36,5 @@ export const unicodeToShortname = (unicode: string): string => {
 	if (!unicodeToShort) {
 		unicodeToShort = buildMap();
 	}
-	return unicodeToShort.get(unicode) ?? unicode;
+	return unicodeToShort.get(stripVariationSelectors(unicode)) ?? unicode;
 };


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

When a visitor sends a native emoji (e.g. 👍 from the livechat emoji picker), the generated PDF transcript renders it as corrupted characters such as `=M` instead of a readable shortcode like `:+1:`.

Regression from #39411 (emojione removal): `emojibase-data` stores emoji with a variation selector (`1F44D FE0F`), while `@rocket.chat/message-parser` emits the bare codepoint (`1F44D`). The exact `Map` lookup in `unicodeToShortname` missed, the raw emoji reached react-pdf's Latin font, and its UTF-16 surrogates were truncated to `=M`. The old `emojione.toShort` was regex-based and tolerant of this.

This strips variation selectors from both the map keys and the lookup input, so bare and selector-suffixed emoji resolve to the same shortcode.

https://rocketchat.atlassian.net/browse/CORE-2465

## Steps to test or reproduce

1. Enable Omnichannel with an online agent
2. As a visitor at /livechat, send 👍 alone and inside text
3. Close the conversation as the agent and generate the PDF transcript
4. The PDF shows `:+1:` instead of corrupted characters

## Further comments

Added `emoji.spec.ts` covering bare, variation-selector-suffixed, and skin-tone emoji plus the non-emoji fallback.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<img width="731" height="356" alt="image" src="https://github.com/user-attachments/assets/5292839a-7c76-4c5c-9ec3-08e5f35d0e70" />

<img width="709" height="417" alt="image" src="https://github.com/user-attachments/assets/e4eb4eae-3276-4c81-a7d1-cfdfd7a3f64b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emoji name conversion by consistently handling Unicode variation selectors.
  * Added support for correctly mapping skin-tone emoji variants.
  * Preserved the original emoji when no matching shortname is available.

* **Tests**
  * Added coverage for standard emoji, variation-selector variants, skin-tone emoji, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->