### PR TITLE
regression: custom emojis with mixed skin-tone names missing from search

### DIFF
--- a/apps/meteor/app/emoji/client/helpers.ts
+++ b/apps/meteor/app/emoji/client/helpers.ts
@@ -180,11 +180,15 @@ export const getEmojisBySearchTerm = (
 			tone = `_tone${actualTone}`;
 		}
 
-		const mixedTones = current.match(MIXED_TONE_SUFFIX);
-		const categoryName = current.replace(MIXED_TONE_SUFFIX, '');
-		if (mixedTones && !(actualTone > 0 && Number(mixedTones[1]) === actualTone)) {
-			continue;
+		const isNative = emojiPackage === 'native';
+		if (isNative) {
+			const mixedTones = current.match(MIXED_TONE_SUFFIX);
+			if (mixedTones && !(actualTone > 0 && Number(mixedTones[1]) === actualTone)) {
+				continue;
+			}
 		}
+
+		const categoryName = isNative ? current.replace(MIXED_TONE_SUFFIX, '') : current;
 
 		const isCategoryEmoji = Object.values(emoji.packages[emojiPackage].emojisByCategory).some(
 			(contents) => contents.indexOf(categoryName) !== -1,

--- a/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
+++ b/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
@@ -38,6 +38,18 @@ const getToneRegexes = () => {
 	return [exactFinalTone, colorBlind, seeColor];
 };
 
+const matchesEmojiSuggestion = (id: string, key: string, filterRegex: RegExp, [exactFinalTone, colorBlind, seeColor]: RegExp[]) => {
+	if (!filterRegex.test(id)) {
+		return false;
+	}
+
+	if (emoji.list[id]?.emojiPackage === 'emojiCustom') {
+		return true;
+	}
+
+	return exactFinalTone.test(id.substring(key.length)) || seeColor.test(key) || !colorBlind.test(id);
+};
+
 export type CannedResponse = { _id: string; shortcut: string; text: string };
 
 export type ComposerPopupProviderProps = {
@@ -209,7 +221,7 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 					title: t('Emoji'),
 					triggerLength: 2,
 					getItemsFromLocal: async (filter: string) => {
-						const [exactFinalTone, colorBlind, seeColor] = getToneRegexes();
+						const toneRegexes = getToneRegexes();
 
 						const emojiSort = (recents: string[]) => (a: { _id: string }, b: { _id: string }) => {
 							const aExact = a._id === key ? 2 : 0;
@@ -247,10 +259,7 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 								const data = collection[key];
 								return { _id, data };
 							})
-							.filter(
-								({ _id }) =>
-									filterRegex.test(_id) && (exactFinalTone.test(_id.substring(key.length)) || seeColor.test(key) || !colorBlind.test(_id)),
-							)
+							.filter(({ _id }) => matchesEmojiSuggestion(_id, key, filterRegex, toneRegexes))
 							.sort(emojiSort(recents))
 							.slice(0, 10);
 					},
@@ -270,7 +279,7 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 				suffix: ' ',
 				triggerAnywhere: false,
 				getItemsFromLocal: async (filter: string) => {
-					const [exactFinalTone, colorBlind, seeColor] = getToneRegexes();
+					const toneRegexes = getToneRegexes();
 
 					const emojiSort = (recents: string[]) => (a: { _id: string }, b: { _id: string }) => {
 						let idA = a._id;
@@ -305,10 +314,7 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 							const data = collection[key];
 							return { _id, data };
 						})
-						.filter(
-							({ _id }) =>
-								filterRegex.test(_id) && (exactFinalTone.test(_id.substring(key.length)) || seeColor.test(key) || !colorBlind.test(_id)),
-						)
+						.filter(({ _id }) => matchesEmojiSuggestion(_id, key, filterRegex, toneRegexes))
 						.sort(emojiSort(recents))
 						.slice(0, 10);
 				},

--- a/apps/meteor/tests/unit/app/emoji/helpers.spec.ts
+++ b/apps/meteor/tests/unit/app/emoji/helpers.spec.ts
@@ -29,6 +29,20 @@ const registerNativeEmojis = () => {
 	}
 };
 
+const registerCustomEmoji = (name: string) => {
+	if (!emoji.packages.emojiCustom) {
+		emoji.packages.emojiCustom = {
+			emojiCategories: [{ key: 'rocket', i18n: 'Custom' as any }],
+			emojisByCategory: { rocket: [] },
+			toneList: {},
+			render: (html: string) => html,
+			renderPicker: () => '<span class="emoji-custom" />',
+		} as any;
+	}
+	emoji.packages.emojiCustom.emojisByCategory.rocket.push(name);
+	emoji.list[`:${name}:`] = { emojiPackage: 'emojiCustom', name } as any;
+};
+
 describe('Emoji Client Helpers', () => {
 	beforeEach(() => {
 		emoji.packages.base.emojisByCategory.recent = [];
@@ -72,6 +86,11 @@ describe('Emoji Client Helpers', () => {
 			expect(result).to.exist;
 			expect(result?.image).to.include('👍🏼');
 			expect(result?.emoji).to.equal('thumbsup_tone2');
+		});
+
+		it('finds a custom emoji whose name ends in a mixed skin-tone suffix (CORE-2473)', () => {
+			registerCustomEmoji('mycustom_tone1-2');
+			expect(names('mycustom_tone1-2')).to.include('mycustom_tone1-2');
 		});
 	});
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Custom emojis whose name ends in a mixed skin-tone suffix (`_tone[1-5]-[1-5]`, e.g. `myemoji_tone1-2`) are created fine and show when browsing the custom category, but never appear in **emoji search** — neither in the picker search nor the composer `:` autocomplete.

Root cause: the search/autocomplete code detects native skin-tone variants by pattern-matching the emoji **name**, and hides them unless the matching tone is selected. Custom emoji names are literal, so a custom name shaped like a tone variant was wrongly filtered out. Fixed by scoping that tone handling to native emojis only.

- **Picker search** (`getEmojisBySearchTerm`): the mixed-tone skip and the category-name stripping now apply only when the emoji belongs to the `native` package. Custom emojis keep their full literal name, so they resolve in their category and surface in results.
- **Composer autocomplete** (`ComposerPopupProvider`): the duplicated filter in the `:` and `+:` popups was extracted into a single `matchesEmojiSuggestion` predicate that skips the native skin-tone filtering for custom emojis.

Native emojis are unaffected — the existing "excludes skin-tone variants from search" behavior is unchanged.

## Issue(s)

[CORE-2473](https://rocketchat.atlassian.net/browse/CORE-2473)

## Steps to test or reproduce

1. Administration → Workspace → Custom Emoji → create an emoji named `myemoji_tone1-2` (or any name ending in `_tone[1-5]-[1-5]`).
2. Open the emoji picker and search for `myemoji_tone1-2` → it now appears and is selectable.
3. In the message composer type `:myemoji_tone1-2` → it now appears in the autocomplete.
4. Regression check: searching a native emoji (e.g. `+1`) still does **not** list its `_tone` variants.

## Further comments

[CORE-2473]: https://rocketchat.atlassian.net/browse/CORE-2473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emoji search and suggestions for custom emojis with mixed skin-tone suffixes.
  * Corrected skin-tone filtering so it applies appropriately to native emojis without excluding valid custom emoji results.
  * Standardized emoji matching across composer popup suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->